### PR TITLE
fix(PluginsClient.js): fix ChatOpenAI Azure Config Issue

### DIFF
--- a/api/app/clients/PluginsClient.js
+++ b/api/app/clients/PluginsClient.js
@@ -150,6 +150,7 @@ Only respond with your conversational reply to the following User Message:
   }
 
   createLLM(modelOptions, configOptions) {
+    let azure = {};
     let credentials = { openAIApiKey: this.openAIApiKey };
     let configuration = {
       apiKey: this.openAIApiKey,
@@ -158,14 +159,21 @@ Only respond with your conversational reply to the following User Message:
     if (this.azure) {
       credentials = {};
       configuration = {};
+      const { azureOpenAIApiInstanceName, ...rest } = this.azure;
+      azure = {
+        azureOpenAIBasePath: `https://${azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments`,
+        ...rest,
+      };
     }
 
     if (this.options.debug) {
       console.debug('createLLM: configOptions');
       console.debug(configOptions);
+      console.debug('createLLM: azure');
+      console.debug(azure);
     }
 
-    return new ChatOpenAI({ credentials, configuration, ...modelOptions }, configOptions);
+    return new ChatOpenAI({ credentials, configuration, ...azure, ...modelOptions }, configOptions);
   }
 
   async initialize({ user, message, onAgentAction, onChainEnd, signal }) {

--- a/api/app/clients/PluginsClient.js
+++ b/api/app/clients/PluginsClient.js
@@ -169,8 +169,6 @@ Only respond with your conversational reply to the following User Message:
     if (this.options.debug) {
       console.debug('createLLM: configOptions');
       console.debug(configOptions);
-      console.debug('createLLM: azure');
-      console.debug(azure);
     }
 
     return new ChatOpenAI({ credentials, configuration, ...azure, ...modelOptions }, configOptions);

--- a/api/app/clients/PluginsClient.js
+++ b/api/app/clients/PluginsClient.js
@@ -159,11 +159,7 @@ Only respond with your conversational reply to the following User Message:
     if (this.azure) {
       credentials = {};
       configuration = {};
-      const { azureOpenAIApiInstanceName, ...rest } = this.azure;
-      azure = {
-        azureOpenAIBasePath: `https://${azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments`,
-        ...rest,
-      };
+      ({ azure } = this);
     }
 
     if (this.options.debug) {


### PR DESCRIPTION
## Summary

The `createLLM` function in `PluginsClient.js` had an issue when using Azure. Langchain is not properly handling the Azure configuration options from environment variables. This was the default behavior before but is not anymore (maybe due to the env variables taking precedent in the past or some weird scoping issue with the app).

This commit fixes the issue by providing it explicitly to the model initialization. Note this may not work if you have a deployment in another region. e.g.  "https://westeurope.api.cognitive.microsoft.com/openai/deployments"

That will need to be handled in a future update with [azureOpenAIBasePath](https://js.langchain.com/docs/api/chat_models_openai/classes/ChatOpenAI#azureopenaibasepath).

Note this will only work with the default endpoint base path


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
