### PR TITLE
✨ feat: LaTeX Rendering and Markdown in `Thoughts` Dropdown

### DIFF
--- a/client/src/components/Artifacts/Thinking.tsx
+++ b/client/src/components/Artifacts/Thinking.tsx
@@ -1,7 +1,8 @@
-import { useState, useMemo, memo, useCallback } from 'react';
+import React, { useState, useMemo, memo, useCallback } from 'react';
 import { useRecoilValue } from 'recoil';
 import { Atom, ChevronDown } from 'lucide-react';
 import type { MouseEvent, FC } from 'react';
+import Markdown from '~/components/Chat/Messages/Content/Markdown';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 import store from '~/store';
@@ -21,12 +22,18 @@ const CONTENT_STYLES = {
 } as const;
 
 export const ThinkingContent: FC<{ children: React.ReactNode; isPart?: boolean }> = memo(
-  ({ isPart, children }) => (
-    <div className={CONTENT_STYLES.wrapper}>
-      <div className={isPart === true ? CONTENT_STYLES.partBorder : CONTENT_STYLES.border} />
-      <p className={CONTENT_STYLES.text}>{children}</p>
-    </div>
-  ),
+  ({ isPart, children }) => {
+    return (
+      <div className={CONTENT_STYLES.wrapper}>
+        <div className={isPart === true ? CONTENT_STYLES.partBorder : CONTENT_STYLES.border} />
+        {typeof children === 'string' ? (
+          <Markdown content={children} isLatestMessage={false} />
+        ) : (
+          <p className={CONTENT_STYLES.text}>{children}</p>
+        )}
+      </div>
+    );
+  },
 );
 
 export const ThinkingButton = memo(

--- a/client/src/components/Chat/Messages/Content/Markdown.tsx
+++ b/client/src/components/Chat/Messages/Content/Markdown.tsx
@@ -166,6 +166,46 @@ export const p: React.ElementType = memo(({ children }: TParagraphProps) => {
   return <p className="mb-2 whitespace-pre-wrap">{children}</p>;
 });
 
+export const h1: React.ElementType = memo(({ children, ...props }: TParagraphProps) => {
+  return (
+    <h1 className="mb-2 mt-4 text-3xl font-bold" {...props}>
+      {children}
+    </h1>
+  );
+});
+
+export const h2: React.ElementType = memo(({ children, ...props }: TParagraphProps) => {
+  return (
+    <h2 className="mb-2 mt-4 text-2xl font-bold" {...props}>
+      {children}
+    </h2>
+  );
+});
+
+export const h3: React.ElementType = memo(({ children, ...props }: TParagraphProps) => {
+  return (
+    <h3 className="mb-1 mt-3 text-xl font-bold" {...props}>
+      {children}
+    </h3>
+  );
+});
+
+export const ol: React.ElementType = memo(({ children, ...props }: TParagraphProps) => {
+  return (
+    <ol className="ml-6 list-decimal" {...props}>
+      {children}
+    </ol>
+  );
+});
+
+export const ul: React.ElementType = memo(({ children, ...props }: TParagraphProps) => {
+  return (
+    <ul className="ml-6 list-disc" {...props}>
+      {children}
+    </ul>
+  );
+});
+
 const cursor = ' ';
 
 type TContentProps = {
@@ -234,6 +274,11 @@ const Markdown = memo(({ content = '', showCursor, isLatestMessage }: TContentPr
               code,
               a,
               p,
+              h1,
+              h2,
+              h3,
+              ol,
+              ul,
               artifact: Artifact,
             } as {
               [nodeType: string]: React.ElementType;


### PR DESCRIPTION
## Summary

Closes: https://discord.com/channels/1086345563026489514/1348231180868255804

This pull request includes changes to enhance the rendering of markdown content and improve the consistency of imports in the `Thinking` component. The most important changes include adding support for various HTML elements in markdown and updating the import statements to include `React`.

Enhancements to markdown rendering:

* [`client/src/components/Chat/Messages/Content/Markdown.tsx`](diffhunk://#diff-f771a1e3c75088c33d06db77e64fcbaafeb5532c099f39ff92b7e25f16f38c67R169-R208): Added support for `h1`, `h2`, `h3`, `ol`, and `ul` elements by defining them as memoized components.
* [`client/src/components/Chat/Messages/Content/Markdown.tsx`](diffhunk://#diff-f771a1e3c75088c33d06db77e64fcbaafeb5532c099f39ff92b7e25f16f38c67R277-R281): Updated the `Markdown` component to include the newly added elements in the component mapping.

Improvements to `Thinking` component:

* [`client/src/components/Artifacts/Thinking.tsx`](diffhunk://#diff-17e6447c97857ec47ff75bb7c58d57c50750500182dc380fedbd6cf6360e94aeL1-R5): Updated the import statements to include `React` and added the `Markdown` component for rendering children if they are of type string. [[1]](diffhunk://#diff-17e6447c97857ec47ff75bb7c58d57c50750500182dc380fedbd6cf6360e94aeL1-R5) [[2]](diffhunk://#diff-17e6447c97857ec47ff75bb7c58d57c50750500182dc380fedbd6cf6360e94aeL24-R36)


Before:
<img width="823" alt="before" src="https://github.com/user-attachments/assets/76aadb6d-2b9d-41c6-a0b8-893cbe443e7e" />

After:
<img width="823" alt="after" src="https://github.com/user-attachments/assets/aba85083-8dd7-480b-bf3e-2b9ca2524d5f" />


## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
