### PR TITLE
💾 feat: Anthropic Prompt Caching

### DIFF
--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -169,11 +169,15 @@ class AnthropicClient extends BaseClient {
       options.baseURL = this.options.reverseProxyUrl;
     }
 
-    if (requestOptions?.model && requestOptions.model.includes('claude-3-5-sonnet')) {
+    if (
+      this.supportsCacheControl &&
+      requestOptions?.model &&
+      requestOptions.model.includes('claude-3-5-sonnet')
+    ) {
       options.defaultHeaders = {
         'anthropic-beta': 'max-tokens-3-5-sonnet-2024-07-15,prompt-caching-2024-07-31',
       };
-    } else if (this.supportsCacheControl === true) {
+    } else if (this.supportsCacheControl) {
       options.defaultHeaders = {
         'anthropic-beta': 'prompt-caching-2024-07-31',
       };
@@ -727,7 +731,7 @@ class AnthropicClient extends BaseClient {
         {
           type: 'text',
           text: this.systemMessage,
-          cache_control: 'ephemeral',
+          cache_control: { type: 'ephemeral' },
         },
       ];
     } else if (this.systemMessage) {

--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -204,10 +204,17 @@ class AnthropicClient extends BaseClient {
    * @returns {number} The correct token count for the current message.
    */
   calculateCurrentTokenCount({ tokenCountMap, currentMessageId, usage }) {
-    const originalEstimate = tokenCountMap[currentMessageId];
+    const originalEstimate = tokenCountMap[currentMessageId] || 0;
+
+    if (!usage || typeof usage.input_tokens !== 'number') {
+      return originalEstimate;
+    }
 
     tokenCountMap[currentMessageId] = 0;
-    const totalTokensFromMap = Object.values(tokenCountMap).reduce((sum, count) => sum + count, 0);
+    const totalTokensFromMap = Object.values(tokenCountMap).reduce((sum, count) => {
+      const numCount = Number(count);
+      return sum + (isNaN(numCount) ? 0 : numCount);
+    }, 0);
     const totalInputTokens =
       (usage.input_tokens ?? 0) +
       (usage.cache_creation_input_tokens ?? 0) +

--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -242,7 +242,7 @@ class AnthropicClient extends BaseClient {
    * @param {AnthropicStreamUsage} [params.usage]
    * @param {string} [params.model]
    * @param {string} [params.context='message']
-   * @returns {Promise<{ promptTokens: number, completionTokens: number } | undefined>}
+   * @returns {Promise<void>}
    */
   async recordTokenUsage({ promptTokens, completionTokens, usage, model, context = 'message' }) {
     if (usage != null && usage?.input_tokens != null) {
@@ -264,7 +264,7 @@ class AnthropicClient extends BaseClient {
         },
       );
 
-      return { promptTokens: input + write + read, completionTokens };
+      return;
     }
 
     await spendTokens(

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -550,9 +550,23 @@ class BaseClient {
     ) {
       let completionTokens;
 
-      /** @type {StreamUsage | null} */
+      /**
+       * Metadata about input/output costs for the current message.
+       *
+       * Stream usage should only be used for token calculation if files are
+       * being resent with every message (default behavior; or `false`, allow with no attachments),
+       * and the `promptPrefix` (custom instructions) is not set, as the legacy token
+       * estimations would be more accurate in that case.
+       *
+       * TODO: included system messages in the `orderedMessages` accounting, potentially as a
+       * separate message in the UI. ChatGPT does this through "hidden" system messages.
+       * @type {StreamUsage | null} */
       const usage =
-        this.getStreamUsage != null && this.calculateCurrentTokenCount != null
+        (this.options.resendFiles ||
+          (!this.options.resendFiles && !this.options.attachments?.length)) &&
+        !this.options.promptPrefix &&
+        this.getStreamUsage != null &&
+        this.calculateCurrentTokenCount != null
           ? this.getStreamUsage()
           : null;
 

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -27,9 +27,9 @@ const {
   createContextHandlers,
 } = require('./prompts');
 const { encodeAndFormat } = require('~/server/services/Files/images/encode');
+const { spendTokens } = require('~/models/spendTokens');
 const { isEnabled, sleep } = require('~/server/utils');
 const { handleOpenAIErrors } = require('./tools/util');
-const spendTokens = require('~/models/spendTokens');
 const { createLLM, RunManager } = require('./llm');
 const ChatGPTClient = require('./ChatGPTClient');
 const { summaryBuffer } = require('./memory');

--- a/api/app/clients/llm/RunManager.js
+++ b/api/app/clients/llm/RunManager.js
@@ -1,5 +1,5 @@
 const { createStartHandler } = require('~/app/clients/callbacks');
-const spendTokens = require('~/models/spendTokens');
+const { spendTokens } = require('~/models/spendTokens');
 const { logger } = require('~/config');
 
 class RunManager {

--- a/api/app/clients/prompts/addCacheControl.js
+++ b/api/app/clients/prompts/addCacheControl.js
@@ -1,0 +1,43 @@
+/**
+ * Anthropic API: Adds cache control to the appropriate user messages in the payload.
+ * @param {Array<AnthropicMessage>} messages - The array of message objects.
+ * @returns {Array<AnthropicMessage>} - The updated array of message objects with cache control added.
+ */
+function addCacheControl(messages) {
+  if (!Array.isArray(messages) || messages.length < 2) {
+    return messages;
+  }
+
+  const updatedMessages = [...messages];
+  let userMessagesFound = 0;
+
+  for (let i = updatedMessages.length - 1; i >= 0 && userMessagesFound < 2; i--) {
+    if (updatedMessages[i].role === 'user') {
+      if (typeof updatedMessages[i].content === 'string') {
+        updatedMessages[i] = {
+          ...updatedMessages[i],
+          content: [
+            {
+              type: 'text',
+              text: updatedMessages[i].content,
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        };
+      } else if (Array.isArray(updatedMessages[i].content)) {
+        updatedMessages[i] = {
+          ...updatedMessages[i],
+          content: updatedMessages[i].content.map((item) => ({
+            ...item,
+            cache_control: { type: 'ephemeral' },
+          })),
+        };
+      }
+      userMessagesFound++;
+    }
+  }
+
+  return updatedMessages;
+}
+
+module.exports = addCacheControl;

--- a/api/app/clients/prompts/addCacheControl.spec.js
+++ b/api/app/clients/prompts/addCacheControl.spec.js
@@ -1,0 +1,161 @@
+const addCacheControl = require('./addCacheControl');
+
+describe('addCacheControl', () => {
+  test('should add cache control to the last two user messages with array content', () => {
+    const messages = [
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Hi there' }] },
+      { role: 'user', content: [{ type: 'text', text: 'How are you?' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'I\'m doing well, thanks!' }] },
+      { role: 'user', content: [{ type: 'text', text: 'Great!' }] },
+    ];
+
+    const result = addCacheControl(messages);
+
+    expect(result[0].content[0]).not.toHaveProperty('cache_control');
+    expect(result[2].content[0].cache_control).toEqual({ type: 'ephemeral' });
+    expect(result[4].content[0].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  test('should add cache control to the last two user messages with string content', () => {
+    const messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+      { role: 'user', content: 'How are you?' },
+      { role: 'assistant', content: 'I\'m doing well, thanks!' },
+      { role: 'user', content: 'Great!' },
+    ];
+
+    const result = addCacheControl(messages);
+
+    expect(result[0].content).toBe('Hello');
+    expect(result[2].content[0]).toEqual({
+      type: 'text',
+      text: 'How are you?',
+      cache_control: { type: 'ephemeral' },
+    });
+    expect(result[4].content[0]).toEqual({
+      type: 'text',
+      text: 'Great!',
+      cache_control: { type: 'ephemeral' },
+    });
+  });
+
+  test('should handle mixed string and array content', () => {
+    const messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+      { role: 'user', content: [{ type: 'text', text: 'How are you?' }] },
+    ];
+
+    const result = addCacheControl(messages);
+
+    expect(result[0].content[0]).toEqual({
+      type: 'text',
+      text: 'Hello',
+      cache_control: { type: 'ephemeral' },
+    });
+    expect(result[2].content[0].cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  test('should handle less than two user messages', () => {
+    const messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ];
+
+    const result = addCacheControl(messages);
+
+    expect(result[0].content[0]).toEqual({
+      type: 'text',
+      text: 'Hello',
+      cache_control: { type: 'ephemeral' },
+    });
+    expect(result[1].content).toBe('Hi there');
+  });
+
+  test('should return original array if no user messages', () => {
+    const messages = [
+      { role: 'assistant', content: 'Hi there' },
+      { role: 'assistant', content: 'How can I help?' },
+    ];
+
+    const result = addCacheControl(messages);
+
+    expect(result).toEqual(messages);
+  });
+
+  test('should handle empty array', () => {
+    const messages = [];
+    const result = addCacheControl(messages);
+    expect(result).toEqual([]);
+  });
+
+  test('should handle non-array input', () => {
+    const messages = 'not an array';
+    const result = addCacheControl(messages);
+    expect(result).toBe('not an array');
+  });
+
+  test('should not modify assistant messages', () => {
+    const messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+      { role: 'user', content: 'How are you?' },
+    ];
+
+    const result = addCacheControl(messages);
+
+    expect(result[1].content).toBe('Hi there');
+  });
+
+  test('should handle multiple content items in user messages', () => {
+    const messages = [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Hello' },
+          { type: 'image', url: 'http://example.com/image.jpg' },
+        ],
+      },
+      { role: 'assistant', content: 'Hi there' },
+      { role: 'user', content: 'How are you?' },
+    ];
+
+    const result = addCacheControl(messages);
+
+    expect(result[0].content[0].cache_control).toEqual({ type: 'ephemeral' });
+    expect(result[0].content[1].cache_control).toEqual({ type: 'ephemeral' });
+    expect(result[2].content[0]).toEqual({
+      type: 'text',
+      text: 'How are you?',
+      cache_control: { type: 'ephemeral' },
+    });
+  });
+
+  test('should handle an array with mixed content types', () => {
+    const messages = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+      { role: 'user', content: [{ type: 'text', text: 'How are you?' }] },
+      { role: 'assistant', content: 'I\'m doing well, thanks!' },
+      { role: 'user', content: 'Great!' },
+    ];
+
+    const result = addCacheControl(messages);
+
+    expect(result[0].content[0]).toEqual({
+      type: 'text',
+      text: 'Hello',
+      cache_control: { type: 'ephemeral' },
+    });
+    expect(result[2].content[0].cache_control).toEqual({ type: 'ephemeral' });
+    expect(result[4].content[0]).toEqual({
+      type: 'text',
+      text: 'Great!',
+      cache_control: { type: 'ephemeral' },
+    });
+    expect(result[1].content).toBe('Hi there');
+    expect(result[3].content).toBe('I\'m doing well, thanks!');
+  });
+});

--- a/api/app/clients/prompts/addCacheControl.spec.js
+++ b/api/app/clients/prompts/addCacheControl.spec.js
@@ -143,18 +143,21 @@ describe('addCacheControl', () => {
     ];
 
     const result = addCacheControl(messages);
+    console.dir(result, { depth: null });
 
-    expect(result[0].content[0]).toEqual({
+    expect(result[0].content).toEqual('Hello');
+    expect(result[2].content[0]).toEqual({
       type: 'text',
-      text: 'Hello',
+      text: 'How are you?',
       cache_control: { type: 'ephemeral' },
     });
-    expect(result[2].content[0].cache_control).toEqual({ type: 'ephemeral' });
-    expect(result[4].content[0]).toEqual({
-      type: 'text',
-      text: 'Great!',
-      cache_control: { type: 'ephemeral' },
-    });
+    expect(result[4].content).toEqual([
+      {
+        type: 'text',
+        text: 'Great!',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
     expect(result[1].content).toBe('Hi there');
     expect(result[3].content).toBe('I\'m doing well, thanks!');
   });

--- a/api/app/clients/prompts/index.js
+++ b/api/app/clients/prompts/index.js
@@ -1,3 +1,4 @@
+const addCacheControl = require('./addCacheControl');
 const formatMessages = require('./formatMessages');
 const summaryPrompts = require('./summaryPrompts');
 const handleInputs = require('./handleInputs');
@@ -8,6 +9,7 @@ const createVisionPrompt = require('./createVisionPrompt');
 const createContextHandlers = require('./createContextHandlers');
 
 module.exports = {
+  addCacheControl,
   ...formatMessages,
   ...summaryPrompts,
   ...handleInputs,

--- a/api/app/clients/specs/AnthropicClient.test.js
+++ b/api/app/clients/specs/AnthropicClient.test.js
@@ -211,7 +211,21 @@ describe('AnthropicClient', () => {
       expect(anthropicClient._options.defaultHeaders).toBeDefined();
       expect(anthropicClient._options.defaultHeaders).toHaveProperty('anthropic-beta');
       expect(anthropicClient._options.defaultHeaders['anthropic-beta']).toBe(
-        'max-tokens-3-5-sonnet-2024-07-15',
+        'max-tokens-3-5-sonnet-2024-07-15,prompt-caching-2024-07-31',
+      );
+    });
+
+    it('should add beta header for claude-3-haiku model', () => {
+      const client = new AnthropicClient('test-api-key');
+      const modelOptions = {
+        model: 'claude-3-haiku-2028',
+      };
+      client.setOptions({ modelOptions });
+      const anthropicClient = client.getClient(modelOptions);
+      expect(anthropicClient._options.defaultHeaders).toBeDefined();
+      expect(anthropicClient._options.defaultHeaders).toHaveProperty('anthropic-beta');
+      expect(anthropicClient._options.defaultHeaders['anthropic-beta']).toBe(
+        'prompt-caching-2024-07-31',
       );
     });
 
@@ -224,6 +238,147 @@ describe('AnthropicClient', () => {
       });
       const anthropicClient = client.getClient();
       expect(anthropicClient.defaultHeaders).not.toHaveProperty('anthropic-beta');
+    });
+  });
+
+  describe('calculateCurrentTokenCount', () => {
+    let client;
+
+    beforeEach(() => {
+      client = new AnthropicClient('test-api-key');
+    });
+
+    it('should calculate correct token count when usage is provided', () => {
+      const tokenCountMap = {
+        msg1: 10,
+        msg2: 20,
+        currentMsg: 30,
+      };
+      const currentMessageId = 'currentMsg';
+      const usage = {
+        input_tokens: 70,
+        output_tokens: 50,
+      };
+
+      const result = client.calculateCurrentTokenCount({ tokenCountMap, currentMessageId, usage });
+
+      expect(result).toBe(40); // 70 - (10 + 20) = 40
+    });
+
+    it('should return original estimate if calculation results in negative value', () => {
+      const tokenCountMap = {
+        msg1: 40,
+        msg2: 50,
+        currentMsg: 30,
+      };
+      const currentMessageId = 'currentMsg';
+      const usage = {
+        input_tokens: 80,
+        output_tokens: 50,
+      };
+
+      const result = client.calculateCurrentTokenCount({ tokenCountMap, currentMessageId, usage });
+
+      expect(result).toBe(30); // Original estimate
+    });
+
+    it('should handle cache creation and read input tokens', () => {
+      const tokenCountMap = {
+        msg1: 10,
+        msg2: 20,
+        currentMsg: 30,
+      };
+      const currentMessageId = 'currentMsg';
+      const usage = {
+        input_tokens: 50,
+        cache_creation_input_tokens: 10,
+        cache_read_input_tokens: 20,
+        output_tokens: 40,
+      };
+
+      const result = client.calculateCurrentTokenCount({ tokenCountMap, currentMessageId, usage });
+
+      expect(result).toBe(50); // (50 + 10 + 20) - (10 + 20) = 50
+    });
+
+    it('should handle missing usage properties', () => {
+      const tokenCountMap = {
+        msg1: 10,
+        msg2: 20,
+        currentMsg: 30,
+      };
+      const currentMessageId = 'currentMsg';
+      const usage = {
+        output_tokens: 40,
+      };
+
+      const result = client.calculateCurrentTokenCount({ tokenCountMap, currentMessageId, usage });
+
+      expect(result).toBe(30); // Original estimate
+    });
+
+    it('should handle empty tokenCountMap', () => {
+      const tokenCountMap = {};
+      const currentMessageId = 'currentMsg';
+      const usage = {
+        input_tokens: 50,
+        output_tokens: 40,
+      };
+
+      const result = client.calculateCurrentTokenCount({ tokenCountMap, currentMessageId, usage });
+
+      expect(result).toBe(50);
+      expect(Number.isNaN(result)).toBe(false);
+    });
+
+    it('should handle zero values in usage', () => {
+      const tokenCountMap = {
+        msg1: 10,
+        currentMsg: 20,
+      };
+      const currentMessageId = 'currentMsg';
+      const usage = {
+        input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        output_tokens: 0,
+      };
+
+      const result = client.calculateCurrentTokenCount({ tokenCountMap, currentMessageId, usage });
+
+      expect(result).toBe(20); // Should return original estimate
+      expect(Number.isNaN(result)).toBe(false);
+    });
+
+    it('should handle undefined usage', () => {
+      const tokenCountMap = {
+        msg1: 10,
+        currentMsg: 20,
+      };
+      const currentMessageId = 'currentMsg';
+      const usage = undefined;
+
+      const result = client.calculateCurrentTokenCount({ tokenCountMap, currentMessageId, usage });
+
+      expect(result).toBe(20); // Should return original estimate
+      expect(Number.isNaN(result)).toBe(false);
+    });
+
+    it('should handle non-numeric values in tokenCountMap', () => {
+      const tokenCountMap = {
+        msg1: 'ten',
+        currentMsg: 20,
+      };
+      const currentMessageId = 'currentMsg';
+      const usage = {
+        input_tokens: 30,
+        output_tokens: 10,
+      };
+
+      const result = client.calculateCurrentTokenCount({ tokenCountMap, currentMessageId, usage });
+
+      expect(result).toBe(30); // Should return 30 (input_tokens) - 0 (ignored 'ten') = 30
+      expect(Number.isNaN(result)).toBe(false);
     });
   });
 });

--- a/api/models/Message.js
+++ b/api/models/Message.js
@@ -212,8 +212,8 @@ async function updateMessageText(req, { messageId, text }) {
  *
  * @async
  * @function updateMessage
- * @param {Object} message - The message object containing update data.
  * @param {Object} req - The request object.
+ * @param {Object} message - The message object containing update data.
  * @param {string} message.messageId - The unique identifier for the message.
  * @param {string} [message.text] - The new text content of the message.
  * @param {Object[]} [message.files] - The files associated with the message.

--- a/api/models/Transaction.js
+++ b/api/models/Transaction.js
@@ -21,12 +21,15 @@ transactionSchema.methods.calculateTokenValue = function () {
   }
 };
 
-// Static method to create a transaction and update the balance
-transactionSchema.statics.create = async function (transactionData) {
+/**
+ * Static method to create a transaction and update the balance
+ * @param {txData} txData - Transaction data.
+ */
+transactionSchema.statics.create = async function (txData) {
   const Transaction = this;
 
-  const transaction = new Transaction(transactionData);
-  transaction.endpointTokenConfig = transactionData.endpointTokenConfig;
+  const transaction = new Transaction(txData);
+  transaction.endpointTokenConfig = txData.endpointTokenConfig;
   transaction.calculateTokenValue();
 
   // Save the transaction

--- a/api/models/schema/transaction.js
+++ b/api/models/schema/transaction.js
@@ -30,6 +30,9 @@ const transactionSchema = mongoose.Schema(
     rate: Number,
     rawAmount: Number,
     tokenValue: Number,
+    inputTokens: { type: Number },
+    writeTokens: { type: Number },
+    readTokens: { type: Number },
   },
   {
     timestamps: true,

--- a/api/models/spendTokens.js
+++ b/api/models/spendTokens.js
@@ -66,4 +66,74 @@ const spendTokens = async (txData, tokenUsage) => {
   }
 };
 
-module.exports = spendTokens;
+/**
+ * Creates transactions to record the spending of structured tokens.
+ *
+ * @function
+ * @async
+ * @param {Object} txData - Transaction data.
+ * @param {mongoose.Schema.Types.ObjectId} txData.user - The user ID.
+ * @param {String} txData.conversationId - The ID of the conversation.
+ * @param {String} txData.model - The model name.
+ * @param {String} txData.context - The context in which the transaction is made.
+ * @param {EndpointTokenConfig} [txData.endpointTokenConfig] - The current endpoint token config.
+ * @param {String} [txData.valueKey] - The value key (optional).
+ * @param {Object} tokenUsage - The number of tokens used.
+ * @param {Object} tokenUsage.promptTokens - The number of prompt tokens used.
+ * @param {Number} tokenUsage.promptTokens.input - The number of input tokens.
+ * @param {Number} tokenUsage.promptTokens.write - The number of write tokens.
+ * @param {Number} tokenUsage.promptTokens.read - The number of read tokens.
+ * @param {Number} tokenUsage.completionTokens - The number of completion tokens used.
+ * @returns {Promise<void>} - Returns nothing.
+ * @throws {Error} - Throws an error if there's an issue creating the transactions.
+ */
+const spendStructuredTokens = async (txData, tokenUsage) => {
+  const { promptTokens, completionTokens } = tokenUsage;
+  logger.debug(
+    `[spendStructuredTokens] conversationId: ${txData.conversationId}${
+      txData?.context ? ` | Context: ${txData?.context}` : ''
+    } | Token usage: `,
+    {
+      promptTokens,
+      completionTokens,
+    },
+  );
+  let prompt, completion;
+  try {
+    if (promptTokens) {
+      const { input = 0, write = 0, read = 0 } = promptTokens;
+      const promptAmount = input + write + read;
+      prompt = await Transaction.createStructured({
+        ...txData,
+        tokenType: 'prompt',
+        rawAmount: -promptAmount,
+        inputTokens: input,
+        writeTokens: write,
+        readTokens: read,
+      });
+    }
+
+    if (completionTokens) {
+      completion = await Transaction.create({
+        ...txData,
+        tokenType: 'completion',
+        rawAmount: -completionTokens,
+      });
+    }
+
+    prompt &&
+      completion &&
+      logger.debug('[spendStructuredTokens] Transaction data record against balance:', {
+        user: txData.user,
+        prompt: prompt.tokenValue,
+        promptRate: prompt.rate,
+        completion: completion.tokenValue,
+        completionRate: completion.rate,
+        balance: completion.balance,
+      });
+  } catch (err) {
+    logger.error('[spendStructuredTokens]', err);
+  }
+};
+
+module.exports = { spendTokens, spendStructuredTokens };

--- a/api/models/spendTokens.js
+++ b/api/models/spendTokens.js
@@ -11,7 +11,7 @@ const { logger } = require('~/config');
  * @param {String} txData.conversationId - The ID of the conversation.
  * @param {String} txData.model - The model name.
  * @param {String} txData.context - The context in which the transaction is made.
- * @param {String} [txData.endpointTokenConfig] - The current endpoint token config.
+ * @param {EndpointTokenConfig} [txData.endpointTokenConfig] - The current endpoint token config.
  * @param {String} [txData.valueKey] - The value key (optional).
  * @param {Object} tokenUsage - The number of tokens used.
  * @param {Number} tokenUsage.promptTokens - The number of prompt tokens used.

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -71,6 +71,17 @@ const tokenValues = Object.assign(
 );
 
 /**
+ * Mapping of model token sizes to their respective multipliers for cached input, read and write.
+ * See Anthropic's documentation on this: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#pricing
+ * The rates are 1 USD per 1M tokens.
+ * @type {Object.<string, {write: number, read: number }>}
+ */
+const cacheTokenValues = {
+  'claude-3-5-sonnet': { write: 3.75, read: 0.3 },
+  'claude-3-haiku': { write: 0.3, read: 0.03 },
+};
+
+/**
  * Retrieves the key associated with a given model name.
  *
  * @param {string} model - The model name to match.
@@ -122,7 +133,7 @@ const getValueKey = (model, endpoint) => {
  *
  * @param {Object} params - The parameters for the function.
  * @param {string} [params.valueKey] - The key corresponding to the model name.
- * @param {string} [params.tokenType] - The type of token (e.g., 'prompt' or 'completion').
+ * @param {'prompt' | 'completion'} [params.tokenType] - The type of token (e.g., 'prompt' or 'completion').
  * @param {string} [params.model] - The model name to derive the value key from if not provided.
  * @param {string} [params.endpoint] - The endpoint name to derive the value key from if not provided.
  * @param {EndpointTokenConfig} [params.endpointTokenConfig] - The token configuration for the endpoint.
@@ -147,7 +158,41 @@ const getMultiplier = ({ valueKey, tokenType, model, endpoint, endpointTokenConf
   }
 
   // If we got this far, and values[tokenType] is undefined somehow, return a rough average of default multipliers
-  return tokenValues[valueKey][tokenType] ?? defaultRate;
+  return tokenValues[valueKey]?.[tokenType] ?? defaultRate;
 };
 
-module.exports = { tokenValues, getValueKey, getMultiplier, defaultRate };
+/**
+ * Retrieves the cache multiplier for a given value key and token type. If no value key is provided,
+ * it attempts to derive it from the model name.
+ *
+ * @param {Object} params - The parameters for the function.
+ * @param {string} [params.valueKey] - The key corresponding to the model name.
+ * @param {'write' | 'read'} [params.cacheType] - The type of token (e.g., 'write' or 'read').
+ * @param {string} [params.model] - The model name to derive the value key from if not provided.
+ * @param {string} [params.endpoint] - The endpoint name to derive the value key from if not provided.
+ * @param {EndpointTokenConfig} [params.endpointTokenConfig] - The token configuration for the endpoint.
+ * @returns {number | null} The multiplier for the given parameters, or `null` if not found.
+ */
+const getCacheMultiplier = ({ valueKey, cacheType, model, endpoint, endpointTokenConfig }) => {
+  if (endpointTokenConfig) {
+    return endpointTokenConfig?.[model]?.[cacheType] ?? null;
+  }
+
+  if (valueKey && cacheType) {
+    return cacheTokenValues[valueKey]?.[cacheType] ?? null;
+  }
+
+  if (!cacheType || !model) {
+    return null;
+  }
+
+  valueKey = getValueKey(model, endpoint);
+  if (!valueKey) {
+    return null;
+  }
+
+  // If we got this far, and values[cacheType] is undefined somehow, return a rough average of default multipliers
+  return cacheTokenValues[valueKey]?.[cacheType] ?? null;
+};
+
+module.exports = { tokenValues, getValueKey, getMultiplier, getCacheMultiplier, defaultRate };

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -1,9 +1,9 @@
 const {
+  defaultRate,
+  tokenValues,
   getValueKey,
   getMultiplier,
   getCacheMultiplier,
-  defaultRate,
-  tokenValues,
 } = require('./tx');
 
 describe('getValueKey', () => {

--- a/api/server/middleware/abortMiddleware.js
+++ b/api/server/middleware/abortMiddleware.js
@@ -2,9 +2,9 @@ const { isAssistantsEndpoint } = require('librechat-data-provider');
 const { sendMessage, sendError, countTokens, isEnabled } = require('~/server/utils');
 const { truncateText, smartTruncateText } = require('~/app/clients/prompts');
 const clearPendingReq = require('~/cache/clearPendingReq');
+const { spendTokens } = require('~/models/spendTokens');
 const abortControllers = require('./abortControllers');
 const { saveMessage, getConvo } = require('~/models');
-const spendTokens = require('~/models/spendTokens');
 const { abortRun } = require('./abortRun');
 const { logger } = require('~/config');
 

--- a/api/server/services/Threads/manage.js
+++ b/api/server/services/Threads/manage.js
@@ -8,8 +8,8 @@ const {
 } = require('librechat-data-provider');
 const { retrieveAndProcessFile } = require('~/server/services/Files/process');
 const { recordMessage, getMessages } = require('~/models/Message');
+const { spendTokens } = require('~/models/spendTokens');
 const { saveConvo } = require('~/models/Conversation');
-const spendTokens = require('~/models/spendTokens');
 const { countTokens } = require('~/server/utils');
 
 /**

--- a/api/typedefs.js
+++ b/api/typedefs.js
@@ -31,6 +31,16 @@
  * @typedef {import('@anthropic-ai/sdk').default.MessageParam} AnthropicMessage
  * @memberof typedefs
  */
+/**
+ * @exports AnthropicMessageStartEvent
+ * @typedef {import('@anthropic-ai/sdk').default.MessageStartEvent} AnthropicMessageStartEvent
+ * @memberof typedefs
+ */
+/**
+ * @exports AnthropicMessageDeltaEvent
+ * @typedef {import('@anthropic-ai/sdk').default.MessageDeltaEvent} AnthropicMessageDeltaEvent
+ * @memberof typedefs
+ */
 
 /**
  * @exports GenerativeModel

--- a/api/typedefs.js
+++ b/api/typedefs.js
@@ -27,6 +27,12 @@
  */
 
 /**
+ * @exports AnthropicMessage
+ * @typedef {import('@anthropic-ai/sdk').default.MessageParam} AnthropicMessage
+ * @memberof typedefs
+ */
+
+/**
  * @exports GenerativeModel
  * @typedef {import('@google/generative-ai').GenerativeModel} GenerativeModel
  * @memberof typedefs
@@ -1309,6 +1315,20 @@
  * @method onRunStepCompleted Handles the completion of a run step.
  * @method handleMessageEvent Handles events related to messages within the run.
  * @method messageCompleted Handles the completion of a message processing.
+ */
+
+/* TX Types */
+
+/**
+ * @typedef {object} txData - Transaction data.
+ * @property {mongoose.Schema.Types.ObjectId} user - The user ID.
+ * @property {String} conversationId - The ID of the conversation.
+ * @property {String} model - The model name.
+ * @property {String} context - The context in which the transaction is made.
+ * @property {EndpointTokenConfig} [endpointTokenConfig] - The current endpoint token config.
+ * @property {object} [cacheUsage] - Cache usage, if any.
+ * @property {String} [valueKey] - The value key (optional).
+ * @memberof typedefs
  */
 
 /* Native app/client methods */

--- a/api/typedefs.js
+++ b/api/typedefs.js
@@ -31,11 +31,13 @@
  * @typedef {import('@anthropic-ai/sdk').default.MessageParam} AnthropicMessage
  * @memberof typedefs
  */
+
 /**
  * @exports AnthropicMessageStartEvent
  * @typedef {import('@anthropic-ai/sdk').default.MessageStartEvent} AnthropicMessageStartEvent
  * @memberof typedefs
  */
+
 /**
  * @exports AnthropicMessageDeltaEvent
  * @typedef {import('@anthropic-ai/sdk').default.MessageDeltaEvent} AnthropicMessageDeltaEvent
@@ -1339,6 +1341,15 @@
  * @property {object} [cacheUsage] - Cache usage, if any.
  * @property {String} [valueKey] - The value key (optional).
  * @memberof typedefs
+ */
+
+/**
+ * https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#pricing
+ * @typedef {object} AnthropicStreamUsage - Stream usage for Anthropic
+ * @property {number} [input_tokens] - The number of input tokens used.
+ * @property {number} [cache_creation_input_tokens] - The number of cache creation input tokens used (write).
+ * @property {number} [cache_read_input_tokens] - The number of cache input tokens used (read).
+ * @property {number} [output_tokens] - The number of output tokens used.
  */
 
 /* Native app/client methods */

--- a/api/typedefs.js
+++ b/api/typedefs.js
@@ -1352,6 +1352,10 @@
  * @property {number} [output_tokens] - The number of output tokens used.
  */
 
+/**
+ * @typedef {AnthropicStreamUsage} StreamUsage - Stream usage for all providers (currently only Anthropic)
+ */
+
 /* Native app/client methods */
 
 /**


### PR DESCRIPTION
## Summary

Closes #3661 

This PR introduces [prompt caching functionality for the Anthropic API](https://www.anthropic.com/news/prompt-caching), significantly reducing costs for longer, multi-turn conversations using Claude 3.5 Sonnet and Claude 3 Haiku models (Anthropic states that Opus will be added later).

The implementation is an adaptation of Anthropic's cookbook for [Multi-turn Conversation with Incremental Caching](https://github.com/anthropics/anthropic-cookbook/blob/main/misc/prompt_caching.ipynb)

**With this change comes much more accurate transaction recording for Anthropic API**, as the stream usage metadata is being leveraged for provider counts of input tokens, cache input costs, and output tokens.

**Furthermore, this PR also introduces a more accurate token counting method for message payload building**, which is also possible through stream usage metadata, with some caveats highlighted below.

**Stream usage should only be used for user message token count re-calculation if:**
- The stream usage is available, with input tokens greater than 0,
- the current provider client (anthropic only atm) provides a function to calculate the current token count,
- files are being resent with every message (default behavior; or if `false`, with no attachments),
- the `promptPrefix` (custom instructions) is not set (also default behavior, unless the user is using presets).

In these cases, the legacy token estimations would be more accurate. The reason is, instructions and files can be removed if these conditions are met, which would cause token counts to be inaccurate earlier in the thread.

Revisiting conversations before this change was also considered, and it was reasoned that this is fine since the stream usage metadata would make those conversations more accurate provided the above caveats are not met.

In any case, transaction data is more accurate than before for all anthropic models, and none of the token accounting affects prompt caching other than the models being used, and that the messages payload meets the requirements of Anthropic API.

**TODO:**

In light of the caveats, adding system messages to the `orderedMessages` token accounting could help us create accurate counts in these cases, potentially as a separate message in the UI. ChatGPT does this through "hidden" system messages, and we could add an option to toggle them as well as view their current placements.

---

## More details

- Added a new `addCacheControl` function to handle the addition of cache control to user messages.
- Updated the `AnthropicClient` to support prompt caching for compatible models.
- Implemented logic to determine if a model supports cache control and apply it when appropriate.
- Added new types and updated existing ones to support structured token transactions.
- Modified the token spending logic to account for cache write and read operations.
- Created unit tests for the `addCacheControl` function to ensure proper functionality.
- Updated transaction handling to support structured token usage recording.
- Adds logic for calculating the correct user message token count off of stream usage metadata, allowing us to discard estimations

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules