### PR TITLE
🔧 chore: Update Deepseek Pricing, Google Safety Settings

### DIFF
--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -886,7 +886,8 @@ class GoogleClient extends BaseClient {
   }
 
   getSafetySettings() {
-    const isGemini2 = this.modelOptions.model.includes('gemini-2.0');
+    const model = this.modelOptions.model;
+    const isGemini2 = model.includes('gemini-2.0') && !model.includes('thinking');
     const mapThreshold = (value) => {
       if (isGemini2 && value === 'BLOCK_NONE') {
         return 'OFF';

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -96,6 +96,8 @@ const tokenValues = Object.assign(
     'claude-': { prompt: 0.8, completion: 2.4 },
     'command-r-plus': { prompt: 3, completion: 15 },
     'command-r': { prompt: 0.5, completion: 1.5 },
+    'deepseek-reasoner': { prompt: 0.14, completion: 0.55 },
+    deepseek: { prompt: 0.07, completion: 0.28 },
     /* cohere doesn't have rates for the older command models,
   so this was from https://artificialanalysis.ai/models/command-light/providers */
     command: { prompt: 0.38, completion: 0.38 },

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -263,6 +263,37 @@ describe('AWS Bedrock Model Tests', () => {
   });
 });
 
+describe('Deepseek Model Tests', () => {
+  const deepseekModels = ['deepseek-chat', 'deepseek-coder', 'deepseek-reasoner'];
+
+  it('should return the correct prompt multipliers for all models', () => {
+    const results = deepseekModels.map((model) => {
+      const valueKey = getValueKey(model);
+      const multiplier = getMultiplier({ valueKey, tokenType: 'prompt' });
+      return tokenValues[valueKey].prompt && multiplier === tokenValues[valueKey].prompt;
+    });
+    expect(results.every(Boolean)).toBe(true);
+  });
+
+  it('should return the correct completion multipliers for all models', () => {
+    const results = deepseekModels.map((model) => {
+      const valueKey = getValueKey(model);
+      const multiplier = getMultiplier({ valueKey, tokenType: 'completion' });
+      return tokenValues[valueKey].completion && multiplier === tokenValues[valueKey].completion;
+    });
+    expect(results.every(Boolean)).toBe(true);
+  });
+
+  it('should return the correct prompt multipliers for reasoning model', () => {
+    const model = 'deepseek-reasoner';
+    const valueKey = getValueKey(model);
+    expect(valueKey).toBe(model);
+    const multiplier = getMultiplier({ valueKey, tokenType: 'prompt' });
+    const result = tokenValues[valueKey].prompt && multiplier === tokenValues[valueKey].prompt;
+    expect(result).toBe(true);
+  });
+});
+
 describe('getCacheMultiplier', () => {
   it('should return the correct cache multiplier for a given valueKey and cacheType', () => {
     expect(getCacheMultiplier({ valueKey: 'claude-3-5-sonnet', cacheType: 'write' })).toBe(

--- a/api/server/services/Endpoints/google/llm.js
+++ b/api/server/services/Endpoints/google/llm.js
@@ -87,7 +87,8 @@ function getLLMConfig(credentials, options = {}) {
     maxRetries: 2,
   };
 
-  const isGemini2 = llmConfig.model.includes('gemini-2.0');
+  /** Used only for Safety Settings */
+  const isGemini2 = llmConfig.model.includes('gemini-2.0') && !llmConfig.model.includes('thinking');
   const isGenerativeModel = llmConfig.model.includes('gemini');
   const isChatModel = !isGenerativeModel && llmConfig.model.includes('chat');
   const isTextModel = !isGenerativeModel && !isChatModel && /code|text/.test(llmConfig.model);

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -82,7 +82,8 @@ const anthropicModels = {
 };
 
 const deepseekModels = {
-  deepseek: 127500,
+  'deepseek-reasoner': 63000, // -1000 from max (API)
+  deepseek: 63000, // -1000 from max (API)
 };
 
 const metaModels = {

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -385,8 +385,15 @@ describe('Meta Models Tests', () => {
     });
 
     test('should match Deepseek model variations', () => {
-      expect(getModelMaxTokens('deepseek-chat')).toBe(127500);
-      expect(getModelMaxTokens('deepseek-coder')).toBe(127500);
+      expect(getModelMaxTokens('deepseek-chat')).toBe(
+        maxTokensMap[EModelEndpoint.openAI]['deepseek'],
+      );
+      expect(getModelMaxTokens('deepseek-coder')).toBe(
+        maxTokensMap[EModelEndpoint.openAI]['deepseek'],
+      );
+      expect(getModelMaxTokens('deepseek-reasoner')).toBe(
+        maxTokensMap[EModelEndpoint.openAI]['deepseek-reasoner'],
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

I updated the pricing details for deepseek models and fixed the safety settings for the google "thinking" model. 

- Inserted new token values for deepseek models in tx.js and tokens.js 
- Added tests in tx.spec.js to confirm the correct token multipliers 
- Modified the safety setting logic in GoogleClient to exclude "thinking" from gemini-2.0 checks
    - See this [forum](https://discuss.ai.google.dev/t/safety-settings-2025-update-broken-again/59360/3) for more info

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

I tested these changes by running the updated unit tests for deepseek models to validate the new pricing multipliers. I also confirmed the google safety logic no longer mislabels "thinking" models as gemini-2.0. I recommend verifying these changes further with manual endpoint calls to ensure model-specific behavior aligns with expected results.

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes