### PR TITLE
Update .env.example

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -42,6 +42,7 @@ OPENAI_MODELS=gpt-3.5-turbo,gpt-3.5-turbo-0301,text-davinci-003,gpt-4
 # Also used for Sydney and jailbreak
 
 # BingAI Tokens: the "_U" cookies value from bing.com 
+# Set to "user_provided" to allow user provided token.
 # Leave it blank to disable this endpoint. 
 BINGAI_TOKEN=
 
@@ -56,7 +57,8 @@ BINGAI_TOKEN=
 
 # ChatGPT Browser Client (free but use at your own risk) 
 # Access token from https://chat.openai.com/api/auth/session 
-# Exposes your access token to `CHATGPT_REVERSE_PROXY` 
+# Exposes your access token to `CHATGPT_REVERSE_PROXY`
+# Set to "user_provided" to allow user provided token.
 # Leave it blank to disable this endpoint 
 CHATGPT_TOKEN=
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -42,9 +42,9 @@ OPENAI_MODELS=gpt-3.5-turbo,gpt-3.5-turbo-0301,text-davinci-003,gpt-4
 # Also used for Sydney and jailbreak
 
 # BingAI Tokens: the "_U" cookies value from bing.com 
-# Set to "user_provided" to allow user provided token.
+# Set to "user_provided" to allow the user to provide its token from the UI.
 # Leave it blank to disable this endpoint. 
-BINGAI_TOKEN=
+BINGAI_TOKEN=user_provided
 
 # BingAI Host: 
 # Necessary for some people in different countries, e.g. China (https://cn.bing.com) 
@@ -58,9 +58,9 @@ BINGAI_TOKEN=
 # ChatGPT Browser Client (free but use at your own risk) 
 # Access token from https://chat.openai.com/api/auth/session 
 # Exposes your access token to `CHATGPT_REVERSE_PROXY`
-# Set to "user_provided" to allow user provided token.
+# Set to "user_provided" to allow the user to provide its token from the UI.
 # Leave it blank to disable this endpoint 
-CHATGPT_TOKEN=
+CHATGPT_TOKEN=user_provided
 
 # Identify the available models, separated by commas. The first will be default. 
 # Leave it blank to use internal settings. 

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,112 +1,105 @@
+##########################
 # Server configuration. 
-# The server will listen to localhost:3080 request by default. You can set the target ip as you want.
-# If you want this server can be used outside your local machine, for example to share with other 
-# machine or expose this from a docker container, set HOST=0.0.0.0 or your external ip interface.
-#
-# Tips: HOST=0.0.0.0 means listening on all interface. It's not a real ip. Use localhost:port rather
-# than 0.0.0.0:port to open it.
-HOST=localhost 
+##########################
+
+# The server will listen to localhost:3080 by default. You can change the target IP as you want. 
+# If you want to make this server available externally, for example to share the server with others 
+# or expose this from a Docker container, set host to 0.0.0.0 or your external IP interface. 
+# Tips: Setting host to 0.0.0.0 means listening on all interfaces. It's not a real IP.  
+# Use localhost:port rather than 0.0.0.0:port to access the server. 
+HOST=localhost
 PORT=3080
 NODE_ENV=development
 
-# Change this to proxy any API request. It's useful if your machine have difficulty calling the original API server.
-# PROXY="http://YOUR_PROXY_SERVER"
+# Change this to proxy any API request. 
+# It's useful if your machine has difficulty calling the original API server. 
+# PROXY=
 
-# Change this to your MongoDB URI if different and I recommend appending chatgpt-clone
-MONGO_URI="mongodb://127.0.0.1:27017/chatgpt-clone"
+# Change this to your MongoDB URI if different and I recommend appending chatgpt-clone 
+MONGO_URI=mongodb://127.0.0.1:27017/chatgpt-clone
 
+##########################
+# OpenAI Endpoint: 
+##########################
 
-#############################
-# Endpoint OpenAI:
-#############################
-
-# Access key from OpenAI platform
-# Leave it blank to disable this endpoint
+# Access key from OpenAI platform. 
+# Leave it blank to disable this feature. 
 OPENAI_KEY=
 
-# Identify the available models, sperate by comma, and not space in it
-# The first will be default
-# Leave it blank to use internal settings.
+# Identify the available models, separated by commas *without spaces*. 
+# The first will be default. 
+# Leave it blank to use internal settings. 
 OPENAI_MODELS=gpt-3.5-turbo,gpt-3.5-turbo-0301,text-davinci-003,gpt-4
 
-# Reverse proxy setting for OpenAI
-# https://github.com/waylaidwanderer/node-chatgpt-api#using-a-reverse-proxy
-# OPENAI_REVERSE_PROXY=<YOUR REVERSE PROXY>
+# Reverse proxy settings for OpenAI: 
+# https://github.com/waylaidwanderer/node-chatgpt-api#using-a-reverse-proxy 
+# OPENAI_REVERSE_PROXY=
 
+##########################
+# BingAI Endpoint:   
+##########################
 
-#############################
-# Endpoint BingAI (Also jailbreak Sydney):
-#############################
+# Also used for Sydney and jailbreak
 
-# BingAI Tokens: the "_U" cookies value from bing.com
-# Leave it and BINGAI_USER_TOKEN blank to disable this endpoint.
-# Set to "user_provided" to allow user provided token.
-# BINGAI_TOKEN="user_provided"
-BINGAI_TOKEN=user_provided
+# BingAI Tokens: the "_U" cookies value from bing.com 
+# Leave it blank to disable this endpoint. 
+BINGAI_TOKEN=
 
-# BingAI Host:     
-# Necessary for some people in different countries, e.g. China (https://cn.bing.com)
-# Leave it blank to use default server.
-# BINGAI_HOST="https://cn.bing.com"
+# BingAI Host: 
+# Necessary for some people in different countries, e.g. China (https://cn.bing.com) 
+# Leave it blank to use default server. 
+# BINGAI_HOST=https://cn.bing.com 
 
+##########################
+# ChatGPT Endpoint: 
+##########################
 
-#############################
-# Endpoint chatGPT:
-#############################
-
-# ChatGPT Browser Client (free but use at your own risk)
-# Access token from https://chat.openai.com/api/auth/session
-# Exposes your access token to CHATGPT_REVERSE_PROXY
-# Leave it blank to disable this endpoint
-# Set to "user_provide" to allow user provided token.
-# CHATGPT_TOKEN="user_provide"
+# ChatGPT Browser Client (free but use at your own risk) 
+# Access token from https://chat.openai.com/api/auth/session 
+# Exposes your access token to `CHATGPT_REVERSE_PROXY` 
+# Leave it blank to disable this endpoint 
 CHATGPT_TOKEN=
 
-# Identify the available models, sperate by comma, and not space in it
-# The first will be default
-# Leave it blank to use internal settings.
+# Identify the available models, separated by commas. The first will be default. 
+# Leave it blank to use internal settings. 
 CHATGPT_MODELS=text-davinci-002-render-sha,text-davinci-002-render-paid,gpt-4
 
-# Reverse proxy setting for OpenAI
-# https://github.com/waylaidwanderer/node-chatgpt-api#using-a-reverse-proxy
-# By default it will use the node-chatgpt-api recommended proxy, (it's a third party server)
-# CHATGPT_REVERSE_PROXY=<YOUR REVERSE PROXY>
+# Reverse proxy settings for ChatGPT 
+# https://github.com/waylaidwanderer/node-chatgpt-api#using-a-reverse-proxy 
+# By default, the server will use the node-chatgpt-api recommended proxy (a third party server). 
+# CHATGPT_REVERSE_PROXY= 
 
+##########################
+# Search: 
+##########################
 
-#############################
-# Search:
-#############################
+# ENABLING SEARCH MESSAGES/CONVOS 
+# Requires the installation of the free self-hosted Meilisearch or a paid Remote Plan (Remote not tested) 
+# The easiest setup for this is through docker-compose, which takes care of it for you. 
+SEARCH=TRUE
 
-# ENABLING SEARCH MESSAGES/CONVOS
-# Requires installation of free self-hosted Meilisearch or Paid Remote Plan (Remote not tested)
-# The easiest setup for this is through docker-compose, which takes care of it for you.
-# SEARCH=1
-SEARCH=1
+# REQUIRED FOR SEARCH: MeiliSearch Host, mainly for the API server to connect to the search server. 
+# Replace '0.0.0.0' with 'meilisearch' if serving MeiliSearch with docker-compose. 
+MEILI_HOST=http://0.0.0.0:7700
 
-# REQUIRED FOR SEARCH: MeiliSearch Host, mainly for api server to connect to the search server.
-# must replace '0.0.0.0' with 'meilisearch' if serving meilisearch with docker-compose
-# MEILI_HOST='http://meilisearch:7700' # <-- docker-compose (should already be setup on docker-compose.yml)
-MEILI_HOST='http://0.0.0.0:7700' # <-- local/remote
+# REQUIRED FOR SEARCH: MeiliSearch HTTP Address, mainly for docker-compose to expose the search server. 
+# Replace '0.0.0.0' with 'meilisearch' if serving MeiliSearch with docker-compose. 
+MEILI_HTTP_ADDR=0.0.0.0:7700
 
-# REQUIRED FOR SEARCH: MeiliSearch HTTP Address, mainly for docker-compose to expose the search server.
-# must replace '0.0.0.0' with 'meilisearch' if serving meilisearch with docker-compose
-# MEILI_HTTP_ADDR='meilisearch:7700'  # <-- docker-compose (should already be setup on docker-compose.yml)
-MEILI_HTTP_ADDR='0.0.0.0:7700'  # <-- local/remote
-
-# REQUIRED FOR SEARCH: In production env., needs a secure key, feel free to generate your own.
-# This master key must be at least 16 bytes, composed of valid UTF-8 characters.
-# Meilisearch will throw an error and refuse to launch if no master key is provided or if it is under 16 bytes, 
-# Meilisearch will suggest a secure autogenerated master key.
+# REQUIRED FOR SEARCH: In production env., a secure key is needed. You can generate your own. 
+# This master key must be at least 16 bytes, composed of valid UTF-8 characters. 
+# MeiliSearch will throw an error and refuse to launch if no master key is provided, 
+# or if it is under 16 bytes. MeiliSearch will suggest a secure autogenerated master key.
 # Using docker, it seems recognized as production so use a secure key.
-# MEILI_MASTER_KEY=                                           # <-- empty/insecure key works for local/remote
-MEILI_MASTER_KEY=JKMW-hGc7v_D1FkJVdbRSDNFLZcUv3S75yrxXP0SmcU # <-- ready made secure key for docker-compose
+# This is a ready made secure key for docker-compose, you can replace it with your own.
+MEILI_MASTER_KEY=JKMW-hGc7v_D1FkJVdbRSDNFLZcUv3S75yrxXP0SmcU
 
-
-#############################
+##########################
 # User System
-#############################
+##########################
 
-# Enable the user system.
-# this is not a ready to use user system.
-# dont't use it, unless you can write your own code.
-# ENABLE_USER_SYSTEM=  # <-- make sure you don't comment this back in if you're not using your own user system
+# ENABLING THE USER SYSTEM
+# This is not a ready to use user system.
+# Don't use it, unless you can write your own code.
+# Do not uncomment this unless you implemented your own user system
+# ENABLE_USER_SYSTEM=


### PR DESCRIPTION
I continued the work on the standardization of the layout. I eliminated duplicate key=value pairs to simplify the configuration and reduce the likelihood of errors. I also updated some of the commented instructions and notes throughout the file to keep the instructions clear while making it easier to prevent errors when using a script to parse the key=value pairs.