### PR TITLE
🌐 feat: librechat.yaml from URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ DEBUG_CONSOLE=false
 #===============#
 # Configuration #
 #===============#
+# Use an absolute path, a relative path, or a URL
 
 # CONFIG_PATH="/alternative/path/to/librechat.yaml"
 

--- a/api/server/services/Config/loadCustomConfig.js
+++ b/api/server/services/Config/loadCustomConfig.js
@@ -3,6 +3,8 @@ const { CacheKeys, configSchema } = require('librechat-data-provider');
 const loadYaml = require('~/utils/loadYaml');
 const { getLogStores } = require('~/cache');
 const { logger } = require('~/config');
+const axios = require('axios');
+const yaml = require('js-yaml');
 
 const projectRoot = path.resolve(__dirname, '..', '..', '..', '..');
 const defaultConfigPath = path.resolve(projectRoot, 'librechat.yaml');
@@ -19,19 +21,43 @@ async function loadCustomConfig() {
   // Use CONFIG_PATH if set, otherwise fallback to defaultConfigPath
   const configPath = process.env.CONFIG_PATH || defaultConfigPath;
 
-  const customConfig = loadYaml(configPath);
-  if (!customConfig) {
-    i === 0 &&
-      logger.info(
-        'Custom config file missing or YAML format invalid.\n\nCheck out the latest config file guide for configurable options and features.\nhttps://docs.librechat.ai/install/configuration/custom_config.html\n\n',
-      );
-    i === 0 && i++;
-    return null;
+  let customConfig;
+
+  if (configPath.startsWith('http://') || configPath.startsWith('https://')) {
+    try {
+      const response = await axios.get(configPath);
+      customConfig = response.data; // This is a YAML string when downloaded
+    } catch (error) {
+      i === 0 && logger.error(`Failed to fetch the remote config file from ${configPath}`, error);
+      i === 0 && i++;
+      return null;
+    }
+  } else {
+    customConfig = loadYaml(configPath);
+    if (!customConfig) {
+      i === 0 &&
+        logger.info(
+          'Custom config file missing or YAML format invalid.\n\nCheck out the latest config file guide for configurable options and features.\nhttps://docs.librechat.ai/install/configuration/custom_config.html\n\n',
+        );
+      i === 0 && i++;
+      return null;
+    }
+  }
+
+  if (typeof customConfig === 'string') {
+    try {
+      customConfig = yaml.load(customConfig);
+    } catch (parseError) {
+      i === 0 && logger.info(`Failed to parse the YAML config from ${configPath}`, parseError);
+      i === 0 && i++;
+      return null;
+    }
   }
 
   const result = configSchema.strict().safeParse(customConfig);
   if (!result.success) {
-    logger.error(`Invalid custom config file at ${configPath}`, result.error);
+    i === 0 && logger.error(`Invalid custom config file at ${configPath}`, result.error);
+    i === 0 && i++;
     return null;
   } else {
     logger.info('Custom config file loaded:');
@@ -43,8 +69,6 @@ async function loadCustomConfig() {
     const cache = getLogStores(CacheKeys.CONFIG_STORE);
     await cache.set(CacheKeys.CUSTOM_CONFIG, customConfig);
   }
-
-  // TODO: handle remote config
 
   return customConfig;
 }

--- a/api/server/services/Config/loadCustomConfig.js
+++ b/api/server/services/Config/loadCustomConfig.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { CacheKeys, configSchema } = require('librechat-data-provider');
+const getLogStores = require('~/cache/getLogStores');
 const loadYaml = require('~/utils/loadYaml');
-const { getLogStores } = require('~/cache');
 const { logger } = require('~/config');
 const axios = require('axios');
 const yaml = require('js-yaml');

--- a/api/server/services/Config/loadCustomConfig.js
+++ b/api/server/services/Config/loadCustomConfig.js
@@ -23,10 +23,10 @@ async function loadCustomConfig() {
 
   let customConfig;
 
-  if (configPath.startsWith('http://') || configPath.startsWith('https://')) {
+  if (/^https?:\/\//.test(configPath)) {
     try {
       const response = await axios.get(configPath);
-      customConfig = response.data; // This is a YAML string when downloaded
+      customConfig = response.data;
     } catch (error) {
       i === 0 && logger.error(`Failed to fetch the remote config file from ${configPath}`, error);
       i === 0 && i++;

--- a/api/server/services/Config/loadCustomConfig.spec.js
+++ b/api/server/services/Config/loadCustomConfig.spec.js
@@ -1,0 +1,153 @@
+jest.mock('axios');
+jest.mock('~/cache/getLogStores');
+jest.mock('~/utils/loadYaml');
+
+const axios = require('axios');
+const loadCustomConfig = require('./loadCustomConfig');
+const getLogStores = require('~/cache/getLogStores');
+const loadYaml = require('~/utils/loadYaml');
+const { logger } = require('~/config');
+
+describe('loadCustomConfig', () => {
+  const mockSet = jest.fn();
+  const mockCache = { set: mockSet };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    delete process.env.CONFIG_PATH;
+    getLogStores.mockReturnValue(mockCache);
+  });
+
+  it('should return null and log error if remote config fetch fails', async () => {
+    process.env.CONFIG_PATH = 'http://example.com/config.yaml';
+    axios.get.mockRejectedValue(new Error('Network error'));
+    const result = await loadCustomConfig();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for an invalid local config file', async () => {
+    process.env.CONFIG_PATH = 'localConfig.yaml';
+    loadYaml.mockReturnValueOnce(null);
+    const result = await loadCustomConfig();
+    expect(result).toBeNull();
+  });
+
+  it('should parse, validate, and cache a valid local configuration', async () => {
+    const mockConfig = {
+      version: '1.0',
+      cache: true,
+      endpoints: {
+        custom: [
+          {
+            name: 'mistral',
+            apiKey: 'user_provided',
+            baseURL: 'https://api.mistral.ai/v1',
+          },
+        ],
+      },
+    };
+    process.env.CONFIG_PATH = 'validConfig.yaml';
+    loadYaml.mockReturnValueOnce(mockConfig);
+    const result = await loadCustomConfig();
+
+    expect(result).toEqual(mockConfig);
+    expect(mockSet).toHaveBeenCalledWith(expect.anything(), mockConfig);
+  });
+
+  it('should return null and log if config schema validation fails', async () => {
+    const invalidConfig = { invalidField: true };
+    process.env.CONFIG_PATH = 'invalidConfig.yaml';
+    loadYaml.mockReturnValueOnce(invalidConfig);
+
+    const result = await loadCustomConfig();
+
+    expect(result).toBeNull();
+  });
+
+  it('should handle and return null on YAML parse error for a string response from remote', async () => {
+    process.env.CONFIG_PATH = 'http://example.com/config.yaml';
+    axios.get.mockResolvedValue({ data: 'invalidYAMLContent' });
+
+    const result = await loadCustomConfig();
+
+    expect(result).toBeNull();
+  });
+
+  it('should return the custom config object for a valid remote config file', async () => {
+    const mockConfig = {
+      version: '1.0',
+      cache: true,
+      endpoints: {
+        custom: [
+          {
+            name: 'mistral',
+            apiKey: 'user_provided',
+            baseURL: 'https://api.mistral.ai/v1',
+          },
+        ],
+      },
+    };
+    process.env.CONFIG_PATH = 'http://example.com/config.yaml';
+    axios.get.mockResolvedValue({ data: mockConfig });
+    const result = await loadCustomConfig();
+    expect(result).toEqual(mockConfig);
+    expect(mockSet).toHaveBeenCalledWith(expect.anything(), mockConfig);
+  });
+
+  it('should return null if the remote config file is not found', async () => {
+    process.env.CONFIG_PATH = 'http://example.com/config.yaml';
+    axios.get.mockRejectedValue({ response: { status: 404 } });
+    const result = await loadCustomConfig();
+    expect(result).toBeNull();
+  });
+
+  it('should return null if the local config file is not found', async () => {
+    process.env.CONFIG_PATH = 'nonExistentConfig.yaml';
+    loadYaml.mockReturnValueOnce(null);
+    const result = await loadCustomConfig();
+    expect(result).toBeNull();
+  });
+
+  it('should not cache the config if cache is set to false', async () => {
+    const mockConfig = {
+      version: '1.0',
+      cache: false,
+      endpoints: {
+        custom: [
+          {
+            name: 'mistral',
+            apiKey: 'user_provided',
+            baseURL: 'https://api.mistral.ai/v1',
+          },
+        ],
+      },
+    };
+    process.env.CONFIG_PATH = 'validConfig.yaml';
+    loadYaml.mockReturnValueOnce(mockConfig);
+    await loadCustomConfig();
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it('should log the loaded custom config', async () => {
+    const mockConfig = {
+      version: '1.0',
+      cache: true,
+      endpoints: {
+        custom: [
+          {
+            name: 'mistral',
+            apiKey: 'user_provided',
+            baseURL: 'https://api.mistral.ai/v1',
+          },
+        ],
+      },
+    };
+    process.env.CONFIG_PATH = 'validConfig.yaml';
+    loadYaml.mockReturnValueOnce(mockConfig);
+    await loadCustomConfig();
+    expect(logger.info).toHaveBeenCalledWith('Custom config file loaded:');
+    expect(logger.info).toHaveBeenCalledWith(JSON.stringify(mockConfig, null, 2));
+    expect(logger.debug).toHaveBeenCalledWith('Custom config:', mockConfig);
+  });
+});

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -147,7 +147,11 @@ const processDeleteRequest = async ({ req, files }) => {
 const processFileURL = async ({ fileStrategy, userId, URL, fileName, basePath, context }) => {
   const { saveURL, getFileURL } = getStrategyFunctions(fileStrategy);
   try {
-    const { bytes, type, dimensions } = await saveURL({ userId, URL, fileName, basePath });
+    const {
+      bytes = 0,
+      type = '',
+      dimensions = {},
+    } = (await saveURL({ userId, URL, fileName, basePath })) || {};
     const filepath = await getFileURL({ fileName: `${userId}/${fileName}`, basePath });
     return await createFile(
       {

--- a/docs/install/configuration/dotenv.md
+++ b/docs/install/configuration/dotenv.md
@@ -106,8 +106,20 @@ UID=1000
 GID=1000
 ```
 
-### librechat.yaml path
-Set an alternative path for the LibreChat config file
+### Configuration Path - `librechat.yaml`
+Specify an alternative location for the LibreChat configuration file. 
+You may specify an **absolute path**, a **relative path**, or a **URL**. The filename in the path is flexible and does not have to be `librechat.yaml`; any valid configuration file will work.
+
+> **Note**: If you prefer LibreChat to search for the configuration file in the root directory (which is the default behavior), simply leave this option commented out.
+
+```sh
+# To set an alternative configuration path or URL, uncomment the line below and replace it with your desired path or URL.
+# CONFIG_PATH="/your/alternative/path/to/config.yaml"
+```
+
+---
+
+I'm glad I could help. If there's anything else you need assistance with, feel free to ask!
 
 > Note: leave commented out to have LibreChat look for the config file in the root folder (default behavior)
 

--- a/docs/install/configuration/dotenv.md
+++ b/docs/install/configuration/dotenv.md
@@ -117,16 +117,6 @@ You may specify an **absolute path**, a **relative path**, or a **URL**. The fil
 # CONFIG_PATH="/your/alternative/path/to/config.yaml"
 ```
 
----
-
-I'm glad I could help. If there's anything else you need assistance with, feel free to ask!
-
-> Note: leave commented out to have LibreChat look for the config file in the root folder (default behavior)
-
-```sh
-CONFIG_PATH="/alternative/path/to/librechat.yaml"
-```
-
 ## Endpoints
 In this section you can configure the endpoints and models selection, their API keys, and the proxy and reverse proxy settings for the endpoints that support it. 
 


### PR DESCRIPTION
## Summary

Originally https://github.com/danny-avila/LibreChat/pull/2035

Allow a URL as valid input for `CONFIG_PATH`

This added functionality can be very useful in many situations, for example:
    - Railway and other hosting services (Zeabur, HuggingFace, Portainer, Unraid, Render...) that don't allow easy management of such files
    - Remote management
    - Deploying the same configuration on multiple instances 

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing
Locally tested multiple scenarios:
✅ Valid URL
✅ Valid URL to invalid file (parsing error)
✅ Invalid URL
✅ Valid path
✅ Invalid path
✅ Default location with config file (commented var)
✅ Default location without config file (commented var)

### **Test Configuration**:
- Local install, Windows 11
- Docker install, Windows 11

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings