### PR TITLE
🖼️ fix: correct image extraction

### DIFF
--- a/api/app/clients/output_parsers/addImages.js
+++ b/api/app/clients/output_parsers/addImages.js
@@ -62,8 +62,8 @@ function addImages(intermediateSteps, responseMessage) {
     }
     const observedImagePath = observation.match(/!\[[^(]*\]\([^)]*\)/g);
     if (observedImagePath && !responseMessage.text.includes(observedImagePath[0])) {
-      responseMessage.text += '\n' + observation;
-      logger.debug('[addImages] added image from intermediateSteps:', observation);
+      responseMessage.text += '\n' + observedImagePath[0];
+      logger.debug('[addImages] added image from intermediateSteps:', observedImagePath[0]);
     }
   });
 }

--- a/api/app/clients/output_parsers/addImages.js
+++ b/api/app/clients/output_parsers/addImages.js
@@ -60,7 +60,7 @@ function addImages(intermediateSteps, responseMessage) {
     if (!observation || !observation.includes('![')) {
       return;
     }
-    const observedImagePath = observation.match(/!\[.*\]\([^)]*\)/g);
+    const observedImagePath = observation.match(/!\[[^(]*\]\([^)]*\)/g);
     if (observedImagePath && !responseMessage.text.includes(observedImagePath[0])) {
       responseMessage.text += '\n' + observation;
       logger.debug('[addImages] added image from intermediateSteps:', observation);


### PR DESCRIPTION
## Summary

This pull request addresses an issue where the entire document, including metadata and vector values, was being returned when using the AzureAI plugin. The root cause was identified in the `addImages` function, which incorrectly extracted images from the document. The function was returning the entire document if at least one image was present, leading to the inclusion of metadata and vector values.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

The changes were tested by creating a Markdown string with multiple images and verifying that the `addImages` function correctly extracts each image without including the intermediate text. Additionally, it was confirmed that only the first image is returned, and the entire document is not included in the response.

### **Test Configuration**:

1. Create a Markdown string with multiple images and intermediate text.
2. Pass the string to the `addImages` function.
3. Verify that the output is an array of image tags without the intermediate text.
4. Ensure that only the first image is returned and the entire document is not included in the response.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
