### PR TITLE
🔧 refactor: Improve Params Handling, Remove Legacy Items, & Update Configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -210,12 +210,6 @@ ASSISTANTS_API_KEY=user_provided
 # https://www.librechat.ai/docs/configuration/librechat_yaml/ai_endpoints/azure#using-assistants-with-azure
 
 #============#
-# OpenRouter #
-#============#
-# !!!Warning: Use the variable above instead of this one. Using this one will override the OpenAI endpoint
-# OPENROUTER_API_KEY=
-
-#============#
 # Plugins    #
 #============#
 

--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -105,7 +105,9 @@ class AnthropicClient extends BaseClient {
 
     const modelMatch = matchModelName(this.modelOptions.model, EModelEndpoint.anthropic);
     this.isClaude3 = modelMatch.includes('claude-3');
-    this.isLegacyOutput = !modelMatch.includes('claude-3-5-sonnet');
+    this.isLegacyOutput = !(
+      /claude-3[-.]5-sonnet/.test(modelMatch) || /claude-3[-.]7/.test(modelMatch)
+    );
     this.supportsCacheControl = this.options.promptCache && checkPromptCacheSupport(modelMatch);
 
     if (

--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -7,8 +7,7 @@ const {
   getResponseSender,
   validateVisionModel,
 } = require('librechat-data-provider');
-const { SplitStreamHandler, GraphEvents } = require('@librechat/agents');
-const { encodeAndFormat } = require('~/server/services/Files/images/encode');
+const { SplitStreamHandler: _Handler, GraphEvents } = require('@librechat/agents');
 const {
   truncateText,
   formatMessage,
@@ -24,6 +23,7 @@ const {
 } = require('~/server/services/Endpoints/anthropic/helpers');
 const { getModelMaxTokens, getModelMaxOutputTokens, matchModelName } = require('~/utils');
 const { spendTokens, spendStructuredTokens } = require('~/models/spendTokens');
+const { encodeAndFormat } = require('~/server/services/Files/images/encode');
 const Tokenizer = require('~/server/services/Tokenizer');
 const { logger, sendEvent } = require('~/config');
 const { sleep } = require('~/server/utils');
@@ -31,6 +31,15 @@ const BaseClient = require('./BaseClient');
 
 const HUMAN_PROMPT = '\n\nHuman:';
 const AI_PROMPT = '\n\nAssistant:';
+
+class SplitStreamHandler extends _Handler {
+  getDeltaContent(chunk) {
+    return (chunk?.delta?.text ?? chunk?.completion) || '';
+  }
+  getReasoningDelta(chunk) {
+    return chunk?.delta?.thinking || '';
+  }
+}
 
 /** Helper function to introduce a delay before retrying */
 function delayBeforeRetry(attempts, baseDelay = 1000) {
@@ -807,50 +816,16 @@ class AnthropicClient extends BaseClient {
             }
           });
 
-          /** @param {string} chunk */
-          const handleChunk = (chunk) => {
-            this.streamHandler.handle({
-              choices: [
-                {
-                  delta: {
-                    content: chunk,
-                  },
-                },
-              ],
-            });
-          };
-          /** @param {string} chunk */
-          const handleReasoningChunk = (chunk) => {
-            this.streamHandler.handle({
-              choices: [
-                {
-                  delta: {
-                    reasoning_content: chunk,
-                  },
-                },
-              ],
-            });
-          };
-
           for await (const completion of response) {
-            // Handle each completion as before
             const type = completion?.type ?? '';
             if (tokenEventTypes.has(type)) {
               logger.debug(`[AnthropicClient] ${type}`, completion);
               this[type] = completion;
             }
-            if (completion?.delta?.thinking) {
-              handleReasoningChunk(completion.delta.thinking);
-            } else if (completion?.delta?.text) {
-              handleChunk(completion.delta.text);
-            } else if (completion.completion) {
-              handleChunk(completion.completion);
-            }
-
+            this.streamHandler.handle(completion);
             await sleep(streamRate);
           }
 
-          // Successful processing, exit loop
           break;
         } catch (error) {
           attempts += 1;

--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -735,9 +735,16 @@ class AnthropicClient extends BaseClient {
       stop_sequences,
       temperature,
       metadata,
-      top_p,
-      top_k,
     };
+
+    if (!/claude-3[-.]7/.test(model)) {
+      if (top_p !== undefined) {
+        requestOptions.top_p = top_p;
+      }
+      if (top_k !== undefined) {
+        requestOptions.top_k = top_k;
+      }
+    }
 
     if (this.useMessages) {
       requestOptions.messages = payload;

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -5,10 +5,11 @@ const {
   isAgentsEndpoint,
   isParamEndpoint,
   EModelEndpoint,
+  excludedKeys,
   ErrorTypes,
   Constants,
 } = require('librechat-data-provider');
-const { getMessages, saveMessage, updateMessage, saveConvo } = require('~/models');
+const { getMessages, saveMessage, updateMessage, saveConvo, getConvo } = require('~/models');
 const { addSpaceIfNeeded, isEnabled } = require('~/server/utils');
 const { truncateToolCallOutputs } = require('./prompts');
 const checkBalance = require('~/models/checkBalance');
@@ -55,6 +56,10 @@ class BaseClient {
      * Flag to determine if the client re-submitted the latest assistant message.
      * @type {boolean | undefined} */
     this.continued;
+    /**
+     * Flag to determine if the client has already fetched the conversation while saving new messages.
+     * @type {boolean | undefined} */
+    this.fetchedConvo;
     /** @type {TMessage[]} */
     this.currentMessages = [];
     /** @type {import('librechat-data-provider').VisionModes | undefined} */
@@ -863,16 +868,39 @@ class BaseClient {
       return { message: savedMessage };
     }
 
-    const conversation = await saveConvo(
-      this.options.req,
-      {
-        conversationId: message.conversationId,
-        endpoint: this.options.endpoint,
-        endpointType: this.options.endpointType,
-        ...endpointOptions,
-      },
-      { context: 'api/app/clients/BaseClient.js - saveMessageToDatabase #saveConvo' },
-    );
+    const fieldsToKeep = {
+      conversationId: message.conversationId,
+      endpoint: this.options.endpoint,
+      endpointType: this.options.endpointType,
+      ...endpointOptions,
+    };
+
+    const existingConvo =
+      this.fetchedConvo === true
+        ? null
+        : await getConvo(this.options.req.user.id, message.conversationId);
+
+    const unsetFields = {};
+    if (existingConvo != null) {
+      this.fetchedConvo = true;
+      for (const key in existingConvo) {
+        if (!key) {
+          continue;
+        }
+        if (excludedKeys.has(key)) {
+          continue;
+        }
+
+        if (endpointOptions?.[key] === undefined) {
+          unsetFields[key] = 1;
+        }
+      }
+    }
+
+    const conversation = await saveConvo(this.options.req, fieldsToKeep, {
+      context: 'api/app/clients/BaseClient.js - saveMessageToDatabase #saveConvo',
+      unsetFields,
+    });
 
     return { message: savedMessage, conversation };
   }

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -878,7 +878,7 @@ class BaseClient {
     const existingConvo =
       this.fetchedConvo === true
         ? null
-        : await getConvo(this.options.req.user.id, message.conversationId);
+        : await getConvo(this.options.req?.user?.id, message.conversationId);
 
     const unsetFields = {};
     if (existingConvo != null) {

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -109,12 +109,7 @@ class OpenAIClient extends BaseClient {
     const omniPattern = /\b(o1|o3)\b/i;
     this.isOmni = omniPattern.test(this.modelOptions.model);
 
-    const { OPENROUTER_API_KEY, OPENAI_FORCE_PROMPT } = process.env ?? {};
-    if (OPENROUTER_API_KEY && !this.azure) {
-      this.apiKey = OPENROUTER_API_KEY;
-      this.useOpenRouter = true;
-    }
-
+    const { OPENAI_FORCE_PROMPT } = process.env ?? {};
     const { reverseProxyUrl: reverseProxy } = this.options;
 
     if (!this.useOpenRouter && reverseProxy && reverseProxy.includes(KnownEndpoints.openrouter)) {

--- a/api/app/clients/specs/AnthropicClient.test.js
+++ b/api/app/clients/specs/AnthropicClient.test.js
@@ -405,4 +405,111 @@ describe('AnthropicClient', () => {
       expect(Number.isNaN(result)).toBe(false);
     });
   });
+
+  describe('maxOutputTokens handling for different models', () => {
+    it('should not cap maxOutputTokens for Claude 3.5 Sonnet models', () => {
+      const client = new AnthropicClient('test-api-key');
+      const highTokenValue = anthropicSettings.legacy.maxOutputTokens.default * 10;
+
+      client.setOptions({
+        modelOptions: {
+          model: 'claude-3-5-sonnet',
+          maxOutputTokens: highTokenValue,
+        },
+      });
+
+      expect(client.modelOptions.maxOutputTokens).toBe(highTokenValue);
+
+      // Test with decimal notation
+      client.setOptions({
+        modelOptions: {
+          model: 'claude-3.5-sonnet',
+          maxOutputTokens: highTokenValue,
+        },
+      });
+
+      expect(client.modelOptions.maxOutputTokens).toBe(highTokenValue);
+    });
+
+    it('should not cap maxOutputTokens for Claude 3.7 models', () => {
+      const client = new AnthropicClient('test-api-key');
+      const highTokenValue = anthropicSettings.legacy.maxOutputTokens.default * 2;
+
+      client.setOptions({
+        modelOptions: {
+          model: 'claude-3-7-sonnet',
+          maxOutputTokens: highTokenValue,
+        },
+      });
+
+      expect(client.modelOptions.maxOutputTokens).toBe(highTokenValue);
+
+      // Test with decimal notation
+      client.setOptions({
+        modelOptions: {
+          model: 'claude-3.7-sonnet',
+          maxOutputTokens: highTokenValue,
+        },
+      });
+
+      expect(client.modelOptions.maxOutputTokens).toBe(highTokenValue);
+    });
+
+    it('should cap maxOutputTokens for Claude 3.5 Haiku models', () => {
+      const client = new AnthropicClient('test-api-key');
+      const highTokenValue = anthropicSettings.legacy.maxOutputTokens.default * 2;
+
+      client.setOptions({
+        modelOptions: {
+          model: 'claude-3-5-haiku',
+          maxOutputTokens: highTokenValue,
+        },
+      });
+
+      expect(client.modelOptions.maxOutputTokens).toBe(
+        anthropicSettings.legacy.maxOutputTokens.default,
+      );
+
+      // Test with decimal notation
+      client.setOptions({
+        modelOptions: {
+          model: 'claude-3.5-haiku',
+          maxOutputTokens: highTokenValue,
+        },
+      });
+
+      expect(client.modelOptions.maxOutputTokens).toBe(
+        anthropicSettings.legacy.maxOutputTokens.default,
+      );
+    });
+
+    it('should cap maxOutputTokens for Claude 3 Haiku and Opus models', () => {
+      const client = new AnthropicClient('test-api-key');
+      const highTokenValue = anthropicSettings.legacy.maxOutputTokens.default * 2;
+
+      // Test haiku
+      client.setOptions({
+        modelOptions: {
+          model: 'claude-3-haiku',
+          maxOutputTokens: highTokenValue,
+        },
+      });
+
+      expect(client.modelOptions.maxOutputTokens).toBe(
+        anthropicSettings.legacy.maxOutputTokens.default,
+      );
+
+      // Test opus
+      client.setOptions({
+        modelOptions: {
+          model: 'claude-3-opus',
+          maxOutputTokens: highTokenValue,
+        },
+      });
+
+      expect(client.modelOptions.maxOutputTokens).toBe(
+        anthropicSettings.legacy.maxOutputTokens.default,
+      );
+    });
+  });
 });

--- a/api/app/clients/specs/OpenAIClient.test.js
+++ b/api/app/clients/specs/OpenAIClient.test.js
@@ -202,14 +202,6 @@ describe('OpenAIClient', () => {
       expect(client.modelOptions.temperature).toBe(0.7);
     });
 
-    it('should set apiKey and useOpenRouter if OPENROUTER_API_KEY is present', () => {
-      process.env.OPENROUTER_API_KEY = 'openrouter-key';
-      client.setOptions({});
-      expect(client.apiKey).toBe('openrouter-key');
-      expect(client.useOpenRouter).toBe(true);
-      delete process.env.OPENROUTER_API_KEY; // Cleanup
-    });
-
     it('should set FORCE_PROMPT based on OPENAI_FORCE_PROMPT or reverseProxyUrl', () => {
       process.env.OPENAI_FORCE_PROMPT = 'true';
       client.setOptions({});
@@ -534,7 +526,6 @@ describe('OpenAIClient', () => {
     afterEach(() => {
       delete process.env.AZURE_OPENAI_DEFAULT_MODEL;
       delete process.env.AZURE_USE_MODEL_AS_DEPLOYMENT_NAME;
-      delete process.env.OPENROUTER_API_KEY;
     });
 
     it('should call getCompletion and fetchEventSource when using a text/instruct model', async () => {

--- a/api/models/Conversation.js
+++ b/api/models/Conversation.js
@@ -104,10 +104,16 @@ module.exports = {
         update.expiredAt = null;
       }
 
+      /** @type {{ $set: Partial<TConversation>; $unset?: Record<keyof TConversation, number> }} */
+      const updateOperation = { $set: update };
+      if (metadata && metadata.unsetFields && Object.keys(metadata.unsetFields).length > 0) {
+        updateOperation.$unset = metadata.unsetFields;
+      }
+
       /** Note: the resulting Model object is necessary for Meilisearch operations */
       const conversation = await Conversation.findOneAndUpdate(
         { conversationId, user: req.user.id },
-        update,
+        updateOperation,
         {
           new: true,
           upsert: true,

--- a/api/models/Token.js
+++ b/api/models/Token.js
@@ -13,6 +13,13 @@ const Token = mongoose.model('Token', tokenSchema);
  */
 async function fixIndexes() {
   try {
+    if (
+      process.env.NODE_ENV === 'CI' ||
+      process.env.NODE_ENV === 'development' ||
+      process.env.NODE_ENV === 'test'
+    ) {
+      return;
+    }
     const indexes = await Token.collection.indexes();
     logger.debug('Existing Token Indexes:', JSON.stringify(indexes, null, 2));
     const unwantedTTLIndexes = indexes.filter(

--- a/api/models/schema/convoSchema.js
+++ b/api/models/schema/convoSchema.js
@@ -20,8 +20,6 @@ const convoSchema = mongoose.Schema(
       index: true,
     },
     messages: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Message' }],
-    // google only
-    examples: { type: [{ type: mongoose.Schema.Types.Mixed }], default: undefined },
     agentOptions: {
       type: mongoose.Schema.Types.Mixed,
     },
@@ -48,12 +46,12 @@ if (process.env.MEILI_HOST && process.env.MEILI_MASTER_KEY) {
   convoSchema.plugin(mongoMeili, {
     host: process.env.MEILI_HOST,
     apiKey: process.env.MEILI_MASTER_KEY,
-    indexName: 'convos', // Will get created automatically if it doesn't exist already
+    /** Note: Will get created automatically if it doesn't exist already */
+    indexName: 'convos',
     primaryKey: 'conversationId',
   });
 }
 
-// Create TTL index
 convoSchema.index({ expiredAt: 1 }, { expireAfterSeconds: 0 });
 convoSchema.index({ createdAt: 1, updatedAt: 1 });
 convoSchema.index({ conversationId: 1, user: 1 }, { unique: true });

--- a/api/models/schema/defaults.js
+++ b/api/models/schema/defaults.js
@@ -1,3 +1,5 @@
+const mongoose = require('mongoose');
+
 const conversationPreset = {
   // endpoint: [azureOpenAI, openAI, anthropic, chatGPTBrowser]
   endpoint: {
@@ -24,6 +26,7 @@ const conversationPreset = {
     required: false,
   },
   // for google only
+  examples: { type: [{ type: mongoose.Schema.Types.Mixed }], default: undefined },
   modelLabel: {
     type: String,
     required: false,
@@ -129,56 +132,6 @@ const conversationPreset = {
   },
 };
 
-const agentOptions = {
-  model: {
-    type: String,
-    required: false,
-  },
-  // for azureOpenAI, openAI only
-  chatGptLabel: {
-    type: String,
-    required: false,
-  },
-  modelLabel: {
-    type: String,
-    required: false,
-  },
-  promptPrefix: {
-    type: String,
-    required: false,
-  },
-  temperature: {
-    type: Number,
-    required: false,
-  },
-  top_p: {
-    type: Number,
-    required: false,
-  },
-  // for google only
-  topP: {
-    type: Number,
-    required: false,
-  },
-  topK: {
-    type: Number,
-    required: false,
-  },
-  maxOutputTokens: {
-    type: Number,
-    required: false,
-  },
-  presence_penalty: {
-    type: Number,
-    required: false,
-  },
-  frequency_penalty: {
-    type: Number,
-    required: false,
-  },
-};
-
 module.exports = {
   conversationPreset,
-  agentOptions,
 };

--- a/api/models/schema/presetSchema.js
+++ b/api/models/schema/presetSchema.js
@@ -23,8 +23,6 @@ const presetSchema = mongoose.Schema(
     order: {
       type: Number,
     },
-    // google only
-    examples: [{ type: mongoose.Schema.Types.Mixed }],
     ...conversationPreset,
     agentOptions: {
       type: mongoose.Schema.Types.Mixed,

--- a/api/server/services/Endpoints/anthropic/llm.js
+++ b/api/server/services/Endpoints/anthropic/llm.js
@@ -43,13 +43,20 @@ function getLLMConfig(apiKey, options = {}) {
     model: mergedOptions.model,
     stream: mergedOptions.stream,
     temperature: mergedOptions.temperature,
-    topP: mergedOptions.topP,
-    topK: mergedOptions.topK,
     stopSequences: mergedOptions.stop,
     maxTokens:
       mergedOptions.maxOutputTokens || anthropicSettings.maxOutputTokens.reset(mergedOptions.model),
     clientOptions: {},
   };
+
+  if (!/claude-3[-.]7/.test(mergedOptions.model)) {
+    if (mergedOptions.topP !== undefined) {
+      requestOptions.topP = mergedOptions.topP;
+    }
+    if (mergedOptions.topK !== undefined) {
+      requestOptions.topK = mergedOptions.topK;
+    }
+  }
 
   const supportsCacheControl =
     systemOptions.promptCache === true && checkPromptCacheSupport(requestOptions.model);

--- a/api/server/services/Endpoints/anthropic/llm.spec.js
+++ b/api/server/services/Endpoints/anthropic/llm.spec.js
@@ -1,0 +1,112 @@
+const { anthropicSettings } = require('librechat-data-provider');
+const { getLLMConfig } = require('~/server/services/Endpoints/anthropic/llm');
+
+jest.mock('https-proxy-agent', () => ({
+  HttpsProxyAgent: jest.fn().mockImplementation((proxy) => ({ proxy })),
+}));
+
+describe('getLLMConfig', () => {
+  it('should create a basic configuration with default values', () => {
+    const result = getLLMConfig('test-api-key', { modelOptions: {} });
+
+    expect(result.llmConfig).toHaveProperty('apiKey', 'test-api-key');
+    expect(result.llmConfig).toHaveProperty('model', anthropicSettings.model.default);
+    expect(result.llmConfig).toHaveProperty('stream', true);
+    expect(result.llmConfig).toHaveProperty('maxTokens');
+  });
+
+  it('should include proxy settings when provided', () => {
+    const result = getLLMConfig('test-api-key', {
+      modelOptions: {},
+      proxy: 'http://proxy:8080',
+    });
+
+    expect(result.llmConfig.clientOptions).toHaveProperty('httpAgent');
+    expect(result.llmConfig.clientOptions.httpAgent).toHaveProperty('proxy', 'http://proxy:8080');
+  });
+
+  it('should include reverse proxy URL when provided', () => {
+    const result = getLLMConfig('test-api-key', {
+      modelOptions: {},
+      reverseProxyUrl: 'http://reverse-proxy',
+    });
+
+    expect(result.llmConfig.clientOptions).toHaveProperty('baseURL', 'http://reverse-proxy');
+  });
+
+  it('should include topK and topP for non-Claude-3.7 models', () => {
+    const result = getLLMConfig('test-api-key', {
+      modelOptions: {
+        model: 'claude-3-opus',
+        topK: 10,
+        topP: 0.9,
+      },
+    });
+
+    expect(result.llmConfig).toHaveProperty('topK', 10);
+    expect(result.llmConfig).toHaveProperty('topP', 0.9);
+  });
+
+  it('should include topK and topP for Claude-3.5 models', () => {
+    const result = getLLMConfig('test-api-key', {
+      modelOptions: {
+        model: 'claude-3-5-sonnet',
+        topK: 10,
+        topP: 0.9,
+      },
+    });
+
+    expect(result.llmConfig).toHaveProperty('topK', 10);
+    expect(result.llmConfig).toHaveProperty('topP', 0.9);
+  });
+
+  it('should NOT include topK and topP for Claude-3-7 models (hyphen notation)', () => {
+    const result = getLLMConfig('test-api-key', {
+      modelOptions: {
+        model: 'claude-3-7-sonnet',
+        topK: 10,
+        topP: 0.9,
+      },
+    });
+
+    expect(result.llmConfig).not.toHaveProperty('topK');
+    expect(result.llmConfig).not.toHaveProperty('topP');
+  });
+
+  it('should NOT include topK and topP for Claude-3.7 models (decimal notation)', () => {
+    const result = getLLMConfig('test-api-key', {
+      modelOptions: {
+        model: 'claude-3.7-sonnet',
+        topK: 10,
+        topP: 0.9,
+      },
+    });
+
+    expect(result.llmConfig).not.toHaveProperty('topK');
+    expect(result.llmConfig).not.toHaveProperty('topP');
+  });
+
+  it('should handle custom maxOutputTokens', () => {
+    const result = getLLMConfig('test-api-key', {
+      modelOptions: {
+        model: 'claude-3-opus',
+        maxOutputTokens: 2048,
+      },
+    });
+
+    expect(result.llmConfig).toHaveProperty('maxTokens', 2048);
+  });
+
+  it('should handle promptCache setting', () => {
+    const result = getLLMConfig('test-api-key', {
+      modelOptions: {
+        model: 'claude-3-5-sonnet',
+        promptCache: true,
+      },
+    });
+
+    // We're not checking specific header values since that depends on the actual helper function
+    // Just verifying that the promptCache setting is processed
+    expect(result.llmConfig).toBeDefined();
+  });
+});

--- a/api/server/services/ModelService.js
+++ b/api/server/services/ModelService.js
@@ -129,9 +129,6 @@ const fetchOpenAIModels = async (opts, _models = []) => {
     //   .split('/deployments')[0]
     //   .concat(`/models?api-version=${azure.azureOpenAIApiVersion}`);
     // apiKey = azureOpenAIApiKey;
-  } else if (process.env.OPENROUTER_API_KEY) {
-    reverseProxyUrl = 'https://openrouter.ai/api/v1';
-    apiKey = process.env.OPENROUTER_API_KEY;
   }
 
   if (reverseProxyUrl) {
@@ -218,7 +215,7 @@ const getOpenAIModels = async (opts) => {
     return models;
   }
 
-  if (userProvidedOpenAI && !process.env.OPENROUTER_API_KEY) {
+  if (userProvidedOpenAI) {
     return models;
   }
 

--- a/api/server/services/ModelService.spec.js
+++ b/api/server/services/ModelService.spec.js
@@ -161,22 +161,6 @@ describe('getOpenAIModels', () => {
     expect(models).toEqual(expect.arrayContaining(['openai-model', 'openai-model-2']));
   });
 
-  it('attempts to use OPENROUTER_API_KEY if set', async () => {
-    process.env.OPENROUTER_API_KEY = 'test-router-key';
-    const expectedModels = ['model-router-1', 'model-router-2'];
-
-    axios.get.mockResolvedValue({
-      data: {
-        data: expectedModels.map((id) => ({ id })),
-      },
-    });
-
-    const models = await getOpenAIModels({ user: 'user456' });
-
-    expect(models).toEqual(expect.arrayContaining(expectedModels));
-    expect(axios.get).toHaveBeenCalled();
-  });
-
   it('utilizes proxy configuration when PROXY is set', async () => {
     axios.get.mockResolvedValue({
       data: {

--- a/client/src/components/SidePanel/Parameters/Panel.tsx
+++ b/client/src/components/SidePanel/Parameters/Panel.tsx
@@ -1,3 +1,4 @@
+import { RotateCcw } from 'lucide-react';
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import { getSettingsKeys, tConvoUpdateSchema } from 'librechat-data-provider';
 import type { TPreset } from 'librechat-data-provider';
@@ -24,6 +25,7 @@ const excludedKeys = new Set([
   '_id',
   'tools',
   'model',
+  'files',
 ]);
 
 export default function Parameters() {
@@ -105,6 +107,31 @@ export default function Parameters() {
     });
   }, [parameters, setConversation]);
 
+  const resetParameters = useCallback(() => {
+    setConversation((prev) => {
+      if (!prev) {
+        return prev;
+      }
+
+      const updatedConversation = { ...prev };
+      const resetKeys: string[] = [];
+
+      Object.keys(updatedConversation).forEach((key) => {
+        if (excludedKeys.has(key)) {
+          return;
+        }
+
+        if (updatedConversation[key] !== undefined) {
+          resetKeys.push(key);
+          delete updatedConversation[key];
+        }
+      });
+
+      logger.log('parameters', 'parameters reset, affected keys:', resetKeys);
+      return updatedConversation;
+    });
+  }, [setConversation]);
+
   const openDialog = useCallback(() => {
     const newPreset = tConvoUpdateSchema.parse({
       ...conversation,
@@ -146,7 +173,17 @@ export default function Parameters() {
           );
         })}
       </div>
-      <div className="mt-6 flex justify-center">
+      <div className="mt-4 flex justify-center">
+        <button
+          type="button"
+          onClick={resetParameters}
+          className="btn btn-neutral flex w-full items-center justify-center gap-2 px-4 py-2 text-sm"
+        >
+          <RotateCcw className="h-4 w-4" aria-hidden="true" />
+          {localize('com_ui_reset_var', { 0: localize('com_ui_model_parameters') })}
+        </button>
+      </div>
+      <div className="mt-2 flex justify-center">
         <button
           onClick={openDialog}
           className="btn btn-primary focus:shadow-outline flex w-full items-center justify-center px-4 py-2 font-semibold text-white hover:bg-green-600 focus:border-green-500"

--- a/client/src/components/SidePanel/Parameters/Panel.tsx
+++ b/client/src/components/SidePanel/Parameters/Panel.tsx
@@ -1,6 +1,6 @@
 import { RotateCcw } from 'lucide-react';
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
-import { getSettingsKeys, tConvoUpdateSchema } from 'librechat-data-provider';
+import { excludedKeys, getSettingsKeys, tConvoUpdateSchema } from 'librechat-data-provider';
 import type { TPreset } from 'librechat-data-provider';
 import { SaveAsPresetDialog } from '~/components/Endpoints';
 import { useSetIndexOptions, useLocalize } from '~/hooks';
@@ -9,24 +9,6 @@ import { getEndpointField, logger } from '~/utils';
 import { componentMapping } from './components';
 import { useChatContext } from '~/Providers';
 import { settings } from './settings';
-
-const excludedKeys = new Set([
-  'conversationId',
-  'title',
-  'endpoint',
-  'endpointType',
-  'createdAt',
-  'updatedAt',
-  'messages',
-  'isArchived',
-  'tags',
-  'user',
-  '__v',
-  '_id',
-  'tools',
-  'model',
-  'files',
-]);
 
 export default function Parameters() {
   const localize = useLocalize();

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -35,10 +35,5 @@
     "test/setupTests.js",
     "env.d.ts",
     "../config/translations/**/*.ts"
-  ],
-  "references": [
-    {
-      "path": "./tsconfig.node.json"
-    }
   ]
 }

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -1,9 +1,0 @@
-{
-  "compilerOptions": {
-    "composite": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
-  },
-  "include": ["vite.config.ts"]
-}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
       useCredentials: true,
       workbox: {
         globPatterns: ['**/*'],
+        globIgnores: ['images/**/*'],
         maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
         navigateFallbackDenylist: [/^\/oauth/],
       },

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -37,13 +37,11 @@ export default defineConfig({
       },
       useCredentials: true,
       workbox: {
-        globPatterns: [
-          'assets/**/*.{png,jpg,svg,ico}',
-          '**/*.{js,css,html,ico,woff2}',
-        ],
+        globPatterns: ['**/*'],
         maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
         navigateFallbackDenylist: [/^\/oauth/],
       },
+      includeAssets: ['**/*'],
       manifest: {
         name: 'LibreChat',
         short_name: 'LibreChat',
@@ -70,7 +68,7 @@ export default defineConfig({
           {
             src: '/assets/icon-192x192.png',
             sizes: '192x192',
-            type: 'image/png'
+            type: 'image/png',
           },
           {
             src: '/assets/maskable-icon.png',
@@ -113,10 +111,7 @@ export default defineConfig({
             if (id.includes('node_modules/highlight.js')) {
               return 'markdown_highlight';
             }
-            if (
-              id.includes('node_modules/hast-util-raw') ||
-              id.includes('node_modules/katex')
-            ) {
+            if (id.includes('node_modules/hast-util-raw') || id.includes('node_modules/katex')) {
               return 'markdown_large';
             }
             // Group TanStack libraries together.
@@ -141,10 +136,7 @@ export default defineConfig({
         entryFileNames: 'assets/[name].[hash].js',
         chunkFileNames: 'assets/[name].[hash].js',
         assetFileNames: (assetInfo) => {
-          if (
-            assetInfo.names &&
-            /\.(woff|woff2|eot|ttf|otf)$/.test(assetInfo.names)
-          ) {
+          if (assetInfo.names && /\.(woff|woff2|eot|ttf|otf)$/.test(assetInfo.names)) {
             return 'assets/fonts/[name][extname]';
           }
           return 'assets/[name].[hash][extname]';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ const compat = new FlatCompat({
 export default [
   {
     ignores: [
+      'client/vite.config.ts',
       'client/dist/**/*',
       'client/public/**/*',
       'client/coverage/**/*',

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -224,7 +224,6 @@ endpoints:
     - name: 'OpenRouter'
       # For `apiKey` and `baseURL`, you can use environment variables that you define.
       # recommended environment variables:
-      # Known issue: you should not use `OPENROUTER_API_KEY` as it will then override the `openAI` endpoint to use OpenRouter as well.
       apiKey: '${OPENROUTER_KEY}'
       baseURL: 'https://openrouter.ai/api/v1'
       models:

--- a/package-lock.json
+++ b/package-lock.json
@@ -41798,7 +41798,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.6992",
+      "version": "0.7.6993",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.7",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.6992",
+  "version": "0.7.6993",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 import type { ZodError } from 'zod';
 import type { TModelsConfig } from './types';
 import { EModelEndpoint, eModelEndpointSchema } from './schemas';
-import { fileConfigSchema } from './file-config';
 import { specsConfigSchema, TSpecsConfig } from './models';
+import { fileConfigSchema } from './file-config';
 import { FileSources } from './types/files';
 import { MCPServersSchema } from './mcp';
 
@@ -34,6 +34,8 @@ export const defaultRetrievalModels = [
 export const excludedKeys = new Set([
   'conversationId',
   'title',
+  'iconURL',
+  'greeting',
   'endpoint',
   'endpointType',
   'createdAt',

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -31,6 +31,25 @@ export const defaultRetrievalModels = [
   'gpt-4-1106',
 ];
 
+export const excludedKeys = new Set([
+  'conversationId',
+  'title',
+  'endpoint',
+  'endpointType',
+  'createdAt',
+  'updatedAt',
+  'expiredAt',
+  'messages',
+  'isArchived',
+  'tags',
+  'user',
+  '__v',
+  '_id',
+  'tools',
+  'model',
+  'files',
+]);
+
 export enum SettingsViews {
   default = 'default',
   advanced = 'advanced',

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -252,7 +252,8 @@ export const googleSettings = {
   },
 };
 
-const ANTHROPIC_MAX_OUTPUT = 8192;
+const ANTHROPIC_MAX_OUTPUT = 128000;
+const DEFAULT_MAX_OUTPUT = 8192;
 const LEGACY_ANTHROPIC_MAX_OUTPUT = 4096;
 export const anthropicSettings = {
   model: {
@@ -280,16 +281,19 @@ export const anthropicSettings = {
     min: 1,
     max: ANTHROPIC_MAX_OUTPUT,
     step: 1,
-    default: ANTHROPIC_MAX_OUTPUT,
+    default: DEFAULT_MAX_OUTPUT,
     reset: (modelName: string) => {
-      if (modelName.includes('claude-3-5-sonnet') || modelName.includes('claude-3-7-sonnet')) {
-        return ANTHROPIC_MAX_OUTPUT;
+      if (/claude-3[-.]5-sonnet/.test(modelName) || /claude-3[-.]7/.test(modelName)) {
+        return DEFAULT_MAX_OUTPUT;
       }
 
       return 4096;
     },
     set: (value: number, modelName: string) => {
-      if (!modelName.includes('claude-3-5-sonnet') && value > LEGACY_ANTHROPIC_MAX_OUTPUT) {
+      if (
+        !(/claude-3[-.]5-sonnet/.test(modelName) || /claude-3[-.]7/.test(modelName)) &&
+        value > LEGACY_ANTHROPIC_MAX_OUTPUT
+      ) {
         return LEGACY_ANTHROPIC_MAX_OUTPUT;
       }
 

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -760,37 +760,8 @@ export const googleSchema = tConversationSchema
     spec: true,
     maxContextTokens: true,
   })
-  .transform((obj) => {
-    return {
-      ...obj,
-      model: obj.model ?? google.model.default,
-      modelLabel: obj.modelLabel ?? null,
-      promptPrefix: obj.promptPrefix ?? null,
-      examples: obj.examples ?? [{ input: { content: '' }, output: { content: '' } }],
-      temperature: obj.temperature ?? google.temperature.default,
-      maxOutputTokens: obj.maxOutputTokens ?? google.maxOutputTokens.default,
-      topP: obj.topP ?? google.topP.default,
-      topK: obj.topK ?? google.topK.default,
-      iconURL: obj.iconURL ?? undefined,
-      greeting: obj.greeting ?? undefined,
-      spec: obj.spec ?? undefined,
-      maxContextTokens: obj.maxContextTokens ?? undefined,
-    };
-  })
-  .catch(() => ({
-    model: google.model.default,
-    modelLabel: null,
-    promptPrefix: null,
-    examples: [{ input: { content: '' }, output: { content: '' } }],
-    temperature: google.temperature.default,
-    maxOutputTokens: google.maxOutputTokens.default,
-    topP: google.topP.default,
-    topK: google.topK.default,
-    iconURL: undefined,
-    greeting: undefined,
-    spec: undefined,
-    maxContextTokens: undefined,
-  }));
+  .transform((obj: Partial<TConversation>) => removeNullishValues(obj))
+  .catch(() => ({}));
 
 /**
    * TODO: Map the following fields:


### PR DESCRIPTION
## Summary

- Refactored stream handling in AnthropicClient by introducing a custom SplitStreamHandler that extracts delta text and reasoning smoothly, without needing to create new objects mid-stream
- Removed legacy logic and environment references for OPENROUTER_API_KEY from .env.example, OpenAIClient, ModelService, and related tests.
    - Closes #2097
- Added comprehensive unit tests for getLLMConfig to verify proxy settings, reverse proxy URLs, and conditional inclusion of topK/topP parameters.
- Restructured parameter handling in AnthropicClient so that top_k and top_p parameters are only included for non-claude-3.7 models, and I validated this behavior with targeted tests.
- Updated maxOutputTokens handling and tests to enforce appropriate token cap limits across various Claude model variants.
- Skipped index fixing in CI, development, and test environments within the Token model to avoid unnecessary index operations.
- Adjusted default token values and schema transformations (including simplifying the googleSchema transformation) to better support model-specific constraints.
- Excluded image files from service worker caching and revised client configuration (Vite config, tsconfig, and ESLint settings) to pre-cache all assets, in hopes of resolving offline usage.
- Add frontend/backend feature for Resetting parameters

Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change that improves code quality)
- [x] CI/Chore (updates to development workflows and configurations)

Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules