### PR TITLE
🔧 fix: S3 Download Stream with Key Extraction and Blob Storage Encoding for Vision

### DIFF
--- a/api/typedefs.js
+++ b/api/typedefs.js
@@ -403,6 +403,12 @@
  * @memberof typedefs
  */
 
+/**
+ * @exports MessageContentImageUrl
+ * @typedef {import('librechat-data-provider').Agents.MessageContentImageUrl} MessageContentImageUrl
+ * @memberof typedefs
+ */
+
 /** Prompts */
 /**
  * @exports TPrompt
@@ -757,6 +763,11 @@
 /**
  * @exports MongooseSchema
  * @typedef {import('mongoose').Schema} MongooseSchema
+ * @memberof typedefs
+ */
+/**
+ * @exports MongoFile
+ * @typedef {import('@librechat/data-schemas').IMongoFile} MongoFile
  * @memberof typedefs
  */
 


### PR DESCRIPTION
## Summary

Closes #6510

I improved S3 file handling and image encoding for vision payloads in LibreChat by refining how file keys are extracted and how blob storage streams are processed. This update enhances error logging and stream management while clarifying type definitions.

- Added extractKeyFromS3Url in api/server/services/Files/S3/crud.js to reliably parse and extract the S3 key from a full URL.
- Refactored getS3FileStream to utilize the extracted key and log detailed errors.
- Updated encodeAndFormat in api/server/services/Files/images/encode.js to support blob storage sources (S3 and Azure) by streaming file data and converting it to a base64 payload.
- Configured stream event listeners to collect data chunks for robust base64 conversion.
- Augmented typedefs in api/typedefs.js by adding MongoFile and MessageContentImageUrl definitions for improved type safety.

Change Type:
- [x] Bug fix (non-breaking change which fixes an issue)

Testing:
- Manually tested S3 file retrieval and image encoding workflows using simulated S3 and Azure blob storage inputs.
- Verified that base64 conversion occurs correctly and errors are logged with sufficient detail.
- Ran local unit tests to ensure all changes work as expected.

Checklist:
- [x] My code adheres to this project’s style guidelines.
- [x] I performed a self-review of my own code.
- [x] I added comments in complex areas.
- [x] I made pertinent documentation changes.
- [x] My changes do not introduce new warnings.
- [x] I wrote tests demonstrating the efficacy of my changes.
- [x] Local unit tests pass with my changes.
- [x] Any changes dependent on mine have been merged and published in downstream modules.