### PR TITLE
🔧 fix: Axios Proxy Usage And Bump `mongoose`

### DIFF
--- a/api/config/index.js
+++ b/api/config/index.js
@@ -66,7 +66,7 @@ function createAxiosInstance() {
 
       /** @type {AxiosProxyConfig} */
       const proxyConfig = {
-        host: url.hostname,
+        host: url.hostname.replace(/^\[|\]$/g, ''),
         protocol: url.protocol.replace(':', ''),
       };
 

--- a/api/config/index.js
+++ b/api/config/index.js
@@ -48,15 +48,37 @@ const sendEvent = (res, event) => {
   res.write(`event: message\ndata: ${JSON.stringify(event)}\n\n`);
 };
 
+/**
+ * Creates and configures an Axios instance with optional proxy settings.
+ *
+ * @typedef {import('axios').AxiosInstance} AxiosInstance
+ * @typedef {import('axios').AxiosProxyConfig} AxiosProxyConfig
+ *
+ * @returns {AxiosInstance} A configured Axios instance
+ * @throws {Error} If there's an issue creating the Axios instance or parsing the proxy URL
+ */
 function createAxiosInstance() {
   const instance = axios.create();
 
   if (process.env.proxy) {
-    const url = new URL(process.env.proxy);
-    instance.defaults.proxy = {
-      host: url.hostname,
-      protocol: url.protocol.replace(':', ''),
-    };
+    try {
+      const url = new URL(process.env.proxy);
+
+      /** @type {AxiosProxyConfig} */
+      const proxyConfig = {
+        host: url.hostname,
+        protocol: url.protocol.replace(':', ''),
+      };
+
+      if (url.port) {
+        proxyConfig.port = parseInt(url.port, 10);
+      }
+
+      instance.defaults.proxy = proxyConfig;
+    } catch (error) {
+      console.error('Error parsing proxy URL:', error);
+      throw new Error(`Invalid proxy URL: ${process.env.proxy}`);
+    }
   }
 
   return instance;

--- a/api/config/index.spec.js
+++ b/api/config/index.spec.js
@@ -1,0 +1,126 @@
+const axios = require('axios');
+const { createAxiosInstance } = require('./index');
+
+// Mock axios
+jest.mock('axios', () => ({
+  interceptors: {
+    request: { use: jest.fn(), eject: jest.fn() },
+    response: { use: jest.fn(), eject: jest.fn() },
+  },
+  create: jest.fn().mockReturnValue({
+    defaults: {
+      proxy: null,
+    },
+    get: jest.fn().mockResolvedValue({ data: {} }),
+    post: jest.fn().mockResolvedValue({ data: {} }),
+    put: jest.fn().mockResolvedValue({ data: {} }),
+    delete: jest.fn().mockResolvedValue({ data: {} }),
+  }),
+  get: jest.fn().mockResolvedValue({ data: {} }),
+  post: jest.fn().mockResolvedValue({ data: {} }),
+  put: jest.fn().mockResolvedValue({ data: {} }),
+  delete: jest.fn().mockResolvedValue({ data: {} }),
+  reset: jest.fn().mockImplementation(function () {
+    this.get.mockClear();
+    this.post.mockClear();
+    this.put.mockClear();
+    this.delete.mockClear();
+    this.create.mockClear();
+  }),
+}));
+
+describe('createAxiosInstance', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Reset mocks
+    jest.clearAllMocks();
+    // Create a clean copy of process.env
+    process.env = { ...originalEnv };
+    // Default: no proxy
+    delete process.env.proxy;
+  });
+
+  afterAll(() => {
+    // Restore original process.env
+    process.env = originalEnv;
+  });
+
+  test('creates an axios instance without proxy when no proxy env is set', () => {
+    const instance = createAxiosInstance();
+
+    expect(axios.create).toHaveBeenCalledTimes(1);
+    expect(instance.defaults.proxy).toBeNull();
+  });
+
+  test('configures proxy correctly with hostname and protocol', () => {
+    process.env.proxy = 'http://example.com';
+
+    const instance = createAxiosInstance();
+
+    expect(axios.create).toHaveBeenCalledTimes(1);
+    expect(instance.defaults.proxy).toEqual({
+      host: 'example.com',
+      protocol: 'http',
+    });
+  });
+
+  test('configures proxy correctly with hostname, protocol and port', () => {
+    process.env.proxy = 'https://proxy.example.com:8080';
+
+    const instance = createAxiosInstance();
+
+    expect(axios.create).toHaveBeenCalledTimes(1);
+    expect(instance.defaults.proxy).toEqual({
+      host: 'proxy.example.com',
+      protocol: 'https',
+      port: 8080,
+    });
+  });
+
+  test('handles proxy URLs with authentication', () => {
+    process.env.proxy = 'http://user:pass@proxy.example.com:3128';
+
+    const instance = createAxiosInstance();
+
+    expect(axios.create).toHaveBeenCalledTimes(1);
+    expect(instance.defaults.proxy).toEqual({
+      host: 'proxy.example.com',
+      protocol: 'http',
+      port: 3128,
+      // Note: The current implementation doesn't handle auth - if needed, add this functionality
+    });
+  });
+
+  test('throws error when proxy URL is invalid', () => {
+    process.env.proxy = 'invalid-url';
+
+    expect(() => createAxiosInstance()).toThrow('Invalid proxy URL');
+    expect(axios.create).toHaveBeenCalledTimes(1);
+  });
+
+  // If you want to test the actual URL parsing more thoroughly
+  test('handles edge case proxy URLs correctly', () => {
+    // IPv6 address
+    process.env.proxy = 'http://[::1]:8080';
+
+    let instance = createAxiosInstance();
+
+    expect(instance.defaults.proxy).toEqual({
+      host: '::1',
+      protocol: 'http',
+      port: 8080,
+    });
+
+    // URL with path (which should be ignored for proxy config)
+    process.env.proxy = 'http://proxy.example.com:8080/some/path';
+
+    instance = createAxiosInstance();
+
+    expect(instance.defaults.proxy).toEqual({
+      host: 'proxy.example.com',
+      protocol: 'http',
+      port: 8080,
+    });
+  });
+});

