### PR TITLE
📝 docs: Update `librechat.example.yaml`

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -58,10 +58,10 @@ interface:
       By using the Website, you acknowledge that you have read these Terms of Service and agree to be bound by them.
 
   endpointsMenu: true
-  modelSelect: false
+  modelSelect: true
   parameters: true
   sidePanel: true
-  presets: false
+  presets: true
   prompts: true
   bookmarks: true
   multiConvo: true


### PR DESCRIPTION
## Summary
Enable modelSelect and Presets by default

More details:
`modelSelect` and `presets` were disabled in the example config which can be confusing for new users
see: https://discordapp.com/channels/1086345563026489514/1334249641230729339

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)