### PR TITLE
WIP: Local Upload Documents as Input for Models instead of using RAG incas…

### DIFF
--- a/api/config/paths.js
+++ b/api/config/paths.js
@@ -9,6 +9,7 @@ module.exports = {
   fonts: path.resolve(__dirname, '..', '..', 'client', 'public', 'fonts'),
   assets: path.resolve(__dirname, '..', '..', 'client', 'public', 'assets'),
   imageOutput: path.resolve(__dirname, '..', '..', 'client', 'public', 'images'),
+  filesOutput: path.resolve(__dirname, '..', '..', 'client', 'public', 'files'),
   structuredTools: path.resolve(__dirname, '..', 'app', 'clients', 'tools', 'structured'),
   pluginManifest: path.resolve(__dirname, '..', 'app', 'clients', 'tools', 'manifest.json'),
 };

--- a/api/server/services/Files/Local/crud.js
+++ b/api/server/services/Files/Local/crud.js
@@ -234,24 +234,22 @@ const deleteLocalFile = async (req, file) => {
  *            - filepath: The path where the file is saved.
  *            - bytes: The size of the file in bytes.
  */
-async function uploadLocalFile({ req, file, file_id }) {
+async function uploadLocalFile({ req, file, file_id , upload_directory = req.app.locals.paths.uploads }) {
   const inputFilePath = file.path;
   const inputBuffer = await fs.promises.readFile(inputFilePath);
   const bytes = Buffer.byteLength(inputBuffer);
 
-  const { uploads } = req.app.locals.paths;
-  const userPath = path.join(uploads, req.user.id);
+  const userPath = path.join(upload_directory, req.user.id);
 
   if (!fs.existsSync(userPath)) {
     fs.mkdirSync(userPath, { recursive: true });
   }
-
   const fileName = `${file_id}__${path.basename(inputFilePath)}`;
+
   const newPath = path.join(userPath, fileName);
-
   await fs.promises.writeFile(newPath, inputBuffer);
-  const filepath = path.posix.join('/', 'uploads', req.user.id, path.basename(newPath));
 
+  const filepath = path.posix.join('/', path.basename(upload_directory), req.user.id, path.basename(newPath));
   return { filepath, bytes };
 }
 

--- a/api/server/services/Files/Local/files.js
+++ b/api/server/services/Files/Local/files.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+const path = require('path');
+const { updateFile } = require('~/models/File');
+
+/**
+ * Encodes a file to base64.
+ * @param {string} filePath - The path to the image file.
+ * @returns {Promise<string>} A promise that resolves with the base64 encoded image data.
+ */
+function encodeFile(filePath) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(data.toString('base64'));
+      }
+    });
+  });
+}
+
+/**
+ * Local: Updates the file and encodes the file to base64,
+ * for file payload handling: tuple order of [filepath, base64].
+ * @param {Object} req - The request object.
+ * @param {MongoFile} file - The file object.
+ * @param {Object} outputPaths - The output paths for public and the file(or image) object.
+ * @returns {Promise<[MongoFile, string]>} - A promise that resolves to an array of results from updateFile and encodeFile.
+ */
+async function prepareFileLocal(req, file, outputPaths) {
+  const { publicPath, fileOutput } = outputPaths;
+  const userPath = path.join(fileOutput, req.user.id);
+
+  if (!fs.existsSync(userPath)) {
+    fs.mkdirSync(userPath, { recursive: true });
+  }
+  const filepath = path.join(publicPath, file.filepath);
+
+  const promises = [];
+  promises.push(updateFile({ file_id: file.file_id }));
+
+  promises.push(encodeFile(filepath));
+  return await Promise.all(promises);
+}
+
+module.exports = { encodeFile, prepareFileLocal };

--- a/api/server/services/Files/Local/images.js
+++ b/api/server/services/Files/Local/images.js
@@ -3,7 +3,6 @@ const path = require('path');
 const sharp = require('sharp');
 const { resizeImageBuffer } = require('../images/resize');
 const { updateUser } = require('~/models/userMethods');
