### PR TITLE
🤖 feat: Enhance Assistant Model Handling for Model Specs

### DIFF
--- a/client/src/components/Chat/Menus/Models/ModelSpecsMenu.tsx
+++ b/client/src/components/Chat/Menus/Models/ModelSpecsMenu.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
-import { EModelEndpoint } from 'librechat-data-provider';
 import { Content, Portal, Root } from '@radix-ui/react-popover';
 import { useGetEndpointsQuery } from 'librechat-data-provider/react-query';
+import { EModelEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
 import type { TModelSpec, TConversation, TEndpointsConfig } from 'librechat-data-provider';
+import { useChatContext, useAssistantsMapContext } from '~/Providers';
 import { getConvoSwitchLogic, getModelSpecIconURL } from '~/utils';
 import { useDefaultConvo, useNewConvo } from '~/hooks';
-import { useChatContext } from '~/Providers';
 import MenuButton from './MenuButton';
 import ModelSpecs from './ModelSpecs';
 import store from '~/store';
@@ -18,6 +18,7 @@ export default function ModelSpecsMenu({ modelSpecs }: { modelSpecs?: TModelSpec
   const { data: endpointsConfig = {} as TEndpointsConfig } = useGetEndpointsQuery();
   const modularChat = useRecoilValue(store.modularChat);
   const getDefaultConversation = useDefaultConvo();
+  const assistantMap = useAssistantsMapContext();
 
   const onSelectSpec = (spec: TModelSpec) => {
     const { preset } = spec;
@@ -45,6 +46,10 @@ export default function ModelSpecsMenu({ modelSpecs }: { modelSpecs?: TModelSpec
 
     if (newEndpointType) {
       preset.endpointType = newEndpointType;
+    }
+
+    if (isAssistantsEndpoint(newEndpoint) && preset.assistant_id != null && !(preset.model ?? '')) {
+      preset.model = assistantMap?.[newEndpoint]?.[preset.assistant_id]?.model;
     }
 
     const isModular = isCurrentModular && isNewModular && shouldSwitch;

--- a/client/src/hooks/Input/useSelectMention.ts
+++ b/client/src/hooks/Input/useSelectMention.ts
@@ -64,6 +64,10 @@ export default function useSelectMention({
         preset.endpointType = newEndpointType;
       }
 
+      if (isAssistantsEndpoint(newEndpoint) && preset.assistant_id != null && !(preset.model ?? '')) {
+        preset.model = assistantMap?.[newEndpoint]?.[preset.assistant_id]?.model;
+      }
+
       const isModular = isCurrentModular && isNewModular && shouldSwitch;
       if (isExistingConversation && isModular) {
         template.endpointType = newEndpointType as EModelEndpoint | undefined;
@@ -90,7 +94,7 @@ export default function useSelectMention({
         keepAddedConvos: isModular,
       });
     },
-    [conversation, getDefaultConversation, modularChat, newConversation, endpointsConfig],
+    [conversation, getDefaultConversation, modularChat, newConversation, endpointsConfig, assistantMap],
   );
 
   type Kwargs = {

--- a/client/src/hooks/useNewConvo.ts
+++ b/client/src/hooks/useNewConvo.ts
@@ -6,6 +6,7 @@ import {
 } from 'librechat-data-provider/react-query';
 import { useNavigate } from 'react-router-dom';
 import {
+  Constants,
   FileSources,
   isParamEndpoint,
   LocalStorageKeys,
@@ -116,7 +117,7 @@ const useNewConvo = (index = 0) => {
               ) ?? assistants[0]?.id;
           }
 
-          if (currentAssistantId && isAssistantEndpoint && conversation.conversationId === 'new') {
+          if (currentAssistantId && isAssistantEndpoint && conversation.conversationId === Constants.NEW_CONVO) {
             const assistant = assistants.find((asst) => asst.id === currentAssistantId);
             conversation.model = assistant?.model;
             updateLastSelectedModel({
@@ -147,12 +148,12 @@ const useNewConvo = (index = 0) => {
           clearAllLatestMessages();
         }
 
-        if (conversation.conversationId === 'new' && !modelsData) {
+        if (conversation.conversationId === Constants.NEW_CONVO && !modelsData) {
           const appTitle = localStorage.getItem(LocalStorageKeys.APP_TITLE) ?? '';
           if (appTitle) {
             document.title = appTitle;
           }
-          navigate('/c/new');
+          navigate(`/c/${Constants.NEW_CONVO}`);
         }
 
         clearTimeout(timeoutIdRef.current);
@@ -189,12 +190,12 @@ const useNewConvo = (index = 0) => {
         isParamEndpoint(_template.endpoint ?? '', _template.endpointType ?? '') === true ||
         isParamEndpoint(_preset?.endpoint ?? '', _preset?.endpointType ?? '');
       const template =
-        paramEndpoint === true && templateConvoId && templateConvoId === 'new'
+        paramEndpoint === true && templateConvoId && templateConvoId === Constants.NEW_CONVO
           ? { endpoint: _template.endpoint }
           : _template;
 
       const conversation = {
-        conversationId: 'new',
+        conversationId: Constants.NEW_CONVO as string,
         title: 'New Chat',
         endpoint: null,
         ...template,

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -87,22 +87,23 @@ const firstLocalConvoKey = LocalStorageKeys.LAST_CONVO_SETUP + '_0';
  * update without updating last convo setup when same endpoint */
 export function updateLastSelectedModel({
   endpoint,
-  model,
+  model = '',
 }: {
   endpoint: string;
-  model: string | undefined;
+  model?: string;
 }) {
   if (!model) {
     return;
   }
-  const lastConversationSetup = JSON.parse(localStorage.getItem(firstLocalConvoKey) || '{}');
+  /* Note: an empty string value is possible */
+  const lastConversationSetup = JSON.parse((localStorage.getItem(firstLocalConvoKey) ?? '{}') || '{}');
 
   if (lastConversationSetup.endpoint === endpoint) {
     lastConversationSetup.model = model;
     localStorage.setItem(firstLocalConvoKey, JSON.stringify(lastConversationSetup));
   }
 
-  const lastSelectedModels = JSON.parse(localStorage.getItem(LocalStorageKeys.LAST_MODEL) || '{}');
+  const lastSelectedModels = JSON.parse((localStorage.getItem(LocalStorageKeys.LAST_MODEL) ?? '{}') || '{}');
   lastSelectedModels[endpoint] = model;
   localStorage.setItem(LocalStorageKeys.LAST_MODEL, JSON.stringify(lastSelectedModels));
 }


### PR DESCRIPTION
## Summary

- Added logic in ModelSpecsMenu and useSelectMention to set the model for assistants when an assistant_id is present but no model is specified by the model spec.
- Updated useNewConvo hook to use the Constants.NEW_CONVO instead of hardcoded 'new' string for better maintainability.
- Modified updateLastSelectedModel function in endpoints.ts to handle empty string values and improve JSON parsing robustness.