### PR TITLE
🦙 refactor: Normalize Ollama Config Names

### DIFF
--- a/api/server/services/Config/loadConfigEndpoints.js
+++ b/api/server/services/Config/loadConfigEndpoints.js
@@ -1,6 +1,6 @@
 const { EModelEndpoint, extractEnvVariable } = require('librechat-data-provider');
+const { isUserProvided, normalizeEndpointName } = require('~/server/utils');
 const { getCustomConfig } = require('./getCustomConfig');
-const { isUserProvided } = require('~/server/utils');
 
 /**
  * Load config endpoints from the cached configuration object
@@ -29,7 +29,8 @@ async function loadConfigEndpoints(req) {
 
     for (let i = 0; i < customEndpoints.length; i++) {
       const endpoint = customEndpoints[i];
-      const { baseURL, apiKey, name, iconURL, modelDisplayLabel } = endpoint;
+      const { baseURL, apiKey, name: configName, iconURL, modelDisplayLabel } = endpoint;
+      const name = normalizeEndpointName(configName);
 
       const resolvedApiKey = extractEnvVariable(apiKey);
       const resolvedBaseURL = extractEnvVariable(baseURL);

--- a/api/server/services/Config/loadConfigModels.js
+++ b/api/server/services/Config/loadConfigModels.js
@@ -1,16 +1,7 @@
-const { Providers } = require('@librechat/agents');
 const { EModelEndpoint, extractEnvVariable } = require('librechat-data-provider');
+const { isUserProvided, normalizeEndpointName } = require('~/server/utils');
 const { fetchModels } = require('~/server/services/ModelService');
 const { getCustomConfig } = require('./getCustomConfig');
-const { isUserProvided } = require('~/server/utils');
-
-/**
- * @param {string} name
- * @returns {string}
- */
-function normalizeEndpointName(name = '') {
-  return name.toLowerCase() === Providers.OLLAMA ? Providers.OLLAMA : name;
-}
 
 /**
  * Load config endpoints from the cached configuration object

--- a/api/server/utils/handleText.js
+++ b/api/server/utils/handleText.js
@@ -7,6 +7,7 @@ const {
   defaultRetrievalModels,
   defaultAssistantsVersion,
 } = require('librechat-data-provider');
+const { Providers } = require('@librechat/agents');
 const { getCitations, citeText } = require('./citations');
 const partialRight = require('lodash/partialRight');
 const { sendMessage } = require('./streamResponse');
@@ -212,13 +213,23 @@ function generateConfig(key, baseURL, endpoint) {
   return config;
 }
 
+/**
+ * Normalize the endpoint name to system-expected value.
+ * @param {string} name
+ * @returns {string}
+ */
+function normalizeEndpointName(name = '') {
+  return name.toLowerCase() === Providers.OLLAMA ? Providers.OLLAMA : name;
+}
+
 module.exports = {
-  createOnProgress,
   isEnabled,
   handleText,
   formatSteps,
   formatAction,
-  addSpaceIfNeeded,
   isUserProvided,
   generateConfig,
+  addSpaceIfNeeded,
+  createOnProgress,
+  normalizeEndpointName,
 };


### PR DESCRIPTION
## Summary

Closes #4654

I standardized the Ollama endpoint name normalization across endpoint and model configurations, improving code consistency and maintainability.

- Moved `normalizeEndpointName` function from `loadConfigModels.js` to `handleText.js` for centralized access
- Added JSDoc documentation to `normalizeEndpointName` function to clarify its purpose and parameters
- Implemented name normalization in `loadConfigEndpoints.js` to match the behavior in `loadConfigModels.js`
- Destructured `configName` from endpoint object and applied normalization before use
- Reordered exports in `handleText.js` for better readability
- Removed duplicate imports across files

### Testing

To test these changes:

1. Configure custom Ollama endpoints with varying name cases (e.g., "ollama", "Ollama", "OLLAMA")
2. Verify all variations are normalized correctly in both endpoint and model configurations
3. Ensure existing endpoint functionality remains intact
4. Check that the normalized names are consistently used throughout the application

### Test Configuration:
- Custom Ollama endpoint configurations
- Various case variations of "ollama" in endpoint names