### PR TITLE
feat: Bing Image Creator (on MS Edge browsers only)

### DIFF
--- a/api/app/bingai.js
+++ b/api/app/bingai.js
@@ -47,6 +47,16 @@ const askBing = async ({
       parentMessageId,
       toneStyle,
       onProgress,
+      clientOptions: {
+        features: {
+          genImage: {
+            server: {
+              enable: true,
+              type: 'markdown_list',
+            },
+          },
+        },
+      },
     };
   } else {
     options = {
@@ -56,6 +66,16 @@ const askBing = async ({
       parentMessageId,
       toneStyle,
       onProgress,
+      clientOptions: {
+        features: {
+          genImage: {
+            server: {
+              enable: true,
+              type: 'markdown_list',
+            },
+          },
+        },
+      },
     };
 
     // don't give those parameters for new conversation

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/backend",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "",
   "scripts": {
     "start": "echo 'please run this from the root directory'",
@@ -24,7 +24,7 @@
     "@dqbd/tiktoken": "^1.0.2",
     "@fortaine/fetch-event-source": "^3.0.6",
     "@keyv/mongo": "^2.1.8",
-    "@waylaidwanderer/chatgpt-api": "^1.37.0",
+    "@waylaidwanderer/chatgpt-api": "^1.37.2",
     "axios": "^1.3.4",
     "bcryptjs": "^2.4.3",
     "cheerio": "^1.0.0-rc.12",

--- a/api/server/routes/ask/bingAI.js
+++ b/api/server/routes/ask/bingAI.js
@@ -172,7 +172,8 @@ const ask = async ({
     let unfinished = false;
     if (partialText?.trim()?.length > response.text.length) {
       response.text = partialText;
-      unfinished = true;
+      unfinished = false;
+      //setting "unfinished" to false fix bing image generation error msg and allows to continue a convo after being triggered by censorship (bing does remember the context after a "censored error" so there is no reason to end the convo)
     }
 
     let responseMessage = {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/frontend",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "",
   "scripts": {
     "data-provider": "cd .. && npm run build:data-provider",

--- a/client/src/components/Messages/Content/Content.jsx
+++ b/client/src/components/Messages/Content/Content.jsx
@@ -33,6 +33,8 @@ const Content = React.memo(({ content, message }) => {
   const latestMessage = useRecoilValue(store.latestMessage);
   const isInitializing = content === '<span className="result-streaming">█</span>';
   const isLatestMessage = message?.messageId === latestMessage?.messageId;
+  const currentContent = content?.replace('z-index: 1;', '') ?? '';
+  const isIFrame = currentContent.includes('<iframe');
 
   useEffect(() => {
     let timer1, timer2;
@@ -68,9 +70,8 @@ const Content = React.memo(({ content, message }) => {
     [rehypeRaw],
   ];
 
-  if (!isInitializing || !isLatestMessage) {
-    //commented out to fix bing image creator errors
-    //rehypePlugins.pop();
+  if ((!isInitializing || !isLatestMessage) && !isIFrame) {
+    rehypePlugins.pop();
   }
 
   return (
@@ -83,7 +84,9 @@ const Content = React.memo(({ content, message }) => {
         p,
       }}
     >
-      {isLatestMessage && isSubmitting && !isInitializing ? (content ?? '') + cursor : content}
+      {isLatestMessage && isSubmitting && !isInitializing
+        ? currentContent + cursor
+        : currentContent}
     </ReactMarkdown>
   );
 });

--- a/client/src/components/Messages/Content/Content.jsx
+++ b/client/src/components/Messages/Content/Content.jsx
@@ -69,7 +69,8 @@ const Content = React.memo(({ content, message }) => {
   ];
 
   if (!isInitializing || !isLatestMessage) {
-    rehypePlugins.pop();
+    //commented out to fix bing image creator errors
+    //rehypePlugins.pop();
   }
 
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "LibreChat",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "LibreChat",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "hasInstallScript": true,
       "license": "ISC",
       "workspaces": [
@@ -44,14 +44,14 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.5.4",
         "@dqbd/tiktoken": "^1.0.2",
         "@fortaine/fetch-event-source": "^3.0.6",
         "@keyv/mongo": "^2.1.8",
-        "@waylaidwanderer/chatgpt-api": "^1.37.0",
+        "@waylaidwanderer/chatgpt-api": "^1.37.2",
         "axios": "^1.3.4",
         "bcryptjs": "^2.4.3",
         "cheerio": "^1.0.0-rc.12",
@@ -95,7 +95,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
@@ -7777,9 +7777,9 @@
       }
     },
     "node_modules/@waylaidwanderer/chatgpt-api": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/@waylaidwanderer/chatgpt-api/-/chatgpt-api-1.37.1.tgz",
-      "integrity": "sha512-GkyHQayv4xbVp/XElPLI47+HRS9s392+AGldnMTZLsO0/GLDIS/vJaLK1l1g19hKTWUqc6RaLSEMFF4Pm1BkSw==",
+      "version": "1.37.2",
+      "resolved": "https://registry.npmjs.org/@waylaidwanderer/chatgpt-api/-/chatgpt-api-1.37.2.tgz",
+      "integrity": "sha512-7b/++pAaNtFXU91/+1ajZCMp7OD9AjfygDy1WSI21w83d2jSofmuJbZbL+oOWuqkUapncOEa9Lcqkl9XZ9THCg==",
       "dependencies": {
         "@dqbd/tiktoken": "^1.0.2",
         "@fastify/cors": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LibreChat",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "",
   "workspaces": [
     "api",


### PR DESCRIPTION
## Description:

- ✨Feature: Bing Image Creator
- 🪲Bugfix - LibreChat crash when requesting an image from Bing or Sydney:
    - https://discord.com/channels/1086345563026489514/1086345563026489517/1131105692896465017
    - https://discord.com/channels/1086345563026489514/1131262872106848258

So, bing image creator is now working properly with Bing and Sydney, as a result LibreChat doesn't crash anymore when asking an image from bing. 

To make it work without ending the convo I had to set `unfinished` to `false` at line 175 of `bingAI.js` 
This has the added benefit of allowing to continue the conversation after a censorship trigger (without loosing the context of the censored part!)

![image](https://github.com/danny-avila/LibreChat/assets/32828263/3c24d2e3-803b-448d-9689-b69b116d7882)

![image](https://github.com/danny-avila/LibreChat/assets/32828263/bf546b44-d5ac-4aab-9496-72ec95aab3e6)

## TO-DO
- ❗add logic to the rehype plugins pop to detect when an image is created 
- ❗Update the documentation to specify that Bing Image Creator requires the full cookie string

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [ ] Documentation update  

## How Has This Been Tested?
Tested all endpoints while working on this, I haven't noticed anything not working as expected


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
