### PR TITLE
chore: vite warning resolutions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tests_e2e:
     name: Run Playwright tests
-    if: github.event.pull_request.head.repo.full_name == danny-avila/LibreChat
+    if: github.event.pull_request.head.repo.full_name == 'danny-avila/LibreChat'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     env:

--- a/client/package.json
+++ b/client/package.json
@@ -97,7 +97,7 @@
     "@types/node": "^20.3.0",
     "@types/react": "^18.2.11",
     "@types/react-dom": "^18.2.4",
-    "@vitejs/plugin-react": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.4",
     "autoprefixer": "^10.4.13",
     "babel-jest": "^29.5.0",
     "babel-loader": "^9.1.2",
@@ -125,7 +125,7 @@
     "ts-jest": "^29.1.0",
     "ts-loader": "^9.4.2",
     "typescript": "^5.0.4",
-    "vite": "^4.3.9",
+    "vite": "^4.4.9",
     "vite-plugin-html": "^3.2.0"
   }
 }

--- a/client/src/components/ui/AlertDialog.tsx
+++ b/client/src/components/ui/AlertDialog.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 

--- a/client/src/components/ui/Checkbox.tsx
+++ b/client/src/components/ui/Checkbox.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { Check } from 'lucide-react';

--- a/client/src/components/ui/DropdownMenu.tsx
+++ b/client/src/components/ui/DropdownMenu.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { Check, ChevronRight, Circle } from 'lucide-react';

--- a/client/src/components/ui/HoverCard.tsx
+++ b/client/src/components/ui/HoverCard.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
 

--- a/client/src/components/ui/InputNumber.tsx
+++ b/client/src/components/ui/InputNumber.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 
 // import { NumericFormat } from 'react-number-format';

--- a/client/src/components/ui/Slider.tsx
+++ b/client/src/components/ui/Slider.tsx
@@ -1,11 +1,8 @@
-'use client';
-
 import * as React from 'react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 import { useDoubleClick } from '@zattoo/use-double-click';
+import type { clickEvent } from '@zattoo/use-double-click';
 import { cn } from '../../utils';
-
-type clickEvent = (event: React.MouseEvent<HTMLButtonElement>) => void;
 
 interface SliderProps extends React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> {
   doubleClickHandler?: clickEvent;
@@ -23,7 +20,7 @@ const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, S
       </SliderPrimitive.Track>
       <SliderPrimitive.Thumb
         onClick={
-          useDoubleClick(doubleClickHandler) ??
+          useDoubleClick(doubleClickHandler as clickEvent) ??
           (() => {
             return;
           })

--- a/client/src/components/ui/Tabs.tsx
+++ b/client/src/components/ui/Tabs.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import * as React from 'react';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -13,7 +13,7 @@
   font-family: Signifier;
   font-style: normal;
   font-weight: 400;
-  src: url("../fonts/signifier-light.woff2") format("woff2")
+  src: url("$fonts/signifier-light.woff2") format("woff2")
 }
 
 @font-face {
@@ -21,7 +21,7 @@
   font-family: Signifier;
   font-style: italic;
   font-weight: 400;
-  src: url("../fonts/signifier-light-italic.woff2") format("woff2")
+  src: url("$fonts/signifier-light-italic.woff2") format("woff2")
 }
 
 @font-face {
@@ -29,7 +29,7 @@
   font-family: Signifier;
   font-style: normal;
   font-weight: 700;
-  src: url("../fonts/signifier-bold.woff2") format("woff2")
+  src: url("$fonts/signifier-bold.woff2") format("woff2")
 }
 
 @font-face {
@@ -37,7 +37,7 @@
   font-family: Signifier;
   font-style: italic;
   font-weight: 700;
-  src: url("../fonts/signifier-bold-italic.woff2") format("woff2")
+  src: url("$fonts/signifier-bold-italic.woff2") format("woff2")
 }
 
 @font-face {
@@ -45,7 +45,7 @@
   font-family: Söhne;
   font-style: normal;
   font-weight: 400;
-  src: url("../fonts/soehne-buch.woff2") format("woff2")
+  src: url("$fonts/soehne-buch.woff2") format("woff2")
 }
 
 @font-face {
@@ -53,7 +53,7 @@
   font-family: Söhne;
   font-style: italic;
   font-weight: 400;
-  src: url("../fonts/soehne-buch-kursiv.woff2") format("woff2")
+  src: url("$fonts/soehne-buch-kursiv.woff2") format("woff2")
 }
 
 @font-face {
@@ -61,7 +61,7 @@
   font-family: Söhne;
   font-style: normal;
   font-weight: 500;
-  src: url("../fonts/soehne-kraftig.woff2") format("woff2")
+  src: url("$fonts/soehne-kraftig.woff2") format("woff2")
 }
 
 @font-face {
@@ -69,7 +69,7 @@
   font-family: Söhne;
   font-style: italic;
   font-weight: 500;
-  src: url("../fonts/soehne-kraftig-kursiv.woff2") format("woff2")
+  src: url("$fonts/soehne-kraftig-kursiv.woff2") format("woff2")
 }
 
 @font-face {
@@ -77,7 +77,7 @@
   font-family: Söhne;
   font-style: normal;
   font-weight: 600;
-  src: url("../fonts/soehne-halbfett.woff2") format("woff2")
+  src: url("$fonts/soehne-halbfett.woff2") format("woff2")
 }
 
 @font-face {
@@ -85,7 +85,7 @@
   font-family: Söhne;
   font-style: italic;
   font-weight: 600;
-  src: url("../fonts/soehne-halbfett-kursiv.woff2") format("woff2")
+  src: url("$fonts/soehne-halbfett-kursiv.woff2") format("woff2")
 }
 
 @font-face {
@@ -93,7 +93,7 @@
   font-family: Söhne Mono;
   font-style: normal;
   font-weight: 400;
-  src: url("../fonts/soehne-mono-buch.woff2") format("woff2")
+  src: url("$fonts/soehne-mono-buch.woff2") format("woff2")
 }
 
 @font-face {
@@ -101,7 +101,7 @@
   font-family: Söhne Mono;
   font-style: normal;
   font-weight: 700;
-  src: url("../fonts/soehne-mono-halbfett.woff2") format("woff2")
+  src: url("$fonts/soehne-mono-halbfett.woff2") format("woff2")
 }
 
 @font-face {
@@ -109,7 +109,7 @@
   font-family: Söhne Mono;
   font-style: italic;
   font-weight: 400;
-  src: url("../fonts/soehne-mono-buch-kursiv.woff2") format("woff2")
+  src: url("$fonts/soehne-mono-buch-kursiv.woff2") format("woff2")
 }
 
 /* * {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
-import path from 'path';
+import path, { resolve } from 'path';
 import type { Plugin } from 'vite';
 
 // https://vitejs.dev/config/
@@ -42,6 +42,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '~': path.join(__dirname, 'src/'),
+      $fonts: resolve('public/fonts'),
     },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,7 +173,7 @@
         "@types/node": "^20.3.0",
         "@types/react": "^18.2.11",
         "@types/react-dom": "^18.2.4",
-        "@vitejs/plugin-react": "^4.0.0",
+        "@vitejs/plugin-react": "^4.0.4",
         "autoprefixer": "^10.4.13",
         "babel-jest": "^29.5.0",
         "babel-loader": "^9.1.2",
@@ -201,7 +201,7 @@
         "ts-jest": "^29.1.0",
         "ts-loader": "^9.4.2",
         "typescript": "^5.0.4",
-        "vite": "^4.3.9",
+        "vite": "^4.4.9",
         "vite-plugin-html": "^3.2.0"
       }
     },
@@ -23261,9 +23261,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.27.0.tgz",
-      "integrity": "sha512-aOltLCrYZ0FhJDm7fCqwTjIUEVjWjcydKBV/Zeid6Mn8BWgDCUBBWT5beM5ieForYNo/1ZHuGJdka26kvQ3Gzg==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
+      "integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -25802,14 +25802,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.7.tgz",
-      "integrity": "sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
+      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
-        "postcss": "^8.4.26",
-        "rollup": "^3.25.2"
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -30532,7 +30532,7 @@
         "@types/node": "^20.3.0",
         "@types/react": "^18.2.11",
         "@types/react-dom": "^18.2.4",
-        "@vitejs/plugin-react": "^4.0.0",
+        "@vitejs/plugin-react": "^4.0.4",
         "@zattoo/use-double-click": "1.2.0",
         "autoprefixer": "^10.4.13",
         "axios": "^1.3.4",
@@ -30597,7 +30597,7 @@
         "ts-loader": "^9.4.2",
         "typescript": "^5.0.4",
         "url": "^0.11.0",
-        "vite": "^4.3.9",
+        "vite": "^4.4.9",
         "vite-plugin-html": "^3.2.0"
       }
     },
@@ -43380,9 +43380,9 @@
       }
     },
     "rollup": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.27.0.tgz",
-      "integrity": "sha512-aOltLCrYZ0FhJDm7fCqwTjIUEVjWjcydKBV/Zeid6Mn8BWgDCUBBWT5beM5ieForYNo/1ZHuGJdka26kvQ3Gzg==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
+      "integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -45196,15 +45196,15 @@
       }
     },
     "vite": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.7.tgz",
-      "integrity": "sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
+      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.26",
-        "rollup": "^3.25.2"
+        "postcss": "^8.4.27",
+        "rollup": "^3.27.1"
       },
       "dependencies": {
         "@esbuild/android-arm": {


### PR DESCRIPTION
## Summary

This PR includes several chore updates and fixes:

- Updated `@vitejs/plugin-react` to version 4.0.4. and Updated `vite` to version 4.4.9.
- Updated `vite.config.ts` to resolve fonts and updated styles.css accordingly.
- Removed artifacts related to `next.js` ("use client") from UI primitives, which resolves vite warnings
- Fixed a type error in the `onClick` event handler of `Slider.tsx`.
- also fixed condition for playwright workflow to trigger on PRs from main repo (where secrets are accessible)

Font resolution fix was discussed in [this StackOverflow thread](https://stackoverflow.com/questions/75601350/tailwind-and-vite-warnings-didnt-resolve-at-build-time-it-will-remain-unchan) and applied it. Several UI primitives had 'use client'; their respective warnings have been resolved by removing them. Lastly, there's a similar issue with `tanstack/query`, as discussed in [this GitHub issue](https://github.com/TanStack/query/issues/5273). There was hope that the latest versions of `vite-plugin-react` and `vite` would resolve this, but it remains an ongoing issue for that plugin library, so the warnings persist until their libraries address the underlying issue.

## Change Type

- [x] Chore
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.