### PR TITLE
🐋 chore: Cleanup Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ WORKDIR /app
 # values.
 RUN touch .env
 RUN npm config set fetch-retry-maxtimeout 300000
-RUN apk add --no-cache g++ make python3 py3-pip
-RUN npm install -g node-gyp
+
 RUN apk --no-cache add curl && \
     npm install
 


### PR DESCRIPTION
## Summary

There appears to be no benefit to the additional packages being installed. Build will still fail in arm64 env from time to time.

This step does help as fails 99% of the time without it:
`RUN npm config set fetch-retry-maxtimeout 300000`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] New documents have been locally validated with mkdocs