### PR TITLE
🐛 fix: Ensure Default ModelSpecs Are Set Correctly

### DIFF
--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -862,6 +862,7 @@ class GoogleClient extends BaseClient {
 
   getSaveOptions() {
     return {
+      endpointType: null,
       artifacts: this.options.artifacts,
       promptPrefix: this.options.promptPrefix,
       modelLabel: this.options.modelLabel,

--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -6,6 +6,7 @@ const loadCustomConfig = require('./Config/loadCustomConfig');
 const handleRateLimits = require('./Config/handleRateLimits');
 const { loadDefaultInterface } = require('./start/interface');
 const { azureConfigSetup } = require('./start/azureOpenAI');
+const { processModelSpecs } = require('./start/modelSpecs');
 const { loadAndFormatTools } = require('./ToolService');
 const { agentsConfigSetup } = require('./start/agents');
 const { initializeRoles } = require('~/models/Role');
@@ -122,9 +123,9 @@ const AppService = async (app) => {
 
   app.locals = {
     ...defaultLocals,
-    modelSpecs: config.modelSpecs,
     fileConfig: config?.fileConfig,
     secureImageLinks: config?.secureImageLinks,
+    modelSpecs: processModelSpecs(endpoints, config.modelSpecs),
     ...endpointLocals,
   };
 };

--- a/api/server/services/start/modelSpecs.js
+++ b/api/server/services/start/modelSpecs.js
@@ -1,0 +1,61 @@
+const { EModelEndpoint } = require('librechat-data-provider');
+const { normalizeEndpointName } = require('~/server/utils');
+const { logger } = require('~/config');
+
+/**
+ * Sets up Model Specs from the config (`librechat.yaml`) file.
+ * @param {TCustomConfig['endpoints']} endpoints - The loaded custom configuration for endpoints.
+ * @param {TCustomConfig['modelSpecs'] | undefined} [modelSpecs] - The loaded custom configuration for model specs.
+ * @returns {TCustomConfig['modelSpecs'] | undefined} The processed model specs, if any.
+ */
+function processModelSpecs(endpoints, _modelSpecs) {
+  if (!_modelSpecs) {
+    return undefined;
+  }
+
+  /** @type {TCustomConfig['modelSpecs']['list']} */
+  const modelSpecs = [];
+  /** @type {TCustomConfig['modelSpecs']['list']} */
+  const list = _modelSpecs.list;
+
+  const customEndpoints = endpoints[EModelEndpoint.custom] ?? [];
+
+  for (const spec of list) {
+    if (EModelEndpoint[spec.preset.endpoint] && spec.preset.endpoint !== EModelEndpoint.custom) {
+      modelSpecs.push(spec);
+      continue;
+    } else if (spec.preset.endpoint === EModelEndpoint.custom) {
+      logger.warn(
+        `Model Spec with endpoint "${spec.preset.endpoint}" is not supported. You must specify the name of the custom endpoint (case-sensitive, as defined in your config). Skipping model spec...`,
+      );
+      continue;
+    }
+
+    const normalizedName = normalizeEndpointName(spec.preset.endpoint);
+    const endpoint = customEndpoints.find(
+      (customEndpoint) => normalizedName === normalizeEndpointName(customEndpoint.name),
+    );
+
+    if (!endpoint) {
+      logger.warn(`Model spec with endpoint "${spec.preset.endpoint}" was skipped: Endpoint not found in configuration. The \`endpoint\` value must exactly match either a system-defined endpoint or a custom endpoint defined by the user.
+
+For more information, see the documentation at https://www.librechat.ai/docs/configuration/librechat_yaml/object_structure/model_specs#endpoint`);
+      continue;
+    }
+
+    modelSpecs.push({
+      ...spec,
+      preset: {
+        ...spec.preset,
+        endpoint: normalizedName,
+      },
+    });
+  }
+
+  return {
+    ..._modelSpecs,
+    list: modelSpecs,
+  };
+}
+
+module.exports = { processModelSpecs };

--- a/client/src/components/Chat/Messages/Content/EditMessage.tsx
+++ b/client/src/components/Chat/Messages/Content/EditMessage.tsx
@@ -1,6 +1,5 @@
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { EModelEndpoint } from 'librechat-data-provider';
 import { useRef, useEffect, useCallback } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { useForm } from 'react-hook-form';
 import { useUpdateMessageMutation } from 'librechat-data-provider/react-query';
 import type { TEditProps } from '~/common';
@@ -31,8 +30,6 @@ const EditMessage = ({
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const { conversationId, parentMessageId, messageId } = message;
-  const { endpoint: _endpoint, endpointType } = conversation ?? { endpoint: null };
-  const endpoint = endpointType ?? _endpoint;
   const updateMessageMutation = useUpdateMessageMutation(conversationId ?? '');
   const localize = useLocalize();
 
@@ -181,9 +178,7 @@ const EditMessage = ({
             <button
               ref={submitButtonRef}
               className="btn btn-primary relative mr-2"
-              disabled={
-                isSubmitting || (endpoint === EModelEndpoint.google && !message.isCreatedByUser)
-              }
+              disabled={isSubmitting}
               onClick={handleSubmit(resubmitMessage)}
             >
               {localize('com_ui_save_submit')}

--- a/client/src/components/Endpoints/EndpointSettings.tsx
+++ b/client/src/components/Endpoints/EndpointSettings.tsx
@@ -1,9 +1,9 @@
 import { useRecoilValue } from 'recoil';
-import { SettingsViews } from 'librechat-data-provider';
-import { useGetModelsQuery } from 'librechat-data-provider/react-query';
+import { SettingsViews, TConversation } from 'librechat-data-provider';
+import { useGetModelsQuery, useGetEndpointsQuery } from 'librechat-data-provider/react-query';
 import type { TSettingsProps } from '~/common';
 import { getSettings } from './Settings';
-import { cn } from '~/utils';
+import { cn, getEndpointField } from '~/utils';
 import store from '~/store';
 
 export default function Settings({
@@ -13,15 +13,17 @@ export default function Settings({
   className = '',
 }: TSettingsProps) {
   const modelsQuery = useGetModelsQuery();
+  const { data: endpointsConfig } = useGetEndpointsQuery();
   const currentSettingsView = useRecoilValue(store.currentSettingsView);
-  if (!conversation?.endpoint || currentSettingsView !== SettingsViews.default) {
+  const endpointType = getEndpointField(endpointsConfig, conversation?.endpoint ?? '', 'type');
+  const endpoint = endpointType ?? conversation?.endpoint ?? '';
+  if (!endpoint || currentSettingsView !== SettingsViews.default) {
     return null;
   }
 
   const { settings, multiViewSettings } = getSettings();
-  const { endpoint: _endpoint, endpointType } = conversation;
-  const models = modelsQuery?.data?.[_endpoint] ?? [];
-  const endpoint = endpointType ?? _endpoint;
+  const { endpoint: _endpoint } = conversation as TConversation;
+  const models = modelsQuery.data?.[_endpoint ?? ''] ?? [];
   const OptionComponent = settings[endpoint];
 
   if (OptionComponent) {
@@ -39,7 +41,7 @@ export default function Settings({
 
   const MultiViewComponent = multiViewSettings[endpoint];
 
-  if (!MultiViewComponent) {
+  if (MultiViewComponent == null) {
     return null;
   }
 

--- a/client/src/components/Endpoints/Settings/settings.ts
+++ b/client/src/components/Endpoints/Settings/settings.ts
@@ -8,7 +8,7 @@ import BedrockSettings from './Bedrock';
 import BingAISettings from './BingAI';
 import OpenAISettings from './OpenAI';
 
-const settings: { [key: string]: FC<TModelSelectProps> } = {
+const settings: { [key: string]: FC<TModelSelectProps> | undefined } = {
   [EModelEndpoint.assistants]: AssistantsSettings,
   [EModelEndpoint.azureAssistants]: AssistantsSettings,
   [EModelEndpoint.agents]: OpenAISettings,

--- a/client/src/hooks/Config/useAppStartup.ts
+++ b/client/src/hooks/Config/useAppStartup.ts
@@ -4,7 +4,6 @@ import { useRecoilState, useSetRecoilState } from 'recoil';
 import { LocalStorageKeys } from 'librechat-data-provider';
 import { useAvailablePluginsQuery } from 'librechat-data-provider/react-query';
 import type { TStartupConfig, TPlugin, TUser } from 'librechat-data-provider';
-import { data as modelSpecs } from '~/components/Chat/Menus/Models/fakeData';
 import { mapPlugins, selectPlugins, processPlugins } from '~/utils';
 import useConfigOverride from './useConfigOverride';
 import store from '~/store';
@@ -36,17 +35,21 @@ export default function useAppStartup({
 
   /** Set the app title */
   useEffect(() => {
-    if (startupConfig?.appTitle) {
-      document.title = startupConfig.appTitle;
-      localStorage.setItem(LocalStorageKeys.APP_TITLE, startupConfig.appTitle);
+    const appTitle = startupConfig?.appTitle ?? '';
+    if (!appTitle) {
+      return;
     }
+    document.title = appTitle;
+    localStorage.setItem(LocalStorageKeys.APP_TITLE, appTitle);
   }, [startupConfig]);
 
   /** Set the default spec's preset as default */
   useEffect(() => {
-    if (defaultPreset && defaultPreset.spec) {
+    if (defaultPreset && defaultPreset.spec != null) {
       return;
     }
+
+    const modelSpecs = startupConfig?.modelSpecs?.list;
 
     if (!modelSpecs || !modelSpecs.length) {
       return;
@@ -63,7 +66,7 @@ export default function useAppStartup({
       iconURL: defaultSpec.iconURL,
       spec: defaultSpec.name,
     });
-  }, [defaultPreset, setDefaultPreset]);
+  }, [defaultPreset, setDefaultPreset, startupConfig?.modelSpecs?.list]);
 
   /** Set the available Plugins */
   useEffect(() => {
@@ -75,17 +78,20 @@ export default function useAppStartup({
       return;
     }
 
-    if (!user.plugins || user.plugins.length === 0) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    const userPlugins = user.plugins ?? [];
+
+    if (userPlugins.length === 0) {
       setAvailableTools({ pluginStore });
       return;
     }
 
-    const tools = [...user.plugins]
+    const tools = [...userPlugins]
       .map((el) => allPlugins.map[el])
-      .filter((el): el is TPlugin => el !== undefined);
+      .filter((el: TPlugin | undefined): el is TPlugin => el !== undefined);
 
     /* Filter Last Selected Tools */
-    const localStorageItem = localStorage.getItem(LocalStorageKeys.LAST_TOOLS);
+    const localStorageItem = localStorage.getItem(LocalStorageKeys.LAST_TOOLS) ?? '';
     if (!localStorageItem) {
       return setAvailableTools({ pluginStore, ...mapPlugins(tools) });
     }
@@ -94,7 +100,7 @@ export default function useAppStartup({
       .filter((tool: TPlugin) =>
         tools.some((existingTool) => existingTool.pluginKey === tool.pluginKey),
       )
-      .filter((tool: TPlugin) => !!tool);
+      .filter((tool: TPlugin | undefined) => !!tool);
     localStorage.setItem(LocalStorageKeys.LAST_TOOLS, JSON.stringify(filteredTools));
 
     setAvailableTools({ pluginStore, ...mapPlugins(tools) });

--- a/package-lock.json
+++ b/package-lock.json
@@ -36286,7 +36286,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.691",
+      "version": "0.7.692",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.7",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.691",
+  "version": "0.7.692",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -4,7 +4,7 @@ import type { ZodError } from 'zod';
 import type { TModelsConfig } from './types';
 import { EModelEndpoint, eModelEndpointSchema } from './schemas';
 import { fileConfigSchema } from './file-config';
-import { specsConfigSchema } from './models';
+import { specsConfigSchema, TSpecsConfig } from './models';
 import { FileSources } from './types/files';
 import { MCPServersSchema } from './mcp';
 
@@ -427,6 +427,82 @@ export enum EImageOutputType {
   JPEG = 'jpeg',
 }
 
+export const intefaceSchema = z
+  .object({
+    privacyPolicy: z
+      .object({
+        externalUrl: z.string().optional(),
+        openNewTab: z.boolean().optional(),
+      })
+      .optional(),
+    termsOfService: z
+      .object({
+        externalUrl: z.string().optional(),
+        openNewTab: z.boolean().optional(),
+        modalAcceptance: z.boolean().optional(),
+        modalTitle: z.string().optional(),
+        modalContent: z.string().or(z.array(z.string())).optional(),
+      })
+      .optional(),
+    endpointsMenu: z.boolean().optional(),
+    modelSelect: z.boolean().optional(),
+    parameters: z.boolean().optional(),
+    sidePanel: z.boolean().optional(),
+    multiConvo: z.boolean().optional(),
+    bookmarks: z.boolean().optional(),
+    presets: z.boolean().optional(),
+    prompts: z.boolean().optional(),
+    agents: z.boolean().optional(),
+  })
+  .default({
+    endpointsMenu: true,
+    modelSelect: true,
+    parameters: true,
+    sidePanel: true,
+    presets: true,
+    multiConvo: true,
+    bookmarks: true,
+    prompts: true,
+    agents: true,
+  });
+
+export type TInterfaceConfig = z.infer<typeof intefaceSchema>;
+
+export type TStartupConfig = {
+  appTitle: string;
+  socialLogins?: string[];
+  interface?: TInterfaceConfig;
+  discordLoginEnabled: boolean;
+  facebookLoginEnabled: boolean;
+  githubLoginEnabled: boolean;
+  googleLoginEnabled: boolean;
+  openidLoginEnabled: boolean;
+  openidLabel: string;
+  openidImageUrl: string;
+  /** LDAP Auth Configuration */
+  ldap?: {
+    /** LDAP enabled */
+    enabled: boolean;
+    /** Whether LDAP uses username vs. email */
+    username?: boolean;
+  };
+  serverDomain: string;
+  emailLoginEnabled: boolean;
+  registrationEnabled: boolean;
+  socialLoginEnabled: boolean;
+  passwordResetEnabled: boolean;
+  emailEnabled: boolean;
+  checkBalance: boolean;
+  showBirthdayIcon: boolean;
+  helpAndFaqURL: string;
+  customFooter?: string;
+  modelSpecs?: TSpecsConfig;
+  sharedLinksEnabled: boolean;
+  publicSharedLinksEnabled: boolean;
+  analyticsGtmId?: string;
+  instanceProjectId: string;
+};
+
 export const configSchema = z.object({
   version: z.string(),
   cache: z.boolean().default(true),
@@ -435,44 +511,7 @@ export const configSchema = z.object({
   includedTools: z.array(z.string()).optional(),
   filteredTools: z.array(z.string()).optional(),
   mcpServers: MCPServersSchema.optional(),
-  interface: z
-    .object({
-      privacyPolicy: z
-        .object({
-          externalUrl: z.string().optional(),
-          openNewTab: z.boolean().optional(),
-        })
-        .optional(),
-      termsOfService: z
-        .object({
-          externalUrl: z.string().optional(),
-          openNewTab: z.boolean().optional(),
-          modalAcceptance: z.boolean().optional(),
-          modalTitle: z.string().optional(),
-          modalContent: z.string().or(z.array(z.string())).optional(),
-        })
-        .optional(),
-      endpointsMenu: z.boolean().optional(),
-      modelSelect: z.boolean().optional(),
-      parameters: z.boolean().optional(),
-      sidePanel: z.boolean().optional(),
-      multiConvo: z.boolean().optional(),
-      bookmarks: z.boolean().optional(),
-      presets: z.boolean().optional(),
-      prompts: z.boolean().optional(),
-      agents: z.boolean().optional(),
-    })
-    .default({
-      endpointsMenu: true,
-      modelSelect: true,
-      parameters: true,
-      sidePanel: true,
-      presets: true,
-      multiConvo: true,
-      bookmarks: true,
-      prompts: true,
-      agents: true,
-    }),
+  interface: intefaceSchema,
   fileStrategy: fileSourceSchema.default(FileSources.local),
   actions: z
     .object({

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -173,7 +173,7 @@ export const updateUserPlugins = (payload: t.TUpdateUserPlugins) => {
 
 /* Config */
 
-export const getStartupConfig = (): Promise<t.TStartupConfig> => {
+export const getStartupConfig = (): Promise<config.TStartupConfig> => {
   return request.get(endpoints.config());
 };
 

--- a/packages/data-provider/src/models.ts
+++ b/packages/data-provider/src/models.ts
@@ -37,7 +37,7 @@ export const tModelSpecSchema = z.object({
 export const specsConfigSchema = z.object({
   enforce: z.boolean().default(false),
   prioritize: z.boolean().default(true),
-  list: z.array(tModelSpecSchema).optional(),
+  list: z.array(tModelSpecSchema).min(1),
 });
 
 export type TSpecsConfig = z.infer<typeof specsConfigSchema>;

--- a/packages/data-provider/src/react-query/react-query-service.ts
+++ b/packages/data-provider/src/react-query/react-query-service.ts
@@ -5,6 +5,7 @@ import type {
   QueryObserverResult,
 } from '@tanstack/react-query';
 import { initialModelsConfig, LocalStorageKeys } from '../config';
+import type { TStartupConfig } from '../config';
 import { defaultOrderQuery } from '../types/assistants';
 import * as dataService from '../data-service';
 import * as m from '../types/mutations';
@@ -423,18 +424,14 @@ export const useUpdateUserPluginsMutation = (
 };
 
 export const useGetStartupConfig = (
-  config?: UseQueryOptions<t.TStartupConfig>,
-): QueryObserverResult<t.TStartupConfig> => {
-  return useQuery<t.TStartupConfig>(
-    [QueryKeys.startupConfig],
-    () => dataService.getStartupConfig(),
-    {
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-      refetchOnMount: false,
-      ...config,
-    },
-  );
+  config?: UseQueryOptions<TStartupConfig>,
+): QueryObserverResult<TStartupConfig> => {
+  return useQuery<TStartupConfig>([QueryKeys.startupConfig], () => dataService.getStartupConfig(), {
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchOnMount: false,
+    ...config,
+  });
 };
 
 export const useGetCustomConfigSpeechQuery = (

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -643,6 +643,13 @@ export const tQueryParamsSchema = tConversationSchema
      * */
     resendFiles: true,
     /**
+     * @endpoints openAI, custom, azureOpenAI
+     *
+     * System parameter that only affects the above endpoints.
+     * Image detail for re-sizing according to OpenAI spec, defaults to `auto`
+     * */
+    imageDetail: true,
+    /**
      * AKA Custom Instructions, dynamically added to chat history as a system message;
      * for `bedrock` endpoint, this is used as the `system` model param if the provider uses it;
      * for `assistants` endpoint, this is used as the `additional_instructions` model param:

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -526,7 +526,7 @@ const DocumentType: z.ZodType<DocumentTypeValue> = z.lazy(() =>
 export const tConversationSchema = z.object({
   conversationId: z.string().nullable(),
   endpoint: eModelEndpointSchema.nullable(),
-  endpointType: eModelEndpointSchema.optional(),
+  endpointType: eModelEndpointSchema.nullable().optional(),
   isArchived: z.boolean().optional(),
   title: z.string().nullable().or(z.literal('New Chat')).default('New Chat'),
   user: z.string().optional(),

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -688,6 +688,8 @@ export const tQueryParamsSchema = tConversationSchema
     agent_id: true,
     /** @endpoints assistants, azureAssistants */
     assistant_id: true,
+    /** @endpoints assistants, azureAssistants */
+    append_current_datetime: true,
     /**
      * @endpoints assistants, azureAssistants
      *

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -559,9 +559,9 @@ export const tConversationSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   /* Files */
+  resendFiles: z.boolean().optional(),
   file_ids: z.array(z.string()).optional(),
   /* vision */
-  resendFiles: z.boolean().optional(),
   imageDetail: eImageDetailSchema.optional(),
   /* assistant */
   assistant_id: z.string().optional(),
@@ -571,16 +571,17 @@ export const tConversationSchema = z.object({
   region: z.string().optional(),
   maxTokens: coerceNumber.optional(),
   additionalModelRequestFields: DocumentType.optional(),
-  /* assistant + agents */
+  /* assistants */
   instructions: z.string().optional(),
   additional_instructions: z.string().optional(),
+  append_current_datetime: z.boolean().optional(),
   /** Used to overwrite active conversation settings when saving a Preset */
   presetOverride: z.record(z.unknown()).optional(),
   stop: z.array(z.string()).optional(),
   /* frontend components */
-  iconURL: z.string().optional(),
   greeting: z.string().optional(),
-  spec: z.string().optional(),
+  spec: z.string().nullable().optional(),
+  iconURL: z.string().nullable().optional(),
   /*
   Deprecated fields
   */
@@ -606,7 +607,6 @@ export const tConversationSchema = z.object({
   agentOptions: tAgentOptionsSchema.nullable().optional(),
   /** @deprecated Prefer `modelLabel` over `chatGptLabel` */
   chatGptLabel: z.string().nullable().optional(),
-  append_current_datetime: z.boolean().optional(),
 });
 
 export const tPresetSchema = tConversationSchema

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -10,7 +10,6 @@ import type {
   TConversationTag,
   TBanner,
 } from './schemas';
-import type { TSpecsConfig } from './models';
 export type TOpenAIMessage = OpenAI.Chat.ChatCompletionMessageParam;
 
 export * from './schemas';
@@ -311,63 +310,6 @@ export type TVerifyEmail = {
 };
 
 export type TResendVerificationEmail = Omit<TVerifyEmail, 'token'>;
-
-export type TInterfaceConfig = {
-  privacyPolicy?: {
-    externalUrl?: string;
-    openNewTab?: boolean;
-  };
-  termsOfService?: {
-    externalUrl?: string;
-    openNewTab?: boolean;
-    modalAcceptance?: boolean;
-    modalTitle?: string;
-    modalContent?: string;
-  };
-  endpointsMenu: boolean;
-  modelSelect: boolean;
-  parameters: boolean;
-  sidePanel: boolean;
-  presets: boolean;
-  multiConvo: boolean;
-  bookmarks: boolean;
-  prompts: boolean;
-};
-
-export type TStartupConfig = {
-  appTitle: string;
-  socialLogins?: string[];
-  interface?: TInterfaceConfig;
-  discordLoginEnabled: boolean;
-  facebookLoginEnabled: boolean;
-  githubLoginEnabled: boolean;
-  googleLoginEnabled: boolean;
-  openidLoginEnabled: boolean;
-  openidLabel: string;
-  openidImageUrl: string;
-  /** LDAP Auth Configuration */
-  ldap?: {
-    /** LDAP enabled */
-    enabled: boolean;
-    /** Whether LDAP uses username vs. email */
-    username?: boolean;
-  };
-  serverDomain: string;
-  emailLoginEnabled: boolean;
-  registrationEnabled: boolean;
-  socialLoginEnabled: boolean;
-  passwordResetEnabled: boolean;
-  emailEnabled: boolean;
-  checkBalance: boolean;
-  showBirthdayIcon: boolean;
-  helpAndFaqURL: string;
-  customFooter?: string;
-  modelSpecs?: TSpecsConfig;
-  sharedLinksEnabled: boolean;
-  publicSharedLinksEnabled: boolean;
-  analyticsGtmId?: string;
-  instanceProjectId: string;
-};
 
 export type TRefreshTokenResponse = {
   token: string;

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -108,7 +108,7 @@ export type TUser = {
   avatar: string;
   role: string;
   provider: string;
-  plugins: string[];
+  plugins?: string[];
   createdAt: string;
   updatedAt: string;
 };


### PR DESCRIPTION
## Summary

Relevant documentation updates: https://github.com/LibreChat-AI/librechat.ai/pull/197

I fixed an issue where default model specifications (modelSpecs) were not being set correctly when there was no default preset, which caused problems during app startup for users without a preset spec. Additionally, I updated type definitions related to user plugins and incremented the data-provider package version.

- Updated the logic in `useAppStartup.ts` to set default modelSpecs when `defaultPreset` is not available.
- Removed the unused import of `fakeData` from `useAppStartup.ts`.
- Updated the `TUser` type in `data-provider` to make the `plugins` field optional.
- Bumped the `librechat-data-provider` package version from `0.7.691` to `0.7.692` in `package.json`.
- Fixed the "Save & Submit" functionality for the Google endpoint when editing messages by adjusting the disabled condition in `EditMessage.tsx`.
- Modified `tConversationSchema` to make `endpointType` nullable and optional for improved flexibility.
- Added `endpointType` to `getSaveOptions` in `GoogleClient.js` and enhanced endpoint handling in the `Settings` component.
- Added the `append_current_datetime` parameter to `tQueryParamsSchema` to improve endpoint functionality.
- Refactored configuration schemas and types for improved structure and clarity, affecting several files in the data provider.
- Implemented the `processModelSpecs` function to enhance model specs processing from configuration.
- Added `imageDetail` parameter for OpenAI endpoints in `tQueryParamsSchema` for better image processing options.
- Fixed a bug where default `modelSpecs` were not being set during application startup.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested these changes by running the application locally and verifying that default modelSpecs are correctly set for users without a preset spec. I also tested the app startup process to ensure that the app title and available plugins are configured as expected, and that there are no regressions for existing users.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes