### PR TITLE
🎯 fix: Google AI Client Stability; feat: `gemini-exp` models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,7 +140,7 @@ GOOGLE_KEY=user_provided
 # GOOGLE_REVERSE_PROXY=
 
 # Gemini API (AI Studio)
-# GOOGLE_MODELS=gemini-1.5-flash-latest,gemini-1.0-pro,gemini-1.0-pro-001,gemini-1.0-pro-latest,gemini-1.0-pro-vision-latest,gemini-1.5-pro-latest,gemini-pro,gemini-pro-vision
+# GOOGLE_MODELS=gemini-exp-1121,gemini-exp-1114,gemini-1.5-flash-latest,gemini-1.0-pro,gemini-1.0-pro-001,gemini-1.0-pro-latest,gemini-1.0-pro-vision-latest,gemini-1.5-pro-latest,gemini-pro,gemini-pro-vision
 
 # Vertex AI
 # GOOGLE_MODELS=gemini-1.5-flash-preview-0514,gemini-1.5-pro-preview-0514,gemini-1.0-pro-vision-001,gemini-1.0-pro-002,gemini-1.0-pro-001,gemini-pro-vision,gemini-1.0-pro

--- a/api/package.json
+++ b/api/package.json
@@ -41,7 +41,7 @@
     "@keyv/redis": "^2.8.1",
     "@langchain/community": "^0.3.13",
     "@langchain/core": "^0.3.17",
-    "@langchain/google-genai": "^0.1.3",
+    "@langchain/google-genai": "^0.1.4",
     "@langchain/google-vertexai": "^0.1.2",
     "@langchain/textsplitters": "^0.1.0",
     "@librechat/agents": "^1.7.7",

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -49,6 +49,7 @@ const googleModels = {
   /* Max I/O is combined so we subtract the amount from max response tokens for actual total */
   gemini: 30720, // -2048 from max
   'gemini-pro-vision': 12288, // -4096 from max
+  'gemini-exp': 8000,
   'gemini-1.5': 1048576, // -8192 from max
   'text-bison-32k': 32758, // -10 from max
   'chat-bison-32k': 32758, // -10 from max

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@keyv/redis": "^2.8.1",
         "@langchain/community": "^0.3.13",
         "@langchain/core": "^0.3.17",
-        "@langchain/google-genai": "^0.1.3",
+        "@langchain/google-genai": "^0.1.4",
         "@langchain/google-vertexai": "^0.1.2",
         "@langchain/textsplitters": "^0.1.0",
         "@librechat/agents": "^1.7.7",
@@ -218,10 +218,9 @@
       }
     },
     "api/node_modules/@langchain/google-genai": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-0.1.3.tgz",
-      "integrity": "sha512-GHZV4qEMoi+rnqSM5I+ADXwUSBRSD0hsmlS1lTQEGW9HmvzPu3zryvYjuRAoelZSENTmZmBatdM+kgiV8H2+JA==",
-      "license": "MIT",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-0.1.4.tgz",
+      "integrity": "sha512-b8qrqnHYbNseaAikrWyxuDTww6CUIse82F5/BmF2GtWVR25yJrNUWETfTp7o7iIMxhFR0PuQag4gEZOL74F5Tw==",
       "dependencies": {
         "@google/generative-ai": "^0.21.0",
         "zod-to-json-schema": "^3.22.4"


### PR DESCRIPTION
## Summary

- Removed the 7-second timeout constraint that was likely causing AbortError in the Google client
- Increased delay timings from 12 to 15 seconds for generative models to prevent premature timeouts
- Created a regex constant `EXCLUDED_GENAI_MODELS` to better identify and handle Gemini models
- Updated model detection logic to use regex testing instead of string, to use `@google/generative-ai` explicitly for latest models
- Removed beta API version specification for generative models to use the stable release
- Simplified the GenAI client initialization by removing unnecessary configuration
- Updated `@langchain/google-genai` package from 0.1.3 to 0.1.4 for latest model support
- Improved debug logging to accurately reflect the model type being used

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes