### PR TITLE
📱fix: set initial nav visibility for small screens

### DIFF
--- a/client/src/components/Nav/Nav.spec.tsx
+++ b/client/src/components/Nav/Nav.spec.tsx
@@ -1,0 +1,102 @@
+import 'test/resizeObserver.mock';
+import 'test/matchMedia.mock';
+import 'test/localStorage.mock';
+
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { AuthContextProvider } from '~/hooks/AuthContext';
+import { SearchContext } from '~/Providers';
+import Nav from './Nav';
+
+const renderNav = ({ search, navVisible, setNavVisible }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <RecoilRoot>
+      <BrowserRouter>
+        <QueryClientProvider client={queryClient}>
+          <AuthContextProvider>
+            <SearchContext.Provider value={search}>
+              <Nav navVisible={navVisible} setNavVisible={setNavVisible} />
+            </SearchContext.Provider>
+          </AuthContextProvider>
+        </QueryClientProvider>
+      </BrowserRouter>
+    </RecoilRoot>,
+  );
+};
+
+const mockMatchMedia = (mediaQueryList?: string[]) => {
+  mediaQueryList = mediaQueryList || [];
+
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: mediaQueryList.includes(query),
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+};
+
+describe('Nav', () => {
+  beforeEach(() => {
+    mockMatchMedia();
+  });
+
+  it('renders visible', () => {
+    const { getByTestId } = renderNav({
+      search: { data: [], pageNumber: 1 },
+      navVisible: true,
+      setNavVisible: jest.fn(),
+    });
+
+    expect(getByTestId('nav')).toBeVisible();
+  });
+
+  it('renders hidden', async () => {
+    const { getByTestId } = renderNav({
+      search: { data: [], pageNumber: 1 },
+      navVisible: false,
+      setNavVisible: jest.fn(),
+    });
+
+    expect(getByTestId('nav')).not.toBeVisible();
+  });
+
+  it('renders hidden when small screen is detected', async () => {
+    mockMatchMedia(['(max-width: 768px)']);
+
+    const navVisible = true;
+    const mockSetNavVisible = jest.fn();
+
+    const { getByTestId } = renderNav({
+      search: { data: [], pageNumber: 1 },
+      navVisible: navVisible,
+      setNavVisible: mockSetNavVisible,
+    });
+
+    // nav is initially visible
+    expect(getByTestId('nav')).toBeVisible();
+
+    // when small screen is detected, the nav is hidden
+    expect(mockSetNavVisible.mock.calls).toHaveLength(1);
+    const updatedNavVisible = mockSetNavVisible.mock.calls[0][0](navVisible);
+    expect(updatedNavVisible).not.toEqual(navVisible);
+    expect(updatedNavVisible).toBeFalsy();
+  });
+});

--- a/client/src/components/Nav/Nav.tsx
+++ b/client/src/components/Nav/Nav.tsx
@@ -42,6 +42,10 @@ const Nav = ({ navVisible, setNavVisible }) => {
 
   useEffect(() => {
     if (isSmallScreen) {
+      const savedNavVisible = localStorage.getItem('navVisible');
+      if (savedNavVisible === null) {
+        toggleNavVisible();
+      }
       setNavWidth('320px');
     } else {
       setNavWidth('260px');

--- a/client/src/components/Nav/Nav.tsx
+++ b/client/src/components/Nav/Nav.tsx
@@ -106,6 +106,7 @@ const Nav = ({ navVisible, setNavVisible }) => {
     <TooltipProvider delayDuration={250}>
       <Tooltip>
         <div
+          data-testid="nav"
           className={
             'nav active max-w-[320px] flex-shrink-0 overflow-x-hidden bg-gray-50 dark:bg-gray-850 md:max-w-[260px]'
           }

--- a/client/test/localStorage.mock
+++ b/client/test/localStorage.mock
@@ -1,0 +1,21 @@
+let store = {};
+Object.defineProperty(window, 'localStorage', {
+    writable: true,
+    value: {
+        getItem: jest.fn().mockImplementation((key) => {
+            if(key in store) {
+                return store[key];
+            }
+            return null;
+        }),
+        setItem: jest.fn().mockImplementation((key, value) => {
+            store[key] = value.toString();
+        }),
+        clear: jest.fn().mockImplementation(() => {
+            store = {};
+        }),
+        removeItem: jest.fn().mockImplementation(() => {
+            delete store[key];
+        }),
+    },
+});

--- a/client/test/resizeObserver.mock
+++ b/client/test/resizeObserver.mock
@@ -1,0 +1,8 @@
+Object.defineProperty(window, 'ResizeObserver', {
+  writable: true,
+  value: jest.fn().mockImplementation(() => ({
+    disconnect: jest.fn(),
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+  }))
+});


### PR DESCRIPTION
## Summary

This PR contributes a fix to the `Nav` component so that it is initially hidden the first time a user visits the app on a mobile device and/or small screen. The problem is that when a user visits the app on a small screen for the very first time, they will see an empty nav obscuring most of the screen. This is confusing for users the first time they use the app.

For reference:

|Before|After|
|---|---|
|![mobile-nav-visibility-1](https://github.com/danny-avila/LibreChat/assets/1165361/911e3a70-6692-45a5-b122-69e785f0666b)|![mobile-nav-visibility-2](https://github.com/danny-avila/LibreChat/assets/1165361/d525f98d-a86e-48e3-b877-ae166e9a5db3)|

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Added `Nav.spec.tsx` to test that the nav visibility is changed when small screen is detected and localStorage does not have any data yet. Note that there were no tests for the `Nav` component already and there was a fair bit of setup required to test it, so if there's a better way to set up these tests, please let me know.

### **Test Configuration**:

- Simulate mobile device viewport in browser (i.e. width < 768px) and/or test with an actual mobile device.
- Clear the `navVisible` value in local storage (i.e. `localStorage.removeItem('navVisible')`).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
