### PR TITLE
🔧 feat: Read NGINX Config and Cleanup Docker Images 🐳

### DIFF
--- a/config/deployed-update.js
+++ b/config/deployed-update.js
@@ -40,6 +40,19 @@ const shouldRebase = process.argv.includes('--rebase');
   console.orange(downCommand);
   execSync(downCommand, { stdio: 'inherit' });
 
+  console.purple('Removing all tags for LibreChat `deployed` images...');
+  const repositories = ['ghcr.io/danny-avila/librechat-dev-api', 'librechat-client'];
+  repositories.forEach((repo) => {
+    const tags = execSync(`sudo docker images ${repo} -q`, { encoding: 'utf8' })
+      .split('\n')
+      .filter(Boolean);
+    tags.forEach((tag) => {
+      const removeImageCommand = `sudo docker rmi ${tag}`;
+      console.orange(removeImageCommand);
+      execSync(removeImageCommand, { stdio: 'inherit' });
+    });
+  });
+
   console.purple('Pulling latest LibreChat images...');
   const pullCommand = 'sudo docker-compose -f ./deploy-compose.yml pull api';
   console.orange(pullCommand);

--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -36,6 +36,8 @@ services:
     depends_on:
       - api
     restart: always
+    volumes:
+      - ./client/nginx.conf:/etc/nginx/conf.d/default.conf
   mongodb:
     container_name: chat-mongodb
     # ports:  # Uncomment this to access mongodb from outside docker, not safe in deployment


### PR DESCRIPTION
## Summary

This update is aimed at refining the deployment process of our NGINX service by adjusting the volume mapping in the Docker Compose file to include the current NGINX configuration from the client directory. This ensures that users pulling the remote image get the latest configuration changes, addressing an issue where NGINX was not updating in all instances. The motivation behind this improvement is the recent addition of image uploads to the gpt-4-vision API, which necessitated an increase in the NGINX file upload limit from the default 1 MB. Alongside this, the update script has been enhanced to remove old Docker images, keeping the system lean and preventing accumulation of unused, amd most up-to-date images.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Confirm that NGINX correctly uses the updated configuration and that the update script removes old Docker images as expected. The testing process involves:

1. Deploying NGINX with the updated `docker-compose.yml` and verifying that the `nginx.conf` is correctly utilized.
    - I ran `docker exec -it LibreChat-NGINX cat /etc/nginx/conf.d/default.conf` before and after making local changes to the client/nginx.conf file, after seeing the changes I just made
2. Testing the image upload feature of the gpt-4-vision API to ensure that files larger than 1 MB can be uploaded successfully.
3. Running the update script and checking if old Docker images are properly removed without affecting running containers.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes