### PR TITLE
Add complete Helm chart example for Kubernetes deployment

### DIFF
--- a/chart/.gitignore
+++ b/chart/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+values.yaml
+notes.md
+librechat-config.yaml

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: librechat
+description: A Helm chart for LibreChat application
+version: 0.3.7
+appVersion: "latest"

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "librechat.name" -}}
+{{ .Chart.Name }}
+{{- end -}}

--- a/chart/templates/configmap.yaml
+++ b/chart/templates/configmap.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: env-config
+data:
+  .env: |
+    UID={{ .Values.uid }}
+    GID={{ .Values.gid }}
+    RAG_PORT={{ .Values.rag_api.service.port }}
+    OPENAI_API_KEY={{ .Values.openai_api_key }}
+    CREDS_KEY={{ .Values.creds_key }}
+    CREDS_IV={{ .Values.creds_iv }}
+    HOST={{ .Values.host }}
+    PORT={{ .Values.port }}
+    MONGO_URI={{ .Values.mongo_uri }}
+    DOMAIN_CLIENT={{ .Values.domain_client }}
+    DOMAIN_SERVER={{ .Values.domain_server }}
+    NO_INDEX={{ .Values.no_index }}
+    CONSOLE_JSON={{ .Values.console_json }}
+    DEBUG_LOGGING={{ .Values.debug_logging }}
+    DEBUG_CONSOLE={{ .Values.debug_console }}
+    PROXY={{ .Values.proxy }}
+    SEARCH={{ .Values.search }}
+    MEILI_NO_ANALYTICS={{ .Values.meili_no_analytics }}
+    MEILI_HOST={{ .Values.meili_host }}
+    MEILI_MASTER_KEY={{ .Values.meili_master_key }}
+    STT_API_KEY={{ .Values.stt_api_key }}
+    TTS_API_KEY={{ .Values.tts_api_key }}
+    OPENAI_MODERATION={{ .Values.openai_moderation }}
+    OPENAI_MODERATION_API_KEY={{ .Values.openai_moderation_api_key }}
+    BAN_VIOLATIONS={{ .Values.ban_violations }}
+    BAN_DURATION={{ .Values.ban_duration }}
+    BAN_INTERVAL={{ .Values.ban_interval }}
+    LOGIN_VIOLATION_SCORE={{ .Values.login_violation_score }}
+    REGISTRATION_VIOLATION_SCORE={{ .Values.registration_violation_score }}
+    CONCURRENT_VIOLATION_SCORE={{ .Values.concurrent_violation_score }}
+    MESSAGE_VIOLATION_SCORE={{ .Values.message_violation_score }}
+    NON_BROWSER_VIOLATION_SCORE={{ .Values.non_browser_violation_score }}
+    LOGIN_MAX={{ .Values.login_max }}
+    LOGIN_WINDOW={{ .Values.login_window }}
+    REGISTER_MAX={{ .Values.register_max }}
+    REGISTER_WINDOW={{ .Values.register_window }}
+    LIMIT_CONCURRENT_MESSAGES={{ .Values.limit_concurrent_messages }}
+    CONCURRENT_MESSAGE_MAX={{ .Values.concurrent_message_max }}
+    LIMIT_MESSAGE_IP={{ .Values.limit_message_ip }}
+    MESSAGE_IP_MAX={{ .Values.message_ip_max }}
+    MESSAGE_IP_WINDOW={{ .Values.message_ip_window }}
+    LIMIT_MESSAGE_USER={{ .Values.limit_message_user }}
+    MESSAGE_USER_MAX={{ .Values.message_user_max }}
+    MESSAGE_USER_WINDOW={{ .Values.message_user_window }}
+    ILLEGAL_MODEL_REQ_SCORE={{ .Values.illegal_model_req_score }}
+    CHECK_BALANCE={{ .Values.check_balance }}
+    ALLOW_EMAIL_LOGIN={{ .Values.allow_email_login }}
+    ALLOW_REGISTRATION={{ .Values.allow_registration }}
+    ALLOW_SOCIAL_LOGIN={{ .Values.allow_social_login }}
+    ALLOW_SOCIAL_REGISTRATION={{ .Values.allow_social_registration }}
+    SESSION_EXPIRY={{ .Values.session_expiry }}
+    REFRESH_TOKEN_EXPIRY={{ .Values.refresh_token_expiry }}
+    JWT_SECRET={{ .Values.jwt_secret }}
+    JWT_REFRESH_SECRET={{ .Values.jwt_refresh_secret }}
+    APP_TITLE={{ .Values.app_title }}
+    HELP_AND_FAQ_URL={{ .Values.help_and_faq_url }}

--- a/chart/templates/deployment-api.yaml
+++ b/chart/templates/deployment-api.yaml
@@ -1,0 +1,171 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  labels:
+    app: api
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+        - name: api
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.api.service.port }}
+          env:
+            - name: HOST
+              value: "{{ .Values.host }}"
+            - name: NODE_ENV
+              value: "production"
+            - name: MONGO_URI
+              value: "{{ .Values.mongo_uri }}"
+            - name: MEILI_HOST
+              value: "{{ .Values.meili_host }}"
+            - name: RAG_PORT
+              value: "{{ .Values.rag_api.service.port }}"
+            - name: RAG_API_URL
+              value: "http://rag-api:{{ .Values.rag_api.service.port }}"
+            - name: UID
+              value: "{{ .Values.uid }}"
+            - name: GID
+              value: "{{ .Values.gid }}"
+            - name: CREDS_KEY
+              value: "{{ .Values.creds_key }}"
+            - name: CREDS_IV
+              value: "{{ .Values.creds_iv }}"
+            - name: DOMAIN_CLIENT
+              value: "{{ .Values.domain_client }}"
+            - name: DOMAIN_SERVER
+              value: "{{ .Values.domain_server }}"
+            - name: NO_INDEX
+              value: "{{ .Values.no_index }}"
+            - name: CONSOLE_JSON
+              value: "{{ .Values.console_json }}"
+            - name: DEBUG_LOGGING
+              value: "{{ .Values.debug_logging }}"
+            - name: DEBUG_CONSOLE
+              value: "{{ .Values.debug_console }}"
+            - name: SEARCH
+              value: "{{ .Values.search }}"
+            - name: MEILI_NO_ANALYTICS
+              value: "{{ .Values.meili_no_analytics }}"
+            - name: MEILI_MASTER_KEY
+              value: "{{ .Values.meili_master_key }}"
+            - name: STT_API_KEY
+              value: "{{ .Values.stt_api_key }}"
+            - name: TTS_API_KEY
+              value: "{{ .Values.tts_api_key }}"
+            - name: OPENAI_MODERATION
+              value: "{{ .Values.openai_moderation }}"
+            - name: OPENAI_MODERATION_API_KEY
+              value: "{{ .Values.openai_moderation_api_key }}"
+            - name: BAN_VIOLATIONS
+              value: "{{ .Values.ban_violations }}"
+            - name: BAN_DURATION
+              value: "{{ .Values.ban_duration }}"
+            - name: BAN_INTERVAL
+              value: "{{ .Values.ban_interval }}"
+            - name: LOGIN_VIOLATION_SCORE
+              value: "{{ .Values.login_violation_score }}"
+            - name: REGISTRATION_VIOLATION_SCORE
+              value: "{{ .Values.registration_violation_score }}"
+            - name: CONCURRENT_VIOLATION_SCORE
+              value: "{{ .Values.concurrent_violation_score }}"
+            - name: MESSAGE_VIOLATION_SCORE
+              value: "{{ .Values.message_violation_score }}"
+            - name: NON_BROWSER_VIOLATION_SCORE
+              value: "{{ .Values.non_browser_violation_score }}"
+            - name: LOGIN_MAX
+              value: "{{ .Values.login_max }}"
+            - name: LOGIN_WINDOW
+              value: "{{ .Values.login_window }}"
+            - name: REGISTER_MAX
+              value: "{{ .Values.register_max }}"
+            - name: REGISTER_WINDOW
+              value: "{{ .Values.register_window }}"
+            - name: LIMIT_CONCURRENT_MESSAGES
+              value: "{{ .Values.limit_concurrent_messages }}"
+            - name: CONCURRENT_MESSAGE_MAX
+              value: "{{ .Values.concurrent_message_max }}"
+            - name: LIMIT_MESSAGE_IP
+              value: "{{ .Values.limit_message_ip }}"
+            - name: MESSAGE_IP_MAX
+              value: "{{ .Values.message_ip_max }}"
+            - name: MESSAGE_IP_WINDOW
+              value: "{{ .Values.message_ip_window }}"
+            - name: LIMIT_MESSAGE_USER
+              value: "{{ .Values.limit_message_user }}"
+            - name: MESSAGE_USER_MAX
+              value: "{{ .Values.message_user_max }}"
+            - name: MESSAGE_USER_WINDOW
+              value: "{{ .Values.message_user_window }}"
+            - name: ILLEGAL_MODEL_REQ_SCORE
+              value: "{{ .Values.illegal_model_req_score }}"
+            - name: CHECK_BALANCE
+              value: "{{ .Values.check_balance }}"
+            - name: ALLOW_EMAIL_LOGIN
+              value: "{{ .Values.allow_email_login }}"
+            - name: ALLOW_REGISTRATION
+              value: "{{ .Values.allow_registration }}"
+            - name: ALLOW_SOCIAL_LOGIN
+              value: "{{ .Values.allow_social_login }}"
+            - name: ALLOW_SOCIAL_REGISTRATION
+              value: "{{ .Values.allow_social_registration }}"
+            - name: SESSION_EXPIRY
+              value: "{{ .Values.session_expiry }}"
+            - name: REFRESH_TOKEN_EXPIRY
+              value: "{{ .Values.refresh_token_expiry }}"
+            - name: JWT_SECRET
+              value: "{{ .Values.jwt_secret }}"
+            - name: JWT_REFRESH_SECRET
+              value: "{{ .Values.jwt_refresh_secret }}"
+            - name: APP_TITLE
+              value: "{{ .Values.app_title }}"
+            - name: HELP_AND_FAQ_URL
+              value: "{{ .Values.help_and_faq_url }}"
+            - name: REDIS_URL
+              value: "{{ .Values.redis_uri }}"
+            - name: USE_REDIS
+              value: "{{ .Values.use_redis }}"
+            - name: OPENAI_API_KEY
+              value: "{{ .Values.openai_api_key }}"
+            - name: ASSISTANTS_API_KEY
+              value: "{{ .Values.assistants_api_key }}"              
+            - name: PROXY
+              value: "{{ .Values.proxy }}"
+            - name: HTTP_PROXY
+              value: "{{ .Values.proxy }}"
+            - name: HTTPS_PROXY
+              value: "{{ .Values.proxy }}"
+            - name: NO_PROXY
+              value: "localhost,127.0.0.1,.yourdomain.com,10.0.0.0/8,192.168.0.0/16,172.16.0.0/12"
+          volumeMounts:
+            - name: env-file
+              mountPath: /app/.env
+            - name: images
+              mountPath: /app/client/public/images
+            - name: logs
+              mountPath: /app/api/logs
+            - name: librechat-config
+              mountPath: /app/librechat.yaml
+              subPath: librechat.yaml
+      volumes:
+        - name: env-file
+          configMap:
+            name: env-config
+        - name: images
+          persistentVolumeClaim:
+            claimName: pvc-images
+        - name: logs
+          persistentVolumeClaim:
+            claimName: pvc-logs
+        - name: librechat-config
+          configMap:
+            name: librechat-config

