### PR TITLE
🛅 fix: Login/Registration Dynamic page titles based on `APP_TITLE`

### DIFF
--- a/client/src/components/Auth/Login.tsx
+++ b/client/src/components/Auth/Login.tsx
@@ -21,6 +21,10 @@ function Login() {
     }
   }, [isAuthenticated, navigate]);
 
+  useEffect(() => {
+    document.title = startupConfig?.appTitle || 'LibreChat';
+  }, [startupConfig?.appTitle]);
+
   if (!startupConfig) {
     return null;
   }

--- a/client/src/components/Auth/Registration.tsx
+++ b/client/src/components/Auth/Registration.tsx
@@ -13,6 +13,10 @@ const Registration: React.FC = () => {
   const { data: startupConfig } = useGetStartupConfig();
   const localize = useLocalize();
 
+  useEffect(() => {
+    document.title = startupConfig?.appTitle || 'LibreChat';
+  }, [startupConfig?.appTitle]);
+
   const {
     register,
     watch,


### PR DESCRIPTION
Related to #2702

Updates the website title on the Login and Registration pages to match the `APP_TITLE` from `.env` configuration.

- Adds a `useEffect` hook in both `Login.tsx` and `Registration.tsx` components to dynamically set the document title to the `appTitle` obtained from `startupConfig`. This ensures that the website title on these pages reflects the current `APP_TITLE` setting from `.env`.
- Utilizes a fallback title 'LibreChat' in case `appTitle` is not available in the `startupConfig`, maintaining a default behavior.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/danny-avila/LibreChat/issues/2702?shareId=c1d6533e-4706-45a3-a9cf-560656fbc810).