### PR TITLE
🪰 fix: Azure Parsing and Assistants Payload

### DIFF
--- a/api/app/clients/ChatGPTClient.js
+++ b/api/app/clients/ChatGPTClient.js
@@ -236,7 +236,7 @@ class ChatGPTClient extends BaseClient {
           baseURL: this.langchainProxy,
           azureOptions: this.azure,
         })
-        : this.azureEndpoint.split(/\/(chat|completion)/)[0];
+        : this.azureEndpoint.split(/(?<!\/)\/(chat|completion)\//)[0];
 
       if (this.options.forcePrompt) {
         baseURL += '/completions';

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1064,7 +1064,8 @@ ${convo}
             baseURL: this.langchainProxy,
             azureOptions: this.azure,
           })
-          : this.azureEndpoint.split(/\/(chat|completion)/)[0];
+          : this.azureEndpoint.split(/(?<!\/)\/(chat|completion)\//)[0];
+
         opts.defaultQuery = { 'api-version': this.azure.azureOpenAIApiVersion };
         opts.defaultHeaders = { ...opts.defaultHeaders, 'api-key': this.apiKey };
       }

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -744,9 +744,10 @@ class OpenAIClient extends BaseClient {
     /** @type {TAzureConfig | undefined} */
     const azureConfig = this.options?.req?.app?.locals?.[EModelEndpoint.azureOpenAI];
 
-    const resetTitleOptions =
+    const resetTitleOptions = !!(
       (this.azure && azureConfig) ||
-      (azureConfig && this.options.endpoint === EModelEndpoint.azureOpenAI);
+      (azureConfig && this.options.endpoint === EModelEndpoint.azureOpenAI)
+    );
 
     if (resetTitleOptions) {
       const { modelGroupMap, groupMap } = azureConfig;

--- a/api/server/services/Endpoints/assistants/buildOptions.js
+++ b/api/server/services/Endpoints/assistants/buildOptions.js
@@ -1,9 +1,10 @@
 const buildOptions = (endpoint, parsedBody) => {
   // eslint-disable-next-line no-unused-vars
-  const { promptPrefix, chatGptLabel, resendImages, imageDetail, ...rest } = parsedBody;
+  const { promptPrefix, assistant_id, ...rest } = parsedBody;
   const endpointOption = {
     endpoint,
     promptPrefix,
+    assistant_id,
     modelOptions: {
       ...rest,
     },


### PR DESCRIPTION
## Summary

This PR resolves 2 minor issues recently reported.

- Pass only relevant endpoint options to the Assistants API to avoid sending unnecessary data
- Fix the regex for the Azure endpoint to prevent edge cases in certain config option combinations

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes