### PR TITLE
🔧 fix: Add missing `finish_reason` to stream chunks

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1364,6 +1364,14 @@ ${convo}
         }
 
         for await (const chunk of stream) {
+          // Add finish_reason: null if missing in any choice
+          if (chunk.choices) {
+            chunk.choices.forEach(choice => {
+              if (!('finish_reason' in choice)) {
+                choice.finish_reason = null;
+              }
+            });
+          }
           this.streamHandler.handle(chunk);
           if (abortController.signal.aborted) {
             stream.controller.abort();


### PR DESCRIPTION
# Summary
Adds `finish_reason: null` to any streaming chunk that's missing the `finish_reason` field. This improves compatibility with providers like AWS Bedrock that may omit this field in intermediate chunks.

# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing instructions
1. Set up a chat completion stream with a provider that omits `finish_reason` (e.g., AWS Bedrock)
2. Verify that:
   - All chunks now have a `finish_reason` field
   - Intermediate chunks have `finish_reason: null`
   - The final chunk retains its original `finish_reason` value (e.g., "stop", "length", etc.)
3. Confirm that regular OpenAI API responses are unaffected (they already include `finish_reason`)

# Checklist
- [x] I have performed a self-review of my code
- [x] I have tested my changes locally