### PR TITLE
🪨 feat: AWS Bedrock Default Credentials Chain

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -916,7 +916,8 @@ ${convo}
     if (
       this.usage &&
       typeof this.usage === 'object' &&
-      typeof this.usage?.completion_tokens_details === 'object'
+      'completion_tokens_details' in this.usage &&
+      typeof this.usage.completion_tokens_details === 'object'
     ) {
       const outputTokens = Math.abs(
         this.usage.completion_tokens_details.reasoning_tokens - this.usage[this.outputTokensKey],

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -914,8 +914,9 @@ ${convo}
    */
   getStreamUsage() {
     if (
+      this.usage &&
       typeof this.usage === 'object' &&
-      typeof this.usage.completion_tokens_details === 'object'
+      typeof this.usage?.completion_tokens_details === 'object'
     ) {
       const outputTokens = Math.abs(
         this.usage.completion_tokens_details.reasoning_tokens - this.usage[this.outputTokensKey],

--- a/api/server/services/Config/EndpointService.js
+++ b/api/server/services/Config/EndpointService.js
@@ -45,7 +45,9 @@ module.exports = {
       AZURE_ASSISTANTS_BASE_URL,
       EModelEndpoint.azureAssistants,
     ),
-    [EModelEndpoint.bedrock]: generateConfig(process.env.BEDROCK_AWS_SECRET_ACCESS_KEY),
+    [EModelEndpoint.bedrock]: generateConfig(
+      process.env.BEDROCK_AWS_SECRET_ACCESS_KEY ?? process.env.BEDROCK_AWS_DEFAULT_REGION,
+    ),
     /* key will be part of separate config */
     [EModelEndpoint.agents]: generateConfig(process.env.I_AM_A_TEAPOT),
   },

--- a/api/server/services/Endpoints/bedrock/options.js
+++ b/api/server/services/Endpoints/bedrock/options.js
@@ -19,7 +19,7 @@ const getOptions = async ({ req, endpointOption }) => {
   const expiresAt = req.body.key;
   const isUserProvided = BEDROCK_AWS_SECRET_ACCESS_KEY === AuthType.USER_PROVIDED;
 
-  const credentials = isUserProvided
+  let credentials = isUserProvided
     ? await getUserKey({ userId: req.user.id, name: EModelEndpoint.bedrock })
     : {
       accessKeyId: BEDROCK_AWS_ACCESS_KEY_ID,
@@ -28,6 +28,14 @@ const getOptions = async ({ req, endpointOption }) => {
 
   if (!credentials) {
     throw new Error('Bedrock credentials not provided. Please provide them again.');
+  }
+
+  if (
+    !isUserProvided &&
+    (credentials.accessKeyId === undefined || credentials.accessKeyId === '') &&
+    (credentials.secretAccessKey === undefined || credentials.secretAccessKey === '')
+  ) {
+    credentials = undefined;
   }
 
   if (expiresAt && isUserProvided) {


### PR DESCRIPTION
## Summary

Relevant docs PR: https://github.com/LibreChat-AI/librechat.ai/pull/123

- Modified the Bedrock endpoint configuration to use AWS cascading default providers when credentials are omitted. This allows for more flexible authentication methods, including environment variables, SSO credentials, web identity tokens, shared credentials files, and EC2/ECS Instance Metadata Service.
- Updated the `getOptions` function in the Bedrock options file to set credentials to undefined when both access key and secret access key are empty or undefined for non-user provided credentials. This change enables the use of AWS's default credential provider chain.

## Other changes
- Fixed a bug in the `getStreamUsage` method of the OpenAIClient by adding an additional check for the existence of the `usage` object before accessing its properties. This prevents potential errors when the usage data is not available.

## Testing

To test these changes:

1. For the Bedrock changes:
   - Set up various AWS credential scenarios (e.g., using environment variables, SSO, EC2 instance role) and verify that the application can authenticate successfully without explicitly providing credentials.
   - Test with empty or undefined `BEDROCK_AWS_ACCESS_KEY_ID` and `BEDROCK_AWS_SECRET_ACCESS_KEY` to ensure the default credential provider chain is used.

### Test Configuration:

- AWS credentials set up in various ways (environment variables, ~/.aws/credentials, EC2 instance role, etc.)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have tested my changes in various AWS credential scenarios and OpenAI API response conditions