### PR TITLE
Refactoring ChatForm and Textarea to Solve Frequent Re-rendering Issues During Text Input

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -1,5 +1,4 @@
 import { useRecoilState } from 'recoil';
-import type { ChangeEvent } from 'react';
 import { useChatContext } from '~/Providers';
 import { useRequiresKey } from '~/hooks';
 import AttachFile from './Files/AttachFile';
@@ -8,9 +7,25 @@ import SendButton from './SendButton';
 import FileRow from './Files/FileRow';
 import Textarea from './Textarea';
 import store from '~/store';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import React from 'react';
+
+type Inputs = {
+  text: string;
+};
 
 export default function ChatForm({ index = 0 }) {
-  const [text, setText] = useRecoilState(store.textByIndex(index));
+  const { handleSubmit, getValues, setValue } = useForm<Inputs>({
+    defaultValues: { text: '' },
+  });
+
+  const textAreaRef = React.useRef<HTMLTextAreaElement | null>(null);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const onSubmit: SubmitHandler<Inputs> = (_data) => {
+    submitMessage();
+  };
+
   const [showStopButton, setShowStopButton] = useRecoilState(store.showStopButtonByIndex(index));
 
   const {
@@ -25,8 +40,10 @@ export default function ChatForm({ index = 0 }) {
   } = useChatContext();
 
   const submitMessage = () => {
+    const text = getValues('text');
     ask({ text });
-    setText('');
+    setValue('text', '');
+    textAreaRef.current?.setRangeText('', 0, text.length, 'end');
   };
 
   const { requiresKey } = useRequiresKey();
@@ -35,10 +52,7 @@ export default function ChatForm({ index = 0 }) {
 
   return (
     <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        submitMessage();
-      }}
+      onSubmit={handleSubmit(onSubmit)}
       className="stretch mx-2 flex flex-row gap-3 last:mb-2 md:mx-4 md:last:mb-6 lg:mx-auto lg:max-w-2xl xl:max-w-3xl"
     >
       <div className="relative flex h-full flex-1 items-stretch md:flex-col">
@@ -56,13 +70,12 @@ export default function ChatForm({ index = 0 }) {
             />
             {endpoint && (
               <Textarea
-                value={text}
-                disabled={requiresKey}
-                onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setText(e.target.value)}
-                setText={setText}
+                disabled={requiresKey ?? false}
+                onChange={(e) => setValue('text', e.target.value)}
                 submitMessage={submitMessage}
                 endpoint={_endpoint}
                 endpointType={endpointType}
+                ref={textAreaRef}
               />
             )}
             <AttachFile
@@ -73,9 +86,7 @@ export default function ChatForm({ index = 0 }) {
             {isSubmitting && showStopButton ? (
               <StopButton stop={handleStopGenerating} setShowStopButton={setShowStopButton} />
             ) : (
-              endpoint && (
-                <SendButton text={text} disabled={filesLoading || isSubmitting || requiresKey} />
-              )
+              endpoint && <SendButton disabled={filesLoading || isSubmitting || requiresKey} />
             )}
           </div>
         </div>

--- a/client/src/components/Chat/Input/SendButton.tsx
+++ b/client/src/components/Chat/Input/SendButton.tsx
@@ -3,7 +3,7 @@ import { cn } from '~/utils';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '~/components/ui/';
 import { useLocalize } from '~/hooks';
 
-export default function SendButton({ text, disabled }) {
+export default function SendButton({ disabled }) {
   const localize = useLocalize();
 
   return (
@@ -11,7 +11,7 @@ export default function SendButton({ text, disabled }) {
       <Tooltip>
         <TooltipTrigger asChild>
           <button
-            disabled={!text || disabled}
+            disabled={disabled}
             className={cn(
               'absolute bottom-1.5 right-2 rounded-lg border border-black p-0.5 text-white transition-colors enabled:bg-black disabled:bg-black disabled:text-gray-400 disabled:opacity-10 dark:border-white dark:bg-white dark:disabled:bg-white md:bottom-3 md:right-3',
             )}

--- a/client/src/components/Chat/Input/Textarea.tsx
+++ b/client/src/components/Chat/Input/Textarea.tsx
@@ -1,3 +1,4 @@
+import React, { ForwardedRef } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 import {
   supportsFiles,
@@ -7,53 +8,63 @@ import {
 import { useGetFileConfig } from '~/data-provider';
 import { cn, removeFocusOutlines } from '~/utils';
 import { useTextarea } from '~/hooks';
+import { EModelEndpoint } from 'librechat-data-provider';
 
-export default function Textarea({
-  value,
-  disabled,
-  onChange,
-  setText,
-  submitMessage,
-  endpoint,
-  endpointType,
-}) {
-  const { data: fileConfig = defaultFileConfig } = useGetFileConfig({
-    select: (data) => mergeFileConfig(data),
-  });
-  const {
-    textAreaRef,
-    handlePaste,
-    handleKeyUp,
-    handleKeyDown,
-    handleCompositionStart,
-    handleCompositionEnd,
-  } = useTextarea({ setText, submitMessage, disabled });
-  const endpointFileConfig = fileConfig.endpoints[endpoint ?? ''];
-  return (
-    <TextareaAutosize
-      ref={textAreaRef}
-      autoFocus
-      value={value}
-      disabled={!!disabled}
-      onChange={onChange}
-      onPaste={handlePaste}
-      onKeyUp={handleKeyUp}
-      onKeyDown={handleKeyDown}
-      onCompositionStart={handleCompositionStart}
-      onCompositionEnd={handleCompositionEnd}
-      id="prompt-textarea"
-      tabIndex={0}
-      data-testid="text-input"
-      style={{ height: 44, overflowY: 'auto' }}
-      rows={1}
-      className={cn(
-        supportsFiles[endpointType ?? endpoint ?? ''] && !endpointFileConfig?.disabled
-          ? ' pl-10 md:pl-[55px]'
-          : 'pl-3 md:pl-4',
-        'm-0 w-full resize-none border-0 bg-transparent py-[10px] pr-10 placeholder-black/50 focus:ring-0 focus-visible:ring-0 dark:bg-transparent dark:placeholder-white/50 md:py-3.5 md:pr-12 ',
-        removeFocusOutlines,
-        'max-h-[65vh] md:max-h-[85vh]',
-      )}
-    />
-  );
+interface TextareaProps {
+  disabled?: boolean;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  submitMessage: () => void;
+  endpoint: EModelEndpoint | null;
+  endpointType: EModelEndpoint | undefined;
 }
+
+const Textarea = React.forwardRef(
+  (
+    { disabled = false, onChange, submitMessage, endpoint, endpointType }: TextareaProps,
+    ref: ForwardedRef<HTMLTextAreaElement>,
+  ) => {
+    const { data: fileConfig = defaultFileConfig } = useGetFileConfig({
+      select: (data) => mergeFileConfig(data),
+    });
+    const {
+      handlePaste,
+      handleKeyUp,
+      handleKeyDown,
+      handleCompositionStart,
+      handleCompositionEnd,
+    } = useTextarea({
+      submitMessage,
+      disabled,
+      textAreaRef: ref as React.MutableRefObject<HTMLTextAreaElement | null>,
+    });
+    const endpointFileConfig = fileConfig.endpoints[endpoint ?? ''];
+    return (
+      <TextareaAutosize
+        ref={ref}
+        autoFocus
+        disabled={!!disabled}
+        onChange={onChange}
+        onPaste={handlePaste}
+        onKeyUp={handleKeyUp}
+        onKeyDown={handleKeyDown}
+        onCompositionStart={handleCompositionStart}
+        onCompositionEnd={handleCompositionEnd}
+        id="prompt-textarea"
+        tabIndex={0}
+        data-testid="text-input"
+        style={{ height: 44, overflowY: 'auto' }}
+        rows={1}
+        className={cn(
+          supportsFiles[endpointType ?? endpoint ?? ''] && !endpointFileConfig?.disabled
+            ? ' pl-10 md:pl-[55px]'
+            : 'pl-3 md:pl-4',
+          'm-0 w-full resize-none border-0 bg-transparent py-[10px] pr-10 placeholder-black/50 focus:ring-0 focus-visible:ring-0 dark:bg-transparent dark:placeholder-white/50 md:py-3.5 md:pr-12 ',
+          removeFocusOutlines,
+          'max-h-[65vh] md:max-h-[85vh]',
+        )}
+      />
+    );
+  },
+);
+
+export default Textarea;

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -53,11 +53,6 @@ const submissionByIndex = atomFamily<TSubmission | null, string | number>({
   default: null,
 });
 
-const textByIndex = atomFamily<string, string | number>({
-  key: 'textByIndex',
-  default: '',
-});
-
 const showStopButtonByIndex = atomFamily<boolean, string | number>({
   key: 'showStopButtonByIndex',
   default: false,
@@ -117,7 +112,6 @@ export default {
   filesByIndex,
   presetByIndex,
   submissionByIndex,
-  textByIndex,
   showStopButtonByIndex,
   abortScrollFamily,
   isSubmittingFamily,


### PR DESCRIPTION
## Summary
Fixes #2036

This PR addresses an issue where the `Textarea` component within the `ChatForm` was causing frequent re-rendering during text input, leading to performance degradation and, in some cases, making it difficult for users to type. By integrating `React Hook Form` for form state management and refactoring the `Textarea` component to efficiently handle changes, we aim to enhance the user experience by reducing unnecessary re-renders and improving text input responsiveness.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Issue Reproduction Video

This is a video demonstrating the issue that this PR aims to resolve. The screen freezes due to frequent re-rendering of the TextArea during Japanese text input.

https://github.com/danny-avila/LibreChat/assets/1153289/bbe139bd-1259-4ea2-9bd5-81aac812aeb9

# Video After Fixing the Issue
The re-rendering during input has been eliminated.

https://github.com/danny-avila/LibreChat/assets/1153289/9fc7e447-946d-4abf-9da3-3dbdf2f196e8

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
