### PR TITLE
🛂 feat(oauth): add domain restriction on social login

### DIFF
--- a/api/server/middleware/checkDomainAllowed.js
+++ b/api/server/middleware/checkDomainAllowed.js
@@ -1,0 +1,25 @@
+const { isDomainAllowed } = require('~/server/services/AuthService');
+const { logger } = require('~/config');
+
+/**
+ * Checks the domain's social login is allowed
+ *
+ * @async
+ * @function
+ * @param {Object} req - Express request object.
+ * @param {Object} res - Express response object.
+ * @param {Function} next - Next middleware function.
+ *
+ * @returns {Promise<function|Object>} - Returns a Promise which when resolved calls next middleware if the domain's email is allowed
+ */
+const checkDomainAllowed = async (req, res, next = () => {}) => {
+  const email = req?.user?.email;
+  if (email && !(await isDomainAllowed(email))) {
+    logger.error(`[Social Login] [Social Login not allowed] [Email: ${email}]`);
+    return res.redirect('/login');
+  } else {
+    return next();
+  }
+};
+
+module.exports = checkDomainAllowed;

--- a/api/server/middleware/index.js
+++ b/api/server/middleware/index.js
@@ -1,5 +1,6 @@
 const abortMiddleware = require('./abortMiddleware');
 const checkBan = require('./checkBan');
+const checkDomainAllowed = require('./checkDomainAllowed');
 const uaParser = require('./uaParser');
 const setHeaders = require('./setHeaders');
 const loginLimiter = require('./loginLimiter');
@@ -38,4 +39,5 @@ module.exports = {
   validateModel,
   moderateText,
   noIndex,
+  checkDomainAllowed,
 };

--- a/api/server/routes/oauth.js
+++ b/api/server/routes/oauth.js
@@ -4,7 +4,7 @@ const passport = require('passport');
 const express = require('express');
 const router = express.Router();
 const { setAuthTokens } = require('~/server/services/AuthService');
-const { loginLimiter, checkBan } = require('~/server/middleware');
+const { loginLimiter, checkBan, checkDomainAllowed } = require('~/server/middleware');
 const { logger } = require('~/config');
 
 const domains = {
@@ -16,6 +16,7 @@ router.use(loginLimiter);
 
 const oauthHandler = async (req, res) => {
   try {
+    await checkDomainAllowed(req, res);
     await checkBan(req, res);
     if (req.banned) {
       return;


### PR DESCRIPTION
# Pull Request Template


### ⚠️ Before Submitting a PR, read the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) in full!

## Summary

This feature aims to add the domain validation in the social login process. So far, the domain validation was only used during the login/password registration process.

## Change Type

Please delete any irrelevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)


## Testing

Add a domain in the config file under the key `registration.allowedDomains` and try to social log in with a domain name not allowed.
 
### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
- [X] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] New documents have been locally validated with mkdocs
