### PR TITLE
🔐 feat: Toggle Access to Prompts via `librechat.yaml`

### DIFF
--- a/api/server/services/AppService.interface.spec.js
+++ b/api/server/services/AppService.interface.spec.js
@@ -1,0 +1,73 @@
+jest.mock('~/models/Role', () => ({
+  initializeRoles: jest.fn(),
+  updatePromptsAccess: jest.fn(),
+  getRoleByName: jest.fn(),
+  updateRoleByName: jest.fn(),
+}));
+
+jest.mock('~/config', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('./Config/loadCustomConfig', () => jest.fn());
+jest.mock('./start/interface', () => ({
+  loadDefaultInterface: jest.fn(),
+}));
+jest.mock('./ToolService', () => ({
+  loadAndFormatTools: jest.fn().mockReturnValue({}),
+}));
+jest.mock('./start/checks', () => ({
+  checkVariables: jest.fn(),
+  checkHealth: jest.fn(),
+  checkConfig: jest.fn(),
+  checkAzureVariables: jest.fn(),
+}));
+
+const AppService = require('./AppService');
+const { loadDefaultInterface } = require('./start/interface');
+
+describe('AppService interface.prompts configuration', () => {
+  let app;
+  let mockLoadCustomConfig;
+
+  beforeEach(() => {
+    app = { locals: {} };
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockLoadCustomConfig = require('./Config/loadCustomConfig');
+  });
+
+  it('should set prompts to true when loadDefaultInterface returns true', async () => {
+    mockLoadCustomConfig.mockResolvedValue({});
+    loadDefaultInterface.mockResolvedValue({ prompts: true });
+
+    await AppService(app);
+
+    expect(app.locals.interfaceConfig.prompts).toBe(true);
+    expect(loadDefaultInterface).toHaveBeenCalled();
+  });
+
+  it('should set prompts to false when loadDefaultInterface returns false', async () => {
+    mockLoadCustomConfig.mockResolvedValue({ interface: { prompts: false } });
+    loadDefaultInterface.mockResolvedValue({ prompts: false });
+
+    await AppService(app);
+
+    expect(app.locals.interfaceConfig.prompts).toBe(false);
+    expect(loadDefaultInterface).toHaveBeenCalled();
+  });
+
+  it('should not set prompts when loadDefaultInterface returns undefined', async () => {
+    mockLoadCustomConfig.mockResolvedValue({});
+    loadDefaultInterface.mockResolvedValue({});
+
+    await AppService(app);
+
+    expect(app.locals.interfaceConfig.prompts).toBeUndefined();
+    expect(loadDefaultInterface).toHaveBeenCalled();
+  });
+});

--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -45,7 +45,7 @@ const AppService = async (app) => {
 
   const socialLogins =
     config?.registration?.socialLogins ?? configDefaults?.registration?.socialLogins;
-  const interfaceConfig = loadDefaultInterface(config, configDefaults);
+  const interfaceConfig = await loadDefaultInterface(config, configDefaults);
 
   const defaultLocals = {
     paths,

--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -23,6 +23,7 @@ jest.mock('./Files/Firebase/initialize', () => ({
 }));
 jest.mock('~/models/Role', () => ({
   initializeRoles: jest.fn(),
+  updatePromptsAccess: jest.fn(),
 }));
 jest.mock('./ToolService', () => ({
   loadAndFormatTools: jest.fn().mockReturnValue({

--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -97,8 +97,6 @@ describe('AppService', () => {
       socialLogins: ['testLogin'],
       fileStrategy: 'testStrategy',
       interfaceConfig: expect.objectContaining({
-        privacyPolicy: undefined,
-        termsOfService: undefined,
         endpointsMenu: true,
         modelSelect: true,
         parameters: true,

--- a/api/server/services/start/interface.spec.js
+++ b/api/server/services/start/interface.spec.js
@@ -1,0 +1,45 @@
+const { SystemRoles } = require('librechat-data-provider');
+const { updatePromptsAccess } = require('~/models/Role');
+const { loadDefaultInterface } = require('./interface');
+
+jest.mock('~/models/Role', () => ({
+  updatePromptsAccess: jest.fn(),
+}));
+
+describe('loadDefaultInterface', () => {
+  it('should call updatePromptsAccess with the correct parameters when prompts is true', async () => {
+    const config = { interface: { prompts: true } };
+    const configDefaults = { interface: {} };
+
+    await loadDefaultInterface(config, configDefaults);
+
+    expect(updatePromptsAccess).toHaveBeenCalledWith(SystemRoles.USER, true);
+  });
+
+  it('should call updatePromptsAccess with false when prompts is false', async () => {
+    const config = { interface: { prompts: false } };
+    const configDefaults = { interface: {} };
+
+    await loadDefaultInterface(config, configDefaults);
+
+    expect(updatePromptsAccess).toHaveBeenCalledWith(SystemRoles.USER, false);
+  });
+
+  it('should call updatePromptsAccess with undefined when prompts is not specified in config', async () => {
+    const config = {};
+    const configDefaults = { interface: {} };
+
+    await loadDefaultInterface(config, configDefaults);
+
+    expect(updatePromptsAccess).toHaveBeenCalledWith(SystemRoles.USER, undefined);
+  });
+
+  it('should call updatePromptsAccess with undefined when prompts is explicitly undefined', async () => {
+    const config = { interface: { prompts: undefined } };
+    const configDefaults = { interface: {} };
+
+    await loadDefaultInterface(config, configDefaults);
+
+    expect(updatePromptsAccess).toHaveBeenCalledWith(SystemRoles.USER, undefined);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -31493,7 +31493,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.414",
+      "version": "0.7.415",
       "license": "ISC",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.414",
+  "version": "0.7.415",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -944,7 +944,7 @@ export enum Constants {
   /** Key for the app's version. */
   VERSION = 'v0.7.4',
   /** Key for the Custom Config's version (librechat.yaml). */
-  CONFIG_VERSION = '1.1.5',
+  CONFIG_VERSION = '1.1.6',
   /** Standard value for the first message's `parentMessageId` value, to indicate no parent exists. */
   NO_PARENT = '00000000-0000-0000-0000-000000000000',
   /** Standard value for the initial conversationId before a request is sent */

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -414,6 +414,7 @@ export const configSchema = z.object({
       parameters: z.boolean().optional(),
       sidePanel: z.boolean().optional(),
       presets: z.boolean().optional(),
+      prompts: z.boolean().optional(),
     })
     .default({
       endpointsMenu: true,


### PR DESCRIPTION
## Summary 

I implemented a feature to toggle role access to prompts through the librechat.yaml configuration file. This change enhances the flexibility of the application's interface configuration and improves role-based access control.

- Added a new `prompts` property to the interface configuration in the `librechat.yaml` file
    - Updated the `configSchema` in `config.ts` to include the new `prompts` property
- Implemented `updatePromptsAccess` function in `Role.js` to update the USER role's prompt access based on the configuration
- Modified `loadDefaultInterface` in `interface.js` to handle the new `prompts` property and call `updatePromptsAccess` asynchronously


### Other Changes

- Incremented the `CONFIG_VERSION` to '1.1.6' to reflect the changes in the configuration structure
- Updated the package version of `librechat-data-provider` to 0.7.415

## Testing

- Created new test files `AppService.interface.spec.js` and `interface.spec.js` to ensure proper functionality of the new feature

To test this feature:

1. Set the `prompts` property in the `interface` section of your `librechat.yaml` file to `true` or `false`
2. Start the application and verify that the USER role's access to prompts is updated accordingly
3. Run the new test files to ensure the functionality works as expected

### Test Configuration:

- Use a test `librechat.yaml` file with various `prompts` configurations to verify the behavior

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes