### PR TITLE
🔎 update meilisearch to v1.5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,6 @@ BINGAI_TOKEN=user_provided
 
 CHATGPT_TOKEN=
 CHATGPT_MODELS=text-davinci-002-render-sha,gpt-4
-
 # CHATGPT_REVERSE_PROXY=<YOUR REVERSE PROXY>
 
 #============#

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 
 # Logs
 data-node
-meili_data
+meili_data*
 data/
 logs
 *.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     command: mongod --noauth
   meilisearch:
     container_name: chat-meilisearch
-    image: getmeili/meilisearch:v1.0
+    image: getmeili/meilisearch:v1.5
     restart: always
     # ports: # Uncomment this to access meilisearch from outside docker
     #   - 7700:7700 # if exposing these ports, make sure your master key is not the default value
@@ -69,4 +69,4 @@ services:
       - MEILI_HTTP_ADDR=meilisearch:7700
       - MEILI_NO_ANALYTICS=true
     volumes:
-      - ./meili_data:/meili_data
+      - ./meili_data_v1.5:/meili_data

--- a/docs/general_info/breaking_changes.md
+++ b/docs/general_info/breaking_changes.md
@@ -4,6 +4,11 @@
 **If you experience any issues after updating, we recommend clearing your browser cache and cookies.**
 Certain changes in the updates may impact cookies, leading to unexpected behaviors if not cleared properly.
 
+## v0.6.x
+
+- **Meilisearch Update**: Following the recent update to Meilisearch, an unused folder named `meili_data` may be present in your root directory. This folder is no longer required and can be **safely deleted** to free up space.
+- **New Indexing Data Location**: The indexing data has been relocated. It will now be stored in a new folder named `meili_data_v1.x`, where `1.x` represents the version of Meilisearch. For instance, with the current Meilisearch version `1.5`, the folder will be `meili_data_v1.5`.
+
 ## v0.5.9
 
 - It's now required to set a **JWT_REFRESH_SECRET** in your .env file as of [#927](https://github.com/danny-avila/LibreChat/pull/927)


### PR DESCRIPTION
## Summary

This update introduces a seamless transition to the latest version of Meilisearch, ensuring minimal disruption for our users. By adopting a new naming convention for the indexing folder (`meili_data_v1.x`), we eliminate the need for users to manually delete outdated indexing data. This approach is designed to be user-friendly, especially for those who may overlook the breaking changes documentation.

**What's New:**
- **docker-compose.yml**: The Meilisearch version has been set to 1.5 and the volume for the indexing data has been updated
- **Documentation Update**: The "breaking changes" document has been updated to reflect the recent changes.
- **.gitignore Adjustment**: The `.gitignore` file has been modified to ignore `meili_data*`, ensuring that all versions of indexing data folders are excluded from version control.

**Key Benefits:**
- **Enhanced Performance**: Users will experience improved indexing and search speeds, contributing to a more efficient LibreChat experience.
- **Future-Proofing**: The folder name change lays the groundwork for hassle-free future updates to Meilisearch, without any breaking changes.
- **Fallback Safety**: In the event a user updates without consulting the breaking changes notes, the worst-case scenario is a small amount of redundant meilisearch indexing data, which can be easily managed.

## Change Type
- [x] 🔎 meilisearch update to v1.5

## Testing
- Performed the update and tested the results on Windows 11
