### PR TITLE
🐞 fix(client): Prevent Async Reset of Latest Message

### DIFF
--- a/api/server/services/Runs/StreamRunManager.js
+++ b/api/server/services/Runs/StreamRunManager.js
@@ -571,7 +571,7 @@ class StreamRunManager {
     const isMessage = step.type === StepTypes.MESSAGE_CREATION;
 
     if (isMessage) {
-      logger.warn('RunStep Message completion: to be handled by Message Event.', step);
+      logger.debug('RunStep Message completion: to be handled by Message Event.', step);
       return;
     }
 

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -65,6 +65,7 @@ export default function ChatRoute() {
         /* this is necessary to load all existing settings */
         preset: initialConvoQuery.data as TPreset,
         modelsData: modelsQuery.data,
+        keepLatestMessage: true,
       });
       hasSetConversation.current = !!assistants;
     } else if (!hasSetConversation.current && conversationId === 'new' && assistants) {
@@ -75,6 +76,7 @@ export default function ChatRoute() {
         template: initialConvoQuery.data,
         preset: initialConvoQuery.data as TPreset,
         modelsData: modelsQuery.data,
+        keepLatestMessage: true,
       });
       hasSetConversation.current = true;
     }


### PR DESCRIPTION

## Summary

In the ChatRoute component, I addressed a critical issue where the `newConversation` function was inadvertently resetting the `latestMessage` state, causing it to fire asynchronously and finalize after the correct `latestMessage` had already been set by the `useMessageHelpers` hook.

Said another way, when you refresh an existing conversation, it would treat it as if you were creating a completely new message branch from the head instead of following the current thread:
![image](https://github.com/danny-avila/LibreChat/assets/110412045/33cefabd-18d0-4325-b7eb-750e74871433)

The fix was simple and as follows:
```ts
// for existing conversations on refresh, i.e. "http://domain/c/{conversationId}"
      newConversation({
        // ...otherFields
        keepLatestMessage: true,
      });
```

### Other Changes

- Minor: changed a logger.warn operation to logger.debug in `StreamRunManager`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

To test this change, follow these steps:

- talk to AI
- click on the newly created conversation item on left-hand side
- refresh to refresh using the current conversation link
- send a new follow-up message
- observe the new messages remain in thread

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules