### PR TITLE
fix: typo when including proxy for langchain

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   printWidth: 100,
   useTabs: false,
-  tabWidth: 2,
+  // tabWidth: 2,
   semi: true,
   singleQuote: true,
   // bracketSpacing: false,

--- a/api/app/clients/PluginsClient.js
+++ b/api/app/clients/PluginsClient.js
@@ -112,8 +112,8 @@ Only respond with your conversational reply to the following User Message:
     super.setOptions(options);
     this.isGpt3 = this.modelOptions.model.startsWith('gpt-3');
 
-    if (this.reverseProxyUrl) {
-      this.langchainProxy = this.reverseProxyUrl.match(/.*v1/)[0];
+    if (this.options.reverseProxyUrl) {
+      this.langchainProxy = this.options.reverseProxyUrl.match(/.*v1/)[0];
     }
   }
 
@@ -469,7 +469,7 @@ Only respond with your conversational reply to the following User Message:
     }
 
     // testing if this works with browser endpoint
-    if (!this.isGpt3 && this.reverseProxyUrl) {
+    if (!this.isGpt3 && this.options.reverseProxyUrl) {
       instructionsPayload.role = 'user';
     }
 


### PR DESCRIPTION
Proxy must mirror OpenAI API endpoints, starting with v1. 

Example: 
`OPENAI_REVERSE_PROXY=http://localhost:8080/v1/chat/completions`