### PR TITLE
feat: add configuration for user private assistants

### DIFF
--- a/api/server/controllers/assistants/chatV1.js
+++ b/api/server/controllers/assistants/chatV1.js
@@ -28,9 +28,8 @@ const checkBalance = require('~/models/checkBalance');
 const { getConvo } = require('~/models/Conversation');
 const getLogStores = require('~/cache/getLogStores');
 const { getModelMaxTokens } = require('~/utils');
-const { getOpenAIClient } = require('./helpers');
+const { getOpenAIClient, fetchAssistants } = require('./helpers');
 const { logger } = require('~/config');
-
 const { handleAbortError } = require('~/server/middleware');
 
 const ten_minutes = 1000 * 60 * 10;
@@ -60,28 +59,18 @@ const chatV1 = async (req, res) => {
     parentMessageId: _parentId = Constants.NO_PARENT,
   } = req.body;
 
-  /** @type {Partial<TAssistantEndpoint>} */
-  const assistantsConfig = req.app.locals?.[endpoint];
-
-  if (assistantsConfig) {
-    const { supportedIds, excludedIds } = assistantsConfig;
+  req.query.endpoint = endpoint;
+  const body = await fetchAssistants(req, res);
+  const assistantSupported = body.data.some((assistant) => assistant.id === assistant_id);
+  if (!assistantSupported) {
     const error = { message: 'Assistant not supported' };
-    if (supportedIds?.length && !supportedIds.includes(assistant_id)) {
-      return await handleAbortError(res, req, error, {
-        sender: 'System',
-        conversationId: convoId,
-        messageId: v4(),
-        parentMessageId: _messageId,
-        error,
-      });
-    } else if (excludedIds?.length && excludedIds.includes(assistant_id)) {
-      return await handleAbortError(res, req, error, {
-        sender: 'System',
-        conversationId: convoId,
-        messageId: v4(),
-        parentMessageId: _messageId,
-      });
-    }
+    return await handleAbortError(res, req, error, {
+      sender: 'System',
+      conversationId: convoId,
+      messageId: v4(),
+      parentMessageId: _messageId,
+      error,
+    });
   }
 
   /** @type {OpenAIClient} */

--- a/api/server/controllers/assistants/chatV2.js
+++ b/api/server/controllers/assistants/chatV2.js
@@ -27,7 +27,7 @@ const checkBalance = require('~/models/checkBalance');
 const { getConvo } = require('~/models/Conversation');
 const getLogStores = require('~/cache/getLogStores');
 const { getModelMaxTokens } = require('~/utils');
-const { getOpenAIClient } = require('./helpers');
+const { getOpenAIClient, fetchAssistants } = require('./helpers');
 const { logger } = require('~/config');
 
 const { handleAbortError } = require('~/server/middleware');
@@ -60,28 +60,19 @@ const chatV2 = async (req, res) => {
     parentMessageId: _parentId = Constants.NO_PARENT,
   } = req.body;
 
-  /** @type {Partial<TAssistantEndpoint>} */
-  const assistantsConfig = req.app.locals?.[endpoint];
+  req.query.endpoint = endpoint;
+  const body = await fetchAssistants(req, res);
+  const assistantSupported = body.data.some((assistant) => assistant.id === assistant_id);
 
-  if (assistantsConfig) {
-    const { supportedIds, excludedIds } = assistantsConfig;
+  if (!assistantSupported) {
     const error = { message: 'Assistant not supported' };
-    if (supportedIds?.length && !supportedIds.includes(assistant_id)) {
-      return await handleAbortError(res, req, error, {
-        sender: 'System',
-        conversationId: convoId,
-        messageId: v4(),
-        parentMessageId: _messageId,
-        error,
-      });
-    } else if (excludedIds?.length && excludedIds.includes(assistant_id)) {
-      return await handleAbortError(res, req, error, {
-        sender: 'System',
-        conversationId: convoId,
-        messageId: v4(),
-        parentMessageId: _messageId,
-      });
-    }
+    return await handleAbortError(res, req, error, {
+      sender: 'System',
+      conversationId: convoId,
+      messageId: v4(),
+      parentMessageId: _messageId,
+      error,
+    });
   }
 
   /** @type {OpenAIClient} */

--- a/api/server/controllers/assistants/v1.js
+++ b/api/server/controllers/assistants/v1.js
@@ -146,8 +146,14 @@ const listAssistants = async (req, res) => {
     if (req.app.locals?.[req.query.endpoint]) {
       /** @type {Partial<TAssistantEndpoint>} */
       const assistantsConfig = req.app.locals[req.query.endpoint];
-      const { supportedIds, excludedIds } = assistantsConfig;
-      if (supportedIds?.length) {
+      const { supportedIds, excludedIds, private } = assistantsConfig;
+      if (private) {
+        const userId = req.user.id.toString();
+        body.data = body.data.filter(
+          (assistant) =>
+            userId === assistant.metadata?.author || assistant.metadata?.author === undefined,
+        );
+      } else if (supportedIds?.length) {
         body.data = body.data.filter((assistant) => supportedIds.includes(assistant.id));
       } else if (excludedIds?.length) {
         body.data = body.data.filter((assistant) => !excludedIds.includes(assistant.id));

--- a/api/server/controllers/assistants/v1.js
+++ b/api/server/controllers/assistants/v1.js
@@ -61,7 +61,6 @@ const retrieveAssistant = async (req, res) => {
   try {
     /* NOTE: not actually being used right now */
     const { openai } = await getOpenAIClient({ req, res });
-
     const assistant_id = req.params.id;
     const assistant = await openai.beta.assistants.retrieve(assistant_id);
     res.json(assistant);
@@ -142,24 +141,6 @@ const deleteAssistant = async (req, res) => {
 const listAssistants = async (req, res) => {
   try {
     const body = await fetchAssistants(req, res);
-
-    if (req.app.locals?.[req.query.endpoint]) {
-      /** @type {Partial<TAssistantEndpoint>} */
-      const assistantsConfig = req.app.locals[req.query.endpoint];
-      const { supportedIds, excludedIds, private } = assistantsConfig;
-      if (private) {
-        const userId = req.user.id.toString();
-        body.data = body.data.filter(
-          (assistant) =>
-            userId === assistant.metadata?.author || assistant.metadata?.author === undefined,
-        );
-      } else if (supportedIds?.length) {
-        body.data = body.data.filter((assistant) => supportedIds.includes(assistant.id));
-      } else if (excludedIds?.length) {
-        body.data = body.data.filter((assistant) => !excludedIds.includes(assistant.id));
-      }
-    }
-
     res.json(body);
   } catch (error) {
     logger.error('[/assistants] Error listing assistants', error);

--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -505,7 +505,7 @@ describe('AppService updating app.locals and issuing warnings', () => {
 
     const { logger } = require('~/config');
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Both `supportedIds` and `excludedIds` are defined'),
+      expect.stringContaining('endpoint has both \'supportedIds\' and \'excludedIds\' defined'),
     );
   });
 

--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -218,6 +218,7 @@ describe('AppService', () => {
             pollIntervalMs: 5000,
             timeoutMs: 30000,
             supportedIds: ['id1', 'id2'],
+            privateAssistants: false,
           },
         },
       }),
@@ -232,6 +233,7 @@ describe('AppService', () => {
         pollIntervalMs: 5000,
         timeoutMs: 30000,
         supportedIds: expect.arrayContaining(['id1', 'id2']),
+        privateAssistants: false,
       }),
     );
   });

--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -505,7 +505,31 @@ describe('AppService updating app.locals and issuing warnings', () => {
 
     const { logger } = require('~/config');
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('endpoint has both \'supportedIds\' and \'excludedIds\' defined'),
+      expect.stringContaining(
+        'The \'assistants\' endpoint has both \'supportedIds\' and \'excludedIds\' defined.',
+      ),
+    );
+  });
+
+  it('should log a warning when privateAssistants and supportedIds or excludedIds are provided', async () => {
+    const mockConfig = {
+      endpoints: {
+        assistants: {
+          privateAssistants: true,
+          supportedIds: ['id1'],
+        },
+      },
+    };
+    require('./Config/loadCustomConfig').mockImplementationOnce(() => Promise.resolve(mockConfig));
+
+    const app = { locals: {} };
+    await require('./AppService')(app);
+
+    const { logger } = require('~/config');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'The \'assistants\' endpoint has both \'privateAssistants\' and \'supportedIds\' or \'excludedIds\' defined.',
+      ),
     );
   });
 

--- a/api/server/services/start/assistants.js
+++ b/api/server/services/start/assistants.js
@@ -29,7 +29,15 @@ function assistantsConfigSetup(config, prevConfig = {}) {
   const parsedConfig = assistantEndpointSchema.parse(assistantsConfig);
   if (assistantsConfig.supportedIds?.length && assistantsConfig.excludedIds?.length) {
     logger.warn(
-      `Both \`supportedIds\` and \`excludedIds\` are defined for the ${EModelEndpoint.assistants} endpoint; \`excludedIds\` field will be ignored.`,
+      `Configuration conflict: The '${EModelEndpoint.assistants}' endpoint has both 'supportedIds' and 'excludedIds' defined. The 'excludedIds' will be ignored.`,
+    );
+  }
+  if (
+    assistantsConfig.privateAssistants &&
+    (assistantsConfig.supportedIds?.length || assistantsConfig.excludedIds?.length)
+  ) {
+    logger.warn(
+      `Configuration conflict: The '${EModelEndpoint.assistants}' endpoint has both 'privateAssistants' and 'supportedIds' or 'excludedIds' defined. The 'supportedIds' and 'excludedIds' will be ignored.`,
     );
   }
 
@@ -41,7 +49,7 @@ function assistantsConfigSetup(config, prevConfig = {}) {
     supportedIds: parsedConfig.supportedIds,
     capabilities: parsedConfig.capabilities,
     excludedIds: parsedConfig.excludedIds,
-    private: parsedConfig.private,
+    privateAssistants: parsedConfig.privateAssistants,
     timeoutMs: parsedConfig.timeoutMs,
   };
 }

--- a/api/server/services/start/assistants.js
+++ b/api/server/services/start/assistants.js
@@ -41,6 +41,7 @@ function assistantsConfigSetup(config, prevConfig = {}) {
     supportedIds: parsedConfig.supportedIds,
     capabilities: parsedConfig.capabilities,
     excludedIds: parsedConfig.excludedIds,
+    private: parsedConfig.private,
     timeoutMs: parsedConfig.timeoutMs,
   };
 }

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -46,6 +46,8 @@ endpoints:
   #   # Should only be one or the other, either `supportedIds` or `excludedIds`
   #   supportedIds: ["asst_supportedAssistantId1", "asst_supportedAssistantId2"]
   #   # excludedIds: ["asst_excludedAssistantId"]
+  #   Only show assistants that the user created or that were created externally (e.g. in Assistants playground).
+  #   # private: false # Does not work with `supportedIds` or `excludedIds`
   #   # (optional) Models that support retrieval, will default to latest known OpenAI models that support the feature
   #   retrievalModels: ["gpt-4-turbo-preview"]
   #   # (optional) Assistant Capabilities available to all users. Omit the ones you wish to exclude. Defaults to list below.
@@ -56,12 +58,13 @@ endpoints:
       apiKey: '${GROQ_API_KEY}'
       baseURL: 'https://api.groq.com/openai/v1/'
       models:
-        default: [
-          "llama3-70b-8192",
-          "llama3-8b-8192",
-          "llama2-70b-4096",
-          "mixtral-8x7b-32768",
-          "gemma-7b-it",
+        default:
+          [
+            'llama3-70b-8192',
+            'llama3-8b-8192',
+            'llama2-70b-4096',
+            'mixtral-8x7b-32768',
+            'gemma-7b-it',
           ]
         fetch: false
       titleConvo: true
@@ -128,7 +131,6 @@ endpoints:
       # Recommended: Drop the stop parameter from the request as Openrouter models use a variety of stop tokens.
       dropParams: ['stop']
       modelDisplayLabel: 'OpenRouter'
-
 # fileConfig:
 #   endpoints:
 #     assistants:

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -47,7 +47,7 @@ endpoints:
   #   supportedIds: ["asst_supportedAssistantId1", "asst_supportedAssistantId2"]
   #   # excludedIds: ["asst_excludedAssistantId"]
   #   Only show assistants that the user created or that were created externally (e.g. in Assistants playground).
-  #   # private: false # Does not work with `supportedIds` or `excludedIds`
+  #   # privateAssistants: false # Does not work with `supportedIds` or `excludedIds`
   #   # (optional) Models that support retrieval, will default to latest known OpenAI models that support the feature
   #   retrievalModels: ["gpt-4-turbo-preview"]
   #   # (optional) Assistant Capabilities available to all users. Omit the ones you wish to exclude. Defaults to list below.

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -144,6 +144,7 @@ export const assistantEndpointSchema = z.object({
   version: z.union([z.string(), z.number()]).default(2),
   supportedIds: z.array(z.string()).min(1).optional(),
   excludedIds: z.array(z.string()).min(1).optional(),
+  private: z.boolean().optional(),
   retrievalModels: z.array(z.string()).min(1).optional().default(defaultRetrievalModels),
   capabilities: z
     .array(z.nativeEnum(Capabilities))

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -144,7 +144,7 @@ export const assistantEndpointSchema = z.object({
   version: z.union([z.string(), z.number()]).default(2),
   supportedIds: z.array(z.string()).min(1).optional(),
   excludedIds: z.array(z.string()).min(1).optional(),
-  private: z.boolean().optional(),
+  privateAssistants: z.boolean().optional(),
   retrievalModels: z.array(z.string()).min(1).optional().default(defaultRetrievalModels),
   capabilities: z
     .array(z.nativeEnum(Capabilities))


### PR DESCRIPTION
## Summary

Adds the option to only see assistants that you (the user) created or that don't have an author. This is important for privacy reasons when multiple users are sharing the same API-Key. Otherwise a user could get personal information from e.g. a file that another user uploaded.
See this isssue: https://github.com/danny-avila/LibreChat/issues/1926

The specific use case that led to this PR:
- we don't want users to see other users assistants
- we still want to make some assistants available to all users (assistants without a metadata.author field)
## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing
Note: assistant configuration for azure is currently not working as intended (see https://github.com/danny-avila/LibreChat/pull/2824/files)
In librechat.yaml:
```
endpoints:
  assistants:
    userOnly: true
```
1. Login User1 and create an assistant.
2. Login User2 and does not have access to the assistant.
### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted. (https://github.com/LibreChat-AI/librechat.ai/pull/37)
