### PR TITLE
🤖 refactor: Remove Default Model Params for All Endpoints

### DIFF
--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -83,11 +83,13 @@ class AnthropicClient extends BaseClient {
       this.options = options;
     }
 
-    const modelOptions = this.options.modelOptions || {};
-    this.modelOptions = {
-      ...modelOptions,
-      model: modelOptions.model || anthropicSettings.model.default,
-    };
+    this.modelOptions = Object.assign(
+      {
+        model: anthropicSettings.model.default,
+      },
+      this.modelOptions,
+      this.options.modelOptions,
+    );
 
     const modelMatch = matchModelName(this.modelOptions.model, EModelEndpoint.anthropic);
     this.isClaude3 = modelMatch.startsWith('claude-3');

--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -120,19 +120,7 @@ class GoogleClient extends BaseClient {
       .filter((ex) => ex)
       .filter((obj) => obj.input.content !== '' && obj.output.content !== '');
 
-    const modelOptions = this.options.modelOptions || {};
-    this.modelOptions = {
-      ...modelOptions,
-      // set some good defaults (check for undefined in some cases because they may be 0)
-      model: modelOptions.model || settings.model.default,
-      temperature:
-        typeof modelOptions.temperature === 'undefined'
-          ? settings.temperature.default
-          : modelOptions.temperature,
-      topP: typeof modelOptions.topP === 'undefined' ? settings.topP.default : modelOptions.topP,
-      topK: typeof modelOptions.topK === 'undefined' ? settings.topK.default : modelOptions.topK,
-      // stop: modelOptions.stop // no stop method for now
-    };
+    this.modelOptions = this.options.modelOptions || {};
 
     this.options.attachments?.then((attachments) => this.checkVisionRequest(attachments));
 
@@ -808,7 +796,7 @@ class GoogleClient extends BaseClient {
       });
 
       reply = titleResponse.content;
-
+      // TODO: RECORD TOKEN USAGE
       return reply;
     }
   }

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -85,26 +85,7 @@ class OpenAIClient extends BaseClient {
       this.apiKey = this.options.openaiApiKey;
     }
 
-    const modelOptions = this.options.modelOptions || {};
-
-    if (!this.modelOptions) {
-      this.modelOptions = {
-        ...modelOptions,
-        model: modelOptions.model || 'gpt-3.5-turbo',
-        temperature:
-          typeof modelOptions.temperature === 'undefined' ? 0.8 : modelOptions.temperature,
-        top_p: typeof modelOptions.top_p === 'undefined' ? 1 : modelOptions.top_p,
-        presence_penalty:
-          typeof modelOptions.presence_penalty === 'undefined' ? 1 : modelOptions.presence_penalty,
-        stop: modelOptions.stop,
-      };
-    } else {
-      // Update the modelOptions if it already exists
-      this.modelOptions = {
-        ...this.modelOptions,
-        ...modelOptions,
-      };
-    }
+    this.modelOptions = Object.assign({}, this.modelOptions, this.options.modelOptions);
 
     this.defaultVisionModel = this.options.visionModel ?? 'gpt-4-vision-preview';
     if (typeof this.options.attachments?.then === 'function') {

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -6,6 +6,7 @@ const {
   ImageDetail,
   EModelEndpoint,
   resolveHeaders,
+  openAISettings,
   ImageDetailCost,
   CohereConstants,
   getResponseSender,
@@ -85,7 +86,13 @@ class OpenAIClient extends BaseClient {
       this.apiKey = this.options.openaiApiKey;
     }
 
-    this.modelOptions = Object.assign({}, this.modelOptions, this.options.modelOptions);
+    this.modelOptions = Object.assign(
+      {
+        model: openAISettings.model.default,
+      },
+      this.modelOptions,
+      this.options.modelOptions,
+    );
 
     this.defaultVisionModel = this.options.visionModel ?? 'gpt-4-vision-preview';
     if (typeof this.options.attachments?.then === 'function') {

--- a/api/server/middleware/buildEndpointOption.js
+++ b/api/server/middleware/buildEndpointOption.js
@@ -1,4 +1,4 @@
-const { parseConvo, EModelEndpoint } = require('librechat-data-provider');
+const { parseCompactConvo, EModelEndpoint } = require('librechat-data-provider');
 const { getModelsConfig } = require('~/server/controllers/ModelController');
 const azureAssistants = require('~/server/services/Endpoints/azureAssistants');
 const assistants = require('~/server/services/Endpoints/assistants');
@@ -24,7 +24,7 @@ const buildFunction = {
 
 async function buildEndpointOption(req, res, next) {
   const { endpoint, endpointType } = req.body;
-  const parsedBody = parseConvo({ endpoint, endpointType, conversation: req.body });
+  const parsedBody = parseCompactConvo({ endpoint, endpointType, conversation: req.body });
 
   if (req.app.locals.modelSpecs?.list && req.app.locals.modelSpecs?.enforce) {
     /** @type {{ list: TModelSpec[] }}*/

--- a/api/server/services/Endpoints/anthropic/addTitle.js
+++ b/api/server/services/Endpoints/anthropic/addTitle.js
@@ -21,7 +21,11 @@ const addTitle = async (req, { text, response, client }) => {
   const titleCache = getLogStores(CacheKeys.GEN_TITLE);
   const key = `${req.user.id}-${response.conversationId}`;
 
-  const title = await client.titleConvo({ text, responseText: response?.text });
+  const title = await client.titleConvo({
+    text,
+    responseText: response?.text,
+    conversationId: response.conversationId,
+  });
   await titleCache.set(key, title, 120000);
   await saveConvo(
     req,

--- a/api/server/services/Endpoints/anthropic/buildOptions.js
+++ b/api/server/services/Endpoints/anthropic/buildOptions.js
@@ -1,3 +1,5 @@
+const { removeNullishValues } = require('librechat-data-provider');
+
 const buildOptions = (endpoint, parsedBody) => {
   const {
     modelLabel,
@@ -10,7 +12,7 @@ const buildOptions = (endpoint, parsedBody) => {
     ...modelOptions
   } = parsedBody;
 
-  const endpointOption = {
+  const endpointOption = removeNullishValues({
     endpoint,
     modelLabel,
     promptPrefix,
@@ -20,7 +22,7 @@ const buildOptions = (endpoint, parsedBody) => {
     spec,
     maxContextTokens,
     modelOptions,
-  };
+  });
 
   return endpointOption;
 };

--- a/api/server/services/Endpoints/anthropic/buildOptions.js
+++ b/api/server/services/Endpoints/anthropic/buildOptions.js
@@ -3,12 +3,13 @@ const buildOptions = (endpoint, parsedBody) => {
     modelLabel,
     promptPrefix,
     maxContextTokens,
-    resendFiles,
+    resendFiles = true,
     iconURL,
     greeting,
     spec,
-    ...rest
+    ...modelOptions
   } = parsedBody;
+
   const endpointOption = {
     endpoint,
     modelLabel,
@@ -18,9 +19,7 @@ const buildOptions = (endpoint, parsedBody) => {
     greeting,
     spec,
     maxContextTokens,
-    modelOptions: {
-      ...rest,
-    },
+    modelOptions,
   };
 
   return endpointOption;

--- a/api/server/services/Endpoints/assistants/buildOptions.js
+++ b/api/server/services/Endpoints/assistants/buildOptions.js
@@ -1,6 +1,6 @@
 const buildOptions = (endpoint, parsedBody) => {
   // eslint-disable-next-line no-unused-vars
-  const { promptPrefix, assistant_id, iconURL, greeting, spec, ...rest } = parsedBody;
+  const { promptPrefix, assistant_id, iconURL, greeting, spec, ...modelOptions } = parsedBody;
   const endpointOption = {
     endpoint,
     promptPrefix,
@@ -8,9 +8,7 @@ const buildOptions = (endpoint, parsedBody) => {
     iconURL,
     greeting,
     spec,
-    modelOptions: {
-      ...rest,
-    },
+    modelOptions,
   };
 
   return endpointOption;

--- a/api/server/services/Endpoints/assistants/buildOptions.js
+++ b/api/server/services/Endpoints/assistants/buildOptions.js
@@ -1,7 +1,9 @@
+const { removeNullishValues } = require('librechat-data-provider');
+
 const buildOptions = (endpoint, parsedBody) => {
   // eslint-disable-next-line no-unused-vars
   const { promptPrefix, assistant_id, iconURL, greeting, spec, ...modelOptions } = parsedBody;
-  const endpointOption = {
+  const endpointOption = removeNullishValues({
     endpoint,
     promptPrefix,
     assistant_id,
@@ -9,7 +11,7 @@ const buildOptions = (endpoint, parsedBody) => {
     greeting,
     spec,
     modelOptions,
-  };
+  });
 
   return endpointOption;
 };

--- a/api/server/services/Endpoints/azureAssistants/buildOptions.js
+++ b/api/server/services/Endpoints/azureAssistants/buildOptions.js
@@ -1,6 +1,6 @@
 const buildOptions = (endpoint, parsedBody) => {
   // eslint-disable-next-line no-unused-vars
-  const { promptPrefix, assistant_id, iconURL, greeting, spec, ...rest } = parsedBody;
+  const { promptPrefix, assistant_id, iconURL, greeting, spec, ...modelOptions } = parsedBody;
   const endpointOption = {
     endpoint,
     promptPrefix,
@@ -8,9 +8,7 @@ const buildOptions = (endpoint, parsedBody) => {
     iconURL,
     greeting,
     spec,
-    modelOptions: {
-      ...rest,
-    },
+    modelOptions,
   };
 
   return endpointOption;

--- a/api/server/services/Endpoints/azureAssistants/buildOptions.js
+++ b/api/server/services/Endpoints/azureAssistants/buildOptions.js
@@ -1,7 +1,9 @@
+const { removeNullishValues } = require('librechat-data-provider');
+
 const buildOptions = (endpoint, parsedBody) => {
   // eslint-disable-next-line no-unused-vars
   const { promptPrefix, assistant_id, iconURL, greeting, spec, ...modelOptions } = parsedBody;
-  const endpointOption = {
+  const endpointOption = removeNullishValues({
     endpoint,
     promptPrefix,
     assistant_id,
@@ -9,7 +11,7 @@ const buildOptions = (endpoint, parsedBody) => {
     greeting,
     spec,
     modelOptions,
-  };
+  });
 
   return endpointOption;
 };

--- a/api/server/services/Endpoints/custom/buildOptions.js
+++ b/api/server/services/Endpoints/custom/buildOptions.js
@@ -3,12 +3,12 @@ const buildOptions = (endpoint, parsedBody, endpointType) => {
     chatGptLabel,
     promptPrefix,
     maxContextTokens,
-    resendFiles,
+    resendFiles = true,
     imageDetail,
     iconURL,
     greeting,
     spec,
-    ...rest
+    ...modelOptions
   } = parsedBody;
   const endpointOption = {
     endpoint,
@@ -21,9 +21,7 @@ const buildOptions = (endpoint, parsedBody, endpointType) => {
     greeting,
     spec,
     maxContextTokens,
-    modelOptions: {
-      ...rest,
-    },
+    modelOptions,
   };
 
   return endpointOption;

--- a/api/server/services/Endpoints/custom/buildOptions.js
+++ b/api/server/services/Endpoints/custom/buildOptions.js
@@ -1,3 +1,5 @@
+const { removeNullishValues } = require('librechat-data-provider');
+
 const buildOptions = (endpoint, parsedBody, endpointType) => {
   const {
     chatGptLabel,
@@ -10,7 +12,7 @@ const buildOptions = (endpoint, parsedBody, endpointType) => {
     spec,
     ...modelOptions
   } = parsedBody;
-  const endpointOption = {
+  const endpointOption = removeNullishValues({
     endpoint,
     endpointType,
     chatGptLabel,
@@ -22,7 +24,7 @@ const buildOptions = (endpoint, parsedBody, endpointType) => {
     spec,
     maxContextTokens,
     modelOptions,
-  };
+  });
 
   return endpointOption;
 };

--- a/api/server/services/Endpoints/google/addTitle.js
+++ b/api/server/services/Endpoints/google/addTitle.js
@@ -47,7 +47,11 @@ const addTitle = async (req, { text, response, client }) => {
   const titleCache = getLogStores(CacheKeys.GEN_TITLE);
   const key = `${req.user.id}-${response.conversationId}`;
 
-  const title = await titleClient.titleConvo({ text, responseText: response?.text });
+  const title = await titleClient.titleConvo({
+    text,
+    responseText: response?.text,
+    conversationId: response.conversationId,
+  });
   await titleCache.set(key, title, 120000);
   await saveConvo(
     req,

--- a/api/server/services/Endpoints/google/buildOptions.js
+++ b/api/server/services/Endpoints/google/buildOptions.js
@@ -1,16 +1,24 @@
 const buildOptions = (endpoint, parsedBody) => {
-  const { examples, modelLabel, promptPrefix, iconURL, greeting, spec, ...rest } = parsedBody;
-  const endpointOption = {
+  const {
     examples,
-    endpoint,
     modelLabel,
+    resendFiles = true,
     promptPrefix,
     iconURL,
     greeting,
     spec,
-    modelOptions: {
-      ...rest,
-    },
+    ...modelOptions
+  } = parsedBody;
+  const endpointOption = {
+    examples,
+    endpoint,
+    modelLabel,
+    resendFiles,
+    promptPrefix,
+    iconURL,
+    greeting,
+    spec,
+    modelOptions,
   };
 
   return endpointOption;

--- a/api/server/services/Endpoints/google/buildOptions.js
+++ b/api/server/services/Endpoints/google/buildOptions.js
@@ -1,3 +1,5 @@
+const { removeNullishValues } = require('librechat-data-provider');
+
 const buildOptions = (endpoint, parsedBody) => {
   const {
     examples,
@@ -9,7 +11,7 @@ const buildOptions = (endpoint, parsedBody) => {
     spec,
     ...modelOptions
   } = parsedBody;
-  const endpointOption = {
+  const endpointOption = removeNullishValues({
     examples,
     endpoint,
     modelLabel,
@@ -19,7 +21,7 @@ const buildOptions = (endpoint, parsedBody) => {
     greeting,
     spec,
     modelOptions,
-  };
+  });
 
   return endpointOption;
 };

--- a/api/server/services/Endpoints/gptPlugins/buildOptions.js
+++ b/api/server/services/Endpoints/gptPlugins/buildOptions.js
@@ -1,3 +1,5 @@
+const { removeNullishValues } = require('librechat-data-provider');
+
 const buildOptions = (endpoint, parsedBody) => {
   const {
     chatGptLabel,
@@ -10,7 +12,7 @@ const buildOptions = (endpoint, parsedBody) => {
     maxContextTokens,
     ...modelOptions
   } = parsedBody;
-  const endpointOption = {
+  const endpointOption = removeNullishValues({
     endpoint,
     tools:
       tools
@@ -24,7 +26,7 @@ const buildOptions = (endpoint, parsedBody) => {
     spec,
     maxContextTokens,
     modelOptions,
-  };
+  });
 
   return endpointOption;
 };

--- a/api/server/services/Endpoints/openAI/addTitle.js
+++ b/api/server/services/Endpoints/openAI/addTitle.js
@@ -21,7 +21,11 @@ const addTitle = async (req, { text, response, client }) => {
   const titleCache = getLogStores(CacheKeys.GEN_TITLE);
   const key = `${req.user.id}-${response.conversationId}`;
 
-  const title = await client.titleConvo({ text, responseText: response?.text });
+  const title = await client.titleConvo({
+    text,
+    responseText: response?.text,
+    conversationId: response.conversationId,
+  });
   await titleCache.set(key, title, 120000);
   await saveConvo(
     req,

--- a/api/server/services/Endpoints/openAI/buildOptions.js
+++ b/api/server/services/Endpoints/openAI/buildOptions.js
@@ -1,3 +1,5 @@
+const { removeNullishValues } = require('librechat-data-provider');
+
 const buildOptions = (endpoint, parsedBody) => {
   const {
     chatGptLabel,
@@ -10,7 +12,7 @@ const buildOptions = (endpoint, parsedBody) => {
     spec,
     ...modelOptions
   } = parsedBody;
-  const endpointOption = {
+  const endpointOption = removeNullishValues({
     endpoint,
     chatGptLabel,
     promptPrefix,
@@ -21,7 +23,7 @@ const buildOptions = (endpoint, parsedBody) => {
     spec,
     maxContextTokens,
     modelOptions,
-  };
+  });
 
   return endpointOption;
 };

--- a/api/server/services/Endpoints/openAI/buildOptions.js
+++ b/api/server/services/Endpoints/openAI/buildOptions.js
@@ -3,12 +3,12 @@ const buildOptions = (endpoint, parsedBody) => {
     chatGptLabel,
     promptPrefix,
     maxContextTokens,
-    resendFiles,
+    resendFiles = true,
     imageDetail,
     iconURL,
     greeting,
     spec,
-    ...rest
+    ...modelOptions
   } = parsedBody;
   const endpointOption = {
     endpoint,
@@ -20,9 +20,7 @@ const buildOptions = (endpoint, parsedBody) => {
     greeting,
     spec,
     maxContextTokens,
-    modelOptions: {
-      ...rest,
-    },
+    modelOptions,
   };
 
   return endpointOption;

--- a/client/src/components/Chat/Messages/Content/Markdown.tsx
+++ b/client/src/components/Chat/Messages/Content/Markdown.tsx
@@ -140,7 +140,7 @@ const Markdown = memo(({ content = '', isEdited, showCursor, isLatestMessage }: 
     return (
       <div className="absolute">
         <p className="relative">
-          <span className={cn(showCursor === true ? 'result-thinking' : '')} />
+          <span className="result-thinking" />
         </p>
       </div>
     );

--- a/client/src/components/Endpoints/Settings/OpenAI.tsx
+++ b/client/src/components/Endpoints/Settings/OpenAI.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
 import TextareaAutosize from 'react-textarea-autosize';
 import {
+  openAISettings,
   EModelEndpoint,
-  ImageDetail,
-  imageDetailNumeric,
   imageDetailValue,
+  imageDetailNumeric,
 } from 'librechat-data-provider';
 import type { TModelSelectProps, OnInputNumberChange } from '~/common';
 import {
@@ -240,7 +240,12 @@ export default function Settings({ conversation, setOption, models, readonly }: 
               <Label htmlFor="temp-int" className="text-left text-sm font-medium">
                 {localize('com_endpoint_temperature')}{' '}
                 <small className="opacity-40">
-                  ({localize('com_endpoint_default_with_num', '1')})
+                  (
+                  {localize(
+                    'com_endpoint_default_with_num',
+                    openAISettings.temperature.default + '',
+                  )}
+                  )
                 </small>
               </Label>
               <InputNumber
@@ -249,9 +254,9 @@ export default function Settings({ conversation, setOption, models, readonly }: 
                 disabled={readonly}
                 value={temperatureValue as number}
                 onChange={setTemperature as OnInputNumberChange}
-                max={2}
-                min={0}
-                step={0.01}
+                max={openAISettings.temperature.max}
+                min={openAISettings.temperature.min}
+                step={openAISettings.temperature.step}
                 controls={false}
                 className={cn(
                   defaultTextProps,
@@ -264,12 +269,12 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             </div>
             <Slider
               disabled={readonly}
-              value={[(temperatureValue as number) ?? 1]}
+              value={[temperatureValue ?? openAISettings.temperature.default]}
               onValueChange={(value) => setTemperature(value[0])}
-              doubleClickHandler={() => setTemperature(1)}
-              max={2}
-              min={0}
-              step={0.01}
+              doubleClickHandler={() => setTemperature(openAISettings.temperature.default)}
+              max={openAISettings.temperature.max}
+              min={openAISettings.temperature.min}
+              step={openAISettings.temperature.step}
               className="flex h-4 w-full"
             />
           </HoverCardTrigger>
@@ -280,16 +285,18 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             <div className="flex justify-between">
               <Label htmlFor="top-p-int" className="text-left text-sm font-medium">
                 {localize('com_endpoint_top_p')}{' '}
-                <small className="opacity-40">({localize('com_endpoint_default')}: 1)</small>
+                <small className="opacity-40">
+                  ({localize('com_endpoint_default_with_num', openAISettings.top_p.default + '')})
+                </small>
               </Label>
               <InputNumber
                 id="top-p-int"
                 disabled={readonly}
                 value={topPValue as number}
                 onChange={(value) => setTopP(Number(value))}
-                max={1}
-                min={0}
-                step={0.01}
+                max={openAISettings.top_p.max}
+                min={openAISettings.top_p.min}
+                step={openAISettings.top_p.step}
                 controls={false}
                 className={cn(
                   defaultTextProps,
@@ -302,12 +309,12 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             </div>
             <Slider
               disabled={readonly}
-              value={[(topPValue as number) ?? 1]}
+              value={[topPValue ?? openAISettings.top_p.default]}
               onValueChange={(value) => setTopP(value[0])}
-              doubleClickHandler={() => setTopP(1)}
-              max={1}
-              min={0}
-              step={0.01}
+              doubleClickHandler={() => setTopP(openAISettings.top_p.default)}
+              max={openAISettings.top_p.max}
+              min={openAISettings.top_p.min}
+              step={openAISettings.top_p.step}
               className="flex h-4 w-full"
             />
           </HoverCardTrigger>
@@ -319,16 +326,23 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             <div className="flex justify-between">
               <Label htmlFor="freq-penalty-int" className="text-left text-sm font-medium">
                 {localize('com_endpoint_frequency_penalty')}{' '}
-                <small className="opacity-40">({localize('com_endpoint_default')}: 0)</small>
+                <small className="opacity-40">
+                  (
+                  {localize(
+                    'com_endpoint_default_with_num',
+                    openAISettings.frequency_penalty.default + '',
+                  )}
+                  )
+                </small>
               </Label>
               <InputNumber
                 id="freq-penalty-int"
                 disabled={readonly}
                 value={freqPValue as number}
                 onChange={(value) => setFreqP(Number(value))}
-                max={2}
-                min={-2}
-                step={0.01}
+                max={openAISettings.frequency_penalty.max}
+                min={openAISettings.frequency_penalty.min}
+                step={openAISettings.frequency_penalty.step}
                 controls={false}
                 className={cn(
                   defaultTextProps,
@@ -341,12 +355,12 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             </div>
             <Slider
               disabled={readonly}
-              value={[(freqPValue as number) ?? 0]}
+              value={[freqPValue ?? openAISettings.frequency_penalty.default]}
               onValueChange={(value) => setFreqP(value[0])}
-              doubleClickHandler={() => setFreqP(0)}
-              max={2}
-              min={-2}
-              step={0.01}
+              doubleClickHandler={() => setFreqP(openAISettings.frequency_penalty.default)}
+              max={openAISettings.frequency_penalty.max}
+              min={openAISettings.frequency_penalty.min}
+              step={openAISettings.frequency_penalty.step}
               className="flex h-4 w-full"
             />
           </HoverCardTrigger>
@@ -358,16 +372,23 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             <div className="flex justify-between">
               <Label htmlFor="pres-penalty-int" className="text-left text-sm font-medium">
                 {localize('com_endpoint_presence_penalty')}{' '}
-                <small className="opacity-40">({localize('com_endpoint_default')}: 0)</small>
+                <small className="opacity-40">
+                  (
+                  {localize(
+                    'com_endpoint_default_with_num',
+                    openAISettings.presence_penalty.default + '',
+                  )}
+                  )
+                </small>
               </Label>
               <InputNumber
                 id="pres-penalty-int"
                 disabled={readonly}
                 value={presPValue as number}
                 onChange={(value) => setPresP(Number(value))}
-                max={2}
-                min={-2}
-                step={0.01}
+                max={openAISettings.presence_penalty.max}
+                min={openAISettings.presence_penalty.min}
+                step={openAISettings.presence_penalty.step}
                 controls={false}
                 className={cn(
                   defaultTextProps,
@@ -380,12 +401,12 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             </div>
             <Slider
               disabled={readonly}
-              value={[(presPValue as number) ?? 0]}
+              value={[presPValue ?? openAISettings.presence_penalty.default]}
               onValueChange={(value) => setPresP(value[0])}
-              doubleClickHandler={() => setPresP(0)}
-              max={2}
-              min={-2}
-              step={0.01}
+              doubleClickHandler={() => setPresP(openAISettings.presence_penalty.default)}
+              max={openAISettings.presence_penalty.max}
+              min={openAISettings.presence_penalty.min}
+              step={openAISettings.presence_penalty.step}
               className="flex h-4 w-full"
             />
           </HoverCardTrigger>
@@ -408,7 +429,7 @@ export default function Settings({ conversation, setOption, models, readonly }: 
             <Input
               id="image-detail-value"
               disabled={true}
-              value={imageDetail ?? ImageDetail.auto}
+              value={imageDetail ?? openAISettings.imageDetail.default}
               className={cn(
                 defaultTextProps,
                 optionText,
@@ -422,7 +443,7 @@ export default function Settings({ conversation, setOption, models, readonly }: 
               <HoverCardTrigger>
                 <Switch
                   id="resend-files"
-                  checked={resendFiles ?? true}
+                  checked={resendFiles ?? openAISettings.resendFiles.default}
                   onCheckedChange={(checked: boolean) => setResendFiles(checked)}
                   disabled={readonly}
                   className="flex"
@@ -436,13 +457,14 @@ export default function Settings({ conversation, setOption, models, readonly }: 
                   id="image-detail-slider"
                   disabled={readonly}
                   value={[
-                    imageDetailNumeric[imageDetail ?? ''] ?? imageDetailNumeric[ImageDetail.auto],
+                    imageDetailNumeric[imageDetail ?? ''] ??
+                      imageDetailNumeric[openAISettings.imageDetail.default],
                   ]}
                   onValueChange={(value) => setImageDetail(imageDetailValue[value[0]])}
-                  doubleClickHandler={() => setImageDetail(ImageDetail.auto)}
-                  max={2}
-                  min={0}
-                  step={1}
+                  doubleClickHandler={() => setImageDetail(openAISettings.imageDetail.default)}
+                  max={openAISettings.imageDetail.max}
+                  min={openAISettings.imageDetail.min}
+                  step={openAISettings.imageDetail.step}
                 />
                 <OptionHover endpoint={optionEndpoint ?? ''} type="detail" side={ESide.Bottom} />
               </HoverCardTrigger>

--- a/package-lock.json
+++ b/package-lock.json
@@ -31493,7 +31493,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.412",
+      "version": "0.7.413",
       "license": "ISC",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.412",
+  "version": "0.7.413",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -82,7 +82,7 @@ export const ImageVisionTool: FunctionTool = {
 };
 
 export const isImageVisionTool = (tool: FunctionTool | FunctionToolCall) =>
-  tool.type === 'function' && tool.function?.name === ImageVisionTool?.function?.name;
+  tool.type === 'function' && tool.function?.name === ImageVisionTool.function?.name;
 
 export const openAISettings = {
   model: {
@@ -123,6 +123,9 @@ export const openAISettings = {
   },
   imageDetail: {
     default: ImageDetail.auto,
+    min: 0,
+    max: 2,
+    step: 1,
   },
 };
 
@@ -840,22 +843,22 @@ export const compactOpenAISchema = tConversationSchema
   })
   .transform((obj: Partial<TConversation>) => {
     const newObj: Partial<TConversation> = { ...obj };
-    if (newObj.temperature === 1) {
+    if (newObj.temperature === openAISettings.temperature.default) {
       delete newObj.temperature;
     }
-    if (newObj.top_p === 1) {
+    if (newObj.top_p === openAISettings.top_p.default) {
       delete newObj.top_p;
     }
-    if (newObj.presence_penalty === 0) {
+    if (newObj.presence_penalty === openAISettings.presence_penalty.default) {
       delete newObj.presence_penalty;
     }
-    if (newObj.frequency_penalty === 0) {
+    if (newObj.frequency_penalty === openAISettings.frequency_penalty.default) {
       delete newObj.frequency_penalty;
     }
-    if (newObj.resendFiles === true) {
+    if (newObj.resendFiles === openAISettings.resendFiles.default) {
       delete newObj.resendFiles;
     }
-    if (newObj.imageDetail === ImageDetail.auto) {
+    if (newObj.imageDetail === openAISettings.imageDetail.default) {
       delete newObj.imageDetail;
     }
 


### PR DESCRIPTION
## Summary

- Refactored all provider handling to remove default model options, which now only passes the user set values, either from a previous conversation or existing settings, to avoid potential model behavior issues as was exhibited by use of Llama3.1 with Ollama
- The only exception is the model value, if for some reason it was not included (edge case)


## Other changes

- Implemented the use of removeNullishValues function in buildOptions for all endpoints, reducing unnecessary data.
- Refactored the OpenAISettings component to use a config object for setting defaults app-wide, enhancing maintainability and consistency.
- Modified the Markdown component to always show the cursor when empty, improving user experience.
- Added missing conversationId parameter to title methods for Anthropic, Google, and OpenAI endpoints to ensure proper transaction handling.

## TODO:

- Added a TODO note in GoogleClient for recording token usage in the future.
