### PR TITLE
👐 a11y: New Chat button - focus, mobile label, collapsed sidebar label

### DIFF
--- a/client/src/components/Chat/Menus/HeaderNewChat.tsx
+++ b/client/src/components/Chat/Menus/HeaderNewChat.tsx
@@ -1,18 +1,20 @@
 import { NewChatIcon } from '~/components/svg';
 import { useChatContext } from '~/Providers';
-import { useMediaQuery } from '~/hooks';
+import { useMediaQuery, useLocalize } from '~/hooks';
 
 export default function HeaderNewChat() {
   const { newConversation } = useChatContext();
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
+  const localize = useLocalize();
   if (isSmallScreen) {
     return null;
   }
   return (
     <button
       data-testid="wide-header-new-chat-button"
+      aria-label={localize("com_ui_new_chat")}
       type="button"
-      className="btn btn-neutral btn-small border-token-border-medium relative ml-2 flex hidden h-9 w-9 items-center justify-center whitespace-nowrap rounded-lg rounded-lg border focus:ring-0 focus:ring-offset-0 md:flex"
+      className="btn btn-neutral btn-small border-token-border-medium relative ml-2 flex hidden h-9 w-9 items-center justify-center whitespace-nowrap rounded-lg rounded-lg border focus:border-black-500 dark:focus:border-white-500 md:flex"
       onClick={() => newConversation()}
     >
       <div className="flex w-full items-center justify-center gap-2">

--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -151,10 +151,10 @@ export default function Conversation({
             aria-label={`${localize('com_ui_rename')} ${localize('com_ui_chat')}`}
           />
           <div className="flex gap-1">
-            <button onClick={cancelRename} aria-label='cancel new name'>
+            <button onClick={cancelRename} aria-label={`${localize('com_ui_cancel')} ${localize('com_ui_rename')}`}>
               <X aria-hidden={true} className="transition-colors h-4 w-4 duration-200 ease-in-out hover:opacity-70" />
             </button>
-            <button onClick={onRename} aria-label='submit new name'>
+            <button onClick={onRename} aria-label={`${localize('com_ui_submit')} ${localize('com_ui_rename')}`}>
               <Check aria-hidden={true} className="transition-colors h-4 w-4 duration-200 ease-in-out hover:opacity-70" />
             </button>
           </div>

--- a/client/src/components/Nav/MobileNav.tsx
+++ b/client/src/components/Nav/MobileNav.tsx
@@ -19,7 +19,8 @@ export default function MobileNav({
       <button
         type="button"
         data-testid="mobile-header-new-chat-button"
-        className="inline-flex size-10 items-center justify-center rounded-full hover:bg-surface-hover"
+        aria-label={localize('com_nav_open_sidebar')}
+        className="m-1 inline-flex size-10 items-center justify-center rounded-full hover:bg-surface-hover"
         onClick={() =>
           setNavVisible((prev) => {
             localStorage.setItem('navVisible', JSON.stringify(!prev));
@@ -49,7 +50,8 @@ export default function MobileNav({
       </h1>
       <button
         type="button"
-        className="inline-flex size-10 items-center justify-center rounded-full hover:bg-surface-hover"
+        aria-label={localize('com_ui_new_chat')}
+        className="m-1 inline-flex size-10 items-center justify-center rounded-full hover:bg-surface-hover"
         onClick={() => newConversation()}
       >
         <svg


### PR DESCRIPTION
## Summary

This PR is to address the following new chat button accessibility properties:
 - #3946 
 - #3945 
 - #3944 
Note: I added localization for `cancel` and `submit` new name labels in conversation
## Change Type

- [x] Improve accessibility

### **Test Configuration**:
The changes should work for both light and dark themes:
<img width="476" alt="Screenshot 2024-09-16 at 2 31 08 PM" src="https://github.com/user-attachments/assets/99935f02-7976-47c7-9fc3-0e91b8edbf83">

<img width="365" alt="Screenshot 2024-09-16 at 2 27 32 PM" src="https://github.com/user-attachments/assets/8d4efc0b-ba3c-4210-9b9b-eae0b52c13cd">

--------------------------
<img width="454" alt="Screenshot 2024-09-16 at 1 38 30 PM" src="https://github.com/user-attachments/assets/0adc7354-5173-4c4d-bc02-5e1c14affd22">
<img width="482" alt="Screenshot 2024-09-16 at 1 38 08 PM" src="https://github.com/user-attachments/assets/d770f190-5e9a-4aba-a277-a9c179bc77c4">

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings