### PR TITLE
🔧 fix: handle known OpenAI errors with empty intermediate reply

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1462,7 +1462,11 @@ ${convo}
         (err instanceof OpenAI.OpenAIError && err?.message?.includes('missing finish_reason'))
       ) {
         logger.error('[OpenAIClient] Known OpenAI error:', err);
-        return intermediateReply.join('');
+        if (intermediateReply.length > 0) {
+          return intermediateReply.join('');
+        } else {
+          throw err;
+        }
       } else if (err instanceof OpenAI.APIError) {
         if (intermediateReply.length > 0) {
           return intermediateReply.join('');


### PR DESCRIPTION
## Summary
* Improves handling of known OpenAI errors, making it consistent with the behavior for other errors
* If intermediate content is empty when encountering a known error, report an error to the client instead of a success with empty content.
* This prevents the UI from showing a blank successful response, ensuring users see an error message and are prompted to retry.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

To test this change:

1. Mock a response that returns an empty content with missing finish_reason:
```json
{
  "status": 200,
  "body": {
    "object": "chat.completion.chunk",
    "choices": [
      {
        "index": 0,
        "message": {
          "role": "assistant",
          "content": ""
        }
      }
    ],
    "usage": {
      "completion_tokens": 0
    }
  }
}
```


2. Verify that instead of showing a blank message, the UI now shows an error state and allows retrying the request.

## Checklist

- [x] I have performed a self-review of my own code
- [x] Local unit tests pass with my changes