### PR TITLE
🔧 fix(data-provider): add openapi-types dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27599,6 +27599,7 @@
         "axios": "^1.3.4",
         "js-yaml": "^4.1.0",
         "openai": "4.11.1",
+        "openapi-types": "^12.1.3",
         "zod": "^3.22.4"
       },
       "devDependencies": {

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -43,6 +43,7 @@
     "axios": "^1.3.4",
     "js-yaml": "^4.1.0",
     "openai": "4.11.1",
+    "openapi-types": "^12.1.3",
     "zod": "^3.22.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Necessary fix overlooked in #1696 as build for api image would've caught it.