### PR TITLE
Comment out text area focus disablement for improved iOS PWA experience

### DIFF
--- a/client/src/hooks/Input/useTextarea.ts
+++ b/client/src/hooks/Input/useTextarea.ts
@@ -90,8 +90,9 @@ export default function useTextarea({
       setShowBingToneSetting(false);
     }
 
+    // Disabled to improve app experience in PWA mode on iOS
     if (convoId !== Constants.SEARCH) {
-      textAreaRef.current?.focus();
+      //textAreaRef.current?.focus();
     }
     // setShowBingToneSetting is a recoil setter, so it doesn't need to be in the dependency array
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

Commented out the textAreaRef.current?.focus() call to prevent automatic focus in Progressive Web App mode on iOS (addressing current UX concerns).

Fixes issue [https://github.com/danny-avila/LibreChat/issues/3874](https://github.com/danny-avila/LibreChat/issues/3874)

## Change Type

- Bug fix (non-breaking change which fixes an issue)

## Testing

iOS 18.3; Safari (PWA mode); iPhone 13 
iPad OS 18.3; Safari (PWA mode); iPad Pro Gen 7

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
