### PR TITLE
Bug fix in Convo 🐞, Enhance Conversation component with updated styles, hover effects 🚀, & RenameIcon resized 🔄

### DIFF
--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -1,4 +1,3 @@
-import { useRecoilValue } from 'recoil';
 import { useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { EModelEndpoint } from 'librechat-data-provider';
@@ -13,6 +12,7 @@ import DeleteButton from './NewDeleteButton';
 import { getEndpointField } from '~/utils';
 import RenameButton from './RenameButton';
 import store from '~/store';
+import { useRecoilValue } from 'recoil';
 
 type KeyEvent = KeyboardEvent<HTMLInputElement>;
 
@@ -24,6 +24,7 @@ export default function Conversation({ conversation, retainView, toggleNav, isLa
   const { refreshConversations } = useConversations();
   const { navigateToConvo } = useNavigateToConvo();
   const { showToast } = useToastContext();
+  const [hovering, setHovering] = useState(false);
 
   const { conversationId, title } = conversation;
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -113,7 +114,7 @@ export default function Conversation({ conversation, retainView, toggleNav, isLa
 
   const aProps = {
     className:
-      'group relative rounded-lg active:opacity-50 flex cursor-pointer items-center mt-2 gap-3 break-all rounded-lg bg-gray-800 py-2 px-2',
+      'group relative rounded-lg active:opacity-90 flex cursor-pointer items-center mt-2 gap-3 break-all rounded-lg bg-gray-800 py-2 px-2',
   };
 
   const activeConvo =
@@ -122,7 +123,7 @@ export default function Conversation({ conversation, retainView, toggleNav, isLa
 
   if (!activeConvo) {
     aProps.className =
-      'group relative rounded-lg active:opacity-50 flex cursor-pointer items-center mt-2 gap-3 break-all rounded-lg py-2 px-2 hover:bg-gray-900';
+      'group relative rounded-lg active:opacity-90 flex cursor-pointer items-center mt-2 gap-3 break-all rounded-lg py-2 px-2 hover:bg-gray-900';
   }
 
   return (
@@ -130,11 +131,13 @@ export default function Conversation({ conversation, retainView, toggleNav, isLa
       href={`/c/${conversationId}`}
       data-testid="convo-item"
       onClick={clickHandler}
+      onMouseEnter={() => setHovering(true)}
+      onMouseLeave={() => setHovering(false)}
       {...aProps}
       title={title}
     >
       {icon}
-      <div className="relative line-clamp-1 max-h-5 flex-1 grow overflow-hidden">
+      <div className="relative mr-8 line-clamp-1 max-h-5 flex-1 grow overflow-hidden">
         {renaming === true ? (
           <input
             ref={inputRef}
@@ -146,16 +149,17 @@ export default function Conversation({ conversation, retainView, toggleNav, isLa
             onKeyDown={handleKeyDown}
           />
         ) : (
-          title
+          <span className={`${activeConvo ? 'text-white' : 'text-white'} text-sm`}>{title}</span>
         )}
       </div>
-      {activeConvo ? (
-        <div className="absolute bottom-0 right-1 top-0 w-20 bg-gradient-to-l from-gray-800 from-60% to-transparent"></div>
-      ) : (
-        <div className="from--gray-900 absolute bottom-0 right-0 top-0 w-2 bg-gradient-to-l from-0% to-transparent group-hover:w-1 group-hover:from-60%"></div>
-      )}
-      {activeConvo ? (
-        <div className="visible absolute right-1 z-10 flex text-gray-400">
+      <div
+        className={`absolute bottom-0 top-0 ${
+          activeConvo ? `w-${title.length * 5}` : 'w-20'
+        } from-bg-black to-bg-gray-900 z-0 h-full rounded-r-lg bg-gradient-to-l transition-all`}
+      />
+
+      {hovering || activeConvo ? (
+        <div className="visible absolute bottom-0 right-1 top-0 z-10 flex items-center gap-0">
           <RenameButton renaming={renaming} onRename={onRename} renameHandler={renameHandler} />
           <DeleteButton
             conversationId={conversationId}
@@ -165,7 +169,11 @@ export default function Conversation({ conversation, retainView, toggleNav, isLa
           />
         </div>
       ) : (
-        <div className="absolute bottom-0 right-0 top-0 w-20 rounded-lg bg-gradient-to-l from-black from-0% to-transparent  group-hover:from-gray-900" />
+        <div
+          className={`absolute bottom-0 right-${
+            hovering || activeConvo ? 10 : 0
+          } top-0 w-20 rounded-lg bg-gradient-to-l from-black from-0% to-transparent group-hover:from-gray-900`}
+        />
       )}
     </a>
   );

--- a/client/src/components/svg/RenameIcon.tsx
+++ b/client/src/components/svg/RenameIcon.tsx
@@ -4,7 +4,7 @@ export default function RenameIcon() {
       stroke="currentColor"
       fill="none"
       strokeWidth="2"
-      viewBox="0 0 24 24"
+      viewBox="0 0 23 23"
       strokeLinecap="round"
       strokeLinejoin="round"
       className="h-4 w-4"


### PR DESCRIPTION
## Summary

Resolved the problem with the right corner of the convo not being rounded, improved and added a small animation in the transition, added the event of showing the Rename and Delete icons when hovering the mouse like in ChatGPT and resized the button size from RenameIcon to better fit.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Before:**
![Captura de tela 2024-02-06 072345](https://github.com/danny-avila/LibreChat/assets/140329135/0d4b015e-52cb-4847-951b-450c432c3767)
**After:**
![Captura de tela 2024-02-06 111032](https://github.com/danny-avila/LibreChat/assets/140329135/43441a4e-9f52-414b-96c0-72d3c458d723)


***Now:***
![Captura de tela 2024-02-07 054404](https://github.com/danny-avila/LibreChat/assets/140329135/ab1ea509-a148-4c00-a403-254dfcaaddcb)


https://github.com/danny-avila/LibreChat/assets/140329135/5f952e2b-fb0f-4955-8c9b-7fa9b1a06e04


