### PR TITLE
🔄 refactor(config): Move `connectWithTimeout` Outside of Helpers Module 

### DIFF
--- a/config/add-balance.js
+++ b/config/add-balance.js
@@ -1,11 +1,12 @@
 const path = require('path');
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
-const { askQuestion, silentExit, connectWithTimeout } = require('./helpers');
+const { askQuestion, silentExit } = require('./helpers');
 const Transaction = require('~/models/Transaction');
 const User = require('~/models/User');
+const connect = require('./connect');
 
 (async () => {
-  await connectWithTimeout();
+  await connect();
 
   /**
    * Show the welcome / help menu

--- a/config/ban-user.js
+++ b/config/ban-user.js
@@ -1,11 +1,12 @@
 const path = require('path');
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
-const { askQuestion, silentExit, connectWithTimeout } = require('./helpers');
+const { askQuestion, silentExit } = require('./helpers');
 const banViolation = require('~/cache/banViolation');
 const User = require('~/models/User');
+const connect = require('./connect');
 
 (async () => {
-  await connectWithTimeout();
+  await connect();
 
   console.purple('---------------------');
   console.purple('Ban a user account!');

--- a/config/connect.js
+++ b/config/connect.js
@@ -1,0 +1,32 @@
+const path = require('path');
+require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
+const connectDb = require('~/lib/db/connectDb');
+
+async function connect() {
+  /**
+   * Connect to the database
+   * - If it takes a while, we'll warn the user
+   */
+  let timeout = setTimeout(() => {
+    console.orange(
+      'This is taking a while... You may need to check your connection if this fails.',
+    );
+    timeout = setTimeout(() => {
+      console.orange('Still going... Might as well assume the connection failed...');
+      timeout = setTimeout(() => {
+        console.orange('Error incoming in 3... 2... 1...');
+      }, 13000);
+    }, 10000);
+  }, 5000);
+  // Attempt to connect to the database
+  try {
+    console.orange('Warming up the engines...');
+    await connectDb();
+    clearTimeout(timeout);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+}
+
+module.exports = connect;

--- a/config/create-user.js
+++ b/config/create-user.js
@@ -1,11 +1,12 @@
 const path = require('path');
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { registerUser } = require('~/server/services/AuthService');
-const { askQuestion, silentExit, connectWithTimeout } = require('./helpers');
+const { askQuestion, silentExit } = require('./helpers');
 const User = require('~/models/User');
+const connect = require('./connect');
 
 (async () => {
-  await connectWithTimeout();
+  await connect();
 
   /**
    * Show the welcome / help menu

--- a/config/delete-user.js
+++ b/config/delete-user.js
@@ -1,10 +1,11 @@
 const path = require('path');
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
-const { connectWithTimeout, askQuestion, silentExit } = require('./helpers');
+const { askQuestion, silentExit } = require('./helpers');
 const User = require('~/models/User');
+const connect = require('./connect');
 
 (async () => {
-  await connectWithTimeout();
+  await connect();
 
   /**
    * Show the welcome / help menu

--- a/config/helpers.js
+++ b/config/helpers.js
@@ -6,8 +6,6 @@ const fs = require('fs');
 const path = require('path');
 const readline = require('readline');
 const { execSync } = require('child_process');
-require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
-const connectDb = require('~/lib/db/connectDb');
 
 const askQuestion = (query) => {
   const rl = readline.createInterface({
@@ -45,33 +43,6 @@ const silentExit = (code = 0) => {
   process.exit(code);
 };
 
-async function connectWithTimeout() {
-  /**
-   * Connect to the database
-   * - If it takes a while, we'll warn the user
-   */
-  let timeout = setTimeout(() => {
-    console.orange(
-      'This is taking a while... You may need to check your connection if this fails.',
-    );
-    timeout = setTimeout(() => {
-      console.orange('Still going... Might as well assume the connection failed...');
-      timeout = setTimeout(() => {
-        console.orange('Error incoming in 3... 2... 1...');
-      }, 13000);
-    }, 10000);
-  }, 5000);
-  // Attempt to connect to the database
-  try {
-    console.orange('Warming up the engines...');
-    await connectDb();
-    clearTimeout(timeout);
-  } catch (e) {
-    console.error(e);
-    silentExit(1);
-  }
-}
-
 // Set the console colours
 console.orange = (msg) => console.log('\x1b[33m%s\x1b[0m', msg);
 console.green = (msg) => console.log('\x1b[32m%s\x1b[0m', msg);
@@ -87,6 +58,5 @@ module.exports = {
   askQuestion,
   silentExit,
   isDockerRunning,
-  connectWithTimeout,
   deleteNodeModules,
 };

--- a/config/list-balances.js
+++ b/config/list-balances.js
@@ -1,11 +1,12 @@
 const path = require('path');
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
-const { connectWithTimeout, silentExit } = require('./helpers');
+const { silentExit } = require('./helpers');
 const Balance = require('~/models/Balance');
 const User = require('~/models/User');
+const connect = require('./connect');
 
 (async () => {
-  await connectWithTimeout();
+  await connect();
 
   /**
    * Show the welcome / help menu


### PR DESCRIPTION
## Summary: 

I've refactored some parts of our codebase to enhance the performance and maintainability. Specifically, I have moved the `connectWithTimeout` function out of the helpers module. 

This was done to prevent module requisites when running the update script, which will eventually lead to a smoother script execution.

Renamed the db connect function to \`connect\`

## Change Type:

- [x] Refactor (non-breaking change which improves existing functionality)


## Checklist:

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented on any complex areas of my code
- [x] I have made corresponding documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests proving that my changes are effective
- [x] All local unit tests pass with my changes.