### PR TITLE
fix: Update Root component styling to use h-dvh instead of h-screen

### DIFF
--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -59,7 +59,7 @@ export default function Root() {
 
   return (
     <>
-      <div className="flex h-screen">
+      <div className="flex h-dvh">
         <Nav navVisible={navVisible} setNavVisible={setNavVisible} />
         <div className="relative z-0 flex h-full w-full overflow-hidden">
           <div className="relative flex h-full max-w-full flex-1 flex-col overflow-hidden">

--- a/package-lock.json
+++ b/package-lock.json
@@ -24593,19 +24593,19 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.3.tgz",
-      "integrity": "sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
+      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
         "chokidar": "^3.5.3",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.2.12",
+        "fast-glob": "^3.3.0",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.18.2",
+        "jiti": "^1.19.1",
         "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
@@ -26665,7 +26665,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.3.4",
+      "version": "0.3.8",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.3.4",


### PR DESCRIPTION
## Summary

Use h-dvh instead of h-screen for the Root element.
This fixes a problem that caused the input box to be displayed off-screen on mobile devices #1436 .

update tailwindcss@3.4.1 to use h-dvh.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I have confirmed that the text box appears within the screen in Android Chrome, Windows Chrome and iPad Safari.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
