### PR TITLE
🐛 fix: Prevent Default Values in OpenAI/Custom Endpoint Agents

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@langchain/google-genai": "^0.1.6",
     "@langchain/google-vertexai": "^0.1.6",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^1.9.92",
+    "@librechat/agents": "^1.9.93",
     "axios": "^1.7.7",
     "bcryptjs": "^2.4.3",
     "cheerio": "^1.0.0-rc.12",

--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@langchain/google-genai": "^0.1.6",
     "@langchain/google-vertexai": "^0.1.6",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^1.9.93",
+    "@librechat/agents": "^1.9.94",
     "axios": "^1.7.7",
     "bcryptjs": "^2.4.3",
     "cheerio": "^1.0.0-rc.12",

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -40,6 +40,7 @@ const { createRun } = require('./run');
 const { logger } = require('~/config');
 
 /** @typedef {import('@librechat/agents').MessageContentComplex} MessageContentComplex */
+/** @typedef {import('@langchain/core/runnables').RunnableConfig} RunnableConfig */
 
 const providerParsers = {
   [EModelEndpoint.openAI]: openAISchema,
@@ -488,6 +489,7 @@ class AgentClient extends BaseClient {
       //   });
       // }
 
+      /** @type {Partial<RunnableConfig> & { version: 'v1' | 'v2'; run_id?: string; streamMode: string }} */
       const config = {
         configurable: {
           thread_id: this.conversationId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "@langchain/google-genai": "^0.1.6",
         "@langchain/google-vertexai": "^0.1.6",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^1.9.92",
+        "@librechat/agents": "^1.9.93",
         "axios": "^1.7.7",
         "bcryptjs": "^2.4.3",
         "cheerio": "^1.0.0-rc.12",
@@ -640,35 +640,6 @@
       },
       "peerDependencies": {
         "@langchain/core": ">=0.2.21 <0.4.0"
-      }
-    },
-    "api/node_modules/@librechat/agents": {
-      "version": "1.9.92",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-1.9.92.tgz",
-      "integrity": "sha512-kWkUf3/ZVKbrg/BlFH5XJzafyzuUSC2JVBRdI7WJUGmbto1Wxx+LdMy0A8k665gReRjg3ebqbZxo7NqUH9uxlw==",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-sdk/credential-provider-node": "^3.613.0",
-        "@aws-sdk/types": "^3.609.0",
-        "@langchain/anthropic": "^0.3.11",
-        "@langchain/aws": "^0.1.3",
-        "@langchain/community": "^0.3.14",
-        "@langchain/core": "^0.3.26",
-        "@langchain/google-genai": "^0.1.6",
-        "@langchain/google-vertexai": "^0.1.6",
-        "@langchain/langgraph": "^0.2.34",
-        "@langchain/mistralai": "^0.0.26",
-        "@langchain/ollama": "^0.1.1",
-        "@langchain/openai": "^0.3.14",
-        "@smithy/eventstream-codec": "^2.2.0",
-        "@smithy/protocol-http": "^3.0.6",
-        "@smithy/signature-v4": "^2.0.10",
-        "@smithy/util-utf8": "^2.0.0",
-        "dotenv": "^16.4.5",
-        "nanoid": "^3.3.7"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "api/node_modules/@types/node": {
@@ -9215,8 +9186,6 @@
       "version": "0.3.15",
       "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.3.15.tgz",
       "integrity": "sha512-yG4cv33u7zYar14yqZCI7o2KjwRb+9S7upVzEmVVETimpicm9UjpkMfX4qa4A4IslM1TtC4uy2Ymu9EcINZSpQ==",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@langchain/openai": ">=0.2.0 <0.4.0",
         "binary-extensions": "^2.2.0",
@@ -9728,8 +9697,6 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "optional": true,
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -10203,6 +10170,35 @@
       "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@librechat/agents": {
+      "version": "1.9.93",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-1.9.93.tgz",
+      "integrity": "sha512-F9ZiDYpREKRgDMr94ki0BuX1TOYn8gqK38sT366qwTusoi5C6gdfUX+l0RUV5UmIbOYtq+t8eMEJfbXgVGRSZg==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-sdk/credential-provider-node": "^3.613.0",
+        "@aws-sdk/types": "^3.609.0",
+        "@langchain/anthropic": "^0.3.11",
+        "@langchain/aws": "^0.1.3",
+        "@langchain/community": "^0.3.14",
+        "@langchain/core": "^0.3.26",
+        "@langchain/google-genai": "^0.1.6",
+        "@langchain/google-vertexai": "^0.1.6",
+        "@langchain/langgraph": "^0.2.34",
+        "@langchain/mistralai": "^0.0.26",
+        "@langchain/ollama": "^0.1.1",
+        "@langchain/openai": "^0.3.14",
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/signature-v4": "^2.0.10",
+        "@smithy/util-utf8": "^2.0.0",
+        "dotenv": "^16.4.5",
+        "nanoid": "^3.3.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@librechat/backend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "@langchain/google-genai": "^0.1.6",
         "@langchain/google-vertexai": "^0.1.6",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^1.9.93",
+        "@librechat/agents": "^1.9.94",
         "axios": "^1.7.7",
         "bcryptjs": "^2.4.3",
         "cheerio": "^1.0.0-rc.12",
@@ -640,6 +640,35 @@
       },
       "peerDependencies": {
         "@langchain/core": ">=0.2.21 <0.4.0"
+      }
+    },
+    "api/node_modules/@librechat/agents": {
+      "version": "1.9.94",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-1.9.94.tgz",
+      "integrity": "sha512-v/f2WmBKfP7PcMeKQn0BuzdxLkgZ5BXi3dx1jXLwWTM/1Qmtjrb1dGdZ+z3jIdsq9f86tSCbgCyO5dzTI9H4Hw==",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-sdk/credential-provider-node": "^3.613.0",
+        "@aws-sdk/types": "^3.609.0",
+        "@langchain/anthropic": "^0.3.11",
+        "@langchain/aws": "^0.1.3",
+        "@langchain/community": "^0.3.14",
+        "@langchain/core": "^0.3.26",
+        "@langchain/google-genai": "^0.1.6",
+        "@langchain/google-vertexai": "^0.1.6",
+        "@langchain/langgraph": "^0.2.34",
+        "@langchain/mistralai": "^0.0.26",
+        "@langchain/ollama": "^0.1.1",
+        "@langchain/openai": "^0.3.14",
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/signature-v4": "^2.0.10",
+        "@smithy/util-utf8": "^2.0.0",
+        "dotenv": "^16.4.5",
+        "nanoid": "^3.3.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "api/node_modules/@types/node": {
@@ -9186,6 +9215,8 @@
       "version": "0.3.15",
       "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.3.15.tgz",
       "integrity": "sha512-yG4cv33u7zYar14yqZCI7o2KjwRb+9S7upVzEmVVETimpicm9UjpkMfX4qa4A4IslM1TtC4uy2Ymu9EcINZSpQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@langchain/openai": ">=0.2.0 <0.4.0",
         "binary-extensions": "^2.2.0",
@@ -9697,6 +9728,8 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "optional": true,
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -10170,35 +10203,6 @@
       "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@librechat/agents": {
-      "version": "1.9.93",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-1.9.93.tgz",
-      "integrity": "sha512-F9ZiDYpREKRgDMr94ki0BuX1TOYn8gqK38sT366qwTusoi5C6gdfUX+l0RUV5UmIbOYtq+t8eMEJfbXgVGRSZg==",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-sdk/credential-provider-node": "^3.613.0",
-        "@aws-sdk/types": "^3.609.0",
-        "@langchain/anthropic": "^0.3.11",
-        "@langchain/aws": "^0.1.3",
-        "@langchain/community": "^0.3.14",
-        "@langchain/core": "^0.3.26",
-        "@langchain/google-genai": "^0.1.6",
-        "@langchain/google-vertexai": "^0.1.6",
-        "@langchain/langgraph": "^0.2.34",
-        "@langchain/mistralai": "^0.0.26",
-        "@langchain/ollama": "^0.1.1",
-        "@langchain/openai": "^0.3.14",
-        "@smithy/eventstream-codec": "^2.2.0",
-        "@smithy/protocol-http": "^3.0.6",
-        "@smithy/signature-v4": "^2.0.10",
-        "@smithy/util-utf8": "^2.0.0",
-        "dotenv": "^16.4.5",
-        "nanoid": "^3.3.7"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@librechat/backend": {


### PR DESCRIPTION
## Summary

I fixed an issue where OpenAI and custom endpoint agents were incorrectly using default values

- Updated `@librechat/agents` package to version `^1.9.94` to prevent OpenAI and custom endpoint agents from using default values.
- Added typing for `RunnableConfig` in the agents client for improved code quality and readability.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested the application to confirm that the agents now correctly use their specified configuration values and client options are assigned properly. I ensured that there are no new warnings or errors and that all existing tests pass successfully.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes