### PR TITLE
🛠 fix: Adding Balance Localization For All Languages

### DIFF
--- a/client/src/localization/languages/Ar.ts
+++ b/client/src/localization/languages/Ar.ts
@@ -914,4 +914,5 @@ export default {
   com_ui_collapse_chat: 'طي الدردشة',
   com_endpoint_message_new: 'رسالة {0}',
   com_ui_speech_while_submitting: 'لا يمكن إرسال الكلام أثناء إنشاء الرد',
+  com_nav_balance: 'توازن:',
 };

--- a/client/src/localization/languages/Br.ts
+++ b/client/src/localization/languages/Br.ts
@@ -816,4 +816,5 @@ export default {
   com_ui_decline: 'Eu não aceito',
   com_ui_terms_and_conditions: 'Termos e Condições',
   com_ui_no_terms_content: 'Nenhum conteúdo de termos e condições para exibir',
+  com_nav_balance: 'Equilíbrio:',
 };

--- a/client/src/localization/languages/De.ts
+++ b/client/src/localization/languages/De.ts
@@ -946,4 +946,5 @@ export default {
   com_ui_collapse_chat: 'Chat einklappen',
   com_ui_speech_while_submitting: 'Spracheingabe nicht möglich während eine Antwort generiert wird',
   com_endpoint_message_new: 'Nachricht {0}',
+  com_nav_balance: 'Gleichgewicht:',
 };

--- a/client/src/localization/languages/Es.ts
+++ b/client/src/localization/languages/Es.ts
@@ -1203,4 +1203,5 @@ export default {
   com_endpoint_message_new: 'Mensaje {0}',
   com_ui_speech_while_submitting:
     'No se puede enviar un mensaje de voz mientras se está generando una respuesta',
+  com_nav_balance: 'Balance:',
 };

--- a/client/src/localization/languages/Fi.ts
+++ b/client/src/localization/languages/Fi.ts
@@ -711,4 +711,5 @@ export default {
   com_nav_lang_indonesia: 'Indonesia',
   com_nav_lang_hebrew: 'עברית',
   com_nav_lang_finnish: 'Suomi',
+  com_nav_balance: 'Saldo:',
 };

--- a/client/src/localization/languages/Fr.ts
+++ b/client/src/localization/languages/Fr.ts
@@ -965,4 +965,5 @@ export default {
   com_ui_speech_while_submitting:
     'Impossible de soumettre un message vocal pendant la génération d\'une réponse',
   com_endpoint_message_new: 'Message {0}',
+  com_nav_balance: 'Équilibre:',
 };

--- a/client/src/localization/languages/He.ts
+++ b/client/src/localization/languages/He.ts
@@ -440,4 +440,5 @@ export default {
   com_nav_lang_indonesia: 'Indonesia',
   com_nav_lang_hebrew: 'עברית',
   com_nav_lang_finnish: 'Suomi',
+  com_nav_balance: 'לְאַזֵן:',
 };

--- a/client/src/localization/languages/Id.ts
+++ b/client/src/localization/languages/Id.ts
@@ -397,4 +397,5 @@ export default {
   com_nav_lang_indonesia: 'Indonesia',
   com_nav_lang_hebrew: 'עברית',
   com_nav_lang_finnish: 'Suomi',
+  com_nav_balance: 'Keseimbangan:',
 };

--- a/client/src/localization/languages/It.ts
+++ b/client/src/localization/languages/It.ts
@@ -959,4 +959,5 @@ export default {
   com_endpoint_message_new: 'Messaggio {0}',
   com_ui_speech_while_submitting:
     'Impossibile inviare il messaggio mentre è in corso la generazione di una risposta',
+  com_nav_balance: 'Bilancia:',
 };

--- a/client/src/localization/languages/Jp.ts
+++ b/client/src/localization/languages/Jp.ts
@@ -912,4 +912,5 @@ export default {
   com_ui_collapse_chat: 'チャットを折りたたむ',
   com_endpoint_message_new: 'メッセージ {0}',
   com_ui_speech_while_submitting: '応答の生成中は音声を送信できません',
+  com_nav_balance: 'バランス:',
 };

--- a/client/src/localization/languages/Ko.ts
+++ b/client/src/localization/languages/Ko.ts
@@ -1150,4 +1150,5 @@ export default {
   com_ui_collapse_chat: '채팅 접기',
   com_endpoint_message_new: '메시지 {0}',
   com_ui_speech_while_submitting: '응답 생성 중에는 음성을 전송할 수 없습니다',
+  com_nav_balance: '균형:',
 };

--- a/client/src/localization/languages/Nl.ts
+++ b/client/src/localization/languages/Nl.ts
@@ -350,4 +350,5 @@ export default {
   com_nav_lang_indonesia: 'Indonesia',
   com_nav_lang_hebrew: 'עברית',
   com_nav_lang_finnish: 'Suomi',
+  com_nav_balance: 'Evenwicht:',
 };

--- a/client/src/localization/languages/Pl.ts
+++ b/client/src/localization/languages/Pl.ts
@@ -284,4 +284,5 @@ export default {
   com_nav_lang_indonesia: 'Indonesia',
   com_nav_lang_hebrew: 'עברית',
   com_nav_lang_finnish: 'Suomi',
+  com_nav_balance: 'Balansować:',
 };

--- a/client/src/localization/languages/Sv.ts
+++ b/client/src/localization/languages/Sv.ts
@@ -337,4 +337,5 @@ export default {
   com_nav_lang_indonesia: 'Indonesia',
   com_nav_lang_hebrew: 'עברית',
   com_nav_lang_finnish: 'Suomi',
+  com_nav_balance: 'Balans:',
 };

--- a/client/src/localization/languages/Tr.ts
+++ b/client/src/localization/languages/Tr.ts
@@ -644,4 +644,5 @@ export default {
   com_nav_lang_indonesia: 'Indonesia',
   com_nav_lang_hebrew: 'עברית',
   com_nav_lang_finnish: 'Suomi',
+  com_nav_balance: 'Denge:',
 };

--- a/client/src/localization/languages/Vi.ts
+++ b/client/src/localization/languages/Vi.ts
@@ -335,4 +335,5 @@ export default {
   com_nav_lang_indonesia: 'Indonesia',
   com_nav_lang_hebrew: 'עברית',
   com_nav_lang_finnish: 'Suomi',
+  com_nav_balance: 'Sự cân bằng:',
 };

--- a/client/src/localization/languages/Zh.ts
+++ b/client/src/localization/languages/Zh.ts
@@ -904,4 +904,5 @@ export default {
   com_ui_collapse_chat: '收起聊天',
   com_endpoint_message_new: '消息 {0}',
   com_ui_speech_while_submitting: '正在生成回复时无法提交语音',
+  com_nav_balance: '平衡:',
 };

--- a/client/src/localization/languages/ZhTraditional.ts
+++ b/client/src/localization/languages/ZhTraditional.ts
@@ -881,4 +881,5 @@ export default {
   com_ui_collapse_chat: '收合對話',
   com_endpoint_message_new: '訊息 {0}',
   com_ui_speech_while_submitting: '正在產生回應時無法送出語音',
+  com_nav_balance: '平衡:',
 };


### PR DESCRIPTION
## Summary
I noticed that the word “Balance” is only in English and has no localization. I fixed it 😉

## Change Type
- [x] Translation update

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings

