### PR TITLE
🔧 fix: drop `reasoning_effort` for o1-preview/mini models

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1307,7 +1307,10 @@ ${convo}
       ) {
         delete modelOptions.stream;
         delete modelOptions.stop;
-      } else if (!this.isOmni && modelOptions.reasoning_effort != null) {
+      } else if (
+        (!this.isOmni || /^o1-(mini|preview)/i.test(modelOptions.model)) &&
+        modelOptions.reasoning_effort != null
+      ) {
         delete modelOptions.reasoning_effort;
       }
 


### PR DESCRIPTION
## Summary

Drop reasoning_effort for these models as it only supported for o1-2024-12-17 and above schema.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
