### PR TITLE
🎨 refactor: Prevent Font Asset Hashing in Vite Config

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -120,7 +120,12 @@ export default defineConfig({
         },
         entryFileNames: 'assets/[name].[hash].js',
         chunkFileNames: 'assets/[name].[hash].js',
-        assetFileNames: 'assets/[name].[hash].[ext]',
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name && /\.(woff|woff2|eot|ttf|otf)$/.test(assetInfo.name)) {
+            return 'assets/[name][extname]';
+          }
+          return 'assets/[name].[hash][extname]';
+        },
       },
       /**
        * Ignore "use client" waning since we are not using SSR


### PR DESCRIPTION
## Summary

- Modified the `assetFileNames` function in the `build.rollupOptions` section of `vite.config.ts`.
- Implemented a conditional statement to check for font file extensions (woff, woff2, eot, ttf, otf).
- Set font assets to use the format 'assets/[name][extname]', preserving the original filename without a hash.
- Maintained the existing hash-based naming convention for all other asset types.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

To test this change:

1. Run a build of the client application using `npm run build` or equivalent command.
2. Inspect the output directory, particularly the `assets` folder.
3. Verify that font files are named without a hash (e.g., `fontname.woff2`) while other assets still include a hash.
4. Test the application to ensure fonts are loading correctly and there are no regressions in asset loading.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes