### PR TITLE
Updated socialLogins to be able to reuse existing REDIS connection

### DIFF
--- a/api/server/socialLogins.js
+++ b/api/server/socialLogins.js
@@ -1,8 +1,8 @@
-const Redis = require('ioredis');
 const passport = require('passport');
 const session = require('express-session');
 const MemoryStore = require('memorystore')(session);
 const RedisStore = require('connect-redis').default;
+const Keyv = require('keyv');
 const {
   setupOpenId,
   googleLogin,
@@ -13,12 +13,15 @@ const {
 } = require('~/strategies');
 const { isEnabled } = require('~/server/utils');
 const { logger } = require('~/config');
+const keyvRedis = require('~/cache/keyvRedis');
 
 /**
  *
  * @param {Express.Application} app
  */
 const configureSocialLogins = (app) => {
+  logger.info('Configuring social logins...');
+
   if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
     passport.use(googleLogin());
   }
@@ -41,17 +44,15 @@ const configureSocialLogins = (app) => {
     process.env.OPENID_SCOPE &&
     process.env.OPENID_SESSION_SECRET
   ) {
+    logger.info('Configuring OpenID Connect...');
     const sessionOptions = {
       secret: process.env.OPENID_SESSION_SECRET,
       resave: false,
       saveUninitialized: false,
     };
     if (isEnabled(process.env.USE_REDIS)) {
-      const client = new Redis(process.env.REDIS_URI);
-      client
-        .on('error', (err) => logger.error('ioredis error:', err))
-        .on('ready', () => logger.info('ioredis successfully initialized.'))
-        .on('reconnecting', () => logger.info('ioredis reconnecting...'));
+      logger.info('Using Redis for session storage in OpenID...');
+      const keyv = new Keyv({ store: keyvRedis });
       sessionOptions.store = new RedisStore({ client, prefix: 'librechat' });
     } else {
       sessionOptions.store = new MemoryStore({
@@ -61,6 +62,8 @@ const configureSocialLogins = (app) => {
     app.use(session(sessionOptions));
     app.use(passport.session());
     setupOpenId();
+
+    logger.info('OpenID Connect configured.');
   }
 };
 

--- a/api/server/socialLogins.js
+++ b/api/server/socialLogins.js
@@ -53,7 +53,7 @@ const configureSocialLogins = (app) => {
     if (isEnabled(process.env.USE_REDIS)) {
       logger.info('Using Redis for session storage in OpenID...');
       const keyv = new Keyv({ store: keyvRedis });
-      sessionOptions.store = new RedisStore({ client, prefix: 'librechat' });
+      sessionOptions.store = new RedisStore({ client: keyv.opts.store.redis, prefix: 'librechat' });
     } else {
       sessionOptions.store = new MemoryStore({
         checkPeriod: 86400000, // prune expired entries every 24h


### PR DESCRIPTION
## Summary

The `socialLogins` module has been updated to reuse existing Redis connections, including those configured for clustered environments.
The original code recreated a new Redis plain connection.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.