### PR TITLE
fix: set baseUrl for GenAI client

### DIFF
--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -610,7 +610,7 @@ class GoogleClient extends BaseClient {
       return new GenAI(this.apiKey).getGenerativeModel({
         ...clientOptions,
         model,
-      });
+      }, {baseUrl: this.options.reverseProxyUrl});
     }
 
     logger.debug('Creating Chat Google Generative AI client');


### PR DESCRIPTION
# Pull Request Template

## Summary

When using google "GenAI" api, the proxy configuration is not used.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

set GOOGLE_REVERSE_PROXY in the .env file and verify the requests for GenAI are sent to the proxy

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
