### PR TITLE
🛠️ fix: Merge Textarea Ref with Form for Simplified Handling

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -33,7 +33,6 @@ const ChatForm = ({ index = 0 }) => {
     textAreaRef,
     submitButtonRef,
     disabled: !!requiresKey,
-    setValue: methods.setValue,
   });
 
   const {
@@ -56,9 +55,6 @@ const ChatForm = ({ index = 0 }) => {
       }
       ask({ text: data.text });
       methods.reset();
-      if (textAreaRef.current) {
-        textAreaRef.current.value = '';
-      }
     },
     [ask, methods],
   );

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -29,14 +29,12 @@ const ChatForm = ({ index = 0 }) => {
     defaultValues: { text: '' },
   });
 
-  const { handlePaste, handleKeyUp, handleKeyDown, handleCompositionStart, handleCompositionEnd } =
-    useTextarea({
-      textAreaRef,
-      submitButtonRef,
-      disabled: !!requiresKey,
-      setValue: methods.setValue,
-      getValues: methods.getValues,
-    });
+  const { handlePaste, handleKeyDown, handleCompositionStart, handleCompositionEnd } = useTextarea({
+    textAreaRef,
+    submitButtonRef,
+    disabled: !!requiresKey,
+    setValue: methods.setValue,
+  });
 
   const {
     ask,
@@ -84,6 +82,13 @@ const ChatForm = ({ index = 0 }) => {
     [requiresKey, invalidAssistant],
   );
 
+  const { ref, ...registerProps } = methods.register('text', {
+    required: true,
+    onChange: (e) => {
+      methods.setValue('text', e.target.value);
+    },
+  });
+
   return (
     <form
       onSubmit={methods.handleSubmit((data) => submitMessage(data))}
@@ -104,19 +109,14 @@ const ChatForm = ({ index = 0 }) => {
             />
             {endpoint && (
               <TextareaAutosize
-                {...methods.register('text', {
-                  required: true,
-                  onChange: (e) => {
-                    methods.setValue('text', e.target.value);
-                  },
-                })}
+                {...registerProps}
                 autoFocus
                 ref={(e) => {
+                  ref(e);
                   textAreaRef.current = e;
                 }}
                 disabled={disableInputs}
                 onPaste={handlePaste}
-                onKeyUp={handleKeyUp}
                 onKeyDown={handleKeyDown}
                 onCompositionStart={handleCompositionStart}
                 onCompositionEnd={handleCompositionEnd}


### PR DESCRIPTION
## Summary

I've made a crucial fix by removing custom textarea event handlers and merging the Textarea ref with the form as prescribed by the react-hook-form documentation. This resolves issues that arose from not merging the ref correctly, which previously led to the implementation of unnecessary custom handlers.

https://www.react-hook-form.com/faqs/#Howtosharerefusage

Tested on both firefox and chrome.

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes