### PR TITLE
🔼 a11y: Proper attributes for the side panel toggle button

### DIFF
--- a/client/src/components/Nav/NavToggle.tsx
+++ b/client/src/components/Nav/NavToggle.tsx
@@ -34,7 +34,9 @@ export default function NavToggle({
     >
       <TooltipAnchor
         side={side === 'right' ? 'left' : 'right'}
-        aria-label={`toggle-${side === 'left' ? 'chat-history' : 'controls'}-nav`}
+        aria-label={side === 'left' ? localize('com_ui_chat_history') : localize('com_ui_controls')}
+        aria-expanded={navVisible}
+        aria-controls={side === 'left' ? 'chat-history-nav' : 'controls-nav'}
         id={`toggle-${side}-nav`}
         onClick={onToggle}
         role="button"


### PR DESCRIPTION
## Summary
Added aria-expanded and aria-controls attributes to the side panel toggle button for better accessibility. These attributes help assistive technologies understand the current state of the panel and what action can be taken by the user.

- `aria-expanded` now reflects the open/closed state of the panel (true/false)
- `aria-controls` specifies the controlled nav element by its ID
- updated aria-label using the localize function to provide a more descriptive and user-friendly name

Related #4487 

## Change Type

- [x] Improve accessibility

## Testing
<img width="1511" alt="스크린샷 2024-10-27 오후 3 13 42" src="https://github.com/user-attachments/assets/a7a3e20b-20bc-4db7-abf5-25c1a360f939">

<img width="1512" alt="스크린샷 2024-10-27 오후 3 14 23" src="https://github.com/user-attachments/assets/8d1869e4-4c03-4fcf-8be0-a481955bea16">

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
