### PR TITLE
📋 feat: Accumulate Text Parts to Clipboard for Assistant Outputs

### DIFF
--- a/client/src/hooks/Messages/useMessageHelpers.ts
+++ b/client/src/hooks/Messages/useMessageHelpers.ts
@@ -1,6 +1,6 @@
 import copy from 'copy-to-clipboard';
 import { useEffect, useRef, useCallback } from 'react';
-import { EModelEndpoint } from 'librechat-data-provider';
+import { EModelEndpoint, ContentTypes } from 'librechat-data-provider';
 import { useGetEndpointsQuery } from 'librechat-data-provider/react-query';
 import type { TMessage } from 'librechat-data-provider';
 import type { TMessageProps } from '~/common';
@@ -25,7 +25,7 @@ export default function useMessageHelpers(props: TMessageProps) {
   } = useChatContext();
   const assistantMap = useAssistantsMapContext();
 
-  const { text, children, messageId = null, isCreatedByUser } = message ?? {};
+  const { text, content, children, messageId = null, isCreatedByUser } = message ?? {};
   const edit = messageId === currentEditId;
   const isLast = !children?.length;
 
@@ -46,8 +46,10 @@ export default function useMessageHelpers(props: TMessageProps) {
     }
   }, [isLast, message, setLatestMessage, conversation?.conversationId]);
 
-  const enterEdit = (cancel?: boolean) =>
-    setCurrentEditId && setCurrentEditId(cancel ? -1 : messageId);
+  const enterEdit = useCallback(
+    (cancel?: boolean) => setCurrentEditId && setCurrentEditId(cancel ? -1 : messageId),
+    [messageId, setCurrentEditId],
+  );
 
   const handleScroll = useCallback(() => {
     if (isSubmitting) {
@@ -79,14 +81,26 @@ export default function useMessageHelpers(props: TMessageProps) {
     regenerate(message);
   };
 
-  const copyToClipboard = (setIsCopied: React.Dispatch<React.SetStateAction<boolean>>) => {
-    setIsCopied(true);
-    copy(text ?? '');
+  const copyToClipboard = useCallback(
+    (setIsCopied: React.Dispatch<React.SetStateAction<boolean>>) => {
+      setIsCopied(true);
+      let messageText = text ?? '';
+      if (content) {
+        messageText = content.reduce((acc, curr, i) => {
+          if (curr.type === ContentTypes.TEXT) {
+            return acc + curr.text.value + (i === content.length - 1 ? '' : '\n');
+          }
+          return acc;
+        }, '');
+      }
+      copy(messageText ?? '');
 
-    setTimeout(() => {
-      setIsCopied(false);
-    }, 3000);
-  };
+      setTimeout(() => {
+        setIsCopied(false);
+      }, 3000);
+    },
+    [text, content],
+  );
 
   return {
     ask,


### PR DESCRIPTION
## Summary:

Closes #1844 

- Implemented a feature that accumulates text parts from assistant outputs to clipboard. This feature enhances the user experience by allowing users to easily copy and paste assistant outputs.
- Enhanced the performance of `enterEdit` and `copyToClipboard` functions by adding `useCallback` hooks. These hooks ensure that the functions are not recreated on each render, thereby improving the performance of the application.
- These changes do not introduce any breaking changes to the existing functionality of the application and do not require any additional dependencies.

## Checklist:

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes