### PR TITLE
🐋 refactor: Mount Config File in Docker and Add to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ client/dist/images
 data-node
 .env
 **/.env
+librechat.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - ./.env.development:/app/.env.development
       - ./.env.production:/app/.env.production
       - ./images:/app/client/public/images
+      - ./librechat.yaml:/app/librechat.yaml
   mongodb:
     container_name: chat-mongodb
     image: mongo


### PR DESCRIPTION
## Summary

In the recent changes, I refactored the Docker compose configuration file to mount the `librechat.yaml` config file. This allows the Docker container to access the necessary configuration settings directly from this file. In addition, I have also added the `librechat.yaml` config file to `.dockerignore` to prevent unnecessary rebuilding of Docker images when changes are made to this file.

## Change Type

- [x] Refactoring (no functional changes, no api changes)

## Testing

To test these changes, you can rebuild the Docker image and run it. Ensure that the application works as expected and the settings from the `librechat.yaml` config file are being used correctly. Also, make changes to the `librechat.yaml` config file and verify if the Docker image is not being unnecessarily rebuilt. 

### **Test Configuration**:

- Docker version: Latest
- Docker compose version: Latest

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have documented any important changes
- [x] My changes do not introduce new warnings
- [x] Any dependent changes have been merged and published in downstream modules.