### PR TITLE
fix: update social profile picture

### DIFF
--- a/api/strategies/discordStrategy.js
+++ b/api/strategies/discordStrategy.js
@@ -17,11 +17,6 @@ const discordLogin = async () =>
         const email = profile.email;
         const discordId = profile.id;
 
-        const oldUser = await User.findOne({ email });
-        if (oldUser) {
-          return cb(null, oldUser);
-        }
-
         let avatarURL;
         if (profile.avatar) {
           const format = profile.avatar.startsWith('a_') ? 'gif' : 'png';
@@ -29,6 +24,13 @@ const discordLogin = async () =>
         } else {
           const defaultAvatarNum = Number(profile.discriminator) % 5;
           avatarURL = `https://cdn.discordapp.com/embed/avatars/${defaultAvatarNum}.png`;
+        }
+
+        const oldUser = await User.findOne({ email });
+        if (oldUser) {
+          oldUser.avatar = avatarURL;
+          await oldUser.save();
+          return cb(null, oldUser);
         }
 
         const newUser = await User.create({

--- a/api/strategies/githubStrategy.js
+++ b/api/strategies/githubStrategy.js
@@ -23,6 +23,8 @@ const githubLogin = async () =>
 
         const oldUser = await User.findOne({ email });
         if (oldUser) {
+          oldUser.avatar = profile.photos[0].value;
+          await oldUser.save();
           return cb(null, oldUser);
         }
 

--- a/api/strategies/googleStrategy.js
+++ b/api/strategies/googleStrategy.js
@@ -17,6 +17,8 @@ const googleLogin = async () =>
       try {
         const oldUser = await User.findOne({ email: profile.emails[0].value });
         if (oldUser) {
+          oldUser.avatar = profile.photos[0].value;
+          await oldUser.save();
           return cb(null, oldUser);
         }
       } catch (err) {


### PR DESCRIPTION
Fix the bug that when someone tries to log in again, it updates the profile picture to that of the social login. It only works for Google, Github and Discord. Obviously, if the profile pictures between Google and Github are different, the image will change every time a different login is made.

In the future, a setting could be added to select which social platform's profile picture you want to keep.

## Change Type

- [x] Bug fix

## Testing

### Succesfull test:

npm run test:client
npm run e2e
npm run lint (no new error)

### Check if the profile picture update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
