### PR TITLE
🔧 fix(OpenAIClient): do not invoke abortCompletion on completion error

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -859,7 +859,6 @@ ${convo}
         (err instanceof OpenAI.OpenAIError && err?.message?.includes('missing finish_reason'))
       ) {
         logger.error('[OpenAIClient] Known OpenAI error:', err);
-        await abortController.abortCompletion();
         return intermediateReply;
       } else if (err instanceof OpenAI.APIError) {
         if (intermediateReply) {


### PR DESCRIPTION
## Summary

This change is a result of the `abortMiddleware` functioning how it should now, requiring `abortCompletion` only to be called by that specific module.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

**Before:**

when using the azure openai gpt-4-vision model, or openrouter, or experience an error during/after generation, the AI message seems stuck - won't finish, and you have to force stop before continue the conversation.

**After:**

no longer observed

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
