### PR TITLE
🎚️ fix: Google `top_k` Slider Step to Integers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36522,7 +36522,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.429",
+      "version": "0.7.430",
       "license": "ISC",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.429",
+  "version": "0.7.430",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -232,7 +232,7 @@ export const googleSettings = {
   topK: {
     min: 1,
     max: 40,
-    step: 0.01,
+    step: 1,
     default: 40,
   },
 };


### PR DESCRIPTION
## Summary

I adjusted the step value for the Google topK slider from 0.01 to 1, ensuring integer-only selections for this parameter.

- Modified the `googleSettings` object in `schemas.ts`
- Changed the `step` property of the `topK` setting from 0.01 to 1
- Maintained the existing min (1), max (40), and default (40) values

Closes  #4403

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

To test this change:

1. Navigate to the Google model settings in the UI
2. Locate the topK slider
3. Verify that the slider now moves in whole number increments
4. Confirm that the minimum (1), maximum (40), and default (40) values remain unchanged

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have tested that the topK slider now only allows integer values