### PR TITLE
🔐 fix: Assign ADMIN role based on first registration in LDAP strategy

### DIFF
--- a/api/strategies/ldapStrategy.js
+++ b/api/strategies/ldapStrategy.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const LdapStrategy = require('passport-ldapauth');
+const { SystemRoles } = require('librechat-data-provider');
 const { findUser, createUser, updateUser } = require('~/models/userMethods');
+const { countUsers } = require('~/models/userMethods');
 const { isEnabled } = require('~/server/utils');
 const logger = require('~/utils/logger');
 
@@ -109,6 +111,7 @@ const ldapLogin = new LdapStrategy(ldapOptions, async (userinfo, done) => {
     }
 
     if (!user) {
+      const isFirstRegisteredUser = (await countUsers()) === 0;
       user = {
         provider: 'ldap',
         ldapId,
@@ -116,6 +119,7 @@ const ldapLogin = new LdapStrategy(ldapOptions, async (userinfo, done) => {
         email: mail,
         emailVerified: true, // The ldap server administrator should verify the email
         name: fullName,
+        role: isFirstRegisteredUser ? SystemRoles.ADMIN : SystemRoles.USER,
       };
       const userId = await createUser(user);
       user._id = userId;


### PR DESCRIPTION
Closes #4971