### PR TITLE
🔨 feat: Use `x-strict` attribute in OpenAPI Actions for Strict Function Definition

### DIFF
--- a/packages/data-provider/src/actions.ts
+++ b/packages/data-provider/src/actions.ts
@@ -129,13 +129,13 @@ export class FunctionSignature {
     this.name = name;
     this.description = description;
     this.parameters = parameters;
-    this.strict = strict || false;
+    this.strict = strict ?? false;
   }
 
   toObjectTool(): FunctionTool {
-    const parameters = { 
+    const parameters = {
       ...this.parameters,
-      additionalProperties: this.strict ? false : undefined
+      additionalProperties: this.strict ? false : undefined,
     };
 
     return {
@@ -144,7 +144,7 @@ export class FunctionSignature {
         name: this.name,
         description: this.description,
         parameters,
-        strict: this.strict
+        strict: this.strict,
       },
     };
   }
@@ -384,8 +384,8 @@ export function openapiToFunction(
       const defaultOperationId = `${method}_${path}`;
       const operationId = operationObj.operationId || sanitizeOperationId(defaultOperationId);
       const description = operationObj.summary || operationObj.description || '';
-      const isStrict = operationObj['x-strict'] || false;
-      
+      const isStrict = operationObj['x-strict'] ?? false;
+
       const parametersSchema: OpenAPISchema = {
         type: 'object',
         properties: {},

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -39,7 +39,7 @@ export type FunctionTool = {
     name: string;
     parameters: Record<string, unknown>;
     strict?: boolean;
-    additionnalProperties?: boolean; // must be false if strict is true https://platform.openai.com/docs/guides/structured-outputs/some-type-specific-keywords-are-not-yet-supported
+    additionalProperties?: boolean; // must be false if strict is true https://platform.openai.com/docs/guides/structured-outputs/some-type-specific-keywords-are-not-yet-supported
   };
 };
 

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -38,6 +38,8 @@ export type FunctionTool = {
     description: string;
     name: string;
     parameters: Record<string, unknown>;
+    strict?: boolean;
+    additionnalProperties?: boolean; // must be false if strict is true https://platform.openai.com/docs/guides/structured-outputs/some-type-specific-keywords-are-not-yet-supported
   };
 };
 


### PR DESCRIPTION
…tants which generates function calls with stric attribute

# Pull Request Template
⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

https://github.com/LibreChat-AI/librechat.ai/pull/219

## Summary

https://github.com/danny-avila/LibreChat/discussions/4637

By default the assistant actions are function calls not using the new "strict" mode available since structured output is available in gpt-4o.
With this patch we can use the new strict mode for assistants by simply adding a 'x-strict': true flag in the openapi spec of an action.

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

The client must have the updated data-provider package.

1. add 'x-strict': true in the openapi spec of an existing action
2. go to the https://platform.openai.com/assistants/<id  of the assistant > ( or refresh the page )
3. In the functions list click on the ones matching the change and verify
  -   "strict": true  is  present at the same level as "name"
  -  "additionalProperties": false is present in the "parameters" object


### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] A pull request for updating the documentation has been submitted.
