### PR TITLE
fix: prepare script no longer breaks local installation

### DIFF
--- a/config/prepare.js
+++ b/config/prepare.js
@@ -1,0 +1,12 @@
+const { exec } = require('child_process');
+
+if (process.env.NODE_ENV !== 'CI') {
+  exec('npx husky install', (error, stdout, stderr) => {
+    if (error) {
+      console.error(`exec error: ${error}`);
+      return;
+    }
+    console.log(`stdout: ${stdout}`);
+    console.error(`stderr: ${stderr}`);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:api": "cd api && npm run test",
     "e2e:update": "playwright test --config=e2e/playwright.config.js --update-snapshots",
     "e2e:report": "npx playwright show-report e2e/playwright-report",
-    "prepare": "test \"$NODE_ENV\" != \"CI\" && husky install",
+    "prepare": "node config/prepare.js",
     "format": "prettier-eslint --write \"{,!(node_modules)/**/}*.{js,jsx,ts,tsx}\""
   },
   "repository": {


### PR DESCRIPTION
Addresses a breaking issue for local installations introduced in #491 