### PR TITLE
🗨️ fix: Loading Shared Saved Prompts

### DIFF
--- a/api/models/Prompt.js
+++ b/api/models/Prompt.js
@@ -125,7 +125,7 @@ const getAllPromptGroups = async (req, filter) => {
 
     if (searchShared) {
       const project = await getProjectByName(Constants.GLOBAL_PROJECT_NAME, 'promptGroupIds');
-      if (project && project.promptGroupIds.length > 0) {
+      if (project && project.promptGroupIds && project.promptGroupIds.length > 0) {
         const projectQuery = { _id: { $in: project.promptGroupIds }, ...query };
         delete projectQuery.author;
         combinedQuery = searchSharedOnly ? projectQuery : { $or: [projectQuery, query] };
@@ -179,7 +179,7 @@ const getPromptGroups = async (req, filter) => {
     if (searchShared) {
       // const projects = req.user.projects || []; // TODO: handle multiple projects
       const project = await getProjectByName(Constants.GLOBAL_PROJECT_NAME, 'promptGroupIds');
-      if (project && project.promptGroupIds.length > 0) {
+      if (project && project.promptGroupIds && project.promptGroupIds.length > 0) {
         const projectQuery = { _id: { $in: project.promptGroupIds }, ...query };
         delete projectQuery.author;
         combinedQuery = searchSharedOnly ? projectQuery : { $or: [projectQuery, query] };


### PR DESCRIPTION
## Summary

There is a bug where if no saved prompts have ever been shared, it will fail to load shared saved prompts. Since the default is to load all prompts (both personal and shared) by default it fails to load prompts. It will appear as if the saved prompts feature is broken, because you can create them but can't view them.

The root cause is that `project.promptGroupIds` is undefined for new projects, rather than being an empty list. A quick null check fixes the issue.

## Change Type

Please delete any irrelevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

To reproduce the bug:
* Create a new LibreChat instance with an empty database
* Create a user and sign in
* Attempt to create a saved prompt. Creation will succeed (it will be written to the database) but the UI won't update
* Change the filter to show only personal prompts, not both shared and personal.
* Now you can view the prompt you created

