### PR TITLE
👓 fix: Assistants Vision Prompt Error Handling (legacy)

### DIFF
--- a/api/server/controllers/assistants/chatV1.js
+++ b/api/server/controllers/assistants/chatV1.js
@@ -375,7 +375,6 @@ const chatV1 = async (req, res) => {
 
       visionPromise = openai.chat.completions
         .create({
-          model: openai._options.model,
           messages: [visionMessage],
           max_tokens: 4000,
         })

--- a/api/server/controllers/assistants/chatV1.js
+++ b/api/server/controllers/assistants/chatV1.js
@@ -314,7 +314,9 @@ const chatV1 = async (req, res) => {
     }
 
     if (typeof endpointOption.artifactsPrompt === 'string' && endpointOption.artifactsPrompt) {
-      body.additional_instructions = `${body.additional_instructions ?? ''}\n${endpointOption.artifactsPrompt}`.trim();
+      body.additional_instructions = `${body.additional_instructions ?? ''}\n${
+        endpointOption.artifactsPrompt
+      }`.trim();
     }
 
     if (instructions) {
@@ -371,11 +373,15 @@ const chatV1 = async (req, res) => {
       visionMessage.content = createVisionPrompt(plural);
       visionMessage = formatMessage({ message: visionMessage, endpoint: EModelEndpoint.openAI });
 
-      visionPromise = openai.chat.completions.create({
-        model: 'gpt-4-vision-preview',
-        messages: [visionMessage],
-        max_tokens: 4000,
-      });
+      visionPromise = openai.chat.completions
+        .create({
+          model,
+          messages: [visionMessage],
+          max_tokens: 4000,
+        })
+        .catch((error) => {
+          logger.error('[/assistants/chat/] Error creating vision prompt', error);
+        });
 
       const pluralized = plural ? 's' : '';
       body.additional_instructions = `${

--- a/api/server/controllers/assistants/chatV1.js
+++ b/api/server/controllers/assistants/chatV1.js
@@ -375,7 +375,7 @@ const chatV1 = async (req, res) => {
 
       visionPromise = openai.chat.completions
         .create({
-          model,
+          model: openai._options.model,
           messages: [visionMessage],
           max_tokens: 4000,
         })

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -151,7 +151,7 @@ const processVisionRequest = async (client, currentAction) => {
 
   /** @type {ChatCompletion | undefined} */
   const completion = await client.visionPromise;
-  if (completion.usage) {
+  if (completion && completion.usage) {
     recordUsage({
       user: client.req.user.id,
       model: client.req.body.model,


### PR DESCRIPTION
## Summary

- Added a try-catch block to the vision prompt creation in the chatV1 controller to catch and log any errors that occur during this process.
- Updated the model parameter in the vision prompt creation to use the dynamic `model` variable instead of the hardcoded 'gpt-4-vision-preview'.
- Modified the processVisionRequest function in ToolService to check if the completion exists before accessing its usage property, preventing potential undefined errors.
- Improved code formatting for better readability, particularly in the construction of the `additional_instructions` string.

Closes #4526

Remember:
- The Load Balancer should distribute traffic evenly
- If one droplet goes down, traffic should automatically route to the others
- You can monitor the Load Balancer metrics in DO dashboard

Would you like me to suggest some specific stress testing tools or show you how to monitor specific metrics?

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have tested the error handling scenarios
- [x] Local unit tests pass with my changes