### PR TITLE
🔧 fix: Error Handling Improvements

### DIFF
--- a/api/server/services/Endpoints/custom/initializeClient.js
+++ b/api/server/services/Endpoints/custom/initializeClient.js
@@ -4,6 +4,8 @@ const { isUserProvided, extractEnvVariable } = require('~/server/utils');
 const getCustomConfig = require('~/cache/getCustomConfig');
 const { OpenAIClient } = require('~/app');
 
+const envVarRegex = /^\${(.+)}$/;
+
 const { PROXY } = process.env;
 
 const initializeClient = async ({ req, res, endpointOption }) => {
@@ -19,6 +21,14 @@ const initializeClient = async ({ req, res, endpointOption }) => {
 
   const CUSTOM_API_KEY = extractEnvVariable(endpointConfig.apiKey);
   const CUSTOM_BASE_URL = extractEnvVariable(endpointConfig.baseURL);
+
+  if (CUSTOM_API_KEY.match(envVarRegex)) {
+    throw new Error(`Missing API Key for ${endpoint}.`);
+  }
+
+  if (CUSTOM_BASE_URL.match(envVarRegex)) {
+    throw new Error(`Missing Base URL for ${endpoint}.`);
+  }
 
   const customOptions = {
     addParams: endpointConfig.addParams,

--- a/client/src/components/Endpoints/Icon.tsx
+++ b/client/src/components/Endpoints/Icon.tsx
@@ -16,7 +16,7 @@ import { cn } from '~/utils';
 
 const Icon: React.FC<IconProps> = (props) => {
   const { user } = useAuthContext();
-  const { size = 30, isCreatedByUser, button, model = '', endpoint, error, jailbreak } = props;
+  const { size = 30, isCreatedByUser, button, model = '', endpoint, jailbreak } = props;
 
   if (isCreatedByUser) {
     const username = user?.name || 'User';
@@ -130,11 +130,11 @@ const Icon: React.FC<IconProps> = (props) => {
         )}
       >
         {icon}
-        {error && (
+        {/* {error && (
           <span className="absolute right-0 top-[20px] -mr-2 flex h-4 w-4 items-center justify-center rounded-full border border-white bg-red-500 text-[10px] text-white">
             !
           </span>
-        )}
+        )} */}
       </div>
     );
   }

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -200,11 +200,12 @@ export const tPresetSchema = tConversationSchema
   })
   .merge(
     z.object({
-      conversationId: z.string().optional(),
+      conversationId: z.string().nullable().optional(),
       presetId: z.string().nullable().optional(),
       title: z.string().nullable().optional(),
       defaultPreset: z.boolean().optional(),
       order: z.number().optional(),
+      endpoint: extendedModelEndpointSchema.nullable(),
     }),
   );
 


### PR DESCRIPTION
## Summary:

I have made minor improvements in useSSE, refactored tPresetSchema, fixed issues in custom and updated the style of the Icon.

- In useSSE, the `completed` set is now used to prevent unnecessary abort requests. I also set the preset with `newConversation` calls using initial conversation settings to prevent the default Preset from being overridden along with the default settings. In the event of a parsing error in `onerror`, the function now returns as expected errors from the server are properly formatted.
- For tPresetSchema, the `conversationId` type now matches `tConversationSchema` but is optional. The `extendedModelEndpointSchema` is used for the `endpoint`.
- In the custom module, `initializeClient` will now throw an error if apiKey or baseURL are admin provided but no environment variable was found.
- For the Icon style, I've removed the error bubble from the message icon.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing:

- I tested useSSE by initiating new conversations and aborting some, ensuring that no unnecessary abort requests were sent.
- I verified the changes to tPresetSchema by creating various presets and checking that the `conversationId` type matches `tConversationSchema`.
- I tested the changes in the custom module by providing admin credentials without having environment variables set, and confirmed that an error was thrown.
- I visually inspected the message icon after the style change to confirm that the error bubble was removed. 

Ensure that you update the corresponding unit tests to reflect these changes and also manually test these changes in a local environment.

## Checklist:

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.