### PR TITLE
    fix: fonts warning

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '~': path.join(__dirname, 'src/'),
-      $fonts: resolve('public/fonts'),
+      $fonts: resolve('fonts'),
     },
   },
 });

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '~': path.join(__dirname, 'src/'),
-      $fonts: resolve('fonts'),
+      $fonts: resolve('/fonts'),
     },
   },
 });


### PR DESCRIPTION
## Summary

I was getting this warning while running the frontend:

    files in the public directory are served at the root path.
    Instead of /public/fonts/soehne-buch.woff2, use /fonts/soehne-buch.woff2.

I fixed it by changing the resolver in vite.config.ts from 'public/fonts' to just 'fonts'

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual testing to verify no error and no change in how it looks.
