### PR TITLE
fix(CodeBlock.tsx): fix copy-to-clipboard functionality on some browsers

### DIFF
--- a/client/src/components/Messages/Content/CodeBlock.tsx
+++ b/client/src/components/Messages/Content/CodeBlock.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, RefObject } from 'react';
+import copy from 'copy-to-clipboard';
 import { Clipboard, CheckMark } from '~/components';
 import { InfoIcon } from 'lucide-react';
 import { cn } from '~/utils/';
@@ -22,10 +23,12 @@ const CodeBar: React.FC<CodeBarProps> = React.memo(({ lang, codeRef, plugin = nu
           onClick={async () => {
             const codeString = codeRef.current?.textContent;
             if (codeString) {
-              navigator.clipboard.writeText(codeString).then(() => {
-                setIsCopied(true);
-                setTimeout(() => setIsCopied(false), 3000);
-              });
+              setIsCopied(true);
+              copy(codeString);
+
+              setTimeout(() => {
+                setIsCopied(false);
+              }, 3000);
             }
           }}
         >


### PR DESCRIPTION
## Summary

The CodeBar component has been updated to use the copy function from the copy-to-clipboard library instead of the navigator.clipboard.writeText method. This should fix the issue with browser incompatibility with navigator SDK and allow users to copy code from the CodeBlock component successfully.

## Change Type


- [x] Bug fix (non-breaking change which fixes an issue)

Addresses #804 