### PR TITLE
refactor: mask apiKey in log output

### DIFF
--- a/api/server/services/Config/loadCustomConfig.js
+++ b/api/server/services/Config/loadCustomConfig.js
@@ -100,8 +100,14 @@ https://www.librechat.ai/docs/configuration/stt_tts`);
 
     return null;
   } else {
+    const apiKeyReplacer = (key, value) => {
+      if (key === 'apiKey' && value !== 'user_provided') {
+        return '***';
+      }
+      return value;
+    };
     logger.info('Custom config file loaded:');
-    logger.info(JSON.stringify(customConfig, null, 2));
+    logger.info(JSON.stringify(customConfig, apiKeyReplacer, 2));
     logger.debug('Custom config:', customConfig);
   }
 


### PR DESCRIPTION
## Summary

The custom configuration file is logged on startup and may contain API keys. Best practice would be to avoid logging secrets. (Special-cased user_provided value.)

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### **Test Configuration**:

```
version: 1.2.1
cache: true
endpoints:
  custom:
    - name: "Mistral"
      apiKey: "secret-string"
      baseURL: "https://api.mistral.ai/v1"
```

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works