### PR TITLE
🗨️ fix: respect line breaks in prompt variables

### DIFF
--- a/client/src/components/Prompts/Groups/VariableForm.tsx
+++ b/client/src/components/Prompts/Groups/VariableForm.tsx
@@ -3,7 +3,7 @@ import { useForm, useFieldArray, Controller, useWatch } from 'react-hook-form';
 import type { TPromptGroup } from 'librechat-data-provider';
 import { extractVariableInfo, wrapVariable, replaceSpecialVars } from '~/utils';
 import { useAuthContext, useLocalize, useSubmitMessage } from '~/hooks';
-import { Input } from '~/components/ui';
+import { Textarea } from '~/components/ui';
 
 type FormValues = {
   fields: { variable: string; value: string }[];
@@ -103,11 +103,18 @@ export default function VariableForm({
                 name={`fields.${index}.value`}
                 control={control}
                 render={({ field }) => (
-                  <Input
+                  <Textarea
                     {...field}
                     id={`fields.${index}.value`}
-                    className="input text-grey-darker rounded border px-3 py-2 focus:bg-white dark:border-gray-500 dark:focus:bg-gray-700"
+                    className="input text-grey-darker h-10 rounded border px-3 py-2 focus:bg-white dark:border-gray-500 dark:focus:bg-gray-700"
                     placeholder={uniqueVariables[index]}
+                    onKeyDown={(e) => {
+                      // Submit the form on enter like you would with an Input component
+                      if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault();
+                        handleSubmit((data) => onSubmit(data))();
+                      }
+                    }}
                   />
                 )}
               />

--- a/client/src/components/Prompts/PromptEditor.tsx
+++ b/client/src/components/Prompts/PromptEditor.tsx
@@ -70,7 +70,7 @@ const PromptEditor: React.FC<Props> = ({ name, isEditing, setIsEditing }) => {
                 onBlur={() => setIsEditing(false)}
               />
             ) : (
-              <span className="block break-words px-2 py-1 dark:text-gray-200">{field.value}</span>
+              <pre className="block break-words px-2 py-1 dark:text-gray-200">{field.value}</pre>
             )
           }
         />


### PR DESCRIPTION
# Pull Request Template

## Summary

_This PR addresses two small bugs in the prompt dialogs:_
1.\
Allows inputting multi-line variables in prompt dialogs / doesn't strip pasted text of its line breaks.

- the main change here is swapping an input with a textarea. 
- I have maintained the enter to submit functionality, but made sure you can add new lines with `shift+enter` so that it works the same as the main chat dialog. 
- this should fix #3284.


2.\
Don't strip newlines in the editing section of a prompt template, i.e. from this:
<img width="1520" alt="Screenshot 2024-07-26 at 22 11 02" src="https://github.com/user-attachments/assets/6bc5f36d-be03-4bbe-9583-85c4a9c2fecc">
to this:
<img width="1516" alt="Screenshot 2024-07-26 at 22 11 24" src="https://github.com/user-attachments/assets/7c2f63b0-93c7-4d7f-b7c0-3d4b15cdb1eb">


## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested inputting values with new lines as variables in the prompt dialog. Can confirm it works as expected on brave/chromium and firefox.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
