### PR TITLE
fix(logout.controller.js): destructure logoutUser function

### DIFF
--- a/api/server/controllers/auth/logout.controller.js
+++ b/api/server/controllers/auth/logout.controller.js
@@ -1,4 +1,4 @@
-const logoutUser = require('../../services/auth.service');
+const { logoutUser } = require('../../services/auth.service');
 
 const logoutController = async (req, res) => {
   const { signedCookies = {} } = req;


### PR DESCRIPTION
Fixes a wrong import of logoutUser introduced in #197 

```bash
TypeError: logoutUser is not a function
    at logoutController (/app/api/server/controllers/auth/logout.controller.js:7:26)
    at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)
    at next (/app/node_modules/express/lib/router/route.js:144:13)
    at complete (/app/node_modules/passport/lib/middleware/authenticate.js:271:13)
    at /app/node_modules/passport/lib/middleware/authenticate.js:278:15
    at pass (/app/node_modules/passport/lib/authenticator.js:428:14)
    at Authenticator.transformAuthInfo (/app/node_modules/passport/lib/authenticator.js:450:5)
    at /app/node_modules/passport/lib/middleware/authenticate.js:275:22
    at req.login.req.logIn (/app/node_modules/passport/lib/http/request.js:44:13)
    at strategy.success (/app/node_modules/passport/lib/middleware/authenticate.js:256:13)
```


it needed destructuring 
from
`const logoutUser = require('../../services/auth.service');`
to
`const { logoutUser } = require('../../services/auth.service');`