### PR TITLE
🎨 feat: Title Improvements

### DIFF
--- a/api/server/middleware/abortRun.js
+++ b/api/server/middleware/abortRun.js
@@ -75,7 +75,6 @@ async function abortRun(req, res) {
   });
 
   const finalEvent = {
-    title: 'New Chat',
     final: true,
     conversation,
     runMessages,

--- a/api/server/routes/assistants/chat.js
+++ b/api/server/routes/assistants/chat.js
@@ -247,7 +247,6 @@ router.post('/', validateModel, buildEndpointOption, setHeaders, async (req, res
       }
 
       finalEvent = {
-        title: 'New Chat',
         final: true,
         conversation: await getConvo(req.user.id, conversationId),
         runMessages,
@@ -477,7 +476,6 @@ router.post('/', validateModel, buildEndpointOption, setHeaders, async (req, res
 
       conversation = {
         conversationId,
-        title: 'New Chat',
         endpoint: EModelEndpoint.assistants,
         promptPrefix: promptPrefix,
         instructions: instructions,
@@ -607,7 +605,6 @@ router.post('/', validateModel, buildEndpointOption, setHeaders, async (req, res
     };
 
     sendMessage(res, {
-      title: 'New Chat',
       final: true,
       conversation,
       requestMessage: {

--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -68,6 +68,7 @@ export const useGenTitleMutation = (): UseMutationResult<
           title: response.title,
         } as TConversation);
       });
+      document.title = response.title;
     },
   });
 };

--- a/client/src/hooks/SSE/useSSE.ts
+++ b/client/src/hooks/SSE/useSSE.ts
@@ -192,10 +192,19 @@ export default function useSSE(submission: TSubmission | null, index = 0) {
 
       let update = {} as TConversation;
       setConversation((prevState) => {
+        let title = prevState?.title;
+        const parentId = requestMessage.parentMessageId;
+        if (parentId !== Constants.NO_PARENT && title?.toLowerCase()?.includes('new chat')) {
+          const convos = queryClient.getQueryData<ConversationData>([QueryKeys.allConversations]);
+          const cachedConvo = getConversationById(convos, conversationId);
+          title = cachedConvo?.title;
+        }
+
         update = tConvoUpdateSchema.parse({
           ...prevState,
           conversationId,
           thread_id,
+          title,
           messages: [requestMessage.messageId, responseMessage.messageId],
         }) as TConversation;
 


### PR DESCRIPTION
**Summary**:

This change enhances the user experience by dynamically updating the document title (displayed in the browser tab) upon successful completion of the `genTitle` mutation. Additionally, it ensures that the generated title persists throughout the active conversation, even when additional messages are exchanged.

- Implemented logic to update the `document.title` with the generated title upon successful completion of the `gentitle` mutation.
- Maintained the generated title throughout the active conversation, ensuring it remains visible in the browser tab even when new messages are sent or received for the assistants endpoint
- Improved the overall user experience by providing a more contextual and informative browser tab title, reflecting the current conversation state.
- Remove "New Chat" placeholders used in assistants route handling

Closes #2354 

**Testing**:

To verify the changes, follow these steps:

**Test Configuration**:
- Browser: Latest versions of Chrome, Firefox, and Safari
- Environment: Development and Production

1. Start a new conversation.
2. Send a message to trigger the `gentitle` mutation.
3. Observe that the browser tab title updates with the generated title upon successful completion of the mutation.
4. Continue the conversation by sending additional messages.
5. Ensure that the generated title persists in the browser tab throughout the active conversation.

**Checklist**:

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules