### PR TITLE
feat: Parse markdown in conversation greeting

### DIFF
--- a/client/src/components/Chat/Landing.tsx
+++ b/client/src/components/Chat/Landing.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
 import { EModelEndpoint, isAssistantsEndpoint, Constants } from 'librechat-data-provider';
 import { useGetEndpointsQuery, useGetStartupConfig } from 'librechat-data-provider/react-query';
 import type { ReactNode } from 'react';
@@ -56,6 +57,23 @@ export default function Landing({ Header }: { Header?: ReactNode }) {
 
   const { submitMessage } = useSubmitMessage();
   const sendConversationStarter = (text: string) => submitMessage({ text });
+  const asMarkdown = (content) => (
+    <ReactMarkdown
+      components={{
+        a: (props) => {
+          const { ['node']: _, href, children, ...otherProps } = props;
+          return (
+            <a className="underline" href={href} target="_blank" rel="noreferrer" {...otherProps}>
+              {children}
+            </a>
+          );
+        },
+        p: ({ node, ...props }) => <span {...props} />,
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
 
   return (
     <TooltipProvider delayDuration={50}>
@@ -97,11 +115,13 @@ export default function Landing({ Header }: { Header?: ReactNode }) {
             </div> */}
               </div>
             ) : (
-              <h2 className="mb-5 max-w-[75vh] px-12 text-center text-lg font-medium dark:text-white md:px-0 md:text-2xl">
-                {isAssistant
-                  ? conversation?.greeting ?? localize('com_nav_welcome_assistant')
-                  : conversation?.greeting ?? localize('com_nav_welcome_message')}
-              </h2>
+              <div className="mb-5 max-w-[75vh] px-12 text-center text-lg font-medium dark:text-white md:px-0 md:text-2xl">
+                {asMarkdown(
+                  isAssistant
+                    ? conversation?.greeting ?? localize('com_nav_welcome_assistant')
+                    : conversation?.greeting ?? localize('com_nav_welcome_message'),
+                )}
+              </div>
             )}
             <div className="mt-8 flex flex-wrap justify-center gap-3 px-4">
               {conversation_starters.length > 0 &&


### PR DESCRIPTION
## Summary

I added support for Markdown in modelSpecs.greeting similar to the implementation of Markdown support in the enviroment variable `CUSTOM_FOOTER`.

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

I run all tests of `npm run test:client`, all passed.
I then built the container and started the app. With modelSpecs configured as described below. All types of greetings were rendered.

### **Test Configuration**:

```yaml
modelSpecs:
  list:
    - name: markdown-greeting
      default: false
      label: Markdown Greeting
      description: "Test Markdown"
      preset:
        endpoint: "azureOpenAI"
        model: gpt-4
        modelLabel: Markdown Greeting
        greeting: |
          ## Welcome to Markdown Greeting

          [LibreChat](https://www.librechat.ai/)
    - name: plain-greeting
      default: false
      label: Markdown Greeting
      description: "Test Plain"
      preset:
        endpoint: "azureOpenAI"
        model: gpt-4
        modelLabel: Markdown Greeting
        greeting: |
          Welcome to Plain Greeting
    - name: no-greeting
      default: false
      label: No Greeting
      description: "Test no greeting"
      preset:
        endpoint: "azureOpenAI"
        model: gpt-4
        modelLabel: No Greeting
```


## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted.

See https://github.com/LibreChat-AI/librechat.ai/pull/118 for documentation change
