### PR TITLE
📝 docs: Correct Google OAuth Callback URL Example

### DIFF
--- a/docs/install/configuration/OAuth2-and-OIDC/google.md
+++ b/docs/install/configuration/OAuth2-and-OIDC/google.md
@@ -89,7 +89,7 @@ DOMAIN_SERVER=https://your-domain.com # use http://localhost:3080 if not using a
 
 GOOGLE_CLIENT_ID=your_client_id
 GOOGLE_CLIENT_SECRET=your_client_secret
-GOOGLE_CALLBACK_URL=/oauth/github/callback
+GOOGLE_CALLBACK_URL=/oauth/google/callback
 ```
 
 - Save the `.env` file


### PR DESCRIPTION
## Summary

The Google OAuth documentation calls out `github` as the provider in the callback URL example. This may add confusion for some users during the set up process in Google Cloud. I've updated the example with `google` as the provider and checked that the other OAuth/OIDC markdown files all follow the same pattern. 

## Change Type

- [ ] Documentation update

## Testing

Viewed the affected markdown files to ensure correctness.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
