### PR TITLE
🐛 fix: Ensure fallback for iconURL in MessageRender component

### DIFF
--- a/client/src/components/Chat/Messages/MessageIcon.tsx
+++ b/client/src/components/Chat/Messages/MessageIcon.tsx
@@ -35,6 +35,7 @@ const MessageIcon = memo(
     }, [assistant, agent, assistantAvatar, agentAvatar]);
 
     const iconURL = iconData?.iconURL;
+
     const endpoint = useMemo(
       () => getIconEndpoint({ endpointsConfig, iconURL, endpoint: iconData?.endpoint }),
       [endpointsConfig, iconURL, iconData?.endpoint],

--- a/client/src/components/Chat/Messages/ui/MessageRender.tsx
+++ b/client/src/components/Chat/Messages/ui/MessageRender.tsx
@@ -75,13 +75,14 @@ const MessageRender = memo(
       () => ({
         endpoint: msg?.endpoint ?? conversation?.endpoint,
         model: msg?.model ?? conversation?.model,
-        iconURL: msg?.iconURL,
+        iconURL: msg?.iconURL ?? conversation?.iconURL,
         modelLabel: messageLabel,
         isCreatedByUser: msg?.isCreatedByUser,
       }),
       [
         messageLabel,
         conversation?.endpoint,
+        conversation?.iconURL,
         conversation?.model,
         msg?.model,
         msg?.iconURL,


### PR DESCRIPTION
## Summary

Closes #6666 

I've modified the `iconURL` property to use the conversation's icon URL as a fallback if the message's icon URL is not available

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
