### PR TITLE
🔧 fix(redis): Resolve Redis Standalone vs Cluster mode discrepancy for social logins

### DIFF
--- a/api/cache/redis.js
+++ b/api/cache/redis.js
@@ -1,4 +1,9 @@
 const Redis = require('ioredis');
+const { logger } = require('~/config');
 const { REDIS_URI } = process.env ?? {};
-const redis = new Redis.Cluster(REDIS_URI);
+const redis = new Redis(REDIS_URI);
+redis
+  .on('error', (err) => logger.error('ioredis error:', err))
+  .on('ready', () => logger.info('ioredis successfully initialized.'))
+  .on('reconnecting', () => logger.info('ioredis reconnecting...'));
 module.exports = redis;


### PR DESCRIPTION
## Summary

Resolves an issue with OpenID authentication requests hanging and timing out when using Redis in Standalone mode (see also  #2843).

Steps to reproduce:
- Set up a Standalone Redis server.
- Set the `USE_REDIS` and `REDIS_URI` env vars.
- Set the `ALLOW_SOCIAL_LOGIN` and `OPENID_*` env vars.
- Navigate to login page.
- Click _Continue with OpenID_.
- Request times out.

This issue can be traced to the way social logins are configured at startup, since a `RedisStore` is configured for session storage with the client from `api/cache/redis.js`, but this client assumes that Redis is running in Cluster mode, and as a result it fails to connect (times out). The connection error is silently ignored, so it doesn't show up in the log output. By contrast, the `api/cache/keyvRedis.js` client successfully connects to Redis in Standalone mode and reports `Redis initialized`. 

As it stands, neither `redis.js` nor `keyvRedis.js` support Cluster mode and doing so would require introducing additional configuration and logic, so the proposed fix is to resolve the immediate discrepancy to ensure that both work with Redis in Standalone mode. The suggestions proposed in #2843 to support Cluster mode could be considered for a subsequent enhancement.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### **Test Configuration**:

I have confirmed that the proposed updates work with an AWS ElasticCache Redis installation running in Standalone mode. There's no additional configuration required to test this besides setting the environment variables to use redis and OpenID authentication.

### **Test Script**:

The following script adapted from `api/cache/redis.js` can be used to show the problem when `REDIS_URI` points to a Standalone installation:

```js
const Redis = require('ioredis');
const { REDIS_URI } = process.env; 

const redisCluster = new Redis.Cluster(REDIS_URI, { lazyConnect: true });
redisCluster.connect()
  .then(() => console.log('redis cluster initialized'))
  .catch((err) => console.error(`redis cluster error: ${err}`));

const redisStandalone = new Redis(REDIS_URI, { lazyConnect: true });
redisStandalone.connect()
  .then(() => console.log('redis standalone initialized'))
  .catch((err) => console.error(`redis standalone error: ${err}`));
```

The following output is expected when running the script:

```
redis cluster error: Error: `startupNodes` should contain at least one node.
redis standalone initialized
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
