### PR TITLE
fix: replaced deprecated MongoDB count() with countDocuments 

### DIFF
--- a/config/user-stats.js
+++ b/config/user-stats.js
@@ -19,8 +19,8 @@ const connect = require('./connect');
   let users = await User.find({});
   let userData = [];
   for (const user of users) {
-    let conversationsCount = (await Conversation.count({ user: user._id })) ?? 0;
-    let messagesCount = (await Message.count({ user: user._id })) ?? 0;
+    let conversationsCount = (await Conversation.countDocuments({ user: user._id })) ?? 0;
+    let messagesCount = (await Message.countDocuments({ user: user._id })) ?? 0;
 
     userData.push({
       User: user.name,


### PR DESCRIPTION
# Pull Request Template

## Summary

MongoDB count() function was deprecated, so it must be replaced with countDocuments()

## Change Type

Please delete any irrelevant options.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

It is only a change of a function name

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] My changes do not introduce new warnings
- [X] Local unit tests pass with my changes
