### PR TITLE
🛠️ fix: Ensure `imageOutputType` is Always Defined

### DIFF
--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -36,6 +36,7 @@ const AppService = async (app) => {
   const config = (await loadCustomConfig()) ?? {};
 
   const fileStrategy = config.fileStrategy ?? FileSources.local;
+  const imageOutputType = config?.imageOutputType ?? EImageOutputType.PNG;
   process.env.CDN_PROVIDER = fileStrategy;
 
   if (fileStrategy === FileSources.firebase) {
@@ -58,9 +59,10 @@ const AppService = async (app) => {
 
   if (!Object.keys(config).length) {
     app.locals = {
-      availableTools,
       fileStrategy,
       socialLogins,
+      availableTools,
+      imageOutputType,
       paths,
     };
 
@@ -177,12 +179,12 @@ const AppService = async (app) => {
 
   app.locals = {
     socialLogins,
-    availableTools,
     fileStrategy,
+    availableTools,
+    imageOutputType,
     fileConfig: config?.fileConfig,
     interface: config?.interface,
     secureImageLinks: config?.secureImageLinks,
-    imageOutputType: config?.imageOutputType ?? EImageOutputType.PNG,
     paths,
     ...endpointLocals,
   };

--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -182,7 +182,7 @@ const AppService = async (app) => {
     fileConfig: config?.fileConfig,
     interface: config?.interface,
     secureImageLinks: config?.secureImageLinks,
-    imageOutputType: config?.imageOutputType?.toLowerCase() ?? EImageOutputType.PNG,
+    imageOutputType: config?.imageOutputType ?? EImageOutputType.PNG,
     paths,
     ...endpointLocals,
   };

--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -139,7 +139,6 @@ describe('AppService', () => {
     );
 
     await AppService(app);
-
     expect(app.locals.imageOutputType).toEqual(EImageOutputType.WEBP);
   });
 
@@ -151,7 +150,15 @@ describe('AppService', () => {
     );
 
     await AppService(app);
+    expect(app.locals.imageOutputType).toEqual(EImageOutputType.PNG);
+  });
 
+  it('should default to `PNG` `imageOutputType` with no provided config', async () => {
+    require('./Config/loadCustomConfig').mockImplementationOnce(() =>
+      Promise.resolve(undefined),
+    );
+
+    await AppService(app);
     expect(app.locals.imageOutputType).toEqual(EImageOutputType.PNG);
   });
 

--- a/api/server/services/Files/images/avatar.js
+++ b/api/server/services/Files/images/avatar.js
@@ -20,7 +20,7 @@ const { logger } = require('~/config');
  * @throws {Error} Throws an error if the user ID is undefined, the input type is invalid, the image fetching fails,
  *                 or any other error occurs during the processing.
  */
-async function resizeAvatar({ userId, input, desiredFormat }) {
+async function resizeAvatar({ userId, input, desiredFormat = 'png' }) {
   try {
     if (userId === undefined) {
       throw new Error('User ID is undefined');

--- a/api/server/services/Files/images/avatar.js
+++ b/api/server/services/Files/images/avatar.js
@@ -1,6 +1,7 @@
 const sharp = require('sharp');
 const fs = require('fs').promises;
 const fetch = require('node-fetch');
+const { EImageOutputType } = require('librechat-data-provider');
 const { resizeAndConvert } = require('./resize');
 const { logger } = require('~/config');
 
@@ -20,7 +21,7 @@ const { logger } = require('~/config');
  * @throws {Error} Throws an error if the user ID is undefined, the input type is invalid, the image fetching fails,
  *                 or any other error occurs during the processing.
  */
-async function resizeAvatar({ userId, input, desiredFormat = 'png' }) {
+async function resizeAvatar({ userId, input, desiredFormat = EImageOutputType.PNG }) {
   try {
     if (userId === undefined) {
       throw new Error('User ID is undefined');


### PR DESCRIPTION


## Summary
`imageOutputType` was undefined in some cases, causing image uploads to fail. To address this issue, I have added the proper default value handling for `imageOutputType` within the image processing function.

This was only happening when an instance doesn't make use of the `librechat.yaml` file.

Closes #2435 

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes