### PR TITLE
🔝fix: Re-order System Message to Top for Mistral API Payloads

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -976,12 +976,18 @@ ${convo}
         ...opts,
       });
 
-      /* hacky fix for Mistral AI API not allowing a singular system message in payload */
+      /* hacky fix for Mistral AI API not allowing a singular system message anywhere in the payload except as the first element */
       if (opts.baseURL.includes('https://api.mistral.ai/v1') && modelOptions.messages) {
         const { messages } = modelOptions;
-        if (messages.length === 1 && messages[0].role === 'system') {
-          modelOptions.messages[0].role = 'user';
+
+        const systemMessageIndex = messages.findIndex((msg) => msg.role === 'system');
+
+        if (systemMessageIndex > 0) {
+          const [systemMessage] = messages.splice(systemMessageIndex, 1);
+          messages.unshift(systemMessage);
         }
+
+        modelOptions.messages = messages;
       }
 
       if (this.options.addParams && typeof this.options.addParams === 'object') {

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -976,7 +976,10 @@ ${convo}
         ...opts,
       });
 
-      /* hacky fix for Mistral AI API not allowing a singular system message anywhere in the payload except as the first element */
+      /* hacky fixes for Mistral AI API:
+      - Re-orders system message to the top of the messages payload, as not allowed anywhere else
+      - If there is only one message and it's a system message, change the role to user
+      */
       if (opts.baseURL.includes('https://api.mistral.ai/v1') && modelOptions.messages) {
         const { messages } = modelOptions;
 
@@ -988,6 +991,10 @@ ${convo}
         }
 
         modelOptions.messages = messages;
+
+        if (messages.length === 1 && messages[0].role === 'system') {
+          modelOptions.messages[0].role = 'user';
+        }
       }
 
       if (this.options.addParams && typeof this.options.addParams === 'object') {


### PR DESCRIPTION
## Summary

I adjusted the sequence of the System Message when sending messages to the Mistral AI API, as it only permits System Messages at the start. This issue was reported and discussed on discord here: https://discord.com/channels/1086345563026489514/1201770731982032926

 - I changed the payload order in the Mistral AI API to ensure that the System Message is always the first item. This was necessary because the Mistral AI API only allows the System Message to be at the start of the payload.
- This change addresses a potential issue that could occur if the System Message is not placed correctly, leading to 400 status error.
- During testing, I made sure to send different payloads using different presets to the Mistral AI API to ensure that the re-ordering works as expected and doesn't cause any issues.


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
