### PR TITLE
👤 fix: Use `user?.username` if `user?.name` is undefined

### DIFF
--- a/client/src/components/Chat/Messages/Message.tsx
+++ b/client/src/components/Chat/Messages/Message.tsx
@@ -42,7 +42,7 @@ export default function Message(props: TMessageProps) {
 
   let messageLabel = '';
   if (isCreatedByUser) {
-    messageLabel = UsernameDisplay ? user?.name : localize('com_user_message');
+    messageLabel = UsernameDisplay ? user?.name || user?.username : localize('com_user_message');
   } else {
     messageLabel = message.sender;
   }

--- a/client/src/components/Endpoints/Icon.tsx
+++ b/client/src/components/Endpoints/Icon.tsx
@@ -33,7 +33,7 @@ const Icon: React.FC<IconProps> = (props) => {
   const avatarSrc = useAvatar(user);
 
   if (isCreatedByUser) {
-    const username = user?.name || 'User';
+    const username = user?.name || user?.username || 'User';
 
     return (
       <div

--- a/client/src/components/Endpoints/Icon.tsx
+++ b/client/src/components/Endpoints/Icon.tsx
@@ -14,6 +14,7 @@ import {
 } from '~/components/svg';
 import { useAuthContext } from '~/hooks/AuthContext';
 import useAvatar from '~/hooks/Messages/useAvatar';
+import useLocalize from '~/hooks/useLocalize';
 import { IconProps } from '~/common';
 import { cn } from '~/utils';
 
@@ -31,9 +32,10 @@ const Icon: React.FC<IconProps> = (props) => {
   } = props;
 
   const avatarSrc = useAvatar(user);
+  const localize = useLocalize();
 
   if (isCreatedByUser) {
-    const username = user?.name || user?.username || 'User';
+    const username = user?.name || user?.username || localize('com_nav_user');
 
     return (
       <div

--- a/client/src/components/Nav/NavLinks.tsx
+++ b/client/src/components/Nav/NavLinks.tsx
@@ -96,7 +96,7 @@ function NavLinks() {
                 className="mt-2 grow overflow-hidden text-ellipsis whitespace-nowrap text-left text-black dark:text-white"
                 style={{ marginTop: '0', marginLeft: '0' }}
               >
-                {user?.name || localize('com_nav_user')}
+                {user?.name || user?.username || localize('com_nav_user')}
               </div>
             </Menu.Button>
 


### PR DESCRIPTION
## Summary
This PR is a patch to show names to users who don't have a `user?.name` but have a `user?.username`. I encountered this issue using Github SSO for [my account](https://github.com/ilsubyeega). 

This issue might need a patch in the future to fill `username` to `name` property in server-side SSO integration


## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update
- [ ] Documentation update


## Testing

I've tested messages and navlinks, but icon (i have no idea how to create it now).
## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] New documents have been locally validated with mkdocs
