### PR TITLE
fix: Prevent Message Misrouting on Conversation Refresh 🔄

### DIFF
--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -1,31 +1,37 @@
 import { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
-import { useGetConvoIdQuery } from 'librechat-data-provider';
+import { useGetConvoIdQuery, useGetModelsQuery } from 'librechat-data-provider';
 import ChatView from '~/components/Chat/ChatView';
 import useAuthRedirect from './useAuthRedirect';
-import { useSetStorage } from '~/hooks';
+import { useNewConvo } from '~/hooks';
 import store from '~/store';
 
 export default function ChatRoute() {
   const index = 0;
-  const setStorage = useSetStorage();
   const { conversationId } = useParams();
-  const { conversation, setConversation } = store.useCreateConversationAtom(index);
+  const { conversation } = store.useCreateConversationAtom(index);
   const { isAuthenticated } = useAuthRedirect();
+  const { newConversation } = useNewConvo();
   const hasSetConversation = useRef(false);
 
+  const modelsQuery = useGetModelsQuery({ enabled: isAuthenticated });
   const initialConvoQuery = useGetConvoIdQuery(conversationId ?? '', {
     enabled: isAuthenticated && conversationId !== 'new',
   });
 
   useEffect(() => {
-    if (initialConvoQuery.data && !hasSetConversation.current) {
-      setStorage(initialConvoQuery.data);
-      setConversation(initialConvoQuery.data);
+    if (conversationId === 'new' && modelsQuery.data && !hasSetConversation.current) {
+      newConversation({ modelsData: modelsQuery.data });
+      hasSetConversation.current = true;
+    } else if (initialConvoQuery.data && modelsQuery.data && !hasSetConversation.current) {
+      newConversation({
+        template: initialConvoQuery.data,
+        modelsData: modelsQuery.data,
+      });
       hasSetConversation.current = true;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialConvoQuery.data]);
+  }, [initialConvoQuery.data, modelsQuery.data]);
 
   if (!isAuthenticated) {
     return null;

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -9,13 +9,12 @@ import {
 } from 'librechat-data-provider';
 import type { ContextType } from '~/common';
 import { Nav, MobileNav } from '~/components/Nav';
-import { useAuthContext, useServerStream, useConversation, useNewConvo } from '~/hooks';
+import { useAuthContext, useServerStream, useConversation } from '~/hooks';
 import store from '~/store';
 
 export default function Root() {
   const location = useLocation();
   const { newConversation } = useConversation();
-  const { newConversation: newConvo } = useNewConvo();
   const { user, isAuthenticated } = useAuthContext();
   const [navVisible, setNavVisible] = useState(() => {
     const savedNavVisible = localStorage.getItem('navVisible');
@@ -44,7 +43,6 @@ export default function Root() {
       newConversation({}, undefined, modelsQuery.data);
     } else if (modelsQuery.data) {
       setModelsConfig(modelsQuery.data);
-      newConvo({ modelsData: modelsQuery.data });
     } else if (modelsQuery.isError) {
       console.error('Failed to get models', modelsQuery.error);
     }


### PR DESCRIPTION
fix: Prevent Message Misrouting on Conversation Refresh 🔄

## Summary

Addresses a critical bug where refreshing the conversation page led to messages being sent to a new, incorrect conversation. This bug fix ensures that the conversation state is preserved on refresh and integrated properly with remote model updates (/api/models).

This change further decouples the new UI route handling from routes/Root.tsx, which is for the better.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

To ensure the fix works as intended, the following testing process was performed:
1. Opened a conversation within the application.
2. Refreshed the page to simulate the user's refresh action.
3. Sent a message to check if it is routed to the currently active conversation.

Instructions for reproducing the test:
- Open any conversation in the application.
- Refresh the browser page.
- Send a new message and verify it is delivered to the correct conversation.

### **Test Configuration**:
- Browser: Chrome Version 104.0.5112.101
- Server Environment: Localhost with a simulated connection to remote message handling services.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes