### PR TITLE
🔧 fix: Mistral type strictness for `usage` & update token values/windows

### DIFF
--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -122,6 +122,12 @@ const tokenValues = Object.assign(
     'grok-2-latest': { prompt: 2.0, completion: 10.0 },
     'grok-2': { prompt: 2.0, completion: 10.0 },
     'grok-beta': { prompt: 5.0, completion: 15.0 },
+    'mistral-large': { prompt: 2.0, completion: 6.0 },
+    'pixtral-large': { prompt: 2.0, completion: 6.0 },
+    'mistral-saba': { prompt: 0.2, completion: 0.6 },
+    codestral: { prompt: 0.3, completion: 0.9 },
+    'ministral-8b': { prompt: 0.1, completion: 0.1 },
+    'ministral-3b': { prompt: 0.04, completion: 0.04 },
   },
   bedrockValues,
 );

--- a/api/server/controllers/agents/run.js
+++ b/api/server/controllers/agents/run.js
@@ -43,6 +43,11 @@ async function createRun({
     agent.model_parameters,
   );
 
+  /** Resolves Mistral type strictness due to new OpenAI usage field */
+  if (agent.endpoint?.toLowerCase().includes(KnownEndpoints.mistral)) {
+    llmConfig.streamUsage = false;
+  }
+
   /** @type {'reasoning_content' | 'reasoning'} */
   let reasoningKey;
   if (

--- a/api/server/controllers/agents/run.js
+++ b/api/server/controllers/agents/run.js
@@ -46,6 +46,7 @@ async function createRun({
   /** Resolves Mistral type strictness due to new OpenAI usage field */
   if (agent.endpoint?.toLowerCase().includes(KnownEndpoints.mistral)) {
     llmConfig.streamUsage = false;
+    llmConfig.usage = true;
   }
 
   /** @type {'reasoning_content' | 'reasoning'} */

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -34,8 +34,14 @@ const mistralModels = {
   'mistral-7b': 31990, // -10 from max
   'mistral-small': 31990, // -10 from max
   'mixtral-8x7b': 31990, // -10 from max
+  'mistral-large': 131000,
   'mistral-large-2402': 127500,
   'mistral-large-2407': 127500,
+  'pixtral-large': 131000,
+  'mistral-saba': 32000,
+  codestral: 256000,
+  'ministral-8b': 131000,
+  'ministral-3b': 131000,
 };
 
 const cohereModels = {


### PR DESCRIPTION
## Summary

Closes #6536
Closes #6490

This is due to OpenAI now using this new format for requesting token usage metadata:

```js
  stream_options: {
    include_usage: true
  },
```

it used to be just `usage: true` and Mistral does not accept the new format.

As long as your custom endpoint `name` field includes "mistral", I will revert the update to the new OpenAI usage field for the old.

For using Azure serverless configuration, I will resolve when addressing #6425