### PR TITLE
🐛 fix: Await saveMessage in abortMiddleware to ensure proper execution

### DIFF
--- a/api/server/middleware/abortMiddleware.js
+++ b/api/server/middleware/abortMiddleware.js
@@ -120,7 +120,7 @@ const createAbortController = (req, res, getAbortData, getReqData) => {
       { promptTokens, completionTokens },
     );
 
-    saveMessage(
+    await saveMessage(
       req,
       { ...responseMessage, user },
       { context: 'api/server/middleware/abortMiddleware.js' },


### PR DESCRIPTION
## Summary

Closes:- #5774 #5776 

Fixed a potential async operation issue in the abort middleware where saveMessage was called without await. This could lead to unhandled promises and potential race conditions in message handling. Previous code was not properly awaiting an async operation, which could lead to unexpected behavior. This fix ensures the async operation completes before continuing execution.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes