### PR TITLE
feat: docker-compose deployment file

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,15 +1,15 @@
-server {
-  listen 80;
-  server_name localhost;
+http {
+  server {
+    listen 80;
+    server_name localhost;
 
-  location /api {
-    # Proxy requests to the API service
-    proxy_pass http://api:3080/api;
-  }
+    location /api {
+      proxy_pass http://api:3080/api;
+    }
 
-  location / {
-    # Serve your React app
-    root /usr/share/nginx/html;
-    try_files $uri $uri/ /index.html;
+    location / {
+      root /usr/share/nginx/html;
+      try_files $uri $uri/ /index.html;
+    }
   }
 }

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,3 +1,7 @@
+events {
+  worker_connections 1024;
+}
+
 http {
   server {
     listen 80;

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -17,8 +17,9 @@ This directory contains files used for developer work
   - Remote Meilisearch may also be possible in the same manner, but is not tested.
 ### deploy-compose.yml: 
 - Similar to above, but with basic configuration for deployment to a cloud provider where multi-container compose works
-  - Tested and working on a $6 droplet on DigitalOcean, just by visiting the server IP.
+  - Tested and working on a $6 droplet on DigitalOcean, just by visiting the http://server-ip/9000.
   - Not a scalable solution, but ideal for quickly hosting on a remote linux server.
+  - You should adjust `server_name localhost;` to match your domain name, replacing localhost, as needed.
 - From root dir of the project, run `docker-compose -f ./docs/dev/deploy-compose.yml up --build`
   - When you don't need to build, run `docker-compose -f ./docs/dev/deploy-compose.yml up`
-- Unlike the single-compose file, this containerizes both MongoDB and Meilisearch, so these are already setup for you.
+- Unlike the single-compose file, this containerizes both MongoDB and Meilisearch, as they are already setup for you.

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -15,3 +15,10 @@ This directory contains files used for developer work
 - This requires you use a MongoDB Atlas connection string for the `MONGO_URI` env var
   - A URI string to a mongodb service accessible to your container is also possible.
   - Remote Meilisearch may also be possible in the same manner, but is not tested.
+### deploy-compose.yml: 
+- Similar to above, but with basic configuration for deployment to a cloud provider where multi-container compose works
+  - Tested and working on a $6 droplet on DigitalOcean, just by visiting the server IP.
+  - Not a scalable solution, but ideal for quickly hosting on a remote linux server.
+- From root dir of the project, run `docker-compose -f ./docs/dev/deploy-compose.yml up --build`
+  - When you don't need to build, run `docker-compose -f ./docs/dev/deploy-compose.yml up`
+- Unlike the single-compose file, this containerizes both MongoDB and Meilisearch, so these are already setup for you.

--- a/docs/dev/deploy-compose.yml
+++ b/docs/dev/deploy-compose.yml
@@ -54,7 +54,7 @@ services:
     ports:
       - 7700:7700
     env_file:
-      - .env
+      - ../../.env
     environment:
       - MEILI_HOST=http://meilisearch:7700
       - MEILI_HTTP_ADDR=meilisearch:7700

--- a/docs/dev/deploy-compose.yml
+++ b/docs/dev/deploy-compose.yml
@@ -1,0 +1,63 @@
+version: "3.4"
+
+services:
+  client:
+    image: nginx:latest
+    restart: always
+    ports:
+      - 3080:80
+    volumes:
+      - ../../client/nginx.conf:/etc/nginx/nginx.conf
+      - /app/client/node_modules
+    depends_on:
+      - api
+  api:
+    container_name: LibreChat
+    ports:
+      - 9000:3080
+    depends_on:
+      - mongodb
+    image: librechat
+    build:
+      context: .
+      target: node
+    restart: always
+    extra_hosts:
+    - "host.docker.internal:host-gateway"
+    env_file:
+      - ../../.env
+    environment:
+      - HOST=0.0.0.0
+      - MONGO_URI=mongodb://mongodb:27017/LibreChat
+      - MEILI_HOST=http://meilisearch:7700
+      - MEILI_HTTP_ADDR=meilisearch:7700
+    volumes:
+      - /app/client/node_modules
+      - ../../api:/app/api
+      - ../../.env:/app/.env
+      - ../../.env.development:/app/.env.development
+      - ../../.env.production:/app/.env.production
+      - /app/api/node_modules
+      - ../../images:/app/client/public/images
+  mongodb:
+    container_name: chat-mongodb
+    ports:
+      - 27018:27017
+    image: mongo
+    restart: always
+    volumes:
+      - ./data-node:/data/db
+    command: mongod --noauth
+  meilisearch:
+    container_name: chat-meilisearch
+    image: getmeili/meilisearch:v1.0
+    ports:
+      - 7700:7700
+    env_file:
+      - .env
+    environment:
+      - MEILI_HOST=http://meilisearch:7700
+      - MEILI_HTTP_ADDR=meilisearch:7700
+      - MEILI_NO_ANALYTICS=true
+    volumes:
+      - ./meili_data:/meili_data

--- a/docs/dev/deploy-compose.yml
+++ b/docs/dev/deploy-compose.yml
@@ -17,9 +17,9 @@ services:
       - 9000:3080
     depends_on:
       - mongodb
-    image: librechat
+    image: librechat_deploy
     build:
-      context: .
+      context: ../../
       target: node
     restart: always
     extra_hosts:

--- a/docs/dev/deploy-compose.yml
+++ b/docs/dev/deploy-compose.yml
@@ -17,10 +17,11 @@ services:
       - 9000:3080
     depends_on:
       - mongodb
-    image: librechat_deploy
-    build:
-      context: ../../
-      target: node
+    image: ghcr.io/danny-avila/librechat:latest
+    # image: librechat_deploy
+    # build:
+    #   context: ../../
+    #   target: node
     restart: always
     extra_hosts:
     - "host.docker.internal:host-gateway"

--- a/docs/dev/deploy-compose.yml
+++ b/docs/dev/deploy-compose.yml
@@ -5,7 +5,8 @@ services:
     image: nginx:latest
     restart: always
     ports:
-      - 3080:80
+      - 80:80
+      - 443:443
     volumes:
       - ../../client/nginx.conf:/etc/nginx/nginx.conf
       - /app/client/node_modules


### PR DESCRIPTION
Adds basic configuration for docker deployment to a cloud provider where multi-container compose works (the default containerization of this project)
  - Tested and working on a $6 droplet on DigitalOcean, just by visiting the http://server-ip/9000.
  - Uses the [latest github container image](https://github.com/users/danny-avila/packages/container/package/librechat) of the app (latest release).
  - Not a scalable solution, but ideal for quickly hosting on a remote linux server.
  - You should adjust `server_name localhost;` to match your domain name, replacing localhost, as needed.
- From root dir of the project, run `docker-compose -f ./docs/dev/deploy-compose.yml up --build`
  - When you don't need to build, run `docker-compose -f ./docs/dev/deploy-compose.yml up`
- Unlike the single-compose file, this containerizes both MongoDB and Meilisearch, as they are already setup for you.