### PR TITLE
Fixup: LOCAL_INSTALL.md PS instructions

### DIFF
--- a/LOCAL_INSTALL.md
+++ b/LOCAL_INSTALL.md
@@ -118,7 +118,7 @@ the provided docker-compose file:
 
    ```shell
    docker build `
-     --target=node-api ` 
+     --target=node-api `
      -t node-api `
      .
    ```


### PR DESCRIPTION
The Powershell command can't be copy-pasted because there's a space after "`"