### PR TITLE
🌍 feat: Extend regex to support international usernames

### DIFF
--- a/api/strategies/validators.js
+++ b/api/strategies/validators.js
@@ -1,6 +1,20 @@
 const { z } = require('zod');
 
-const allowedCharactersRegex = /^[a-zA-Z0-9_.@#$%&*()\p{Script=Latin}\p{Script=Common}]+$/u;
+const allowedCharactersRegex = new RegExp(
+  '^[' +
+    'a-zA-Z0-9_.@#$%&*()' + // Basic Latin characters and symbols
+    '\\p{Script=Latin}' + // Latin script characters
+    '\\p{Script=Common}' + // Characters common across scripts
+    '\\p{Script=Cyrillic}' + // Cyrillic script for Russian, etc.
+    '\\p{Script=Devanagari}' + // Devanagari script for Hindi, etc.
+    '\\p{Script=Han}' + // Han script for Chinese characters, etc.
+    '\\p{Script=Arabic}' + // Arabic script
+    '\\p{Script=Hiragana}' + // Hiragana script for Japanese
+    '\\p{Script=Katakana}' + // Katakana script for Japanese
+    '\\p{Script=Hangul}' + // Hangul script for Korean
+    ']+$', // End of string
+  'u', // Use Unicode mode
+);
 const injectionPatternsRegex = /('|--|\$ne|\$gt|\$lt|\$or|\{|\}|\*|;|<|>|\/|=)/i;
 
 const usernameSchema = z

--- a/api/strategies/validators.spec.js
+++ b/api/strategies/validators.spec.js
@@ -404,9 +404,6 @@ describe('Zod Schemas', () => {
 
     it('should reject invalid usernames', () => {
       const invalidUsernames = [
-        'Дмитрий', // Cyrillic characters
-        'محمد', // Arabic characters
-        '张伟', // Chinese characters
         'john{doe}', // Contains `{` and `}`
         'j', // Only one character
         'a'.repeat(81), // More than 80 characters


### PR DESCRIPTION
## Summary

- update regex: `api/strategies/validators.js`
- update test: `api/strategies/validators.spec.js`

As suggested by `@NoobSkie` on Discord, and in alignment with our ongoing efforts towards internationalization, this pull request introduces significant enhancements to our username validation mechanism.

Previously, our username validation regex was limited to Latin script and a handful of symbols, restricting users from non-Western regions from registering with usernames in their native scripts. Recognizing the importance of inclusivity and the global nature of our user base, I expanded the regex to include:

- Cyrillic (for users in Russia and Eastern Europe)
- Devanagari (for users in India and Nepal)
- Han (covering Chinese, Japanese Kanji, and Korean Hanja)
- Arabic (for users in the Middle East and North Africa)
- Hiragana and Katakana (for Japanese users)
- Hangul (for Korean users)

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code