### PR TITLE
💾 chore: Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,7 +131,7 @@ DEBUG_OPENAI=false
 #   Assistants API   #
 #====================#
 
-# ASSISTANTS_API_KEY=
+ASSISTANTS_API_KEY=user_provided
 # ASSISTANTS_BASE_URL=
 # ASSISTANTS_MODELS=gpt-3.5-turbo-0125,gpt-3.5-turbo-16k-0613,gpt-3.5-turbo-16k,gpt-3.5-turbo,gpt-4,gpt-4-0314,gpt-4-32k-0314,gpt-4-0613,gpt-3.5-turbo-0613,gpt-3.5-turbo-1106,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview
 

--- a/docs/install/configuration/dotenv.md
+++ b/docs/install/configuration/dotenv.md
@@ -375,6 +375,10 @@ OPENAI_FORCE_PROMPT=true
 - Leave `ASSISTANTS_API_KEY=` blank to disable this endpoint
 - Set `ASSISTANTS_API_KEY=` to `user_provided` to allow users to provide their own API key from the WebUI
 
+```bash
+ASSISTANTS_API_KEY=user_provided
+```
+
 - Customize the available models, separated by commas, **without spaces**.
     - The first will be default.
     - Leave it blank or commented out to use internal settings:


### PR DESCRIPTION
## Summary

- Set `ASSISTANTS_API_KEY=` to `user_provided` by default

I had to explain so many times how to make the assistants show in the UI, I figured we might as well set it to 'user_provided' by default, like the other endpoints

## Change Type
- [x] Documentation update