### PR TITLE
✨ feat(saveImageFromUrl): Dynamic Extension Handling

### DIFF
--- a/api/app/clients/tools/saveImageFromUrl.js
+++ b/api/app/clients/tools/saveImageFromUrl.js
@@ -11,18 +11,24 @@ async function saveImageFromUrl(url, outputPath, outputFilename) {
       responseType: 'stream',
     });
 
+    // Get the content type from the response headers
+    const contentType = response.headers['content-type'];
+    let extension = contentType.split('/').pop();
+
     // Check if the output directory exists, if not, create it
     if (!fs.existsSync(outputPath)) {
       fs.mkdirSync(outputPath, { recursive: true });
     }
 
-    // Ensure the output filename has a '.png' extension
-    const filenameWithPngExt = outputFilename.endsWith('.png')
-      ? outputFilename
-      : `${outputFilename}.png`;
+    // Replace or append the correct extension
+    const extRegExp = new RegExp(path.extname(outputFilename) + '$');
+    outputFilename = outputFilename.replace(extRegExp, `.${extension}`);
+    if (!path.extname(outputFilename)) {
+      outputFilename += `.${extension}`;
+    }
 
     // Create a writable stream for the output path
-    const outputFilePath = path.join(outputPath, filenameWithPngExt);
+    const outputFilePath = path.join(outputPath, outputFilename);
     const writer = fs.createWriteStream(outputFilePath);
 
     // Pipe the response data to the output file


### PR DESCRIPTION
## Summary:
This pull request enhances the `saveImageFromUrl` function in our LibreChat application to dynamically handle file extensions based on the content type of the fetched image. 

Previously, the function simply appended a '.png' extension to the file name, which led to inconsistencies and potential compatibility issues with the actual image format. For instance, we encountered problems with double extensions (e.g., 'someimage.jpg.png').

To solve these issues, I've replaced the old method with a more robust approach. By using regular expressions and the path module, the function can now correctly replace or add extensions, ensuring filename consistency and compatibility with the actual image format.

This change is considered a new feature as it adds functionality and improves the current image handling process.

Fixes issues with some image generation reverse proxies where `.png` was expected but `.jpg` was generated.

## Testing:
Test the changes by using various image URLs with different file extensions (e.g., .jpg, .png, .gif), and check if the saved images have the correct and consistent extensions in the file system. Make sure to remove any existing images with the same name to avoid any conflicts.

## Checklist:

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.