### PR TITLE
Fix (PaLM2): Persist PaLM presets after initial message

### DIFF
--- a/api/server/routes/ask/askGoogle.js
+++ b/api/server/routes/ask/askGoogle.js
@@ -139,7 +139,6 @@ const ask = async ({ text, endpointOption, parentMessageId = null, conversationI
     if (parentMessageId == '00000000-0000-0000-0000-000000000000') {
       const title = await titleConvo({ text, response });
       await saveConvo(req.user.id, {
-        ...endpointOption,
         conversationId,
         title
       });

--- a/api/server/routes/ask/askGoogle.js
+++ b/api/server/routes/ask/askGoogle.js
@@ -119,6 +119,13 @@ const ask = async ({ text, endpointOption, parentMessageId = null, conversationI
       abortController
     });
 
+    await saveConvo(req.user.id, {
+      ...endpointOption,
+      ...endpointOption.modelOptions,
+      conversationId,
+      endpoint: 'google'
+    });
+
     await saveMessage(response);
     sendMessage(res, {
       title: await getConvoTitle(req.user.id, conversationId),
@@ -132,7 +139,8 @@ const ask = async ({ text, endpointOption, parentMessageId = null, conversationI
     if (parentMessageId == '00000000-0000-0000-0000-000000000000') {
       const title = await titleConvo({ text, response });
       await saveConvo(req.user.id, {
-        conversationId: conversationId,
+        ...endpointOption,
+        conversationId,
         title
       });
     }

--- a/client/src/utils/handleSubmit.js
+++ b/client/src/utils/handleSubmit.js
@@ -50,7 +50,7 @@ const useMessageHandler = () => {
           currentConversation?.model ??
           endpointsConfig[endpoint]?.availableModels?.[0] ??
           'chat-bison',
-        chatGptLabel: currentConversation?.chatGptLabel ?? null,
+        modelLabel: currentConversation?.modelLabel ?? null,
         promptPrefix: currentConversation?.promptPrefix ?? null,
         examples: currentConversation?.examples ?? [
           { input: { content: '' }, output: { content: '' } }


### PR DESCRIPTION
refactor(askGoogle.js): extract saveConvo function call to a separate function
feat(askGoogle.js): add endpoint property to the conversation object
refactor(handleSubmit.js): rename chatGptLabel to modelLabel in useMessageHandler function