### PR TITLE
🐋 Feat: docker pre-built image by default

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -11,13 +11,13 @@ version: '3.4'
 # WARNING: YOU CAN ONLY SPECIFY EVERY SERVICE NAME ONCE (api, mongodb, meilisearch, ...)
 # IF YOU WANT TO OVERRIDE MULTIPLE SETTINGS IN ONE SERVICE YOU WILL HAVE TO EDIT ACCORDINGLY
 
-# EXAMPLE: if you want to use the config file and the latest docker image the result will be:
+# EXAMPLE: if you want to use the config file and the latest numbered release docker image the result will be:
 
 # services:
 #   api:
 #     volumes:
 #       - ./librechat.yaml:/app/librechat.yaml
-#     image: ghcr.io/danny-avila/librechat-dev:latest
+#     image: ghcr.io/danny-avila/librechat:latest
 
 # ---------------------------------------------------
 
@@ -27,6 +27,13 @@ version: '3.4'
 #   api:
 #     volumes:
 #       - ./librechat.yaml:/app/librechat.yaml
+
+# # LOCAL BUILD
+#   api:
+#     image: librechat
+#     build:
+#       context: .
+#       target: node
 
 # # BUILD FROM LATEST IMAGE
 #   api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,7 @@ services:
       - 3080:3080
     depends_on:
       - mongodb
-    image: librechat
-    build:
-      context: .
-      target: node
+    image: ghcr.io/danny-avila/librechat-dev:latest
     restart: always
     user: "${UID}:${GID}"
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   api:
     container_name: LibreChat
     ports:
-      - 3080:3080
+      - "${PORT}:${PORT}"
     depends_on:
       - mongodb
     image: ghcr.io/danny-avila/librechat-dev:latest

--- a/docs/install/configuration/docker_override.md
+++ b/docs/install/configuration/docker_override.md
@@ -49,7 +49,7 @@ services:
       - ./librechat.yaml:/app/librechat.yaml
 ```
 
-Or, if you want to use a prebuilt image for the `api` service, use the LibreChat config file, and use the older Mongo that doesn't requires AVX support, your `docker-compose.override.yml` might look like this:
+Or, if you want to locally build the image for the `api` service, use the LibreChat config file, and use the older Mongo that doesn't requires AVX support, your `docker-compose.override.yml` might look like this:
 
 ```yaml
 version: '3.4'
@@ -58,7 +58,10 @@ services:
   api:
     volumes:
       - ./librechat.yaml:/app/librechat.yaml
-    image: ghcr.io/danny-avila/librechat-dev:latest
+    image: librechat
+    build:
+      context: .
+      target: node
 
   mongodb:
     image: mongo:4.4.18

--- a/docs/install/installation/docker_compose_install.md
+++ b/docs/install/installation/docker_compose_install.md
@@ -117,23 +117,21 @@ For more info see:
       - MEILI_HOST=http://meilisearch:7700
 ```
 
-- If for some reason you're not able to build the app image, you can pull the latest image from **Dockerhub**.
-- Create a new file named `docker-compose.override.yml` in the same directory as your main `docker-compose.yml` with this content:
+- If you want your docker install to reflect changes made to your local folder, you can build the image locally using this method:
+    - Create a new file named `docker-compose.override.yml` in the same directory as your main `docker-compose.yml` with this content:
 
-```yaml
-version: '3.4'
+    ```yaml
+    version: '3.4'
 
-services:
-  api:
-    image: ghcr.io/danny-avila/librechat-dev:latest
-```
+    services:
+      api:
+        image: librechat
+        build:
+          context: .
+          target: node
+    ```
 
-- Then use `docker compose build` as you would normally
-
-- **Note:** There are different Dockerhub images. the `librechat:latest` image is only updated with new release tags, so it may not have the latest changes to the main branch. To get the latest changes you can use `librechat-dev:latest` instead
-
-
-### **[LibreChat on Docker Hub](https://hub.docker.com/r/chatgptclone/app/tags)**
+    - Then use `docker compose build` as you would normally
 
 ### **[Create a MongoDB database](../configuration/mongodb.md)** (Not required if you'd like to use the local database installed by Docker)
 


### PR DESCRIPTION
## Summary

- Use docker prebuilt image by default 
  - close #1854

The use of the pre-built images was already mentionned in the docs but wasn't the default option. It's more convenient overall for the average user to have the `librechat-dev` set as the default, and leave the local build process as an override option.

---

- Set docker LibreChat ports from `.env`

I also changed the `api` container port to fetch from the .env, since right now it has to be changed from both the compose file and .env file to properly work. I believe this makes it more user-friendly and that the override file should be used if someone wants to unlink them for some reasons.

---

- Docs Update

`docker-compose.override.yml.example`, `docker_override.md` & `docker_compose_install.md` have been updated to reflect these changes.

---

## Change Type

- [x] Enhancement
- [x] Documentation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

- [x] I have made pertinent documentation changes
- [x] 🐋