### PR TITLE
Support local config for reverse proxy

### DIFF
--- a/api/app/clients/chatgpt-browser.js
+++ b/api/app/clients/chatgpt-browser.js
@@ -4,7 +4,7 @@ const set = new Set(["gpt-4", "text-davinci-002-render", "text-davinci-002-rende
 
 const clientOptions = {
   // Warning: This will expose your access token to a third party. Consider the risks before using this.
-  reverseProxyUrl: 'https://bypass.churchless.tech/api/conversation',
+  reverseProxyUrl: process.env.CHATGPT_REVERSE_PROXY || 'https://bypass.churchless.tech/api/conversation',
   // Access token from https://chat.openai.com/api/auth/session
   accessToken: process.env.CHATGPT_TOKEN,
   // debug: true


### PR DESCRIPTION
Using GPT-4 with a plus account via a proxy is cheaper than the API for a moderate number of requests. Having a configurable reverseProxyURL allows [local proxy installs](https://github.com/acheong08/ChatGPT-Proxy-V4) w/o sending data to a 3rd party.