### PR TITLE
🔨 fix(AzureOpenAI): o1 model, `stream` parameter check

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1309,7 +1309,7 @@ ${convo}
       /** @type {(value: void | PromiseLike<void>) => void} */
       let streamResolve;
 
-      if (modelOptions.stream && /\bo1\b/i.test(modelOptions.model)) {
+      if (modelOptions.stream && this.isO1Model) {
         delete modelOptions.stream;
         delete modelOptions.stop;
       }


### PR DESCRIPTION
## Summary

This PR fixes an issue where the `modelOptions.model` param for o1 models  using Azure OpenAI client was being deleted before the stream compatibility check. As a result, the `stream` parameter was not properly validated for these models, leading to errors. The fix ensures that the model check for o1 models of azure clients is checked before deletion to resolve the unsupported parameter issue.

Closes #4379

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Performed `docker build` with this change and tested it manually to ensure the o1 models using Azure OpenAI clients now pass validation properly.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code