### PR TITLE
fix(Browser plugin): use user_provided OpenAI credential for embedding

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -84,10 +84,9 @@ const loadTools = async ({ user, model, functions = null, tools = [], options = 
 
   const customConstructors = {
     browser: async () => {
-      let openAIApiKey = process.env.OPENAI_API_KEY;
-      if (!openAIApiKey) {
-        openAIApiKey = await getUserPluginAuthValue(user, 'OPENAI_API_KEY');
-      }
+      let openAIApiKey = options.openAIApiKey ?? process.env.OPENAI_API_KEY;
+      openAIApiKey = openAIApiKey === 'user_provided' ? null : openAIApiKey;
+      openAIApiKey = openAIApiKey || await getUserPluginAuthValue(user, 'OPENAI_API_KEY');
       return new WebBrowser({ model, embeddings: new OpenAIEmbeddings({ openAIApiKey }) });
     },
     serpapi: async () => {

--- a/api/server/controllers/PluginController.js
+++ b/api/server/controllers/PluginController.js
@@ -18,6 +18,9 @@ const isPluginAuthenticated = (plugin) => {
 
   return plugin.authConfig.every((authFieldObj) => {
     const envValue = process.env[authFieldObj.authField];
+    if (envValue === 'user_provided') {
+      return false;
+    }
     return envValue && envValue.trim() !== '';
   });
 };

--- a/api/server/services/PluginService.js
+++ b/api/server/services/PluginService.js
@@ -40,7 +40,6 @@ const getUserPluginAuthValue = async (user, authField) => {
 //   }
 // };
 
-
 const updateUserPluginAuth = async (userId, authField, pluginKey, value) => {
   try {
     const encryptedValue = encrypt(value);


### PR DESCRIPTION
This was an issue with PluginController.js where it would improperly authenticate the browser plugin when the OPENAI_API_KEY was set to "user_provided" for client-side API authentication. This is now properly handled in the isPluginAuthenticated function.