### PR TITLE
🐛 fix: RAG Results Sorted By Distance

### DIFF
--- a/api/app/clients/tools/util/fileSearch.js
+++ b/api/app/clients/tools/util/fileSearch.js
@@ -106,19 +106,21 @@ const createFileSearchTool = async ({ req, files, entity_id }) => {
 
       const formattedResults = validResults
         .flatMap((result) =>
-          result.data.map(([docInfo, relevanceScore]) => ({
+          result.data.map(([docInfo, distance]) => ({
             filename: docInfo.metadata.source.split('/').pop(),
             content: docInfo.page_content,
-            relevanceScore,
+            distance,
           })),
         )
-        .sort((a, b) => b.relevanceScore - a.relevanceScore)
-        .slice(0, 5);
+        // TODO: results should be sorted by relevance, not distance
+        .sort((a, b) => a.distance - b.distance)
+        // TODO: make this configurable
+        .slice(0, 10);
 
       const formattedString = formattedResults
         .map(
           (result) =>
-            `File: ${result.filename}\nRelevance: ${result.relevanceScore.toFixed(4)}\nContent: ${
+            `File: ${result.filename}\nRelevance: ${1.0 - result.distance.toFixed(4)}\nContent: ${
               result.content
             }\n`,
         )

--- a/api/server/services/Files/Local/crud.js
+++ b/api/server/services/Files/Local/crud.js
@@ -176,6 +176,17 @@ const isValidPath = (req, base, subfolder, filepath) => {
 };
 
 /**
+ * @param {string} filepath
+ */
+const unlinkFile = async (filepath) => {
+  try {
+    await fs.promises.unlink(filepath);
+  } catch (error) {
+    logger.error('Error deleting file:', error);
+  }
+};
+
+/**
  * Deletes a file from the filesystem. This function takes a file object, constructs the full path, and
  * verifies the path's validity before deleting the file. If the path is invalid, an error is thrown.
  *
@@ -217,7 +228,7 @@ const deleteLocalFile = async (req, file) => {
       throw new Error(`Invalid file path: ${file.filepath}`);
     }
 
-    await fs.promises.unlink(filepath);
+    await unlinkFile(filepath);
     return;
   }
 
@@ -233,7 +244,7 @@ const deleteLocalFile = async (req, file) => {
     throw new Error('Invalid file path');
   }
 
-  await fs.promises.unlink(filepath);
+  await unlinkFile(filepath);
 };
 
 /**


### PR DESCRIPTION
## Summary

- Updated the mapping in fileSearch.js to extract “distance” from the result data instead of “relevanceScore.”
     - TODO: Retriever method used in RAG API is incorrectly returning cosine distance
- Changed the sorting logic to order results by ascending distance and increased the slice limit from 5 to 10.
- Revised the output format to display relevance as (1.0 – distance), ensuring that lower distances reflect higher relevance.
- Marked areas with TODO comments for future configurability and improved relevance-based sorting.

### Other Changes

- Caught any errors from `fs.promises.unlink` to allow local file deletions if file is not found

Testing:
- Ran local unit tests and verified that file search results are correctly sorted by distance.
- Manually tested the output formatting to ensure the displayed relevance values are computed as expected.

Checklist:
- [x] My code adheres to this project's style guidelines.
- [x] I performed a self-review of my own code.
- [x] I commented in any complex areas of my code.
- [x] My changes do not introduce new warnings.
- [x] Local unit tests pass with my changes.