### PR TITLE
📑 docs: Update Mistral AI API example about `dropParams`

### DIFF
--- a/docs/install/configuration/custom_config.md
+++ b/docs/install/configuration/custom_config.md
@@ -104,6 +104,7 @@ Each endpoint in the `custom` array should have the following structure:
 # Example Endpoint Object Structure
 endpoints:
   custom:
+      # Example using Mistral AI API
     - name: "Mistral"
       apiKey: "${YOUR_ENV_VAR_KEY}"
       baseURL: "https://api.mistral.ai/v1"
@@ -117,7 +118,8 @@ endpoints:
       modelDisplayLabel: "Mistral"
       addParams:
         safe_mode: true
-      dropParams: ["stop", "temperature", "top_p"]
+      # NOTE: For Mistral, it is necessary to drop the following parameters or you will encounter a 422 Error:
+      dropParams: ["stop", "user", "frequency_penalty", "presence_penalty"]
 ```
 
 ### **name**:
@@ -249,7 +251,7 @@ endpoints:
 
   - Type: Array/List of Strings
   - **Description**: Excludes specified [default parameters](#default-parameters). Useful for APIs that do not accept or recognize certain parameters.
-  - **Example**: `dropParams: ["stop", "temperature", "top_p"]`
+  - **Example**: `dropParams: ["stop", "user", "frequency_penalty", "presence_penalty"]`
   - **Note**: For a list of default parameters sent with every request, see the ["Default Parameters"](#default-parameters) Section below.
 ## Additional Notes
 - Ensure that all URLs and keys are correctly specified to avoid connectivity issues.
@@ -314,7 +316,8 @@ endpoints:
       modelDisplayLabel: "Mistral"
       addParams:
         safe_mode: true
-      dropParams: ["stop", "temperature", "top_p"]
+      # NOTE: For Mistral, it is necessary to drop the following parameters or you will encounter a 422 Error:
+      dropParams: ["stop", "user", "frequency_penalty", "presence_penalty"]
 
      # OpenRouter.ai API
     - name: "OpenRouter"

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -49,12 +49,9 @@ endpoints:
         safe_mode: true # This field is specific to Mistral AI: https://docs.mistral.ai/api/
         
       # Drop Default params parameters from the request. See default params in guide linked below.
-      dropParams: ["stop", "temperature", "top_p"]
-      # - stop # dropped since it's not recognized by Mistral AI API
-      # `temperature` and `top_p` are removed to allow Mistral AI API defaults to be used:
-      # - temperature
-      # - top_p
-
+      # NOTE: For Mistral, it is necessary to drop the following parameters or you will encounter a 422 Error:
+      dropParams: ["stop", "user", "frequency_penalty", "presence_penalty"]
+      
     # OpenRouter.ai Example
     - name: "OpenRouter"
       # For `apiKey` and `baseURL`, you can use environment variables that you define.


### PR DESCRIPTION
Simple change noting the recent update to Mistral AI API in `librechat.yaml` config examples, which is sending Error code 422 for unrecognized fields.