### PR TITLE
🐞 fix: Agent "Resend" Message Attachments + Source Icon Styling

### DIFF
--- a/api/models/File.js
+++ b/api/models/File.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const { fileSchema } = require('@librechat/data-schemas');
+const { logger } = require('~/config');
 
 const File = mongoose.model('File', fileSchema);
 
@@ -24,6 +25,32 @@ const findFileById = async (file_id, options = {}) => {
 const getFiles = async (filter, _sortOptions, selectFields = { text: 0 }) => {
   const sortOptions = { updatedAt: -1, ..._sortOptions };
   return await File.find(filter).select(selectFields).sort(sortOptions).lean();
+};
+
+/**
+ * Retrieves tool files (files that are embedded or have a fileIdentifier) from an array of file IDs
+ * @param {string[]} fileIds - Array of file_id strings to search for
+ * @returns {Promise<Array<IMongoFile>>} Files that match the criteria
+ */
+const getToolFilesByIds = async (fileIds) => {
+  if (!fileIds || !fileIds.length) {
+    return [];
+  }
+
+  try {
+    const filter = {
+      file_id: { $in: fileIds },
+      $or: [{ embedded: true }, { 'metadata.fileIdentifier': { $exists: true } }],
+    };
+
+    const selectFields = { text: 0 };
+    const sortOptions = { updatedAt: -1 };
+
+    return await getFiles(filter, sortOptions, selectFields);
+  } catch (error) {
+    logger.error('[getToolFilesByIds] Error retrieving tool files:', error);
+    throw new Error('Error retrieving tool files');
+  }
 };
 
 /**
@@ -111,6 +138,7 @@ module.exports = {
   File,
   findFileById,
   getFiles,
+  getToolFilesByIds,
   createFile,
   updateFile,
   updateFileUsage,

--- a/client/src/components/Chat/Input/Files/SourceIcon.tsx
+++ b/client/src/components/Chat/Input/Files/SourceIcon.tsx
@@ -13,7 +13,7 @@ const sourceToClassname = {
   [FileSources.azure]: 'azure-bg-color opacity-85',
   [FileSources.execute_code]: 'bg-black text-white opacity-85',
   [FileSources.text]: 'bg-blue-500 dark:bg-blue-900 opacity-85 text-white',
-  [FileSources.vectordb]: 'bg-yellow-100 dark:bg-yellow-900 opacity-85 text-white',
+  [FileSources.vectordb]: 'bg-yellow-700 dark:bg-yellow-900 opacity-85 text-white',
 };
 
 const defaultClassName =

--- a/client/src/components/Chat/Input/Files/SourceIcon.tsx
+++ b/client/src/components/Chat/Input/Files/SourceIcon.tsx
@@ -12,7 +12,7 @@ const sourceToClassname = {
   [FileSources.openai]: 'bg-white/75 dark:bg-black/65',
   [FileSources.azure]: 'azure-bg-color opacity-85',
   [FileSources.execute_code]: 'bg-black text-white opacity-85',
-  [FileSources.text]: 'bg-blue-100 dark:bg-blue-900 opacity-85 text-white',
+  [FileSources.text]: 'bg-blue-500 dark:bg-blue-900 opacity-85 text-white',
   [FileSources.vectordb]: 'bg-yellow-100 dark:bg-yellow-900 opacity-85 text-white',
 };
 


### PR DESCRIPTION
## Summary

I resolved issues with file resend behavior for tool resource message attachments (code interpreter + file search only) and refined source icon styling in LibreChat. This bug was introduced in #6274

 I refactored the conversation file retrieval and improved file processing during agent initialization, while also updating client-side icon colors for better visibility.

- Renamed getToolFiles to getConvoFiles in the Conversation model to simplify file retrieval.
- Added getToolFilesByIds in the File model to efficiently fetch tool files by their IDs.
- Updated agent initialization logic to merge request files with tool files for proper processing.
- Adjusted vectordb and text file icon background colors in the client to enhance visibility.
- Verified functionality via local unit tests and manual runs in development.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in the code to explain the error handling approach
- [x] My changes do not introduce new warnings