### PR TITLE
🛠️ fix: RunManager, AssistantService and useContentHandler Issues

### DIFF
--- a/api/server/services/AssistantService.js
+++ b/api/server/services/AssistantService.js
@@ -286,6 +286,9 @@ function createInProgressHandler(openai, thread_id, messages) {
       openai.seenCompletedMessages.add(message_id);
 
       const message = await openai.beta.threads.messages.retrieve(thread_id, message_id);
+      if (!message?.content?.length) {
+        return;
+      }
       messages.push(message);
 
       let messageIndex = openai.mappedOrder.get(step.id);

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -1,12 +1,10 @@
 import { Suspense } from 'react';
-// import type { ContentPart } from 'librechat-data-provider';
+import type { TMessageContentParts } from 'librechat-data-provider';
 import { UnfinishedMessage } from './MessageContent';
 import { DelayedRender } from '~/components/ui';
 import Part from './Part';
 
-// Content Component
 const ContentParts = ({
-  edit,
   error,
   unfinished,
   isSubmitting,
@@ -17,15 +15,16 @@ const ContentParts = ({
 any) => {
   if (error) {
     // return <ErrorMessage text={text} />;
-  } else if (edit) {
-    // return <EditMessage text={text} isSubmitting={isSubmitting} {...props} />;
   } else {
     const { message } = props;
     const { messageId } = message;
 
     return (
       <>
-        {content.map((part, idx) => {
+        {content.map((part: TMessageContentParts | undefined, idx: number) => {
+          if (!part) {
+            return null;
+          }
           return (
             <Part
               key={`display-${messageId}-${idx}`}

--- a/client/src/hooks/SSE/useContentHandler.ts
+++ b/client/src/hooks/SSE/useContentHandler.ts
@@ -61,8 +61,6 @@ export default function useContentHandler({ setMessages, getMessages }: TUseCont
       response.content.push(initialResponse.content[0]);
     }
 
-    response.content = response.content.filter((p) => p !== undefined);
-
     setMessages([...messages, response]);
   };
 }


### PR DESCRIPTION
## Summary:

- In the RunManager, I refactored the `seenSteps` Set keys for RunSteps using `getDetailsSignature` and `getToolCallSignature` to ensure changes from polling are always captured. This will provide a more accurate and up-to-date state of the steps in a run.

- In the AssistantService, I fixed an issue where empty messages were not being skipped in the `in_progress` method. This was causing unnecessary processing and could lead to confusion for the user.

- In the useContentHandler, I fixed an issue where undefined parts were not being retained and handled within `ContentParts` rendering, which would create a mismatch between client and server of content parts. This was causing errors and preventing proper rendering of content.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes.