### PR TITLE
🕒 feat: Add 5-second timeout for Fetching Model Lists

### DIFF
--- a/api/app/clients/OllamaClient.js
+++ b/api/app/clients/OllamaClient.js
@@ -60,7 +60,9 @@ class OllamaClient {
     try {
       const ollamaEndpoint = deriveBaseURL(baseURL);
       /** @type {Promise<AxiosResponse<OllamaListResponse>>} */
-      const response = await axios.get(`${ollamaEndpoint}/api/tags`);
+      const response = await axios.get(`${ollamaEndpoint}/api/tags`, {
+        timeout: 5000,
+      });
       models = response.data.models.map((tag) => tag.name);
       return models;
     } catch (error) {

--- a/api/server/services/ModelService.js
+++ b/api/server/services/ModelService.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const { EModelEndpoint, defaultModels, CacheKeys } = require('librechat-data-provider');
-const { extractBaseURL, inputSchema, processModelData, logAxiosError } = require('~/utils');
+const { inputSchema, logAxiosError, extractBaseURL, processModelData } = require('~/utils');
 const { OllamaClient } = require('~/app/clients/OllamaClient');
 const getLogStores = require('~/cache/getLogStores');
 
@@ -66,6 +66,7 @@ const fetchModels = async ({
       headers: {
         Authorization: `Bearer ${apiKey}`,
       },
+      timeout: 5000,
     };
 
     if (process.env.PROXY) {
@@ -149,6 +150,7 @@ const fetchOpenAIModels = async (opts, _models = []) => {
       baseURL,
       azure: opts.azure,
       user: opts.user,
+      name: baseURL,
     });
   }
 
@@ -175,7 +177,8 @@ const fetchOpenAIModels = async (opts, _models = []) => {
  * @param {object} opts - The options for fetching the models.
  * @param {string} opts.user - The user ID to send to the API.
  * @param {boolean} [opts.azure=false] - Whether to fetch models from Azure.
- * @param {boolean} [opts.plugins=false] - Whether to fetch models from the plugins.
+ * @param {boolean} [opts.plugins=false] - Whether to fetch models for the plugins endpoint.
+ * @param {boolean} [opts.assistants=false] - Whether to fetch models for the Assistants endpoint.
  */
 const getOpenAIModels = async (opts) => {
   let models = defaultModels[EModelEndpoint.openAI];

--- a/api/server/services/ModelService.spec.js
+++ b/api/server/services/ModelService.spec.js
@@ -291,7 +291,9 @@ describe('fetchModels with Ollama specific logic', () => {
     });
 
     expect(models).toEqual(['Ollama-Base', 'Ollama-Advanced']);
-    expect(axios.get).toHaveBeenCalledWith('https://api.ollama.test.com/api/tags'); // Adjusted to expect only one argument if no options are passed
+    expect(axios.get).toHaveBeenCalledWith('https://api.ollama.test.com/api/tags', {
+      timeout: 5000,
+    });
   });
 
   it('should handle errors gracefully when fetching Ollama models fails', async () => {

--- a/api/utils/axios.js
+++ b/api/utils/axios.js
@@ -42,4 +42,4 @@ const logAxiosError = ({ message, error }) => {
   }
 };
 
-module.exports = logAxiosError;
+module.exports = { logAxiosError };

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -1,17 +1,17 @@
 const loadYaml = require('./loadYaml');
+const axiosHelpers = require('./axios');
 const tokenHelpers = require('./tokens');
 const azureUtils = require('./azureUtils');
 const deriveBaseURL = require('./deriveBaseURL');
-const logAxiosError = require('./logAxiosError');
 const extractBaseURL = require('./extractBaseURL');
 const findMessageContent = require('./findMessageContent');
 
 module.exports = {
   loadYaml,
-  ...tokenHelpers,
-  ...azureUtils,
   deriveBaseURL,
-  logAxiosError,
   extractBaseURL,
+  ...azureUtils,
+  ...axiosHelpers,
+  ...tokenHelpers,
   findMessageContent,
 };


### PR DESCRIPTION
## Summary

I implemented a 5-second timeout for fetching AI provider model lists to improve reliability and performance. This change affects the OllamaClient and ModelService, preventing model fetching operations from hanging indefinitely.

The UI currently waits for all model fetching to finish before loading the main chat, and improved UX should be considered for this as it currently only shows a blank screen.

- Added a 5-second timeout to the Axios GET request in OllamaClient when fetching model tags.
- Implemented a 5-second timeout for the fetchModels function in ModelService.

## Other Changes

- Refactored the logAxiosError utility into a new axios.js file, exporting it as part of an axiosHelpers object.
- Updated import statements and module exports to reflect the new file structure.
- Adjusted the fetchOpenAIModels function to use `baseURL` as the 'name' property for `fetchModels`, to better identify which endpoint is being fetched from.
- Made minor adjustments to comments and type definitions for clarity.

## Testing

To test these changes:

1. Ensure that all AI provider endpoints (OpenAI, Ollama, etc.) are properly configured.
2. Attempt to fetch model lists from various providers.
3. Verify that requests timeout after 5 seconds if no response is received.
4. Check that error handling correctly captures and logs timeout errors.

### **Test Configuration**:
- Ensure you have a stable internet connection.
- Configure multiple AI providers in your environment.
- If possible, simulate slow network conditions to trigger the timeout.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have tested the timeout functionality with various providers