### PR TITLE
🎨 fix: Update MessagesView Styling

### DIFF
--- a/client/src/components/Messages/ScrollToBottom.tsx
+++ b/client/src/components/Messages/ScrollToBottom.tsx
@@ -6,7 +6,7 @@ export default function ScrollToBottom({ scrollHandler }: Props) {
   return (
     <button
       onClick={scrollHandler}
-      className="absolute bottom-[124px] right-6 z-[62] cursor-pointer rounded-full border border-gray-200 bg-gray-50 text-gray-600 dark:border-white/10 dark:bg-white/10 dark:text-gray-200 md:bottom-[180px] lg:bottom-[120px]"
+      className="absolute bottom-5 right-6 z-10 cursor-pointer rounded-full border border-gray-200 bg-gray-50 text-gray-600 dark:border-white/10 dark:bg-white/10 dark:text-gray-200 md:bottom-[180px] lg:bottom-[120px]"
     >
       <svg
         stroke="currentColor"

--- a/client/src/components/Messages/ScrollToBottom.tsx
+++ b/client/src/components/Messages/ScrollToBottom.tsx
@@ -6,7 +6,7 @@ export default function ScrollToBottom({ scrollHandler }: Props) {
   return (
     <button
       onClick={scrollHandler}
-      className="absolute bottom-5 right-6 z-10 cursor-pointer rounded-full border border-gray-200 bg-gray-50 text-gray-600 dark:border-white/10 dark:bg-white/10 dark:text-gray-200 md:bottom-[180px] lg:bottom-[120px]"
+      className="absolute bottom-5 right-6 z-10 cursor-pointer rounded-full border border-gray-200 bg-gray-50 text-gray-600 dark:border-white/10 dark:bg-white/10 dark:text-gray-200 md:bottom-[180px] lg:fixed lg:bottom-[120px]"
     >
       <svg
         stroke="currentColor"

--- a/client/src/components/Messages/ScrollToBottom.tsx
+++ b/client/src/components/Messages/ScrollToBottom.tsx
@@ -6,7 +6,7 @@ export default function ScrollToBottom({ scrollHandler }: Props) {
   return (
     <button
       onClick={scrollHandler}
-      className="absolute bottom-5 right-6 z-10 cursor-pointer rounded-full border border-gray-200 bg-gray-50 text-gray-600 dark:border-white/10 dark:bg-white/10 dark:text-gray-200 md:bottom-[180px] lg:fixed lg:bottom-[120px]"
+      className="absolute bottom-2 right-6 z-10 cursor-pointer rounded-full border border-gray-200 bg-gray-50 text-gray-600 dark:border-white/10 dark:bg-white/10 dark:text-gray-200"
     >
       <svg
         stroke="currentColor"


### PR DESCRIPTION
## Summary

I have made adjustments to the MessagesView component to more closely match the styling of ChatGPT.

The motivation behind these changes is to ensure that the user interface remains consistent as more items are added either alongside or layered over the MessagesView. Right now this is mainly the ScrollToBottom button, which is styled more consistently with this change.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Style update

## Testing

To test these changes, I manually resized the browser window to a variety of dimensions to ensure that the MessagesView component retained the correct styling. 

Specifically, the ScrollToBottom button's position was verified on larger screen resolutions. Reproducing these tests would involve checking the component's behavior at different viewport sizes and confirming that the styles remain consistent with the ChatGPT interface.

### **Test Configuration**:
- Screen resolutions ranging from mobile to 4K displays
- Multiple browsers to ensure cross-browser compatibility

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes