### PR TITLE
🔧 fix: API Key Handling for GoogleSearch and TavilySearch Tools

### DIFF
--- a/api/app/clients/tools/structured/GoogleSearch.js
+++ b/api/app/clients/tools/structured/GoogleSearch.js
@@ -12,9 +12,9 @@ class GoogleSearchResults extends Tool {
     this.envVarApiKey = 'GOOGLE_SEARCH_API_KEY';
     this.envVarSearchEngineId = 'GOOGLE_CSE_ID';
     this.override = fields.override ?? false;
-    this.apiKey = fields.apiKey ?? getEnvironmentVariable(this.envVarApiKey);
+    this.apiKey = fields[this.envVarApiKey] ?? getEnvironmentVariable(this.envVarApiKey);
     this.searchEngineId =
-      fields.searchEngineId ?? getEnvironmentVariable(this.envVarSearchEngineId);
+      fields[this.envVarSearchEngineId] ?? getEnvironmentVariable(this.envVarSearchEngineId);
 
     this.kwargs = fields?.kwargs ?? {};
     this.name = 'google';

--- a/api/app/clients/tools/structured/GoogleSearch.js
+++ b/api/app/clients/tools/structured/GoogleSearch.js
@@ -16,6 +16,12 @@ class GoogleSearchResults extends Tool {
     this.searchEngineId =
       fields[this.envVarSearchEngineId] ?? getEnvironmentVariable(this.envVarSearchEngineId);
 
+    if (!this.override && (!this.apiKey || !this.searchEngineId)) {
+      throw new Error(
+        `Missing ${this.envVarApiKey} or ${this.envVarSearchEngineId} environment variable.`,
+      );
+    }
+
     this.kwargs = fields?.kwargs ?? {};
     this.name = 'google';
     this.description =

--- a/api/app/clients/tools/structured/TavilySearchResults.js
+++ b/api/app/clients/tools/structured/TavilySearchResults.js
@@ -12,7 +12,7 @@ class TavilySearchResults extends Tool {
     this.envVar = 'TAVILY_API_KEY';
     /* Used to initialize the Tool without necessary variables. */
     this.override = fields.override ?? false;
-    this.apiKey = fields.apiKey ?? this.getApiKey();
+    this.apiKey = fields[this.envVar] ?? this.getApiKey();
 
     this.kwargs = fields?.kwargs ?? {};
     this.name = 'tavily_search_results_json';

--- a/api/app/clients/tools/structured/specs/GoogleSearch.spec.js
+++ b/api/app/clients/tools/structured/specs/GoogleSearch.spec.js
@@ -1,0 +1,50 @@
+const GoogleSearch = require('../GoogleSearch');
+
+jest.mock('node-fetch');
+jest.mock('@langchain/core/utils/env');
+
+describe('GoogleSearch', () => {
+  let originalEnv;
+  const mockApiKey = 'mock_api';
+  const mockSearchEngineId = 'mock_search_engine_id';
+
+  beforeAll(() => {
+    originalEnv = { ...process.env };
+  });
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      GOOGLE_SEARCH_API_KEY: mockApiKey,
+      GOOGLE_CSE_ID: mockSearchEngineId,
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    process.env = originalEnv;
+  });
+
+  it('should use mockApiKey and mockSearchEngineId when environment variables are not set', () => {
+    const instance = new GoogleSearch({
+      GOOGLE_SEARCH_API_KEY: mockApiKey,
+      GOOGLE_CSE_ID: mockSearchEngineId,
+    });
+    expect(instance.apiKey).toBe(mockApiKey);
+    expect(instance.searchEngineId).toBe(mockSearchEngineId);
+  });
+
+  it('should throw an error if GOOGLE_SEARCH_API_KEY or GOOGLE_CSE_ID is missing', () => {
+    delete process.env.GOOGLE_SEARCH_API_KEY;
+    expect(() => new GoogleSearch()).toThrow(
+      'Missing GOOGLE_SEARCH_API_KEY or GOOGLE_CSE_ID environment variable.',
+    );
+
+    process.env.GOOGLE_SEARCH_API_KEY = mockApiKey;
+    delete process.env.GOOGLE_CSE_ID;
+    expect(() => new GoogleSearch()).toThrow(
+      'Missing GOOGLE_SEARCH_API_KEY or GOOGLE_CSE_ID environment variable.',
+    );
+  });
+});

--- a/api/app/clients/tools/structured/specs/TavilySearchResults.spec.js
+++ b/api/app/clients/tools/structured/specs/TavilySearchResults.spec.js
@@ -1,0 +1,38 @@
+const TavilySearchResults = require('../TavilySearchResults');
+
+jest.mock('node-fetch');
+jest.mock('@langchain/core/utils/env');
+
+describe('TavilySearchResults', () => {
+  let originalEnv;
+  const mockApiKey = 'mock_api_key';
+
+  beforeAll(() => {
+    originalEnv = { ...process.env };
+  });
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      TAVILY_API_KEY: mockApiKey,
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    process.env = originalEnv;
+  });
+
+  it('should throw an error if TAVILY_API_KEY is missing', () => {
+    delete process.env.TAVILY_API_KEY;
+    expect(() => new TavilySearchResults()).toThrow('Missing TAVILY_API_KEY environment variable.');
+  });
+
+  it('should use mockApiKey when TAVILY_API_KEY is not set in the environment', () => {
+    const instance = new TavilySearchResults({
+      TAVILY_API_KEY: mockApiKey,
+    });
+    expect(instance.apiKey).toBe(mockApiKey);
+  });
+});


### PR DESCRIPTION
## Summary

This pull request addresses several issues and improvements related to handling API keys for GoogleSearch and TavilySearch tools.

- Fixed the way user-provided API keys are handled, ensuring they’re fetched correctly.
- Improved error handling to give clear feedback when environment variables are missing.
- Added new test cases to make sure everything works as expected.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

To test these changes:

1. Run the unit tests for the GoogleSearch and TavilySearch:

```
npm run test api/app/clients/tools/structured/specs/GoogleSearch.spec.js
npm run test api/app/clients/tools/structured/specs/TavilySearchResults.spec.js
```

2. Manually test the GoogleSearch and TavilySearch functionality in the application, ensuring that:

- Ensure TAVILY_API_KEY, GOOGLE_SEARCH_API_KEY, and GOOGLE_CSE_ID are not set in the .env file.
- In Assistant Tools, add GoogleSearch and TavilySearch plugins, providing the required API key fields.
- Write and execute a prompt using these tools.
- Verify that an error occurs due to the API keys not being retrieved correctly.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes