### PR TITLE
🐛 fix: Converted the getter `name` and `description` of Azure AI Search Plugin to a property

### DIFF
--- a/api/app/clients/tools/AzureAiSearch.js
+++ b/api/app/clients/tools/AzureAiSearch.js
@@ -16,6 +16,9 @@ class AzureAISearch extends StructuredTool {
 
   constructor(fields = {}) {
     super();
+    this.name = 'azure-ai-search';
+    this.description =
+      'Use the \'azure-ai-search\' tool to retrieve search results relevant to your input';
 
     // Initialize properties using helper function
     this.serviceEndpoint = this._initializeField(
@@ -66,15 +69,6 @@ class AzureAISearch extends StructuredTool {
     this.schema = z.object({
       query: z.string().describe('Search word or phrase to Azure AI Search'),
     });
-  }
-
-  // Simplified getter methods
-  get name() {
-    return 'azure-ai-search';
-  }
-
-  get description() {
-    return 'Use the \'azure-ai-search\' tool to retrieve search results relevant to your input';
   }
 
   // Improved error handling and logging

--- a/api/app/clients/tools/structured/AzureAISearch.js
+++ b/api/app/clients/tools/structured/AzureAISearch.js
@@ -16,6 +16,9 @@ class AzureAISearch extends StructuredTool {
 
   constructor(fields = {}) {
     super();
+    this.name = 'azure-ai-search';
+    this.description =
+      'Use the \'azure-ai-search\' tool to retrieve search results relevant to your input';
 
     // Initialize properties using helper function
     this.serviceEndpoint = this._initializeField(
@@ -66,15 +69,6 @@ class AzureAISearch extends StructuredTool {
     this.schema = z.object({
       query: z.string().describe('Search word or phrase to Azure AI Search'),
     });
-  }
-
-  // Simplified getter methods
-  get name() {
-    return 'azure-ai-search';
-  }
-
-  get description() {
-    return 'Use the \'azure-ai-search\' tool to retrieve search results relevant to your input';
   }
 
   // Improved error handling and logging


### PR DESCRIPTION
## Summary

Due to the `name` and `description` of the Azure AI Search Plugin becoming getters, an error occurred on the LangChain side, causing the Plugin to stop functioning. This issue was resolved by converting them to properties.

## Detail

This is an error:
<img width="753" alt="スクリーンショット 2024-01-20 14 06 10" src="https://github.com/danny-avila/LibreChat/assets/145686/fb2b39ab-96c2-48c3-b383-59bda7d4f896">

Caused by this `t.name.toLowerCase` (in langchainjs).

https://github.com/langchain-ai/langchainjs/blob/9487f48b5c879e5f8a13d0606dab19462578181b/langchain/src/agents/executor.ts#L437-L439

For some reason, it seems not to work with getters.


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested locally with my Azure environment.

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
