### PR TITLE
🖋️ feat: Add option to render User Messages as Markdown

### DIFF
--- a/client/src/components/Chat/Messages/Content/SearchContent.tsx
+++ b/client/src/components/Chat/Messages/Content/SearchContent.tsx
@@ -22,12 +22,13 @@ const SearchContent = ({ message }: { message: TMessage }) => {
                 key={`display-${messageId}-${idx}`}
                 showCursor={false}
                 isSubmitting={false}
+                isCreatedByUser={message.isCreatedByUser}
+                messageId={message.messageId}
                 part={part}
-                message={message}
               />
             );
           })}
-        {message.unfinished && (
+        {message.unfinished === true && (
           <Suspense>
             <DelayedRender delay={250}>
               <UnfinishedMessage message={message} key={`unfinished-${messageId}`} />

--- a/client/src/components/Nav/SettingsTabs/General/General.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/General.tsx
@@ -1,9 +1,10 @@
 import { useRecoilState } from 'recoil';
 import Cookies from 'js-cookie';
-import React, { useContext, useCallback, useRef } from 'react';
+import React, { useContext, useCallback } from 'react';
 import type { TDangerButtonProps } from '~/common';
-import { ThemeContext, useLocalize } from '~/hooks';
+import UserMsgMarkdownSwitch from './UserMsgMarkdownSwitch';
 import HideSidePanelSwitch from './HideSidePanelSwitch';
+import { ThemeContext, useLocalize } from '~/hooks';
 import AutoScrollSwitch from './AutoScrollSwitch';
 import ArchivedChats from './ArchivedChats';
 import { Dropdown } from '~/components/ui';
@@ -123,8 +124,6 @@ function General() {
 
   const [langcode, setLangcode] = useRecoilState(store.lang);
 
-  const contentRef = useRef(null);
-
   const changeTheme = useCallback(
     (value: string) => {
       setTheme(value);
@@ -155,6 +154,9 @@ function General() {
       </div>
       <div className="border-b border-border-medium pb-3 last-of-type:border-b-0">
         <LangSelector langcode={langcode} onChange={changeLang} />
+      </div>
+      <div className="border-b border-border-medium pb-3 last-of-type:border-b-0">
+        <UserMsgMarkdownSwitch />
       </div>
       <div className="border-b border-border-medium pb-3 last-of-type:border-b-0">
         <AutoScrollSwitch />

--- a/client/src/components/Nav/SettingsTabs/General/UserMsgMarkdownSwitch.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/UserMsgMarkdownSwitch.tsx
@@ -1,0 +1,35 @@
+import { useRecoilState } from 'recoil';
+import { Switch } from '~/components/ui';
+import { useLocalize } from '~/hooks';
+import store from '~/store';
+
+export default function UserMsgMarkdownSwitch({
+  onCheckedChange,
+}: {
+  onCheckedChange?: (value: boolean) => void;
+}) {
+  const localize = useLocalize();
+  const [enableUserMsgMarkdown, setEnableUserMsgMarkdown] = useRecoilState<boolean>(
+    store.enableUserMsgMarkdown,
+  );
+
+  const handleCheckedChange = (value: boolean) => {
+    setEnableUserMsgMarkdown(value);
+    if (onCheckedChange) {
+      onCheckedChange(value);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between">
+      <div> {localize('com_nav_user_msg_markdown')} </div>
+      <Switch
+        id="enableUserMsgMarkdown"
+        checked={enableUserMsgMarkdown}
+        onCheckedChange={handleCheckedChange}
+        className="ml-4 mt-2 ring-ring-primary"
+        data-testid="enableUserMsgMarkdown"
+      />
+    </div>
+  );
+}

--- a/client/src/localization/languages/Eng.ts
+++ b/client/src/localization/languages/Eng.ts
@@ -625,6 +625,7 @@ export default {
   com_nav_welcome_assistant: 'Please Select an Assistant',
   com_nav_welcome_message: 'How can I help you today?',
   com_nav_auto_scroll: 'Auto-Scroll to latest message on chat open',
+  com_nav_user_msg_markdown: 'Render user messages as markdown',
   com_nav_hide_panel: 'Hide right-most side panel',
   com_nav_modular_chat: 'Enable switching Endpoints mid-conversation',
   com_nav_latex_parsing: 'Parsing LaTeX in messages (may affect performance)',

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -23,6 +23,10 @@ const localStorageAtoms = {
   autoScroll: atomWithLocalStorage('autoScroll', false),
   hideSidePanel: atomWithLocalStorage('hideSidePanel', false),
   fontSize: atomWithLocalStorage('fontSize', 'text-base'),
+  enableUserMsgMarkdown: atomWithLocalStorage<boolean>(
+    LocalStorageKeys.ENABLE_USER_MSG_MARKDOWN,
+    true,
+  ),
 
   // Messages settings
   enterToSend: atomWithLocalStorage('enterToSend', true),

--- a/package-lock.json
+++ b/package-lock.json
@@ -36680,7 +36680,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.424",
+      "version": "0.7.425",
       "license": "ISC",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.424",
+  "version": "0.7.425",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1119,6 +1119,8 @@ export enum LocalStorageKeys {
   FILES_DRAFT = 'filesDraft_',
   /** Key for last Selected Prompt Category */
   LAST_PROMPT_CATEGORY = 'lastPromptCategory',
+  /** Key for rendering User Messages as Markdown */
+  ENABLE_USER_MSG_MARKDOWN = 'enableUserMsgMarkdown',
 }
 
 export enum ForkOptions {


### PR DESCRIPTION
## Summary

Closes #1400 

- Added a new setting in the General tab to toggle markdown rendering for user messages
- Implemented `UserMsgMarkdownSwitch` component for the new setting
- Modified `MessageContent` and `Text` components to conditionally render user messages as markdown
- Updated `SearchContent` component to support the new markdown rendering option
- Added a new localization key for the user message markdown setting
- Created a new atom in the settings store for the markdown rendering option
- Updated the `LocalStorageKeys` enum to include the new setting
- Refactored the message rendering logic to use the new setting and render markdown when enabled
- Updated the data-provider package version to 0.7.425

## Testing

To test this feature:

1. Enable the "Render user messages as markdown" option in the General settings
2. Send messages with markdown formatting (e.g., **bold**, *italic*, `code`)
3. Verify that the messages are rendered with the correct markdown formatting
4. Disable the option and confirm that messages are rendered as plain text
5. Test the feature across different chat contexts and ensure it works consistently

### Test Configuration:

- Ensure you have the latest dependencies installed
- Test on multiple browsers to verify cross-browser compatibility
- Check both light and dark themes to ensure proper rendering in both modes

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes