### PR TITLE
🤖 feat: Add Vision Models; fix: Agents `user_provided` Keys

### DIFF
--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -138,9 +138,9 @@ export default function useChatFunctions({
       (msg) => msg.messageId === latestMessage?.parentMessageId,
     );
 
-    let thread_id = parentMessage?.thread_id ?? latestMessage?.thread_id;
+    let thread_id = parentMessage?.thread_id ?? latestMessage?.thread_id ?? '';
     if (!thread_id) {
-      thread_id = currentMessages.find((message) => message.thread_id)?.thread_id;
+      thread_id = currentMessages.find((message) => message.thread_id)?.thread_id ?? '';
     }
 
     const endpointsConfig = queryClient.getQueryData<TEndpointsConfig>([QueryKeys.endpoints]);
@@ -168,6 +168,8 @@ export default function useChatFunctions({
       endpointOption.key = getExpiry();
       endpointOption.thread_id = thread_id;
       endpointOption.modelDisplayLabel = modelDisplayLabel;
+    } else {
+      endpointOption.key = new Date(Date.now() + 60 * 60 * 1000).toISOString();
     }
     const responseSender = getSender({ model: conversation?.model, ...endpointOption });
 
@@ -177,13 +179,14 @@ export default function useChatFunctions({
       isCreatedByUser: true,
       parentMessageId,
       conversationId,
-      messageId: isContinued && messageId ? messageId : intermediateId,
+      messageId: isContinued && messageId != null && messageId ? messageId : intermediateId,
       thread_id,
       error: false,
     };
 
-    const reuseFiles = (isRegenerate || resubmitFiles) && parentMessage?.files;
-    if (setFiles && reuseFiles && parentMessage.files?.length) {
+    const reuseFiles =
+      (isRegenerate || resubmitFiles) && parentMessage?.files && parentMessage.files.length > 0;
+    if (setFiles && reuseFiles === true) {
       currentMsg.files = parentMessage.files;
       setFiles(new Map());
       setFilesToDelete({});

--- a/package-lock.json
+++ b/package-lock.json
@@ -36173,7 +36173,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.57",
+      "version": "0.7.58",
       "license": "ISC",
       "dependencies": {
         "@types/js-yaml": "^4.0.9",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.57",
+  "version": "0.7.58",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -761,6 +761,13 @@ export const visionModels = [
   'gemini-pro-vision',
   'claude-3',
   'gemini-1.5',
+  'gemini-exp',
+  'moondream',
+  'llama3.2-vision',
+  'llama-3.2-90b-vision',
+  'llama-3.2-11b-vision',
+  'llama-3-2-90b-vision',
+  'llama-3-2-11b-vision',
 ];
 export enum VisionModes {
   generative = 'generative',


### PR DESCRIPTION
## Summary 

Closes #4900 

I added several new vision models to the data provider configuration, expanding the available options for image processing capabilities. 

- Added Gemini experimental model `gemini-exp` to the vision models array
- Added Moondream vision model to support additional image processing features
- Added multiple Llama vision models with varying parameters (3.2 series)
- Added alternative naming conventions for Llama models to ensure compatibility
- Incremented the data provider package version from 0.7.57 to 0.7.58

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have made pertinent documentation changes