### PR TITLE
🔓 refactor: Make Image URL Security Optional

### DIFF
--- a/api/server/middleware/validateImageRequest.js
+++ b/api/server/middleware/validateImageRequest.js
@@ -3,9 +3,14 @@ const jwt = require('jsonwebtoken');
 const { logger } = require('~/config');
 
 /**
- * Middleware to validate image request
+ * Middleware to validate image request.
+ * Must be set by `secureImageLinks` via custom config file.
  */
 function validateImageRequest(req, res, next) {
+  if (!req.app.locals.secureImageLinks) {
+    return next();
+  }
+
   const refreshToken = req.headers.cookie ? cookies.parse(req.headers.cookie).refreshToken : null;
   if (!refreshToken) {
     logger.warn('[validateImageRequest] Refresh token not provided');

--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -180,6 +180,7 @@ const AppService = async (app) => {
     fileStrategy,
     fileConfig: config?.fileConfig,
     interface: config?.interface,
+    secureImageLinks: config?.secureImageLinks,
     paths,
     ...endpointLocals,
   };

--- a/docs/install/configuration/custom_config.md
+++ b/docs/install/configuration/custom_config.md
@@ -203,6 +203,12 @@ This example configuration file sets up LibreChat with detailed options across s
 - **Description**: Determines where to save user uploaded/generated files. Defaults to `"local"` if omitted.
 - **Example**: `fileStrategy: "firebase"`
 
+### Image Links
+- **Key**: `secureImageLinks`
+- **Type**: Boolean
+- **Description**: Whether or not to secure access to image links that are hosted locally by the app. Default: false.
+- **Example**: `secureImageLinks: true`
+
 ### File Configuration
 - **Key**: `fileConfig`
 - **Type**: Object

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -189,6 +189,7 @@ export const rateLimitSchema = z.object({
 export const configSchema = z.object({
   version: z.string(),
   cache: z.boolean().optional().default(true),
+  secureImageLinks: z.boolean().optional(),
   interface: z
     .object({
       privacyPolicy: z


### PR DESCRIPTION
Having this on by default creates image access issues in some remote environments that may not be using HTTPS or not adding cookies to requests for whatever reason