### PR TITLE
Enable message regeneration for bingAI endpoint

### DIFF
--- a/client/src/components/Messages/HoverButtons.jsx
+++ b/client/src/components/Messages/HoverButtons.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { cn } from '~/utils/';
 import Clipboard from '../svg/Clipboard';
 import CheckMark from '../svg/CheckMark';
 import EditIcon from '../svg/EditIcon';
@@ -13,14 +14,13 @@ export default function HoverButtons({
   message,
   regenerate
 }) {
-  const { endpoint, jailbreak = false } = conversation;
+  const { endpoint } = conversation;
   const [isCopied, setIsCopied] = React.useState(false);
 
   const branchingSupported =
-    // azureOpenAI, openAI, chatGPTBrowser support branching, so edit enabled
-    !!['azureOpenAI', 'openAI', 'chatGPTBrowser', 'google'].find((e) => e === endpoint) ||
-    // Sydney in bingAI supports branching, so edit enabled
-    (endpoint === 'bingAI' && jailbreak);
+    // azureOpenAI, openAI, chatGPTBrowser support branching, so edit enabled // 5/21/23: Bing is allowing editing and Message regenerating
+    !!['azureOpenAI', 'openAI', 'chatGPTBrowser', 'google', 'bingAI'].find((e) => e === endpoint);
+  // Sydney in bingAI supports branching, so edit enabled
 
   const editEnabled =
     !message?.error &&
@@ -30,7 +30,7 @@ export default function HoverButtons({
     branchingSupported;
 
   // for now, once branching is supported, regerate will be enabled
-  const regenerateEnabled =
+  let regenerateEnabled =
     // !message?.error &&
     !message?.isCreatedByUser &&
     !message?.searchResult &&
@@ -64,7 +64,10 @@ export default function HoverButtons({
       ) : null}
 
       <button
-        className="hover-button active rounded-md p-1 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200 disabled:dark:hover:text-gray-400 md:invisible md:group-hover:visible"
+        className={cn(
+          'hover-button rounded-md p-1 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200 disabled:dark:hover:text-gray-400 md:invisible md:group-hover:visible',
+          message?.isCreatedByUser ? '' : 'active'
+        )}
         onClick={() => copyToClipboard(setIsCopied)}
         type="button"
         title={isCopied ? 'Copied to clipboard' : 'Copy to clipboard'}


### PR DESCRIPTION
feat(HoverButtons.jsx): add active class to copy button only if message is not created by user