### PR TITLE
fix nginx container not containing the actual build output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ CMD ["npm", "start"]
 # Optional: for client with nginx routing
 FROM nginx:stable-alpine AS nginx-client
 WORKDIR /usr/share/nginx/html
-COPY --from=react-client /client/public /usr/share/nginx/html
+COPY --from=react-client /client/dist /usr/share/nginx/html
 # Add your nginx.conf
 COPY /client/nginx.conf /etc/nginx/conf.d/default.conf
 ENTRYPOINT ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
changing to vite has lead to a change in output location. This is however not reflected in dockerfile.