### PR TITLE
🚩 fix: Initialize Conversation Only when Necessary Data is Fetched

### DIFF
--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -1,7 +1,11 @@
 import { useRecoilValue } from 'recoil';
 import { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
-import { useGetConvoIdQuery, useGetModelsQuery } from 'librechat-data-provider/react-query';
+import {
+  useGetConvoIdQuery,
+  useGetModelsQuery,
+  useGetEndpointsQuery,
+} from 'librechat-data-provider/react-query';
 import { useNewConvo, useConfigOverride } from '~/hooks';
 import ChatView from '~/components/Chat/ChatView';
 import useAuthRedirect from './useAuthRedirect';
@@ -21,12 +25,23 @@ export default function ChatRoute() {
   const initialConvoQuery = useGetConvoIdQuery(conversationId ?? '', {
     enabled: isAuthenticated && conversationId !== 'new',
   });
+  const endpointsQuery = useGetEndpointsQuery({ enabled: isAuthenticated && modelsQueryEnabled });
 
   useEffect(() => {
-    if (conversationId === 'new' && modelsQuery.data && !hasSetConversation.current) {
+    if (
+      conversationId === 'new' &&
+      endpointsQuery.data &&
+      modelsQuery.data &&
+      !hasSetConversation.current
+    ) {
       newConversation({ modelsData: modelsQuery.data });
       hasSetConversation.current = true;
-    } else if (initialConvoQuery.data && modelsQuery.data && !hasSetConversation.current) {
+    } else if (
+      initialConvoQuery.data &&
+      endpointsQuery.data &&
+      modelsQuery.data &&
+      !hasSetConversation.current
+    ) {
       newConversation({
         template: initialConvoQuery.data,
         modelsData: modelsQuery.data,
@@ -34,7 +49,7 @@ export default function ChatRoute() {
       hasSetConversation.current = true;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialConvoQuery.data, modelsQuery.data]);
+  }, [initialConvoQuery.data, modelsQuery.data, endpointsQuery.data]);
 
   if (!isAuthenticated) {
     return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2130,41 +2130,6 @@
         "@babel/core": "^7.13.0"
       }
     },
-    "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz",
-      "integrity": "sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.21.0.tgz",
-      "integrity": "sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
@@ -6963,32 +6928,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@rollup/plugin-babel": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.0.4.tgz",
-      "integrity": "sha512-YF7Y52kFdFT/xVSuVdjkV5ZdX/3YtmX0QulG+x0taQOtJdHYzVU61aSSkAgVJ7NOv6qPkIYiJSgSWWN/DM5sGw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.18.6",
-        "@rollup/pluginutils": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0",
-        "@types/babel__core": "^7.1.9",
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/babel__core": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        }
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -25566,13 +25505,10 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
-        "@babel/plugin-proposal-optional-chaining": "^7.21.0",
         "@babel/preset-env": "^7.21.5",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.21.0",
         "@rollup/plugin-alias": "^5.1.0",
-        "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^25.0.2",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.1.0",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -44,13 +44,10 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
-    "@babel/plugin-proposal-optional-chaining": "^7.21.0",
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.0",
     "@rollup/plugin-alias": "^5.1.0",
-    "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^25.0.2",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.1.0",

--- a/packages/data-provider/server-rollup.config.js
+++ b/packages/data-provider/server-rollup.config.js
@@ -3,7 +3,6 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import alias from '@rollup/plugin-alias';
 import json from '@rollup/plugin-json';
-import babel from '@rollup/plugin-babel';
 
 const rootPath = path.resolve(__dirname, '../../');
 const rootServerPath = path.resolve(__dirname, '../../api');
@@ -30,19 +29,6 @@ export default {
     }),
     commonjs(),
     json(),
-    babel({
-      exclude: 'node_modules/**',
-      babelHelpers: 'bundled',
-      presets: [
-        ['@babel/preset-env', { targets: { node: 'current' } }],
-        '@babel/preset-typescript',
-      ],
-      plugins: [
-        '@babel/plugin-syntax-dynamic-import',
-        '@babel/plugin-proposal-nullish-coalescing-operator',
-        '@babel/plugin-proposal-optional-chaining',
-      ],
-    }),
   ],
   external: (id) => {
     // More selective external function


### PR DESCRIPTION
### Summary:

In response to an issue where the initial conversation settings were being applied before all necessary data was fetched from the server, leading to problems with model and endpoint selectors, I've implemented a fix. This issue was only exhibited after running `npm run reinstall` and was likely due to a sequence issue in data fetching and conversation initialization.

I resolved this by ensuring that the conversation is only initialized after all required data (models, endpoints, initialConversationQuery) is successfully fetched from the server. This fix prevents the selectors from being undefined and improves the user experience, especially for new users who are not familiar with the application.

Unrelated but also took the opportunity to remove unecessary packages related to bundling the /api/ code for testing.

Closes #1375 

### Change Type:

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing:

To test this fix, perform the following steps:

1. Clone the repository into a new folder
2. Run `npm run reinstall`
3. Set up the `.env` file, using an existing database
4. Run `npm run backend`
5. Log in or sign up to the application
6. Observe that the model and endpoint selectors are correctly populated and functioning on initial login

Reproduce the steps prior to this fix to confirm it was an issue before but not anymore.

### Checklist:

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented on any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works 
- [x] Local unit tests pass with my changes
- [x] Any dependent changes have been merged and published in downstream modules.