### PR TITLE
🔧 fix: Ensure continuation in image processing on base64 encoding from Blob Storage

### DIFF
--- a/api/server/services/Files/images/encode.js
+++ b/api/server/services/Files/images/encode.js
@@ -110,6 +110,7 @@ async function encodeAndFormat(req, files, endpoint, mode) {
         });
         const base64Data = await streamPromise;
         promises.push([file, base64Data]);
+        continue;
       } catch (error) {
         logger.error(
           `Error processing blob storage file stream for ${file.name} base64 payload:`,


### PR DESCRIPTION
Closes #6593 