### PR TITLE
feature(turbo): Setup Turborepo - faster everything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ meili_data/
 api/node_modules/
 client/node_modules/
 bower_components/
+.turbo
 
 # Floobits
 .floo

--- a/api/package.json
+++ b/api/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "echo 'please run this from the root directory'",
     "server-dev": "echo 'please run this from the root directory'",
+    "watch": "cross-env NODE_ENV=development npx nodemon server/index.js",
     "test": "cross-env NODE_ENV=test jest",
     "test:ci": "jest --ci",
     "test2": "node --inspect app/langchain/test2.js",

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "scripts": {
     "build": "cross-env NODE_ENV=production dotenv -e ../.env -- vite build",
+    "watch": "cross-env NODE_ENV=production dotenv -e ../.env -- vite build --watch",
     "build:ci": "cross-env NODE_ENV=dev vite build --mode ci",
     "dev": "cross-env NODE_ENV=dev dotenv -e ../.env -- vite",
     "preview-prod": "cross-env NODE_ENV=dev dotenv -e ../.env -- vite preview",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "backend-dev": "cross-env NODE_ENV=development npx nodemon api/server/index.js",
     "frontend": "cd client && npm run build",
     "frontend-dev": "cd client && npm run dev",
+    "turbo": "dotenv -- turbo watch --parallel",
     "e2e": "playwright test --config=e2e/playwright.config.local.ts",
     "e2e:ci": "playwright test --config=e2e/playwright.config.ts",
     "e2e:debug": "cross-env PWDEBUG=1 playwright test --config=e2e/playwright.config.local.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "outputs": ["dist/**"]
+    },
+    "watch": {
+      "outputs": ["dist/**", "client/dist/**"]
+    },
+
+    "lint": {}
+  }
+}


### PR DESCRIPTION
﻿This is the beginnings of turbo repo, essentially one command to rule them all.

running `npm run turbo` will run:
- the frontend in "watch" mode (this means files get created instead of a spaning a web server)
- the backend in dev mode
- it will also cache things and speed up rebuilds or even github actions when it arrives (needs to be configured more tho)

This is something I'll clean up and expand upon, but I thought I'd start the PR.

Note: this might work better in docker so the files will actually update (although might be better to enable nginx now for better throughput) 