### PR TITLE
📅 fix: Conversation grouping and labeling for prior years

### DIFF
--- a/client/src/components/Conversations/Conversations.tsx
+++ b/client/src/components/Conversations/Conversations.tsx
@@ -41,7 +41,8 @@ const Conversations = ({
                   paddingLeft: '10px',
                 }}
               >
-                {localize(groupName) ?? groupName}
+                {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
+                {localize(groupName) || groupName}
               </div>
               {convos.map((convo, i) => (
                 <Convo

--- a/client/src/utils/convos.ts
+++ b/client/src/utils/convos.ts
@@ -6,7 +6,6 @@ import {
   parseISO,
   startOfDay,
   startOfYear,
-  startOfToday,
   isWithinInterval,
 } from 'date-fns';
 import { EModelEndpoint, LocalStorageKeys } from 'librechat-data-provider';
@@ -40,7 +39,7 @@ export const dateKeys = {
 };
 
 const getGroupName = (date: Date) => {
-  const now = new Date();
+  const now = new Date(Date.now());
   if (isToday(date)) {
     return dateKeys.today;
   }
@@ -95,7 +94,7 @@ export const groupConversationsByDate = (
 
   const seenConversationIds = new Set();
   const groups = new Map();
-  const today = startOfToday();
+  const now = new Date(Date.now());
 
   conversations.forEach((conversation) => {
     if (!conversation || seenConversationIds.has(conversation.conversationId)) {
@@ -103,7 +102,13 @@ export const groupConversationsByDate = (
     }
     seenConversationIds.add(conversation.conversationId);
 
-    const date = conversation.updatedAt ? parseISO(conversation.updatedAt) : today;
+    let date: Date;
+    if (conversation.updatedAt) {
+      date = parseISO(conversation.updatedAt);
+    } else {
+      date = now;
+    }
+
     const groupName = getGroupName(date);
     if (!groups.has(groupName)) {
       groups.set(groupName, []);


### PR DESCRIPTION
## Summary

- Added a new test case in `convos.spec.ts` to verify the grouping of conversations across multiple years.
- Updated the `Conversations` component to use a null-safe approach when localizing group names.
- Modified the date handling to use the current date consistently, improving the accuracy of date-based groupings.
- Expanded test coverage to ensure proper handling of conversations from different years, including edge cases.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes