### PR TITLE
🚑  fix: Prevent Infinite Re-Rendering of the Password Reset UI

### DIFF
--- a/client/src/components/Auth/RequestPasswordReset.tsx
+++ b/client/src/components/Auth/RequestPasswordReset.tsx
@@ -40,6 +40,9 @@ function RequestPasswordReset() {
   };
 
   useEffect(() => {
+    if (bodyText) {
+      return;
+    }
     if (requestPasswordReset.isSuccess) {
       if (config.data?.emailEnabled) {
         setHeaderText(localize('com_auth_reset_password_link_sent'));
@@ -60,7 +63,7 @@ function RequestPasswordReset() {
       setHeaderText(localize('com_auth_reset_password'));
       setBodyText(undefined);
     }
-  }, [requestPasswordReset.isSuccess, config.data?.emailEnabled, resetLink, localize]);
+  }, [requestPasswordReset.isSuccess, config.data?.emailEnabled, resetLink, localize, bodyText]);
 
   const renderFormContent = () => {
     if (bodyText) {

--- a/client/src/hooks/useLocalize.ts
+++ b/client/src/hooks/useLocalize.ts
@@ -1,8 +1,15 @@
+import { useCallback } from 'react';
 import { useRecoilValue } from 'recoil';
 import { localize } from '~/localization/Translation';
 import store from '~/store';
 
 export default function useLocalize() {
   const lang = useRecoilValue(store.lang);
-  return (phraseKey: string, ...values: string[]) => localize(lang, phraseKey, ...(values ?? []));
+
+  const memoizedLocalize = useCallback(
+    (phraseKey: string, ...values: string[]) => localize(lang, phraseKey, ...(values ?? [])),
+    [lang], // Only recreate the function when `lang` changes
+  );
+
+  return memoizedLocalize;
 }


### PR DESCRIPTION
## Summary

Infinite re-rendering in Password Reset UI when email server is not configured

https://github.com/danny-avila/LibreChat/assets/283038/b94c3c2c-ed2f-44f1-936f-a25a1445cd0a


## Causes

The Infinite re-rendering occurs under the following two conditions:

1. Passing JSX to `setBodyText` within a `useEffect` hook
2. Including the `localize` function in the dependencies array of `useEffect`

## Proposed solutions

There are three options to solve this problem:

1. In `useEffect` hook, check if `bodyText` is undefined before executing `setBodyText`. If `bodyText` is not undefined, the execution is halted
2. Remove `localize` function from the dependencies of `useEffect` hook
3. In `useLocalize` hook, Use `useCallback` to return a new `localize` function only when the `lang` changes, thus avoiding unnecessary re-renders caused by changes in the function reference

Solutions 1 and 3 have been applied in this PR to ensure robustness. In particular, since `useLocalize` is used by many components, it would be beneficial to memorialize it.

Please let me know if there is a better way to prevent re-rendering

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I manually accessed the password reset UI and verified that it does not cause infinite re-rendering

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
