### PR TITLE
Exclude 'set token first' option for bingAI endpoint

### DIFF
--- a/client/src/components/Input/SubmitButton.jsx
+++ b/client/src/components/Input/SubmitButton.jsx
@@ -38,7 +38,7 @@ export default function SubmitButton({
         </div>
       </button>
     );
-  } else if (!isTokenProvided && (endpoint !== 'openAI' || endpoint !== 'azureOpenAI' )) {
+  } else if (!isTokenProvided && endpoint !== 'bingAI' && (endpoint !== 'openAI' || endpoint !== 'azureOpenAI')) {
     return (
       <>
         <button


### PR DESCRIPTION
## Summary of Changes
Removed the "set token first" option for the "bingAI" endpoint in the SubmitButton component. This change was made to improve the user experience when using bingAI without a token. The "set token first" button was overlapping the text input, removing it makes it easier to click the regular submit button, particularly on mobile devices, when using Bing without a token.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Manually tested the button's behavior to ensure it functions as expected with the changes made. Verified that the 'set token first' option is excluded for the 'bingAI' endpoint, while displayed correctly for other endpoints.
**(tested on desktop and mobile)**

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

**Before:** 
![image](https://github.com/danny-avila/LibreChat/assets/32828263/f504b453-d420-4712-8e70-a21af09e51f8)

**After:**
![image](https://github.com/danny-avila/LibreChat/assets/32828263/08f8a475-a7b7-4ab4-89c3-9503a0ee3e99)
