### PR TITLE
🔧 fix: Allow Azure Assistants Chats to be Deleted

### DIFF
--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -1,7 +1,6 @@
 const multer = require('multer');
 const express = require('express');
-const { CacheKeys } = require('librechat-data-provider');
-const { initializeClient } = require('~/server/services/Endpoints/assistants');
+const { CacheKeys, EModelEndpoint } = require('librechat-data-provider');
 const { getConvosByPage, deleteConvos, getConvo, saveConvo } = require('~/models/Conversation');
 const { storage, importFileFilter } = require('~/server/routes/files/multer');
 const requireJwtAuth = require('~/server/middleware/requireJwtAuth');
@@ -11,6 +10,10 @@ const { createImportLimiters } = require('~/server/middleware');
 const getLogStores = require('~/cache/getLogStores');
 const { sleep } = require('~/server/utils');
 const { logger } = require('~/config');
+const assistantClients = {
+  [EModelEndpoint.azureAssistants]: require('~/server/services/Endpoints/azureAssistants'),
+  [EModelEndpoint.assistants]: require('~/server/services/Endpoints/assistants'),
+};
 
 const router = express.Router();
 router.use(requireJwtAuth);
@@ -74,7 +77,7 @@ router.post('/gen_title', async (req, res) => {
 
 router.post('/clear', async (req, res) => {
   let filter = {};
-  const { conversationId, source, thread_id } = req.body.arg;
+  const { conversationId, source, thread_id, endpoint } = req.body.arg;
   if (conversationId) {
     filter = { conversationId };
   }
@@ -83,9 +86,12 @@ router.post('/clear', async (req, res) => {
     return res.status(200).send('No conversationId provided');
   }
 
-  if (thread_id) {
+  if (
+    typeof endpoint != 'undefined' &&
+    Object.prototype.propertyIsEnumerable.call(assistantClients, endpoint)
+  ) {
     /** @type {{ openai: OpenAI}} */
-    const { openai } = await initializeClient({ req, res });
+    const { openai } = await assistantClients[endpoint].initializeClient({ req, res });
     try {
       const response = await openai.beta.threads.del(thread_id);
       logger.debug('Deleted OpenAI thread:', response);

--- a/client/src/components/Conversations/ConvoOptions/DeleteButton.tsx
+++ b/client/src/components/Conversations/ConvoOptions/DeleteButton.tsx
@@ -53,8 +53,9 @@ export default function DeleteButton({
   const confirmDelete = useCallback(() => {
     const messages = queryClient.getQueryData<TMessage[]>([QueryKeys.messages, conversationId]);
     const thread_id = messages?.[messages.length - 1]?.thread_id;
+    const endpoint = messages?.[messages.length - 1]?.endpoint;
 
-    deleteConvoMutation.mutate({ conversationId, thread_id, source: 'button' });
+    deleteConvoMutation.mutate({ conversationId, thread_id, endpoint, source: 'button' });
   }, [conversationId, deleteConvoMutation, queryClient]);
 
   const dialogContent = (

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -144,6 +144,7 @@ export type TUpdateConversationResponse = TConversation;
 export type TDeleteConversationRequest = {
   conversationId?: string;
   thread_id?: string;
+  endpoint?: string;
   source?: string;
 };
 


### PR DESCRIPTION
## Summary

Deletion of an assitants chat with azureAssistants through the left sidebar will crash the application with the following error.

> error: There was an uncaught error: Assistants API key not provided. Please provide it again.

This happen as the assistant chat is detected as a conversation with an assitant endpoint with a dedicated delete API call.
But there exists no detection which assitant endpoint (Azure or OpenAI) is used. Therefore if Azure is used and no OpenAI API key is configured the application still tries to delete the conversation through an API call with OpenAI and then crash.

I added an optional endpoint property to the delete mutation to pass along the desired endpoint.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Build the latest docker image from main. Start the application with an azure assistant endpoint and plugin configured. Do not provide a OpenAI API key. Start a chat with the assistant after the response delete the conversation through the left sidebar. Observe the application crashing.

Apply suggested changes and repeat the previous steps. Observe no crashes, errors or warnings. The chat is is deleted. Start a normal chat without assistant and delete it aswell. Again no warnings etc. 

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Any changes dependent on mine have been merged and published in downstream modules.

- [ ] Local unit tests pass with my changes

`npm run test:api` did not pass on the upstream main as I seem to miss some configuration. Therefore I could not validate those tests running
