### PR TITLE
docs: add "chatgpt_plugins_openapi.md" to readme.md and mkdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Keep up with the latest updates by visiting the releases page - [Releases](https
     * [Stable Diffusion](docs/features/plugins/stable_diffusion.md)
     * [Wolfram](docs/features/plugins/wolfram.md)
     * [Make Your Own Plugin](docs/features/plugins/make_your_own.md)
+    * [Using official ChatGPT Plugins](docs/features/plugins/chatgpt_plugins_openapi.md)
 
   * [Proxy](docs/features/proxy.md)
   * [Bing Jailbreak](docs/features/bing_jailbreak.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
       - Stable Diffusion: 'features/plugins/stable_diffusion.md'
       - Wolfram: 'features/plugins/wolfram.md'
       - Make Your Own Plugin: 'features/plugins/make_your_own.md'
+      - Using official ChatGPT Plugins: 'features/plugins/chatgpt_plugins_openapi.md'
     - Proxy: 'features/proxy.md'
     - Bing Jailbreak: 'features/bing_jailbreak.md' 
   - Cloud Deployment:


### PR DESCRIPTION
Just a quick PR to add `chatgpt_plugins_openapi.md` to the readme "table of content" and to mkdocs 
