### PR TITLE
💊 fix: OpenID proxy support for downloading profile pictures with proxy

### DIFF
--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -25,12 +25,18 @@ const downloadImage = async (url, accessToken) => {
   }
 
   try {
-    const response = await fetch(url, {
+    const options = {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },
-    });
+    };
+
+    if (process.env.PROXY) {
+      options.agent = new HttpsProxyAgent(process.env.PROXY);
+    }
+
+    const response = await fetch(url, options);
 
     if (response.ok) {
       const buffer = await response.buffer();


### PR DESCRIPTION
## Summary

Related to #3261

Add proxy support to `downloadImage` function in `openidStrategy.js`

* Import `HttpsProxyAgent` from `https-proxy-agent`.
* Add `agent` property to the fetch options in `downloadImage` function if `process.env.PROXY` is set.
* Update the `fetch` call in `downloadImage` function to use the proxy agent if available.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

no testing since I don't know how, I'd like to see feedback for this

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
