### PR TITLE
🤖 feat: Private Assistants

### DIFF
--- a/api/models/Assistant.js
+++ b/api/models/Assistant.js
@@ -14,7 +14,7 @@ const Assistant = mongoose.model('assistant', assistantSchema);
  * @param {mongoose.ClientSession} [session] - The transaction session to use (optional).
  * @returns {Promise<Object>} The updated or newly created assistant document as a plain object.
  */
-const updateAssistant = async (searchParams, updateData, session = null) => {
+const updateAssistantDoc = async (searchParams, updateData, session = null) => {
   const options = { new: true, upsert: true, session };
   return await Assistant.findOneAndUpdate(searchParams, updateData, options).lean();
 };
@@ -52,7 +52,7 @@ const deleteAssistant = async (searchParams) => {
 };
 
 module.exports = {
-  updateAssistant,
+  updateAssistantDoc,
   deleteAssistant,
   getAssistants,
   getAssistant,

--- a/api/server/controllers/assistants/chatV1.js
+++ b/api/server/controllers/assistants/chatV1.js
@@ -20,6 +20,7 @@ const {
 } = require('~/server/services/Threads');
 const { sendResponse, sendMessage, sleep, isEnabled, countTokens } = require('~/server/utils');
 const { runAssistant, createOnTextProgress } = require('~/server/services/AssistantService');
+const validateAuthor = require('~/server/middleware/assistants/validateAuthor');
 const { formatMessage, createVisionPrompt } = require('~/app/clients/prompts');
 const { createRun, StreamRunManager } = require('~/server/services/Runs');
 const { addTitle } = require('~/server/services/Endpoints/assistants');
@@ -38,7 +39,7 @@ const ten_minutes = 1000 * 60 * 10;
  * @desc Chat with an assistant
  * @access Public
  * @param {object} req - The request object, containing the request data.
- * @param {TPayload} req.body - The request payload.
+ * @param {object} req.body - The request payload.
  * @param {Express.Response} res - The response object, used to send back a response.
  * @returns {void}
  */
@@ -286,6 +287,7 @@ const chatV1 = async (req, res) => {
     });
 
     openai = _openai;
+    await validateAuthor({ req, openai });
 
     if (previousMessages.length) {
       parentMessageId = previousMessages[previousMessages.length - 1].messageId;

--- a/api/server/controllers/assistants/chatV1.js
+++ b/api/server/controllers/assistants/chatV1.js
@@ -28,9 +28,8 @@ const checkBalance = require('~/models/checkBalance');
 const { getConvo } = require('~/models/Conversation');
 const getLogStores = require('~/cache/getLogStores');
 const { getModelMaxTokens } = require('~/utils');
-const { getOpenAIClient } = require('./helpers');
+const { getOpenAIClient, fetchAssistants } = require('./helpers');
 const { logger } = require('~/config');
-
 const { handleAbortError } = require('~/server/middleware');
 
 const ten_minutes = 1000 * 60 * 10;
@@ -60,28 +59,18 @@ const chatV1 = async (req, res) => {
     parentMessageId: _parentId = Constants.NO_PARENT,
   } = req.body;
 
-  /** @type {Partial<TAssistantEndpoint>} */
-  const assistantsConfig = req.app.locals?.[endpoint];
-
-  if (assistantsConfig) {
-    const { supportedIds, excludedIds } = assistantsConfig;
+  req.query.endpoint = endpoint;
+  const body = await fetchAssistants(req, res);
+  const assistantSupported = body.data.some((assistant) => assistant.id === assistant_id);
+  if (!assistantSupported) {
     const error = { message: 'Assistant not supported' };
-    if (supportedIds?.length && !supportedIds.includes(assistant_id)) {
-      return await handleAbortError(res, req, error, {
-        sender: 'System',
-        conversationId: convoId,
-        messageId: v4(),
-        parentMessageId: _messageId,
-        error,
-      });
-    } else if (excludedIds?.length && excludedIds.includes(assistant_id)) {
-      return await handleAbortError(res, req, error, {
-        sender: 'System',
-        conversationId: convoId,
-        messageId: v4(),
-        parentMessageId: _messageId,
-      });
-    }
+    return await handleAbortError(res, req, error, {
+      sender: 'System',
+      conversationId: convoId,
+      messageId: v4(),
+      parentMessageId: _messageId,
+      error,
+    });
   }
 
   /** @type {OpenAIClient} */

--- a/api/server/controllers/assistants/chatV1.js
+++ b/api/server/controllers/assistants/chatV1.js
@@ -31,15 +31,14 @@ const { getModelMaxTokens } = require('~/utils');
 const { getOpenAIClient } = require('./helpers');
 const { logger } = require('~/config');
 
-const { handleAbortError } = require('~/server/middleware');
-
 const ten_minutes = 1000 * 60 * 10;
 
 /**
  * @route POST /
  * @desc Chat with an assistant
  * @access Public
- * @param {Express.Request} req - The request object, containing the request data.
+ * @param {object} req - The request object, containing the request data.
+ * @param {TPayload} req.body - The request payload.
  * @param {Express.Response} res - The response object, used to send back a response.
  * @returns {void}
  */
@@ -59,30 +58,6 @@ const chatV1 = async (req, res) => {
     conversationId: convoId,
     parentMessageId: _parentId = Constants.NO_PARENT,
   } = req.body;
-
-  /** @type {Partial<TAssistantEndpoint>} */
-  const assistantsConfig = req.app.locals?.[endpoint];
-
-  if (assistantsConfig) {
-    const { supportedIds, excludedIds } = assistantsConfig;
-    const error = { message: 'Assistant not supported' };
-    if (supportedIds?.length && !supportedIds.includes(assistant_id)) {
-      return await handleAbortError(res, req, error, {
-        sender: 'System',
-        conversationId: convoId,
-        messageId: v4(),
-        parentMessageId: _messageId,
-        error,
-      });
-    } else if (excludedIds?.length && excludedIds.includes(assistant_id)) {
-      return await handleAbortError(res, req, error, {
-        sender: 'System',
-        conversationId: convoId,
-        messageId: v4(),
-        parentMessageId: _messageId,
-      });
-    }
-  }
 
   /** @type {OpenAIClient} */
   let openai;

--- a/api/server/controllers/assistants/chatV2.js
+++ b/api/server/controllers/assistants/chatV2.js
@@ -27,7 +27,7 @@ const checkBalance = require('~/models/checkBalance');
 const { getConvo } = require('~/models/Conversation');
 const getLogStores = require('~/cache/getLogStores');
 const { getModelMaxTokens } = require('~/utils');
-const { getOpenAIClient } = require('./helpers');
+const { getOpenAIClient, fetchAssistants } = require('./helpers');
 const { logger } = require('~/config');
 
 const { handleAbortError } = require('~/server/middleware');
@@ -60,28 +60,19 @@ const chatV2 = async (req, res) => {
     parentMessageId: _parentId = Constants.NO_PARENT,
   } = req.body;
 
-  /** @type {Partial<TAssistantEndpoint>} */
-  const assistantsConfig = req.app.locals?.[endpoint];
+  req.query.endpoint = endpoint;
+  const body = await fetchAssistants(req, res);
+  const assistantSupported = body.data.some((assistant) => assistant.id === assistant_id);
 
-  if (assistantsConfig) {
-    const { supportedIds, excludedIds } = assistantsConfig;
+  if (!assistantSupported) {
     const error = { message: 'Assistant not supported' };
-    if (supportedIds?.length && !supportedIds.includes(assistant_id)) {
-      return await handleAbortError(res, req, error, {
-        sender: 'System',
-        conversationId: convoId,
-        messageId: v4(),
-        parentMessageId: _messageId,
-        error,
-      });
-    } else if (excludedIds?.length && excludedIds.includes(assistant_id)) {
-      return await handleAbortError(res, req, error, {
-        sender: 'System',
-        conversationId: convoId,
-        messageId: v4(),
-        parentMessageId: _messageId,
-      });
-    }
+    return await handleAbortError(res, req, error, {
+      sender: 'System',
+      conversationId: convoId,
+      messageId: v4(),
+      parentMessageId: _messageId,
+      error,
+    });
   }
 
   /** @type {OpenAIClient} */

--- a/api/server/controllers/assistants/chatV2.js
+++ b/api/server/controllers/assistants/chatV2.js
@@ -20,6 +20,7 @@ const {
 } = require('~/server/services/Threads');
 const { sendResponse, sendMessage, sleep, isEnabled, countTokens } = require('~/server/utils');
 const { runAssistant, createOnTextProgress } = require('~/server/services/AssistantService');
+const validateAuthor = require('~/server/middleware/assistants/validateAuthor');
 const { createRun, StreamRunManager } = require('~/server/services/Runs');
 const { addTitle } = require('~/server/services/Endpoints/assistants');
 const { getTransactions } = require('~/models/Transaction');
@@ -283,6 +284,7 @@ const chatV2 = async (req, res) => {
     });
 
     openai = _openai;
+    await validateAuthor({ req, openai });
 
     if (previousMessages.length) {
       parentMessageId = previousMessages[previousMessages.length - 1].messageId;

--- a/api/server/controllers/assistants/chatV2.js
+++ b/api/server/controllers/assistants/chatV2.js
@@ -27,7 +27,7 @@ const checkBalance = require('~/models/checkBalance');
 const { getConvo } = require('~/models/Conversation');
 const getLogStores = require('~/cache/getLogStores');
 const { getModelMaxTokens } = require('~/utils');
-const { getOpenAIClient, fetchAssistants } = require('./helpers');
+const { getOpenAIClient } = require('./helpers');
 const { logger } = require('~/config');
 
 const { handleAbortError } = require('~/server/middleware');
@@ -60,19 +60,28 @@ const chatV2 = async (req, res) => {
     parentMessageId: _parentId = Constants.NO_PARENT,
   } = req.body;
 
-  req.query.endpoint = endpoint;
-  const body = await fetchAssistants(req, res);
-  const assistantSupported = body.data.some((assistant) => assistant.id === assistant_id);
+  /** @type {Partial<TAssistantEndpoint>} */
+  const assistantsConfig = req.app.locals?.[endpoint];
 
-  if (!assistantSupported) {
+  if (assistantsConfig) {
+    const { supportedIds, excludedIds } = assistantsConfig;
     const error = { message: 'Assistant not supported' };
-    return await handleAbortError(res, req, error, {
-      sender: 'System',
-      conversationId: convoId,
-      messageId: v4(),
-      parentMessageId: _messageId,
-      error,
-    });
+    if (supportedIds?.length && !supportedIds.includes(assistant_id)) {
+      return await handleAbortError(res, req, error, {
+        sender: 'System',
+        conversationId: convoId,
+        messageId: v4(),
+        parentMessageId: _messageId,
+        error,
+      });
+    } else if (excludedIds?.length && excludedIds.includes(assistant_id)) {
+      return await handleAbortError(res, req, error, {
+        sender: 'System',
+        conversationId: convoId,
+        messageId: v4(),
+        parentMessageId: _messageId,
+      });
+    }
   }
 
   /** @type {OpenAIClient} */

--- a/api/server/controllers/assistants/chatV2.js
+++ b/api/server/controllers/assistants/chatV2.js
@@ -30,8 +30,6 @@ const { getModelMaxTokens } = require('~/utils');
 const { getOpenAIClient } = require('./helpers');
 const { logger } = require('~/config');
 
-const { handleAbortError } = require('~/server/middleware');
-
 const ten_minutes = 1000 * 60 * 10;
 
 /**
@@ -59,30 +57,6 @@ const chatV2 = async (req, res) => {
     conversationId: convoId,
     parentMessageId: _parentId = Constants.NO_PARENT,
   } = req.body;
-
-  /** @type {Partial<TAssistantEndpoint>} */
-  const assistantsConfig = req.app.locals?.[endpoint];
-
-  if (assistantsConfig) {
-    const { supportedIds, excludedIds } = assistantsConfig;
-    const error = { message: 'Assistant not supported' };
-    if (supportedIds?.length && !supportedIds.includes(assistant_id)) {
-      return await handleAbortError(res, req, error, {
-        sender: 'System',
-        conversationId: convoId,
-        messageId: v4(),
-        parentMessageId: _messageId,
-        error,
-      });
-    } else if (excludedIds?.length && excludedIds.includes(assistant_id)) {
-      return await handleAbortError(res, req, error, {
-        sender: 'System',
-        conversationId: convoId,
-        messageId: v4(),
-        parentMessageId: _messageId,
-      });
-    }
-  }
 
   /** @type {OpenAIClient} */
   let openai;

--- a/api/server/controllers/assistants/helpers.js
+++ b/api/server/controllers/assistants/helpers.js
@@ -1,4 +1,9 @@
-const { EModelEndpoint, CacheKeys, defaultAssistantsVersion } = require('librechat-data-provider');
+const {
+  EModelEndpoint,
+  CacheKeys,
+  defaultAssistantsVersion,
+  defaultOrderQuery,
+} = require('librechat-data-provider');
 const {
   initializeClient: initAzureClient,
 } = require('~/server/services/Endpoints/azureAssistants');
@@ -133,8 +138,27 @@ async function getOpenAIClient({ req, res, endpointOption, initAppClient, overri
   return result;
 }
 
-const fetchAssistants = async (req, res) => {
-  const { limit = 100, order = 'desc', after, before, endpoint } = req.query;
+/**
+ * Returns a list of assistants.
+ * @param {object} params
+ * @param {object} params.req - Express Request
+ * @param {AssistantListParams} [params.req.query] - The assistant list parameters for pagination and sorting.
+ * @param {object} params.res - Express Response
+ * @param {string} [params.overrideEndpoint] - The endpoint to override the request endpoint.
+ * @returns {Promise<AssistantListResponse>} 200 - success response - application/json
+ */
+const fetchAssistants = async ({ req, res, overrideEndpoint }) => {
+  const {
+    limit = 100,
+    order = 'desc',
+    after,
+    before,
+    endpoint,
+  } = req.query ?? {
+    endpoint: overrideEndpoint,
+    ...defaultOrderQuery,
+  };
+
   const version = await getCurrentVersion(req, endpoint);
   const query = { limit, order, after, before };
 

--- a/api/server/controllers/assistants/helpers.js
+++ b/api/server/controllers/assistants/helpers.js
@@ -148,22 +148,28 @@ const fetchAssistants = async (req, res) => {
     body = await listAssistantsForAzure({ req, res, version, azureConfig, query });
   }
 
-  const assistants = body.data;
-  const userId = req.user.id.toString();
   const assistantsConfig = req.app.locals[endpoint];
-  body.data = filterAssistants(assistants, userId, assistantsConfig);
+  if (!assistantsConfig) {
+    return body;
+  }
+  body.data = filterAssistants({
+    userId: req.user.id.toString(),
+    assistants: body.data,
+    assistantsConfig,
+  });
   return body;
 };
 
 /**
  * Filter assistants based on configuration.
  *
- * @param {Assistant[]} assistants - The list of assistants to filter.
+ * @param {object} params - The parameters object.
  * @param {string} params.userId -  The user ID to filter private assistants.
+ * @param {Assistant[]} params.assistants - The list of assistants to filter.
  * @param {Partial<TAssistantEndpoint>} params.assistantsConfig -  The assistant configuration.
  * @returns {Assistant[]} - The filtered list of assistants.
  */
-function filterAssistants(assistants, userId, assistantsConfig) {
+function filterAssistants({ assistants, userId, assistantsConfig }) {
   const { supportedIds, excludedIds, privateAssistants } = assistantsConfig;
   if (privateAssistants) {
     return assistants.filter(

--- a/api/server/controllers/assistants/v1.js
+++ b/api/server/controllers/assistants/v1.js
@@ -1,4 +1,5 @@
 const { FileContext } = require('librechat-data-provider');
+const validateAuthor = require('~/server/middleware/assistants/validateAuthor');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { deleteAssistantActions } = require('~/server/services/ActionService');
 const { updateAssistantDoc, getAssistants } = require('~/models/Assistant');
@@ -84,6 +85,7 @@ const retrieveAssistant = async (req, res) => {
 const patchAssistant = async (req, res) => {
   try {
     const { openai } = await getOpenAIClient({ req, res });
+    await validateAuthor({ req, openai });
 
     const assistant_id = req.params.id;
     const { endpoint: _e, ...updateData } = req.body;
@@ -120,6 +122,7 @@ const patchAssistant = async (req, res) => {
 const deleteAssistant = async (req, res) => {
   try {
     const { openai } = await getOpenAIClient({ req, res });
+    await validateAuthor({ req, openai });
 
     const assistant_id = req.params.id;
     const deletionStatus = await openai.beta.assistants.del(assistant_id);
@@ -184,6 +187,7 @@ const uploadAssistantAvatar = async (req, res) => {
 
     let { metadata: _metadata = '{}' } = req.body;
     const { openai } = await getOpenAIClient({ req, res });
+    await validateAuthor({ req, openai });
 
     const image = await uploadImageBuffer({
       req,

--- a/api/server/controllers/assistants/v1.js
+++ b/api/server/controllers/assistants/v1.js
@@ -146,8 +146,14 @@ const listAssistants = async (req, res) => {
     if (req.app.locals?.[req.query.endpoint]) {
       /** @type {Partial<TAssistantEndpoint>} */
       const assistantsConfig = req.app.locals[req.query.endpoint];
-      const { supportedIds, excludedIds } = assistantsConfig;
-      if (supportedIds?.length) {
+      const { supportedIds, excludedIds, private } = assistantsConfig;
+      if (private) {
+        const userId = req.user.id.toString();
+        body.data = body.data.filter(
+          (assistant) =>
+            userId === assistant.metadata?.author || assistant.metadata?.author === undefined,
+        );
+      } else if (supportedIds?.length) {
         body.data = body.data.filter((assistant) => supportedIds.includes(assistant.id));
       } else if (excludedIds?.length) {
         body.data = body.data.filter((assistant) => !excludedIds.includes(assistant.id));

--- a/api/server/controllers/assistants/v1.js
+++ b/api/server/controllers/assistants/v1.js
@@ -140,7 +140,7 @@ const deleteAssistant = async (req, res) => {
  */
 const listAssistants = async (req, res) => {
   try {
-    const body = await fetchAssistants(req, res);
+    const body = await fetchAssistants({ req, res });
     res.json(body);
   } catch (error) {
     logger.error('[/assistants] Error listing assistants', error);

--- a/api/server/controllers/assistants/v1.js
+++ b/api/server/controllers/assistants/v1.js
@@ -61,7 +61,6 @@ const retrieveAssistant = async (req, res) => {
   try {
     /* NOTE: not actually being used right now */
     const { openai } = await getOpenAIClient({ req, res });
-
     const assistant_id = req.params.id;
     const assistant = await openai.beta.assistants.retrieve(assistant_id);
     res.json(assistant);
@@ -142,24 +141,6 @@ const deleteAssistant = async (req, res) => {
 const listAssistants = async (req, res) => {
   try {
     const body = await fetchAssistants(req, res);
-
-    if (req.app.locals?.[req.query.endpoint]) {
-      /** @type {Partial<TAssistantEndpoint>} */
-      const assistantsConfig = req.app.locals[req.query.endpoint];
-      const { supportedIds, excludedIds, private } = assistantsConfig;
-      if (private) {
-        const userId = req.user.id.toString();
-        body.data = body.data.filter(
-          (assistant) =>
-            userId === assistant.metadata?.author || assistant.metadata?.author === undefined,
-        );
-      } else if (supportedIds?.length) {
-        body.data = body.data.filter((assistant) => supportedIds.includes(assistant.id));
-      } else if (excludedIds?.length) {
-        body.data = body.data.filter((assistant) => !excludedIds.includes(assistant.id));
-      }
-    }
-
     res.json(body);
   } catch (error) {
     logger.error('[/assistants] Error listing assistants', error);

--- a/api/server/controllers/assistants/v2.js
+++ b/api/server/controllers/assistants/v2.js
@@ -1,5 +1,6 @@
 const { ToolCallTypes } = require('librechat-data-provider');
 const { validateAndUpdateTool } = require('~/server/services/ActionService');
+const { updateAssistantDoc } = require('~/models/Assistant');
 const { getOpenAIClient } = require('./helpers');
 const { logger } = require('~/config');
 
@@ -37,9 +38,11 @@ const createAssistant = async (req, res) => {
     };
 
     const assistant = await openai.beta.assistants.create(assistantData);
+    const promise = updateAssistantDoc({ assistant_id: assistant.id }, { user: req.user.id });
     if (azureModelIdentifier) {
       assistant.model = azureModelIdentifier;
     }
+    await promise;
     logger.debug('/assistants/', assistant);
     res.status(201).json(assistant);
   } catch (error) {

--- a/api/server/controllers/assistants/v2.js
+++ b/api/server/controllers/assistants/v2.js
@@ -1,4 +1,5 @@
 const { ToolCallTypes } = require('librechat-data-provider');
+const validateAuthor = require('~/server/middleware/assistants/validateAuthor');
 const { validateAndUpdateTool } = require('~/server/services/ActionService');
 const { updateAssistantDoc } = require('~/models/Assistant');
 const { getOpenAIClient } = require('./helpers');
@@ -61,6 +62,7 @@ const createAssistant = async (req, res) => {
  * @returns {Promise<Assistant>} The updated assistant.
  */
 const updateAssistant = async ({ req, openai, assistant_id, updateData }) => {
+  await validateAuthor({ req, openai });
   const tools = [];
 
   let hasFileSearch = false;

--- a/api/server/middleware/assistants/validate.js
+++ b/api/server/middleware/assistants/validate.js
@@ -4,7 +4,7 @@ const { handleAbortError } = require('~/server/middleware/abortMiddleware');
 /**
  * Checks if the assistant is supported or excluded
  * @param {object} req - Express Request
- * @param {TPayload} req.body - The request payload.
+ * @param {object} req.body - The request payload.
  * @param {object} res - Express Response
  * @param {function} next - Express next middleware function.
  * @returns {Promise<void>}

--- a/api/server/middleware/assistants/validate.js
+++ b/api/server/middleware/assistants/validate.js
@@ -1,0 +1,43 @@
+const { v4 } = require('uuid');
+const { handleAbortError } = require('~/server/middleware/abortMiddleware');
+
+/**
+ * Checks if the assistant is supported or excluded
+ * @param {object} req - Express Request
+ * @param {TPayload} req.body - The request payload.
+ * @param {object} res - Express Response
+ * @param {function} next - Express next middleware function.
+ * @returns {Promise<void>}
+ */
+const validateAssistant = async (req, res, next) => {
+  const { endpoint, conversationId, assistant_id, messageId } = req.body;
+
+  /** @type {Partial<TAssistantEndpoint>} */
+  const assistantsConfig = req.app.locals?.[endpoint];
+  if (!assistantsConfig) {
+    return next();
+  }
+
+  const { supportedIds, excludedIds } = assistantsConfig;
+  const error = { message: 'Assistant not supported' };
+  if (supportedIds?.length && !supportedIds.includes(assistant_id)) {
+    return await handleAbortError(res, req, error, {
+      sender: 'System',
+      conversationId,
+      messageId: v4(),
+      parentMessageId: messageId,
+      error,
+    });
+  } else if (excludedIds?.length && excludedIds.includes(assistant_id)) {
+    return await handleAbortError(res, req, error, {
+      sender: 'System',
+      conversationId,
+      messageId: v4(),
+      parentMessageId: messageId,
+    });
+  }
+
+  return next();
+};
+
+module.exports = validateAssistant;

--- a/api/server/middleware/assistants/validateAuthor.js
+++ b/api/server/middleware/assistants/validateAuthor.js
@@ -5,14 +5,19 @@ const { getAssistant } = require('~/models/Assistant');
  * @param {object} params
  * @param {object} params.req - Express Request
  * @param {object} params.req.body - The request payload.
+ * @param {string} params.overrideEndpoint - The override endpoint
+ * @param {string} params.overrideAssistantId - The override assistant ID
  * @param {OpenAIClient} params.openai - OpenAI API Client
  * @returns {Promise<void>}
  */
-const validateAuthor = async ({ req, openai }) => {
+const validateAuthor = async ({ req, openai, overrideEndpoint, overrideAssistantId }) => {
   if (req.user.role === 'ADMIN') {
     return;
   }
-  const { endpoint, assistant_id } = req.body;
+
+  const endpoint = overrideEndpoint ?? req.body.endpoint ?? req.query.endpoint;
+  const assistant_id =
+    overrideAssistantId ?? req.params.id ?? req.body.assistant_id ?? req.query.assistant_id;
 
   /** @type {Partial<TAssistantEndpoint>} */
   const assistantsConfig = req.app.locals?.[endpoint];

--- a/api/server/middleware/assistants/validateAuthor.js
+++ b/api/server/middleware/assistants/validateAuthor.js
@@ -1,0 +1,34 @@
+/**
+ * Checks if the assistant is supported or excluded
+ * @param {object} params
+ * @param {object} params.req - Express Request
+ * @param {object} params.req.body - The request payload.
+ * @param {OpenAIClient} params.openai - OpenAI API Client
+ * @returns {Promise<void>}
+ */
+const validateAuthor = async ({ req, openai }) => {
+  if (req.user.role === 'ADMIN') {
+    return;
+  }
+  const { endpoint, assistant_id } = req.body;
+
+  /** @type {Partial<TAssistantEndpoint>} */
+  const assistantsConfig = req.app.locals?.[endpoint];
+  if (!assistantsConfig) {
+    return;
+  }
+
+  if (!assistantsConfig.privateAssistants) {
+    return;
+  }
+
+  const assistant = await openai.beta.assistants.retrieve(assistant_id);
+  const isValid =
+    req.user.id === assistant.metadata?.author || assistant.metadata?.author === undefined;
+
+  if (!isValid) {
+    throw new Error(`Assistant ${assistant_id} is not authored by the user.`);
+  }
+};
+
+module.exports = validateAuthor;

--- a/api/server/middleware/assistants/validateAuthor.js
+++ b/api/server/middleware/assistants/validateAuthor.js
@@ -1,3 +1,5 @@
+const { getAssistant } = require('~/models/Assistant');
+
 /**
  * Checks if the assistant is supported or excluded
  * @param {object} params
@@ -22,6 +24,10 @@ const validateAuthor = async ({ req, openai }) => {
     return;
   }
 
+  const assistantDoc = await getAssistant({ assistant_id, user: req.user.id });
+  if (assistantDoc) {
+    return;
+  }
   const assistant = await openai.beta.assistants.retrieve(assistant_id);
   if (req.user.id !== assistant?.metadata?.author) {
     throw new Error(`Assistant ${assistant_id} is not authored by the user.`);

--- a/api/server/middleware/assistants/validateAuthor.js
+++ b/api/server/middleware/assistants/validateAuthor.js
@@ -23,10 +23,7 @@ const validateAuthor = async ({ req, openai }) => {
   }
 
   const assistant = await openai.beta.assistants.retrieve(assistant_id);
-  const isValid =
-    req.user.id === assistant.metadata?.author || assistant.metadata?.author === undefined;
-
-  if (!isValid) {
+  if (req.user.id !== assistant?.metadata?.author) {
     throw new Error(`Assistant ${assistant_id} is not authored by the user.`);
   }
 };

--- a/api/server/routes/assistants/actions.js
+++ b/api/server/routes/assistants/actions.js
@@ -4,7 +4,7 @@ const { encryptMetadata, domainParser } = require('~/server/services/ActionServi
 const { actionDelimiter, EModelEndpoint } = require('librechat-data-provider');
 const { getOpenAIClient } = require('~/server/controllers/assistants/helpers');
 const { updateAction, getActions, deleteAction } = require('~/models/Action');
-const { updateAssistant, getAssistant } = require('~/models/Assistant');
+const { updateAssistantDoc, getAssistant } = require('~/models/Assistant');
 const { logger } = require('~/config');
 
 const router = express.Router();
@@ -109,7 +109,7 @@ router.post('/:assistant_id', async (req, res) => {
     let updatedAssistant = await openai.beta.assistants.update(assistant_id, { tools });
     const promises = [];
     promises.push(
-      updateAssistant(
+      updateAssistantDoc(
         { assistant_id },
         {
           actions,
@@ -186,7 +186,7 @@ router.delete('/:assistant_id/:action_id/:model', async (req, res) => {
 
     const promises = [];
     promises.push(
-      updateAssistant(
+      updateAssistantDoc(
         { assistant_id },
         {
           actions: updatedActions,

--- a/api/server/routes/assistants/chatV1.js
+++ b/api/server/routes/assistants/chatV1.js
@@ -8,6 +8,7 @@ const {
   // validateEndpoint,
   buildEndpointOption,
 } = require('~/server/middleware');
+const validateAssistant = require('~/server/middleware/assistants/validate');
 const chatController = require('~/server/controllers/assistants/chatV1');
 
 router.post('/abort', handleAbort());
@@ -20,6 +21,6 @@ router.post('/abort', handleAbort());
  * @param {express.Response} res - The response object, used to send back a response.
  * @returns {void}
  */
-router.post('/', validateModel, buildEndpointOption, setHeaders, chatController);
+router.post('/', validateModel, buildEndpointOption, validateAssistant, setHeaders, chatController);
 
 module.exports = router;

--- a/api/server/routes/assistants/chatV2.js
+++ b/api/server/routes/assistants/chatV2.js
@@ -8,6 +8,7 @@ const {
   // validateEndpoint,
   buildEndpointOption,
 } = require('~/server/middleware');
+const validateAssistant = require('~/server/middleware/assistants/validate');
 const chatController = require('~/server/controllers/assistants/chatV2');
 
 router.post('/abort', handleAbort());
@@ -20,6 +21,6 @@ router.post('/abort', handleAbort());
  * @param {express.Response} res - The response object, used to send back a response.
  * @returns {void}
  */
-router.post('/', validateModel, buildEndpointOption, setHeaders, chatController);
+router.post('/', validateModel, buildEndpointOption, validateAssistant, setHeaders, chatController);
 
 module.exports = router;

--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -505,7 +505,7 @@ describe('AppService updating app.locals and issuing warnings', () => {
 
     const { logger } = require('~/config');
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Both `supportedIds` and `excludedIds` are defined'),
+      expect.stringContaining('endpoint has both \'supportedIds\' and \'excludedIds\' defined'),
     );
   });
 

--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -218,6 +218,7 @@ describe('AppService', () => {
             pollIntervalMs: 5000,
             timeoutMs: 30000,
             supportedIds: ['id1', 'id2'],
+            privateAssistants: false,
           },
         },
       }),
@@ -232,6 +233,7 @@ describe('AppService', () => {
         pollIntervalMs: 5000,
         timeoutMs: 30000,
         supportedIds: expect.arrayContaining(['id1', 'id2']),
+        privateAssistants: false,
       }),
     );
   });

--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -505,7 +505,31 @@ describe('AppService updating app.locals and issuing warnings', () => {
 
     const { logger } = require('~/config');
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('endpoint has both \'supportedIds\' and \'excludedIds\' defined'),
+      expect.stringContaining(
+        'The \'assistants\' endpoint has both \'supportedIds\' and \'excludedIds\' defined.',
+      ),
+    );
+  });
+
+  it('should log a warning when privateAssistants and supportedIds or excludedIds are provided', async () => {
+    const mockConfig = {
+      endpoints: {
+        assistants: {
+          privateAssistants: true,
+          supportedIds: ['id1'],
+        },
+      },
+    };
+    require('./Config/loadCustomConfig').mockImplementationOnce(() => Promise.resolve(mockConfig));
+
+    const app = { locals: {} };
+    await require('./AppService')(app);
+
+    const { logger } = require('~/config');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'The \'assistants\' endpoint has both \'privateAssistants\' and \'supportedIds\' or \'excludedIds\' defined.',
+      ),
     );
   });
 

--- a/api/server/services/Files/Audio/textToSpeech.js
+++ b/api/server/services/Files/Audio/textToSpeech.js
@@ -300,7 +300,7 @@ async function textToSpeech(req, res) {
           break;
         }
       } catch (innerError) {
-        logger.error('Error processing update:', chunk, innerError);
+        logger.error('Error processing manual update:', chunk, innerError);
         if (!res.headersSent) {
           res.status(500).end();
         }
@@ -312,7 +312,10 @@ async function textToSpeech(req, res) {
       res.end();
     }
   } catch (error) {
-    logger.error('An error occurred while creating the audio stream:', error);
+    logger.error(
+      'Error creating the audio stream. Suggestion: check your provider quota. Error:',
+      error,
+    );
     res.status(500).send('An error occurred');
   }
 }

--- a/api/server/services/start/assistants.js
+++ b/api/server/services/start/assistants.js
@@ -29,7 +29,15 @@ function assistantsConfigSetup(config, assistantsEndpoint, prevConfig = {}) {
   const parsedConfig = assistantEndpointSchema.parse(assistantsConfig);
   if (assistantsConfig.supportedIds?.length && assistantsConfig.excludedIds?.length) {
     logger.warn(
-      `Both \`supportedIds\` and \`excludedIds\` are defined for the ${assistantsEndpoint} endpoint; \`excludedIds\` field will be ignored.`,
+      `Configuration conflict: The '${assistantsEndpoint}' endpoint has both 'supportedIds' and 'excludedIds' defined. The 'excludedIds' will be ignored.`,
+    );
+  }
+  if (
+    assistantsConfig.privateAssistants &&
+    (assistantsConfig.supportedIds?.length || assistantsConfig.excludedIds?.length)
+  ) {
+    logger.warn(
+      `Configuration conflict: The '${assistantsEndpoint}' endpoint has both 'privateAssistants' and 'supportedIds' or 'excludedIds' defined. The 'supportedIds' and 'excludedIds' will be ignored.`,
     );
   }
 
@@ -41,7 +49,7 @@ function assistantsConfigSetup(config, assistantsEndpoint, prevConfig = {}) {
     supportedIds: parsedConfig.supportedIds,
     capabilities: parsedConfig.capabilities,
     excludedIds: parsedConfig.excludedIds,
-    private: parsedConfig.private,
+    privateAssistants: parsedConfig.privateAssistants,
     timeoutMs: parsedConfig.timeoutMs,
   };
 }

--- a/api/server/services/start/assistants.js
+++ b/api/server/services/start/assistants.js
@@ -41,6 +41,7 @@ function assistantsConfigSetup(config, assistantsEndpoint, prevConfig = {}) {
     supportedIds: parsedConfig.supportedIds,
     capabilities: parsedConfig.capabilities,
     excludedIds: parsedConfig.excludedIds,
+    private: parsedConfig.private,
     timeoutMs: parsedConfig.timeoutMs,
   };
 }

--- a/api/typedefs.js
+++ b/api/typedefs.js
@@ -273,6 +273,12 @@
  */
 
 /**
+ * @exports TPayload
+ * @typedef {import('librechat-data-provider').TPayload} TPayload
+ * @memberof typedefs
+ */
+
+/**
  * @exports TAzureModelConfig
  * @typedef {import('librechat-data-provider').TAzureModelConfig} TAzureModelConfig
  * @memberof typedefs

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -65,6 +65,8 @@ endpoints:
   #   # Should only be one or the other, either `supportedIds` or `excludedIds`
   #   supportedIds: ["asst_supportedAssistantId1", "asst_supportedAssistantId2"]
   #   # excludedIds: ["asst_excludedAssistantId"]
+  #   Only show assistants that the user created or that were created externally (e.g. in Assistants playground).
+  #   # private: false # Does not work with `supportedIds` or `excludedIds`
   #   # (optional) Models that support retrieval, will default to latest known OpenAI models that support the feature
   #   retrievalModels: ["gpt-4-turbo-preview"]
   #   # (optional) Assistant Capabilities available to all users. Omit the ones you wish to exclude. Defaults to list below.
@@ -75,12 +77,13 @@ endpoints:
       apiKey: '${GROQ_API_KEY}'
       baseURL: 'https://api.groq.com/openai/v1/'
       models:
-        default: [
-          "llama3-70b-8192",
-          "llama3-8b-8192",
-          "llama2-70b-4096",
-          "mixtral-8x7b-32768",
-          "gemma-7b-it",
+        default:
+          [
+            'llama3-70b-8192',
+            'llama3-8b-8192',
+            'llama2-70b-4096',
+            'mixtral-8x7b-32768',
+            'gemma-7b-it',
           ]
         fetch: false
       titleConvo: true
@@ -147,7 +150,6 @@ endpoints:
       # Recommended: Drop the stop parameter from the request as Openrouter models use a variety of stop tokens.
       dropParams: ['stop']
       modelDisplayLabel: 'OpenRouter'
-
 # fileConfig:
 #   endpoints:
 #     assistants:

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -66,7 +66,7 @@ endpoints:
   #   supportedIds: ["asst_supportedAssistantId1", "asst_supportedAssistantId2"]
   #   # excludedIds: ["asst_excludedAssistantId"]
   #   Only show assistants that the user created or that were created externally (e.g. in Assistants playground).
-  #   # private: false # Does not work with `supportedIds` or `excludedIds`
+  #   # privateAssistants: false # Does not work with `supportedIds` or `excludedIds`
   #   # (optional) Models that support retrieval, will default to latest known OpenAI models that support the feature
   #   retrievalModels: ["gpt-4-turbo-preview"]
   #   # (optional) Assistant Capabilities available to all users. Omit the ones you wish to exclude. Defaults to list below.

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -144,6 +144,7 @@ export const assistantEndpointSchema = z.object({
   version: z.union([z.string(), z.number()]).default(2),
   supportedIds: z.array(z.string()).min(1).optional(),
   excludedIds: z.array(z.string()).min(1).optional(),
+  private: z.boolean().optional(),
   retrievalModels: z.array(z.string()).min(1).optional().default(defaultRetrievalModels),
   capabilities: z
     .array(z.nativeEnum(Capabilities))

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -144,7 +144,7 @@ export const assistantEndpointSchema = z.object({
   version: z.union([z.string(), z.number()]).default(2),
   supportedIds: z.array(z.string()).min(1).optional(),
   excludedIds: z.array(z.string()).min(1).optional(),
-  private: z.boolean().optional(),
+  privateAssistants: z.boolean().optional(),
   retrievalModels: z.array(z.string()).min(1).optional().default(defaultRetrievalModels),
   capabilities: z
     .array(z.nativeEnum(Capabilities))

--- a/packages/data-provider/src/createPayload.ts
+++ b/packages/data-provider/src/createPayload.ts
@@ -1,31 +1,24 @@
-import type { TSubmission, TMessage, TEndpointOption } from './types';
-import { tConvoUpdateSchema, EModelEndpoint, isAssistantsEndpoint } from './schemas';
+import type * as t from './types';
 import { EndpointURLs } from './config';
+import * as s from './schemas';
 
-export default function createPayload(submission: TSubmission) {
-  const { conversation, userMessage, messages, endpointOption, isEdited, isContinued } = submission;
-  const { conversationId } = tConvoUpdateSchema.parse(conversation);
+export default function createPayload(submission: t.TSubmission) {
+  const { conversation, userMessage, endpointOption, isEdited, isContinued } = submission;
+  const { conversationId } = s.tConvoUpdateSchema.parse(conversation);
   const { endpoint, endpointType } = endpointOption as {
-    endpoint: EModelEndpoint;
-    endpointType?: EModelEndpoint;
+    endpoint: s.EModelEndpoint;
+    endpointType?: s.EModelEndpoint;
   };
 
   let server = EndpointURLs[endpointType ?? endpoint];
 
-  if (isEdited && isAssistantsEndpoint(endpoint)) {
+  if (isEdited && s.isAssistantsEndpoint(endpoint)) {
     server += '/modify';
   } else if (isEdited) {
     server = server.replace('/ask/', '/edit/');
   }
 
-  type Payload = Partial<TMessage> &
-    Partial<TEndpointOption> & {
-      isContinued: boolean;
-      conversationId: string | null;
-      messages?: typeof messages;
-    };
-
-  const payload: Payload = {
+  const payload: t.TPayload = {
     ...userMessage,
     ...endpointOption,
     isContinued: !!(isEdited && isContinued),

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -37,6 +37,13 @@ export type TEndpointOption = {
   thread_id?: string;
 };
 
+export type TPayload = Partial<TMessage> &
+  Partial<TEndpointOption> & {
+    isContinued: boolean;
+    conversationId: string | null;
+    messages?: TMessages;
+  };
+
 export type TSubmission = {
   plugin?: TResPlugin;
   plugins?: TResPlugin[];

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -6,6 +6,9 @@ export type Schema = OpenAPIV3.SchemaObject & { description?: string };
 export type Reference = OpenAPIV3.ReferenceObject & { description?: string };
 
 export type Metadata = {
+  avatar?: string;
+  author?: string;
+} & {
   [key: string]: unknown;
 };
 


### PR DESCRIPTION
Originally #2831 

Thank you @leon-juenemann 


## Summary

Closes #1926

Adds the option to only see assistants that you (the user) created or that don't have an author. This is important for privacy reasons when multiple users are sharing the same API-Key. Otherwise a user could get personal information from e.g. a file that another user uploaded.

The specific use case that led to this PR:
- we don't want users to see other users assistants
- we still want to make some assistants available to all users (assistants without a metadata.author field)

## Change Type


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

In librechat.yaml:
```
endpoints:
  assistants:
    privateAssistants: true
```
1. Login User1 and create an assistant.
2. Login User2 and does not have access to the assistant.
### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted. (https://github.com/LibreChat-AI/librechat.ai/pull/37)
