### PR TITLE
fix(TextChat): allow space for scrollbar in gradient block

### DIFF
--- a/client/src/components/Input/TextChat.jsx
+++ b/client/src/components/Input/TextChat.jsx
@@ -127,7 +127,7 @@ export default function TextChat({ isSearchView = false }) {
   return (
     <>
       <div
-        className="no-gradient-sm fixed bottom-0 left-0 w-full pt-6 sm:bg-gradient-to-b md:absolute"
+        className="no-gradient-sm fixed bottom-0 left-0 w-full pt-6 sm:bg-gradient-to-b md:absolute md:w-[calc(100%-.5rem)]"
         style={{
           background: `linear-gradient(to bottom, 
                 ${isDark ? 'rgba(52, 53, 65, 0)' : 'rgba(255, 255, 255, 0)'}, 


### PR DESCRIPTION
before this small change, the gradient block element is overlayed on top of the scrollbar

after this change, you can click/drag the scrollbar from a lower starting position

This correctly matches the official site