### PR TITLE
Prevent .nav-mask from obscuring .nav

### DIFF
--- a/client/src/mobile.css
+++ b/client/src/mobile.css
@@ -74,7 +74,7 @@
   }
   .nav-mask {
     position: fixed;
-    z-index: 996;
+    z-index: 30;
     left: 0;
     right: 0;
     top: 0;


### PR DESCRIPTION
Makes the nav usable on mobile