### PR TITLE
🚑 fix: Display Error Message when API Connection fails during Chat

### DIFF
--- a/client/src/hooks/SSE/useSSE.ts
+++ b/client/src/hooks/SSE/useSSE.ts
@@ -587,7 +587,6 @@ export default function useSSE(submission: TSubmission | null, index = 0) {
         console.error(error);
         console.log(e);
         setIsSubmitting(false);
-        return;
       }
 
       errorHandler({ data, submission: { ...submission, message } });


### PR DESCRIPTION
## Summary

A minor change. Currently, if the backend API fails or the network is unavailable during a chat, the chat simply remains silent without any notification. 

<kbd><img width="311" alt="SCR-20240514-klfv" src="https://github.com/danny-avila/LibreChat/assets/283038/d4c37306-cb67-4f1c-a06e-d0f0bd1b889e"></kbd>

I've fixed it to ensure an error message is displayed, letting users know the situation.

<kbd><img width="763" alt="SCR-20240514-kmax" src="https://github.com/danny-avila/LibreChat/assets/283038/62532413-3713-44df-a676-148cd6dcd3b0"></kbd>

In the `useSSE` hook, the `events.onerror` function stops the process when unable to parse a `MessageEvent` and does not call the `errorHandler` function. However, the `errorHandler` function was designed to display the message "Error connecting to server" when the response data is undefined. I determined that calling this function would be possible and appropriate even if it failed to parse the response.

https://github.com/danny-avila/LibreChat/blob/e42709bd1f9e116e806418c359694b452d206aa7/client/src/hooks/SSE/useSSE.ts#L367-L381

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I have confirmed that the error message is displayed when the API is down, ensuring that users are informed of the connection issue.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
