### PR TITLE
feat: allow config of DALL-E-3 System Prompt via env 🎨

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,6 +132,12 @@ DEBUG_OPENAI=false # Set to true to enable debug mode for the OpenAI endpoint
 # This may be the case for LocalAI with some models. To do so, uncomment the following:
 # OPENAI_FORCE_PROMPT=true
 
+# (Advanced) For customization of the DALL-E-3 System prompt, 
+# uncomment the following, and provide your own prompt:
+# See official prompt for reference:
+# https://github.com/spdustin/ChatGPT-AutoExpert/blob/main/_system-prompts/dall-e.md
+# DALLE3_SYSTEM_PROMPT="Your System Prompt here"
+
 ##########################
 # OpenRouter (overrides OpenAI and Plugins Endpoints): 
 ##########################

--- a/api/app/clients/tools/DALL-E.js
+++ b/api/app/clients/tools/DALL-E.js
@@ -58,7 +58,7 @@ Guidelines:
   replaceUnwantedChars(inputString) {
     return inputString
       .replace(/\r\n|\r|\n/g, ' ')
-      .replace('"', '')
+      .replace(/"/g, '')
       .trim();
   }
 

--- a/api/app/clients/tools/structured/specs/DALLE3.spec.js
+++ b/api/app/clients/tools/structured/specs/DALLE3.spec.js
@@ -1,0 +1,199 @@
+const fs = require('fs');
+const path = require('path');
+const OpenAI = require('openai');
+const DALLE3 = require('../DALLE3');
+const saveImageFromUrl = require('../../saveImageFromUrl');
+
+jest.mock('openai');
+
+const generate = jest.fn();
+OpenAI.mockImplementation(() => ({
+  images: {
+    generate,
+  },
+}));
+
+jest.mock('fs', () => {
+  return {
+    existsSync: jest.fn(),
+    mkdirSync: jest.fn(),
+  };
+});
+
+jest.mock('../../saveImageFromUrl', () => {
+  return jest.fn();
+});
+
+jest.mock('path', () => {
+  return {
+    resolve: jest.fn(),
+    join: jest.fn(),
+    relative: jest.fn(),
+  };
+});
+
+describe('DALLE3', () => {
+  let originalEnv;
+  let dalle; // Keep this declaration if you need to use dalle in other tests
+  const mockApiKey = 'mock_api_key';
+
+  beforeAll(() => {
+    // Save the original process.env
+    originalEnv = { ...process.env };
+  });
+
+  beforeEach(() => {
+    // Reset the process.env before each test
+    jest.resetModules();
+    process.env = { ...originalEnv, DALLE_API_KEY: mockApiKey };
+    // Instantiate DALLE3 for tests that do not depend on DALLE3_SYSTEM_PROMPT
+    dalle = new DALLE3();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    // Restore the original process.env after each test
+    process.env = originalEnv;
+  });
+
+  it('should throw an error if DALLE_API_KEY is missing', () => {
+    delete process.env.DALLE_API_KEY;
+    expect(() => new DALLE3()).toThrow('Missing DALLE_API_KEY environment variable.');
+  });
+
+  it('should replace unwanted characters in input string', () => {
+    const input = 'This is a test\nstring with "quotes" and new lines.';
+    const expectedOutput = 'This is a test string with quotes and new lines.';
+    expect(dalle.replaceUnwantedChars(input)).toBe(expectedOutput);
+  });
+
+  it('should generate markdown image URL correctly', () => {
+    const imageName = 'test.png';
+    path.join.mockReturnValue('images/test.png');
+    path.relative.mockReturnValue('images/test.png');
+    const markdownImage = dalle.getMarkdownImageUrl(imageName);
+    expect(markdownImage).toBe('![generated image](/images/test.png)');
+  });
+
+  it('should call OpenAI API with correct parameters', async () => {
+    const mockData = {
+      prompt: 'A test prompt',
+      quality: 'standard',
+      size: '1024x1024',
+      style: 'vivid',
+    };
+
+    const mockResponse = {
+      data: [
+        {
+          url: 'http://example.com/img-test.png',
+        },
+      ],
+    };
+
+    generate.mockResolvedValue(mockResponse);
+    saveImageFromUrl.mockResolvedValue(true);
+    fs.existsSync.mockReturnValue(true);
+    path.resolve.mockReturnValue('/fakepath/images');
+    path.join.mockReturnValue('/fakepath/images/img-test.png');
+    path.relative.mockReturnValue('images/img-test.png');
+
+    const result = await dalle._call(mockData);
+
+    expect(generate).toHaveBeenCalledWith({
+      model: 'dall-e-3',
+      quality: mockData.quality,
+      style: mockData.style,
+      size: mockData.size,
+      prompt: mockData.prompt,
+      n: 1,
+    });
+    expect(result).toContain('![generated image]');
+  });
+
+  it('should use the system prompt if provided', () => {
+    process.env.DALLE3_SYSTEM_PROMPT = 'System prompt for testing';
+    jest.resetModules(); // This will ensure the module is fresh and will read the new env var
+    const DALLE3 = require('../DALLE3'); // Re-require after setting the env var
+    const dalleWithSystemPrompt = new DALLE3();
+    expect(dalleWithSystemPrompt.description_for_model).toBe('System prompt for testing');
+  });
+
+  it('should not use the system prompt if not provided', async () => {
+    delete process.env.DALLE3_SYSTEM_PROMPT;
+    const dalleWithoutSystemPrompt = new DALLE3();
+    expect(dalleWithoutSystemPrompt.description_for_model).not.toBe('System prompt for testing');
+  });
+
+  it('should throw an error if prompt is missing', async () => {
+    const mockData = {
+      quality: 'standard',
+      size: '1024x1024',
+      style: 'vivid',
+    };
+    await expect(dalle._call(mockData)).rejects.toThrow('Missing required field: prompt');
+  });
+
+  it('should throw an error if no image URL is returned from OpenAI API', async () => {
+    const mockData = {
+      prompt: 'A test prompt',
+    };
+    // Simulate a response with an object that has a `url` property set to `undefined`
+    generate.mockResolvedValue({ data: [{ url: undefined }] });
+    await expect(dalle._call(mockData)).rejects.toThrow('No image URL returned from OpenAI API.');
+  });
+
+  it('should log to console if no image name is found in the URL', async () => {
+    const mockData = {
+      prompt: 'A test prompt',
+    };
+    const mockResponse = {
+      data: [
+        {
+          url: 'http://example.com/invalid-url',
+        },
+      ],
+    };
+    console.log = jest.fn(); // Mock console.log
+    generate.mockResolvedValue(mockResponse);
+    await dalle._call(mockData);
+    expect(console.log).toHaveBeenCalledWith('No image name found in the string.');
+  });
+
+  it('should create the directory if it does not exist', async () => {
+    const mockData = {
+      prompt: 'A test prompt',
+    };
+    const mockResponse = {
+      data: [
+        {
+          url: 'http://example.com/img-test.png',
+        },
+      ],
+    };
+    generate.mockResolvedValue(mockResponse);
+    fs.existsSync.mockReturnValue(false); // Simulate directory does not exist
+    await dalle._call(mockData);
+    expect(fs.mkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
+  });
+
+  it('should log an error and return the image URL if there is an error saving the image', async () => {
+    const mockData = {
+      prompt: 'A test prompt',
+    };
+    const mockResponse = {
+      data: [
+        {
+          url: 'http://example.com/img-test.png',
+        },
+      ],
+    };
+    const error = new Error('Error while saving the image');
+    generate.mockResolvedValue(mockResponse);
+    saveImageFromUrl.mockRejectedValue(error);
+    console.error = jest.fn(); // Mock console.error
+    const result = await dalle._call(mockData);
+    expect(console.error).toHaveBeenCalledWith('Error while saving the image:', error);
+    expect(result).toBe(mockResponse.data[0].url);
+  });
+});


### PR DESCRIPTION
## Summary

This update introduces the ability to configure the system prompt for the DALLE-3 tool dynamically. Previously, the system prompt was a fixed environment variable, which limited flexibility. With this change, users can specify a system prompt when initializing the DALLE-3 class, allowing for more tailored image generation based on the given prompt. This enhancement improves the tool's usability for various use cases that require different prompt instructions.

```bash
# (Advanced) For customization of the DALL-E-3 System prompt, 
# uncomment the following, and provide your own prompt:
# See official prompt for reference:
# https://github.com/spdustin/ChatGPT-AutoExpert/blob/main/_system-prompts/dall-e.md
# DALLE3_SYSTEM_PROMPT="Your System Prompt here"
```

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

To ensure the new feature works as expected, I have added unit tests that check whether the system prompt can be set and retrieved correctly. The tests also verify that the default prompt is used when no custom prompt is provided. Additionally, I have tested the image generation process to ensure that the custom system prompt is appropriately applied when generating images.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules (if applicable).