### PR TITLE
Fix: Increase password max length and accept '-' for username in regex

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -25,7 +25,7 @@ const userSchema = mongoose.Schema(
       type: String,
       lowercase: true,
       required: [true, "can't be blank"],
-      match: [/^[a-zA-Z0-9_]+$/, 'is invalid'],
+      match: [/^[a-zA-Z0-9_-]+$/, 'is invalid'],
       index: true
     },
     email: {
@@ -45,7 +45,7 @@ const userSchema = mongoose.Schema(
       type: String,
       trim: true,
       minlength: 8,
-      maxlength: 60
+      maxlength: 128
     },
     avatar: {
       type: String,
@@ -162,9 +162,9 @@ module.exports.validateUser = (user) => {
     username: Joi.string()
       .min(2)
       .max(80)
-      .regex(/^[a-zA-Z0-9_]+$/)
+      .regex(/^[a-zA-Z0-9_-]+$/)
       .required(),
-    password: Joi.string().min(8).max(60).allow('').allow(null)
+    password: Joi.string().min(8).max(128).allow('').allow(null)
   };
 
   return schema.validate(user);

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -77,7 +77,7 @@ Issuer.discover(process.env.OPENID_ISSUER)
               email: userinfo.email || '',
               emailVerified: userinfo.email_verified || false,
               name: fullName
-             });
+            });
           } else {
             user.provider = 'openid';
             user.openidId = userinfo.sub;

--- a/api/strategies/validators.js
+++ b/api/strategies/validators.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 
 const loginSchema = Joi.object().keys({
   email: Joi.string().trim().email().required(),
-  password: Joi.string().trim().min(6).max(128).required()
+  password: Joi.string().trim().min(8).max(128).required()
 });
 
 const registerSchema = Joi.object().keys({
@@ -14,8 +14,8 @@ const registerSchema = Joi.object().keys({
     .regex(/^[a-zA-Z0-9_-]+$/)
     .required(),
   email: Joi.string().trim().email().required(),
-  password: Joi.string().trim().min(6).max(128).required(),
-  confirm_password: Joi.string().trim().min(6).max(128).required()
+  password: Joi.string().trim().min(8).max(128).required(),
+  confirm_password: Joi.string().trim().min(8).max(128).required()
 });
 
 module.exports = {

--- a/api/strategies/validators.js
+++ b/api/strategies/validators.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 
 const loginSchema = Joi.object().keys({
   email: Joi.string().trim().email().required(),
-  password: Joi.string().trim().min(6).max(20).required()
+  password: Joi.string().trim().min(6).max(128).required()
 });
 
 const registerSchema = Joi.object().keys({
@@ -11,11 +11,11 @@ const registerSchema = Joi.object().keys({
     .trim()
     .min(2)
     .max(20)
-    .regex(/^[a-zA-Z0-9_]+$/)
+    .regex(/^[a-zA-Z0-9_-]+$/)
     .required(),
   email: Joi.string().trim().email().required(),
-  password: Joi.string().trim().min(6).max(20).required(),
-  confirm_password: Joi.string().trim().min(6).max(20).required()
+  password: Joi.string().trim().min(6).max(128).required(),
+  confirm_password: Joi.string().trim().min(6).max(128).required()
 });
 
 module.exports = {

--- a/client/src/components/Auth/LoginForm.tsx
+++ b/client/src/components/Auth/LoginForm.tsx
@@ -74,7 +74,7 @@ function LoginForm({ onSubmit }: TLoginFormProps) {
               },
               maxLength: {
                 value: 40,
-                message: 'Password must be less than 128 characters'
+                message: 'Password must be 128 characters or less'
               }
             })}
             aria-invalid={!!errors.password}

--- a/client/src/components/Auth/LoginForm.tsx
+++ b/client/src/components/Auth/LoginForm.tsx
@@ -74,7 +74,7 @@ function LoginForm({ onSubmit }: TLoginFormProps) {
               },
               maxLength: {
                 value: 40,
-                message: 'Password must be less than 40 characters'
+                message: 'Password must be less than 128 characters'
               }
             })}
             aria-invalid={!!errors.password}

--- a/client/src/components/Auth/Registration.tsx
+++ b/client/src/components/Auth/Registration.tsx
@@ -217,11 +217,11 @@ function Registration() {
                 id="confirm_password"
                 data-testid="confirm_password"
                 aria-label="Confirm password"
-                // uncomment to prevent pasting in confirm field
-                onPaste={(e) => {
-                  e.preventDefault();
-                  return false;
-                }}
+                // uncomment to block pasting in confirm field
+                // onPaste={(e) => {
+                //   e.preventDefault();
+                //   return false;
+                // }}
                 {...register('confirm_password', {
                   validate: (value) => value === password || 'Passwords do not match'
                 })}

--- a/client/src/components/Auth/Registration.tsx
+++ b/client/src/components/Auth/Registration.tsx
@@ -188,7 +188,7 @@ function Registration() {
                   },
                   maxLength: {
                     value: 128,
-                    message: 'Password must be less than 128 characters'
+                    message: 'Password must be 128 characters or less'
                   }
                 })}
                 aria-invalid={!!errors.password}

--- a/client/src/components/Auth/Registration.tsx
+++ b/client/src/components/Auth/Registration.tsx
@@ -187,8 +187,8 @@ function Registration() {
                     message: 'Password must be at least 8 characters'
                   },
                   maxLength: {
-                    value: 40,
-                    message: 'Password must be less than 40 characters'
+                    value: 128,
+                    message: 'Password must be less than 128 characters'
                   }
                 })}
                 aria-invalid={!!errors.password}

--- a/client/src/components/Auth/ResetPassword.tsx
+++ b/client/src/components/Auth/ResetPassword.tsx
@@ -95,7 +95,7 @@ function ResetPassword() {
                     },
                     maxLength: {
                       value: 128,
-                      message: 'Password must be less than 128 characters'
+                      message: 'Password must be 128 characters or less'
                     }
                   })}
                   aria-invalid={!!errors.password}

--- a/client/src/components/Auth/ResetPassword.tsx
+++ b/client/src/components/Auth/ResetPassword.tsx
@@ -94,8 +94,8 @@ function ResetPassword() {
                       message: 'Password must be at least 8 characters'
                     },
                     maxLength: {
-                      value: 40,
-                      message: 'Password must be less than 40 characters'
+                      value: 128,
+                      message: 'Password must be less than 128 characters'
                     }
                   })}
                   aria-invalid={!!errors.password}


### PR DESCRIPTION
fix issue: #561 
fix issue: https://discord.com/channels/1086345563026489514/1121274461887402004

Raise the password max length to 128 characters
Add "-" to the regex
Allow pasting in the "password confirmation" box


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

