### PR TITLE
💾 feat: Production-ready Memory Store for `express-session`

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -76,6 +76,7 @@
     "librechat-mcp": "*",
     "lodash": "^4.17.21",
     "meilisearch": "^0.38.0",
+    "memorystore": "^1.6.7",
     "mime": "^3.0.0",
     "module-alias": "^2.2.3",
     "mongoose": "^8.8.3",

--- a/api/server/socialLogins.js
+++ b/api/server/socialLogins.js
@@ -1,6 +1,7 @@
 const Redis = require('ioredis');
 const passport = require('passport');
 const session = require('express-session');
+const MemoryStore = require('memorystore')(session)
 const RedisStore = require('connect-redis').default;
 const {
   setupOpenId,
@@ -48,6 +49,10 @@ const configureSocialLogins = (app) => {
         .on('ready', () => logger.info('ioredis successfully initialized.'))
         .on('reconnecting', () => logger.info('ioredis reconnecting...'));
       sessionOptions.store = new RedisStore({ client, prefix: 'librechat' });
+    } else {
+      sessionOptions.store = new MemoryStore({
+        checkPeriod: 86400000 // prune expired entries every 24h
+      })
     }
     app.use(session(sessionOptions));
     app.use(passport.session());

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "librechat-mcp": "*",
         "lodash": "^4.17.21",
         "meilisearch": "^0.38.0",
+        "memorystore": "^1.6.7",
         "mime": "^3.0.0",
         "module-alias": "^2.2.3",
         "mongoose": "^8.8.3",
@@ -26176,6 +26177,35 @@
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
     },
+    "node_modules/memorystore": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/memorystore/-/memorystore-1.6.7.tgz",
+      "integrity": "sha512-OZnmNY/NDrKohPQ+hxp0muBcBKrzKNtHr55DbqSx9hLsYVNnomSAMRAtI7R64t3gf3ID7tHQA7mG4oL3Hu9hdw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.0",
+        "lru-cache": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/memorystore/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "license": "ISC",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/memorystore/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+      "license": "ISC"
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -30267,6 +30297,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "license": "ISC"
     },
     "node_modules/psl": {
       "version": "1.9.0",


### PR DESCRIPTION
The `express-session` library comes with a session storage meant for testing by default. That is why you get a message like this when you start up LibreChat with OIDC enabled:

    Warning: connect.session() MemoryStore is not
    designed for a production environment, as it will leak
    memory, and will not scale past a single process.

LibreChat can already use Redis as a session storage, although Redis support is still marked as experimental. It also makes the set-up more complex, since you will need to configure and run yet another service.

This pull request provides a simple alternative by using a in-memory session store marked as a production-ready alternative by the guys from `express-session`¹. You can still configure Redis, but this provides a simple, good default for everyone else.

See also https://github.com/danny-avila/LibreChat/discussions/1014

¹⁾ https://github.com/expressjs/session?tab=readme-ov-file#compatible-session-stores

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

- Configure OIDC
- Running without this patch: You should see the memry leak warning from above
- Running with this patch applied: No warning should show up
- In any case, the login via OIDC should still work
