### PR TITLE
Add Sonnet 3.7 bedrock model

### DIFF
--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -667,6 +667,7 @@ const sharedAnthropicModels = [
 ];
 
 export const bedrockModels = [
+  'anthropic.claude-3-7-sonnet-20250219-v1:0',
   'anthropic.claude-3-5-sonnet-20241022-v2:0',
   'anthropic.claude-3-5-sonnet-20240620-v1:0',
   'anthropic.claude-3-5-haiku-20241022-v1:0',


### PR DESCRIPTION
## Summary

Added `anthropic.claude-3-7-sonnet-20250219-v1:0` to AWS bedrock model list.

See https://docs.anthropic.com/en/docs/about-claude/models/all-models

We might want to consider adding the GCP Vertex AI models as well.

## Change Type

- [X] New feature (non-breaking change which adds functionality)
