### PR TITLE
Fix/retain manually uploaded avatar

### DIFF
--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -185,8 +185,6 @@ async function setupOpenId() {
                 buffer: imageBuffer,
               });
               user.avatar = imagePath ?? '';
-            } else {
-              user.avatar = '';
             }
           }
 

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -163,7 +163,7 @@ async function setupOpenId() {
             user.name = fullName;
           }
 
-          if (userinfo.picture) {
+          if (userinfo.picture && !user.avatar.includes('manual=true')) {
             /** @type {string | undefined} */
             const imageUrl = userinfo.picture;
 
@@ -188,8 +188,6 @@ async function setupOpenId() {
             } else {
               user.avatar = '';
             }
-          } else {
-            user.avatar = '';
           }
 
           await user.save();


### PR DESCRIPTION
## Summary

This PR addresses #2056. The OpenID authenticator strategy is modified to prevent overwriting an existing manually-loaded user avatar upon login.  It also prevents overwriting an existing IdP-supplied avatar upon a subsequent login when a new image can't be fetched. 


## Change Type

Please delete any irrelevant options.

- [x ] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Configure LibreChat to use an OIDC IdP. 
2. Log into LibreChat and manually upload an avatar image. Note that it is correctly displayed. 
3. Log out and log back in again.
4. The avatar image uploaded in step 2 should still be present. 

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] Local unit tests pass with my changes
