### PR TITLE
🏷️ fix: Ensure `modelLabel` Field Usage for ModelSpecs/GPTPlugins

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -199,8 +199,8 @@ class OpenAIClient extends BaseClient {
         model: this.modelOptions.model,
         endpoint: this.options.endpoint,
         endpointType: this.options.endpointType,
-        chatGptLabel: this.options.chatGptLabel,
         modelDisplayLabel: this.options.modelDisplayLabel,
+        chatGptLabel: this.options.chatGptLabel || this.options.modelLabel,
       });
 
     this.userLabel = this.options.userLabel || 'User';

--- a/api/server/services/Endpoints/gptPlugins/buildOptions.js
+++ b/api/server/services/Endpoints/gptPlugins/buildOptions.js
@@ -3,6 +3,7 @@ const generateArtifactsPrompt = require('~/app/clients/prompts/artifacts');
 
 const buildOptions = (endpoint, parsedBody) => {
   const {
+    modelLabel,
     chatGptLabel,
     promptPrefix,
     agentOptions,
@@ -16,10 +17,10 @@ const buildOptions = (endpoint, parsedBody) => {
   } = parsedBody;
   const endpointOption = removeNullishValues({
     endpoint,
-    tools:
-      tools
-        .map((tool) => tool?.pluginKey ?? tool)
-        .filter((toolName) => typeof toolName === 'string'),
+    tools: tools
+      .map((tool) => tool?.pluginKey ?? tool)
+      .filter((toolName) => typeof toolName === 'string'),
+    modelLabel,
     chatGptLabel,
     promptPrefix,
     agentOptions,

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -220,13 +220,16 @@ export const getResponseSender = (endpointOption: t.TEndpointOption): string => 
     model: _m,
     endpoint,
     endpointType,
-    modelDisplayLabel,
-    chatGptLabel,
-    modelLabel,
+    modelDisplayLabel: _mdl,
+    chatGptLabel: _cgl,
+    modelLabel: _ml,
     jailbreak,
   } = endpointOption;
 
   const model = _m ?? '';
+  const modelDisplayLabel = _mdl ?? '';
+  const chatGptLabel = _cgl ?? '';
+  const modelLabel = _ml ?? '';
   if (
     [
       EModelEndpoint.openAI,
@@ -238,6 +241,8 @@ export const getResponseSender = (endpointOption: t.TEndpointOption): string => 
   ) {
     if (chatGptLabel) {
       return chatGptLabel;
+    } else if (modelLabel) {
+      return modelLabel;
     } else if (model && /\bo1\b/i.test(model)) {
       return 'o1';
     } else if (model && model.includes('gpt-3')) {
@@ -257,11 +262,11 @@ export const getResponseSender = (endpointOption: t.TEndpointOption): string => 
   }
 
   if (endpoint === EModelEndpoint.anthropic) {
-    return modelLabel ?? 'Claude';
+    return modelLabel || 'Claude';
   }
 
   if (endpoint === EModelEndpoint.bedrock) {
-    return modelLabel ?? alternateName[endpoint];
+    return modelLabel || alternateName[endpoint];
   }
 
   if (endpoint === EModelEndpoint.google) {

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -1018,6 +1018,7 @@ export const compactChatGPTSchema = tConversationSchema
 export const compactPluginsSchema = tConversationSchema
   .pick({
     model: true,
+    modelLabel: true,
     chatGptLabel: true,
     promptPrefix: true,
     temperature: true,
@@ -1033,6 +1034,9 @@ export const compactPluginsSchema = tConversationSchema
   })
   .transform((obj) => {
     const newObj: Partial<TConversation> = { ...obj };
+    if (newObj.modelLabel === null) {
+      delete newObj.modelLabel;
+    }
     if (newObj.chatGptLabel === null) {
       delete newObj.chatGptLabel;
     }


### PR DESCRIPTION
## Summary

Closes https://github.com/danny-avila/LibreChat/issues/4223

- Modified `OpenAIClient.js` to use `modelLabel` as a fallback for `chatGptLabel`, ensuring a consistent label is always available.
- Updated `buildOptions.js` in the gptPlugins service to include `modelLabel` in the endpoint options, allowing for more accurate model identification.
- Refactored the `getResponseSender` function in `parsers.ts` to prioritize `modelLabel` when determining the response sender, improving the accuracy of sender identification.
- Enhanced the `compactPluginsSchema` in `schemas.ts` to include the `modelLabel` field and added logic to remove it when null, maintaining data consistency.

## Testing

To test these changes:

1. Verify that the OpenAI client correctly uses the `modelLabel` as a fallback for `chatGptLabel`.
2. Test the gptPlugins endpoint to ensure it properly includes the `modelLabel` in its options.
3. Check various scenarios in the frontend to confirm that the correct model label is displayed for different endpoints and models.
4. Ensure that the schema changes do not introduce any unexpected behavior when handling plugin-related data.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have tested my changes to ensure they work as expected