### PR TITLE
🕒 feat: Add Configurable MCP Server Timeouts

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -113,12 +113,14 @@ mcpServers:
   everything:
     # type: sse # type can optionally be omitted
     url: http://localhost:3001/sse
+    timeout: 60000  # 1 minute timeout for this server, this is the default timeout for MCP servers.
   puppeteer:
     type: stdio
     command: npx
     args:
       - -y
       - "@modelcontextprotocol/server-puppeteer"
+    timeout: 300000  # 5 minutes timeout for this server
   filesystem:
     # type: stdio
     command: npx

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -3,6 +3,7 @@ import { extractEnvVariable } from './utils';
 
 const BaseOptionsSchema = z.object({
   iconPath: z.string().optional(),
+  timeout: z.number().optional(),
 });
 
 export const StdioOptionsSchema = BaseOptionsSchema.extend({

--- a/packages/mcp/src/connection.ts
+++ b/packages/mcp/src/connection.ts
@@ -43,12 +43,14 @@ export class MCPConnection extends EventEmitter {
   private isInitializing = false;
   private reconnectAttempts = 0;
   iconPath?: string;
+  timeout?: number;
 
   constructor(serverName: string, private readonly options: t.MCPOptions, private logger?: Logger) {
     super();
     this.serverName = serverName;
     this.logger = logger;
     this.iconPath = options.iconPath;
+    this.timeout = options.timeout;
     this.client = new Client(
       {
         name: 'librechat-mcp-client',

--- a/packages/mcp/src/manager.ts
+++ b/packages/mcp/src/manager.ts
@@ -159,7 +159,7 @@ export class MCPManager {
           };
         }
       } catch (error) {
-        this.logger.warn(`[MCP][${serverName}] Not connected, skipping tool fetch`);
+        this.logger.warn(`[MCP][${serverName}] Error fetching tools:`, error);
       }
     }
   }
@@ -183,7 +183,7 @@ export class MCPManager {
           });
         }
       } catch (error) {
-        this.logger.error(`[MCP][${serverName}] Error fetching tools`, error);
+        this.logger.error(`[MCP][${serverName}] Error fetching tools:`, error);
       }
     }
   }
@@ -209,6 +209,7 @@ export class MCPManager {
         },
       },
       CallToolResultSchema,
+      { timeout: connection.timeout },
     );
     return formatToolContent(result, provider);
   }


### PR DESCRIPTION
## Summary

Exposed a configuration parameter `timeout` for MCP servers, this lets us invoke long running tools. Fixes https://github.com/danny-avila/LibreChat/issues/6196

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Testing

See the example librechat.example.yaml and change it on an mcp server of choice.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
