### PR TITLE
👐 a11y: Misc. Improvements

### DIFF
--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -14,6 +14,7 @@ import { useToastContext } from '~/Providers';
 import { ConvoOptions } from './ConvoOptions';
 import { cn } from '~/utils';
 import store from '~/store';
+import { useLocalize } from '~/hooks'
 
 type KeyEvent = KeyboardEvent<HTMLInputElement>;
 
@@ -44,6 +45,7 @@ export default function Conversation({
   const [renaming, setRenaming] = useState(false);
   const [isPopoverActive, setIsPopoverActive] = useState(false);
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
+  const localize = useLocalize();
 
   const clickHandler = async (event: MouseEvent<HTMLAnchorElement>) => {
     if (event.button === 0 && (event.ctrlKey || event.metaKey)) {
@@ -146,6 +148,7 @@ export default function Conversation({
             value={titleInput ?? ''}
             onChange={(e) => setTitleInput(e.target.value)}
             onKeyDown={handleKeyDown}
+            aria-label={`${localize('com_ui_rename')} ${localize('com_ui_chat')}`}
           />
           <div className="flex gap-1">
             <button onClick={cancelRename} aria-label='cancel new name'>

--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -148,11 +148,11 @@ export default function Conversation({
             onKeyDown={handleKeyDown}
           />
           <div className="flex gap-1">
-            <button onClick={cancelRename}>
-              <X className="transition-colors h-4 w-4 duration-200 ease-in-out hover:opacity-70" />
+            <button onClick={cancelRename} aria-label='cancel new name'>
+              <X aria-hidden={true} className="transition-colors h-4 w-4 duration-200 ease-in-out hover:opacity-70" />
             </button>
-            <button onClick={onRename}>
-              <Check className="transition-colors h-4 w-4 duration-200 ease-in-out hover:opacity-70" />
+            <button onClick={onRename} aria-label='submit new name'>
+              <Check aria-hidden={true} className="transition-colors h-4 w-4 duration-200 ease-in-out hover:opacity-70" />
             </button>
           </div>
         </div>

--- a/client/src/components/Conversations/ConvoOptions/ConvoOptions.tsx
+++ b/client/src/components/Conversations/ConvoOptions/ConvoOptions.tsx
@@ -76,7 +76,7 @@ export default function ConvoOptions({
                 : 'opacity-0 focus:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100 data-[open]:opacity-100',
             )}
           >
-            <Ellipsis className="icon-md text-text-secondary" />
+            <Ellipsis className="icon-md text-text-secondary" aria-hidden={true}/>
           </Ariakit.MenuButton>
         }
         items={dropdownItems}

--- a/client/src/components/Nav/NewChat.tsx
+++ b/client/src/components/Nav/NewChat.tsx
@@ -101,7 +101,7 @@ export default function NewChat({
                   <TooltipTrigger asChild>
                     <button
                       id="nav-new-chat-btn"
-                      aria-label="nav-new-chat-btn"
+                      aria-label={localize('com_ui_new_chat')}
                       className="text-text-primary"
                     >
                       <NewChatIcon className="size-5" />

--- a/client/src/components/svg/NewChatIcon.tsx
+++ b/client/src/components/svg/NewChatIcon.tsx
@@ -8,6 +8,7 @@ export default function NewChatIcon({ className = '' }: { className?: string }) 
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={cn('text-black dark:text-white', className)}
+      aria-hidden={true}
     >
       <path
         fillRule="evenodd"

--- a/client/src/components/ui/OGDialogTemplate.tsx
+++ b/client/src/components/ui/OGDialogTemplate.tsx
@@ -71,7 +71,7 @@ const OGDialogTemplate = forwardRef((props: DialogTemplateProps, ref: Ref<HTMLDi
         <div>{leftButtons ? leftButtons : null}</div>
         <div className="flex h-auto gap-3">
           {showCancelButton && (
-            <OGDialogClose className="btn btn-neutral border-token-border-light relative rounded-lg text-sm">
+            <OGDialogClose className="btn btn-neutral border-token-border-light relative rounded-lg text-sm focus:outline-none focus:ring focus:border-blue-500">
               {Cancel}
             </OGDialogClose>
           )}

--- a/client/src/components/ui/OGDialogTemplate.tsx
+++ b/client/src/components/ui/OGDialogTemplate.tsx
@@ -71,7 +71,7 @@ const OGDialogTemplate = forwardRef((props: DialogTemplateProps, ref: Ref<HTMLDi
         <div>{leftButtons ? leftButtons : null}</div>
         <div className="flex h-auto gap-3">
           {showCancelButton && (
-            <OGDialogClose className="btn btn-neutral border-token-border-light relative rounded-lg text-sm focus:outline-none focus:ring focus:border-blue-500">
+            <OGDialogClose className="btn btn-neutral border-token-border-light relative rounded-lg text-sm ring-offset-2 dark:ring-offset-0 focus:ring-2 focus:ring-black">
               {Cancel}
             </OGDialogClose>
           )}


### PR DESCRIPTION
## Summary

This PR is to update librechat with the following accessibility changes
- [x] [Cancel button in the delete modal window has no persistent, visible focus](https://github.com/danny-avila/LibreChat/issues/3829)
- [x] [button icons are not hidden in rename chat thread field](https://github.com/danny-avila/LibreChat/issues/3828)
- [x] [rename chat buttons do not have accessible names](https://github.com/danny-avila/LibreChat/issues/3826)
- [x] [Missing accessible name/label on text field to rename the chat thread](https://github.com/danny-avila/LibreChat/issues/3825)
- [x] [icon in the menu button is not hidden](https://github.com/danny-avila/LibreChat/issues/3821)
- [x] [The button icon in the new chat button is not hidden](https://github.com/danny-avila/LibreChat/issues/3819)
- [x] [accessible name and visible label of new chat button do not match](https://github.com/danny-avila/LibreChat/issues/3817)
## Change Type

- [x] A11y updates

## Testing

- Rename button labels have been added and icons are given `aria-hidden` properties
<img width="1665" alt="Screenshot 2024-09-05 at 10 16 52 AM" src="https://github.com/user-attachments/assets/be455e2f-83e9-4702-a74c-bd9697284a2d">

-------------------

- New chat button has been labeled and icon was given `aria-hidden` property
<img width="1612" alt="Screenshot 2024-09-05 at 10 26 47 AM" src="https://github.com/user-attachments/assets/86a15091-9c03-4db7-8592-814da8e6a6f3">

-------------------

- Conversation options icon has been given `aria-hidden` property
![Screenshot 2024-09-05 at 9 38 19 AM](https://github.com/user-attachments/assets/fa66306f-594f-4893-8641-b5cae60ba58c)

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes