### PR TITLE
🪨 fix: Formatting Edge Case Handling for Bedrock Messages

### DIFF
--- a/api/app/clients/prompts/formatMessages.js
+++ b/api/app/clients/prompts/formatMessages.js
@@ -142,6 +142,9 @@ const formatAgentMessages = (payload) => {
   const messages = [];
 
   for (const message of payload) {
+    if (typeof message.content === 'string') {
+      message.content = [{ type: ContentTypes.TEXT, [ContentTypes.TEXT]: message.content }];
+    }
     if (message.role !== 'assistant') {
       messages.push(formatMessage({ message, langChain: true }));
       continue;

--- a/client/src/components/ui/SelectDropDown.tsx
+++ b/client/src/components/ui/SelectDropDown.tsx
@@ -102,7 +102,6 @@ function SelectDropDown({
   const hasSearchRender = searchRender != null;
   const options = hasSearchRender ? filteredValues : availableValues;
 
-  console.log({ hasSearchRender, options });
   const renderIcon = showOptionIcon && value != null && (value as OptionWithIcon).icon != null;
 
   return (


### PR DESCRIPTION
## Summary 

Closes #4006

- Added a check in the `formatAgentMessages` function to handle cases where `message.content` is a string, converting it to the expected format to prevent message formatting issues in Bedrock.

### Other Changes
- Removed a console.log statement from the SelectDropDown component in the UI, improving code cleanliness and reducing unnecessary console output.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

To test these changes:

1. For the Bedrock fix:
   - Create a conversation using the Bedrock model.
   - Send message as OpenAI, then switch to Bedrock.
   - Verify that all messages are formatted correctly and displayed without issues.

2. For the UI cleanup:
   - Open the browser console while using the application.
   - Interact with any SelectDropDown components.
   - Confirm that no unnecessary console logs appear related to `hasSearchRender` or `options`.

### **Test Configuration**:
- Bedrock model enabled
- Latest version of the application running locally or in a test environment

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have tested my changes to ensure they work as expected