### PR TITLE
📤style: export button icon

### DIFF
--- a/client/src/components/Chat/ExportButton.tsx
+++ b/client/src/components/Chat/ExportButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import type { TConversation } from 'librechat-data-provider';
-import { Download } from 'lucide-react';
+import { Upload } from 'lucide-react';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '~/components/ui';
 import { useLocalize } from '~/hooks';
 import { ExportModal } from '../Nav';
@@ -50,7 +50,7 @@ function ExportButton() {
                   onClick={clickHandler}
                 >
                   <div className="flex w-full items-center justify-center gap-2">
-                    <Download size={16} />
+                    <Upload size={16} />
                   </div>
                 </button>
               </TooltipTrigger>


### PR DESCRIPTION
## Summary

Replaced the export button logo

**Before:**
![image](https://github.com/danny-avila/LibreChat/assets/32828263/cd87cdbc-aa1e-495f-ba66-add771f7b45a)
which was the same (down arrow) as the import button:
![image](https://github.com/danny-avila/LibreChat/assets/32828263/b1bac2c8-4bc6-47b2-a4fa-da0c818c2fe5)

**After:**
![image](https://github.com/danny-avila/LibreChat/assets/32828263/ddb06e2c-505e-411f-bdfb-52f371d5bf9d)

The "up arrow" icon more effectively communicates the function of that button. (Especially since we're using the down arrow for import, and since chatgpt.com are using up arrow to share/export)

## Change Type

- [x] Style

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings

