### PR TITLE
🔥chore: bump firebase dependency

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "express-rate-limit": "^6.9.0",
     "express-session": "^1.17.3",
     "file-type": "^18.7.0",
-    "firebase": "^10.6.0",
+    "firebase": "^10.8.0",
     "googleapis": "^126.0.1",
     "handlebars": "^4.7.7",
     "html": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "express-rate-limit": "^6.9.0",
         "express-session": "^1.17.3",
         "file-type": "^18.7.0",
-        "firebase": "^10.6.0",
+        "firebase": "^10.8.0",
         "googleapis": "^126.0.1",
         "handlebars": "^4.7.7",
         "html": "^1.0.0",
@@ -16268,9 +16268,9 @@
       }
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -27993,7 +27993,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "ISC",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
## Summary

Addressing npm audit, however the warnings will not go away until firebase node SDK is updated: https://github.com/firebase/firebase-js-sdk/pull/8044 https://github.com/firebase/firebase-js-sdk/issues/8038

