### PR TITLE
🐛 fix: Gemini system instructions not sent with null RAG_API_URL

### DIFF
--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -697,7 +697,7 @@ class GoogleClient extends BaseClient {
         promptPrefix = `${promptPrefix ?? ''}\n${this.options.artifactsPrompt}`.trim();
       }
 
-      if (this.options?.promptPrefix?.length) {
+      if (promptPrefix.length) {
         requestOptions.systemInstruction = {
           parts: [
             {


### PR DESCRIPTION
## Summary

System instructions were not being sent to gemini models when RAG_API_URL was not set, as the original promptPrefix was not being populated.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Run a gemini model with `RAG_API_URL` not set and ask it "list available artifact types". It will not be able to provide a list

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

