### PR TITLE
🛠️ fix: Remove `expiresAt` field when setting expiry to "never" (#4293)

### DIFF
--- a/api/server/services/UserService.js
+++ b/api/server/services/UserService.js
@@ -103,10 +103,10 @@ const getUserKeyExpiry = async ({ userId, name }) => {
  * @param {string} params.userId - The unique identifier for the user.
  * @param {string} params.name - The name associated with the key.
  * @param {string} params.value - The value to be encrypted and stored as the key's value.
- * @param {Date} params.expiresAt - The expiry date for the key.
+ * @param {Date} params.expiresAt - The expiry date for the key [optional]
  * @returns {Promise<Object>} The updated or newly inserted key document.
  * @description This function either updates an existing user key or inserts a new one into the database,
- *              after encrypting the provided value. It sets the provided expiry date for the key.
+ *              after encrypting the provided value. It sets the provided expiry date for the key (or unsets for no expiry).
  */
 const updateUserKey = async ({ userId, name, value, expiresAt = null }) => {
   const encryptedValue = await encrypt(value);
@@ -115,13 +115,15 @@ const updateUserKey = async ({ userId, name, value, expiresAt = null }) => {
     name,
     value: encryptedValue,
   };
-
-  // Only add expiresAt to the update object if it's not null
+  const updateQuery = { $set: updateObject };
+  // add expiresAt to the update object if it's not null
   if (expiresAt) {
     updateObject.expiresAt = new Date(expiresAt);
+  } else {
+    // make sure to remove if already present
+    updateQuery.$unset = { expiresAt };
   }
-
-  return await Key.findOneAndUpdate({ userId, name }, updateObject, {
+  return await Key.findOneAndUpdate({ userId, name }, updateQuery, {
     upsert: true,
     new: true,
   }).lean();


### PR DESCRIPTION
## Summary

Make sure to update user provided key in MongoDb correctly - remove existing expiresAt field if we set new expiry to "never"

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested locally, verified in MongoDb that key gets updated correctly

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes do not introduce new warnings
