### PR TITLE
📑 docs: fix mistral ai api example `safe_mode` --> `safe_prompt`

### DIFF
--- a/docs/install/configuration/custom_config.md
+++ b/docs/install/configuration/custom_config.md
@@ -117,7 +117,7 @@ endpoints:
       forcePrompt: false 
       modelDisplayLabel: "Mistral"
       addParams:
-        safe_mode: true
+        safe_prompt: true
       # NOTE: For Mistral, it is necessary to drop the following parameters or you will encounter a 422 Error:
       dropParams: ["stop", "user", "frequency_penalty", "presence_penalty"]
 ```
@@ -242,7 +242,7 @@ endpoints:
   - **Example**: 
 ```yaml
     addParams:
-      safe_mode: true
+      safe_prompt: true
 ```
 
 ### **dropParams**:
@@ -315,7 +315,7 @@ endpoints:
       forcePrompt: false 
       modelDisplayLabel: "Mistral"
       addParams:
-        safe_mode: true
+        safe_prompt: true
       # NOTE: For Mistral, it is necessary to drop the following parameters or you will encounter a 422 Error:
       dropParams: ["stop", "user", "frequency_penalty", "presence_penalty"]
 

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -46,7 +46,7 @@ endpoints:
 
       # Add additional parameters to the request. Default params will be overwritten.
       addParams:
-        safe_mode: true # This field is specific to Mistral AI: https://docs.mistral.ai/api/
+        safe_prompt: true # This field is specific to Mistral AI: https://docs.mistral.ai/api/
         
       # Drop Default params parameters from the request. See default params in guide linked below.
       # NOTE: For Mistral, it is necessary to drop the following parameters or you will encounter a 422 Error:


### PR DESCRIPTION
## Summary

This was a necessary update to [make Mistral AI API work:](https://discord.com/channels/1144547040454508606/1184444810279522374/1195108690353717369):
> We made the API stricter. We did not expect that change to break anything other than incorrect requests, but unfortunately we had not properly documented the safe_prompt flag, which was incorrectly named safe_mode in the documentation (fixed now) and implemented as such by some people. That’s on us - sorry about that.

Closes #1540 

## Change Type

- [x] Documentation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
