### PR TITLE
fix(OpenAIClient/PluginsClient): allow non-v1 reverse proxy, handle "v1/completions" reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,12 @@ DEBUG_OPENAI=false # Set to true to enable debug mode for the OpenAI endpoint
 # https://github.com/waylaidwanderer/node-chatgpt-api#using-a-reverse-proxy 
 # OPENAI_REVERSE_PROXY=
 
+# (Advanced) Sometimes when using Local LLM APIs, you may need to force the API
+# to be called with a `prompt` payload instead of a `messages` payload; to mimic the
+# a `/v1/completions` request instead of `/v1/chat/completions`
+# This may be the case for LocalAI with some models. To do so, uncomment the following:
+# OPENAI_FORCE_PROMPT=true
+
 ##########################
 # OpenRouter (overrides OpenAI and Plugins Endpoints): 
 ##########################

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -136,7 +136,11 @@ class OpenAIClient extends BaseClient {
 
     if (this.options.reverseProxyUrl) {
       this.completionsUrl = this.options.reverseProxyUrl;
-      this.langchainProxy = this.options.reverseProxyUrl.match(/.*v1/)[0];
+      this.langchainProxy = this.options.reverseProxyUrl.match(/.*v1/)?.[0];
+      !this.langchainProxy &&
+        console.warn(`The reverse proxy URL ${this.options.reverseProxyUrl} is not valid for Plugins.
+The url must follow OpenAI specs, for example: https://localhost:8080/v1/chat/completions
+If your reverse proxy is compatible to OpenAI specs in every other way, it may still work without plugins enabled.`);
     } else if (isChatGptModel) {
       this.completionsUrl = 'https://api.openai.com/v1/chat/completions';
     } else {

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -79,12 +79,9 @@ class OpenAIClient extends BaseClient {
     }
 
     const { reverseProxyUrl: reverseProxy } = this.options;
-    if (
+    this.FORCE_PROMPT =
       isEnabled(OPENAI_FORCE_PROMPT) ||
-      (reverseProxy && reverseProxy.includes('completions') && !reverseProxy.includes('chat'))
-    ) {
-      this.FORCE_PROMPT = true;
-    }
+      (reverseProxy && reverseProxy.includes('completions') && !reverseProxy.includes('chat'));
 
     const { model } = this.modelOptions;
 
@@ -134,11 +131,11 @@ class OpenAIClient extends BaseClient {
       this.modelOptions.stop = stopTokens;
     }
 
-    if (this.options.reverseProxyUrl) {
-      this.completionsUrl = this.options.reverseProxyUrl;
-      this.langchainProxy = this.options.reverseProxyUrl.match(/.*v1/)?.[0];
+    if (reverseProxy) {
+      this.completionsUrl = reverseProxy;
+      this.langchainProxy = reverseProxy.match(/.*v1/)?.[0];
       !this.langchainProxy &&
-        console.warn(`The reverse proxy URL ${this.options.reverseProxyUrl} is not valid for Plugins.
+        console.warn(`The reverse proxy URL ${reverseProxy} is not valid for Plugins.
 The url must follow OpenAI specs, for example: https://localhost:8080/v1/chat/completions
 If your reverse proxy is compatible to OpenAI specs in every other way, it may still work without plugins enabled.`);
     } else if (isChatGptModel) {

--- a/api/app/clients/PluginsClient.js
+++ b/api/app/clients/PluginsClient.js
@@ -34,7 +34,11 @@ class PluginsClient extends OpenAIClient {
     this.isGpt3 = this.modelOptions?.model?.includes('gpt-3');
 
     if (this.options.reverseProxyUrl) {
-      this.langchainProxy = this.options.reverseProxyUrl.match(/.*v1/)[0];
+      this.langchainProxy = this.options.reverseProxyUrl.match(/.*v1/)?.[0];
+      !this.langchainProxy &&
+        console.warn(`The reverse proxy URL ${this.options.reverseProxyUrl} is not valid for Plugins.
+The url must follow OpenAI specs, for example: https://localhost:8080/v1/chat/completions
+If your reverse proxy is compatible to OpenAI specs in every other way, it may still work without plugins enabled.`);
     }
   }
 

--- a/api/app/clients/specs/OpenAIClient.test.js
+++ b/api/app/clients/specs/OpenAIClient.test.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const OpenAIClient = require('../OpenAIClient');
 
 jest.mock('meilisearch');
@@ -38,6 +39,54 @@ describe('OpenAIClient', () => {
       expect(client.apiKey).toBe('new-api-key');
       expect(client.modelOptions.model).toBe(model);
       expect(client.modelOptions.temperature).toBe(0.7);
+    });
+
+    it('should set apiKey and useOpenRouter if OPENROUTER_API_KEY is present', () => {
+      process.env.OPENROUTER_API_KEY = 'openrouter-key';
+      client.setOptions({});
+      expect(client.apiKey).toBe('openrouter-key');
+      expect(client.useOpenRouter).toBe(true);
+      delete process.env.OPENROUTER_API_KEY; // Cleanup
+    });
+
+    it('should set FORCE_PROMPT based on OPENAI_FORCE_PROMPT or reverseProxyUrl', () => {
+      process.env.OPENAI_FORCE_PROMPT = 'true';
+      client.setOptions({});
+      expect(client.FORCE_PROMPT).toBe(true);
+      delete process.env.OPENAI_FORCE_PROMPT; // Cleanup
+      client.FORCE_PROMPT = undefined;
+
+      client.setOptions({ reverseProxyUrl: 'https://example.com/completions' });
+      expect(client.FORCE_PROMPT).toBe(true);
+      client.FORCE_PROMPT = undefined;
+
+      client.setOptions({ reverseProxyUrl: 'https://example.com/chat' });
+      expect(client.FORCE_PROMPT).toBe(false);
+    });
+
+    it('should set isChatCompletion based on useOpenRouter, reverseProxyUrl, or model', () => {
+      client.setOptions({ reverseProxyUrl: null });
+      // true by default since default model will be gpt-3.5-turbo
+      expect(client.isChatCompletion).toBe(true);
+      client.isChatCompletion = undefined;
+
+      // false because completions url will force prompt payload
+      client.setOptions({ reverseProxyUrl: 'https://example.com/completions' });
+      expect(client.isChatCompletion).toBe(false);
+      client.isChatCompletion = undefined;
+
+      client.setOptions({ modelOptions: { model: 'gpt-3.5-turbo' }, reverseProxyUrl: null });
+      expect(client.isChatCompletion).toBe(true);
+    });
+
+    it('should set completionsUrl and langchainProxy based on reverseProxyUrl', () => {
+      client.setOptions({ reverseProxyUrl: 'https://localhost:8080/v1/chat/completions' });
+      expect(client.completionsUrl).toBe('https://localhost:8080/v1/chat/completions');
+      expect(client.langchainProxy).toBe('https://localhost:8080/v1');
+
+      client.setOptions({ reverseProxyUrl: 'https://example.com/completions' });
+      expect(client.completionsUrl).toBe('https://example.com/completions');
+      expect(client.langchainProxy).toBeUndefined();
     });
   });
 

--- a/api/server/services/ModelService.js
+++ b/api/server/services/ModelService.js
@@ -28,7 +28,7 @@ const fetchOpenAIModels = async (opts = { azure: false, plugins: false }, _model
   }
 
   if (reverseProxyUrl) {
-    basePath = reverseProxyUrl.match(/.*v1/)[0];
+    basePath = reverseProxyUrl.match(/.*v1/)?.[0];
   }
 
   const cachedModels = await modelsCache.get(basePath);


### PR DESCRIPTION
fixes #1026 
fixes #1027 

Aside from handling the niche case of a reverse proxy pointing to `v1/completions` instead of `v1/chat/completions`, you can also force a `prompt` payload instead of `messages` (useful for some localai models)

```bash
# (Advanced) Sometimes when using Local LLM APIs, you may need to force the API
# to be called with a `prompt` payload instead of a `messages` payload; to mimic the
# a `/v1/completions` request instead of `/v1/chat/completions`
# This may be the case for LocalAI with some models. To do so, uncomment the following:
# OPENAI_FORCE_PROMPT=true
```

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update 

## Testing

ci(OpenAIClient): add tests for OPENROUTER_API_KEY, FORCE_PROMPT, and reverseProxyUrl handling in setOptions

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.