### PR TITLE
🚆docs: update invalid env variables in hetzner ubuntu example

### DIFF
--- a/docs/deployment/hetzner_ubuntu.md
+++ b/docs/deployment/hetzner_ubuntu.md
@@ -100,8 +100,7 @@ nano docker-compose.yml
 ```
 
 ```
-       VITE_APP_TITLE: LibreChat # default, change to your desired app >
-       VITE_SHOW_GOOGLE_LOGIN_OPTION: 'false'  # default, change to true if you want to show google login
+       APP_TITLE: LibreChat # default, change to your desired app >
 ```
 
 ### 2. Create a global environment file and open it up to begin adding the tokens/keys you prepared in the PreReqs section.


### PR DESCRIPTION
# Update Hetzner Ubuntu example


## Summary

This PR updates an outdated deployment example for hetzner which still used `VITE_APP_TITLE` that is now `APP_TITLE`. An older, now unused env variable is also removed.

## Change Type

Please delete any irrelevant options.

- [x] Documentation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
