### PR TITLE
🧹 chore: remove legacy markdown code

### DIFF
--- a/client/src/components/Chat/Messages/Content/Markdown.tsx
+++ b/client/src/components/Chat/Messages/Content/Markdown.tsx
@@ -1,6 +1,5 @@
 import React, { memo, useMemo } from 'react';
 import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
 import remarkMath from 'remark-math';
 import supersub from 'remark-supersub';
 import rehypeKatex from 'rehype-katex';
@@ -8,7 +7,7 @@ import { useRecoilValue } from 'recoil';
 import ReactMarkdown from 'react-markdown';
 import type { PluggableList } from 'unified';
 import rehypeHighlight from 'rehype-highlight';
-import { langSubset, validateIframe, preprocessLaTeX, handleDoubleClick } from '~/utils';
+import { langSubset, preprocessLaTeX, handleDoubleClick } from '~/utils';
 import CodeBlock from '~/components/Messages/Content/CodeBlock';
 import { useFileDownload } from '~/data-provider';
 import useLocalize from '~/hooks/useLocalize';
@@ -136,11 +135,9 @@ const Markdown = memo(({ content = '', isEdited, showCursor, isLatestMessage }: 
         subset: langSubset,
       },
     ],
-    [rehypeRaw],
   ];
 
   if (isInitializing) {
-    rehypePlugins.pop();
     return (
       <div className="absolute">
         <p className="relative">
@@ -150,12 +147,7 @@ const Markdown = memo(({ content = '', isEdited, showCursor, isLatestMessage }: 
     );
   }
 
-  let isValidIframe: string | boolean | null = false;
-  if (isEdited !== true) {
-    isValidIframe = validateIframe(currentContent);
-  }
-
-  if (isEdited === true || (!isLatestMessage && !isValidIframe)) {
+  if (isEdited === true || !isLatestMessage) {
     rehypePlugins.pop();
   }
 


### PR DESCRIPTION
## Summary

- Removed the `rehypeRaw` import and its usage in the `rehypePlugins` array.
- Eliminated the `validateIframe` import and associated logic for iframe validation.
- Simplified the conditional rendering logic by removing the `isValidIframe` check.
- Removed unnecessary code related to `rehypePlugins` manipulation during initialization.