### PR TITLE
🦙 feat: update AWS Bedrock pricing and token metadata for Meta models

### DIFF
--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -1,22 +1,50 @@
 const { matchModelName } = require('../utils');
 const defaultRate = 6;
 
-/** AWS Bedrock pricing */
+/**
+ * AWS Bedrock pricing
+ * source: https://aws.amazon.com/bedrock/pricing/
+ * */
 const bedrockValues = {
+  // Basic llama2 patterns
   'llama2-13b': { prompt: 0.75, completion: 1.0 },
-  'llama2-70b': { prompt: 1.95, completion: 2.56 },
-  'llama3-8b': { prompt: 0.3, completion: 0.6 },
-  'llama3-70b': { prompt: 2.65, completion: 3.5 },
-  'llama3-1-8b': { prompt: 0.3, completion: 0.6 },
-  'llama3-1-70b': { prompt: 2.65, completion: 3.5 },
-  'llama3-1-405b': { prompt: 5.32, completion: 16.0 },
   'llama2:13b': { prompt: 0.75, completion: 1.0 },
   'llama2:70b': { prompt: 1.95, completion: 2.56 },
+  'llama2-70b': { prompt: 1.95, completion: 2.56 },
+
+  // Basic llama3 patterns
+  'llama3-8b': { prompt: 0.3, completion: 0.6 },
   'llama3:8b': { prompt: 0.3, completion: 0.6 },
+  'llama3-70b': { prompt: 2.65, completion: 3.5 },
   'llama3:70b': { prompt: 2.65, completion: 3.5 },
-  'llama3.1:8b': { prompt: 0.3, completion: 0.6 },
-  'llama3.1:70b': { prompt: 2.65, completion: 3.5 },
-  'llama3.1:405b': { prompt: 5.32, completion: 16.0 },
+
+  // llama3-x-Nb pattern
+  'llama3-1-8b': { prompt: 0.22, completion: 0.22 },
+  'llama3-1-70b': { prompt: 0.72, completion: 0.72 },
+  'llama3-1-405b': { prompt: 2.4, completion: 2.4 },
+  'llama3-2-1b': { prompt: 0.1, completion: 0.1 },
+  'llama3-2-3b': { prompt: 0.15, completion: 0.15 },
+  'llama3-2-11b': { prompt: 0.16, completion: 0.16 },
+  'llama3-2-90b': { prompt: 0.72, completion: 0.72 },
+
+  // llama3.x:Nb pattern
+  'llama3.1:8b': { prompt: 0.22, completion: 0.22 },
+  'llama3.1:70b': { prompt: 0.72, completion: 0.72 },
+  'llama3.1:405b': { prompt: 2.4, completion: 2.4 },
+  'llama3.2:1b': { prompt: 0.1, completion: 0.1 },
+  'llama3.2:3b': { prompt: 0.15, completion: 0.15 },
+  'llama3.2:11b': { prompt: 0.16, completion: 0.16 },
+  'llama3.2:90b': { prompt: 0.72, completion: 0.72 },
+
+  // llama-3.x-Nb pattern
+  'llama-3.1-8b': { prompt: 0.22, completion: 0.22 },
+  'llama-3.1-70b': { prompt: 0.72, completion: 0.72 },
+  'llama-3.1-405b': { prompt: 2.4, completion: 2.4 },
+  'llama-3.2-1b': { prompt: 0.1, completion: 0.1 },
+  'llama-3.2-3b': { prompt: 0.15, completion: 0.15 },
+  'llama-3.2-11b': { prompt: 0.16, completion: 0.16 },
+  'llama-3.2-90b': { prompt: 0.72, completion: 0.72 },
+  'llama-3.3-70b': { prompt: 2.65, completion: 3.5 },
   'mistral-7b': { prompt: 0.15, completion: 0.2 },
   'mistral-small': { prompt: 0.15, completion: 0.2 },
   'mixtral-8x7b': { prompt: 0.45, completion: 0.7 },

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -85,16 +85,58 @@ const deepseekModels = {
 };
 
 const metaModels = {
+  // Basic patterns
   llama3: 8000,
   llama2: 4000,
+  'llama-3': 8000,
+  'llama-2': 4000,
+
+  // llama3.x pattern
   'llama3.1': 127500,
+  'llama3.2': 127500,
+  'llama3.3': 127500,
+
+  // llama3-x pattern
   'llama3-1': 127500,
+  'llama3-2': 127500,
+  'llama3-3': 127500,
+
+  // llama-3.x pattern
+  'llama-3.1': 127500,
+  'llama-3.2': 127500,
+  'llama-3.3': 127500,
+
+  // llama3.x:Nb pattern
   'llama3.1:405b': 127500,
   'llama3.1:70b': 127500,
   'llama3.1:8b': 127500,
+  'llama3.2:1b': 127500,
+  'llama3.2:3b': 127500,
+  'llama3.2:11b': 127500,
+  'llama3.2:90b': 127500,
+  'llama3.3:70b': 127500,
+
+  // llama3-x-Nb pattern
   'llama3-1-405b': 127500,
   'llama3-1-70b': 127500,
   'llama3-1-8b': 127500,
+  'llama3-2-1b': 127500,
+  'llama3-2-3b': 127500,
+  'llama3-2-11b': 127500,
+  'llama3-2-90b': 127500,
+  'llama3-3-70b': 127500,
+
+  // llama-3.x-Nb pattern
+  'llama-3.1-405b': 127500,
+  'llama-3.1-70b': 127500,
+  'llama-3.1-8b': 127500,
+  'llama-3.2-1b': 127500,
+  'llama-3.2-3b': 127500,
+  'llama-3.2-11b': 127500,
+  'llama-3.2-90b': 127500,
+  'llama-3.3-70b': 127500,
+
+  // Original llama2/3 patterns
   'llama3-70b': 8000,
   'llama3-8b': 8000,
   'llama2-70b': 4000,


### PR DESCRIPTION
## Summary

I updated the AWS Bedrock pricing and token metadata for Meta's Llama models to ensure accurate pricing calculations and token limits.

- Updated the Bedrock pricing values in `api/models/tx.js` for various Llama 2 and Llama 3 models, adding support for different naming patterns.
- Updated the token limits in `api/utils/tokens.js` for Meta's Llama models, including additional patterns to cover multiple naming conventions.
- Ensured comprehensive patterns to match the various ways Llama models are referenced, improving the accuracy of model matching.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

I tested the pricing calculations and token limit retrieval for the updated Llama models to ensure they return the correct values.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings