### PR TITLE
Added an option to remove hide-panel

### DIFF
--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -96,6 +96,7 @@ describe('AppService', () => {
       interfaceConfig: expect.objectContaining({
         privacyPolicy: undefined,
         termsOfService: undefined,
+        showSideHidePanelOption: undefined,
         endpointsMenu: true,
         modelSelect: true,
         parameters: true,

--- a/api/server/services/start/interface.js
+++ b/api/server/services/start/interface.js
@@ -20,6 +20,8 @@ function loadDefaultInterface(config, configDefaults) {
     sidePanel: interfaceConfig?.sidePanel ?? defaults.sidePanel,
     privacyPolicy: interfaceConfig?.privacyPolicy ?? defaults.privacyPolicy,
     termsOfService: interfaceConfig?.termsOfService ?? defaults.termsOfService,
+    showSideHidePanelOption:
+      interfaceConfig?.showSideHidePanelOption ?? defaults.showSideHidePanelOption,
   };
 
   let i = 0;

--- a/api/server/services/start/interface.js
+++ b/api/server/services/start/interface.js
@@ -20,8 +20,8 @@ function loadDefaultInterface(config, configDefaults) {
     sidePanel: interfaceConfig?.sidePanel ?? defaults.sidePanel,
     privacyPolicy: interfaceConfig?.privacyPolicy ?? defaults.privacyPolicy,
     termsOfService: interfaceConfig?.termsOfService ?? defaults.termsOfService,
-    showSideHidePanelOption:
-      interfaceConfig?.showSideHidePanelOption ?? defaults.showSideHidePanelOption,
+    showSideHidePanelButton:
+      interfaceConfig?.showSideHidePanelButton ?? defaults.showSideHidePanelButton,
   };
 
   let i = 0;

--- a/client/src/hooks/Nav/useSideNavLinks.ts
+++ b/client/src/hooks/Nav/useSideNavLinks.ts
@@ -66,6 +66,11 @@ export default function useSideNavLinks({
       onClick: hidePanel,
       id: 'hide-panel',
     });
+    // Add logic to remove hide panel button as to simplify side nav
+    if (interfaceConfig.showSideHidePanelOption == false) {
+      const index = links.findIndex((ele) => ele.id == 'hide-panel');
+      delete links[index];
+    }
 
     return links;
   }, [assistants, keyProvided, hidePanel, endpoint, interfaceConfig.parameters]);

--- a/client/src/hooks/Nav/useSideNavLinks.ts
+++ b/client/src/hooks/Nav/useSideNavLinks.ts
@@ -67,7 +67,7 @@ export default function useSideNavLinks({
       id: 'hide-panel',
     });
     // Add logic to remove hide panel button as to simplify side nav
-    if (interfaceConfig.showSideHidePanelOption == false) {
+    if (interfaceConfig.showSideHidePanelButton == false) {
       const index = links.findIndex((ele) => ele.id == 'hide-panel');
       delete links[index];
     }

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -347,6 +347,7 @@ export const configSchema = z.object({
       parameters: z.boolean().optional(),
       sidePanel: z.boolean().optional(),
       presets: z.boolean().optional(),
+      showSideHidePanelOption: z.boolean().optional(),
     })
     .default({
       endpointsMenu: true,

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -347,7 +347,7 @@ export const configSchema = z.object({
       parameters: z.boolean().optional(),
       sidePanel: z.boolean().optional(),
       presets: z.boolean().optional(),
-      showSideHidePanelOption: z.boolean().optional(),
+      showSideHidePanelButton: z.boolean().optional(),
     })
     .default({
       endpointsMenu: true,

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -258,6 +258,7 @@ export type TInterfaceConfig = {
   parameters: boolean;
   sidePanel: boolean;
   presets: boolean;
+  showSideHidePanelOption: boolean;
 };
 
 export type TStartupConfig = {

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -258,7 +258,7 @@ export type TInterfaceConfig = {
   parameters: boolean;
   sidePanel: boolean;
   presets: boolean;
-  showSideHidePanelOption: boolean;
+  showSideHidePanelButton: boolean;
 };
 
 export type TStartupConfig = {


### PR DESCRIPTION
## Summary

This PR is to add a variable to remove the `hide-panel` button from the sidebar interface to limit any confusing interactions with the side panel.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Testing
Add the following to your `librechat.yaml` configuration
```yaml

interface:
  showSideHidePanelButton: false
```

### **Test Configuration**:
<img width="669" alt="Screenshot 2024-06-07 at 4 59 24 PM" src="https://github.com/Tanvez/LibreChat/assets/29421667/fa3c02fc-507a-4340-b33f-1c784343cc40">

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.
