### PR TITLE
refactor(MessageHandler -> useServerStream): TS Conversion and Custom Hook instead of RFC

### DIFF
--- a/api/server/middleware/abortMiddleware.js
+++ b/api/server/middleware/abortMiddleware.js
@@ -30,10 +30,11 @@ const createAbortController = (res, req, endpointOption, getAbortData) => {
   const abortController = new AbortController();
   const onStart = (userMessage) => {
     sendMessage(res, { message: userMessage, created: true });
-    abortControllers.set(userMessage.conversationId, { abortController, ...endpointOption });
+    const abortKey = userMessage?.conversationId ?? req.user.id;
+    abortControllers.set(abortKey, { abortController, ...endpointOption });
 
     res.on('finish', function () {
-      abortControllers.delete(userMessage.conversationId);
+      abortControllers.delete(abortKey);
     });
   };
 

--- a/client/src/components/Auth/index.ts
+++ b/client/src/components/Auth/index.ts
@@ -1,4 +1,5 @@
 export { default as Login } from './Login';
 export { default as Registration } from './Registration';
-export { default as RequestPasswordReset } from './RequestPasswordReset';
 export { default as ResetPassword } from './ResetPassword';
+export { default as ApiErrorWatcher } from './ApiErrorWatcher';
+export { default as RequestPasswordReset } from './RequestPasswordReset';

--- a/client/src/components/Plugins/Store/PluginAuthForm.tsx
+++ b/client/src/components/Plugins/Store/PluginAuthForm.tsx
@@ -23,7 +23,7 @@ function PluginAuthForm({ plugin, onSubmit }: TPluginAuthFormProps) {
           className="col-span-1 flex w-full flex-col items-start justify-start gap-2"
           method="POST"
           onSubmit={handleSubmit((auth) =>
-            onSubmit({ pluginKey: plugin?.pluginKey, action: 'install', auth }),
+            onSubmit({ pluginKey: plugin?.pluginKey ?? '', action: 'install', auth }),
           )}
         >
           {plugin?.authConfig?.map((config: TPluginAuthConfig, i: number) => (

--- a/client/src/components/Plugins/Store/PluginStoreDialog.tsx
+++ b/client/src/components/Plugins/Store/PluginStoreDialog.tsx
@@ -84,10 +84,9 @@ function PluginStoreDialog({ isOpen, setIsOpen }: TPluginStoreDialogProps) {
     const getAvailablePluginFromKey = availablePlugins?.find((p) => p.pluginKey === pluginKey);
     setSelectedPlugin(getAvailablePluginFromKey);
 
-    if (
-      getAvailablePluginFromKey?.authConfig.length > 0 &&
-      !getAvailablePluginFromKey?.authenticated
-    ) {
+    const { authConfig, authenticated } = getAvailablePluginFromKey ?? {};
+
+    if (authConfig && authConfig.length > 0 && !authenticated) {
       setShowPluginAuthForm(true);
     } else {
       handleInstall({ pluginKey, action: 'install', auth: null });

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -46,7 +46,7 @@ const AuthContextProvider = ({
   authConfig,
   children,
 }: {
-  authConfig: TAuthConfig;
+  authConfig?: TAuthConfig;
   children: ReactNode;
 }) => {
   const [user, setUser] = useState<TUser | undefined>(undefined);

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -7,4 +7,5 @@ export { default as useLocalize } from './useLocalize';
 export { default as useMediaQuery } from './useMediaQuery';
 export { default as useSetOptions } from './useSetOptions';
 export { default as useGenerations } from './useGenerations';
+export { default as useServerStream } from './useServerStream';
 export { default as useMessageHandler } from './useMessageHandler';

--- a/client/src/hooks/useMessageHandler.ts
+++ b/client/src/hooks/useMessageHandler.ts
@@ -1,7 +1,7 @@
 import { v4 } from 'uuid';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { parseConvo, getResponseSender } from 'librechat-data-provider';
-import type { TMessage } from 'librechat-data-provider';
+import type { TMessage, TSubmission } from 'librechat-data-provider';
 import store from '~/store';
 
 type TAskProps = {
@@ -98,7 +98,7 @@ const useMessageHandler = () => {
       error: false,
     };
 
-    const submission = {
+    const submission: TSubmission = {
       conversation: {
         ...currentConversation,
         conversationId,

--- a/client/src/routes/Chat.tsx
+++ b/client/src/routes/Chat.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
-import { useAuthContext } from '~/hooks/AuthContext';
+import { useAuthContext } from '~/hooks';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
-import Landing from '../components/ui/Landing';
-import Messages from '../components/Messages';
-import TextChat from '../components/Input/TextChat';
+import Landing from '~/components/ui/Landing';
+import Messages from '~/components/Messages';
+import TextChat from '~/components/Input/TextChat';
 
 import store from '~/store';
 import {
@@ -27,12 +27,12 @@ export default function Chat() {
   const navigate = useNavigate();
 
   //disabled by default, we only enable it when messagesTree is null
-  const messagesQuery = useGetMessagesByConvoId(conversationId, { enabled: false });
-  const getConversationMutation = useGetConversationByIdMutation(conversationId);
+  const messagesQuery = useGetMessagesByConvoId(conversationId ?? '', { enabled: false });
+  const getConversationMutation = useGetConversationByIdMutation(conversationId ?? '');
   const { data: config } = useGetStartupConfig();
 
   useEffect(() => {
-    let timeout = setTimeout(() => {
+    const timeout = setTimeout(() => {
       if (!isAuthenticated) {
         navigate('/login', { replace: true });
       }
@@ -97,11 +97,12 @@ export default function Chat() {
       }
     }
     document.title = conversation?.title || config?.appTitle || 'Chat';
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversation, conversationId, config]);
 
   useEffect(() => {
     if (messagesTree === null && conversation?.conversationId) {
-      messagesQuery.refetch(conversation?.conversationId);
+      messagesQuery.refetch({ queryKey: [conversation?.conversationId] });
     }
   }, [conversation?.conversationId, messagesQuery, messagesTree]);
 
@@ -113,6 +114,7 @@ export default function Chat() {
       console.error(messagesQuery.error);
       setMessages(null);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messagesQuery.data, messagesQuery.isError, setMessages]);
 
   if (!isAuthenticated) {

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useState } from 'react';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { Outlet } from 'react-router-dom';
 import {
   useGetEndpointsQuery,
@@ -9,8 +9,7 @@ import {
 } from 'librechat-data-provider';
 
 import { Nav, MobileNav } from '~/components/Nav';
-import { useAuthContext } from '~/hooks/AuthContext';
-import MessageHandler from './MessageHandler';
+import { useAuthContext, useServerStream } from '~/hooks';
 import store from '~/store';
 
 export default function Root() {
@@ -18,6 +17,9 @@ export default function Root() {
     const savedNavVisible = localStorage.getItem('navVisible');
     return savedNavVisible !== null ? JSON.parse(savedNavVisible) : false;
   });
+
+  const submission = useRecoilValue(store.submission);
+  useServerStream(submission ?? null);
 
   const setIsSearchEnabled = useSetRecoilState(store.isSearchEnabled);
   const setEndpointsConfig = useSetRecoilState(store.endpointsConfig);
@@ -71,7 +73,6 @@ export default function Root() {
           </div>
         </div>
       </div>
-      <MessageHandler />
     </>
   );
 }

--- a/client/src/routes/Search.tsx
+++ b/client/src/routes/Search.tsx
@@ -2,8 +2,8 @@ import React, { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
-import Messages from '../components/Messages';
-import TextChat from '../components/Input/TextChat';
+import Messages from '~/components/Messages';
+import TextChat from '~/components/Input/TextChat';
 
 import store from '~/store';
 
@@ -34,6 +34,7 @@ export default function Search() {
       // conversationId (in url) should always follow conversation?.conversationId, unless conversation is null
       navigate(`/chat/${conversation?.conversationId}`);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversation, query, searchQuery]);
 
   // if not a search

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -2,9 +2,14 @@ import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
 import Root from './Root';
 import Chat from './Chat';
 import Search from './Search';
-import { Login, Registration, RequestPasswordReset, ResetPassword } from '../components/Auth';
-import { AuthContextProvider } from '../hooks/AuthContext';
-import ApiErrorWatcher from '../components/Auth/ApiErrorWatcher';
+import {
+  Login,
+  Registration,
+  RequestPasswordReset,
+  ResetPassword,
+  ApiErrorWatcher,
+} from '~/components/Auth';
+import { AuthContextProvider } from '~/hooks/AuthContext';
 
 const AuthLayout = () => (
   <AuthContextProvider>

--- a/client/src/store/conversation.ts
+++ b/client/src/store/conversation.ts
@@ -51,7 +51,7 @@ const messagesSiblingIdxFamily = atomFamily({
 const useConversation = () => {
   const setConversation = useSetRecoilState(conversation);
   const setMessages = useSetRecoilState<TMessagesAtom>(messages);
-  const setSubmission = useSetRecoilState<TSubmission | object | null>(submission.submission);
+  const setSubmission = useSetRecoilState<TSubmission | null>(submission.submission);
   const resetLatestMessage = useResetRecoilState(latestMessage);
 
   const _switchToConversation = (
@@ -73,7 +73,7 @@ const useConversation = () => {
 
     setConversation(conversation);
     setMessages(messages);
-    setSubmission({});
+    setSubmission({} as TSubmission);
     resetLatestMessage();
   };
 

--- a/client/src/store/preset.ts
+++ b/client/src/store/preset.ts
@@ -6,7 +6,7 @@ import { TPreset } from 'librechat-data-provider';
 // an array of saved presets.
 // sample structure
 // [preset1, preset2, preset3]
-const presets = atom({
+const presets = atom<TPreset[]>({
   key: 'presets',
   default: [],
 });

--- a/client/src/store/search.ts
+++ b/client/src/store/search.ts
@@ -2,7 +2,7 @@ import { TMessage } from 'librechat-data-provider';
 import { atom, selector } from 'recoil';
 import { buildTree } from '~/utils';
 
-const isSearchEnabled = atom({
+const isSearchEnabled = atom<boolean | null>({
   key: 'isSearchEnabled',
   default: null,
 });

--- a/client/src/store/submission.ts
+++ b/client/src/store/submission.ts
@@ -12,7 +12,7 @@ import { TSubmission } from 'librechat-data-provider';
 //   isRegenerate=false, // isRegenerate?
 // }
 
-const submission = atom<TSubmission | object | null>({
+const submission = atom<TSubmission | null>({
   key: 'submission',
   default: null,
 });

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -12,32 +12,6 @@ export enum EModelEndpoint {
 
 export const eModelEndpointSchema = z.nativeEnum(EModelEndpoint);
 
-export const tMessageSchema = z.object({
-  messageId: z.string(),
-  clientId: z.string().nullable().optional(),
-  conversationId: z.string().nullable(),
-  parentMessageId: z.string().nullable(),
-  sender: z.string(),
-  text: z.string(),
-  isCreatedByUser: z.boolean(),
-  error: z.boolean(),
-  createdAt: z
-    .string()
-    .optional()
-    .default(() => new Date().toISOString()),
-  updatedAt: z
-    .string()
-    .optional()
-    .default(() => new Date().toISOString()),
-  current: z.boolean().optional(),
-  unfinished: z.boolean().optional(),
-  submitting: z.boolean().optional(),
-  searchResult: z.boolean().optional(),
-  finish_reason: z.string().optional(),
-});
-
-export type TMessage = z.input<typeof tMessageSchema>;
-
 export const tPluginAuthConfigSchema = z.object({
   authField: z.string(),
   label: z.string(),
@@ -75,6 +49,36 @@ export const tAgentOptionsSchema = z.object({
   model: z.string(),
   temperature: z.number(),
 });
+
+export const tMessageSchema = z.object({
+  messageId: z.string(),
+  clientId: z.string().nullable().optional(),
+  conversationId: z.string().nullable(),
+  parentMessageId: z.string().nullable(),
+  responseMessageId: z.string().nullable().optional(),
+  overrideParentMessageId: z.string().nullable().optional(),
+  plugin: tPluginSchema.nullable().optional(),
+  sender: z.string(),
+  text: z.string(),
+  generation: z.string().nullable().optional(),
+  isCreatedByUser: z.boolean(),
+  error: z.boolean(),
+  createdAt: z
+    .string()
+    .optional()
+    .default(() => new Date().toISOString()),
+  updatedAt: z
+    .string()
+    .optional()
+    .default(() => new Date().toISOString()),
+  current: z.boolean().optional(),
+  unfinished: z.boolean().optional(),
+  submitting: z.boolean().optional(),
+  searchResult: z.boolean().optional(),
+  finish_reason: z.string().optional(),
+});
+
+export type TMessage = z.input<typeof tMessageSchema>;
 
 export const tConversationSchema = z.object({
   conversationId: z.string().nullable(),

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -1,4 +1,4 @@
-import type { TMessage, EModelEndpoint, TConversation, TEndpointOption } from './schemas';
+import type { TPlugin, TMessage, TConversation, TEndpointOption } from './schemas';
 
 export * from './schemas';
 
@@ -7,32 +7,14 @@ export type TMessages = TMessage[];
 export type TMessagesAtom = TMessages | null;
 
 export type TSubmission = {
-  clientId?: string;
-  context?: string;
-  conversationId?: string;
-  conversationSignature?: string;
-  current: boolean;
-  endpoint: EModelEndpoint | null;
-  invocationId: number;
-  isCreatedByUser: boolean;
-  jailbreak: boolean;
-  jailbreakConversationId?: string;
-  messageId: string;
-  overrideParentMessageId?: string | boolean;
-  parentMessageId?: string;
-  sender: string;
-  systemMessage?: string;
-  text: string;
-  toneStyle?: string;
-  model?: string;
-  promptPrefix?: string;
-  temperature?: number;
-  top_p?: number;
-  presence_penalty?: number;
-  frequence_penalty?: number;
-  isEdited?: boolean;
-  conversation: TConversation;
+  plugin?: TPlugin;
   message: TMessage;
+  isEdited?: boolean;
+  messages: TMessage[];
+  isRegenerate?: boolean;
+  conversationId?: string;
+  initialResponse: TMessage;
+  conversation: TConversation;
   endpointOption: TEndpointOption;
 };
 
@@ -167,7 +149,7 @@ export type TResetPassword = {
 };
 
 export type TStartupConfig = {
-  appTitle: boolean;
+  appTitle: string;
   googleLoginEnabled: boolean;
   openidLoginEnabled: boolean;
   githubLoginEnabled: boolean;


### PR DESCRIPTION
## Summary

refactor(MessageHandler -> useServerStream): convert all relating files to TS and correct typings based on this change: properly refactor MessageHandler to a custom hook (it was being used as a React Functional Component or RFC before), where it's passed a submission object to instantiate the stream. This is the bare minimum groundwork for potentially having multiple streams running, which would be a big project to modularize a lot of the global state into maps/multiple streams, particular useful for having multiple views or AI conversation in view.

Also fixed an issue with the abortMiddleware, to allow it to behave as expected even when aborted too "early" for the server (before the convoId is generated), In this case, the userId will be used as the abortKey. This should help with more reliability to the stop/continue e2e test.

## Change Type

- [x] Refactor/TS conversion
## Testing

Manual tests confirm no breaking changes, PR will determine how automated tests do. 

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
