### PR TITLE
docs: fix various broken docker_compose_install.md links in docs

### DIFF
--- a/docs/deployment/hetzner_ubuntu.md
+++ b/docs/deployment/hetzner_ubuntu.md
@@ -4,9 +4,9 @@
 
 ## Starting from Zero:
 
-### 1. Login to Hetzner Cloud Console (https://console.hetzner.cloud/projects) and Create a new Ubuntu 20 Project with 4GB Ram. Do not worry about SSH keys *yet*. 
+### 1. Login to Hetzner Cloud Console (https://console.hetzner.cloud/projects) and Create a new Ubuntu 20 Project with 4GB Ram. Do not worry about SSH keys *yet*.
 
-Hetzner will email you the root password. 
+Hetzner will email you the root password.
 
 ### 2. Once you have that, you can login with any SSH terminal with:
 
@@ -79,7 +79,7 @@ sudo reboot
 
 ## Using Docker to Install the Service
 
-### 1. **Recommended: [Docker Install](../install/docker_install.md)**
+### 1. **Recommended: [Docker Install](../install/docker_compose_install.md)**
 From the *server* commandline (as your user, not root):
 
 ```
@@ -95,7 +95,7 @@ nano docker-compose.yml
 ```
        VITE_APP_TITLE: LibreChat # default, change to your desired app >
        VITE_SHOW_GOOGLE_LOGIN_OPTION: 'false'  # default, change to true if you want to show google login
-```       
+```
 
 ### 2. Create a global environment file and open it up to begin adding the tokens/keys you prepared in the PreReqs section.
 ```
@@ -106,9 +106,9 @@ nano .env
 ### 3. In addition to adding all your api tokens and other tokens that you prepared above, change:
 
 ```
-HOST=Localhost 
+HOST=Localhost
 ```
-to 
+to
 ```
 HOST=<yourserverip>
 ```
@@ -130,9 +130,9 @@ MEILI_HTTP_ADDR=meilisearch
 
 It is safe to close the terminal -- the docker app will continue to run.
 
-*To disable external signups, after you have created your admin account, make sure you set 
+*To disable external signups, after you have created your admin account, make sure you set
 ```
-ALLOW_REGISTRATION:False 
+ALLOW_REGISTRATION:False
 ```
 
 ---

--- a/docs/deployment/linode.md
+++ b/docs/deployment/linode.md
@@ -1,6 +1,6 @@
 <img src="https://github.com/danny-avila/LibreChat/assets/32828263/d6e430db-518a-4779-83d3-a2d177907df1" width="250">
 
-# Linode 
+# Linode
 
 ⚠️**Note: Payment is required**
 
@@ -16,19 +16,19 @@
 ## Install Docker:
 - Connect to your Linode server via SSH using a terminal or SSH client.
 - Run the following commands to install Docker and Docker-compose:
-  
+
   ```
   sudo apt update
   sudo apt install docker.io && apt install docker-compose
   ```
-## [Install LibreChat](../install/docker_install.md)
+## [Install LibreChat](../install/docker_compose_install.md)
 
 ## Install and Setup NGINX Proxy Manager:
 
 if you want, you can use NGINX, Apache, or any other proxy manager.
 
-- create a folder 
-  
+- create a folder
+
   ```
   mkdir ngnix-proxy-manager
   cd ngnix-proxy-manager
@@ -54,9 +54,9 @@ if you want, you can use NGINX, Apache, or any other proxy manager.
   ```
 
 ### Start NGINX Proxy Manager
- 
+
  - By executing: `docker-compose up -d`
-  
+
 ### Login to NGINX Proxy Manager
   - **Important: You need to update the default credentials**
 
@@ -71,12 +71,12 @@ Password: changeme
 
 ### Login to NGINX Proxy Manager.
   - Click on "Proxy Host" and add a proxy host.
-    
+
 ![linode-1](https://github.com/danny-avila/LibreChat/assets/32828263/798014ce-6e71-4e1f-9637-3f5f2a7fe402)
 
 
 - If you want, you can add the `Let's Encrypt SSL` certificate.
