### PR TITLE
🐳 feat: Deepseek Reasoning UI

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1292,6 +1292,12 @@ ${convo}
         let reasoningCompleted = false;
         for await (const chunk of stream) {
           if (chunk?.choices?.[0]?.delta?.reasoning_content) {
+            if (reasoningTokens.length === 0) {
+              const thinkingDirective = ':::thinking\n';
+              intermediateReply.push(thinkingDirective);
+              reasoningTokens.push(thinkingDirective);
+              onProgress(thinkingDirective);
+            }
             const reasoning_content = chunk?.choices?.[0]?.delta?.reasoning_content || '';
             intermediateReply.push(reasoning_content);
             reasoningTokens.push(reasoning_content);
@@ -1301,7 +1307,7 @@ ${convo}
           const token = chunk?.choices?.[0]?.delta?.content || '';
           if (!reasoningCompleted && reasoningTokens.length > 0 && token) {
             reasoningCompleted = true;
-            const separatorTokens = '\n\n---\n';
+            const separatorTokens = '\n:::\n';
             reasoningTokens.push(separatorTokens);
             onProgress(separatorTokens);
           }

--- a/client/src/components/Artifacts/Thinking.tsx
+++ b/client/src/components/Artifacts/Thinking.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { Atom, ChevronDown } from 'lucide-react';
+import type { MouseEvent } from 'react';
+import useLocalize from '~/hooks/useLocalize';
+
+interface ThinkingProps {
+  children: React.ReactNode;
+}
+
+const Thinking = ({ children }: ThinkingProps) => {
+  const localize = useLocalize();
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setIsExpanded(!isExpanded);
+  };
+
+  return (
+    <div className="mb-3">
+      <button
+        type="button"
+        onClick={handleClick}
+        className="group mb-3 flex w-fit items-center justify-center rounded-xl bg-surface-tertiary px-3.5 py-2 text-xs leading-[18px] text-text-primary transition-colors hover:bg-surface-secondary"
+      >
+        <Atom size={14} className="mr-1.5 text-text-secondary" />
+        {localize('com_ui_thoughts')}
+        <ChevronDown
+          className="icon-sm ml-1.5 text-text-primary transition-transform duration-200"
+          style={{
+            transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+          }}
+        />
+      </button>
+      {isExpanded && (
+        <div className="relative pl-3 text-text-secondary">
+          <div className="absolute left-0 top-[5px] h-[calc(100%-10px)] border-l-2 border-border-medium dark:border-border-heavy" />
+          <p className="my-4 whitespace-pre-wrap leading-[26px]">{children}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Thinking;

--- a/client/src/components/Chat/Messages/Content/Markdown.tsx
+++ b/client/src/components/Chat/Messages/Content/Markdown.tsx
@@ -17,6 +17,7 @@ import {
 import { Artifact, artifactPlugin } from '~/components/Artifacts/Artifact';
 import { langSubset, preprocessLaTeX, handleDoubleClick } from '~/utils';
 import CodeBlock from '~/components/Messages/Content/CodeBlock';
+import Thinking from '~/components/Artifacts/Thinking';
 import { useFileDownload } from '~/data-provider';
 import useLocalize from '~/hooks/useLocalize';
 import store from '~/store';
@@ -213,6 +214,7 @@ const Markdown = memo(({ content = '', showCursor, isLatestMessage }: TContentPr
               a,
               p,
               artifact: Artifact,
+              thinking: Thinking,
             } as {
               [nodeType: string]: React.ElementType;
             }

--- a/client/src/localization/languages/Eng.ts
+++ b/client/src/localization/languages/Eng.ts
@@ -409,6 +409,7 @@ export default {
   com_ui_more_options: 'More',
   com_ui_more_info: 'More info',
   com_ui_preview: 'Preview',
+  com_ui_thoughts: 'Thoughts',
   com_ui_upload: 'Upload',
   com_ui_connect: 'Connect',
   com_ui_locked: 'Locked',


### PR DESCRIPTION
## Summary

Adds simple reasoning UI for LLMs that clearly distinguish reasoning tokens from standard generation tokens (only `deepseek-reasoner` for now)

Once migrated to new agent framework, will include more metadata such as time elapsed thinking, dynamic thinking status, etc.

![chrome_5XzmS9djv9](https://github.com/user-attachments/assets/f6a7b6bc-bfa8-4002-b4cf-6b0ea0f6333d)


## Change Type

- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