--- a/api/package.json
+++ b/api/package.json
@@ -82,7 +82,7 @@
     "memorystore": "^1.6.7",
     "mime": "^3.0.0",
     "module-alias": "^2.2.3",
-    "mongoose": "^8.9.5",
+    "mongoose": "^8.12.1",
     "multer": "^1.4.5-lts.1",
     "nanoid": "^3.3.7",
     "nodemailer": "^6.9.15",

--- a/api/server/services/Files/Code/crud.js
+++ b/api/server/services/Files/Code/crud.js
@@ -1,7 +1,9 @@
-const axios = require('axios');
 const FormData = require('form-data');
 const { getCodeBaseURL } = require('@librechat/agents');
+const { createAxiosInstance } = require('~/config');
 const { logAxiosError } = require('~/utils');
+
+const axios = createAxiosInstance();
 
 const MAX_FILE_SIZE = 150 * 1024 * 1024;
 
@@ -26,13 +28,6 @@ async function getCodeOutputDownloadStream(fileIdentifier, apiKey) {
       },
       timeout: 15000,
     };
-
-    if (process.env.PROXY) {
-      options.proxy = {
-        host: process.env.PROXY,
-        protocol: process.env.PROXY.startsWith('https') ? 'https' : 'http',
-      };
-    }
 
     const response = await axios(options);
     return response;
@@ -78,13 +73,6 @@ async function uploadCodeEnvFile({ req, stream, filename, apiKey, entity_id = ''
       maxContentLength: MAX_FILE_SIZE,
       maxBodyLength: MAX_FILE_SIZE,
     };
-
-    if (process.env.PROXY) {
-      options.proxy = {
-        host: process.env.PROXY,
-        protocol: process.env.PROXY.startsWith('https') ? 'https' : 'http',
-      };
-    }
 
     const response = await axios.post(`${baseURL}/upload`, form, options);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "memorystore": "^1.6.7",
         "mime": "^3.0.0",
         "module-alias": "^2.2.3",
-        "mongoose": "^8.9.5",
+        "mongoose": "^8.12.1",
         "multer": "^1.4.5-lts.1",
         "nanoid": "^3.3.7",
         "nodemailer": "^6.9.15",
@@ -677,7 +677,6 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
       "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
-      "devOptional": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
@@ -689,6 +688,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "api/node_modules/bson": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
+      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "api/node_modules/cookie-parser": {
@@ -880,13 +887,12 @@
       }
     },
     "api/node_modules/mongodb": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.10.0.tgz",
