### PR TITLE
fix(ESide): enum cannot be used as a value when imported as type

### DIFF
--- a/client/src/components/Endpoints/Settings/AgentSettings.tsx
+++ b/client/src/components/Endpoints/Settings/AgentSettings.tsx
@@ -1,5 +1,4 @@
-import { TModelSelectProps } from '~/common';
-import type { ESide } from '~/common';
+import { TModelSelectProps, ESide } from '~/common';
 import {
   Switch,
   SelectDropDown,

--- a/client/src/components/Endpoints/Settings/OptionHover.tsx
+++ b/client/src/components/Endpoints/Settings/OptionHover.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { HoverCardPortal, HoverCardContent } from '~/components/ui';
-import type { ESide } from '~/common';
+import { ESide } from '~/common';
 import { useLocalize } from '~/hooks';
 
 type TOptionHoverProps = {


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Would throw error to UI now doesn't

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
