### PR TITLE
fix(Settings/Plugins.tsx): fix incorrect params (mismatch) of setOption calls

### DIFF
--- a/client/src/components/Endpoints/Settings/Plugins.tsx
+++ b/client/src/components/Endpoints/Settings/Plugins.tsx
@@ -34,8 +34,8 @@ export default function Settings({ conversation, setOption, models, readonly }: 
   const setPromptPrefix = setOption('promptPrefix');
   const setTemperature = setOption('temperature');
   const setTopP = setOption('top_p');
-  const setFreqP = setOption('presence_penalty');
-  const setPresP = setOption('frequency_penalty');
+  const setFreqP = setOption('frequency_penalty');
+  const setPresP = setOption('presence_penalty');
 
   const toolsSelected = tools && tools.length > 0;
 


### PR DESCRIPTION
Mismatched frequency_penalty and presence_penalty options, having one param update the other

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
  

## How Has This Been Tested?

Manual testing, confirmed working before/after

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
