### PR TITLE
fix: allow setting username in openIdStrategy

### DIFF
--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -83,7 +83,7 @@ async function setupOpenId() {
           } else {
             user.provider = 'openid';
             user.openidId = userinfo.sub;
-            user.username = userinfo.username || userinfo.given_name || '',
+            user.username = userinfo.username || userinfo.given_name || '';
             user.name = fullName;
           }
 

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -83,7 +83,7 @@ async function setupOpenId() {
           } else {
             user.provider = 'openid';
             user.openidId = userinfo.sub;
-            user.username = userinfo.given_name || '';
+            user.username = userinfo.username || userinfo.given_name || '',
             user.name = fullName;
           }
 


### PR DESCRIPTION
Fixed bug when setting username in openIdStrategy.

Instead of firstname we have to set username for existing user, the way as we do for new user.



## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)

