### PR TITLE
🤖 feat(Anthropic): Claude 3 & Vision Support

### DIFF
--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -140,7 +140,8 @@ class AnthropicClient extends BaseClient {
     const availableModels = this.options.modelsConfig?.[EModelEndpoint.anthropic];
     this.isVisionModel = validateVisionModel({ model: this.modelOptions.model, availableModels });
 
-    if (attachments && !this.isVisionModel) {
+    const visionModelAvailable = availableModels?.includes(this.defaultVisionModel);
+    if (attachments && visionModelAvailable && !this.isVisionModel) {
       this.modelOptions.model = this.defaultVisionModel;
       this.isVisionModel = true;
     }

--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -198,7 +198,10 @@ class AnthropicClient extends BaseClient {
         return {
           ...msg,
           // reason: final assistant content cannot end with trailing whitespace
-          content: isLast && msg.role === 'assistant' ? content?.trim() : content,
+          content:
+            isLast && msg.role === 'assistant' && typeof content === 'string'
+              ? content?.trim()
+              : content,
         };
       }
 

--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -531,7 +531,7 @@ class AnthropicClient extends BaseClient {
 
     let prompt = `${promptBody}${promptSuffix}`;
 
-    return { prompt, context, promptTokens: currentTokenCount };
+    return { prompt, context, promptTokens: currentTokenCount, tokenCountMap };
   }
 
   getCompletion() {

--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -137,7 +137,8 @@ class AnthropicClient extends BaseClient {
    * @param {Array<Promise<MongoFile[]> | MongoFile[]> | Record<string, MongoFile[]>} attachments
    */
   checkVisionRequest(attachments) {
-    this.isVisionModel = validateVisionModel(this.modelOptions.model);
+    const availableModels = this.options.modelsConfig?.[EModelEndpoint.anthropic];
+    this.isVisionModel = validateVisionModel({ model: this.modelOptions.model, availableModels });
 
     if (attachments && !this.isVisionModel) {
       this.modelOptions.model = this.defaultVisionModel;

--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -240,7 +240,7 @@ class AnthropicClient extends BaseClient {
 
     logger.debug('[AnthropicClient] orderedMessages', { orderedMessages, parentMessageId });
 
-    if (!this.isClaude3 && this.options.attachments) {
+    if (!this.isVisionModel && this.options.attachments) {
       throw new Error('Attachments are only supported with the Claude 3 family of models');
     } else if (this.options.attachments) {
       const attachments = (await this.options.attachments).filter((file) =>

--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -199,7 +199,7 @@ class AnthropicClient extends BaseClient {
           ...msg,
           // reason: final assistant content cannot end with trailing whitespace
           content:
-            isLast && msg.role === 'assistant' && typeof content === 'string'
+            isLast && this.useMessages && msg.role === 'assistant' && typeof content === 'string'
               ? content?.trim()
               : content,
         };

--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -125,12 +125,18 @@ class GoogleClient extends BaseClient {
     };
 
     /* Validation vision request */
+    this.defaultVisionModel = this.options.visionModel ?? 'gemini-pro-vision';
     const availableModels = this.options.modelsConfig?.[EModelEndpoint.google];
-    if (this.options.attachments && availableModels.includes('gemini-pro-vision')) {
-      this.modelOptions.model = 'gemini-pro-vision';
-    }
-
     this.isVisionModel = validateVisionModel({ model: this.modelOptions.model, availableModels });
+
+    if (
+      this.options.attachments &&
+      availableModels?.includes(this.defaultVisionModel) &&
+      !this.isVisionModel
+    ) {
+      this.modelOptions.model = this.defaultVisionModel;
+      this.isVisionModel = true;
+    }
 
     if (this.isVisionModel && !this.options.attachments) {
       this.modelOptions.model = 'gemini-pro';

--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -4,7 +4,6 @@ const { GoogleVertexAI } = require('langchain/llms/googlevertexai');
 const { ChatGoogleGenerativeAI } = require('@langchain/google-genai');
 const { ChatGoogleVertexAI } = require('langchain/chat_models/googlevertexai');
 const { AIMessage, HumanMessage, SystemMessage } = require('langchain/schema');
-const { encodeAndFormat } = require('~/server/services/Files/images');
 const { encoding_for_model: encodingForModel, get_encoding: getEncoding } = require('tiktoken');
 const {
   validateVisionModel,
@@ -13,6 +12,7 @@ const {
   EModelEndpoint,
   AuthKeys,
 } = require('librechat-data-provider');
+const { encodeAndFormat } = require('~/server/services/Files/images');
 const { getModelMaxTokens } = require('~/utils');
 const { formatMessage } = require('./prompts');
 const BaseClient = require('./BaseClient');
@@ -124,18 +124,22 @@ class GoogleClient extends BaseClient {
       // stop: modelOptions.stop // no stop method for now
     };
 
-    if (this.options.attachments) {
+    /* Validation vision request */
+    const availableModels = this.options.modelsConfig?.[EModelEndpoint.google];
+    if (this.options.attachments && availableModels.includes('gemini-pro-vision')) {
       this.modelOptions.model = 'gemini-pro-vision';
     }
 
-    // TODO: as of 12/14/23, only gemini models are "Generative AI" models provided by Google
-    this.isGenerativeModel = this.modelOptions.model.includes('gemini');
-    this.isVisionModel = validateVisionModel(this.modelOptions.model);
-    const { isGenerativeModel } = this;
+    this.isVisionModel = validateVisionModel({ model: this.modelOptions.model, availableModels });
+
     if (this.isVisionModel && !this.options.attachments) {
       this.modelOptions.model = 'gemini-pro';
       this.isVisionModel = false;
     }
+
+    // TODO: as of 12/14/23, only gemini models are "Generative AI" models provided by Google
+    this.isGenerativeModel = this.modelOptions.model.includes('gemini');
+    const { isGenerativeModel } = this;
     this.isChatModel = !isGenerativeModel && this.modelOptions.model.includes('chat');
     const { isChatModel } = this;
     this.isTextModel =

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -91,6 +91,7 @@ class OpenAIClient extends BaseClient {
       };
     }
 
+    this.defaultVisionModel = this.options.visionModel ?? 'gpt-4-vision-preview';
     this.checkVisionRequest(this.options.attachments);
 
     const { OPENROUTER_API_KEY, OPENAI_FORCE_PROMPT } = process.env ?? {};
@@ -228,8 +229,9 @@ class OpenAIClient extends BaseClient {
     const availableModels = this.options.modelsConfig?.[this.options.endpoint];
     this.isVisionModel = validateVisionModel({ mmodel: this.modelOptions.model, availableModels });
 
-    if (attachments && !this.isVisionModel) {
-      this.modelOptions.model = 'gpt-4-vision-preview';
+    const visionModelAvailable = availableModels?.includes(this.defaultVisionModel);
+    if (attachments && visionModelAvailable && !this.isVisionModel) {
+      this.modelOptions.model = this.defaultVisionModel;
       this.isVisionModel = true;
     }
 

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -225,7 +225,8 @@ class OpenAIClient extends BaseClient {
    * @param {Array<Promise<MongoFile[]> | MongoFile[]> | Record<string, MongoFile[]>} attachments
    */
   checkVisionRequest(attachments) {
-    this.isVisionModel = validateVisionModel(this.modelOptions.model);
+    const availableModels = this.options.modelsConfig?.[this.options.endpoint];
+    this.isVisionModel = validateVisionModel({ mmodel: this.modelOptions.model, availableModels });
 
     if (attachments && !this.isVisionModel) {
       this.modelOptions.model = 'gpt-4-vision-preview';

--- a/api/models/Transaction.js
+++ b/api/models/Transaction.js
@@ -43,9 +43,10 @@ transactionSchema.statics.create = async function (transactionData) {
   ).lean();
 
   return {
+    rate: transaction.rate,
     user: transaction.user.toString(),
-    [transaction.tokenType]: transaction.tokenValue,
     balance: updatedBalance.tokenCredits,
+    [transaction.tokenType]: transaction.tokenValue,
   };
 };
 

--- a/api/models/spendTokens.js
+++ b/api/models/spendTokens.js
@@ -51,7 +51,9 @@ const spendTokens = async (txData, tokenUsage) => {
       logger.debug('[spendTokens] Transaction data record against balance:', {
         user: prompt.user,
         prompt: prompt.prompt,
+        promptRate: prompt.rate,
         completion: completion.completion,
+        completionRate: completion.rate,
         balance: completion.balance,
       });
   } catch (err) {

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -13,6 +13,12 @@ const tokenValues = {
   'gpt-3.5-turbo-1106': { prompt: 1, completion: 2 },
   'gpt-4-1106': { prompt: 10, completion: 30 },
   'gpt-3.5-turbo-0125': { prompt: 0.5, completion: 1.5 },
+  'claude-3-opus': { prompt: 15, completion: 75 },
+  'claude-3-sonnet': { prompt: 3, completion: 15 },
+  'claude-3-haiku': { prompt: 0.25, completion: 1.25 },
+  'claude-2.1': { prompt: 8, completion: 24 },
+  'claude-2': { prompt: 8, completion: 24 },
+  'claude-': { prompt: 0.8, completion: 2.4 },
 };
 
 /**
@@ -46,6 +52,8 @@ const getValueKey = (model, endpoint) => {
     return '32k';
   } else if (modelName.includes('gpt-4')) {
     return '8k';
+  } else if (tokenValues[modelName]) {
+    return modelName;
   }
 
   return undefined;

--- a/api/package.json
+++ b/api/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://librechat.ai",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.5.4",
+    "@anthropic-ai/sdk": "^0.16.1",
     "@azure/search-documents": "^12.0.0",
     "@keyv/mongo": "^2.1.8",
     "@keyv/redis": "^2.8.1",

--- a/api/server/controllers/EditController.js
+++ b/api/server/controllers/EditController.js
@@ -1,7 +1,7 @@
 const { getResponseSender } = require('librechat-data-provider');
-const { sendMessage, createOnProgress } = require('~/server/utils');
-const { saveMessage, getConvoTitle, getConvo } = require('~/models');
 const { createAbortController, handleAbortError } = require('~/server/middleware');
+const { sendMessage, createOnProgress } = require('~/server/utils');
+const { saveMessage, getConvo } = require('~/models');
 const { logger } = require('~/config');
 
 const EditController = async (req, res, next, initializeClient) => {
@@ -131,11 +131,19 @@ const EditController = async (req, res, next, initializeClient) => {
       response = { ...response, ...metadata };
     }
 
+    const conversation = await getConvo(user, conversationId);
+    conversation.title =
+      conversation && !conversation.title ? null : conversation?.title || 'New Chat';
+
+    if (client.options.attachments) {
+      conversation.model = endpointOption.modelOptions.model;
+    }
+
     if (!abortController.signal.aborted) {
       sendMessage(res, {
-        title: await getConvoTitle(user, conversationId),
         final: true,
-        conversation: await getConvo(user, conversationId),
+        conversation,
+        title: conversation.title,
         requestMessage: userMessage,
         responseMessage: response,
       });

--- a/api/server/controllers/ModelController.js
+++ b/api/server/controllers/ModelController.js
@@ -2,6 +2,16 @@ const { CacheKeys } = require('librechat-data-provider');
 const { loadDefaultModels, loadConfigModels } = require('~/server/services/Config');
 const { getLogStores } = require('~/cache');
 
+const getModelsConfig = async (req) => {
+  const cache = getLogStores(CacheKeys.CONFIG_STORE);
+  let modelsConfig = await cache.get(CacheKeys.MODELS_CONFIG);
+  if (!modelsConfig) {
+    modelsConfig = await loadModels(req);
+  }
+
+  return modelsConfig;
+};
+
 /**
  * Loads the models from the config.
  * @param {Express.Request} req - The Express request object.
@@ -27,4 +37,4 @@ async function modelController(req, res) {
   res.send(modelConfig);
 }
 
-module.exports = { modelController, loadModels };
+module.exports = { modelController, loadModels, getModelsConfig };

--- a/api/server/middleware/buildEndpointOption.js
+++ b/api/server/middleware/buildEndpointOption.js
@@ -1,11 +1,12 @@
 const { parseConvo, EModelEndpoint } = require('librechat-data-provider');
+const { getModelsConfig } = require('~/server/controllers/ModelController');
 const { processFiles } = require('~/server/services/Files/process');
 const gptPlugins = require('~/server/services/Endpoints/gptPlugins');
 const anthropic = require('~/server/services/Endpoints/anthropic');
+const assistant = require('~/server/services/Endpoints/assistant');
 const openAI = require('~/server/services/Endpoints/openAI');
 const custom = require('~/server/services/Endpoints/custom');
 const google = require('~/server/services/Endpoints/google');
-const assistant = require('~/server/services/Endpoints/assistant');
 
 const buildFunction = {
   [EModelEndpoint.openAI]: openAI.buildOptions,
@@ -17,7 +18,7 @@ const buildFunction = {
   [EModelEndpoint.assistants]: assistant.buildOptions,
 };
 
-function buildEndpointOption(req, res, next) {
+async function buildEndpointOption(req, res, next) {
   const { endpoint, endpointType } = req.body;
   const parsedBody = parseConvo({ endpoint, endpointType, conversation: req.body });
   req.body.endpointOption = buildFunction[endpointType ?? endpoint](
@@ -25,6 +26,10 @@ function buildEndpointOption(req, res, next) {
     parsedBody,
     endpointType,
   );
+
+  const modelsConfig = await getModelsConfig(req);
+  req.body.endpointOption.modelsConfig = modelsConfig;
+
   if (req.body.files) {
     // hold the promise
     req.body.endpointOption.attachments = processFiles(req.body.files);

--- a/api/server/middleware/validateModel.js
+++ b/api/server/middleware/validateModel.js
@@ -1,8 +1,7 @@
-const { CacheKeys, ViolationTypes } = require('librechat-data-provider');
-const { loadModels } = require('~/server/controllers/ModelController');
-const { logViolation, getLogStores } = require('~/cache');
+const { ViolationTypes } = require('librechat-data-provider');
+const { getModelsConfig } = require('~/server/controllers/ModelController');
 const { handleError } = require('~/server/utils');
-
+const { logViolation } = require('~/cache');
 /**
  * Validates the model of the request.
  *
@@ -17,11 +16,7 @@ const validateModel = async (req, res, next) => {
     return handleError(res, { text: 'Model not provided' });
   }
 
-  const cache = getLogStores(CacheKeys.CONFIG_STORE);
-  let modelsConfig = await cache.get(CacheKeys.MODELS_CONFIG);
-  if (!modelsConfig) {
-    modelsConfig = await loadModels(req);
-  }
+  const modelsConfig = await getModelsConfig(req);
 
   if (!modelsConfig) {
     return handleError(res, { text: 'Models not loaded' });

--- a/api/server/services/Endpoints/anthropic/buildOptions.js
+++ b/api/server/services/Endpoints/anthropic/buildOptions.js
@@ -1,9 +1,10 @@
 const buildOptions = (endpoint, parsedBody) => {
-  const { modelLabel, promptPrefix, ...rest } = parsedBody;
+  const { modelLabel, promptPrefix, resendImages, ...rest } = parsedBody;
   const endpointOption = {
     endpoint,
     modelLabel,
     promptPrefix,
+    resendImages,
     modelOptions: {
       ...rest,
     },

--- a/api/server/services/Files/Firebase/images.js
+++ b/api/server/services/Files/Firebase/images.js
@@ -11,12 +11,13 @@ const { logger } = require('~/config');
  * Converts an image file to the WebP format. The function first resizes the image based on the specified
  * resolution.
  *
- *
- * @param {Express.Request} req - The request object from Express. It should have a `user` property with an `id`
+ * @param {Object} params - The params object.
+ * @param {Express.Request} params.req - The request object from Express. It should have a `user` property with an `id`
  *                       representing the user, and an `app.locals.paths` object with an `imageOutput` path.
- * @param {Express.Multer.File} file - The file object, which is part of the request. The file object should
+ * @param {Express.Multer.File} params.file - The file object, which is part of the request. The file object should
  *                                     have a `path` property that points to the location of the uploaded file.
- * @param {string} [resolution='high'] - Optional. The desired resolution for the image resizing. Default is 'high'.
+ * @param {EModelEndpoint} params.endpoint - The params object.
+ * @param {string} [params.resolution='high'] - Optional. The desired resolution for the image resizing. Default is 'high'.
  *
  * @returns {Promise<{ filepath: string, bytes: number, width: number, height: number}>}
  *          A promise that resolves to an object containing:
@@ -25,10 +26,14 @@ const { logger } = require('~/config');
  *            - width: The width of the converted image.
  *            - height: The height of the converted image.
  */
-async function uploadImageToFirebase(req, file, resolution = 'high') {
+async function uploadImageToFirebase({ req, file, endpoint, resolution = 'high' }) {
   const inputFilePath = file.path;
   const inputBuffer = await fs.promises.readFile(inputFilePath);
-  const { buffer: resizedBuffer, width, height } = await resizeImageBuffer(inputBuffer, resolution);
+  const {
+    buffer: resizedBuffer,
+    width,
+    height,
+  } = await resizeImageBuffer(inputBuffer, resolution, endpoint);
   const extension = path.extname(inputFilePath);
   const userId = req.user.id;
 

--- a/api/server/services/Files/Local/images.js
+++ b/api/server/services/Files/Local/images.js
@@ -13,12 +13,13 @@ const { updateFile } = require('~/models/File');
  * it converts the image to WebP format before saving.
  *
  * The original image is deleted after conversion.
- *
- * @param {Object} req - The request object from Express. It should have a `user` property with an `id`
+ * @param {Object} params - The params object.
+ * @param {Object} params.req - The request object from Express. It should have a `user` property with an `id`
  *                       representing the user, and an `app.locals.paths` object with an `imageOutput` path.
- * @param {Express.Multer.File} file - The file object, which is part of the request. The file object should
+ * @param {Express.Multer.File} params.file - The file object, which is part of the request. The file object should
  *                                     have a `path` property that points to the location of the uploaded file.
- * @param {string} [resolution='high'] - Optional. The desired resolution for the image resizing. Default is 'high'.
+ * @param {EModelEndpoint} params.endpoint - The params object.
+ * @param {string} [params.resolution='high'] - Optional. The desired resolution for the image resizing. Default is 'high'.
  *
  * @returns {Promise<{ filepath: string, bytes: number, width: number, height: number}>}
  *          A promise that resolves to an object containing:
@@ -27,10 +28,14 @@ const { updateFile } = require('~/models/File');
  *            - width: The width of the converted image.
  *            - height: The height of the converted image.
  */
-async function uploadLocalImage(req, file, resolution = 'high') {
+async function uploadLocalImage({ req, file, endpoint, resolution = 'high' }) {
   const inputFilePath = file.path;
   const inputBuffer = await fs.promises.readFile(inputFilePath);
-  const { buffer: resizedBuffer, width, height } = await resizeImageBuffer(inputBuffer, resolution);
+  const {
+    buffer: resizedBuffer,
+    width,
+    height,
+  } = await resizeImageBuffer(inputBuffer, resolution, endpoint);
   const extension = path.extname(inputFilePath);
 
   const { imageOutput } = req.app.locals.paths;

--- a/api/server/services/Files/images/encode.js
+++ b/api/server/services/Files/images/encode.js
@@ -23,6 +23,8 @@ async function fetchImageToBase64(url) {
   }
 }
 
+const base64Only = new Set([EModelEndpoint.google, EModelEndpoint.anthropic]);
+
 /**
  * Encodes and formats the given files.
  * @param {Express.Request} req - The request object.
@@ -50,7 +52,7 @@ async function encodeAndFormat(req, files, endpoint) {
     encodingMethods[source] = prepareImagePayload;
 
     /* Google doesn't support passing URLs to payload */
-    if (source !== FileSources.local && endpoint === EModelEndpoint.google) {
+    if (source !== FileSources.local && base64Only.has(endpoint)) {
       const [_file, imageURL] = await prepareImagePayload(req, file);
       promises.push([_file, await fetchImageToBase64(imageURL)]);
       continue;
@@ -81,6 +83,14 @@ async function encodeAndFormat(req, files, endpoint) {
 
     if (endpoint && endpoint === EModelEndpoint.google) {
       imagePart.image_url = imagePart.image_url.url;
+    } else if (endpoint && endpoint === EModelEndpoint.anthropic) {
+      imagePart.type = 'image';
+      imagePart.source = {
+        type: 'base64',
+        media_type: file.type,
+        data: imageContent,
+      };
+      delete imagePart.image_url;
     }
 
     result.image_urls.push(imagePart);

--- a/api/server/services/Files/images/resize.js
+++ b/api/server/services/Files/images/resize.js
@@ -1,4 +1,5 @@
 const sharp = require('sharp');
+const { EModelEndpoint } = require('librechat-data-provider');
 
 /**
  * Resizes an image from a given buffer based on the specified resolution.
@@ -7,13 +8,14 @@ const sharp = require('sharp');
  * @param {'low' | 'high'} resolution - The resolution to resize the image to.
  *                                      'low' for a maximum of 512x512 resolution,
  *                                      'high' for a maximum of 768x2000 resolution.
+ * @param {EModelEndpoint} endpoint - Identifier for specific endpoint handling
  * @returns {Promise<{buffer: Buffer, width: number, height: number}>} An object containing the resized image buffer and its dimensions.
  * @throws Will throw an error if the resolution parameter is invalid.
  */
-async function resizeImageBuffer(inputBuffer, resolution) {
+async function resizeImageBuffer(inputBuffer, resolution, endpoint) {
   const maxLowRes = 512;
   const maxShortSideHighRes = 768;
-  const maxLongSideHighRes = 2000;
+  const maxLongSideHighRes = endpoint === EModelEndpoint.anthropic ? 1568 : 2000;
 
   let newWidth, newHeight;
   let resizeOptions = { fit: 'inside', withoutEnlargement: true };

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -184,8 +184,8 @@ const processFileURL = async ({ fileStrategy, userId, URL, fileName, basePath, c
 const processImageFile = async ({ req, res, file, metadata }) => {
   const source = req.app.locals.fileStrategy;
   const { handleImageUpload } = getStrategyFunctions(source);
-  const { file_id, temp_file_id } = metadata;
-  const { filepath, bytes, width, height } = await handleImageUpload(req, file);
+  const { file_id, temp_file_id, endpoint } = metadata;
+  const { filepath, bytes, width, height } = await handleImageUpload({ req, file, endpoint });
   const result = await createFile(
     {
       user: req.user.id,

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -75,6 +75,7 @@ const googleModels = {
 };
 
 const anthropicModels = {
+  'claude-3': 200000,
   'claude-2.1': 200000,
   'claude-': 100000,
 };

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -75,9 +75,12 @@ const googleModels = {
 };
 
 const anthropicModels = {
-  'claude-3': 200000,
-  'claude-2.1': 200000,
   'claude-': 100000,
+  'claude-2': 100000,
+  'claude-2.1': 200000,
+  'claude-3-haiku': 200000,
+  'claude-3-sonnet': 200000,
+  'claude-3-opus': 200000,
 };
 
 // Order is important here: by model series and context size (gpt-4 then gpt-3, ascending)

--- a/client/src/components/Endpoints/Settings/Anthropic.tsx
+++ b/client/src/components/Endpoints/Settings/Anthropic.tsx
@@ -6,10 +6,11 @@ import {
   Input,
   Label,
   Slider,
-  InputNumber,
+  Switch,
   HoverCard,
-  HoverCardTrigger,
+  InputNumber,
   SelectDropDown,
+  HoverCardTrigger,
 } from '~/components/ui';
 import OptionHover from './OptionHover';
 import { cn, defaultTextProps, optionText, removeFocusOutlines } from '~/utils/';
@@ -20,8 +21,16 @@ export default function Settings({ conversation, setOption, models, readonly }: 
   if (!conversation) {
     return null;
   }
-  const { model, modelLabel, promptPrefix, temperature, topP, topK, maxOutputTokens } =
-    conversation;
+  const {
+    model,
+    modelLabel,
+    promptPrefix,
+    temperature,
+    topP,
+    topK,
+    maxOutputTokens,
+    resendImages,
+  } = conversation;
 
   const setModel = setOption('model');
   const setModelLabel = setOption('modelLabel');
@@ -30,6 +39,7 @@ export default function Settings({ conversation, setOption, models, readonly }: 
   const setTopP = setOption('topP');
   const setTopK = setOption('topK');
   const setMaxOutputTokens = setOption('maxOutputTokens');
+  const setResendImages = setOption('resendImages');
 
   return (
     <div className="grid grid-cols-5 gap-6">
@@ -243,6 +253,27 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             type="maxoutputtokens"
             side={ESide.Left}
           />
+        </HoverCard>
+        <HoverCard openDelay={500}>
+          <HoverCardTrigger className="grid w-full">
+            <div className="flex justify-between">
+              <Label htmlFor="resend-images" className="text-left text-sm font-medium">
+                {localize('com_endpoint_plug_resend_images')}{' '}
+              </Label>
+              <Switch
+                id="resend-images"
+                checked={resendImages ?? false}
+                onCheckedChange={(checked: boolean) => setResendImages(checked)}
+                disabled={readonly}
+                className="flex"
+              />
+              <OptionHover
+                endpoint={conversation?.endpoint ?? ''}
+                type="resend"
+                side={ESide.Bottom}
+              />
+            </div>
+          </HoverCardTrigger>
         </HoverCard>
       </div>
     </div>

--- a/client/src/components/Endpoints/Settings/OptionHover.tsx
+++ b/client/src/components/Endpoints/Settings/OptionHover.tsx
@@ -25,6 +25,7 @@ const types = {
     topp: 'com_endpoint_anthropic_topp',
     topk: 'com_endpoint_anthropic_topk',
     maxoutputtokens: 'com_endpoint_anthropic_maxoutputtokens',
+    resend: openAI.resend,
   },
   google: {
     temp: 'com_endpoint_google_temp',

--- a/client/src/hooks/SSE/useSSE.ts
+++ b/client/src/hooks/SSE/useSSE.ts
@@ -309,11 +309,6 @@ export default function useSSE(submission: TSubmission | null, index = 0) {
         ...conversation,
       };
 
-      // Revert to previous model if the model was auto-switched by backend due to message attachments
-      if (conversation.model?.includes('vision') && !submissionConvo.model?.includes('vision')) {
-        update.model = submissionConvo?.model;
-      }
-
       setStorage(update);
       return update;
     });

--- a/client/src/hooks/SSE/useSSE.ts
+++ b/client/src/hooks/SSE/useSSE.ts
@@ -309,6 +309,10 @@ export default function useSSE(submission: TSubmission | null, index = 0) {
         ...conversation,
       };
 
+      if (prevState?.model && prevState.model !== submissionConvo.model) {
+        update.model = prevState.model;
+      }
+
       setStorage(update);
       return update;
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
       "version": "0.6.10",
       "license": "ISC",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.5.4",
+        "@anthropic-ai/sdk": "^0.16.1",
         "@azure/search-documents": "^12.0.0",
         "@keyv/mongo": "^2.1.8",
         "@keyv/redis": "^2.8.1",
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.5.10.tgz",
-      "integrity": "sha512-P8xrIuTUO/6wDzcjQRUROXp4WSqtngbXaE4GpEu0PhEmnq/1Q8vbF1s0o7W07EV3j8zzRoyJxAKovUJtNXH7ew==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.16.1.tgz",
+      "integrity": "sha512-vHgvfWEyFy5ktqam56Nrhv8MVa7EJthsRYNi+1OrFFfyrj9tR2/aji1QbVbQjYU/pPhPFaYrdCEC/MLPFrmKwA==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -291,7 +291,8 @@
         "digest-fetch": "^1.3.0",
         "form-data-encoder": "1.7.2",
         "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
       }
     },
     "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -241,6 +241,8 @@ export const defaultModels = {
     'code-bison-32k',
   ],
   [EModelEndpoint.anthropic]: [
+    'claude-3-opus-20240229',
+    'claude-3-sonnet-20240229',
     'claude-2.1',
     'claude-2',
     'claude-1.2',

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -311,11 +311,20 @@ export const supportsBalanceCheck = {
 
 export const visionModels = ['gpt-4-vision', 'llava-13b', 'gemini-pro-vision', 'claude-3'];
 
-export function validateVisionModel(
-  model: string | undefined,
-  additionalModels: string[] | undefined = [],
-) {
+export function validateVisionModel({
+  model,
+  additionalModels = [],
+  availableModels,
+}: {
+  model: string;
+  additionalModels?: string[];
+  availableModels?: string[];
+}) {
   if (!model) {
+    return false;
+  }
+
+  if (availableModels && !availableModels.includes(model)) {
     return false;
   }
 

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -308,7 +308,7 @@ export const supportsBalanceCheck = {
   [EModelEndpoint.custom]: true,
 };
 
-export const visionModels = ['gpt-4-vision', 'llava-13b', 'gemini-pro-vision'];
+export const visionModels = ['gpt-4-vision', 'llava-13b', 'gemini-pro-vision', 'claude-3'];
 
 export function validateVisionModel(
   model: string | undefined,

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -303,6 +303,7 @@ export const modularEndpoints = new Set<EModelEndpoint | string>([
 
 export const supportsBalanceCheck = {
   [EModelEndpoint.openAI]: true,
+  [EModelEndpoint.anthropic]: true,
   [EModelEndpoint.azureOpenAI]: true,
   [EModelEndpoint.gptPlugins]: true,
   [EModelEndpoint.custom]: true,

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -8,6 +8,7 @@ export const supportsFiles = {
   [EModelEndpoint.google]: true,
   [EModelEndpoint.assistants]: true,
   [EModelEndpoint.azureOpenAI]: true,
+  [EModelEndpoint.anthropic]: true,
   [EModelEndpoint.custom]: true,
 };
 

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -391,6 +391,7 @@ export const anthropicSchema = tConversationSchema
     maxOutputTokens: true,
     topP: true,
     topK: true,
+    resendImages: true,
   })
   .transform((obj) => ({
     ...obj,
@@ -401,6 +402,7 @@ export const anthropicSchema = tConversationSchema
     maxOutputTokens: obj.maxOutputTokens ?? 4000,
     topP: obj.topP ?? 0.7,
     topK: obj.topK ?? 5,
+    resendImages: obj.resendImages ?? false,
   }))
   .catch(() => ({
     model: 'claude-1',
@@ -410,6 +412,7 @@ export const anthropicSchema = tConversationSchema
     maxOutputTokens: 4000,
     topP: 0.7,
     topK: 5,
+    resendImages: false,
   }));
 
 export const chatGPTBrowserSchema = tConversationSchema
@@ -568,6 +571,7 @@ export const compactAnthropicSchema = tConversationSchema
     maxOutputTokens: true,
     topP: true,
     topK: true,
+    resendImages: true,
   })
   .transform((obj) => {
     const newObj: Partial<TConversation> = { ...obj };
@@ -582,6 +586,9 @@ export const compactAnthropicSchema = tConversationSchema
     }
     if (newObj.topK === 5) {
       delete newObj.topK;
+    }
+    if (newObj.resendImages !== true) {
+      delete newObj.resendImages;
     }
 
     return removeNullishValues(newObj);


### PR DESCRIPTION
## Summary: 

- **Claude 3 Support**:
  - Introduced multimodal messages and retry logic, and added use of the messages payload for vision and Claude 3 requests.
  - Implemented token accounting (now a balance supported endpoint)
  - Updated anthropic configuration settings (fileSupport, default models).
  - Updated the anthropic SDK.
  - Updated the data provider dependency.
- **Anthropic Vision Support**: With the Claude 3 family, Anthropic now supports multimodal messages.
  - feat: resend previously attached images

Closes #1963 

**Other Changes:**

- Made sure vision models are available before automatically switching upon use of attachments
- Now avoids resetting model if user selected a new model between request and response
- improve transaction logging
- optimize Edit/Ask controllers

## Checklist:
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.