### PR TITLE
🛠️ fix: Correct Unwanted Newlines after Undo in Textarea

### DIFF
--- a/client/src/hooks/Input/useTextarea.ts
+++ b/client/src/hooks/Input/useTextarea.ts
@@ -4,7 +4,7 @@ import { EModelEndpoint } from 'librechat-data-provider';
 import type { TEndpointOption } from 'librechat-data-provider';
 import type { UseFormSetValue } from 'react-hook-form';
 import type { KeyboardEvent } from 'react';
-import { forceResize, insertTextAtCursor, getAssistantName } from '~/utils';
+import { forceResize, insertTextAtCursor, trimUndoneRange, getAssistantName } from '~/utils';
 import { useAssistantsMapContext } from '~/Providers/AssistantsMapContext';
 import useGetSender from '~/hooks/Conversations/useGetSender';
 import useFileHandling from '~/hooks/Files/useFileHandling';
@@ -157,7 +157,16 @@ export default function useTextarea({
   const handleKeyUp = (e: KeyEvent) => {
     const target = e.target as HTMLTextAreaElement;
 
-    if (e.keyCode === 8 && target.value.trim() === '') {
+    const isUndo = e.key === 'z' && (e.ctrlKey || e.metaKey);
+    if (isUndo && target.value.trim() === '') {
+      textAreaRef.current?.setRangeText('', 0, textAreaRef.current?.value?.length, 'end');
+      forceResize(textAreaRef);
+    } else if (isUndo) {
+      trimUndoneRange(textAreaRef);
+      forceResize(textAreaRef);
+    }
+
+    if ((e.keyCode === 8 || e.key === 'Backspace') && target.value.trim() === '') {
       textAreaRef.current?.setRangeText('', 0, textAreaRef.current?.value?.length, 'end');
     }
 

--- a/client/src/utils/textarea.ts
+++ b/client/src/utils/textarea.ts
@@ -32,9 +32,28 @@ export function insertTextAtCursor(element: HTMLTextAreaElement, textToInsert: s
  3) Reseting back to scrollHeight reads and applies the ideal height for the current content dynamically
  */
 export const forceResize = (textAreaRef: React.RefObject<HTMLTextAreaElement>) => {
-  if (textAreaRef.current) {
-    textAreaRef.current.style.height = 'auto';
-    textAreaRef.current.offsetHeight;
-    textAreaRef.current.style.height = `${textAreaRef.current.scrollHeight}px`;
+  if (!textAreaRef.current) {
+    return;
   }
+  textAreaRef.current.style.height = 'auto';
+  textAreaRef.current.offsetHeight;
+  textAreaRef.current.style.height = `${textAreaRef.current.scrollHeight}px`;
+};
+
+/**
+ * Necessary undo event helper for edge cases where undoing pasted content leaves newlines filling the previous container height.
+ */
+export const trimUndoneRange = (textAreaRef: React.RefObject<HTMLTextAreaElement>) => {
+  if (!textAreaRef.current) {
+    return;
+  }
+  const { value, selectionStart, selectionEnd } = textAreaRef.current;
+  const afterCursor = value.substring(selectionEnd).trim();
+  if (afterCursor.length) {
+    return;
+  }
+  const beforeCursor = value.substring(0, selectionStart);
+  const newValue = beforeCursor + afterCursor;
+  textAreaRef.current.value = newValue;
+  textAreaRef.current.setSelectionRange(selectionStart, selectionStart);
 };

--- a/docs/install/configuration/docker_override.md
+++ b/docs/install/configuration/docker_override.md
@@ -109,11 +109,13 @@ The npm commands for "deployed" do this for you but they do not account for over
     "stop:deployed": "docker compose -f ./deploy-compose.yml down",
 ```
 
-For example, if you use `deploy-compose.yml` as your main Docker Compose configuration and you have an override file named `deploy-compose.override.yml` (you can name the override file whatever you want), you would run Docker Compose commands like so:
+I would include the default override file in these commands, but doing so would require one to exist for every setup.
+
+If you use `deploy-compose.yml` as your main Docker Compose configuration and you have an override file named `docker-compose.override.yml` (you can name the override file whatever you want, but you may have this specific file already), you would run Docker Compose commands like so:
 
 ```bash
-docker compose -f deploy-compose.yml -f deploy-compose.override.yml pull
-docker compose -f deploy-compose.yml -f deploy-compose.override.yml up
+docker compose -f deploy-compose.yml -f docker-compose.override.yml pull
+docker compose -f deploy-compose.yml -f docker-compose.override.yml up
 ```
 
 ## MongoDB Authentication


### PR DESCRIPTION
## Summary

Hopefully the last of Textarea changes, this one targeting a chrome quirk.

I enhanced the undo functionality in LibreChat's textarea to fix a Chrome-specific bug that left unwanted newlines after undoing pasted content. The purpose of this improvement is to ensure a smoother user experience, especially when users need to undo their actions within the chat input field.

### Other Changes

- handle deprecated "backspace" identifier in KeyUp event handler
- revise recent documentation update about docker override file concerning deploy-compose.yml usage

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

To ensure the fix worked as intended, I replicated the problematic scenario by:
1. Pasting multiline content into the chat input, observing the unwanted behavior of newline characters remaining after an undo operation.
2. Applying the fix, which involved capturing the undo event and trimming any unnecessary whitespace from the end of the input field's content.

**Test Configuration**:
- Browser: Google Chrome (latest version)
- Environment: Local development 

I specifically focused on testing in Chrome, as the bug was Chrome-specific. However, I also verified behavior in Firefox and Safari to ensure my fix did not adversely affect functionality in those browsers. 

For effective testing, one should:
1. Paste multiline text into the chat input.
2. Perform an undo action using `Ctrl+Z` (or `Cmd+Z` on a Mac).
3. Observe if any newline characters remain after the content has been undone.

Additionally, try starting with text already present in the textarea, then paste and undo to ensure the logic correctly handles content before the cursor.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes