### PR TITLE
🚀 feat: Add Gemini 2.5 Token/Context Values, Increase Max Possible Output to 64k

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,7 +142,7 @@ GOOGLE_KEY=user_provided
 # GOOGLE_AUTH_HEADER=true
 
 # Gemini API (AI Studio)
-# GOOGLE_MODELS=gemini-2.0-flash-exp,gemini-2.0-flash-thinking-exp-1219,gemini-exp-1121,gemini-exp-1114,gemini-1.5-flash-latest,gemini-1.0-pro,gemini-1.0-pro-001,gemini-1.0-pro-latest,gemini-1.0-pro-vision-latest,gemini-1.5-pro-latest,gemini-pro,gemini-pro-vision
+# GOOGLE_MODELS=gemini-2.5-exp-03-25,gemini-2.0-flash-exp,gemini-2.0-flash-thinking-exp-1219,gemini-exp-1121,gemini-exp-1114,gemini-1.5-flash-latest,gemini-1.0-pro,gemini-1.0-pro-001,gemini-1.0-pro-latest,gemini-1.0-pro-vision-latest,gemini-1.5-pro-latest,gemini-pro,gemini-pro-vision
 
 # Vertex AI
 # GOOGLE_MODELS=gemini-1.5-flash-preview-0514,gemini-1.5-pro-preview-0514,gemini-1.0-pro-vision-001,gemini-1.0-pro-002,gemini-1.0-pro-001,gemini-pro-vision,gemini-1.0-pro

--- a/.env.example
+++ b/.env.example
@@ -142,7 +142,7 @@ GOOGLE_KEY=user_provided
 # GOOGLE_AUTH_HEADER=true
 
 # Gemini API (AI Studio)
-# GOOGLE_MODELS=gemini-2.5-exp-03-25,gemini-2.0-flash-exp,gemini-2.0-flash-thinking-exp-1219,gemini-exp-1121,gemini-exp-1114,gemini-1.5-flash-latest,gemini-1.0-pro,gemini-1.0-pro-001,gemini-1.0-pro-latest,gemini-1.0-pro-vision-latest,gemini-1.5-pro-latest,gemini-pro,gemini-pro-vision
+# GOOGLE_MODELS=gemini-2.5-pro-exp-03-25,gemini-2.0-flash-exp,gemini-2.0-flash-thinking-exp-1219,gemini-exp-1121,gemini-exp-1114,gemini-1.5-flash-latest,gemini-1.0-pro,gemini-1.0-pro-001,gemini-1.0-pro-latest,gemini-1.0-pro-vision-latest,gemini-1.5-pro-latest,gemini-pro,gemini-pro-vision
 
 # Vertex AI
 # GOOGLE_MODELS=gemini-1.5-flash-preview-0514,gemini-1.5-pro-preview-0514,gemini-1.0-pro-vision-001,gemini-1.0-pro-002,gemini-1.0-pro-001,gemini-pro-vision,gemini-1.0-pro

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -109,6 +109,7 @@ const tokenValues = Object.assign(
     'gemini-2.0-flash-lite': { prompt: 0.075, completion: 0.3 },
     'gemini-2.0-flash': { prompt: 0.1, completion: 0.7 },
     'gemini-2.0': { prompt: 0, completion: 0 }, // https://ai.google.dev/pricing
+    'gemini-2.5': { prompt: 0, completion: 0 }, // Free for a period of time
     'gemini-1.5-flash-8b': { prompt: 0.075, completion: 0.3 },
     'gemini-1.5-flash': { prompt: 0.15, completion: 0.6 },
     'gemini-1.5': { prompt: 2.5, completion: 10 },

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -58,6 +58,7 @@ const googleModels = {
   gemini: 30720, // -2048 from max
   'gemini-pro-vision': 12288,
   'gemini-exp': 2000000,
+  'gemini-2.5': 1000000, // 1M input tokens, 64k output tokens
   'gemini-2.0': 2000000,
   'gemini-2.0-flash': 1000000,
   'gemini-2.0-flash-lite': 1000000,

--- a/client/src/components/Chat/Input/Files/AttachFile.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFile.tsx
@@ -18,6 +18,7 @@ const AttachFile = ({ disabled }: { disabled?: boolean | null }) => {
         disabled={isUploadDisabled}
         render={
           <button
+            type="button"
             aria-label={localize('com_sidepanel_attach_files')}
             disabled={isUploadDisabled}
             className={cn(

--- a/package-lock.json
+++ b/package-lock.json
@@ -43335,7 +43335,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.75",
+      "version": "0.7.76",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.8.2",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.75",
+  "version": "0.7.76",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -230,7 +230,7 @@ export const googleSettings = {
   },
   maxOutputTokens: {
     min: 1 as const,
-    max: 8192 as const,
+    max: 64000 as const,
     step: 1 as const,
     default: 8192 as const,
   },


### PR DESCRIPTION
## Summary

Closes #6529

I updated the configuration to support Gemini 2.5 by adding its token values and extending the maximum output tokens to accommodate a larger context window.

- Updated .env.example to include "gemini-2.5-pro-exp-03-25" among supported Gemini models.
- Added Gemini 2.5 token pricing in api/models/tx.js with a note on its free trial period.
- Mapped Gemini 2.5 token limits in api/utils/tokens.js to 1M input tokens.
- Bumped the version of the LibreChat data provider (packages/data-provider/package.json) from 0.7.75 to 0.7.76.
- Increased the maximum value for maxOutputTokens in packages/data-provider/src/schemas.ts from 8192 to 64000.

`gemini-2.5-pro-exp-03-25` was not added to the default model list since it's not available on Vertex yet.

### Other Changes

Closes #6571

Change Type:
- [x] New feature (non-breaking change which adds functionality)

Testing:
- Manually verified the .env changes load the new Gemini 2.5 model.
- Confirmed that token mappings in the API reflect the updated values.
- Ran local unit tests to ensure the increased max output token limit is applied without regressions.

Checklist:
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes