### PR TITLE
🧠  feat: Implement O1 Model Support for Max Tokens Handling

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -68,6 +68,8 @@ class OpenAIClient extends BaseClient {
 
     /** @type {OpenAIUsageMetadata | undefined} */
     this.usage;
+    /** @type {boolean|undefined} */
+    this.isO1Model;
   }
 
   // TODO: PluginsClient calls this 3x, unneeded
@@ -97,6 +99,8 @@ class OpenAIClient extends BaseClient {
       this.modelOptions,
       this.options.modelOptions,
     );
+
+    this.isO1Model = /\bo1\b/i.test(this.modelOptions.model);
 
     this.defaultVisionModel = this.options.visionModel ?? 'gpt-4-vision-preview';
     if (typeof this.options.attachments?.then === 'function') {
@@ -545,8 +549,7 @@ class OpenAIClient extends BaseClient {
       promptPrefix = this.augmentedPrompt + promptPrefix;
     }
 
-    const isO1Model = /\bo1\b/i.test(this.modelOptions.model);
-    if (promptPrefix && !isO1Model) {
+    if (promptPrefix && this.isO1Model !== true) {
       promptPrefix = `Instructions:\n${promptPrefix.trim()}`;
       instructions = {
         role: 'system',
@@ -575,7 +578,7 @@ class OpenAIClient extends BaseClient {
     };
 
     /** EXPERIMENTAL */
-    if (promptPrefix && isO1Model) {
+    if (promptPrefix && this.isO1Model === true) {
       const lastUserMessageIndex = payload.findLastIndex((message) => message.role === 'user');
       if (lastUserMessageIndex !== -1) {
         payload[
@@ -1225,6 +1228,11 @@ ${convo}
 
         opts.defaultQuery = { 'api-version': this.azure.azureOpenAIApiVersion };
         opts.defaultHeaders = { ...opts.defaultHeaders, 'api-key': this.apiKey };
+      }
+
+      if (this.isO1Model === true && modelOptions.max_tokens != null) {
+        modelOptions.max_completion_tokens = modelOptions.max_tokens;
+        delete modelOptions.max_tokens;
       }
 
       if (process.env.OPENAI_ORGANIZATION) {


### PR DESCRIPTION
## Summary

- Added an `isO1Model` property to the OpenAIClient class to identify O1 models, instead of relying on one-off check.
- Implemented a check to convert `max_tokens` to `max_completion_tokens` for O1 models.
- Refactored the code to use the `isO1Model` property for conditional logic instead of repeated regex checks.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

To test these changes:

1. Set up a conversation using an O1 model (e.g., gpt-3.5-turbo-0613).
2. Verify that the prompt handling works correctly for O1 models.
3. Check that `max_tokens` is correctly converted to `max_completion_tokens` for O1 models.
4. Ensure that non-O1 models still function as expected.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have tested my changes with both O1 and non-O1 models