### PR TITLE
🐞 fix: Handle Google social login with missing last name

### DIFF
--- a/api/strategies/googleStrategy.js
+++ b/api/strategies/googleStrategy.js
@@ -6,7 +6,7 @@ const getProfileDetails = ({ profile }) => ({
   id: profile.id,
   avatarUrl: profile.photos[0].value,
   username: profile.name.givenName,
-  name: `${profile.name.givenName} ${profile.name.familyName}`,
+  name: `${profile.name.givenName}${profile.name.familyName ? ` ${profile.name.familyName}` : ''}`,
   emailVerified: profile.emails[0].verified,
 });
 


### PR DESCRIPTION
## Summary

Social login with Google was previously displaying 'undefined' when a user's last name was empty or not provided.

<img width="1511" alt="GoogleAccountLastName_undefined" src="https://github.com/user-attachments/assets/56d3f2ed-ed38-43e0-821e-d2de20f2851c" />

Changes:
- Conditionally render last name only if it exists
- Prevent displaying 'undefined' when last name is missing

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- To verify this, one should use Google account without last name for account registration through social login
- After succesful registration, verify that profile name doesn't include 'undefined' as last name (bottom left corner) 

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
