### PR TITLE
🏷️ chore: Add Unofficial Naming Variation for Claude-3.5-Sonnet

### DIFF
--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -55,6 +55,7 @@ const tokenValues = Object.assign(
     'claude-3-opus': { prompt: 15, completion: 75 },
     'claude-3-sonnet': { prompt: 3, completion: 15 },
     'claude-3-5-sonnet': { prompt: 3, completion: 15 },
+    'claude-3.5-sonnet': { prompt: 3, completion: 15 },
     'claude-3-haiku': { prompt: 0.25, completion: 1.25 },
     'claude-2.1': { prompt: 8, completion: 24 },
     'claude-2': { prompt: 8, completion: 24 },
@@ -77,6 +78,7 @@ const tokenValues = Object.assign(
  * @type {Object.<string, {write: number, read: number }>}
  */
 const cacheTokenValues = {
+  'claude-3.5-sonnet': { write: 3.75, read: 0.3 },
   'claude-3-5-sonnet': { write: 3.75, read: 0.3 },
   'claude-3-haiku': { write: 0.3, read: 0.03 },
 };

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -82,6 +82,13 @@ describe('getValueKey', () => {
     expect(getValueKey('claude-3-5-sonnet-turbo')).toBe('claude-3-5-sonnet');
     expect(getValueKey('claude-3-5-sonnet-0125')).toBe('claude-3-5-sonnet');
   });
+
+  it('should return "claude-3.5-sonnet" for model type of "claude-3.5-sonnet-"', () => {
+    expect(getValueKey('claude-3.5-sonnet-20240620')).toBe('claude-3.5-sonnet');
+    expect(getValueKey('anthropic/claude-3.5-sonnet')).toBe('claude-3.5-sonnet');
+    expect(getValueKey('claude-3.5-sonnet-turbo')).toBe('claude-3.5-sonnet');
+    expect(getValueKey('claude-3.5-sonnet-0125')).toBe('claude-3.5-sonnet');
+  });
 });
 
 describe('getMultiplier', () => {

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -60,6 +60,7 @@ const anthropicModels = {
   'claude-3-sonnet': 200000,
   'claude-3-opus': 200000,
   'claude-3-5-sonnet': 200000,
+  'claude-3.5-sonnet': 200000,
 };
 
 const aggregateModels = { ...openAIModels, ...googleModels, ...anthropicModels, ...cohereModels };


### PR DESCRIPTION
## Summary

- Added 'claude-3.5-sonnet' to the tokenValues object in tx.js with the same prompt and completion values as 'claude-3-5-sonnet'
- Included 'claude-3.5-sonnet' in the cacheTokenValues object in tx.js with identical write and read values to 'claude-3-5-sonnet'
- Updated the anthropicModels object in tokens.js to include 'claude-3.5-sonnet' with a max token value of 200000
- Added test cases in tx.spec.js to verify the correct handling of 'claude-3.5-sonnet' variations in the getValueKey function

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes