### PR TITLE
hotfix(azure): Very basic patch to fix azure url

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -113,8 +113,11 @@ class OpenAIClient extends BaseClient {
 
     if (this.azureEndpoint) {
       // Temporary fix for Azure, Reload the correct url
-      this.azure.azureOpenAIApiDeploymentName = this.options.modelOptions.model;
-      this.azureEndpoint = genAzureChatCompletion(this.azure);
+      const azureOptions = this.options.modelOptions || this.options.agentOptions;
+      if (azureOptions) {
+        this.azure.azureOpenAIApiDeploymentName = azureOptions.model.replace('3.5', '35');
+        this.azureEndpoint = genAzureChatCompletion(this.azure);
+      }
       this.completionsUrl = this.azureEndpoint;
     }
 

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -112,6 +112,9 @@ class OpenAIClient extends BaseClient {
     }
 
     if (this.azureEndpoint) {
+      // Temporary fix for Azure, Reload the correct url
+      this.azure.azureOpenAIApiDeploymentName = this.options.modelOptions.model;
+      this.azureEndpoint = genAzureChatCompletion(this.azure);
       this.completionsUrl = this.azureEndpoint;
     }
 

--- a/api/app/titleConvo.js
+++ b/api/app/titleConvo.js
@@ -1,9 +1,9 @@
 const _ = require('lodash');
-const { genAzureChatCompletion, getAzureCredentials } = require('../utils/');
+const { getAzureCredentials } = require('../utils/');
+const { OpenAIClient } = require('./clients');
 
 const titleConvo = async ({ text, response, openAIApiKey, azure = false }) => {
   let title = 'New Chat';
-  const ChatGPTClient = (await import('@waylaidwanderer/chatgpt-api')).default;
 
   try {
     const instructionsPayload = {
@@ -36,11 +36,11 @@ const titleConvo = async ({ text, response, openAIApiKey, azure = false }) => {
     let apiKey = openAIApiKey ?? process.env.OPENAI_API_KEY;
 
     if (azure) {
-      apiKey = process.env.AZURE_API_KEY;
-      titleGenClientOptions.reverseProxyUrl = genAzureChatCompletion(getAzureCredentials());
+      titleGenClientOptions.azure = getAzureCredentials();
+      apiKey = titleGenClientOptions.azure.azureOpenAIApiKey;
     }
 
-    const titleGenClient = new ChatGPTClient(apiKey, titleGenClientOptions);
+    const titleGenClient = new OpenAIClient(apiKey, titleGenClientOptions);
     const result = await titleGenClient.getCompletion([instructionsPayload], null);
     title = result.choices[0].message.content.replace(/\s+/g, ' ').replaceAll('"', '').trim();
   } catch (e) {


### PR DESCRIPTION
# Issue

The current azure setup mostly works except the url being generated is incorrect. We need to use the model name (aka deployment name) you have defined yourself in the azure backend.

Note: This is essentially your own name for the model you are using. It is probably best to use default naming to ensure correct token counting

# Future Fix

I am not sure I understand the flow of information throughout the project to correctly fix the issue as I believe the options are set after initialisation. Ideally we should be passing the model name through when we originally create the azure endpoint url
