### PR TITLE
fix(scripts): remove --volumes flag from down commands

### DIFF
--- a/config/deployed-update.js
+++ b/config/deployed-update.js
@@ -36,7 +36,7 @@ const shouldRebase = process.argv.includes('--rebase');
   }
 
   console.purple('Removing previously made Docker container...');
-  const downCommand = 'sudo docker-compose -f ./deploy-compose.yml down --volumes';
+  const downCommand = 'sudo docker-compose -f ./deploy-compose.yml down';
   console.orange(downCommand);
   execSync(downCommand, { stdio: 'inherit' });
 

--- a/config/update.js
+++ b/config/update.js
@@ -80,7 +80,7 @@ async function validateDockerRunning() {
     console.purple('Removing previously made Docker container...');
     const downCommand = `${sudo}docker-compose ${
       singleCompose ? '-f ./docs/dev/single-compose.yml ' : ''
-    }down --volumes`;
+    }down`;
     console.orange(downCommand);
     execSync(downCommand, { stdio: 'inherit' });
     console.purple('Pruning all LibreChat Docker images...');

--- a/docs/deployment/digitalocean.md
+++ b/docs/deployment/digitalocean.md
@@ -368,7 +368,7 @@ npm run update:deployed
 npm run stop:deployed
 ```
 
-> This simply runs `docker-compose -f ./deploy-compose.yml down --volumes`
+> This simply runs `docker-compose -f ./deploy-compose.yml down`
 
 **Starting the docker container**
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "update:deployed": "node config/deployed-update.js",
     "rebase:deployed": "node config/deployed-update.js --rebase",
     "start:deployed": "docker-compose -f ./deploy-compose.yml up -d",
-    "stop:deployed": "docker-compose -f ./deploy-compose.yml down --volumes",
+    "stop:deployed": "docker-compose -f ./deploy-compose.yml down",
     "upgrade": "node config/upgrade.js",
     "create-user": "node config/create-user.js",
     "backend": "cross-env NODE_ENV=production node api/server/index.js",


### PR DESCRIPTION
## Summary

In this PR, I have removed the `--volumes` flag from all automated scripts and commands to ensure that MongoDB and MeiliSearch data files are preserved and not unintentionally deleted. This change was made to prevent potential data loss during routine operations.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update 

## Testing

The primary test involved running the modified scripts/commands to ensure that containers are stopped and removed without deleting the associated volumes. After running the scripts, I verified that the data in the `./data-node` and `./meili_data` directories remained intact.


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
