### PR TITLE
fix(auth/refresh): send 403 res for invalid token to properly invalidate session

### DIFF
--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -112,7 +112,9 @@ const refreshController = async (req, res) => {
       res.status(401).send('Refresh token expired or not found for this user');
     }
   } catch (err) {
-    res.status(401).send('Invalid refresh token');
+    console.error('Refresh token error', refreshToken);
+    console.error(err);
+    res.status(403).send('Invalid refresh token');
   }
 };
 


### PR DESCRIPTION
## Summary

When an invalid token was provided, the response from api/auth/refresh would direct the user to an empty page. Now, the user will be properly logged out to create a new session

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual testing with invalid cookies, and also testing previous behavior of expired cookie handling

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
