### PR TITLE
Change prepare script to not run in CI mode and remove --ignore-scripts flag from workflow

### DIFF
--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -2,9 +2,9 @@
 name: Backend Unit Tests
 on:
   push:
-    branches: [feat/playwright-jest-cicd]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ feat/playwright-jest-cicd ]
+    branches: [ main, dev ]
 jobs:
   tests_Backend:
     name: Run Backend unit tests
@@ -25,7 +25,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
 
       # - name: Install Linux X64 Sharp
       #   run: npm install --platform=linux --arch=x64 --verbose sharp 

--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -2,9 +2,15 @@
 name: Backend Unit Tests
 on:
   push:
-    branches: [ main, dev ]
+    branches:
+      - main
+      - dev
+      - release/*
   pull_request:
-    branches: [ main, dev ]
+    branches:
+      - main
+      - dev
+      - release/*
 jobs:
   tests_Backend:
     name: Run Backend unit tests

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -2,9 +2,15 @@
 name: Frontend Unit Tests
 on:
   push:
-    branches: [main, dev]
+    branches: 
+      - main
+      - dev
+      - release/*
   pull_request:
-    branches: [main, dev]
+    branches: 
+      - main
+      - dev
+      - release/*
 jobs:
   tests_frontend:
     name: Run frontend unit tests

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:api": "cd api && npm run test",
     "e2e:update": "playwright test --config=e2e/playwright.config.js --update-snapshots",
     "e2e:report": "npx playwright show-report e2e/playwright-report",
-    "prepare": "husky install",
+    "prepare": "test \"$NODE_ENV\" != \"CI\" && husky install",
     "format": "prettier-eslint --write \"{,!(node_modules)/**/}*.{js,jsx,ts,tsx}\""
   },
   "repository": {


### PR DESCRIPTION
﻿Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

- fixes issue with backend test action by removing --ignore-scripts flag and modifying the prepare script to not run husky install when in CI mode


- [X ] Bug fix (non-breaking change which fixes an issue)
  

## How Has This Been Tested?
 Ran backend test workflow successfully on my fork