### PR TITLE
Fix setOptions() to properly handle modelOptions

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -59,6 +59,12 @@ class OpenAIClient extends BaseClient {
           typeof modelOptions.presence_penalty === 'undefined' ? 1 : modelOptions.presence_penalty,
         stop: modelOptions.stop,
       };
+    } else {
+      // Update the modelOptions if it already exists
+      this.modelOptions = {
+        ...this.modelOptions,
+        ...modelOptions,
+      };
     }
 
     if (process.env.OPENROUTER_API_KEY) {


### PR DESCRIPTION
## Summary

For #974

In brief, the issue is that, at least when using the openai client, the model used for titling the chats cannot differ from the model used for the chat itself due to the way setOptions() is coded.

- Adds an else to the check for this.modelOptions
- Allows the modelOptions to be updated when the model is already initialized

## Change Type

Please delete any irrelevant options.

- [ x] Bug fix (non-breaking change which fixes an issue)

## Testing

The testing is purely manual. I ran several chats with and without the change and confirmed that the change I have implemented allows the chat to be titled by `gpt-3.5-turbo` even when a different chat model is used. I have also tested the case where the initial prompt is too large for `gpt-3.5-turbo` and this simply leaves the chat without a title, as the error is caught.

### **Test Configuration**:

## Checklist

- [x ] My code adheres to this project's style guidelines
- [ x] I have performed a self-review of my own code
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes

---

Apologies that I haven't done more testing. The [docs](https://github.com/danny-avila/LibreChat/blob/8580f1c3d35ac0237292e58c4e06c911b55c30fa/docs/contributions/testing.md) regarding testing appear out of date (the `docker-compose.yml` doesn't match that described in `testing.md` and there is no reference to `node-api` elsewhere in the codebase). This isn't my area of expertise, unfortunately, so I can't commit to sorting it out for now.