-  
+
 ![linode-2](https://github.com/danny-avila/LibreChat/assets/32828263/5bd03be9-1e72-4801-8694-db2c540a2833)
 
 

--- a/docs/general_info/breaking_changes.md
+++ b/docs/general_info/breaking_changes.md
@@ -29,15 +29,15 @@ Some users have reported an error after updating their docker containers.
 
 - To fix this error, you need to:
   - Delete the LibreChat image in docker 🗑️
-    
-    **(leave mongo intact to preserve your profiles and history)** 
+
+    **(leave mongo intact to preserve your profiles and history)**
     ![image](https://github.com/fuegovic/LibreChat/assets/32828263/acf15682-435e-44bd-8873-a5dceb3121cc)
   - Repeat the docker update process: 🚀
     - `docker-compose build`
     - `docker-compose up -d`
 
 ## v0.5.4
-Some changes were made in the .env file  
+Some changes were made in the .env file
 **Look at the .env.example for reference.**
 
 - If you previously used social login, you need to:
@@ -62,7 +62,7 @@ ALLOW_SOCIAL_LOGIN=false
 
 ```env
 ##########################
-# Anthropic Endpoint: 
+# Anthropic Endpoint:
 ##########################
 # Access key from https://console.anthropic.com/
 # Leave it blank to disable this feature.
@@ -107,7 +107,7 @@ I had to change the environment variable from AZURE_OPENAI_API_KEY to AZURE_API_
 ---
 
 ### Docker
-- The docker-compose file had some change. Review the [new docker instructions](../install/docker_install.md) to make sure you are setup properly. This is still the simplest and most effective method.
+- The docker-compose file had some change. Review the [new docker instructions](../install/docker_compose_install.md) to make sure you are setup properly. This is still the simplest and most effective method.
 
 ---
 

--- a/docs/install/linux_install.md
+++ b/docs/install/linux_install.md
@@ -12,7 +12,7 @@ In this video, you will learn how to install and run LibreChat, using Docker on 
 - 0:00 - Intro
 - 0:14 - Update the system
 - 0:29 - Clone the repository
-- 0:37 - Docker installation 
+- 0:37 - Docker installation
 - 1:03 - Enter in the folder
 - 1:07 - Create the .env file
 - 1:14 - Build using docker-compose
@@ -30,13 +30,13 @@ Here are the steps to follow:
 - Build the Docker image: `docker-compose build`
 - Start LibreChat: `docker-compose up -d`
 
-Note: If you run the command on the same computer and want to access it, navigate to `localhost:3080`. You should see a login page where you can create or sign in to your account. Then you can choose an AI model and start chatting. 
+Note: If you run the command on the same computer and want to access it, navigate to `localhost:3080`. You should see a login page where you can create or sign in to your account. Then you can choose an AI model and start chatting.
 
 Have fun!
 
 ---
-## **[Docker Install](docker_install.md)** (General documentation)
---- 
+## **[Docker Install](docker_compose_install.md)** (General documentation)
+---
 
 ## **Manual Installation:**
 

--- a/docs/install/mac_install.md
+++ b/docs/install/mac_install.md
@@ -1,5 +1,5 @@
 # Mac Installation Guide
-## **Recommended : [Docker Install](docker_install.md)**
+## **Recommended : [Docker Install](docker_compose_install.md)**
 
 ---
 
@@ -16,7 +16,7 @@
   - Change into the cloned directory by running cd LibreChat
   - If using MongoDB Atlas, remove &w=majority from the default connection string
 Follow the instructions for setting up proxies, access tokens, and user system:
-  
+
 ## [Create a MongoDB database](mongodb.md) (Required)
 
 ## [Get Your API keys and Tokens](apis_and_tokens.md) (Required)
@@ -74,13 +74,13 @@ fi
 npm run backend
 ```
 
-### **Make the script executable by running** 
+### **Make the script executable by running**
 
 ```
   chmod +x start_chatgpt.sh
 ```
 
-### **Start LibreChat by running** 
+### **Start LibreChat by running**
 ```
   ./start_chatgpt.sh
 ```


### PR DESCRIPTION
## Summary

This PR fixes various broken `docker_install.md` links in the docs (these links should be pointing to a `docker_compose_install.md` , but instead, point to non-existent `docker_install.md` file).

## Change Type

- [x] Documentation update 

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
