### PR TITLE
🔧 fix(useMentions): handle empty assistant lists

### DIFF
--- a/client/src/hooks/Input/useMentions.ts
+++ b/client/src/hooks/Input/useMentions.ts
@@ -121,10 +121,10 @@ export default function useMentions({ assistantMap }: { assistantMap: TAssistant
         }),
       })),
       ...(endpointsConfig?.[EModelEndpoint.assistants]
-        ? assistantListMap[EModelEndpoint.assistants]
+        ? assistantListMap[EModelEndpoint.assistants] || []
         : []),
       ...(endpointsConfig?.[EModelEndpoint.azureAssistants]
-        ? assistantListMap[EModelEndpoint.azureAssistants]
+        ? assistantListMap[EModelEndpoint.azureAssistants] || []
         : []),
       ...((interfaceConfig.presets ? presets : [])?.map((preset, index) => ({
         value: preset.presetId ?? `preset-${index}`,


### PR DESCRIPTION
## Summary

fixed @mentions not working

[issue reported in Discord](https://discord.com/channels/1086345563026489514/1086345563026489517/1247897866769272873)

![image](https://github.com/danny-avila/LibreChat/assets/81851188/2b5d5ac2-62a8-4dc4-aaf8-0f5b89184c67)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested that the menu was working by selecting different providers and different assistants. Not tested with Azure Assistants but it should work

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
