### PR TITLE
fix: forking a long conversation breaks chat structure

### DIFF
--- a/api/models/Message.js
+++ b/api/models/Message.js
@@ -73,15 +73,17 @@ async function saveMessage(req, params, metadata) {
  * @async
  * @function bulkSaveMessages
  * @param {Object[]} messages - An array of message objects to save.
+ * @param {boolean} [overrideTimestamp=false] - Indicates whether to override the timestamps of the messages. Defaults to false.
  * @returns {Promise<Object>} The result of the bulk write operation.
  * @throws {Error} If there is an error in saving messages in bulk.
  */
-async function bulkSaveMessages(messages) {
+async function bulkSaveMessages(messages, overrideTimestamp=false) {
   try {
     const bulkOps = messages.map((message) => ({
       updateOne: {
         filter: { messageId: message.messageId },
         update: message,
+        timestamps: !overrideTimestamp,
         upsert: true,
       },
     }));

--- a/api/server/utils/import/fork.spec.js
+++ b/api/server/utils/import/fork.spec.js
@@ -104,7 +104,7 @@ describe('forkConversation', () => {
     expect(bulkSaveMessages).toHaveBeenCalledWith(
       expect.arrayContaining(
         expectedMessagesTexts.map((text) => expect.objectContaining({ text })),
-      ),
+      ), true,
     );
   });
 
@@ -122,7 +122,7 @@ describe('forkConversation', () => {
     expect(bulkSaveMessages).toHaveBeenCalledWith(
       expect.arrayContaining(
         expectedMessagesTexts.map((text) => expect.objectContaining({ text })),
-      ),
+      ), true,
     );
   });
 
@@ -141,7 +141,7 @@ describe('forkConversation', () => {
     expect(bulkSaveMessages).toHaveBeenCalledWith(
       expect.arrayContaining(
         expectedMessagesTexts.map((text) => expect.objectContaining({ text })),
-      ),
+      ), true,
     );
   });
 
@@ -160,7 +160,7 @@ describe('forkConversation', () => {
     expect(bulkSaveMessages).toHaveBeenCalledWith(
       expect.arrayContaining(
         expectedMessagesTexts.map((text) => expect.objectContaining({ text })),
-      ),
+      ), true,
     );
   });
 

--- a/api/server/utils/import/importBatchBuilder.js
+++ b/api/server/utils/import/importBatchBuilder.js
@@ -99,7 +99,7 @@ class ImportBatchBuilder {
   async saveBatch() {
     try {
       await bulkSaveConvos(this.conversations);
-      await bulkSaveMessages(this.messages);
+      await bulkSaveMessages(this.messages, true);
       logger.debug(
         `user: ${this.requestUserId} | Added ${this.conversations.length} conversations and ${this.messages.length} messages to the DB.`,
       );


### PR DESCRIPTION
ref: PR https://github.com/danny-avila/LibreChat/pull/4772 and issue #4761

I think I've found the culprit.

This issue is due to the forking doesn't copy over the `createdAt` attribute of the messages, so the message list queried might be our of order, hence a messed up tree.

The main change is here:

https://github.com/xyqyear/LibreChat/blob/cb98456ba034a86857adaeaa564d2ac7f17cebc8/api/models/Message.js#L80-L86

If `timestamps` is true, then mongoose will override `createdAt` with the current time, which is the default if `timestamps` is set to true for the schema.

## Testing

I've modified exiting tests and the api tests passed.

However, this PR should not be merged right away and should be further investigated to make sure importing doesn't break since importing use the same mechanics.

The current behavior for importing I believe is to just use the default `createdAt` time that mongoose auto inserts. So imports a conversations with more than 16 messages should be having the same issue (needs testing).