### PR TITLE
feat: add support for titling convos with azure endpoint

### DIFF
--- a/api/app/clients/chatgpt-client.js
+++ b/api/app/clients/chatgpt-client.js
@@ -1,5 +1,6 @@
 require('dotenv').config();
 const { KeyvFile } = require('keyv-file');
+const { genAzureEndpoint } = require('../../utils/genAzureEndpoints');
 
 const askClient = async ({
   text,
@@ -43,7 +44,11 @@ const askClient = async ({
 
   if (azure) {
     apiKey = process.env.AZURE_OPENAI_API_KEY;
-    clientOptions.reverseProxyUrl = `https://${process.env.AZURE_OPENAI_API_INSTANCE_NAME}.openai.azure.com/openai/deployments/${process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME}/chat/completions?api-version=${process.env.AZURE_OPENAI_API_VERSION}`;
+    clientOptions.reverseProxyUrl = genAzureEndpoint({ 
+      azureOpenAIApiInstanceName: process.env.AZURE_OPENAI_API_INSTANCE_NAME, 
+      azureOpenAIApiDeploymentName: process.env.AZURE_OPENAI_API_DEPLOYMENT_NAME, 
+      azureOpenAIApiVersion: process.env.AZURE_OPENAI_API_VERSION
+    });
   }
 
   const client = new ChatGPTClient(apiKey, clientOptions, store);

--- a/api/utils/genAzureEndpoints.js
+++ b/api/utils/genAzureEndpoints.js
@@ -1,0 +1,5 @@
+function genAzureEndpoint({ azureOpenAIApiInstanceName, azureOpenAIApiDeploymentName, azureOpenAIApiVersion }) {
+  return `https://${azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments/${azureOpenAIApiDeploymentName}/chat/completions?api-version=${azureOpenAIApiVersion}`;
+}
+
+module.exports = { genAzureEndpoint };


### PR DESCRIPTION
Title + the `genAzureEndpoint` function in `genAzureEndpoints.js` generates the endpoint URL based on the provided parameters. The `chatgpt-client.js` and `titleConvo.js` files now use this function to generate the endpoint URL when the `AZURE_OPENAI_API_KEY` environment variable is set.