### PR TITLE
🐳 chore: Update Dockerfile.multi

### DIFF
--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -38,6 +38,6 @@ ENV HOST=0.0.0.0
 CMD ["node", "server/index.js"]
 
 # Nginx setup
-FROM nginx:1.21.1-alpine AS prod-stage
+FROM nginx:1.27.0-alpine AS prod-stage
 COPY ./client/nginx.conf /etc/nginx/conf.d/default.conf
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Upgrade nginx:1.21.1-alpine to nginx:1.27.0-alpine. Reduce Vulnerabilities report from 59 to 7 by Google image scan.

# Pull Request Template

## Summary

Upgrade nginx:1.21.1-alpine to nginx:1.27.0-alpine. Reduce Vulnerabilities report from 59 to 7 by Google image scan.

## Change Type

Please delete any irrelevant options.

- [  ] Upgrade nginx version in Dockerfile.multi

## Testing

Tested with 

```docker build \
                --platform=linux/amd64 \
                --file=Dockerfile.multi  \
                --tag=librechat:latest
```


