### PR TITLE
🚀 feat: Support for GPT-4 Turbo/0125 Models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,7 +101,7 @@ GOOGLE_KEY=user_provided
 #============#
 
 OPENAI_API_KEY=user_provided
-# OPENAI_MODELS=gpt-3.5-turbo-1106,gpt-4-1106-preview,gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,gpt-4,gpt-4-0314,gpt-4-0613
+# OPENAI_MODELS=gpt-3.5-turbo-1106,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,gpt-4,gpt-4-0314,gpt-4-0613
 
 DEBUG_OPENAI=false
 

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -35,6 +35,10 @@ const getValueKey = (model, endpoint) => {
     return '4k';
   } else if (modelName.includes('gpt-4-1106')) {
     return 'gpt-4-1106';
+  } else if (modelName.includes('gpt-4-0125')) {
+    return 'gpt-4-1106';
+  } else if (modelName.includes('gpt-4-turbo')) {
+    return 'gpt-4-1106';
   } else if (modelName.includes('gpt-4-32k')) {
     return '32k';
   } else if (modelName.includes('gpt-4')) {

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -84,6 +84,12 @@ describe('getMultiplier', () => {
     expect(getMultiplier({ tokenType: 'completion', model: 'gpt-4-1106-vision-preview' })).toBe(
       tokenValues['gpt-4-1106'].completion,
     );
+    expect(getMultiplier({ tokenType: 'completion', model: 'gpt-4-0125-preview' })).toBe(
+      tokenValues['gpt-4-1106'].completion,
+    );
+    expect(getMultiplier({ tokenType: 'completion', model: 'gpt-4-turbo-vision-preview' })).toBe(
+      tokenValues['gpt-4-1106'].completion,
+    );
   });
 
   it('should return defaultRate if derived valueKey does not match any known patterns', () => {

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -45,13 +45,15 @@ const openAIModels = {
   'gpt-4-32k': 32758, // -10 from max
   'gpt-4-32k-0314': 32758, // -10 from max
   'gpt-4-32k-0613': 32758, // -10 from max
+  'gpt-4-1106': 127990, // -10 from max
+  'gpt-4-0125': 127990, // -10 from max
+  'gpt-4-turbo': 127990, // -10 from max
   'gpt-3.5-turbo': 4092, // -5 from max
   'gpt-3.5-turbo-0613': 4092, // -5 from max
   'gpt-3.5-turbo-0301': 4092, // -5 from max
   'gpt-3.5-turbo-16k': 16375, // -10 from max
   'gpt-3.5-turbo-16k-0613': 16375, // -10 from max
   'gpt-3.5-turbo-1106': 16375, // -10 from max
-  'gpt-4-1106': 127990, // -10 from max
   'mistral-': 31990, // -10 from max
 };
 
@@ -145,8 +147,9 @@ function matchModelName(modelName, endpoint = EModelEndpoint.openAI) {
 
   const keys = Object.keys(tokensMap);
   for (let i = keys.length - 1; i >= 0; i--) {
-    if (modelName.includes(keys[i])) {
-      return keys[i];
+    const modelKey = keys[i];
+    if (modelName.includes(modelKey)) {
+      return modelKey;
     }
   }
 

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -80,6 +80,20 @@ describe('getModelMaxTokens', () => {
     );
   });
 
+  // 01/25 Update
+  test('should return correct tokens for gpt-4-turbo/0125 matches', () => {
+    expect(getModelMaxTokens('gpt-4-turbo')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-4-turbo'],
+    );
+    expect(getModelMaxTokens('gpt-4-turbo-preview')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-4-turbo'],
+    );
+    expect(getModelMaxTokens('gpt-4-0125')).toBe(maxTokensMap[EModelEndpoint.openAI]['gpt-4-0125']);
+    expect(getModelMaxTokens('gpt-4-0125-preview')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-4-0125'],
+    );
+  });
+
   test('should return correct tokens for Anthropic models', () => {
     const models = [
       'claude-2.1',
@@ -164,6 +178,16 @@ describe('matchModelName', () => {
     expect(matchModelName('something/gpt-4-1106')).toBe('gpt-4-1106');
     expect(matchModelName('gpt-4-1106-preview')).toBe('gpt-4-1106');
     expect(matchModelName('gpt-4-1106-vision-preview')).toBe('gpt-4-1106');
+  });
+
+  // 01/25 Update
+  it('should return the closest matching key for gpt-4-turbo/0125 matches', () => {
+    expect(matchModelName('openai/gpt-4-0125')).toBe('gpt-4-0125');
+    expect(matchModelName('gpt-4-turbo-preview')).toBe('gpt-4-turbo');
+    expect(matchModelName('gpt-4-turbo-vision-preview')).toBe('gpt-4-turbo');
+    expect(matchModelName('gpt-4-0125')).toBe('gpt-4-0125');
+    expect(matchModelName('gpt-4-0125-preview')).toBe('gpt-4-0125');
+    expect(matchModelName('gpt-4-0125-vision-preview')).toBe('gpt-4-0125');
   });
 
   // Tests for Google models

--- a/docs/install/configuration/dotenv.md
+++ b/docs/install/configuration/dotenv.md
@@ -317,7 +317,7 @@ DEBUG_OPENAI=false
     - Leave it blank or commented out to use internal settings.
 
 ```bash
-OPENAI_MODELS=gpt-3.5-turbo-1106,gpt-4-1106-preview,gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,gpt-4,gpt-4-0314,gpt-4-0613
+OPENAI_MODELS=gpt-3.5-turbo-1106,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo,gpt-3.5-turbo-16k,gpt-3.5-turbo-0301,gpt-4,gpt-4-0314,gpt-4-0613
 ```
 
 - Titling is enabled by default when initiating a conversation.

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -93,6 +93,8 @@ export const defaultModels = {
   [EModelEndpoint.openAI]: [
     'gpt-3.5-turbo-16k-0613',
     'gpt-3.5-turbo-16k',
+    'gpt-4-turbo-preview',
+    'gpt-4-0125-preview',
     'gpt-4-1106-preview',
     'gpt-3.5-turbo',
     'gpt-3.5-turbo-1106',


### PR DESCRIPTION
## Summary:

In this pull request, I added support for the GPT-4 Turbo/0125 models

https://openai.com/blog/new-embedding-models-and-api-updates

Thank you @Niqnil for pointing this out https://github.com/danny-avila/LibreChat/discussions/1642

- Integrated the GPT-4 Turbo/0125 model into the application.
- Ensured compatibility with the current application setup.
- Carried out extensive tests to ensure the new model functions as expected within the application.

## Testing:

The changes were tested by running the application and using the GPT-4 Turbo/0125 model. New unit tests were added and all tests passed successfully. To reproduce the tests, run the application, select the GPT-4 Turbo/0125 model, and use it in various scenarios. 

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.