### PR TITLE
🦙 feat: Fetch list of Ollama Models

### DIFF
--- a/api/typedefs.js
+++ b/api/typedefs.js
@@ -7,6 +7,11 @@
  * @typedef {import('openai').OpenAI} OpenAI
  * @memberof typedefs
  */
+/**
+ * @exports AxiosResponse
+ * @typedef {import('axios').AxiosResponse} AxiosResponse
+ * @memberof typedefs
+ */
 
 /**
  * @exports Anthropic
@@ -1143,5 +1148,33 @@
  * @param {object} params
  * @param {CohereChatStreamRequest | CohereChatRequest} params.payload
  * @param {onTokenProgress} params.onTokenProgress
+ * @memberof typedefs
+ */
+
+/**
+ * @typedef {Object} OllamaModelDetails
+ * @property {string} parent_model - The identifier for the parent model, if any.
+ * @property {string} format - The format of the model.
+ * @property {string} family - The primary family to which the model belongs.
+ * @property {string[]} families - An array of families that include the model.
+ * @property {string} parameter_size - The size of the parameters of the model.
+ * @property {string} quantization_level - The level of quantization of the model.
+ * @memberof typedefs
+ */
+
+/**
+ * @typedef {Object} OllamaModel
+ * @property {string} name - The name of the model, including version tag.
+ * @property {string} model - A redundant copy of the name, including version tag.
+ * @property {string} modified_at - The ISO string representing the last modification date.
+ * @property {number} size - The size of the model in bytes.
+ * @property {string} digest - The digest hash of the model.
+ * @property {OllamaModelDetails} details - Detailed information about the model.
+ * @memberof typedefs
+ */
+
+/**
+ * @typedef {Object} OllamaListResponse
+ * @property {OllamaModel[]} models - the list of models available.
  * @memberof typedefs
  */

--- a/client/src/components/ui/Tag.tsx
+++ b/client/src/components/ui/Tag.tsx
@@ -15,7 +15,7 @@ const TagPrimitiveRoot = React.forwardRef<HTMLDivElement, TagProps>(
       ref={ref}
       {...props}
       className={cn(
-        'flex max-h-8 items-center overflow-y-hidden rounded rounded-3xl border-2 border-green-600 bg-green-600/20 text-sm text-xs text-white',
+        'flex max-h-8 items-center overflow-y-hidden rounded rounded-3xl border-2 border-green-600 bg-green-600/20 text-sm text-xs text-green-600 dark:text-white',
         className,
       )}
     >

--- a/docs/install/configuration/ai_endpoints.md
+++ b/docs/install/configuration/ai_endpoints.md
@@ -288,7 +288,6 @@ Some of the endpoints are marked as **Known,** which means they might have speci
 **Notes:**
 
 - **Known:** icon provided.
-- **Known issue:** fetching list of models is not supported. See [Pull Request 2728](https://github.com/ollama/ollama/pull/2728).
 - Download models with ollama run command. See [Ollama Library](https://ollama.com/library)
 - It's recommend to use the value "current_model" for the `titleModel` to avoid loading more than 1 model per conversation.
     - Doing so will dynamically use the current conversation model for the title generation.
@@ -307,7 +306,9 @@ Some of the endpoints are marked as **Known,** which means they might have speci
           "dolphin-mixtral",
           "mistral-openorca"
           ]
-        fetch: false # fetching list of models is not supported
+      # fetching list of models is supported but the `name` field must start
+      # with `ollama` (case-insensitive), as it does in this example.
+        fetch: true
       titleConvo: true
       titleModel: "current_model"
       summarize: false


### PR DESCRIPTION
## Summary

Now handles fetching of ollama models natively. Since it's not OpenAI-spec, the application will only do this if the name of the custom endpoint begins with `ollama` (case-insensitive).

Note: If you are not using Ollama directly, and instead, through some aggregator or reverse proxy that handles fetching already via OpenAI spec, ensure the name of the endpoint doesn't start with `ollama` (case-insensitive).

### Other changes

Better styling of stop sequences for light mode:

#### before
![image](https://github.com/danny-avila/LibreChat/assets/110412045/8bf7c210-272e-4ac5-9e5c-8f429136c86e)

#### after
![image](https://github.com/danny-avila/LibreChat/assets/110412045/14d5b6b1-a48d-4156-82d0-c4eadaa22593)


## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Added new tests for ModelService testing new ollama-specific behavior

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] New documents have been locally validated with mkdocs
