### PR TITLE
📷 fix: Pass Base64 to Gemini Vision Payload when using CDN URLs

### DIFF
--- a/api/server/services/Files/images/encode.js
+++ b/api/server/services/Files/images/encode.js
@@ -1,5 +1,27 @@
+const axios = require('axios');
 const { EModelEndpoint, FileSources } = require('librechat-data-provider');
 const { getStrategyFunctions } = require('../strategies');
+const { logger } = require('~/config');
+
+/**
+ * Fetches an image from a URL and returns its base64 representation.
+ *
+ * @async
+ * @param {string} url The URL of the image.
+ * @returns {Promise<string>} The base64-encoded string of the image.
+ * @throws {Error} If there's an issue fetching the image or encoding it.
+ */
+async function fetchImageToBase64(url) {
+  try {
+    const response = await axios.get(url, {
+      responseType: 'arraybuffer',
+    });
+    return Buffer.from(response.data).toString('base64');
+  } catch (error) {
+    logger.error('Error fetching image to convert to base64', error);
+    throw error;
+  }
+}
 
 /**
  * Encodes and formats the given files.
@@ -26,6 +48,13 @@ async function encodeAndFormat(req, files, endpoint) {
     }
 
     encodingMethods[source] = prepareImagePayload;
+
+    /* Google doesn't support passing URLs to payload */
+    if (source !== FileSources.local && endpoint === EModelEndpoint.google) {
+      const [_file, imageURL] = await prepareImagePayload(req, file);
+      promises.push([_file, await fetchImageToBase64(imageURL)]);
+      continue;
+    }
     promises.push(prepareImagePayload(req, file));
   }
 


### PR DESCRIPTION
## Summary:
I fixed an issue when using CDN by passing base64 to the Gemini Vision payload since URLs are not supported. 

To verify these changes, simply use a CDN URL with Gemini Vision and observe the successful processing of the payload. 

Closes #1687 

For some reason the Google API is returning "bad" for all images even when not using base64, but I'm going to chalk this up to something wrong on their end.

### **Test Configuration**:
- URLs: CDN URLs
- Gemini Vision: Latest Version

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.