### PR TITLE
fix(nodemon): will now follow nodemonConfig in package file

### DIFF
--- a/api/nodemon.json
+++ b/api/nodemon.json
@@ -1,6 +1,0 @@
-{
-  "ignore": [
-    "api/data/",
-    "data"
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -57,5 +57,11 @@
     "prettier-eslint": "^15.0.1",
     "prettier-eslint-cli": "^7.1.0",
     "prettier-plugin-tailwindcss": "^0.2.2"
+  },
+  "nodemonConfig": {
+    "ignore": [
+      "api/data/",
+      "data"
+    ]
   }
 }


### PR DESCRIPTION
Only affects dev experience (DX)

Since the introduction of npm workspaces, nodemon has been restarting at the end of every message. It won't follow the config unless it's included in the package file.