### PR TITLE
feat: Markdown and Code artifacts

### DIFF
--- a/api/app/clients/prompts/artifacts.js
+++ b/api/app/clients/prompts/artifacts.js
@@ -95,12 +95,21 @@ const artifactTypes = {
       `,
     },
   },
+  'application/vnd.code': {
+    name: 'Code',
+    instructions: [
+      'Use for code snippets or scripts in any programming language.',
+      'Include the language name as the value of the `language` attribute (e.g., `language="python"`)',
+    ],
+  },
   'text/html': {
     name: 'HTML',
     instructions: [
       'The user interface can render single file HTML pages placed within the artifact tags. HTML, JS, and CSS should be in a single file when using the `text/html` type',
       'Images from the web are not allowed, but you can use placeholder images by specifying the width and height like so `<img src="/api/placeholder/400/320" alt="placeholder" />`',
       'The only place external scripts can be imported from is https://cdnjs.cloudflare.com',
+      'It is inappropriate to use "text/html" when sharing snippets, code samples & example HTML or CSS code, as it would be rendered as a webpage and the source code would be obscured. The assistant should instead use "application/vnd.code" defined above.',
+      'If the assistant is unable to follow the above requirements for any reason, use "application/vnd.code" type for the artifact instead, which will not attempt to render the webpage.',
     ],
     example: {
       user: 'Create a basic HTML structure for a blog post',

--- a/api/app/clients/prompts/artifacts.js
+++ b/api/app/clients/prompts/artifacts.js
@@ -3,119 +3,8 @@ const { EModelEndpoint, ArtifactModes } = require('librechat-data-provider');
 const { generateShadcnPrompt } = require('~/app/clients/prompts/shadcn-docs/generate');
 const { components } = require('~/app/clients/prompts/shadcn-docs/components');
 
-// eslint-disable-next-line no-unused-vars
-const artifactsPromptV1 = dedent`The assistant can create and reference artifacts during conversations.
-  
-Artifacts are for substantial, self-contained content that users might modify or reuse, displayed in a separate UI window for clarity.
-
-# Good artifacts are...
-- Substantial content (>15 lines)
-- Content that the user is likely to modify, iterate on, or take ownership of
-- Self-contained, complex content that can be understood on its own, without context from the conversation
-- Content intended for eventual use outside the conversation (e.g., reports, emails, presentations)
-- Content likely to be referenced or reused multiple times
-
-# Don't use artifacts for...
-- Simple, informational, or short content, such as brief code snippets, mathematical equations, or small examples
-- Primarily explanatory, instructional, or illustrative content, such as examples provided to clarify a concept
-- Suggestions, commentary, or feedback on existing artifacts
-- Conversational or explanatory content that doesn't represent a standalone piece of work
-- Content that is dependent on the current conversational context to be useful
-- Content that is unlikely to be modified or iterated upon by the user
-- Request from users that appears to be a one-off question
-
-# Usage notes
-- One artifact per message unless specifically requested
-- Prefer in-line content (don't use artifacts) when possible. Unnecessary use of artifacts can be jarring for users.
-- If a user asks the assistant to "draw an SVG" or "make a website," the assistant does not need to explain that it doesn't have these capabilities. Creating the code and placing it within the appropriate artifact will fulfill the user's intentions.
-- If asked to generate an image, the assistant can offer an SVG instead. The assistant isn't very proficient at making SVG images but should engage with the task positively. Self-deprecating humor about its abilities can make it an entertaining experience for users.
-- The assistant errs on the side of simplicity and avoids overusing artifacts for content that can be effectively presented within the conversation.
-- Always provide complete, specific, and fully functional content without any placeholders, ellipses, or 'remains the same' comments.
-
-<artifact_instructions>
-  When collaborating with the user on creating content that falls into compatible categories, the assistant should follow these steps:
-
-  1. Create the artifact using the following format:
-
-     :::artifact{identifier="unique-identifier" type="mime-type" title="Artifact Title"}
-     \`\`\`
-     Your artifact content here
-     \`\`\`
-     :::
-
-  2. Assign an identifier to the \`identifier\` attribute. For updates, reuse the prior identifier. For new artifacts, the identifier should be descriptive and relevant to the content, using kebab-case (e.g., "example-code-snippet"). This identifier will be used consistently throughout the artifact's lifecycle, even when updating or iterating on the artifact.
-  3. Include a \`title\` attribute to provide a brief title or description of the content.
-  4. Add a \`type\` attribute to specify the type of content the artifact represents. Assign one of the following values to the \`type\` attribute:
-    - HTML: "text/html"
-      - The user interface can render single file HTML pages placed within the artifact tags. HTML, JS, and CSS should be in a single file when using the \`text/html\` type.
-      - Images from the web are not allowed, but you can use placeholder images by specifying the width and height like so \`<img src="/api/placeholder/400/320" alt="placeholder" />\`
-      - The only place external scripts can be imported from is https://cdnjs.cloudflare.com
-    - Mermaid Diagrams: "application/vnd.mermaid"
-      - The user interface will render Mermaid diagrams placed within the artifact tags.
-    - React Components: "application/vnd.react"
-      - Use this for displaying either: React elements, e.g. \`<strong>Hello World!</strong>\`, React pure functional components, e.g. \`() => <strong>Hello World!</strong>\`, React functional components with Hooks, or React component classes
-      - When creating a React component, ensure it has no required props (or provide default values for all props) and use a default export.
-      - Use Tailwind classes for styling. DO NOT USE ARBITRARY VALUES (e.g. \`h-[600px]\`).
-      - Base React is available to be imported. To use hooks, first import it at the top of the artifact, e.g. \`import { useState } from "react"\`
-      - The lucide-react@0.263.1 library is available to be imported. e.g. \`import { Camera } from "lucide-react"\` & \`<Camera color="red" size={48} />\`
-      - The recharts charting library is available to be imported, e.g. \`import { LineChart, XAxis, ... } from "recharts"\` & \`<LineChart ...><XAxis dataKey="name"> ...\`
-      - The assistant can use prebuilt components from the \`shadcn/ui\` library after it is imported: \`import { Alert, AlertDescription, AlertTitle, AlertDialog, AlertDialogAction } from '/components/ui/alert';\`. If using components from the shadcn/ui library, the assistant mentions this to the user and offers to help them install the components if necessary.
-      - Components MUST be imported from \`/components/ui/name\` and NOT from \`/components/name\` or \`@/components/ui/name\`.
-      - NO OTHER LIBRARIES (e.g. zod, hookform) ARE INSTALLED OR ABLE TO BE IMPORTED.
-      - Images from the web are not allowed, but you can use placeholder images by specifying the width and height like so \`<img src="/api/placeholder/400/320" alt="placeholder" />\`
-      - If you are unable to follow the above requirements for any reason, don't use artifacts and use regular code blocks instead, which will not attempt to render the component.
-  5. Include the complete and updated content of the artifact, without any truncation or minimization. Don't use "// rest of the code remains the same...".
-  6. If unsure whether the content qualifies as an artifact, if an artifact should be updated, or which type to assign to an artifact, err on the side of not creating an artifact.
-  7. Always use triple backticks (\`\`\`) to enclose the content within the artifact, regardless of the content type.
-</artifact_instructions>
-
-Here are some examples of correct usage of artifacts:
-
-<examples>
-  <example_docstring>
-    This example demonstrates how to create a Mermaid artifact for a simple flow chart.
-  </example_docstring>
-
-  <example>
-    <user_query>Can you create a simple flow chart showing the process of making tea using Mermaid?</user_query>
-
-    <assistant_response>
-      Sure! Here's a simple flow chart depicting the process of making tea using Mermaid syntax:
-
-      :::artifact{identifier="tea-making-flowchart" type="application/vnd.mermaid" title="Flow chart: Making Tea"}
-      \`\`\`mermaid
-      graph TD
-          A[Start] --> B{Water boiled?}
-          B -->|Yes| C[Add tea leaves to cup]
-          B -->|No| D[Boil water]
-          D --> B
-          C --> E[Pour boiling water into cup]
-          E --> F[Steep tea for desired time]
-          F --> G[Remove tea leaves]
-          G --> H[Add milk or sugar, if desired]
-          H --> I[Enjoy your tea!]
-          I --> J[End]
-      \`\`\`
-      :::
-
-      This flow chart uses Mermaid syntax to visualize the steps involved in making a cup of tea. Here's a brief explanation of the process:
-
-      1. Start
-      2. Check if water is boiled
-      3. If not boiled, boil the water
-      4. Once water is boiled, add tea leaves to the cup
-      5. Pour boiling water into the cup
-      6. Steep the tea for the desired time
-      7. Remove the tea leaves
-      8. Optionally add milk or sugar
-      9. Enjoy your tea!
-      10. End
-
-      This chart provides a clear visual representation of the tea-making process. You can easily modify or expand this chart if you want to add more details or steps to the process. Let me know if you'd like any changes or have any questions!
-    </assistant_response>
-  </example>
-</examples>`;
-const artifactsPrompt = dedent`The assistant can create and reference artifacts during conversations.
+// Common introduction to artifacts
+const artifactsPromptIntroduction = dedent`The assistant can create and reference artifacts during conversations.
   
 Artifacts are for substantial, self-contained content that users might modify or reuse, displayed in a separate UI window for clarity.
 
@@ -142,198 +31,21 @@ Artifacts are for substantial, self-contained content that users might modify or
 - If asked to generate an image, the assistant can offer an SVG instead. The assistant isn't very proficient at making SVG images but should engage with the task positively. Self-deprecating humor about its abilities can make it an entertaining experience for users.
 - The assistant errs on the side of simplicity and avoids overusing artifacts for content that can be effectively presented within the conversation.
 - Always provide complete, specific, and fully functional content for artifacts without any snippets, placeholders, ellipses, or 'remains the same' comments.
-- If an artifact is not necessary or requested, the assistant should not mention artifacts at all, and respond to the user accordingly.
+- If an artifact is not necessary or requested, the assistant should not mention artifacts at all, and respond to the user accordingly.`;
 
-<artifact_instructions>
+// Formatting instructions. Non-antrophic models need more complex instructions.
+const formatInstructionsAntrophic = dedent`
   When collaborating with the user on creating content that falls into compatible categories, the assistant should follow these steps:
-
   1. Create the artifact using the following format:
 
      :::artifact{identifier="unique-identifier" type="mime-type" title="Artifact Title"}
      \`\`\`
      Your artifact content here
      \`\`\`
-     :::
+     :::`;
 
-  2. Assign an identifier to the \`identifier\` attribute. For updates, reuse the prior identifier. For new artifacts, the identifier should be descriptive and relevant to the content, using kebab-case (e.g., "example-code-snippet"). This identifier will be used consistently throughout the artifact's lifecycle, even when updating or iterating on the artifact.
-  3. Include a \`title\` attribute to provide a brief title or description of the content.
-  4. Add a \`type\` attribute to specify the type of content the artifact represents. Assign one of the following values to the \`type\` attribute:
-    - HTML: "text/html"
-      - The user interface can render single file HTML pages placed within the artifact tags. HTML, JS, and CSS should be in a single file when using the \`text/html\` type.
-      - Images from the web are not allowed, but you can use placeholder images by specifying the width and height like so \`<img src="/api/placeholder/400/320" alt="placeholder" />\`
-      - The only place external scripts can be imported from is https://cdnjs.cloudflare.com
-    - SVG: "image/svg+xml"
-      - The user interface will render the Scalable Vector Graphics (SVG) image within the artifact tags.
-      - The assistant should specify the viewbox of the SVG rather than defining a width/height
-    - Mermaid Diagrams: "application/vnd.mermaid"
-      - The user interface will render Mermaid diagrams placed within the artifact tags.
-    - React Components: "application/vnd.react"
-      - Use this for displaying either: React elements, e.g. \`<strong>Hello World!</strong>\`, React pure functional components, e.g. \`() => <strong>Hello World!</strong>\`, React functional components with Hooks, or React component classes
-      - When creating a React component, ensure it has no required props (or provide default values for all props) and use a default export.
-      - Use Tailwind classes for styling. DO NOT USE ARBITRARY VALUES (e.g. \`h-[600px]\`).
-      - Base React is available to be imported. To use hooks, first import it at the top of the artifact, e.g. \`import { useState } from "react"\`
-      - The lucide-react@0.394.0 library is available to be imported. e.g. \`import { Camera } from "lucide-react"\` & \`<Camera color="red" size={48} />\`
-      - The recharts charting library is available to be imported, e.g. \`import { LineChart, XAxis, ... } from "recharts"\` & \`<LineChart ...><XAxis dataKey="name"> ...\`
-      - The three.js library is available to be imported, e.g. \`import * as THREE from "three";\`
-      - The date-fns library is available to be imported, e.g. \`import { compareAsc, format } from "date-fns";\`
-      - The react-day-picker library is available to be imported, e.g. \`import { DayPicker } from "react-day-picker";\`
-      - The assistant can use prebuilt components from the \`shadcn/ui\` library after it is imported: \`import { Alert, AlertDescription, AlertTitle, AlertDialog, AlertDialogAction } from '/components/ui/alert';\`. If using components from the shadcn/ui library, the assistant mentions this to the user and offers to help them install the components if necessary.
-      - Components MUST be imported from \`/components/ui/name\` and NOT from \`/components/name\` or \`@/components/ui/name\`.
-      - NO OTHER LIBRARIES (e.g. zod, hookform) ARE INSTALLED OR ABLE TO BE IMPORTED.
-      - Images from the web are not allowed, but you can use placeholder images by specifying the width and height like so \`<img src="/api/placeholder/400/320" alt="placeholder" />\`
-      - When iterating on code, ensure that the code is complete and functional without any snippets, placeholders, or ellipses.
-      - If you are unable to follow the above requirements for any reason, don't use artifacts and use regular code blocks instead, which will not attempt to render the component.
-  5. Include the complete and updated content of the artifact, without any truncation or minimization. Don't use "// rest of the code remains the same...".
-  6. If unsure whether the content qualifies as an artifact, if an artifact should be updated, or which type to assign to an artifact, err on the side of not creating an artifact.
-  7. Always use triple backticks (\`\`\`) to enclose the content within the artifact, regardless of the content type.
-</artifact_instructions>
-
-Here are some examples of correct usage of artifacts:
-
-<examples>
-  <example_docstring>
-    This example demonstrates how to create a Mermaid artifact for a simple flow chart.
-  </example_docstring>
-
-  <example>
-    <user_query>Can you create a simple flow chart showing the process of making tea using Mermaid?</user_query>
-
-    <assistant_response>
-      Sure! Here's a simple flow chart depicting the process of making tea using Mermaid syntax:
-
-      :::artifact{identifier="tea-making-flowchart" type="application/vnd.mermaid" title="Flow chart: Making Tea"}
-      \`\`\`mermaid
-      graph TD
-          A[Start] --> B{Water boiled?}
-          B -->|Yes| C[Add tea leaves to cup]
-          B -->|No| D[Boil water]
-          D --> B
-          C --> E[Pour boiling water into cup]
-          E --> F[Steep tea for desired time]
-          F --> G[Remove tea leaves]
-          G --> H[Add milk or sugar, if desired]
-          H --> I[Enjoy your tea!]
-          I --> J[End]
-      \`\`\`
-      :::
-
-      This flow chart uses Mermaid syntax to visualize the steps involved in making a cup of tea. Here's a brief explanation of the process:
-
-      1. Start
-      2. Check if water is boiled
-      3. If not boiled, boil the water
-      4. Once water is boiled, add tea leaves to the cup
-      5. Pour boiling water into the cup
-      6. Steep the tea for the desired time
-      7. Remove the tea leaves
-      8. Optionally add milk or sugar
-      9. Enjoy your tea!
-      10. End
-
-      This chart provides a clear visual representation of the tea-making process. You can easily modify or expand this chart if you want to add more details or steps to the process. Let me know if you'd like any changes or have any questions!
-    </assistant_response>
-  </example>
-
-  <example>
-    <user_query>Create a simple React counter component</user_query>
-    <assistant_response>
-      Here's a simple React counter component:
-
-      :::artifact{identifier="react-counter" type="application/vnd.react" title="React Counter"}
-      \`\`\`
-      import { useState } from 'react';
-
-      export default function Counter() {
-        const [count, setCount] = useState(0);
-        return (
-          <div className="p-4">
-            <p className="mb-2">Count: {count}</p>
-            <button className="bg-blue-500 text-white px-4 py-2 rounded" onClick={() => setCount(count + 1)}>
-              Increment
-            </button>
-          </div>
-        );
-      }
-      \`\`\`
-      :::
-
-      This component creates a simple counter with an increment button.
-    </assistant_response>
-  </example>
-
-  <example>
-    <user_query>Create a basic HTML structure for a blog post</user_query>
-    <assistant_response>
-      Here's a basic HTML structure for a blog post:
-
-      :::artifact{identifier="blog-post-html" type="text/html" title="Blog Post HTML"}
-      \`\`\`
-      <!DOCTYPE html>
-      <html lang="en">
-      <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>My Blog Post</title>
-        <style>
-          body { font-family: Arial, sans-serif; line-height: 1.6; max-width: 800px; margin: 0 auto; padding: 20px; }
-          h1 { color: #333; }
-          p { margin-bottom: 15px; }
-        </style>
-      </head>
-      <body>
-        <header>
-          <h1>My First Blog Post</h1>
-        </header>
-        <main>
-          <article>
-            <p>This is the content of my blog post. It's short and sweet!</p>
-          </article>
-        </main>
-        <footer>
-          <p>&copy; 2023 My Blog</p>
-        </footer>
-      </body>
-      </html>
-      \`\`\`
-      :::
-
-      This HTML structure provides a simple layout for a blog post.
-    </assistant_response>
-  </example>
-</examples>`;
-
-const artifactsOpenAIPrompt = dedent`The assistant can create and reference artifacts during conversations.
-  
-Artifacts are for substantial, self-contained content that users might modify or reuse, displayed in a separate UI window for clarity.
-
-# Good artifacts are...
-- Substantial content (>15 lines)
-- Content that the user is likely to modify, iterate on, or take ownership of
-- Self-contained, complex content that can be understood on its own, without context from the conversation
-- Content intended for eventual use outside the conversation (e.g., reports, emails, presentations)
-- Content likely to be referenced or reused multiple times
-
-# Don't use artifacts for...
-- Simple, informational, or short content, such as brief code snippets, mathematical equations, or small examples
-- Primarily explanatory, instructional, or illustrative content, such as examples provided to clarify a concept
-- Suggestions, commentary, or feedback on existing artifacts
-- Conversational or explanatory content that doesn't represent a standalone piece of work
-- Content that is dependent on the current conversational context to be useful
-- Content that is unlikely to be modified or iterated upon by the user
-- Request from users that appears to be a one-off question
-
-# Usage notes
-- One artifact per message unless specifically requested
-- Prefer in-line content (don't use artifacts) when possible. Unnecessary use of artifacts can be jarring for users.
-- If a user asks the assistant to "draw an SVG" or "make a website," the assistant does not need to explain that it doesn't have these capabilities. Creating the code and placing it within the appropriate artifact will fulfill the user's intentions.
-- If asked to generate an image, the assistant can offer an SVG instead. The assistant isn't very proficient at making SVG images but should engage with the task positively. Self-deprecating humor about its abilities can make it an entertaining experience for users.
-- The assistant errs on the side of simplicity and avoids overusing artifacts for content that can be effectively presented within the conversation.
-- Always provide complete, specific, and fully functional content for artifacts without any snippets, placeholders, ellipses, or 'remains the same' comments.
-- If an artifact is not necessary or requested, the assistant should not mention artifacts at all, and respond to the user accordingly.
-
-## Artifact Instructions
+const formatInstructions = dedent`
   When collaborating with the user on creating content that falls into compatible categories, the assistant should follow these steps:
-
   1. Create the artifact using the following remark-directive markdown format:
 
       :::artifact{identifier="unique-identifier" type="mime-type" title="Artifact Title"}
@@ -354,116 +66,24 @@ Artifacts are for substantial, self-contained content that users might modify or
   b. Common mistakes to avoid:
    - Don't split the opening ::: line
    - Don't add extra backticks outside the artifact structure
-   - Don't omit the closing :::
+   - Don't omit the closing :::`;
 
-  2. Assign an identifier to the \`identifier\` attribute. For updates, reuse the prior identifier. For new artifacts, the identifier should be descriptive and relevant to the content, using kebab-case (e.g., "example-code-snippet"). This identifier will be used consistently throughout the artifact's lifecycle, even when updating or iterating on the artifact.
+const formatInstructionsOutro = dedent`2. Assign an identifier to the \`identifier\` attribute. For updates, reuse the prior identifier. For new artifacts, the identifier should be descriptive and relevant to the content, using kebab-case (e.g., "example-code-snippet"). This identifier will be used consistently throughout the artifact's lifecycle, even when updating or iterating on the artifact.
   3. Include a \`title\` attribute to provide a brief title or description of the content.
-  4. Add a \`type\` attribute to specify the type of content the artifact represents. Assign one of the following values to the \`type\` attribute:
-    - HTML: "text/html"
-      - The user interface can render single file HTML pages placed within the artifact tags. HTML, JS, and CSS should be in a single file when using the \`text/html\` type.
-      - Images from the web are not allowed, but you can use placeholder images by specifying the width and height like so \`<img src="/api/placeholder/400/320" alt="placeholder" />\`
-      - The only place external scripts can be imported from is https://cdnjs.cloudflare.com
-    - SVG: "image/svg+xml"
-      - The user interface will render the Scalable Vector Graphics (SVG) image within the artifact tags.
-      - The assistant should specify the viewbox of the SVG rather than defining a width/height
-    - Mermaid Diagrams: "application/vnd.mermaid"
-      - The user interface will render Mermaid diagrams placed within the artifact tags.
-    - React Components: "application/vnd.react"
-      - Use this for displaying either: React elements, e.g. \`<strong>Hello World!</strong>\`, React pure functional components, e.g. \`() => <strong>Hello World!</strong>\`, React functional components with Hooks, or React component classes
-      - When creating a React component, ensure it has no required props (or provide default values for all props) and use a default export.
-      - Use Tailwind classes for styling. DO NOT USE ARBITRARY VALUES (e.g. \`h-[600px]\`).
-      - Base React is available to be imported. To use hooks, first import it at the top of the artifact, e.g. \`import { useState } from "react"\`
-      - The lucide-react@0.394.0 library is available to be imported. e.g. \`import { Camera } from "lucide-react"\` & \`<Camera color="red" size={48} />\`
-      - The recharts charting library is available to be imported, e.g. \`import { LineChart, XAxis, ... } from "recharts"\` & \`<LineChart ...><XAxis dataKey="name"> ...\`
-      - The three.js library is available to be imported, e.g. \`import * as THREE from "three";\`
-      - The date-fns library is available to be imported, e.g. \`import { compareAsc, format } from "date-fns";\`
-      - The react-day-picker library is available to be imported, e.g. \`import { DayPicker } from "react-day-picker";\`
-      - The assistant can use prebuilt components from the \`shadcn/ui\` library after it is imported: \`import { Alert, AlertDescription, AlertTitle, AlertDialog, AlertDialogAction } from '/components/ui/alert';\`. If using components from the shadcn/ui library, the assistant mentions this to the user and offers to help them install the components if necessary.
-      - Components MUST be imported from \`/components/ui/name\` and NOT from \`/components/name\` or \`@/components/ui/name\`.
-      - NO OTHER LIBRARIES (e.g. zod, hookform) ARE INSTALLED OR ABLE TO BE IMPORTED.
-      - Images from the web are not allowed, but you can use placeholder images by specifying the width and height like so \`<img src="/api/placeholder/400/320" alt="placeholder" />\`
-      - When iterating on code, ensure that the code is complete and functional without any snippets, placeholders, or ellipses.
-      - If you are unable to follow the above requirements for any reason, don't use artifacts and use regular code blocks instead, which will not attempt to render the component.
-  5. Include the complete and updated content of the artifact, without any truncation or minimization. Don't use "// rest of the code remains the same...".
-  6. If unsure whether the content qualifies as an artifact, if an artifact should be updated, or which type to assign to an artifact, err on the side of not creating an artifact.
-  7. NEVER use triple backticks to enclose the artifact, ONLY the content within the artifact.
+  4. Add a \`type\` attribute to specify the type of content the artifact represents. Assign one of the following values to the \`type\` attribute:`;
 
-Here are some examples of correct usage of artifacts:
-
-## Examples
-
-### Example 1
-
-    This example demonstrates how to create a Mermaid artifact for a simple flow chart.
-
-    User: Can you create a simple flow chart showing the process of making tea using Mermaid?
-
-    Assistant: Sure! Here's a simple flow chart depicting the process of making tea using Mermaid syntax:
-
-      :::artifact{identifier="tea-making-flowchart" type="application/vnd.mermaid" title="Flow chart: Making Tea"}
-      \`\`\`mermaid
-      graph TD
-          A[Start] --> B{Water boiled?}
-          B -->|Yes| C[Add tea leaves to cup]
-          B -->|No| D[Boil water]
-          D --> B
-          C --> E[Pour boiling water into cup]
-          E --> F[Steep tea for desired time]
-          F --> G[Remove tea leaves]
-          G --> H[Add milk or sugar, if desired]
-          H --> I[Enjoy your tea!]
-          I --> J[End]
-      \`\`\`
-      :::
-
-      This flow chart uses Mermaid syntax to visualize the steps involved in making a cup of tea. Here's a brief explanation of the process:
-
-      1. Start
-      2. Check if water is boiled
-      3. If not boiled, boil the water
-      4. Once water is boiled, add tea leaves to the cup
-      5. Pour boiling water into the cup
-      6. Steep the tea for the desired time
-      7. Remove the tea leaves
-      8. Optionally add milk or sugar
-      9. Enjoy your tea!
-      10. End
-
-      This chart provides a clear visual representation of the tea-making process. You can easily modify or expand this chart if you want to add more details or steps to the process. Let me know if you'd like any changes or have any questions!
-
----
-
-### Example 2
-
-    User: Create a simple React counter component
-    
-    Assistant: Here's a simple React counter component:
-
-      :::artifact{identifier="react-counter" type="application/vnd.react" title="React Counter"}
-      \`\`\`
-      import { useState } from 'react';
-
-      export default function Counter() {
-        const [count, setCount] = useState(0);
-        return (
-          <div className="p-4">
-            <p className="mb-2">Count: {count}</p>
-            <button className="bg-blue-500 text-white px-4 py-2 rounded" onClick={() => setCount(count + 1)}>
-              Increment
-            </button>
-          </div>
-        );
-      }
-      \`\`\`
-      :::
-
-      This component creates a simple counter with an increment button.
-
----
-
-### Example 3
-    User: Create a basic HTML structure for a blog post
-    Assistant: Here's a basic HTML structure for a blog post:
+// Dictionary of all available artifact types. Includes a description and usage examples
+const artifactTypes = {
+  'text/html': {
+    name: 'HTML',
+    instructions: [
+      'The user interface can render single file HTML pages placed within the artifact tags. HTML, JS, and CSS should be in a single file when using the `text/html` type',
+      'Images from the web are not allowed, but you can use placeholder images by specifying the width and height like so `<img src="/api/placeholder/400/320" alt="placeholder" />`',
+      'The only place external scripts can be imported from is https://cdnjs.cloudflare.com',
+    ],
+    example: {
+      user: 'Create a basic HTML structure for a blog post',
+      assistant: dedent`Here's a basic HTML structure for a blog post:
 
       :::artifact{identifier="blog-post-html" type="text/html" title="Blog Post HTML"}
       \`\`\`
@@ -496,9 +116,67 @@ Here are some examples of correct usage of artifacts:
       \`\`\`
       :::
 
-      This HTML structure provides a simple layout for a blog post.
+      This HTML structure provides a simple layout for a blog post.`,
+    },
+  },
+  'image/svg': {
+    name: 'SVG',
+    instructions: [
+      'The user interface will render the Scalable Vector Graphics (SVG) image within the artifact tags.',
+      'The assistant should specify the viewbox of the SVG rather than defining a width/height',
+    ],
+  },
+  'application/vnd.mermaid': {
+    name: 'Mermaid diagrams',
+    instructions: [
+      'The user interface will render Mermaid diagrams placed within the artifact tags.',
+    ],
+  },
+  'application/vnd.react': {
+    name: 'React Components',
+    instructions: [
+      'Use this for displaying either: React elements, e.g. `<strong>Hello World!</strong>`, React pure functional components, e.g. `() => <strong>Hello World!</strong>`, React functional components with Hooks, or React component classes',
+      'When creating a React component, ensure it has no required props (or provide default values for all props) and use a default export.',
+      'Use Tailwind classes for styling. DO NOT USE ARBITRARY VALUES (e.g. `h-[600px]`).',
+      'Base React is available to be imported. To use hooks, first import it at the top of the artifact, e.g. `import { useState } from "react"`',
+      'The lucide-react@0.394.0 library is available to be imported. e.g. `import { Camera } from "lucide-react"` & `<Camera color="red" size={48} />`',
+      'The recharts charting library is available to be imported, e.g. `import { LineChart, XAxis, ... } from "recharts"` & `<LineChart ...><XAxis dataKey="name"> ...`',
+      'The three.js library is available to be imported, e.g. `import * as THREE from "three";`',
+      'The date-fns library is available to be imported, e.g. `import { compareAsc, format } from "date-fns";`',
+      'The react-day-picker library is available to be imported, e.g. `import { DayPicker } from "react-day-picker";`',
+      "The assistant can use prebuilt components from the `shadcn/ui` library after it is imported: `import { Alert, AlertDescription, AlertTitle, AlertDialog, AlertDialogAction } from '/components/ui/alert';`. If using components from the shadcn/ui library, the assistant mentions this to the user and offers to help them install the components if necessary.",
+      'Components MUST be imported from `/components/ui/name` and NOT from `/components/name` or `@/components/ui/name`.',
+      'NO OTHER LIBRARIES (e.g. zod, hookform) ARE INSTALLED OR ABLE TO BE IMPORTED.',
+      'Images from the web are not allowed, but you can use placeholder images by specifying the width and height like so `<img src="/api/placeholder/400/320" alt="placeholder" />`',
+      'When iterating on code, ensure that the code is complete and functional without any snippets, placeholders, or ellipses.',
+      "If you are unable to follow the above requirements for any reason, don't use artifacts and use regular code blocks instead, which will not attempt to render the component.",
+    ],
+    example: {
+      user: 'Create a simple React counter component',
+      assistant: dedent`Here's a simple React counter component:
 
----`;
+      :::artifact{identifier="react-counter" type="application/vnd.react" title="React Counter"}
+      \`\`\`
+      import { useState } from 'react';
+
+      export default function Counter() {
+        const [count, setCount] = useState(0);
+        return (
+          <div className="p-4">
+            <p className="mb-2">Count: {count}</p>
+            <button className="bg-blue-500 text-white px-4 py-2 rounded" onClick={() => setCount(count + 1)}>
+              Increment
+            </button>
+          </div>
+        );
+      }
+      \`\`\`
+      :::
+
+      This component creates a simple counter with an increment button.`,
+    },
+  },
+};
 
 /**
  *
@@ -509,14 +187,75 @@ Here are some examples of correct usage of artifacts:
  */
 const generateArtifactsPrompt = ({ endpoint, artifacts }) => {
   if (artifacts === ArtifactModes.CUSTOM) {
+    // Custom prompt mode, let the user choose it
     return null;
   }
 
-  let prompt = artifactsPrompt;
-  if (endpoint !== EModelEndpoint.anthropic) {
-    prompt = artifactsOpenAIPrompt;
+  const enabledTypes = Object.keys(artifactTypes);
+
+  // Build prompt
+  let prompt = artifactsPromptIntroduction;
+
+  if (endpoint === EModelEndpoint.anthropic) {
+    prompt += `<artifact_instructions>\n\n${formatInstructionsAntrophic}\n\n`;
+  } else {
+    prompt += `## Artifact Instructions\n${formatInstructions}\n\n`;
   }
 
+  prompt += formatInstructionsOutro;
+
+  // List instructions for all enabled artifact types
+  for (const key of enabledTypes) {
+    prompt += `    - ${artifactTypes[key].name}: "${key}"\n`;
+    for (const inst of artifactTypes[key].instructions) {
+      prompt += `      - ${inst}\n`;
+    }
+  }
+
+  prompt += dedent`5. Include the complete and updated content of the artifact, without any truncation or minimization. Don't use "// rest of the code remains the same...".
+  6. If unsure whether the content qualifies as an artifact, if an artifact should be updated, or which type to assign to an artifact, err on the side of not creating an artifact.\n`;
+
+  // Final examples and formatting instructions
+  // Anthrophic uses XML, others regular markdown
+  if (endpoint === EModelEndpoint.anthropic) {
+    prompt += dedent`  7. Always use triple backticks (\`\`\`) to enclose the content within the artifact, regardless of the content type.
+                    </artifact_instructions>
+
+                    Here are some examples of correct usage of artifacts:
+
+                    <examples>\n`;
+
+    // Iterate examples
+    for (const key of enabledTypes) {
+      const example = artifactTypes[key].example;
+      if (example) {
+        prompt += '  <example>\n';
+        prompt += `    <user_query>${example.user}</user_query>\n`;
+        prompt += `    <assistant_response>\n${example.assistant}\n    </assistant_response>\n`;
+        prompt += '  </example>\n';
+      }
+    }
+    prompt += '</examples>\n';
+  } else {
+    prompt += dedent`7. NEVER use triple backticks to enclose the artifact, ONLY the content within the artifact.
+
+      Here are some examples of correct usage of artifacts:
+      
+      ## Examples\n`;
+
+    // Iterate examples
+    let i = 1;
+    for (const key of enabledTypes) {
+      const example = artifactTypes[key].example;
+      if (example) {
+        prompt += `### Example ${i++}\n\n`;
+        prompt += `  User: ${example.user}\n\n`;
+        prompt += `  Assistant: ${example.assistant}\n\n---\n\n`;
+      }
+    }
+  }
+
+  // Add extra information if SHADCNUI is selected
   if (artifacts === ArtifactModes.SHADCNUI) {
     prompt += generateShadcnPrompt({ components, useXML: endpoint === EModelEndpoint.anthropic });
   }

--- a/api/app/clients/prompts/artifacts.js
+++ b/api/app/clients/prompts/artifacts.js
@@ -74,6 +74,27 @@ const formatInstructionsOutro = dedent`2. Assign an identifier to the \`identifi
 
 // Dictionary of all available artifact types. Includes a description and usage examples
 const artifactTypes = {
+  'text/markdown': {
+    name: 'Documents',
+    instructions: ['Plain text, Markdown, or other formatted text documents'],
+    example: {
+      user: 'Can you create a document that contains a list of my favorite fruits?',
+      assistant: dedent`
+      
+      :::artifact{identifier="favorite-fruits" type="text/markdown" title="My Favorite Fruits"}
+      \`\`\`
+      # My Favorite Fruits
+
+      Here's a list of my favorite fruits:
+
+      * Apples
+      * Bananas
+      * Strawberries
+      \`\`\`
+      :::
+      `,
+    },
+  },
   'text/html': {
     name: 'HTML',
     instructions: [

--- a/client/src/components/Artifacts/Artifact.tsx
+++ b/client/src/components/Artifacts/Artifact.tsx
@@ -64,6 +64,7 @@ export function Artifact({
     const title = props.title ?? 'Untitled Artifact';
     const type = props.type ?? 'unknown';
     const identifier = props.identifier ?? 'no-identifier';
+    const language = props.language;
     const artifactKey = `${identifier}_${type}_${title}`.replace(/\s+/g, '_').toLowerCase();
 
     throttledUpdateRef.current(() => {
@@ -74,6 +75,7 @@ export function Artifact({
         identifier,
         title,
         type,
+        language,
         content,
         lastUpdateTime: now,
       };

--- a/client/src/components/Artifacts/Artifacts.tsx
+++ b/client/src/components/Artifacts/Artifacts.tsx
@@ -136,7 +136,7 @@ export default function Artifacts() {
             className={cn('flex-grow overflow-x-auto overflow-y-scroll p-4', isProse(currentArtifact.type) ? 'prose dark:prose-invert light' : 'bg-gray-900')}
           >
             <CodeMarkdown
-              content={formatContent(currentArtifact.content ?? '', currentArtifact.type)}
+              content={formatContent(currentArtifact.content ?? '', currentArtifact.type, currentArtifact.language)}
               isCode={isProse(currentArtifact.type)}
               isSubmitting={isSubmitting}
             />

--- a/client/src/components/Artifacts/Artifacts.tsx
+++ b/client/src/components/Artifacts/Artifacts.tsx
@@ -5,7 +5,7 @@ import * as Tabs from '@radix-ui/react-tabs';
 import { SandpackPreviewRef } from '@codesandbox/sandpack-react';
 import useArtifacts from '~/hooks/Artifacts/useArtifacts';
 import { CodeMarkdown, CopyCodeButton } from './Code';
-import { getFileExtension } from '~/utils/artifacts';
+import { formatContent, isProse, needsPreview } from '~/utils/artifacts';
 import { ArtifactPreview } from './ArtifactPreview';
 import { cn } from '~/utils';
 import store from '~/store';
@@ -44,21 +44,23 @@ export default function Artifacts() {
     setTimeout(() => setIsRefreshing(false), 750);
   };
 
+  const hasPreview = needsPreview(currentArtifact.type ?? '');
+
   return (
     <Tabs.Root value={activeTab} onValueChange={setActiveTab} asChild>
       {/* Main Parent */}
       <div className="flex h-full w-full items-center justify-center py-2">
         {/* Main Container */}
         <div
-          className={`flex h-[97%] w-[97%] flex-col overflow-hidden rounded-xl border border-border-medium bg-surface-primary text-xl text-text-primary shadow-xl transition-all duration-300 ease-in-out ${
-            isVisible
+          className={`flex h-[97%] w-[97%] flex-col overflow-hidden rounded-xl border border-border-medium bg-surface-primary text-xl text-text-primary shadow-xl transition-all duration-300 ease-in-out ${isVisible
               ? 'translate-x-0 scale-100 opacity-100'
               : 'translate-x-full scale-95 opacity-0'
-          }`}
+            }`}
         >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-border-medium bg-surface-primary-alt p-2">
             <div className="flex items-center">
+              {/* Back button*/}
               <button
                 className="mr-2 text-text-secondary"
                 onClick={() => {
@@ -76,15 +78,15 @@ export default function Artifacts() {
                   <path d="M224,128a8,8,0,0,1-8,8H59.31l58.35,58.34a8,8,0,0,1-11.32,11.32l-72-72a8,8,0,0,1,0-11.32l72-72a8,8,0,0,1,11.32,11.32L59.31,120H216A8,8,0,0,1,224,128Z" />
                 </svg>
               </button>
+              {/* Artifact title*/}
               <h3 className="truncate text-sm text-text-primary">{currentArtifact.title}</h3>
             </div>
             <div className="flex items-center">
               {/* Refresh button */}
-              {activeTab === 'preview' && (
+              {hasPreview && activeTab === 'preview' && (
                 <button
-                  className={`mr-2 text-text-secondary transition-transform duration-500 ease-in-out ${
-                    isRefreshing ? 'rotate-180' : ''
-                  }`}
+                  className={`mr-2 text-text-secondary transition-transform duration-500 ease-in-out ${isRefreshing ? 'rotate-180' : ''
+                    }`}
                   onClick={handleRefresh}
                   disabled={isRefreshing}
                   aria-label="Refresh"
@@ -95,7 +97,7 @@ export default function Artifacts() {
                   />
                 </button>
               )}
-              <Tabs.List className="mr-2 inline-flex h-7 rounded-full border border-border-medium bg-surface-tertiary">
+              {hasPreview && <Tabs.List className="mr-2 inline-flex h-7 rounded-full border border-border-medium bg-surface-tertiary">
                 <Tabs.Trigger
                   value="preview"
                   className="border-0.5 flex items-center gap-1 rounded-full border-transparent py-1 pl-2.5 pr-2.5 text-xs font-medium text-text-secondary data-[state=active]:border-border-light data-[state=active]:bg-surface-primary-alt data-[state=active]:text-text-primary"
@@ -108,7 +110,7 @@ export default function Artifacts() {
                 >
                   Code
                 </Tabs.Trigger>
-              </Tabs.List>
+              </Tabs.List>}
               <button
                 className="text-text-secondary"
                 onClick={() => {
@@ -131,12 +133,11 @@ export default function Artifacts() {
           {/* Content */}
           <Tabs.Content
             value="code"
-            className={cn('flex-grow overflow-x-auto overflow-y-scroll bg-gray-900 p-4')}
+            className={cn('flex-grow overflow-x-auto overflow-y-scroll p-4', isProse(currentArtifact.type) ? 'prose dark:prose-invert light' : 'bg-gray-900')}
           >
             <CodeMarkdown
-              content={`\`\`\`${getFileExtension(currentArtifact.type)}\n${
-                currentArtifact.content ?? ''
-              }\`\`\``}
+              content={formatContent(currentArtifact.content ?? '', currentArtifact.type)}
+              isCode={isProse(currentArtifact.type)}
               isSubmitting={isSubmitting}
             />
           </Tabs.Content>
@@ -163,9 +164,8 @@ export default function Artifacts() {
                   <path d="M165.66,202.34a8,8,0,0,1-11.32,11.32l-80-80a8,8,0,0,1,0-11.32l80-80a8,8,0,0,1,11.32,11.32L91.31,128Z" />
                 </svg>
               </button>
-              <span className="text-xs">{`${currentIndex + 1} / ${
-                orderedArtifactIds.length
-              }`}</span>
+              <span className="text-xs">{`${currentIndex + 1} / ${orderedArtifactIds.length
+                }`}</span>
               <button onClick={() => cycleArtifact('next')} className="ml-2 text-text-secondary">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"

--- a/client/src/components/Artifacts/Code.tsx
+++ b/client/src/components/Artifacts/Code.tsx
@@ -30,7 +30,7 @@ export const code: React.ElementType = memo(({ inline, className, children }: TC
 });
 
 export const CodeMarkdown = memo(
-  ({ content = '', isSubmitting }: { content: string; isSubmitting: boolean }) => {
+  ({ content = '', isSubmitting }: { content: string; isSubmitting: boolean, isCode: boolean }) => {
     const scrollRef = useRef<HTMLDivElement>(null);
     const [userScrolled, setUserScrolled] = useState(false);
     const currentContent = content;

--- a/client/src/hooks/Artifacts/useArtifacts.ts
+++ b/client/src/hooks/Artifacts/useArtifacts.ts
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect, useRef } from 'react';
 import { Constants } from 'librechat-data-provider';
 import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
 import { useChatContext } from '~/Providers';
-import { getKey } from '~/utils/artifacts';
+import { getKey, needsPreview } from '~/utils/artifacts';
 import { getLatestText } from '~/utils';
 import store from '~/store';
 
@@ -70,7 +70,7 @@ export default function useArtifacts() {
         );
 
         if (hasEnclosedArtifact && !hasEnclosedArtifactRef.current) {
-          setActiveTab('preview');
+          setActiveTab(needsPreview(latestArtifact?.type) ? 'preview' : 'code');
           hasEnclosedArtifactRef.current = true;
           hasAutoSwitchedToCodeRef.current = false;
         } else if (!hasEnclosedArtifactRef.current && !hasAutoSwitchedToCodeRef.current) {
@@ -93,6 +93,14 @@ export default function useArtifacts() {
   }, [latestMessage]);
 
   const currentArtifact = currentArtifactId != null ? artifacts?.[currentArtifactId] : null;
+
+  // Prevent non-previewable artifacts from using the preview tab
+  useEffect(() => {
+    if(!needsPreview(currentArtifact?.type) && activeTab == "preview") {
+      setActiveTab("code");
+    }
+  }, [currentArtifact])
+
 
   const currentIndex = orderedArtifactIds.indexOf(currentArtifactId ?? '');
   const cycleArtifact = (direction: 'next' | 'prev') => {

--- a/client/src/utils/artifacts.ts
+++ b/client/src/utils/artifacts.ts
@@ -37,6 +37,14 @@ const artifactFilename = {
   // 'tsx': 'tsx',
 };
 
+// Artifacts that need to render an HTML preview window
+const previewableArtifacts = {
+  'application/vnd.mermaid': true,
+  'application/vnd.react': true,
+  'text/html': true,
+  default: false,
+};
+
 const artifactTemplate: Record<
   keyof typeof artifactFilename,
   SandpackPredefinedTemplate | undefined
@@ -83,9 +91,26 @@ export function getArtifactFilename(type: string, language?: string): string {
   return artifactFilename[key] ?? artifactFilename.default;
 }
 
+export function needsPreview(type?: string): boolean {
+  return (type && previewableArtifacts[type]) ?? previewableArtifacts.default;
+}
+
 export function getTemplate(type: string, language?: string): SandpackPredefinedTemplate {
   const key = getKey(type, language);
   return artifactTemplate[key] ?? (artifactTemplate.default as SandpackPredefinedTemplate);
+}
+
+export function isProse(type?: string) {
+  return type === 'text/markdown';
+}
+
+export function formatContent(content: string, type?: string, ) {
+  if(isProse(type)) {
+    // If rendering markdown, no need to add a code block
+    return content;
+  }
+  // Else return a markdown code block
+  return `\`\`\`${getFileExtension(type)}\n${content}\`\`\``;
 }
 
 const standardDependencies = {

--- a/client/src/utils/artifacts.ts
+++ b/client/src/utils/artifacts.ts
@@ -61,14 +61,16 @@ const artifactTemplate: Record<
   // 'tsx': 'tsx',
 };
 
-export function getFileExtension(language?: string): string {
-  switch (language) {
+export function getArtifactLanguage(type?: string, language?: string): string {
+  switch (type) {
     case 'application/vnd.react':
       return 'tsx';
     case 'application/vnd.mermaid':
       return 'mermaid';
     case 'text/html':
       return 'html';
+    case 'application/vnd.code':
+      return language ?? 'txt';
     // case 'jsx':
     //   return 'jsx';
     // case 'tsx':
@@ -104,13 +106,13 @@ export function isProse(type?: string) {
   return type === 'text/markdown';
 }
 
-export function formatContent(content: string, type?: string, ) {
-  if(isProse(type)) {
+export function formatContent(content: string, type?: string, language?: string) {
+  if (isProse(type)) {
     // If rendering markdown, no need to add a code block
     return content;
   }
   // Else return a markdown code block
-  return `\`\`\`${getFileExtension(type)}\n${content}\`\`\``;
+  return `\`\`\`${getArtifactLanguage(type, language)}\n${content}\`\`\``;
 }
 
 const standardDependencies = {


### PR DESCRIPTION
## Summary

Added support for Markdown and Code artifacts, using the `text/markdown` and `application/vnd.code` types.

Markdown works by styling the artifact block as prose and disabling the preview tab, reusing the existing `react-markdown` instance that was used for code rendering.

Code artifacts work the same as previous artifacts, but without the preview tab. The language attribute is extracted from the artifact and used for the code block.

The artifacts prompt generation function has been enhanced to build it dynamically from an array of available artifact types. This will allow future configuration options to disable non-desired types and save prompt tokens (current prompt is ~3000 tokens, and some users may just need prose artifacts).

Should fix #3995 

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

## Testing

Ask any model to create prose or code using artifacts.


## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
