### PR TITLE
🐞Fix: Stable Diffusion User Directory

### DIFF
--- a/api/app/clients/tools/structured/StableDiffusion.js
+++ b/api/app/clients/tools/structured/StableDiffusion.js
@@ -103,8 +103,8 @@ class StableDiffusionAPI extends StructuredTool {
     const filepath = path.join(imageOutputPath, this.userId, imageName);
     this.relativePath = path.relative(clientPath, imageOutputPath);
 
-    if (!fs.existsSync(imageOutputPath)) {
-      fs.mkdirSync(imageOutputPath, { recursive: true });
+    if (!fs.existsSync(path.join(imageOutputPath, this.userId))) {
+      fs.mkdirSync(path.join(imageOutputPath, this.userId), { recursive: true });
     }
 
     try {


### PR DESCRIPTION
## Summary

Stable Diffusion will not create images if the user directory does not exist under the image directory.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Delete my existing user directory under images and stable diffusion will not work.


### **Test Configuration**:

Changed the included code to make it work again.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

