### PR TITLE
🔧 feat: optional librechat.yaml path via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,12 @@ DEBUG_CONSOLE=false
 # UID=1000
 # GID=1000
 
+#===============#
+# Configuration #
+#===============#
+
+# CONFIG_PATH="/alternative/path/to/librechat.yaml"
+
 #===================================================#
 #                     Endpoints                     #
 #===================================================#

--- a/api/server/services/Config/loadCustomConfig.js
+++ b/api/server/services/Config/loadCustomConfig.js
@@ -5,7 +5,7 @@ const { getLogStores } = require('~/cache');
 const { logger } = require('~/config');
 
 const projectRoot = path.resolve(__dirname, '..', '..', '..', '..');
-const configPath = path.resolve(projectRoot, 'librechat.yaml');
+const defaultConfigPath = path.resolve(projectRoot, 'librechat.yaml');
 
 let i = 0;
 
@@ -16,6 +16,9 @@ let i = 0;
  * @returns {Promise<TCustomConfig | null>} A promise that resolves to null or the custom config object.
  * */
 async function loadCustomConfig() {
+  // Use CONFIG_PATH if set, otherwise fallback to defaultConfigPath
+  const configPath = process.env.CONFIG_PATH || defaultConfigPath;
+  
   const customConfig = loadYaml(configPath);
   if (!customConfig) {
     i === 0 &&


### PR DESCRIPTION
## Summary

Implements custom `librechat.yaml` config paths using environment variables. This get's more and more important in perspective of #1390 . Closes #1825.

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [ ] Documentation update

## Testing

@danny-avila please provide information on how to update or include new tests.

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
