### PR TITLE
🌐 fix(actions): Correct URL Formation for Subdomains in `createURL`

### DIFF
--- a/packages/data-provider/specs/actions.spec.ts
+++ b/packages/data-provider/specs/actions.spec.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { OpenAPIV3 } from 'openapi-types';
 import {
+  createURL,
   resolveRef,
   ActionRequest,
   openapiToFunction,
@@ -504,5 +505,47 @@ describe('validateAndParseOpenAPISpec', () => {
     expect(requestBuilders).toHaveProperty('searchAbstracts');
     expect(requestBuilders).toHaveProperty('getFullText');
     expect(requestBuilders).toHaveProperty('saveCitation');
+  });
+});
+
+describe('createURL', () => {
+  it('correctly combines domain and path', () => {
+    expect(createURL('https://example.com', '/api/v1/users')).toBe(
+      'https://example.com/api/v1/users',
+    );
+  });
+
+  it('handles domain with trailing slash', () => {
+    expect(createURL('https://example.com/', '/api/v1/users')).toBe(
+      'https://example.com/api/v1/users',
+    );
+  });
+
+  it('handles path with leading slash', () => {
+    expect(createURL('https://example.com', 'api/v1/users')).toBe(
+      'https://example.com/api/v1/users',
+    );
+  });
+
+  it('handles domain with trailing slash and path with leading slash', () => {
+    expect(createURL('https://example.com/', '/api/v1/users')).toBe(
+      'https://example.com/api/v1/users',
+    );
+  });
+
+  it('handles domain without trailing slash and path without leading slash', () => {
+    expect(createURL('https://example.com', 'api/v1/users')).toBe(
+      'https://example.com/api/v1/users',
+    );
+  });
+
+  it('handles empty path', () => {
+    expect(createURL('https://example.com', '')).toBe('https://example.com/');
+  });
+
+  it('handles domain with subdirectory', () => {
+    expect(createURL('https://example.com/subdirectory', '/api/v1/users')).toBe(
+      'https://example.com/subdirectory/api/v1/users',
+    );
   });
 });

--- a/packages/data-provider/src/actions.ts
+++ b/packages/data-provider/src/actions.ts
@@ -32,8 +32,10 @@ export function sha1(input: string) {
 }
 
 export function createURL(domain: string, path: string) {
-  const myURL = new URL(path, domain);
-  return myURL.toString();
+  const cleanDomain = domain.replace(/\/$/, '');
+  const cleanPath = path.replace(/^\//, '');
+  const fullURL = `${cleanDomain}/${cleanPath}`;
+  return new URL(fullURL).toString();
 }
 
 export class FunctionSignature {
@@ -92,7 +94,7 @@ export class ActionRequest {
   private authHeaders: Record<string, string> = {};
   private authToken?: string;
 
-  async setParams(params: object) {
+  setParams(params: object) {
     this.operationHash = sha1(JSON.stringify(params));
     this.params = params;
 


### PR DESCRIPTION
## Summary
I resolved an issue where the `createURL` function was not handling subdomains correctly, which caused incorrect URL formation.

- Fixed the `createURL` function to correctly concatenate subdomains and paths.
- Adjusted logic to ensure subdomains like `swapi.dev/api` and paths like `/people` form `swapi.dev/api/people`.
- Ensured compatibility and correctness with various subdomain and path combinations.

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
I tested the changes by creating URLs using various subdomain and path combinations to ensure they are formed correctly.
- Actual reproduction: 
- https://github.com/danny-avila/LibreChat/discussions/3146#discussioncomment-9840981
- Added unit tests

### **Test Configuration**:
- Used `swapi.dev/api` with paths like `/people` to verify correct URL formation.
- Confirmed no regression in other URL-related functionalities.

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes