### PR TITLE
docs: Add Azure Instructions (Terraform) to Cloud Deployments Guide

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,7 +39,7 @@
             }
         }
     },
-    "postCreateCommand": ""
+    "postCreateCommand": "",
     // "workspaceMount": "src=${localWorkspaceFolder},dst=/code,type=bind,consistency=cached"
 
     // "runArgs": [
@@ -54,4 +54,5 @@
     // "settings": {
     //     "terminal.integrated.shell.linux": "/bin/bash"
     // },
+    "features": {"ghcr.io/devcontainers/features/git:1": {}}
 }

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Keep up with the latest updates by visiting the releases page - [Releases](https
   * [Cloudflare](docs/deployment/cloudflare.md)
   * [Ngrok](docs/deployment/ngrok.md)
   * [Render](docs/deployment/render.md)
+  * [Azure](https://github.com/thunderbug1/LibreChatAzureDeployment)
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Keep up with the latest updates by visiting the releases page - [Releases](https
   * [Cloudflare](docs/deployment/cloudflare.md)
   * [Ngrok](docs/deployment/ngrok.md)
   * [Render](docs/deployment/render.md)
-  * [Azure](https://github.com/thunderbug1/LibreChatAzureDeployment)
+  * [Azure](docs/deployment/azure.md)
 </details>
 
 <details>

--- a/docs/deployment/azure.md
+++ b/docs/deployment/azure.md
@@ -1,0 +1,5 @@
+# Azure deployment
+
+There are different ways of how a deployment can be done in Azure. 
+One way is to use Terraform to setup all the necessary ressources automatically, here is an [example setup](https://github.com/thunderbug1/LibreChatAzureDeployment) with the setup instructions.
+After following the setup instructions, you will be able to reach your instance with the url that is shown after the "terraform apply" command.


### PR DESCRIPTION
I created a seperate Project containing a Terraform setup to deploy Librechat to Azure.
I don't think that it would be clean to add deplyoment specific files to this repo so I keep it in a different project and set a link in the documenation here.

## Type of change

Please delete options that are not relevant.

- [x] Documentation update  
  

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
##
by running the setup to deploy to Azure

### **Test Configuration**:
##

