### PR TITLE
🔧 fix: OpenAIClient Response Handling for Legacy `/v1/completions`

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -644,6 +644,12 @@ class OpenAIClient extends BaseClient {
 
       if (completionResult && typeof completionResult === 'string') {
         reply = completionResult;
+      } else if (
+        completionResult &&
+        typeof completionResult === 'object' &&
+        Array.isArray(completionResult.choices)
+      ) {
+        reply = completionResult.choices[0]?.text?.replace(this.endToken, '');
       }
     } else if (typeof opts.onProgress === 'function' || this.options.useChatCompletion) {
       reply = await this.chatCompletion({


### PR DESCRIPTION
## Summary

- Added a new condition in the OpenAIClient to handle responses from custom endpoints using the legacy /v1/completions API
- Implemented logic to extract the reply text from the 'choices' array in the response object
- Ensured proper handling of the 'text' field within the first choice of the response
- Removed the endToken from the extracted reply to maintain consistency with other response handling methods

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have tested the changes to ensure they work as expected