### PR TITLE
🪨 fix: add AWS STS session token support to Bedrock client

### DIFF
--- a/api/server/services/Endpoints/bedrock/options.js
+++ b/api/server/services/Endpoints/bedrock/options.js
@@ -12,6 +12,7 @@ const getOptions = async ({ req, endpointOption }) => {
   const {
     BEDROCK_AWS_SECRET_ACCESS_KEY,
     BEDROCK_AWS_ACCESS_KEY_ID,
+    BEDROCK_AWS_SESSION_TOKEN,
     BEDROCK_REVERSE_PROXY,
     BEDROCK_AWS_DEFAULT_REGION,
     PROXY,
@@ -24,6 +25,7 @@ const getOptions = async ({ req, endpointOption }) => {
     : {
       accessKeyId: BEDROCK_AWS_ACCESS_KEY_ID,
       secretAccessKey: BEDROCK_AWS_SECRET_ACCESS_KEY,
+      ...(BEDROCK_AWS_SESSION_TOKEN && { sessionToken: BEDROCK_AWS_SESSION_TOKEN }),
     };
 
   if (!credentials) {


### PR DESCRIPTION
## Summary

Add support for AWS Security Token Service (STS) temporary credentials in Bedrock client configuration. This enables the use of temporary security credentials through session tokens alongside standard AWS access keys.

Fixes https://github.com/danny-avila/LibreChat/issues/4391 & https://github.com/danny-avila/LibreChat/issues/4484

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested with local environment variables set and the following config in docker-compose.override.yml before running 'docker compose up'

```yaml
services:
  api:
    image: librechat
    build:
      context: .
      target: node
    environment:
      - BEDROCK_AWS_DEFAULT_REGION=us-west-2 # A default region must be provided
      - BEDROCK_AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
      - BEDROCK_AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
      - BEDROCK_AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
```

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
