### PR TITLE
Tooltip to inform of reason for disabled action (continued)

### DIFF
--- a/client/src/components/SidePanel/Builder/AssistantPanel.tsx
+++ b/client/src/components/SidePanel/Builder/AssistantPanel.tsx
@@ -426,18 +426,12 @@ export default function AssistantPanel({
                     className="relative w-full"
                     showOnHover={!assistant_id}
                     tabIndex={0}
+                    accessibleWhenDisabled
                   >
                     <button
                       type="button"
                       disabled={!assistant_id}
-                      // TODO: Only if Button is enabled can onClick be called
                       onClick={() => {
-                        if (!assistant_id) {
-                          return showToast({
-                            message: localize('com_assistants_actions_disabled'),
-                            status: 'warning',
-                          });
-                        }
                         setActivePanel(Panel.actions);
                       }}
                       className="btn btn-neutral border-token-border-light relative h-8 w-full rounded-lg font-medium"

--- a/client/src/components/SidePanel/Builder/AssistantPanel.tsx
+++ b/client/src/components/SidePanel/Builder/AssistantPanel.tsx
@@ -28,6 +28,7 @@ import { Spinner } from '~/components/svg';
 import Knowledge from './Knowledge';
 import { Panel } from '~/common';
 import Action from './Action';
+import { TooltipAnchor } from '~/components/ui/Tooltip';
 
 const labelClass = 'mb-2 text-token-text-primary block font-medium';
 const inputClass = cn(
@@ -420,24 +421,32 @@ export default function AssistantPanel({
                   </button>
                 )}
                 {actionsEnabled === true && (
-                  <button
-                    type="button"
-                    disabled={!assistant_id}
-                    onClick={() => {
-                      if (!assistant_id) {
-                        return showToast({
-                          message: localize('com_assistants_actions_disabled'),
-                          status: 'warning',
-                        });
-                      }
-                      setActivePanel(Panel.actions);
-                    }}
-                    className="btn btn-neutral border-token-border-light relative h-8 w-full rounded-lg font-medium"
+                  <TooltipAnchor
+                    description={localize('com_assistants_actions_disabled')}
+                    className="relative w-full"
+                    showOnHover={!assistant_id}
+                    tabIndex={0}
                   >
-                    <div className="flex w-full items-center justify-center gap-2">
-                      {localize('com_assistants_add_actions')}
-                    </div>
-                  </button>
+                    <button
+                      type="button"
+                      disabled={!assistant_id}
+                      // TODO: Only if Button is enabled can onClick be called
+                      onClick={() => {
+                        if (!assistant_id) {
+                          return showToast({
+                            message: localize('com_assistants_actions_disabled'),
+                            status: 'warning',
+                          });
+                        }
+                        setActivePanel(Panel.actions);
+                      }}
+                      className="btn btn-neutral border-token-border-light relative h-8 w-full rounded-lg font-medium"
+                    >
+                      <div className="flex w-full items-center justify-center gap-2">
+                        {localize('com_assistants_add_actions')}
+                      </div>
+                    </button>
+                  </TooltipAnchor>
                 )}
               </div>
             </div>


### PR DESCRIPTION
Continuation of #3239 
## Summary
when creating an action for an assistant the button is sometimes disabled if the assistant has not yet been created therefore without an explanation of why it's disabled this PR informs the user of why the button is disabled.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing
you click on assistance and then you go to assistant builder where you will see that for an assistant that is already created the action button is activated but if you try and create a new action the action button defaults to disabled that is when the tooltip shows why it is disabled.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

@danny-avila 