### PR TITLE
📧 update email templates

### DIFF
--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -172,8 +172,10 @@ const requestPasswordReset = async (email) => {
       user.email,
       'Password Reset Request',
       {
+        appName: process.env.APP_TITLE || 'LibreChat',
         name: user.name,
         link: link,
+        year: new Date().getFullYear(),
       },
       'requestPasswordReset.handlebars',
     );

--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -216,7 +216,9 @@ const resetPassword = async (userId, token, password) => {
     user.email,
     'Password Reset Successfully',
     {
+      appName: process.env.APP_TITLE || 'LibreChat',
       name: user.name,
+      year: new Date().getFullYear(),
     },
     'passwordReset.handlebars',
   );

--- a/api/server/utils/emails/requestPasswordReset.handlebars
+++ b/api/server/utils/emails/requestPasswordReset.handlebars
@@ -1,13 +1,239 @@
-<html>
-    <head>
-        <style>
+<!DOCTYPE HTML
+    PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
-        </style>
-    </head>
-    <body>
-        <p>Hi {{name}},</p>
-        <h1>You have requested to reset your password.</h1>
-        <p> Please click the link below to reset your password.</p>
-        <a href="{{link}}">Reset Password</a>
-    </body>
+<head>
+	<!--[if gte mso 9]>
+<xml>
+<o:OfficeDocumentSettings>
+    <o:AllowPNG />
+    <o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+<![endif]-->
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="x-apple-disable-message-reformatting">
+	<meta name="color-scheme" content="light dark">
+	<!--[if !mso]><!-->
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<!--<![endif]-->
+	<title></title>
+	<style type="text/css">
+	@media (prefers-color-scheme: dark) {
+		.darkmode {
+			background-color: #212121 !important;
+		}
+		.darkmode p {
+			color: #ffffff !important;
+		}
+	}
+	
+	@media only screen and (min-width: 520px) {
+		.u-row {
+			width: 500px !important;
+		}
+		.u-row .u-col {
+			vertical-align: top;
+		}
+		.u-row .u-col-100 {
+			width: 500px !important;
+		}
+	}
+	
+	@media (max-width: 520px) {
+		.u-row-container {
+			max-width: 100% !important;
+			padding-left: 0px !important;
+			padding-right: 0px !important;
+		}
+		.u-row .u-col {
+			min-width: 320px !important;
+			max-width: 100% !important;
+			display: block !important;
+		}
+		.u-row {
+			width: 100% !important;
+		}
+		.u-col {
+			width: 100% !important;
+		}
+		.u-col>div {
+			margin: 0 auto;
+		}
+	}
+	
+	body {
+		margin: 0;
+		padding: 0;
+	}
+	
+	table,
+	tr,
+	td {
+		vertical-align: top;
+		border-collapse: collapse;
+	}
+	
+	p {
+		margin: 0;
+	}
+	
+	.ie-container table,
+	.mso-container table {
+		table-layout: fixed;
+	}
+	
+	* {
+		line-height: inherit;
+	}
+	
+	a[x-apple-data-detectors='true'] {
+		color: inherit !important;
+		text-decoration: none !important;
+	}
+	
+	table,
+	td {
+		color: #ffffff;
+	}
+	
+	#u_body a {
+		color: #0000ee;
+		text-decoration: underline;
+	}
+	</style>
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #212121;color: #ffffff">
+	<!--[if IE]><div class="ie-container"><![endif]-->
+	<!--[if mso]><div class="mso-container"><![endif]-->
+	<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #212121;width:100%" cellpadding="0" cellspacing="0">
+		<tbody>
+			<tr style="vertical-align: top">
+				<td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+					<!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #212121;"><![endif]-->
+					<div class="u-row-container" style="padding: 0px;background-color: transparent">
+						<div class="u-row" style="margin: 0 auto;min-width: 320px;max-width: 500px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+							<div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+								<!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:500px;"><tr style="background-color: transparent;"><![endif]-->
+								<!--[if (mso)|(IE)]><td align="center" width="500" style="background-color: #212121;width: 500px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+								<div class="u-col u-col-100" style="max-width: 320px;min-width: 500px;display: table-cell;vertical-align: top;">
+									<div style="background-color: #212121;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+										<!--[if (!mso)&(!IE)]><!-->
+										<div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+											<!--<![endif]-->
+											<table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+												<tbody>
+													<tr>
+														<td style="overflow-wrap:break-word;word-break:break-word;padding:10px;font-family:arial,helvetica,sans-serif;" align="left">
+															<!--[if mso]><table width="100%"><tr><td><![endif]-->
+															<h1 style="margin: 0px; line-height: 140%; text-align: left; word-wrap: break-word; font-size: 22px; font-weight: 700;">
+                                                                <div>
+                                                                    <div>You have requested to reset your password.
+                                                                    </div>
+                                                                </div>
+                                                            </h1>
+															<!--[if mso]></td></tr></table><![endif]-->
+														</td>
+													</tr>
+												</tbody>
+											</table>
+											<table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+												<tbody>
+													<tr>
+														<td style="overflow-wrap:break-word;word-break:break-word;padding:10px;font-family:arial,helvetica,sans-serif;" align="left">
+															<div style="font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+																<div>Hi {{name}},</div>
+															</div>
+														</td>
+													</tr>
+												</tbody>
+											</table>
+											<table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+												<tbody>
+													<tr>
+														<td style="overflow-wrap:break-word;word-break:break-word;padding:10px;font-family:arial,helvetica,sans-serif;" align="left">
+															<div style="font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+																<p style="line-height: 140%;">Please click the button below to reset your password.</p>
+															</div>
+														</td>
+													</tr>
+												</tbody>
+											</table>
+											<table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+												<tbody>
+													<tr>
+														<td style="overflow-wrap:break-word;word-break:break-word;padding:10px;font-family:arial,helvetica,sans-serif;" align="left">
+															<!--[if mso]><style>.v-button {background: transparent !important;}</style><![endif]-->
+															<div align="left">
+																<!--[if mso]><v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{link}}" style="height:37px; v-text-anchor:middle; width:142px;" arcsize="11%"  stroke="f" fillcolor="#10a37f"><w:anchorlock/><center style="color:#FFFFFF;"><![endif]-->
+																<a href="{{link}}" target="_blank" class="v-button" style="box-sizing: border-box;display: inline-block;text-decoration: none;-webkit-text-size-adjust: none;text-align: center;color: #FFFFFF; background-color: #10a37f; border-radius: 4px;-webkit-border-radius: 4px; -moz-border-radius: 4px; width:auto; max-width:100%; overflow-wrap: break-word; word-break: break-word; word-wrap:break-word; mso-border-alt: none;font-size: 14px;"> <span style="display:block;padding:10px 20px;line-height:120%;"><span
+                                                                            style="line-height: 16.8px;">Reset
+                                                                            Password</span></span>
+																</a>
+																<!--[if mso]></center></v:roundrect><![endif]-->
+															</div>
+														</td>
+													</tr>
+												</tbody>
+											</table>
+											<table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+												<tbody>
+													<tr>
+														<td style="overflow-wrap:break-word;word-break:break-word;padding:10px;font-family:arial,helvetica,sans-serif;" align="left">
+															<div style="font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+																<div>
+																	<div>If you did not request a password reset, please ignore this email.</div>
+																</div>
+															</div>
+														</td>
+													</tr>
+												</tbody>
+											</table>
+											<table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+												<tbody>
+													<tr>
+														<td style="overflow-wrap:break-word;word-break:break-word;padding:10px;font-family:arial,helvetica,sans-serif;" align="left">
+															<div style="font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+																<div>Best regards,</div>
+																<div>The {{appName}} Team</div>
+															</div>
+														</td>
+													</tr>
+												</tbody>
+											</table>
+											<table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+												<tbody>
+													<tr>
+														<td style="overflow-wrap:break-word;word-break:break-word;padding:0px 10px 10px;font-family:arial,helvetica,sans-serif;" align="left">
+															<div style="font-size: 14px; line-height: 140%; text-align: right; word-wrap: break-word;">
+																<div>
+																	<div><sub>© {{year}} {{appName}}. All rights
+                                                                            reserved.</sub></div>
+																</div>
+															</div>
+														</td>
+													</tr>
+												</tbody>
+											</table>
+											<!--[if (!mso)&(!IE)]><!-->
+										</div>
+										<!--<![endif]-->
+									</div>
+								</div>
+								<!--[if (mso)|(IE)]></td><![endif]-->
+								<!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+							</div>
+						</div>
+					</div>
+					<!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	<!--[if mso]></div><![endif]-->
+	<!--[if IE]></div><![endif]-->
+</body>
+
 </html>

