### PR TITLE
🪨 feat: add session token variable for AWS Bedrock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,7 @@ BINGAI_TOKEN=user_provided
 # BEDROCK_AWS_DEFAULT_REGION=us-east-1 # A default region must be provided
 # BEDROCK_AWS_ACCESS_KEY_ID=someAccessKey
 # BEDROCK_AWS_SECRET_ACCESS_KEY=someSecretAccessKey
+# BEDROCK_AWS_SESSION_TOKEN=someSessionToken
 
 # Note: This example list is not meant to be exhaustive. If omitted, all known, supported model IDs will be included for you.
 # BEDROCK_AWS_MODELS=anthropic.claude-3-5-sonnet-20240620-v1:0,meta.llama3-1-8b-instruct-v1:0


### PR DESCRIPTION
# Pull Request Template

## Summary

This pull request adds a new environment variable `BEDROCK_AWS_SESSION_TOKEN` to the `.env.example` file.
This change enables session token-based authentication for AWS Bedrock, complementing the existing access key and secret key support.

Closes: [#4895](https://github.com/danny-avila/LibreChat/issues/4895)

### Related Pull Requests

This PR is related to [#4655](https://github.com/danny-avila/LibreChat/pull/4655), which introduces initial support for environment variables for AWS Bedrock. This PR complements it by adding the `BEDROCK_AWS_SESSION_TOKEN` variable for session token-based authentication.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

The changes were tested locally to ensure the `.env.example` file is updated correctly, with no syntax errors or issues when loaded into the application.

### **Test Configuration**:
- No specific testing configuration is required as this is a static file update.

## Checklist

- [x] My code adheres to this project's style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented in any complex areas of my code (if applicable).
- [x] I have made pertinent documentation changes.
- [x] My changes do not introduce new warnings.
- [x] Local unit tests pass with my changes.