### PR TITLE
🛠️ fix: Preserve Dollar Signs in Code Blocks for LaTeX Parsing 

### DIFF
--- a/client/src/utils/latex.spec.ts
+++ b/client/src/utils/latex.spec.ts
@@ -83,4 +83,23 @@ describe('processLaTeX', () => {
     LaTeX is a typesetting system commonly used for mathematical and scientific documents. It provides a wide range of formatting options and symbols for expressing mathematical expressions.`;
     expect(processLaTeX(complexBlockLatex)).toBe(expectedOutput);
   });
+
+  describe('processLaTeX with code block exception', () => {
+    test('ignores dollar signs inside inline code', () => {
+      const content = 'This is inline code: `$100`';
+      expect(processLaTeX(content)).toBe(content);
+    });
+
+    test('ignores dollar signs inside multi-line code blocks', () => {
+      const content = '```\n$100\n# $1000\n```';
+      expect(processLaTeX(content)).toBe(content);
+    });
+
+    test('processes LaTeX outside of code blocks', () => {
+      const content =
+        'Outside \\(x^2 + y^2 = z^2\\) and inside code block: ```\n$100\n# $1000\n```';
+      const expected = 'Outside $x^2 + y^2 = z^2$ and inside code block: ```\n$100\n# $1000\n```';
+      expect(processLaTeX(content)).toBe(expected);
+    });
+  });
 });

--- a/client/src/utils/latex.ts
+++ b/client/src/utils/latex.ts
@@ -1,18 +1,35 @@
 // Regex to check if the processed content contains any potential LaTeX patterns
 const containsLatexRegex =
   /\\\(.*?\\\)|\\\[.*?\\\]|\$.*?\$|\\begin\{equation\}.*?\\end\{equation\}/;
+
 // Regex for inline and block LaTeX expressions
 const inlineLatex = new RegExp(/\\\((.+?)\\\)/, 'g');
-// const blockLatex = new RegExp(/\\\[(.*?)\\\]/, 'gs');
 const blockLatex = new RegExp(/\\\[(.*?[^\\])\\\]/, 'gs');
 
-export const processLaTeX = (content: string) => {
+// Function to restore code blocks
+const restoreCodeBlocks = (content: string, codeBlocks: string[]) => {
+  return content.replace(/<<CODE_BLOCK_(\d+)>>/g, (match, index) => codeBlocks[index]);
+};
+
+// Regex to identify code blocks and inline code
+const codeBlockRegex = /(```[\s\S]*?```|`.*?`)/g;
+
+export const processLaTeX = (_content: string) => {
+  let content = _content;
+  // Temporarily replace code blocks and inline code with placeholders
+  const codeBlocks: string[] = [];
+  let index = 0;
+  content = content.replace(codeBlockRegex, (match) => {
+    codeBlocks[index] = match;
+    return `<<CODE_BLOCK_${index++}>>`;
+  });
+
   // Escape dollar signs followed by a digit or space and digit
   let processedContent = content.replace(/(\$)(?=\s?\d)/g, '\\$');
 
-  // If no LaTeX patterns are found, return the processed content
+  // If no LaTeX patterns are found, restore code blocks and return the processed content
   if (!containsLatexRegex.test(processedContent)) {
-    return processedContent;
+    return restoreCodeBlocks(processedContent, codeBlocks);
   }
 
   // Convert LaTeX expressions to a markdown compatible format
@@ -20,5 +37,6 @@ export const processLaTeX = (content: string) => {
     .replace(inlineLatex, (match: string, equation: string) => `$${equation}$`) // Convert inline LaTeX
     .replace(blockLatex, (match: string, equation: string) => `$$${equation}$$`); // Convert block LaTeX
 
-  return processedContent;
+  // Restore code blocks
+  return restoreCodeBlocks(processedContent, codeBlocks);
 };


### PR DESCRIPTION
## Summary:

I fixed an issue where dollar signs inside code blocks were being incorrectly escaped during the LaTeX parsing process.

- Modified the LaTeX parser to ignore dollar signs within code blocks, ensuring they are preserved as literals.
- Updated the parser logic to correctly differentiate between code block boundaries and regular text.
- Added unit tests to verify that dollar signs within code blocks are not escaped and remain unchanged after parsing.
- Conducted manual testing with various LaTeX snippets containing code blocks to confirm that the fix works as intended.

Closes #1611 

## Testing:

To ensure the fix is effective, I created unit tests that include scenarios where LaTeX strings with code blocks are processed. These tests check if dollar signs inside the code blocks remain intact. For manual testing, I used LaTeX snippets with dollar signs in code blocks, ran them through the parser, and verified that the output did not escape the dollar signs.

## Checklist:

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in complex areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes