### PR TITLE
🔐 feat: Enhance Bedrock Credential Handling

### DIFF
--- a/api/server/services/Endpoints/bedrock/options.js
+++ b/api/server/services/Endpoints/bedrock/options.js
@@ -61,7 +61,6 @@ const getOptions = async ({ req, endpointOption }) => {
   /** @type {import('@librechat/agents').BedrockConverseClientOptions} */
   const requestOptions = Object.assign(
     {
-      credentials,
       model: endpointOption.model,
       region: BEDROCK_AWS_DEFAULT_REGION,
       streaming: true,
@@ -79,6 +78,10 @@ const getOptions = async ({ req, endpointOption }) => {
     },
     endpointOption.model_parameters,
   );
+
+  if (credentials) {
+    requestOptions.credentials = credentials;
+  }
 
   const configOptions = {};
   if (PROXY) {


### PR DESCRIPTION
## Summary

A user reported they were still not able to use AWS IAM role policy with the changes from https://github.com/danny-avila/LibreChat/pull/4038. It was found that making these changes made it work, despite that the previous changes were working with `~/.aws/credentials` when access keys were omitted.

- Modified the `getOptions` function in the Bedrock options file to omit the credentials field from the initial `requestOptions` object.
- Added a conditional check to include credentials in `requestOptions` only if they are explicitly provided.
- This change allows the AWS SDK to fall back to its default credential chain when no specific credentials are set, improving flexibility and adherence to AWS best practices.
- Maintained existing functionality for cases where credentials are explicitly provided.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

To test this change:

1. Ensure that AWS credentials are properly configured in your environment (e.g., in `~/.aws/credentials`, environment variables, or EC2 instance profile).
2. Run the application and attempt to use the Bedrock endpoint without explicitly providing credentials.
3. Verify that the application successfully authenticates with AWS and can interact with Bedrock services.
4. Test again with explicitly provided credentials to ensure that functionality is maintained.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have tested my changes in various AWS credential scenarios