### PR TITLE
📜 refactor: Log Error Messages when OAuth Fails

### DIFF
--- a/api/server/routes/oauth.js
+++ b/api/server/routes/oauth.js
@@ -28,6 +28,12 @@ const oauthHandler = async (req, res) => {
   }
 };
 
+router.get('/error', (req, res) => {
+  // A single error message is pushed by passport when authentication fails.
+  logger.error('Error in OAuth authentication:', { message: req.session.messages.pop() });
+  res.redirect(`${domains.client}/login`);
+});
+
 /**
  * Google Routes
  */
@@ -42,7 +48,7 @@ router.get(
 router.get(
   '/google/callback',
   passport.authenticate('google', {
-    failureRedirect: `${domains.client}/login`,
+    failureRedirect: `${domains.client}/oauth/error`,
     failureMessage: true,
     session: false,
     scope: ['openid', 'profile', 'email'],
@@ -62,7 +68,7 @@ router.get(
 router.get(
   '/facebook/callback',
   passport.authenticate('facebook', {
-    failureRedirect: `${domains.client}/login`,
+    failureRedirect: `${domains.client}/oauth/error`,
     failureMessage: true,
     session: false,
     scope: ['public_profile'],
@@ -81,7 +87,7 @@ router.get(
 router.get(
   '/openid/callback',
   passport.authenticate('openid', {
-    failureRedirect: `${domains.client}/login`,
+    failureRedirect: `${domains.client}/oauth/error`,
     failureMessage: true,
     session: false,
   }),
@@ -99,7 +105,7 @@ router.get(
 router.get(
   '/github/callback',
   passport.authenticate('github', {
-    failureRedirect: `${domains.client}/login`,
+    failureRedirect: `${domains.client}/oauth/error`,
     failureMessage: true,
     session: false,
     scope: ['user:email', 'read:user'],
@@ -117,7 +123,7 @@ router.get(
 router.get(
   '/discord/callback',
   passport.authenticate('discord', {
-    failureRedirect: `${domains.client}/login`,
+    failureRedirect: `${domains.client}/oauth/error`,
     failureMessage: true,
     session: false,
     scope: ['identify', 'email'],


### PR DESCRIPTION
## Summary

When OAuth Authentication fails, passport is configured to redirect to login page, the error message is stored in req.session.messages but not logged. Resulting in no OAuth logs being printed and making it harder to debug OAuth issues.

This fix adds a new route `/oauth/error` to handle and log OAuth errors before redirecting to login page.

## Change Type

Please delete any irrelevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

Any previously failed OAuth login attempts without any errors logged will log after this commit.

For me, Currently ES256 JWT algorithm results in OAuth failure and no logs produced, tested that the error message is logged correctly after the change.

### **Test Configuration**:

- Authentik with EC keys as OIDC provider.
- Full FQDN production ready setup with SSL, Nginx as reverse proxy.

## Checklist

Please delete any irrelevant options. (removed documentation items)

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [X] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
