### PR TITLE
chore: un-expose mongodb ports in compose files

### DIFF
--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -44,7 +44,7 @@ services:
     restart: always
     volumes:
       - ./data-node:/data/db
-    command: mongod --noauth --bind_ip 0.0.0.0
+    command: mongod --noauth
   meilisearch:
     container_name: chat-meilisearch
     image: getmeili/meilisearch:v1.0

--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -38,13 +38,13 @@ services:
     restart: always
   mongodb:
     container_name: chat-mongodb
-    ports:
-      - 27018:27017
+    # ports:  # Uncomment this to access mongodb from outside docker, not safe in deployment
+    #   - 27018:27017
     image: mongo
     restart: always
     volumes:
       - ./data-node:/data/db
-    command: mongod --noauth
+    command: mongod --noauth --bind_ip 0.0.0.0
   meilisearch:
     container_name: chat-meilisearch
     image: getmeili/meilisearch:v1.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     restart: always
     volumes:
       - ./data-node:/data/db
-    command: mongod --noauth --bind_ip 0.0.0.0
+    command: mongod --noauth
   meilisearch:
     container_name: chat-meilisearch
     image: getmeili/meilisearch:v1.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,13 +46,13 @@ services:
       - ./images:/app/client/public/images
   mongodb:
     container_name: chat-mongodb
-    ports:
-      - 27018:27017
+    # ports:  # Uncomment this to access mongodb from outside docker, not safe in deployment
+    #   - 27018:27017
     image: mongo
     restart: always
     volumes:
       - ./data-node:/data/db
-    command: mongod --noauth
+    command: mongod --noauth --bind_ip 0.0.0.0
   meilisearch:
     container_name: chat-meilisearch
     image: getmeili/meilisearch:v1.0


### PR DESCRIPTION
This update simply removes the port exposure for mongodb from all compose files so mongo cannot be accessed outside of the container group. The next step would be to add authentication but it's trickier to do in existing databases. For those wishing direct access to their database, i would only recommend it in a local environment, and even then, only if they have authentication setup. The default behavior will be to secure those ports.

An alternative to remote access could be https://github.com/mongo-express/mongo-express provided it is also secured in the container group.

This is particularly important for deployments, as there is a pretty widespread nefarious script targeting mongo databases exposed by docker: https://security.stackexchange.com/questions/270965/how-did-i-get-hacked

Unfortunately, I myself was affected and at least one other person was.