### PR TITLE
STT with Browser Multilingual Recognition

### DIFF
--- a/client/src/hooks/Input/useSpeechToTextBrowser.ts
+++ b/client/src/hooks/Input/useSpeechToTextBrowser.ts
@@ -7,6 +7,7 @@ import SpeechRecognition, { useSpeechRecognition } from 'react-speech-recognitio
 const useSpeechToTextBrowser = () => {
   const { showToast } = useToastContext();
   const [endpointSTT] = useRecoilState<string>(store.endpointSTT);
+  const [lang] = useRecoilState<string>(store.lang);
 
   const { transcript, listening, resetTranscript, browserSupportsSpeechRecognition } =
     useSpeechRecognition();
@@ -16,7 +17,7 @@ const useSpeechToTextBrowser = () => {
       if (listening) {
         SpeechRecognition.stopListening();
       } else {
-        SpeechRecognition.startListening();
+        SpeechRecognition.startListening({ language: lang });
       }
     } else {
       showToast({


### PR DESCRIPTION
## Summary

Allow STT with browser to recognize the language according to the users' language set for librechat.
![image](https://github.com/danny-avila/LibreChat/assets/56987501/e734ec38-2b48-41f2-ad32-206f34a47da8)


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Change language in setting, and STT with browser is about to recognize the language you set to.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
