### PR TITLE
🐋 ci: create smaller Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 # v0.7.2
 
 # Base node image
-FROM node:18-alpine3.18 AS node
+FROM node:20-alpine AS node
 
-RUN apk add g++ make py3-pip
-RUN npm install -g node-gyp
 RUN apk --no-cache add curl
 
 RUN mkdir -p /app && chown node:node /app
@@ -14,20 +12,20 @@ USER node
 
 COPY --chown=node:node . .
 
-# Allow mounting of these files, which have no default
-# values.
-RUN touch .env
-RUN npm config set fetch-retry-maxtimeout 600000
-RUN npm config set fetch-retries 5
-RUN npm config set fetch-retry-mintimeout 15000
-RUN npm install --no-audit
+RUN \
+    # Allow mounting of these files, which have no default
+    touch .env ; \
+    # Create directories for the volumes to inherit the correct permissions
+    mkdir -p /app/client/public/images /app/api/logs ; \
+    npm config set fetch-retry-maxtimeout 600000 ; \
+    npm config set fetch-retries 5 ; \
+    npm config set fetch-retry-mintimeout 15000 ; \
+    npm install --no-audit; \
+    # React client build
+    NODE_OPTIONS="--max-old-space-size=2048" npm run frontend; \
+    npm prune --production; \
+    npm cache clean --force
 
-# React client build
-ENV NODE_OPTIONS="--max-old-space-size=2048"
-RUN npm run frontend
-
-# Create directories for the volumes to inherit
-# the correct permissions
 RUN mkdir -p /app/client/public/images /app/api/logs
 
 # Node API setup

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -7,32 +7,31 @@ FROM node:20-alpine AS base
 FROM base AS data-provider-build
 WORKDIR /app/packages/data-provider
 COPY ./packages/data-provider ./
-RUN npm install
+RUN npm install; npm cache clean --force
 RUN npm run build
+RUN npm prune --production
 
 # React client build
-FROM data-provider-build AS client-build
+FROM base AS client-build
 WORKDIR /app/client
 COPY ./client/package*.json ./
 # Copy data-provider to client's node_modules
-RUN mkdir -p /app/client/node_modules/librechat-data-provider/
-RUN cp -R /app/packages/data-provider/* /app/client/node_modules/librechat-data-provider/
-RUN npm install
+COPY --from=data-provider-build /app/packages/data-provider/ /app/client/node_modules/librechat-data-provider/
+RUN npm install; npm cache clean --force
 COPY ./client/ ./
 ENV NODE_OPTIONS="--max-old-space-size=2048"
 RUN npm run build
 
 # Node API setup
-FROM data-provider-build AS api-build
+FROM base AS api-build
 WORKDIR /app/api
 COPY api/package*.json ./
 COPY api/ ./
 # Copy helper scripts
 COPY config/ ./
 # Copy data-provider to API's node_modules
-RUN mkdir -p /app/api/node_modules/librechat-data-provider/
-RUN cp -R /app/packages/data-provider/* /app/api/node_modules/librechat-data-provider/
-RUN npm install
+COPY --from=data-provider-build /app/packages/data-provider/ /app/api/node_modules/librechat-data-provider/
+RUN npm install --include prod; npm cache clean --force
 COPY --from=client-build /app/client/dist /app/client/dist
 EXPOSE 3080
 ENV HOST=0.0.0.0


### PR DESCRIPTION
## Summary

This change reduces the size of the built Docker images significantly by removing the npm dev dependencies and the npm cache.

It also removes the workarounds for the broken ARM builds. This allows to use Node 20 for the main Docker build (as it is already with the Dockerfile.multi build). It seems with node:20-alpine and the flags set the build is pretty stable (also on ARM).

Changes of Docker image sizes:
- librechat-dev is down from 477.71 MB to 166.13 MB (compressed) - see https://hub.docker.com/r/derkoe/librechat-dev/tags
- librechat-dev-api is down from 405.77 MB to 146.81 MB (compressed) - see https://hub.docker.com/r/derkoe/librechat-dev-api/tags

Uncompressed images sizes:
```
REPOSITORY                    TAG       IMAGE ID       CREATED          SIZE
librechat/librechat-dev-api   latest    91b3ff876ac8   21 minutes ago   1.77GB
librechat/librechat-dev       latest    3faa53a2ccac   22 minutes ago   1.49GB
derkoe/librechat-dev-api      latest    900453f157c3   5 hours ago      593MB
derkoe/librechat-dev          latest    3a36052c1fe8   5 hours ago      680MB
```

## Change Type

Docker build change - the rest of the code is not affected (not sure what to choose from the PR template list).

## Testing

- I have built the images multiple times with GitHub Workflow: https://github.com/derkoe/LibreChat/actions/workflows/dev-images.yml
- I have switched our deployment of LibreChat to the new Docker image (docker pull ghcr.io/derkoe/librechat-dev:latest).

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] New documents have been locally validated with mkdocs
