### PR TITLE
🖼️ fix: Clipboard Files & File Name Issues

### DIFF
--- a/api/server/services/Files/Firebase/images.js
+++ b/api/server/services/Files/Firebase/images.js
@@ -38,7 +38,7 @@ async function uploadImageToFirebase({ req, file, file_id, endpoint, resolution 
   const userId = req.user.id;
 
   let webPBuffer;
-  let fileName = `${file_id}-${path.basename(inputFilePath)}`;
+  let fileName = `${file_id}__${path.basename(inputFilePath)}`;
   if (extension.toLowerCase() === '.webp') {
     webPBuffer = resizedBuffer;
   } else {

--- a/api/server/services/Files/Firebase/images.js
+++ b/api/server/services/Files/Firebase/images.js
@@ -26,7 +26,7 @@ const { logger } = require('~/config');
  *            - width: The width of the converted image.
  *            - height: The height of the converted image.
  */
-async function uploadImageToFirebase({ req, file, endpoint, resolution = 'high' }) {
+async function uploadImageToFirebase({ req, file, file_id, endpoint, resolution = 'high' }) {
   const inputFilePath = file.path;
   const inputBuffer = await fs.promises.readFile(inputFilePath);
   const {
@@ -38,7 +38,7 @@ async function uploadImageToFirebase({ req, file, endpoint, resolution = 'high' 
   const userId = req.user.id;
 
   let webPBuffer;
-  let fileName = path.basename(inputFilePath);
+  let fileName = `${file_id}-${path.basename(inputFilePath)}`;
   if (extension.toLowerCase() === '.webp') {
     webPBuffer = resizedBuffer;
   } else {

--- a/api/server/services/Files/Local/images.js
+++ b/api/server/services/Files/Local/images.js
@@ -18,6 +18,7 @@ const { updateFile } = require('~/models/File');
  *                       representing the user, and an `app.locals.paths` object with an `imageOutput` path.
  * @param {Express.Multer.File} params.file - The file object, which is part of the request. The file object should
  *                                     have a `path` property that points to the location of the uploaded file.
+ * @param {string} params.file_id - The file ID.
  * @param {EModelEndpoint} params.endpoint - The params object.
  * @param {string} [params.resolution='high'] - Optional. The desired resolution for the image resizing. Default is 'high'.
  *
@@ -28,7 +29,7 @@ const { updateFile } = require('~/models/File');
  *            - width: The width of the converted image.
  *            - height: The height of the converted image.
  */
-async function uploadLocalImage({ req, file, endpoint, resolution = 'high' }) {
+async function uploadLocalImage({ req, file, file_id, endpoint, resolution = 'high' }) {
   const inputFilePath = file.path;
   const inputBuffer = await fs.promises.readFile(inputFilePath);
   const {
@@ -45,7 +46,8 @@ async function uploadLocalImage({ req, file, endpoint, resolution = 'high' }) {
     fs.mkdirSync(userPath, { recursive: true });
   }
 
-  const newPath = path.join(userPath, path.basename(inputFilePath));
+  const fileName = `${file_id}-${path.basename(inputFilePath)}`;
+  const newPath = path.join(userPath, fileName);
 
   if (extension.toLowerCase() === '.webp') {
     const bytes = Buffer.byteLength(resizedBuffer);

--- a/api/server/services/Files/Local/images.js
+++ b/api/server/services/Files/Local/images.js
@@ -46,7 +46,7 @@ async function uploadLocalImage({ req, file, file_id, endpoint, resolution = 'hi
     fs.mkdirSync(userPath, { recursive: true });
   }
 
-  const fileName = `${file_id}-${path.basename(inputFilePath)}`;
+  const fileName = `${file_id}__${path.basename(inputFilePath)}`;
   const newPath = path.join(userPath, fileName);
 
   if (extension.toLowerCase() === '.webp') {

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -185,7 +185,12 @@ const processImageFile = async ({ req, res, file, metadata }) => {
   const source = req.app.locals.fileStrategy;
   const { handleImageUpload } = getStrategyFunctions(source);
   const { file_id, temp_file_id, endpoint } = metadata;
-  const { filepath, bytes, width, height } = await handleImageUpload({ req, file, endpoint });
+  const { filepath, bytes, width, height } = await handleImageUpload({
+    req,
+    file,
+    file_id,
+    endpoint,
+  });
   const result = await createFile(
     {
       user: req.user.id,

--- a/client/src/hooks/Input/useTextarea.ts
+++ b/client/src/hooks/Input/useTextarea.ts
@@ -179,7 +179,14 @@ export default function useTextarea({
       if (e.clipboardData && e.clipboardData.files.length > 0) {
         e.preventDefault();
         setFilesLoading(true);
-        handleFiles(e.clipboardData.files);
+        const timestampedFiles: File[] = [];
+        for (const file of e.clipboardData.files) {
+          const newFile = new File([file], `clipboard_${+new Date()}_${file.name}`, {
+            type: file.type,
+          });
+          timestampedFiles.push(newFile);
+        }
+        handleFiles(timestampedFiles);
       }
     },
     [handleFiles, setFilesLoading, setText],


### PR DESCRIPTION
## Summary

When images/files were being pasted from clipboard, they would share the same name which would cause overwriting issues, during both the temporary upload process as well as finalizing the upload by writing to the target file source.

File names are now timestamped when they are from the clipbaord and file_ids are now included in all new file paths.

Also fixed an issue with Anthropic/Google, where multiple images could not be handled.

Closes #2016 

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
