### PR TITLE
🪙 feat: Assistants Token Balance & other improvements

### DIFF
--- a/api/cache/getLogStores.js
+++ b/api/cache/getLogStores.js
@@ -47,7 +47,7 @@ const namespaces = {
   concurrent: createViolationInstance('concurrent'),
   non_browser: createViolationInstance('non_browser'),
   message_limit: createViolationInstance('message_limit'),
-  token_balance: createViolationInstance('token_balance'),
+  token_balance: createViolationInstance(ViolationTypes.TOKEN_BALANCE),
   registrations: createViolationInstance('registrations'),
   [ViolationTypes.FILE_UPLOAD_LIMIT]: createViolationInstance(ViolationTypes.FILE_UPLOAD_LIMIT),
   [ViolationTypes.ILLEGAL_MODEL_REQUEST]: createViolationInstance(

--- a/api/models/Transaction.js
+++ b/api/models/Transaction.js
@@ -50,4 +50,23 @@ transactionSchema.statics.create = async function (transactionData) {
   };
 };
 
-module.exports = mongoose.model('Transaction', transactionSchema);
+const Transaction = mongoose.model('Transaction', transactionSchema);
+
+/**
+ * Queries and retrieves transactions based on a given filter.
+ * @async
+ * @function getTransactions
+ * @param {Object} filter - MongoDB filter object to apply when querying transactions.
+ * @returns {Promise<Array>} A promise that resolves to an array of matched transactions.
+ * @throws {Error} Throws an error if querying the database fails.
+ */
+async function getTransactions(filter) {
+  try {
+    return await Transaction.find(filter).lean();
+  } catch (error) {
+    console.error('Error querying transactions:', error);
+    throw error;
+  }
+}
+
+module.exports = { Transaction, getTransactions };

--- a/api/models/checkBalance.js
+++ b/api/models/checkBalance.js
@@ -1,5 +1,6 @@
+const { ViolationTypes } = require('librechat-data-provider');
+const { logViolation } = require('~/cache');
 const Balance = require('./Balance');
-const { logViolation } = require('../cache');
 /**
  * Checks the balance for a user and determines if they can spend a certain amount.
  * If the user cannot spend the amount, it logs a violation and denies the request.
@@ -25,7 +26,7 @@ const checkBalance = async ({ req, res, txData }) => {
     return true;
   }
 
-  const type = 'token_balance';
+  const type = ViolationTypes.TOKEN_BALANCE;
   const errorMessage = {
     type,
     balance,

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -22,14 +22,12 @@ const Key = require('./Key');
 const User = require('./User');
 const Session = require('./Session');
 const Balance = require('./Balance');
-const Transaction = require('./Transaction');
 
 module.exports = {
   User,
   Key,
   Session,
   Balance,
-  Transaction,
 
   hashPassword,
   updateUser,

--- a/api/models/spendTokens.js
+++ b/api/models/spendTokens.js
@@ -1,4 +1,4 @@
-const Transaction = require('./Transaction');
+const { Transaction } = require('./Transaction');
 const { logger } = require('~/config');
 
 /**

--- a/api/server/routes/assistants/chat.js
+++ b/api/server/routes/assistants/chat.js
@@ -229,7 +229,7 @@ router.post('/', validateModel, buildEndpointOption, setHeaders, async (req, res
         transactions.reduce((acc, curr) => acc + curr.rawAmount, 0),
       );
       // TODO: make promptBuffer a config option; buffer for titles, needs buffer for system instructions
-      const promptBuffer = 200;
+      const promptBuffer = parentMessageId === Constants.NO_PARENT && !_thread_id ? 200 : 0;
       // 5 is added for labels
       let promptTokens = (await countTokens(text + (promptPrefix ?? ''))) + 5;
       promptTokens += totalPreviousTokens + promptBuffer;
@@ -242,7 +242,6 @@ router.post('/', validateModel, buildEndpointOption, setHeaders, async (req, res
           user: req.user.id,
           tokenType: 'prompt',
           amount: promptTokens,
-          endpoint: EModelEndpoint.assistants,
         },
       });
     }

--- a/api/server/routes/assistants/chat.js
+++ b/api/server/routes/assistants/chat.js
@@ -1,10 +1,10 @@
 const { v4 } = require('uuid');
 const express = require('express');
 const {
-  EModelEndpoint,
   Constants,
   RunStatus,
   CacheKeys,
+  EModelEndpoint,
   ViolationTypes,
 } = require('librechat-data-provider');
 const {

--- a/client/src/components/Messages/Content/Error.tsx
+++ b/client/src/components/Messages/Content/Error.tsx
@@ -1,6 +1,5 @@
 // file deepcode ignore HardcodedNonCryptoSecret: No hardcoded secrets
-
-import React from 'react';
+import { ViolationTypes } from 'librechat-data-provider';
 import type { TOpenAIMessage } from 'librechat-data-provider';
 import { formatJSON, extractJson, isJson } from '~/utils/json';
 import CodeBlock from './CodeBlock';
@@ -15,7 +14,7 @@ type TMessageLimit = {
 };
 
 type TTokenBalance = {
-  type: 'token_balance';
+  type: ViolationTypes;
   balance: number;
   tokenCost: number;
   promptTokens: number;

--- a/client/src/components/SidePanel/Switcher.tsx
+++ b/client/src/components/SidePanel/Switcher.tsx
@@ -52,7 +52,7 @@ export default function Switcher({ isCollapsed }: SwitcherProps) {
   const currentAssistant = assistantMap?.[selectedAssistant ?? ''];
 
   return (
-    <Select defaultValue={selectedAssistant as string | undefined} onValueChange={onSelect}>
+    <Select value={selectedAssistant as string | undefined} onValueChange={onSelect}>
       <SelectTrigger
         className={cn(
           'flex items-center gap-2 [&>span]:line-clamp-1 [&>span]:flex [&>span]:w-full [&>span]:items-center [&>span]:gap-1 [&>span]:truncate [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0',

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -56,3 +56,18 @@ export function mapEndpoints(endpointsConfig: TEndpointsConfig) {
     (a, b) => (endpointsConfig?.[a]?.order ?? 0) - (endpointsConfig?.[b]?.order ?? 0),
   );
 }
+
+export function updateLastSelectedModel({
+  endpoint,
+  model,
+}: {
+  endpoint: string;
+  model: string | undefined;
+}) {
+  if (!model) {
+    return;
+  }
+  const lastSelectedModels = JSON.parse(localStorage.getItem('lastSelectedModel') || '{}');
+  lastSelectedModels[endpoint] = model;
+  localStorage.setItem('lastSelectedModel', JSON.stringify(lastSelectedModels));
+}

--- a/config/add-balance.js
+++ b/config/add-balance.js
@@ -1,7 +1,7 @@
 const path = require('path');
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { askQuestion, silentExit } = require('./helpers');
-const Transaction = require('~/models/Transaction');
+const { Transaction } = require('~/models/Transaction');
 const User = require('~/models/User');
 const connect = require('./connect');
 

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -342,11 +342,12 @@ export const modularEndpoints = new Set<EModelEndpoint | string>([
 ]);
 
 export const supportsBalanceCheck = {
+  [EModelEndpoint.custom]: true,
   [EModelEndpoint.openAI]: true,
   [EModelEndpoint.anthropic]: true,
-  [EModelEndpoint.azureOpenAI]: true,
   [EModelEndpoint.gptPlugins]: true,
-  [EModelEndpoint.custom]: true,
+  [EModelEndpoint.assistants]: true,
+  [EModelEndpoint.azureOpenAI]: true,
 };
 
 export const visionModels = ['gpt-4-vision', 'llava-13b', 'gemini-pro-vision', 'claude-3'];
@@ -436,6 +437,10 @@ export enum ViolationTypes {
    * Illegal Model Request (not available).
    */
   ILLEGAL_MODEL_REQUEST = 'illegal_model_request',
+  /**
+   * Token Limit Violation.
+   */
+  TOKEN_BALANCE = 'token_balance',
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #2105 

This PR properly integrates the Assistants endpoint with the token balance system.

It is not explicitly known how Assistants builds its context window of message. In my experience, it is pretty generous and adds a lot if not every message to the context that it can possibly fit.

OpenAI's statement on this:

> The tokens used for the Assistant API are billed at the chosen language model's per-token input / output rates and the assistant intelligently chooses which context from the thread to include when calling the model 

To be conservative, Assistants will count all the tokens of all previous messages and use that as the context for balance calculations, up to the limit of their context window.

**Other Changes**

- Fixed an issue with the Assistant Select not re-rendering correctly when the assistant was changed: made "select" explicitly controlled
- Fixed an issue with the last selected model being used for the assistants endpoint when no model is defined. This should not be the case for the assistants endpoint, as each assistant has a "default" model and that should be used instead, and is unique in this regard.
- Prevent `assistant_id` from being recorded to non-assistants conversations

**TODO (in another PR), reflect token spending for the following:**

- Code interpreter | $0.03 / session
- Retrieval | $0.20 / GB / assistant / day (free until 04/01/2024)
- Account for system/override Instructions (already accounting for `additional_instructions`)


## Change Type


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] New documents have been locally validated with mkdocs
