### PR TITLE
⬆️ fix(SendButton): correct dark theme background when `enabled`

### DIFF
--- a/client/src/components/Chat/Input/SendButton.tsx
+++ b/client/src/components/Chat/Input/SendButton.tsx
@@ -6,7 +6,7 @@ export default function SendButton({ text, disabled }) {
     <button
       disabled={!text || disabled}
       className={cn(
-        'enabled:bg-brand-purple absolute rounded-lg rounded-md border border-black p-0.5 p-1 text-white transition-colors enabled:bg-black disabled:bg-black disabled:text-gray-400 disabled:opacity-10 dark:border-white dark:bg-white dark:disabled:bg-white ',
+        'absolute rounded-lg rounded-md border border-black p-0.5 p-1 text-white transition-colors enabled:bg-black enabled:dark:bg-white disabled:bg-black disabled:text-gray-400 disabled:opacity-10 dark:border-white dark:bg-white dark:disabled:bg-white ',
         'bottom-1.5 right-1.5 md:bottom-2.5 md:right-3 md:p-[2px]',
       )}
       data-testid="send-button"


### PR DESCRIPTION
Minor fix. since the disabled variable becomes active almost at all times now, the tailwind css for `enabled` was observed without a proper dark mode setting

**Before:**
![image](https://github.com/danny-avila/LibreChat/assets/110412045/44a4bde2-79ac-4518-96e1-d3fb266d5134)

**After:**
![image](https://github.com/danny-avila/LibreChat/assets/110412045/3766f5bc-7e47-46e7-b7ca-f58bcd2d8375)
