### PR TITLE
🔀 fix: Correct Expected Behavior for Modular Chat Feature

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/MenuItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/MenuItem.tsx
@@ -65,16 +65,18 @@ const MenuItem: FC<MenuItemProps> = ({
         getEndpointField(endpointsConfig, currentEndpoint, 'type') ?? currentEndpoint;
       const newEndpointType = getEndpointField(endpointsConfig, newEndpoint, 'type') ?? newEndpoint;
 
-      if (
-        isExistingConversation &&
-        (modularEndpoints.has(endpoint ?? '') ||
-          modularEndpoints.has(currentEndpointType ?? '') ||
-          isAssistantSwitch) &&
-        (modularEndpoints.has(newEndpoint ?? '') ||
-          modularEndpoints.has(newEndpointType ?? '') ||
-          isAssistantSwitch) &&
-        (endpoint === newEndpoint || modularChat || isAssistantSwitch)
-      ) {
+      const hasEndpoint = modularEndpoints.has(currentEndpoint ?? '');
+      const hasCurrentEndpointType = modularEndpoints.has(currentEndpointType ?? '');
+      const isCurrentModular = hasEndpoint || hasCurrentEndpointType || isAssistantSwitch;
+
+      const hasNewEndpoint = modularEndpoints.has(newEndpoint ?? '');
+      const hasNewEndpointType = modularEndpoints.has(newEndpointType ?? '');
+      const isNewModular = hasNewEndpoint || hasNewEndpointType || isAssistantSwitch;
+
+      const endpointsMatch = currentEndpoint === newEndpoint;
+      const shouldSwitch = endpointsMatch || modularChat || isAssistantSwitch;
+
+      if (isExistingConversation && isCurrentModular && isNewModular && shouldSwitch) {
         template.endpointType = newEndpointType;
 
         const currentConvo = getDefaultConversation({


### PR DESCRIPTION
## Summary

The app was exhibiting behavior of modular chat even when the feature was disabled. This is corrected as the issue stemmed from incorrect use of a variable.

I took the opportunity to make the conditions for endpoint switching more clear even if it makes the frontend logic more verbose.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.