### PR TITLE
🗃️ fix: revise RAG prompt

### DIFF
--- a/api/app/clients/prompts/createContextHandlers.js
+++ b/api/app/clients/prompts/createContextHandlers.js
@@ -8,8 +8,6 @@ In your response, remember to follow these guidelines:
 - If you don't know the answer, simply say that you don't know.
 - If you are unsure how to answer, ask for clarification.
 - Avoid mentioning that you obtained the information from the context.
-
-Answer appropriately in the user's language.
 `;
 
 function createContextHandlers(req, userMessageContent) {
@@ -94,36 +92,39 @@ function createContextHandlers(req, userMessageContent) {
 
       const resolvedQueries = await Promise.all(queryPromises);
 
-      const context = resolvedQueries
-        .map((queryResult, index) => {
-          const file = processedFiles[index];
-          let contextItems = queryResult.data;
+      const context =
+        resolvedQueries.length === 0
+          ? '\n\tThe semantic search did not return any results.'
+          : resolvedQueries
+            .map((queryResult, index) => {
+              const file = processedFiles[index];
+              let contextItems = queryResult.data;
 
-          const generateContext = (currentContext) =>
-            `
+              const generateContext = (currentContext) =>
+                `
           <file>
             <filename>${file.filename}</filename>
             <context>${currentContext}
             </context>
           </file>`;
 
-          if (useFullContext) {
-            return generateContext(`\n${contextItems}`);
-          }
+              if (useFullContext) {
+                return generateContext(`\n${contextItems}`);
+              }
 
-          contextItems = queryResult.data
-            .map((item) => {
-              const pageContent = item[0].page_content;
-              return `
+              contextItems = queryResult.data
+                .map((item) => {
+                  const pageContent = item[0].page_content;
+                  return `
             <contextItem>
               <![CDATA[${pageContent?.trim()}]]>
             </contextItem>`;
+                })
+                .join('');
+
+              return generateContext(contextItems);
             })
             .join('');
-
-          return generateContext(contextItems);
-        })
-        .join('');
 
       if (useFullContext) {
         const prompt = `${header}


### PR DESCRIPTION
Closes https://github.com/danny-avila/LibreChat/issues/2987

### Before
![image](https://github.com/danny-avila/LibreChat/assets/110412045/14e6159a-c2f2-4f89-84c2-8051345d52e1)


### After
![image](https://github.com/danny-avila/LibreChat/assets/110412045/b88793d6-7081-461b-8f16-d5e6141c228a)

This behavior is frequently observed when no "context" is returned in the prompt. The instruction to answer in the user's language seems to trigger a response in Spanish, maybe due to the xml tags?