### PR TITLE
🚀 feat: Add CLI Helper Scripts to API Container Image

### DIFF
--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -24,6 +24,8 @@ FROM data-provider-build AS api-build
 WORKDIR /app/api
 COPY api/package*.json ./
 COPY api/ ./
+# Copy helper scripts
+COPY config/ ./
 # Copy data-provider to API's node_modules
 RUN mkdir -p /app/api/node_modules/librechat-data-provider/
 RUN cp -R /app/packages/data-provider/* /app/api/node_modules/librechat-data-provider/

--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,13 @@
     "server-dev": "echo 'please run this from the root directory'",
     "test": "cross-env NODE_ENV=test jest",
     "b:test": "NODE_ENV=test bun jest",
-    "test:ci": "jest --ci"
+    "test:ci": "jest --ci",
+    "add-balance": "node ./add-balance.js",
+    "list-balances": "node ./list-balances.js",
+    "user-stats": "node ./user-stats.js",
+    "create-user": "node ./create-user.js",
+    "ban-user": "node ./ban-user.js",
+    "delete-user": "node ./delete-user.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- Add CLI scripts to API image built by Dockerfile.multi, used by deploy-compose.yml file

Previously, these could not be used when entering the API image container's terminal but now they can.

**Note:** The newly added scripts found in the api/package.json file are only meant to be used within the API image container terminal.

API image: https://github.com/users/danny-avila/packages/container/package/librechat-api

Default image: https://github.com/users/danny-avila/packages/container/package/librechat

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules