### PR TITLE
Enable HTTPS when PRIVKEY and CERTKEY are provided. 

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -7,9 +7,16 @@
 # or expose this from a Docker container, set host to 0.0.0.0 or your external IP interface. 
 # Tips: Setting host to 0.0.0.0 means listening on all interfaces. It's not a real IP.  
 # Use localhost:port rather than 0.0.0.0:port to access the server. 
+#
+# To Enable HTTPS provide the path and filename for PRIVKEY and CERTKEY. Both can be generated using 
+# letsencrypt for a standalone setup with your domain name. You'll need to ensure that when you generate
+# your keys that port 80 is open and not in use by node so that letsencrypt can complete the verification. 
+
 HOST=localhost
 PORT=3080
 NODE_ENV=development
+PRIVKEY=
+CERTKEY=
 
 # Change this to proxy any API request. 
 # It's useful if your machine has difficulty calling the original API server. 


### PR DESCRIPTION
 If no PRIVKEY and CERTKEY are provided, Chatgpt-Clone runs as usual with "Server listening on http://localhost:3080". Else, if PRIVKEY and CERTKEY are provided in the .env file, along with HOST=[domainname], the console statement says "Server listening on https://[domain name]:443". 