### PR TITLE
fix(Anthropic): only include fields defined by API reference in payload

### DIFF
--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -268,14 +268,25 @@ class AnthropicClient extends BaseClient {
     };
 
     let text = '';
-    const { model, stream, maxOutputTokens, ...rest } = this.modelOptions;
+    const {
+      stream,
+      model,
+      temperature,
+      maxOutputTokens,
+      stop: stop_sequences,
+      topP: top_p,
+      topK: top_k,
+    } = this.modelOptions;
     const requestOptions = {
       prompt: payload,
       model,
       stream: stream || true,
       max_tokens_to_sample: maxOutputTokens || 1500,
+      stop_sequences,
+      temperature,
       metadata,
-      ...rest,
+      top_p,
+      top_k,
     };
     if (this.options.debug) {
       console.log('AnthropicClient: requestOptions');


### PR DESCRIPTION
hopefully closes #932 as only the fields defined here are being passed: https://docs.anthropic.com/claude/reference/complete_post