### PR TITLE
feature: ChatGPT style show/hide panel button, panel state saving in local storage

### DIFF
--- a/client/src/components/Nav/NewChat.jsx
+++ b/client/src/components/Nav/NewChat.jsx
@@ -13,7 +13,7 @@ export default function NewChat() {
   return (
     <a
       onClick={clickHandler}
-      className="mb-2 flex flex-shrink-0 cursor-pointer items-center gap-3 rounded-md border border-white/20 px-3 py-3 text-sm text-white transition-colors duration-200 hover:bg-gray-500/10"
+      className="mb-2 flex flex-grow flex-shrink-0 cursor-pointer items-center gap-3 rounded-md border border-white/20 px-3 py-3 text-sm text-white transition-colors duration-200 hover:bg-gray-500/10"
     >
       <svg
         stroke="currentColor"

--- a/client/src/components/Nav/index.jsx
+++ b/client/src/components/Nav/index.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useGetConversationsQuery, useSearchQuery } from '~/data-provider';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
@@ -9,7 +9,7 @@ import NewChat from './NewChat';
 import Pages from '../Conversations/Pages';
 import Panel from '../svg/Panel';
 import Spinner from '../svg/Spinner';
-import { ThemeContext } from '~/hooks/ThemeContext';
+// import { ThemeContext } from '~/hooks/ThemeContext';
 import { cn } from '~/utils/';
 import store from '~/store';
 import { useAuthContext } from '~/hooks/AuthContext';
@@ -38,7 +38,7 @@ import useDebounce from '~/hooks/useDebounce';
 export default function Nav({ navVisible, setNavVisible }) {
   const [isHovering, setIsHovering] = useState(false);
   const { isAuthenticated } = useAuthContext();
-  const { theme, } = useContext(ThemeContext);
+  // const { theme, } = useContext(ThemeContext);
   const containerRef = useRef(null);
   const scrollPositionRef = useRef(null);
 
@@ -180,7 +180,17 @@ export default function Nav({ navVisible, setNavVisible }) {
         <div className="flex h-full min-h-0 flex-col ">
           <div className="scrollbar-trigger relative flex h-full w-full flex-1 items-start border-white/20">
             <nav className="relative flex h-full flex-1 flex-col space-y-1 p-2">
-              <NewChat />
+              <div className='flex flex-row'>
+                <NewChat />
+                <button
+                  type='button'
+                  className={cn('nav-close-button inline-flex h-11 w-11 border border-white/20 items-center justify-center rounded-md text-white hover:bg-gray-500/10')}
+                  onClick={toggleNavVisible}
+                >
+                  <span className='sr-only'>Close sidebar</span>
+                  <Panel open={false} />
+                </button>
+              </div>
               <div
                 className={`flex-1 flex-col overflow-y-auto ${isHovering ? '' : 'scrollbar-transparent'
                 } border-b border-white/20`}
@@ -210,23 +220,17 @@ export default function Nav({ navVisible, setNavVisible }) {
             </nav>
           </div>
         </div>
-        <button
-          type="button"
-          className={cn('nav-close-button -ml-0.5 -mt-2.5 inline-flex h-10 w-10 items-center justify-center rounded-md focus:outline-none focus:ring-white md:-ml-1 md:-mt-2.5', theme === 'dark' ? 'text-gray-500 hover:text-gray-400' : 'text-gray-400 hover:text-gray-500')}
-          onClick={toggleNavVisible}
-        >
-          <span className="sr-only">Close sidebar</span>
-          <Panel />
-        </button>
       </div>
       {!navVisible && (
         <button
           type="button"
-          className="nav-open-button fixed left-2 top-0.5 z-10 inline-flex h-10 w-10 items-center justify-center rounded-md text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-white dark:text-gray-500 dark:hover:text-gray-400"
+          className="nav-open-button mt-1 fixed left-2 top-0.5 z-10 inline-flex h-10 w-10 items-center justify-center rounded-md border text-gray-400 hover:text-gray-500 focus:outline-none focus:ring-white dark:text-gray-500 dark:hover:text-gray-400"
           onClick={toggleNavVisible}
         >
-          <span className="sr-only">Open sidebar</span>
-          <Panel open={true} />
+          <div className="flex items-center justify-center">
+            <span className="sr-only">Open sidebar</span>
+            <Panel open={true} />
+          </div>
         </button>
       )}
 

--- a/client/src/components/Nav/index.jsx
+++ b/client/src/components/Nav/index.jsx
@@ -1,18 +1,19 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useState, useEffect, useRef, useContext, useCallback } from 'react';
-import NewChat from './NewChat';
-import Panel from '../svg/Panel';
-import Spinner from '../svg/Spinner';
-import Pages from '../Conversations/Pages';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useGetConversationsQuery, useSearchQuery } from '~/data-provider';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+
 import Conversations from '../Conversations';
 import NavLinks from './NavLinks';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { useGetConversationsQuery, useSearchQuery } from '~/data-provider';
-import useDebounce from '~/hooks/useDebounce';
-import store from '~/store';
-import { useAuthContext } from '~/hooks/AuthContext';
+import NewChat from './NewChat';
+import Pages from '../Conversations/Pages';
+import Panel from '../svg/Panel';
+import Spinner from '../svg/Spinner';
 import { ThemeContext } from '~/hooks/ThemeContext';
 import { cn } from '~/utils/';
+import store from '~/store';
+import { useAuthContext } from '~/hooks/AuthContext';
+import useDebounce from '~/hooks/useDebounce';
 
 // import resolveConfig from 'tailwindcss/resolveConfig';
 // const tailwindConfig = import('../../../tailwind.config.cjs');
@@ -165,8 +166,6 @@ export default function Nav({ navVisible, setNavVisible }) {
   useEffect(() => {
     if (isMobile()) {
       setNavVisible(false);
-    } else {
-      setNavVisible(true);
     }
   }, [conversationId, setNavVisible]);
 
@@ -183,8 +182,7 @@ export default function Nav({ navVisible, setNavVisible }) {
             <nav className="relative flex h-full flex-1 flex-col space-y-1 p-2">
               <NewChat />
               <div
-                className={`flex-1 flex-col overflow-y-auto ${
-                  isHovering ? '' : 'scrollbar-transparent'
+                className={`flex-1 flex-col overflow-y-auto ${isHovering ? '' : 'scrollbar-transparent'
                 } border-b border-white/20`}
                 onMouseEnter={() => setIsHovering(true)}
                 onMouseLeave={() => setIsHovering(false)}
@@ -218,7 +216,7 @@ export default function Nav({ navVisible, setNavVisible }) {
           onClick={toggleNavVisible}
         >
           <span className="sr-only">Close sidebar</span>
-          <Panel/>
+          <Panel />
         </button>
       </div>
       {!navVisible && (
@@ -228,7 +226,7 @@ export default function Nav({ navVisible, setNavVisible }) {
           onClick={toggleNavVisible}
         >
           <span className="sr-only">Open sidebar</span>
-          <Panel open={true}/>
+          <Panel open={true} />
         </button>
       )}
 

--- a/client/src/components/svg/Panel.jsx
+++ b/client/src/components/svg/Panel.jsx
@@ -4,8 +4,8 @@ export default function Panel({ open = false, className }) {
   const openPanel = (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
+      width="20"
+      height="20"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -23,8 +23,8 @@ export default function Panel({ open = false, className }) {
   const closePanel = (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
+      width="20"
+      height="20"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"

--- a/client/src/mobile.css
+++ b/client/src/mobile.css
@@ -3,12 +3,13 @@
   visibility: visible;
 }
 
-.nav-close-button {
+.nav-open-button {
   display: block;
   position: absolute;
-  left: 100%;
-  top: 12px;
-  margin-left: 20px;
+}
+
+.nav-close-button {
+  margin-left: 10px;
 }
 
 .nav {
@@ -106,5 +107,10 @@
   }
 
   .input-panel {
+  }
+
+  .nav-open-button
+  {
+    visibility: hidden;
   }
 }

--- a/client/src/routes/Root.jsx
+++ b/client/src/routes/Root.jsx
@@ -1,19 +1,24 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useState } from 'react';
-import { Outlet } from 'react-router-dom';
-import MessageHandler from '../components/MessageHandler';
-import Nav from '../components/Nav';
-import MobileNav from '../components/Nav/MobileNav';
 import {
-  useGetSearchEnabledQuery,
   useGetEndpointsQuery,
-  useGetPresetsQuery
+  useGetPresetsQuery,
+  useGetSearchEnabledQuery
 } from '~/data-provider';
+
+import MessageHandler from '../components/MessageHandler';
+import MobileNav from '../components/Nav/MobileNav';
+import Nav from '../components/Nav';
+import { Outlet } from 'react-router-dom';
 import store from '~/store';
-import { useSetRecoilState } from 'recoil';
 import { useAuthContext } from '~/hooks/AuthContext';
+import { useSetRecoilState } from 'recoil';
+
 export default function Root() {
-  const [navVisible, setNavVisible] = useState(false);
+  const [navVisible, setNavVisible] = useState(() => {
+    const savedNavVisible = localStorage.getItem('navVisible');
+    return savedNavVisible !== null ? JSON.parse(savedNavVisible) : false;
+  });
 
   const setIsSearchEnabled = useSetRecoilState(store.isSearchEnabled);
   const setEndpointsConfig = useSetRecoilState(store.endpointsConfig);
@@ -23,6 +28,10 @@ export default function Root() {
   const searchEnabledQuery = useGetSearchEnabledQuery();
   const endpointsQuery = useGetEndpointsQuery();
   const presetsQuery = useGetPresetsQuery({ enabled: !!user });
+
+  useEffect(() => {
+    localStorage.setItem('navVisible', JSON.stringify(navVisible));
+  }, [navVisible]);
 
   useEffect(() => {
     if (endpointsQuery.data) {


### PR DESCRIPTION
This PR adds ChatGPT style show/hide panel button and the state is saved in local storage.
In mobile view it hides the button since we have a hamberger menu for that.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update  
  

## How Has This Been Tested?
Tested manually in desktop & mobile view.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
