### PR TITLE
doc update: firebase.md

### DIFF
--- a/docs/features/firebase.md
+++ b/docs/features/firebase.md
@@ -72,3 +72,32 @@ FIREBASE_STORAGE_BUCKET=storage_bucket #storageBucket
 FIREBASE_MESSAGING_SENDER_ID=messaging_sender_id #messagingSenderId
 FIREBASE_APP_ID=1:your_app_id #appId
 ```
+
+- Return one last time to the Project Overview.
+
+![Project Overview](https://github.com/danny-avila/LibreChat/assets/81851188/c425f4bb-a494-42f2-9fdc-ff2c8ce005e1)
+
+- Select `Storage`
+
+![image](https://github.com/danny-avila/LibreChat/assets/32828263/16a0f850-cdd4-4875-8342-ab67bfb59804)
+
+- Select `Rules` and delete `: if false;` on this line: `allow read, write: if false;`
+
+    - your updated rules should look like this:
+
+    ```bash
+    rules_version = '2';
+    service firebase.storage {
+      match /b/{bucket}/o {
+        match /{allPaths=**} {
+          allow read, write 
+        }
+      }
+    }
+    ```
+
+![image](https://github.com/danny-avila/LibreChat/assets/32828263/c190011f-c1a6-47c7-986e-8d309b5f8704)
+
+- Publish your updated rules
+
+![image](https://github.com/danny-avila/LibreChat/assets/32828263/5e6a17c3-5aba-419a-a18f-be910b1f25d5)


### PR DESCRIPTION
## Summary
Tested Firebase CDN on 2 different builds of LibreChat (I've set up a new instance of Firebase CDN twice) and couldn't get it to work without updating the rules. I updated the documentation to include the rule changes.

- Here's the error I was getting before changing the rules:
![image](https://github.com/danny-avila/LibreChat/assets/32828263/16332640-16bd-4522-ab22-063b8c5e46c1)

- The updated rules (I needed to delete `: if false;` on this line: `allow read, write: if false;`):

    ```bash
    rules_version = '2';
    service firebase.storage {
      match /b/{bucket}/o {
        match /{allPaths=**} {
          allow read, write 
        }
      }
    }
    ```

---

- Update `firebase.md`: include instruction to update the rules

## Change Type
- [x] Documentation update 

## Testing
- I went back and forth between the original rules and the updated rules and was able to confirm that the change was needed to work without errors for me (tested with multiple accounts on 2 builds of LibreChat)

## Checklist
- [x] 🔥