### PR TITLE
Fix bug where admin cannot delete any prompts. Fixes #5486

### DIFF
--- a/api/models/Prompt.js
+++ b/api/models/Prompt.js
@@ -417,7 +417,12 @@ module.exports = {
   deletePrompt: async ({ promptId, groupId, author, role }) => {
     const query = { _id: promptId, groupId, author };
     if (role === SystemRoles.ADMIN) {
-      delete query.author;
+      const prompt = await Prompt.findOne({ _id: promptId, groupId }).lean();
+      if (!prompt) {
+        throw new Error('Failed to delete the prompt: prompt not found');
+      }
+
+      query.author = prompt.author;
     }
     const { deletedCount } = await Prompt.deleteOne(query);
     if (deletedCount === 0) {

--- a/api/server/routes/prompts.js
+++ b/api/server/routes/prompts.js
@@ -214,10 +214,8 @@ const deletePromptController = async (req, res) => {
     const { promptId } = req.params;
     const { groupId } = req.query;
     const author = req.user.id;
-    const query = { promptId, groupId, author };
-    if (req.user.role === SystemRoles.ADMIN) {
-      delete query.author;
-    }
+    const role = req.user.role;
+    const query = { promptId, groupId, author, role };
     const result = await deletePrompt(query);
     res.status(200).send(result);
   } catch (error) {


### PR DESCRIPTION
## Summary
Fixes bug where admin users cannot delete saved prompts

Judging by the code, the intent was to allow admin users to delete saved prompts owned by any user. But there's a bug making it so that admin users can't delete any saved prompts, even ones they own.

## Change Type

Please delete any irrelevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

* Sign in as admin
* Create prompt
* Create shared prompt
* Sign out
* Sign in as non-admin
* Create prompt
* Verify able to delete prompt
* Create shared prompt
* Verify unable to delete shared prompt created by admin
* Sign out
* Sign in as admin
* Verify able to delete shared prompt from other user
* Verify able to delete own (non-shared) prompt
* Verify able to delete own (shared) prompt

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
