### PR TITLE
👐 refactor: Agents Accessibility and Gemini Error Handling

### DIFF
--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -641,7 +641,7 @@ class GoogleClient extends BaseClient {
     let error;
     try {
       if (!EXCLUDED_GENAI_MODELS.test(modelName) && !this.project_id) {
-        /** @type {GenAI} */
+        /** @type {GenerativeModel} */
         const client = this.client;
         /** @type {GenerateContentRequest} */
         const requestOptions = {
@@ -665,7 +665,17 @@ class GoogleClient extends BaseClient {
         /** @type {GenAIUsageMetadata} */
         let usageMetadata;
 
-        const result = await client.generateContentStream(requestOptions);
+        abortController.signal.addEventListener(
+          'abort',
+          () => {
+            logger.warn('[GoogleClient] Request was aborted', abortController.signal.reason);
+          },
+          { once: true },
+        );
+
+        const result = await client.generateContentStream(requestOptions, {
+          signal: abortController.signal,
+        });
         for await (const chunk of result.stream) {
           usageMetadata = !usageMetadata
             ? chunk?.usageMetadata

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -146,6 +146,18 @@ process.on('uncaughtException', (err) => {
     logger.error('There was an uncaught error:', err);
   }
 
+  if (err.message.includes('abort')) {
+    logger.warn('There was an uncatchable AbortController error.');
+    return;
+  }
+
+  if (err.message.includes('GoogleGenerativeAI')) {
+    logger.warn(
+      '\n\n`GoogleGenerativeAI` errors cannot be caught due to an upstream issue, see: https://github.com/google-gemini/generative-ai-js/issues/303',
+    );
+    return;
+  }
+
   if (err.message.includes('fetch failed')) {
     if (messageCount === 0) {
       logger.warn('Meilisearch error, search will be disabled');

--- a/client/src/components/SidePanel/AgentSwitcher.tsx
+++ b/client/src/components/SidePanel/AgentSwitcher.tsx
@@ -74,6 +74,7 @@ export default function AgentSwitcher({ isCollapsed }: SwitcherProps) {
       ariaLabel={'agent'}
       setValue={onSelect}
       items={agentOptions}
+      iconClassName="assistant-item"
       SelectIcon={
         <Icon
           isCreatedByUser={false}

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -1,3 +1,4 @@
+import { Plus } from 'lucide-react';
 import React, { useMemo, useCallback } from 'react';
 import { useGetModelsQuery } from 'librechat-data-provider/react-query';
 import { Controller, useWatch, useForm, FormProvider } from 'react-hook-form';
@@ -212,33 +213,53 @@ export default function AgentPanel({
         aria-label="Agent configuration form"
       >
         <div className="mt-2 flex w-full flex-wrap gap-2">
-          <Controller
-            name="agent"
-            control={control}
-            render={({ field }) => (
-              <AgentSelect
-                reset={reset}
-                value={field.value}
-                agentQuery={agentQuery}
-                setCurrentAgentId={setCurrentAgentId}
-                selectedAgentId={current_agent_id ?? null}
-                createMutation={create}
-              />
-            )}
-          />
-          {/* Select Button */}
+          <div className="w-full">
+            <Controller
+              name="agent"
+              control={control}
+              render={({ field }) => (
+                <AgentSelect
+                  reset={reset}
+                  value={field.value}
+                  agentQuery={agentQuery}
+                  setCurrentAgentId={setCurrentAgentId}
+                  selectedAgentId={current_agent_id ?? null}
+                  createMutation={create}
+                />
+              )}
+            />
+          </div>
+          {/* Create + Select Button */}
           {agent_id && (
-            <Button
-              variant="submit"
-              disabled={!agent_id}
-              onClick={(e) => {
-                e.preventDefault();
-                handleSelectAgent();
-              }}
-              aria-label="Select agent"
-            >
-              {localize('com_ui_select')}
-            </Button>
+            <div className="flex w-full gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full justify-center"
+                onClick={() => {
+                  reset(defaultAgentFormValues);
+                  setCurrentAgentId(undefined);
+                }}
+              >
+                <Plus className="mr-1 h-4 w-4" />
+                {localize('com_ui_create') +
+                  ' ' +
+                  localize('com_ui_new') +
+                  ' ' +
+                  localize('com_ui_agent')}
+              </Button>
+              <Button
+                variant="submit"
+                disabled={!agent_id}
+                onClick={(e) => {
+                  e.preventDefault();
+                  handleSelectAgent();
+                }}
+                aria-label={localize('com_ui_select') + ' ' + localize('com_ui_agent')}
+              >
+                {localize('com_ui_select')}
+              </Button>
+            </div>
           )}
         </div>
         {!canEditAgent && (

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -212,7 +212,7 @@ export default function AgentPanel({
         className="scrollbar-gutter-stable h-auto w-full flex-shrink-0 overflow-x-hidden"
         aria-label="Agent configuration form"
       >
-        <div className="mt-2 flex w-full flex-wrap gap-2">
+        <div className="mx-1 mt-2 flex w-full flex-wrap gap-2">
           <div className="w-full">
             <Controller
               name="agent"

--- a/client/src/components/SidePanel/Agents/AgentPanelSkeleton.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanelSkeleton.tsx
@@ -4,7 +4,7 @@ import { Skeleton } from '~/components/ui';
 export default function AgentPanelSkeleton() {
   return (
     <div className="scrollbar-gutter-stable h-auto w-full flex-shrink-0 overflow-x-hidden">
-      <div className="mt-2 flex w-full flex-wrap gap-2">
+      <div className="mx-1 mt-2 flex w-full flex-wrap gap-2">
         {/* Agent Select Dropdown */}
         <div className="w-full">
           <Skeleton className="h-[40px] w-full rounded-md" />

--- a/client/src/components/SidePanel/Agents/AgentPanelSkeleton.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanelSkeleton.tsx
@@ -4,10 +4,16 @@ import { Skeleton } from '~/components/ui';
 export default function AgentPanelSkeleton() {
   return (
     <div className="scrollbar-gutter-stable h-auto w-full flex-shrink-0 overflow-x-hidden">
-      {/* Agent Select and Button */}
-      <div className="mt-1 flex w-full gap-2">
-        <Skeleton className="h-[40px] w-4/5 rounded-lg" />
-        <Skeleton className="h-[40px] w-1/5 rounded-lg" />
+      <div className="mt-2 flex w-full flex-wrap gap-2">
+        {/* Agent Select Dropdown */}
+        <div className="w-full">
+          <Skeleton className="h-[40px] w-full rounded-md" />
+        </div>
+        {/* Create and Select Buttons */}
+        <div className="flex w-full gap-2">
+          <Skeleton className="h-[40px] w-3/4 rounded-md" /> {/* Create Button */}
+          <Skeleton className="h-[40px] w-1/4 rounded-md" /> {/* Select Button */}
+        </div>
       </div>
 
       <div className="h-auto bg-white px-4 pb-8 pt-3 dark:bg-transparent">

--- a/client/src/components/SidePanel/Agents/AgentSelect.tsx
+++ b/client/src/components/SidePanel/Agents/AgentSelect.tsx
@@ -11,7 +11,7 @@ import ControlCombobox from '~/components/ui/ControlCombobox';
 import { useLocalize } from '~/hooks';
 
 const keys = new Set(Object.keys(defaultAgentFormValues));
-const SELECT_ID = 'agent-select';
+const SELECT_ID = 'agent-builder-combobox';
 
 export default function AgentSelect({
   reset,

--- a/client/src/components/SidePanel/Agents/AgentSelect.tsx
+++ b/client/src/components/SidePanel/Agents/AgentSelect.tsx
@@ -1,13 +1,13 @@
-import { Plus, EarthIcon } from 'lucide-react';
+import { EarthIcon } from 'lucide-react';
 import { useCallback, useEffect, useRef } from 'react';
 import { AgentCapabilities, defaultAgentFormValues } from 'librechat-data-provider';
 import type { UseMutationResult, QueryObserverResult } from '@tanstack/react-query';
 import type { Agent, AgentCreateParams } from 'librechat-data-provider';
 import type { UseFormReset } from 'react-hook-form';
 import type { TAgentCapabilities, AgentForm, TAgentOption } from '~/common';
-import { cn, createDropdownSetter, createProviderOption, processAgentOption } from '~/utils';
 import { useListAgentsQuery, useGetStartupConfig } from '~/data-provider';
-import SelectDropDown from '~/components/ui/SelectDropDown';
+import { cn, createProviderOption, processAgentOption } from '~/utils';
+import ControlCombobox from '~/components/ui/ControlCombobox';
 import { useLocalize } from '~/hooks';
 
 const keys = new Set(Object.keys(defaultAgentFormValues));
@@ -152,51 +152,35 @@ export default function AgentSelect({
   }, [selectedAgentId, agents, onSelect]);
 
   const createAgent = localize('com_ui_create') + ' ' + localize('com_ui_agent');
-  const hasAgentValue = !!(typeof currentAgentValue === 'object'
-    ? currentAgentValue.value != null && currentAgentValue.value !== ''
-    : typeof currentAgentValue !== 'undefined');
 
   return (
-    <SelectDropDown
-      value={!hasAgentValue ? createAgent : (currentAgentValue as TAgentOption)}
-      setValue={createDropdownSetter(onSelect)}
-      availableValues={
-        agents ?? [
+    <ControlCombobox
+      containerClassName="px-0"
+      selectedValue={(currentAgentValue?.value ?? '') + ''}
+      displayValue={currentAgentValue?.label ?? ''}
+      selectPlaceholder={createAgent}
+      iconSide="right"
+      searchPlaceholder={localize('com_agents_search_name')}
+      SelectIcon={currentAgentValue?.icon}
+      setValue={onSelect}
+      items={
+        agents?.map((agent) => ({
+          label: agent.name ?? '',
+          value: agent.id ?? '',
+          icon: agent.icon,
+        })) ?? [
           {
             label: 'Loading...',
             value: '',
           },
         ]
       }
-      iconSide="left"
-      optionIconSide="right"
-      showAbove={false}
-      showLabel={false}
-      emptyTitle={true}
-      showOptionIcon={true}
-      containerClassName="flex-grow"
-      searchClassName="dark:from-gray-850"
-      searchPlaceholder={localize('com_agents_search_name')}
-      optionsClass="hover:bg-gray-20/50 dark:border-gray-700"
-      optionsListClass="rounded-lg shadow-lg dark:bg-gray-850 dark:border-gray-700 dark:last:border"
-      currentValueClass={cn(
-        'text-md font-semibold text-gray-900 dark:text-white',
-        hasAgentValue ? 'text-gray-500' : '',
-      )}
       className={cn(
-        'rounded-md dark:border-gray-700 dark:bg-gray-850',
-        'z-50 flex h-[40px] w-full flex-none items-center justify-center truncate px-4 hover:cursor-pointer hover:border-green-500 focus:border-gray-400',
+        'z-50 flex h-[40px] w-full flex-none items-center justify-center truncate rounded-md bg-transparent font-bold',
       )}
-      renderOption={() => (
-        <span className="flex items-center gap-1.5 truncate">
-          <span className="absolute inset-y-0 left-0 flex items-center pl-2 text-gray-800 dark:text-gray-100">
-            <Plus className="w-[16px]" />
-          </span>
-          <span className={cn('ml-4 flex h-6 items-center gap-1 text-gray-800 dark:text-gray-100')}>
-            {createAgent}
-          </span>
-        </span>
-      )}
+      ariaLabel={localize('com_ui_agent')}
+      isCollapsed={false}
+      showCarat={true}
     />
   );
 }

--- a/client/src/components/SidePanel/Agents/AgentSelect.tsx
+++ b/client/src/components/SidePanel/Agents/AgentSelect.tsx
@@ -11,6 +11,7 @@ import ControlCombobox from '~/components/ui/ControlCombobox';
 import { useLocalize } from '~/hooks';
 
 const keys = new Set(Object.keys(defaultAgentFormValues));
+const SELECT_ID = 'agent-select';
 
 export default function AgentSelect({
   reset,
@@ -120,6 +121,9 @@ export default function AgentSelect({
       }
 
       resetAgentForm(agent);
+      setTimeout(() => {
+        document.getElementById(SELECT_ID)?.focus();
+      }, 5);
     },
     [agents, createMutation, setCurrentAgentId, agentQuery.data, resetAgentForm, reset],
   );
@@ -155,6 +159,7 @@ export default function AgentSelect({
 
   return (
     <ControlCombobox
+      selectId={SELECT_ID}
       containerClassName="px-0"
       selectedValue={(currentAgentValue?.value ?? '') + ''}
       displayValue={currentAgentValue?.label ?? ''}

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -1,14 +1,14 @@
 import React, { useMemo, useEffect } from 'react';
 import { ChevronLeft, RotateCcw } from 'lucide-react';
-import { getSettingsKeys } from 'librechat-data-provider';
 import { useFormContext, useWatch, Controller } from 'react-hook-form';
+import { getSettingsKeys, alternateName } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { AgentForm, AgentModelPanelProps, StringOption } from '~/common';
 import { componentMapping } from '~/components/SidePanel/Parameters/components';
 import { agentSettings } from '~/components/SidePanel/Parameters/settings';
-import { getEndpointField, cn, cardStyle } from '~/utils';
+import ControlCombobox from '~/components/ui/ControlCombobox';
 import { useGetEndpointsQuery } from '~/data-provider';
-import { SelectDropDown } from '~/components/ui';
+import { getEndpointField, cn } from '~/utils';
 import { useLocalize } from '~/hooks';
 import { Panel } from '~/common';
 
@@ -109,37 +109,41 @@ export default function Parameters({
             name="provider"
             control={control}
             rules={{ required: true, minLength: 1 }}
-            render={({ field, fieldState: { error } }) => (
-              <>
-                <SelectDropDown
-                  id="provider"
-                  aria-labelledby="provider-label"
-                  aria-label={localize('com_ui_provider')}
-                  aria-required="true"
-                  emptyTitle={true}
-                  value={field.value ?? ''}
-                  title={localize('com_ui_provider')}
-                  placeholder={localize('com_ui_select_provider')}
-                  searchPlaceholder={localize('com_ui_select_search_provider')}
-                  setValue={field.onChange}
-                  availableValues={providers}
-                  showAbove={false}
-                  showLabel={false}
-                  className={cn(
-                    cardStyle,
-                    'flex h-9 w-full flex-none items-center justify-center border-none px-4 hover:cursor-pointer',
-                    (field.value === undefined || field.value === '') &&
-                      'border-2 border-yellow-400',
+            render={({ field, fieldState: { error } }) => {
+              const value =
+                typeof field.value === 'string'
+                  ? field.value
+                  : ((field.value as StringOption)?.value ?? '');
+              const display =
+                typeof field.value === 'string'
+                  ? field.value
+                  : ((field.value as StringOption)?.label ?? '');
+
+              return (
+                <>
+                  <ControlCombobox
+                    selectedValue={value}
+                    displayValue={alternateName[display] ?? display}
+                    selectPlaceholder={localize('com_ui_select_provider')}
+                    searchPlaceholder={localize('com_ui_select_search_provider')}
+                    setValue={field.onChange}
+                    items={providers.map((provider) => ({
+                      label: typeof provider === 'string' ? provider : provider.label,
+                      value: typeof provider === 'string' ? provider : provider.value,
+                    }))}
+                    className={cn(error ? 'border-2 border-red-500' : '')}
+                    ariaLabel={localize('com_ui_provider')}
+                    isCollapsed={false}
+                    showCarat={true}
+                  />
+                  {error && (
+                    <span className="model-panel-error text-sm text-red-500 transition duration-300 ease-in-out">
+                      {localize('com_ui_field_required')}
+                    </span>
                   )}
-                  containerClassName={cn('rounded-md', error ? 'border-red-500 border-2' : '')}
-                />
-                {error && (
-                  <span className="model-panel-error text-sm text-red-500 transition duration-300 ease-in-out">
-                    {localize('com_ui_field_required')}
-                  </span>
-                )}
-              </>
-            )}
+                </>
+              );
+            }}
           />
         </div>
         {/* Model */}
@@ -158,39 +162,36 @@ export default function Parameters({
             name="model"
             control={control}
             rules={{ required: true, minLength: 1 }}
-            render={({ field, fieldState: { error } }) => (
-              <>
-                <SelectDropDown
-                  id="model"
-                  aria-labelledby="model-label"
-                  aria-label={localize('com_ui_model')}
-                  aria-required="true"
-                  emptyTitle={true}
-                  placeholder={
-                    provider
-                      ? localize('com_ui_select_model')
-                      : localize('com_ui_select_provider_first')
-                  }
-                  value={field.value}
-                  setValue={field.onChange}
-                  availableValues={models}
-                  showAbove={false}
-                  showLabel={false}
-                  disabled={!provider}
-                  className={cn(
-                    cardStyle,
-                    'flex h-[40px] w-full flex-none items-center justify-center border-none px-4',
-                    !provider ? 'cursor-not-allowed bg-gray-200' : 'hover:cursor-pointer',
+            render={({ field, fieldState: { error } }) => {
+              return (
+                <>
+                  <ControlCombobox
+                    selectedValue={field.value || ''}
+                    selectPlaceholder={
+                      provider
+                        ? localize('com_ui_select_model')
+                        : localize('com_ui_select_provider_first')
+                    }
+                    searchPlaceholder={localize('com_ui_select_model')}
+                    setValue={field.onChange}
+                    items={models.map((model) => ({
+                      label: model,
+                      value: model,
+                    }))}
+                    disabled={!provider}
+                    className={cn('disabled:opacity-50', error ? 'border-2 border-red-500' : '')}
+                    ariaLabel={localize('com_ui_model')}
+                    isCollapsed={false}
+                    showCarat={true}
+                  />
+                  {provider && error && (
+                    <span className="text-sm text-red-500 transition duration-300 ease-in-out">
+                      {localize('com_ui_field_required')}
+                    </span>
                   )}
-                  containerClassName={cn('rounded-md', error ? 'border-red-500 border-2' : '')}
-                />
-                {provider && error && (
-                  <span className="text-sm text-red-500 transition duration-300 ease-in-out">
-                    {localize('com_ui_field_required')}
-                  </span>
-                )}
-              </>
-            )}
+                </>
+              );
+            }}
           />
         </div>
       </div>

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -78,8 +78,8 @@ export default function Parameters({
 
   return (
     <div className="scrollbar-gutter-stable h-full min-h-[50vh] overflow-auto pb-12 text-sm">
-      <div className="model-panel relative flex flex-col items-center px-16 py-6 text-center">
-        <div className="absolute left-0 top-6">
+      <div className="model-panel relative flex flex-col items-center px-16 py-4 text-center">
+        <div className="absolute left-0 top-4">
           <button
             type="button"
             className="btn btn-neutral relative"

--- a/client/src/components/SidePanel/AssistantSwitcher.tsx
+++ b/client/src/components/SidePanel/AssistantSwitcher.tsx
@@ -78,6 +78,7 @@ export default function AssistantSwitcher({ isCollapsed }: SwitcherProps) {
       ariaLabel={'assistant'}
       setValue={onSelect}
       items={assistantOptions}
+      iconClassName="assistant-item"
       SelectIcon={
         <Icon
           isCreatedByUser={false}

--- a/client/src/components/ui/ControlCombobox.tsx
+++ b/client/src/components/ui/ControlCombobox.tsx
@@ -16,9 +16,11 @@ interface ControlComboboxProps {
   selectPlaceholder?: string;
   isCollapsed: boolean;
   SelectIcon?: React.ReactNode;
+  containerClassName?: string;
   showCarat?: boolean;
   className?: string;
   disabled?: boolean;
+  iconSide?: 'left' | 'right';
 }
 
 const ROW_HEIGHT = 36;
@@ -31,11 +33,13 @@ function ControlCombobox({
   ariaLabel,
   searchPlaceholder,
   selectPlaceholder,
+  containerClassName,
   isCollapsed,
   SelectIcon,
   showCarat,
   className,
   disabled,
+  iconSide = 'left',
 }: ControlComboboxProps) {
   const [searchValue, setSearchValue] = useState('');
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -77,7 +81,7 @@ function ControlCombobox({
   }, [isCollapsed]);
 
   return (
-    <div className="flex w-full items-center justify-center px-1">
+    <div className={cn('flex w-full items-center justify-center px-1', containerClassName)}>
       <Ariakit.SelectLabel store={select} className="sr-only">
         {ariaLabel}
       </Ariakit.SelectLabel>
@@ -93,7 +97,7 @@ function ControlCombobox({
           className,
         )}
       >
-        {SelectIcon != null && (
+        {SelectIcon != null && iconSide === 'left' && (
           <div className="assistant-item flex h-5 w-5 items-center justify-center overflow-hidden rounded-full">
             {SelectIcon}
           </div>
@@ -105,6 +109,11 @@ function ControlCombobox({
                 ? displayValue || selectPlaceholder
                 : selectedValue || selectPlaceholder}
             </span>
+            {SelectIcon != null && iconSide === 'right' && (
+              <div className="assistant-item flex h-5 w-5 items-center justify-center overflow-hidden rounded-full">
+                {SelectIcon}
+              </div>
+            )}
             {showCarat && <ChevronDown className="h-4 w-4 text-text-secondary" />}
           </>
         )}
@@ -141,12 +150,17 @@ function ControlCombobox({
                   )}
                   render={<Ariakit.SelectItem value={value} />}
                 >
-                  {icon != null && (
+                  {icon != null && iconSide === 'left' && (
                     <div className="assistant-item mr-2 flex h-5 w-5 items-center justify-center overflow-hidden rounded-full">
                       {icon}
                     </div>
                   )}
                   <span className="flex-grow truncate text-left">{label}</span>
+                  {icon != null && iconSide === 'right' && (
+                    <div className="assistant-item mr-2 flex h-5 w-5 items-center justify-center overflow-hidden rounded-full">
+                      {icon}
+                    </div>
+                  )}
                 </Ariakit.ComboboxItem>
               )}
             </SelectRenderer>

--- a/client/src/components/ui/ControlCombobox.tsx
+++ b/client/src/components/ui/ControlCombobox.tsx
@@ -22,6 +22,7 @@ interface ControlComboboxProps {
   className?: string;
   disabled?: boolean;
   iconSide?: 'left' | 'right';
+  selectId?: string;
 }
 
 const ROW_HEIGHT = 36;
@@ -42,6 +43,7 @@ function ControlCombobox({
   disabled,
   iconClassName,
   iconSide = 'left',
+  selectId,
 }: ControlComboboxProps) {
   const [searchValue, setSearchValue] = useState('');
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -99,6 +101,7 @@ function ControlCombobox({
       <Ariakit.Select
         ref={buttonRef}
         store={select}
+        id={selectId}
         disabled={disabled}
         className={cn(
           'flex items-center justify-center gap-2 rounded-full bg-surface-secondary',

--- a/client/src/components/ui/ControlCombobox.tsx
+++ b/client/src/components/ui/ControlCombobox.tsx
@@ -17,6 +17,7 @@ interface ControlComboboxProps {
   isCollapsed: boolean;
   SelectIcon?: React.ReactNode;
   containerClassName?: string;
+  iconClassName?: string;
   showCarat?: boolean;
   className?: string;
   disabled?: boolean;
@@ -39,6 +40,7 @@ function ControlCombobox({
   showCarat,
   className,
   disabled,
+  iconClassName,
   iconSide = 'left',
 }: ControlComboboxProps) {
   const [searchValue, setSearchValue] = useState('');
@@ -80,6 +82,15 @@ function ControlCombobox({
     }
   }, [isCollapsed]);
 
+  const selectIconClassName = cn(
+    'flex h-5 w-5 items-center justify-center overflow-hidden rounded-full',
+    iconClassName,
+  );
+  const optionIconClassName = cn(
+    'mr-2 flex h-5 w-5 items-center justify-center overflow-hidden rounded-full',
+    iconClassName,
+  );
+
   return (
     <div className={cn('flex w-full items-center justify-center px-1', containerClassName)}>
       <Ariakit.SelectLabel store={select} className="sr-only">
@@ -98,9 +109,7 @@ function ControlCombobox({
         )}
       >
         {SelectIcon != null && iconSide === 'left' && (
-          <div className="assistant-item flex h-5 w-5 items-center justify-center overflow-hidden rounded-full">
-            {SelectIcon}
-          </div>
+          <div className={selectIconClassName}>{SelectIcon}</div>
         )}
         {!isCollapsed && (
           <>
@@ -110,9 +119,7 @@ function ControlCombobox({
                 : selectedValue || selectPlaceholder}
             </span>
             {SelectIcon != null && iconSide === 'right' && (
-              <div className="assistant-item flex h-5 w-5 items-center justify-center overflow-hidden rounded-full">
-                {SelectIcon}
-              </div>
+              <div className={selectIconClassName}>{SelectIcon}</div>
             )}
             {showCarat && <ChevronDown className="h-4 w-4 text-text-secondary" />}
           </>
@@ -151,15 +158,11 @@ function ControlCombobox({
                   render={<Ariakit.SelectItem value={value} />}
                 >
                   {icon != null && iconSide === 'left' && (
-                    <div className="assistant-item mr-2 flex h-5 w-5 items-center justify-center overflow-hidden rounded-full">
-                      {icon}
-                    </div>
+                    <div className={optionIconClassName}>{icon}</div>
                   )}
                   <span className="flex-grow truncate text-left">{label}</span>
                   {icon != null && iconSide === 'right' && (
-                    <div className="assistant-item mr-2 flex h-5 w-5 items-center justify-center overflow-hidden rounded-full">
-                      {icon}
-                    </div>
+                    <div className={optionIconClassName}>{icon}</div>
                   )}
                 </Ariakit.ComboboxItem>
               )}

--- a/client/src/components/ui/ControlCombobox.tsx
+++ b/client/src/components/ui/ControlCombobox.tsx
@@ -1,6 +1,6 @@
-import { Search } from 'lucide-react';
 import * as Ariakit from '@ariakit/react';
 import { matchSorter } from 'match-sorter';
+import { Search, ChevronDown } from 'lucide-react';
 import { useMemo, useState, useRef, memo, useEffect } from 'react';
 import { SelectRenderer } from '@ariakit/react-core/select/select-renderer';
 import type { OptionWithIcon } from '~/common';
@@ -16,6 +16,9 @@ interface ControlComboboxProps {
   selectPlaceholder?: string;
   isCollapsed: boolean;
   SelectIcon?: React.ReactNode;
+  showCarat?: boolean;
+  className?: string;
+  disabled?: boolean;
 }
 
 const ROW_HEIGHT = 36;
@@ -30,6 +33,9 @@ function ControlCombobox({
   selectPlaceholder,
   isCollapsed,
   SelectIcon,
+  showCarat,
+  className,
+  disabled,
 }: ControlComboboxProps) {
   const [searchValue, setSearchValue] = useState('');
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -78,11 +84,13 @@ function ControlCombobox({
       <Ariakit.Select
         ref={buttonRef}
         store={select}
+        disabled={disabled}
         className={cn(
           'flex items-center justify-center gap-2 rounded-full bg-surface-secondary',
           'text-text-primary hover:bg-surface-tertiary',
           'border border-border-light',
           isCollapsed ? 'h-10 w-10' : 'h-10 w-full rounded-md px-3 py-2 text-sm',
+          className,
         )}
       >
         {SelectIcon != null && (
@@ -91,7 +99,14 @@ function ControlCombobox({
           </div>
         )}
         {!isCollapsed && (
-          <span className="flex-grow truncate text-left">{displayValue ?? selectPlaceholder}</span>
+          <>
+            <span className="flex-grow truncate text-left">
+              {displayValue != null
+                ? displayValue || selectPlaceholder
+                : selectedValue || selectPlaceholder}
+            </span>
+            {showCarat && <ChevronDown className="h-4 w-4 text-text-secondary" />}
+          </>
         )}
       </Ariakit.Select>
       <Ariakit.SelectPopover

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -685,6 +685,7 @@
   "com_ui_more_info": "More info",
   "com_ui_my_prompts": "My Prompts",
   "com_ui_name": "Name",
+  "com_ui_new": "New",
   "com_ui_new_chat": "New chat",
   "com_ui_next": "Next",
   "com_ui_no": "No",


### PR DESCRIPTION
## Summary

Closes #5954 

I implemented a series of enhancements across both the server and client components to improve error handling, accessibility, and layout consistency in LibreChat. I improved the GoogleClient’s abort handling and error filtering, replaced outdated dropdowns with the more accessible ControlCombobox, refined focus management in agent selection, and updated UI styling in agent and model panels. I also introduced a new translation key for clearer user copy.

- Updated type annotations and added abort event handling in GoogleClient to catch aborted requests and log warnings for GoogleGenerativeAI errors.
- Improved global error handling in the API server to ignore uncatchable abort errors and log advisory messages for upstream issues.
- Added a selectId prop to AgentSelect and ControlCombobox to maintain focus after agent selection.
- Replaced SelectDropDown components with ControlCombobox in AgentSelect and ModelPanel for better accessibility and consistency.
- Adjusted layout and styling in AgentPanel, AgentPanelSkeleton, and ModelPanel to improve spacing, alignment, and responsiveness.
- Added iconClassName, containerClassName, and iconSide props for enhanced customization in ControlCombobox, AgentSwitcher, and AssistantSwitcher.
- Introduced a new translation key to support improved UI clarity.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Testing:
- Manually simulated aborted content generation requests in GoogleClient to verify that abort events are caught and logged.
- Verified in the UI that the new selectId prop keeps focus on the agent selection component after updates.
- Confirmed that layout changes and styling adjustments render correctly across agent panels, skeleton components, and model panels.
- Ensured that the new translation key integrates seamlessly into the UI copy.

Checklist:
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules