### PR TITLE
📖 docs: fix link pointing to dotenv guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,13 @@
-#=============================================================#
-#                   LibreChat Configuration                   #
-#=============================================================#
-# Please refer to the reference documentation for assistance  #
-# with configuring your LibreChat environment. The guide is   #
-# available both online and within your local LibreChat       #
-# directory:                                                  #
-# Online: https://docs.librechat.ai/install/dotenv.html       #
-# Locally: ./docs/install/dotenv.md                           #
-#=============================================================#
+#=====================================================================#
+#                       LibreChat Configuration                       #
+#=====================================================================#
+# Please refer to the reference documentation for assistance          #
+# with configuring your LibreChat environment. The guide is           #
+# available both online and within your local LibreChat               #
+# directory:                                                          #
+# Online: https://docs.librechat.ai/install/configuration/dotenv.html #
+# Locally: ./docs/install/configuration/dotenv.md                     #
+#=====================================================================#
 
 #==================================================#
 #               Server Configuration               #


### PR DESCRIPTION
## Summary

Doc link was changed, but `.env.example` still had an old link.

## Change Type

Please delete any irrelevant options.

- [x] Documentation update

## Testing

N/A

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
