### PR TITLE
🐛 fix: Preserve Default Model in Message Requests

### DIFF
--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -506,9 +506,6 @@ export const compactOpenAISchema = tConversationSchema
   })
   .transform((obj: Partial<TConversation>) => {
     const newObj: Partial<TConversation> = { ...obj };
-    if (newObj.model === 'gpt-3.5-turbo') {
-      delete newObj.model;
-    }
     if (newObj.temperature === 1) {
       delete newObj.temperature;
     }
@@ -545,9 +542,6 @@ export const compactGoogleSchema = tConversationSchema
   })
   .transform((obj) => {
     const newObj: Partial<TConversation> = { ...obj };
-    if (newObj.model === google.model.default) {
-      delete newObj.model;
-    }
     if (newObj.temperature === google.temperature.default) {
       delete newObj.temperature;
     }
@@ -577,9 +571,6 @@ export const compactAnthropicSchema = tConversationSchema
   })
   .transform((obj) => {
     const newObj: Partial<TConversation> = { ...obj };
-    if (newObj.model === 'claude-1') {
-      delete newObj.model;
-    }
     if (newObj.temperature === 1) {
       delete newObj.temperature;
     }
@@ -603,11 +594,6 @@ export const compactChatGPTSchema = tConversationSchema
   })
   .transform((obj) => {
     const newObj: Partial<TConversation> = { ...obj };
-    // model: obj.model ?? 'text-davinci-002-render-sha',
-    if (newObj.model === 'text-davinci-002-render-sha') {
-      delete newObj.model;
-    }
-
     return removeNullishValues(newObj);
   })
   .catch(() => ({}));
@@ -626,9 +612,6 @@ export const compactPluginsSchema = tConversationSchema
   })
   .transform((obj) => {
     const newObj: Partial<TConversation> = { ...obj };
-    if (newObj.model === 'gpt-3.5-turbo') {
-      delete newObj.model;
-    }
     if (newObj.chatGptLabel === null) {
       delete newObj.chatGptLabel;
     }


### PR DESCRIPTION
## Summary:

- Previously, the default model was being removed from the message request for certain endpoints. 
    - The original intention was to reduce/optimize the payload size as defaults are applied when modelOptions are omitted
    - However, the `model` field is now required for every request as of #1841 

![image](https://github.com/danny-avila/LibreChat/assets/110412045/fb5671ee-0612-4ce2-8c96-648b1e6af03a)

- I've modified the relevant logic to ensure that the default model is preserved in all scenarios.

![image](https://github.com/danny-avila/LibreChat/assets/110412045/2cd37acc-b604-44db-9079-0939af8a51e8)


## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)

Checklist:
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.