### PR TITLE
fix: .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,8 +73,8 @@ MESSAGE_USER_WINDOW=1 # in minutes, determines the window of time for MESSAGE_US
 
 # If you have permission problems, set here the UID and GID of the user running
 # the docker compose command. The applications in the container will run with these uid/gid.
-UID=1000
-GID=1000
+# UID=1000
+# GID=1000
 
 # Change this to proxy any API request. 
 # It's useful if your machine has difficulty calling the original API server. 


### PR DESCRIPTION
## Summary

Comment out `UID` and `GID` by default in the .env.example file

This fix an issue where the mongodb and meilisearch container get stuck in a reboot loop for some users:

![image](https://github.com/danny-avila/LibreChat/assets/32828263/4864ca68-a26a-453a-927d-37a40599e748)

**Note:**
`docker-compose up` does output a warning when they are commented out but everything starts properly
![image](https://github.com/danny-avila/LibreChat/assets/32828263/62893f6b-6e6a-414d-ae80-60c28c9938f1)

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)
