### PR TITLE
minor fixes: chatGPTBrowser markdown, fix cursor in previous message, isEdited edge case, unnecessary console logs

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -412,8 +412,21 @@ class BaseClient {
     // depending on subclass implementation of handling messages
     // When this is an edit, all messages are already in currentMessages, both user and response
     if (isEdited) {
-      /* TODO: edge case where latest message doesn't exist */
-      this.currentMessages[this.currentMessages.length - 1].text = generation;
+      let latestMessage = this.currentMessages[this.currentMessages.length - 1];
+      if (!latestMessage) {
+        latestMessage = {
+          messageId: responseMessageId,
+          conversationId,
+          parentMessageId: userMessage.messageId,
+          isCreatedByUser: false,
+          model: this.modelOptions.model,
+          sender: this.sender,
+          text: generation,
+        };
+        this.currentMessages.push(userMessage, latestMessage);
+      } else {
+        latestMessage.text = generation;
+      }
     } else {
       this.currentMessages.push(userMessage);
     }

--- a/api/server/routes/ask/askChatGPTBrowser.js
+++ b/api/server/routes/ask/askChatGPTBrowser.js
@@ -103,6 +103,7 @@ const ask = async ({
             unfinished: true,
             cancelled: false,
             error: false,
+            isCreatedByUser: false,
           });
         }
       },
@@ -110,6 +111,7 @@ const ask = async ({
 
     getPartialMessage = getPartialText;
     const abortController = new AbortController();
+    let i = 0;
     let response = await browserClient({
       text,
       parentMessageId: userParentMessageId,
@@ -128,8 +130,12 @@ const ask = async ({
 
         sendMessage(res, {
           message: { ...userMessage, conversationId: data.conversation_id },
-          created: true,
+          created: i === 0,
         });
+
+        if (i === 0) {
+          i++;
+        }
       },
     });
 
@@ -152,6 +158,7 @@ const ask = async ({
       unfinished: false,
       cancelled: false,
       error: false,
+      isCreatedByUser: false,
     };
 
     await saveMessage(responseMessage);
@@ -220,7 +227,8 @@ const ask = async ({
       parentMessageId: overrideParentMessageId || userMessageId,
       unfinished: false,
       cancelled: false,
-      // error: true,
+      error: true,
+      isCreatedByUser: false,
       text: `${getPartialMessage() ?? ''}\n\nError message: "${error.message}"`,
     };
     await saveMessage(errorMessage);

--- a/client/src/hooks/useMessageHandler.ts
+++ b/client/src/hooks/useMessageHandler.ts
@@ -6,7 +6,7 @@ import type { TAskFunction } from '~/common';
 import store from '~/store';
 
 const useMessageHandler = () => {
-  const latestMessage = useRecoilValue(store.latestMessage);
+  const [latestMessage, setLatestMessage] = useRecoilState(store.latestMessage);
   const setSiblingIdx = useSetRecoilState(
     store.messagesSiblingIdxFamily(latestMessage?.parentMessageId),
   );
@@ -134,6 +134,7 @@ const useMessageHandler = () => {
     } else {
       setMessages([...submission.messages, currentMsg, initialResponse]);
     }
+    setLatestMessage(initialResponse);
     setSubmission(submission);
   };
 


### PR DESCRIPTION
## Summary

- fix(chatGPTBrowser): render markdown formatting by setting isCreatedByUser
- Also fixed issue where chatGPTBrowser messages would unnecessarily trigger multiple console logs in the browser 
- fix: isEdited edge case where latest Message is not saved due to aborting too quickly
- fix(useMessageHandler): avoid double appearance of cursor by setting latest message at initial response creation time

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual testing and all e2e tests should pass

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.

