### PR TITLE
chore(playwright.yml): run the e2e workflow only for main repo, remove caching

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   tests_e2e:
     name: Run Playwright tests
+    if: github.event.pull_request.head.repo.full_name == danny-avila/LibreChat
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:
@@ -37,13 +38,13 @@ jobs:
           node-version: 18
           cache: 'npm'
 
-      - name: Cache Node.js modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+      # - name: Cache Node.js modules
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.npm
+      #     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-node-
 
       - name: Install global dependencies
         run: npm ci
@@ -57,13 +58,13 @@ jobs:
       - name: Build Client
         run: npm run frontend
 
-      - name: Cache Playwright installations
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/ms-playwright/
-          key: ${{ runner.os }}-pw-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-pw-
+      # - name: Cache Playwright installations
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ~/.cache/ms-playwright/
+      #     key: ${{ runner.os }}-pw-${{ hashFiles('**/package-lock.json') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-pw-
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium && npm install -D @playwright/test@latest
@@ -78,4 +79,3 @@ jobs:
           name: playwright-report
           path: e2e/playwright-report/
           retention-days: 30
-  


### PR DESCRIPTION
this is necessary as forks do not get access to github secrets.

I removed caching as no apparent benefit is gained from it.