### PR TITLE
feat: block temporary email providers

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -62,6 +62,7 @@
     "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^7.4.1",
     "express-session": "^1.18.1",
+    "fakefilter": "^0.1.1110",
     "file-type": "^18.7.0",
     "firebase": "^11.0.2",
     "googleapis": "^126.0.1",

--- a/api/server/services/domains.js
+++ b/api/server/services/domains.js
@@ -16,13 +16,25 @@ async function isEmailDomainAllowed(email) {
   }
 
   const customConfig = await getCustomConfig();
-  if (!customConfig) {
+  // If no custom config or no registration restrictions, allow all domains
+  if (!customConfig || !customConfig.registration) {
     return true;
-  } else if (!customConfig?.registration?.allowedDomains) {
+  }
+  const { allowedDomains, disableFakeEmails } = customConfig.registration;
+  // If no domain restrictions are configured
+  if (!allowedDomains && !disableFakeEmails) {
     return true;
   }
 
-  return customConfig.registration.allowedDomains.includes(domain);
+  if (allowedDomains && !allowedDomains.includes(domain)) {
+    return false;
+  }
+
+  if (disableFakeEmails && isFakeDomain(domain)) {
+    return false;
+  }
+
+  return true;
 }
 
 /**

--- a/api/server/services/domains.spec.js
+++ b/api/server/services/domains.spec.js
@@ -57,6 +57,51 @@ describe('isEmailDomainAllowed', () => {
     const result = await isEmailDomainAllowed(email);
     expect(result).toBe(false);
   });
+
+  it('should return true if disableFakeEmails is false and domain is temporary', async () => {
+    const email = 'user@mailinator.com';
+    getCustomConfig.mockResolvedValue({
+      registration: {
+        disableFakeEmails: false,
+      },
+    });
+    const result = await isEmailDomainAllowed(email);
+    expect(result).toBe(true);
+  });
+
+  it('should return false if disableFakeEmails is true and domain is temporary', async () => {
+    const email = 'user@mailinator.com';
+    getCustomConfig.mockResolvedValue({
+      registration: {
+        disableFakeEmails: true,
+      },
+    });
+    const result = await isEmailDomainAllowed(email);
+    expect(result).toBe(false);
+  });
+
+  it('should return true if disableFakeEmails is true and domain is safe', async () => {
+    const email = 'user@domain1.com';
+    getCustomConfig.mockResolvedValue({
+      registration: {
+        disableFakeEmails: true,
+      },
+    });
+    const result = await isEmailDomainAllowed(email);
+    expect(result).toBe(true);
+  });
+
+  it('should return false if disableFakeEmails is true, domain is temporary and is included in allowedDomains', async () => {
+    const email = 'user@domain1.com';
+    getCustomConfig.mockResolvedValue({
+      registration: {
+        disableFakeEmails: true,
+        allowedDomains: ['mailinator.com'],
+      },
+    });
+    const result = await isEmailDomainAllowed(email);
+    expect(result).toBe(false);
+  });
 });
 
 describe('isActionDomainAllowed', () => {

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -70,6 +70,7 @@ interface:
 # Example Registration Object Structure (optional)
 registration:
   socialLogins: ['github', 'google', 'discord', 'openid', 'facebook', 'apple']
+  # disableFakeEmails: true # Disable fake/temporary emails
   # allowedDomains:
   # - "gmail.com"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "express-mongo-sanitize": "^2.2.0",
         "express-rate-limit": "^7.4.1",
         "express-session": "^1.18.1",
+        "fakefilter": "^0.1.1110",
         "file-type": "^18.7.0",
         "firebase": "^11.0.2",
         "googleapis": "^126.0.1",
@@ -19852,6 +19853,12 @@
       "engines": [
         "node >=0.6.0"
       ]
+    },
+    "node_modules/fakefilter": {
+      "version": "0.1.1110",
+      "resolved": "https://registry.npmjs.org/fakefilter/-/fakefilter-0.1.1110.tgz",
+      "integrity": "sha512-pVoY/yiLdscpI9JT98OcAjDtoR4k6rBZO4m96zQndYaHA7y8nUsGTCXEx5ZB0k2BfNpE54GMaE+5RofHZnR5DA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -526,6 +526,7 @@ export const configSchema = z.object({
   registration: z
     .object({
       socialLogins: z.array(z.string()).optional(),
+      disableFakeEmails: z.boolean().optional(),
       allowedDomains: z.array(z.string()).optional(),
     })
     .default({ socialLogins: defaultSocialLogins }),


### PR DESCRIPTION
## Summary

Checks the email address against a list of temporary emails to block new registrations that use temporary/fake email address (#4808)

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Added relevant unit tests.

Run `npm run test:api`

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
