### PR TITLE
Release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ﻿# # Changelog
 <details open>
+<summary><strong>2023-05-11</strong></summary>
+ 
+**Released [v0.4.2](https://github.com/danny-avila/chatgpt-clone/releases/tag/v0.4.2)**
+ 
+ChatGPT-Clone received some important upgrades and improvements. A new contributor, [@qcgm1978](https://github.com/qcgm1978), makes their first contribution by adding a null check for adaptiveCards variable. Additionally, support for titling conversations with the Azure endpoint is added by [@danny-avila](https://github.com/danny-avila) in PR [#234](https://github.com/danny-avila/chatgpt-clone/pull/234). In PR [#235](https://github.com/danny-avila/chatgpt-clone/pull/235), [@danny-avila](https://github.com/danny-avila) also makes some necessary fixes to titling, quotation marks, and endpoints being unavailable with only the Azure key provided. The logging system is now powered by Pino and sanitization, thanks to [@danorlando](https://github.com/danorlando) in PR [#227](https://github.com/danny-avila/chatgpt-clone/pull/227). To bulletproof the Docker container, the .dockerignore file is updated to include the client/.env file by [@danny-avila](https://github.com/danny-avila) in PR [#241](https://github.com/danny-avila/chatgpt-clone/pull/241). This issue was brought to our attention on discord.
+
+There is active work on the new Plugins feature, converting the frontend to Typescript, and looking to integrate Palm2, google's new generative AI accessible via API, to the project as a new endpoint.
+
+You can check the full changelog in between [v0.4.1](https://github.com/danny-avila/chatgpt-clone/releases/tag/v0.4.1) and [v0.4.2](https://github.com/danny-avila/chatgpt-clone/releases/tag/v0.4.2) [here](https://github.com/danny-avila/chatgpt-clone/compare/v0.4.1...v0.4.2)."
+
+For discussion and suggestion you can join us: **[community discord server](https://discord.gg/NGaa9RPCft)**
+</details>
+
+<details>
 <summary><strong>2023-05-09</strong></summary>
  
 **Released [v0.4.1](https://github.com/danny-avila/chatgpt-clone/releases/tag/v0.4.1)**
@@ -20,8 +34,6 @@
 
 For discussion and suggestion you can join us: **[community discord server](https://discord.gg/NGaa9RPCft)**
 </details>
-
-
  <details>
 <summary><strong>2023-05-07</strong></summary>
 

--- a/README.md
+++ b/README.md
@@ -41,28 +41,20 @@
 ##
 
 <details open>
-<summary><strong>2023-05-09</strong></summary>
+<summary><strong>2023-05-11</strong></summary>
  
-**Released [v0.4.1](https://github.com/danny-avila/chatgpt-clone/releases/tag/v0.4.1)**
+**Released [v0.4.2](https://github.com/danny-avila/chatgpt-clone/releases/tag/v0.4.2)**
  
- * update user system section of readme by @danorlando in #207
- * remove github-passport and update package.lock files by @danorlando in #208
- * Update README.md by @fuegovic in #209
- * fix: fix browser refresh redirecting to /chat/new by @danorlando in #210
- * fix: fix issue with validation when google account has multiple spaces in username by @danorlando in #211
- * chore: update docker image version to use latest by @danny-avila in #218
- * update documentation structure by @fuegovic in #220
- * Feat: Add Azure support by @danny-avila in #219
- * Update Message.js by @DavidDev1334 in #191
- 
-⚠️ **IMPORTANT :** Since V0.4.0 You should register and login with a local account (email and password) for the first time sign-up. if you use login for the first time with a social login account (eg. Google, facebook, etc.), the conversations and presets that you created before the user system was implemented will NOT be migrated to that account.
+ChatGPT-Clone received some important upgrades and improvements. A new contributor, [@qcgm1978](https://github.com/qcgm1978), makes their first contribution by adding a null check for adaptiveCards variable. Additionally, support for titling conversations with the Azure endpoint is added by [@danny-avila](https://github.com/danny-avila) in PR [#234](https://github.com/danny-avila/chatgpt-clone/pull/234). In PR [#235](https://github.com/danny-avila/chatgpt-clone/pull/235), [@danny-avila](https://github.com/danny-avila) also makes some necessary fixes to titling, quotation marks, and endpoints being unavailable with only the Azure key provided. The logging system is now powered by Pino and sanitization, thanks to [@danorlando](https://github.com/danorlando) in PR [#227](https://github.com/danny-avila/chatgpt-clone/pull/227). To bulletproof the Docker container, the .dockerignore file is updated to include the client/.env file by [@danny-avila](https://github.com/danny-avila) in PR [#241](https://github.com/danny-avila/chatgpt-clone/pull/241). This issue was brought to our attention on discord.
 
-⚠️ **Breaking - new Env Variables :** Since V0.4.0 You will need to add the new env variables from .env.example for the app to work, even if you're not using multiple users for your purposes.
+There is active work on the new Plugins feature, converting the frontend to Typescript, and looking to integrate Palm2, google's new generative AI accessible via API, to the project as a new endpoint.
+
+You can check the full changelog in between [v0.4.1](https://github.com/danny-avila/chatgpt-clone/releases/tag/v0.4.1) and [v0.4.2](https://github.com/danny-avila/chatgpt-clone/releases/tag/v0.4.2) [here](https://github.com/danny-avila/chatgpt-clone/compare/v0.4.1...v0.4.2)."
 
 For discussion and suggestion you can join us: **[community discord server](https://discord.gg/NGaa9RPCft)**
 </details>
 
-[Full Changelog](CHANGELOG.md)
+[Past Updates](CHANGELOG.md)
 ##
 
 <h1>Table of Contents</h1>

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ There is active work on the new Plugins feature, converting the frontend to Type
 
 You can check the full changelog in between [v0.4.1](https://github.com/danny-avila/chatgpt-clone/releases/tag/v0.4.1) and [v0.4.2](https://github.com/danny-avila/chatgpt-clone/releases/tag/v0.4.2) [here](https://github.com/danny-avila/chatgpt-clone/compare/v0.4.1...v0.4.2)."
 
+⚠️ **IMPORTANT :** Since V0.4.0 You should register and login with a local account (email and password) for the first time sign-up. if you use login for the first time with a social login account (eg. Google, facebook, etc.), the conversations and presets that you created before the user system was implemented will NOT be migrated to that account.
+
+⚠️ **Breaking - new Env Variables :** Since V0.4.0 You will need to add the new env variables from .env.example for the app to work, even if you're not using multiple users for your purposes.
+
 For discussion and suggestion you can join us: **[community discord server](https://discord.gg/NGaa9RPCft)**
 </details>
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt-clone",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-clone",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "ISC",
       "dependencies": {
         "@dqbd/tiktoken": "^1.0.2",

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-clone",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "main": "server/index.js",
   "scripts": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt-clone",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-clone",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-clone",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt-clone",
-  "version": "0.3.3",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-clone",
-      "version": "0.3.2",
+      "version": "0.4.2",
       "license": "ISC",
       "devDependencies": {
         "@playwright/test": "^1.32.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-clone",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "scripts": {
     "e2e": "playwright test --config=e2e/playwright.config.js",


### PR DESCRIPTION
ChatGPT-Clone received some important upgrades and improvements. A new contributor, [@qcgm1978](https://github.com/qcgm1978), makes their first contribution by adding a null check for adaptiveCards variable. Additionally, support for titling conversations with the Azure endpoint is added by [@danny-avila](https://github.com/danny-avila) in PR [#234](https://github.com/danny-avila/chatgpt-clone/pull/234). In PR [#235](https://github.com/danny-avila/chatgpt-clone/pull/235), [@danny-avila](https://github.com/danny-avila) also makes some necessary fixes to titling, quotation marks, and endpoints being unavailable with only the Azure key provided. The logging system is now powered by Pino and sanitization, thanks to [@danorlando](https://github.com/danorlando) in PR [#227](https://github.com/danny-avila/chatgpt-clone/pull/227). To bulletproof the Docker container, the .dockerignore file is updated to include the client/.env file by [@danny-avila](https://github.com/danny-avila) in PR [#241](https://github.com/danny-avila/chatgpt-clone/pull/241). This issue was brought to our attention on discord.