### PR TITLE
🔈fix: Accessible name on 'Prev' button in Prompts UI

### DIFF
--- a/client/src/components/Chat/Prompts.tsx
+++ b/client/src/components/Chat/Prompts.tsx
@@ -77,6 +77,7 @@ export default function Prompts() {
             onClick={prevPage}
             disabled={!hasPreviousPage}
             className="m-0 self-start p-0 hover:bg-transparent"
+            aria-label="previous"
           >
             <ChevronLeft className={`${hasPreviousPage ? '' : 'text-gray-500'}`} />
           </Button>


### PR DESCRIPTION
Fixes #5310

Add `aria-label="previous"` attribute to the 'Prev' button in the Prompts Panel.

* Modify `client/src/components/Chat/Prompts.tsx` to include `aria-label="previous"` attribute for the button.

## Change Type

- [x] Bug fix

## Testing

Tested on Desktop Firefox and Mobile Chrome

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
