### PR TITLE
feat: Add Option to Disable Titling, Config Titling Model, and Title Prompt Improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,16 @@ OPENAI_API_KEY=user_provided
 # Leave it blank to use internal settings. 
 # OPENAI_MODELS=gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,text-davinci-003,gpt-4,gpt-4-0314,gpt-4-0613
 
+# Titling is enabled by default when initiating a conversation.
+# Uncomment the following variable to disable this feature.
+# TITLE_CONVO=false
+
+# The model used for titling by default is gpt-3.5-turbo-0613 to assure it works with the default method.
+# gpt-3.5-turbo should also work when using the official API (and not a reverse proxy).
+# You can change the model used by uncommenting the following and setting it to the model you want
+# Must be compatible with the OpenAI Endpoint.
+# OPENAI_TITLE_MODEL=gpt-3.5-turbo
+
 # Reverse proxy settings for OpenAI: 
 # https://github.com/waylaidwanderer/node-chatgpt-api#using-a-reverse-proxy 
 # OPENAI_REVERSE_PROXY=

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -2,6 +2,7 @@ const BaseClient = require('./BaseClient');
 const ChatGPTClient = require('./ChatGPTClient');
 const { encoding_for_model: encodingForModel, get_encoding: getEncoding } = require('tiktoken');
 const { maxTokensMap, genAzureChatCompletion } = require('../../utils');
+const { truncateText } = require('./prompts');
 const { runTitleChain } = require('./chains');
 const { createLLM } = require('./llm');
 
@@ -406,12 +407,14 @@ class OpenAIClient extends BaseClient {
   async titleConvo({ text, responseText = '' }) {
     let title = 'New Chat';
     const convo = `||>User:
-"${text}"
+"${truncateText(text)}"
 ||>Response:
-"${JSON.stringify(responseText)}"`;
+"${JSON.stringify(truncateText(responseText))}"`;
+
+    const { OPENAI_TITLE_MODEL } = process.env ?? {};
 
     const modelOptions = {
-      model: 'gpt-3.5-turbo-0613',
+      model: OPENAI_TITLE_MODEL ?? 'gpt-3.5-turbo-0613',
       temperature: 0.2,
       presence_penalty: 0,
       frequency_penalty: 0,
@@ -446,7 +449,7 @@ class OpenAIClient extends BaseClient {
     } catch (e) {
       console.error(e.message);
       console.log('There was an issue generating title with LangChain, trying the old method...');
-      modelOptions.model = 'gpt-3.5-turbo';
+      modelOptions.model = OPENAI_TITLE_MODEL ?? 'gpt-3.5-turbo';
       const instructionsPayload = [
         {
           role: 'system',

--- a/api/app/clients/chains/runTitleChain.js
+++ b/api/app/clients/chains/runTitleChain.js
@@ -15,7 +15,7 @@ const createLanguageChain = ({ llm }) =>
   });
 
 const titleSchema = z.object({
-  title: z.string().describe('The title-cased title of the conversation in the given language.'),
+  title: z.string().describe('The conversation title in title-case, in the given language.'),
 });
 const createTitleChain = ({ llm, convo }) => {
   const titlePrompt = createTitlePrompt({ convo });

--- a/api/app/clients/prompts/index.js
+++ b/api/app/clients/prompts/index.js
@@ -1,9 +1,11 @@
 const instructions = require('./instructions');
 const titlePrompts = require('./titlePrompts');
 const refinePrompts = require('./refinePrompts');
+const truncateText = require('./truncateText');
 
 module.exports = {
   ...refinePrompts,
   ...instructions,
   ...titlePrompts,
+  truncateText,
 };

--- a/api/app/clients/prompts/titlePrompts.js
+++ b/api/app/clients/prompts/titlePrompts.js
@@ -16,7 +16,7 @@ const createTitlePrompt = ({ convo }) => {
   const titlePrompt = new ChatPromptTemplate({
     promptMessages: [
       SystemMessagePromptTemplate.fromTemplate(
-        `Write a concise title for this conversation in the given language. Title in 5 Words or Less. No Punctuation or Quotation. All first letters of every word must be capitalized (resembling title-case), written in the given Language.
+        `Write a concise title for this conversation in the given language. Title in 5 Words or Less. No Punctuation or Quotation. Must be in Title Case, written in the given Language.
 ${convo}`,
       ),
       HumanMessagePromptTemplate.fromTemplate('Language: {language}'),

--- a/api/app/clients/prompts/truncateText.js
+++ b/api/app/clients/prompts/truncateText.js
@@ -1,0 +1,10 @@
+const MAX_CHAR = 255;
+
+function truncateText(text) {
+  if (text.length > MAX_CHAR) {
+    return `${text.slice(0, MAX_CHAR)}... [text truncated for brevity]`;
+  }
+  return text;
+}
+
+module.exports = truncateText;

--- a/api/app/titleConvoBing.js
+++ b/api/app/titleConvoBing.js
@@ -1,7 +1,13 @@
+const { isEnabled } = require('../server/utils');
 const throttle = require('lodash/throttle');
 
 const titleConvo = async ({ text, response }) => {
   let title = 'New Chat';
+  const { TITLE_CONVO = 'true' } = process.env ?? {};
+  if (!isEnabled(TITLE_CONVO)) {
+    return title;
+  }
+
   const { BingAIClient } = await import('@waylaidwanderer/chatgpt-api');
   const titleGenerator = new BingAIClient({
     userToken: process.env.BINGAI_TOKEN,

--- a/api/server/routes/endpoints/openAI/addTitle.js
+++ b/api/server/routes/endpoints/openAI/addTitle.js
@@ -1,6 +1,12 @@
+const { isEnabled } = require('../../../utils');
 const { saveConvo } = require('../../../../models');
 
 const addTitle = async (req, { text, response, client }) => {
+  const { TITLE_CONVO = 'true' } = process.env ?? {};
+  if (!isEnabled(TITLE_CONVO)) {
+    return;
+  }
+
   const title = await client.titleConvo({ text, responseText: response?.text });
   await saveConvo(req.user.id, {
     conversationId: response.conversationId,


### PR DESCRIPTION
## Summary

PR Title says most of it, no pun intended. Added the following environment variables that add the extra configuration:
`TITLE_CONVO` and `OPENAI_TITLE_MODEL`

They don't have to be set, in which case, titling will work as before.

Title prompts have been capped around 200 tokens. More specifically, both the user and response text used in the title prompt are capped at tweet size (255 characters). This may lead to some title degradation, but overall performs as before. Being such a small feature, it's worth spending less tokens here, and can now be disabled altogether.

```bash
# Titling is enabled by default when initiating a conversation.
# Uncomment the following variable to disable this feature.
# TITLE_CONVO=false

# The model used for titling by default is gpt-3.5-turbo-0613 to assure it works with the default method.
# gpt-3.5-turbo should also work when using the official API (and not a reverse proxy).
# You can change the model used by uncommenting the following and setting it to the model you want
# Must be compatible with the OpenAI Endpoint.
# OPENAI_TITLE_MODEL=gpt-3.5-turbo
```

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing
Manual testing, new features work as described

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
