### PR TITLE
refactor: Add question rate limiting middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ LOGIN_WINDOW=5 # in minutes, determines how long an IP is banned for after LOGIN
 REGISTER_MAX=5 # The max amount of registrations allowed per IP per REGISTER_WINDOW
 REGISTER_WINDOW=60 # in minutes, determines how long an IP is banned for after REGISTER_MAX registrations
 
+# Question rate limiting.
+QUESTION_MAX=350 # The max amount of questions allowed per IP per QUESTION_WINDOW
+QUESTION_WINDOW=60 # in minutes, determines how long an IP is banned for after QUESTION_MAX questions
+
 # Change this to proxy any API request. 
 # It's useful if your machine has difficulty calling the original API server. 
 # PROXY=

--- a/api/server/middleware/index.js
+++ b/api/server/middleware/index.js
@@ -3,6 +3,7 @@ const setHeaders = require('./setHeaders');
 const loginLimiter = require('./loginLimiter');
 const requireJwtAuth = require('./requireJwtAuth');
 const registerLimiter = require('./registerLimiter');
+const questionLimiter = require('./questionLimiter');
 const requireLocalAuth = require('./requireLocalAuth');
 const validateEndpoint = require('./validateEndpoint');
 const validateMessageReq = require('./validateMessageReq');
@@ -15,6 +16,7 @@ module.exports = {
   loginLimiter,
   requireJwtAuth,
   registerLimiter,
+  questionLimiter,
   requireLocalAuth,
   validateEndpoint,
   validateMessageReq,

--- a/api/server/middleware/questionLimiter.js
+++ b/api/server/middleware/questionLimiter.js
@@ -1,0 +1,57 @@
+const rateLimit = require('express-rate-limit');
+const crypto = require('crypto');
+const { getResponseSender } = require('../routes/endpoints/schemas');
+const { saveMessage } = require('../../models');
+const { handleError } = require('../utils');
+const buildEndpointOption = require('./buildEndpointOption');
+
+const windowMs = (process.env?.QUESTION_WINDOW ?? 60) * 60 * 1000; // default: 60 minutes
+const max = process.env?.QUESTION_MAX ?? 350; // default: limit each IP to 350 requests per windowMs
+const windowInMinutes = windowMs / 60000;
+
+/**
+ * Respond with an error message and save it.
+ */
+const respondWithError = async (sender, conversationId, parentMessageId, error, res) => {
+  const errorMessage = {
+    sender,
+    messageId: crypto.randomUUID(),
+    conversationId,
+    parentMessageId,
+    unfinished: false,
+    cancelled: false,
+    error: true,
+    final: true,
+    text: error.message,
+    isCreatedByUser: false,
+  };
+
+  await saveMessage(errorMessage);
+  handleError(res, errorMessage);
+};
+
+/**
+ * Rate limit handler for excessive requests.
+ */
+function handler(req, res) {
+  buildEndpointOption(req, res, () => {});
+
+  const { endpointOption, conversationId, parentMessageId = null } = req.body;
+  const errorText = `You've asked too many questions in a short time. Please wait for ${windowInMinutes} minutes before asking another question.`;
+
+  return respondWithError(
+    getResponseSender(endpointOption),
+    conversationId,
+    parentMessageId,
+    new Error(errorText),
+    res,
+  );
+}
+
+const questionLimiter = rateLimit({
+  windowMs,
+  max,
+  handler,
+});
+
+module.exports = questionLimiter;

--- a/api/server/middleware/questionLimiter.js
+++ b/api/server/middleware/questionLimiter.js
@@ -12,7 +12,7 @@ const windowInMinutes = windowMs / 60000;
 /**
  * Respond with an error message and save it.
  */
-const respondWithError = async (sender, conversationId, parentMessageId, error, res) => {
+const respondWithError = async (sender, conversationId, parentMessageId, res) => {
   const errorMessage = {
     sender,
     messageId: crypto.randomUUID(),
@@ -22,7 +22,10 @@ const respondWithError = async (sender, conversationId, parentMessageId, error, 
     cancelled: false,
     error: true,
     final: true,
-    text: error.message,
+    text: JSON.stringify({
+      type: 'too_many_requests',
+      windowInMinutes,
+    }),
     isCreatedByUser: false,
   };
 
@@ -37,15 +40,9 @@ function handler(req, res) {
   buildEndpointOption(req, res, () => {});
 
   const { endpointOption, conversationId, parentMessageId = null } = req.body;
-  const errorText = `You've asked too many questions in a short time. Please wait for ${windowInMinutes} minutes before asking another question.`;
+  console.log(conversationId, parentMessageId);
 
-  return respondWithError(
-    getResponseSender(endpointOption),
-    conversationId,
-    parentMessageId,
-    new Error(errorText),
-    res,
-  );
+  return respondWithError(getResponseSender(endpointOption), conversationId, parentMessageId, res);
 }
 
 const questionLimiter = rateLimit({

--- a/api/server/routes/ask/index.js
+++ b/api/server/routes/ask/index.js
@@ -6,12 +6,13 @@ const bingAI = require('./bingAI');
 const gptPlugins = require('./gptPlugins');
 const askChatGPTBrowser = require('./askChatGPTBrowser');
 const anthropic = require('./anthropic');
+const { questionLimiter } = require('../../middleware');
 
-router.use(['/azureOpenAI', '/openAI'], openAI);
-router.use('/google', google);
-router.use('/bingAI', bingAI);
-router.use('/chatGPTBrowser', askChatGPTBrowser);
-router.use('/gptPlugins', gptPlugins);
-router.use('/anthropic', anthropic);
+router.use(['/azureOpenAI', '/openAI'], questionLimiter, openAI);
+router.use('/google', questionLimiter, google);
+router.use('/bingAI', questionLimiter, bingAI);
+router.use('/chatGPTBrowser', questionLimiter, askChatGPTBrowser);
+router.use('/gptPlugins', questionLimiter, gptPlugins);
+router.use('/anthropic', questionLimiter, anthropic);
 
 module.exports = router;

--- a/client/src/utils/getError.ts
+++ b/client/src/utils/getError.ts
@@ -17,6 +17,8 @@ const getError = (text: string) => {
       return 'Invalid API key. Please check your API key and try again. You can do this by clicking on the model logo in the left corner of the textbox and selecting "Set Token" for the current selected endpoint. Thank you for your understanding.';
     } else if (json.type === 'insufficient_quota') {
       return 'We apologize for any inconvenience caused. The default API key has reached its limit. To continue using this service, please set up your own API key. You can do this by clicking on the model logo in the left corner of the textbox and selecting "Set Token" for the current selected endpoint. Thank you for your understanding.';
+    } else if (json.type === 'too_many_requests') {
+      return `You've asked too many questions in a short time. Please wait for ${json.windowInMinutes} minutes before asking another question.`;
     } else {
       return `Something went wrong. Here's the specific error message we encountered: ${errorMessage}`;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26774,7 +26774,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "ISC",
       "dependencies": {
         "@tanstack/react-query": "^4.28.0",


### PR DESCRIPTION
This commit adds question rate limiting middleware to limit the number of questions allowed per IP within a certain time window. The max amount of questions allowed per IP is set to 350 within a 60-minute window. The middleware is implemented as `questionLimiter` and is added to the `/azureOpenAI`, `/openAI`, `/google`, `/bingAI`, `/chatGPTBrowser`, `/gptPlugins`, and `/anthropic` routes in the `ask` module.
