### PR TITLE
feat: change default agent model to default OpenAI models, fetch api for model list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ OPENAI_API_KEY="user_provided"
 # Identify the available models, separated by commas *without spaces*. 
 # The first will be default. 
 # Leave it blank to use internal settings. 
-OPENAI_MODELS=gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,text-davinci-003,gpt-4,gpt-4-0314,gpt-4-0613
+# OPENAI_MODELS=gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,text-davinci-003,gpt-4,gpt-4-0314,gpt-4-0613
 
 # Reverse proxy settings for OpenAI: 
 # https://github.com/waylaidwanderer/node-chatgpt-api#using-a-reverse-proxy 
@@ -124,7 +124,7 @@ ANTHROPIC_MODELS=claude-1,claude-instant-1,claude-2
 # Identify the available models, separated by commas *without spaces*. 
 # The first will be default. 
 # Leave it blank to use internal settings. 
-PLUGIN_MODELS=gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,gpt-4,gpt-4-0314,gpt-4-0613
+# PLUGIN_MODELS=gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,gpt-4,gpt-4-0314,gpt-4-0613
 
 # For securely storing credentials, you need a fixed key and IV. You can set them here for prod and dev environments
 # If you don't set them, the app will crash on startup.

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   printWidth: 100,
+  tabWidth: 2,
   useTabs: false,
-  // tabWidth: 2,
   semi: true,
   singleQuote: true,
   // bracketSpacing: false,


### PR DESCRIPTION
By changing default agent model to default OpenAI models (for example, using gpt-4 instead of gpt-4-0613), it's possible to use plugins with some reverse proxies that offer free access to OpenAI API, like ChimeraGPT (others listed here but haven't tested them: https://github.com/NovaOSS/free-ai-apis).

Fetching the models via API also allows the model selection dropdowns to properly reflect what's available to use. They must follow the openAI api spec if not the official api, which ChimeraGPT does for its api/models endpoint.

Setting the openAI API keys to user_provided will use a default list of models, or whichever you provide via env variables (e.g., OPENAI_MODELS, PLUGIN_MODELS. As a result, I've commented these variables from the example file so that fetching is the default behavior for those copying the example file.

Also fixed an unrelated bug concerning appending images to plugins response, in case the model did not include it.
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
 
## How Has This Been Tested?

Tests need to be added, but I've manually tried the affected endpoints as well as including models via .env file

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules