### PR TITLE
feat: Enable 8192 max token output for claude-3-5-sonnet-20240620

### DIFF
--- a/client/src/components/Endpoints/Settings/Anthropic.tsx
+++ b/client/src/components/Endpoints/Settings/Anthropic.tsx
@@ -30,6 +30,7 @@ export default function Settings({ conversation, setOption, models, readonly }: 
     maxContextTokens,
     resendFiles,
   } = conversation ?? {};
+  const isClaude35Sonnet = model === 'claude-3-5-sonnet-20240620';
   const [setMaxContextTokens, maxContextTokensValue] = useDebouncedInput<number | null | undefined>(
     {
       setOption,
@@ -259,7 +260,7 @@ export default function Settings({ conversation, setOption, models, readonly }: 
               <Label htmlFor="max-tokens-int" className="text-left text-sm font-medium">
                 {localize('com_endpoint_max_output_tokens')}{' '}
                 <small className="opacity-40">
-                  ({localize('com_endpoint_default_with_num', '4000')})
+                  ({localize('com_endpoint_default_with_num', isClaude35Sonnet ? '8192' : '4000')})
                 </small>
               </Label>
               <InputNumber
@@ -267,7 +268,7 @@ export default function Settings({ conversation, setOption, models, readonly }: 
                 disabled={readonly}
                 value={maxOutputTokens}
                 onChange={(value) => setMaxOutputTokens(Number(value))}
-                max={4000}
+                max={isClaude35Sonnet ? 8192 : 4000}
                 min={1}
                 step={1}
                 controls={false}
@@ -282,10 +283,10 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             </div>
             <Slider
               disabled={readonly}
-              value={[maxOutputTokens ?? 4000]}
+              value={[maxOutputTokens ?? (isClaude35Sonnet ? 8192 : 4000)]}
               onValueChange={(value) => setMaxOutputTokens(value[0])}
-              doubleClickHandler={() => setMaxOutputTokens(0)}
-              max={4000}
+              doubleClickHandler={() => setMaxOutputTokens(isClaude35Sonnet ? 8192 : 4000)}
+              max={isClaude35Sonnet ? 8192 : 4000}
               min={1}
               step={1}
               className="flex h-4 w-full"


### PR DESCRIPTION
## Summary

Updated Anthropic API calls to support 8192 max output tokens for claude-3-5-sonnet-20240620. Announced on x.com by Anthropic dev Alex Albert. 

![image](https://github.com/user-attachments/assets/c2290dcc-9cf5-43b0-a657-223fd4768396)

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Select the Anthropic model `claude-3-5-sonnet-20240620` in the user interface and change `Max Output Tokens` to 8192. Query the assistant. Example: `You have been upgraded to output up to 8192 tokens per response! Write a 10,000 word essay on whatever subject you prefer. Make it comical and ridiculous.`

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [N/A] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [X] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
- [X] Any changes dependent on mine have been merged and published in downstream modules.
- [N/A] A pull request for updating the documentation has been submitted.
