### PR TITLE
🔧 fix: Improve the message in case when prompt exceeds the model limit 

### DIFF
--- a/client/src/components/Messages/Content/Error.tsx
+++ b/client/src/components/Messages/Content/Error.tsx
@@ -42,6 +42,7 @@ const errorMessages = {
     const { expiredAt, endpoint } = json;
     return localize('com_error_expired_user_key', endpoint, expiredAt);
   },
+  [ErrorTypes.PROMPT_LENGTH]: 'com_error_prompt_length',
   [ViolationTypes.BAN]:
     'Your account has been temporarily banned due to violations of our service.',
   invalid_api_key:
@@ -87,9 +88,9 @@ const errorMessages = {
 const Error = ({ text }: { text: string }) => {
   const localize = useLocalize();
   const jsonString = extractJson(text);
+
   const errorMessage = text.length > 512 && !jsonString ? text.slice(0, 512) + '...' : text;
   const defaultResponse = `Something went wrong. Here's the specific error message we encountered: ${errorMessage}`;
-
   if (!isJson(jsonString)) {
     return defaultResponse;
   }

--- a/client/src/localization/languages/Eng.ts
+++ b/client/src/localization/languages/Eng.ts
@@ -23,6 +23,8 @@ export default {
   com_error_invalid_user_key: 'Invalid key provided. Please provide a valid key and try again.',
   com_error_expired_user_key:
     'Provided key for {0} expired at {1}. Please provide a new key and try again.',
+  com_error_prompt_length:
+    'The prompt is too long and exceeds the token limit. Please shorten your prompt or attach part of it as a text file.',
   com_files_no_results: 'No results.',
   com_files_filter: 'Filter files...',
   com_files_number_selected: '{0} of {1} file(s) selected',

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -839,6 +839,11 @@ export enum ErrorTypes {
    * Moderation error
    */
   MODERATION = 'moderation',
+
+  /**
+   * Prompt exceeds max length
+   */
+  PROMPT_LENGTH = 'prompt_length',
 }
 
 /**


### PR DESCRIPTION
## Summary
When message is over the model's limit, chat returns generic error that "something went wrong". 
![image](https://github.com/user-attachments/assets/9baede9a-7878-4ce5-90ad-b78ed99d3c70)
This does not tell user what exactly went wrong and how to fix it.

This PR changes message text informing user that his prompt exceeds that max limit and suggest to shorten it.
![image](https://github.com/user-attachments/assets/a4341135-81f1-4b48-bdeb-65965b182c02)


## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

To test this copy prompt from [HugePrompt.txt](https://github.com/user-attachments/files/16795624/HugePrompt.txt) and send it as a chat message. 
You should see the message `The prompt is too long and exceeds the token limit. Please shorten your prompt or attach part of it as a text file.` 

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
