### PR TITLE
🇬 refactor: Update default Google Models and Parameters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,7 +119,7 @@ GOOGLE_KEY=user_provided
 # GOOGLE_MODELS=gemini-1.5-flash-latest,gemini-1.0-pro,gemini-1.0-pro-001,gemini-1.0-pro-latest,gemini-1.0-pro-vision-latest,gemini-1.5-pro-latest,gemini-pro,gemini-pro-vision
 
 # Vertex AI
-# GOOGLE_MODELS=gemini-1.5-flash-preview-0514,gemini-1.5-pro-preview-0409,gemini-1.0-pro-vision-001,gemini-pro,gemini-pro-vision,chat-bison,chat-bison-32k,codechat-bison,codechat-bison-32k,text-bison,text-bison-32k,text-unicorn,code-gecko,code-bison,code-bison-32k
+# GOOGLE_MODELS=gemini-1.5-flash-preview-0514,gemini-1.5-pro-preview-0514,gemini-1.0-pro-vision-001,gemini-pro,gemini-pro-vision
 
 # Google Gemini Safety Settings
 # NOTE (Vertex AI): You do not have access to the BLOCK_NONE setting by default.

--- a/.env.example
+++ b/.env.example
@@ -119,7 +119,7 @@ GOOGLE_KEY=user_provided
 # GOOGLE_MODELS=gemini-1.5-flash-latest,gemini-1.0-pro,gemini-1.0-pro-001,gemini-1.0-pro-latest,gemini-1.0-pro-vision-latest,gemini-1.5-pro-latest,gemini-pro,gemini-pro-vision
 
 # Vertex AI
-# GOOGLE_MODELS=gemini-1.5-flash-preview-0514,gemini-1.5-pro-preview-0514,gemini-1.0-pro-vision-001,gemini-pro,gemini-pro-vision
+# GOOGLE_MODELS=gemini-1.5-flash-preview-0514,gemini-1.5-pro-preview-0514,gemini-1.0-pro-vision-001,gemini-1.0-pro-002,gemini-1.0-pro-001,gemini-pro-vision,gemini-1.0-pro
 
 # Google Gemini Safety Settings
 # NOTE (Vertex AI): You do not have access to the BLOCK_NONE setting by default.

--- a/client/src/components/Endpoints/Settings/Google.tsx
+++ b/client/src/components/Endpoints/Settings/Google.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 import { EModelEndpoint, endpointSettings } from 'librechat-data-provider';
 import type { TModelSelectProps, OnInputNumberChange } from '~/common';
@@ -30,25 +29,6 @@ export default function Settings({ conversation, setOption, models, readonly }: 
     maxContextTokens,
     maxOutputTokens,
   } = conversation ?? {};
