### PR TITLE
🐞 fix: Add Null Checks for BaseURL in Agent Config

### DIFF
--- a/api/server/controllers/agents/run.js
+++ b/api/server/controllers/agents/run.js
@@ -45,7 +45,7 @@ async function createRun({
 
   /** @type {'reasoning_content' | 'reasoning'} */
   let reasoningKey;
-  if (llmConfig.configuration?.baseURL.includes(KnownEndpoints.openrouter)) {
+  if (llmConfig.configuration?.baseURL?.includes(KnownEndpoints.openrouter)) {
     reasoningKey = 'reasoning';
   }
   if (/o1(?!-(?:mini|preview)).*$/.test(llmConfig.model)) {

--- a/api/server/services/Endpoints/openAI/llm.js
+++ b/api/server/services/Endpoints/openAI/llm.js
@@ -58,7 +58,7 @@ function getLLMConfig(apiKey, options = {}) {
 
   /** @type {OpenAIClientOptions['configuration']} */
   const configOptions = {};
-  if (useOpenRouter || reverseProxyUrl.includes(KnownEndpoints.openrouter)) {
+  if (useOpenRouter || (reverseProxyUrl && reverseProxyUrl.includes(KnownEndpoints.openrouter))) {
     llmConfig.include_reasoning = true;
     configOptions.baseURL = reverseProxyUrl;
     configOptions.defaultHeaders = Object.assign(


### PR DESCRIPTION
## Summary:  

I addressed a runtime error encountered in issue #5904 by adding null checks to the LLM configuration. This ensures that the baseURL and reverseProxyUrl are verified before invoking string methods.

- Added an optional chaining check for baseURL in run.js to safely call the includes method
- Bug introduced in #5904 
- Updated the condition in llm.js by verifying that reverseProxyUrl exists before using includes. 

Closes #5907