### PR TITLE
📝 docs: RAG API service communicate with Ollama service on Linux

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -100,6 +100,7 @@ version: '3.4'
 # # USE RAG API IMAGE WITH LOCAL EMBEDDINGS SUPPORT
 #  rag_api:
 #    image: ghcr.io/danny-avila/librechat-rag-api-dev:latest
+# # For Linux user: 
 #    extra_hosts:
 #      - "host.docker.internal:host-gateway"
 

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -100,6 +100,8 @@ version: '3.4'
 # # USE RAG API IMAGE WITH LOCAL EMBEDDINGS SUPPORT
 #  rag_api:
 #    image: ghcr.io/danny-avila/librechat-rag-api-dev:latest
+#    extra_hosts:
+#      - "host.docker.internal:host-gateway"
 
 # # ADD OLLAMA
 #  ollama:


### PR DESCRIPTION
Minor change to help RAG API service to communicate with Ollama service on Linux.

Related PR:
- https://github.com/danny-avila/LibreChat/issues/2671