### PR TITLE
🎯 feat(config): Custom Endpoint Request Headers

### DIFF
--- a/api/server/services/Endpoints/custom/initializeClient.js
+++ b/api/server/services/Endpoints/custom/initializeClient.js
@@ -22,6 +22,13 @@ const initializeClient = async ({ req, res, endpointOption }) => {
   const CUSTOM_API_KEY = extractEnvVariable(endpointConfig.apiKey);
   const CUSTOM_BASE_URL = extractEnvVariable(endpointConfig.baseURL);
 
+  let resolvedHeaders = {};
+  if (endpointConfig.headers && typeof endpointConfig.headers === 'object') {
+    Object.keys(endpointConfig.headers).forEach((key) => {
+      resolvedHeaders[key] = extractEnvVariable(endpointConfig.headers[key]);
+    });
+  }
+
   if (CUSTOM_API_KEY.match(envVarRegex)) {
     throw new Error(`Missing API Key for ${endpoint}.`);
   }
@@ -31,6 +38,7 @@ const initializeClient = async ({ req, res, endpointOption }) => {
   }
 
   const customOptions = {
+    headers: resolvedHeaders,
     addParams: endpointConfig.addParams,
     dropParams: endpointConfig.dropParams,
     titleConvo: endpointConfig.titleConvo,

--- a/docs/install/configuration/custom_config.md
+++ b/docs/install/configuration/custom_config.md
@@ -253,6 +253,21 @@ endpoints:
   - **Description**: Excludes specified [default parameters](#default-parameters). Useful for APIs that do not accept or recognize certain parameters.
   - **Example**: `dropParams: ["stop", "user", "frequency_penalty", "presence_penalty"]`
   - **Note**: For a list of default parameters sent with every request, see the ["Default Parameters"](#default-parameters) Section below.
+
+### **headers**:
+
+  > Adds additional headers to requests. Can reference an environment variable
+
+  - Type: Object/Dictionary
+  - **Description**: The `headers` object specifies custom headers for requests. Useful for authentication and setting content types.
+  - **Example**: 
+  - **Note**: Supports dynamic environment variable values, which use the format: `"${VARIABLE_NAME}"`
+```yaml
+    headers:
+      x-api-key: "${ENVIRONMENT_VARIABLE}"
+      Content-Type: "application/json"
+```
+
 ## Additional Notes
 - Ensure that all URLs and keys are correctly specified to avoid connectivity issues.
 

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -23,6 +23,7 @@ export const endpointSchema = z.object({
   summaryModel: z.string().optional(),
   forcePrompt: z.boolean().optional(),
   modelDisplayLabel: z.string().optional(),
+  headers: z.record(z.any()).optional(),
 });
 
 export const configSchema = z.object({


### PR DESCRIPTION
I introduced a new `headers` parameter in the `librechat.yaml` configuration file to enable the definition of custom headers for all a custom endpoint's requests. This enhancement is beneficial for setting authentication tokens or specifying content types, and it also supports dynamic values via environment variables.

- Added a `headers` parameter to the `librechat.yaml` file to allow custom headers to be included in requests.
- Implemented support for referencing environment variables within the `headers` configuration, facilitating different settings across various deployment environments.

### Testing

To ensure the `headers` parameter works as intended, perform the following steps:
1. Update the `librechat.yaml` file with custom headers as shown in the example.
2. Reference an environment variable in one of the custom headers.
3. Deploy the application in an environment where the referenced environment variable is set.
4. Make a request to any endpoint and verify that the custom headers are correctly attached to the request.
5. Change the environment variable and repeat the request to ensure the header value updates dynamically.

Screenshot of configuring the example given in docs: 
![image](https://github.com/danny-avila/LibreChat/assets/110412045/4920cf58-d22f-494b-b2fe-4b12667061eb)


### Test Configuration:
- Ensure that the environment variable used in the `librechat.yaml` is properly set in the test environment.
- Use a tool to inspect the headers of outgoing requests to confirm the presence of custom headers.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes