### PR TITLE
🔧 fix: Ensure ShareView document title is configured

### DIFF
--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -1,19 +1,30 @@
 import { memo } from 'react';
 import { useParams } from 'react-router-dom';
-import { useGetSharedMessages } from 'librechat-data-provider/react-query';
+import { useGetSharedMessages, useGetStartupConfig } from 'librechat-data-provider/react-query';
 import { ShareContext } from '~/Providers';
 import { Spinner } from '~/components/svg';
 import MessagesView from './MessagesView';
-import { useLocalize } from '~/hooks';
+import { useLocalize, useDocumentTitle } from '~/hooks';
 import { buildTree } from '~/utils';
 import Footer from '../Chat/Footer';
 
 function SharedView() {
   const localize = useLocalize();
+  const { data: config } = useGetStartupConfig();
   const { shareId } = useParams();
   const { data, isLoading } = useGetSharedMessages(shareId ?? '');
   const dataTree = data && buildTree({ messages: data.messages });
   const messagesTree = dataTree?.length === 0 ? null : dataTree ?? null;
+
+  // configure document title
+  let docTitle = '';
+  if (config?.appTitle && data?.title) {
+    docTitle = `${data?.title} | ${config.appTitle}`;
+  } else {
+    docTitle = data?.title || config?.appTitle || document.title;
+  }
+
+  useDocumentTitle(docTitle);
 
   return (
     <ShareContext.Provider value={{ isSharedConvo: true }}>

--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -1,10 +1,10 @@
 import { memo } from 'react';
 import { useParams } from 'react-router-dom';
 import { useGetSharedMessages, useGetStartupConfig } from 'librechat-data-provider/react-query';
+import { useLocalize, useDocumentTitle } from '~/hooks';
 import { ShareContext } from '~/Providers';
 import { Spinner } from '~/components/svg';
 import MessagesView from './MessagesView';
-import { useLocalize, useDocumentTitle } from '~/hooks';
 import { buildTree } from '~/utils';
 import Footer from '../Chat/Footer';
 

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -27,3 +27,4 @@ export { default as useOnClickOutside } from './useOnClickOutside';
 export { default as useSpeechToText } from './Input/useSpeechToText';
 export { default as useTextToSpeech } from './Input/useTextToSpeech';
 export { default as useGenerationsByLatest } from './useGenerationsByLatest';
+export { default as useDocumentTitle } from './useDocumentTitle';


### PR DESCRIPTION
## Summary

This PR updates the document title on the shared link view to reflect the conversation title and application title. This will improve accessibility and link sharing/bookmarking.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested changes locally to confirm that the shared link view displays the conversation title and application title. 

Steps:

1. Start a new conversation.
2. In the conversation panel, go to _Export > Share_
3. Click _Create Link_
4. Visit shared link.
5. Confirm that the `document.title` follows the format `{conversationTitle} | {appTitle}`.
   - The `appTitle` should match the configured `APP_TITLE` environment variable. Default is `LibreChat` if not configured.
   - The `conversationTitle` should match the displayed heading (h1).

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
