### PR TITLE
Enable google search for gemini-1.5-pro and gemini-2.0-flash-exp

### DIFF
--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -27,19 +27,16 @@ const {
   truncateText,
 } = require('./prompts');
 const BaseClient = require('./BaseClient');
-
 const loc = process.env.GOOGLE_LOC || 'us-central1';
 const publisher = 'google';
 const endpointPrefix = `${loc}-aiplatform.googleapis.com`;
 const tokenizersCache = {};
-
 const settings = endpointSettings[EModelEndpoint.google];
 const EXCLUDED_GENAI_MODELS = /gemini-(?:1\.0|1-0|pro)/;
 
 
 const isNewGeminiModel = (model) => {
-  return model.includes('gemini-exp-1206') || 
-         model.includes('gemini-2.');
+  return model.includes('gemini-2.');
 };
 
 class GoogleClient extends BaseClient {
@@ -743,17 +740,48 @@ class GoogleClient extends BaseClient {
 
       const delay = modelName.includes('flash') ? 8 : 15;
       const result = await client.generateContentStream(requestOptions);
-      for await (const chunk of result.stream) {
-        const chunkText = chunk.text();
-        await this.generateTextStream(chunkText, onProgress, {
-          delay,
-        });
-        reply += chunkText;
-        await sleep(streamRate);
-      }
-      return reply;
-    }
+      let lastGroundingMetadata = null;
 
+      for await (const chunk of result.stream) {
+        // Get the text content from the first candidate's content parts
+        const text = chunk.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+        
+        // Store the grounding metadata from the last chunk that has it
+        if (chunk.candidates?.[0]?.groundingMetadata) {
+          lastGroundingMetadata = chunk.candidates[0].groundingMetadata;
+        }
+
+        // Only send text content if there is any
+        if (text) {
+          await this.generateTextStream(text, onProgress, {
+            delay,
+            metadata: lastGroundingMetadata ? { groundingMetadata: lastGroundingMetadata } : undefined
+          });
+          reply += text;
+          await sleep(streamRate);
+        }
+      }
+
+      // Send final completion message with metadata
+      const finalMessage = {
+        text: reply,
+        isComplete: true,
+        metadata: lastGroundingMetadata ? { groundingMetadata: lastGroundingMetadata } : undefined
+      };
+
+      await onProgress(finalMessage);
+
+      // Set metadata for BaseClient to save
+      if (lastGroundingMetadata) {
+        this.metadata = { groundingMetadata: lastGroundingMetadata };
+      }
+
+      return {
+        text: reply,
+        groundingMetadata: lastGroundingMetadata
+      };
+
+    }
     const stream = await model.stream(messages, {
       signal: abortController.signal,
       safetySettings: _payload.safetySettings,
@@ -922,10 +950,25 @@ class GoogleClient extends BaseClient {
   async sendCompletion(payload, opts = {}) {
     payload.safetySettings = this.getSafetySettings();
 
-    let reply = '';
-    reply = await this.getCompletion(payload, opts);
-    return reply.trim();
+    const response = await this.getCompletion(payload, opts);
+    
+    // Handle both string and object responses
+    if (typeof response === 'string') {
+      return response.trim();
+    }
+
+    // If response is an object with text and metadata
+    if (response && typeof response === 'object') {
+      const { text, groundingMetadata } = response;
+      if (groundingMetadata) {
+        this.metadata = { groundingMetadata };
+      }
+      return text.trim();
+    }
+
+    return '';
   }
+
 
   getSafetySettings() {
     return [
@@ -975,3 +1018,4 @@ class GoogleClient extends BaseClient {
 }
 
 module.exports = GoogleClient;
+

--- a/api/app/clients/TextStream.js
+++ b/api/app/clients/TextStream.js
@@ -9,6 +9,7 @@ class TextStream extends Readable {
     this.minChunkSize = options.minChunkSize ?? 2;
     this.maxChunkSize = options.maxChunkSize ?? 4;
     this.delay = options.delay ?? 20; // Time in milliseconds
+    this.metadata = options.metadata;
   }
 
   _read() {
@@ -35,7 +36,13 @@ class TextStream extends Readable {
   async processTextStream(onProgressCallback) {
     const streamPromise = new Promise((resolve, reject) => {
       this.on('data', (chunk) => {
-        onProgressCallback(chunk.toString());
+        const payload = {
+          text: chunk.toString(),
+        };
+        if (this.metadata) {
+          payload.metadata = this.metadata;
+        }
+        onProgressCallback(payload);
       });
 
       this.on('end', () => {

--- a/api/models/Message.js
+++ b/api/models/Message.js
@@ -204,6 +204,7 @@ async function updateMessage(req, message, metadata) {
       isCreatedByUser: updatedMessage.isCreatedByUser,
       tokenCount: updatedMessage.tokenCount,
       isEdited: true,
+      groundingMetadata: updatedMessage.groundingMetadata,
     };
   } catch (err) {
     logger.error('Error updating message:', err);

--- a/api/models/schema/defaults.js
+++ b/api/models/schema/defaults.js
@@ -130,6 +130,11 @@ const conversationPreset = {
   max_tokens: {
     type: Number,
   },
+  // for google only
+  enableSearch: {
+    type: Boolean,
+    required: false,
+  },
 };
 
 const agentOptions = {

--- a/api/models/schema/messageSchema.js
+++ b/api/models/schema/messageSchema.js
@@ -116,6 +116,7 @@ const messageSchema = mongoose.Schema(
       type: String,
     },
     attachments: { type: [{ type: mongoose.Schema.Types.Mixed }], default: undefined },
+    groundingMetadata: { type: mongoose.Schema.Types.Mixed, default: undefined },
     /*
     attachments: {
       type: [

--- a/api/server/services/Endpoints/google/build.js
+++ b/api/server/services/Endpoints/google/build.js
@@ -11,8 +11,10 @@ const buildOptions = (endpoint, parsedBody) => {
     greeting,
     spec,
     artifacts,
+    enableSearch,
     ...modelOptions
   } = parsedBody;
+
   const endpointOption = removeNullishValues({
     examples,
     endpoint,
@@ -22,6 +24,7 @@ const buildOptions = (endpoint, parsedBody) => {
     iconURL,
     greeting,
     spec,
+    enableSearch,
     modelOptions,
   });
 

--- a/client/src/components/Chat/Messages/Content/MessageContent.tsx
+++ b/client/src/components/Chat/Messages/Content/MessageContent.tsx
@@ -80,11 +80,22 @@ const DisplayMessage = ({ text, isCreatedByUser, message, showCursor }: TDisplay
     () => message.messageId === latestMessage?.messageId,
     [message.messageId, latestMessage?.messageId],
   );
-
   let content: React.ReactElement;
   if (!isCreatedByUser) {
     content = (
-      <Markdown content={text} showCursor={showCursorState} isLatestMessage={isLatestMessage} />
+      <>
+        <Markdown content={text} showCursor={showCursorState} isLatestMessage={isLatestMessage} />
+        {message.groundingMetadata?.searchEntryPoint?.renderedContent && (
+          <div className="mt-4 rounded-lg border border-token-border-light bg-token-surface-secondary p-4">
+            <div 
+              className="prose dark:prose-invert"
+              dangerouslySetInnerHTML={{ 
+                __html: message.groundingMetadata.searchEntryPoint.renderedContent 
+              }} 
+            />
+          </div>
+        )}
+      </>
     );
   } else if (enableUserMsgMarkdown) {
     content = <MarkdownLite content={text} />;

--- a/client/src/components/Endpoints/Settings/Google.tsx
+++ b/client/src/components/Endpoints/Settings/Google.tsx
@@ -53,6 +53,8 @@ export default function Settings({ conversation, setOption, models, readonly }: 
   const setMaxOutputTokens = setOption('maxOutputTokens');
   const setEnableSearch = setOption('enableSearch');
 
+  const isSearchEnabled = model?.startsWith('gemini-1.5-') || model?.startsWith('gemini-2.');
+
   return (
     <div className="grid grid-cols-5 gap-6">
       <div className="col-span-5 flex flex-col items-center justify-start gap-6 sm:col-span-3">
@@ -107,21 +109,23 @@ export default function Settings({ conversation, setOption, models, readonly }: 
           <HoverCardTrigger className="grid w-full items-center gap-2">
             <div className="flex justify-between">
               <Label htmlFor="enable-search" className="text-left text-sm font-medium">
-                Enable Search{' '}
+                {localize('com_endpoint_google_enable_search')}{' '}
                 <small className="opacity-40">
                   ({localize('com_endpoint_default')}: {google.enableSearch.default ? 'Yes' : 'No'})
                 </small>
               </Label>
               <Switch
                 id="enable-search"
-                disabled={readonly}
+                disabled={readonly || !isSearchEnabled}
                 checked={enableSearch ?? google.enableSearch.default}
                 onCheckedChange={(checked) => setEnableSearch(checked)}
               />
             </div>
           </HoverCardTrigger>
           <OptionHoverAlt
-            description="Enable Google Search functionality for enhanced responses"
+            description={isSearchEnabled ? 
+              localize('com_endpoint_google_search_info') : 
+              localize('com_endpoint_google_search_info_unavailable')}
             side={ESide.Left}
           />
         </HoverCard>

--- a/client/src/components/Endpoints/Settings/Google.tsx
+++ b/client/src/components/Endpoints/Settings/Google.tsx
@@ -5,6 +5,7 @@ import {
   Input,
   Label,
   Slider,
+  Switch,
   HoverCard,
   InputNumber,
   SelectDropDown,
@@ -28,6 +29,7 @@ export default function Settings({ conversation, setOption, models, readonly }: 
     topK,
     maxContextTokens,
     maxOutputTokens,
+    enableSearch,
   } = conversation ?? {};
 
   const [setMaxContextTokens, maxContextTokensValue] = useDebouncedInput<number | null | undefined>(
@@ -49,6 +51,7 @@ export default function Settings({ conversation, setOption, models, readonly }: 
   const setTopP = setOption('topP');
   const setTopK = setOption('topK');
   const setMaxOutputTokens = setOption('maxOutputTokens');
+  const setEnableSearch = setOption('enableSearch');
 
   return (
     <div className="grid grid-cols-5 gap-6">
@@ -100,6 +103,28 @@ export default function Settings({ conversation, setOption, models, readonly }: 
         </div>
       </div>
       <div className="col-span-5 flex flex-col items-center justify-start gap-6 px-3 sm:col-span-2">
+        <HoverCard openDelay={300}>
+          <HoverCardTrigger className="grid w-full items-center gap-2">
+            <div className="flex justify-between">
+              <Label htmlFor="enable-search" className="text-left text-sm font-medium">
+                Enable Search{' '}
+                <small className="opacity-40">
+                  ({localize('com_endpoint_default')}: {google.enableSearch.default ? 'Yes' : 'No'})
+                </small>
+              </Label>
+              <Switch
+                id="enable-search"
+                disabled={readonly}
+                checked={enableSearch ?? google.enableSearch.default}
+                onCheckedChange={(checked) => setEnableSearch(checked)}
+              />
+            </div>
+          </HoverCardTrigger>
+          <OptionHoverAlt
+            description="Enable Google Search functionality for enhanced responses"
+            side={ESide.Left}
+          />
+        </HoverCard>
         <HoverCard openDelay={300}>
           <HoverCardTrigger className="grid w-full items-center gap-2">
             <div className="mt-1 flex w-full justify-between">

--- a/client/src/localization/languages/Ar.ts
+++ b/client/src/localization/languages/Ar.ts
@@ -172,6 +172,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     'الحد الأقصى لعدد الرموز التي يمكن إنشاؤها في الرد. حدد قيمة أقل للردود الأقصر وقيمة أعلى للردود الأطول.',
   com_endpoint_google_custom_name_placeholder: 'قم بتعيين اسم مخصص لـ Google',
+  com_endpoint_google_enable_search: 'تمكين بحث Google',
+  com_endpoint_google_search_info: 'تمكين وظائف بحث Google للحصول على ردود محسنة',
+  com_endpoint_google_search_info_unavailable: 'البحث متاح فقط لنماذج Gemini 1.5 و 2.0',
   com_endpoint_prompt_prefix_placeholder:
     'قم بتعيين تعليمات مخصصة أو سياق. يتم تجاهله إذا كان فارغًا.',
   com_endpoint_custom_name: 'اسم مخصص',

--- a/client/src/localization/languages/Br.ts
+++ b/client/src/localization/languages/Br.ts
@@ -474,6 +474,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     'Número máximo de tokens que podem ser gerados na resposta. Especifique um valor mais baixo para respostas mais curtas e um valor mais alto para respostas mais longas. Nota: os modelos podem parar antes de atingir esse máximo.',
   com_endpoint_google_custom_name_placeholder: 'Defina um nome personalizado para o Google',
+  com_endpoint_google_enable_search: 'Ativar Pesquisa Google',
+  com_endpoint_google_search_info: 'Ativar funcionalidade de pesquisa Google para respostas aprimoradas',
+  com_endpoint_google_search_info_unavailable: 'A pesquisa está disponível apenas para modelos Gemini 1.5 e 2.0',
   com_endpoint_prompt_prefix_placeholder:
     'Defina instruções ou contexto personalizados. Ignorado se vazio.',
   com_endpoint_instructions_assistants_placeholder:

--- a/client/src/localization/languages/De.ts
+++ b/client/src/localization/languages/De.ts
@@ -443,6 +443,9 @@ export default {
     'Maximale Anzahl von Token, die in der Antwort generiert werden können. Gib einen niedrigeren Wert für kürzere Antworten und einen höheren Wert für längere Antworten an. Hinweis: Modelle können möglicherweise vor Erreichen dieses Maximums stoppen.',
   com_endpoint_google_custom_name_placeholder:
     'Lege einen benutzerdefinierten Namen für Google fest',
+  com_endpoint_google_enable_search: 'Google-Suche aktivieren',
+  com_endpoint_google_search_info: 'Google-Suchfunktionalität für verbesserte Antworten aktivieren',
+  com_endpoint_google_search_info_unavailable: 'Suche ist nur für Gemini 1.5 und 2.0 Modelle verfügbar',
   com_endpoint_prompt_prefix_placeholder:
     'Lege benutzerdefinierte Anweisungen oder Kontext fest. Wird ignoriert, wenn leer.',
   com_endpoint_instructions_assistants_placeholder:

--- a/client/src/localization/languages/Eng.ts
+++ b/client/src/localization/languages/Eng.ts
@@ -544,6 +544,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     'Maximum number of tokens that can be generated in the response. Specify a lower value for shorter responses and a higher value for longer responses. Note: models may stop before reaching this maximum.',
   com_endpoint_google_custom_name_placeholder: 'Set a custom name for Google',
+  com_endpoint_google_enable_search: 'Enable Google Search',
+  com_endpoint_google_search_info: 'Enable Google Search functionality for enhanced responses',
+  com_endpoint_google_search_info_unavailable: 'Search is only available for Gemini 1.5 and 2.0 models',
   com_endpoint_prompt_prefix_placeholder: 'Set custom instructions or context. Ignored if empty.',
   com_endpoint_instructions_assistants_placeholder:
     'Overrides the instructions of the assistant. This is useful for modifying the behavior on a per-run basis.',

--- a/client/src/localization/languages/Es.ts
+++ b/client/src/localization/languages/Es.ts
@@ -280,6 +280,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     'Número máximo de tokens que se pueden generar en la respuesta. Especifique un valor más bajo para respuestas más cortas y un valor más alto para respuestas más largas.',
   com_endpoint_google_custom_name_placeholder: 'Establecer un nombre personalizado para Google',
+  com_endpoint_google_enable_search: 'Activar Búsqueda de Google',
+  com_endpoint_google_search_info: 'Activar la funcionalidad de búsqueda de Google para respuestas mejoradas',
+  com_endpoint_google_search_info_unavailable: 'La búsqueda solo está disponible para los modelos Gemini 1.5 y 2.0',
   com_endpoint_prompt_prefix_placeholder:
     'Configurar instrucciones personalizadas o contexto. Se ignora si está vacío.',
   com_endpoint_instructions_assistants_placeholder:

--- a/client/src/localization/languages/Fi.ts
+++ b/client/src/localization/languages/Fi.ts
@@ -419,6 +419,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     'Maksimimäärä tokeneillre, joita generoidaan tulokseen. Valitse pienempi arvo saadaksesi lyhyempiä vastauksia, ja suurempi arvo pitkiä vastauksia varten.',
   com_endpoint_google_custom_name_placeholder: 'Aseta Googlelle mukautettu nimi',
+  com_endpoint_google_enable_search: 'Ota Google-haku käyttöön',
+  com_endpoint_google_search_info: 'Ota Google-hakutoiminto käyttöön parannettuja vastauksia varten',
+  com_endpoint_google_search_info_unavailable: 'Haku on käytettävissä vain Gemini 1.5- ja 2.0-malleissa',
   com_endpoint_prompt_prefix_placeholder:
     'Aseta mukautetut ohjeet tai konteksti. Jätetään huomiotta, jos tyhjä.',
   com_endpoint_instructions_assistants_placeholder:

--- a/client/src/localization/languages/Fr.ts
+++ b/client/src/localization/languages/Fr.ts
@@ -199,6 +199,9 @@ export default {
   com_endpoint_google_custom_name_placeholder: 'Définir un nom personnalisé pour Google',
   com_endpoint_google_prompt_prefix_placeholder:
     'Définir des instructions ou un contexte personnalisés. Ignoré si vide.',
+  com_endpoint_google_enable_search: 'Activer la Recherche Google',
+  com_endpoint_google_search_info: 'Activer la fonctionnalité de recherche Google pour des réponses améliorées',
+  com_endpoint_google_search_info_unavailable: 'La recherche est uniquement disponible pour les modèles Gemini 1.5 et 2.0',
   com_endpoint_custom_name: 'Nom personnalisé',
   com_endpoint_prompt_prefix: 'Préfixe du prompt',
   com_endpoint_temperature: 'Température',

--- a/client/src/localization/languages/He.ts
+++ b/client/src/localization/languages/He.ts
@@ -223,6 +223,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     ' המספר המרבי של אסימונים שניתן להפיק בתגובה. ציין ערך נמוך יותר עבור תגובות קצרות יותר וערך גבוה יותר עבור תגובות ארוכות יותר.',
   com_endpoint_google_custom_name_placeholder: 'הגדר שם מותאם אישית עבור Google',
+  com_endpoint_google_enable_search: 'הפעל חיפוש Google',
+  com_endpoint_google_search_info: 'הפעל פונקציונליות חיפוש Google לתשובות משופרות',
+  com_endpoint_google_search_info_unavailable: 'החיפוש זמין רק עבור דגמי Gemini 1.5 ו-2.0',
   com_endpoint_prompt_prefix_placeholder: 'הגדר הוראות מותאמות אישית או הקשר. התעלמו אם ריק.',
   com_endpoint_instructions_assistants_placeholder:
     'עובר את הוראות הסייען. זה שימושי לשינוי ההתנהגות על בסיס ריצה.',

--- a/client/src/localization/languages/Id.ts
+++ b/client/src/localization/languages/Id.ts
@@ -191,6 +191,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     'Jumlah maksimum token yang dapat dihasilkan dalam respons. Tentukan nilai yang lebih rendah untuk respons yang lebih pendek dan nilai yang lebih tinggi untuk respons yang lebih panjang.',
   com_endpoint_google_custom_name_placeholder: 'Tetapkan nama kustom untuk Google',
+  com_endpoint_google_enable_search: 'Aktifkan Pencarian Google',
+  com_endpoint_google_search_info: 'Aktifkan fungsi pencarian Google untuk respons yang lebih baik',
+  com_endpoint_google_search_info_unavailable: 'Pencarian hanya tersedia untuk model Gemini 1.5 dan 2.0',
   com_endpoint_prompt_prefix_placeholder:
     'Tetapkan instruksi kustom atau konteks. Diabaikan jika kosong.',
   com_endpoint_custom_name: 'Nama Kustom',

--- a/client/src/localization/languages/It.ts
+++ b/client/src/localization/languages/It.ts
@@ -330,6 +330,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     'Numero massimo di token che possono essere generati nella risposta. Specifica un valore più basso per risposte più brevi e un valore più alto per risposte più lunghe.',
   com_endpoint_google_custom_name_placeholder: 'Imposta un nome personalizzato per Google',
+  com_endpoint_google_enable_search: 'Abilita Ricerca Google',
+  com_endpoint_google_search_info: 'Abilita la funzionalità di ricerca Google per risposte migliorate',
+  com_endpoint_google_search_info_unavailable: 'La ricerca è disponibile solo per i modelli Gemini 1.5 e 2.0',
   com_endpoint_prompt_prefix_placeholder:
     'Imposta istruzioni personalizzate o contesto. Ignorato se vuoto.',
   com_endpoint_instructions_assistants_placeholder:

--- a/client/src/localization/languages/Jp.ts
+++ b/client/src/localization/languages/Jp.ts
@@ -468,6 +468,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     ' 	生成されるレスポンスの最大トークン数。短いレスポンスには低い値を、長いレスポンスには高い値を指定します。',
   com_endpoint_google_custom_name_placeholder: 'Googleのカスタム名を設定する',
+  com_endpoint_google_enable_search: 'Google検索を有効にする',
+  com_endpoint_google_search_info: 'より良い応答のためにGoogle検索機能を有効にする',
+  com_endpoint_google_search_info_unavailable: '検索はGemini 1.5および2.0モデルでのみ利用可能です', 
   com_endpoint_prompt_prefix_placeholder:
     'custom instructions か context を設定する。空の場合は無視されます。',
   com_endpoint_instructions_assistants_placeholder:

--- a/client/src/localization/languages/Ko.ts
+++ b/client/src/localization/languages/Ko.ts
@@ -171,6 +171,9 @@ export default {
   com_endpoint_google_custom_name_placeholder: 'Google에 대한 사용자 정의 이름 설정',
   com_endpoint_prompt_prefix_placeholder:
     '사용자 정의 지시사항 또는 컨텍스트를 설정하세요. 비어 있으면 무시됩니다.',
+  com_endpoint_google_enable_search: 'Google 검색 활성화',
+  com_endpoint_google_search_info: '향상된 응답을 위해 Google 검색 기능 활성화',
+  com_endpoint_google_search_info_unavailable: '검색은 Gemini 1.5 및 2.0 모델에서만 사용 가능합니다',
   com_endpoint_custom_name: '사용자 정의 이름',
   com_endpoint_prompt_prefix: '프롬프트 접두사',
   com_endpoint_temperature: '온도',

--- a/client/src/localization/languages/Nl.ts
+++ b/client/src/localization/languages/Nl.ts
@@ -182,6 +182,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     '	Maximum aantal tokens dat kan worden gegenereerd in de reactie. Geef een lagere waarde op voor kortere reacties en een hogere waarde voor langere reacties.',
   com_endpoint_google_custom_name_placeholder: 'Stel een aangepaste naam in voor Google',
+  com_endpoint_google_enable_search: 'Google Zoeken inschakelen',
+  com_endpoint_google_search_info: 'Schakel Google Zoeken-functionaliteit in voor verbeterde antwoorden',
+  com_endpoint_google_search_info_unavailable: 'Zoeken is alleen beschikbaar voor Gemini 1.5 en 2.0 modellen',
   com_endpoint_prompt_prefix_placeholder:
     'Stel aangepaste instructies of context in. Wordt genegeerd indien leeg.',
   com_endpoint_custom_name: 'Aangepaste naam',

--- a/client/src/localization/languages/Pl.ts
+++ b/client/src/localization/languages/Pl.ts
@@ -147,6 +147,9 @@ export default {
   com_endpoint_google_custom_name_placeholder: 'Ustaw niestandardową nazwę dla Google',
   com_endpoint_google_prompt_prefix_placeholder:
     'Ustaw niestandardowe instrukcje lub kontekst. Jeśli puste, zostanie zignorowane.',
+  com_endpoint_google_enable_search: 'Włącz wyszukiwarkę Google',
+  com_endpoint_google_search_info: 'Włącz funkcję wyszukiwania Google dla lepszych odpowiedzi',
+  com_endpoint_google_search_info_unavailable: 'Wyszukiwanie jest dostępne tylko dla modeli Gemini 1.5 i 2.0',
   com_endpoint_custom_name: 'Niestandardowa nazwa',
   com_endpoint_prompt_prefix: 'Prefiks promptu',
   com_endpoint_temperature: 'Temperatura',

--- a/client/src/localization/languages/Ru.ts
+++ b/client/src/localization/languages/Ru.ts
@@ -199,6 +199,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     ' 	Максимальное количество токенов, которые могут быть сгенерированы в ответе. Укажите меньшее значение для более коротких ответов и большее значение для более длинных ответов.',
   com_endpoint_google_custom_name_placeholder: 'Задайте кастомное имя для Google',
+  com_endpoint_google_enable_search: 'Включить поиск Google',
+  com_endpoint_google_search_info: 'Включить функцию поиска Google для улучшенных ответов',
+  com_endpoint_google_search_info_unavailable: 'Поиск доступен только для моделей Gemini 1.5 и 2.0',
   com_endpoint_prompt_prefix_placeholder:
     'Задайте пользовательские инструкции или контекст. Игнорируется, если пусто.',
   com_endpoint_custom_name: 'Кастомное имя',

--- a/client/src/localization/languages/Sv.ts
+++ b/client/src/localization/languages/Sv.ts
@@ -177,6 +177,9 @@ export default {
   com_endpoint_google_custom_name_placeholder: 'Ange ett anpassat namn för Google',
   com_endpoint_prompt_prefix_placeholder:
     'Ange anpassade instruktioner eller kontext. Ignoreras om tom.',
+  com_endpoint_google_enable_search: 'Aktivera Google-sökning',
+  com_endpoint_google_search_info: 'Aktivera Google-sökfunktionalitet för förbättrade svar',
+  com_endpoint_google_search_info_unavailable: 'Sökning är endast tillgänglig för Gemini 1.5 och 2.0 modeller',
   com_endpoint_custom_name: 'Anpassat namn',
   com_endpoint_prompt_prefix: 'Uppmaningsprefix',
   com_endpoint_temperature: 'Temperatur',

--- a/client/src/localization/languages/Tr.ts
+++ b/client/src/localization/languages/Tr.ts
@@ -378,6 +378,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     'Yanıttaki maksimum token sayısı. Daha kısa yanıtlar için düşük bir değer, daha uzun yanıtlar için yüksek bir değer belirtin.',
   com_endpoint_google_custom_name_placeholder: 'Google için özel bir ad ayarlayın',
+  com_endpoint_google_enable_search: 'Google Aramayı Etkinleştir',
+  com_endpoint_google_search_info: 'Gelişmiş yanıtlar için Google Arama işlevini etkinleştir',
+  com_endpoint_google_search_info_unavailable: 'Arama yalnızca Gemini 1.5 ve 2.0 modelleri için kullanılabilir',
   com_endpoint_prompt_prefix_placeholder:
     'Özel talimatlar veya bağlam ayarlayın. Boşsa yok sayılır.',
   com_endpoint_instructions_assistants_placeholder:

--- a/client/src/localization/languages/Vi.ts
+++ b/client/src/localization/languages/Vi.ts
@@ -180,6 +180,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     'Số mã thông báo tối đa có thể được tạo ra trong phản hồi. Chỉ định một giá trị thấp hơn cho các phản hồi ngắn hơn và một giá trị cao hơn cho các phản hồi dài hơn.',
   com_endpoint_google_custom_name_placeholder: 'Đặt tên tùy chỉnh cho Google',
+  com_endpoint_google_enable_search: 'Bật Tìm kiếm Google',
+  com_endpoint_google_search_info: 'Bật chức năng tìm kiếm Google để có câu trả lời nâng cao',
+  com_endpoint_google_search_info_unavailable: 'Tìm kiếm chỉ khả dụng cho các mô hình Gemini 1.5 và 2.0',
   com_endpoint_prompt_prefix_placeholder:
     'Đặt hướng dẫn hoặc ngữ cảnh tùy chỉnh. Bỏ qua nếu trống.',
   com_endpoint_custom_name: 'Tên tùy chỉnh',

--- a/client/src/localization/languages/Zh.ts
+++ b/client/src/localization/languages/Zh.ts
@@ -444,6 +444,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     '响应中可以生成的最大令牌数。指定较低的值以获得较短的响应，指定较高的值以获得较长的响应。注意：模型可能会在达到此最大值之前停止。',
   com_endpoint_google_custom_name_placeholder: '为 Google 设置一个名称',
+  com_endpoint_google_enable_search: '启用 Google 搜索',
+  com_endpoint_google_search_info: '启用 Google 搜索功能以获得增强的响应',
+  com_endpoint_google_search_info_unavailable: '搜索功能仅适用于 Gemini 1.5 和 2.0 模型',
   com_endpoint_prompt_prefix_placeholder: '自定义指令和上下文，默认为空。',
   com_endpoint_instructions_assistants_placeholder:
     '覆盖助手的指令。这对于需要逐次修改行为非常有用。',

--- a/client/src/localization/languages/ZhTraditional.ts
+++ b/client/src/localization/languages/ZhTraditional.ts
@@ -169,6 +169,9 @@ export default {
   com_endpoint_google_maxoutputtokens:
     '設定回應中可生成的最大 token 數。若希望回應簡短，請設定較低的數值；若需較長的回應，則設定較高的數值。',
   com_endpoint_google_custom_name_placeholder: '為 Google 設定自訂名稱',
+  com_endpoint_google_enable_search: '啟用 Google 搜尋',
+  com_endpoint_google_search_info: '啟用 Google 搜尋功能以獲得增強的回應',
+  com_endpoint_google_search_info_unavailable: '搜尋功能僅適用於 Gemini 1.5 和 2.0 模型',
   com_endpoint_prompt_prefix_placeholder: '設定自訂提示或前後文。如果為空則忽略。',
   com_endpoint_custom_name: '自訂名稱',
   com_endpoint_prompt_prefix: '提示起始字串',

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -240,6 +240,9 @@ export const googleSettings = {
     step: 1,
     default: 40,
   },
+  enableSearch: {
+    default: false,
+  },
 };
 
 const ANTHROPIC_MAX_OUTPUT = 8192;
@@ -551,6 +554,7 @@ export const tConversationSchema = z.object({
   /* google */
   context: z.string().nullable().optional(),
   examples: z.array(tExampleSchema).optional(),
+  enableSearch: z.boolean().optional(),
   /* DB */
   tags: z.array(z.string()).optional(),
   createdAt: z.string(),
@@ -686,6 +690,7 @@ export const googleSchema = tConversationSchema
     greeting: true,
     spec: true,
     maxContextTokens: true,
+    enableSearch: true,
   })
   .transform((obj) => {
     return {
@@ -698,6 +703,7 @@ export const googleSchema = tConversationSchema
       maxOutputTokens: obj.maxOutputTokens ?? google.maxOutputTokens.default,
       topP: obj.topP ?? google.topP.default,
       topK: obj.topK ?? google.topK.default,
+      enableSearch: obj.enableSearch ?? google.enableSearch.default,
       iconURL: obj.iconURL ?? undefined,
       greeting: obj.greeting ?? undefined,
       spec: obj.spec ?? undefined,
@@ -713,6 +719,7 @@ export const googleSchema = tConversationSchema
     maxOutputTokens: google.maxOutputTokens.default,
     topP: google.topP.default,
     topK: google.topK.default,
+    enableSearch: google.enableSearch.default,
     iconURL: undefined,
     greeting: undefined,
     spec: undefined,
@@ -986,6 +993,7 @@ export const compactGoogleSchema = tConversationSchema
     greeting: true,
     spec: true,
     maxContextTokens: true,
+    enableSearch: true,
   })
   .transform((obj) => {
     const newObj: Partial<TConversation> = { ...obj };
@@ -1000,6 +1008,9 @@ export const compactGoogleSchema = tConversationSchema
     }
     if (newObj.topK === google.topK.default) {
       delete newObj.topK;
+    }
+    if (newObj.enableSearch === google.enableSearch.default) {
+      delete newObj.enableSearch;
     }
 
     return removeNullishValues(newObj);
@@ -1118,3 +1129,4 @@ export const compactAgentsSchema = tConversationSchema
   })
   .transform(removeNullishValues)
   .catch(() => ({}));
+

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -476,6 +476,15 @@ export const tMessageSchema = z.object({
   thread_id: z.string().optional(),
   /* frontend components */
   iconURL: z.string().optional(),
+  /* google grounding metadata */
+  groundingMetadata: z.object({
+    webSearchQueries: z.array(z.string()).optional(),
+    retrievalQueries: z.array(z.string()).optional(),
+    groundingChunks: z.array(z.record(z.any())).optional(),
+    groundingSupports: z.array(z.record(z.any())).optional(),
+    searchEntryPoint: z.record(z.any()).optional(),
+    retrievalMetadata: z.record(z.any()).optional(),
+  }).optional(),
 });
 
 export type TAttachmentMetadata = { messageId: string; toolCallId: string };
@@ -1129,4 +1138,5 @@ export const compactAgentsSchema = tConversationSchema
   })
   .transform(removeNullishValues)
   .catch(() => ({}));
+
 


### PR DESCRIPTION


## Summary
This is a more a PoC than a PR, it's quite cool to have google search natively supported by the model as in google's aistudio.

It will probably be rejected for various reasons but maybe some people are interested in the feature. 
In the settings of  the Google Endpoint there is a "Enable Search" switch ( localized in all supported languages ).
When the switch is activated the google_search tool is added to the model ( it is not the same tool for 1.5 and for 2.0 ), and it enables the model to use google search, and there is an added snippet generated by google added in the response.
The snippet seems more or less mandatory according to google gemini doc: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/ground-gemini , https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/grounding-search-suggestions

Note that the patch manages only the GenAI api, not the vertex-ai api ( for the time being I can't test vertex ai and it seems gemini-2.0 is not yet supported on vertex-ai. if you are in Europe your data sent to GenAI is not used for training ).

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Testing

Check the "Enable Search" setting on a google endpoint, ask about the weather in whatever place in the world and check:
- up-to-date results
- an added snippet with a link to google

I have tested  with models gemini-1.5-pro-002 and gemini-2.0-flash-exp.
Note that all google models do not support grounding. One way to check if a given model is supported is to check in https://aistudio.google.com if the model supports grounding. The gemini-exp-1206 does not support it.



### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes : no, but could do them if this PR is considered further

- [x] My changes do not introduce new warnings
