### PR TITLE
⚛️ fix(atomWithLocalStorage): Handle Parsing Error

### DIFF
--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -6,16 +6,24 @@ import type { TOptionSettings } from '~/common';
 function atomWithLocalStorage<T>(key: string, defaultValue: T) {
   return atom<T>({
     key,
-    default: defaultValue, // Set the default value directly
+    default: defaultValue,
     effects_UNSTABLE: [
       ({ setSelf, onSet }) => {
-        // Load the initial value from localStorage if it exists
         const savedValue = localStorage.getItem(key);
         if (savedValue !== null) {
-          setSelf(JSON.parse(savedValue));
+          try {
+            const parsedValue = JSON.parse(savedValue);
+            setSelf(parsedValue);
+          } catch (e) {
+            console.error(
+              `Error parsing localStorage key "${key}", \`savedValue\`: defaultValue, error:`,
+              e,
+            );
+            localStorage.setItem(key, JSON.stringify(defaultValue));
+            setSelf(defaultValue);
+          }
         }
 
-        // Update localStorage whenever the atom's value changes
         onSet((newValue: T) => {
           localStorage.setItem(key, JSON.stringify(newValue));
         });


### PR DESCRIPTION
## Summary

When most of the storage options were replaced with a generic `atomWithLocalStorage` function, the `savedValue` was always assumed to be safe to parse. This turns out not to be the case, whether set by a browser or how the value was parsed in the past, and now any unsafe values will resort to the default value during a parsing error.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.