-
-  const isGemini = model?.toLowerCase()?.includes('gemini');
-
-  const maxOutputTokensMax = isGemini
-    ? google.maxOutputTokens.maxGemini
-    : google.maxOutputTokens.max;
-  const maxOutputTokensDefault = isGemini
-    ? google.maxOutputTokens.defaultGemini
-    : google.maxOutputTokens.default;
-
-  useEffect(
-    () => {
-      if (model) {
-        setOption('maxOutputTokens')(Math.min(Number(maxOutputTokens) ?? 0, maxOutputTokensMax));
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [model],
-  );
 
   const [setMaxContextTokens, maxContextTokensValue] = useDebouncedInput<number | null | undefined>(
     {
@@ -281,15 +261,15 @@ export default function Settings({ conversation, setOption, models, readonly }: 
               <Label htmlFor="max-tokens-int" className="text-left text-sm font-medium">
                 {localize('com_endpoint_max_output_tokens')}{' '}
                 <small className="opacity-40">
-                  ({localize('com_endpoint_default_with_num', maxOutputTokensDefault + '')})
+                  ({localize('com_endpoint_default_with_num', google.maxOutputTokens.default + '')})
                 </small>
               </Label>
               <InputNumber
                 id="max-tokens-int"
                 disabled={readonly}
                 value={maxOutputTokens}
-                onChange={(value) => setMaxOutputTokens(value ?? maxOutputTokensDefault)}
-                max={maxOutputTokensMax}
+                onChange={(value) => setMaxOutputTokens(Number(value))}
+                max={google.maxOutputTokens.max}
                 min={google.maxOutputTokens.min}
                 step={google.maxOutputTokens.step}
                 controls={false}
@@ -304,10 +284,10 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             </div>
             <Slider
               disabled={readonly}
-              value={[maxOutputTokens ?? maxOutputTokensDefault]}
+              value={[maxOutputTokens ?? google.maxOutputTokens.default]}
               onValueChange={(value) => setMaxOutputTokens(value[0])}
-              doubleClickHandler={() => setMaxOutputTokens(maxOutputTokensDefault)}
-              max={maxOutputTokensMax}
+              doubleClickHandler={() => setMaxOutputTokens(google.maxOutputTokens.default)}
+              max={google.maxOutputTokens.max}
               min={google.maxOutputTokens.min}
               step={google.maxOutputTokens.step}
               className="flex h-4 w-full"

--- a/packages/data-provider/src/generate.ts
+++ b/packages/data-provider/src/generate.ts
@@ -555,18 +555,6 @@ export const generateGoogleSchema = (customGoogle: GoogleSettings) => {
       maxContextTokens: true,
     })
     .transform((obj) => {
-      const isGemini = obj?.model?.toLowerCase()?.includes('gemini');
-
-      const maxOutputTokensMax = isGemini
-        ? defaults.maxOutputTokens.maxGemini
-        : defaults.maxOutputTokens.max;
-      const maxOutputTokensDefault = isGemini
-        ? defaults.maxOutputTokens.defaultGemini
-        : defaults.maxOutputTokens.default;
-
-      let maxOutputTokens = obj.maxOutputTokens ?? maxOutputTokensDefault;
-      maxOutputTokens = Math.min(maxOutputTokens, maxOutputTokensMax);
-
       return {
         ...obj,
         model: obj.model ?? defaults.model.default,
@@ -574,7 +562,7 @@ export const generateGoogleSchema = (customGoogle: GoogleSettings) => {
         promptPrefix: obj.promptPrefix ?? null,
         examples: obj.examples ?? [{ input: { content: '' }, output: { content: '' } }],
         temperature: obj.temperature ?? defaults.temperature.default,
-        maxOutputTokens,
+        maxOutputTokens: obj.maxOutputTokens ?? defaults.maxOutputTokens.default,
         topP: obj.topP ?? defaults.topP.default,
         topK: obj.topK ?? defaults.topK.default,
         maxContextTokens: obj.maxContextTokens ?? undefined,

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -118,27 +118,25 @@ export const openAISettings = {
 
 export const googleSettings = {
   model: {
-    default: 'chat-bison',
+    default: 'gemini-1.5-flash-latest',
   },
   maxOutputTokens: {
     min: 1,
-    max: 2048,
+    max: 8192,
     step: 1,
-    default: 1024,
-    maxGemini: 8192,
-    defaultGemini: 8192,
+    default: 8192,
   },
   temperature: {
     min: 0,
-    max: 1,
+    max: 2,
     step: 0.01,
-    default: 0.2,
+    default: 1,
   },
   topP: {
     min: 0,
     max: 1,
     step: 0.01,
-    default: 0.8,
+    default: 0.95,
   },
   topK: {
     min: 1,
@@ -474,18 +472,6 @@ export const googleSchema = tConversationSchema
     maxContextTokens: true,
   })
   .transform((obj) => {
-    const isGemini = obj?.model?.toLowerCase()?.includes('gemini');
-
-    const maxOutputTokensMax = isGemini
-      ? google.maxOutputTokens.maxGemini
-      : google.maxOutputTokens.max;
-    const maxOutputTokensDefault = isGemini
-      ? google.maxOutputTokens.defaultGemini
-      : google.maxOutputTokens.default;
-
-    let maxOutputTokens = obj.maxOutputTokens ?? maxOutputTokensDefault;
-    maxOutputTokens = Math.min(maxOutputTokens, maxOutputTokensMax);
-
     return {
       ...obj,
       model: obj.model ?? google.model.default,
@@ -493,7 +479,7 @@ export const googleSchema = tConversationSchema
       promptPrefix: obj.promptPrefix ?? null,
       examples: obj.examples ?? [{ input: { content: '' }, output: { content: '' } }],
       temperature: obj.temperature ?? google.temperature.default,
-      maxOutputTokens,
+      maxOutputTokens: obj.maxOutputTokens ?? google.maxOutputTokens.default,
       topP: obj.topP ?? google.topP.default,
       topK: obj.topK ?? google.topK.default,
       iconURL: obj.iconURL ?? undefined,


### PR DESCRIPTION
## Summary

Gemini models default to different parameter settings. Eg. the latest models have temperature from 0-2 with default of 1. Max output defaults to 8192, top_p defaults to 0.95. The default model and parameters are for chat-bison which is pretty much a deprecated model that no one uses. My suggestion is to change the default model along with the default parameters to be more in line with the current offerings. Most LibreChat users will use aistudio instead of Vertex anyway, where bison models would be irrelevant. 

This PR changes the default model from chat-bison to gemini, as well as updates the default parameters. I also updated the .env.example with the latest / greatest model tags as of 05/18. This should result in a better default experience for most users. I also removed the the PALM / bison family of models from .env.example as they have been mostly superseded by Gemini. 

The resulting code is more consistent with the other providers, and would be easier to maintain moving forward. Incoming PR to update documentation as well. https://github.com/LibreChat-AI/librechat.ai/pull/30

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
