### PR TITLE
🔄 refactor(EditPresetDialog): Update Model on Endpoint Change

### DIFF
--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -196,6 +196,7 @@ export type TEditPresetProps = {
   title?: string;
 };
 
+export type TSetOptions = (options: Record<string, unknown>) => void;
 export type TSetOptionsPayload = {
   setOption: TSetOption;
   setExample: TSetExample;
@@ -205,6 +206,7 @@ export type TSetOptionsPayload = {
   // getConversation: () => TConversation | TPreset | null;
   checkPluginSelection: (value: string) => boolean;
   setTools: (newValue: string, remove?: boolean) => void;
+  setOptions?: TSetOptions;
 };
 
 export type TPresetItemProps = {

--- a/client/src/components/Chat/Menus/Presets/EditPresetDialog.tsx
+++ b/client/src/components/Chat/Menus/Presets/EditPresetDialog.tsx
@@ -49,6 +49,9 @@ const EditPresetDialog = ({
     }
 
     const models = modelsConfig[preset.endpoint];
+    if (!models) {
+      return;
+    }
     if (!models.length) {
       return;
     }

--- a/client/src/components/ui/AlertDialog.tsx
+++ b/client/src/components/ui/AlertDialog.tsx
@@ -7,12 +7,10 @@ const AlertDialog = AlertDialogPrimitive.Root;
 
 const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
-const AlertDialogPortal = ({
-  className = '',
-  children,
-  ...props
-}: AlertDialogPrimitive.AlertDialogPortalProps) => (
-  <AlertDialogPrimitive.Portal className={cn(className)} {...props}>
+type AlertPortalProps = AlertDialogPrimitive.AlertDialogPortalProps & { className?: string };
+
+const AlertDialogPortal = ({ className = '', children, ...props }: AlertPortalProps) => (
+  <AlertDialogPrimitive.Portal className={cn(className)} {...(props as AlertPortalProps)}>
     <div className="fixed inset-0 z-50 flex items-end justify-center sm:items-center">
       {children}
     </div>

--- a/client/src/hooks/Conversations/usePresetIndexOptions.ts
+++ b/client/src/hooks/Conversations/usePresetIndexOptions.ts
@@ -1,6 +1,6 @@
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import type { TPreset, TPlugin } from 'librechat-data-provider';
-import type { TSetOptionsPayload, TSetExample, TSetOption } from '~/common';
+import type { TSetOptionsPayload, TSetExample, TSetOption, TSetOptions } from '~/common';
 import { useChatContext } from '~/Providers/ChatContext';
 import { cleanupPreset } from '~/utils';
 import store from '~/store';
@@ -16,6 +16,18 @@ const usePresetIndexOptions: TUsePresetOptions = (_preset) => {
     return false;
   }
   const getConversation: () => TPreset | null = () => preset;
+
+  const setOptions: TSetOptions = (options) => {
+    const update = { ...options };
+    setPreset((prevState) =>
+      cleanupPreset({
+        preset: {
+          ...prevState,
+          ...update,
+        },
+      }),
+    );
+  };
 
   const setOption: TSetOption = (param) => (newValue) => {
     const update = {};
@@ -155,6 +167,7 @@ const usePresetIndexOptions: TUsePresetOptions = (_preset) => {
     setOption,
     setExample,
     addExample,
+    setOptions,
     removeExample,
     getConversation,
     checkPluginSelection,

--- a/client/src/hooks/Conversations/useSetIndexOptions.ts
+++ b/client/src/hooks/Conversations/useSetIndexOptions.ts
@@ -157,13 +157,13 @@ const useSetIndexOptions: TUseSetOptions = (preset = false) => {
   };
 
   return {
+    setTools,
     setOption,
     setExample,
     addExample,
     removeExample,
     setAgentOption,
     checkPluginSelection,
-    setTools,
   };
 };
 


### PR DESCRIPTION
## Summary

- Refactored EditPresetDialog to listen for endpoint changes.
- Updated the preset model dynamically based on the new endpoint.
- Ensured existing functionality remains unaffected by the changes.

### Other Changes

- Prevent unknown endpoint edge case for custom endpoints when switching endpoints
- Fix minor type issue with alert dialog
- Closes https://github.com/danny-avila/LibreChat/issues/2927

## Change Type

- [x] Refactor (non-breaking change which improves the codebase without adding features)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes