### PR TITLE
fix: Update FluxAPI response format for Claude 3.7 compatibility

### DIFF
--- a/api/app/clients/tools/structured/FluxAPI.js
+++ b/api/app/clients/tools/structured/FluxAPI.js
@@ -300,22 +300,22 @@ class FluxAPI extends Tool {
         const imageResponse = await fetch(imageUrl, fetchOptions);
         const arrayBuffer = await imageResponse.arrayBuffer();
         const base64 = Buffer.from(arrayBuffer).toString('base64');
-        const content = [
-          {
-            type: ContentTypes.IMAGE_URL,
-            image_url: {
-              url: `data:image/png;base64,${base64}`,
-            },
-          },
-        ];
-
-        const response = [
+        return [
           {
             type: ContentTypes.TEXT,
             text: displayMessage,
           },
+          {
+            content: [
+              {
+                type: ContentTypes.IMAGE_URL,
+                image_url: {
+                  url: `data:image/png;base64,${base64}`,
+                },
+              },
+            ],
+          },
         ];
-        return [response, { content }];
       } catch (error) {
         logger.error('Error processing image for agent:', error);
         return this.returnValue(`Failed to process the image. ${error.message}`);


### PR DESCRIPTION
# Pull Request: Fix FluxAPI Response Format for Claude 3.7 on AWS Bedrock

## Summary
This PR fixes an issue with the FluxAPI image generation tool when used with Claude 3.7 on AWS Bedrock. The current response format causes a validation error (`The format of the value at messages.2.content.0.toolResult.content.0.json is invalid`), preventing generated images from being displayed. The fix updates the response format to use a cleaner, properly typed structure that meets the schema requirements of AWS Bedrock's implementation.

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
I tested this fix with the following process:

1. Connected to Claude 3.7 via AWS Bedrock via Agents in LibreChat
2. Used the Flux tool to generate various images with different prompts
3. Verified that images now appear correctly in the chat interface
4. Confirmed that the error message no longer appears

I also tested with other models to ensure backward compatibility.


### **Test Configuration**:
- LibreChat version: 0.7.7
- LLM: Claude 3.7 Sonnet
- Provider: AWS Bedrock via Agents
- Browser: Chrome
- OS: OSX

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings

## Technical Details of Changes
The fix modifies the structure of the response in FluxAPI.js when returning image generation results. The previous implementation used a nested array structure that was causing validation errors. The updated code uses a flat typed structure that matches the expected schema format.

**Before:**
```javascript
const content = [
  {
    type: ContentTypes.IMAGE_URL,
    image_url: {
      url: `data:image/png;base64,${base64}`,
    },
  },
];
const response = [
  {
    type: ContentTypes.TEXT,
    text: displayMessage,
  },
];
return [response, { content }];
```

**After:**
```javascript
return [
  {
    type: ContentTypes.TEXT,
    text: displayMessage,
  },
  {
    content: [
      {
        type: ContentTypes.IMAGE_URL,
        image_url: {
          url: `data:image/png;base64,${base64}`,
        },
      },
    ],
  },
];
```

This change is minimal but solves the compatibility issue by providing response format compatible with the AWS Bedrock API requirements.