### PR TITLE
🐞 fix: Handle Empty Model Error in Assistants Form

### DIFF
--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -18,6 +18,8 @@ import type { LucideIcon } from 'lucide-react';
 
 export type GenericSetter<T> = (value: T | ((currentValue: T) => T)) => void;
 
+export type LastSelectedModels = Record<EModelEndpoint, string>;
+
 export type NavLink = {
   title: string;
   label?: string;

--- a/client/src/components/SidePanel/Builder/AssistantPanel.tsx
+++ b/client/src/components/SidePanel/Builder/AssistantPanel.tsx
@@ -317,19 +317,28 @@ export default function AssistantPanel({
             <Controller
               name="model"
               control={control}
-              render={({ field }) => (
-                <SelectDropDown
-                  emptyTitle={true}
-                  value={field.value}
-                  setValue={field.onChange}
-                  availableValues={modelsQuery.data?.[EModelEndpoint.assistants] ?? []}
-                  showAbove={false}
-                  showLabel={false}
-                  className={cn(
-                    cardStyle,
-                    'flex h-[40px] w-full flex-none items-center justify-center px-4 hover:cursor-pointer',
+              rules={{ required: true, minLength: 1 }}
+              render={({ field, fieldState: { error } }) => (
+                <>
+                  <SelectDropDown
+                    emptyTitle={true}
+                    value={field.value}
+                    setValue={field.onChange}
+                    availableValues={modelsQuery.data?.[EModelEndpoint.assistants] ?? []}
+                    showAbove={false}
+                    showLabel={false}
+                    className={cn(
+                      cardStyle,
+                      'flex h-[40px] w-full flex-none items-center justify-center px-4 hover:cursor-pointer',
+                    )}
+                    containerClassName={cn('rounded-md', error ? 'border-red-500 border-2' : '')}
+                  />
+                  {error && (
+                    <span className="text-sm text-red-500 transition duration-300 ease-in-out">
+                      {localize('com_ui_field_required')}
+                    </span>
                   )}
-                />
+                </>
               )}
             />
           </div>

--- a/client/src/components/SidePanel/Builder/AssistantSelect.tsx
+++ b/client/src/components/SidePanel/Builder/AssistantSelect.tsx
@@ -4,17 +4,24 @@ import {
   defaultAssistantFormValues,
   defaultOrderQuery,
   isImageVisionTool,
+  EModelEndpoint,
   Capabilities,
   FileSources,
 } from 'librechat-data-provider';
 import type { UseFormReset } from 'react-hook-form';
 import type { UseMutationResult } from '@tanstack/react-query';
 import type { Assistant, AssistantCreateParams } from 'librechat-data-provider';
-import type { AssistantForm, Actions, TAssistantOption, ExtendedFile } from '~/common';
+import type {
+  AssistantForm,
+  Actions,
+  TAssistantOption,
+  ExtendedFile,
+  LastSelectedModels,
+} from '~/common';
 import SelectDropDown from '~/components/ui/SelectDropDown';
 import { useListAssistantsQuery } from '~/data-provider';
+import { useLocalize, useLocalStorage } from '~/hooks';
 import { useFileMapContext } from '~/Providers';
-import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 
 const keys = new Set(['name', 'id', 'description', 'instructions', 'model']);
@@ -35,6 +42,10 @@ export default function AssistantSelect({
   const localize = useLocalize();
   const fileMap = useFileMapContext();
   const lastSelectedAssistant = useRef<string | null>(null);
+  const [lastSelectedModels] = useLocalStorage<LastSelectedModels>(
+    'lastSelectedModel',
+    {} as LastSelectedModels,
+  );
 
   const assistants = useListAssistantsQuery(defaultOrderQuery, {
     select: (res) =>
@@ -79,7 +90,10 @@ export default function AssistantSelect({
       createMutation.reset();
       if (!assistant) {
         setCurrentAssistantId(undefined);
-        return reset(defaultAssistantFormValues);
+        return reset({
+          ...defaultAssistantFormValues,
+          model: lastSelectedModels?.[EModelEndpoint.assistants] ?? '',
+        });
       }
 
       const update = {
@@ -127,7 +141,7 @@ export default function AssistantSelect({
       reset(formValues);
       setCurrentAssistantId(assistant?.id);
     },
-    [assistants.data, reset, setCurrentAssistantId, createMutation],
+    [assistants.data, reset, setCurrentAssistantId, createMutation, lastSelectedModels],
   );
 
   useEffect(() => {

--- a/client/src/localization/languages/Eng.tsx
+++ b/client/src/localization/languages/Eng.tsx
@@ -46,6 +46,7 @@ export default {
   com_assistants_update_error: 'There was an error updating your assistant.',
   com_assistants_create_success: 'Successfully created',
   com_assistants_create_error: 'There was an error creating your assistant.',
+  com_ui_field_required: 'This field is required',
   com_ui_download_error: 'Error downloading file. The file may have been deleted.',
   com_ui_attach_error_type: 'Unsupported file type for endpoint:',
   com_ui_attach_error_size: 'File size limit exceeded for endpoint:',


### PR DESCRIPTION
## Summary

Implemented changes to ensure the AssistantsForm component handles empty model selection gracefully and uses the last selected model as the default value for model selection.

- Addressed an issue where an empty model selection caused errors in the form validation
- Added error handling for required model selection, prompting the user to choose a valid model
- Implemented logic to use the last selected model as the default value when creating a new assistant
- Improved the overall user experience by providing clear feedback and error messages

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### **Test Configuration**:
- Browser: Latest versions of Chrome, Firefox, and Safari
- Environment: Development and Production

To test these changes, follow these steps:

1. Open the AssistantsForm component in the application
2. Attempt to create a new assistant without selecting a model
3. Verify that an error message is displayed, prompting you to select a valid model
4. Select a model and proceed with the assistant creation process
5. Verify that the last selected model is pre-populated as the default value when creating a new assistant

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules