### PR TITLE
🔼 feat: Add Auto Submit For URL Query Params

### DIFF
--- a/client/src/hooks/Input/useQueryParams.ts
+++ b/client/src/hooks/Input/useQueryParams.ts
@@ -162,7 +162,7 @@ export default function useQueryParams({
       });
 
       const decodedPrompt = queryParams.prompt || '';
-      const shouldAutoSubmit = queryParams.submit === 'true';
+      const shouldAutoSubmit = queryParams.submit?.toLowerCase() === 'true';
       delete queryParams.prompt;
       delete queryParams.submit;
       const validSettings = processValidSettings(queryParams);


### PR DESCRIPTION
## Summary

This pull request adds a new feature that allows users to automatically submit a prompt via a URL parameter. By including the `submit=true` parameter in the URL (e.g., `/c/new?prompt=${encodedPrompt}&submit=true`), users will be able to prepopulate and instantly submit their prompt without needing to click the submit button. This feature enhances automation capabilities, making it easier for users to integrate LibreChat with tools like Raycast, Alfred, and other automation systems.

See: https://github.com/danny-avila/LibreChat/issues/6427

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

To test the new feature, please follow these steps:
1. Access the LibreChat application and navigate to the new prompt creation route using the provided URL format.
2. Ensure that you encode the prompt properly using URI encoding.
3. Verify that when you include `&submit=true` in the URL, the prompt is automatically submitted after being prepopulated.
4. Check that accessing the URL without the `submit=true` parameter still allows users to manually submit their prompts as expected.

### **Test Configuration**:
- Ensure that you are running the latest version of LibreChat in your local development environment.
- Test on different browsers to verify cross-browser functionality.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted. [See here](https://github.com/LibreChat-AI/librechat.ai/pull/269)