### PR TITLE
feat: stop-backend.js and update.js linux support

### DIFF
--- a/config/stop-backend.js
+++ b/config/stop-backend.js
@@ -1,0 +1,23 @@
+// eslint-disable-next-line
+const helpers = require('./helpers');
+const { exec } = require('child_process');
+const { promisify } = require('util');
+
+const isWindows = process.platform === 'win32';
+const execAsync = promisify(exec);
+
+async function main() {
+  try {
+    if (isWindows) {
+      console.red('The backend process has been terminated');
+      await execAsync('taskkill /F /IM node.exe /T');
+    } else {
+      await execAsync('pkill -f api/server/index.js');
+      console.orange('The backend process has been terminated');
+    }
+  } catch (err) {
+    console.red('The backend process has been terminated', err.message);
+  }
+}
+
+main();

--- a/config/update.js
+++ b/config/update.js
@@ -1,7 +1,10 @@
 const { execSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const rimraf = require('rimraf');
 const { askQuestion, isDockerRunning, silentExit } = require('./helpers');
+
+const isWindows = process.platform === 'win32';
 
 const config = {
   localUpdate: process.argv.includes('-l'),
@@ -51,7 +54,11 @@ function deleteNodeModules(dir) {
   const nodeModulesPath = path.join(dir, 'node_modules');
   if (fs.existsSync(nodeModulesPath)) {
     console.purple(`Deleting node_modules in ${dir}`);
-    execSync(`rd /s /q "${nodeModulesPath}"`, { stdio: 'inherit', shell: 'cmd.exe' });
+    if (isWindows) {
+      execSync(`rd /s /q "${nodeModulesPath}"`, { stdio: 'inherit', shell: 'cmd.exe' });
+    } else {
+      rimraf.sync(nodeModulesPath);
+    }
   }
 }
 

--- a/config/update.js
+++ b/config/update.js
@@ -10,6 +10,7 @@ const config = {
   localUpdate: process.argv.includes('-l'),
   dockerUpdate: process.argv.includes('-d'),
   useSingleComposeFile: process.argv.includes('-s'),
+  useSudo: process.argv.includes('--sudo'),
 };
 
 // Set the directories
@@ -70,7 +71,7 @@ function deleteNodeModules(dir) {
   }
 
   await validateDockerRunning();
-  const { dockerUpdate, useSingleComposeFile: singleCompose } = config;
+  const { dockerUpdate, useSingleComposeFile: singleCompose, useSudo } = config;
 
   // Fetch latest repo
   console.purple('Fetching the latest repo...');
@@ -86,9 +87,12 @@ function deleteNodeModules(dir) {
 
   if (dockerUpdate) {
     console.purple('Removing previously made Docker container...');
-    const downCommand = `docker-compose ${
+    let downCommand = `docker-compose ${
       singleCompose ? '-f ./docs/dev/single-compose.yml ' : ''
     }down --volumes`;
+    if (useSudo) {
+      downCommand = `sudo ${downCommand}`;
+    }
     console.orange(downCommand);
     execSync(downCommand, { stdio: 'inherit' });
     console.purple('Pruning all LibreChat Docker images...');
@@ -102,9 +106,12 @@ function deleteNodeModules(dir) {
     console.purple('Removing all unused dangling Docker images...');
     execSync('docker image prune -f', { stdio: 'inherit' });
     console.purple('Building new LibreChat image...');
-    const buildCommand = `docker-compose ${
+    let buildCommand = `docker-compose ${
       singleCompose ? '-f ./docs/dev/single-compose.yml ' : ''
     }build`;
+    if (useSudo) {
+      buildCommand = `sudo ${buildCommand}`;
+    }
     console.orange(buildCommand);
     execSync(buildCommand, { stdio: 'inherit' });
   } else {
@@ -127,6 +134,9 @@ function deleteNodeModules(dir) {
   let startCommand = 'npm run backend';
   if (dockerUpdate) {
     startCommand = `docker-compose ${singleCompose ? '-f ./docs/dev/single-compose.yml ' : ''}up`;
+    if (useSudo) {
+      startCommand = `sudo ${startCommand}`;
+    }
   }
   console.green('Your LibreChat app is now up to date! Start the app with the following command:');
   console.purple(startCommand);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "update:local": "node config/update.js -l",
     "update:docker": "node config/update.js -d",
     "update:single": "node config/update.js -s",
+    "update:sudo": "node config/update.js --sudo",
     "upgrade": "node config/upgrade.js",
     "create-user": "node config/create-user.js",
     "backend": "cross-env NODE_ENV=production node api/server/index.js",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "create-user": "node config/create-user.js",
     "backend": "cross-env NODE_ENV=production node api/server/index.js",
     "backend:dev": "cross-env NODE_ENV=development npx nodemon api/server/index.js",
+    "backend:stop": "node config/stop-backend.js",
     "build:data-provider": "cd packages/data-provider && npm run build",
     "frontend": "npm run build:data-provider && cd client && npm run build",
     "frontend:ci": "npm run build:data-provider && cd client && npm run build:ci",


### PR DESCRIPTION
## the sudo option needs to be tested

## feat:
- `npm run backend:stop` , a convenient way to stop the local install for Windows and Unix environements
- `npm run update:sudo` , add sudo to the docker commands

## bugfix:
- `npm run update:local` now working in Unix environements (it was previously calling cmd.exe with no alternative for unix systems)

--- 

![image](https://github.com/danny-avila/LibreChat/assets/32828263/9c37f823-8478-417b-aecc-85925d3864df)

![image](https://github.com/danny-avila/LibreChat/assets/32828263/7adfb39c-bcab-4a0a-b722-4601e538575c)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
  

## How Has This Been Tested?
both scripts have been tested in Windows 11 and Ubuntu 22.04.2 LTS

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code