--- a/chart/templates/deployment-meilisearch.yaml
+++ b/chart/templates/deployment-meilisearch.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: meilisearch
+  labels:
+    app: meilisearch
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: meilisearch
+  template:
+    metadata:
+      labels:
+        app: meilisearch
+    spec:
+      containers:
+        - name: meilisearch
+          image: "{{ .Values.meilisearch.image.repository }}:{{ .Values.meilisearch.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.meilisearch.service.port }}
+          env:
+            - name: MEILI_HOST
+              value: "http://meilisearch:7700"
+            - name: MEILI_NO_ANALYTICS
+              value: "true"
+          volumeMounts:
+            - name: meili-data
+              mountPath: /meili_data
+      volumes:
+        - name: meili-data
+          persistentVolumeClaim:
+            claimName: meilisearch-pvc

--- a/chart/templates/deployment-mongodb.yaml
+++ b/chart/templates/deployment-mongodb.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongodb
+  labels:
+    app: mongodb
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: mongodb
+  template:
+    metadata:
+      labels:
+        app: mongodb
+    spec:
+      containers:
+        - name: mongodb
+          image: "{{ .Values.mongodb.image.repository }}:{{ .Values.mongodb.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.mongodb.service.port }}
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: mongodb-pvc

--- a/chart/templates/deployment-rag-api.yaml
+++ b/chart/templates/deployment-rag-api.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rag-api
+  labels:
+    app: rag-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rag-api
+  template:
+    metadata:
+      labels:
+        app: rag-api
+    spec:
+      containers:
+        - name: rag-api
+          image: "{{ .Values.rag_api.image.repository }}:{{ .Values.rag_api.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.rag_api.service.port }}
+          env:
+            - name: DB_HOST
+              value: "vectordb"
+            - name: RAG_PORT
+              value: "{{ .Values.rag_api.service.port }}"
+            - name: OPENAI_API_KEY
+              value: "{{ .Values.openai_api_key }}"
+          volumeMounts:
+            - name: env-file
+              mountPath: /app/.env
+      volumes:
+        - name: env-file
+          configMap:
+            name: env-config

