### PR TITLE
Setup tests with new user system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,4 @@ src/style - official.css
 # meilisearch
 meilisearch
 data.ms/*
-
+auth.json

--- a/e2e/specs/landing.spec.js
+++ b/e2e/specs/landing.spec.js
@@ -1,7 +1,18 @@
 import { expect, test } from '@playwright/test';
 
-test('landing page', async ({ page }) => {
-  await page.goto('http://localhost:3080/');
-  const pageTitle = await page.textContent('#landing-title');
-  expect(pageTitle.length).toBeGreaterThan(0);
+test.describe('Landing suite', () => {
+  let myBrowser;
+
+  test.beforeEach(async ({ browser }) => {
+    myBrowser = await browser.newContext({
+      storageState: 'e2e/auth.json',
+    });
+  });
+
+  test('Landing title', async () => {
+    const page = await myBrowser.newPage();
+    await page.goto('http://localhost:3080/');
+    const pageTitle = await page.textContent('#landing-title')
+    expect(pageTitle.length).toBeGreaterThan(0);
+  });
 });

--- a/e2e/specs/login.spec.js
+++ b/e2e/specs/login.spec.js
@@ -2,6 +2,8 @@ import { expect, test } from '@playwright/test';
 
 test('landing page', async ({ page }) => {
   await page.goto('http://localhost:3080/');
-  const pageTitle = await page.textContent('#landing-title');
+  const pageTitle = await page.$eval('h1', pageTitle => pageTitle.textContent);
+  console.log('pageTitle', pageTitle);
   expect(pageTitle.length).toBeGreaterThan(0);
+  expect(pageTitle).toEqual('Welcome back');
 });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "e2e:update": "playwright test --config=e2e/playwright.config.js --update-snapshots",
     "e2e:debug": "cross-env PWDEBUG=1 playwright test --config=e2e/playwright.config.js",
     "e2e:report": "npx playwright show-report e2e/playwright-report",
-    "e2e:auth": "npx playwright codegen --save-storage=auth.json http://localhost:3080/",
+    "e2e:auth": "npx playwright codegen --save-storage=e2e/auth.json http://localhost:3080/",
     "prepare": "husky install",
     "format": "prettier-eslint --write \"{,!(node_modules)/**/}*.{js,jsx,ts,tsx}\""
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "e2e:update": "playwright test --config=e2e/playwright.config.js --update-snapshots",
     "e2e:debug": "cross-env PWDEBUG=1 playwright test --config=e2e/playwright.config.js",
     "e2e:report": "npx playwright show-report e2e/playwright-report",
+    "e2e:auth": "npx playwright codegen --save-storage=auth.json http://localhost:3080/",
     "prepare": "husky install",
     "format": "prettier-eslint --write \"{,!(node_modules)/**/}*.{js,jsx,ts,tsx}\""
   },


### PR DESCRIPTION
To start writing frontend tests:

1. Run `npx install playwright` from the root directory
2. Start the App and make sure it is accessible via the default Url: `http://localhost:3080/`
3. Run `npm run e2e:auth` from the root directory
    - This will open a browser for you to save an authenticated state
    - Signup with a new account, for testing purposes (social logins will not work for testing)
    - Login, then Close the browser
    - You will now have the authenticated state saved in e2e/auth.json
4. Confirm tests run by running `npm run e2e`
5. Begin writing tests. Use the tests in `e2e/specs` as reference