### PR TITLE
fix: HOST config in .env file not working

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   api:
     container_name: LibreChat
     ports:
-      - "${PORT}:${PORT}"
+      - "${HOST}:${PORT}:${PORT}"
     depends_on:
       - mongodb
       - rag_api


### PR DESCRIPTION
## Summary

At the top of the .env file, we have a [HOST](https://github.com/danny-avila/LibreChat/blob/e4c07eb8951866c2fd6a9dc0129737627f842ff0/.env.example#L16) config.

This HOST variable is currently not working in a `docker-compose` environment.

The container created by docker-compose will always listen on `0.0.0.0`, which could cause unintentional exposure to the public network and become a **security disaster**.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

After this fix, the HOST variable in the .env file should work in the docker-compose environment. 
(A docker-compose environment can be set up by following [this document](https://docs.librechat.ai/install/installation/docker_compose_install.html).)

Testing can be done by:

1. Setting the HOST variable in the `.env` file to a new value.
2. Restart containers by executing: `docker-compose down && docker-compose up -d`
3. See if this new value takes effects by checking the PORTS column of: `docker ps`

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings