### PR TITLE
🤖 feat: Support New 'o1' Model

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -107,7 +107,8 @@ class OpenAIClient extends BaseClient {
       this.checkVisionRequest(this.options.attachments);
     }
 
-    this.isO1Model = /\bo1\b/i.test(this.modelOptions.model);
+    const o1Pattern = /\bo1\b/i;
+    this.isO1Model = o1Pattern.test(this.modelOptions.model);
 
     const { OPENROUTER_API_KEY, OPENAI_FORCE_PROMPT } = process.env ?? {};
     if (OPENROUTER_API_KEY && !this.azure) {
@@ -147,7 +148,7 @@ class OpenAIClient extends BaseClient {
     const { model } = this.modelOptions;
 
     this.isChatCompletion =
-      /\bo1\b/i.test(model) || model.includes('gpt') || this.useOpenRouter || !!reverseProxy;
+      o1Pattern.test(model) || model.includes('gpt') || this.useOpenRouter || !!reverseProxy;
     this.isChatGptModel = this.isChatCompletion;
     if (
       model.includes('text-davinci') ||
@@ -1325,7 +1326,11 @@ ${convo}
       /** @type {(value: void | PromiseLike<void>) => void} */
       let streamResolve;
 
-      if (this.isO1Model === true && this.azure && modelOptions.stream) {
+      if (
+        this.isO1Model === true &&
+        (this.azure || /o1(?!-(?:mini|preview)).*$/.test(modelOptions.model)) &&
+        modelOptions.stream
+      ) {
         delete modelOptions.stream;
         delete modelOptions.stop;
       }

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -2,7 +2,7 @@ const z = require('zod');
 const { EModelEndpoint } = require('librechat-data-provider');
 
 const openAIModels = {
-  o1: 127500, // -500 from max
+  o1: 195000, // -5000 from max
   'o1-mini': 127500, // -500 from max
   'o1-preview': 127500, // -500 from max
   'gpt-4': 8187, // -5 from max

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -248,6 +248,32 @@ describe('getModelMaxTokens', () => {
   test('should return undefined for a model when using an unsupported endpoint', () => {
     expect(getModelMaxTokens('azure-gpt-3', 'unsupportedEndpoint')).toBeUndefined();
   });
+
+  test('should return correct max context tokens for o1-series models', () => {
+    // Standard o1 variations
+    const o1Tokens = maxTokensMap[EModelEndpoint.openAI]['o1'];
+    expect(getModelMaxTokens('o1')).toBe(o1Tokens);
+    expect(getModelMaxTokens('o1-latest')).toBe(o1Tokens);
+    expect(getModelMaxTokens('o1-2024-12-17')).toBe(o1Tokens);
+    expect(getModelMaxTokens('o1-something-else')).toBe(o1Tokens);
+    expect(getModelMaxTokens('openai/o1-something-else')).toBe(o1Tokens);
+
+    // Mini variations
+    const o1MiniTokens = maxTokensMap[EModelEndpoint.openAI]['o1-mini'];
+    expect(getModelMaxTokens('o1-mini')).toBe(o1MiniTokens);
+    expect(getModelMaxTokens('o1-mini-latest')).toBe(o1MiniTokens);
+    expect(getModelMaxTokens('o1-mini-2024-09-12')).toBe(o1MiniTokens);
+    expect(getModelMaxTokens('o1-mini-something')).toBe(o1MiniTokens);
+    expect(getModelMaxTokens('openai/o1-mini-something')).toBe(o1MiniTokens);
+
+    // Preview variations
+    const o1PreviewTokens = maxTokensMap[EModelEndpoint.openAI]['o1-preview'];
+    expect(getModelMaxTokens('o1-preview')).toBe(o1PreviewTokens);
+    expect(getModelMaxTokens('o1-preview-latest')).toBe(o1PreviewTokens);
+    expect(getModelMaxTokens('o1-preview-2024-09-12')).toBe(o1PreviewTokens);
+    expect(getModelMaxTokens('o1-preview-something')).toBe(o1PreviewTokens);
+    expect(getModelMaxTokens('openai/o1-preview-something')).toBe(o1PreviewTokens);
+  });
 });
 
 describe('matchModelName', () => {


### PR DESCRIPTION
## Summary 

I added support for the new 'o1' model in the `OpenAIClient`, updated token limits, and expanded unit tests.

Currently, this model is only available to OpenAI billing tier 5.

https://platform.openai.com/docs/models#o1

- Updated `OpenAIClient.js` to detect and handle 'o1' models correctly.
- Modified `tokens.js` to adjust the max token limits for 'o1' series models.
- Added comprehensive unit tests in `tokens.spec.js` to cover 'o1' model variations.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

I ran the updated unit tests to ensure that the 'o1' models are correctly supported and that token limits are accurately calculated. All tests pass successfully.

### **Test Configuration**:

- **Node.js version**: [Your Node.js version]
- **Operating System**: [Your operating system]

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes