### PR TITLE
fix(titleConvo): use openAIApiKey and azure config from route handler

### DIFF
--- a/api/app/titleConvo.js
+++ b/api/app/titleConvo.js
@@ -2,7 +2,7 @@
 const _ = require('lodash');
 const { genAzureChatCompletion, getAzureCredentials } = require('../utils/');
 
-const titleConvo = async ({ text, response, oaiApiKey }) => {
+const titleConvo = async ({ text, response, openAIApiKey, azure = false }) => {
   let title = 'New Chat';
   const ChatGPTClient = (await import('@waylaidwanderer/chatgpt-api')).default;
 
@@ -19,7 +19,6 @@ const titleConvo = async ({ text, response, oaiApiKey }) => {
     ||>Title:`
     };
 
-    const azure = process.env.AZURE_API_KEY ? true : false;
     const options = {
       azure,
       reverseProxyUrl: process.env.OPENAI_REVERSE_PROXY || null,
@@ -35,7 +34,9 @@ const titleConvo = async ({ text, response, oaiApiKey }) => {
       frequency_penalty: 0
     };
 
-    let apiKey = oaiApiKey || process.env.OPENAI_API_KEY;
+    let apiKey = openAIApiKey ?? process.env.OPENAI_API_KEY;
+
+    console.log('title api key', apiKey);
 
     if (azure) {
       apiKey = process.env.AZURE_API_KEY;

--- a/api/server/routes/ask/gptPlugins.js
+++ b/api/server/routes/ask/gptPlugins.js
@@ -167,17 +167,17 @@ const ask = async ({ text, endpoint, endpointOption, parentMessageId = null, con
       ...endpointOption
     };
 
-    let oaiApiKey = req.body?.token ?? process.env.OPENAI_API_KEY;
+    let openAIApiKey = req.body?.token ?? process.env.OPENAI_API_KEY;
     if (process.env.PLUGINS_USE_AZURE) {
       clientOptions.azure = getAzureCredentials();
-      oaiApiKey = clientOptions.azure.azureOpenAIApiKey;
+      openAIApiKey = clientOptions.azure.azureOpenAIApiKey;
     }
 
-    if (oaiApiKey && oaiApiKey.includes('azure') && !clientOptions.azure) {
+    if (openAIApiKey && openAIApiKey.includes('azure') && !clientOptions.azure) {
       clientOptions.azure = JSON.parse(req.body?.token) ?? getAzureCredentials();
-      oaiApiKey = clientOptions.azure.azureOpenAIApiKey;
+      openAIApiKey = clientOptions.azure.azureOpenAIApiKey;
     }
-    const chatAgent = new PluginsClient(oaiApiKey, clientOptions);
+    const chatAgent = new PluginsClient(openAIApiKey, clientOptions);
 
     const onAgentAction = (action) => {
       const formattedAction = formatAction(action);
@@ -235,7 +235,12 @@ const ask = async ({ text, endpoint, endpointOption, parentMessageId = null, con
     res.end();
 
     if (parentMessageId == '00000000-0000-0000-0000-000000000000' && newConvo) {
-      const title = await titleConvo({ text, response });
+      const title = await titleConvo({
+        text,
+        response,
+        openAIApiKey,
+        azure: !!clientOptions.azure,
+      });
       await saveConvo(req.user.id, {
         conversationId: conversationId,
         title

--- a/api/server/routes/ask/openAI.js
+++ b/api/server/routes/ask/openAI.js
@@ -138,15 +138,15 @@ const ask = async ({ text, endpointOption, parentMessageId = null, endpoint, con
       ...endpointOption
     };
 
-    let oaiApiKey = req.body?.token ?? process.env.OPENAI_API_KEY;
+    let openAIApiKey = req.body?.token ?? process.env.OPENAI_API_KEY;
 
     if (process.env.AZURE_API_KEY && endpoint === 'azureOpenAI') {
       clientOptions.azure = JSON.parse(req.body?.token) ?? getAzureCredentials();
       // clientOptions.reverseProxyUrl = process.env.AZURE_REVERSE_PROXY ?? genAzureChatCompletion({ ...clientOptions.azure });
-      oaiApiKey = clientOptions.azure.azureOpenAIApiKey;
+      openAIApiKey = clientOptions.azure.azureOpenAIApiKey;
     }
 
-    const client = new OpenAIClient(oaiApiKey, clientOptions);
+    const client = new OpenAIClient(openAIApiKey, clientOptions);
 
     let response = await client.sendMessage(text, {
       user,
@@ -180,7 +180,12 @@ const ask = async ({ text, endpointOption, parentMessageId = null, endpoint, con
     res.end();
 
     if (parentMessageId == '00000000-0000-0000-0000-000000000000' && newConvo) {
-      const title = await titleConvo({ text, response });
+      const title = await titleConvo({
+        text,
+        response,
+        openAIApiKey,
+        azure: endpoint === 'azureOpenAI'
+      });
       await saveConvo(req.user.id, {
         conversationId,
         title

--- a/api/server/routes/ask/openAI.js
+++ b/api/server/routes/ask/openAI.js
@@ -142,7 +142,6 @@ const ask = async ({ text, endpointOption, parentMessageId = null, endpoint, con
 
     if (process.env.AZURE_API_KEY && endpoint === 'azureOpenAI') {
       clientOptions.azure = JSON.parse(req.body?.token) ?? getAzureCredentials();
-      // clientOptions.reverseProxyUrl = process.env.AZURE_REVERSE_PROXY ?? genAzureChatCompletion({ ...clientOptions.azure });
       openAIApiKey = clientOptions.azure.azureOpenAIApiKey;
     }
 


### PR DESCRIPTION
## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


Titling conversations was not working because of user_provided tokens, and now will consistently get its configuration from the openAI and gptPlugins route handlers