### PR TITLE
💻 fix: Prevent `DataTable` component Text Selection

### DIFF
--- a/client/src/components/Chat/Input/Files/Table/DataTable.tsx
+++ b/client/src/components/Chat/Input/Files/Table/DataTable.tsx
@@ -220,7 +220,7 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
           )}
         </div>
         <Button
-          className="dark:border-gray-500 dark:hover:bg-gray-600"
+          className="dark:border-gray-500 dark:hover:bg-gray-600 select-none"
           variant="outline"
           size="sm"
           onClick={() => table.previousPage()}
@@ -229,7 +229,7 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
           {localize('com_ui_prev')}
         </Button>
         <Button
-          className="dark:border-gray-500 dark:hover:bg-gray-600"
+          className="dark:border-gray-500 dark:hover:bg-gray-600 select-none"
           variant="outline"
           size="sm"
           onClick={() => table.nextPage()}


### PR DESCRIPTION
## Summary

Fixes the issue with `userSelect` in the `DataTable` component to prevent text selection on buttons. This change ensures a better user experience by making the buttons unselectable. This resolves issue #2749.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

N/A

### Test Configuration

N/A

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
