### PR TITLE
🚀 feat: Support for GPT-3.5 Turbo/0125 Model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,7 +101,7 @@ GOOGLE_KEY=user_provided
 #============#
 
 OPENAI_API_KEY=user_provided
-# OPENAI_MODELS=gpt-3.5-turbo-0301,gpt-3.5-turbo,gpt-4,gpt-4-0613,gpt-4-vision-preview,gpt-3.5-turbo-0613,gpt-3.5-turbo-16k-0613,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo-1106,gpt-3.5-turbo-instruct,gpt-3.5-turbo-instruct-0914,gpt-3.5-turbo-16k
+# OPENAI_MODELS=gpt-3.5-turbo-0125,gpt-3.5-turbo-0301,gpt-3.5-turbo,gpt-4,gpt-4-0613,gpt-4-vision-preview,gpt-3.5-turbo-0613,gpt-3.5-turbo-16k-0613,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo-1106,gpt-3.5-turbo-instruct,gpt-3.5-turbo-instruct-0914,gpt-3.5-turbo-16k
 
 DEBUG_OPENAI=false
 
@@ -127,7 +127,7 @@ DEBUG_OPENAI=false
 # Plugins    #
 #============#
 
-# PLUGIN_MODELS=gpt-4,gpt-4-turbo-preview,gpt-4-0125-preview,gpt-4-1106-preview,gpt-4-0613,gpt-3.5-turbo,gpt-3.5-turbo-1106,gpt-3.5-turbo-0613
+# PLUGIN_MODELS=gpt-4,gpt-4-turbo-preview,gpt-4-0125-preview,gpt-4-1106-preview,gpt-4-0613,gpt-3.5-turbo,gpt-3.5-turbo-0125,gpt-3.5-turbo-1106,gpt-3.5-turbo-0613
 
 DEBUG_PLUGINS=true
 

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -30,6 +30,8 @@ const getValueKey = (model, endpoint) => {
 
   if (modelName.includes('gpt-3.5-turbo-16k')) {
     return '16k';
+  } else if (modelName.includes('gpt-3.5-turbo-0125')) {
+    return 'gpt-3.5-turbo-0125';
   } else if (modelName.includes('gpt-3.5-turbo-1106')) {
     return 'gpt-3.5-turbo-1106';
   } else if (modelName.includes('gpt-3.5')) {

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -12,6 +12,7 @@ const tokenValues = {
   '16k': { prompt: 3, completion: 4 },
   'gpt-3.5-turbo-1106': { prompt: 1, completion: 2 },
   'gpt-4-1106': { prompt: 10, completion: 30 },
+  'gpt-3.5-turbo-0125': { prompt: 0.5, completion: 1.5 },
 };
 
 /**

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -90,6 +90,9 @@ describe('getMultiplier', () => {
     expect(getMultiplier({ tokenType: 'completion', model: 'gpt-4-turbo-vision-preview' })).toBe(
       tokenValues['gpt-4-1106'].completion,
     );
+    expect(getMultiplier({ tokenType: 'completion', model: 'gpt-3.5-turbo-0125' })).toBe(
+      tokenValues['gpt-3.5-turbo-0125'].completion,
+    );
   });
 
   it('should return defaultRate if derived valueKey does not match any known patterns', () => {

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -55,6 +55,7 @@ const openAIModels = {
   'gpt-3.5-turbo-16k': 16375, // -10 from max
   'gpt-3.5-turbo-16k-0613': 16375, // -10 from max
   'gpt-3.5-turbo-1106': 16375, // -10 from max
+  'gpt-3.5-turbo-0125': 16375, // -10 from max
   'mistral-': 31990, // -10 from max
 };
 

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -92,6 +92,9 @@ describe('getModelMaxTokens', () => {
     expect(getModelMaxTokens('gpt-4-0125-preview')).toBe(
       maxTokensMap[EModelEndpoint.openAI]['gpt-4-0125'],
     );
+    expect(getModelMaxTokens('gpt-3.5-turbo-0125')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-3.5-turbo-0125'],
+    );
   });
 
   test('should return correct tokens for Anthropic models', () => {

--- a/docs/install/configuration/dotenv.md
+++ b/docs/install/configuration/dotenv.md
@@ -317,7 +317,7 @@ DEBUG_OPENAI=false
     - Leave it blank or commented out to use internal settings.
 
 ```bash
-OPENAI_MODELS=gpt-3.5-turbo-0301,gpt-3.5-turbo,gpt-4,gpt-4-0613,gpt-4-vision-preview,gpt-3.5-turbo-0613,gpt-3.5-turbo-16k-0613,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo-1106,gpt-3.5-turbo-instruct,gpt-3.5-turbo-instruct-0914,gpt-3.5-turbo-16k
+OPENAI_MODELS=gpt-3.5-turbo-0125,gpt-3.5-turbo-0301,gpt-3.5-turbo,gpt-4,gpt-4-0613,gpt-4-vision-preview,gpt-3.5-turbo-0613,gpt-3.5-turbo-16k-0613,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo-1106,gpt-3.5-turbo-instruct,gpt-3.5-turbo-instruct-0914,gpt-3.5-turbo-16k
 ```
 
 - Titling is enabled by default when initiating a conversation.
@@ -383,7 +383,7 @@ Here are some useful documentation about plugins:
 - Identify the available models, separated by commas **without spaces**. The first model in the list will be set as default. Leave it blank or commented out to use internal settings.
 
 ```bash
-PLUGIN_MODELS=gpt-4,gpt-4-turbo-preview,gpt-4-0125-preview,gpt-4-1106-preview,gpt-4-0613,gpt-3.5-turbo,gpt-3.5-turbo-1106,gpt-3.5-turbo-0613
+PLUGIN_MODELS=gpt-4,gpt-4-turbo-preview,gpt-4-0125-preview,gpt-4-1106-preview,gpt-4-0613,gpt-3.5-turbo,gpt-3.5-turbo-0125,gpt-3.5-turbo-1106,gpt-3.5-turbo-0613
 ```
 
 - Set to false or comment out to disable debug mode for plugins

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -91,6 +91,7 @@ export const defaultModels = {
     'claude-instant-1-100k',
   ],
   [EModelEndpoint.openAI]: [
+    'gpt-3.5-turbo-0125',
     'gpt-3.5-turbo-16k-0613',
     'gpt-3.5-turbo-16k',
     'gpt-4-turbo-preview',


### PR DESCRIPTION
## Summary:

In this pull request, I added support for the GPT-3.5 Turbo/0125 model

https://openai.com/blog/new-embedding-models-and-api-updates

- Integrated the GPT-3.5 Turbo/0125 model into the application.
- Ensured expected max context and rate was observed

## Testing:

The changes were tested by running the application and using the GPT-3.5 Turbo/0125 model. New unit tests were added and all tests passed successfully. To reproduce the tests, run the application, select the GPT-3.5 Turbo/0125 model, and use it in various scenarios. 

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.