### PR TITLE
🔡 fix: Rendering of Bidirectional Text

### DIFF
--- a/client/src/components/Chat/Messages/Content/Container.tsx
+++ b/client/src/components/Chat/Messages/Content/Container.tsx
@@ -2,7 +2,10 @@ import { TMessage } from 'librechat-data-provider';
 import Files from './Files';
 
 const Container = ({ children, message }: { children: React.ReactNode; message: TMessage }) => (
-  <div className="text-message flex min-h-[20px] flex-col items-start gap-3 overflow-x-auto [.text-message+&]:mt-5">
+  <div
+    className="text-message flex min-h-[20px] flex-col items-start gap-3 overflow-x-auto [.text-message+&]:mt-5"
+    dir="auto"
+  >
     {message.isCreatedByUser && <Files message={message} />}
     {children}
   </div>

--- a/client/src/components/Chat/Messages/Content/EditMessage.tsx
+++ b/client/src/components/Chat/Messages/Content/EditMessage.tsx
@@ -162,6 +162,7 @@ const EditMessage = ({
           contentEditable={true}
           value={editedText}
           suppressContentEditableWarning={true}
+          dir="auto"
         />
       </div>
       <div className="mt-2 flex w-full justify-center text-center">

--- a/client/src/components/Chat/Messages/Content/SearchContent.tsx
+++ b/client/src/components/Chat/Messages/Content/SearchContent.tsx
@@ -44,6 +44,7 @@ const SearchContent = ({ message }: { message: TMessage }) => {
         'markdown prose dark:prose-invert light w-full break-words',
         message.isCreatedByUser ? 'whitespace-pre-wrap dark:text-gray-20' : 'dark:text-gray-70',
       )}
+      dir="auto"
     >
       <MarkdownLite content={message.text ?? ''} />
     </div>

--- a/client/src/components/Messages/Content/EditMessage.tsx
+++ b/client/src/components/Messages/Content/EditMessage.tsx
@@ -87,6 +87,7 @@ const EditMessage = ({
         contentEditable={true}
         ref={textEditor}
         suppressContentEditableWarning={true}
+        dir="auto"
       >
         {text}
       </div>

--- a/client/src/components/Nav/SearchBar.tsx
+++ b/client/src/components/Nav/SearchBar.tsx
@@ -72,6 +72,7 @@ const SearchBar = forwardRef((props: SearchBarProps, ref: Ref<HTMLDivElement>) =
         placeholder={localize('com_nav_search_placeholder')}
         onKeyUp={handleKeyUp}
         autoComplete="off"
+        dir="auto"
       />
       <X
         className={cn(

--- a/client/src/components/ui/TextareaAutosize.tsx
+++ b/client/src/components/ui/TextareaAutosize.tsx
@@ -5,6 +5,6 @@ export const TextareaAutosize = forwardRef<HTMLTextAreaElement, TextareaAutosize
   (props, ref) => {
     const [, setIsRerendered] = useState(false);
     useLayoutEffect(() => setIsRerendered(true), []);
-    return <ReactTextareaAutosize {...props} ref={ref} />;
+    return <ReactTextareaAutosize dir="auto" {...props} ref={ref} />;
   },
 );


### PR DESCRIPTION
## Summary

This basically adds bidirectional text support for key components across the UI, addressing an issue where mixing a RTL (Right-to-Left) language with a LTR (Left-to-Right) language in the same input renders the text unreadable.

Before the fix:
<img width="797" alt="image" src="https://github.com/danny-avila/LibreChat/assets/59054736/d1d01be0-27ff-45dc-b34b-3fe6779acb07">
<img width="733" alt="image" src="https://github.com/danny-avila/LibreChat/assets/59054736/302faa73-3afc-42e2-926b-3bc3e52b6e20">

After:
<img width="779" alt="image" src="https://github.com/danny-avila/LibreChat/assets/59054736/5d68f850-a112-4934-aa5d-95b05e1d4c72">
<img width="746" alt="image" src="https://github.com/danny-avila/LibreChat/assets/59054736/461843e0-4131-4235-82fd-ad229da3aeb2">

For readers of both RTL and LTR languages, this fix significantly improves text readability.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing
N/A

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
