### PR TITLE
🔧 fix: android `@` popover issue

### DIFF
--- a/client/src/hooks/Input/useTextarea.ts
+++ b/client/src/hooks/Input/useTextarea.ts
@@ -14,11 +14,6 @@ import store from '~/store';
 
 type KeyEvent = KeyboardEvent<HTMLTextAreaElement>;
 
-const keyMap = {
-  50: '2',
-  192: '@',
-};
-
 export default function useTextarea({
   textAreaRef,
   submitButtonRef,
@@ -141,35 +136,22 @@ export default function useTextarea({
     assistantMap,
   ]);
 
-  const handleKeyUp = useCallback(
-    (e: KeyEvent) => {
-      let normalizedKey = e.key;
+  const handleKeyUp = useCallback(() => {
+    const text = textAreaRef.current?.value;
+    if (!(text && text[text.length - 1] === '@')) {
+      return;
+    }
 
-      if (!normalizedKey || normalizedKey === 'Unidentified') {
-        normalizedKey = keyMap[e.keyCode] || normalizedKey;
-      }
+    const startPos = textAreaRef.current?.selectionStart;
+    if (!startPos) {
+      return;
+    }
 
-      if (normalizedKey !== '@' && normalizedKey !== '2') {
-        return;
-      }
+    const isAtStart = startPos === 1;
+    const isPrecededBySpace = textAreaRef.current?.value.charAt(startPos - 2) === ' ';
 
-      const text = textAreaRef.current?.value;
-      if (!(text && text[text.length - 1] === '@')) {
-        return;
-      }
-
-      const startPos = textAreaRef.current?.selectionStart;
-      if (!startPos) {
-        return;
-      }
-
-      const isAtStart = startPos === 1;
-      const isPrecededBySpace = textAreaRef.current?.value.charAt(startPos - 2) === ' ';
-
-      setShowMentionPopover(isAtStart || isPrecededBySpace);
-    },
-    [textAreaRef, setShowMentionPopover],
-  );
+    setShowMentionPopover(isAtStart || isPrecededBySpace);
+  }, [textAreaRef, setShowMentionPopover]);
 
   const handleKeyDown = useCallback(
     (e: KeyEvent) => {


### PR DESCRIPTION
## Summary

fixing <kbd>@</kbd>popover issue

https://github.com/danny-avila/LibreChat/commit/b6d6343f541eed6995899a132fd3b4db87ccecc6#commitcomment-141788636

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Android with `Chrome 124` and `Samsung Browser 25.0.1.3`
- Windows with `Brave 1.65.130`, `Chrome 124`, `Edge 124` and `Firefox 124`
- iPadOS with `Chrome 124` and `Safari`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] New documents have been locally validated with mkdocs
