### PR TITLE
fix: return 404 instead of 200

### DIFF
--- a/api/server/index.js
+++ b/api/server/index.js
@@ -71,9 +71,8 @@ const startServer = async () => {
   app.use('/api/assistants', routes.assistants);
   app.use('/api/files', routes.files);
 
-  // Static files
-  app.get('/*', function (req, res) {
-    res.sendFile(path.join(projectPath, 'dist', 'index.html'));
+  app.use((req, res) => {
+    res.status(404).sendFile(path.join(projectPath, 'dist', 'index.html'));
   });
 
   app.listen(port, host, () => {


### PR DESCRIPTION
## Summary

I fixed an issue in the code where invalid paths were returning a 200 status code instead of the expected 404

![Screenshot 2023-12-06 190216](https://github.com/danny-avila/LibreChat/assets/81851188/3bfff668-72ee-4b91-b0c3-d7fa0795205c)


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

# NOTE: I tried a lot of things, various email/social logins, chat delete, etc... **BUT** I'm not 100% sure that this won't create new bugs

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