--- a/chart/templates/deployment-redis.yaml
+++ b/chart/templates/deployment-redis.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  replicas: {{ .Values.redis.replicaCount }}
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.redis.service.port }}
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-secret
+                  key: password
+          volumeMounts:
+            - name: redis-pvc
+              mountPath: /data
+      volumes:
+        - name: redis-pvc
+          persistentVolumeClaim:
+            claimName: {{ .Values.redis.persistentVolumeClaim }}

--- a/chart/templates/deployment-vectordb.yaml
+++ b/chart/templates/deployment-vectordb.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vectordb
+  labels:
+    app: vectordb
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: vectordb
+  template:
+    metadata:
+      labels:
+        app: vectordb
+    spec:
+      containers:
+        - name: vectordb
+          image: "{{ .Values.vectordb.image.repository }}:{{ .Values.vectordb.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.vectordb.service.port }}
+          env:
+            - name: POSTGRES_DB
+              value: "mydatabase"
+            - name: POSTGRES_USER
+              value: "myuser"
+            - name: POSTGRES_PASSWORD
+              value: "mypassword"
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: pgdata
+          persistentVolumeClaim:
+            claimName: vectordb-pvc

--- a/chart/templates/librechat-config.yaml.example
+++ b/chart/templates/librechat-config.yaml.example
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: librechat-config
+data:
+  librechat.yaml: |
+    version: "1.0"
+    endpoints:
+      custom:
+        - name: "Ollama"
+          apiKey: "ollama"
+          baseURL: "your_ollama_url/v1/chat/completions"
+          models:
+            default: [
+              "Meta-Llama-3-8B-Instruct-GGUF"
+            ]
+            fetch: true
+          titleConvo: true
+          titleModel: "current_model"
+          summarize: false
+          summaryModel: "current_model"
+          forcePrompt: false
+          modelDisplayLabel: "Ollama"

--- a/chart/templates/pvc.yaml
+++ b/chart/templates/pvc.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongodb-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: meilisearch-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vectordb-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-images
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-logs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/chart/templates/service-api.yaml
+++ b/chart/templates/service-api.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  labels:
+    app: api
+spec:
+  type: NodePort
+  ports:
+    - port: {{ .Values.api.service.port }}
+      targetPort: {{ .Values.api.service.port }}
+      nodePort: {{ .Values.api.service.nodePort }}
+      protocol: TCP
+      name: api
+  selector:
+    app: api

--- a/chart/templates/service-meilisearch.yaml
+++ b/chart/templates/service-meilisearch.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: meilisearch
+  labels:
+    app: meilisearch
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.meilisearch.service.port }}
+      targetPort: {{ .Values.meilisearch.service.port }}
+      protocol: TCP
+      name: meilisearch
+  selector:
+    app: meilisearch

--- a/chart/templates/service-mongodb.yaml
+++ b/chart/templates/service-mongodb.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: mongodb
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.mongodb.service.port }}
+      targetPort: {{ .Values.mongodb.service.port }}
+      protocol: TCP
+      name: mongodb
+  selector:
+    app: mongodb

--- a/chart/templates/service-rag-api.yaml
+++ b/chart/templates/service-rag-api.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rag-api
+  labels:
+    app: rag-api
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.rag_api.service.port }}
+      targetPort: {{ .Values.rag_api.service.port }}
+      protocol: TCP
+      name: rag-api
+  selector:
+    app: rag-api

--- a/chart/templates/service-redis.yaml
+++ b/chart/templates/service-redis.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.redis.service.port }}
+      targetPort: {{ .Values.redis.service.port }}
+      protocol: TCP
+      name: redis
+  selector:
+    app: redis

--- a/chart/templates/service-vectordb.yaml
+++ b/chart/templates/service-vectordb.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vectordb
+  labels:
+    app: vectordb
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.vectordb.service.port }}
+      targetPort: {{ .Values.vectordb.service.port }}
+      protocol: TCP
+      name: vectordb
+  selector:
+    app: vectordb

