### PR TITLE
🔧 Fix: Increase `client_max_body_size` for Nginx File Uploads 📤

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -7,6 +7,10 @@ server {
 
   server_name localhost;
 
+   # Increase the client_max_body_size to allow larger file uploads
+   # The default limits for image uploads as of 11/22/23 is 20MB/file, and 25MB/request
+  client_max_body_size 25M;
+
   location /api {
     proxy_pass http://api:3080/api;
   }


### PR DESCRIPTION
## Summary

This pull request addresses an issue where users were unable to upload large files through the Nginx server. The `client_max_body_size` directive has been increased to allow for larger file uploads. This change will enable users to upload bigger files without encountering errors related to file size limitations.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Testing was conducted by attempting to upload files of various sizes through the Nginx server. Before the changes, files above the previous limit would fail to upload, resulting in a `413 Request Entity Too Large` error. After the adjustment, files up to the new size limit were uploaded successfully without errors.

### **Test Configuration**:
- Nginx version: specify version
- File sizes for testing: specify sizes used for testing

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes