### PR TITLE
🔧 fix: Drop openai version to fix API.Batches is not a constructor error

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -74,7 +74,7 @@
     "multer": "^1.4.5-lts.1",
     "nodejs-gpt": "^1.37.4",
     "nodemailer": "^6.9.4",
-    "openai": "4.36.0",
+    "openai": "^4.29.0",
     "openai-chat-tokens": "^0.2.8",
     "openid-client": "^5.4.2",
     "passport": "^0.6.0",


### PR DESCRIPTION
## Summary

This pull request addresses an issue where `API.Batches` was not being recognized as a constructor in some API endpoints. The root cause was identified as a compatibility problem with the OpenAI SDK version `4.36.0`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

