### PR TITLE
🤖 fix: Collaborative Agents are only editable by ADMIN

### DIFF
--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -110,7 +110,6 @@ const getAgentHandler = async (req, res) => {
         isCollaborative: agent.isCollaborative,
       });
     }
-
     return res.status(200).json(agent);
   } catch (error) {
     logger.error('[/Agents/:id] Error retrieving agent', error);
@@ -131,15 +130,23 @@ const updateAgentHandler = async (req, res) => {
   try {
     const id = req.params.id;
     const { projectIds, removeProjectIds, ...updateData } = req.body;
+    const isAdmin = req.user.role === SystemRoles.ADMIN;
+    const existingAgent = await getAgent({ id });
+    const isAuthor = existingAgent.author.toString() === req.user.id;
 
-    let updatedAgent;
-    const query = { id, author: req.user.id };
-    if (req.user.role === SystemRoles.ADMIN) {
-      delete query.author;
+    if (!existingAgent) {
+      return res.status(404).json({ error: 'Agent not found' });
     }
-    if (Object.keys(updateData).length > 0) {
-      updatedAgent = await updateAgent(query, updateData);
+    const hasEditPermission = existingAgent.isCollaborative || isAdmin || isAuthor;
+
+    if (!hasEditPermission) {
+      return res.status(403).json({
+        error: 'You do not have permission to modify this non-collaborative agent',
+      });
     }
+
+    let updatedAgent =
+      Object.keys(updateData).length > 0 ? await updateAgent({ id }, updateData) : existingAgent;
 
     if (projectIds || removeProjectIds) {
       updatedAgent = await updateAgentProjects({


### PR DESCRIPTION
## Summary

I expect users to be able to edit Agents, that are set to "Allow other users to edit your agent" (collaborative). Currently only the ADMIN can do this.
I know Agents are still in development. Hopefully contributions are still possible. Sharing/Editing Agents is very useful to me.
## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Create an Agent.
2. Set the "Share to all users" and "Allow other users to edit your agent" option
3. Try to edit the Agent on an account that is not ADMIN
4. You get an error.

### **Test Configuration**:
You need to configure Librechat to use the new Agents! See: https://github.com/danny-avila/LibreChat/issues/3607

Add to .env:
ENDPOINTS=agents
EXPERIMENTAL_AGENTS=true

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code