### PR TITLE
🦙 fix: Update Title Message Role for Ollama if None Provided

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -827,7 +827,7 @@ class OpenAIClient extends BaseClient {
 
       const instructionsPayload = [
         {
-          role: this.options.titleMessageRole ?? 'system',
+          role: this.options.titleMessageRole ?? (this.isOllama ? 'user' : 'system'),
           content: `Please generate ${titleInstruction}
 
 ${convo}


### PR DESCRIPTION
## Summary

Closes #3510 

Addresses issue with llama3.1 not generating titles due to `system` message role

- Modified the `OpenAIClient.js` file to update the `role` property in the `instructionsPayload`.
- Implemented a conditional check to set the role to 'user' if `isOllama` is true and `titleMessageRole` is not explicitly passed.
- Maintained the default 'system' role for non-Ollama models to ensure backward compatibility.
- This fix resolves the issue where llama3.1 was not generating titles due to not being able to handle system messages as the only message in the payload

## Testing

To test this change:

1. Set up an Ollama endpoint in LibreChat.
2. Initiate a conversation using the llama3.1 model.
3. Verify that the conversation title is generated correctly.

Additionally, ensure that title generation still works as expected for non-Ollama models.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have tested my changes to ensure they resolve the issue with llama3.1 title generation
- [x] Local unit tests pass with my changes