### PR TITLE
fix(docker): handle .env file to read frontend vars during build easily

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,2 @@
 **/node_modules
-api/.env
-.env
 client/dist/images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,18 @@
 # Base node image
 FROM node:19-alpine AS node
 COPY . /app
+# Copy .env file
+COPY .env .env
 # Install dependencies
 WORKDIR /app
 RUN npm ci
 
-# Frontend variables as build args
-ARG VITE_APP_TITLE
-ARG VITE_SHOW_GOOGLE_LOGIN_OPTION
-
-# You will need to add your VITE variables to the docker-compose file
-ENV VITE_APP_TITLE=$VITE_APP_TITLE
-ENV VITE_SHOW_GOOGLE_LOGIN_OPTION=$VITE_SHOW_GOOGLE_LOGIN_OPTION
-
 # React client build
 ENV NODE_OPTIONS="--max-old-space-size=2048"
 RUN npm run frontend
+
+# Remove .env file after build
+RUN rm .env
 
 # Node API setup
 EXPOSE 3080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,6 @@ services:
     build:
       context: .
       target: node
-      args:
-        VITE_APP_TITLE: LibreChat # default, change to your desired app name
-        VITE_SHOW_GOOGLE_LOGIN_OPTION: false # default, change to true if you have google auth setup
     # image: chatgptclone/app:latest # Uncomment this & comment above to build from docker hub image
     restart: always
     # extra_hosts: # if you are running APIs on docker you need access to, you will need to uncomment this line and next


### PR DESCRIPTION
- Remove api/.env and .env from .dockerignore file
- Add COPY .env .env to Dockerfile to copy .env file to docker build
- Add RUN rm .env to Dockerfile to remove .env file after build
- Remove build args from docker-compose.yml file

Closes #511 and a better method will be added for handling build variables