### PR TITLE
🔀 fix: Address Convo/Preset Switching Issues

### DIFF
--- a/client/src/components/Chat/Input/Mention.tsx
+++ b/client/src/components/Chat/Input/Mention.tsx
@@ -99,7 +99,7 @@ export default function Mention({
             } else if (e.key === 'ArrowUp') {
               setActiveIndex((prevIndex) => (prevIndex - 1 + matches.length) % matches.length);
             } else if (e.key === 'Enter' || e.key === 'Tab') {
-              const mentionOption = matches[0] as MentionOption | undefined;
+              const mentionOption = matches[activeIndex] as MentionOption | undefined;
               if (mentionOption?.type === 'endpoint') {
                 e.preventDefault();
               } else if (e.key === 'Enter') {

--- a/client/src/components/Conversations/ArchiveButton.tsx
+++ b/client/src/components/Conversations/ArchiveButton.tsx
@@ -1,12 +1,10 @@
-import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '~/components/ui';
+import { useParams, useNavigate } from 'react-router-dom';
 import type { MouseEvent, FocusEvent, KeyboardEvent } from 'react';
-import { useParams } from 'react-router-dom';
-
-import { useArchiveConversationMutation } from '~/data-provider';
-
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '~/components/ui';
 import { useConversations, useLocalize, useNewConvo } from '~/hooks';
-import { useToastContext } from '~/Providers';
+import { useArchiveConversationMutation } from '~/data-provider';
 import { NotificationSeverity } from '~/common';
+import { useToastContext } from '~/Providers';
 
 type ArchiveButtonProps = {
   conversationId: string;
@@ -23,8 +21,9 @@ export default function ArchiveButton({
   className = '',
 }: ArchiveButtonProps) {
   const localize = useLocalize();
-  const { newConversation } = useNewConvo();
+  const navigate = useNavigate();
   const { showToast } = useToastContext();
+  const { newConversation } = useNewConvo();
   const { refreshConversations } = useConversations();
   const { conversationId: currentConvoId } = useParams();
 
@@ -42,8 +41,9 @@ export default function ArchiveButton({
       { conversationId, isArchived: shouldArchive },
       {
         onSuccess: () => {
-          if (currentConvoId === conversationId) {
+          if (currentConvoId === conversationId || currentConvoId === 'new') {
             newConversation();
+            navigate('/c/new', { replace: true });
           }
           refreshConversations();
           retainView();

--- a/client/src/components/Conversations/DeleteButton.tsx
+++ b/client/src/components/Conversations/DeleteButton.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
-import { useParams } from 'react-router-dom';
 import { QueryKeys } from 'librechat-data-provider';
 import { useQueryClient } from '@tanstack/react-query';
+import { useParams, useNavigate } from 'react-router-dom';
 import type { TMessage } from 'librechat-data-provider';
 import { useDeleteConversationMutation } from '~/data-provider';
 import {
@@ -26,13 +26,15 @@ export default function DeleteButton({
   className = '',
 }) {
   const localize = useLocalize();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { newConversation } = useNewConvo();
   const { conversationId: currentConvoId } = useParams();
   const deleteConvoMutation = useDeleteConversationMutation({
     onSuccess: () => {
-      if (currentConvoId === conversationId) {
+      if (currentConvoId === conversationId || currentConvoId === 'new') {
         newConversation();
+        navigate('/c/new', { replace: true });
       }
       retainView();
     },

--- a/client/src/hooks/SSE/useSSE.ts
+++ b/client/src/hooks/SSE/useSSE.ts
@@ -390,6 +390,11 @@ export default function useSSE(submission: TSubmission | null, index = 0) {
         });
         setIsSubmitting(false);
         return;
+      } else if (!data.conversationId) {
+        const errorResponse = parseErrorResponse(data);
+        setMessages([...messages, message, errorResponse]);
+        setIsSubmitting(false);
+        return;
       }
 
       console.log('Error:', data);

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -400,25 +400,33 @@ export const openAISchema = tConversationSchema
     maxContextTokens: true,
     max_tokens: true,
   })
-  .transform((obj) => ({
-    ...obj,
-    model: obj.model ?? openAISettings.model.default,
-    chatGptLabel: obj.modelLabel ?? obj.chatGptLabel ?? null,
-    promptPrefix: obj.promptPrefix ?? null,
-    temperature: obj.temperature ?? openAISettings.temperature.default,
-    top_p: obj.top_p ?? openAISettings.top_p.default,
-    presence_penalty: obj.presence_penalty ?? openAISettings.presence_penalty.default,
-    frequency_penalty: obj.frequency_penalty ?? openAISettings.frequency_penalty.default,
-    resendFiles:
-      typeof obj.resendFiles === 'boolean' ? obj.resendFiles : openAISettings.resendFiles.default,
-    imageDetail: obj.imageDetail ?? openAISettings.imageDetail.default,
-    stop: obj.stop ?? undefined,
-    iconURL: obj.iconURL ?? undefined,
-    greeting: obj.greeting ?? undefined,
-    spec: obj.spec ?? undefined,
-    maxContextTokens: obj.maxContextTokens ?? undefined,
-    max_tokens: obj.max_tokens ?? undefined,
-  }))
+  .transform((obj) => {
+    const result = {
+      ...obj,
+      model: obj.model ?? openAISettings.model.default,
+      chatGptLabel: obj.chatGptLabel ?? obj.modelLabel ?? null,
+      promptPrefix: obj.promptPrefix ?? null,
+      temperature: obj.temperature ?? openAISettings.temperature.default,
+      top_p: obj.top_p ?? openAISettings.top_p.default,
+      presence_penalty: obj.presence_penalty ?? openAISettings.presence_penalty.default,
+      frequency_penalty: obj.frequency_penalty ?? openAISettings.frequency_penalty.default,
+      resendFiles:
+        typeof obj.resendFiles === 'boolean' ? obj.resendFiles : openAISettings.resendFiles.default,
+      imageDetail: obj.imageDetail ?? openAISettings.imageDetail.default,
+      stop: obj.stop ?? undefined,
+      iconURL: obj.iconURL ?? undefined,
+      greeting: obj.greeting ?? undefined,
+      spec: obj.spec ?? undefined,
+      maxContextTokens: obj.maxContextTokens ?? undefined,
+      max_tokens: obj.max_tokens ?? undefined,
+    };
+
+    if (obj.modelLabel) {
+      result.modelLabel = null;
+    }
+
+    return result;
+  })
   .catch(() => ({
     model: openAISettings.model.default,
     chatGptLabel: null,
@@ -605,27 +613,35 @@ export const gptPluginsSchema = tConversationSchema
     spec: true,
     maxContextTokens: true,
   })
-  .transform((obj) => ({
-    ...obj,
-    model: obj.model ?? 'gpt-3.5-turbo',
-    chatGptLabel: obj.modelLabel ?? obj.chatGptLabel ?? null,
-    promptPrefix: obj.promptPrefix ?? null,
-    temperature: obj.temperature ?? 0.8,
-    top_p: obj.top_p ?? 1,
-    presence_penalty: obj.presence_penalty ?? 0,
-    frequency_penalty: obj.frequency_penalty ?? 0,
-    tools: obj.tools ?? [],
-    agentOptions: obj.agentOptions ?? {
-      agent: EAgent.functions,
-      skipCompletion: true,
-      model: 'gpt-3.5-turbo',
-      temperature: 0,
-    },
-    iconURL: obj.iconURL ?? undefined,
-    greeting: obj.greeting ?? undefined,
-    spec: obj.spec ?? undefined,
-    maxContextTokens: obj.maxContextTokens ?? undefined,
-  }))
+  .transform((obj) => {
+    const result = {
+      ...obj,
+      model: obj.model ?? 'gpt-3.5-turbo',
+      chatGptLabel: obj.chatGptLabel ?? obj.modelLabel ?? null,
+      promptPrefix: obj.promptPrefix ?? null,
+      temperature: obj.temperature ?? 0.8,
+      top_p: obj.top_p ?? 1,
+      presence_penalty: obj.presence_penalty ?? 0,
+      frequency_penalty: obj.frequency_penalty ?? 0,
+      tools: obj.tools ?? [],
+      agentOptions: obj.agentOptions ?? {
+        agent: EAgent.functions,
+        skipCompletion: true,
+        model: 'gpt-3.5-turbo',
+        temperature: 0,
+      },
+      iconURL: obj.iconURL ?? undefined,
+      greeting: obj.greeting ?? undefined,
+      spec: obj.spec ?? undefined,
+      maxContextTokens: obj.maxContextTokens ?? undefined,
+    };
+
+    if (obj.modelLabel) {
+      result.modelLabel = null;
+    }
+
+    return result;
+  })
   .catch(() => ({
     model: 'gpt-3.5-turbo',
     chatGptLabel: null,


### PR DESCRIPTION
## Summary

- Addressed Mentions not using active index when cycling through mention items
- Correctly navigate to new conversation when deleting/archiving a new, active convo
- Ensure openAI/custom/gptPlugins presets only have one label value present (`chatGptLabel`), despite two different fields (`chatGptLabel` and `modelLabel` being interchangeable)
    - This issue would prevent "presets" from correctly taking effect or saving the correct label value when they are available along with "modelSpecs"
- Handle Error display issue when `enforceModelSpecs` correctly blocks a request for an existing conversation

## Change Type


- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual tests, will soon add E2E tests

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.