### PR TITLE
🔍 fix: `USE_REDIS` condition, Markdown list counter, code highlights

### DIFF
--- a/api/cache/clearPendingReq.js
+++ b/api/cache/clearPendingReq.js
@@ -35,7 +35,7 @@ const clearPendingReq = async ({ userId, cache: _cache }) => {
     return;
   }
 
-  const key = `${USE_REDIS ? namespace : ''}:${userId ?? ''}`;
+  const key = `${isEnabled(USE_REDIS) ? namespace : ''}:${userId ?? ''}`;
   const currentReq = +((await cache.get(key)) ?? 0);
 
   if (currentReq && currentReq >= 1) {

--- a/api/server/socialLogins.js
+++ b/api/server/socialLogins.js
@@ -9,6 +9,7 @@ const {
   discordLogin,
   facebookLogin,
 } = require('~/strategies');
+const { isEnabled } = require('~/server/utils');
 const { logger } = require('~/config');
 
 /**
@@ -40,7 +41,7 @@ const configureSocialLogins = (app) => {
       resave: false,
       saveUninitialized: false,
     };
-    if (process.env.USE_REDIS) {
+    if (isEnabled(process.env.USE_REDIS)) {
       const client = new Redis(process.env.REDIS_URI);
       client
         .on('error', (err) => logger.error('ioredis error:', err))

--- a/client/src/components/Chat/Messages/Content/Markdown.tsx
+++ b/client/src/components/Chat/Messages/Content/Markdown.tsx
@@ -109,12 +109,11 @@ const cursor = ' ';
 
 type TContentProps = {
   content: string;
-  isEdited?: boolean;
   showCursor?: boolean;
   isLatestMessage: boolean;
 };
 
-const Markdown = memo(({ content = '', isEdited, showCursor, isLatestMessage }: TContentProps) => {
+const Markdown = memo(({ content = '', showCursor, isLatestMessage }: TContentProps) => {
   const LaTeXParsing = useRecoilValue<boolean>(store.LaTeXParsing);
 
   const isInitializing = content === '';
@@ -145,10 +144,6 @@ const Markdown = memo(({ content = '', isEdited, showCursor, isLatestMessage }: 
         </p>
       </div>
     );
-  }
-
-  if (isEdited === true || !isLatestMessage) {
-    rehypePlugins.pop();
   }
 
   return (

--- a/client/src/components/Chat/Messages/Content/MessageContent.tsx
+++ b/client/src/components/Chat/Messages/Content/MessageContent.tsx
@@ -84,12 +84,7 @@ const DisplayMessage = ({ text, isCreatedByUser, message, showCursor }: TDisplay
         )}
       >
         {!isCreatedByUser ? (
-          <Markdown
-            content={text}
-            isEdited={message.isEdited}
-            showCursor={showCursorState}
-            isLatestMessage={isLatestMessage}
-          />
+          <Markdown content={text} showCursor={showCursorState} isLatestMessage={isLatestMessage} />
         ) : (
           <>{text}</>
         )}

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -41,12 +41,7 @@ const DisplayMessage = ({ text, isCreatedByUser = false, message, showCursor }: 
       )}
     >
       {!isCreatedByUser ? (
-        <Markdown
-          content={text}
-          isEdited={message.isEdited}
-          showCursor={showCursorState}
-          isLatestMessage={isLatestMessage}
-        />
+        <Markdown content={text} showCursor={showCursorState} isLatestMessage={isLatestMessage} />
       ) : (
         <>{text}</>
       )}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1945,10 +1945,12 @@ button.scroll-convo {
 .markdown ol > li {
   position: relative;
   padding-left: 0.375em;
+  counter-increment: list-counter;
 }
 
 .prose ol > li::marker,
 .markdown ol > li::marker {
+  content: counter(list-counter) ". ";
   color: var(--tw-prose-counters);
   font-weight: 400;
 }
@@ -1957,11 +1959,33 @@ button.scroll-convo {
 .prose ol ol,
 .markdown ol ol {
   list-style-type: lower-alpha;
+  counter-reset: list-counter-alpha;
+}
+
+.prose ol ol > li,
+.markdown ol ol > li {
+  counter-increment: list-counter-alpha;
+}
+
+.prose ol ol > li::marker,
+.markdown ol ol > li::marker {
+  content: counter(list-counter-alpha, lower-alpha) ". ";
 }
 
 .prose ol ol ol,
 .markdown ol ol ol {
   list-style-type: lower-roman;
+  counter-reset: list-counter-roman;
+}
+
+.prose ol ol ol > li,
+.markdown ol ol ol > li {
+  counter-increment: list-counter-roman;
+}
+
+.prose ol ol ol > li::marker,
+.markdown ol ol ol > li::marker {
+  content: counter(list-counter-roman, lower-roman) ". ";
 }
 
 /* Unordered lists */
@@ -2023,6 +2047,28 @@ button.scroll-convo {
 .prose li::marker,
 .markdown li::marker {
   color: currentColor;
+}
+
+/* Reset counter for new sections */
+.prose h1 + ol,
+.prose h2 + ol,
+.prose h3 + ol,
+.prose h4 + ol,
+.prose h5 + ol,
+.prose h6 + ol,
+.markdown h1 + ol,
+.markdown h2 + ol,
+.markdown h3 + ol,
+.markdown h4 + ol,
+.markdown h5 + ol,
+.markdown h6 + ol {
+  counter-reset: list-counter;
+}
+
+/* Reset counter after unordered lists */
+.prose ul + ol,
+.markdown ul + ol {
+  counter-reset: list-counter;
 }
 
 /* Keyframes */


### PR DESCRIPTION
## Summary

Closes #3804

- Updated the USE_REDIS condition check in clearPendingReq.js and socialLogins.js to use the isEnabled utility function, ensuring consistent evaluation of the USE_REDIS environment variable.
- Restored the Markdown rehype highlight functionality in Markdown.tsx, MessageContent.tsx, and Part.tsx components, which was being accidentally removed programmatically in a previous update
- Removed the isEdited prop from Markdown component as it's no longer needed for controlling the rehype plugins.
- Simplified the Markdown component usage in MessageContent and Part components by removing the unnecessary isEdited prop.
- Fixed markdown list counter as a regression from recent changes to list styling