-      "integrity": "sha512-gP9vduuYWb9ZkDM546M+MP2qKVk5ZG2wPF63OvSRuUbqCR+11ZCAE1mOfllhlAG0wcoJY5yDL/rV3OmYEwXIzg==",
-      "devOptional": true,
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.14.2.tgz",
+      "integrity": "sha512-kMEHNo0F3P6QKDq17zcDuPeaywK/YaJVCEQRzPF3TOM/Bl9MFg64YE5Tu7ifj37qZJMhwU1tl2Ioivws5gRG5Q==",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.5",
-        "bson": "^6.7.0",
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.3",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
@@ -894,7 +900,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
         "mongodb-client-encryption": ">=6.0.0 <7",
@@ -929,7 +935,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
       "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
-      "devOptional": true,
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
         "whatwg-url": "^13.0.0"
@@ -939,7 +944,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
       "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
-      "devOptional": true,
       "dependencies": {
         "punycode": "^2.3.0"
       },
@@ -951,7 +955,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "devOptional": true,
       "engines": {
         "node": ">=12"
       }
@@ -960,7 +963,6 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
       "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
-      "devOptional": true,
       "dependencies": {
         "tr46": "^4.1.1",
         "webidl-conversions": "^7.0.0"
@@ -1006,6 +1008,27 @@
       },
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "api/node_modules/mongoose": {
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.12.1.tgz",
+      "integrity": "sha512-UW22y8QFVYmrb36hm8cGncfn4ARc/XsYWQwRTaj0gxtQk1rDuhzDO1eBantS+hTTatfAIS96LlRCJrcNHvW5+Q==",
+      "dependencies": {
+        "bson": "^6.10.3",
+        "kareem": "2.6.3",
+        "mongodb": "~6.14.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
       }
     },
     "api/node_modules/node-fetch": {
@@ -22564,6 +22587,8 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.1.tgz",
       "integrity": "sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=16.20.1"
       }
@@ -31839,6 +31864,8 @@
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.12.0.tgz",
       "integrity": "sha512-RM7AHlvYfS7jv7+BXund/kR64DryVI+cHbVAy9P61fnb1RcWZqOW1/Wj2YhqMCx+MuYhqTRGv7AwHBzmsCKBfA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
         "bson": "^6.10.1",
@@ -31893,6 +31920,8 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
       "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/webidl-conversions": "*"
       }
@@ -31901,6 +31930,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
       "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/whatwg-url": "^11.0.2",
         "whatwg-url": "^14.1.0 || ^13.0.0"
@@ -31910,6 +31941,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
       "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -31921,33 +31954,14 @@
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.0.tgz",
       "integrity": "sha512-jlf/foYIKywAt3x/XWKZ/3rz8OSJPiWktjmk891alJUEjiVxKX9LEO92qH3hv4aJ0mN3MWPvGMCy8jQi95xK4w==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "^5.0.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/mongoose": {
-      "version": "8.9.5",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.5.tgz",
-      "integrity": "sha512-SPhOrgBm0nKV3b+IIHGqpUTOmgVL5Z3OO9AwkFEmvOZznXTvplbomstCnPOGAyungtRXE5pJTgKpKcZTdjeESg==",
-      "dependencies": {
-        "bson": "^6.10.1",
-        "kareem": "2.6.3",
-        "mongodb": "~6.12.0",
-        "mpath": "0.9.0",
-        "mquery": "5.0.0",
-        "ms": "2.1.3",
-        "sift": "17.1.3"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mongoose"
       }
     },
     "node_modules/moo-color": {
@@ -41152,9 +41166,9 @@
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
       "version": "0.0.2",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "mongoose": "^8.9.5"
+        "mongoose": "^8.12.1"
       },
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",
@@ -41182,6 +41196,14 @@
         "keyv": "^4.5.4"
       }
     },
+    "packages/data-schemas/node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "packages/data-schemas/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -41193,12 +41215,11 @@
       }
     },
     "packages/data-schemas/node_modules/bson": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
-      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
-      "license": "Apache-2.0",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.3.tgz",
+      "integrity": "sha512-MTxGsqgYTwfshYWTRdmZRC+M7FnG1b4y7RO7p2k3X24Wq0yv1m77Wsj0BzlPzd/IowgESfsruQCUToa7vbOpPQ==",
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       }
     },
     "packages/data-schemas/node_modules/glob": {
@@ -41238,15 +41259,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "packages/data-schemas/node_modules/kareem": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
-      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "packages/data-schemas/node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -41264,33 +41276,34 @@
       }
     },
     "packages/data-schemas/node_modules/mongodb": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
-      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
-      "license": "Apache-2.0",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.14.2.tgz",
+      "integrity": "sha512-kMEHNo0F3P6QKDq17zcDuPeaywK/YaJVCEQRzPF3TOM/Bl9MFg64YE5Tu7ifj37qZJMhwU1tl2Ioivws5gRG5Q==",
       "dependencies": {
-        "bson": "^5.5.0",
-        "mongodb-connection-string-url": "^2.6.0",
-        "socks": "^2.7.1"
+        "@mongodb-js/saslprep": "^1.1.9",
+        "bson": "^6.10.3",
+        "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
-        "node": ">=14.20.1"
-      },
-      "optionalDependencies": {
-        "@mongodb-js/saslprep": "^1.1.0"
+        "node": ">=16.20.1"
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.0.0",
-        "kerberos": "^1.0.0 || ^2.0.0",
-        "mongodb-client-encryption": ">=2.3.0 <3",
-        "snappy": "^7.2.2"
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
           "optional": true
         },
         "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
           "optional": true
         },
         "kerberos": {
@@ -41301,25 +41314,36 @@
         },
         "snappy": {
           "optional": true
+        },
+        "socks": {
+          "optional": true
         }
       }
     },
-    "packages/data-schemas/node_modules/mongoose": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.6.tgz",
-      "integrity": "sha512-1oVPRHvcmPVwk/zeSTEzayzQEVeYQM1D5zrkLsttfNNB7pPRUmkKeFu6gpbvyEswOuZLrWJjqB8kSTY+k2AZOA==",
-      "license": "MIT",
+    "packages/data-schemas/node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
       "dependencies": {
-        "bson": "^5.5.0",
-        "kareem": "2.5.1",
-        "mongodb": "5.9.2",
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "packages/data-schemas/node_modules/mongoose": {
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.12.1.tgz",
+      "integrity": "sha512-UW22y8QFVYmrb36hm8cGncfn4ARc/XsYWQwRTaj0gxtQk1rDuhzDO1eBantS+hTTatfAIS96LlRCJrcNHvW5+Q==",
+      "dependencies": {
+        "bson": "^6.10.3",
+        "kareem": "2.6.3",
+        "mongodb": "~6.14.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
-        "sift": "16.0.1"
+        "sift": "17.1.3"
       },
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       },
       "funding": {
         "type": "opencollective",
@@ -41342,11 +41366,28 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/data-schemas/node_modules/sift": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
-      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==",
-      "license": "MIT"
+    "packages/data-schemas/node_modules/tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/data-schemas/node_modules/whatwg-url": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.1.tgz",
+      "integrity": "sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==",
+      "dependencies": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "packages/mcp": {
       "name": "librechat-mcp",

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -60,7 +60,7 @@
     "access": "public"
   },
   "dependencies": {
-    "mongoose": "^8.9.5"
+    "mongoose": "^8.12.1"
   },
   "peerDependencies": {
     "keyv": "^4.5.4"


### PR DESCRIPTION
## Summary:

Closes #6285

I updated the Axios instance creation to improve proxy configuration and error handling, refactored file upload functions to use the centralized Axios instance, and bumped the mongoose dependency to resolve nested schema errors.

- Updated the Axios instance by stripping square brackets from IPv6 hostnames, parsing the port and protocol correctly, and wrapping proxy URL parsing in a try/catch block that logs errors and throws a descriptive error when the proxy URL is invalid.
- Added a comprehensive suite of unit tests in api/config/index.spec.js to verify various proxy URL scenarios, including URLs with authentication, ports, IPv6 addresses, and paths.
- Refactored file upload functions in the Files service to remove redundant proxy handling, ensuring they leverage the updated Axios instance configuration.
- Bumped the mongoose dependency in both the API and data-schemas packages to address nested schema errors.

Testing:
- Ran all unit tests with Jest to ensure that Axios instance creation works as expected in both valid and error conditions.
- Manually tested file upload functionality to verify that the new Axios configuration is correctly applied.
- Verified that the schema errors were resolved after upgrading mongoose.

Checklist:
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules