### PR TITLE
🔑 fix: Azure Serverless Support for API Key Header & Version 

### DIFF
--- a/api/app/clients/ChatGPTClient.js
+++ b/api/app/clients/ChatGPTClient.js
@@ -227,6 +227,16 @@ class ChatGPTClient extends BaseClient {
       this.azure = !serverless && azureOptions;
       this.azureEndpoint =
         !serverless && genAzureChatCompletion(this.azure, modelOptions.model, this);
+      if (serverless === true) {
+        this.options.defaultQuery = azureOptions.azureOpenAIApiVersion
+          ? { 'api-version': azureOptions.azureOpenAIApiVersion }
+          : undefined;
+        this.options.headers['api-key'] = this.apiKey;
+      }
+    }
+
+    if (this.options.defaultQuery) {
+      opts.defaultQuery = this.options.defaultQuery;
     }
 
     if (this.options.headers) {

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -838,6 +838,12 @@ class OpenAIClient extends BaseClient {
       this.options.dropParams = azureConfig.groupMap[groupName].dropParams;
       this.options.forcePrompt = azureConfig.groupMap[groupName].forcePrompt;
       this.azure = !serverless && azureOptions;
+      if (serverless === true) {
+        this.options.defaultQuery = azureOptions.azureOpenAIApiVersion
+          ? { 'api-version': azureOptions.azureOpenAIApiVersion }
+          : undefined;
+        this.options.headers['api-key'] = this.apiKey;
+      }
     }
 
     const titleChatCompletion = async () => {
@@ -1169,6 +1175,10 @@ ${convo}
         opts.defaultHeaders = { ...opts.defaultHeaders, ...this.options.headers };
       }
 
+      if (this.options.defaultQuery) {
+        opts.defaultQuery = this.options.defaultQuery;
+      }
+
       if (this.options.proxy) {
         opts.httpAgent = new HttpsProxyAgent(this.options.proxy);
       }
@@ -1207,6 +1217,12 @@ ${convo}
         this.azure = !serverless && azureOptions;
         this.azureEndpoint =
           !serverless && genAzureChatCompletion(this.azure, modelOptions.model, this);
+        if (serverless === true) {
+          this.options.defaultQuery = azureOptions.azureOpenAIApiVersion
+            ? { 'api-version': azureOptions.azureOpenAIApiVersion }
+            : undefined;
+          this.options.headers['api-key'] = this.apiKey;
+        }
       }
 
       if (this.azure || this.options.azure) {

--- a/api/server/services/Endpoints/azureAssistants/initialize.js
+++ b/api/server/services/Endpoints/azureAssistants/initialize.js
@@ -135,6 +135,12 @@ const initializeClient = async ({ req, res, version, endpointOption, initAppClie
       clientOptions.reverseProxyUrl = baseURL ?? clientOptions.reverseProxyUrl;
       clientOptions.headers = opts.defaultHeaders;
       clientOptions.azure = !serverless && azureOptions;
+      if (serverless === true) {
+        clientOptions.defaultQuery = azureOptions.azureOpenAIApiVersion
+          ? { 'api-version': azureOptions.azureOpenAIApiVersion }
+          : undefined;
+        clientOptions.headers['api-key'] = apiKey;
+      }
     }
   }
 

--- a/api/server/services/Endpoints/gptPlugins/initialize.js
+++ b/api/server/services/Endpoints/gptPlugins/initialize.js
@@ -96,6 +96,12 @@ const initializeClient = async ({ req, res, endpointOption }) => {
 
     apiKey = azureOptions.azureOpenAIApiKey;
     clientOptions.azure = !serverless && azureOptions;
+    if (serverless === true) {
+      clientOptions.defaultQuery = azureOptions.azureOpenAIApiVersion
+        ? { 'api-version': azureOptions.azureOpenAIApiVersion }
+        : undefined;
+      clientOptions.headers['api-key'] = apiKey;
+    }
   } else if (useAzure || (apiKey && apiKey.includes('{"azure') && !clientOptions.azure)) {
     clientOptions.azure = userProvidesKey ? JSON.parse(userValues.apiKey) : getAzureCredentials();
     apiKey = clientOptions.azure.azureOpenAIApiKey;

--- a/api/server/services/Endpoints/openAI/initialize.js
+++ b/api/server/services/Endpoints/openAI/initialize.js
@@ -97,6 +97,12 @@ const initializeClient = async ({
 
     apiKey = azureOptions.azureOpenAIApiKey;
     clientOptions.azure = !serverless && azureOptions;
+    if (serverless === true) {
+      clientOptions.defaultQuery = azureOptions.azureOpenAIApiVersion
+        ? { 'api-version': azureOptions.azureOpenAIApiVersion }
+        : undefined;
+      clientOptions.headers['api-key'] = apiKey;
+    }
   } else if (isAzureOpenAI) {
     clientOptions.azure = userProvidesKey ? JSON.parse(userValues.apiKey) : getAzureCredentials();
     apiKey = clientOptions.azure.azureOpenAIApiKey;

--- a/api/server/services/Endpoints/openAI/llm.js
+++ b/api/server/services/Endpoints/openAI/llm.js
@@ -29,6 +29,7 @@ function getLLMConfig(apiKey, options = {}) {
     modelOptions = {},
     reverseProxyUrl,
     useOpenRouter,
+    defaultQuery,
     headers,
     proxy,
     azure,
@@ -72,6 +73,10 @@ function getLLMConfig(apiKey, options = {}) {
     if (headers) {
       configOptions.baseOptions = { headers };
     }
+  }
+
+  if (defaultQuery) {
+    configOptions.baseOptions.defaultQuery = defaultQuery;
   }
 
   if (proxy) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36137,7 +36137,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.55",
+      "version": "0.7.56",
       "license": "ISC",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.55",
+  "version": "0.7.56",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/specs/azure.spec.ts
+++ b/packages/data-provider/specs/azure.spec.ts
@@ -94,8 +94,8 @@ describe('validateAzureGroups', () => {
     expect(isValid).toBe(true);
     const modelGroup = modelGroupMap['gpt-5-turbo'];
     expect(modelGroup).toBeDefined();
-    expect(modelGroup.group).toBe('japan-east');
-    expect(groupMap[modelGroup.group]).toBeDefined();
+    expect(modelGroup?.group).toBe('japan-east');
+    expect(groupMap[modelGroup?.group ?? '']).toBeDefined();
     expect(modelNames).toContain('gpt-5-turbo');
     const { azureOptions } = mapModelToAzureConfig({
       modelName: 'gpt-5-turbo',
@@ -323,6 +323,7 @@ describe('validateAzureGroups for Serverless Configurations', () => {
 
     expect(azureOptions).toEqual({
       azureOpenAIApiKey: 'def456',
+      azureOpenAIApiVersion: '',
     });
     expect(baseURL).toEqual('https://new-serverless.example.com/v1/completions');
     expect(serverless).toBe(true);
@@ -381,10 +382,10 @@ describe('validateAzureGroups with modelGroupMap and groupMap', () => {
     const { isValid, modelGroupMap, groupMap } = validateAzureGroups(validConfigs);
     expect(isValid).toBe(true);
     expect(modelGroupMap['gpt-4-turbo']).toBeDefined();
-    expect(modelGroupMap['gpt-4-turbo'].group).toBe('us-east');
+    expect(modelGroupMap['gpt-4-turbo']?.group).toBe('us-east');
     expect(groupMap['us-east']).toBeDefined();
-    expect(groupMap['us-east'].apiKey).toBe('prod-1234');
-    expect(groupMap['us-east'].models['gpt-4-turbo']).toBeDefined();
+    expect(groupMap['us-east']?.apiKey).toBe('prod-1234');
+    expect(groupMap['us-east']?.models['gpt-4-turbo']).toBeDefined();
     const { azureOptions, baseURL, headers } = mapModelToAzureConfig({
       modelName: 'gpt-4-turbo',
       modelGroupMap,
@@ -765,6 +766,7 @@ describe('validateAzureGroups with modelGroupMap and groupMap', () => {
     );
     expect(azureOptions7).toEqual({
       azureOpenAIApiKey: 'mistral-key',
+      azureOpenAIApiVersion: '',
     });
 
     const {
@@ -782,6 +784,7 @@ describe('validateAzureGroups with modelGroupMap and groupMap', () => {
     );
     expect(azureOptions8).toEqual({
       azureOpenAIApiKey: 'llama-key',
+      azureOpenAIApiVersion: '',
     });
   });
 });

--- a/packages/data-provider/src/azure.ts
+++ b/packages/data-provider/src/azure.ts
@@ -63,13 +63,13 @@ export function validateAzureGroups(configs: TAzureGroups): TAzureConfigValidati
       const {
         group: groupName,
         apiKey,
-        instanceName,
-        deploymentName,
-        version,
-        baseURL,
+        instanceName = '',
+        deploymentName = '',
+        version = '',
+        baseURL = '',
         additionalHeaders,
         models,
-        serverless,
+        serverless = false,
         ...rest
       } = group;
 
@@ -120,9 +120,11 @@ export function validateAzureGroups(configs: TAzureGroups): TAzureConfigValidati
           continue;
         }
 
+        const groupDeploymentName = group.deploymentName ?? '';
+        const groupVersion = group.version ?? '';
         if (typeof model === 'boolean') {
           // For boolean models, check if group-level deploymentName and version are present.
-          if (!group.deploymentName || !group.version) {
+          if (!groupDeploymentName || !groupVersion) {
             errors.push(
               `Model "${modelName}" in group "${groupName}" is missing a deploymentName or version.`,
             );
@@ -133,11 +135,10 @@ export function validateAzureGroups(configs: TAzureGroups): TAzureConfigValidati
             group: groupName,
           };
         } else {
+          const modelDeploymentName = model.deploymentName ?? '';
+          const modelVersion = model.version ?? '';
           // For object models, check if deploymentName and version are required but missing.
-          if (
-            (!model.deploymentName && !group.deploymentName) ||
-            (!model.version && !group.version)
-          ) {
+          if ((!modelDeploymentName && !groupDeploymentName) || (!modelVersion && !groupVersion)) {
             errors.push(
               `Model "${modelName}" in group "${groupName}" is missing a required deploymentName or version.`,
             );
@@ -146,8 +147,8 @@ export function validateAzureGroups(configs: TAzureGroups): TAzureConfigValidati
 
           modelGroupMap[modelName] = {
             group: groupName,
-            // deploymentName: model.deploymentName || group.deploymentName,
-            // version: model.version || group.version,
+            // deploymentName: modelDeploymentName || groupDeploymentName,
+            // version: modelVersion || groupVersion,
           };
         }
       }
@@ -190,26 +191,27 @@ export function mapModelToAzureConfig({
     );
   }
 
-  const instanceName = groupConfig.instanceName;
+  const instanceName = groupConfig.instanceName ?? '';
 
-  if (!instanceName && !groupConfig.serverless) {
+  if (!instanceName && groupConfig.serverless !== true) {
     throw new Error(
       `Group "${modelConfig.group}" is missing an instanceName for non-serverless configuration.`,
     );
   }
 
-  if (groupConfig.serverless && !groupConfig.baseURL) {
+  const baseURL = groupConfig.baseURL ?? '';
+  if (groupConfig.serverless === true && !baseURL) {
     throw new Error(
       `Group "${modelConfig.group}" is missing the required base URL for serverless configuration.`,
     );
   }
 
-  if (groupConfig.serverless) {
+  if (groupConfig.serverless === true) {
     const result: MappedAzureConfig = {
       azureOptions: {
         azureOpenAIApiKey: extractEnvVariable(groupConfig.apiKey),
       },
-      baseURL: extractEnvVariable(groupConfig.baseURL as string),
+      baseURL: extractEnvVariable(baseURL),
       serverless: true,
     };
 
@@ -232,11 +234,11 @@ export function mapModelToAzureConfig({
   }
 
   const modelDetails = groupConfig.models[modelName];
-  const { deploymentName, version } =
+  const { deploymentName = '', version = '' } =
     typeof modelDetails === 'object'
       ? {
-        deploymentName: modelDetails.deploymentName || groupConfig.deploymentName,
-        version: modelDetails.version || groupConfig.version,
+        deploymentName: modelDetails.deploymentName ?? groupConfig.deploymentName,
+        version: modelDetails.version ?? groupConfig.version,
       }
       : {
         deploymentName: groupConfig.deploymentName,
@@ -264,8 +266,8 @@ export function mapModelToAzureConfig({
 
   const result: MappedAzureConfig = { azureOptions };
 
-  if (groupConfig.baseURL) {
-    result.baseURL = extractEnvVariable(groupConfig.baseURL);
+  if (baseURL) {
+    result.baseURL = extractEnvVariable(baseURL);
   }
 
   if (groupConfig.additionalHeaders) {
@@ -287,15 +289,17 @@ export function mapGroupToAzureConfig({
     throw new Error(`Group named "${groupName}" not found in configuration.`);
   }
 
-  const instanceName = groupConfig.instanceName as string;
+  const instanceName = groupConfig.instanceName ?? '';
+  const serverless = groupConfig.serverless ?? false;
+  const baseURL = groupConfig.baseURL ?? '';
 
-  if (!instanceName && !groupConfig.serverless) {
+  if (!instanceName && !serverless) {
     throw new Error(
       `Group "${groupName}" is missing an instanceName for non-serverless configuration.`,
     );
   }
 
-  if (groupConfig.serverless && !groupConfig.baseURL) {
+  if (serverless && !baseURL) {
     throw new Error(
       `Group "${groupName}" is missing the required base URL for serverless configuration.`,
     );
@@ -316,20 +320,20 @@ export function mapGroupToAzureConfig({
     // DeploymentName and Version set below
   };
 
-  if (groupConfig.serverless) {
+  if (serverless) {
     return {
       azureOptions,
-      baseURL: extractEnvVariable(groupConfig.baseURL ?? ''),
+      baseURL: extractEnvVariable(baseURL),
       serverless: true,
       ...(groupConfig.additionalHeaders && { headers: groupConfig.additionalHeaders }),
     };
   }
 
-  const { deploymentName, version } =
+  const { deploymentName = '', version = '' } =
     typeof modelDetails === 'object'
       ? {
-        deploymentName: modelDetails.deploymentName || groupConfig.deploymentName,
-        version: modelDetails.version || groupConfig.version,
+        deploymentName: modelDetails.deploymentName ?? groupConfig.deploymentName,
+        version: modelDetails.version ?? groupConfig.version,
       }
       : {
         deploymentName: groupConfig.deploymentName,
@@ -347,8 +351,8 @@ export function mapGroupToAzureConfig({
 
   const result: MappedAzureConfig = { azureOptions };
 
-  if (groupConfig.baseURL) {
-    result.baseURL = extractEnvVariable(groupConfig.baseURL);
+  if (baseURL) {
+    result.baseURL = extractEnvVariable(baseURL);
   }
 
   if (groupConfig.additionalHeaders) {

--- a/packages/data-provider/src/azure.ts
+++ b/packages/data-provider/src/azure.ts
@@ -209,6 +209,7 @@ export function mapModelToAzureConfig({
   if (groupConfig.serverless === true) {
     const result: MappedAzureConfig = {
       azureOptions: {
+        azureOpenAIApiVersion: extractEnvVariable(groupConfig.version ?? ''),
         azureOpenAIApiKey: extractEnvVariable(groupConfig.apiKey),
       },
       baseURL: extractEnvVariable(baseURL),
@@ -315,6 +316,7 @@ export function mapGroupToAzureConfig({
   const modelDetails = groupConfig.models[firstModelName];
 
   const azureOptions: AzureOptions = {
+    azureOpenAIApiVersion: extractEnvVariable(groupConfig.version ?? ''),
     azureOpenAIApiKey: extractEnvVariable(groupConfig.apiKey),
     azureOpenAIApiInstanceName: extractEnvVariable(instanceName),
     // DeploymentName and Version set below

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -114,10 +114,10 @@ export type TAzureModelMapSchema = {
   group: string;
 };
 
-export type TAzureModelGroupMap = Record<string, TAzureModelMapSchema>;
+export type TAzureModelGroupMap = Record<string, TAzureModelMapSchema | undefined>;
 export type TAzureGroupMap = Record<
   string,
-  TAzureBaseSchema & { models: Record<string, TAzureModelConfig> }
+  (TAzureBaseSchema & { models: Record<string, TAzureModelConfig | undefined> }) | undefined
 >;
 
 export type TValidatedAzureConfig = {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1080,7 +1080,7 @@ export enum Constants {
   /** Key for the app's version. */
   VERSION = 'v0.7.5',
   /** Key for the Custom Config's version (librechat.yaml). */
-  CONFIG_VERSION = '1.1.7',
+  CONFIG_VERSION = '1.1.8',
   /** Standard value for the first message's `parentMessageId` value, to indicate no parent exists. */
   NO_PARENT = '00000000-0000-0000-0000-000000000000',
   /** Standard value for the initial conversationId before a request is sent */


### PR DESCRIPTION
## Summary

I implemented support for Azure serverless mode by adding proper handling of API key headers and version query parameters across all clients and endpoints.

- Added support for `api-key` header in serverless mode for Azure OpenAI API requests
- Implemented `azureOpenAIApiVersion` query parameter support for serverless endpoints
- Updated Azure validation and extraction types with proper optional chaining and defaults
- Added tests to verify serverless configurations expect `azureOpenAIApiVersion`
- Fixed typing issues in Azure config validation for model groups and maps
- Added proper null checks and default values for Azure configuration properties

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested the changes by:

1. Verifying API requests include proper headers and query parameters in serverless mode
2. Running the updated test suite for Azure configurations
3. Testing with a live Azure serverless endpoint to confirm authentication works
4. Validating different Azure config scenarios handle optional properties correctly

### Test Configuration:

```yaml
endpoints:
  azureOpenAI:
    groups:
    - group: "llama318b-inference"
      apiKey: "${LLAMA318B_SERVERLESS_API_KEY}" 
      baseURL: "https://example.services.ai.azure.com/models/"
      serverless: true
      models:
        Meta-Llama-3.1-8B-Instruct: true
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes