### PR TITLE
Add fast tab for bing tone

### DIFF
--- a/client/src/components/Main/BingStyles.jsx
+++ b/client/src/components/Main/BingStyles.jsx
@@ -45,6 +45,12 @@ function BingStyles(props, ref) {
           value="fast"
           className={`${value === 'fast' ? selectedClass(value) : defaultClasses}`}
         >
+          {'Fast'}
+        </TabsTrigger>
+        <TabsTrigger
+          value="balanced"
+          className={`${value === 'balanced' ? selectedClass(value) : defaultClasses}`}
+        >
           {'Balanced'}
         </TabsTrigger>
         <TabsTrigger

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -60,7 +60,7 @@ transform: translateY(-60px);
 }
 
 .balanced-tab {
-  background: linear-gradient(90deg, #DC8000 10.79%, #F09005 87.08%);
+  background: linear-gradient(90deg, #D7871A 10.79%, #9F6005 87.08%);
 }
 
 .precise-tab {

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -37,7 +37,7 @@ bottom: 39px;
 z-index: 995;
 margin-left: auto; 
 margin-right: auto; 
-width: 308px; /* Need a specific value to work */
+width: 408px; /* Need a specific value to work */
 transition: all 0.5s ease-in-out;
 pointer-events: none;
 transform: translateY(-60px);
@@ -57,6 +57,10 @@ transform: translateY(-60px);
 
 .fast-tab {
   background: linear-gradient(90deg, #2870EA 10.79%, #1B4AEF 87.08%);
+}
+
+.balanced-tab {
+  background: linear-gradient(90deg, #DC8000 10.79%, #F09005 87.08%);
 }
 
 .precise-tab {


### PR DESCRIPTION
The old (GPT-4 version balanced version) is still available from the chatgpt-api side. The new one is explicitly named as a 'fast'. To be consistent with the chatgpt-api, this PR add a fast tab as a new 'balanced' version. 