### PR TITLE
🧹 chore: remove deprecated model from documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,7 +101,7 @@ GOOGLE_KEY=user_provided
 #============#
 
 OPENAI_API_KEY=user_provided
-# OPENAI_MODELS=gpt-3.5-turbo-1106,gpt-4-1106-preview,gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,text-davinci-003,gpt-4,gpt-4-0314,gpt-4-0613
+# OPENAI_MODELS=gpt-3.5-turbo-1106,gpt-4-1106-preview,gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,gpt-4,gpt-4-0314,gpt-4-0613
 
 DEBUG_OPENAI=false
 

--- a/docs/install/configuration/dotenv.md
+++ b/docs/install/configuration/dotenv.md
@@ -317,7 +317,7 @@ DEBUG_OPENAI=false
     - Leave it blank or commented out to use internal settings.
 
 ```bash
-OPENAI_MODELS=gpt-3.5-turbo-1106,gpt-4-1106-preview,gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,text-davinci-003,gpt-4,gpt-4-0314,gpt-4-0613
+OPENAI_MODELS=gpt-3.5-turbo-1106,gpt-4-1106-preview,gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,gpt-4,gpt-4-0314,gpt-4-0613
 ```
 
 - Titling is enabled by default when initiating a conversation.

--- a/docs/install/configuration/free_ai_apis.md
+++ b/docs/install/configuration/free_ai_apis.md
@@ -31,7 +31,7 @@ OPENAI_API_KEY=your-naga-ai-api-key
 # Reverse proxy settings for OpenAI: 
 OPENAI_REVERSE_PROXY=https://api.naga.ac/v1/chat/completions
 
-# OPENAI_MODELS=gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,text-davinci-003,gpt-4,gpt-4-0314,gpt-4-0613
+# OPENAI_MODELS=gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,gpt-4,gpt-4-0314,gpt-4-0613
 ```
 
 **Important**: As of v0.6.6, it's recommend you use the `librechat.yaml` [Configuration file (guide here)](./custom_config.md) to add Reverse Proxies as separate endpoints.


### PR DESCRIPTION
## Summary

- remove `text-davinci-003` from `.env.example` and from documentation

![image](https://github.com/danny-avila/LibreChat/assets/32828263/2984e4d1-7d2c-4cf6-9f2e-992ad6e49dc1)


**Starting January 4, 2024, [older completion models](https://platform.openai.com/docs/deprecations) will no longer be available**
![image](https://github.com/danny-avila/LibreChat/assets/32828263/3d65459a-6af9-4aa5-a298-df8b0d078cef)


## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] 🧹
