### PR TITLE
📝 docs: update `.env.example` with RAG API variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,7 +87,6 @@ ANTHROPIC_API_KEY=user_provided
 # Azure      #
 #============#
 
-
 # Note: these variables are DEPRECATED
 # Use the `librechat.yaml` configuration for `azureOpenAI` instead
 # You may also continue to use them if you opt out of using the `librechat.yaml` configuration
@@ -137,7 +136,6 @@ GOOGLE_KEY=user_provided
 # GOOGLE_SAFETY_HATE_SPEECH=BLOCK_ONLY_HIGH
 # GOOGLE_SAFETY_HARASSMENT=BLOCK_ONLY_HIGH
 # GOOGLE_SAFETY_DANGEROUS_CONTENT=BLOCK_ONLY_HIGH
-
 
 #============#
 # OpenAI     #
@@ -261,13 +259,21 @@ MEILI_NO_ANALYTICS=true
 MEILI_HOST=http://0.0.0.0:7700
 MEILI_MASTER_KEY=DrhYf7zENyR6AlUCKmnz0eYASOQdl6zxH7s7MKFSfFCt
 
-
 #==================================================#
 #          Speech to Text & Text to Speech         #
 #==================================================#
 
 STT_API_KEY=
 TTS_API_KEY=
+
+#==================================================#
+#                        RAG                       #
+#==================================================#
+
+# RAG_OPENAI_BASEURL=
+# RAG_OPENAI_API_KEY=
+# EMBEDDINGS_PROVIDER=openai
+# EMBEDDINGS_MODEL=text-embedding-3-small
 
 #===================================================#
 #                    User System                    #

--- a/.env.example
+++ b/.env.example
@@ -269,6 +269,7 @@ TTS_API_KEY=
 #==================================================#
 #                        RAG                       #
 #==================================================#
+# More info: https://www.librechat.ai/docs/configuration/rag_api
 
 # RAG_OPENAI_BASEURL=
 # RAG_OPENAI_API_KEY=


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

RAG does not follow the `OPENAI_REVERSE_PROXY` setting. I didn't realize this until I looked at `https://github.com/danny-avila/rag_api` and found that RAG has a special `RAG_OPENAI_BASEURL`, otherwise it will be the default `https://api.openai.com/v1/`. This is not good, I believe many people have the need to use a proxy. Therefore, I added these lines to the `.env` file and added comments, making it convenient for people with the same needs without affecting the default settings. 

## Change Type

Please delete any irrelevant options.

- [ ] This change requires a documentation update

## Testing

No problem. 

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] My changes do not introduce new warnings
