### PR TITLE
⚙️ fix: Plugin Message Handling Errors

### DIFF
--- a/api/models/Message.js
+++ b/api/models/Message.js
@@ -108,6 +108,9 @@ ${JSON.stringify(params, null, 2)}
     return message.toObject();
   } catch (err) {
     logger.error('Error saving message:', err);
+    if (metadata && metadata?.context) {
+      logger.info(`\`saveMessage\` context: ${metadata.context}`);
+    }
     throw err;
   }
 }
@@ -178,7 +181,7 @@ async function recordMessage({
       new: true,
     });
   } catch (err) {
-    logger.error('Error saving message:', err);
+    logger.error('Error recording message:', err);
     throw err;
   }
 }
@@ -217,10 +220,12 @@ async function updateMessageText(req, { messageId, text }) {
  * @param {boolean} [message.isCreatedByUser] - Indicates if the message was created by the user.
  * @param {string} [message.sender] - The identifier of the sender.
  * @param {number} [message.tokenCount] - The number of tokens in the message.
+ * @param {Object} [metadata] - The operation metadata
+ * @param {string} [metadata.context] - The operation metadata
  * @returns {Promise<TMessage>} The updated message document.
  * @throws {Error} If there is an error in updating the message or if the message is not found.
  */
-async function updateMessage(req, message) {
+async function updateMessage(req, message, metadata) {
   try {
     const { messageId, ...update } = message;
     update.isEdited = true;
@@ -248,6 +253,9 @@ async function updateMessage(req, message) {
     };
   } catch (err) {
     logger.error('Error updating message:', err);
+    if (metadata && metadata?.context) {
+      logger.info(`\`updateMessage\` context: ${metadata.context}`);
+    }
     throw err;
   }
 }

--- a/api/models/schema/messageSchema.js
+++ b/api/models/schema/messageSchema.js
@@ -129,6 +129,7 @@ if (process.env.MEILI_HOST && process.env.MEILI_MASTER_KEY) {
 }
 
 messageSchema.index({ createdAt: 1 });
+messageSchema.index({ messageId: 1, user: 1 }, { unique: true });
 
 const Message = mongoose.models.Message || mongoose.model('Message', messageSchema);
 


### PR DESCRIPTION
## Summary

I prevented `dupe_key` or `getKeyIndex` errors caused by https://github.com/danny-avila/LibreChat/pull/3363

- Add unique index for `messageId` and `user` in `messageSchema`
- Use `updateMessage` for updating plugin messages
- Add enhanced logging for `updateMessage`
- Prevent `dupe_key` or `getKeyIndex` errors

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested the changes locally by creating, updating, and querying plugin messages to ensure the unique index works as expected and that no duplicate key errors occur.

### **Test Configuration**:

- MongoDB version: 4.4.10
- Node.js version: 14.17.5

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes