### PR TITLE
🎨 fix: Terms and Conditions Modal Styling

### DIFF
--- a/client/src/components/Endpoints/SaveAsPresetDialog.tsx
+++ b/client/src/components/Endpoints/SaveAsPresetDialog.tsx
@@ -76,7 +76,7 @@ const SaveAsPresetDialog = ({ open, onOpenChange, preset }: TEditPresetProps) =>
                 aria-label={localize('com_endpoint_preset_name')}
                 className={cn(
                   defaultTextProps,
-                  'flex h-10 max-h-10 w-full resize-none border-gray-100 px-3 py-2 dark:border-gray-600',
+                  'flex h-10 max-h-10 w-full resize-none border-border-medium px-3 py-2 ',
                   removeFocusOutlines,
                 )}
               />

--- a/client/src/components/ui/TermsAndConditionsModal.tsx
+++ b/client/src/components/ui/TermsAndConditionsModal.tsx
@@ -1,4 +1,4 @@
-import Markdown from '~/components/Chat/Messages/Content/Markdown';
+import MarkdownLite from '~/components/Chat/Messages/Content/MarkdownLite';
 import DialogTemplate from '~/components/ui/DialogTemplate';
 import { useAcceptTermsMutation } from '~/data-provider';
 import { useToastContext } from '~/Providers';
@@ -60,7 +60,7 @@ const TermsAndConditionsModal = ({
           <div className="max-h-[60vh] overflow-y-auto p-4">
             <div className="prose dark:prose-invert w-full max-w-none !text-text-primary">
               {modalContent != null && modalContent ? (
-                <Markdown content={modalContent} isLatestMessage={false} />
+                <MarkdownLite content={modalContent} />
               ) : (
                 <p>{localize('com_ui_no_terms_content')}</p>
               )}

--- a/client/src/components/ui/TermsAndConditionsModal.tsx
+++ b/client/src/components/ui/TermsAndConditionsModal.tsx
@@ -1,10 +1,9 @@
-import { useLocalize } from '~/hooks';
-import { OGDialog } from '~/components/ui';
-import DialogTemplate from '~/components/ui/DialogTemplate';
-import { useAuthContext } from '~/hooks';
 import Markdown from '~/components/Chat/Messages/Content/Markdown';
-import { useToastContext } from '~/Providers';
+import DialogTemplate from '~/components/ui/DialogTemplate';
 import { useAcceptTermsMutation } from '~/data-provider';
+import { useToastContext } from '~/Providers';
+import { OGDialog } from '~/components/ui';
+import { useLocalize } from '~/hooks';
 
 const TermsAndConditionsModal = ({
   open,
@@ -59,8 +58,8 @@ const TermsAndConditionsModal = ({
         showCancelButton={false}
         main={
           <div className="max-h-[60vh] overflow-y-auto p-4">
-            <div className="prose dark:prose-invert w-full max-w-none !text-black dark:!text-white">
-              {modalContent ? (
+            <div className="prose dark:prose-invert w-full max-w-none !text-text-primary">
+              {modalContent != null && modalContent ? (
                 <Markdown content={modalContent} isLatestMessage={false} />
               ) : (
                 <p>{localize('com_ui_no_terms_content')}</p>
@@ -72,13 +71,13 @@ const TermsAndConditionsModal = ({
           <>
             <button
               onClick={handleDecline}
-              className="border-border-none bg-surface-500 dark:hover:bg-surface-600 inline-flex h-10 items-center justify-center rounded-lg px-4 py-2 text-sm text-white hover:bg-gray-600"
+              className="inline-flex h-10 items-center justify-center rounded-lg border border-border-heavy bg-surface-secondary px-4 py-2 text-sm text-text-primary hover:bg-surface-active"
             >
               {localize('com_ui_decline')}
             </button>
             <button
               onClick={handleAccept}
-              className="border-border-none bg-surface-500 inline-flex h-10 items-center justify-center rounded-lg px-4 py-2 text-sm text-white hover:bg-green-600 dark:hover:bg-green-600"
+              className="inline-flex h-10 items-center justify-center rounded-lg border border-border-heavy bg-surface-secondary px-4 py-2 text-sm text-text-primary hover:bg-green-500 hover:text-white focus:bg-green-500 focus:text-white dark:hover:bg-green-600 dark:focus:bg-green-600"
             >
               {localize('com_ui_accept')}
             </button>

--- a/client/src/components/ui/TermsAndConditionsModal.tsx
+++ b/client/src/components/ui/TermsAndConditionsModal.tsx
@@ -57,7 +57,13 @@ const TermsAndConditionsModal = ({
         showCloseButton={false}
         showCancelButton={false}
         main={
-          <div className="max-h-[60vh] overflow-y-auto p-4">
+          <section
+            // Motivation: This is a dialog, so its content should be focusable
+            // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+            tabIndex={0}
+            className="max-h-[60vh] overflow-y-auto p-4"
+            aria-label={localize('com_ui_terms_and_conditions')}
+          >
             <div className="prose dark:prose-invert w-full max-w-none !text-text-primary">
               {modalContent != null && modalContent ? (
                 <MarkdownLite content={modalContent} />
@@ -65,7 +71,7 @@ const TermsAndConditionsModal = ({
                 <p>{localize('com_ui_no_terms_content')}</p>
               )}
             </div>
-          </div>
+          </section>
         }
         buttons={
           <>

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -11,7 +11,7 @@ import TermsAndConditionsModal from '~/components/ui/TermsAndConditionsModal';
 import { Banner } from '~/components/Banners';
 
 export default function Root() {
-  const { isAuthenticated, logout, token } = useAuthContext();
+  const { isAuthenticated, logout } = useAuthContext();
   const navigate = useNavigate();
   const [navVisible, setNavVisible] = useState(() => {
     const savedNavVisible = localStorage.getItem('navVisible');
@@ -27,7 +27,7 @@ export default function Root() {
   const [showTerms, setShowTerms] = useState(false);
   const { data: config } = useGetStartupConfig();
   const { data: termsData } = useUserTermsQuery({
-    enabled: isAuthenticated && !!config?.interface?.termsOfService?.modalAcceptance,
+    enabled: isAuthenticated && config?.interface?.termsOfService?.modalAcceptance === true,
   });
 
   useEffect(() => {
@@ -66,7 +66,7 @@ export default function Root() {
               </div>
             </div>
           </AgentsMapContext.Provider>
-          {config?.interface?.termsOfService?.modalAcceptance && (
+          {config?.interface?.termsOfService?.modalAcceptance === true && (
             <TermsAndConditionsModal
               open={showTerms}
               onOpenChange={setShowTerms}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36680,7 +36680,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.423",
+      "version": "0.7.424",
       "license": "ISC",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.423",
+  "version": "0.7.424",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -311,7 +311,7 @@ export type TInterfaceConfig = {
     openNewTab?: boolean;
     modalAcceptance?: boolean;
     modalTitle?: string;
-    modalContent?: string | string[];
+    modalContent?: string;
   };
   endpointsMenu: boolean;
   modelSelect: boolean;


### PR DESCRIPTION
## Summary

Closes #4168 

- Refactored the TermsAndConditionsModal to use MarkdownLite instead of Markdown for better performance and lighter rendering.
- Fixed a modal styling issue where buttons in light mode were not visible or accessible.
- Updated the SaveAsPresetDialog to use consistent border color styling.
- Improved the TermsAndConditionsModal layout and button styling for better visibility in both light and dark modes.
- Refactored the Root component to use a strict boolean check for the terms of service modal acceptance.
- Updated the TInterfaceConfig type in the data provider to use a string for modalContent instead of string | string[].
- Bumped the version of the data provider package to 0.7.424.

## Testing

To test these changes:

1. Verify that the TermsAndConditionsModal renders correctly in both light and dark modes.
2. Check that the buttons in the modal are visible and accessible in light mode.
3. Ensure that the SaveAsPresetDialog has consistent border styling.
4. Test the Root component to confirm that the terms of service modal appears when appropriate.
5. Verify that the MarkdownLite component renders the content correctly in the TermsAndConditionsModal.

### Test Configuration:

- Test in both light and dark modes
- Test with various screen sizes to ensure responsive design
- Verify functionality in different browsers (Chrome, Firefox, Safari)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have tested my changes in both light and dark modes
- [x] I have verified that the TermsAndConditionsModal renders correctly with MarkdownLite