### PR TITLE
🔧 feat(actions): Allow Multiple Actions from Same Domain per Assistant

### DIFF
--- a/api/server/routes/assistants/actions.js
+++ b/api/server/routes/assistants/actions.js
@@ -74,14 +74,7 @@ router.post('/:assistant_id', async (req, res) => {
     const { actions: _actions = [] } = assistant_data ?? {};
     const actions = [];
     for (const action of _actions) {
-      const [action_domain, current_action_id] = action.split(actionDelimiter);
-      if (action_domain === domain && !_action_id) {
-        // TODO: dupe check on the frontend
-        return res.status(400).json({
-          message: `Action sets cannot have duplicate domains - ${domain} already exists on another action`,
-        });
-      }
-
+      const [_action_domain, current_action_id] = action.split(actionDelimiter);
       if (current_action_id === action_id) {
         continue;
       }


### PR DESCRIPTION
After evaluating some real use cases for actions, it is apparent to allow multiple actions with the same domain per assistant.

The ID will make the identifier for action sets unique, so this should be valid across assistants and within assistant.

Noting that indices need to be dropped and created after this change for `metadata.domain`


```bash
db.actions.dropIndex({ 'metadata.domain': 1 });
db.actions.createIndex({ 'metadata.domain': 1 });
```