### PR TITLE
🪙 fix(Google): Update `maxOutputTokens` Condition

### DIFF
--- a/client/src/components/Endpoints/Settings/Google.tsx
+++ b/client/src/components/Endpoints/Settings/Google.tsx
@@ -22,12 +22,12 @@ export default function Settings({ conversation, setOption, models, readonly }: 
   const { model, modelLabel, promptPrefix, temperature, topP, topK, maxOutputTokens } =
     conversation ?? {};
 
-  const isGeminiPro = model?.toLowerCase()?.includes('gemini-pro');
+  const isGemini = model?.toLowerCase()?.includes('gemini');
 
-  const maxOutputTokensMax = isGeminiPro
+  const maxOutputTokensMax = isGemini
     ? google.maxOutputTokens.maxGeminiPro
     : google.maxOutputTokens.max;
-  const maxOutputTokensDefault = isGeminiPro
+  const maxOutputTokensDefault = isGemini
     ? google.maxOutputTokens.defaultGeminiPro
     : google.maxOutputTokens.default;
 


### PR DESCRIPTION
## Summary

The frontend condition for determining which max value to use was checking for 'gemini-pro' when it should be more generally as 'gemini'

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] New documents have been locally validated with mkdocs
