### PR TITLE
🐛 fix: Correct Model Parameters Merging and Panel UI

### DIFF
--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -97,12 +97,15 @@ const initializeAgentOptions = async ({
     agent.endpoint = provider.toLowerCase();
   }
 
-  const model_parameters = agent.model_parameters ?? { model: agent.model };
-  const _endpointOption = isInitialAgent
-    ? endpointOption
-    : {
-      model_parameters,
-    };
+  const model_parameters = Object.assign(
+    {},
+    agent.model_parameters ?? { model: agent.model },
+    isInitialAgent === true ? endpointOption?.model_parameters : {},
+  );
+  const _endpointOption =
+    isInitialAgent === true
+      ? Object.assign({}, endpointOption, { model_parameters })
+      : { model_parameters };
 
   const options = await getOptions({
     req,

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -177,10 +177,10 @@ export type AgentPanelProps = {
 };
 
 export type AgentModelPanelProps = {
-  setActivePanel: React.Dispatch<React.SetStateAction<Panel>>;
-  providers: Option[];
-  models: Record<string, string[]>;
   agent_id?: string;
+  providers: Option[];
+  models: Record<string, string[] | undefined>;
+  setActivePanel: React.Dispatch<React.SetStateAction<Panel>>;
 };
 
 export type AugmentedColumnDef<TData, TValue> = ColumnDef<TData, TValue> & DataColumnMeta;

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useEffect } from 'react';
-import { ChevronLeft } from 'lucide-react';
+import { ChevronLeft, RotateCcw } from 'lucide-react';
 import { getSettingsKeys } from 'librechat-data-provider';
-import { useFormContext, Controller } from 'react-hook-form';
+import { useFormContext, useWatch, Controller } from 'react-hook-form';
 import { useGetEndpointsQuery } from 'librechat-data-provider/react-query';
 import type * as t from 'librechat-data-provider';
 import type { AgentForm, AgentModelPanelProps, StringOption } from '~/common';
@@ -19,10 +19,11 @@ export default function Parameters({
 }: AgentModelPanelProps) {
   const localize = useLocalize();
 
-  const { control, setValue, watch } = useFormContext<AgentForm>();
-  const modelParameters = watch('model_parameters');
-  const providerOption = watch('provider');
-  const model = watch('model');
+  const { control, setValue } = useFormContext<AgentForm>();
+
+  const model = useWatch({ control, name: 'model' });
+  const providerOption = useWatch({ control, name: 'provider' });
+  const modelParameters = useWatch({ control, name: 'model_parameters' });
 
   const provider = useMemo(() => {
     const value =
@@ -69,6 +70,10 @@ export default function Parameters({
 
   const setOption = (optionKey: keyof t.AgentModelParameters) => (value: t.AgentParameterValue) => {
     setValue(`model_parameters.${optionKey}`, value);
+  };
+
+  const handleResetParameters = () => {
+    setValue('model_parameters', {} as t.AgentModelParameters);
   };
 
   return (
@@ -208,6 +213,17 @@ export default function Parameters({
                 />
               );
             })}
+          </div>
+          {/* Reset Parameters Button */}
+          <div className="mt-6 flex justify-center">
+            <button
+              type="button"
+              onClick={handleResetParameters}
+              className="btn btn-neutral flex w-full items-center justify-center gap-2 px-4 py-2 text-sm"
+            >
+              <RotateCcw className="h-4 w-4" />
+              {localize('com_ui_reset_var', localize('com_ui_model_parameters'))}
+            </button>
           </div>
         </div>
       )}

--- a/client/src/localization/languages/Eng.ts
+++ b/client/src/localization/languages/Eng.ts
@@ -187,6 +187,7 @@ export default {
   com_ui_provider: 'Provider',
   com_ui_model: 'Model',
   com_ui_region: 'Region',
+  com_ui_reset_var: 'Reset {0}',
   com_ui_model_parameters: 'Model Parameters',
   com_ui_model_save_success: 'Model parameters saved successfully',
   com_ui_select_model: 'Select a model',


### PR DESCRIPTION
## Summary

I fixed issues with model parameter merging in agent initialization and corrected form field watching in the Model Panel. I also added a reset button for model parameters.

Addresses concern raised by 

- Refactored agent initialization to correctly merge `model_parameters` with existing endpoint options.
- Fixed the Model Panel by switching from `watch` to `useWatch` in `react-hook-form` to observe the correct form fields.
- Added a reset button to the Model Panel to reset model parameters to their default values.
- Updated localization strings for the reset button label.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested the changes by:

- Creating new agents and verifying that model parameters are correctly merged during initialization.
- Checking that the Model Panel now watches and updates the correct form fields.
- Using the reset button to ensure it resets model parameters to their default values without issues.

### Test Configuration:

- **Operating System:** [Your OS]
- **Node.js Version:** [Your Node.js version]
- **Browser:** [Browser used for testing]

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes