### PR TITLE
🔧 refactor: Enable Scrolling Chat Message with PageDown and PageUp keys

### DIFF
--- a/client/src/components/Chat/Messages/MessagesView.tsx
+++ b/client/src/components/Chat/Messages/MessagesView.tsx
@@ -33,6 +33,7 @@ export default function MessagesView({
         <div
           onScroll={debouncedHandleScroll}
           ref={scrollableRef}
+          tabIndex={0}
           style={{
             height: '100%',
             overflowY: 'auto',


### PR DESCRIPTION
## Summary

Enabled scrolling through chat messages using the `PageUp` and `PageDown` keys by adding `tabIndex={0}`. This change is intended to improve accessibility.

## Change Type

- [x] Refactoring

## Testing

Verified that chat messages can be scrolled using the PageUp and PageDown keys.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

