### PR TITLE
🔧 fix: Make assistant tool filtering compatible with plugin filtering

### DIFF
--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -73,10 +73,6 @@ function loadAndFormatTools({ directory, adminFilter = [], adminIncluded = [] })
       continue;
     }
 
-    if (included.size > 0 && !included.has(file)) {
-      continue;
-    }
-
     let toolInstance = null;
     try {
       toolInstance = new ToolClass({ override: true });
@@ -89,6 +85,14 @@ function loadAndFormatTools({ directory, adminFilter = [], adminIncluded = [] })
     }
 
     if (!toolInstance) {
+      continue;
+    }
+
+    if (filter.has(toolInstance.name) && included.size === 0) {
+      continue;
+    }
+
+    if (included.size > 0 && !included.has(file) && !included.has(toolInstance.name)) {
       continue;
     }
 


### PR DESCRIPTION
Fixes #3324 



## Summary
The `includedTools` config option expects the `pluginKey`/`tool.name` for filtering included tools, which is incompatible with the implementation in `loadAndFormatTools` used for loading assistant tools.

This change uses **both** `filename` and `tool.name` for filtering tools in `ToolService.loadAndFormatTools` in order to make it compatible with the old implementation as well as the behaviour of plugin filtering.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Use a configuration with assistants + plugins enabled.
2. Set includedTools to ['calculator', 'azure-ai-search'] in librechat.yaml
3. Verify plugins are properly filtered in plugins.
4. Create/Update assistant try to add tool.
5. Observe the Calculator and  Azure AI Search tool being available.

### **Test Configuration**:

1. Use a configuration with assistants + plugins enabled.
2. Set includedTools to ['calculator', 'azure-ai-search'] in librechat.yaml

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
