### PR TITLE
🗨️ fix: Reset prompt groups query when changing filters

### DIFF
--- a/client/src/hooks/Prompts/usePromptGroupsNav.ts
+++ b/client/src/hooks/Prompts/usePromptGroupsNav.ts
@@ -3,8 +3,11 @@ import { useMemo, useRef, useEffect, useCallback } from 'react';
 import { usePromptGroupsInfiniteQuery } from '~/data-provider';
 import debounce from 'lodash/debounce';
 import store from '~/store';
+import { useQueryClient } from '@tanstack/react-query';
+import { QueryKeys } from 'librechat-data-provider';
 
 export default function usePromptGroupsNav() {
+  const queryClient = useQueryClient();
   const category = useRecoilValue(store.promptsCategory);
   const [name, setName] = useRecoilState(store.promptsName);
   const [pageSize, setPageSize] = useRecoilState(store.promptsPageSize);
@@ -28,6 +31,7 @@ export default function usePromptGroupsNav() {
   useEffect(() => {
     maxPageNumberReached.current = 1;
     setPageNumber(1);
+    queryClient.resetQueries([QueryKeys.promptGroups, name, category, pageSize]);
   }, [pageSize, name, category, setPageNumber]);
 
   const promptGroups = useMemo(() => {


### PR DESCRIPTION
## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Create at least 11 different prompts in the prompts library. Go to the next page. Use the keyword filter and then remove it. You should still be able to use the pagination feature.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
