### PR TITLE
✨ feat: Quality-of-Life Chat/Edit-Message Enhancements

### DIFF
--- a/client/src/components/Artifacts/Mermaid.tsx
+++ b/client/src/components/Artifacts/Mermaid.tsx
@@ -47,7 +47,6 @@ const MermaidDiagram: React.FC<MermaidDiagramProps> = ({ content }) => {
         diagramPadding: 8,
         htmlLabels: true,
         useMaxWidth: true,
-        defaultRenderer: 'dagre-d3',
         padding: 15,
         wrappingWidth: 200,
       },

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -20,27 +20,20 @@ import {
   useQueryParams,
   useSubmitMessage,
 } from '~/hooks';
+import { cn, removeFocusRings, checkIfScrollable } from '~/utils';
 import FileFormWrapper from './Files/FileFormWrapper';
 import { TextareaAutosize } from '~/components/ui';
 import { useGetFileConfig } from '~/data-provider';
-import { cn, removeFocusRings } from '~/utils';
 import TextareaHeader from './TextareaHeader';
 import PromptsCommand from './PromptsCommand';
 import AudioRecorder from './AudioRecorder';
 import { mainTextareaId } from '~/common';
+import CollapseChat from './CollapseChat';
 import StreamAudio from './StreamAudio';
 import StopButton from './StopButton';
 import SendButton from './SendButton';
 import Mention from './Mention';
 import store from '~/store';
-import CollapseChat from './CollapseChat';
-
-const checkIfScrollable = (element: HTMLTextAreaElement | null) => {
-  if (!element) {
-    return false;
-  }
-  return element.scrollHeight > element.clientHeight;
-};
 
 const ChatForm = ({ index = 0 }) => {
   const submitButtonRef = useRef<HTMLButtonElement>(null);
@@ -75,6 +68,7 @@ const ChatForm = ({ index = 0 }) => {
   const { handlePaste, handleKeyDown, handleCompositionStart, handleCompositionEnd } = useTextarea({
     textAreaRef,
     submitButtonRef,
+    setIsScrollable,
     disabled: !!(requiresKey ?? false),
   });
 
@@ -139,6 +133,12 @@ const ChatForm = ({ index = 0 }) => {
       textAreaRef.current.focus();
     }
   }, [isSearching, disableInputs]);
+
+  useEffect(() => {
+    if (textAreaRef.current) {
+      checkIfScrollable(textAreaRef.current);
+    }
+  }, []);
 
   const endpointSupportsFiles: boolean = supportsFiles[endpointType ?? endpoint ?? ''] ?? false;
   const isUploadDisabled: boolean = endpointFileConfig?.disabled ?? false;

