### PR TITLE
📒 docs: Add newline for list to be correctly rendered in docs UI

### DIFF
--- a/docs/install/configuration/litellm.md
+++ b/docs/install/configuration/litellm.md
@@ -6,6 +6,7 @@ weight: -7
 
 # Using LibreChat with LiteLLM Proxy 
 Use **[LiteLLM Proxy](https://docs.litellm.ai/docs/simple_proxy)** for: 
+
 * Calling 100+ LLMs Huggingface/Bedrock/TogetherAI/etc. in the OpenAI ChatCompletions & Completions format
 * Load balancing - between Multiple Models + Deployments of the same model LiteLLM proxy can handle 1k+ requests/second during load tests
 * Authentication & Spend Tracking Virtual Keys


### PR DESCRIPTION
This is a tiny PR. I just spotted a small issue in the docs and thought I'd report it.

Currently on the "Using LibreChat with LiteLLM Proxy" documentation page the bullet list in the first paragraph is not rendered correctly. See [docs page](https://docs.librechat.ai/install/configuration/litellm.html).

<img width="796" alt="image" src="https://github.com/danny-avila/LibreChat/assets/12040852/91702ea3-8ad2-494d-ac07-1302968ae7e6">

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
