### PR TITLE
🌍 i18n: "Balance" Localization For ZhTraditional

### DIFF
--- a/client/src/localization/languages/ZhTraditional.ts
+++ b/client/src/localization/languages/ZhTraditional.ts
@@ -881,5 +881,5 @@ export default {
   com_ui_collapse_chat: '收合對話',
   com_endpoint_message_new: '訊息 {0}',
   com_ui_speech_while_submitting: '正在產生回應時無法送出語音',
-  com_nav_balance: '余額',
+  com_nav_balance: '餘額',
 };


### PR DESCRIPTION
## Summary
As a native speaker, Traditional Chinese still has some errors in the "Balance". The latest submission of Traditional Chinese "`余额`" is the same as Simplified Chinese "`余额`".

TL;DR:
The balance in ZhTraditional should be written as "`餘額`".

## Change Type
* Translation update

## Checklist
Please delete any irrelevant options.

* [x]  My code adheres to this project's style guidelines
* [x]  I have performed a self-review of my own code