### PR TITLE
npm all prod(deps): bump mdast-util-from-markdown from 1.3.0 to 1.3.1…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16832,9 +16832,9 @@
       }
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.0.tgz",
-      "integrity": "sha512-HN3W1gRIuN/ZW295c7zi7g9lVBllMgZE40RxCX37wrTPWXCWtpvOZdfnuK+1WNpvZje6XuJeI3Wnb4TJEUem+g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
+      "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.0",


### PR DESCRIPTION
… (#447)

Bumps [mdast-util-from-markdown](https://github.com/syntax-tree/mdast-util-from-markdown) from 1.3.0 to 1.3.1.
- [Release notes](https://github.com/syntax-tree/mdast-util-from-markdown/releases)
- [Commits](https://github.com/syntax-tree/mdast-util-from-markdown/compare/1.3.0...1.3.1)

---
updated-dependencies:
- dependency-name: mdast-util-from-markdown dependency-type: indirect update-type: version-update:semver-patch ...

﻿Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.