### PR TITLE
feat: Enhance MongoDB-MeiliSearch Syncing, fix: TypeError Issue in `db/indexSync.js`, and Search Pagination

### DIFF
--- a/api/lib/db/indexSync.js
+++ b/api/lib/db/indexSync.js
@@ -1,6 +1,5 @@
-const mongoose = require('mongoose');
-const Conversation = mongoose.models.Conversation;
-const Message = mongoose.models.Message;
+const Conversation = require('../../models/schema/convoSchema');
+const Message = require('../../models/schema/messageSchema');
 const { MeiliSearch } = require('meilisearch');
 let currentTimeout = null;
 
@@ -37,12 +36,12 @@ async function indexSync(req, res, next) {
 
     if (messageCount !== messagesIndexed) {
       console.log('Messages out of sync, indexing');
-      await Message.syncWithMeili();
+      Message.syncWithMeili();
     }
 
     if (convoCount !== convosIndexed) {
       console.log('Convos out of sync, indexing');
-      await Conversation.syncWithMeili();
+      Conversation.syncWithMeili();
     }
   } catch (err) {
     // console.log('in index sync');

--- a/api/models/Conversation.js
+++ b/api/models/Conversation.js
@@ -54,8 +54,6 @@ module.exports = {
       const cache = {};
       const convoMap = {};
       const promises = [];
-      // will handle a syncing solution soon
-      const deletedConvoIds = [];
 
       convoIds.forEach((convo) =>
         promises.push(
@@ -66,23 +64,17 @@ module.exports = {
         ),
       );
 
-      const results = (await Promise.all(promises)).filter((convo, i) => {
-        if (!convo) {
-          deletedConvoIds.push(convoIds[i].conversationId);
-          return false;
-        } else {
-          const page = Math.floor(i / pageSize) + 1;
-          if (!cache[page]) {
-            cache[page] = [];
-          }
-          cache[page].push(convo);
-          convoMap[convo.conversationId] = convo;
-          return true;
+      const results = (await Promise.all(promises)).filter(Boolean);
+
+      results.forEach((convo, i) => {
+        const page = Math.floor(i / pageSize) + 1;
+        if (!cache[page]) {
+          cache[page] = [];
         }
+        cache[page].push(convo);
+        convoMap[convo.conversationId] = convo;
       });
 
-      // const startIndex = (pageNumber - 1) * pageSize;
-      // const convos = results.slice(startIndex, startIndex + pageSize);
       const totalPages = Math.ceil(results.length / pageSize);
       cache.pages = totalPages;
       cache.pageSize = pageSize;
@@ -92,8 +84,6 @@ module.exports = {
         pages: totalPages || 1,
         pageNumber,
         pageSize,
-        // will handle a syncing solution soon
-        filter: new Set(deletedConvoIds),
         convoMap,
       };
     } catch (error) {

--- a/api/models/plugins/mongoMeili.js
+++ b/api/models/plugins/mongoMeili.js
@@ -103,7 +103,6 @@ const createMeiliMongooseModel = function ({ index, attributesToIndex }) {
           // Case: Insert
           // If document does not exist in Meili Index, Its an insert case
           if (!indexMap.has(id)) {
-            console.log(`${id} is not indexed`);
             await index.addDocuments([doc]);
             updateOps.push({
               updateOne: { filter: update, update: { $set: { _meiliIndex: true } } },

--- a/api/models/plugins/mongoMeili.js
+++ b/api/models/plugins/mongoMeili.js
@@ -117,11 +117,13 @@ const createMeiliMongooseModel = function ({ index, attributesToIndex }) {
         if (updateOps.length > 0) {
           await this.collection.bulkWrite(updateOps);
           console.log(
-            `Finished indexing ${primaryKey === 'messageId' ? 'messages' : 'conversations'}`,
+            `[Meilisearch] Finished indexing ${
+              primaryKey === 'messageId' ? 'messages' : 'conversations'
+            }`,
           );
         }
       } catch (error) {
-        console.log('Error adding document to Meili');
+        console.log('[Meilisearch] Error adding document to Meili');
         console.error(error);
       }
     }

--- a/api/models/plugins/mongoMeili.js
+++ b/api/models/plugins/mongoMeili.js
@@ -153,7 +153,7 @@ const createMeiliMongooseModel = function ({ index, attributesToIndex }) {
             },
             { _id: 1 },
           ),
-        );
+        ).lean();
 
         // Add additional data from mongodb into Meili search hits
         const populatedHits = data.hits.map(function (hit) {
@@ -162,7 +162,7 @@ const createMeiliMongooseModel = function ({ index, attributesToIndex }) {
           const originalHit = _.find(hitsFromMongoose, query);
 
           return {
-            ...(originalHit ? originalHit.toJSON() : {}),
+            ...(originalHit ?? {}),
             ...hit,
           };
         });

--- a/api/server/routes/ask/anthropic.js
+++ b/api/server/routes/ask/anthropic.js
@@ -10,7 +10,11 @@ const { handleError, sendMessage, createOnProgress } = require('./handlers');
 const abortControllers = new Map();
 
 router.post('/abort', requireJwtAuth, async (req, res) => {
-  return await abortMessage(req, res, abortControllers);
+  try {
+    return await abortMessage(req, res, abortControllers);
+  } catch (err) {
+    console.error(err);
+  }
 });
 
 router.post('/', requireJwtAuth, async (req, res) => {

--- a/api/server/routes/ask/gptPlugins.js
+++ b/api/server/routes/ask/gptPlugins.js
@@ -15,7 +15,11 @@ const requireJwtAuth = require('../../../middleware/requireJwtAuth');
 const abortControllers = new Map();
 
 router.post('/abort', requireJwtAuth, async (req, res) => {
-  return await abortMessage(req, res, abortControllers);
+  try {
+    return await abortMessage(req, res, abortControllers);
+  } catch (err) {
+    console.error(err);
+  }
 });
 
 router.post('/', requireJwtAuth, async (req, res) => {

--- a/api/server/routes/ask/openAI.js
+++ b/api/server/routes/ask/openAI.js
@@ -9,7 +9,11 @@ const requireJwtAuth = require('../../../middleware/requireJwtAuth');
 const abortControllers = new Map();
 
 router.post('/abort', requireJwtAuth, async (req, res) => {
-  return await abortMessage(req, res, abortControllers);
+  try {
+    return await abortMessage(req, res, abortControllers);
+  } catch (err) {
+    console.error(err);
+  }
 });
 
 router.post('/', requireJwtAuth, async (req, res) => {

--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -27,7 +27,8 @@ router.post('/clear', requireJwtAuth, async (req, res) => {
     filter = { conversationId };
   }
 
-  console.log('source:', source);
+  // for debugging deletion source
+  // console.log('source:', source);
 
   if (source === 'button' && !conversationId) {
     return res.status(200).send('No conversationId provided');

--- a/api/server/routes/search.js
+++ b/api/server/routes/search.js
@@ -90,11 +90,6 @@ router.get('/', requireJwtAuth, async function (req, res) {
   }
 });
 
-router.get('/clear', async function (req, res) {
-  await Message.resetIndex();
-  res.send('cleared');
-});
-
 router.get('/test', async function (req, res) {
   const { q } = req.query;
   const messages = (

--- a/client/src/localization/languages/Eng.tsx
+++ b/client/src/localization/languages/Eng.tsx
@@ -2,7 +2,7 @@
 
 export default {
   com_ui_examples: 'Examples',
-  com_ui_new_chat: 'New Chat',
+  com_ui_new_chat: 'New chat',
   com_ui_example_quantum_computing: 'Explain quantum computing in simple terms',
   com_ui_example_10_year_old_b_day: 'Got any creative ideas for a 10 year old\'s birthday?',
   com_ui_example_http_in_js: 'How do I make an HTTP request in Javascript?',


### PR DESCRIPTION
## Summary

The PR includes improved database synchronization between MongoDB collections and MeiliSearch indices. Synchronization is only triggered if a discrepancy is detected as determined by `db/indexSync.js`. The proposed strategy is robust, ensuring the entire index is no longer deleted. Discrepancies are detected and updates made on both the database and MeiliSearch correspondingly. While more labor intensive than the method this replaces, the syncing is no longer thread-blocking as the method is allowed to perform asynchronously.

Related to this, the TypeError issue for Conversation and Message models in `db/indexSync.js` is addressed, `TypeError: Cannot read properties of undefined (reading 'countDocuments')`. 

Issue discovered due to indexing createdAt timestamps and missing Mongoose.models.Message when the script runs for syncing, possibly as the second index makes mongoose.model objects unavailable at the exact runtime that indexSync runs. Proposed changes to import the models directly resolves this. Identified an issue with Meilisearch SDK processing batch data if one problematic message exists. No errors are thrown either in the server code or meiliSearch instance logs, and this strategy guards against this shortcoming.

Unrelated to above, but also discovered an error with abort routes being called after a long-hanging message, which could potentially crash server. Issue is resolved by catching error in abort routes.

Also took the liberty to fix pagination for search results

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested convo/message deletion/editing both in app and in db directly. Syncing is performing well and the new strategy is hardly ever triggered, but in case a discrepancy arises, it performs well and as expected.

Also switched between local/docker server instances multiple times, which effectively resets all indexing.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes.