### PR TITLE
bugfix/feat:Allow other LDAP field besides "mail" to map to email adress, or fallback to made up email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -412,6 +412,7 @@ LDAP_CA_CERT_PATH=
 # LDAP_LOGIN_USES_USERNAME=true
 # LDAP_ID=
 # LDAP_USERNAME=
+# LDAP_EMAIL=
 # LDAP_FULL_NAME=
 
 #========================#

--- a/api/strategies/ldapStrategy.js
+++ b/api/strategies/ldapStrategy.js
@@ -14,6 +14,7 @@ const {
   LDAP_FULL_NAME,
   LDAP_ID,
   LDAP_USERNAME,
+  LDAP_EMAIL,
   LDAP_TLS_REJECT_UNAUTHORIZED,
 } = process.env;
 
@@ -42,6 +43,9 @@ if (LDAP_ID) {
 }
 if (LDAP_USERNAME) {
   searchAttributes.push(LDAP_USERNAME);
+}
+if (LDAP_EMAIL) {
+  searchAttributes.push(LDAP_EMAIL);
 }
 const rejectUnauthorized = isEnabled(LDAP_TLS_REJECT_UNAUTHORIZED);
 
@@ -76,15 +80,6 @@ const ldapLogin = new LdapStrategy(ldapOptions, async (userinfo, done) => {
     return done(null, false, { message: 'Invalid credentials' });
   }
 
-  if (!userinfo.mail) {
-    logger.warn(
-      '[ldapStrategy]',
-      'No email attributes found in userinfo',
-      JSON.stringify(userinfo, null, 2),
-    );
-    return done(null, false, { message: 'Invalid credentials' });
-  }
-
   try {
     const ldapId =
       (LDAP_ID && userinfo[LDAP_ID]) || userinfo.uid || userinfo.sAMAccountName || userinfo.mail;
@@ -100,12 +95,14 @@ const ldapLogin = new LdapStrategy(ldapOptions, async (userinfo, done) => {
     const username =
       (LDAP_USERNAME && userinfo[LDAP_USERNAME]) || userinfo.givenName || userinfo.mail;
 
+    const mail = (LDAP_EMAIL && userinfo[LDAP_EMAIL]) || userinfo.mail || username + '@ldap.local';
+
     if (!user) {
       user = {
         provider: 'ldap',
         ldapId,
         username,
-        email: userinfo.mail,
+        email: mail,
         emailVerified: true, // The ldap server administrator should verify the email
         name: fullName,
       };
@@ -116,7 +113,7 @@ const ldapLogin = new LdapStrategy(ldapOptions, async (userinfo, done) => {
       // so update the user information with the values registered in LDAP
       user.provider = 'ldap';
       user.ldapId = ldapId;
-      user.email = userinfo.mail;
+      user.email = mail;
       user.username = username;
       user.name = fullName;
     }


### PR DESCRIPTION
## Summary
if the `userinfo` of LDAP does not return a `mail` field, librechat will not authenticate even if ldap authenticated succesfully. 

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] A pull request for updating the documentation has been submitted.
   - https://github.com/LibreChat-AI/librechat.ai/pull/128
