### PR TITLE
🖌️ fix: ordered lists markers

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -2006,7 +2006,7 @@ button.scroll-convo {
   list-style-position: outside;
   margin-top: 1em;
   margin-bottom: 1em;
-  padding-left: 2em;
+  padding-left: 3em;
 }
 
 .prose li,
@@ -2085,12 +2085,12 @@ button.scroll-convo {
 }
 
 /* Remove extra spacing */
-.prose > ul > li > *:first-child,
+/* .prose > ul > li > *:first-child,
 .prose > ol > li > *:first-child,
 .markdown > ul > li > *:first-child,
 .markdown > ol > li > *:first-child {
   margin-top: 1.25em;
-}
+} */
 
 .prose > ul > li > *:last-child,
 .prose > ol > li > *:last-child,

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -2037,23 +2037,11 @@ button.scroll-convo {
 .prose ol ol,
 .markdown ol ol {
   list-style-type: lower-alpha;
-  counter-reset: list-counter-alpha;
-}
-
-.prose ol ol > li,
-.markdown ol ol > li {
-  counter-increment: list-counter-alpha;
 }
 
 .prose ol ol ol,
 .markdown ol ol ol {
   list-style-type: lower-roman;
-  counter-reset: list-counter-roman;
-}
-
-.prose ol ol ol > li,
-.markdown ol ol ol > li {
-  counter-increment: list-counter-roman;
 }
 
 /* Unordered lists */
@@ -2115,28 +2103,6 @@ button.scroll-convo {
 .prose li::marker,
 .markdown li::marker {
   color: currentColor;
-}
-
-/* Reset counter for new sections */
-.prose h1 + ol,
-.prose h2 + ol,
-.prose h3 + ol,
-.prose h4 + ol,
-.prose h5 + ol,
-.prose h6 + ol,
-.markdown h1 + ol,
-.markdown h2 + ol,
-.markdown h3 + ol,
-.markdown h4 + ol,
-.markdown h5 + ol,
-.markdown h6 + ol {
-  counter-reset: list-counter;
-}
-
-/* Reset counter after unordered lists */
-.prose ul + ol,
-.markdown ul + ol {
-  counter-reset: list-counter;
 }
 
 /* Keyframes */

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -2084,14 +2084,6 @@ button.scroll-convo {
   margin-bottom: 0.75em;
 }
 
-/* Remove extra spacing */
-/* .prose > ul > li > *:first-child,
-.prose > ol > li > *:first-child,
-.markdown > ul > li > *:first-child,
-.markdown > ol > li > *:first-child {
-  margin-top: 1.25em;
-} */
-
 .prose > ul > li > *:last-child,
 .prose > ol > li > *:last-child,
 .markdown > ul > li > *:last-child,

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -2006,7 +2006,7 @@ button.scroll-convo {
   list-style-position: outside;
   margin-top: 1em;
   margin-bottom: 1em;
-  padding-left: 1.625em;
+  padding-left: 2em;
 }
 
 .prose li,
@@ -2019,19 +2019,16 @@ button.scroll-convo {
 .prose ol,
 .markdown ol {
   list-style-type: decimal;
-  counter-reset: list-counter;
 }
 
 .prose ol > li,
 .markdown ol > li {
   position: relative;
   padding-left: 0.375em;
-  counter-increment: list-counter;
 }
 
 .prose ol > li::marker,
 .markdown ol > li::marker {
-  content: counter(list-counter) '. ';
   color: var(--tw-prose-counters);
   font-weight: 400;
 }
@@ -2048,11 +2045,6 @@ button.scroll-convo {
   counter-increment: list-counter-alpha;
 }
 
-.prose ol ol > li::marker,
-.markdown ol ol > li::marker {
-  content: counter(list-counter-alpha, lower-alpha) '. ';
-}
-
 .prose ol ol ol,
 .markdown ol ol ol {
   list-style-type: lower-roman;
@@ -2062,11 +2054,6 @@ button.scroll-convo {
 .prose ol ol ol > li,
 .markdown ol ol ol > li {
   counter-increment: list-counter-roman;
-}
-
-.prose ol ol ol > li::marker,
-.markdown ol ol ol > li::marker {
-  content: counter(list-counter-roman, lower-roman) '. ';
 }
 
 /* Unordered lists */


### PR DESCRIPTION
## Summary

Originally #4546

Removed `::marker` pseudo-element css `content` definitions to let browser generate appropriates list item markers.
Also gave a little more room for markers to show because of Webkit slightly different text positioning.

Closes #4120, #4472.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Open LibreChat in Safari and prompt any model to return an ordered list with more than 9 items.
Check that markers with 2 or more digits are shown correctly.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
