### PR TITLE
🚀 feat: GPT-4.5, Anthropic Tool Header, and OpenAPI Ref Resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,7 +175,7 @@ GOOGLE_KEY=user_provided
 #============#
 
 OPENAI_API_KEY=user_provided
-# OPENAI_MODELS=o1,o1-mini,o1-preview,gpt-4o,chatgpt-4o-latest,gpt-4o-mini,gpt-3.5-turbo-0125,gpt-3.5-turbo-0301,gpt-3.5-turbo,gpt-4,gpt-4-0613,gpt-4-vision-preview,gpt-3.5-turbo-0613,gpt-3.5-turbo-16k-0613,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo-1106,gpt-3.5-turbo-instruct,gpt-3.5-turbo-instruct-0914,gpt-3.5-turbo-16k
+# OPENAI_MODELS=o1,o1-mini,o1-preview,gpt-4o,gpt-4.5-preview,chatgpt-4o-latest,gpt-4o-mini,gpt-3.5-turbo-0125,gpt-3.5-turbo-0301,gpt-3.5-turbo,gpt-4,gpt-4-0613,gpt-4-vision-preview,gpt-3.5-turbo-0613,gpt-3.5-turbo-16k-0613,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo-1106,gpt-3.5-turbo-instruct,gpt-3.5-turbo-instruct-0914,gpt-3.5-turbo-16k
 
 DEBUG_OPENAI=false
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@
   - [Fork Messages & Conversations](https://www.librechat.ai/docs/features/fork) for Advanced Context control
 
 - 💬 **Multimodal & File Interactions**:  
-  - Upload and analyze images with Claude 3, GPT-4o, o1, Llama-Vision, and Gemini 📸  
+  - Upload and analyze images with Claude 3, GPT-4.5, GPT-4o, o1, Llama-Vision, and Gemini 📸  
   - Chat with Files using Custom Endpoints, OpenAI, Azure, Anthropic, AWS Bedrock, & Google 🗃️
 
 - 🌎 **Multilingual UI**:  

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -298,7 +298,9 @@ class OpenAIClient extends BaseClient {
   }
 
   getEncoding() {
-    return this.model?.includes('gpt-4o') ? 'o200k_base' : 'cl100k_base';
+    return this.modelOptions?.model && /gpt-4[^-\s]/.test(this.modelOptions.model)
+      ? 'o200k_base'
+      : 'cl100k_base';
   }
 
   /**
@@ -605,7 +607,7 @@ class OpenAIClient extends BaseClient {
   }
 
   initializeLLM({
-    model = 'gpt-4o-mini',
+    model = openAISettings.model.default,
     modelName,
     temperature = 0.2,
     max_tokens,
@@ -706,7 +708,7 @@ class OpenAIClient extends BaseClient {
 
     const { OPENAI_TITLE_MODEL } = process.env ?? {};
 
-    let model = this.options.titleModel ?? OPENAI_TITLE_MODEL ?? 'gpt-4o-mini';
+    let model = this.options.titleModel ?? OPENAI_TITLE_MODEL ?? openAISettings.model.default;
     if (model === Constants.CURRENT_MODEL) {
       model = this.modelOptions.model;
     }
@@ -899,7 +901,7 @@ ${convo}
     let prompt;
 
     // TODO: remove the gpt fallback and make it specific to endpoint
-    const { OPENAI_SUMMARY_MODEL = 'gpt-4o-mini' } = process.env ?? {};
+    const { OPENAI_SUMMARY_MODEL = openAISettings.model.default } = process.env ?? {};
     let model = this.options.summaryModel ?? OPENAI_SUMMARY_MODEL;
     if (model === Constants.CURRENT_MODEL) {
       model = this.modelOptions.model;

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -79,6 +79,7 @@ const tokenValues = Object.assign(
     'o1-mini': { prompt: 1.1, completion: 4.4 },
     'o1-preview': { prompt: 15, completion: 60 },
     o1: { prompt: 15, completion: 60 },
+    'gpt-4.5': { prompt: 75, completion: 150 },
     'gpt-4o-mini': { prompt: 0.15, completion: 0.6 },
     'gpt-4o': { prompt: 2.5, completion: 10 },
     'gpt-4o-2024-05-13': { prompt: 5, completion: 15 },
@@ -167,6 +168,8 @@ const getValueKey = (model, endpoint) => {
     return 'o1-mini';
   } else if (modelName.includes('o1')) {
     return 'o1';
+  } else if (modelName.includes('gpt-4.5')) {
+    return 'gpt-4.5';
   } else if (modelName.includes('gpt-4o-2024-05-13')) {
     return 'gpt-4o-2024-05-13';
   } else if (modelName.includes('gpt-4o-mini')) {

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -50,6 +50,16 @@ describe('getValueKey', () => {
     expect(getValueKey('gpt-4-0125')).toBe('gpt-4-1106');
   });
 
+  it('should return "gpt-4.5" for model type of "gpt-4.5"', () => {
+    expect(getValueKey('gpt-4.5-preview')).toBe('gpt-4.5');
+    expect(getValueKey('gpt-4.5-2024-08-06')).toBe('gpt-4.5');
+    expect(getValueKey('gpt-4.5-2024-08-06-0718')).toBe('gpt-4.5');
+    expect(getValueKey('openai/gpt-4.5')).toBe('gpt-4.5');
+    expect(getValueKey('openai/gpt-4.5-2024-08-06')).toBe('gpt-4.5');
+    expect(getValueKey('gpt-4.5-turbo')).toBe('gpt-4.5');
+    expect(getValueKey('gpt-4.5-0125')).toBe('gpt-4.5');
+  });
+
   it('should return "gpt-4o" for model type of "gpt-4o"', () => {
     expect(getValueKey('gpt-4o-2024-08-06')).toBe('gpt-4o');
     expect(getValueKey('gpt-4o-2024-08-06-0718')).toBe('gpt-4o');

--- a/api/server/services/Endpoints/anthropic/helpers.js
+++ b/api/server/services/Endpoints/anthropic/helpers.js
@@ -48,7 +48,8 @@ function getClaudeHeaders(model, supportsCacheControl) {
     };
   } else if (/claude-3[-.]7/.test(model)) {
     return {
-      'anthropic-beta': 'output-128k-2025-02-19,prompt-caching-2024-07-31',
+      'anthropic-beta':
+        'token-efficient-tools-2025-02-19,output-128k-2025-02-19,prompt-caching-2024-07-31',
     };
   } else {
     return {

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -13,6 +13,7 @@ const openAIModels = {
   'gpt-4-32k-0613': 32758, // -10 from max
   'gpt-4-1106': 127500, // -500 from max
   'gpt-4-0125': 127500, // -500 from max
+  'gpt-4.5': 127500, // -500 from max
   'gpt-4o': 127500, // -500 from max
   'gpt-4o-mini': 127500, // -500 from max
   'gpt-4o-2024-05-13': 127500, // -500 from max

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -103,6 +103,16 @@ describe('getModelMaxTokens', () => {
     );
   });
 
+  test('should return correct tokens for gpt-4.5 matches', () => {
+    expect(getModelMaxTokens('gpt-4.5')).toBe(maxTokensMap[EModelEndpoint.openAI]['gpt-4.5']);
+    expect(getModelMaxTokens('gpt-4.5-preview')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-4.5'],
+    );
+    expect(getModelMaxTokens('openai/gpt-4.5-preview')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-4.5'],
+    );
+  });
+
   test('should return correct tokens for Anthropic models', () => {
     const models = [
       'claude-2.1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -41798,7 +41798,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.6993",
+      "version": "0.7.6994",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.7",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.6993",
+  "version": "0.7.6994",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -15,6 +15,7 @@ export const defaultRetrievalModels = [
   'o1-preview',
   'o1-mini-2024-09-12',
   'o1-mini',
+  'o3-mini',
   'chatgpt-4o-latest',
   'gpt-4o-2024-05-13',
   'gpt-4o-2024-08-06',
@@ -651,6 +652,8 @@ export const alternateName = {
 const sharedOpenAIModels = [
   'gpt-4o-mini',
   'gpt-4o',
+  'gpt-4.5-preview',
+  'gpt-4.5-preview-2025-02-27',
   'gpt-3.5-turbo',
   'gpt-3.5-turbo-0125',
   'gpt-4-turbo',
@@ -723,7 +726,7 @@ export const bedrockModels = [
 
 export const defaultModels = {
   [EModelEndpoint.azureAssistants]: sharedOpenAIModels,
-  [EModelEndpoint.assistants]: ['chatgpt-4o-latest', ...sharedOpenAIModels],
+  [EModelEndpoint.assistants]: [...sharedOpenAIModels, 'chatgpt-4o-latest'],
   [EModelEndpoint.agents]: sharedOpenAIModels, // TODO: Add agent models (agentsModels)
   [EModelEndpoint.google]: [
     // Shared Google Models between Vertex AI & Gen AI
@@ -742,8 +745,8 @@ export const defaultModels = {
   ],
   [EModelEndpoint.anthropic]: sharedAnthropicModels,
   [EModelEndpoint.openAI]: [
-    'chatgpt-4o-latest',
     ...sharedOpenAIModels,
+    'chatgpt-4o-latest',
     'gpt-4-vision-preview',
     'gpt-3.5-turbo-instruct-0914',
     'gpt-3.5-turbo-instruct',
@@ -808,6 +811,7 @@ export const supportsBalanceCheck = {
 };
 
 export const visionModels = [
+  'gpt-4.5',
   'gpt-4o',
   'gpt-4o-mini',
   'o1',

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -128,7 +128,6 @@ export const envVarRegex = /^\${(.+)}$/;
 export function extractEnvVariable(value: string) {
   const envVarMatch = value.match(envVarRegex);
   if (envVarMatch) {
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     return process.env[envVarMatch[1]] || value;
   }
   return value;
@@ -211,6 +210,29 @@ export const parseConvo = ({
   return convo;
 };
 
+/** Match GPT followed by digit, optional decimal, and optional suffix
+ *
+ * Examples: gpt-4, gpt-4o, gpt-4.5, gpt-5a, etc. */
+const extractGPTVersion = (modelStr: string): string => {
+  const gptMatch = modelStr.match(/gpt-(\d+(?:\.\d+)?)([a-z])?/i);
+  if (gptMatch) {
+    const version = gptMatch[1];
+    const suffix = gptMatch[2] || '';
+    return `GPT-${version}${suffix}`;
+  }
+  return '';
+};
+
+/** Match omni models (o1, o3, etc.), "o" followed by a digit, possibly with decimal */
+const extractOmniVersion = (modelStr: string): string => {
+  const omniMatch = modelStr.match(/\bo(\d+(?:\.\d+)?)\b/i);
+  if (omniMatch) {
+    const version = omniMatch[1];
+    return `o${version}`;
+  }
+  return '';
+};
+
 export const getResponseSender = (endpointOption: t.TEndpointOption): string => {
   const {
     model: _m,
@@ -238,18 +260,13 @@ export const getResponseSender = (endpointOption: t.TEndpointOption): string => 
       return chatGptLabel;
     } else if (modelLabel) {
       return modelLabel;
-    } else if (model && /\bo1\b/i.test(model)) {
-      return 'o1';
-    } else if (model && /\bo3\b/i.test(model)) {
-      return 'o3';
-    } else if (model && model.includes('gpt-3')) {
-      return 'GPT-3.5';
-    } else if (model && model.includes('gpt-4o')) {
-      return 'GPT-4o';
-    } else if (model && model.includes('gpt-4')) {
-      return 'GPT-4';
+    } else if (model && extractOmniVersion(model)) {
+      return extractOmniVersion(model);
     } else if (model && model.includes('mistral')) {
       return 'Mistral';
+    } else if (model && model.includes('gpt-')) {
+      const gptVersion = extractGPTVersion(model);
+      return gptVersion || 'GPT';
     }
     return (alternateName[endpoint] as string | undefined) ?? 'ChatGPT';
   }
@@ -279,14 +296,13 @@ export const getResponseSender = (endpointOption: t.TEndpointOption): string => 
       return modelLabel;
     } else if (chatGptLabel) {
       return chatGptLabel;
+    } else if (model && extractOmniVersion(model)) {
+      return extractOmniVersion(model);
     } else if (model && model.includes('mistral')) {
       return 'Mistral';
-    } else if (model && model.includes('gpt-3')) {
-      return 'GPT-3.5';
-    } else if (model && model.includes('gpt-4o')) {
-      return 'GPT-4o';
-    } else if (model && model.includes('gpt-4')) {
-      return 'GPT-4';
+    } else if (model && model.includes('gpt-')) {
+      const gptVersion = extractGPTVersion(model);
+      return gptVersion || 'GPT';
     } else if (modelDisplayLabel) {
       return modelDisplayLabel;
     }

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -179,34 +179,34 @@ export const isImageVisionTool = (tool: FunctionTool | FunctionToolCall) =>
 
 export const openAISettings = {
   model: {
-    default: 'gpt-4o',
+    default: 'gpt-4o-mini' as const,
   },
   temperature: {
-    min: 0,
-    max: 2,
-    step: 0.01,
-    default: 1,
+    min: 0 as const,
+    max: 2 as const,
+    step: 0.01 as const,
+    default: 1 as const,
   },
   top_p: {
-    min: 0,
-    max: 1,
-    step: 0.01,
-    default: 1,
+    min: 0 as const,
+    max: 1 as const,
+    step: 0.01 as const,
+    default: 1 as const,
   },
   presence_penalty: {
-    min: 0,
-    max: 2,
-    step: 0.01,
-    default: 0,
+    min: 0 as const,
+    max: 2 as const,
+    step: 0.01 as const,
+    default: 0 as const,
   },
   frequency_penalty: {
-    min: 0,
-    max: 2,
-    step: 0.01,
-    default: 0,
+    min: 0 as const,
+    max: 2 as const,
+    step: 0.01 as const,
+    default: 0 as const,
   },
   resendFiles: {
-    default: true,
+    default: true as const,
   },
   maxContextTokens: {
     default: undefined,
@@ -215,72 +215,72 @@ export const openAISettings = {
     default: undefined,
   },
   imageDetail: {
-    default: ImageDetail.auto,
-    min: 0,
-    max: 2,
-    step: 1,
+    default: ImageDetail.auto as const,
+    min: 0 as const,
+    max: 2 as const,
+    step: 1 as const,
   },
 };
 
 export const googleSettings = {
   model: {
-    default: 'gemini-1.5-flash-latest',
+    default: 'gemini-1.5-flash-latest' as const,
   },
   maxOutputTokens: {
-    min: 1,
-    max: 8192,
-    step: 1,
-    default: 8192,
+    min: 1 as const,
+    max: 8192 as const,
+    step: 1 as const,
+    default: 8192 as const,
   },
   temperature: {
-    min: 0,
-    max: 2,
-    step: 0.01,
-    default: 1,
+    min: 0 as const,
+    max: 2 as const,
+    step: 0.01 as const,
+    default: 1 as const,
   },
   topP: {
-    min: 0,
-    max: 1,
-    step: 0.01,
-    default: 0.95,
+    min: 0 as const,
+    max: 1 as const,
+    step: 0.01 as const,
+    default: 0.95 as const,
   },
   topK: {
-    min: 1,
-    max: 40,
-    step: 1,
-    default: 40,
+    min: 1 as const,
+    max: 40 as const,
+    step: 1 as const,
+    default: 40 as const,
   },
 };
 
-const ANTHROPIC_MAX_OUTPUT = 128000;
-const DEFAULT_MAX_OUTPUT = 8192;
-const LEGACY_ANTHROPIC_MAX_OUTPUT = 4096;
+const ANTHROPIC_MAX_OUTPUT = 128000 as const;
+const DEFAULT_MAX_OUTPUT = 8192 as const;
+const LEGACY_ANTHROPIC_MAX_OUTPUT = 4096 as const;
 export const anthropicSettings = {
   model: {
-    default: 'claude-3-5-sonnet-latest',
+    default: 'claude-3-5-sonnet-latest' as const,
   },
   temperature: {
-    min: 0,
-    max: 1,
-    step: 0.01,
-    default: 1,
+    min: 0 as const,
+    max: 1 as const,
+    step: 0.01 as const,
+    default: 1 as const,
   },
   promptCache: {
-    default: true,
+    default: true as const,
   },
   thinking: {
-    default: true,
+    default: true as const,
   },
   thinkingBudget: {
-    min: 1024,
-    step: 100,
-    max: 200000,
-    default: 2000,
+    min: 1024 as const,
+    step: 100 as const,
+    max: 200000 as const,
+    default: 2000 as const,
   },
   maxOutputTokens: {
-    min: 1,
+    min: 1 as const,
     max: ANTHROPIC_MAX_OUTPUT,
-    step: 1,
+    step: 1 as const,
     default: DEFAULT_MAX_OUTPUT,
     reset: (modelName: string) => {
       if (/claude-3[-.]5-sonnet/.test(modelName) || /claude-3[-.]7/.test(modelName)) {
@@ -301,28 +301,28 @@ export const anthropicSettings = {
     },
   },
   topP: {
-    min: 0,
-    max: 1,
-    step: 0.01,
-    default: 0.7,
+    min: 0 as const,
+    max: 1 as const,
+    step: 0.01 as const,
+    default: 0.7 as const,
   },
   topK: {
-    min: 1,
-    max: 40,
-    step: 1,
-    default: 5,
+    min: 1 as const,
+    max: 40 as const,
+    step: 1 as const,
+    default: 5 as const,
   },
   resendFiles: {
-    default: true,
+    default: true as const,
   },
   maxContextTokens: {
     default: undefined,
   },
   legacy: {
     maxOutputTokens: {
-      min: 1,
+      min: 1 as const,
       max: LEGACY_ANTHROPIC_MAX_OUTPUT,
-      step: 1,
+      step: 1 as const,
       default: LEGACY_ANTHROPIC_MAX_OUTPUT,
     },
   },
@@ -330,34 +330,34 @@ export const anthropicSettings = {
 
 export const agentsSettings = {
   model: {
-    default: 'gpt-3.5-turbo-test',
+    default: 'gpt-3.5-turbo-test' as const,
   },
   temperature: {
-    min: 0,
-    max: 1,
-    step: 0.01,
-    default: 1,
+    min: 0 as const,
+    max: 1 as const,
+    step: 0.01 as const,
+    default: 1 as const,
   },
   top_p: {
-    min: 0,
-    max: 1,
-    step: 0.01,
-    default: 1,
+    min: 0 as const,
+    max: 1 as const,
+    step: 0.01 as const,
+    default: 1 as const,
   },
   presence_penalty: {
-    min: 0,
-    max: 2,
-    step: 0.01,
-    default: 0,
+    min: 0 as const,
+    max: 2 as const,
+    step: 0.01 as const,
+    default: 0 as const,
   },
   frequency_penalty: {
-    min: 0,
-    max: 2,
-    step: 0.01,
-    default: 0,
+    min: 0 as const,
+    max: 2 as const,
+    step: 0.01 as const,
+    default: 0 as const,
   },
   resendFiles: {
-    default: true,
+    default: true as const,
   },
   maxContextTokens: {
     default: undefined,
@@ -366,7 +366,7 @@ export const agentsSettings = {
     default: undefined,
   },
   imageDetail: {
-    default: ImageDetail.auto,
+    default: ImageDetail.auto as const,
   },
 };
 


### PR DESCRIPTION
## Summary

- Added a new 'anthropic-beta' header for Claude 3.7 to include token-efficient tools per updated documentation.
- Revised the OpenAPI $ref resolution logic to correctly resolve schema, parameter, and requestBody references, with extra test cases to verify accuracy.
- Updated GPT-4.5 handling in token calculations and vision support across API models, along with modifications in environment examples and tests.
- Refactored parser logic to extract GPT and omni model versions more reliably to support future releases.
- Improved model handling in the OpenAI client by switching to default settings and enhancing encoding logic based on model types.
- Updated the README to reflect GPT-4.5 support in the image analysis feature.
- Adjusted settings in schemas using "as const" for tighter type safety and set gpt-4o-mini as the new default for cost efficiency.


Closes #6109
Closes #6110

Checklist:
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules