### PR TITLE
🫧 fix: Tool Auth Form Button to Prevent Form Bubbling

### DIFF
--- a/client/src/components/Plugins/Store/PluginAuthForm.tsx
+++ b/client/src/components/Plugins/Store/PluginAuthForm.tsx
@@ -78,8 +78,18 @@ function PluginAuthForm({ plugin, onSubmit, isEntityTool }: TPluginAuthFormProps
           })}
           <button
             disabled={!isDirty || !isValid || isSubmitting}
-            type="submit"
+            type="button"
             className="btn btn-primary relative"
+            onClick={() => {
+              handleSubmit((auth) =>
+                onSubmit({
+                  pluginKey: plugin?.pluginKey ?? '',
+                  action: 'install',
+                  auth,
+                  isEntityTool,
+                }),
+              )();
+            }}
           >
             <div className="flex items-center justify-center gap-2">
               {localize('com_ui_save')}


### PR DESCRIPTION
## Summary

I modified the PluginAuthForm component to prevent form submission from bubbling up to the parent form by changing the submit button type and implementing manual submission handling.

- Changed submit button type from "submit" to "button" to prevent automatic form submission
- Added onClick handler to manually trigger form submission
- Implemented direct form submission using handleSubmit with auth parameters
- Maintained existing validation checks (isDirty, isValid, isSubmitting)
- Preserved plugin installation parameters including pluginKey, action, and isEntityTool flags

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested the changes by:
1. Verifying the form submission works correctly with the new button type
2. Ensuring validation states are properly maintained
3. Confirming the form data is correctly passed to the parent component
4. Testing that no unwanted form submissions occur

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have tested the functionality thoroughly