--- a/client/src/components/Chat/Input/CollapseChat.tsx
+++ b/client/src/components/Chat/Input/CollapseChat.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Minimize2 } from 'lucide-react';
+import { TooltipAnchor } from '~/components/ui';
+import { useLocalize } from '~/hooks';
+import { cn } from '~/utils';
+
+const CollapseChat = ({
+  isScrollable,
+  isCollapsed,
+  setIsCollapsed,
+}: {
+  isScrollable: boolean;
+  isCollapsed: boolean;
+  setIsCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
+  const localize = useLocalize();
+  if (!isScrollable) {
+    return null;
+  }
+
+  if (isCollapsed) {
+    return null;
+  }
+
+  return (
+    <TooltipAnchor
+      role="button"
+      description={localize('com_ui_collapse_chat')}
+      aria-label={localize('com_ui_collapse_chat')}
+      onClick={() => setIsCollapsed(true)}
+      className={cn(
+        'absolute right-2 top-2 z-10 size-[35px] rounded-full p-2 transition-colors',
+        'hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-primary focus:ring-opacity-50',
+      )}
+    >
+      <Minimize2 className="h-full w-full" />
+    </TooltipAnchor>
+  );
+};
+
+export default CollapseChat;

--- a/client/src/components/Chat/Messages/Content/EditMessage.tsx
+++ b/client/src/components/Chat/Messages/Content/EditMessage.tsx
@@ -21,6 +21,7 @@ const EditMessage = ({
   setSiblingIdx,
 }: TEditProps) => {
   const { addedIndex } = useAddedChatContext();
+  const submitButtonRef = useRef<HTMLButtonElement | null>(null);
   const { getMessages, setMessages, conversation } = useChatContext();
   const [latestMultiMessage, setLatestMultiMessage] = useRecoilState(
     store.latestMessageFamily(addedIndex),
@@ -131,6 +132,10 @@ const EditMessage = ({
         e.preventDefault();
         enterEdit(true);
       }
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        submitButtonRef.current?.click();
+      }
     },
     [enterEdit],
   );
@@ -166,6 +171,7 @@ const EditMessage = ({
       </div>
       <div className="mt-2 flex w-full justify-center text-center">
         <button
+          ref={submitButtonRef}
           className="btn btn-primary relative mr-2"
           disabled={
             isSubmitting || (endpoint === EModelEndpoint.google && !message.isCreatedByUser)

--- a/client/src/components/Chat/Messages/Content/EditMessage.tsx
+++ b/client/src/components/Chat/Messages/Content/EditMessage.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { useUpdateMessageMutation } from 'librechat-data-provider/react-query';
 import type { TEditProps } from '~/common';
 import { useChatContext, useAddedChatContext } from '~/Providers';
-import { TextareaAutosize } from '~/components/ui';
+import { TextareaAutosize, TooltipAnchor } from '~/components/ui';
 import { cn, removeFocusRings } from '~/utils';
 import { useLocalize } from '~/hooks';
 import Container from './Container';
@@ -21,6 +21,7 @@ const EditMessage = ({
   setSiblingIdx,
 }: TEditProps) => {
   const { addedIndex } = useAddedChatContext();
+  const saveButtonRef = useRef<HTMLButtonElement | null>(null);
   const submitButtonRef = useRef<HTMLButtonElement | null>(null);
   const { getMessages, setMessages, conversation } = useChatContext();
   const [latestMultiMessage, setLatestMultiMessage] = useRecoilState(
@@ -128,13 +129,17 @@ const EditMessage = ({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        enterEdit(true);
-      }
       if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault();
         submitButtonRef.current?.click();
+      }
+      if (e.key === 's' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        saveButtonRef.current?.click();
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        enterEdit(true);
       }
     },
     [enterEdit],
@@ -170,26 +175,42 @@ const EditMessage = ({
         />
       </div>
       <div className="mt-2 flex w-full justify-center text-center">
-        <button
-          ref={submitButtonRef}
-          className="btn btn-primary relative mr-2"
-          disabled={
-            isSubmitting || (endpoint === EModelEndpoint.google && !message.isCreatedByUser)
+        <TooltipAnchor
+          description="Ctrl + Enter / ⌘ + Enter"
+          render={
+            <button
+              ref={submitButtonRef}
+              className="btn btn-primary relative mr-2"
+              disabled={
+                isSubmitting || (endpoint === EModelEndpoint.google && !message.isCreatedByUser)
+              }
+              onClick={handleSubmit(resubmitMessage)}
+            >
+              {localize('com_ui_save_submit')}
+            </button>
           }
-          onClick={handleSubmit(resubmitMessage)}
-        >
-          {localize('com_ui_save_submit')}
-        </button>
-        <button
-          className="btn btn-secondary relative mr-2"
-          disabled={isSubmitting}
-          onClick={handleSubmit(updateMessage)}
-        >
-          {localize('com_ui_save')}
-        </button>
-        <button className="btn btn-neutral relative" onClick={() => enterEdit(true)}>
-          {localize('com_ui_cancel')}
-        </button>
+        />
+        <TooltipAnchor
+          description="Shift + Enter"
+          render={
+            <button
+              ref={saveButtonRef}
+              className="btn btn-secondary relative mr-2"
+              disabled={isSubmitting}
+              onClick={handleSubmit(updateMessage)}
+            >
+              {localize('com_ui_save')}
+            </button>
+          }
+        />
+        <TooltipAnchor
+          description="Esc"
+          render={
+            <button className="btn btn-neutral relative" onClick={() => enterEdit(true)}>
+              {localize('com_ui_cancel')}
+            </button>
+          }
+        />
       </div>
     </Container>
   );

--- a/client/src/components/Chat/Messages/HoverButtons.tsx
+++ b/client/src/components/Chat/Messages/HoverButtons.tsx
@@ -60,8 +60,34 @@ export default function HoverButtons({
 
   const { isCreatedByUser, error } = message;
 
-  if (error) {
-    return null;
+  const renderRegenerate = () => {
+    if (!regenerateEnabled) {
+      return null;
+    }
+    return (
+      <button
+        className={cn(
+          'hover-button active rounded-md p-1 hover:bg-gray-100 hover:text-gray-500 focus:opacity-100 dark:text-gray-400/70 dark:hover:bg-gray-700 dark:hover:text-gray-200 disabled:dark:hover:text-gray-400 md:invisible md:group-hover:visible md:group-[.final-completion]:visible',
+          !isLast ? 'md:opacity-0 md:group-hover:opacity-100' : '',
+        )}
+        onClick={regenerate}
+        type="button"
+        title={localize('com_ui_regenerate')}
+      >
+        <RegenerateIcon
+          className="hover:text-gray-500 dark:hover:text-gray-200 disabled:dark:hover:text-gray-400"
+          size="19"
+        />
+      </button>
+    );
+  };
+
+  if (error === true) {
+    return (
+      <div className="visible mt-0 flex justify-center gap-1 self-end text-gray-500 lg:justify-start">
+        {renderRegenerate()}
+      </div>
+    );
   }
 
   const onEdit = () => {
@@ -84,6 +110,7 @@ export default function HoverButtons({
       )}
       {isEditableEndpoint && (
         <button
+          id={`edit-${message.messageId}`}
           className={cn(
             'hover-button rounded-md p-1 hover:bg-gray-100 hover:text-gray-500 focus:opacity-100 dark:text-gray-400/70 dark:hover:bg-gray-700 dark:hover:text-gray-200 disabled:dark:hover:text-gray-400 md:group-hover:visible md:group-[.final-completion]:visible',
             isCreatedByUser ? '' : 'active',
@@ -113,22 +140,7 @@ export default function HoverButtons({
       >
         {isCopied ? <CheckMark className="h-[18px] w-[18px]" /> : <Clipboard size="19" />}
       </button>
-      {regenerateEnabled ? (
-        <button
-          className={cn(
-            'hover-button active rounded-md p-1 hover:bg-gray-100 hover:text-gray-500 focus:opacity-100 dark:text-gray-400/70 dark:hover:bg-gray-700 dark:hover:text-gray-200 disabled:dark:hover:text-gray-400 md:invisible md:group-hover:visible md:group-[.final-completion]:visible',
-            !isLast ? 'md:opacity-0 md:group-hover:opacity-100' : '',
-          )}
-          onClick={regenerate}
-          type="button"
-          title={localize('com_ui_regenerate')}
-        >
-          <RegenerateIcon
-            className="hover:text-gray-500 dark:hover:text-gray-200 disabled:dark:hover:text-gray-400"
-            size="19"
-          />
-        </button>
-      ) : null}
+      {renderRegenerate()}
       <Fork
         isLast={isLast}
         messageId={message.messageId}

--- a/client/src/components/Chat/Messages/MessagesView.tsx
+++ b/client/src/components/Chat/Messages/MessagesView.tsx
@@ -36,6 +36,7 @@ export default function MessagesView({
     <div className="flex-1 overflow-hidden overflow-y-auto">
       <div className="relative h-full">
         <div
+          className="scrollbar-gutter-stable"
           onScroll={debouncedHandleScroll}
           ref={scrollableRef}
           style={{

--- a/client/src/hooks/Input/useHandleKeyUp.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.ts
@@ -54,6 +54,7 @@ const useHandleKeyUp = ({
     permissionType: PermissionTypes.MULTI_CONVO,
     permission: Permissions.USE,
   });
+  const latestMessage = useRecoilValue(store.latestMessageFamily(index));
   const setShowPromptsPopover = useSetRecoilState(store.showPromptsPopoverFamily(index));
 
   // Get the current state of command toggles
@@ -94,12 +95,32 @@ const useHandleKeyUp = ({
     [handleAtCommand, handlePlusCommand, handlePromptsCommand],
   );
 
+  const handleUpArrow = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!latestMessage) {
+        return;
+      }
+
+      const element = document.getElementById(`edit-${latestMessage.parentMessageId}`);
+      if (!element) {
+        return;
+      }
+      event.preventDefault();
+      element.click();
+    },
+    [latestMessage],
+  );
+
   /**
    * Main key up handler.
    */
   const handleKeyUp = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
       const text = textAreaRef.current?.value;
+      if (event.key === 'ArrowUp' && text?.length === 0) {
+        handleUpArrow(event);
+        return;
+      }
       if (typeof text !== 'string' || text.length === 0) {
         return;
       }
@@ -115,7 +136,7 @@ const useHandleKeyUp = ({
         handler();
       }
     },
-    [textAreaRef, commandHandlers],
+    [textAreaRef, commandHandlers, handleUpArrow],
   );
 
   return handleKeyUp;

--- a/client/src/hooks/Input/useTextarea.ts
+++ b/client/src/hooks/Input/useTextarea.ts
@@ -4,7 +4,13 @@ import { useRecoilValue, useRecoilState } from 'recoil';
 import { Constants } from 'librechat-data-provider';
 import type { TEndpointOption } from 'librechat-data-provider';
 import type { KeyboardEvent } from 'react';
-import { forceResize, insertTextAtCursor, getEntityName, getEntity } from '~/utils';
+import {
+  forceResize,
+  insertTextAtCursor,
+  getEntityName,
+  getEntity,
+  checkIfScrollable,
+} from '~/utils';
 import { useAssistantsMapContext } from '~/Providers/AssistantsMapContext';
 import { useAgentsMapContext } from '~/Providers/AgentsMapContext';
 import useGetSender from '~/hooks/Conversations/useGetSender';
@@ -20,10 +26,12 @@ type KeyEvent = KeyboardEvent<HTMLTextAreaElement>;
 export default function useTextarea({
   textAreaRef,
   submitButtonRef,
+  setIsScrollable,
   disabled = false,
 }: {
   textAreaRef: React.RefObject<HTMLTextAreaElement>;
   submitButtonRef: React.RefObject<HTMLButtonElement>;
+  setIsScrollable: React.Dispatch<React.SetStateAction<boolean>>;
   disabled?: boolean;
 }) {
   const localize = useLocalize();
@@ -170,6 +178,10 @@ export default function useTextarea({
 
   const handleKeyDown = useCallback(
     (e: KeyEvent) => {
+      if (textAreaRef.current && checkIfScrollable(textAreaRef.current)) {
+        const scrollable = checkIfScrollable(textAreaRef.current);
+        scrollable && setIsScrollable(scrollable);
+      }
       if (e.key === 'Enter' && isSubmitting) {
         return;
       }
@@ -209,7 +221,15 @@ export default function useTextarea({
         submitButtonRef.current?.click();
       }
     },
-    [isSubmitting, checkHealth, filesLoading, enterToSend, textAreaRef, submitButtonRef],
+    [
+      isSubmitting,
+      checkHealth,
+      filesLoading,
+      enterToSend,
+      setIsScrollable,
+      textAreaRef,
+      submitButtonRef,
+    ],
   );
 
   const handleCompositionStart = () => {

--- a/client/src/localization/languages/Ar.ts
+++ b/client/src/localization/languages/Ar.ts
@@ -913,4 +913,5 @@ export default {
   com_endpoint_ai: 'الذكاء الاصطناعي',
   com_endpoint_message_new: 'الرسالة {0} أو اكتب "@" للتبديل إلى الذكاء الاصطناعي',
   com_nav_maximize_chat_space: 'تكبير مساحة الدردشة',
+  com_ui_collapse_chat: 'طي الدردشة',
 };

--- a/client/src/localization/languages/De.ts
+++ b/client/src/localization/languages/De.ts
@@ -945,4 +945,5 @@ export default {
   com_ui_bookmarks_add: 'Lesezeichen hinzufügen',
   com_endpoint_message_new: 'Nachricht {0} oder "@" eingeben, um KI zu wechseln',
   com_nav_maximize_chat_space: 'Chat-Bereich maximieren',
+  com_ui_collapse_chat: 'Chat einklappen',
 };

--- a/client/src/localization/languages/Eng.ts
+++ b/client/src/localization/languages/Eng.ts
@@ -3,6 +3,7 @@
 // file deepcode ignore HardcodedNonCryptoSecret: No hardcoded secrets present in this file
 
 export default {
+  com_ui_collapse_chat: 'Collapse Chat',
   com_ui_enter_api_key: 'Enter API Key',
   com_ui_librechat_code_api_title: 'Run AI Code',
   com_ui_librechat_code_api_subtitle: 'Secure. Multi-language. Input/Output Files.',

--- a/client/src/localization/languages/Es.ts
+++ b/client/src/localization/languages/Es.ts
@@ -1201,4 +1201,5 @@ export default {
   com_endpoint_message_new: 'Mensaje {0} o escriba "@" para cambiar de IA',
   com_nav_maximize_chat_space: 'Maximizar espacio del chat',
   com_endpoint_ai: 'IA',
+  com_ui_collapse_chat: 'Contraer Chat',
 };

--- a/client/src/localization/languages/Fr.ts
+++ b/client/src/localization/languages/Fr.ts
@@ -963,4 +963,5 @@ export default {
   com_nav_maximize_chat_space: 'Maximiser l\'espace de discussion',
   com_endpoint_message_new: 'Message {0} ou tapez "@" pour changer d\'IA',
   com_ui_page: 'Page',
+  com_ui_collapse_chat: 'Réduire la discussion',
 };

--- a/client/src/localization/languages/It.ts
+++ b/client/src/localization/languages/It.ts
@@ -957,4 +957,5 @@ export default {
   com_endpoint_ai: 'IA',
   com_nav_maximize_chat_space: 'Massimizza spazio chat',
   com_ui_page: 'Pagina',
+  com_ui_collapse_chat: 'Comprimi Chat',
 };

--- a/client/src/localization/languages/Jp.ts
+++ b/client/src/localization/languages/Jp.ts
@@ -911,4 +911,5 @@ export default {
   com_endpoint_ai: 'AI',
   com_endpoint_message_new: 'メッセージ {0} または「@」を入力してAIを切り替え',
   com_nav_maximize_chat_space: 'チャット画面を最大化',
+  com_ui_collapse_chat: 'チャットを折りたたむ',
 };

--- a/client/src/localization/languages/Ko.ts
+++ b/client/src/localization/languages/Ko.ts
@@ -1149,4 +1149,5 @@ export default {
   com_endpoint_ai: '인공지능',
   com_nav_maximize_chat_space: '채팅창 최대화',
   com_endpoint_message_new: '메시지 {0} 또는 "@"를 입력하여 AI 전환',
+  com_ui_collapse_chat: '채팅 접기',
 };

--- a/client/src/localization/languages/Ru.ts
+++ b/client/src/localization/languages/Ru.ts
@@ -1175,4 +1175,5 @@ export default {
   com_endpoint_message_new: 'Сообщение {0} или введите "@" для смены ИИ',
   com_nav_maximize_chat_space: 'Развернуть чат',
   com_ui_bookmarks_add: 'Добавить закладку',
+  com_ui_collapse_chat: 'Свернуть чат',
 };

--- a/client/src/localization/languages/Zh.ts
+++ b/client/src/localization/languages/Zh.ts
@@ -903,4 +903,5 @@ export default {
   com_ui_page: '页面',
   com_nav_maximize_chat_space: '最大化聊天窗口',
   com_endpoint_message_new: '发送消息 {0} 或输入"@"切换AI',
+  com_ui_collapse_chat: '收起聊天',
 };

--- a/client/src/localization/languages/ZhTraditional.ts
+++ b/client/src/localization/languages/ZhTraditional.ts
@@ -880,4 +880,5 @@ export default {
   com_nav_maximize_chat_space: '最大化聊天視窗',
   com_endpoint_ai: 'AI',
   com_endpoint_message_new: '輸入訊息 {0} 或輸入 "@" 以切換 AI',
+  com_ui_collapse_chat: '收合對話',
 };

--- a/client/src/utils/artifacts.ts
+++ b/client/src/utils/artifacts.ts
@@ -131,7 +131,7 @@ const standardDependencies = {
 
 const mermaidDependencies = Object.assign(
   {
-    mermaid: '^11.0.2',
+    mermaid: '^11.4.1',
     'react-zoom-pan-pinch': '^3.6.1',
   },
   standardDependencies,

--- a/client/src/utils/mermaid.ts
+++ b/client/src/utils/mermaid.ts
@@ -50,7 +50,6 @@ const MermaidDiagram: React.FC<MermaidDiagramProps> = ({ content }) => {
         diagramPadding: 8,
         htmlLabels: true,
         useMaxWidth: true,
-        defaultRenderer: "dagre-d3",
         padding: 15,
         wrappingWidth: 200,
       },

--- a/client/src/utils/textarea.ts
+++ b/client/src/utils/textarea.ts
@@ -73,3 +73,15 @@ export function removeCharIfLast(textarea: HTMLTextAreaElement, charToRemove: st
 
   textarea.focus();
 }
+
+/**
+ * Check if the textarea is scrollable.
+ * @param element
+ * @returns
+ */
+export const checkIfScrollable = (element: HTMLTextAreaElement | null) => {
+  if (!element) {
+    return false;
+  }
+  return element.scrollHeight > element.clientHeight;
+};


### PR DESCRIPTION
## Summary

I implemented several enhancements to improve the user experience in message editing and chat input.

- Added the functionality to edit the latest user message by pressing the up arrow key when the input is empty.
- Re-introduced the regenerate button in `HoverButtons` for error handling, allowing users to retry failed messages easily.
- Added the ability to collapse the chat input when it reaches the maximum height, allowing visibility of messages for reference
- Enhanced the `EditMessage` component by adding keyboard shortcuts for saving (`Ctrl+S`), submitting (`Ctrl+Enter`), and canceling (`Esc`).

![chrome_1qtcLmWrmK](https://github.com/user-attachments/assets/0a4e928c-bf24-4713-a721-607d71709049)
![chrome_zTYf3SNGnK](https://github.com/user-attachments/assets/de8e3700-cd50-48dd-96c3-16876bcd531d)
![chrome_zTs47GP8d7](https://github.com/user-attachments/assets/1752d9f8-5652-4acb-9aed-986368354ae6)


## Other Changes

- Fixed a rendering error for Mermaid flowchart syntax by updating dependencies.

Closes #3658
Closes #4184

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

I tested the new features by performing the following steps:

- Verified that pressing the up arrow key with an empty input allows editing the latest user message.
- Triggered error states to ensure the regenerate button appears and functions correctly in `HoverButtons`.
- Checked that the textarea detects scrollability and collapses appropriately when reaching maximum height.
- Tested the keyboard shortcuts in the `EditMessage` component for saving (`Ctrl+S`), submitting (`Ctrl+Enter`), and canceling (`Esc`).
- Confirmed that Mermaid flowchart syntax renders correctly after updating dependencies.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings