### PR TITLE
🖌️ style: Update conversation history groups

### DIFF
--- a/client/src/utils/convos.spec.ts
+++ b/client/src/utils/convos.spec.ts
@@ -15,12 +15,21 @@ describe('Conversation Utilities', () => {
       const conversations = [
         { conversationId: '1', updatedAt: '2023-04-01T12:00:00Z' },
         { conversationId: '2', updatedAt: new Date().toISOString() },
+        { conversationId: '3', updatedAt: new Date(Date.now() - 86400000).toISOString() }, // 86400 seconds ago = yesterday
+        { conversationId: '4', updatedAt: new Date(Date.now() - 86400000 * 2).toISOString() }, // 2 days ago (previous 7 days)
+        { conversationId: '5', updatedAt: new Date(Date.now() - 86400000 * 8).toISOString() }, // 8 days ago (previous 30 days)
       ];
       const grouped = groupConversationsByDate(conversations as TConversation[]);
       expect(grouped[0][0]).toBe('Today');
       expect(grouped[0][1]).toHaveLength(1);
-      expect(grouped[1][0]).toBe(' 2023');
+      expect(grouped[1][0]).toBe('Yesterday');
       expect(grouped[1][1]).toHaveLength(1);
+      expect(grouped[2][0]).toBe('Previous 7 days');
+      expect(grouped[2][1]).toHaveLength(1);
+      expect(grouped[3][0]).toBe('Previous 30 days');
+      expect(grouped[3][1]).toHaveLength(1);
+      expect(grouped[4][0]).toBe(' 2023');
+      expect(grouped[4][1]).toHaveLength(1);
     });
 
     it('returns an empty array for no conversations', () => {

--- a/client/src/utils/convos.ts
+++ b/client/src/utils/convos.ts
@@ -1,4 +1,4 @@
-import { parseISO, isToday, isWithinInterval, subDays, getMonth, getYear, startOfYear } from 'date-fns';
+import { parseISO, isToday, isWithinInterval, subDays, getMonth, getYear, startOfDay, startOfYear } from 'date-fns';
 import type {
   TConversation,
   ConversationData,
@@ -11,7 +11,7 @@ const getGroupName = (date: Date) => {
   if (isToday(date)) {
     return 'Today';
   }
-  if (isWithinInterval(date, { start: subDays(now, 1), end: now })) {
+  if (isWithinInterval(date, { start: startOfDay(subDays(now, 1)), end: now })) {
     return 'Yesterday';
   }
   if (isWithinInterval(date, { start: subDays(now, 7), end: now })) {

--- a/client/src/utils/convos.ts
+++ b/client/src/utils/convos.ts
@@ -11,6 +11,9 @@ const getGroupName = (date: Date) => {
   if (isToday(date)) {
     return 'Today';
   }
+  if (isWithinInterval(date, { start: subDays(now, 1), end: now })) {
+    return 'Yesterday';
+  }
   if (isWithinInterval(date, { start: subDays(now, 7), end: now })) {
     return 'Previous 7 days';
   }

--- a/client/src/utils/convos.ts
+++ b/client/src/utils/convos.ts
@@ -1,4 +1,4 @@
-import { parseISO, isToday, isWithinInterval, subDays, getYear } from 'date-fns';
+import { parseISO, isToday, isWithinInterval, subDays, getMonth, getYear, startOfYear } from 'date-fns';
 import type {
   TConversation,
   ConversationData,
@@ -16,6 +16,9 @@ const getGroupName = (date: Date) => {
   }
   if (isWithinInterval(date, { start: subDays(now, 30), end: now })) {
     return 'Last 30 days';
+  }
+  if (isWithinInterval(date, { start: startOfYear(now), end: now })) {
+    return ' ' + getMonth(date).toString();
   }
   return ' ' + getYear(date).toString();
 };

--- a/client/src/utils/convos.ts
+++ b/client/src/utils/convos.ts
@@ -1,4 +1,4 @@
-import { parseISO, isToday, isWithinInterval, subDays, getMonth, getYear, startOfDay, startOfYear } from 'date-fns';
+import { parseISO, isToday, isWithinInterval, subDays, getMonth, getYear, startOfDay, startOfYear, format } from 'date-fns';
 import type {
   TConversation,
   ConversationData,
@@ -21,7 +21,7 @@ const getGroupName = (date: Date) => {
     return 'Previous 30 days';
   }
   if (isWithinInterval(date, { start: startOfYear(now), end: now })) {
-    return ' ' + getMonth(date).toString();
+    return ' ' + format(getMonth(date), 'MMMM');
   }
   return ' ' + getYear(date).toString();
 };

--- a/client/src/utils/convos.ts
+++ b/client/src/utils/convos.ts
@@ -1,4 +1,14 @@
-import { parseISO, isToday, isWithinInterval, subDays, getMonth, getYear, startOfDay, startOfYear, format } from 'date-fns';
+import {
+  parseISO,
+  isToday,
+  isWithinInterval,
+  subDays,
+  getMonth,
+  getYear,
+  startOfDay,
+  startOfYear,
+  format,
+} from 'date-fns';
 import type {
   TConversation,
   ConversationData,
@@ -21,7 +31,7 @@ const getGroupName = (date: Date) => {
     return 'Previous 30 days';
   }
   if (isWithinInterval(date, { start: startOfYear(now), end: now })) {
-    return ' ' + format(getMonth(date), 'MMMM');
+    return ' ' + format(date, 'MMMM');
   }
   return ' ' + getYear(date).toString();
 };

--- a/client/src/utils/convos.ts
+++ b/client/src/utils/convos.ts
@@ -12,10 +12,10 @@ const getGroupName = (date: Date) => {
     return 'Today';
   }
   if (isWithinInterval(date, { start: subDays(now, 7), end: now })) {
-    return 'Last 7 days';
+    return 'Previous 7 days';
   }
   if (isWithinInterval(date, { start: subDays(now, 30), end: now })) {
-    return 'Last 30 days';
+    return 'Previous 30 days';
   }
   if (isWithinInterval(date, { start: startOfYear(now), end: now })) {
     return ' ' + getMonth(date).toString();


### PR DESCRIPTION
## Summary

Minor updates to make the conversation groups displayed in the frontend match those of ChatGPT.

Before:
- Today
- _Last_ 7 days
- _Last_ 30 days
- (year, if chat was updated more than 30d ago)

After:
- Today
- Yesterday
- _Previous_ 7 days
- _Previous_ 30 days
- (month, if chat was updated >30d ago but during this year)
- (year, if chat was updated >30d ago but during previous years)

## Change Type

- [x] Style update

## Testing

I manually validated conversations in each of the groups by ensuring I had proper `updatedAt` values in the `conversations` table. I also updated `convos.spec.ts` to validate Yesterday, Previous 7 days, and Previous 30 days. I couldn't find a good way to test groups with month names without using conditionals in the test case (the month-based group for January will only show up starting on February 1 for example).

There is a test that was already failing prior to this change:
```
FAIL src/utils/convos.spec.ts (7.281 s)
  ● Conversation Utilities with Fake Data › groupConversationsByDate › correctly groups conversations from fake data by date
```

This is due to the fake data all falling in the "Last 30 days" group, whereas yesterday some of them would have fallen in the "Last 7 days" group. I'm not sure the best way to fix this, but since I haven't introduced any new regressions/issues, I'm submitting anyway.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
