### PR TITLE
🤖 feat(google): Add safety settings configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,20 @@ GOOGLE_KEY=user_provided
 # Vertex AI
 # GOOGLE_MODELS=gemini-1.5-pro-preview-0409,gemini-1.0-pro-vision-001,gemini-pro,gemini-pro-vision,chat-bison,chat-bison-32k,codechat-bison,codechat-bison-32k,text-bison,text-bison-32k,text-unicorn,code-gecko,code-bison,code-bison-32k
 
+# Google Gemini Safety Settings
+# NOTE (Vertex AI): You do not have access to the BLOCK_NONE setting by default.
+# To use this restricted HarmBlockThreshold setting, you will need to either:
+#
+# (a) Get access through an allowlist via your Google account team
+# (b) Switch your account type to monthly invoiced billing following this instruction:
+#     https://cloud.google.com/billing/docs/how-to/invoiced-billing
+#
+# GOOGLE_SAFETY_SEXUALLY_EXPLICIT=BLOCK_ONLY_HIGH
+# GOOGLE_SAFETY_HATE_SPEECH=BLOCK_ONLY_HIGH
+# GOOGLE_SAFETY_HARASSMENT=BLOCK_ONLY_HIGH
+# GOOGLE_SAFETY_DANGEROUS_CONTENT=BLOCK_ONLY_HIGH
+
+
 #============#
 # OpenAI     #
 #============#

--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -29,13 +29,6 @@ const tokenizersCache = {};
 
 const settings = endpointSettings[EModelEndpoint.google];
 
-require('dotenv').config();
-
-let GOOGLE_SAFETY_SEXUALLY_EXPLICIT = process.env.GOOGLE_SAFETY_SEXUALLY_EXPLICIT || 'HARM_BLOCK_THRESHOLD_UNSPECIFIED';
-let GOOGLE_SAFETY_HATE_SPEECH = process.env.GOOGLE_SAFETY_HATE_SPEECH || 'HARM_BLOCK_THRESHOLD_UNSPECIFIED';
-let GOOGLE_SAFETY_HARASSMENT = process.env.GOOGLE_SAFETY_HARASSMENT || 'HARM_BLOCK_THRESHOLD_UNSPECIFIED';
-let GOOGLE_SAFETY_DANGEROUS_CONTENT = process.env.GOOGLE_SAFETY_DANGEROUS_CONTENT || 'HARM_BLOCK_THRESHOLD_UNSPECIFIED';
-
 class GoogleClient extends BaseClient {
   constructor(credentials, options = {}) {
     super('apiKey', options);
@@ -735,6 +728,10 @@ class GoogleClient extends BaseClient {
     const modelName = payload.parameters?.model;
   
     if (modelName && modelName.toLowerCase().includes('gemini')) {
+      const GOOGLE_SAFETY_SEXUALLY_EXPLICIT = process.env.GOOGLE_SAFETY_SEXUALLY_EXPLICIT || 'HARM_BLOCK_THRESHOLD_UNSPECIFIED';
+      const GOOGLE_SAFETY_HATE_SPEECH = process.env.GOOGLE_SAFETY_HATE_SPEECH || 'HARM_BLOCK_THRESHOLD_UNSPECIFIED';
+      const GOOGLE_SAFETY_HARASSMENT = process.env.GOOGLE_SAFETY_HARASSMENT || 'HARM_BLOCK_THRESHOLD_UNSPECIFIED';
+      const GOOGLE_SAFETY_DANGEROUS_CONTENT = process.env.GOOGLE_SAFETY_DANGEROUS_CONTENT || 'HARM_BLOCK_THRESHOLD_UNSPECIFIED';
       const safetySettings = [
         {
           category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',

--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -732,26 +732,30 @@ class GoogleClient extends BaseClient {
   }
 
   async sendCompletion(payload, opts = {}) {
-    let safetySettings = [
-      {
-        category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-        threshold: GOOGLE_SAFETY_SEXUALLY_EXPLICIT,
-      },
-      {
-        category: 'HARM_CATEGORY_HATE_SPEECH',
-        threshold: GOOGLE_SAFETY_HATE_SPEECH,
-      },
-      {
-        category: 'HARM_CATEGORY_HARASSMENT',
-        threshold: GOOGLE_SAFETY_HARASSMENT,
-      },
-      {
-        category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
-        threshold: GOOGLE_SAFETY_DANGEROUS_CONTENT,
-      },
-    ];
+    const modelName = payload.parameters?.model;
   
-    payload.safetySettings = safetySettings;
+    if (modelName && modelName.toLowerCase().includes('gemini')) {
+      const safetySettings = [
+        {
+          category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+          threshold: GOOGLE_SAFETY_SEXUALLY_EXPLICIT,
+        },
+        {
+          category: 'HARM_CATEGORY_HATE_SPEECH',
+          threshold: GOOGLE_SAFETY_HATE_SPEECH,
+        },
+        {
+          category: 'HARM_CATEGORY_HARASSMENT',
+          threshold: GOOGLE_SAFETY_HARASSMENT,
+        },
+        {
+          category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+          threshold: GOOGLE_SAFETY_DANGEROUS_CONTENT,
+        },
+      ];
+  
+      payload.safetySettings = safetySettings;
+    }
   
     let reply = '';
     reply = await this.getCompletion(payload, opts);

--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -29,6 +29,13 @@ const tokenizersCache = {};
 
 const settings = endpointSettings[EModelEndpoint.google];
 
+require('dotenv').config();
+
+let GOOGLE_SAFETY_SEXUALLY_EXPLICIT = process.env.GOOGLE_SAFETY_SEXUALLY_EXPLICIT || 'HARM_BLOCK_THRESHOLD_UNSPECIFIED';
+let GOOGLE_SAFETY_HATE_SPEECH = process.env.GOOGLE_SAFETY_HATE_SPEECH || 'HARM_BLOCK_THRESHOLD_UNSPECIFIED';
+let GOOGLE_SAFETY_HARASSMENT = process.env.GOOGLE_SAFETY_HARASSMENT || 'HARM_BLOCK_THRESHOLD_UNSPECIFIED';
+let GOOGLE_SAFETY_DANGEROUS_CONTENT = process.env.GOOGLE_SAFETY_DANGEROUS_CONTENT || 'HARM_BLOCK_THRESHOLD_UNSPECIFIED';
+
 class GoogleClient extends BaseClient {
   constructor(credentials, options = {}) {
     super('apiKey', options);
@@ -610,11 +617,11 @@ class GoogleClient extends BaseClient {
     const { onProgress, abortController } = options;
     const { parameters, instances } = _payload;
     const { messages: _messages, context, examples: _examples } = instances?.[0] ?? {};
-
+  
     let examples;
-
+  
     let clientOptions = { ...parameters, maxRetries: 2 };
-
+  
     if (this.project_id) {
       clientOptions['authOptions'] = {
         credentials: {
@@ -623,16 +630,16 @@ class GoogleClient extends BaseClient {
         projectId: this.project_id,
       };
     }
-
+  
     if (!parameters) {
       clientOptions = { ...clientOptions, ...this.modelOptions };
     }
-
+  
     if (this.isGenerativeModel && !this.project_id) {
       clientOptions.modelName = clientOptions.model;
       delete clientOptions.model;
     }
-
+  
     if (_examples && _examples.length) {
       examples = _examples
         .map((ex) => {
@@ -646,19 +653,19 @@ class GoogleClient extends BaseClient {
           };
         })
         .filter((ex) => ex);
-
+  
       clientOptions.examples = examples;
     }
-
+  
     const model = this.createLLM(clientOptions);
-
+  
     let reply = '';
     const messages = this.isTextModel ? _payload.trim() : _messages;
-
+  
     if (!this.isVisionModel && context && messages?.length > 0) {
       messages.unshift(new SystemMessage(context));
     }
-
+  
     const modelName = clientOptions.modelName ?? clientOptions.model ?? '';
     if (modelName?.includes('1.5') && !this.project_id) {
       /** @type {GenerativeModel} */
@@ -666,7 +673,7 @@ class GoogleClient extends BaseClient {
       const requestOptions = {
         contents: _payload,
       };
-
+  
       if (this.options?.promptPrefix?.length) {
         requestOptions.systemInstruction = {
           parts: [
@@ -676,7 +683,10 @@ class GoogleClient extends BaseClient {
           ],
         };
       }
-
+  
+      const safetySettings = _payload.safetySettings;
+      requestOptions.safetySettings = safetySettings;
+  
       const result = await client.generateContentStream(requestOptions);
       for await (const chunk of result.stream) {
         const chunkText = chunk.text();
@@ -687,12 +697,14 @@ class GoogleClient extends BaseClient {
       }
       return reply;
     }
-
+  
+    const safetySettings = _payload.safetySettings;
     const stream = await model.stream(messages, {
       signal: abortController.signal,
       timeout: 7000,
+      safetySettings: safetySettings,
     });
-
+  
     for await (const chunk of stream) {
       const chunkText = chunk?.content ?? chunk;
       this.generateTextStream(chunkText, onProgress, {
@@ -700,7 +712,7 @@ class GoogleClient extends BaseClient {
       });
       reply += chunkText;
     }
-
+  
     return reply;
   }
 
@@ -720,6 +732,27 @@ class GoogleClient extends BaseClient {
   }
 
   async sendCompletion(payload, opts = {}) {
+    let safetySettings = [
+      {
+        category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
+        threshold: GOOGLE_SAFETY_SEXUALLY_EXPLICIT,
+      },
+      {
+        category: 'HARM_CATEGORY_HATE_SPEECH',
+        threshold: GOOGLE_SAFETY_HATE_SPEECH,
+      },
+      {
+        category: 'HARM_CATEGORY_HARASSMENT',
+        threshold: GOOGLE_SAFETY_HARASSMENT,
+      },
+      {
+        category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+        threshold: GOOGLE_SAFETY_DANGEROUS_CONTENT,
+      },
+    ];
+  
+    payload.safetySettings = safetySettings;
+  
     let reply = '';
     reply = await this.getCompletion(payload, opts);
     return reply.trim();

--- a/docs/install/configuration/dotenv.md
+++ b/docs/install/configuration/dotenv.md
@@ -296,14 +296,48 @@ GOOGLE_KEY=user_provided
 GOOGLE_REVERSE_PROXY=
 ```
 
-- Customize the available models, separated by commas, **without spaces**.
-    - The first will be default.
-    - Leave it blank or commented out to use internal settings (default: all listed below).
+Depending on whether you are using the Vertex AI or Gemini API, you can choose the corresponding set of models. Customize the available models, separated by commas, **without spaces**. The first model in the list will be used as the default. Leave the line blank or commented out to use the internal settings (default: all models listed below).
 
 ```bash
-# all available models as of 12/16/23
-GOOGLE_MODELS=gemini-pro,gemini-pro-vision,chat-bison,chat-bison-32k,codechat-bison,codechat-bison-32k,text-bison,text-bison-32k,text-unicorn,code-gecko,code-bison,code-bison-32k
+# Gemini API
+# GOOGLE_MODELS=gemini-1.0-pro,gemini-1.0-pro-001,gemini-1.0-pro-latest,gemini-1.0-pro-vision-latest,gemini-1.5-pro-latest,gemini-pro,gemini-pro-vision
+
+# Vertex AI
+# GOOGLE_MODELS=gemini-1.5-pro-preview-0409,gemini-1.0-pro-vision-001,gemini-pro,gemini-pro-vision,chat-bison,chat-bison-32k,codechat-bison,codechat-bison-32k,text-bison,text-bison-32k,text-unicorn,code-gecko,code-bison,code-bison-32k
 ```
+
+Both the Vertex AI and Gemini API provide safety settings that allow you to control the level of content filtering based on different categories. You can configure these settings using the following environment variables:
+
+```bash
+# Google Safety Settings
+# NOTE: You do not have access to the BLOCK_NONE setting by default.
+# To use this restricted HarmBlockThreshold setting, you will need to either:
+#
+# (a) Get access through an allowlist via your Google account team
+# (b) Switch your account type to monthly invoiced billing following this instruction:
+#     https://cloud.google.com/billing/docs/how-to/invoiced-billing
+#
+# GOOGLE_SAFETY_SEXUALLY_EXPLICIT=BLOCK_ONLY_HIGH
+# GOOGLE_SAFETY_HATE_SPEECH=BLOCK_ONLY_HIGH
+# GOOGLE_SAFETY_HARASSMENT=BLOCK_ONLY_HIGH
+# GOOGLE_SAFETY_DANGEROUS_CONTENT=BLOCK_ONLY_HIGH
+```
+
+The available safety settings are:
+
+- `GOOGLE_SAFETY_SEXUALLY_EXPLICIT`: Controls the filtering of sexually explicit content.
+- `GOOGLE_SAFETY_HATE_SPEECH`: Controls the filtering of hate speech content.
+- `GOOGLE_SAFETY_HARASSMENT`: Controls the filtering of harassment content.
+- `GOOGLE_SAFETY_DANGEROUS_CONTENT`: Controls the filtering of dangerous content.
+
+For each setting, you can choose one of the following values:
+
+- `BLOCK_NONE`: Do not block any content in this category (requires additional access).
+- `BLOCK_LOW_AND_ABOVE`: Block content with low or higher probability of belonging to this category.
+- `BLOCK_MED_AND_ABOVE`: Block content with medium or higher probability of belonging to this category.
+- `BLOCK_ONLY_HIGH`: Only block content with high probability of belonging to this category.
+
+If you leave the safety settings commented out, the default values provided by the API will be used.
 
 ### OpenAI
 


### PR DESCRIPTION
# Pull Request: Add Safety Settings Configuration for Google Gemini API

## Summary

This pull request addresses the feature request raised in issue #2564. It adds the ability to configure safety settings for the Google Gemini API in LibreChat. Users can now customize the thresholds for various safety categories, providing more control over the content filtering behavior of the Gemini API.

The changes include:
- Implement safety settings configuration in GoogleClient.js
- Add safety settings variables in .env.example
- Update documentation to explain safety settings and clarify model usage

These changes give developers the flexibility to tailor the Gemini API's safety settings to their specific requirements, ensuring that the API's functionality is not unnecessarily limited by the default settings.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

To test these changes:

1. Set the desired safety settings in the `.env` file based on the variables defined in `.env.example`.
2. Run the LibreChat application and verify that the Gemini API is using the configured safety settings.
3. Test various scenarios to ensure the safety settings are working as expected.

### **Test Configuration**:
- LibreChat version: latest
- Google Vertex AI APi

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] New documents have been locally validated with mkdocs

Closes #2564