### PR TITLE
🏷️ a11y: add aria-label to close button and aria-hidden to SVG

### DIFF
--- a/client/src/components/Chat/Input/AddedConvo.tsx
+++ b/client/src/components/Chat/Input/AddedConvo.tsx
@@ -43,6 +43,7 @@ export default function AddedConvo({
       <button
         className="text-token-text-secondary flex-shrink-0"
         type="button"
+        aria-label="Close added conversation"
         onClick={() => setAddedConvo(null)}
       >
         <svg
@@ -52,6 +53,7 @@ export default function AddedConvo({
           fill="none"
           viewBox="0 0 24 24"
           className="icon-lg"
+          aria-hidden="true"
         >
           <path
             fill="currentColor"


### PR DESCRIPTION
Fixes #3641

Add accessible name to the close button for added conversations and hide SVG from assistive technology.

* Add `aria-label="Close added conversation"` to the `button` element.
* Add `aria-hidden="true"` to the `svg` element.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/danny-avila/LibreChat/issues/3641?shareId=f8508266-c8cf-47fd-8141-3cd23466de61).