### PR TITLE
🔧 fix: Update username reference to use user.name in greeting display

### DIFF
--- a/client/src/components/Chat/Landing.tsx
+++ b/client/src/components/Chat/Landing.tsx
@@ -124,8 +124,8 @@ export default function Landing({ centerFormOnLanding }: { centerFormOnLanding: 
             </div>
           ) : (
             <SplitText
-              key={`split-text-${getGreeting()}${user?.username || ''}`}
-              text={getGreeting() + (user?.username ? ', ' + user.username : '')}
+              key={`split-text-${getGreeting()}${user?.name || ''}`}
+              text={getGreeting() + (user?.name ? ', ' + user.name : '')}
               className="text-4xl font-medium text-text-primary"
               delay={50}
               textAlign="center"


### PR DESCRIPTION
## Summary

created this PR to have more uniformity with the UI. because we use `user.name` for the user tab. then we should also use the `user.name` for the greetings message.

FROM:
<img width="1464" alt="Screenshot 2025-03-26 at 08 52 30" src="https://github.com/user-attachments/assets/52852ccc-4e7b-426a-a216-51e377cc6ff9" />


TO:
<img width="1464" alt="Screenshot 2025-03-26 at 08 52 38" src="https://github.com/user-attachments/assets/fe33f5a6-ac91-4491-96d1-1fbff0b5abbe" />


This pull request includes a small change to the `client/src/components/Chat/Landing.tsx` file. The change updates the `key` and `text` properties of the `SplitText` component to use the `name` property of the `user` object instead of the `username` property.

* [`client/src/components/Chat/Landing.tsx`](diffhunk://#diff-f0b27b0b922e125b587712dba5ece0763f3f54abdc4e7371d23430883a5c8b0aL127-R128): Updated `SplitText` component to use `user.name` instead of `user.username` for the `key` and `text` properties.


## Change Type

- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
