### PR TITLE
🚦 docs: Update `traefik.md` - Documentation Fix for edge case race condition

### DIFF
--- a/docs/deployment/traefik.md
+++ b/docs/deployment/traefik.md
@@ -37,7 +37,6 @@ services:
        - "traefik.http.routers.librechat.tls.certresolver=leresolver"
        - "traefik.http.services.librechat.loadbalancer.server.port=3080"
      networks:
-       - web
        - librechat_default
      volumes:
        - ./librechat.yaml:/app/librechat.yaml
@@ -51,7 +50,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "./letsencrypt:/letsencrypt"
      networks:
-      - web
+      - librechat_default
      command:
       - "--log.level=DEBUG"
       - "--api.insecure=true"


### PR DESCRIPTION
# Pull Request Template


### ⚠️ Before Submitting a PR, read the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) in full!

## Summary

Sometimes Traefik created a race condition where LibreChat was up on tcp/3080, and while Traefik was up on tcp/443, it could not route to the LibreChat container due to the multiple interfaces -- depending on how they came up. This is easily solved by simply using one interface.

## Change Type

Please delete any irrelevant options.

- [x] Documentation update


## Testing

Tested in our deployment

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [X] New documents have been locally validated with mkdocs
