### PR TITLE
chore: comment out meilisearch ports in compose files

### DIFF
--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -48,8 +48,8 @@ services:
   meilisearch:
     container_name: chat-meilisearch
     image: getmeili/meilisearch:v1.0
-    ports:
-      - 7700:7700
+    # ports: # Uncomment this to access meilisearch from outside docker
+    #   - 7700:7700 # if exposing these ports, make sure your master key is not the default value
     env_file:
       - .env
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,8 @@ services:
     container_name: chat-meilisearch
     image: getmeili/meilisearch:v1.0
     restart: always
-    ports:
-      - 7700:7700
+    # ports: # Uncomment this to access meilisearch from outside docker
+    #   - 7700:7700 # if exposing these ports, make sure your master key is not the default value
     env_file:
       - .env
     environment:


### PR DESCRIPTION
Similar to https://github.com/danny-avila/LibreChat/pull/786 to disable the port exposure by default.

Meilisearch is more secure by default compared to mongodb since you need a master key set, without which its services can't be accessed. However, this project provides a default value for ease of startup, and so this is to protect anyone deploying against bad actors who are familiar with the default key and who may want to disrupt their meilisearch indices or steal their messages information.

As already mentioned, this is particularly important for deployments