### PR TITLE
fix: fix infinite query failure when conversationId is not found

### DIFF
--- a/client/src/data-provider/react-query-service.ts
+++ b/client/src/data-provider/react-query-service.ts
@@ -63,13 +63,11 @@ export const useGetConversationByIdQuery = (
 //to make it work with how the Chat component is structured
 export const useGetConversationByIdMutation = (
   id: string,
-  callback: (data: t.TConversation) => void
 ): UseMutationResult<t.TConversation> => {
   const queryClient = useQueryClient();
   return useMutation(() => dataService.getConversationById(id),
     {
       onSuccess: (res: t.TConversation) => {
-        callback(res);
        queryClient.invalidateQueries([QueryKeys.conversation, id]);
       },
     }   

--- a/client/src/routes/Chat.jsx
+++ b/client/src/routes/Chat.jsx
@@ -20,7 +20,7 @@ export default function Chat() {
 
   //disabled by default, we only enable it when messagesTree is null
   const messagesQuery = useGetMessagesByConvoId(conversationId, { enabled: false });
-  const getConversationMutation = useGetConversationByIdMutation(conversationId, setConversation);
+  const getConversationMutation = useGetConversationByIdMutation(conversationId);
 
   // when conversation changed or conversationId (in url) changed
   useEffect(() => {
@@ -31,7 +31,17 @@ export default function Chat() {
         newConversation();
       } else if (conversationId) {
         // fetch it from server
-        getConversationMutation.mutate();
+        getConversationMutation.mutate(conversationId, {
+          onSuccess: (data) => {
+            setConversation(data);
+          },
+          onError: (error) => {
+            console.error('failed to fetch the conversation');
+            console.error(error);
+            navigate(`/chat/new`);
+            newConversation();
+          }
+        });
         setMessages(null);
       } else {
         navigate(`/chat/new`);
@@ -44,15 +54,6 @@ export default function Chat() {
       navigate(`/chat/${conversation?.conversationId}`);
     }
   }, [conversation, conversationId]);
-
-  useEffect(() => {
-    if(getConversationMutation.isError) {
-      console.error('failed to fetch the conversation');
-      console.error(getConversationMutation.error);
-      newConversation();
-    }
-  }, [getConversationMutation.isError, newConversation]);
-
 
   useEffect(() => {
     if (messagesTree === null && conversation?.conversationId) {


### PR DESCRIPTION
This fixes the issue that occurs when a bad conversation id is in the url and it tries to fetch it with an infinite loop that continuously fails.