### PR TITLE
Fix: Correct default threshold for HARM_CATEGORY_CIVIC_INTEGRITY

### DIFF
--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -921,7 +921,7 @@ class GoogleClient extends BaseClient {
       },
       {
         category: 'HARM_CATEGORY_CIVIC_INTEGRITY',
-        threshold: mapThreshold(process.env.GOOGLE_SAFETY_CIVIC_INTEGRITY || 'BLOCK_NONE'),
+        threshold: mapThreshold(process.env.GOOGLE_SAFETY_CIVIC_INTEGRITY || 'BLOCK_ONLY_HIGH'),
       },
     ];
   }

--- a/api/server/services/Endpoints/google/llm.js
+++ b/api/server/services/Endpoints/google/llm.js
@@ -44,7 +44,7 @@ function getSafetySettings(isGemini2) {
     },
     {
       category: 'HARM_CATEGORY_CIVIC_INTEGRITY',
-      threshold: mapThreshold(process.env.GOOGLE_SAFETY_CIVIC_INTEGRITY || 'BLOCK_NONE'),
+      threshold: mapThreshold(process.env.GOOGLE_SAFETY_CIVIC_INTEGRITY || 'BLOCK_ONLY_HIGH'),
     },
   ];
 }


### PR DESCRIPTION
## Summary

Fixes an issue where invalid threshold values were being used for the Civic Integrity safety setting in the Google AI Studio integration, causing API errors. The default value and mapping logic have been updated to use valid thresholds.

The current default value of `BLOCK_NONE` does not work.
The same goes for `HARM_BLOCK_THRESHOLD_UNSPECIFIED` | `OFF`.
Fix this #5401 

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

-
### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] I have written tests demonstrating that my changes are effective or that my feature works
