### PR TITLE
⌛ feat: `initTimeout` for Slow Starting MCP Servers

### DIFF
--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -4,6 +4,7 @@ import { extractEnvVariable } from './utils';
 const BaseOptionsSchema = z.object({
   iconPath: z.string().optional(),
   timeout: z.number().optional(),
+  initTimeout: z.number().optional(),
 });
 
 export const StdioOptionsSchema = BaseOptionsSchema.extend({

--- a/packages/mcp/src/connection.ts
+++ b/packages/mcp/src/connection.ts
@@ -269,7 +269,7 @@ export class MCPConnection extends EventEmitter {
         this.transport = this.constructTransport(this.options);
         this.setupTransportDebugHandlers();
 
-        const connectTimeout = 10000;
+	const connectTimeout = this.options.initTimeout ?? 10000
         await Promise.race([
           this.client.connect(this.transport),
           new Promise((_resolve, reject) =>

--- a/packages/mcp/src/connection.ts
+++ b/packages/mcp/src/connection.ts
@@ -269,7 +269,7 @@ export class MCPConnection extends EventEmitter {
         this.transport = this.constructTransport(this.options);
         this.setupTransportDebugHandlers();
 
-	const connectTimeout = this.options.initTimeout ?? 10000
+	const connectTimeout = this.options.initTimeout ?? 10000;
         await Promise.race([
           this.client.connect(this.transport),
           new Promise((_resolve, reject) =>


### PR DESCRIPTION
## Summary

I have some MCP servers that boot slower than the hardcoded timeout of 10000 milliseconds.

To mitigate this problem, I have changed the value from being hardcoded into being an optional parameter `initTimeout` that can be set in the config:
```
mcpServers:
   some-server-name:
     initTimeout: 20000
```
If not set, it defaults to 10000, i.e. the current value.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Two test methods:
 1. Add an MCP server that boots slower than 10000 milliseconds. That will fail with the current version of LibreChat. When setting the new `initTimeout` to a sufficiently high value, the addition of the slow starting MCP server will succeed.
 2. Add an MCP server with normal boot times below 10000 milliseconds. Then set the new `initTimeout` to a very low value, and try to start the system. It should fail to add the MCP server since it will not have time to boot.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code

Not sure about the documentation. I can't find any reference to the existing config parameter `timeout` in [the docs](https://github.com/search?q=repo%3ALibreChat-AI%2Flibrechat.ai%20timeout&type=code). If that is not documented, I'm not sure about this neither.
