### PR TITLE
📱 feat: improve mobile viewport behavior with interactive-widget meta

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -11,7 +11,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon-180x180.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" />
     <style>
       html,
       body {


### PR DESCRIPTION
When focusing on the input field in mobile browsers, the on-screen keyboard previously caused the top part of the viewport (model/title area) to scroll out of view. This commit adds `interactive-widget=resizes-content` to the viewport meta tag, ensuring that the content resizes appropriately when the keyboard is displayed. The result is a more native app-like experience where the important top content remains visible.

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [ ] New feature (non-breaking change which adds functionality)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes do not introduce new warnings
- [ ] Local unit tests pass with my changes
