### PR TITLE
⚓ refactor(loadConfigModels): Stricter Default Model Fallback

### DIFF
--- a/api/server/services/Config/loadConfigModels.js
+++ b/api/server/services/Config/loadConfigModels.js
@@ -53,7 +53,7 @@ async function loadConfigModels(req) {
   /**
    * @type {Record<string, string[]>}
    * Map to associate unique keys with endpoint names; note: one key may can correspond to multiple endpoints */
-  const uniqueKeyToNameMap = {};
+  const uniqueKeyToEndpointsMap = {};
   /**
    * @type {Record<string, Partial<TEndpoint>>}
    * Map to associate endpoint names to their configurations */
@@ -81,8 +81,8 @@ async function loadConfigModels(req) {
           name,
           userIdQuery: models.userIdQuery,
         });
-      uniqueKeyToNameMap[uniqueKey] = uniqueKeyToNameMap[uniqueKey] || [];
-      uniqueKeyToNameMap[uniqueKey].push(name);
+      uniqueKeyToEndpointsMap[uniqueKey] = uniqueKeyToEndpointsMap[uniqueKey] || [];
+      uniqueKeyToEndpointsMap[uniqueKey].push(name);
       continue;
     }
 
@@ -97,7 +97,7 @@ async function loadConfigModels(req) {
   for (let i = 0; i < fetchedData.length; i++) {
     const currentKey = uniqueKeys[i];
     const modelData = fetchedData[i];
-    const associatedNames = uniqueKeyToNameMap[currentKey];
+    const associatedNames = uniqueKeyToEndpointsMap[currentKey];
 
     for (const name of associatedNames) {
       const endpoint = endpointsMap[name];

--- a/api/server/services/Config/loadConfigModels.spec.js
+++ b/api/server/services/Config/loadConfigModels.spec.js
@@ -268,6 +268,15 @@ describe('loadConfigModels', () => {
       endpoints: {
         custom: [
           {
+            name: 'EndpointWithSameFetchKey',
+            apiKey: 'API_KEY',
+            baseURL: 'http://example.com',
+            models: {
+              fetch: true,
+              default: ['defaultModel1'],
+            },
+          },
+          {
             name: 'EmptyFetchModel',
             apiKey: 'API_KEY',
             baseURL: 'http://example.com',
@@ -283,14 +292,7 @@ describe('loadConfigModels', () => {
     fetchModels.mockResolvedValue([]);
 
     const result = await loadConfigModels(mockRequest);
-
-    expect(fetchModels).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'EmptyFetchModel',
-        apiKey: 'API_KEY',
-      }),
-    );
-
+    expect(fetchModels).toHaveBeenCalledTimes(1);
     expect(result.EmptyFetchModel).toEqual(['defaultModel1', 'defaultModel2']);
   });
 

--- a/api/typedefs.js
+++ b/api/typedefs.js
@@ -278,6 +278,12 @@
  */
 
 /**
+ * @exports TEndpoint
+ * @typedef {import('librechat-data-provider').TEndpoint} TEndpoint
+ * @memberof typedefs
+ */
+
+/**
  * @exports TEndpointsConfig
  * @typedef {import('librechat-data-provider').TEndpointsConfig} TEndpointsConfig
  * @memberof typedefs

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -150,6 +150,8 @@ export const endpointSchema = z.object({
   customOrder: z.number().optional(),
 });
 
+export type TEndpoint = z.infer<typeof endpointSchema>;
+
 export const azureEndpointSchema = z
   .object({
     groups: azureGroupConfigsSchema,


### PR DESCRIPTION
## Summary

Refactored the `loadConfigModels` function to return default models based on the endpoint, rather than the fetch basis. This change ensures that the correct default models are loaded for each endpoint.

- Refactored `loadConfigModels` to return default models on an endpoint basis, instead of a fetch basis.
- Updated `loadConfigModels.spec` to include stricter tests for default model matching, ensuring the new implementation adheres to the expected behavior.
- Introduced the `TEndpoint` type/typedef for better code readability and maintainability.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ensure that all tests, including the updated `loadConfigModels.spec` tests, pass successfully.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.