### PR TITLE
📖 docs: Note on 'host.docker.internal' for Ollama Config

### DIFF
--- a/docs/install/configuration/ai_endpoints.md
+++ b/docs/install/configuration/ai_endpoints.md
@@ -322,7 +322,7 @@ Some of the endpoints are marked as **Known,** which means they might have speci
 ```yaml
     - name: "Ollama"
       apiKey: "ollama"
-      baseURL: "http://localhost:11434/v1/"
+      baseURL: "http://localhost:11434/v1/chat/completions" # use 'host.docker.internal' instead of localhost if running LibreChat in a docker container 
       models:
         default: [
           "llama2",

--- a/docs/install/configuration/ai_endpoints.md
+++ b/docs/install/configuration/ai_endpoints.md
@@ -322,7 +322,8 @@ Some of the endpoints are marked as **Known,** which means they might have speci
 ```yaml
     - name: "Ollama"
       apiKey: "ollama"
-      baseURL: "http://localhost:11434/v1/chat/completions" # use 'host.docker.internal' instead of localhost if running LibreChat in a docker container 
+      # use 'host.docker.internal' instead of localhost if running LibreChat in a docker container
+      baseURL: "http://localhost:11434/v1/chat/completions" 
       models:
         default: [
           "llama2",


### PR DESCRIPTION
## Summary

The docs suggest a URL to access ollama ("http://localhost:11434/v1/") that is not working. This pull request fixes the URL to  "http://localhost:11434/v1/chat/completions"

Additionally there is an issue on Mac and Windows when accessing localhost from a docker container. It will not be found as the container is run in a VM. So in this case, you should use 'host.docker.internal' instead. I added this as a comment.

Thanks to Berry from the discord for his support!

## Change Type

- [x] Documentation update

## Testing

I tested the URL "http://host.docker.internal:11434/v1/chat/completions" on my machine, with the ollama version 0.1.30