### PR TITLE
🔍 feat: Add Entity ID Support for File Search Shared Resources

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -256,7 +256,7 @@ const loadTools = async ({
         if (toolContext) {
           toolContextMap[tool] = toolContext;
         }
-        return createFileSearchTool({ req: options.req, files });
+        return createFileSearchTool({ req: options.req, files, entity_id: agent?.id });
       };
       continue;
     } else if (mcpToolPattern.test(tool)) {

--- a/api/server/services/Files/VectorDB/crud.js
+++ b/api/server/services/Files/VectorDB/crud.js
@@ -50,13 +50,14 @@ const deleteVectors = async (req, file) => {
  * @param {Express.Multer.File} params.file - The file object, which is part of the request. The file object should
  *                                     have a `path` property that points to the location of the uploaded file.
  * @param {string} params.file_id - The file ID.
+ * @param {string} [params.entity_id] - The entity ID for shared resources.
  *
  * @returns {Promise<{ filepath: string, bytes: number }>}
  *          A promise that resolves to an object containing:
  *            - filepath: The path where the file is saved.
  *            - bytes: The size of the file in bytes.
  */
-async function uploadVectors({ req, file, file_id }) {
+async function uploadVectors({ req, file, file_id, entity_id }) {
   if (!process.env.RAG_API_URL) {
     throw new Error('RAG_API_URL not defined');
   }
@@ -66,8 +67,11 @@ async function uploadVectors({ req, file, file_id }) {
     const formData = new FormData();
     formData.append('file_id', file_id);
     formData.append('file', fs.createReadStream(file.path));
+    if (entity_id != null && entity_id) {
+      formData.append('entity_id', entity_id);
+    }
 
-    const formHeaders = formData.getHeaders(); // Automatically sets the correct Content-Type
+    const formHeaders = formData.getHeaders();
 
     const response = await axios.post(`${process.env.RAG_API_URL}/embed`, formData, {
       headers: {

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -479,6 +479,7 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
   }
 
   let fileInfoMetadata;
+  const entity_id = messageAttachment === true ? undefined : agent_id;
   if (tool_resource === EToolResources.execute_code) {
     const { handleFileUpload: uploadCodeEnvFile } = getStrategyFunctions(FileSources.execute_code);
     const result = await loadAuthValues({ userId: req.user.id, authFields: [EnvVar.CODE_API_KEY] });
@@ -488,7 +489,7 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
       stream,
       filename: file.originalname,
       apiKey: result[EnvVar.CODE_API_KEY],
-      entity_id: messageAttachment === true ? undefined : agent_id,
+      entity_id,
     });
     fileInfoMetadata = { fileIdentifier };
   }
@@ -512,6 +513,7 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
     req,
     file,
     file_id,
+    entity_id,
   });
 
   let filepath = _filepath;


### PR DESCRIPTION
## Summary

I added support for `entity_id` as an alternative to `user_id` in various API endpoints to allow sharing resources between users when using Agents.

related RAG API PR: https://github.com/danny-avila/rag_api/pull/107

Closes #4999

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes