### PR TITLE
🔧 fix: Fetch PWA Manifest with credentials over CORS

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
       devOptions: {
         enabled: false, // enable/disable registering SW in development mode
       },
+      useCredentials: true,
       workbox: {
         globPatterns: ['assets/**/*.{png,jpg,svg,ico}', '**/*.{js,css,html,ico,woff2}'],
         maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,


### PR DESCRIPTION
## Summary

When behind authentication (for eg: Cloudflare Access), browsers
won't send credentials when fetching the manifest file by default.

To fix, this change adds `crossorigin="use-credentials"` to the
manifest link tag which allows the browser to attach credentials.
Because of limitations with Vite, for now this needs to happen as
a manual post build step.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Ran `npm run frontend` and ensured the `manifest` link in `client/dist/index.html` had the expected `crossorigin` attribute.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code

