### PR TITLE
🔧 fix: Add `modelLabel` to OpenAIClient Save Options

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -423,6 +423,7 @@ class OpenAIClient extends BaseClient {
       promptPrefix: this.options.promptPrefix,
       resendFiles: this.options.resendFiles,
       imageDetail: this.options.imageDetail,
+      modelLabel: this.options.modelLabel,
       iconURL: this.options.iconURL,
       greeting: this.options.greeting,
       spec: this.options.spec,

--- a/api/app/clients/PluginsClient.js
+++ b/api/app/clients/PluginsClient.js
@@ -43,6 +43,7 @@ class PluginsClient extends OpenAIClient {
     return {
       artifacts: this.options.artifacts,
       chatGptLabel: this.options.chatGptLabel,
+      modelLabel: this.options.modelLabel,
       promptPrefix: this.options.promptPrefix,
       tools: this.options.tools,
       ...this.modelOptions,

--- a/api/app/clients/specs/OpenAIClient.test.js
+++ b/api/app/clients/specs/OpenAIClient.test.js
@@ -412,6 +412,7 @@ describe('OpenAIClient', () => {
     it('should return the correct save options', () => {
       const options = client.getSaveOptions();
       expect(options).toHaveProperty('chatGptLabel');
+      expect(options).toHaveProperty('modelLabel');
       expect(options).toHaveProperty('promptPrefix');
     });
   });


### PR DESCRIPTION
## Summary

I added `modelLabel` to the save options of `OpenAIClient` and `PluginsClient` to ensure that the model label is properly saved and accessible for downstream use. This resolves an issue exhibited with modelSpecs highlighted here: https://github.com/danny-avila/LibreChat/issues/4975#issuecomment-2542685348

- Added `modelLabel` to the save options in `OpenAIClient.getSaveOptions()`.
- Added `modelLabel` to the save options in `PluginsClient.getSaveOptions()`.
- Updated `OpenAIClient` tests to verify `modelLabel` is included in the save options.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran the existing unit tests to verify that the changes did not introduce any regressions. I updated the `OpenAIClient` tests to ensure `modelLabel` is included in the save options.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes