### PR TITLE
🌊 feat: add streaming support for o1 models

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1308,11 +1308,6 @@ ${convo}
       /** @type {(value: void | PromiseLike<void>) => void} */
       let streamResolve;
 
-      if (modelOptions.stream && this.isO1Model) {
-        delete modelOptions.stream;
-        delete modelOptions.stop;
-      }
-
       if (modelOptions.stream) {
         streamPromise = new Promise((resolve) => {
           streamResolve = resolve;


### PR DESCRIPTION
# Add streaming support for o1 models

Issue #4759 : Enhancement: Add streaming support for o1-preview and o1-mini 


## Summary

This PR adds streaming support for o1 models by removing the if condition that was checking if the model was o1 before deleting the modelOptions.stream and modelOptions.stop parameters in the OpenAIClient.js file.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Backend unit tests are passed:
npm run test:api

![clip](https://github.com/user-attachments/assets/8133468d-3a1d-4471-ad8e-31740eb404ce)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code


