### PR TITLE
👨‍🔧 fix: recognize command+click on macos

### DIFF
--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -37,7 +37,7 @@ export default function Conversation({ conversation, retainView, toggleNav, isLa
   const [isPopoverActive, setIsPopoverActive] = useState(false);
 
   const clickHandler = async (event: React.MouseEvent<HTMLAnchorElement>) => {
-    if (event.button === 0 && event.ctrlKey) {
+    if (event.button === 0 && (event.ctrlKey || event.metaKey)) {
       toggleNav();
       return;
     }

--- a/client/src/components/Nav/NewChat.tsx
+++ b/client/src/components/Nav/NewChat.tsx
@@ -71,7 +71,7 @@ export default function NewChat({
   const { conversation } = store.useCreateConversationAtom(index);
 
   const clickHandler = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    if (event.button === 0 && !event.ctrlKey) {
+    if (event.button === 0 && !(event.ctrlKey || event.metaKey)) {
       event.preventDefault();
       newConvo();
       navigate('/c/new');


### PR DESCRIPTION
## Summary

Fixes an issue where "command+click" combination was not being recognized on MacOS. The desired behavior was working fine on Windows using "ctrl+click", but the MacOS equivalent was broken.

This was preventing new tabs from opening while holding "command" (meta key) on MacOS and clicking.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue

## Testing

I verified this change fixes the issue by building locally and testing.

After making changes locally, I re-built the docker images locally, ran the app, and verified the issue is fixed.

### **Test Configuration**:

Docker Compose, after making changes and rebuilding (without cache) locally.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes - WIP