### PR TITLE
🐋 fix(Dockerfile): add additional deps., handle permissions, `--no-audit` flag on install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,23 @@
 # Base node image
 FROM node:18-alpine AS node
 
-COPY . /app
+RUN mkdir -p /app && chown node:node /app
 WORKDIR /app
+
+USER node
+
+COPY --chown=node:node . .
 
 # Allow mounting of these files, which have no default
 # values.
 RUN touch .env
 RUN npm config set fetch-retry-maxtimeout 300000
+RUN apk add g++ make py3-pip
+RUN npm install -g node-gyp
+
 
 RUN apk --no-cache add curl && \
-    npm install
+    npm install --no-audit
 
 # React client build
 ENV NODE_OPTIONS="--max-old-space-size=2048"


### PR DESCRIPTION
## Summary

Docker buiild on linux/arm64 is consistently failing.

Citing my sources to tag this issue across all proposed possible solutions, as maybe someone smarter from these discussions can weigh in.

> The key solution for me was using npm install --no-audit, which also just makes it run much faster, and auditing can probably just be done independently of the normal build/CI process.

**NEW:** Trying this now

https://github.com/nodejs/docker-node/issues/1946#issuecomment-2009336133

> Increase the network timeout set network-timeout 300000
    Add additional dependencies
    Install node-gyp

This makes the github workflow work 65% of the time, albeit incredibly slow (average build time is 13 minutes as opposed to amd build time of 2 minutes).

 https://github.com/nodejs/docker-node/issues/1335#issuecomment-1743914810

> This also looks to be affecting another project: https://github.com/benphelps/homepage/actions/runs/3382149679
> 
> Going from
> 
> ```diff
> -FROM node:current-alpine
> +FROM docker.io/node:18-alpine
> ```
> 
> fixes it. Hard for me to tell if this is a problem with the image or Node at this point.

Unfortunately, this does not fix it for LibreChat

https://github.com/nodejs/docker-node/issues/1798#issuecomment-1302493673


### Potential Triggers

Is `sharp` package the culprit?

https://github.com/lovell/sharp/issues/2482

QEMU error?

https://github.com/nodejs/docker-node/issues/1798

## Permissions Error

Also addressed in this update is a possible fix for a permissions issue some users in linux environments tend to have.

Brought to my attention here:

https://github.com/danny-avila/LibreChat/discussions/1441#discussioncomment-8860059

https://github.com/danny-avila/LibreChat/issues/2150#event-12193512200 / https://github.com/danny-avila/LibreChat/discussions/2151

Noticed that this Dockerfile uses node user to potentially combat against this. It was also suggested by `gpt-4-turbo` before I stumbled on this build, kind of serendipitous as I found it while investigating the issues above
https://github.com/hudeldudel/postman-exporter/commit/26864d6fc4ba955778338477c2d17b5c8b8e3f13