--- a/chart/values.yaml.example
+++ b/chart/values.yaml.example
@@ -1,0 +1,108 @@
+replicaCount: 1
+
+api:
+  image:
+    repository: ghcr.io/danny-avila/librechat-dev-api
+    tag: latest
+  service:
+    port: 3080
+    nodePort: 30080
+
+mongodb:
+  image:
+    repository: bitnami/mongodb
+    tag: latest
+  service:
+    port: 27017
+
+meilisearch:
+  image:
+    repository: getmeili/meilisearch
+    tag: v1.7.3
+  service:
+    port: 7700
+
+vectordb:
+  image:
+    repository: ankane/pgvector
+    tag: latest
+  service:
+    port: 5432
+
+rag_api:
+  image:
+    repository: ghcr.io/danny-avila/librechat-rag-api-dev-lite
+    tag: latest
+  service:
+    port: 8000
+
+redis:
+  replicaCount: 1
+  image:
+    repository: bitnami/redis
+    tag: latest
+  service:
+    port: 6379
+  persistentVolumeClaim: redis-pvc
+
+uid: "1000"
+gid: "1000"
+
+openai_api_key: "your_openai_api_key_here"
+assistants_api_key: "your_openai_api_key_here"
+
+creds_key: "your_creds_key_here"
+creds_iv: "your_creds_iv_here"
+
+host: "0.0.0.0"
+port: 3080
+mongo_uri: "mongodb://mongodb:27017/LibreChat"
+domain_client: "http://api:3080"
+domain_server: "http://api:3080"
+no_index: "true"
+console_json: "false"
+debug_logging: "true"
+debug_console: "false"
+search: "true"
+meili_no_analytics: "true"
+meili_host: "http://meilisearch:7700"
+meili_master_key: "your_meili_master_key_here"
+stt_api_key: ""
+tts_api_key: ""
+openai_moderation: "false"
+openai_moderation_api_key: ""
+ban_violations: "true"
+ban_duration: 7200000
+ban_interval: 20
+login_violation_score: 1
+registration_violation_score: 1
+concurrent_violation_score: 1
+message_violation_score: 1
+non_browser_violation_score: 20
+login_max: 7
+login_window: 5
+register_max: 5
+register_window: 60
+limit_concurrent_messages: "true"
+concurrent_message_max: 2
+limit_message_ip: "true"
+message_ip_max: 40
+message_ip_window: 1
+limit_message_user: "false"
+message_user_max: 40
+message_user_window: 1
+illegal_model_req_score: 5
+check_balance: "false"
+allow_email_login: "true"
+allow_registration: "true"
+allow_social_login: "false"
+allow_social_registration: "false"
+session_expiry: 900000
+refresh_token_expiry: 604800000
+jwt_secret: "your_jwt_secret_here"
+jwt_refresh_secret: "your_jwt_refresh_secret_here"
+app_title: "LibreChat"
+help_and_faq_url: "https://librechat.ai"
+redis_uri: "redis://your_redis_password:redis:6379"
+use_redis: "true"
+proxy: "your_proxy_here"


### PR DESCRIPTION
## Summary

This pull request adds a complete Helm chart example for deploying the project in Kubernetes. It includes configurations for deployments, services, and ingress. Please review and provide feedback.

## Change Type

Please delete any irrelevant options.

- [*] New feature (non-breaking change which adds functionality)
- [*] This change requires a documentation update

## Testing

I tested the Helm chart manually by deploying it in a Kubernetes cluster using k3s. Below are the steps to reproduce the test:

1. Ensure you have a running Kubernetes cluster and Helm installed on your system.

2. Prepare the Configuration Files:
   - Before deploying the chart, rename the files `values.yaml.example` and `librechat-config.yaml.example` by removing `.example` from the file names.
   - Fill in your parameters in the `values.yaml` and `librechat-config.yaml` files.

3. Deploy the Helm Chart:
   - Use Helm to deploy the chart to your Kubernetes cluster.
     ```bash
     cd chart
     helm upgrade --install --namespace librechat --create-namespace --values values.yaml librechat .
     ```

4. Access the Application:
   - Access the application through NodePort `30080`.

### **Test Configuration**:

- **Kubernetes Version**: Server Version: v1.28.8+k3s1
- **Helm Version**: v3.12.3

### **Test Configuration**:

- **Kubernetes Version**: Server Version: v1.28.8+k3s1
- **Helm Version**: v3.12.3

## Checklist

Please delete any irrelevant options.


