### PR TITLE
🗨️ fix: Prevent Resetting Title to 'New Chat' on Follow-Up Message 

### DIFF
--- a/client/src/hooks/SSE/useSSE.ts
+++ b/client/src/hooks/SSE/useSSE.ts
@@ -243,7 +243,6 @@ export default function useSSE(submission: TSubmission | null, index = 0) {
       let title = prevState?.title;
       if (parentMessageId !== Constants.NO_PARENT && title?.toLowerCase()?.includes('new chat')) {
         const convos = queryClient.getQueryData<ConversationData>([QueryKeys.allConversations]);
-
         const cachedConvo = getConversationById(convos, conversationId);
         title = cachedConvo?.title;
       }

--- a/client/src/hooks/SSE/useSSE.ts
+++ b/client/src/hooks/SSE/useSSE.ts
@@ -24,7 +24,12 @@ import type {
   TSubmission,
   ConversationData,
 } from 'librechat-data-provider';
-import { addConversation, deleteConversation, updateConversation } from '~/utils';
+import {
+  addConversation,
+  deleteConversation,
+  updateConversation,
+  getConversationById,
+} from '~/utils';
 import { useGenTitleMutation } from '~/data-provider';
 import useContentHandler from './useContentHandler';
 import { useAuthContext } from '../AuthContext';
@@ -231,13 +236,22 @@ export default function useSSE(submission: TSubmission | null, index = 0) {
       ]);
     }
 
-    const { conversationId } = message;
+    const { conversationId, parentMessageId } = message;
 
     let update = {} as TConversation;
     setConversation((prevState) => {
+      let title = prevState?.title;
+      if (parentMessageId !== Constants.NO_PARENT && title?.toLowerCase()?.includes('new chat')) {
+        const convos = queryClient.getQueryData<ConversationData>([QueryKeys.allConversations]);
+
+        const cachedConvo = getConversationById(convos, conversationId);
+        title = cachedConvo?.title;
+      }
+
       update = tConvoUpdateSchema.parse({
         ...prevState,
         conversationId,
+        title,
       }) as TConversation;
 
       setStorage(update);
@@ -248,7 +262,7 @@ export default function useSSE(submission: TSubmission | null, index = 0) {
       if (!convoData) {
         return convoData;
       }
-      if (message.parentMessageId === Constants.NO_PARENT) {
+      if (parentMessageId === Constants.NO_PARENT) {
         return addConversation(convoData, update);
       } else {
         return updateConversation(convoData, update);

--- a/client/src/utils/convos.ts
+++ b/client/src/utils/convos.ts
@@ -3,7 +3,6 @@ import {
   isToday,
   isWithinInterval,
   subDays,
-  getMonth,
   getYear,
   startOfDay,
   startOfYear,
@@ -161,4 +160,21 @@ export const deleteConversation = (
   }
 
   return newData;
+};
+
+export const getConversationById = (
+  data: ConversationData | undefined,
+  conversationId: string | null,
+): TConversation | undefined => {
+  if (!data || !conversationId) {
+    return undefined;
+  }
+
+  for (const page of data.pages) {
+    const conversation = page.conversations.find((c) => c.conversationId === conversationId);
+    if (conversation) {
+      return conversation;
+    }
+  }
+  return undefined;
 };


### PR DESCRIPTION
**Summary:**

Closes #1861

In this update, I fixed an issue where the title was resetting to 'New Chat' on the follow-up or second message in a new conversation.

The conversations cache is updated when finalizing a message response. However, the state is intentionally not updated following the title generation as the user may have affected the conversation state and not updating it prevents mixture. This fix updates the state where is customary, on new message request, pulling the newly generated title from the cache. If the cache is undefined or the conversation cannot be found, the default is "New Chat".

A helper function was introduced for the infinite query data retrieval: `getConversationById`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented on any complex areas of my code
- [x] I have made pertinent updates to the documentation
- [x] My changes do not introduce new warnings
- [x] I have written tests that demonstrate my changes are effective
- [x] Local unit tests pass with my changes
- [x] Any dependent changes have been merged and published in downstream modules.