### PR TITLE
🎨 style: remove break-all class in modelSpec menu

### DIFF
--- a/client/src/components/Chat/Menus/Models/ModelSpec.tsx
+++ b/client/src/components/Chat/Menus/Models/ModelSpec.tsx
@@ -71,7 +71,7 @@ const MenuItem: FC<MenuItemProps> = ({
           <div>
             <div className="flex items-center gap-2">
               {showIconInMenu && <SpecIcon currentSpec={spec} endpointsConfig={endpointsConfig} />}
-              <div className="break-all">
+              <div>
                 {title}
                 <div className="text-token-text-tertiary">{description}</div>
               </div>


### PR DESCRIPTION
## Summary

Removes the `break-all` class added in #2731, as it doesn't seem to affect how long Chinese modelSpec descriptions are displayed, but causes long English descriptions to break on characters instead of on words. 

Before:

![image](https://github.com/user-attachments/assets/05be3438-ffe3-49f0-b644-ad9ec55e253d)

After:
![image](https://github.com/user-attachments/assets/3a67069f-7a76-4754-9f8a-bd060e92f0ff)


## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Test config:

All `npm run test:client` tests pass.

The display of the menu is the same in both desktop and landscape, and across different UI languages.
Tested in Firefox, Edge, Chrome.

Tested with the following config:

```yaml
modelSpecs:
  list:
    - name: claude-3-5-sonnet
      label: Claude
      description: Claude is an equally capable alternative to ChatGPT, with a different personality and approach to conversation
      preset:
        endpoint: anthropic
        model: claude-3-5-sonnet-20241022
        modelLabel: Claude
    - name: gpt-4o
      label: ChatGPT
      description: ChatGPT is great for general conversation and answering questions
      preset:
        endpoint: openAI
        model: chatgpt-4o-latest
        modelLabel: ChatGPT
    - name: o1-preview
      label: GPT-o1
      description: GPT-o1 is good at performing complex reasoning. It's slower and more verbose than ChatGPT.
      preset:
        endpoint: openAI
        model: o1-preview
        modelLabel: GPT-o1
    - name: "gemini"
      label: "Gemini"
      description: 该模型能够同时处理文本、图像、音频、视频和代码等多种数据类型，并具备生成高质量代码的能力。
      preset:
        endpoint: "google"
        model: "gemini-1.5-pro-latest"
        modelLabel: "Gemini"
```

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
