### PR TITLE
📚 documentation update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,7 +135,7 @@ AZURE_AI_SEARCH_SEARCH_OPTION_SELECT=
 
 # DALL·E 3
 #----------------
-DALLE_API_KEY=user_provided
+# DALLE_API_KEY=
 # DALLE3_SYSTEM_PROMPT="Your System Prompt here"
 # DALLE_REVERSE_PROXY=
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
     <img
       src="https://img.shields.io/badge/DOCS-blue.svg?style=for-the-badge&logo=read-the-docs&logoColor=white&labelColor=000000&logoWidth=20">
   </a>
-  <a aria-label="Sponsors" href="#sponsors">
+  <a aria-label="Sponsors" href="https://github.com/sponsors/danny-avila">
     <img
       src="https://img.shields.io/badge/SPONSORS-brightgreen.svg?style=for-the-badge&logo=github-sponsors&logoColor=white&labelColor=000000&logoWidth=20">
   </a>
@@ -146,7 +146,6 @@ Keep up with the latest updates by visiting the releases page - [Releases](https
   * [Project Roadmap](https://github.com/users/danny-avila/projects/2)
 </details>
 
-
 ---
 
 ## Star History
@@ -157,17 +156,9 @@ Keep up with the latest updates by visiting the releases page - [Releases](https
 
 ---
 
-## Sponsors
-
-  Sponsored by <a href="https://github.com/mjtechguy"><b>@mjtechguy</b></a>, <a href="https://github.com/SphaeroX"><b>@SphaeroX</b></a>, <a href="https://github.com/DavidDev1334"><b>@DavidDev1334</b></a>, <a href="https://github.com/fuegovic"><b>@fuegovic</b></a>, <a href="https://github.com/Pharrcyde"><b>@Pharrcyde</b></a> 
-  
----
-
 ## Contributors
 Contributions and suggestions bug reports and fixes are welcome!
 Please read the documentation before you do!
-
----
 
 For new features, components, or extensions, please open an issue and discuss before sending a PR. 
 

--- a/docs/features/pandoranext.md
+++ b/docs/features/pandoranext.md
@@ -2,7 +2,7 @@
 
 If you're looking to use the `ChatGPT` Endpoint in LibreChat, setting up a reverse proxy is a essential. PandoraNext offers a robust solution for this purpose. This guide will walk you through deploying PandoraNext to enable the `CHATGPT_REVERSE_PROXY` for use with LibreChat.
 
-> Using this method you will only be able to use `text-davinci-002-render-sha` with PandoraNext in LibreChat. Other models offer with the `plus` subscription do not work.
+> Using this method you will only be able to use `text-davinci-002-render-sha` with PandoraNext in LibreChat. Other models offered with the `plus` subscription do not work.
 
 You can use it locally in docker or deploy it onthe web for remote access.
 
@@ -155,4 +155,5 @@ For local deployment using Docker, the steps are as follows:
 ## Final Notes
 
 - The `proxy_api_prefix` should be sufficiently random and unique to prevent errors.
+- The default `token.json` doesn't need to be modified to use with LibreChat
 - Ensure you have obtained a license ID from the [PandoraNext Dashboard](https://dash.pandoranext.com/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,11 +22,30 @@
     <img 
       src="https://img.shields.io/badge/GITHUB-blue.svg?style=for-the-badge&logo=github&logoColor=white&labelColor=000000&logoWidth=20">
   </a>
-<a aria-label="Sponsors" href="#sponsors">
+<a aria-label="Sponsors" href="https://github.com/sponsors/danny-avila">
     <img
       src="https://img.shields.io/badge/SPONSORS-brightgreen.svg?style=for-the-badge&logo=github-sponsors&logoColor=white&labelColor=000000&logoWidth=20">
   </a>
 </p>
+
+# Features
+ - 🖥️ UI matching ChatGPT, including Dark mode, Streaming, and 11-2023 updates
+ - 💬 Multimodal Chat:
+     - Upload and analyze images with GPT-4-Vision 📸 
+     - More filetypes and Assistants API integration in Active Development 🚧 
+ - 🌎 Multilingual UI:
+     - English, 中文, Deutsch, Español, Français, Italiano, Polski, Português Brasileiro, Русский
+     - 日本語, Svenska, 한국어, Tiếng Việt, 繁體中文, العربية, Türkçe, Nederlands
+ - 🤖 AI model selection: OpenAI API, Azure, BingAI, ChatGPT Browser, PaLM2, Anthropic (Claude), Plugins
+ - 💾 Create, Save, & Share Custom Presets
+ - 🔄 Edit, Resubmit, and Continue messages with conversation branching
+ - 📤 Export conversations as screenshots, markdown, text, json.
+ - 🔍 Search all messages/conversations
+ - 🔌 Plugins, including web access, image generation with DALL-E-3 and more
+ - 👥 Multi-User, Secure Authentication with Moderation and Token spend tools
+ - ⚙️ Configure Proxy, Reverse Proxy, Docker, many Deployment options, and completely Open-Source
+
+[For a thorough review of our features, see our docs here](https://docs.librechat.ai/features/plugins/introduction.html) 📚
 
 ## All-In-One AI Conversations with LibreChat ##
 LibreChat brings together the future of assistant AIs with the revolutionary technology of OpenAI's ChatGPT. Celebrating the original styling, LibreChat gives you the ability to integrate multiple AI models. It also integrates and enhances original client features such as conversation and message search, prompt templates and plugins.
@@ -45,20 +64,7 @@ With LibreChat, you no longer need to opt for ChatGPT Plus and can instead use f
   </iframe>
 </p>
 
-# Features
-
-- Response streaming identical to ChatGPT through server-sent events
-- UI from original ChatGPT, including Dark mode
-- AI model selection (through 5 endpoints: OpenAI API, BingAI, ChatGPT Browser, PaLM2, Plugins)
-- Create, Save, & Share custom presets - [More info on prompt presets here](https://github.com/danny-avila/LibreChat/releases/tag/v0.3.0)
-- Edit and Resubmit messages with conversation branching
-- Search all messages/conversations - [More info here](https://github.com/danny-avila/LibreChat/releases/tag/v0.1.0)
-- Plugins now available (including web access, image generation and more)
-
----
-
 ## ⚠️ [Breaking Changes](general_info/breaking_changes.md) ⚠️
-**Applies to [v0.5.4](general_info/breaking_changes.md#v054) & [v0.5.5](general_info/breaking_changes.md#v055)**
 
 **Please read this before updating from a previous version**
 
@@ -66,21 +72,15 @@ With LibreChat, you no longer need to opt for ChatGPT Plus and can instead use f
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=danny-avila/LibreChat&type=Date)](https://star-history.com/#danny-avila/LibreChat&Date)
-
----
-
-## Sponsors
-
-  Sponsored by <a href="https://github.com/mjtechguy"><b>@mjtechguy</b></a>, <a href="https://github.com/SphaeroX"><b>@SphaeroX</b></a>, <a href="https://github.com/DavidDev1334"><b>@DavidDev1334</b></a>, <a href="https://github.com/fuegovic"><b>@fuegovic</b></a>, <a href="https://github.com/Pharrcyde"><b>@Pharrcyde</b></a> 
+<a href="https://star-history.com/#danny-avila/LibreChat&Date">
+  <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=danny-avila/LibreChat&type=Date&theme=dark" onerror="this.src='https://api.star-history.com/svg?repos=danny-avila/LibreChat&type=Date'" />
+</a>
 
 ---
 
 ## Contributors
 Contributions and suggestions bug reports and fixes are welcome!
 Please read the documentation before you do!
-
----
 
 For new features, components, or extensions, please open an issue and discuss before sending a PR. 
 

--- a/docs/install/dotenv.md
+++ b/docs/install/dotenv.md
@@ -298,10 +298,10 @@ AZURE_AI_SEARCH_SEARCH_OPTION_SELECT=
 ```
 
 #### DALL-E 3:
-- OpenAI API key for DALL-E / DALL-E-3. Set to user_provided to have the user provide their own key when installing the plugin.
+- OpenAI API key for DALL-E / DALL-E-3. Leave commented out to have the user provide their own key when installing the plugin. If you want to provide your own key for all users you can uncomment this line and add your OpenAI API key here.
 
 ```bash
-DALLE_API_KEY=user_provided
+# DALLE_API_KEY=
 ```
 
 - For customization of the DALL-E-3 System prompt, uncomment the following, and provide your own prompt. **(Advanced)** 


### PR DESCRIPTION
## Summary
- `.env.example`: Change `DALLE_API_KEY=` that was set by default to `user_provided` (which is not a valid option). Now commented out by default.
- `dotenv.md`: Update to reflect the change to `DALLE_API_KEY=`
- `README.md`: Remove the outdated `sponsors` section and chage the sponsor button to point to https://github.com/sponsors/danny-avila 
- `index.md` : Update to follow the recent layout change of the readme (features first) and update sponsors (same as the above)
- `pandoranext.md`: Fix typo and add note in the bottom to make it clear that the default `token.json` doesn't need to be edited to use in LibreChat

## Change Type
- [x] Documentation update 

## Checklist
- [x] 📃
