### PR TITLE
🐳 docs: Add deploy to Zeabur button and guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
 <a href="https://railway.app/template/b5k2mn?referralCode=HI9hWz">
   <img src="https://railway.app/button.svg" alt="Deploy on Railway" height="30">
 </a>
+<a href="https://zeabur.com/templates/0X2ZY8">
+  <img src="https://zeabur.com/button.svg" alt="Deploy on Zeabur" height="30"/>
+</a>
 <a href="https://template.cloud.sealos.io/deploy?templateName=librechat">
   <img src="https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg" alt="Deploy on Sealos" height="30">
 </a>

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -16,3 +16,4 @@ weight: 3
   * 🔎 [Meilisearch in Render](meilisearch_in_render.md) 
   * 🏗️ [Hetzner](hetzner_ubuntu.md) 
   * 🌈 [Heroku](heroku.md)
+  * 🦓 [Zeabur](zeabur.md)

--- a/docs/deployment/zeabur.md
+++ b/docs/deployment/zeabur.md
@@ -1,0 +1,43 @@
+---
+title: 🦓 Zeabur 
+description: Instructions for deploying LibreChat on Zeabur 
+weight: -1
+---
+# Zeabur Deployment
+
+This guide will walk you through deploying LibreChat on Zeabur.
+
+## Sign up for a Zeabur account
+
+If you don't have a Zeabur account, you need to sign up for one.
+Visit [here](https://zeabur.com/login) and click on `Login with GitHub` to create an account and sign in.
+
+![Sign up for a Zeabur account](https://i.imgur.com/aUuOcWg.png)
+
+## Deploy with button
+
+Zeabur has already prepared a one-click deployment template for LibreChat, so you can start the deployment directly by clicking the button below without any additional configuration.
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/0X2ZY8)
+
+In the template page, select the region where you want to deploy LibreChat, and then click the Deploy button to start the deployment.
+
+![Select Region and Deploy](https://i.imgur.com/cpfrA0k.png)
+
+## Bind a domain 
+
+After the deployment is complete, you will find that there is a new project in your Zeabur account, which contains three services: a MongoDB, a Meilisearch, and a LibreChat.
+
+![Project Detail](https://i.imgur.com/4SRMoba.png)
+
+To access your deployed LibreChat, you need to select the LibreChat service, click on the Network tab below, and then click Generate Domain to create a subdomain under .zeabur.app.
+
+![Bind domain](https://i.imgur.com/2RabEIF.png)
+
+## Conclusion
+
+You can now access it by clicking the link.
+
+![](https://i.imgur.com/o4k3HYA.png)
+
+Congratulations! You've successfully deployed LibreChat on Zeabur.


### PR DESCRIPTION
## Summary

This PR is based on modifications from #1722 , with the most significant change being the removal of the referral code from the deploy button, based on the suggestion by @danny-avila. 

(By the way, Zeabur is more than happy to offer referral credits to the maintainers of LibreChat as a token of appreciation for your contributions to the open-source community, so please be sure to let me know if you are interested.)

Another important update is the creation of documentation for deploying to Zeabur. Although one-click deployment is already quite straightforward, pairing it with a richly illustrated walk-through can help everyone understand how to use the template more quickly.

<img width="1438" alt="Screenshot 2024-02-04 at 10 05 36 PM" src="https://github.com/danny-avila/LibreChat/assets/21105863/9ca87d12-a4e0-434e-8546-e35e532d81c5">

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation update
- [ ] Translation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
