### PR TITLE
🛠️ fix: Custom Endpoint issues, Improve SSE Response Handling

### DIFF
--- a/api/server/middleware/abortMiddleware.js
+++ b/api/server/middleware/abortMiddleware.js
@@ -14,7 +14,7 @@ async function abortMessage(req, res) {
   }
 
   if (!abortControllers.has(abortKey) && !res.headersSent) {
-    return res.status(404).send({ message: 'Request not found' });
+    return res.status(204).send({ message: 'Request not found' });
   }
 
   const { abortController } = abortControllers.get(abortKey);
@@ -25,6 +25,8 @@ async function abortMessage(req, res) {
   if (res.headersSent && finalEvent) {
     return sendMessage(res, finalEvent);
   }
+
+  res.setHeader('Content-Type', 'application/json');
 
   res.send(JSON.stringify(finalEvent));
 }

--- a/client/src/components/Chat/Landing.tsx
+++ b/client/src/components/Chat/Landing.tsx
@@ -23,6 +23,7 @@ export default function Landing({ Header }: { Header?: ReactNode }) {
   const endpointType = getEndpointField(endpointsConfig, endpoint, 'type');
   const iconURL = getEndpointField(endpointsConfig, endpoint, 'iconURL');
   const iconKey = endpointType ? 'unknown' : endpoint ?? 'unknown';
+  const Icon = icons[iconKey];
 
   return (
     <div className="relative h-full">
@@ -31,7 +32,8 @@ export default function Landing({ Header }: { Header?: ReactNode }) {
         <div className="mb-3 h-[72px] w-[72px]">
           <div className="gizmo-shadow-stroke relative flex h-full items-center justify-center rounded-full bg-white text-black">
             {endpoint &&
-              icons[iconKey]({
+              Icon &&
+              Icon({
                 size: 41,
                 context: 'landing',
                 className: 'h-2/3 w-2/3',

--- a/client/src/components/Chat/Menus/Endpoints/MenuItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/MenuItem.tsx
@@ -82,7 +82,7 @@ const MenuItem: FC<MenuItemProps> = ({
         <div className="flex grow items-center justify-between gap-2">
           <div>
             <div className="flex items-center gap-2">
-              {
+              {Icon && (
                 <Icon
                   size={18}
                   endpoint={endpoint}
@@ -90,7 +90,7 @@ const MenuItem: FC<MenuItemProps> = ({
                   className="icon-md shrink-0 dark:text-white"
                   iconURL={getEndpointField(endpointsConfig, endpoint, 'iconURL')}
                 />
-              }
+              )}
               <div>
                 {title}
                 <div className="text-token-text-tertiary">{description}</div>

--- a/client/src/components/Chat/Menus/Presets/PresetItems.tsx
+++ b/client/src/components/Chat/Menus/Presets/PresetItems.tsx
@@ -97,7 +97,8 @@ const PresetItems: FC<{
 
             const iconKey = getEndpointField(endpointsConfig, preset.endpoint, 'type')
               ? 'unknown'
-              : preset.endpoint ?? 'unknown';
+              : preset.endpointType ?? preset.endpoint ?? 'unknown';
+            const Icon = icons[iconKey];
 
             return (
               <Close asChild key={`preset-${preset.presetId}`}>
@@ -109,12 +110,15 @@ const PresetItems: FC<{
                       title={getPresetTitle(preset)}
                       disableHover={true}
                       onClick={() => onSelectPreset(preset)}
-                      icon={icons[iconKey]({
-                        context: 'menu-item',
-                        iconURL: getEndpointField(endpointsConfig, preset.endpoint, 'iconURL'),
-                        className: 'icon-md mr-1 dark:text-white',
-                        endpoint: preset.endpoint,
-                      })}
+                      icon={
+                        Icon &&
+                        Icon({
+                          context: 'menu-item',
+                          iconURL: getEndpointField(endpointsConfig, preset.endpoint, 'iconURL'),
+                          className: 'icon-md mr-1 dark:text-white',
+                          endpoint: preset.endpoint,
+                        })
+                      }
                       selected={false}
                       data-testid={`preset-item-${preset}`}
                     >


### PR DESCRIPTION
## Summary: 

I implemented general improvements in the useSSE hook and abortMiddleware, and fixed a bug affecting presets when a custom endpoint is removed. 

- The changes include the addition of endpointType to fetch URL in the useSSE hook and using the EndpointURLs enum for better code consistency and maintainability. 
- In the abortMiddleware, I refactored the code to send a 204 status when the abortController is not found or active. I also set the expected header `application/json` when it was not set. 
- To handle the 204 response, I set the `data` to the initiated response within the abortConversation handling in useSSE.
- Improved the error handling UX to make it clear when there is an explicit error. This will help in debugging and provide a smoother user experience. 
- Fixed a bug in the custom preset that was causing frontend errors when removed custom endpoints were being used.

Closes #1509 

## Testing:

To test these changes, I manually triggered various responses and errors and ensured that they were handled correctly. I also used different types of endpoints to verify that the endpointType addition works as expected.

**Test Configuration**: Local development environment.

## Checklist:

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.