### PR TITLE
🌍 i18n: Fix "Balance" Localization For Zh&ZhTraditional

### DIFF
--- a/client/src/localization/languages/Zh.ts
+++ b/client/src/localization/languages/Zh.ts
@@ -904,5 +904,5 @@ export default {
   com_ui_collapse_chat: '收起聊天',
   com_endpoint_message_new: '消息 {0}',
   com_ui_speech_while_submitting: '正在生成回复时无法提交语音',
-  com_nav_balance: '平衡',
+  com_nav_balance: '余额',
 };

--- a/client/src/localization/languages/ZhTraditional.ts
+++ b/client/src/localization/languages/ZhTraditional.ts
@@ -881,5 +881,5 @@ export default {
   com_ui_collapse_chat: '收合對話',
   com_endpoint_message_new: '訊息 {0}',
   com_ui_speech_while_submitting: '正在產生回應時無法送出語音',
-  com_nav_balance: '平衡',
+  com_nav_balance: '余額',
 };


### PR DESCRIPTION
## Summary

Fix "Balance" Localization For Zh&ZhTraditional because [this PR](https://github.com/danny-avila/LibreChat/pull/5594) was automatically generated

## Change Type
- Translation update


## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
