### PR TITLE
monodb is recommended in backend

### DIFF
--- a/docs/contributions/how_to_contribute.md
+++ b/docs/contributions/how_to_contribute.md
@@ -27,6 +27,7 @@ weight: -10
 4. ✅ [Github Desktop](https://desktop.github.com/) - ^^Optional^^
 5. ✨ [VSCode](https://code.visualstudio.com/Download) - ^^Recommended^^ Source-code Editor
 6. 🐳 [Docker Desktop](https://www.docker.com/products/docker-desktop/) - ^^Recommended^^ (more on that later)
+7. 🐳 [Mongodb](https://www.mongodb.com/) - ^^Recommended^^.
 
 ### Recommended VSCode extensions
 


### PR DESCRIPTION
I have tried many times to run this project following the instructions in the [get_started](https://www.librechat.ai/docs/development/get_started) section, but it won't launch after installing `MongoDB`. I haven't seen any previous recommendations or mentions of this tool as a requirement for launching the project.

## Change Type
- [x] Documentation update

i just add this line to the  [get_started](https://www.librechat.ai/docs/development/get_started) 
https://github.com/danny-avila/LibreChat/blob/0553231b1fa7a244b608536355b3a0526a1ffe12/docs/contributions/how_to_contribute.md?plain=1#L30
