### PR TITLE
🤖 fix: Minor Assistants Endpoint Fixes

### DIFF
--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -5,8 +5,8 @@ const {
   defaultSocialLogins,
 } = require('librechat-data-provider');
 const { checkVariables, checkHealth, checkConfig, checkAzureVariables } = require('./start/checks');
+const { azureAssistantsDefaults, assistantsConfigSetup } = require('./start/assistants');
 const { initializeFirebase } = require('./Files/Firebase/initialize');
-const { assistantsConfigSetup } = require('./start/assistants');
 const loadCustomConfig = require('./Config/loadCustomConfig');
 const handleRateLimits = require('./Config/handleRateLimits');
 const { azureConfigSetup } = require('./start/azureOpenAI');
@@ -70,8 +70,15 @@ const AppService = async (app) => {
     checkAzureVariables();
   }
 
+  if (config?.endpoints?.[EModelEndpoint.azureOpenAI]?.assistants) {
+    endpointLocals[EModelEndpoint.assistants] = azureAssistantsDefaults();
+  }
+
   if (config?.endpoints?.[EModelEndpoint.assistants]) {
-    endpointLocals[EModelEndpoint.assistants] = assistantsConfigSetup(config);
+    endpointLocals[EModelEndpoint.assistants] = assistantsConfigSetup(
+      config,
+      endpointLocals[EModelEndpoint.assistants],
+    );
   }
 
   app.locals = {

--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -154,9 +154,7 @@ describe('AppService', () => {
   });
 
   it('should default to `PNG` `imageOutputType` with no provided config', async () => {
-    require('./Config/loadCustomConfig').mockImplementationOnce(() =>
-      Promise.resolve(undefined),
-    );
+    require('./Config/loadCustomConfig').mockImplementationOnce(() => Promise.resolve(undefined));
 
     await AppService(app);
     expect(app.locals.imageOutputType).toEqual(EImageOutputType.PNG);
@@ -228,6 +226,27 @@ describe('AppService', () => {
         supportedIds: expect.arrayContaining(['id1', 'id2']),
       }),
     );
+  });
+
+  it('should correctly configure minimum Azure OpenAI Assistant values', async () => {
+    const assistantGroups = [azureGroups[0], { ...azureGroups[1], assistants: true }];
+    require('./Config/loadCustomConfig').mockImplementationOnce(() =>
+      Promise.resolve({
+        endpoints: {
+          [EModelEndpoint.azureOpenAI]: {
+            groups: assistantGroups,
+            assistants: true,
+          },
+        },
+      }),
+    );
+
+    process.env.WESTUS_API_KEY = 'westus-key';
+    process.env.EASTUS_API_KEY = 'eastus-key';
+
+    await AppService(app);
+    expect(app.locals).toHaveProperty(EModelEndpoint.assistants);
+    expect(app.locals[EModelEndpoint.assistants].capabilities.length).toEqual(3);
   });
 
   it('should correctly configure Azure OpenAI endpoint based on custom config', async () => {

--- a/api/server/services/start/assistants.js
+++ b/api/server/services/start/assistants.js
@@ -6,11 +6,23 @@ const {
 const { logger } = require('~/config');
 
 /**
- * Sets up the Assistants configuration from the config (`librechat.yaml`) file.
- * @param {TCustomConfig} config - The loaded custom configuration.
+ * Sets up the minimum, default Assistants configuration if Azure OpenAI Assistants option is enabled.
  * @returns {Partial<TAssistantEndpoint>} The Assistants endpoint configuration.
  */
-function assistantsConfigSetup(config) {
+function azureAssistantsDefaults() {
+  return {
+    capabilities: [Capabilities.tools, Capabilities.actions, Capabilities.code_interpreter],
+  };
+}
+
+/**
+ * Sets up the Assistants configuration from the config (`librechat.yaml`) file.
+ * @param {TCustomConfig} config - The loaded custom configuration.
+ * @param {Partial<TAssistantEndpoint>} [prevConfig]
+ * - The previously loaded assistants configuration from Azure OpenAI Assistants option.
+ * @returns {Partial<TAssistantEndpoint>} The Assistants endpoint configuration.
+ */
+function assistantsConfigSetup(config, prevConfig = {}) {
   const assistantsConfig = config.endpoints[EModelEndpoint.assistants];
   const parsedConfig = assistantEndpointSchema.parse(assistantsConfig);
   if (assistantsConfig.supportedIds?.length && assistantsConfig.excludedIds?.length) {
@@ -18,12 +30,6 @@ function assistantsConfigSetup(config) {
       `Both \`supportedIds\` and \`excludedIds\` are defined for the ${EModelEndpoint.assistants} endpoint; \`excludedIds\` field will be ignored.`,
     );
   }
-
-  const prevConfig = config.endpoints[EModelEndpoint.azureOpenAI]?.assistants
-    ? {
-      capabilities: [Capabilities.tools, Capabilities.actions, Capabilities.code_interpreter],
-    }
-    : {};
 
   return {
     ...prevConfig,
@@ -37,4 +43,4 @@ function assistantsConfigSetup(config) {
   };
 }
 
-module.exports = { assistantsConfigSetup };
+module.exports = { azureAssistantsDefaults, assistantsConfigSetup };

--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -315,8 +315,7 @@ export const useCreateAssistantMutation = (
           return options?.onSuccess?.(newAssistant, variables, context);
         }
 
-        const currentAssistants = listRes.data;
-        currentAssistants.push(newAssistant);
+        const currentAssistants = [newAssistant, ...JSON.parse(JSON.stringify(listRes.data))];
 
         queryClient.setQueryData<AssistantListResponse>([QueryKeys.assistants, defaultOrderQuery], {
           ...listRes,


### PR DESCRIPTION
## Summary

- Made sure that default values for azure openai assistant capabilities are loaded if no assistants config is provided.
     - added a new test for this case
- Also fixed a frontend issue where mutating cached objects would cause context data not to be updated in several parts of the app (assistants map context)

## Change Type

- [x] Refactor


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] New documents have been locally validated with mkdocs