### PR TITLE
🌏 refactor: Improve Title Prompt for Multilingual Titles

### DIFF
--- a/api/app/clients/prompts/titlePrompts.js
+++ b/api/app/clients/prompts/titlePrompts.js
@@ -28,7 +28,7 @@ ${convo}`,
 };
 
 const titleInstruction =
-  'a concise, 5-word-or-less title for the conversation, using its same language, with no punctuation. Apply title case conventions appropriate for the language. For English, use AP Stylebook Title Case. Never directly mention the language name or the word "title"';
+  'a concise, 5-word-or-less title for the conversation, using its same language, with no punctuation. Apply title case conventions appropriate for the language. Never directly mention the language name or the word "title"';
 const titleFunctionPrompt = `In this environment you have access to a set of tools you can use to generate the conversation title.
   
 You may call them like this:


### PR DESCRIPTION
## Summary
When gpt-3.5-turbo is set to used as titling model, it can only generate English title, no matter what language the conversation is in. However, set gpt-4 or smarter model as titling model does not have this issue.
After checking the titleprompt, I found out, gpt-3.5 accidentally recognize the word "English" in it, and only generate english title.
Below is the title generated only in English before changing titleprompt:
![image](https://github.com/danny-avila/LibreChat/assets/56987501/222a93d0-c4db-4603-9707-8f078f9b3e8b)
Below is the titles generated with different language recognized after changing titleprompt:
![image](https://github.com/danny-avila/LibreChat/assets/56987501/a928fbc1-0307-4aac-91ad-94c394709bc3)

After testing, removing the word "English" in titleprompt doesn't affect the titling performance.


## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing

Let gpt-3.5-turbo generate different titles in different language.

### **Test Configuration**:

titleConvo: true
titleModel: "gpt-3.5-turbo"

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes do not introduce new warnings
