### PR TITLE
🏗️ fix(config): Resolve Paths Correctly for Helper Scripts on Linux and Windows

### DIFF
--- a/config/connect.js
+++ b/config/connect.js
@@ -1,5 +1,11 @@
 const path = require('path');
-require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
+
+require('module-alias/register');
+const moduleAlias = require('module-alias');
+
+const basePath = path.resolve(__dirname, '..', 'api');
+moduleAlias.addAlias('~', basePath);
+
 const connectDb = require('~/lib/db/connectDb');
 
 async function connect() {


### PR DESCRIPTION

## Summary

The `api/config` directory scripts were not working on Windows systems due to module-alias not resolving correctly. After one fix in `connect.js`, all scripts are confirmed working on both Operating Systems.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested before/after

Before: not working on Windows, working on linux
After: working on both

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
