### PR TITLE
🔎 update meilisearch to v1.6 / 0.37.0

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -59,7 +59,7 @@
     "langchain": "^0.0.214",
     "librechat-data-provider": "*",
     "lodash": "^4.17.21",
-    "meilisearch": "^0.33.0",
+    "meilisearch": "^0.37.0",
     "mime": "^3.0.0",
     "module-alias": "^2.2.3",
     "mongoose": "^7.1.1",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,11 +33,11 @@ services:
     command: mongod --noauth
   meilisearch:
     container_name: chat-meilisearch
-    image: getmeili/meilisearch:v1.5
+    image: getmeili/meilisearch:v1.6
     restart: always
     user: "${UID}:${GID}"
     environment:
       - MEILI_HOST=http://meilisearch:7700
       - MEILI_NO_ANALYTICS=true
     volumes:
-      - ./meili_data_v1.5:/meili_data
+      - ./meili_data_v1.6:/meili_data

--- a/docs/general_info/breaking_changes.md
+++ b/docs/general_info/breaking_changes.md
@@ -11,6 +11,13 @@ Certain changes in the updates may impact cookies, leading to unexpected behavio
 
 ---
 
+## 🔎Meilisearch v1.6
+
+- **Meilisearch Update**: Following the recent update to Meilisearch, an unused folder named `meili_data_v1.5` may be present in your root directory. This folder is no longer required and **can be safely deleted** to free up space.
+- **New Indexing Data Location**: With the current Meilisearch version `1.6`, the new indexing data location folder will be `meili_data_v1.6`.
+
+---
+
 ## 🥷🪦 Ninja - March 4, 2024
 - Since Ninja has shut down, the ChatGPTbrowser endpoint is no longer available in LibreChat.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "langchain": "^0.0.214",
         "librechat-data-provider": "*",
         "lodash": "^4.17.21",
-        "meilisearch": "^0.33.0",
+        "meilisearch": "^0.37.0",
         "mime": "^3.0.0",
         "module-alias": "^2.2.3",
         "mongoose": "^7.1.1",
@@ -19213,9 +19213,9 @@
       }
     },
     "node_modules/meilisearch": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.33.0.tgz",
-      "integrity": "sha512-bYPb9WyITnJfzf92e7QFK8Rc50DmshFWxypXCs3ILlpNh8pT15A7KSu9Xgnnk/K3G/4vb3wkxxtFS4sxNkWB8w==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.37.0.tgz",
+      "integrity": "sha512-LdbK6JmRghCawrmWKJSEQF0OiE82md+YqJGE/U2JcCD8ROwlhTx0KM6NX4rQt0u0VpV0QZVG9umYiu3CSSIJAQ==",
       "dependencies": {
         "cross-fetch": "^3.1.6"
       }
@@ -27993,7 +27993,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "ISC",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
## Summary

This is pretty much a re-post of #1621 by @itzraiss 

I've been testing v1.6 for a little while on both the HF demo and my personal instance

### Notable changes
- Improve indexing speed
- Disk space usage reduction
- see: https://github.com/meilisearch/meilisearch/releases/tag/v1.6.0

## Change Type

- [x] 🔎 Meilisearch Update to v1.6
- [x] 🔎 Meilisearch Update to v0.37.0
- [x] 📂 New Indexing Data Location
- [x] ✏️ Breaking Changes -> new index location