-const { updateFile } = require('~/models/File');
 
 /**
  * Converts an image file to the target format. The function first resizes the image based on the specified
@@ -67,45 +66,6 @@ async function uploadLocalImage({ req, file, file_id, endpoint, resolution = 'hi
 }
 
 /**
- * Encodes an image file to base64.
- * @param {string} imagePath - The path to the image file.
- * @returns {Promise<string>} A promise that resolves with the base64 encoded image data.
- */
-function encodeImage(imagePath) {
-  return new Promise((resolve, reject) => {
-    fs.readFile(imagePath, (err, data) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(data.toString('base64'));
-      }
-    });
-  });
-}
-
-/**
- * Local: Updates the file and encodes the image to base64,
- * for image payload handling: tuple order of [filepath, base64].
- * @param {Object} req - The request object.
- * @param {MongoFile} file - The file object.
- * @returns {Promise<[MongoFile, string]>} - A promise that resolves to an array of results from updateFile and encodeImage.
- */
-async function prepareImagesLocal(req, file) {
-  const { publicPath, imageOutput } = req.app.locals.paths;
-  const userPath = path.join(imageOutput, req.user.id);
-
-  if (!fs.existsSync(userPath)) {
-    fs.mkdirSync(userPath, { recursive: true });
-  }
-  const filepath = path.join(publicPath, file.filepath);
-
-  const promises = [];
-  promises.push(updateFile({ file_id: file.file_id }));
-  promises.push(encodeImage(filepath));
-  return await Promise.all(promises);
-}
-
-/**
  * Uploads a user's avatar to local server storage and returns the URL.
  * If the 'manual' flag is set to 'true', it also updates the user's avatar URL in the database.
  *
@@ -147,4 +107,4 @@ async function processLocalAvatar({ buffer, userId, manual }) {
   return url;
 }
 
-module.exports = { uploadLocalImage, encodeImage, prepareImagesLocal, processLocalAvatar };
+module.exports = { uploadLocalImage, processLocalAvatar };

--- a/api/server/services/Files/Local/index.js
+++ b/api/server/services/Files/Local/index.js
@@ -1,7 +1,9 @@
 const images = require('./images');
+const files = require('./files');
 const crud = require('./crud');
 
 module.exports = {
   ...crud,
   ...images,
+  ...files,
 };

--- a/api/server/services/Files/strategies.js
+++ b/api/server/services/Files/strategies.js
@@ -15,7 +15,8 @@ const {
   saveLocalBuffer,
   deleteLocalFile,
   uploadLocalImage,
-  prepareImagesLocal,
+  uploadLocalFile,
+  prepareFileLocal,
   processLocalAvatar,
   getLocalFileStream,
 } = require('./Local');
@@ -35,7 +36,7 @@ const firebaseStrategy = () => ({
   getFileURL: getFirebaseURL,
   deleteFile: deleteFirebaseFile,
   saveBuffer: saveBufferToFirebase,
-  prepareImagePayload: prepareImageURL,
+  prepareFilePayload: prepareImageURL,
   processAvatar: processFirebaseAvatar,
   handleImageUpload: uploadImageToFirebase,
   getDownloadStream: getFirebaseFileStream,
@@ -46,15 +47,14 @@ const firebaseStrategy = () => ({
  *
  * */
 const localStrategy = () => ({
-  /** @type {typeof uploadVectors | null} */
-  handleFileUpload: null,
+  handleFileUpload: uploadLocalFile,
   saveURL: saveFileFromURL,
   getFileURL: getLocalFileURL,
   saveBuffer: saveLocalBuffer,
   deleteFile: deleteLocalFile,
   processAvatar: processLocalAvatar,
   handleImageUpload: uploadLocalImage,
-  prepareImagePayload: prepareImagesLocal,
+  prepareFilePayload: prepareFileLocal,
   getDownloadStream: getLocalFileStream,
 });
 
@@ -73,8 +73,8 @@ const vectorStrategy = () => ({
   processAvatar: null,
   /** @type {typeof uploadLocalImage | null} */
   handleImageUpload: null,
-  /** @type {typeof prepareImagesLocal | null} */
-  prepareImagePayload: null,
+  /** @type {typeof prepareFileLocal | null} */
+  prepareFilePayload: null,
   /** @type {typeof getLocalFileStream | null} */
   getDownloadStream: null,
   handleFileUpload: uploadVectors,
@@ -97,8 +97,8 @@ const openAIStrategy = () => ({
   processAvatar: null,
   /** @type {typeof uploadLocalImage | null} */
   handleImageUpload: null,
-  /** @type {typeof prepareImagesLocal | null} */
-  prepareImagePayload: null,
+  /** @type {typeof prepareFileLocal | null} */
+  prepareFilePayload: null,
   deleteFile: deleteOpenAIFile,
   handleFileUpload: uploadOpenAIFile,
   getDownloadStream: getOpenAIFileStream,
@@ -120,8 +120,8 @@ const codeOutputStrategy = () => ({
   processAvatar: null,
   /** @type {typeof uploadLocalImage | null} */
   handleImageUpload: null,
-  /** @type {typeof prepareImagesLocal | null} */
-  prepareImagePayload: null,
+  /** @type {typeof prepareFileLocal | null} */
+  prepareFilePayload: null,
   /** @type {typeof deleteLocalFile | null} */
   deleteFile: null,
   /** @type {typeof uploadVectors | null} */


### PR DESCRIPTION
## Summary

Related Issue: This is the PR for https://github.com/danny-avila/LibreChat/issues/4502 I made it WIP because the discussion in a feature might lead to changes

Changes in the code:
- processFileUpload is using local upload in case RAG_API_URL is not defined and it is not an assistant Upload
- enhanced strategies to be able to use non-vector upload for generic files
- refactor (image)-encode method to be used for all kind of files
- enhanced uploadLocalFile for local strategy to specify directory
- moved all relevant file operations form local strategy to file.js

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
