### PR TITLE
📁 feat: Add C# Support for Native File Search

### DIFF
--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -109,7 +109,7 @@ export const excelMimeTypes =
   /^application\/(vnd\.ms-excel|msexcel|x-msexcel|x-ms-excel|x-excel|x-dos_ms_excel|xls|x-xls|vnd\.openxmlformats-officedocument\.spreadsheetml\.sheet)$/;
 
 export const textMimeTypes =
-  /^(text\/(x-c|x-c\+\+|x-java|html|markdown|x-php|x-python|x-script\.python|x-ruby|x-tex|plain|css|javascript|csv))$/;
+  /^(text\/(x-c|x-csharp|x-c\+\+|x-java|html|markdown|x-php|x-python|x-script\.python|x-ruby|x-tex|plain|css|javascript|csv))$/;
 
 export const applicationMimeTypes =
   /^(application\/(epub\+zip|csv|json|pdf|x-tar|typescript|vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation|spreadsheetml\.sheet)|xml|zip))$/;


### PR DESCRIPTION
## Summary 

Closes #4056 

- Updated the `textMimeTypes` regular expression in `file-config.ts` to include the MIME type for C# files (`x-csharp`).

**Note:** OpenAI Assistants API does not support files ending with `.cs` extension. To circumvent this, you can save the code as `.txt`, also the planned update will help address this: https://github.com/danny-avila/LibreChat/issues/2755

## Testing

![image](https://github.com/user-attachments/assets/2f2d9830-80d7-4a05-b60e-56f9af8383c8)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have tested the changes to ensure they work as expected