### PR TITLE
Set UID/GID for docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ APP_TITLE=LibreChat
 HOST=localhost
 PORT=3080
 
+# If you have permission problems, set here the UID and GID of the user running
+# the docker compose command. The applications in the container will run with these uid/gid.
+UID=1000
+GID=1000
+
 # Change this to proxy any API request. 
 # It's useful if your machine has difficulty calling the original API server. 
 # PROXY=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       target: node                             # ^------v
     # image: ghcr.io/danny-avila/librechat:latest # Uncomment this & comment above to build from docker hub image
     restart: always
+    user: "${UID}:${GID}"
     extra_hosts: # if you are running APIs on docker you need access to, you will need to uncomment this line and next
     - "host.docker.internal:host-gateway"
     env_file:
@@ -50,6 +51,7 @@ services:
     #   - 27018:27017
     image: mongo
     restart: always
+    user: "${UID}:${GID}"
     volumes:
       - ./data-node:/data/db
     command: mongod --noauth
@@ -61,6 +63,7 @@ services:
     #   - 7700:7700 # if exposing these ports, make sure your master key is not the default value
     env_file:
       - .env
+    user: "${UID}:${GID}"
     environment:
       - MEILI_HOST=http://meilisearch:7700
       - MEILI_HTTP_ADDR=meilisearch:7700

--- a/docs/install/docker_install.md
+++ b/docs/install/docker_install.md
@@ -32,6 +32,11 @@ How to set up the user/auth system and Google login.
 ### Running LibreChat
 Once you have completed all the setup, you can start the LibreChat application by running the command `docker-compose up` in your terminal. After running this command, you can access the LibreChat application at `http://localhost:3080`.
 
+If you build your own containers out of the git checkout with `docker up -d --build` you should pre-create the mount points for the volumes. This avoids occasional trouble with directory permissions when rebuilding:
+```
+mkdir meili_data images .env.production .env.development data-node
+```
+
 **Note:** MongoDB does not support older ARM CPUs like those found in Raspberry Pis. However, you can make it work by setting MongoDB’s version to mongo:4.4.18 in docker-compose.yml, the most recent version compatible with
 
 That's it! If you need more detailed information on configuring your compose file, see my notes below.

--- a/docs/install/docker_install.md
+++ b/docs/install/docker_install.md
@@ -1,6 +1,6 @@
-# Docker Installation Guide
+# Docker Compose Installation Guide
 
-Docker installation is recommended for most use cases. It's the easiest, simplest, and most reliable method to get started.
+Docker Compose installation is recommended for most use cases. It's the easiest, simplest, and most reliable method to get started.
 
 See the video guide for [Windows](windows_install.md#recommended) or [Ubuntu 22.04 LTS](linux_install.md#recommended)
 ## Installation and Configuration
@@ -116,4 +116,4 @@ That's it! If you need more detailed information on configuring your compose fil
 
 ---
 
-### Note: If you're still having trouble, before creating a new issue, please search for similar ones on our [#issues thread on our discord](https://discord.gg/weqZFtD9C4) or our [troubleshooting discussion](https://github.com/danny-avila/LibreChat/discussions/categories/troubleshooting) on our Discussions page. If you don't find a relevant issue, feel free to create a new one and provide as much detail as possible.
+>⚠️ Note: If you're having trouble, before creating a new issue, please search for similar ones on our [#issues thread on our discord](https://discord.gg/weqZFtD9C4) or our [troubleshooting discussion](https://github.com/danny-avila/LibreChat/discussions/categories/troubleshooting) on our Discussions page. If you don't find a relevant issue, feel free to create a new one and provide as much detail as possible.


### PR DESCRIPTION
## Summary

Solves issue "Wrong permissions with docker-compose". When installing locally under Linux with 
`docker-compose up -d --build` normally the mount targets for some volumes are not defined: They are created under root
ownership. Files inside these volumes are created with ownership of the UID/GID that the daemons inside the corresponding
container run under. Some as "root", others as 999:0. The patch enforces a certain UID/GID that should be configured in .env
and set to the user's UID/GID. This way daemons run with proper IDs and create files belonging to the user. The directories
need to be created before the first `docker-compose build`, this advice has been noted in docker-compose.md .

## Change Type

Please delete any irrelevant options.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ x] Documentation update 

## Testing

1. git clone repository
2. edit .env and set proper UID/GID
3. create the directories `mkdir meili_data images .env.production .env.development data-node`
4. `docker-compose up -d --build`
5. `docker-compose down`
6. `docker-compose up -d --build`

If step 6 finishes without an error related to permission/ownership of the file `meili_data/data.ms/auth/data.mdb`,
all works well.

### **Test Configuration**:

Tested under Ubuntu 22.04, docker.io 20.10.25-0ubuntu1~22.04.1

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
