### PR TITLE
feat: single-service docker compose file for easier deployment

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -7,3 +7,11 @@ This directory contains files used for developer work
 - alternate linting rules, used in development
 ### meilisearch.yml: 
 - Dockerfile for building meilisearch image independently from project
+### single-compose.yml: 
+- Dockerfile for building app image without meilisearch and mongodb services
+  - This is useful for deploying on Google, Azure, etc., as a single, leaner container.
+- From root dir of the project, run `docker-compose -f ./docs/dev/single-compose.yml up --build`
+  - When you don't need to build, run `docker-compose -f ./docs/dev/single-compose.yml up`
+- This requires you use a MongoDB Atlas connection string for the `MONGO_URI` env var
+  - A URI string to a mongodb service accessible to your container is also possible.
+  - Remote Meilisearch may also be possible in the same manner, but is not tested.

--- a/docs/dev/single-compose.yml
+++ b/docs/dev/single-compose.yml
@@ -1,0 +1,31 @@
+version: "3.4"
+
+services:
+  api:
+    container_name: LibreChat-App
+    ports:
+      - 3080:3080               # Change it to 9000:3080 to use nginx
+    image: librechat                # Comment this & uncomment below to build from docker hub image
+    build:                                   # ^------
+      context: ../../                         # ^------
+      target: node                             # ^------v
+    # image: ghcr.io/danny-avila/librechat:latest # Uncomment this & comment above to build from docker hub image
+    restart: always
+    extra_hosts: # if you are running APIs on docker you need access to, you will need to uncomment this line and next
+    - "host.docker.internal:host-gateway"
+    env_file:
+      - ../../.env
+    environment:
+      - HOST=0.0.0.0
+      # it's best to set it in your .env file, but uncomment if you prefer it in compose file
+      # MONGO_URI=<Your MongoDB Atlas connection string here> 
+      # - CHATGPT_REVERSE_PROXY=http://host.docker.internal:8080/api/conversation # if you are hosting your own chatgpt reverse proxy with docker
+      # - OPENAI_REVERSE_PROXY=http://host.docker.internal:8070/v1/chat/completions # if you are hosting your own chatgpt reverse proxy with docker
+    volumes:
+      - /app/client/node_modules
+      - ../../api:/app/api
+      - ../../.env:/app/.env
+      - ../../.env.development:/app/.env.development
+      - ../../.env.production:/app/.env.production
+      - /app/api/node_modules
+      - ../../images:/app/client/public/images


### PR DESCRIPTION
feat(single-compose.yml): add single-compose.yml for building leaner app container without meilisearch and mongodb services
- This is useful for deploying on cloud services such as Google, Azure, etc., as a single, leaner container.
- Instructions for running the container are added to the README.md file.
- The container requires a MongoDB Atlas connection string for the `MONGO_URI` environment variable.
- Remote Meilisearch may also be possible, but is not tested.


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update  
 

## How Has This Been Tested?

Manual use

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
