### PR TITLE
🗣️ fix: Set Audio Run ID at Top of Autoplayback Request

### DIFF
--- a/client/src/components/Chat/Input/StreamAudio.tsx
+++ b/client/src/components/Chat/Input/StreamAudio.tsx
@@ -49,7 +49,8 @@ export default function StreamAudio({ index = 0 }) {
 
   useEffect(() => {
     const latestText = getLatestText(latestMessage);
-    const shouldFetch =
+
+    const shouldFetch = !!(
       token &&
       automaticPlayback &&
       isSubmitting &&
@@ -60,7 +61,8 @@ export default function StreamAudio({ index = 0 }) {
       !latestMessage.messageId.includes('_') &&
       !isFetching &&
       activeRunId &&
-      activeRunId !== audioRunId;
+      activeRunId !== audioRunId
+    );
 
     if (!shouldFetch) {
       return;
@@ -80,12 +82,12 @@ export default function StreamAudio({ index = 0 }) {
         const cache = await caches.open('tts-responses');
         const cachedResponse = await cache.match(cacheKey);
 
+        setAudioRunId(activeRunId);
         if (cachedResponse) {
           console.log('Audio found in cache');
           const audioBlob = await cachedResponse.blob();
           const blobUrl = URL.createObjectURL(audioBlob);
           setGlobalAudioURL(blobUrl);
-          setAudioRunId(activeRunId);
           setIsFetching(false);
           return;
         }
@@ -113,7 +115,6 @@ export default function StreamAudio({ index = 0 }) {
           mediaSource = new MediaSourceAppender(type);
           setGlobalAudioURL(mediaSource.mediaSourceUrl);
         }
-        setAudioRunId(activeRunId);
 
         let done = false;
         const chunks: Uint8Array[] = [];


### PR DESCRIPTION
## Summary

- Set audio run ID at the start of fetchAudio requests to prevent multiple requests per run, improving request handling and efficiency.

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing
To test these changes:
Monitor fetchAudio requests to confirm that the audio run ID is set correctly and that no duplicate requests occur.

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes