### PR TITLE
🚨 feat: Implement `INPUT_LENGTH` Error Type

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -2,10 +2,10 @@ const crypto = require('crypto');
 const fetch = require('node-fetch');
 const {
   supportsBalanceCheck,
+  ErrorTypes,
   Constants,
   CacheKeys,
   Time,
-  ErrorTypes,
 } = require('librechat-data-provider');
 const { getMessages, saveMessage, updateMessage, saveConvo } = require('~/models');
 const { addSpaceIfNeeded, isEnabled } = require('~/server/utils');

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1,6 +1,12 @@
 const crypto = require('crypto');
 const fetch = require('node-fetch');
-const { supportsBalanceCheck, Constants, CacheKeys, Time } = require('librechat-data-provider');
+const {
+  supportsBalanceCheck,
+  Constants,
+  CacheKeys,
+  Time,
+  ErrorTypes,
+} = require('librechat-data-provider');
 const { getMessages, saveMessage, updateMessage, saveConvo } = require('~/models');
 const { addSpaceIfNeeded, isEnabled } = require('~/server/utils');
 const checkBalance = require('~/models/checkBalance');
@@ -383,9 +389,10 @@ class BaseClient {
 
     const latestMessage = orderedWithInstructions[orderedWithInstructions.length - 1];
     if (payload.length === 0 && !shouldSummarize && latestMessage) {
-      throw new Error(
-        `Prompt token count of ${latestMessage.tokenCount} exceeds max token count of ${this.maxContextTokens}.`,
-      );
+      const info = `${latestMessage.tokenCount} / ${this.maxContextTokens}`;
+      const errorMessage = `{ "type": "${ErrorTypes.CONTEXT_LENGTH}", "info": "${info}" }`;
+      logger.warn(`Prompt token count exceeds max token count (${info}).`);
+      throw new Error(errorMessage);
     }
 
     if (usePrevSummary) {

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -390,7 +390,7 @@ class BaseClient {
     const latestMessage = orderedWithInstructions[orderedWithInstructions.length - 1];
     if (payload.length === 0 && !shouldSummarize && latestMessage) {
       const info = `${latestMessage.tokenCount} / ${this.maxContextTokens}`;
-      const errorMessage = `{ "type": "${ErrorTypes.CONTEXT_LENGTH}", "info": "${info}" }`;
+      const errorMessage = `{ "type": "${ErrorTypes.INPUT_LENGTH}", "info": "${info}" }`;
       logger.warn(`Prompt token count exceeds max token count (${info}).`);
       throw new Error(errorMessage);
     }

--- a/client/src/components/Messages/Content/Error.tsx
+++ b/client/src/components/Messages/Content/Error.tsx
@@ -33,6 +33,10 @@ type TExpiredKey = {
   endpoint: string;
 };
 
+type TContextLength = {
+  info: string;
+};
+
 const errorMessages = {
   [ErrorTypes.MODERATION]: 'com_error_moderation',
   [ErrorTypes.NO_USER_KEY]: 'com_error_no_user_key',
@@ -41,6 +45,10 @@ const errorMessages = {
   [ErrorTypes.EXPIRED_USER_KEY]: (json: TExpiredKey, localize: LocalizeFunction) => {
     const { expiredAt, endpoint } = json;
     return localize('com_error_expired_user_key', endpoint, expiredAt);
+  },
+  [ErrorTypes.CONTEXT_LENGTH]: (json: TContextLength, localize: LocalizeFunction) => {
+    const { info } = json;
+    return localize('com_error_context_length', info);
   },
   [ViolationTypes.BAN]:
     'Your account has been temporarily banned due to violations of our service.',

--- a/client/src/components/Messages/Content/Error.tsx
+++ b/client/src/components/Messages/Content/Error.tsx
@@ -33,7 +33,7 @@ type TExpiredKey = {
   endpoint: string;
 };
 
-type TContextLength = {
+type TInputLength = {
   info: string;
 };
 
@@ -46,9 +46,9 @@ const errorMessages = {
     const { expiredAt, endpoint } = json;
     return localize('com_error_expired_user_key', endpoint, expiredAt);
   },
-  [ErrorTypes.CONTEXT_LENGTH]: (json: TContextLength, localize: LocalizeFunction) => {
+  [ErrorTypes.INPUT_LENGTH]: (json: TInputLength, localize: LocalizeFunction) => {
     const { info } = json;
-    return localize('com_error_context_length', info);
+    return localize('com_error_input_length', info);
   },
   [ViolationTypes.BAN]:
     'Your account has been temporarily banned due to violations of our service.',

--- a/client/src/localization/languages/Eng.ts
+++ b/client/src/localization/languages/Eng.ts
@@ -25,6 +25,8 @@ export default {
   com_error_invalid_user_key: 'Invalid key provided. Please provide a valid key and try again.',
   com_error_expired_user_key:
     'Provided key for {0} expired at {1}. Please provide a new key and try again.',
+  com_error_context_length:
+    'The latest message token count is too long, exceeding the token limit ({0} respectively). Please shorten your message, adjust the max context size from the conversation parameters, or fork the conversation to continue.',
   com_files_no_results: 'No results.',
   com_files_filter: 'Filter files...',
   com_files_number_selected: '{0} of {1} file(s) selected',

--- a/client/src/localization/languages/Eng.ts
+++ b/client/src/localization/languages/Eng.ts
@@ -25,7 +25,7 @@ export default {
   com_error_invalid_user_key: 'Invalid key provided. Please provide a valid key and try again.',
   com_error_expired_user_key:
     'Provided key for {0} expired at {1}. Please provide a new key and try again.',
-  com_error_context_length:
+  com_error_input_length:
     'The latest message token count is too long, exceeding the token limit ({0} respectively). Please shorten your message, adjust the max context size from the conversation parameters, or fork the conversation to continue.',
   com_files_no_results: 'No results.',
   com_files_filter: 'Filter files...',

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -839,6 +839,11 @@ export enum ErrorTypes {
    * Moderation error
    */
   MODERATION = 'moderation',
+
+  /**
+   * Prompt exceeds max length
+   */
+  CONTEXT_LENGTH = 'CONTEXT_LENGTH',
 }
 
 /**

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -843,7 +843,7 @@ export enum ErrorTypes {
   /**
    * Prompt exceeds max length
    */
-  CONTEXT_LENGTH = 'CONTEXT_LENGTH',
+  INPUT_LENGTH = 'INPUT_LENGTH',
 }
 
 /**


### PR DESCRIPTION
## Summary

Continued from https://github.com/danny-avila/LibreChat/pull/3836

- Added a new INPUT_LENGTH error type to the ErrorTypes enum in the data provider package.
- Modified the BaseClient class to throw a structured error when the latest message token count exceeds the maximum context tokens.
- Updated the Error component in the client to handle and display the new INPUT_LENGTH error type.
- Added a new localization string for the INPUT_LENGTH error message in English.
- Refactored error handling logic in the BaseClient to provide more detailed information about token count and limits.

Testing:

To test these changes:

1. Attempt to send a message that exceeds the maximum token limit for the current conversation.
2. Verify that the appropriate error message is displayed, including the current token count and the maximum limit.
3. Test with different language settings to ensure proper localization of the error message.
4. Verify that the error is properly logged on the server side.

I recommend thorough testing of edge cases, such as messages just at the token limit and messages significantly over the limit, to ensure consistent behavior.