### PR TITLE
feat(client): Toast Provider to show Toasts from higher on the DOM tree

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import { RouterProvider } from 'react-router-dom';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { QueryClient, QueryClientProvider, QueryCache } from '@tanstack/react-query';
 import { ScreenshotProvider, ThemeProvider, useApiErrorBoundary } from './hooks';
+import { ToastProvider } from './Providers';
 import Toast from './components/ui/Toast';
 import { router } from './routes';
 
@@ -25,10 +26,12 @@ const App = () => {
       <RecoilRoot>
         <ThemeProvider>
           <RadixToast.Provider>
-            <RouterProvider router={router} />
-            <ReactQueryDevtools initialIsOpen={false} position="top-right" />
-            <Toast />
-            <RadixToast.Viewport className="pointer-events-none fixed inset-0 z-[60] mx-auto my-2 flex max-w-[560px] flex-col items-stretch justify-start md:pb-5" />
+            <ToastProvider>
+              <RouterProvider router={router} />
+              <ReactQueryDevtools initialIsOpen={false} position="top-right" />
+              <Toast />
+              <RadixToast.Viewport className="pointer-events-none fixed inset-0 z-[60] mx-auto my-2 flex max-w-[560px] flex-col items-stretch justify-start md:pb-5" />
+            </ToastProvider>
           </RadixToast.Provider>
         </ThemeProvider>
       </RecoilRoot>

--- a/client/src/Providers/ToastContext.tsx
+++ b/client/src/Providers/ToastContext.tsx
@@ -1,0 +1,17 @@
+import { createContext } from 'react';
+import type { TShowToast } from '~/common';
+import { useToast } from '~/hooks';
+
+type ToastContextType = {
+  showToast: ({ message, severity, showIcon }: TShowToast) => void;
+};
+
+export const ToastContext = createContext<ToastContextType>({
+  showToast: () => ({}),
+});
+
+export default function ToastProvider({ children }) {
+  const { showToast } = useToast();
+
+  return <ToastContext.Provider value={{ showToast }}>{children}</ToastContext.Provider>;
+}

--- a/client/src/Providers/index.ts
+++ b/client/src/Providers/index.ts
@@ -1,0 +1,2 @@
+export { default as ToastProvider } from './ToastContext';
+export * from './ToastContext';

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -28,6 +28,12 @@ export enum NotificationSeverity {
   ERROR = 'error',
 }
 
+export type TShowToast = {
+  message: string;
+  severity?: NotificationSeverity;
+  showIcon?: boolean;
+};
+
 export type TBaseSettingsProps = {
   conversation: TConversation | TPreset | null;
   className?: string;

--- a/client/src/hooks/useToast.ts
+++ b/client/src/hooks/useToast.ts
@@ -1,5 +1,6 @@
-import { useRef, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
+import { useRef, useEffect } from 'react';
+import type { TShowToast } from '~/common';
 import { NotificationSeverity } from '~/common';
 import store from '~/store';
 
@@ -14,12 +15,6 @@ export default function useToast(timeoutDuration = 100) {
       }
     };
   }, []);
-
-  type TShowToast = {
-    message: string;
-    severity?: NotificationSeverity;
-    showIcon?: boolean;
-  };
 
   const showToast = ({
     message,


### PR DESCRIPTION
## Summary

Title. Necessary because if a component unmounts, it will not show the toast (React will yeet it)

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

To show a Toast message, do the following wherever you'd like (usually as a result of a user action; in my example, onClick)

```ts
import { useContext } from 'react';
import { NotificationSeverity } from '~/common';
import { ToastContext } from '~/Providers';

export default function SomeComponent() {
  const { showToast } = useContext(ToastContext);

  return (
    <div 
        onClick={() => showToast({
        message: 'TESTING 1. 2. 3',
        severity: NotificationSeverity.SUCCESS,
        showIcon: false,
    })}>
        {"Click to me show Toast!"}
    </div>
  )
}

```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
