### PR TITLE
🔧 fix: Recognize `azureAssistants` Endpoint Config

### DIFF
--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -78,16 +78,16 @@ const AppService = async (app) => {
   if (config?.endpoints?.[EModelEndpoint.azureAssistants]) {
     endpointLocals[EModelEndpoint.azureAssistants] = assistantsConfigSetup(
       config,
-      endpointLocals[EModelEndpoint.azureAssistants],
       EModelEndpoint.azureAssistants,
+      endpointLocals[EModelEndpoint.azureAssistants],
     );
   }
 
   if (config?.endpoints?.[EModelEndpoint.assistants]) {
     endpointLocals[EModelEndpoint.assistants] = assistantsConfigSetup(
       config,
-      endpointLocals[EModelEndpoint.assistants],
       EModelEndpoint.assistants,
+      endpointLocals[EModelEndpoint.assistants],
     );
   }
 

--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -79,6 +79,7 @@ const AppService = async (app) => {
     endpointLocals[EModelEndpoint.azureAssistants] = assistantsConfigSetup(
       config,
       endpointLocals[EModelEndpoint.azureAssistants],
+      EModelEndpoint.azureAssistants,
     );
   }
 
@@ -86,6 +87,7 @@ const AppService = async (app) => {
     endpointLocals[EModelEndpoint.assistants] = assistantsConfigSetup(
       config,
       endpointLocals[EModelEndpoint.assistants],
+      EModelEndpoint.assistants,
     );
   }
 

--- a/api/server/services/start/assistants.js
+++ b/api/server/services/start/assistants.js
@@ -25,7 +25,7 @@ function azureAssistantsDefaults() {
  * - The previously loaded assistants configuration from Azure OpenAI Assistants option.
  * @returns {Partial<TAssistantEndpoint>} The Assistants endpoint configuration.
  */
-function assistantsConfigSetup(config, prevConfig = {}, assistantsEndpoint) {
+function assistantsConfigSetup(config, assistantsEndpoint, prevConfig = {}) {
   const assistantsConfig = config.endpoints[assistantsEndpoint];
   const parsedConfig = assistantEndpointSchema.parse(assistantsConfig);
   if (assistantsConfig.supportedIds?.length && assistantsConfig.excludedIds?.length) {

--- a/api/server/services/start/assistants.js
+++ b/api/server/services/start/assistants.js
@@ -20,9 +20,9 @@ function azureAssistantsDefaults() {
 /**
  * Sets up the Assistants configuration from the config (`librechat.yaml`) file.
  * @param {TCustomConfig} config - The loaded custom configuration.
- * @param {Partial<TAssistantEndpoint>} [prevConfig]
  * @param {EModelEndpoint.assistants|EModelEndpoint.azureAssistants} [assistantsEndpoint] - The Assistants endpoint name.
  * - The previously loaded assistants configuration from Azure OpenAI Assistants option.
+ * @param {Partial<TAssistantEndpoint>} [prevConfig]
  * @returns {Partial<TAssistantEndpoint>} The Assistants endpoint configuration.
  */
 function assistantsConfigSetup(config, assistantsEndpoint, prevConfig = {}) {

--- a/api/server/services/start/assistants.js
+++ b/api/server/services/start/assistants.js
@@ -20,7 +20,7 @@ function azureAssistantsDefaults() {
 /**
  * Sets up the Assistants configuration from the config (`librechat.yaml`) file.
  * @param {TCustomConfig} config - The loaded custom configuration.
- * @param {EModelEndpoint.assistants|EModelEndpoint.azureAssistants} [assistantsEndpoint] - The Assistants endpoint name.
+ * @param {EModelEndpoint.assistants|EModelEndpoint.azureAssistants} assistantsEndpoint - The Assistants endpoint name.
  * - The previously loaded assistants configuration from Azure OpenAI Assistants option.
  * @param {Partial<TAssistantEndpoint>} [prevConfig]
  * @returns {Partial<TAssistantEndpoint>} The Assistants endpoint configuration.

--- a/api/server/services/start/assistants.js
+++ b/api/server/services/start/assistants.js
@@ -21,15 +21,16 @@ function azureAssistantsDefaults() {
  * Sets up the Assistants configuration from the config (`librechat.yaml`) file.
  * @param {TCustomConfig} config - The loaded custom configuration.
  * @param {Partial<TAssistantEndpoint>} [prevConfig]
+ * @param {EModelEndpoint.assistants|EModelEndpoint.azureAssistants} [assistantsEndpoint] - The Assistants endpoint name.
  * - The previously loaded assistants configuration from Azure OpenAI Assistants option.
  * @returns {Partial<TAssistantEndpoint>} The Assistants endpoint configuration.
  */
-function assistantsConfigSetup(config, prevConfig = {}) {
-  const assistantsConfig = config.endpoints[EModelEndpoint.assistants];
+function assistantsConfigSetup(config, prevConfig = {}, assistantsEndpoint) {
+  const assistantsConfig = config.endpoints[assistantsEndpoint];
   const parsedConfig = assistantEndpointSchema.parse(assistantsConfig);
   if (assistantsConfig.supportedIds?.length && assistantsConfig.excludedIds?.length) {
     logger.warn(
-      `Both \`supportedIds\` and \`excludedIds\` are defined for the ${EModelEndpoint.assistants} endpoint; \`excludedIds\` field will be ignored.`,
+      `Both \`supportedIds\` and \`excludedIds\` are defined for the ${assistantsEndpoint} endpoint; \`excludedIds\` field will be ignored.`,
     );
   }
 


### PR DESCRIPTION
## Summary

when set azureAssistants endpoints in librechat.yaml:
azureAssistants:
    # "retrieval" omitted.
    capabilities: ["code_interpreter", "actions", "tools"]

start app error:
error: There was an uncaught error: [
  {
    "code": "invalid_type",
    "expected": "object",
    "received": "undefined",
    "path": [],
    "message": "Required"
  }
]

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Testing

function assistantsConfigSetup:
const assistantsConfig = config.endpoints[EModelEndpoint.assistants];

this assistantsConfig is null, cause this error


### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
