### PR TITLE
📋 refactor: Prevent RTF Paste to Clipboard Only Plain Text

### DIFF
--- a/client/src/components/Messages/Content/CodeBlock.tsx
+++ b/client/src/components/Messages/Content/CodeBlock.tsx
@@ -33,7 +33,7 @@ const CodeBar: React.FC<CodeBarProps> = React.memo(({ lang, codeRef, error, plug
             const codeString = codeRef.current?.textContent;
             if (codeString) {
               setIsCopied(true);
-              copy(codeString);
+              copy(codeString, { format: 'text/plain' });
 
               setTimeout(() => {
                 setIsCopied(false);

--- a/client/src/hooks/Messages/useCopyToClipboard.ts
+++ b/client/src/hooks/Messages/useCopyToClipboard.ts
@@ -19,7 +19,7 @@ export default function useCopyToClipboard({
           return acc;
         }, '');
       }
-      copy(messageText ?? '');
+      copy(messageText ?? '', { format: 'text/plain' });
 
       setTimeout(() => {
         setIsCopied(false);


### PR DESCRIPTION
### Summary

- Modified clipboard handling to strip out RTF, allowing only plain text to be pasted.
- Ensured compatibility with existing text handling functions.
- Improved the user experience by maintaining consistency in text formatting across different paste operations.

### Change Type
- [x] Documentation update

### Testing
I tested the changes by pasting various text formats into the application to ensure only plain text is accepted. 

### Test Configuration:
- Operating System: Ubuntu 20.04
- Browser: Chrome 94

### Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes