### PR TITLE
🐋 refactor(docker-compose): use "HOST" in `ports` field

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   api:
     container_name: LibreChat
     ports:
-      - "${PORT}:${PORT}"
+      - "${HOST}:${PORT}:${PORT}"
     depends_on:
       - mongodb
       - rag_api


### PR DESCRIPTION
## Summary

I've wasting hours figuring how to expose my librechat to localhost only, while I am using docker compose. No matter what I changed the "HOST" in .env file to doesn't made any change, the port was always exposed to 0.0.0.0:PORT.
Then I found out that the variable "HOST" is missed in the docker-compose.yml file (which users should not change!). After adding the variable to the port column, everything works perfect. The docker will expose librechat to any IP that is set as HOST in .evn file.
![image](https://github.com/danny-avila/LibreChat/assets/56987501/37536b5d-fd44-40b3-9485-c995fcf55be8)


## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

## Checklist

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes do not introduce new warnings
