### PR TITLE
🦙 fix: Ollama System Message order

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -129,6 +129,10 @@ class OpenAIClient extends BaseClient {
       this.useOpenRouter = true;
     }
 
+    if (this.options.endpoint?.toLowerCase() === 'ollama') {
+      this.isOllama = true;
+    }
+
     this.FORCE_PROMPT =
       isEnabled(OPENAI_FORCE_PROMPT) ||
       (reverseProxy && reverseProxy.includes('completions') && !reverseProxy.includes('chat'));
@@ -1121,7 +1125,7 @@ ${convo}
       });
 
       /* Re-orders system message to the top of the messages payload, as not allowed anywhere else */
-      if (opts.baseURL.includes('api.mistral.ai') && modelOptions.messages) {
+      if (modelOptions.messages && (opts.baseURL.includes('api.mistral.ai') || this.isOllama)) {
         const { messages } = modelOptions;
 
         const systemMessageIndex = messages.findIndex((msg) => msg.role === 'system');
@@ -1165,7 +1169,7 @@ ${convo}
         });
       }
 
-      if (this.message_file_map && this.options.endpoint?.toLowerCase() === 'ollama') {
+      if (this.message_file_map && this.isOllama) {
         const ollamaClient = new OllamaClient({ baseURL });
         return await ollamaClient.chatCompletion({
           payload: modelOptions,


### PR DESCRIPTION
## Summary

It was reported that when using custom instructions, llama3 models used via ollama would repeat their initial message. This was debugged to be because of the order of the system message, as exemplified in the model card by Meta:

https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-3/

### Before
![image](https://github.com/danny-avila/LibreChat/assets/110412045/0a3e7eec-2c9a-4654-858f-0260d874246d)



### After
![image](https://github.com/danny-avila/LibreChat/assets/110412045/67723dde-8de9-4003-8441-62c286fd67a0)



## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] New documents have been locally validated with mkdocs
