### PR TITLE
🔧 fix: Update Token Calculations and Mapping, MCP `env` Initialization

### DIFF
--- a/api/app/clients/specs/BaseClient.test.js
+++ b/api/app/clients/specs/BaseClient.test.js
@@ -164,7 +164,7 @@ describe('BaseClient', () => {
     const result = await TestClient.getMessagesWithinTokenLimit({ messages });
 
     expect(result.context).toEqual(expectedContext);
-    expect(result.summaryIndex).toEqual(expectedIndex);
+    expect(result.messagesToRefine.length - 1).toEqual(expectedIndex);
     expect(result.remainingContextTokens).toBe(expectedRemainingContextTokens);
     expect(result.messagesToRefine).toEqual(expectedMessagesToRefine);
   });
@@ -200,7 +200,7 @@ describe('BaseClient', () => {
     const result = await TestClient.getMessagesWithinTokenLimit({ messages });
 
     expect(result.context).toEqual(expectedContext);
-    expect(result.summaryIndex).toEqual(expectedIndex);
+    expect(result.messagesToRefine.length - 1).toEqual(expectedIndex);
     expect(result.remainingContextTokens).toBe(expectedRemainingContextTokens);
     expect(result.messagesToRefine).toEqual(expectedMessagesToRefine);
   });

--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -2,6 +2,7 @@ const {
   FileSources,
   EModelEndpoint,
   loadOCRConfig,
+  processMCPEnv,
   getConfigDefaults,
 } = require('librechat-data-provider');
 const { checkVariables, checkHealth, checkConfig, checkAzureVariables } = require('./start/checks');
@@ -54,7 +55,7 @@ const AppService = async (app) => {
 
   if (config.mcpServers != null) {
     const mcpManager = await getMCPManager();
-    await mcpManager.initializeMCP(config.mcpServers);
+    await mcpManager.initializeMCP(config.mcpServers, processMCPEnv);
     await mcpManager.mapAvailableTools(availableTools);
   }
 

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -178,6 +178,7 @@ const initializeAgentOptions = async ({
     agent.provider = options.provider;
   }
 
+  /** @type {import('@librechat/agents').ClientOptions} */
   agent.model_parameters = Object.assign(model_parameters, options.llmConfig);
   if (options.configOptions) {
     agent.model_parameters.configuration = options.configOptions;
@@ -196,6 +197,7 @@ const initializeAgentOptions = async ({
 
   const tokensModel =
     agent.provider === EModelEndpoint.azureOpenAI ? agent.model : agent.model_parameters.model;
+  const maxTokens = agent.model_parameters.maxOutputTokens ?? agent.model_parameters.maxTokens ?? 0;
 
   return {
     ...agent,
@@ -204,7 +206,7 @@ const initializeAgentOptions = async ({
     toolContextMap,
     maxContextTokens:
       agent.max_context_tokens ??
-      (getModelMaxTokens(tokensModel, providerEndpointMap[provider]) ?? 4000) * 0.9,
+      ((getModelMaxTokens(tokensModel, providerEndpointMap[provider]) ?? 4000) - maxTokens) * 0.9,
   };
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40808,7 +40808,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.72",
+      "version": "0.7.73",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.8.2",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -85,3 +85,26 @@ export const MCPOptionsSchema = z.union([
 ]);
 
 export const MCPServersSchema = z.record(z.string(), MCPOptionsSchema);
+
+export type MCPOptions = z.infer<typeof MCPOptionsSchema>;
+
+/**
+ * Recursively processes an object to replace environment variables in string values
+ * @param {MCPOptions} obj - The object to process
+ * @returns {MCPOptions} - The processed object with environment variables replaced
+ */
+export function processMCPEnv(obj: MCPOptions): MCPOptions {
+  if (obj === null || obj === undefined) {
+    return obj;
+  }
+
+  if ('env' in obj && obj.env) {
+    const processedEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(obj.env)) {
+      processedEnv[key] = extractEnvVariable(value);
+    }
+    obj.env = processedEnv;
+  }
+
+  return obj;
+}

--- a/packages/mcp/src/manager.ts
+++ b/packages/mcp/src/manager.ts
@@ -33,7 +33,7 @@ export class MCPManager {
 
   public async initializeMCP(
     mcpServers: t.MCPServers,
-    processMCPEnv: (obj: MCPOptions) => MCPOptions,
+    processMCPEnv?: (obj: MCPOptions) => MCPOptions,
   ): Promise<void> {
     this.logger.info('[MCP] Initializing servers');
 
@@ -41,7 +41,7 @@ export class MCPManager {
     const initializedServers = new Set();
     const connectionResults = await Promise.allSettled(
       entries.map(async ([serverName, _config], i) => {
-        const config = processMCPEnv(_config);
+        const config = processMCPEnv ? processMCPEnv(_config) : _config;
         const connection = new MCPConnection(serverName, config, this.logger);
 
         connection.on('connectionChange', (state) => {

--- a/packages/mcp/src/manager.ts
+++ b/packages/mcp/src/manager.ts
@@ -1,5 +1,5 @@
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
-import type { JsonSchemaType } from 'librechat-data-provider';
+import type { JsonSchemaType, MCPOptions } from 'librechat-data-provider';
 import type { Logger } from 'winston';
 import type * as t from './types/mcp';
 import { formatToolContent } from './parsers';
@@ -31,13 +31,17 @@ export class MCPManager {
     return MCPManager.instance;
   }
 
-  public async initializeMCP(mcpServers: t.MCPServers): Promise<void> {
+  public async initializeMCP(
+    mcpServers: t.MCPServers,
+    processMCPEnv: (obj: MCPOptions) => MCPOptions,
+  ): Promise<void> {
     this.logger.info('[MCP] Initializing servers');
 
     const entries = Object.entries(mcpServers);
     const initializedServers = new Set();
     const connectionResults = await Promise.allSettled(
-      entries.map(async ([serverName, config], i) => {
+      entries.map(async ([serverName, _config], i) => {
+        const config = processMCPEnv(_config);
         const connection = new MCPConnection(serverName, config, this.logger);
 
         connection.on('connectionChange', (state) => {


### PR DESCRIPTION
## Summary

I updated the agent’s context token calculations by accounting for reserved maxOutputTokens, refactored BaseClient’s token mapping logic to use only payload messages, and enhanced MCP initialization to process environment variables dynamically.

- Adjusted maxContextTokens in agent initialization by subtracting the maxOutputTokens (or maxTokens) from the model’s maximum tokens and applying a 90% factor.
- Refactored BaseClient to remove redundant summaryIndex logic and generate tokenCountMap only for messages actively used in the payload.
- Updated BaseClient tests to assert the revised token mapping behavior using messagesToRefine.
- Enhanced MCP initialization by introducing processMCPEnv to replace environment variable placeholders in MCP configuration objects before establishing connections.
- Added explicit type annotations and documentation comments to improve code clarity and maintainability.

Testing:
- Executed local unit and integration tests covering agent initialization, payload token mapping, and MCP configuration.
- Verified that no warnings are introduced and all tests pass.

Change Type:
- [x] Bug fix (non-breaking change which fixes an issue)

Checklist:
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules