### PR TITLE
⚠️ refactor: Use Error Content Part Instead Of Throwing Error for Agents

### DIFF
--- a/api/app/clients/prompts/formatAgentMessages.spec.js
+++ b/api/app/clients/prompts/formatAgentMessages.spec.js
@@ -325,4 +325,37 @@ describe('formatAgentMessages', () => {
     );
     expect(result[0].content).not.toContain('Analyzing the problem...');
   });
+
+  it('should exclude ERROR type content parts', () => {
+    const payload = [
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Hello there' },
+          {
+            type: ContentTypes.ERROR,
+            [ContentTypes.ERROR]:
+              'An error occurred while processing the request: Something went wrong',
+          },
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Final answer' },
+        ],
+      },
+    ];
+
+    const result = formatAgentMessages(payload);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(AIMessage);
+    expect(result[0].content).toEqual([
+      { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Hello there' },
+      { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Final answer' },
+    ]);
+
+    // Make sure no error content exists in the result
+    const hasErrorContent = result[0].content.some(
+      (item) =>
+        item.type === ContentTypes.ERROR || JSON.stringify(item).includes('An error occurred'),
+    );
+    expect(hasErrorContent).toBe(false);
+  });
 });

--- a/api/app/clients/prompts/formatMessages.js
+++ b/api/app/clients/prompts/formatMessages.js
@@ -211,6 +211,8 @@ const formatAgentMessages = (payload) => {
       } else if (part.type === ContentTypes.THINK) {
         hasReasoning = true;
         continue;
+      } else if (part.type === ContentTypes.ERROR) {
+        continue;
       } else {
         currentContent.push(part);
       }

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -812,7 +812,10 @@ class AgentClient extends BaseClient {
           '[api/server/controllers/agents/client.js #sendCompletion] Unhandled error type',
           err,
         );
-        throw err;
+        this.contentParts.push({
+          type: ContentTypes.ERROR,
+          [ContentTypes.ERROR]: `An error occurred while processing the request${err?.message ? `: ${err.message}` : ''}`,
+        });
       }
     }
   }

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -32,7 +32,12 @@ const Part = memo(({ part, isSubmitting, attachments, showCursor, isCreatedByUse
   }
 
   if (part.type === ContentTypes.ERROR) {
-    return <ErrorMessage text={part[ContentTypes.TEXT].value} className="my-2" />;
+    return (
+      <ErrorMessage
+        text={part[ContentTypes.ERROR] ?? part[ContentTypes.TEXT]?.value}
+        className="my-2"
+      />
+    );
   } else if (part.type === ContentTypes.TEXT) {
     const text = typeof part.text === 'string' ? part.text : part.text.value;
 


### PR DESCRIPTION
## Summary

I refactored the agent error handling workflow to push an error content part instead of throwing errors during execution. This change guarantees that error messages are encapsulated within a structured content part and excluded from subsequent message payloads for smoother processing and display.

- Updated the agent client in api/server/controllers/agents/client.js to append an error content part with a formatted message instead of throwing an error.
- Modified the message formatting in api/app/clients/prompts/formatMessages.js to skip any parts marked as ERROR.
- Added a comprehensive test in api/app/clients/prompts/formatAgentMessages.spec.js to verify that error parts are excluded from the final AIMessage content.
- Adjusted the error rendering in client/src/components/Chat/Messages/Content/Part.tsx to display the error message from the ERROR property when available.
  
Testing:
- Ran the updated unit tests to confirm that error messages are handled as content parts and are omitted from formatted outputs.
- Simulated agent error scenarios to ensure the correct error message is pushed and rendered without causing unintended interruptions.

Checklist:
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented complex areas of my code as needed
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
- [x] Any dependent changes have been merged and published in downstream modules