### PR TITLE
🧹 chore(.eslintrc.js): Update Import Order of The React Types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -95,7 +95,7 @@ module.exports = {
             position: 'before',
           },
         ],
-        pathGroupsExcludedImportTypes: ['builtin'], // Exclude these types from the path group rule
+        pathGroupsExcludedImportTypes: ['builtin', 'type'], // Exclude these types from the path group rule
         warnOnUnassignedImports: true, // Warn for unassigned imports
         // alphabetize: { order: 'asc', caseInsensitive: true }, // Alphabetize imports within each group
       },


### PR DESCRIPTION
## Summary

ref: #2928

Fix an issue where react type imports were incorrectly placed before built-in imports. This was due to the current configuration in `.eslintrc.js` that defined a `pathGroup` for `{react, react-dom/**}`. 

I modified the `pathGroupsExcludedImportTypes` to include `type`. This ensures that type imports from React are no longer affected by the `pathGroups` rules and are placed correctly according to `groups` property.

Please let me know if there are any other issues!

## Change Type

- [x] Bug fix (minor configuration change)

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] My changes do not introduce new warnings
