### PR TITLE
fix(Anthropic): Correct Payload & Increase Default Token Size 🔧

### DIFF
--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -268,13 +268,14 @@ class AnthropicClient extends BaseClient {
     };
 
     let text = '';
+    const { model, stream, maxOutputTokens, ...rest } = this.modelOptions;
     const requestOptions = {
       prompt: payload,
-      model: this.modelOptions.model,
-      stream: this.modelOptions.stream || true,
-      max_tokens_to_sample: this.modelOptions.maxOutputTokens || 1500,
+      model,
+      stream: stream || true,
+      max_tokens_to_sample: maxOutputTokens || 1500,
       metadata,
-      ...modelOptions,
+      ...rest,
     };
     if (this.options.debug) {
       console.log('AnthropicClient: requestOptions');

--- a/api/server/routes/ask/anthropic.js
+++ b/api/server/routes/ask/anthropic.js
@@ -91,7 +91,7 @@ router.post(
 
       let response = await client.sendMessage(text, {
         getIds,
-        debug: false,
+        debug: true,
         user: req.user.id,
         conversationId,
         parentMessageId,

--- a/api/server/routes/ask/anthropic.js
+++ b/api/server/routes/ask/anthropic.js
@@ -91,7 +91,7 @@ router.post(
 
       let response = await client.sendMessage(text, {
         getIds,
-        debug: true,
+        // debug: true,
         user: req.user.id,
         conversationId,
         parentMessageId,

--- a/api/server/routes/endpoints/schemas.js
+++ b/api/server/routes/endpoints/schemas.js
@@ -191,7 +191,7 @@ const anthropicSchema = tConversationSchema
     modelLabel: obj.modelLabel ?? null,
     promptPrefix: obj.promptPrefix ?? null,
     temperature: obj.temperature ?? 1,
-    maxOutputTokens: obj.maxOutputTokens ?? 1024,
+    maxOutputTokens: obj.maxOutputTokens ?? 4000,
     topP: obj.topP ?? 0.7,
     topK: obj.topK ?? 5,
   }))
@@ -200,7 +200,7 @@ const anthropicSchema = tConversationSchema
     modelLabel: null,
     promptPrefix: null,
     temperature: 1,
-    maxOutputTokens: 1024,
+    maxOutputTokens: 4000,
     topP: 0.7,
     topK: 5,
   }));

--- a/client/src/components/Endpoints/Settings/Anthropic.tsx
+++ b/client/src/components/Endpoints/Settings/Anthropic.tsx
@@ -203,14 +203,14 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             <div className="flex justify-between">
               {localize('com_endpoint_max_output_tokens')}{' '}
               <small className="opacity-40">
-                ({localize('com_endpoint_default_with_num', '1024')})
+                ({localize('com_endpoint_default_with_num', '4000')})
               </small>
               <InputNumber
                 id="max-tokens-int"
                 disabled={readonly}
                 value={maxOutputTokens}
                 onChange={(value) => setMaxOutputTokens(Number(value))}
-                max={1024}
+                max={4000}
                 min={1}
                 step={1}
                 controls={false}
@@ -225,10 +225,10 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             </div>
             <Slider
               disabled={readonly}
-              value={[maxOutputTokens ?? 1024]}
+              value={[maxOutputTokens ?? 4000]}
               onValueChange={(value) => setMaxOutputTokens(value[0])}
               doubleClickHandler={() => setMaxOutputTokens(0)}
-              max={1024}
+              max={4000}
               min={1}
               step={1}
               className="flex h-4 w-full"

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -267,7 +267,7 @@ export const anthropicSchema = tConversationSchema
     modelLabel: obj.modelLabel ?? null,
     promptPrefix: obj.promptPrefix ?? null,
     temperature: obj.temperature ?? 1,
-    maxOutputTokens: obj.maxOutputTokens ?? 1024,
+    maxOutputTokens: obj.maxOutputTokens ?? 4000,
     topP: obj.topP ?? 0.7,
     topK: obj.topK ?? 5,
   }))
@@ -276,7 +276,7 @@ export const anthropicSchema = tConversationSchema
     modelLabel: null,
     promptPrefix: null,
     temperature: 1,
-    maxOutputTokens: 1024,
+    maxOutputTokens: 4000,
     topP: 0.7,
     topK: 5,
   }));


### PR DESCRIPTION
Closes #932

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Only the following fields are sent in the payload to anthropic servers. Also tested 4000 max_tokens_to_sample setting, and was non-breaking (though the max may be lower as can't confirm)

```
{
  prompt: 'text',
  model: 'claude-instant-1-100k',
  stream: true,
  max_tokens_to_sample: 4000,
  metadata: { user_id: '64fd734a81cf513500537e72' },
  temperature: 1,
  topP: 0.7,
  topK: 5,
  stop: [ '||>', '\n\nHuman:', '<|diff_marker|>' ]
}
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
