### PR TITLE
🎯 feat: Enhance Title Parameter Parsing with new Anthropic Format

### DIFF
--- a/api/app/clients/prompts/titlePrompts.js
+++ b/api/app/clients/prompts/titlePrompts.js
@@ -99,10 +99,24 @@ ONLY include the generated translation without quotations, nor its related key</
  * @returns {string} The parsed parameter's value or a default value if not found.
  */
 function parseParamFromPrompt(prompt, paramName) {
-  const paramRegex = new RegExp(`<${paramName}>([\\s\\S]+?)</${paramName}>`);
+  // Handle null/undefined prompt
+  if (!prompt) {
+    return `No ${paramName} provided`;
+  }
+
+  // Try original format first: <title>value</title>
+  const simpleRegex = new RegExp(`<${paramName}>(.*?)</${paramName}>`, 's');
+  const simpleMatch = prompt.match(simpleRegex);
+
+  if (simpleMatch) {
+    return simpleMatch[1].trim();
+  }
+
+  // Try parameter format: <parameter name="title">value</parameter>
+  const paramRegex = new RegExp(`<parameter name="${paramName}">(.*?)</parameter>`, 's');
   const paramMatch = prompt.match(paramRegex);
 
-  if (paramMatch && paramMatch[1]) {
+  if (paramMatch) {
     return paramMatch[1].trim();
   }
 

--- a/api/app/clients/prompts/titlePrompts.spec.js
+++ b/api/app/clients/prompts/titlePrompts.spec.js
@@ -1,0 +1,73 @@
+const { parseParamFromPrompt } = require('./titlePrompts');
+describe('parseParamFromPrompt', () => {
+  // Original simple format tests
+  test('extracts parameter from simple format', () => {
+    const prompt = '<title>Simple Title</title>';
+    expect(parseParamFromPrompt(prompt, 'title')).toBe('Simple Title');
+  });
+
+  // Parameter format tests
+  test('extracts parameter from parameter format', () => {
+    const prompt =
+      '<function_calls> <invoke name="submit_title"> <parameter name="title">Complex Title</parameter> </invoke>';
+    expect(parseParamFromPrompt(prompt, 'title')).toBe('Complex Title');
+  });
+
+  // Edge cases and error handling
+  test('returns NO TOOL INVOCATION message for non-matching content', () => {
+    const prompt = 'Some random text without parameters';
+    expect(parseParamFromPrompt(prompt, 'title')).toBe(
+      'NO TOOL INVOCATION: Some random text without parameters',
+    );
+  });
+
+  test('returns default message for empty prompt', () => {
+    expect(parseParamFromPrompt('', 'title')).toBe('No title provided');
+  });
+
+  test('returns default message for null prompt', () => {
+    expect(parseParamFromPrompt(null, 'title')).toBe('No title provided');
+  });
+
+  // Multiple parameter tests
+  test('works with different parameter names', () => {
+    const prompt = '<name>John Doe</name>';
+    expect(parseParamFromPrompt(prompt, 'name')).toBe('John Doe');
+  });
+
+  test('handles multiline content', () => {
+    const prompt = `<parameter name="description">This is a
+    multiline
+    description</parameter>`;
+    expect(parseParamFromPrompt(prompt, 'description')).toBe(
+      'This is a\n    multiline\n    description',
+    );
+  });
+
+  // Whitespace handling
+  test('trims whitespace from extracted content', () => {
+    const prompt = '<title>  Padded Title  </title>';
+    expect(parseParamFromPrompt(prompt, 'title')).toBe('Padded Title');
+  });
+
+  test('handles whitespace in parameter format', () => {
+    const prompt = '<parameter name="title">  Padded Parameter Title  </parameter>';
+    expect(parseParamFromPrompt(prompt, 'title')).toBe('Padded Parameter Title');
+  });
+
+  // Invalid format tests
+  test('handles malformed tags', () => {
+    const prompt = '<title>Incomplete Tag';
+    expect(parseParamFromPrompt(prompt, 'title')).toBe('NO TOOL INVOCATION: <title>Incomplete Tag');
+  });
+
+  test('handles empty tags', () => {
+    const prompt = '<title></title>';
+    expect(parseParamFromPrompt(prompt, 'title')).toBe('');
+  });
+
+  test('handles empty parameter tags', () => {
+    const prompt = '<parameter name="title"></parameter>';
+    expect(parseParamFromPrompt(prompt, 'title')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

I enhanced the `parseParamFromPrompt` function to support Anthropic's function format and added comprehensive unit tests to ensure reliability.

Closes  #4652

- Added support for Anthropic's parameter format: `<parameter name="title">value</parameter>`
- Implemented null/undefined prompt handling with descriptive default messages
- Created a new regex pattern to match both simple and parameter formats
- Added comprehensive unit tests covering:
  - Simple format extraction
  - Parameter format extraction
  - Edge cases and error handling
  - Multiline content handling
  - Whitespace handling
  - Invalid format scenarios
- Improved error messages for better debugging
- Maintained backward compatibility with existing format: `<title>value</title>`

### Testing

I thoroughly tested the changes through unit tests covering various scenarios:

**Test Configuration**:
- Simple format extraction
- Parameter format extraction
- Edge cases (empty, null, malformed tags)
- Multiline content
- Whitespace handling
- Invalid formats

To test these changes:
1. Run `npm test` in the api directory
2. Verify all test cases pass
3. Test with both simple and parameter formats in the application

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes