### PR TITLE
🪙 feat: Update token value for gpt-4o

### DIFF
--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -40,9 +40,9 @@ const tokenValues = Object.assign(
     'o1-preview': { prompt: 15, completion: 60 },
     'o1-mini': { prompt: 3, completion: 12 },
     o1: { prompt: 15, completion: 60 },
-    'gpt-4o-2024-08-06': { prompt: 2.5, completion: 10 },
     'gpt-4o-mini': { prompt: 0.15, completion: 0.6 },
-    'gpt-4o': { prompt: 5, completion: 15 },
+    'gpt-4o': { prompt: 2.5, completion: 10 },
+    'gpt-4o-2024-05-13': { prompt: 5, completion: 15 },
     'gpt-4-1106': { prompt: 10, completion: 30 },
     'gpt-3.5-turbo-0125': { prompt: 0.5, completion: 1.5 },
     'claude-3-opus': { prompt: 15, completion: 75 },
@@ -104,8 +104,8 @@ const getValueKey = (model, endpoint) => {
     return 'o1-mini';
   } else if (modelName.includes('o1')) {
     return 'o1';
-  } else if (modelName.includes('gpt-4o-2024-08-06')) {
-    return 'gpt-4o-2024-08-06';
+  } else if (modelName.includes('gpt-4o-2024-05-13')) {
+    return 'gpt-4o-2024-05-13';
   } else if (modelName.includes('gpt-4o-mini')) {
     return 'gpt-4o-mini';
   } else if (modelName.includes('gpt-4o')) {

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -50,8 +50,10 @@ describe('getValueKey', () => {
   });
 
   it('should return "gpt-4o" for model type of "gpt-4o"', () => {
-    expect(getValueKey('gpt-4o-2024-05-13')).toBe('gpt-4o');
+    expect(getValueKey('gpt-4o-2024-08-06')).toBe('gpt-4o');
+    expect(getValueKey('gpt-4o-2024-08-06-0718')).toBe('gpt-4o');
     expect(getValueKey('openai/gpt-4o')).toBe('gpt-4o');
+    expect(getValueKey('openai/gpt-4o-2024-08-06')).toBe('gpt-4o');
     expect(getValueKey('gpt-4o-turbo')).toBe('gpt-4o');
     expect(getValueKey('gpt-4o-0125')).toBe('gpt-4o');
   });
@@ -60,14 +62,14 @@ describe('getValueKey', () => {
     expect(getValueKey('gpt-4o-mini-2024-07-18')).toBe('gpt-4o-mini');
     expect(getValueKey('openai/gpt-4o-mini')).toBe('gpt-4o-mini');
     expect(getValueKey('gpt-4o-mini-0718')).toBe('gpt-4o-mini');
-    expect(getValueKey('gpt-4o-2024-08-06-0718')).not.toBe('gpt-4o');
+    expect(getValueKey('gpt-4o-2024-08-06-0718')).not.toBe('gpt-4o-mini');
   });
 
-  it('should return "gpt-4o-2024-08-06" for model type of "gpt-4o-2024-08-06"', () => {
-    expect(getValueKey('gpt-4o-2024-08-06-2024-07-18')).toBe('gpt-4o-2024-08-06');
-    expect(getValueKey('openai/gpt-4o-2024-08-06')).toBe('gpt-4o-2024-08-06');
-    expect(getValueKey('gpt-4o-2024-08-06-0718')).toBe('gpt-4o-2024-08-06');
-    expect(getValueKey('gpt-4o-2024-08-06-0718')).not.toBe('gpt-4o');
+  it('should return "gpt-4o-2024-05-13" for model type of "gpt-4o-2024-05-13"', () => {
+    expect(getValueKey('gpt-4o-2024-05-13')).toBe('gpt-4o-2024-05-13');
+    expect(getValueKey('openai/gpt-4o-2024-05-13')).toBe('gpt-4o-2024-05-13');
+    expect(getValueKey('gpt-4o-2024-05-13-0718')).toBe('gpt-4o-2024-05-13');
+    expect(getValueKey('gpt-4o-2024-05-13-0718')).not.toBe('gpt-4o');
   });
 
   it('should return "gpt-4o" for model type of "chatgpt-4o"', () => {
@@ -134,7 +136,7 @@ describe('getMultiplier', () => {
   });
 
   it('should return the correct multiplier for gpt-4o', () => {
-    const valueKey = getValueKey('gpt-4o-2024-05-13');
+    const valueKey = getValueKey('gpt-4o-2024-08-06');
     expect(getMultiplier({ valueKey, tokenType: 'prompt' })).toBe(tokenValues['gpt-4o'].prompt);
     expect(getMultiplier({ valueKey, tokenType: 'completion' })).toBe(
       tokenValues['gpt-4o'].completion,

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -14,6 +14,7 @@ const openAIModels = {
   'gpt-4-0125': 127500, // -500 from max
   'gpt-4o': 127500, // -500 from max
   'gpt-4o-mini': 127500, // -500 from max
+  'gpt-4o-2024-05-13': 127500, // -500 from max
   'gpt-4o-2024-08-06': 127500, // -500 from max
   'gpt-4-turbo': 127500, // -500 from max
   'gpt-4-vision': 127500, // -500 from max


### PR DESCRIPTION
## Summary

Link to the issue: #4386 

This PR updates the token calculations for the `gpt-4o` model to use the `gpt-4o-2024-08-06` model's pricing. This change is necessary because `gpt-4o` now points to the `gpt-4o-2024-08-06` model since October 3rd, 2024, as per the official OpenAI announcement and API documentation.

The main changes include:
1. Updating the token values for `gpt-4o` to $2.50/1m prompt tokens and $10/1m completion tokens.
2. Adding a new entry for the legacy model `gpt-4o-2024-05-13` with $5/1m prompt tokens and $15/1m completion tokens.
3. Adjusting the `getValueKey` function to correctly identify and price these models.
4. Updating relevant test cases to reflect these changes.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Backend unit tests are passed:
`npm run test:api`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes