### PR TITLE
🛠️ fix: Error Message Parsing and ChatOpenAI credentials

### DIFF
--- a/api/app/clients/llm/createLLM.js
+++ b/api/app/clients/llm/createLLM.js
@@ -3,38 +3,6 @@ const { sanitizeModelName } = require('../../../utils');
 const { isEnabled } = require('../../../server/utils');
 
 /**
- * @typedef {Object} ModelOptions
- * @property {string} modelName - The name of the model.
- * @property {number} [temperature] - The temperature setting for the model.
- * @property {number} [presence_penalty] - The presence penalty setting.
- * @property {number} [frequency_penalty] - The frequency penalty setting.
- * @property {number} [max_tokens] - The maximum number of tokens to generate.
- */
-
-/**
- * @typedef {Object} ConfigOptions
- * @property {string} [basePath] - The base path for the API requests.
- * @property {Object} [baseOptions] - Base options for the API requests, including headers.
- * @property {Object} [httpAgent] - The HTTP agent for the request.
- * @property {Object} [httpsAgent] - The HTTPS agent for the request.
- */
-
-/**
- * @typedef {Object} Callbacks
- * @property {Function} [handleChatModelStart] - A callback function for handleChatModelStart
- * @property {Function} [handleLLMEnd] - A callback function for handleLLMEnd
- * @property {Function} [handleLLMError] - A callback function for handleLLMError
- */
-
-/**
- * @typedef {Object} AzureOptions
- * @property {string} [azureOpenAIApiKey] - The Azure OpenAI API key.
- * @property {string} [azureOpenAIApiInstanceName] - The Azure OpenAI API instance name.
- * @property {string} [azureOpenAIApiDeploymentName] - The Azure OpenAI API deployment name.
- * @property {string} [azureOpenAIApiVersion] - The Azure OpenAI API version.
- */
-
-/**
  * Creates a new instance of a language model (LLM) for chat interactions.
  *
  * @param {Object} options - The options for creating the LLM.
@@ -96,6 +64,7 @@ function createLLM({
       configuration,
       ...azureOptions,
       ...modelOptions,
+      ...credentials,
       callbacks,
     },
     configOptions,

--- a/api/typedefs.js
+++ b/api/typedefs.js
@@ -337,3 +337,39 @@
  * @property {number} order - The order of the endpoint.
  * @memberof typedefs
  */
+
+/**
+ * @typedef {Object} ModelOptions
+ * @property {string} modelName - The name of the model.
+ * @property {number} [temperature] - The temperature setting for the model.
+ * @property {number} [presence_penalty] - The presence penalty setting.
+ * @property {number} [frequency_penalty] - The frequency penalty setting.
+ * @property {number} [max_tokens] - The maximum number of tokens to generate.
+ * @memberof typedefs
+ */
+
+/**
+ * @typedef {Object} ConfigOptions
+ * @property {string} [basePath] - The base path for the API requests.
+ * @property {Object} [baseOptions] - Base options for the API requests, including headers.
+ * @property {Object} [httpAgent] - The HTTP agent for the request.
+ * @property {Object} [httpsAgent] - The HTTPS agent for the request.
+ * @memberof typedefs
+ */
+
+/**
+ * @typedef {Object} Callbacks
+ * @property {Function} [handleChatModelStart] - A callback function for handleChatModelStart
+ * @property {Function} [handleLLMEnd] - A callback function for handleLLMEnd
+ * @property {Function} [handleLLMError] - A callback function for handleLLMError
+ * @memberof typedefs
+ */
+
+/**
+ * @typedef {Object} AzureOptions
+ * @property {string} [azureOpenAIApiKey] - The Azure OpenAI API key.
+ * @property {string} [azureOpenAIApiInstanceName] - The Azure OpenAI API instance name.
+ * @property {string} [azureOpenAIApiDeploymentName] - The Azure OpenAI API deployment name.
+ * @property {string} [azureOpenAIApiVersion] - The Azure OpenAI API version.
+ * @memberof typedefs
+ */

--- a/client/src/hooks/useSSE.ts
+++ b/client/src/hooks/useSSE.ts
@@ -209,16 +209,23 @@ export default function useSSE(submission: TSubmission | null, index = 0) {
   };
 
   const errorHandler = ({ data, submission }: { data?: TResData; submission: TSubmission }) => {
-    const { messages, message } = submission;
+    const { messages, message, initialResponse } = submission;
 
     const conversationId = message?.conversationId ?? submission?.conversationId;
     const parseErrorResponse = (data: TResData | Partial<TMessage>) => {
       const metadata = data['responseMessage'] ?? data;
-      return tMessageSchema.parse({
+      const errorMessage = {
+        ...initialResponse,
         ...metadata,
         error: true,
         parentMessageId: message?.messageId,
-      });
+      };
+
+      if (!errorMessage.messageId) {
+        errorMessage.messageId = v4();
+      }
+
+      return tMessageSchema.parse(errorMessage);
     };
 
     if (!data) {


### PR DESCRIPTION
## Summary

I've improved the parsing of error messages in the error handler of the `useSSE` hook. 

I've also made sure the `ChatOpenAI` class always uses the client-defined `openAIApiKey`. This was necessary as langchain looks for `OPENAI_API_KEY` from the env and has recently made a change to prioritize the key, even if "user_provided", in the API call.

In the process, I also moved type definitions defined from the `createLLM` module to the main definition file (api/typedefs).

## Change Type
- [x] Refactoring

## Testing
To test these changes, run the application and trigger different error scenarios to check the parsing of error messages. Pay particular attention to the error handling within the `useSSE` hook.

Next, check the use of the `openAIApiKey` in the `ChatOpenAI` class. Make sure the client-defined `openAIApiKey` is being used consistently.

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented on any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests that prove my changes are effective or that my feature works
- [x] Local unit tests pass with my changes