### PR TITLE
fix(getIcon.jsx): match initial styling better with official

### DIFF
--- a/client/src/utils/getIcon.jsx
+++ b/client/src/utils/getIcon.jsx
@@ -22,8 +22,8 @@ const getIcon = props => {
       >
         <img
           className="rounded-sm"
-          src={user?.avatar || `https://avatars.dicebear.com/api/initials/${user?.name}.svg`}
-          alt=""
+          src={user?.avatar || `https://api.dicebear.com/6.x/initials/svg?seed=${user?.name}&fontFamily=Verdana&fontSize=36`}
+          alt="avatar"
         />
       </div>
     );


### PR DESCRIPTION
official:
![image](https://github.com/danny-avila/chatgpt-clone/assets/110412045/9889d68e-4cb0-407a-884c-6c148547c754)

update (resolution not accurate to actual, i manually scaled it down in paint lol):
![image](https://github.com/danny-avila/chatgpt-clone/assets/110412045/c9da192b-ea11-4bc7-a27d-c3951f80dc42)