### PR TITLE
🚅 docs(ai_endpoints): Reflect correct LiteLLM baseURL when using docker-compose

### DIFF
--- a/docs/install/configuration/ai_endpoints.md
+++ b/docs/install/configuration/ai_endpoints.md
@@ -298,6 +298,7 @@ Some of the endpoints are marked as **Known,** which means they might have speci
     - name: "LiteLLM"
       apiKey: "sk-from-config-file"
       baseURL: "http://localhost:8000/v1"
+      # if using LiteLLM example in docker-compose.override.yml.example, use "http://litellm:8000/v1"
       models:
         default: ["gpt-3.5-turbo"]
         fetch: true


### PR DESCRIPTION
Added note to LiteLLM baseURL to reflect docker-compose usage.  Using localhost won't work as those ports aren't exposed through the docker example (and, in my case, would conflict if they were).

# Pull Request Template


### ⚠️ Before Submitting a PR, read the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) in full!

## Summary

If using the LiteLLM configuration provided in docker-compose.override.yml.example, the corresponding librechat.yaml example provided in the documentation will not work.  This is a simple documentation update to provide the correct baseURL using the docker container name vs localhost.  As mentioned above, localhost will fail as port 8000 is not exposed.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update
- [X] Documentation update


## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] I have made pertinent documentation changes