### PR TITLE
fix: coping text from dark mode shouldn't keep the color styl

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,7 +5,12 @@ import * as RadixToast from '@radix-ui/react-toast';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { QueryClient, QueryClientProvider, QueryCache } from '@tanstack/react-query';
-import { ScreenshotProvider, ThemeProvider, useApiErrorBoundary } from './hooks';
+import {
+  ScreenshotProvider,
+  ThemeProvider,
+  useApiErrorBoundary,
+  useColorStrippingCopy,
+} from './hooks';
 import { ToastProvider } from './Providers';
 import Toast from './components/ui/Toast';
 import { LiveAnnouncer } from '~/a11y';
@@ -13,7 +18,7 @@ import { router } from './routes';
 
 const App = () => {
   const { setError } = useApiErrorBoundary();
-
+  useColorStrippingCopy();
   const queryClient = new QueryClient({
     queryCache: new QueryCache({
       onError: (error) => {

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -30,3 +30,4 @@ export { default as useSpeechToText } from './Input/useSpeechToText';
 export { default as useTextToSpeech } from './Input/useTextToSpeech';
 export { default as useGenerationsByLatest } from './useGenerationsByLatest';
 export { default as useDocumentTitle } from './useDocumentTitle';
+export { default as useColorStrippingCopy } from './useColorStrippingCopy';

--- a/client/src/hooks/useColorStrippingCopy.tsx
+++ b/client/src/hooks/useColorStrippingCopy.tsx
@@ -1,0 +1,36 @@
+// useColorStrippingCopy.ts
+import { useEffect } from 'react';
+
+const useColorStrippingCopy = () => {
+  useEffect(() => {
+    const handleCopy = (event: ClipboardEvent) => {
+      const selection = document.getSelection();
+      if (selection && selection.rangeCount > 0) {
+        const range = selection.getRangeAt(0);
+        const clonedSelection = range.cloneContents();
+        const div = document.createElement('div');
+        div.appendChild(clonedSelection);
+
+        // Remove color and background-color styles
+        const elements = div.getElementsByTagName('*');
+        Array.from(elements).forEach((el) => {
+          if (el instanceof HTMLElement) {
+            el.style.color = '';
+            el.style.backgroundColor = '';
+          }
+        });
+
+        if (event.clipboardData) {
+          event.clipboardData.setData('text/html', div.innerHTML);
+          event.clipboardData.setData('text/plain', div.innerText);
+          event.preventDefault();
+        }
+      }
+    };
+
+    document.addEventListener('copy', handleCopy);
+    return () => document.removeEventListener('copy', handleCopy);
+  }, []);
+};
+
+export default useColorStrippingCopy;


### PR DESCRIPTION


# Pull Request Template


## Summary

When copying text from an answer in dark mode, the copied content retains the dark mode styling (light text on dark background) when pasted into other applications like Google Docs.
This is unlike other writing assistance platforms, such as ChatGPT, which have implemented a fix for this issue.
This fix registers a copy event listener that removes the styling from the text.
Fixes: #3954 


## Change Type

Please delete any irrelevant options.

- [x] Bug fix 

## Testing

Just copy a message from the bot that has formatting into Google Docs. 
### **Test Configuration**:

## Checklist

Please delete any irrelevant options.


- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
