### PR TITLE
📋 refactor: allow paste in confirm field when resetting passwords

### DIFF
--- a/client/src/components/Auth/ResetPassword.tsx
+++ b/client/src/components/Auth/ResetPassword.tsx
@@ -140,10 +140,10 @@ function ResetPassword() {
                   id="confirm_password"
                   aria-label={localize('com_auth_password_confirm')}
                   // uncomment to prevent pasting in confirm field
-                  onPaste={(e) => {
-                    e.preventDefault();
-                    return false;
-                  }}
+                  //onPaste={(e) => {
+                  //  e.preventDefault();
+                  //  return false;
+                  //}}
                   {...register('confirm_password', {
                     validate: (value) =>
                       value === password || localize('com_auth_password_not_match'),

--- a/client/src/components/Auth/ResetPassword.tsx
+++ b/client/src/components/Auth/ResetPassword.tsx
@@ -139,11 +139,6 @@ function ResetPassword() {
                   type="password"
                   id="confirm_password"
                   aria-label={localize('com_auth_password_confirm')}
-                  // uncomment to prevent pasting in confirm field
-                  //onPaste={(e) => {
-                  //  e.preventDefault();
-                  //  return false;
-                  //}}
                   {...register('confirm_password', {
                     validate: (value) =>
                       value === password || localize('com_auth_password_not_match'),


### PR DESCRIPTION
## Summary

I've simply commented out the section where paste prevention is defined. Not allowing users to paste passwords makes it harder to use long passwords from password managers that are not browser plugins (e.g. keepass). NIST says it better than me,

NIST SP 800-53B, Section 5.1.1.2, Paragraph 10

> Verifiers SHOULD permit claimants to use “paste” functionality when entering a memorized secret. This facilitates the use of password managers, which are widely used and in many cases increase the likelihood that users will choose stronger memorized secrets.

https://pages.nist.gov/800-63-3/sp800-63b.html

## Change Type

- [x] New feature (non-breaking change which adds functionality)


## Testing

In the `deploy-compose.yml` file, change the `api` service to build a image locally rather than pulling `ghcr.io/danny-avila/librechat-dev-api:latest`.
Start the containers, ask to reset the password of your user, click the link in the mail you get,  and try to paste your password into both fields. Previously you could only paste into the "Password" field, and not the "Confirm password" field.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] New documents have been locally validated with mkdocs
