### PR TITLE
🔧 fix: STT/TTS external checks

### DIFF
--- a/client/src/components/Nav/SettingsTabs/Speech/Speech.tsx
+++ b/client/src/components/Nav/SettingsTabs/Speech/Speech.tsx
@@ -75,12 +75,17 @@ function Speech() {
         playbackRate: { value: playbackRate, setFunc: setPlaybackRate },
       };
 
-      if (settings[key].value !== newValue || settings[key].value === newValue || !settings[key]) {
+      if (
+        (settings[key].value !== newValue || settings[key].value === newValue || !settings[key]) &&
+        settings[key].value !== 'sttExternal' &&
+        settings[key].value !== 'ttsExternal'
+      ) {
         return;
       }
 
       const setting = settings[key];
       setting.setFunc(newValue);
+      console.log(`Setting ${key} to ${newValue}`);
     },
     [
       sttExternal,

--- a/client/src/components/Nav/SettingsTabs/Speech/Speech.tsx
+++ b/client/src/components/Nav/SettingsTabs/Speech/Speech.tsx
@@ -85,7 +85,6 @@ function Speech() {
 
       const setting = settings[key];
       setting.setFunc(newValue);
-      console.log(`Setting ${key} to ${newValue}`);
     },
     [
       sttExternal,


### PR DESCRIPTION
## Summary

this fix addresses an issue where a condition was incorrectly checking for values stored in localStorage. The condition mistakenly assumed that the variables controlling the external STT/TTS features, which are tied to the settings variable, were also stored in localStorage. Since these variables were already declared with a default value of false, the assignment was skipped

With this fix, the variables are now properly managed, ensuring that the STT/TTS features are enabled as intended

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

checked with `stt`/`tts` and without them

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
