### PR TITLE
docs: fix docker install guide broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Keep up with the latest updates by visiting the releases page - [Releases](https
   <summary><strong>Getting Started</strong></summary>
 
   * Installation
-    * [Docker Install🐳](docs/install/docker_install.md)
+    * [Docker Compose Install🐳](docs/install/docker_compose_install.md)
     * [Linux Install🐧](docs/install/linux_install.md)
     * [Mac Install🍎](docs/install/mac_install.md)
     * [Windows Install💙](docs/install/windows_install.md)


### PR DESCRIPTION
## Change Type

- [x] Documentation update 

Fixes a broken link in the readme for the Docker Install🐳 guide.