### PR TITLE
fix(vite): hide source map from client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "data-provider": "cd .. && npm run build:data-provider",
     "build": "cross-env NODE_ENV=production dotenv -e ../.env -- vite build",
-    "build:ci": "cross-env NODE_ENV=dev vite build --mode ci",
-    "dev": "cross-env NODE_ENV=dev dotenv -e ../.env -- vite",
-    "preview-prod": "cross-env NODE_ENV=dev dotenv -e ../.env -- vite preview",
+    "build:ci": "cross-env NODE_ENV=development vite build --mode ci",
+    "dev": "cross-env NODE_ENV=development dotenv -e ../.env -- vite",
+    "preview-prod": "cross-env NODE_ENV=development dotenv -e ../.env -- vite preview",
     "test": "cross-env NODE_ENV=test jest --watch",
     "test:ci": "cross-env NODE_ENV=test jest --ci"
   },

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   plugins: [react(), sourcemapExclude({ excludeNodeModules: true })],
   publicDir: './public',
   build: {
-    sourcemap: true,
+    sourcemap: process.env.NODE_ENV === 'development',
     outDir: './dist',
     rollupOptions: {
       // external: ['uuid'],


### PR DESCRIPTION
By user request, thanks @walber on discord for highlighting this

### Before
![image](https://github.com/danny-avila/LibreChat/assets/110412045/8189bfbe-5cf5-4339-bec9-7d0f44338da7)

### After
![image](https://github.com/danny-avila/LibreChat/assets/110412045/3ab04648-b3be-4097-9f5a-5f444bf1bf01)

After some research, I can see that Vite was configured to build the source map along with bundling, which is what "shows" the non-minified code on the frontend.

The source map is useful for dev but it's not a big deal because all of this code is client-side, and is completely open source on github, but definitely not best practice to show it.

