### PR TITLE
🉐 fix: incorrect handling for composing CJK texts in Safari

### DIFF
--- a/client/src/hooks/Input/useTextarea.ts
+++ b/client/src/hooks/Input/useTextarea.ts
@@ -191,6 +191,9 @@ export default function useTextarea({
       const isNonShiftEnter = e.key === 'Enter' && !e.shiftKey;
       const isCtrlEnter = e.key === 'Enter' && (e.ctrlKey || e.metaKey);
 
+      // NOTE: isComposing and e.key behave differently in Safari compared to other browsers, forcing us to use e.keyCode instead
+      const isComposingInput = isComposing.current || e.key === 'Process' || e.keyCode === 229;
+
       if (isNonShiftEnter && filesLoading) {
         e.preventDefault();
       }
@@ -204,7 +207,7 @@ export default function useTextarea({
         !enterToSend &&
         !isCtrlEnter &&
         textAreaRef.current &&
-        !isComposing.current
+        !isComposingInput
       ) {
         e.preventDefault();
         insertTextAtCursor(textAreaRef.current, '\n');
@@ -212,7 +215,7 @@ export default function useTextarea({
         return;
       }
 
-      if ((isNonShiftEnter || isCtrlEnter) && !isComposing.current) {
+      if ((isNonShiftEnter || isCtrlEnter) && !isComposingInput) {
         const globalAudio = document.getElementById(globalAudioId) as HTMLAudioElement | undefined;
         if (globalAudio) {
           console.log('Unmuting global audio');


### PR DESCRIPTION
## Summary

Fixed an issue where line breaks were not correctly applied in Mac/Safari environments for languages that require pressing the Enter key to confirm text input (e.g., Japanese, Chinese, etc.).

This issue was largely resolved for most environments in https://github.com/danny-avila/LibreChat/pull/3103, but the problem persisted in Mac/Safari due to differences in the behavior of isComposing.

In addition to using isComposing for composition detection, there are also [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) and [KeyboardEvent.keyCode](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode). However, in Mac/Safari, it was impossible to make correct judgments using either isComposing or KeyboardEvent.key, so I reluctantly used keyCode for detection, despite it being deprecated.

To prevent issues when keyCode is removed in the future, I have implemented the keyCode-based detection after attempting detection using isComposing and key.

> This PR appears to be related to https://github.com/danny-avila/LibreChat/issues/3412.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Testing can be done using a similar approach as in https://github.com/danny-avila/LibreChat/pull/3103.

When creating the pull request, I conducted tests in the following environment:

| OS | Browser | note |
| --- | --- | --- |
| macOS 15.2 | Safari 18.2 (20620.1.16.11.8) | |
| macOS 15.2 | Chrome 131.0.6778.267 | |
| Windows 11 (23H2) | Chrome 132.0.6834.111 | |
| Windows 11 (23H2) | Firefox 134.0.2 | |
| Android 15 | Chrome 132.0.6834.122 | |
| iPadOS 16.5 | Safari | Due to the limitations of the device I own, I'm using a slightly older version. |

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
  - ⚠️ While no warnings appear during testing or building, many IDEs display strikethrough lines on the relevant parts due to the use of deprecated properties.