### PR TITLE
👤 fix: Avatar Check in User Auth

### DIFF
--- a/api/strategies/process.js
+++ b/api/strategies/process.js
@@ -7,7 +7,7 @@ const User = require('~/models/User');
  * '?manual=true', it updates the user's avatar with the provided URL. For local file storage, it directly updates
  * the avatar URL, while for other storage types, it processes the avatar URL using the specified file strategy.
  *
- * @param {User} oldUser - The existing user object that needs to be updated. Expected to have an 'avatar' property.
+ * @param {User} oldUser - The existing user object that needs to be updated.
  * @param {string} avatarUrl - The new avatar URL to be set for the user.
  *
  * @returns {Promise<void>}
@@ -19,10 +19,10 @@ const handleExistingUser = async (oldUser, avatarUrl) => {
   const fileStrategy = process.env.CDN_PROVIDER;
   const isLocal = fileStrategy === FileSources.local;
 
-  if (isLocal && !oldUser.avatar.includes('?manual=true')) {
+  if (isLocal && (oldUser.avatar === null || !oldUser.avatar.includes('?manual=true'))) {
     oldUser.avatar = avatarUrl;
     await oldUser.save();
-  } else if (!isLocal && !oldUser.avatar.includes('?manual=true')) {
+  } else if (!isLocal && (oldUser.avatar === null || !oldUser.avatar.includes('?manual=true'))) {
     const userId = oldUser._id;
     const newavatarUrl = await uploadAvatar({ userId, input: avatarUrl, fileStrategy });
     oldUser.avatar = newavatarUrl;


### PR DESCRIPTION
# Pull Request Template

## Summary

We use LibreChat with the following configuration:

```
ALLOW_EMAIL_LOGIN=false
ALLOW_REGISTRATION=false
ALLOW_SOCIAL_LOGIN=true
ALLOW_SOCIAL_REGISTRATION=false
```

Then we `npm run create-user` the new users and let them login through the Google authenticator. This fails in the `api/strategies/process.js` file, because the method `handleExistingUser` supposes that the `oldUser` has an avatar. Which is not the case for our setup.

This PR checks if there is an avatar in the user, and only then checks if it's a `?manual=true` avatar.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

We tested it with new users and this patch makes them capable of logging in.

### **Test Configuration**:

Only `ALLOW_SOCIAL_LOGIN=TRUE`, and then using Google OAuth.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
