### PR TITLE
🌍: Correct Localized Text of "Save & Submit" Button

### DIFF
--- a/client/src/components/Chat/Messages/Content/EditMessage.tsx
+++ b/client/src/components/Chat/Messages/Content/EditMessage.tsx
@@ -102,10 +102,10 @@ const EditMessage = ({
           }
           onClick={resubmitMessage}
         >
-          {localize('com_ui_save')} {'&'} {localize('com_ui_submit')}
+          {localize('com_ui_save_submit')}
         </button>
         <button
-          className="btn btn-secondary relative mr-2"
+          className="btn btn-neutral relative mr-2"
           disabled={isSubmitting}
           onClick={updateMessage}
         >

--- a/client/src/components/Chat/Messages/Content/EditMessage.tsx
+++ b/client/src/components/Chat/Messages/Content/EditMessage.tsx
@@ -105,7 +105,7 @@ const EditMessage = ({
           {localize('com_ui_save_submit')}
         </button>
         <button
-          className="btn btn-neutral relative mr-2"
+          className="btn btn-secondary relative mr-2"
           disabled={isSubmitting}
           onClick={updateMessage}
         >

--- a/client/src/components/Chat/Messages/SiblingSwitch.tsx
+++ b/client/src/components/Chat/Messages/SiblingSwitch.tsx
@@ -44,7 +44,7 @@ export default function SiblingSwitch({
         </svg>
       </button>
       <span className="flex-shrink-0 flex-grow tabular-nums">
-        {siblingIdx + 1}/{siblingCount}
+        {siblingIdx + 1} / {siblingCount}
       </span>
       <button
         className="disabled:text-gray-300 dark:text-white dark:disabled:text-gray-400"

--- a/client/src/components/Messages/Content/EditMessage.tsx
+++ b/client/src/components/Messages/Content/EditMessage.tsx
@@ -96,7 +96,7 @@ const EditMessage = ({
           disabled={isSubmitting}
           onClick={resubmitMessage}
         >
-          {localize('com_ui_save')} {'&'} {localize('com_ui_submit')}
+          {localize('com_ui_save_submit')}
         </button>
         <button
           className="btn btn-secondary relative mr-2"

--- a/client/src/components/Messages/SiblingSwitch.tsx
+++ b/client/src/components/Messages/SiblingSwitch.tsx
@@ -44,7 +44,7 @@ export default function SiblingSwitch({
         </svg>
       </button>
       <span className="flex-shrink-0 flex-grow">
-        {siblingIdx + 1}/{siblingCount}
+        {siblingIdx + 1} / {siblingCount}
       </span>
       <button
         className="disabled:text-gray-300 dark:text-white dark:disabled:text-gray-400"

--- a/client/src/localization/languages/Eng.tsx
+++ b/client/src/localization/languages/Eng.tsx
@@ -38,6 +38,7 @@ export default {
   com_ui_upload_invalid: 'Invalid file for upload. Must be an image not exceeding 2 MB',
   com_ui_cancel: 'Cancel',
   com_ui_save: 'Save',
+  com_ui_save_submit: 'Save & Submit',
   com_ui_copy_to_clipboard: 'Copy to clipboard',
   com_ui_copied_to_clipboard: 'Copied to clipboard',
   com_ui_regenerate: 'Regenerate',

--- a/client/src/localization/languages/Es.tsx
+++ b/client/src/localization/languages/Es.tsx
@@ -37,6 +37,7 @@ export default {
   com_ui_upload_invalid: 'Archivo inválido para subir',
   com_ui_cancel: 'Cancelar',
   com_ui_save: 'Guardar',
+  com_ui_save_submit: 'Guardar y enviar',
   com_ui_copy_to_clipboard: 'Copiar al portapapeles',
   com_ui_copied_to_clipboard: 'Copiado al portapapeles',
   com_ui_regenerate: 'Regenerar',

--- a/client/src/localization/languages/Fr.tsx
+++ b/client/src/localization/languages/Fr.tsx
@@ -41,6 +41,7 @@ export default {
     'Fichier invalide pour le téléversement. Doit être une image ne dépassant pas 2 Mo',
   com_ui_cancel: 'Annuler',
   com_ui_save: 'Sauvegarder',
+  com_ui_save_submit: 'Enregistrer & Soumettre',
   com_ui_copy_to_clipboard: 'Copier dans le presse-papier',
   com_ui_copied_to_clipboard: 'Copié dans le presse-papier',
   com_ui_regenerate: 'Régénérer',

--- a/client/src/localization/languages/Ru.tsx
+++ b/client/src/localization/languages/Ru.tsx
@@ -15,6 +15,7 @@ export default {
   com_ui_limitation_harmful_biased:
     'Иногда может создавать вредные инструкции или предвзятое содержимое',
   com_ui_limitation_limited_2021: 'Ограниченные знания о мире и событиях после 2021 года',
+  com_ui_experimental: 'Экспериментальный',
   com_ui_input: 'Ввод',
   com_ui_close: 'Закрыть',
   com_ui_model: 'Модель',
@@ -36,6 +37,7 @@ export default {
   com_ui_upload_invalid: 'Недопустимый файл для загрузки',
   com_ui_cancel: 'Отмена',
   com_ui_save: 'Сохранить',
+  com_ui_save_submit: 'Сохранить и отправить',
   com_ui_copy_to_clipboard: 'Копировать в буфер обмена',
   com_ui_copied_to_clipboard: 'Скопировано в буфер обмена',
   com_ui_regenerate: 'Повторная генерация',
@@ -257,6 +259,7 @@ export default {
     'Убедитесь что нажали на \'Create and Continue\' чтобы получить как минимум \'Vertex AI User\'. Наконец, создайте JSON-ключ чтобы импортировать его сюда.',
   com_nav_welcome_message: 'Чем я могу помочь вам сегодня?',
   com_nav_auto_scroll: 'Автоматически проматывать к самым новым сообщениям при открытии',
+  com_nav_modular_chat: 'Разрешить менять точки подключения в середине разговора',
   com_nav_plugin_store: 'Магазин плагинов',
   com_nav_plugin_search: 'Поиск плагинов',
   com_nav_plugin_auth_error:
@@ -291,7 +294,7 @@ export default {
   com_nav_clear_conversation: 'Удалить разговоры',
   com_nav_clear_conversation_confirm_message:
     'Вы уверены, что хотите удалить все разговоры? Это действие нельзя отменить.',
-  com_nav_help_faq: 'Помощь и ЧаВо',
+  com_nav_help_faq: 'Помощь и Вопросы',
   com_nav_settings: 'Настройки',
   com_nav_search_placeholder: 'Поиск сообщений',
   com_nav_setting_general: 'Общие',


### PR DESCRIPTION
An example with two languages, Russian and Spanish; the remaining languages will also need to be translated.

was
![image](https://github.com/danny-avila/LibreChat/assets/110278369/fd5bbcc5-b10d-4c7e-b593-cfb8869446c7)
![image](https://github.com/danny-avila/LibreChat/assets/110278369/20878482-b5d8-4094-b2ce-524029aedd51)


how it became
![image](https://github.com/danny-avila/LibreChat/assets/110278369/7dc75457-ae40-4381-954d-a57f33ae429d)
![image](https://github.com/danny-avila/LibreChat/assets/110278369/edf93c9a-69c9-4243-8786-e31630b543a8)

Here I added spaces between the /
![image](https://github.com/danny-avila/LibreChat/assets/110278369/4fe356c4-778b-4f08-810a-96b963858343)

