### PR TITLE
🛠️ fix: Chrome App Crash on Endpoint Selection in Edit Preset Dialog

### DIFF
--- a/client/src/components/Chat/Menus/Presets/EditPresetDialog.tsx
+++ b/client/src/components/Chat/Menus/Presets/EditPresetDialog.tsx
@@ -11,7 +11,7 @@ import {
   mapEndpoints,
   getConvoSwitchLogic,
 } from '~/utils';
-import { Input, Label, Dropdown, Dialog, DialogClose, DialogButton } from '~/components';
+import { Input, Label, SelectDropDown, Dialog, DialogClose, DialogButton } from '~/components';
 import { useSetIndexOptions, useLocalize, useDebouncedInput } from '~/hooks';
 import PopoverButtons from '~/components/Chat/Input/PopoverButtons';
 import DialogTemplate from '~/components/ui/DialogTemplate';
@@ -146,10 +146,13 @@ const EditPresetDialog = ({
                   <Label htmlFor="endpoint" className="mb-1 text-left text-sm font-medium">
                     {localize('com_endpoint')}
                   </Label>
-                  <Dropdown
+                  <SelectDropDown
                     value={endpoint || ''}
-                    onChange={switchEndpoint}
-                    options={availableEndpoints}
+                    setValue={switchEndpoint}
+                    showLabel={false}
+                    emptyTitle={true}
+                    searchPlaceholder={localize('com_endpoint_search')}
+                    availableValues={availableEndpoints}
                   />
                 </div>
               </div>

--- a/client/src/localization/languages/Eng.ts
+++ b/client/src/localization/languages/Eng.ts
@@ -564,6 +564,7 @@ export default {
   com_endpoint_export: 'Export',
   com_endpoint_export_share: 'Export/Share',
   com_endpoint_assistant: 'Assistant',
+  com_endpoint_search: 'Search endpoint by name',
   com_endpoint_use_active_assistant: 'Use Active Assistant',
   com_endpoint_assistant_model: 'Assistant Model',
   com_endpoint_save_as_preset: 'Save As Preset',


### PR DESCRIPTION
## Summary

- Replaced the `Dropdown` component with `SelectDropDown` in the EditPresetDialog component to resolve the Chrome-specific crash.
- Updated the component props to match the new `SelectDropDown` interface, ensuring proper functionality.
- Added a new localization key `com_endpoint_search` to support the search placeholder in the endpoint selection dropdown.