### PR TITLE
fix(docker): update .dockerignore to include client/.env file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 **/node_modules
-**/.env
+api/.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:19-alpine AS react-client
 WORKDIR /client
 # copy package.json into the container at /client
+COPY /client/.env /client/.env
 COPY /client/package*.json /client/
 # install dependencies
 RUN npm ci


### PR DESCRIPTION
This allows socials for authentication system using docker

make sure you have the following in `api/.env`
```
GOOGLE_CLIENT_ID=your client id
GOOGLE_CLIENT_SECRET=your client secret
GOOGLE_CALLBACK_URL=/oauth/google/callback
```

the env variables in client/.env as shown in client/.env.example file, but the following set to 'true'

`VITE_SHOW_GOOGLE_LOGIN_OPTION=true`

follow the guide here: <https://github.com/danny-avila/chatgpt-clone/blob/main/documents/features/user_auth_system.md>