### PR TITLE
👩‍💻 fix: Minor UI fixes

### DIFF
--- a/client/src/components/SidePanel/AssistantSwitcher.tsx
+++ b/client/src/components/SidePanel/AssistantSwitcher.tsx
@@ -27,6 +27,7 @@ export default function AssistantSwitcher({ isCollapsed }: SwitcherProps) {
       const assistant_id =
         localStorage.getItem(`assistant_id__${index}`) ?? assistants[0]?.id ?? '';
       const assistant = assistantMap?.[assistant_id];
+
       if (!assistant) {
         return;
       }
@@ -34,6 +35,7 @@ export default function AssistantSwitcher({ isCollapsed }: SwitcherProps) {
       if (endpoint !== EModelEndpoint.assistants) {
         return;
       }
+
       setOption('model')(assistant.model);
       setOption('assistant_id')(assistant_id);
     }

--- a/client/src/hooks/Messages/useMessageHelpers.ts
+++ b/client/src/hooks/Messages/useMessageHelpers.ts
@@ -62,11 +62,12 @@ export default function useMessageHelpers(props: TMessageProps) {
   const assistant =
     conversation?.endpoint === EModelEndpoint.assistants && assistantMap?.[message?.model ?? ''];
 
+  const iconEndpoint = message?.endpoint ?? conversation?.endpoint;
   const icon = Icon({
     ...conversation,
     ...(message as TMessage),
     iconURL: !assistant
-      ? getEndpointField(endpointsConfig, conversation?.endpoint, 'iconURL')
+      ? getEndpointField(endpointsConfig, iconEndpoint, 'iconURL')
       : (assistant?.metadata?.avatar as string | undefined) ?? '',
     model: message?.model ?? conversation?.model,
     assistantName: assistant ? (assistant.name as string | undefined) : '',

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -58,7 +58,7 @@ export default function ChatRoute() {
         modelsData: modelsQuery.data,
         template: conversation ? conversation : undefined,
       });
-      hasSetConversation.current = !!assistants;
+      hasSetConversation.current = true;
     } else if (
       initialConvoQuery.data &&
       endpointsQuery.data &&
@@ -73,7 +73,7 @@ export default function ChatRoute() {
         modelsData: modelsQuery.data,
         keepLatestMessage: true,
       });
-      hasSetConversation.current = !!assistants;
+      hasSetConversation.current = true;
     } else if (
       !hasSetConversation.current &&
       !modelsQuery.data?.initial &&


### PR DESCRIPTION
## Summary

Prevent issue where UI will unexpectedly fire a new conversation when switching endpoints on initial load. 

Was previously addressed by https://github.com/danny-avila/LibreChat/pull/2536 but the fix here only works when the "beta" modular endpoints feature is disabled. This new way reverts the Route handling to its original design, where `newConversation` only fires once.

The AssistantSwitcher is reliably making sure that the assistant_id is defined, and message submission is disabled without a valid assistant_id, so it's safe to rely on AssistantSwitcher's "after-effect"

Also fixed a bug where switching to an endpoint with a defined iconURL would change all previous messages' icons. This was not intended and was easily remedied by defining an "iconEndpoint"

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] New documents have been locally validated with mkdocs