--- a/api/server/utils/emails/verifyEmail.handlebars
+++ b/api/server/utils/emails/verifyEmail.handlebars
@@ -93,13 +93,18 @@
 	td {
 		color: #ffffff;
 	}
+	
+	#u_body a {
+		color: #0000ee;
+		text-decoration: underline;
+	}
 	</style>
 </head>
 
 <body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #212121;color: #ffffff">
 	<!--[if IE]><div class="ie-container"><![endif]-->
 	<!--[if mso]><div class="mso-container"><![endif]-->
-	<table style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #212121;width:100%" cellpadding="0" cellspacing="0">
+	<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #212121;width:100%" cellpadding="0" cellspacing="0">
 		<tbody>
 			<tr style="vertical-align: top">
 				<td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
@@ -118,8 +123,25 @@
 												<tbody>
 													<tr>
 														<td style="overflow-wrap:break-word;word-break:break-word;padding:10px;font-family:arial,helvetica,sans-serif;" align="left">
+															<!--[if mso]><table width="100%"><tr><td><![endif]-->
+															<h1 style="margin: 0px; line-height: 140%; text-align: left; word-wrap: break-word; font-size: 22px; font-weight: 700;">
+                                                                <div>
+                                                                    <div>Welcome to {{appName}}!</div>
+                                                                </div>
+                                                            </h1>
+															<!--[if mso]></td></tr></table><![endif]-->
+														</td>
+													</tr>
+												</tbody>
+											</table>
+											<table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+												<tbody>
+													<tr>
+														<td style="overflow-wrap:break-word;word-break:break-word;padding:10px;font-family:arial,helvetica,sans-serif;" align="left">
 															<div style="font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
