### PR TITLE
🎨 style: Privacy Policy & Terms of Service

### DIFF
--- a/client/src/components/Auth/Login.tsx
+++ b/client/src/components/Auth/Login.tsx
@@ -96,9 +96,10 @@ function Login() {
 
   const privacyPolicyRender = privacyPolicy?.externalUrl && (
     <a
-      className="text-xs font-medium text-gray-500"
+      className="text-xs font-medium text-green-500"
       href={privacyPolicy.externalUrl}
-      target={privacyPolicy.openNewTab ? '_blank' : undefined} rel="noreferrer"
+      target={privacyPolicy.openNewTab ? '_blank' : undefined}
+      rel="noreferrer"
     >
       {localize('com_ui_privacy_policy')}
     </a>
@@ -106,9 +107,10 @@ function Login() {
 
   const termsOfServiceRender = termsOfService?.externalUrl && (
     <a
-      className="text-xs font-medium text-gray-500"
+      className="text-xs font-medium text-green-500"
       href={termsOfService.externalUrl}
-      target={termsOfService.openNewTab ? '_blank' : undefined} rel="noreferrer"
+      target={termsOfService.openNewTab ? '_blank' : undefined}
+      rel="noreferrer"
     >
       {localize('com_ui_terms_of_service')}
     </a>

--- a/client/src/components/Chat/Footer.tsx
+++ b/client/src/components/Chat/Footer.tsx
@@ -10,9 +10,10 @@ export default function Footer() {
 
   const privacyPolicyRender = privacyPolicy?.externalUrl && (
     <a
-      className=" text-gray-500 underline"
+      className=" text-gray-600 underline dark:text-gray-300"
       href={privacyPolicy.externalUrl}
-      target={privacyPolicy.openNewTab ? '_blank' : undefined} rel="noreferrer"
+      target={privacyPolicy.openNewTab ? '_blank' : undefined}
+      rel="noreferrer"
     >
       {localize('com_ui_privacy_policy')}
     </a>
@@ -20,9 +21,10 @@ export default function Footer() {
 
   const termsOfServiceRender = termsOfService?.externalUrl && (
     <a
-      className=" text-gray-500 underline"
+      className=" text-gray-600 underline dark:text-gray-300"
       href={termsOfService.externalUrl}
-      target={termsOfService.openNewTab ? '_blank' : undefined} rel="noreferrer"
+      target={termsOfService.openNewTab ? '_blank' : undefined}
+      rel="noreferrer"
     >
       {localize('com_ui_terms_of_service')}
     </a>


### PR DESCRIPTION
## Summary

Update the styling of `Privacy Policy` & `Terms of Service`

- `Login.tsx` : Match color of official ChatGPT
- `Footer.tsx` : Match color of `appTitle`

### Before:
![image](https://github.com/danny-avila/LibreChat/assets/32828263/5c19395a-29e8-4cf8-829b-d18a56f52c56)
![image](https://github.com/danny-avila/LibreChat/assets/32828263/7e3112c0-4937-4405-be53-cb5171e6795e)
![image](https://github.com/danny-avila/LibreChat/assets/32828263/b6f02de7-d8a6-4ac9-9c73-b38151667e9e)
![image](https://github.com/danny-avila/LibreChat/assets/32828263/751b5564-5e5c-4533-a103-1a6f322c3894)

### After:
![image](https://github.com/danny-avila/LibreChat/assets/32828263/b34d6198-433f-4018-905a-4d95b08e2b81)
![image](https://github.com/danny-avila/LibreChat/assets/32828263/b274308b-4bba-4084-acaf-b7abee35a6c3)
![image](https://github.com/danny-avila/LibreChat/assets/32828263/5bde4e84-69e2-475d-ba46-f50218d15ca6)
![image](https://github.com/danny-avila/LibreChat/assets/32828263/73ab5401-b8b6-4591-81fc-3988c8f7e15e)



## Change Type

- [x] 🎨 Style update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
