### PR TITLE
Allow private and global assistants

### DIFF
--- a/api/server/controllers/assistants/helpers.js
+++ b/api/server/controllers/assistants/helpers.js
@@ -254,7 +254,11 @@ const fetchAssistants = async ({ req, res, overrideEndpoint }) => {
 function filterAssistants({ assistants, userId, assistantsConfig }) {
   const { supportedIds, excludedIds, privateAssistants } = assistantsConfig;
   if (privateAssistants) {
-    return assistants.filter((assistant) => userId === assistant.metadata?.author);
+    let filteredAssistants = assistants.filter((assistant) => userId === assistant.metadata?.author);
+    if (supportedIds?.length) {
+      filteredAssistants = filteredAssistants.concat(assistants.filter((assistant) => supportedIds.includes(assistant.id)))
+    }
+    return filteredAssistants;
   } else if (supportedIds?.length) {
     return assistants.filter((assistant) => supportedIds.includes(assistant.id));
   } else if (excludedIds?.length) {


### PR DESCRIPTION
Note: This is a proposal for https://github.com/danny-avila/LibreChat/issues/3296 which is an option that I need as well. Would love to know whether people think this is the right approach, and if this is being addressed in v2. If people agree with this approach I can go ahead and write some unit tests and make sure it all works as expected.

## Summary

When the private assistants configuration is enabled, use the supportedIds configuration to explicitly call out which assistants should be included regardless of who the author is (hence making them "Global").

Previously the "undefined" author was used as a way to indicate global assistants but that was removed shortly after https://github.com/danny-avila/LibreChat/pull/2881 -> "we still want to make some assistants available to all users (assistants without a metadata.author field)"

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Translation update

## Testing

Have not written unit tests yet.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
