### PR TITLE
feat: allow any reverse proxy URLs, add proxy support to model fetching

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -145,10 +145,6 @@ class OpenAIClient extends BaseClient {
     if (reverseProxy) {
       this.completionsUrl = reverseProxy;
       this.langchainProxy = extractBaseURL(reverseProxy);
-      !this.langchainProxy &&
-        console.warn(`The reverse proxy URL ${reverseProxy} is not valid for Plugins.
-The url must follow OpenAI specs, for example: https://localhost:8080/v1/chat/completions
-If your reverse proxy is compatible to OpenAI specs in every other way, it may still work without plugins enabled.`);
     } else if (isChatGptModel) {
       this.completionsUrl = 'https://api.openai.com/v1/chat/completions';
     } else {

--- a/api/app/clients/PluginsClient.js
+++ b/api/app/clients/PluginsClient.js
@@ -36,10 +36,6 @@ class PluginsClient extends OpenAIClient {
 
     if (this.options.reverseProxyUrl) {
       this.langchainProxy = extractBaseURL(this.options.reverseProxyUrl);
-      !this.langchainProxy &&
-        console.warn(`The reverse proxy URL ${this.options.reverseProxyUrl} is not valid for Plugins.
-The url must follow OpenAI specs, for example: https://localhost:8080/v1/chat/completions
-If your reverse proxy is compatible to OpenAI specs in every other way, it may still work without plugins enabled.`);
     }
   }
 

--- a/api/app/clients/specs/OpenAIClient.test.js
+++ b/api/app/clients/specs/OpenAIClient.test.js
@@ -94,7 +94,7 @@ describe('OpenAIClient', () => {
 
       client.setOptions({ reverseProxyUrl: 'https://example.com/completions' });
       expect(client.completionsUrl).toBe('https://example.com/completions');
-      expect(client.langchainProxy).toBe(null);
+      expect(client.langchainProxy).toBe('https://example.com/completions');
     });
   });
 

--- a/api/utils/extractBaseURL.js
+++ b/api/utils/extractBaseURL.js
@@ -1,6 +1,7 @@
 /**
  * Extracts a valid OpenAI baseURL from a given string, matching "url/v1," also an added suffix,
  * ending with "/openai" (to allow the Cloudflare, LiteLLM pattern).
+ * Returns the original URL if no match is found.
  *
  * Examples:
  * - `https://open.ai/v1/chat` -> `https://open.ai/v1`
@@ -9,12 +10,11 @@
  * - `https://open.ai/v1/hi/openai` -> `https://open.ai/v1/hi/openai`
  *
  * @param {string} url - The URL to be processed.
- * @returns {string|null} The matched pattern or null if no match is found.
+ * @returns {string} The matched pattern or input if no match is found.
  */
 function extractBaseURL(url) {
-  // First, let's make sure the URL contains '/v1'.
   if (!url.includes('/v1')) {
-    return null;
+    return url;
   }
 
   // Find the index of '/v1' to use it as a reference point.

--- a/api/utils/extractBaseURL.spec.js
+++ b/api/utils/extractBaseURL.spec.js
@@ -28,9 +28,9 @@ describe('extractBaseURL', () => {
     );
   });
 
-  test('should return null if the URL does not match the expected pattern', () => {
+  test('should return input if the URL does not match the expected pattern', () => {
     const url = 'https://someotherdomain.com/notv1';
-    expect(extractBaseURL(url)).toBeNull();
+    expect(extractBaseURL(url)).toBe(url);
   });
 
   // Test our JSDoc examples.


### PR DESCRIPTION
Previously would prevent any reverse proxies, to follow the strict /v1 pattern. I don't think this is necessary anymore, as most will know they need a baseURL from their proxy, and that their api should handle all the specs as openai does.