### PR TITLE
🪚 refactor: Optimize `CONSOLE_JSON` Debug Logs with Truncation

### DIFF
--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -186,8 +186,29 @@ const debugTraverse = winston.format.printf(({ level, message, timestamp, ...met
   }
 });
 
+const jsonTruncateFormat = winston.format((info) => {
+  const truncateObject = (obj) => {
+    const newObj = {};
+    Object.entries(obj).forEach(([key, value]) => {
+      if (typeof value === 'string') {
+        newObj[key] = truncateLongStrings(value, 255);
+      } else if (Array.isArray(value)) {
+        newObj[key] = value.map(condenseArray);
+      } else if (typeof value === 'object' && value !== null) {
+        newObj[key] = truncateObject(value);
+      } else {
+        newObj[key] = value;
+      }
+    });
+    return newObj;
+  };
+
+  return truncateObject(info);
+});
+
 module.exports = {
   redactFormat,
   redactMessage,
   debugTraverse,
+  jsonTruncateFormat,
 };

--- a/api/config/winston.js
+++ b/api/config/winston.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const winston = require('winston');
 require('winston-daily-rotate-file');
-const { redactFormat, redactMessage, debugTraverse } = require('./parsers');
+const { redactFormat, redactMessage, debugTraverse, jsonTruncateFormat } = require('./parsers');
 
 const logDir = path.join(__dirname, '..', 'logs');
 
@@ -112,7 +112,7 @@ if (useDebugConsole) {
     new winston.transports.Console({
       level: 'debug',
       format: useConsoleJson
-        ? winston.format.combine(fileFormat, debugTraverse, winston.format.json())
+        ? winston.format.combine(fileFormat, jsonTruncateFormat(), winston.format.json())
         : winston.format.combine(fileFormat, debugTraverse),
     }),
   );
@@ -120,7 +120,7 @@ if (useDebugConsole) {
   transports.push(
     new winston.transports.Console({
       level: 'info',
-      format: winston.format.combine(fileFormat, winston.format.json()),
+      format: winston.format.combine(fileFormat, jsonTruncateFormat(), winston.format.json()),
     }),
   );
 } else {


### PR DESCRIPTION
## Summary

I implemented a new logging format to optimize `CONSOLE_JSON` debug logs by truncating long strings and condensing arrays. This was already done for non-JSON logging to console. This enhancement improves log readability and reduces log file sizes while maintaining essential debugging information.

- Created `jsonTruncateFormat` in parsers.js to handle log message truncation
- Implemented recursive object traversal to process nested objects and arrays
- Set string truncation limit to 255 characters for optimal log size
- Applied the new format to Console transports in winston.js configuration
- Maintained JSON formatting for structured logging while reducing verbosity
- Updated debug console configuration to use the new truncation format

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

I tested the changes by:
1. Generating debug logs with various payload sizes
2. Verifying truncation of long strings
3. Confirming nested object handling
4. Checking array condensing functionality
5. Validating JSON structure remains intact

### Test Configuration:
- Environment: Development
- Debug Mode: Enabled
- Console JSON: Enabled

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes