### PR TITLE
npm all prod(deps): bump @babel/plugin-transform-react-jsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2774,16 +2774,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.21.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.21.5.tgz",
-      "integrity": "sha512-ELdlq61FpoEkHO6gFRpfj0kUgSwQTGoaEU8eMRoS8Dv3v6e7BjEAj5WMtIBRdHUeAioMhKP5HyxNzNnP+heKbA==",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.3.tgz",
+      "integrity": "sha512-JEulRWG2f04a7L8VWaOngWiK6p+JOSpB+DAtwfJgOaej1qdbNxqtK7MwTBHjUA10NeFcszlFNqCdbRcirzh2uQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.21.4",
         "@babel/helper-plugin-utils": "^7.21.5",
         "@babel/plugin-syntax-jsx": "^7.21.4",
-        "@babel/types": "^7.21.5"
+        "@babel/types": "^7.22.3"
       },
       "engines": {
         "node": ">=6.9.0"


### PR DESCRIPTION
(#446) Bumps [@babel/plugin-transform-react-jsx](https://github.com/babel/babel/tree/HEAD/packages/babel-plugin-transform-react-jsx) from 7.21.5 to 7.22.3.
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.22.3/packages/babel-plugin-transform-react-jsx)

---
updated-dependencies:
- dependency-name: "@babel/plugin-transform-react-jsx" dependency-type: indirect update-type: version-update:semver-minor ...

﻿Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.