### PR TITLE
Enhance Redis cluster support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -495,15 +495,22 @@ HELP_AND_FAQ_URL=https://librechat.ai
 # Google tag manager id
 #ANALYTICS_GTM_ID=user provided google tag manager id
 
+#===============#
+# REDIS Options #
+#===============#
+
+# REDIS_URI=10.10.10.10:6379
+# USE_REDIS=true
+
+# USE_REDIS_CLUSTER=true
+# REDIS_CA=/path/to/ca.crt
+
 #==================================================#
 #                      Others                      #
 #==================================================#
 #   You should leave the following commented out   #
 
 # NODE_ENV=
-
-# REDIS_URI=
-# USE_REDIS=
 
 # E2E_USER_EMAIL=
 # E2E_USER_PASSWORD=

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -1,18 +1,15 @@
 const KeyvRedis = require('@keyv/redis');
 const { isEnabled } = require('~/server/utils');
-<<<<<<< HEAD
 const logger = require('~/config/winston');
-=======
 const fs = require('fs');
 const ioredis = require('ioredis');
->>>>>>> 82717228 (feat: Enhance Redis support with cluster configuration and TLS options)
 
 const { REDIS_URI, USE_REDIS, USE_REDIS_CLUSTER, REDIS_CA } = process.env;
 
 let keyvRedis;
 
 function mapURI(uri) {
-  const regex = /^(?<scheme>[a-zA-Z]+):\/\/(?<user>[^:]*):?(?<password>[^@]*)?@?(?<host>[^:\/]+):?(?<port>\d+)?/;
+  const regex = /^(?:(?<scheme>\w+):\/\/)?(?:(?<user>[^:@]+)(?::(?<password>[^@]+))?@)?(?<host>[\w.-]+)(?::(?<port>\d{1,5}))?$/;
   const match = uri.match(regex);
 
   if (match) {

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -7,7 +7,7 @@ const ioredis = require('ioredis');
 const { REDIS_URI, USE_REDIS, USE_REDIS_CLUSTER, REDIS_CA, REDIS_KEY_PREFIX, REDIS_MAX_LISTENERS } = process.env;
 
 let keyvRedis;
-const redis_prefix = REDIS_KEY_PREFIX || "";
+const redis_prefix = REDIS_KEY_PREFIX || '';
 const redis_max_listeners = REDIS_MAX_LISTENERS || 10;
 
 function mapURI(uri) {

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -9,39 +9,40 @@ const { REDIS_URI, USE_REDIS, USE_REDIS_CLUSTER, REDIS_CA } = process.env;
 let keyvRedis;
 
 function mapURI(uri) {
-  const regex = /^(?:(?<scheme>\w+):\/\/)?(?:(?<user>[^:@]+)(?::(?<password>[^@]+))?@)?(?<host>[\w.-]+)(?::(?<port>\d{1,5}))?$/;
+  const regex =
+    /^(?:(?<scheme>\w+):\/\/)?(?:(?<user>[^:@]+)(?::(?<password>[^@]+))?@)?(?<host>[\w.-]+)(?::(?<port>\d{1,5}))?$/;
   const match = uri.match(regex);
 
   if (match) {
-      const { scheme, user, password, host, port } = match.groups;
+    const { scheme, user, password, host, port } = match.groups;
 
-      return {
-          scheme: scheme || 'none',
-          user: user || null,
-          password: password || null,
-          host: host || null,
-          port: port || null,
-      };
+    return {
+      scheme: scheme || 'none',
+      user: user || null,
+      password: password || null,
+      host: host || null,
+      port: port || null,
+    };
   } else {
-      // Handle cases without a scheme
-      const parts = uri.split(':');
-      if (parts.length === 2) {
-          return {
-              scheme: 'none',
-              user: null,
-              password: null,
-              host: parts[0],
-              port: parts[1],
-          };
-      }
-
+    // Handle cases without a scheme
+    const parts = uri.split(':');
+    if (parts.length === 2) {
       return {
-          scheme: 'none',
-          user: null,
-          password: null,
-          host: uri,
-          port: null,
+        scheme: 'none',
+        user: null,
+        password: null,
+        host: parts[0],
+        port: parts[1],
       };
+    }
+
+    return {
+      scheme: 'none',
+      user: null,
+      password: null,
+      host: uri,
+      port: null,
+    };
   }
 }
 

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -14,7 +14,6 @@ let keyvRedis;
 if (REDIS_URI && isEnabled(USE_REDIS)) {
   let redisOptions = null;
   let keyvOpts = { useRedisSets: false };
-  let keyvRedis;
   if (REDIS_CA) {
     const ca = fs.readFileSync(REDIS_CA);
     redisOptions = { tls: { ca } };

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -11,6 +11,43 @@ const { REDIS_URI, USE_REDIS, USE_REDIS_CLUSTER, REDIS_CA } = process.env;
 
 let keyvRedis;
 
+function mapURI(uri) {
+  const regex = /^(?<scheme>[a-zA-Z]+):\/\/(?<user>[^:]*):?(?<password>[^@]*)?@?(?<host>[^:\/]+):?(?<port>\d+)?/;
+  const match = uri.match(regex);
+
+  if (match) {
+      const { scheme, user, password, host, port } = match.groups;
+
+      return {
+          scheme: scheme || 'none',
+          user: user || null,
+          password: password || null,
+          host: host || null,
+          port: port || null,
+      };
+  } else {
+      // Handle cases without a scheme
+      const parts = uri.split(':');
+      if (parts.length === 2) {
+          return {
+              scheme: 'none',
+              user: null,
+              password: null,
+              host: parts[0],
+              port: parts[1],
+          };
+      }
+
+      return {
+          scheme: 'none',
+          user: null,
+          password: null,
+          host: uri,
+          port: null,
+      };
+  }
+}
+
 if (REDIS_URI && isEnabled(USE_REDIS)) {
   let redisOptions = null;
   let keyvOpts = { useRedisSets: false };
@@ -19,18 +56,21 @@ if (REDIS_URI && isEnabled(USE_REDIS)) {
     redisOptions = { tls: { ca } };
   }
   if (isEnabled(USE_REDIS_CLUSTER)) {
-    const hosts = REDIS_URI.split(',')
-      .map((host) => {
-        // TODO parse `host` input to handle connection strings
-        return { host: host };
-      });
+    const hosts = REDIS_URI.split(',').map((item) => {
+      var value = mapURI(item);
+
+      return {
+        host: value.host,
+        port: value.port
+      };
+    });
     const cluster = new ioredis.Cluster(hosts, { redisOptions });
     keyvRedis = new KeyvRedis(cluster, keyvOpts);
   } else {
     keyvRedis = new KeyvRedis(REDIS_URI, keyvOpts);
   }
   keyvRedis.on('error', (err) => logger.error('KeyvRedis connection error:', err));
-  keyvRedis.setMaxListeners(20);
+  keyvRedis.setMaxListeners(0);
   logger.info(
     '[Optional] Redis initialized. Note: Redis support is experimental. If you have issues, disable it. Cache needs to be flushed for values to refresh.',
   );

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -1,13 +1,31 @@
 const KeyvRedis = require('@keyv/redis');
 const { isEnabled } = require('~/server/utils');
+<<<<<<< HEAD
 const logger = require('~/config/winston');
+=======
+const fs = require('fs');
+const ioredis = require('ioredis');
+>>>>>>> 82717228 (feat: Enhance Redis support with cluster configuration and TLS options)
 
-const { REDIS_URI, USE_REDIS } = process.env;
+const { REDIS_URI, USE_REDIS, USE_REDIS_CLUSTER, REDIS_CA } = process.env;
 
 let keyvRedis;
 
 if (REDIS_URI && isEnabled(USE_REDIS)) {
-  keyvRedis = new KeyvRedis(REDIS_URI, { useRedisSets: false });
+  let redisOptions = null;
+  let keyvOpts = { useRedisSets: false };
+  let keyvRedis;
+  if (REDIS_CA) {
+    const ca = fs.readFileSync(REDIS_CA);
+    redisOptions = { tls: { ca } };
+  }
+  if (USE_REDIS_CLUSTER) {
+    const hosts = REDIS_URI.split(',').map((host) => {return { url: host }});
+    const cluster = new ioredis.Cluster(hosts, { redisOptions });
+    keyvRedis = new KeyvRedis(cluster, keyvOpts);
+  } else {
+    keyvRedis = new KeyvRedis(REDIS_URI, keyvOpts);
+  }
   keyvRedis.on('error', (err) => logger.error('KeyvRedis connection error:', err));
   keyvRedis.setMaxListeners(20);
   logger.info(

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -18,8 +18,12 @@ if (REDIS_URI && isEnabled(USE_REDIS)) {
     const ca = fs.readFileSync(REDIS_CA);
     redisOptions = { tls: { ca } };
   }
-  if (USE_REDIS_CLUSTER) {
-    const hosts = REDIS_URI.split(',').map((host) => {return { url: host }});
+  if (isEnabled(USE_REDIS_CLUSTER)) {
+    const hosts = REDIS_URI.split(',')
+      .map((host) => {
+        // TODO parse `host` input to handle connection strings
+        return { host: host };
+      });
     const cluster = new ioredis.Cluster(hosts, { redisOptions });
     keyvRedis = new KeyvRedis(cluster, keyvOpts);
   } else {

--- a/api/cache/keyvRedis.js
+++ b/api/cache/keyvRedis.js
@@ -59,7 +59,7 @@ if (REDIS_URI && isEnabled(USE_REDIS)) {
 
       return {
         host: value.host,
-        port: value.port
+        port: value.port,
       };
     });
     const cluster = new ioredis.Cluster(hosts, { redisOptions });


### PR DESCRIPTION
## Summary

This adds support for connecting to Redis clusters with TLS authentication, specifically enabling LibreChat to work with Google Memorystore Redis Cluster.
The changes are focused on the `api/cache/keyvRedis.js` file.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Config Changes

There are two new environment variables:

| Key | Type | Description | Example |
| -----------| --- | ----------- | ---------|
| USE_REDIS_CLUSTER | `boolean` | Instructs LibreChat to use the `Cluster` mode to connect to Redis | `true` |
| REDIS_CA | `string` | If set, instruct LibreChat to use TLS with server authentication, using the file set in this variable as a PEM-encoded certificate authority. | `/memorystore/ca` |
| REDIS_KEY_PREFIX | `string` | Default is empty string. If set, all keys will automatically be set with a prefix. It is useful, for example, when more than one different instance of LibreChat with REDIS connection is present in the same environment (ie.: Staging, Stable, ...) | `librechat-staging:` |
| REDIS_MAX_LISTENERS | `number` | Maximum number of event listeners allowed for the Redis client instance. It helps prevent memory leaks by limiting event listeners. If set to 0 (zero) it will be considered limitless. Defaults to 10 if not specified. | `10` |

## Testing

Regex testing:
![image](https://github.com/user-attachments/assets/d762bc6f-c0e4-4e44-b639-fc2616a62fc4)

Started a node pod in the cluster via `kubectl run --rm -it node-18 --image node:18-bullseye` (should have used node-20 but that was what the developer-defined in `.devcontainer/Dockerfile` so I went with it.

Then attached to that running pod via vscode: https://code.visualstudio.com/docs/devcontainers/attach-container 

Checked out the code, defined my `.env` file (using the deployment env vars where required, like MongoDB or pointing to the RAG API), and used my very own vscode debug file to check my work.

I was able to validate that the object is correctly recognized as a Cluster after creation:
![image](https://github.com/user-attachments/assets/9c65ddaf-187d-4756-911c-d60ffb0ca2ef)

We see the TLS definition there:
![image](https://github.com/user-attachments/assets/0ca3b430-37e1-4c40-a598-825c1322fcd8)

After letting the program run for a while and breaking, for instance, in here:
![image](https://github.com/user-attachments/assets/fdfe3b35-1e9f-44ba-b863-e4c4e0c84a70)

I can now see that the Redis client is in the `read` status. 
![image](https://github.com/user-attachments/assets/acaa2a29-2aa2-4904-96e4-0b91eeef2659)

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings