### PR TITLE
fix: conversation title truncation

### DIFF
--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -114,9 +114,9 @@ export default function Conversation({ conversation, retainView, toggleNav, i })
   }
 
   return (
-    <a data-testid="convo-item" onClick={() => clickHandler()} {...aProps}>
+    <a data-testid="convo-item" onClick={() => clickHandler()} {...aProps} title={title}>
       {icon}
-      <div className="relative max-h-5 flex-1 overflow-hidden text-ellipsis break-all">
+      <div className="relative line-clamp-1 max-h-5 flex-1 text-ellipsis break-all">
         {renaming === true ? (
           <input
             ref={inputRef}


### PR DESCRIPTION

## Summary

- Make title truncation work with ellipsis
  - The class for ellipsis was already there, but it didn't work because of `overflow-hidden`, but `line-clamp-1` fixes this
- Add tooltip, to see the full title

This would fix my own issue (#1236), but feel free to just reject this PR, if you want to keep it the same way it works on chat.openai.com (as it currently is).

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update 

## Testing

Tested in Chrome and Firefox.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
