### PR TITLE
🔨 fix(ToolCall): Check output string type before performing `.toLowerCase()`

### DIFF
--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -33,7 +33,8 @@ export default function ToolCall({
 
   const [function_name, _domain] = name.split(actionDelimiter) as [string, string | undefined];
   const domain = _domain?.replaceAll(actionDomainSeparator, '.') ?? null;
-  const error = output?.toLowerCase()?.includes('error processing tool');
+  const error =
+    typeof output === 'string' && output.toLowerCase().includes('error processing tool');
 
   const args = useMemo(() => {
     if (typeof _args === 'string') {


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Fixes issue #4303: This PR adds a type check for `output` before calling `.toLowerCase()` to ensure it is a string. This prevents potential runtime errors when `output` is `undefined` or not a string.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Create an assistant action, and let the assistant call it. It used to throw errors and break the UI, now it works perfectly.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
