### PR TITLE
🐛 fix: use OpenID token signature algo as discovered from the server.

### DIFF
--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -115,7 +115,7 @@ async function setupOpenId() {
     }
     const issuer = await Issuer.discover(process.env.OPENID_ISSUER);
     const supported_alg = {
-      id_token_signed_response_alg: issuer.id_token_signing_alg_values_supported[0] || 'RS256',
+      id_token_signed_response_alg: issuer.id_token_signing_alg_values_supported?.[0] || 'RS256',
       // request_object_signing_alg: jar ? alg : undefined, // Both in v5 and v6
       // userinfo_signed_response_alg: jwtUserinfo ? alg : undefined, // Only in v6
       // introspection_signed_response_alg: alg, // Only in v6

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -114,12 +114,15 @@ async function setupOpenId() {
       logger.info(`[openidStrategy] proxy agent added: ${process.env.PROXY}`);
     }
     const issuer = await Issuer.discover(process.env.OPENID_ISSUER);
+    /* Supported Algorithms, openid-client v5 doesn't set it automatically as discovered from server.
+      - id_token_signed_response_alg      // defaults to 'RS256'
+      - request_object_signing_alg        // defaults to 'RS256'
+      - userinfo_signed_response_alg      // not in v5
+      - introspection_signed_response_alg // not in v5
+      - authorization_signed_response_alg // not in v5
+    */
     const supported_alg = {
       id_token_signed_response_alg: issuer.id_token_signing_alg_values_supported?.[0] || 'RS256',
-      // request_object_signing_alg: jar ? alg : undefined, // Both in v5 and v6
-      // userinfo_signed_response_alg: jwtUserinfo ? alg : undefined, // Only in v6
-      // introspection_signed_response_alg: alg, // Only in v6
-      // authorization_signed_response_alg: alg, // Only in v6
     };
     const client = new issuer.Client({
       client_id: process.env.OPENID_CLIENT_ID,

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -114,11 +114,18 @@ async function setupOpenId() {
       logger.info(`[openidStrategy] proxy agent added: ${process.env.PROXY}`);
     }
     const issuer = await Issuer.discover(process.env.OPENID_ISSUER);
+    const supported_alg = {
+      id_token_signed_response_alg: issuer.id_token_signing_alg_values_supported[0] || 'RS256',
+      // request_object_signing_alg: jar ? alg : undefined, // Both in v5 and v6
+      // userinfo_signed_response_alg: jwtUserinfo ? alg : undefined, // Only in v6
+      // introspection_signed_response_alg: alg, // Only in v6
+      // authorization_signed_response_alg: alg, // Only in v6
+    };
     const client = new issuer.Client({
       client_id: process.env.OPENID_CLIENT_ID,
       client_secret: process.env.OPENID_CLIENT_SECRET,
       redirect_uris: [process.env.DOMAIN_SERVER + process.env.OPENID_CALLBACK_URL],
-      id_token_signed_response_alg: issuer.id_token_signing_alg_values_supported[0] || 'RS256',
+      ...supported_alg,
     });
     const requiredRole = process.env.OPENID_REQUIRED_ROLE;
     const requiredRoleParameterPath = process.env.OPENID_REQUIRED_ROLE_PARAMETER_PATH;

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -118,6 +118,7 @@ async function setupOpenId() {
       client_id: process.env.OPENID_CLIENT_ID,
       client_secret: process.env.OPENID_CLIENT_SECRET,
       redirect_uris: [process.env.DOMAIN_SERVER + process.env.OPENID_CALLBACK_URL],
+      id_token_signed_response_alg: issuer.id_token_signing_alg_values_supported[0] || 'RS256',
     });
     const requiredRole = process.env.OPENID_REQUIRED_ROLE;
     const requiredRoleParameterPath = process.env.OPENID_REQUIRED_ROLE_PARAMETER_PATH;


### PR DESCRIPTION
## Summary

Currently if an Authentication server uses a different Token Signing Algorithm other than the default 'RS256', it will fail.

This change sets the OpenID Token Algorithm to the one advertised by the Authentication server.

`id_token_signed_response_alg` has to be set at the time of the Client object creation, it doesn't take account of that property even if set before or after the creation of the Client object.

All authentication servers advertise their token signing algorithm in `id_token_signing_alg_values_supported` as an array with one element (as far as I can check)

I tried to see if updating the `openid-client` package will resolve the issue without this patch fix, but it seems that package has fundamentally changed a lot and requires a lot of changes to use that.

This patch fix will last until the next re-write of openid-client strategy.

Fixes #5358.

## Change Type

Please delete any irrelevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

- Use any OIDC authentication server that signs the response Tokens with EllipticCrypto (EC) Keys instead of the RSA keys.
- Only RS256 (signed with RSA keys) will work before the patch.
- After this patch, any algorithm should be accepted as advertised by the authentication server.

### **Test Configuration**:

- Authentik with two keys with different algorithms (EC and RSA).
- Token signing with different keys, both worked as expected without any user intervention.

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [X] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
