### PR TITLE
fix: branching and forking sometimes break conversation structure

### DIFF
--- a/client/src/utils/buildTree.ts
+++ b/client/src/utils/buildTree.ts
@@ -34,9 +34,8 @@ export default function buildTree({
     messageMap[message.messageId] = extendedMessage;
   });
 
-  messages.forEach((message) => {
-    const parentId = message.parentMessageId ?? '';
-    const extendedMessage = messageMap[message.messageId];
+  Object.values(messageMap).forEach((extendedMessage) => {
+    const parentId = extendedMessage.parentMessageId ?? '';
 
     const parentMessage = messageMap[parentId];
     if (parentMessage) {

--- a/client/src/utils/buildTree.ts
+++ b/client/src/utils/buildTree.ts
@@ -32,6 +32,11 @@ export default function buildTree({
     }
 
     messageMap[message.messageId] = extendedMessage;
+  });
+
+  messages.forEach((message) => {
+    const parentId = message.parentMessageId ?? '';
+    const extendedMessage = messageMap[message.messageId];
 
     const parentMessage = messageMap[parentId];
     if (parentMessage) {


### PR DESCRIPTION
## Summary

As reported in #4761 and #3813, conversations will seemingly randomly collapse when regenerating or forking. I believe this is because in [buildTree.ts](https://github.com/danny-avila/LibreChat/blob/main/client/src/utils/buildTree.ts), the function assumes messages are in the correct order when building the tree (parents are before their children). But for some reason, this is only the case when there are less than 17 messages in the conversation.

If the messages are not in correct order, when looking for a message's parent in `messageMap`, the parent might not have put into the map yet resulting in the current message becoming a root message.

What I've done is to populate `messageMap` first in one loop, and then in another loop look for a message's parent. This way, the parent should be found wherever it is in the message list.

I don't know if messages should be in the correct order when queried from the api given the previous assumption in `buildTree.ts` but this change should resolve the issue anyway.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`npm run test:client` is passing.

I have not introduced any changes to the api.

I've tested my changes with a conversation described in https://github.com/danny-avila/LibreChat/issues/4761#issuecomment-2493085783 

Before the change: conversatios with more than 16 messages will collapse after forking. Conversations with more than 16 messages and include any branching will collapse.

After the changes: all is good.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