-																<div>Hi {{name}},</div>
+																<div>
+																	<div>Dear {{name}},</div>
+																</div>
 															</div>
 														</td>
 													</tr>
@@ -131,7 +153,38 @@
 														<td style="overflow-wrap:break-word;word-break:break-word;padding:10px;font-family:arial,helvetica,sans-serif;" align="left">
 															<div style="font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
 																<div>
-																	<div>Your password has been updated successfully! </div>
+																	<div>Thank you for registering with {{appName}}. To complete your registration and verify your email address, please click the button below:</div>
+																</div>
+															</div>
+														</td>
+													</tr>
+												</tbody>
+											</table>
+											<table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+												<tbody>
+													<tr>
+														<td style="overflow-wrap:break-word;word-break:break-word;padding:10px;font-family:arial,helvetica,sans-serif;" align="left">
+															<!--[if mso]><style>.v-button {background: transparent !important;}</style><![endif]-->
+															<div align="left">
+																<!--[if mso]><v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="href=&quot;{{verificationLink}}&quot;" style="height:37px; v-text-anchor:middle; width:114px;" arcsize="11%"  stroke="f" fillcolor="#10a37f"><w:anchorlock/><center style="color:#FFFFFF;"><![endif]-->
+																<a href="href=&quot;{{verificationLink}}&quot;" target="_blank" class="v-button" style="box-sizing: border-box;display: inline-block;text-decoration: none;-webkit-text-size-adjust: none;text-align: center;color: #FFFFFF; background-color: #10a37f; border-radius: 4px;-webkit-border-radius: 4px; -moz-border-radius: 4px; width:auto; max-width:100%; overflow-wrap: break-word; word-break: break-word; word-wrap:break-word; mso-border-alt: none;font-size: 14px;"> <span style="display:block;padding:10px 20px;line-height:120%;">
+                                                                        <div>
+                                                                            <div>Verify Email</div>
+                                                                        </div>
+                                                                    </span> </a>
+																<!--[if mso]></center></v:roundrect><![endif]-->
+															</div>
+														</td>
+													</tr>
+												</tbody>
+											</table>
+											<table style="font-family:arial,helvetica,sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+												<tbody>
+													<tr>
+														<td style="overflow-wrap:break-word;word-break:break-word;padding:10px;font-family:arial,helvetica,sans-serif;" align="left">
+															<div style="font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+																<div>
+																	<div>If you did not create an account with {{appName}}, please ignore this email.</div>
 																</div>
 															</div>
 														</td>


### PR DESCRIPTION
## Summary

- Update existing email templates
- Add email template for "email verification" even though the feature as not been implemented yet

The new templates automatically fetch the `APP_TITLE` from the .env if provided, the year (for the © at the bottom) and the user name (this was already in place).

**Before:**
![image](https://github.com/danny-avila/LibreChat/assets/32828263/0f1276cb-a2ec-4da0-9970-fca2fb39959a)

**After:**
![image](https://github.com/danny-avila/LibreChat/assets/32828263/c416946b-8de7-465c-962c-18171a7013e3)

---

`requestPasswordReset.handlebars`:
![image](https://github.com/danny-avila/LibreChat/assets/32828263/3c22dc62-0189-4230-a2ac-eb9c7bf106f1)

`passwordReset.handlebars`:
![image](https://github.com/danny-avila/LibreChat/assets/32828263/6d58f358-7100-4569-ac6e-272d499df482)

`verifyEmail.handlebars`  (not in use):
![image](https://github.com/danny-avila/LibreChat/assets/32828263/90f0c678-0209-4f3d-8c3a-22436e672373)


## Testing
Since not all email clients handle styling in the same way, I’ve tested this across various platforms, including:
- Gmail
- Outlook
- iOS Mail
- Zoho (website)

## Checklist

- [x] 📧✨
