### PR TITLE
🐛 fix: Artifacts Type Error, Tool Token Counts, and Agent Chat Import

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -931,6 +931,24 @@ class BaseClient {
             continue;
           }
 
+          if (item.type === 'tool_call' && item.tool_call != null) {
+            const toolName = item.tool_call?.name || '';
+            if (toolName != null && toolName && typeof toolName === 'string') {
+              numTokens += this.getTokenCount(toolName);
+            }
+
+            const args = item.tool_call?.args || '';
+            if (args != null && args && typeof args === 'string') {
+              numTokens += this.getTokenCount(args);
+            }
+
+            const output = item.tool_call?.output || '';
+            if (output != null && output && typeof output === 'string') {
+              numTokens += this.getTokenCount(output);
+            }
+            continue;
+          }
+
           const nestedValue = item[item.type];
 
           if (!nestedValue) {

--- a/api/server/utils/import/importers.js
+++ b/api/server/utils/import/importers.js
@@ -113,7 +113,7 @@ async function importLibreChatConvo(
        */
       const traverseMessages = async (messages, parentMessageId = null) => {
         for (const message of messages) {
-          if (!message.text) {
+          if (!message.text && !message.content) {
             continue;
           }
 
@@ -121,6 +121,7 @@ async function importLibreChatConvo(
           if (message.sender?.toLowerCase() === 'user' || message.isCreatedByUser) {
             savedMessage = await importBatchBuilder.saveMessage({
               text: message.text,
+              content: message.content,
               sender: 'user',
               isCreatedByUser: true,
               parentMessageId: parentMessageId,
@@ -128,6 +129,7 @@ async function importLibreChatConvo(
           } else {
             savedMessage = await importBatchBuilder.saveMessage({
               text: message.text,
+              content: message.content,
               sender: message.sender,
               isCreatedByUser: false,
               model: options.model,

--- a/client/src/components/Chat/Input/Files/FilePreview.tsx
+++ b/client/src/components/Chat/Input/Files/FilePreview.tsx
@@ -21,7 +21,11 @@ const FilePreview = ({
 }) => {
   const radius = 55; // Radius of the SVG circle
   const circumference = 2 * Math.PI * radius;
-  const progress = useProgress(file?.['progress'] ?? 1, 0.001, (file as ExtendedFile).size ?? 1);
+  const progress = useProgress(
+    file?.['progress'] ?? 1,
+    0.001,
+    (file as ExtendedFile | undefined)?.size ?? 1,
+  );
 
   // Calculate the offset based on the loading progress
   const offset = circumference - progress * circumference;


### PR DESCRIPTION
## Summary

I fixed issues related to undefined file sizes in the `FilePreview` component, incorrect token counts for tool calls in context window management, and message import functionality to support the `content` field.

- Fixed potential undefined `size` in `FilePreview` component to prevent runtime errors when `size` is not defined.
- Handled token counts for `tool_call` messages in context window management to ensure accurate token calculations in `BaseClient.js`.
- Updated message import functionality to support the `content` field, ensuring that messages with `content` are properly imported.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested these changes by:

- **FilePreview Component**: Uploaded files with and without the `size` property to ensure the `FilePreview` component handles both cases without errors and displays progress correctly.
- **Context Window Management**: Created conversations involving tool calls and verified that the token counts are calculated correctly without causing context window overflows.
- **Message Import Functionality**: Imported conversations containing messages with the `content` field to confirm they are imported properly and display as expected in the chat history.

### **Test Configuration**:

- **Environment**: Local development environment
- **Node.js Version**: _Specify the version used, e.g., v14.17.0_
- **Operating System**: _Specify your OS, e.g., Windows 10 / macOS Catalina / Ubuntu 20.04_

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes