### PR TITLE
🔧 fix: Consolidate Text Parsing and TTS Edge Initialization

### DIFF
--- a/api/models/plugins/mongoMeili.js
+++ b/api/models/plugins/mongoMeili.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const mongoose = require('mongoose');
 const { MeiliSearch } = require('meilisearch');
+const { parseTextParts, ContentTypes } = require('librechat-data-provider');
 const { cleanUpPrimaryKeyValue } = require('~/lib/utils/misc');
 const logger = require('~/config/meiliLogger');
 
@@ -238,10 +239,7 @@ const createMeiliMongooseModel = function ({ index, attributesToIndex }) {
       }
 
       if (object.content && Array.isArray(object.content)) {
-        object.text = object.content
-          .filter((item) => item.type === 'text' && item.text && item.text.value)
-          .map((item) => item.text.value)
-          .join(' ');
+        object.text = parseTextParts(object.content);
         delete object.content;
       }
 

--- a/client/package.json
+++ b/client/package.json
@@ -73,7 +73,7 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.394.0",
     "match-sorter": "^6.3.4",
-    "msedge-tts": "^1.3.4",
+    "msedge-tts": "^2.0.0",
     "qrcode.react": "^4.2.0",
     "rc-input-number": "^7.4.2",
     "react": "^18.2.0",

--- a/client/src/hooks/Input/useTextToSpeechExternal.ts
+++ b/client/src/hooks/Input/useTextToSpeechExternal.ts
@@ -67,7 +67,10 @@ function useTextToSpeechExternal({
         return playPromise().catch(console.error);
       }
       console.error(error);
-      showToast({ message: localize('com_nav_audio_play_error', { 0: error.message }), status: 'error' });
+      showToast({
+        message: localize('com_nav_audio_play_error', { 0: error.message }),
+        status: 'error',
+      });
     });
 
     newAudio.onended = () => {
@@ -87,7 +90,7 @@ function useTextToSpeechExternal({
     setDownloadFile(false);
   };
 
-  const { mutate: processAudio } = useTextToSpeechMutation({
+  const { mutate: processAudio, isLoading } = useTextToSpeechMutation({
     onMutate: (variables) => {
       const inputText = (variables.get('input') ?? '') as string;
       if (inputText.length >= 4096) {
@@ -182,7 +185,7 @@ function useTextToSpeechExternal({
 
   useEffect(() => cancelPromiseSpeech, [cancelPromiseSpeech]);
 
-  const isLoading = useMemo(
+  const isFetching = useMemo(
     () => isLast && globalIsFetching && !globalIsPlaying,
     [globalIsFetching, globalIsPlaying, isLast],
   );
@@ -192,7 +195,7 @@ function useTextToSpeechExternal({
   return {
     generateSpeechExternal,
     cancelSpeech,
-    isLoading,
+    isLoading: isFetching || isLoading,
     audioRef,
     voices: voicesData,
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1667,7 +1667,7 @@
         "lodash": "^4.17.21",
         "lucide-react": "^0.394.0",
         "match-sorter": "^6.3.4",
-        "msedge-tts": "^1.3.4",
+        "msedge-tts": "^2.0.0",
         "qrcode.react": "^4.2.0",
         "rc-input-number": "^7.4.2",
         "react": "^18.2.0",
@@ -3301,6 +3301,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "client/node_modules/msedge-tts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/msedge-tts/-/msedge-tts-2.0.0.tgz",
+      "integrity": "sha512-9qmAh80/rvEFCWDlfqHvrZzf9zioEqksiwpNKSy8MuBud27D6FNPVTHNDc1c37dX0u6w7iYe++Dg/V0a9fAFSw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "axios": "^1.5.0",
+        "buffer": "^6.0.3",
+        "crypto-browserify": "^3.12.0",
+        "isomorphic-ws": "^5.0.0",
+        "process": "^0.11.10",
+        "randombytes": "^2.1.0",
+        "stream-browserify": "^3.0.0",
+        "ws": "^8.14.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "client/node_modules/node-releases": {
@@ -34287,21 +34306,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/msedge-tts": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/msedge-tts/-/msedge-tts-1.3.4.tgz",
-      "integrity": "sha512-0dj86Gg9VzdOJZVCkSSK/O5Eg0NM9W5p8LsXAEPe7qUmsvdAugPUTcPwt9tyz4GThAzAFBBu554kevH8StLEHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.5.0",
-        "buffer": "^6.0.3",
-        "crypto-browserify": "^3.12.0",
-        "isomorphic-ws": "^5.0.0",
-        "process": "^0.11.10",
-        "stream-browserify": "^3.0.0",
-        "ws": "^8.14.1"
-      }
     },
     "node_modules/multer": {
       "version": "1.4.5-lts.1",

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -375,6 +375,9 @@ export function parseTextParts(contentParts: a.TMessageContentParts[]): string {
   let result = '';
 
   for (const part of contentParts) {
+    if (!part.type) {
+      continue;
+    }
     if (part.type === ContentTypes.TEXT) {
       const textValue = typeof part.text === 'string' ? part.text : part.text.value;
 

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -387,6 +387,17 @@ export function parseTextParts(contentParts: a.TMessageContentParts[]): string {
         result += ' ';
       }
       result += textValue;
+    } else if (part.type === ContentTypes.THINK) {
+      const textValue = typeof part.think === 'string' ? part.think : '';
+      if (
+        result.length > 0 &&
+        textValue.length > 0 &&
+        result[result.length - 1] !== ' ' &&
+        textValue[0] !== ' '
+      ) {
+        result += ' ';
+      }
+      result += textValue;
     }
   }
 


### PR DESCRIPTION
Closes #6581

## Summary

I refactored the text parsing logic and improved the text-to-speech functionality

- Refactored the mongoMeili model to use the parseTextParts function for cleaner text extraction.
- Updated parseTextParts in the data provider to skip parts missing a type and ensure proper spacing between text segments, including support for THINK content.
- Upgraded the msedge-tts dependency to v2.0.0 and enabled logger initialization for better debugging.
- Implemented initialization attempt tracking in useTextToSpeechEdge to prevent excessive retry attempts.
- Enhanced useTextToSpeechExternal with a consolidated loading state and refined toast notifications for clearer error feedback.
- Streamlined audio streaming by extracting the audioStream from the TTS response.