### PR TITLE
🐛 fix: Safeguard against undefined addedEndpoints

### DIFF
--- a/api/server/services/start/modelSpecs.js
+++ b/api/server/services/start/modelSpecs.js
@@ -21,7 +21,7 @@ function processModelSpecs(endpoints, _modelSpecs, interfaceConfig) {
 
   const customEndpoints = endpoints?.[EModelEndpoint.custom] ?? [];
 
-  if (interfaceConfig.modelSelect !== true && _modelSpecs.addedEndpoints.length > 0) {
+  if (interfaceConfig.modelSelect !== true && (_modelSpecs.addedEndpoints?.length ?? 0) > 0) {
     logger.warn(
       `To utilize \`addedEndpoints\`, which allows provider/model selections alongside model specs, set \`modelSelect: true\` in the interface configuration.
 


### PR DESCRIPTION
## Summary

Fixes a bug where LibreChat would fail to start if `interfaceConfig.modelSelect` is false, `modelSpecs` are being used, and `addedEndpoints` is not defined.

This change uses optional chaining to safely access the length property only if _modelSpecs.addedEndpoints exists, and nullish coalescing to default to 0 if it doesn't exist. This prevents the error when addedEndpoints isn't defined on _modelSpecs.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
