### PR TITLE
chore: Add automatically the filename : line_nu in log messages, and do some cleaning  

### DIFF
--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -206,7 +206,7 @@ class AnthropicClient extends BaseClient {
       parentMessageId,
     });
 
-    logger.debug('[AnthropicClient] orderedMessages', { orderedMessages, parentMessageId });
+    logger.debug('orderedMessages', { orderedMessages, parentMessageId });
 
     if (this.options.attachments) {
       const attachments = await this.options.attachments;
@@ -295,7 +295,7 @@ class AnthropicClient extends BaseClient {
         return map;
       }, {});
 
-    logger.debug('[AnthropicClient]', {
+    logger.debug({
       messagesInWindow: messagesInWindow.length,
       remainingContextTokens,
     });
@@ -587,7 +587,7 @@ class AnthropicClient extends BaseClient {
       requestOptions.system = this.systemMessage;
     }
 
-    logger.debug('[AnthropicClient]', { ...requestOptions });
+    logger.debug({ ...requestOptions });
 
     const handleChunk = (currentChunk) => {
       if (currentChunk) {
@@ -606,7 +606,7 @@ class AnthropicClient extends BaseClient {
           response = await this.createResponse(client, requestOptions);
 
           signal.addEventListener('abort', () => {
-            logger.debug('[AnthropicClient] message aborted!');
+            logger.debug('message aborted!');
             if (response.controller?.abort) {
               response.controller.abort();
             }
@@ -636,7 +636,7 @@ class AnthropicClient extends BaseClient {
           }
         } finally {
           signal.removeEventListener('abort', () => {
-            logger.debug('[AnthropicClient] message aborted!');
+            logger.debug('message aborted!');
             if (response.controller?.abort) {
               response.controller.abort();
             }
@@ -749,7 +749,7 @@ class AnthropicClient extends BaseClient {
     };
 
     await titleChatCompletion();
-    logger.debug('[AnthropicClient] Convo Title: ' + title);
+    logger.debug('Convo Title: ' + title);
     return title;
   }
 }

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -280,14 +280,14 @@ class BaseClient {
     if (instructions) {
       ({ tokenCount, ..._instructions } = instructions);
     }
-    _instructions && logger.debug('[BaseClient] instructions tokenCount: ' + tokenCount);
+    _instructions && logger.debug('instructions tokenCount: ' + tokenCount);
     let payload = this.addInstructions(formattedMessages, _instructions);
     let orderedWithInstructions = this.addInstructions(orderedMessages, instructions);
 
     let { context, remainingContextTokens, messagesToRefine, summaryIndex } =
       await this.getMessagesWithinTokenLimit(orderedWithInstructions);
 
-    logger.debug('[BaseClient] Context Count (1/2)', {
+    logger.debug('Context Count (1/2)', {
       remainingContextTokens,
       maxContextTokens: this.maxContextTokens,
     });
@@ -337,7 +337,7 @@ class BaseClient {
     // Make sure to only continue summarization logic if the summary message was generated
     shouldSummarize = summaryMessage && shouldSummarize;
 
-    logger.debug('[BaseClient] Context Count (2/2)', {
+    logger.debug('Context Count (2/2)', {
       remainingContextTokens,
       maxContextTokens: this.maxContextTokens,
     });
@@ -358,8 +358,8 @@ class BaseClient {
 
     const promptTokens = this.maxContextTokens - remainingContextTokens;
 
-    logger.debug('[BaseClient] tokenCountMap:', tokenCountMap);
-    logger.debug('[BaseClient]', {
+    logger.debug('tokenCountMap:', tokenCountMap);
+    logger.debug({
       promptTokens,
       remainingContextTokens,
       payloadSize: payload.length,
@@ -412,10 +412,10 @@ class BaseClient {
     );
 
     if (tokenCountMap) {
-      logger.debug('[BaseClient] tokenCountMap', tokenCountMap);
+      logger.debug('tokenCountMap', tokenCountMap);
       if (tokenCountMap[userMessage.messageId]) {
         userMessage.tokenCount = tokenCountMap[userMessage.messageId];
-        logger.debug('[BaseClient] userMessage', userMessage);
+        logger.debug('userMessage', userMessage);
       }
 
       this.handleTokenCountMap(tokenCountMap);
@@ -479,7 +479,7 @@ class BaseClient {
   }
 
   async loadHistory(conversationId, parentMessageId = null) {
-    logger.debug('[BaseClient] Loading history:', { conversationId, parentMessageId });
+    logger.debug('Loading history:', { conversationId, parentMessageId });
 
     const messages = (await getMessages({ conversationId })) ?? [];
 
@@ -514,7 +514,7 @@ class BaseClient {
 
     if (this.previous_summary) {
       const { messageId, summary, tokenCount, summaryTokenCount } = this.previous_summary;
-      logger.debug('[BaseClient] Previous summary:', {
+      logger.debug('Previous summary:', {
         messageId,
         summary,
         tokenCount,

--- a/api/app/clients/ChatGPTClient.js
+++ b/api/app/clients/ChatGPTClient.js
@@ -293,7 +293,7 @@ class ChatGPTClient extends BaseClient {
         ...modelOptions,
         ...this.options.addParams,
       };
-      logger.debug('[ChatGPTClient] chatCompletion: added params', {
+      logger.debug('chatCompletion: added params', {
         addParams: this.options.addParams,
         modelOptions,
       });
@@ -303,7 +303,7 @@ class ChatGPTClient extends BaseClient {
       this.options.dropParams.forEach((param) => {
         delete modelOptions[param];
       });
-      logger.debug('[ChatGPTClient] chatCompletion: dropped params', {
+      logger.debug('chatCompletion: dropped params', {
         dropParams: this.options.dropParams,
         modelOptions,
       });

--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -340,7 +340,7 @@ class GoogleClient extends BaseClient {
       payload.instances[0].examples = this.options.examples;
     }
 
-    logger.debug('[GoogleClient] buildMessages', payload);
+    logger.debug('buildMessages', payload);
 
     return { prompt: payload };
   }
@@ -351,7 +351,7 @@ class GoogleClient extends BaseClient {
       parentMessageId,
     });
 
-    logger.debug('[GoogleClient]', {
+    logger.debug({
       orderedMessages,
       parentMessageId,
     });

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -170,7 +170,7 @@ class OpenAIClient extends BaseClient {
     }
 
     if (this.options.debug) {
-      logger.debug('[OpenAIClient] maxContextTokens', this.maxContextTokens);
+      logger.debug('maxContextTokens', this.maxContextTokens);
     }
 
     this.maxResponseTokens = this.modelOptions.max_tokens || 1024;
@@ -339,7 +339,7 @@ class OpenAIClient extends BaseClient {
   resetTokenizersIfNecessary() {
     if (tokenizerCallsCount >= 25) {
       if (this.options.debug) {
-        logger.debug('[OpenAIClient] freeAndResetAllEncoders: reached 25 encodings, resetting...');
+        logger.debug('freeAndResetAllEncoders: reached 25 encodings, resetting...');
       }
       this.constructor.freeAndResetAllEncoders();
     }
@@ -613,7 +613,7 @@ class OpenAIClient extends BaseClient {
         return result.trim();
       }
 
-      logger.debug('[OpenAIClient] sendCompletion: result', result);
+      logger.debug('sendCompletion: result', result);
 
       if (this.isChatCompletion) {
         reply = result.choices[0].message.content;
@@ -814,7 +814,7 @@ ${convo}
 
     if (this.options.titleMethod === 'completion') {
       await titleChatCompletion();
-      logger.debug('[OpenAIClient] Convo Title: ' + title);
+      logger.debug('Convo Title: ' + title);
       return title;
     }
 
@@ -829,7 +829,7 @@ ${convo}
       title = await runTitleChain({ llm, text, convo, signal: this.abortController.signal });
     } catch (e) {
       if (e?.message?.toLowerCase()?.includes('abort')) {
-        logger.debug('[OpenAIClient] Aborted title generation');
+        logger.debug('Aborted title generation');
         return;
       }
       logger.error(
@@ -840,12 +840,12 @@ ${convo}
       await titleChatCompletion();
     }
 
-    logger.debug('[OpenAIClient] Convo Title: ' + title);
+    logger.debug('Convo Title: ' + title);
     return title;
   }
 
   async summarizeMessages({ messagesToRefine, remainingContextTokens }) {
-    logger.debug('[OpenAIClient] Summarizing messages...');
+    logger.debug('Summarizing messages...');
     let context = messagesToRefine;
     let prompt;
 
@@ -905,7 +905,7 @@ ${convo}
     // by recreating the summary prompt (single message) to avoid LangChain handling
 
     const initialPromptTokens = this.maxContextTokens - remainingContextTokens;
-    logger.debug('[OpenAIClient] initialPromptTokens', initialPromptTokens);
+    logger.debug('initialPromptTokens', initialPromptTokens);
 
     const llm = this.initializeLLM({
       model,
@@ -931,7 +931,7 @@ ${convo}
       const summaryTokenCount = this.getTokenCountForMessage(summaryMessage);
 
       if (this.options.debug) {
-        logger.debug('[OpenAIClient] summaryTokenCount', summaryTokenCount);
+        logger.debug('summaryTokenCount', summaryTokenCount);
         logger.debug(
           `[OpenAIClient] Summarization complete: remainingContextTokens: ${remainingContextTokens}, after refining: ${
             remainingContextTokens - summaryTokenCount
@@ -942,7 +942,7 @@ ${convo}
       return { summaryMessage, summaryTokenCount };
     } catch (e) {
       if (e?.message?.toLowerCase()?.includes('abort')) {
-        logger.debug('[OpenAIClient] Aborted summarization');
+        logger.debug('Aborted summarization');
         const { run, runId } = this.runManager.getRunByConversationId(this.conversationId);
         if (run && run.error) {
           const { error } = run;
@@ -996,7 +996,7 @@ ${convo}
       }
 
       const baseURL = extractBaseURL(this.completionsUrl);
-      logger.debug('[OpenAIClient] chatCompletion', { baseURL, modelOptions });
+      logger.debug('chatCompletion', { baseURL, modelOptions });
       const opts = {
         baseURL,
       };
@@ -1104,7 +1104,7 @@ ${convo}
           ...modelOptions,
           ...this.options.addParams,
         };
-        logger.debug('[OpenAIClient] chatCompletion: added params', {
+        logger.debug('chatCompletion: added params', {
           addParams: this.options.addParams,
           modelOptions,
         });
@@ -1114,7 +1114,7 @@ ${convo}
         this.options.dropParams.forEach((param) => {
           delete modelOptions[param];
         });
-        logger.debug('[OpenAIClient] chatCompletion: dropped params', {
+        logger.debug('chatCompletion: dropped params', {
           dropParams: this.options.dropParams,
           modelOptions,
         });
@@ -1192,7 +1192,7 @@ ${convo}
         this.metadata = { finish_reason };
       }
 
-      logger.debug('[OpenAIClient] chatCompletion response', chatCompletion);
+      logger.debug('chatCompletion response', chatCompletion);
 
       if (!message?.content?.trim() && intermediateReply.length) {
         logger.debug(

--- a/api/app/clients/PluginsClient.js
+++ b/api/app/clients/PluginsClient.js
@@ -91,7 +91,7 @@ class PluginsClient extends OpenAIClient {
     const pastMessages = formatLangChainMessages(this.currentMessages.slice(0, -1), {
       userName: this.options?.name,
     });
-    logger.debug('[PluginsClient] pastMessages: ' + pastMessages.length);
+    logger.debug('pastMessages: ' + pastMessages.length);
 
     // TODO: use readOnly memory, TokenBufferMemory? (both unavailable in LangChainJS)
     const memory = new BufferMemory({
@@ -121,7 +121,7 @@ class PluginsClient extends OpenAIClient {
       return;
     }
 
-    logger.debug('[PluginsClient] Requested Tools', this.options.tools);
+    logger.debug('Requested Tools', this.options.tools);
     logger.debug(
       '[PluginsClient] Loaded Tools',
       this.tools.map((tool) => tool.name),
@@ -130,7 +130,7 @@ class PluginsClient extends OpenAIClient {
     const handleAction = (action, runId, callback = null) => {
       this.saveLatestAction(action);
 
-      logger.debug('[PluginsClient] Latest Agent Action ', this.actions[this.actions.length - 1]);
+      logger.debug('Action:', action);
 
       if (typeof callback === 'function') {
         callback(action, runId);
@@ -159,7 +159,7 @@ class PluginsClient extends OpenAIClient {
       }),
     });
 
-    logger.debug('[PluginsClient] Loaded agent.');
+    logger.debug('Loaded agent.');
   }
 
   async executorCall(message, { signal, stream, onToolStart, onToolEnd }) {
@@ -178,7 +178,7 @@ class PluginsClient extends OpenAIClient {
       logger.debug(`[PluginsClient] Attempt ${attempts} of ${maxAttempts}`);
 
       if (errorMessage.length > 0) {
-        logger.debug('[PluginsClient] Caught error, input: ' + JSON.stringify(input));
+        logger.debug('Caught error, input: ' + JSON.stringify(input));
       }
 
       try {
@@ -216,7 +216,7 @@ class PluginsClient extends OpenAIClient {
 
   async handleResponseMessage(responseMessage, saveOptions, user) {
     const { output, errorMessage, ...result } = this.result;
-    logger.debug('[PluginsClient][handleResponseMessage] Output:', {
+    logger.debug('Output:', {
       output,
       errorMessage,
       ...result,
@@ -244,7 +244,7 @@ class PluginsClient extends OpenAIClient {
       this.setOptions(opts);
       return super.sendMessage(message, opts);
     }
-    logger.debug('[PluginsClient] sendMessage', { message, opts });
+    logger.debug('sendMessage', { message, opts });
     const {
       user,
       isEdited,
@@ -274,10 +274,10 @@ class PluginsClient extends OpenAIClient {
     );
 
     if (tokenCountMap) {
-      logger.debug('[PluginsClient] tokenCountMap', { tokenCountMap });
+      logger.debug('tokenCountMap', { tokenCountMap });
       if (tokenCountMap[userMessage.messageId]) {
         userMessage.tokenCount = tokenCountMap[userMessage.messageId];
-        logger.debug('[PluginsClient] userMessage.tokenCount', userMessage.tokenCount);
+        logger.debug('userMessage.tokenCount', userMessage.tokenCount);
       }
       this.handleTokenCountMap(tokenCountMap);
     }
@@ -363,7 +363,7 @@ class PluginsClient extends OpenAIClient {
       return await this.handleResponseMessage(responseMessage, saveOptions, user);
     }
 
-    logger.debug('[PluginsClient] Completion phase: this.result', this.result);
+    logger.debug('Completion phase: this.result', this.result);
 
     const promptPrefix = buildPromptPrefix({
       result: this.result,
@@ -371,20 +371,20 @@ class PluginsClient extends OpenAIClient {
       functionsAgent: this.functionsAgent,
     });
 
-    logger.debug('[PluginsClient]', { promptPrefix });
+    logger.debug({ promptPrefix });
 
     payload = await this.buildCompletionPrompt({
       messages: this.currentMessages,
       promptPrefix,
     });
 
-    logger.debug('[PluginsClient] buildCompletionPrompt Payload', payload);
+    logger.debug('buildCompletionPrompt Payload', payload);
     responseMessage.text = await this.sendCompletion(payload, opts);
     return await this.handleResponseMessage(responseMessage, saveOptions, user);
   }
 
   async buildCompletionPrompt({ messages, promptPrefix: _promptPrefix }) {
-    logger.debug('[PluginsClient] buildCompletionPrompt messages', messages);
+    logger.debug('buildCompletionPrompt messages', messages);
 
     const orderedMessages = messages;
     let promptPrefix = _promptPrefix.trim();

--- a/api/app/clients/PluginsClient.js
+++ b/api/app/clients/PluginsClient.js
@@ -237,14 +237,14 @@ class PluginsClient extends OpenAIClient {
     return { ...responseMessage, ...result };
   }
 
-  async sendMessage(message, opts = {}) {
+  async sendMessage(HumanMessage, opts = {}) {
     // If a message is edited, no tools can be used.
     const completionMode = this.options.tools.length === 0 || opts.isEdited;
     if (completionMode) {
       this.setOptions(opts);
-      return super.sendMessage(message, opts);
+      return super.sendMessage(HumanMessage, opts);
     }
-    logger.debug('sendMessage', { message, opts });
+    logger.debug('sendMessage', { HumanMessage, opts });
     const {
       user,
       isEdited,
@@ -256,7 +256,7 @@ class PluginsClient extends OpenAIClient {
       onChainEnd,
       onToolStart,
       onToolEnd,
-    } = await this.handleStartMethods(message, opts);
+    } = await this.handleStartMethods(HumanMessage, opts);
 
     this.currentMessages.push(userMessage);
 
@@ -316,7 +316,7 @@ class PluginsClient extends OpenAIClient {
 
     await this.initialize({
       user,
-      message,
+      message: HumanMessage,
       onAgentAction,
       onChainEnd,
       signal: this.abortController.signal,
@@ -326,7 +326,7 @@ class PluginsClient extends OpenAIClient {
     // const stream = async (text) => {
     //   await this.generateTextStream.call(this, text, opts.onProgress, { delay: 1 });
     // };
-    await this.executorCall(message, {
+    await this.executorCall(HumanMessage, {
       signal: this.abortController.signal,
       // stream,
       onToolStart,
@@ -367,7 +367,7 @@ class PluginsClient extends OpenAIClient {
 
     const promptPrefix = buildPromptPrefix({
       result: this.result,
-      message,
+      message: HumanMessage,
       functionsAgent: this.functionsAgent,
     });
 

--- a/api/app/clients/TextStream.js
+++ b/api/app/clients/TextStream.js
@@ -39,7 +39,7 @@ class TextStream extends Readable {
       });
 
       this.on('end', () => {
-        // logger.debug('[processTextStream] Stream ended');
+        // logger.debug('Stream ended');
         resolve();
       });
 

--- a/api/app/clients/agents/CustomAgent/outputParser.js
+++ b/api/app/clients/agents/CustomAgent/outputParser.js
@@ -188,14 +188,14 @@ class CustomOutputParser extends ZeroShotAgentOutputParser {
 
         const inputMatch = this.actionValues.exec(returnValues.log); //new
         if (inputMatch) {
-          logger.debug('[CustomOutputParser] inputMatch', inputMatch);
+          logger.debug('inputMatch', inputMatch);
           returnValues.toolInput = inputMatch[1].replaceAll('"', '').trim();
           returnValues.log = returnValues.log.replace(this.actionValues, '');
         }
 
         return returnValues;
       } else {
-        logger.debug('[CustomOutputParser] No valid tool mentioned.', this.tools, text);
+        logger.debug('No valid tool mentioned.', this.tools, text);
         return {
           tool: 'self-reflection',
           toolInput: 'Hypothetical actions: \n"' + text + '"\n',

--- a/api/app/clients/agents/Functions/FunctionsAgent.js
+++ b/api/app/clients/agents/Functions/FunctionsAgent.js
@@ -114,7 +114,7 @@ class FunctionsAgent extends Agent {
       valuesForLLM,
       callbackManager,
     );
-    logger.debug('[FunctionsAgent] plan message', message);
+    logger.debug('plan message', message);
     return parseOutput(message);
   }
 }

--- a/api/app/clients/callbacks/createStartHandler.js
+++ b/api/app/clients/callbacks/createStartHandler.js
@@ -42,7 +42,7 @@ const createStartHandler = ({
     }
 
     prelimPromptTokens += promptTokensEstimate(payload);
-    logger.debug('[createStartHandler]', {
+    logger.debug({
       prelimPromptTokens,
       tokenBuffer,
     });

--- a/api/app/clients/llm/RunManager.js
+++ b/api/app/clients/llm/RunManager.js
@@ -66,7 +66,7 @@ class RunManager {
           });
 
           if (metadata.context !== 'title') {
-            logger.debug('[RunManager] handleLLMEnd:', {
+            logger.debug('handleLLMEnd:', {
               output: _output,
             });
           }

--- a/api/app/clients/memory/summaryBuffer.js
+++ b/api/app/clients/memory/summaryBuffer.js
@@ -24,7 +24,7 @@ const summaryBuffer = async ({
   signal,
 }) => {
   if (previous_summary) {
-    logger.debug('[summaryBuffer]', { previous_summary });
+    logger.debug({ previous_summary });
   }
 
   const formattedMessages = formatLangChainMessages(context, formatOptions);
@@ -46,7 +46,7 @@ const summaryBuffer = async ({
   const messages = await chatPromptMemory.chatHistory.getMessages();
 
   if (debug) {
-    logger.debug('[summaryBuffer]', { summary_buffer_messages: messages.length });
+    logger.debug({ summary_buffer_messages: messages.length });
   }
 
   const predictSummary = await predictNewSummary({
@@ -57,7 +57,7 @@ const summaryBuffer = async ({
   });
 
   if (debug) {
-    logger.debug('[summaryBuffer]', { summary: predictSummary });
+    logger.debug({ summary: predictSummary });
   }
 
   return { role: 'system', content: predictSummary };

--- a/api/app/clients/output_parsers/addImages.js
+++ b/api/app/clients/output_parsers/addImages.js
@@ -63,7 +63,7 @@ function addImages(intermediateSteps, responseMessage) {
     const observedImagePath = observation.match(/!\[.*\]\([^)]*\)/g);
     if (observedImagePath && !responseMessage.text.includes(observedImagePath[0])) {
       responseMessage.text += '\n' + observation;
-      logger.debug('[addImages] added image from intermediateSteps:', observation);
+      logger.debug('added image from intermediateSteps:', observation);
     }
   });
 }

--- a/api/app/clients/tools/DALL-E.js
+++ b/api/app/clients/tools/DALL-E.js
@@ -111,7 +111,7 @@ Error Message: ${error.message}`;
     const extension = imageExt.startsWith('.') ? imageExt.slice(1) : imageExt;
     const imageName = `img-${uuidv4()}.${extension}`;
 
-    logger.debug('[DALL-E-2]', {
+    logger.debug({
       imageName,
       imageBasename,
       imageExt,

--- a/api/app/clients/tools/dynamic/OpenAPIPlugin.js
+++ b/api/app/clients/tools/dynamic/OpenAPIPlugin.js
@@ -101,34 +101,34 @@ async function createOpenAPIPlugin({ data, llm, user, message, memory, signal })
   const headers = {};
   const { auth, name_for_model, description_for_model, description_for_human } = data;
   if (auth && AuthDefinition.parse(auth)) {
-    logger.debug('[createOpenAPIPlugin] auth detected', auth);
+    logger.debug('auth detected', auth);
     const { openai } = auth.verification_tokens;
     if (AuthBearer.parse(auth)) {
       headers.authorization = `Bearer ${openai}`;
-      logger.debug('[createOpenAPIPlugin] added auth bearer', headers);
+      logger.debug('added auth bearer', headers);
     }
   }
 
   const chainOptions = { llm };
 
   if (data.headers && data.headers['librechat_user_id']) {
-    logger.debug('[createOpenAPIPlugin] id detected', headers);
+    logger.debug('id detected', headers);
     headers[data.headers['librechat_user_id']] = user;
   }
 
   if (Object.keys(headers).length > 0) {
-    logger.debug('[createOpenAPIPlugin] headers detected', headers);
+    logger.debug('headers detected', headers);
     chainOptions.headers = headers;
   }
 
   if (data.params) {
-    logger.debug('[createOpenAPIPlugin] params detected', data.params);
+    logger.debug('params detected', data.params);
     chainOptions.params = data.params;
   }
 
   let history = '';
   if (memory) {
-    logger.debug('[createOpenAPIPlugin] openAPI chain: memory detected', memory);
+    logger.debug('openAPI chain: memory detected', memory);
     const { history: chat_history } = await memory.loadMemoryVariables({});
     history = chat_history?.length > 0 ? `\n\n## Chat History:\n${chat_history}\n` : '';
   }

--- a/api/app/clients/tools/structured/DALLE3.js
+++ b/api/app/clients/tools/structured/DALLE3.js
@@ -146,7 +146,7 @@ Error Message: ${error.message}`;
     const extension = imageExt.startsWith('.') ? imageExt.slice(1) : imageExt;
     const imageName = `img-${uuidv4()}.${extension}`;
 
-    logger.debug('[DALL-E-3]', {
+    logger.debug({
       imageName,
       imageBasename,
       imageExt,

--- a/api/app/clients/tools/structured/DALLE3.js
+++ b/api/app/clients/tools/structured/DALLE3.js
@@ -146,7 +146,7 @@ Error Message: ${error.message}`;
     const extension = imageExt.startsWith('.') ? imageExt.slice(1) : imageExt;
     const imageName = `img-${uuidv4()}.${extension}`;
 
-    logger.debug({
+    logger.debug('[DALL-E-3]', {
       imageName,
       imageBasename,
       imageExt,

--- a/api/app/clients/tools/util/loadSpecs.js
+++ b/api/app/clients/tools/util/loadSpecs.js
@@ -31,7 +31,7 @@ function validateJson(json) {
   try {
     return ManifestDefinition.parse(json);
   } catch (error) {
-    logger.debug('[validateJson] manifest parsing error', error);
+    logger.debug('manifest parsing error', error);
     return false;
   }
 }
@@ -63,7 +63,7 @@ async function loadSpecs({ llm, user, message, tools = [], map = false, memory, 
   const validJsons = [];
   const constructorMap = {};
 
-  logger.debug('[validateJson] files', files);
+  logger.debug('files', files);
 
   for (const file of files) {
     if (path.extname(file) === '.json') {
@@ -72,7 +72,7 @@ async function loadSpecs({ llm, user, message, tools = [], map = false, memory, 
       const json = JSON.parse(fileContent);
 
       if (!validateJson(json)) {
-        logger.debug('[validateJson] Invalid json', json);
+        logger.debug('Invalid json', json);
         continue;
       }
 
@@ -104,7 +104,7 @@ async function loadSpecs({ llm, user, message, tools = [], map = false, memory, 
 
   const plugins = (await Promise.all(validJsons)).filter((plugin) => plugin);
 
-  //   logger.debug('[validateJson] plugins', plugins);
+  //   logger.debug('plugins', plugins);
   //   logger.debug(plugins[0].name);
 
   return plugins;

--- a/api/config/winston.js
+++ b/api/config/winston.js
@@ -31,7 +31,6 @@ function wrapLogMethod(originalMethod) {
   return function (message, ...args) {
     const err = new Error();
     const stack = err.stack.split('\n');
-    // Start parsing from the first relevant entry, which seems to be the second one based on your stack example.
     let relevantStack = stack[2] || stack[1]; // Fallback to an earlier stack if needed
     // Adjusted regex to optionally match function calls in parentheses
     let match = relevantStack
@@ -48,7 +47,7 @@ function wrapLogMethod(originalMethod) {
       const relativePath = path.relative(basePath, match[1]);
       message = `[./api/${relativePath}:${match[2]}] ${message}`;
     } else {
-      // Log the entire stack if no match is found (optional, for debugging purposes)
+      // Log the entire stack if no match is found (for debugging purposes of this mechanism)
       console.log('Failed to parse stack:', err.stack);
       message = `[can't detect location] ${message}`;
     }
@@ -75,8 +74,22 @@ const fileFormat = winston.format.combine(
   winston.format.timestamp({ format: () => new Date().toISOString() }),
   winston.format.errors({ stack: true }),
   winston.format.splat(),
-  // winston.format.printf((info) => `${info.timestamp} [${info.level}]: ${info.message}`),
   // redactErrors(),
+);
+
+const consoleFormat = winston.format.combine(
+  redactFormat(),
+  winston.format.colorize({ all: true }),
+  winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+  // redactErrors(),
+  winston.format.printf((info) => {
+    const message = `${info.timestamp} ${info.level}: ${info.message}`;
+    if (info.level.includes('error')) {
+      return redactMessage(message);
+    }
+
+    return message;
+  }),
 );
 
 const transports = [
@@ -89,10 +102,6 @@ const transports = [
     maxFiles: '14d',
     format: fileFormat,
   }),
-  // new winston.transports.Console({
-  //   level: level(),
-  //   format: fileFormat,
-  // }),
   // new winston.transports.DailyRotateFile({
   //   level: 'info',
   //   filename: `${logDir}/info-%DATE%.log`,
@@ -128,38 +137,27 @@ if (
   );
 }
 
-const consoleFormat = winston.format.combine(
-  redactFormat(),
-  winston.format.colorize({ all: true }),
-  winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
-  // redactErrors(),
-  winston.format.printf((info) => {
-    const message = `${info.timestamp} ${info.level}: ${info.message}`;
-    if (info.level.includes('error')) {
-      return redactMessage(message);
-    }
-
-    return message;
-  }),
-);
-
 if (useDebugConsole) {
   transports.push(
     new winston.transports.Console({
-      level: 'debug',
-      format: useConsoleJson
-        ? winston.format.combine(fileFormat, debugTraverse, winston.format.json())
-        : winston.format.combine(fileFormat, debugTraverse),
+      level: 'debug', // Use 'debug' level for more detailed logging
+      format: consoleFormat,
     }),
   );
 } else if (useConsoleJson) {
+  // If console JSON is used, create two separate console transports
   transports.push(
+    new winston.transports.Console({
+      level: 'debug',
+      format: winston.format.combine(fileFormat, debugTraverse, winston.format.json()),
+    }),
     new winston.transports.Console({
       level: 'info',
       format: winston.format.combine(fileFormat, winston.format.json()),
     }),
   );
 } else {
+  // Default to a basic info-level logging if no specific features are enabled
   transports.push(
     new winston.transports.Console({
       level: 'info',

--- a/api/lib/db/indexSync.js
+++ b/api/lib/db/indexSync.js
@@ -45,18 +45,18 @@ async function indexSync(req, res, next) {
     );
 
     if (messageCount !== messagesIndexed) {
-      logger.debug('[indexSync] Messages out of sync, indexing');
+      logger.debug('Messages out of sync, indexing');
       Message.syncWithMeili();
     }
 
     if (convoCount !== convosIndexed) {
-      logger.debug('[indexSync] Convos out of sync, indexing');
+      logger.debug('Convos out of sync, indexing');
       Conversation.syncWithMeili();
     }
   } catch (err) {
-    // logger.debug('[indexSync] in index sync');
+    // logger.debug('in index sync');
     if (err.message.includes('not found')) {
-      logger.debug('[indexSync] Creating indices...');
+      logger.debug('Creating indices...');
       currentTimeout = setTimeout(async () => {
         try {
           await Message.syncWithMeili();
@@ -75,7 +75,7 @@ async function indexSync(req, res, next) {
 }
 
 process.on('exit', () => {
-  logger.debug('[indexSync] Clearing sync timeouts before exiting...');
+  logger.debug('Clearing sync timeouts before exiting...');
   clearTimeout(currentTimeout);
 });
 

--- a/api/models/Balance.js
+++ b/api/models/Balance.js
@@ -16,7 +16,7 @@ balanceSchema.statics.check = async function ({
   const tokenCost = amount * multiplier;
   const { tokenCredits: balance } = (await this.findOne({ user }, 'tokenCredits').lean()) ?? {};
 
-  logger.debug('[Balance.check]', {
+  logger.debug({
     user,
     model,
     endpoint,
@@ -36,7 +36,7 @@ balanceSchema.statics.check = async function ({
     };
   }
 
-  logger.debug('[Balance.check]', { tokenCost });
+  logger.debug({ tokenCost });
 
   return { canSpend: balance >= tokenCost, balance, tokenCost };
 };

--- a/api/models/plugins/mongoMeili.js
+++ b/api/models/plugins/mongoMeili.js
@@ -66,7 +66,7 @@ const createMeiliMongooseModel = function ({ index, attributesToIndex }) {
           offset += batchSize;
         }
 
-        logger.debug('[syncWithMeili]', { indexMap: indexMap.size, mongoMap: mongoMap.size });
+        logger.debug({ indexMap: indexMap.size, mongoMap: mongoMap.size });
 
         const updateOps = [];
 

--- a/api/models/spendTokens.js
+++ b/api/models/spendTokens.js
@@ -41,7 +41,7 @@ const spendTokens = async (txData, tokenUsage) => {
     }
 
     if (!completionTokens) {
-      logger.debug('[spendTokens] !completionTokens', { prompt, completion });
+      logger.debug('!completionTokens', { prompt, completion });
       return;
     }
 
@@ -53,7 +53,7 @@ const spendTokens = async (txData, tokenUsage) => {
 
     prompt &&
       completion &&
-      logger.debug('[spendTokens] Transaction data record against balance:', {
+      logger.debug('Transaction data record against balance:', {
         user: prompt.user,
         prompt: prompt.prompt,
         promptRate: prompt.rate,

--- a/api/server/controllers/AskController.js
+++ b/api/server/controllers/AskController.js
@@ -15,7 +15,7 @@ const AskController = async (req, res, next, initializeClient, addTitle) => {
     overrideParentMessageId = null,
   } = req.body;
 
-  logger.debug('[AskController]', { text, conversationId, ...endpointOption });
+  logger.debug({ text, conversationId, ...endpointOption });
 
   let userMessage;
   let promptTokens;
@@ -84,7 +84,7 @@ const AskController = async (req, res, next, initializeClient, addTitle) => {
     const { abortController, onStart } = createAbortController(req, res, getAbortData);
 
     res.on('close', () => {
-      logger.debug('[AskController] Request closed');
+      logger.debug('Request closed');
       if (!abortController) {
         return;
       } else if (abortController.signal.aborted) {
@@ -94,7 +94,7 @@ const AskController = async (req, res, next, initializeClient, addTitle) => {
       }
 
       abortController.abort();
-      logger.debug('[AskController] Request aborted on close');
+      logger.debug('Request aborted on close');
     });
 
     const messageOptions = {

--- a/api/server/controllers/EditController.js
+++ b/api/server/controllers/EditController.js
@@ -18,7 +18,7 @@ const EditController = async (req, res, next, initializeClient) => {
     overrideParentMessageId = null,
   } = req.body;
 
-  logger.debug('[EditController]', {
+  logger.debug({
     text,
     generation,
     isContinued,
@@ -83,7 +83,7 @@ const EditController = async (req, res, next, initializeClient) => {
   const { abortController, onStart } = createAbortController(req, res, getAbortData);
 
   res.on('close', () => {
-    logger.debug('[EditController] Request closed');
+    logger.debug('Request closed');
     if (!abortController) {
       return;
     } else if (abortController.signal.aborted) {
@@ -93,7 +93,7 @@ const EditController = async (req, res, next, initializeClient) => {
     }
 
     abortController.abort();
-    logger.debug('[EditController] Request aborted on close');
+    logger.debug('Request aborted on close');
   });
 
   try {

--- a/api/server/middleware/abortRun.js
+++ b/api/server/middleware/abortRun.js
@@ -43,7 +43,7 @@ async function abortRun(req, res) {
   try {
     await cache.set(cacheKey, 'cancelled', three_minutes);
     const cancelledRun = await openai.beta.threads.runs.cancel(thread_id, run_id);
-    logger.debug('[abortRun] Cancelled run:', cancelledRun);
+    logger.debug('Cancelled run:', cancelledRun);
   } catch (error) {
     logger.error('[abortRun] Error cancelling run', error);
     if (

--- a/api/server/middleware/validateImageRequest.js
+++ b/api/server/middleware/validateImageRequest.js
@@ -32,7 +32,7 @@ function validateImageRequest(req, res, next) {
   }
 
   if (req.path.includes(payload.id)) {
-    logger.debug('[validateImageRequest] Image request validated');
+    logger.debug('Image request validated');
     next();
   } else {
     res.status(403).send('Access Denied');

--- a/api/server/routes/edit/gptPlugins.js
+++ b/api/server/routes/edit/gptPlugins.js
@@ -166,7 +166,7 @@ router.post(
         response.parentMessageId = overrideParentMessageId;
       }
 
-      logger.debug('[/edit/gptPlugins] CLIENT RESPONSE', response);
+      logger.debug('CLIENT RESPONSE', response);
       response.plugin = { ...plugin, loading: false };
       await saveMessage({ ...response, user });
 

--- a/api/server/routes/presets.js
+++ b/api/server/routes/presets.js
@@ -34,7 +34,7 @@ router.post('/delete', async (req, res) => {
     filter = { presetId };
   }
 
-  logger.debug('[/presets/delete] delete preset filter', filter);
+  logger.debug('delete preset filter', filter);
 
   try {
     const deleteCount = await deletePresets(req.user.id, filter);

--- a/api/server/routes/search.js
+++ b/api/server/routes/search.js
@@ -33,7 +33,7 @@ router.get('/', async function (req, res) {
     const key = `${user}:search:${q}`;
     const cached = await cache.get(key);
     if (cached) {
-      logger.debug('[/search] cache hit: ' + key);
+      logger.debug('cache hit: ' + key);
       const { pages, pageSize, messages } = cached;
       res
         .status(200)

--- a/api/server/services/Threads/manage.js
+++ b/api/server/services/Threads/manage.js
@@ -581,7 +581,7 @@ async function processMessages({ openai, client, messages = [] }) {
         continue;
       }
 
-      logger.debug('[processMessages] Processing annotations:', annotations);
+      logger.debug('Processing annotations:', annotations);
       for (const annotation of annotations) {
         let file;
         const type = annotation.type;

--- a/api/server/utils/sendEmail.js
+++ b/api/server/utils/sendEmail.js
@@ -63,7 +63,7 @@ const sendEmail = async (email, subject, payload, template) => {
         logger.error('[sendEmail]', error);
         return error;
       } else {
-        logger.debug('[sendEmail]', info);
+        logger.debug(info);
         return info;
       }
     });


### PR DESCRIPTION
## Summary

the main change is` api/config/winston.js`
1) **Automatically** add to log messages the **file name and the line number** of the logger source code.
2) File name and line nu are formatted so that  VS Code Terminal will detect it and make it **clickable**, to ease getting to the relevant **source code line** from the log.
Example:

> 2024-04-15 11:13:36 info: [./api/server/index.js:99] Server listening at http://localhost:3080

_[[./api/server/index.js:99]](https://github.com/danny-avila/LibreChat/blob/main/api/server/index.js#L99)_ is created automatically and when you click on it in VS Code on this part it will bring you to the line in the code that produced the message

Other less important changes:

3) **FIX BUG**: changed in /api/app/clients/PluginsClient.js from `logger.debug('sendMessage', { message, opts });` -> `logger.debug('sendMessage', { HumanMessage, opts });` 
since the message argument name is part of the logger system and causes this log instance to malfunction. 
in other words: Don't call logger.debug with message as one of the parameters 

> There might be more places where this is applicable, 

4) Most of the changes are removing the explicit filename from the logger.debug commands since it is now generated automatically and is not needed anymore. 


## Change Type

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)


## Testing

Mainly manual work, and fixing a test that failed.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [X] My changes do not introduce new warnings
- [X] Local unit tests pass with my changes

