### PR TITLE
Fix: fix javascript heap out of memory error from vite

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,7 +8,7 @@
       "ESNext"
     ],
     "allowJs": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -32,12 +32,7 @@ export default defineConfig({
             return "vendor";
           }
         },
-        sourcemapIgnoreList: (relativeSourcePath) => {
-          const normalizedPath = path.normalize(relativeSourcePath);
-          return normalizedPath.includes("node_modules");
-        },
       },
-      cache: false,
     },
   },
   resolve: {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import type { Plugin } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -19,11 +20,25 @@ export default defineConfig({
       }
     }
   },
-  plugins: [react()],
+  plugins: [react(), sourcemapExclude({ excludeNodeModules: true }),],
   publicDir: './public',
   build: {
     sourcemap: true,
-    outDir: './dist'
+    outDir: './dist',
+    rollupOptions: {
+      output: {
+        manualChunks: (id) => {
+          if (id.includes("node_modules")) {
+            return "vendor";
+          }
+        },
+        sourcemapIgnoreList: (relativeSourcePath) => {
+          const normalizedPath = path.normalize(relativeSourcePath);
+          return normalizedPath.includes("node_modules");
+        },
+      },
+      cache: false,
+    },
   },
   resolve: {
     alias: {
@@ -31,3 +46,22 @@ export default defineConfig({
     }
   }
 });
+
+interface SourcemapExclude {
+  excludeNodeModules?: boolean;
+}
+export function sourcemapExclude(opts?: SourcemapExclude): Plugin {
+  return {
+      name: "sourcemap-exclude",
+      transform(code: string, id: string) {
+          if (opts?.excludeNodeModules && id.includes("node_modules")) {
+              return {
+                  code,
+                  // https://github.com/rollup/rollup/blob/master/docs/plugin-development/index.md#source-code-transformations
+                  map: { mappings: "" },
+              };
+          }
+      },
+  };
+}
+


### PR DESCRIPTION
This should hopefully fix the Javascript heap out of memory issue being thrown sometimes from Vite when building.

Was unable to reproduce the issue locally, so will require further testing from those experiencing the issue, but this optimizes the sourcemap to exclude vendor packages, which appeared to be the cause of the problem according to this thread: https://github.com/vitejs/vite/issues/2433