### PR TITLE
🐛 fix: Remove `resendImages`, `imageDetail` from `modelOptions` for Custom Endpoints

### DIFF
--- a/api/server/services/Endpoints/custom/buildOptions.js
+++ b/api/server/services/Endpoints/custom/buildOptions.js
@@ -1,10 +1,12 @@
 const buildOptions = (endpoint, parsedBody, endpointType) => {
-  const { chatGptLabel, promptPrefix, ...rest } = parsedBody;
+  const { chatGptLabel, promptPrefix, resendImages, imageDetail, ...rest } = parsedBody;
   const endpointOption = {
     endpoint,
     endpointType,
     chatGptLabel,
     promptPrefix,
+    resendImages,
+    imageDetail,
     modelOptions: {
       ...rest,
     },


### PR DESCRIPTION
## Summary:

In this pull request, I removed the `resendImages` and `imageDetail` fields from the modelOptions for custom endpoints. This is the new behavior for `openAI` and I simply forgot to include it for `custom` endpoints with #1535 

When these fields are introduced to the payload, it causes Error code 422 with Mistral AI API.

This change does not require any dependencies and does not introduce new warnings. The change has been fully tested and does not break any existing functionality.

## Testing:

The testing was done using the application's inbuilt testing suite, along with some manual testing for user experience. The test included creating new custom endpoints and ensuring that the absence of `resendImages` and `imageDetail` did not affect the functionality.

**Test Configuration**: 
- LibreChat version: latest
- Environment: Local development

## Checklist:
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes.