### PR TITLE
Ollama should start automatically by default, Ollama without nvidia support (e.g. for Apple server).

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -107,12 +107,23 @@ version: '3.4'
 # # ADD OLLAMA
 #  ollama:
 #    image: ollama/ollama:latest
+#    restart: always
 #    deploy:
 #      resources:
 #        reservations:
 #          devices:
 #            - driver: nvidia
 #              capabilities: [compute, utility]
+#    ports:
+#      - "11434:11434"
+#    volumes:
+#      - ./ollama:/root/.ollama
+
+# # ADD OLLAMA without nvidia support
+#  ollama:
+#    image: ollama/ollama:latest
+#    restart: always
+#    deploy:
 #    ports:
 #      - "11434:11434"
 #    volumes:


### PR DESCRIPTION
add autostart to ollama and add ollama without nvidia support

## Summary

The docker-compose file should suggest an ollama installation where the autostart is activated by default.
I spend one day figuring out why the chat did not work after reboot. Therfore, ollama should start automatically like librechat.

For the apple servers, there is no nvidia support needed. Therefore, a code block without nvidia is helpful for a fast proof-of-concept installation.



