### PR TITLE
🤖 feat: Support for new AWS Nova Models & Updated Anthropic Rates

### DIFF
--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -56,8 +56,8 @@ const tokenValues = Object.assign(
     'claude-3-sonnet': { prompt: 3, completion: 15 },
     'claude-3-5-sonnet': { prompt: 3, completion: 15 },
     'claude-3.5-sonnet': { prompt: 3, completion: 15 },
-    'claude-3-5-haiku': { prompt: 1, completion: 5 },
-    'claude-3.5-haiku': { prompt: 1, completion: 5 },
+    'claude-3-5-haiku': { prompt: 0.8, completion: 4 },
+    'claude-3.5-haiku': { prompt: 0.8, completion: 4 },
     'claude-3-haiku': { prompt: 0.25, completion: 1.25 },
     'claude-2.1': { prompt: 8, completion: 24 },
     'claude-2': { prompt: 8, completion: 24 },
@@ -83,8 +83,8 @@ const tokenValues = Object.assign(
 const cacheTokenValues = {
   'claude-3.5-sonnet': { write: 3.75, read: 0.3 },
   'claude-3-5-sonnet': { write: 3.75, read: 0.3 },
-  'claude-3.5-haiku': { write: 1.25, read: 0.1 },
-  'claude-3-5-haiku': { write: 1.25, read: 0.1 },
+  'claude-3.5-haiku': { write: 1, read: 0.08 },
+  'claude-3-5-haiku': { write: 1, read: 0.08 },
   'claude-3-haiku': { write: 0.3, read: 0.03 },
 };
 

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -211,4 +211,11 @@ const getCacheMultiplier = ({ valueKey, cacheType, model, endpoint, endpointToke
   return cacheTokenValues[valueKey]?.[cacheType] ?? null;
 };
 
-module.exports = { tokenValues, getValueKey, getMultiplier, getCacheMultiplier, defaultRate };
+module.exports = {
+  tokenValues,
+  getValueKey,
+  getMultiplier,
+  getCacheMultiplier,
+  defaultRate,
+  cacheTokenValues,
+};

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -30,6 +30,9 @@ const bedrockValues = {
   'amazon.titan-text-lite-v1': { prompt: 0.15, completion: 0.2 },
   'amazon.titan-text-express-v1': { prompt: 0.2, completion: 0.6 },
   'amazon.titan-text-premier-v1:0': { prompt: 0.5, completion: 1.5 },
+  'amazon.nova-micro-v1:0': { prompt: 0.035, completion: 0.14 },
+  'amazon.nova-lite-v1:0': { prompt: 0.06, completion: 0.24 },
+  'amazon.nova-pro-v1:0': { prompt: 0.8, completion: 3.2 },
 };
 
 /**

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -4,6 +4,7 @@ const {
   tokenValues,
   getValueKey,
   getMultiplier,
+  cacheTokenValues,
   getCacheMultiplier,
 } = require('./tx');
 
@@ -211,6 +212,7 @@ describe('getMultiplier', () => {
 
 describe('AWS Bedrock Model Tests', () => {
   const awsModels = [
+    'anthropic.claude-3-5-haiku-20241022-v1:0',
     'anthropic.claude-3-haiku-20240307-v1:0',
     'anthropic.claude-3-sonnet-20240229-v1:0',
     'anthropic.claude-3-opus-20240229-v1:0',
@@ -237,6 +239,9 @@ describe('AWS Bedrock Model Tests', () => {
     'ai21.j2-ultra-v1',
     'amazon.titan-text-lite-v1',
     'amazon.titan-text-express-v1',
+    'amazon.nova-micro-v1:0',
+    'amazon.nova-lite-v1:0',
+    'amazon.nova-pro-v1:0',
   ];
 
   it('should return the correct prompt multipliers for all models', () => {
@@ -260,12 +265,24 @@ describe('AWS Bedrock Model Tests', () => {
 
 describe('getCacheMultiplier', () => {
   it('should return the correct cache multiplier for a given valueKey and cacheType', () => {
-    expect(getCacheMultiplier({ valueKey: 'claude-3-5-sonnet', cacheType: 'write' })).toBe(3.75);
-    expect(getCacheMultiplier({ valueKey: 'claude-3-5-sonnet', cacheType: 'read' })).toBe(0.3);
-    expect(getCacheMultiplier({ valueKey: 'claude-3-5-haiku', cacheType: 'write' })).toBe(1.25);
-    expect(getCacheMultiplier({ valueKey: 'claude-3-5-haiku', cacheType: 'read' })).toBe(0.1);
-    expect(getCacheMultiplier({ valueKey: 'claude-3-haiku', cacheType: 'write' })).toBe(0.3);
-    expect(getCacheMultiplier({ valueKey: 'claude-3-haiku', cacheType: 'read' })).toBe(0.03);
+    expect(getCacheMultiplier({ valueKey: 'claude-3-5-sonnet', cacheType: 'write' })).toBe(
+      cacheTokenValues['claude-3-5-sonnet'].write,
+    );
+    expect(getCacheMultiplier({ valueKey: 'claude-3-5-sonnet', cacheType: 'read' })).toBe(
+      cacheTokenValues['claude-3-5-sonnet'].read,
+    );
+    expect(getCacheMultiplier({ valueKey: 'claude-3-5-haiku', cacheType: 'write' })).toBe(
+      cacheTokenValues['claude-3-5-haiku'].write,
+    );
+    expect(getCacheMultiplier({ valueKey: 'claude-3-5-haiku', cacheType: 'read' })).toBe(
+      cacheTokenValues['claude-3-5-haiku'].read,
+    );
+    expect(getCacheMultiplier({ valueKey: 'claude-3-haiku', cacheType: 'write' })).toBe(
+      cacheTokenValues['claude-3-haiku'].write,
+    );
+    expect(getCacheMultiplier({ valueKey: 'claude-3-haiku', cacheType: 'read' })).toBe(
+      cacheTokenValues['claude-3-haiku'].read,
+    );
   });
 
   it('should return null if cacheType is provided but not found in cacheTokenValues', () => {

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -117,6 +117,10 @@ const amazonModels = {
   'amazon.titan-text-lite-v1': 4000,
   'amazon.titan-text-express-v1': 8000,
   'amazon.titan-text-premier-v1:0': 31500, // -500 from max
+  // https://aws.amazon.com/ai/generative-ai/nova/
+  'amazon.nova-micro-v1:0': 127000, // -1000 from max,
+  'amazon.nova-lite-v1:0': 295000, // -5000 from max,
+  'amazon.nova-pro-v1:0': 295000, // -5000 from max,
 };
 
 const bedrockModels = {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -629,6 +629,7 @@ const sharedAnthropicModels = [
 export const bedrockModels = [
   'anthropic.claude-3-5-sonnet-20241022-v2:0',
   'anthropic.claude-3-5-sonnet-20240620-v1:0',
+  'anthropic.claude-3-5-haiku-20241022-v1:0',
   'anthropic.claude-3-haiku-20240307-v1:0',
   'anthropic.claude-3-opus-20240229-v1:0',
   'anthropic.claude-3-sonnet-20240229-v1:0',


### PR DESCRIPTION
## Summary

Originally #4851

Note, for Amazon Nova models only cross-region inference ids are currently supported.

Full list (not yet updated with nova models)
https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html

So in the US, `us.amazon.nova-pro-v1:0` will work and not `amazon.nova-pro-v1:0`

Closes #4849

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes