### PR TITLE
🤖 feat: Recognize `chatgpt-4o-latest`, update default OpenAI Models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,7 +147,7 @@ GOOGLE_KEY=user_provided
 #============#
 
 OPENAI_API_KEY=user_provided
-# OPENAI_MODELS=gpt-4o,gpt-4o-mini,gpt-3.5-turbo-0125,gpt-3.5-turbo-0301,gpt-3.5-turbo,gpt-4,gpt-4-0613,gpt-4-vision-preview,gpt-3.5-turbo-0613,gpt-3.5-turbo-16k-0613,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo-1106,gpt-3.5-turbo-instruct,gpt-3.5-turbo-instruct-0914,gpt-3.5-turbo-16k
+# OPENAI_MODELS=gpt-4o,chatgpt-4o-latest,gpt-4o-mini,gpt-3.5-turbo-0125,gpt-3.5-turbo-0301,gpt-3.5-turbo,gpt-4,gpt-4-0613,gpt-4-vision-preview,gpt-3.5-turbo-0613,gpt-3.5-turbo-16k-0613,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo-1106,gpt-3.5-turbo-instruct,gpt-3.5-turbo-instruct-0914,gpt-3.5-turbo-16k
 
 DEBUG_OPENAI=false
 

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -63,6 +63,13 @@ describe('getValueKey', () => {
     expect(getValueKey('gpt-4o-2024-08-06-0718')).not.toBe('gpt-4o');
   });
 
+  it('should return "gpt-4o" for model type of "chatgpt-4o"', () => {
+    expect(getValueKey('chatgpt-4o-latest')).toBe('gpt-4o');
+    expect(getValueKey('openai/chatgpt-4o-latest')).toBe('gpt-4o');
+    expect(getValueKey('chatgpt-4o-latest-0916')).toBe('gpt-4o');
+    expect(getValueKey('chatgpt-4o-latest-0718')).toBe('gpt-4o');
+  });
+
   it('should return "claude-3-5-sonnet" for model type of "claude-3-5-sonnet-"', () => {
     expect(getValueKey('claude-3-5-sonnet-20240620')).toBe('claude-3-5-sonnet');
     expect(getValueKey('anthropic/claude-3-5-sonnet')).toBe('claude-3-5-sonnet');
@@ -133,6 +140,17 @@ describe('getMultiplier', () => {
     );
     expect(getMultiplier({ valueKey, tokenType: 'completion' })).not.toBe(
       tokenValues['gpt-4-1106'].completion,
+    );
+  });
+
+  it('should return the correct multiplier for chatgpt-4o-latest', () => {
+    const valueKey = getValueKey('chatgpt-4o-latest');
+    expect(getMultiplier({ valueKey, tokenType: 'prompt' })).toBe(tokenValues['gpt-4o'].prompt);
+    expect(getMultiplier({ valueKey, tokenType: 'completion' })).toBe(
+      tokenValues['gpt-4o'].completion,
+    );
+    expect(getMultiplier({ valueKey, tokenType: 'completion' })).not.toBe(
+      tokenValues['gpt-4o-mini'].completion,
     );
   });
 

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.411",
+  "version": "0.7.412",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -11,6 +11,7 @@ export const defaultSocialLogins = ['google', 'facebook', 'openid', 'github', 'd
 
 export const defaultRetrievalModels = [
   'gpt-4o',
+  'chatgpt-4o-latest',
   'gpt-4o-2024-05-13',
   'gpt-4o-2024-08-06',
   'gpt-4o-mini',
@@ -514,6 +515,8 @@ export const alternateName = {
 };
 
 const sharedOpenAIModels = [
+  'gpt-4o-mini',
+  'gpt-4o',
   'gpt-3.5-turbo',
   'gpt-3.5-turbo-0125',
   'gpt-4-turbo',
@@ -533,7 +536,7 @@ const sharedOpenAIModels = [
 
 export const defaultModels = {
   [EModelEndpoint.azureAssistants]: sharedOpenAIModels,
-  [EModelEndpoint.assistants]: ['gpt-4o-mini', 'gpt-4o', ...sharedOpenAIModels],
+  [EModelEndpoint.assistants]: ['chatgpt-4o-latest', ...sharedOpenAIModels],
   [EModelEndpoint.google]: [
     'gemini-pro',
     'gemini-pro-vision',
@@ -562,8 +565,7 @@ export const defaultModels = {
     'claude-instant-1-100k',
   ],
   [EModelEndpoint.openAI]: [
-    'gpt-4o-mini',
-    'gpt-4o',
+    'chatgpt-4o-latest',
     ...sharedOpenAIModels,
     'gpt-4-vision-preview',
     'gpt-3.5-turbo-instruct-0914',


### PR DESCRIPTION
## Summary

Closes https://github.com/danny-avila/LibreChat/issues/3642

- Added recognition for the "chatgpt-4o-latest" model in the `getValueKey` function, mapping it to "gpt-4o" for token calculations.
- Updated the `.env.example` file to include "chatgpt-4o-latest" in the `OPENAI_MODELS` list.
- Modified the default retrieval models in `config.ts` to include "chatgpt-4o-latest".
- Updated the default models for OpenAI and Assistants endpoints to prioritize "chatgpt-4o-latest".
- Added unit tests in `tx.spec.js` to ensure correct handling of the new model type.
- Bumped the data-provider package version to 0.7.412 to reflect these changes.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Unit tests updated to handle `chatgpt-4o-latest` cases.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes