### PR TITLE
🐛 fix: Load `dotenv` at Top of Call Stack

### DIFF
--- a/api/server/index.js
+++ b/api/server/index.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const path = require('path');
 require('module-alias')({ base: path.resolve(__dirname, '..') });
 const cors = require('cors');


### PR DESCRIPTION
Closes #1511 

## Summary

I have fixed the issue where the Meilisearch was not functioning as expected due to an error Message.syncWithMeili is not a function. This was due to the execution order of Mongoose starting before the .env file was loaded. I have added `require('dotenv').config();` at the top of `/server/index.js` to ensure the .env file is loaded before the execution of Mongoose.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I manually tested this fix by installing LibreChat and Meilisearch manually, launching Meilisearch with a master key, configuring search for LibreChat, and then conducting a search. The error logs were checked to ensure the error was no longer present. 

### **Test Configuration**:
- Operating System: Ubuntu 20.04.6
- LibreChat version: Latest
- Meilisearch: Running in production with master key

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes