### PR TITLE
🔎 update meilisearch to v1.6 / 0.37.0

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -57,7 +57,7 @@
     "langchain": "^0.0.214",
     "librechat-data-provider": "*",
     "lodash": "^4.17.21",
-    "meilisearch": "^0.33.0",
+    "meilisearch": "^0.37.0",
     "module-alias": "^2.2.3",
     "mongoose": "^7.1.1",
     "multer": "^1.4.5-lts.1",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,11 +35,11 @@ services:
     command: mongod --noauth
   meilisearch:
     container_name: chat-meilisearch
-    image: getmeili/meilisearch:v1.5
+    image: getmeili/meilisearch:v1.6
     restart: always
     user: "${UID}:${GID}"
     environment:
       - MEILI_HOST=http://meilisearch:7700
       - MEILI_NO_ANALYTICS=true
     volumes:
-      - ./meili_data_v1.5:/meili_data
+      - ./meili_data_v1.6:/meili_data

--- a/docs/general_info/breaking_changes.md
+++ b/docs/general_info/breaking_changes.md
@@ -17,7 +17,7 @@ Certain changes in the updates may impact cookies, leading to unexpected behavio
 ## v0.6.x
 
 - **Meilisearch Update**: Following the recent update to Meilisearch, an unused folder named `meili_data` may be present in your root directory. This folder is no longer required and can be **safely deleted** to free up space.
-- **New Indexing Data Location**: The indexing data has been relocated. It will now be stored in a new folder named `meili_data_v1.x`, where `1.x` represents the version of Meilisearch. For instance, with the current Meilisearch version `1.5`, the folder will be `meili_data_v1.5`.
+- **New Indexing Data Location**: The indexing data has been relocated. It will now be stored in a new folder named `meili_data_v1.x`, where `1.x` represents the version of Meilisearch. For instance, with the current Meilisearch version `1.6`, the folder will be `meili_data_v1.6`.
 
 ## v0.5.9
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "langchain": "^0.0.214",
         "librechat-data-provider": "*",
         "lodash": "^4.17.21",
-        "meilisearch": "^0.33.0",
+        "meilisearch": "^0.37.0",
         "module-alias": "^2.2.3",
         "mongoose": "^7.1.1",
         "multer": "^1.4.5-lts.1",
@@ -18317,9 +18317,9 @@
       }
     },
     "node_modules/meilisearch": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.33.0.tgz",
-      "integrity": "sha512-bYPb9WyITnJfzf92e7QFK8Rc50DmshFWxypXCs3ILlpNh8pT15A7KSu9Xgnnk/K3G/4vb3wkxxtFS4sxNkWB8w==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.37.0.tgz",
+      "integrity": "sha512-LdbK6JmRghCawrmWKJSEQF0OiE82md+YqJGE/U2JcCD8ROwlhTx0KM6NX4rQt0u0VpV0QZVG9umYiu3CSSIJAQ==",
       "dependencies": {
         "cross-fetch": "^3.1.6"
       }


### PR DESCRIPTION
## Summary

This update introduces a transition to the latest version of Meilisearch.

What's New (In Meilisearch):

🔒 Master key and API keys
Learn to secure your Meilisearch instance and manage public API keys.

⚡ Meilisearch indexes documents 2x faster
Take a look at the performance boosts in Meilisearch 1.6.

🐬 MySQL Full-Text Search Limits and New Alternatives Solutions
Comparing MySQL full-text search features with other search engines.

🎓 Dropdown Autocomplete Search Anything in Laravel
Learn to build instant dropdown search with Laravel and Meilisearch.

⚛️ The Two Reacts
Dan Abramov writes on components state, server data, and React.

## Change Type

- [x] 🔎 meilisearch update to v1.6
- [x] 🔎 meilisearch update to v0.37.0