### PR TITLE
fix(Chat): correctly render when refreshing/visiting a conversation page

### DIFF
--- a/client/src/components/Nav/NewChat.tsx
+++ b/client/src/components/Nav/NewChat.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useLocalize, useConversation } from '~/hooks';
 
 export default function NewChat() {
   const { newConversation } = useConversation();
+  const navigate = useNavigate();
   const localize = useLocalize();
 
   const clickHandler = () => {
-    // dispatch(setInputValue(''));
-    // dispatch(setQuery(''));
     newConversation();
+    navigate('/chat/new');
   };
 
   return (

--- a/client/src/routes/Chat.tsx
+++ b/client/src/routes/Chat.tsx
@@ -27,7 +27,7 @@ export default function Chat() {
   const navigate = useNavigate();
 
   //disabled by default, we only enable it when messagesTree is null
-  const messagesQuery = useGetMessagesByConvoId(conversationId ?? '', { enabled: false });
+  const messagesQuery = useGetMessagesByConvoId(conversationId ?? '', { enabled: !messagesTree });
   const getConversationMutation = useGetConversationByIdMutation(conversationId ?? '');
   const { data: config } = useGetStartupConfig();
 
@@ -89,7 +89,8 @@ export default function Chat() {
       setShouldNavigate(false);
     }
     // conversationId (in url) should always follow conversation?.conversationId, unless conversation is null
-    else if (conversation?.conversationId !== conversationId) {
+    // messagesTree is null when user navigates, but not on page refresh, so we need to navigate in this case
+    else if (conversation?.conversationId !== conversationId && !messagesTree) {
       if (shouldNavigate) {
         navigate(`/chat/${conversation?.conversationId}`);
       } else {


### PR DESCRIPTION
Reported on discord.

UI was not rendering messages when refreshing/visiting a conversation page.

messagesTree is null when user navigates, but not on page refresh. We only need to "navigate" when a user triggers navigation (new chat button or clicking on a conversation), not when the conversation page is visited/refreshed

## Change Type


- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

manual testing, chrome source debugging

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
