### PR TITLE
WIP: feat: Configurable timeout and retry for custom endpoints

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1214,6 +1214,8 @@ ${convo}
       const openai = new OpenAI({
         fetch: this.fetch,
         apiKey: this.apiKey,
+        timeout: this.options.timeout ?? 10 * 60 * 1000, // 10 minutes default timeout
+        maxRetries: this.options.maxRetries ?? 2, // Default to 2 retries
         ...opts,
       });
 

--- a/api/app/clients/specs/OpenAIClient.test.js
+++ b/api/app/clients/specs/OpenAIClient.test.js
@@ -249,6 +249,34 @@ describe('OpenAIClient', () => {
       expect(client.completionsUrl).toBe('https://example.com/completions');
       expect(client.langchainProxy).toBe('https://example.com/completions');
     });
+
+    it('should set default timeout and maxRetries when creating OpenAI client', async () => {
+      const mockMessages = [{ role: 'user', content: 'test' }];
+      await client.chatCompletion({ payload: mockMessages });
+      expect(OpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeout: 10 * 60 * 1000,
+          maxRetries: 2,
+        }),
+      );
+    });
+
+    it('should use custom timeout and maxRetries from options when provided', async () => {
+      const customOptions = {
+        ...defaultOptions,
+        timeout: 5000,
+        maxRetries: 3,
+      };
+      const customClient = new OpenAIClient('test-api-key', customOptions);
+      const mockMessages = [{ role: 'user', content: 'test' }];
+      await customClient.chatCompletion({ payload: mockMessages });
+      expect(OpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeout: 5000,
+          maxRetries: 3,
+        }),
+      );
+    });
   });
 
   describe('setOptions with Simplified Azure Integration', () => {

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -115,6 +115,8 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
     titleMessageRole: endpointConfig.titleMessageRole,
     streamRate: endpointConfig.streamRate,
     endpointTokenConfig,
+    timeout: endpointConfig.timeout,
+    maxRetries: endpointConfig.maxRetries,
   };
 
   /** @type {undefined | TBaseEndpoint} */


### PR DESCRIPTION
# Summary

This PR adds two new configuration options for custom endpoints:
- `timeout`: Sets request timeout in milliseconds (default: 10 minutes)
- `maxRetries`: Sets maximum retry attempts for failed requests (default: 2)

These settings map directly to the OpenAI SDK configuration options and help prevent hanging requests and improve error handling through automatic retries.

Fixes https://github.com/danny-avila/LibreChat/discussions/5567

**Example Usage:**
```yaml
endpoints:
  custom:
    - name: "Example"
      timeout: 5000      # 5 second timeout
      maxRetries: 3      # Retry failed requests up to 3 times
```

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

1. Configure a custom endpoint with timeout and maxRetries:
```yaml
endpoints:
  custom:
    - name: "Test Endpoint"
      timeout: 5000
      maxRetries: 3
```

2. Test scenarios:
- Normal API calls work as expected
- Set a low timeout (1ms) and saw error as expected

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes