### PR TITLE
🛠️ fix(ldap): `LDAP_LOGIN_USES_USERNAME` config

### DIFF
--- a/api/server/services/Config/ldap.js
+++ b/api/server/services/Config/ldap.js
@@ -15,6 +15,8 @@ const getLdapConfig = () => {
   if (ldapLoginUsesUsername) {
     ldap.username = true;
   }
+  
+  return ldap;
 };
 
 module.exports = {


### PR DESCRIPTION
## Summary

This PR fixes an issue with the LDAP login configuration where the system was not switching to username input when the `LDAP_LOGIN_USES_USERNAME` environment variable was set to true. The problem was caused by a missing return statement in the `getLdapConfig` function in `ldap.js`. This change ensures that the LDAP configuration is correctly returned when username login is enabled, allowing users to log in with their username as intended.

This PR resolves issue #3471.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing

To test this change:
1. Set `LDAP_LOGIN_USES_USERNAME=true` in the .env file
2. Restart the application to ensure the new environment variable is loaded
3. Navigate to the login page
4. Attempt to log in
5. Verify that the login form now accepts a username instead of an email

### **Test Configuration**:
- LDAP enabled
- `LDAP_LOGIN_USES_USERNAME` set to true in .env file

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
