### PR TITLE
fix: New GPT-4 model icon in presets and chat input

### DIFF
--- a/client/src/components/Input/NewConversationMenu/PresetItem.jsx
+++ b/client/src/components/Input/NewConversationMenu/PresetItem.jsx
@@ -10,6 +10,7 @@ export default function PresetItem({ preset = {}, value, onSelect, onChangePrese
   const icon = getIcon({
     size: 20,
     endpoint: preset?.endpoint,
+    model: preset?.model,
     error: false,
     className: 'mr-2'
   });
@@ -21,7 +22,7 @@ export default function PresetItem({ preset = {}, value, onSelect, onChangePrese
       const { chatGptLabel, model } = preset;
       if (model) _title += `: ${model}`;
       if (chatGptLabel) _title += ` as ${chatGptLabel}`;
-    }  else if (endpoint === 'google') {
+    } else if (endpoint === 'google') {
       const { modelLabel, model } = preset;
       if (model) _title += `: ${model}`;
       if (modelLabel) _title += ` as ${modelLabel}`;

--- a/client/src/utils/getIcon.jsx
+++ b/client/src/utils/getIcon.jsx
@@ -30,15 +30,13 @@ const getIcon = props => {
     let icon, bg, name;
     if (endpoint === 'azureOpenAI') {
       const { chatGptLabel } = props;
-
       icon = <GPTIcon size={size * 0.7} />;
       bg = 'linear-gradient(0.375turn, #61bde2, #4389d0)';
       name = chatGptLabel || 'ChatGPT';
     } else if (endpoint === 'openAI') {
       const { chatGptLabel } = props;
-
       icon = <GPTIcon size={size * 0.7} />;
-      bg = model && model.toLowerCase() === 'gpt-4' ? 'black' : (chatGptLabel
+      bg = model && model.toLowerCase() === 'gpt-4' ? '#AB68FF' : (chatGptLabel
         ? `rgba(16, 163, 127, ${button ? 0.75 : 1})`
         : `rgba(16, 163, 127, ${button ? 0.75 : 1})`);
       name = chatGptLabel || 'ChatGPT';
@@ -48,13 +46,12 @@ const getIcon = props => {
       name = modelLabel || 'PaLM2';
     } else if (endpoint === 'bingAI') {
       const { jailbreak } = props;
-
       icon = <BingIcon size={size * 0.7} />;
       bg = jailbreak ? `radial-gradient(circle at 90% 110%, #F0F0FA, #D0E0F9)` : `transparent`;
       name = jailbreak ? 'Sydney' : 'BingAI';
     } else if (endpoint === 'chatGPTBrowser') {
       icon = <GPTIcon size={size * 0.7} />;
-      bg = model && model.toLowerCase() === 'gpt-4' ? 'black' : `rgba(0, 163, 255, ${button ? 0.75 : 1})`;
+      bg = model && model.toLowerCase() === 'gpt-4' ? '#AB68FF' : `rgba(0, 163, 255, ${button ? 0.75 : 1})`;
       name = 'ChatGPT';
     } else if (endpoint === null) {
       icon = <GPTIcon size={size * 0.7} />;


### PR DESCRIPTION
<img width="443" alt="Screenshot 2023-05-15 at 22 39 47" src="https://github.com/danny-avila/chatgpt-clone/assets/42793498/9676d8e5-4f50-4705-bebc-442993a1dafd">

- Updated GPT4 model icon to the newest ChatGPT's purple one
- Added GPT4 model check in preview popup