### PR TITLE
🪙 feat: automatically add start balance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -350,6 +350,7 @@ ILLEGAL_MODEL_REQ_SCORE=5
 #========================#
 
 CHECK_BALANCE=false
+# START_BALANCE=20000 # note: the number of tokens that will be credited after registration.
 
 #========================#
 # Registration and Login #

--- a/api/models/userMethods.js
+++ b/api/models/userMethods.js
@@ -1,8 +1,8 @@
 const bcrypt = require('bcryptjs');
 const signPayload = require('~/server/services/signPayload');
 const { isEnabled } = require('~/server/utils/handleText');
-const User = require('./User');
 const Balance = require('./Balance');
+const User = require('./User');
 
 /**
  * Retrieve a user by ID and convert the found user document to a plain object.


### PR DESCRIPTION
## Summary

This pull request introduces a new feature for automatic assignment of an initial balance upon user registration. This functionality addresses the related issue [#2687](https://github.com/danny-avila/LibreChat/issues/2687). 

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

To test the new feature, you need to add the following variables to your `.env` file:
```
CHECK_BALANCE=true
START_BALANCE=20000
```
Where `START_BALANCE` represents the number of tokens that will be automatically assigned to the user upon registration. After a new user is registered, they will automatically receive 20,000 tokens.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.

