### PR TITLE
⚓ refactor(loadConfigModels): Fallback to Default Models if Fetch Fails

### DIFF
--- a/api/server/services/Config/loadConfigModels.js
+++ b/api/server/services/Config/loadConfigModels.js
@@ -69,6 +69,8 @@ async function loadConfigModels(req) {
           apiKey: API_KEY,
           name,
           userIdQuery: models.userIdQuery,
+        }).then((result) => {
+          return !result?.length ? models.default ?? [] : result;
         });
       uniqueKeyToNameMap[uniqueKey] = uniqueKeyToNameMap[uniqueKey] || [];
       uniqueKeyToNameMap[uniqueKey].push(name);

--- a/api/server/services/Config/loadConfigModels.spec.js
+++ b/api/server/services/Config/loadConfigModels.spec.js
@@ -262,4 +262,66 @@ describe('loadConfigModels', () => {
       }),
     );
   });
+
+  it('falls back to default models if fetching returns an empty array', async () => {
+    getCustomConfig.mockResolvedValue({
+      endpoints: {
+        custom: [
+          {
+            name: 'EmptyFetchModel',
+            apiKey: 'API_KEY',
+            baseURL: 'http://example.com',
+            models: {
+              fetch: true,
+              default: ['defaultModel1', 'defaultModel2'],
+            },
+          },
+        ],
+      },
+    });
+
+    fetchModels.mockResolvedValue([]);
+
+    const result = await loadConfigModels(mockRequest);
+
+    expect(fetchModels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'EmptyFetchModel',
+        apiKey: 'API_KEY',
+      }),
+    );
+
+    expect(result.EmptyFetchModel).toEqual(['defaultModel1', 'defaultModel2']);
+  });
+
+  it('falls back to default models if fetching returns a falsy value', async () => {
+    getCustomConfig.mockResolvedValue({
+      endpoints: {
+        custom: [
+          {
+            name: 'FalsyFetchModel',
+            apiKey: 'API_KEY',
+            baseURL: 'http://example.com',
+            models: {
+              fetch: true,
+              default: ['defaultModel1', 'defaultModel2'],
+            },
+          },
+        ],
+      },
+    });
+
+    fetchModels.mockResolvedValue(false);
+
+    const result = await loadConfigModels(mockRequest);
+
+    expect(fetchModels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'FalsyFetchModel',
+        apiKey: 'API_KEY',
+      }),
+    );
+
+    expect(result.FalsyFetchModel).toEqual(['defaultModel1', 'defaultModel2']);
+  });
 });


### PR DESCRIPTION
## Summary

I implemented a fallback mechanism to use the default models specified for the custom endpoint if fetching was also enabled and fails.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added unit tests for the new fallback method

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes