### PR TITLE
🔧 Fix: Excessive Line Spacing in Markdown-rendered User Messages

### DIFF
--- a/client/src/components/Chat/Messages/Content/MessageContent.tsx
+++ b/client/src/components/Chat/Messages/Content/MessageContent.tsx
@@ -97,6 +97,7 @@ const DisplayMessage = ({ text, isCreatedByUser, message, showCursor }: TDisplay
           isSubmitting ? 'submitting' : '',
           showCursorState && !!text.length ? 'result-streaming' : '',
           'markdown prose message-content dark:prose-invert light w-full break-words',
+          isCreatedByUser && !enableUserMsgMarkdown && 'whitespace-pre-wrap',
           isCreatedByUser ? 'dark:text-gray-20' : 'dark:text-gray-100',
         )}
       >

--- a/client/src/components/Chat/Messages/Content/MessageContent.tsx
+++ b/client/src/components/Chat/Messages/Content/MessageContent.tsx
@@ -97,7 +97,7 @@ const DisplayMessage = ({ text, isCreatedByUser, message, showCursor }: TDisplay
           isSubmitting ? 'submitting' : '',
           showCursorState && !!text.length ? 'result-streaming' : '',
           'markdown prose message-content dark:prose-invert light w-full break-words',
-          isCreatedByUser ? 'whitespace-pre-wrap dark:text-gray-20' : 'dark:text-gray-100',
+          isCreatedByUser ? 'dark:text-gray-20' : 'dark:text-gray-100',
         )}
       >
         {content}

--- a/client/src/components/Chat/Messages/Content/Parts/Text.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Text.tsx
@@ -45,6 +45,7 @@ const TextPart = memo(({ text, isCreatedByUser, messageId, showCursor }: TextPar
         isSubmitting ? 'submitting' : '',
         showCursorState && !!text.length ? 'result-streaming' : '',
         'markdown prose message-content dark:prose-invert light w-full break-words',
+        isCreatedByUser && !enableUserMsgMarkdown && 'whitespace-pre-wrap',
         isCreatedByUser ? 'dark:text-gray-20' : 'dark:text-gray-70',
       )}
     >

--- a/client/src/components/Chat/Messages/Content/Parts/Text.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Text.tsx
@@ -45,7 +45,7 @@ const TextPart = memo(({ text, isCreatedByUser, messageId, showCursor }: TextPar
         isSubmitting ? 'submitting' : '',
         showCursorState && !!text.length ? 'result-streaming' : '',
         'markdown prose message-content dark:prose-invert light w-full break-words',
-        isCreatedByUser ? 'whitespace-pre-wrap dark:text-gray-20' : 'dark:text-gray-70',
+        isCreatedByUser ? 'dark:text-gray-20' : 'dark:text-gray-70',
       )}
     >
       {content}

--- a/client/src/components/Chat/Messages/Content/SearchContent.tsx
+++ b/client/src/components/Chat/Messages/Content/SearchContent.tsx
@@ -43,7 +43,7 @@ const SearchContent = ({ message }: { message: TMessage }) => {
     <div
       className={cn(
         'markdown prose dark:prose-invert light w-full break-words',
-        message.isCreatedByUser ? 'whitespace-pre-wrap dark:text-gray-20' : 'dark:text-gray-70',
+        message.isCreatedByUser ? 'dark:text-gray-20' : 'dark:text-gray-70',
       )}
       dir="auto"
     >

--- a/client/src/components/Chat/Messages/Content/SearchContent.tsx
+++ b/client/src/components/Chat/Messages/Content/SearchContent.tsx
@@ -1,12 +1,15 @@
 import { Suspense } from 'react';
+import { useRecoilValue } from 'recoil';
 import type { TMessage, TMessageContentParts } from 'librechat-data-provider';
 import { UnfinishedMessage } from './MessageContent';
 import { DelayedRender } from '~/components/ui';
 import MarkdownLite from './MarkdownLite';
 import { cn } from '~/utils';
+import store from '~/store';
 import Part from './Part';
 
 const SearchContent = ({ message }: { message: TMessage }) => {
+  const enableUserMsgMarkdown = useRecoilValue(store.enableUserMsgMarkdown);
   const { messageId } = message;
   if (Array.isArray(message.content) && message.content.length > 0) {
     return (
@@ -43,6 +46,7 @@ const SearchContent = ({ message }: { message: TMessage }) => {
     <div
       className={cn(
         'markdown prose dark:prose-invert light w-full break-words',
+        message.isCreatedByUser && !enableUserMsgMarkdown && 'whitespace-pre-wrap',
         message.isCreatedByUser ? 'dark:text-gray-20' : 'dark:text-gray-70',
       )}
       dir="auto"


### PR DESCRIPTION
## Summary

This PR addresses an issue where excessive line spacing was added　when rendering user messages in Markdown format, resulting in an unintended appearance.

### Before:
<kbd><img width="500" alt="image" src="https://github.com/user-attachments/assets/87a68b67-0a80-42e4-8c0f-53b52d6f1c98"></kbd>

### After fix: 
#### User message rendered in markdown
<kbd><img width="500" alt="image" src="https://github.com/user-attachments/assets/efec3fd2-0270-426b-ac82-c56c5bde4153"></kbd>

#### User message rendered as plain text
<kbd><img width="500" alt="image" src="https://github.com/user-attachments/assets/9f019ba5-a066-43ed-8b1e-2aae0cb1ec57"></kbd>



## Details

Currently, Markdown-rendered user messages have a `whitespace-pre-wrap` class applied to their wrapper div. This class introduces extra line spacing in markdown text.

This fix removes the `whitespace-pre-wrap` class from the wrapper div for markdown-rendered user messages, ensuring the line spacing is consistent and appropriate.

Please let me know if this solution isn't suitable.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I have manually verified the following:

* Markdown-rendered user messages display with correct line spacing
* Markdown formatting functions properly
* Non-markdown user messages maintain appropriate line breaks

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

