### PR TITLE
🔧 chore: bump mongoose to 8.8.3 for CVE-2024-53900

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -77,7 +77,7 @@
     "meilisearch": "^0.38.0",
     "mime": "^3.0.0",
     "module-alias": "^2.2.3",
-    "mongoose": "^7.3.3",
+    "mongoose": "^8.8.3",
     "multer": "^1.4.5-lts.1",
     "nanoid": "^3.3.7",
     "nodejs-gpt": "^1.37.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "meilisearch": "^0.38.0",
         "mime": "^3.0.0",
         "module-alias": "^2.2.3",
-        "mongoose": "^7.3.3",
+        "mongoose": "^8.8.3",
         "multer": "^1.4.5-lts.1",
         "nanoid": "^3.3.7",
         "nodejs-gpt": "^1.37.4",
@@ -463,6 +463,14 @@
         "undici-types": "~5.26.4"
       }
     },
+    "api/node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "api/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -472,6 +480,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "api/node_modules/bson": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.1.tgz",
+      "integrity": "sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "api/node_modules/cookie-parser": {
@@ -557,6 +573,14 @@
         "node": ">= 0.6"
       }
     },
+    "api/node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "api/node_modules/langsmith": {
       "version": "0.1.59",
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.1.59.tgz",
@@ -577,6 +601,117 @@
           "optional": true
         }
       }
+    },
+    "api/node_modules/mongodb": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.10.0.tgz",
+      "integrity": "sha512-gP9vduuYWb9ZkDM546M+MP2qKVk5ZG2wPF63OvSRuUbqCR+11ZCAE1mOfllhlAG0wcoJY5yDL/rV3OmYEwXIzg==",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.7.0",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "api/node_modules/mongodb-connection-string-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
+      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
+      }
+    },
+    "api/node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "api/node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "api/node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "api/node_modules/mongoose": {
+      "version": "8.8.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.8.3.tgz",
+      "integrity": "sha512-/I4n/DcXqXyIiLRfAmUIiTjj3vXfeISke8dt4U4Y8Wfm074Wa6sXnQrXN49NFOFf2mM1kUdOXryoBvkuCnr+Qw==",
+      "dependencies": {
+        "bson": "^6.7.0",
+        "kareem": "2.6.3",
+        "mongodb": "~6.10.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "api/node_modules/mongoose/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "api/node_modules/ms": {
       "version": "2.0.0",
@@ -627,6 +762,11 @@
           "optional": true
         }
       }
+    },
+    "api/node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="
     },
     "api/node_modules/tr46": {
       "version": "0.0.3",
@@ -10380,7 +10520,6 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.8.tgz",
       "integrity": "sha512-qKwC/M/nNNaKUBMQ0nuzm47b7ZYWQHN3pcXq4IIcoSBc2hOIrflAxJduIvvqmhoz3gR2TacTAs8vlsCVPkiEdQ==",
-      "devOptional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -16476,6 +16615,8 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
       "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14.20.1"
       }
@@ -23837,14 +23978,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/kareem": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
-      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/katex": {
       "version": "0.16.10",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.10.tgz",
@@ -26068,8 +26201,7 @@
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "devOptional": true
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
@@ -26904,6 +27036,8 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
       "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "bson": "^5.5.0",
         "mongodb-connection-string-url": "^2.6.0",
@@ -27108,27 +27242,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/mongoose": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.1.tgz",
-      "integrity": "sha512-c3MY8P1mGUGO+0H8rqxMNmAmhP0xb2EPNItfr7tHAHkh52uB0owH4Gu6q1GTUYj8yoHEDG5MN2V1aBBR6aJPuA==",
-      "dependencies": {
-        "bson": "^5.5.0",
-        "kareem": "2.5.1",
-        "mongodb": "5.9.2",
-        "mpath": "0.9.0",
-        "mquery": "5.0.0",
-        "ms": "2.1.3",
-        "sift": "16.0.1"
-      },
-      "engines": {
-        "node": ">=14.20.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mongoose"
       }
     },
     "node_modules/moo": {
@@ -32479,11 +32592,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/sift": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
-      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
-    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -32697,7 +32805,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "devOptional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }


### PR DESCRIPTION
https://github.com/danny-avila/LibreChat/security/dependabot/24