### PR TITLE
fix(getUserPluginAuthValue): throws error if no user matches

### DIFF
--- a/api/server/services/PluginService.js
+++ b/api/server/services/PluginService.js
@@ -2,18 +2,38 @@ const PluginAuth = require('~/models/schema/pluginAuthSchema');
 const { encrypt, decrypt } = require('~/server/utils/');
 const { logger } = require('~/config');
 
-const getUserPluginAuthValue = async (user, authField) => {
+/**
+ * Asynchronously retrieves and decrypts the authentication value for a user's plugin, based on a specified authentication field.
+ *
+ * @param {string} userId - The unique identifier of the user for whom the plugin authentication value is to be retrieved.
+ * @param {string} authField - The specific authentication field (e.g., 'API_KEY', 'URL') whose value is to be retrieved and decrypted.
+ * @returns {Promise<string|null>} A promise that resolves to the decrypted authentication value if found, or `null` if no such authentication value exists for the given user and field.
+ *
+ * The function throws an error if it encounters any issue during the retrieval or decryption process, or if the authentication value does not exist.
+ *
+ * @example
+ * // To get the decrypted value of the 'token' field for a user with userId '12345':
+ * getUserPluginAuthValue('12345', 'token').then(value => {
+ *   console.log(value);
+ * }).catch(err => {
+ *   console.error(err);
+ * });
+ *
+ * @throws {Error} Throws an error if there's an issue during the retrieval or decryption process, or if the authentication value does not exist.
+ * @async
+ */
+const getUserPluginAuthValue = async (userId, authField) => {
   try {
-    const pluginAuth = await PluginAuth.findOne({ user, authField }).lean();
+    const pluginAuth = await PluginAuth.findOne({ userId, authField }).lean();
     if (!pluginAuth) {
-      return null;
+      throw new Error(`No plugin auth ${authField} found for user ${userId}`);
     }
 
     const decryptedValue = decrypt(pluginAuth.value);
     return decryptedValue;
   } catch (err) {
     logger.error('[getUserPluginAuthValue]', err);
-    return err;
+    throw err;
   }
 };
 


### PR DESCRIPTION
## Summary

Fixes a critical error where authentication could continue if it was ever provided before. `userId` must match

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
