### PR TITLE
🌏 i18n: modify username min length in Ko.ts (3→2)

### DIFF
--- a/client/src/localization/languages/Ko.ts
+++ b/client/src/localization/languages/Ko.ts
@@ -122,7 +122,7 @@ export default {
   com_auth_name_max_length: '이름은 80자를 초과할 수 없습니다',
   com_auth_username: '사용자명',
   com_auth_username_required: '사용자명이 필요합니다',
-  com_auth_username_min_length: '사용자명은 최소 3자 이상이어야 합니다',
+  com_auth_username_min_length: '사용자명은 최소 2자 이상이어야 합니다',
   com_auth_username_max_length: '사용자명은 20자를 초과할 수 없습니다',
   com_auth_already_have_account: '이미 계정이 있으신가요?',
   com_auth_login: '로그인',
@@ -1055,7 +1055,7 @@ export const comparisons = {
   },
   com_auth_username_min_length: {
     english: 'Username must be at least 2 characters',
-    translated: '사용자명은 최소 3자 이상이어야 합니다',
+    translated: '사용자명은 최소 2자 이상이어야 합니다',
   },
   com_auth_username_max_length: {
     english: 'Username must be less than 20 characters',

--- a/client/src/localization/prompts/instructions/Ko.md
+++ b/client/src/localization/prompts/instructions/Ko.md
@@ -357,7 +357,7 @@ Write a prompt that is mindful of the nuances in the language with respect to it
 
 - **com_auth_username_min_length**:
   - **english**: Username must be at least 2 characters
-  - **translated**: 사용자명은 최소 3자 이상이어야 합니다
+  - **translated**: 사용자명은 최소 2자 이상이어야 합니다
 
 - **com_auth_username_max_length**:
   - **english**: Username must be less than 20 characters


### PR DESCRIPTION
## Summary
Update Korean translation in Ko.ts to fix incorrect username minimum length requirement.
The Korean translation incorrectly stated "사용자명은 최소 3자 이상이어야 합니다" (username must be at least 3 characters), while the system actually requires 2 characters minimum. 
Changed to "사용자명은 최소 2자 이상이어야 합니다" to match the actual system requirement.

## Change Type

Please delete any irrelevant options.

- [x] Translation update

## Checklist

- [x] I have made pertinent documentation changes
- [x] A pull request for updating the documentation has been submitted.
