### PR TITLE
Add social sites to MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,15 @@ theme:
     - content.action.edit
     - content.code.copy
 
+extra:
+  social:
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/CEe6vDg9Ky
+    - icon: fontawesome/brands/github
+      link: https://github.com/danny-avila/LibreChat
+    - icon: fontawesome/brands/youtube
+      link: https://www.youtube.com/@LibreChat
+
 markdown_extensions:
   - attr_list
   - admonition


### PR DESCRIPTION
Add Social Icons to the footer of MkDocs site.

![image](https://github.com/danny-avila/LibreChat/assets/11950213/efdb562b-5a14-42cc-afa4-adbbe8274474)



## Type of change

Please delete options that are not relevant.

- [x] Documentation update  
  

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
##

docker run --rm -v /root/chatgpt-clone/:/docs squidfunk/mkdocs-material build
running build create a site folder in /root/chatgpt-clone
then python -m http.server in the site folder

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
