### PR TITLE
Add emoji to conversation auto titles

### DIFF
--- a/api/app/clients/prompts/titlePrompts.js
+++ b/api/app/clients/prompts/titlePrompts.js
@@ -16,7 +16,17 @@ const createTitlePrompt = ({ convo }) => {
   const titlePrompt = new ChatPromptTemplate({
     promptMessages: [
       SystemMessagePromptTemplate.fromTemplate(
-        `Write a concise title for this conversation in the given language. Title in 5 Words or Less. No Punctuation or Quotation. Must be in Title Case, written in the given Language.
+        `Write a concise title for this conversation in the given language.
+Title in 5 Words or Less. No Punctuation or Quotation.
+Must be in Title Case, written in the given Language.
+Find an appropriate emoji to start the title.
+Examples:
+🌿 Sustainable Gardening Tips
+🚀 Space Exploration Future Plans
+🎨 Modern Art Movement Analysis
+🏋️ Effective Workout Routines Explained
+🍳 Quick Healthy Breakfast Ideas
+
 ${convo}`,
       ),
       HumanMessagePromptTemplate.fromTemplate('Language: {language}'),


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.


## Summary

Add an emoji to the start of the auto conversation title, it's quite cute and visually helpful to differentiate between the conversations.  New auto-titler prompt:

```
Write a concise title for this conversation in the given language.
Title in 5 Words or Less. No Punctuation or Quotation.
Must be in Title Case, written in the given Language.
Find an appropriate emoji to start the title.
Examples:
🌿 Sustainable Gardening Tips
🚀 Space Exploration Future Plans
🎨 Modern Art Movement Analysis
🏋️ Effective Workout Routines Explained
🍳 Quick Healthy Breakfast Ideas
```

## Change Type
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Both a new look, and claude 3.5 generated the training list which may nudge the titler away from the way it worked before.

If you don't approve of this, is there a simple way for those using docker to update prompts for themselves?

## Testing

Tested on my server, look nice!

## Checklist

Please delete any irrelevant options.
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings

