### PR TITLE
🐛 fix: Prevent Crash on Duplicate Message ID

### DIFF
--- a/api/models/Message.js
+++ b/api/models/Message.js
@@ -71,7 +71,42 @@ async function saveMessage(req, params, metadata) {
   } catch (err) {
     logger.error('Error saving message:', err);
     logger.info(`---\`saveMessage\` context: ${metadata?.context}`);
-    throw err;
+    
+    // Check if this is a duplicate key error (MongoDB error code 11000)
+    if (err.code === 11000 && err.message.includes('duplicate key error')) {
+      // Log the duplicate key error but don't crash the application
+      logger.warn(`Duplicate messageId detected: ${params.messageId}. Continuing execution.`);
+      
+      try {
+        // Try to find the existing message with this ID
+        const existingMessage = await Message.findOne({
+          messageId: params.messageId,
+          user: req.user.id
+        });
+        
+        // If we found it, return it
+        if (existingMessage) {
+          return existingMessage.toObject();
+        }
+        
+        // If we can't find it (unlikely but possible in race conditions)
+        return {
+          ...params,
+          messageId: params.messageId,
+          user: req.user.id
+        };
+      } catch (findError) {
+        // If the findOne also fails, log it but don't crash
+        logger.warn(`Could not retrieve existing message with ID ${params.messageId}: ${findError.message}`);
+        return {
+          ...params,
+          messageId: params.messageId,
+          user: req.user.id
+        };
+      }
+    }
+    
+    throw err; // Re-throw other errors
   }
 }
 

--- a/api/models/Message.js
+++ b/api/models/Message.js
@@ -71,29 +71,29 @@ async function saveMessage(req, params, metadata) {
   } catch (err) {
     logger.error('Error saving message:', err);
     logger.info(`---\`saveMessage\` context: ${metadata?.context}`);
-    
+
     // Check if this is a duplicate key error (MongoDB error code 11000)
     if (err.code === 11000 && err.message.includes('duplicate key error')) {
       // Log the duplicate key error but don't crash the application
       logger.warn(`Duplicate messageId detected: ${params.messageId}. Continuing execution.`);
-      
+
       try {
         // Try to find the existing message with this ID
         const existingMessage = await Message.findOne({
           messageId: params.messageId,
-          user: req.user.id
+          user: req.user.id,
         });
-        
+
         // If we found it, return it
         if (existingMessage) {
           return existingMessage.toObject();
         }
-        
+
         // If we can't find it (unlikely but possible in race conditions)
         return {
           ...params,
           messageId: params.messageId,
-          user: req.user.id
+          user: req.user.id,
         };
       } catch (findError) {
         // If the findOne also fails, log it but don't crash
@@ -101,11 +101,11 @@ async function saveMessage(req, params, metadata) {
         return {
           ...params,
           messageId: params.messageId,
-          user: req.user.id
+          user: req.user.id,
         };
       }
     }
-    
+
     throw err; // Re-throw other errors
   }
 }


### PR DESCRIPTION
Added error handling for MongoDB error code 11000 (duplicate key error) in saveMessage function. This prevents the application from crashing when trying to save messages with duplicate IDs, which can happen during aborted requests. Now logs a warning and continues execution safely.

Closes: #5774
Closes: #5776

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Since this error occurs specifically in production environments and is difficult to reproduce locally, testing was performed through:

1. **Code Review Analysis**:
   - Identified the root cause: MongoDB error code 11000 (duplicate key error) in the saveMessage function
   - Added specific error handling to catch this error code and prevent application crashes
   - Ensured the solution preserves the existing return value contract by retrieving the duplicate message

2. **Function Contract Preservation**:
   - The fix maintains the expected behavior of the saveMessage function
   - When a duplicate messageId is detected, it retrieves and returns the existing message
   - This ensures that code depending on the return value will continue to work properly

3. **Defensive Coding**:
   - Implemented additional error handling to handle edge cases
   - Added comprehensive logging for better visibility of the issue
   - The solution degrades in case of unexpected scenarios

### **Test Configuration**:
- LibreChat latest
- MongoDB

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in the code to explain the error handling approach
- [x] My changes do not introduce new warnings