### PR TITLE
feat: replace special variables in instructions presets

### DIFF
--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -24,6 +24,8 @@ import { getArtifactsMode } from '~/utils/artifacts';
 import { getEndpointField, logger } from '~/utils';
 import useUserKey from '~/hooks/Input/useUserKey';
 import store from '~/store';
+import { replaceSpecialVars } from '~/utils/prompts';
+import { useAuthContext } from '~/hooks';
 
 const logChatRequest = (request: Record<string, unknown>) => {
   logger.log('=====================================\nAsk function called with:');
@@ -62,9 +64,9 @@ export default function useChatFunctions({
   const setShowStopButton = useSetRecoilState(store.showStopButtonByIndex(index));
   const setFilesToDelete = useSetFilesToDelete();
   const getSender = useGetSender();
-
   const queryClient = useQueryClient();
   const { getExpiry } = useUserKey(conversation?.endpoint ?? '');
+  const { user } = useAuthContext();
 
   const ask: TAskFunction = (
     {
@@ -111,6 +113,14 @@ export default function useChatFunctions({
     const isEditOrContinue = isEdited || isContinued;
 
     let currentMessages: TMessage[] | null = overrideMessages ?? getMessages() ?? [];
+
+    // Check and replace special variables in promptPrefix
+    if (conversation?.promptPrefix) {
+      conversation.promptPrefix = replaceSpecialVars({
+        text: conversation.promptPrefix,
+        user
+      });
+    }
 
     // construct the query message
     // this is not a real messageId, it is used as placeholder before real messageId returned


### PR DESCRIPTION
# Pull Request Template

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

https://github.com/LibreChat-AI/librechat.ai/pull/132

## Summary
Following discussion at: https://github.com/danny-avila/LibreChat/discussions/3713

This is a proposal to replace the specials variable: {{current_date}} and {{current_user}} in the presets before sending the request to backed.
The evaluation is done client-side,  by the same function as for the custom prompts.
## Change Type

Please delete any irrelevant options.

- [x ] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

Configure a preset with custom instructions like this:

"You are a helpful assistant. Today is {{current_date}}. You are talking with {{current_user}}"

The endpoint will know the current date and the user it's chatting with, like for custom prompts.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] A pull request for updating the documentation has been submitted.
