### PR TITLE
🐋 fix(Dockerfile): Create Necessary Directories at Build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ RUN npm install --no-audit
 ENV NODE_OPTIONS="--max-old-space-size=2048"
 RUN npm run frontend
 
+# Create directories for the volumes to inherit
+# the correct permissions
+RUN mkdir -p /app/client/public/images /app/api/logs
+
 # Node API setup
 EXPOSE 3080
 ENV HOST=0.0.0.0


### PR DESCRIPTION
## Summary

When creating volumes for /app/client/public/images and /app/api/logs docker will inherit the permissions from the existing directores in the image. Since they are missing it defaults to root, and since librechat now uses the "node" user instead of "root" storing images, files and logs will fail.

Fix by creating those directories in the docker image with the node user, so that if docker creates the volumes the permissions are inherited and the directories are owned by "node" and not "root".

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update
- [ ] Documentation update

## Testing

Run the docker image with named or anonymous volumes. Test that dall-e works. Or check run `ls -lh /app/client/public/` to see the permissions.

```yaml
librechat:
  image: ghcr.io/danny-avila/librechat:v0.7.0
  restart: always
  volumes:
    - librechat-images:/app/client/public/images

volumes:
  librechat-images:
```
