### PR TITLE
⚙️ fix: Ensure Azure AI Search TOP is a number

### DIFF
--- a/api/app/clients/tools/AzureAiSearch.js
+++ b/api/app/clients/tools/AzureAiSearch.js
@@ -77,7 +77,7 @@ class AzureAISearch extends StructuredTool {
     try {
       const searchOption = {
         queryType: this.queryType,
-        top: this.top,
+        top: typeof this.top === 'string' ? Number(this.top) : this.top,
       };
       if (this.select) {
         searchOption.select = this.select.split(',');

--- a/api/app/clients/tools/structured/AzureAISearch.js
+++ b/api/app/clients/tools/structured/AzureAISearch.js
@@ -83,7 +83,7 @@ class AzureAISearch extends StructuredTool {
     try {
       const searchOption = {
         queryType: this.queryType,
-        top: this.top,
+        top: typeof this.top === 'string' ? Number(this.top) : this.top,
       };
       if (this.select) {
         searchOption.select = this.select.split(',');


### PR DESCRIPTION
## Summary

Configuration of the parameter top for the AzureAiSearch tool through the enviroment variable `AZURE_AI_SEARCH_SEARCH_OPTION_TOP` is currently not possible. The enviroment variable is of course a string but the code explicitly requires a type number. If you set the enviroment variable, any message sent to the tool will result in an error in the log and fail to execute the Ai Search request.

> error: Azure AI Search request failed Error "searchRequest.top with value 1 must be of type number." occurred in serializing the payload - undefined

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Build the latest docker image from main, and configure the enviroment variable. Observe the problems above. Rebuild the docker image and observe a successful request to the AI Search.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
