### PR TITLE
📖 docs: Update ShuttleAI Fibonacci Image

### DIFF
--- a/docs/install/configuration/ai_endpoints.md
+++ b/docs/install/configuration/ai_endpoints.md
@@ -155,7 +155,7 @@ Some of the endpoints are marked as **Known,** which means they might have speci
       dropParams: ["user"]
 ```
 
-![image](https://github.com/danny-avila/LibreChat/client/public/assets/ShuttleAI_Fibonacci.png)
+![image](https://raw.githubusercontent.com/danny-avila/LibreChat/main/client/public/assets/ShuttleAI_Fibonacci.png)
 
 ## Fireworks
 > Fireworks API key: [fireworks.ai/api-keys](https://fireworks.ai/api-keys)


### PR DESCRIPTION
## Summary
Fixed the incorrect image URL for the `ai_endpoints.md` section of the docs.
Simple change, just from github.com url to raw.githubusercontent.com url.

## Change Type
- [0] Bug fix (non-breaking change which fixes an issue)
- [1] Documentation update

## Checklist
- [1] My code adheres to this project's style guidelines
- [1] I have performed a self-review of my own code
- [1] I have made pertinent documentation changes
- [1] My changes do not introduce new warnings
- [1] New documents have been locally validated with mkdocs
