### PR TITLE
Fix: OpenRouter

### DIFF
--- a/api/server/services/ModelService.js
+++ b/api/server/services/ModelService.js
@@ -29,6 +29,7 @@ const fetchOpenAIModels = async (opts = { azure: false, plugins: false }, _model
 
   if (OPENROUTER_API_KEY) {
     reverseProxyUrl = 'https://openrouter.ai/api/v1';
+    apiKey = OPENROUTER_API_KEY
   }
 
   if (reverseProxyUrl) {


### PR DESCRIPTION
## Summary

Failed to fetch models from OpenAI API when set OPENROUTER_API_KEY on .env file

To fix it, you have to change the ModelService.js file and put this:

if (OPENROUTER_API_KEY) {
    reverseProxyUrl = 'https://openrouter.ai/api/v1';
    apiKey = OPENROUTER_API_KEY
  }


## Change Type

Please delete any irrelevant options.

- [X] Bug fix (non-breaking change which fixes an issue)



## Checklist

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [X] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [X] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
- [X] Any changes dependent on mine have been merged and published in downstream modules.
