### PR TITLE
fix: Assistants conversations in db

### DIFF
--- a/api/models/Conversation.js
+++ b/api/models/Conversation.js
@@ -96,6 +96,30 @@ module.exports = {
         update.conversationId = newConversationId;
       }
 
+      if (convo.assistant_id && (!convo.spec || !convo.iconURL)) {
+        const modelSpecs = req?.app?.locals?.modelSpecs;
+
+        if (modelSpecs && Array.isArray(modelSpecs.list)) {
+          const matchingSpec = modelSpecs.list.find(
+            (spec) => spec.preset && spec.preset.assistant_id === convo.assistant_id,
+          );
+
+          if (matchingSpec) {
+            if (!update.spec && matchingSpec.name) {
+              update.spec = matchingSpec.name;
+            }
+
+            if (!update.iconURL) {
+              update.iconURL = matchingSpec.iconURL || matchingSpec.preset?.iconURL || null;
+            }
+          } else {
+            logger.debug(
+              `[saveConvo] No matching modelSpec found for assistant_id: ${convo.assistant_id}`,
+            );
+          }
+        }
+      }
+
       if (req.body.isTemporary) {
         const expiredAt = new Date();
         expiredAt.setDate(expiredAt.getDate() + 30);


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

This change saves the spec and iconURL for assistants in the db, as it happens for agents and base models. Prior to this fix, chats made with assistants would result in a generic sparkle icon on the chat list, and selecting one would put the modelspec picker to 'none selected'.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] 
## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
