### PR TITLE
Calculate token usage for streaming chat

### DIFF
--- a/api/app/clients/chatgpt-client.js
+++ b/api/app/clients/chatgpt-client.js
@@ -1,6 +1,8 @@
 require('dotenv').config();
 const { KeyvFile } = require('keyv-file');
 const { genAzureEndpoint } = require('../../utils/genAzureEndpoints');
+const tiktoken = require("@dqbd/tiktoken");
+const encoding_for_model = tiktoken.encoding_for_model;
 
 const askClient = async ({
   text,
@@ -24,6 +26,11 @@ const askClient = async ({
   };
 
   const azure = process.env.AZURE_OPENAI_API_KEY ? true : false;
+  if (promptPrefix == null) {
+    promptText = "You are ChatGPT, a large language model trained by OpenAI.";
+  } else {
+    promptText = promptPrefix;
+  }
   const maxContextTokens = model === 'gpt-4' ? 8191 : model === 'gpt-4-32k' ? 32767 : 4095; // 1 less than maximum
   const clientOptions = {
     reverseProxyUrl: process.env.OPENAI_REVERSE_PROXY || null,
@@ -61,8 +68,25 @@ const askClient = async ({
     ...(parentMessageId && conversationId ? { parentMessageId, conversationId } : {})
   };
 
+  const enc = encoding_for_model(model);
+  const text_tokens = enc.encode(text);
+  const prompt_tokens = enc.encode(promptText);
+  // console.log("Prompt tokens = ", prompt_tokens.length);
+  // console.log("Message Tokens = ", text_tokens.length);
+
   const res = await client.sendMessage(text, { ...options, userId });
-  return res;
+  // return res;
+  // create a new response object that includes the token counts
+const newRes = {
+  ...res, 
+  usage: {
+    prompt_tokens: prompt_tokens.length,
+    completion_tokens: text_tokens.length,
+    total_tokens: prompt_tokens.length + text_tokens.length
+  }
+};
+
+return newRes;
 };
 
 module.exports = { askClient };


### PR DESCRIPTION
- used existing @dqbd/tiktoken lib to calculate the token usage per chat request.
- injected the token back in the response, so that it can be saved with the message and can be used later for tracking per user usage.
- encoding varies for model. the code selects the encoding based on the model used in the request.
- All encoders are loaded at once and then used as per the model. I tested with loading the specific encoder based on the model selection, but I didn't see any major difference in my local deployment. It may be useful for platforms like vercel or where we have resource constraints.
- the response json will have an extra object "usage" containing the token information and should look like:
chat-clone     |      CLIENT RESPONSE {
chat-clone     |   response: 'response-message',
chat-clone     |   conversationId: '6f050ab2-9512-4c09-b321-6031c26f153f',
chat-clone     |   parentMessageId: 'dee3f972-a36a-41de-bf9f-4c12fc314b9b',
chat-clone     |   messageId: '338ef54f-3619-44af-9ad9-4e6d43401475',
chat-clone     |   details: {},
**chat-clone     |   usage: { prompt_tokens: 15, completion_tokens: 7, total_tokens: 22 }**
chat-clone     | }