### PR TITLE
documentation update: mongodb

### DIFF
--- a/docs/install/dotenv.md
+++ b/docs/install/dotenv.md
@@ -30,7 +30,9 @@ PORT=3080
 
 ### MongoDB Database
 
-- Change this to your MongoDB URI if different. It is recommend to append LibreChat.
+- Change this to your MongoDB URI if different. You should also add `LibreChat` or your own `APP_TITLE` as the database name in the URI. For example:
+  - if you are using docker, the URI format is `mongodb://<ip>:<port>/<database>`. Your `MONGO_URI` should look like this: `mongodb://127.0.0.1:27018/LibreChat`
+  - if you are using an online db, the URI format is `mongodb+srv://<username>:<password>@<host>/<database>?<options>`. Your `MONGO_URI` should look like this: `mongodb+srv://username:password@host.mongodb.net/LibreChat?retryWrites=true` (`retryWrites=true` is the only option you need when using the online db)
 - Instruction on how to create an online MongoDB database (useful for use without docker):
     - [Online MongoDB](./mongodb.md)
 - Securely access your docker MongoDB database:

--- a/docs/install/mongodb.md
+++ b/docs/install/mongodb.md
@@ -80,10 +80,10 @@
 
   ![image](https://github.com/fuegovic/LibreChat/assets/32828263/ccc52648-39fa-4f45-8e2b-96c93ffede4a)
 
-- Make sure to replace `<password>` with the database password you created in the "[database credentials](#database-credentials)" section above. Do not forget to remove the `<` `>` around the password. Also remove `&w=majority` at the end of the connection string.
+- The URI format is `mongodb+srv://<username>:<password>@<host>/<database>?<options>`. Make sure to replace `<password>` with the database password you created in the "[database credentials](#database-credentials)" section above. Do not forget to remove the `<` `>` around the password. Also remove `&w=majority` at the end of the connection string. `retryWrites=true` is the only option you need to keep. You should also add `LibreChat` or your own `APP_TITLE` as the database name in the URI.
 - example:
 ```
-mongodb+srv://fuegovic:1Gr8Banana@render-librechat.fgycwpi.mongo.net/?retryWrites=true
+mongodb+srv://fuegovic:1Gr8Banana@render-librechat.fgycwpi.mongo.net/LibreChat?retryWrites=true
 ```
 
 ---


### PR DESCRIPTION
## Summary

Adds information about the connection string format for the docker db and the online db in `dotenv.md` and `mongodb.md`
Specifically how to specify the database name in both connection strings:
`mongodb://<ip>:<port>/<database>`
`mongodb+srv://<username>:<password>@<host>/<database>?<options>`

## Change Type
- [x] Documentation update 