### PR TITLE
fix: update the node version of devcontainer from v19 to v20

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   app:
-    image: node:19-bullseye
+    image: node:20-bookworm
     # restart: always
     links:
       - mongodb


### PR DESCRIPTION
## Summary

I updated the Node version in devcontainer from v19 to v20.
(Updated the base image from node:19-bullseye to node:20-bookworm)

## Change Type

Development environment.

## Testing

https://github.com/danny-avila/LibreChat/assets/2719533/ab950703-8200-452a-b7b9-4dd043b22b40

### **Test Configuration**:

After connecting to devcontainer and running `npm run rebuild:package-lock`, I executed the following and then tested.

```
/workspaces# rm -rf node_modules/ packages/data-provider/node_modules/ packages/data-provider/dist/ client/dist/ api/node_modules/
/workspaces# cd packages/data-provider/
/workspaces# npm install
/workspaces# npm run build
/workspaces# cd ../../client
/workspaces# npm install
/workspaces# cd ..
/workspaces# npm install
/workspaces# npm run frontend:dev
```

After executing the above, I opened another virtual terminal and executed the following.

```
/workspaces# npm run backend:dev
```

I thought that changing package-lock.json might affect the build results of Dockerfile and Dockerfile.multi, so I did not include changes to package-lock.json in this PR.

## Checklist

- [x] I have performed a self-review of my own code
