### PR TITLE
🚚 chore: Remove client-dist volume from deploy-compose.yml

### DIFF
--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -30,7 +30,6 @@ services:
         target: /app/librechat.yaml
       - ./images:/app/client/public/images
       - ./logs:/app/api/logs
-      - client-dist:/app/client/dist  # Share client dist files
 
   client:
     image: nginx:1.27.0-alpine
@@ -43,7 +42,6 @@ services:
     restart: always
     volumes:
       - ./client/nginx.conf:/etc/nginx/conf.d/default.conf
-      - client-dist:/usr/share/nginx/html  # Use shared client dist files
   mongodb:
     container_name: chat-mongodb
     # ports:  # Uncomment this to access mongodb from outside docker, not safe in deployment
@@ -88,4 +86,3 @@ services:
 
 volumes:
   pgdata2:
-  client-dist:  # Define a named volume for client dist files


### PR DESCRIPTION
**Summary**:

Removed the client-dist volume from the deploy-compose.yml file. This change affects the deployment of the application by removing the shared volume for the client distribution files.

This change was necessary as it was causing cache issues for `deploy-compose` usage

- Deleted the volume definition for client-dist.
- Removed the volume mount for client-dist in the client and nginx services.

**Checklist**:

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules