### PR TITLE
style: update symbols for the next/previous page buttons to make navigation more intuitive

### DIFF
--- a/client/src/components/Conversations/Pages.tsx
+++ b/client/src/components/Conversations/Pages.tsx
@@ -35,7 +35,7 @@ export default function Pages({
         }
         disabled={pageNumber <= 1}
       >
-        &lt;&lt;
+        &lt;
       </button>
       <span className="flex-none text-gray-400">
         {pageNumber} / {pages}
@@ -48,7 +48,7 @@ export default function Pages({
         }
         disabled={pageNumber >= pages}
       >
-        &gt;&gt;
+        &gt;
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary

Currently >> and << symbols are used as next and previous page buttons.
<details>
  <summary>Screenshot</summary>
  
  ![TpbKogM6i5](https://github.com/danny-avila/LibreChat/assets/40185941/6b190e78-a080-41e7-9864-6e3cb6286430)
</details>
This might confuse users into thinking they'd jump to the last or first page. Replacing them with > and < makes it clear that these buttons navigate one page at a time. This change intends to make the navigation more intuitive and user-friendly.


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

small style change, no testing needed