### PR TITLE
fix: Correct max context lengths for together.ai chat models

### DIFF
--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -94,7 +94,59 @@ const anthropicModels = {
   'claude-3-opus': 200000,
 };
 
-const aggregateModels = { ...openAIModels, ...googleModels, ...anthropicModels, ...cohereModels };
+const togetherAIModels = {
+  // models with context sizes != 4096 are included in this list
+  // as that is the default max context size
+  // https://docs.together.ai/docs/inference-models
+  'allenai/OLMo-7B-Instruct': 2038,
+  'allenai/OLMo-7B-Twin-2T': 2038,
+  'allenai/OLMo-7B': 2038,
+  'Austism/chronos-hermes-13b': 2038,
+  'cognitivecomputations/dolphin-2.5-mixtral-8x7b': 32758,
+  'databricks/dbrx-instruct': 32758,
+  'deepseek-ai/deepseek-coder-33b-instruct': 16374,
+  'google/gemma-2b-it': 8182,
+  'google/gemma-7b-it': 8182,
+  'codellama/CodeLlama-13b-Instruct-hf': 16374,
+  'codellama/CodeLlama-34b-Instruct-hf': 16374,
+  'codellama/CodeLlama-7b-Instruct-hf': 16374,
+  'meta-llama/Llama-3-8b-chat-hf': 7990,
+  'meta-llama/Llama-3-70b-chat-hf': 7990,
+  'microsoft/WizardLM-2-8x22B': 65526,
+  'mistralai/Mistral-7B-Instruct-v0.1': 8182,
+  'mistralai/Mistral-7B-Instruct-v0.2': 32758,
+  'mistralai/Mixtral-8x7B-Instruct-v0.1': 32758,
+  'mistralai/Mixtral-8x22B-Instruct-v0.1': 65526,
+  'NousResearch/Nous-Capybara-7B-V1p9': 8182,
+  'NousResearch/Nous-Hermes-2-Mistral-7B-DPO': 32758,
+  'NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO': 32758,
+  'NousResearch/Nous-Hermes-2-Mixtral-8x7B-SFT': 32758,
+  'openchat/openchat-3.5-1210': 8182,
+  'Open-Orca/Mistral-7B-OpenOrca': 8182,
+  'Qwen/Qwen1.5-0.5B-Chat': 32758,
+  'Qwen/Qwen1.5-1.8B-Chat': 32758,
+  'Qwen/Qwen1.5-4B-Chat': 32758,
+  'Qwen/Qwen1.5-7B-Chat': 32758,
+  'Qwen/Qwen1.5-14B-Chat': 32758,
+  'Qwen/Qwen1.5-32B-Chat': 32758,
+  'Qwen/Qwen1.5-72B-Chat': 32758,
+  'snorkelai/Snorkel-Mistral-PairRM-DPO': 32758,
+  'togethercomputer/alpaca-7b': 2038,
+  'teknium/OpenHermes-2-Mistral-7B': 8182,
+  'teknium/OpenHermes-2p5-Mistral-7B': 8182,
+  'togethercomputer/Llama-2-7B-32K-Instruct': 32758,
+  'togethercomputer/RedPajama-INCITE-Chat-3B-v1': 2038,
+  'togethercomputer/RedPajama-INCITE-7B-Chat': 2038,
+  'togethercomputer/StripedHyena-Nous-7B': 32758,
+};
+
+const aggregateModels = {
+  ...openAIModels,
+  ...googleModels,
+  ...anthropicModels,
+  ...cohereModels,
+  ...togetherAIModels,
+};
 
 // Order is important here: by model series and context size (gpt-4 then gpt-3, ascending)
 const maxTokensMap = {


### PR DESCRIPTION
# Pull Request Template

## Summary

Models from together.ai defaulted to 4095 as the default context length due to naming format.  This patch fixes that by providing the correct max token context lengths.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

All unit tests pass.  I tested this with a long context (12000 token) with `mistralai/Mixtral-8x22B-Instruct-v0.1` on calling together.ai (custom endpoint) and it works as expected.  Previously an error would occur. 

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] Local unit tests pass with my changes
