### PR TITLE
🚀 feat: Add `OPENAI_ORGANIZATION` for all OpenAI Requests 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,8 @@ DEBUG_OPENAI=false
 
 # OPENAI_REVERSE_PROXY=
 
+# OPENAI_ORGANIZATION= 
+
 #============#
 # OpenRouter #
 #============#

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -954,6 +954,10 @@ ${convo}
         opts.defaultHeaders = { ...opts.defaultHeaders, 'api-key': this.apiKey };
       }
 
+      if (process.env.OPENAI_ORGANIZATION) {
+        opts.organization = process.env.OPENAI_ORGANIZATION;
+      }
+
       let chatCompletion;
       const openai = new OpenAI({
         apiKey: this.apiKey,

--- a/api/server/services/ModelService.js
+++ b/api/server/services/ModelService.js
@@ -53,6 +53,10 @@ const fetchModels = async ({ apiKey, baseURL, name = 'OpenAI', azure = false }) 
       payload.httpsAgent = new HttpsProxyAgent(PROXY);
     }
 
+    if (process.env.OPENAI_ORGANIZATION && baseURL.includes('openai')) {
+      payload.headers['OpenAI-Organization'] = process.env.OPENAI_ORGANIZATION;
+    }
+
     const res = await axios.get(`${baseURL}${azure ? '' : '/models'}`, payload);
     models = res.data.data.map((item) => item.id);
   } catch (err) {

--- a/docs/install/configuration/dotenv.md
+++ b/docs/install/configuration/dotenv.md
@@ -285,6 +285,13 @@ GOOGLE_MODELS=gemini-pro,gemini-pro-vision,chat-bison,chat-bison-32k,codechat-bi
 OPENAI_API_KEY=user_provided
 ```
 
+- You can specify which organization to use for each API request to OpenAI. However, it is not required if you are only part of a single organization or intend to use your default organization. You can check your [default organization here](https://platform.openai.com/account/api-keys). This can also help you limit your LibreChat instance from allowing API keys outside of your organization to be used, as a mismatch between key and organization will throw an API error.
+
+```bash
+# Optional
+OPENAI_ORGANIZATION=org-Y6rfake63IhVorgqfPQmGmgtId
+```
+
 - Set to true to enable debug mode for the OpenAI endpoint
 
 ```bash


### PR DESCRIPTION
## Summary

You can now specify which organization to use for each API request to OpenAI. However, it is not required if you are only part of a single organization or intend to use your default organization. You can check your [default organization here](https://platform.openai.com/account/api-keys). 

This can also help you limit your LibreChat instance from allowing API keys outside of your organization to be used, as a mismatch between key and organization will throw an API error.

```bash
OPENAI_ORGANIZATION=org-Y6rfake63IhVorgqfPQmGmgtId
```

All outgoing requests to OpenAI, including langchain/plugin requests, should result in error 401 no such organization if the org id is invalid or there is a mismatch.

Closes #1570

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.