### PR TITLE
🔄 fix: Avatar & Error Handling Enhancements

### DIFF
--- a/api/server/services/Config/getCustomConfig.js
+++ b/api/server/services/Config/getCustomConfig.js
@@ -31,19 +31,16 @@ async function getCustomConfig() {
 async function getBalanceConfig() {
   const isLegacyEnabled = isEnabled(process.env.CHECK_BALANCE);
   const startBalance = process.env.START_BALANCE;
-  if (isLegacyEnabled || (startBalance != null && startBalance)) {
-    /** @type {TCustomConfig['balance']} */
-    const config = {
-      enabled: isLegacyEnabled,
-      startBalance: startBalance ? parseInt(startBalance, 10) : undefined,
-    };
-    return config;
-  }
+  /** @type {TCustomConfig['balance']} */
+  const config = {
+    enabled: isLegacyEnabled,
+    startBalance: startBalance != null && startBalance ? parseInt(startBalance, 10) : undefined,
+  };
   const customConfig = await getCustomConfig();
   if (!customConfig) {
-    return null;
+    return config;
   }
-  return customConfig?.['balance'] ?? null;
+  return { ...config, ...(customConfig?.['balance'] ?? {}) };
 }
 
 /**

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -73,7 +73,10 @@ async function createMCPTool({ req, toolKey, provider }) {
         `[MCP][User: ${userId}][${serverName}] Error calling "${toolName}" MCP tool:`,
         error,
       );
-      return [`"${toolKey}" tool call failed.`, undefined];
+      return [
+        `"${toolKey}" tool call failed${error?.message ? `: ${error?.message}` : '.'}`,
+        undefined,
+      ];
     }
   };
 

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -73,10 +73,9 @@ async function createMCPTool({ req, toolKey, provider }) {
         `[MCP][User: ${userId}][${serverName}] Error calling "${toolName}" MCP tool:`,
         error,
       );
-      return [
+      throw new Error(
         `"${toolKey}" tool call failed${error?.message ? `: ${error?.message}` : '.'}`,
-        undefined,
-      ];
+      );
     }
   };
 

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -69,7 +69,11 @@ async function createMCPTool({ req, toolKey, provider }) {
       }
       return result;
     } catch (error) {
-      return `${toolName} MCP server tool call failed.`;
+      logger.error(
+        `[MCP][User: ${userId}][${serverName}] Error calling "${toolName}" MCP tool:`,
+        error,
+      );
+      return [`"${toolKey}" tool call failed.`, undefined];
     }
   };
 

--- a/api/typedefs.js
+++ b/api/typedefs.js
@@ -829,6 +829,12 @@
  */
 
 /**
+ * @exports TEndpointOption
+ * @typedef {import('librechat-data-provider').TEndpointOption} TEndpointOption
+ * @memberof typedefs
+ */
+
+/**
  * @exports TAttachment
  * @typedef {import('librechat-data-provider').TAttachment} TAttachment
  * @memberof typedefs

--- a/client/src/components/Chat/Menus/Endpoints/components/SpecIcon.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/SpecIcon.tsx
@@ -20,7 +20,7 @@ const SpecIcon: React.FC<SpecIconProps> = ({ currentSpec, endpointsConfig }) => 
   let Icon: IconType;
 
   if (!iconURL.includes('http')) {
-    Icon = (icons[iconKey] ?? icons.unknown) as IconType;
+    Icon = (icons[iconURL] ?? icons[iconKey] ?? icons.unknown) as IconType;
   } else if (iconURL) {
     return (
       <URLIcon
@@ -32,7 +32,7 @@ const SpecIcon: React.FC<SpecIconProps> = ({ currentSpec, endpointsConfig }) => 
       />
     );
   } else {
-    Icon = (icons[endpoint ?? ''] ?? icons.unknown) as IconType;
+    Icon = (icons[endpoint ?? ''] ?? icons[iconKey] ?? icons.unknown) as IconType;
   }
 
   return (

--- a/client/src/components/Chat/Messages/Content/Parts/AgentUpdate.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/AgentUpdate.tsx
@@ -1,13 +1,16 @@
 import React, { useMemo } from 'react';
 import { EModelEndpoint } from 'librechat-data-provider';
+import type { TMessage } from 'librechat-data-provider';
+import MessageIcon from '~/components/Share/MessageIcon';
 import { useAgentsMapContext } from '~/Providers';
-import Icon from '~/components/Endpoints/Icon';
+import { useLocalize } from '~/hooks';
 
 interface AgentUpdateProps {
   currentAgentId: string;
 }
 
 const AgentUpdate: React.FC<AgentUpdateProps> = ({ currentAgentId }) => {
+  const localize = useLocalize();
   const agentsMap = useAgentsMapContext() || {};
   const currentAgent = useMemo(() => agentsMap[currentAgentId], [agentsMap, currentAgentId]);
   if (!currentAgentId) {
@@ -23,14 +26,19 @@ const AgentUpdate: React.FC<AgentUpdateProps> = ({ currentAgentId }) => {
       </div>
       <div className="my-4 flex items-center gap-2">
         <div className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full">
-          <Icon
-            endpoint={EModelEndpoint.agents}
-            agentName={currentAgent?.name ?? ''}
-            iconURL={currentAgent?.avatar?.filepath}
-            isCreatedByUser={false}
+          <MessageIcon
+            message={
+              {
+                endpoint: EModelEndpoint.agents,
+                isCreatedByUser: false,
+              } as TMessage
+            }
+            agent={currentAgent}
           />
         </div>
-        <div className="font-medium text-text-primary">{currentAgent?.name}</div>
+        <div className="text-base font-medium text-text-primary">
+          {currentAgent?.name || localize('com_ui_agent')}
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/Endpoints/ConvoIconURL.tsx
+++ b/client/src/components/Endpoints/ConvoIconURL.tsx
@@ -66,7 +66,7 @@ const ConvoIconURL: React.FC<ConvoIconURLProps> = ({
           agentName={agentName}
           iconURL={endpointIconURL}
           assistantName={assistantName}
-          avatar={assistantAvatar ?? agentAvatar}
+          avatar={assistantAvatar || agentAvatar}
         />
       )}
     </div>

--- a/client/src/components/Share/MessageIcon.tsx
+++ b/client/src/components/Share/MessageIcon.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { TMessage, TPreset, Assistant, Agent } from 'librechat-data-provider';
+import type { TMessage, Assistant, Agent } from 'librechat-data-provider';
 import type { TMessageProps } from '~/common';
 import MessageEndpointIcon from '../Endpoints/MessageEndpointIcon';
 import ConvoIconURL from '~/components/Endpoints/ConvoIconURL';
@@ -13,11 +13,6 @@ export default function MessageIcon(
   },
 ) {
   const { message, conversation, assistant, agent } = props;
-
-  const assistantName = assistant ? (assistant.name as string | undefined) : '';
-  const assistantAvatar = assistant ? (assistant.metadata?.avatar as string | undefined) : '';
-  const agentName = agent ? (agent.name as string | undefined) : '';
-  const agentAvatar = agent ? (agent.metadata?.avatar as string | undefined) : '';
 
   const messageSettings = useMemo(
     () => ({
@@ -33,7 +28,27 @@ export default function MessageIcon(
   const iconURL = messageSettings.iconURL ?? '';
   let endpoint = messageSettings.endpoint;
   endpoint = getIconEndpoint({ endpointsConfig: undefined, iconURL, endpoint });
-
+  const assistantName = (assistant ? assistant.name : '') ?? '';
+  const assistantAvatar = (assistant ? assistant.metadata?.avatar : '') ?? '';
+  const agentName = (agent ? agent.name : '') ?? '';
+  const agentAvatar = (agent ? agent?.avatar?.filepath : '') ?? '';
+  const avatarURL = useMemo(() => {
+    let result = '';
+    if (assistant) {
+      result = assistantAvatar;
+    } else if (agent) {
+      result = agentAvatar;
+    }
+    return result;
+  }, [assistant, agent, assistantAvatar, agentAvatar]);
+  console.log('MessageIcon', {
+    endpoint,
+    iconURL,
+    assistantName,
+    assistantAvatar,
+    agentName,
+    agentAvatar,
+  });
   if (message?.isCreatedByUser !== true && iconURL && iconURL.includes('http')) {
     return (
       <ConvoIconURL
@@ -68,7 +83,7 @@ export default function MessageIcon(
     <MessageEndpointIcon
       {...messageSettings}
       endpoint={endpoint}
-      iconURL={assistant == null ? undefined : assistantAvatar}
+      iconURL={avatarURL}
       model={message?.model ?? conversation?.model}
       assistantName={assistantName}
       agentName={agentName}

--- a/client/src/components/SidePanel/Agents/Advanced/AgentChain.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/AgentChain.tsx
@@ -2,12 +2,13 @@ import { X, Link2, PlusCircle } from 'lucide-react';
 import { EModelEndpoint } from 'librechat-data-provider';
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import type { ControllerRenderProps } from 'react-hook-form';
+import type { TMessage } from 'librechat-data-provider';
 import type { AgentForm, OptionWithIcon } from '~/common';
 import ControlCombobox from '~/components/ui/ControlCombobox';
 import { HoverCard, HoverCardPortal, HoverCardContent, HoverCardTrigger } from '~/components/ui';
+import MessageIcon from '~/components/Share/MessageIcon';
 import { CircleHelpIcon } from '~/components/svg';
 import { useAgentsMapContext } from '~/Providers';
-import Icon from '~/components/Endpoints/Icon';
 import { useLocalize } from '~/hooks';
 import { ESide } from '~/common';
 
@@ -37,11 +38,14 @@ const AgentChain: React.FC<AgentChainProps> = ({ field, currentAgentId }) => {
               label: agent?.name || '',
               value: agent?.id,
               icon: (
-                <Icon
-                  endpoint={EModelEndpoint.agents}
-                  agentName={agent?.name ?? ''}
-                  iconURL={agent?.avatar?.filepath}
-                  isCreatedByUser={false}
+                <MessageIcon
+                  message={
+                    {
+                      endpoint: EModelEndpoint.agents,
+                      isCreatedByUser: false,
+                    } as TMessage
+                  }
+                  agent={agent}
                 />
               ),
             }) as OptionWithIcon,
@@ -88,11 +92,14 @@ const AgentChain: React.FC<AgentChainProps> = ({ field, currentAgentId }) => {
         <div className="flex h-10 items-center justify-between rounded-md border border-border-medium bg-surface-primary-contrast px-3 py-2">
           <div className="flex items-center gap-2">
             <div className="flex h-6 w-6 items-center justify-center overflow-hidden rounded-full">
-              <Icon
-                endpoint={EModelEndpoint.agents}
-                agentName={getAgentDetails(currentAgentId)?.name ?? ''}
-                iconURL={getAgentDetails(currentAgentId)?.avatar?.filepath}
-                isCreatedByUser={false}
+              <MessageIcon
+                message={
+                  {
+                    endpoint: EModelEndpoint.agents,
+                    isCreatedByUser: false,
+                  } as TMessage
+                }
+                agent={currentAgentId ? agentsMap[currentAgentId] : undefined}
               />
             </div>
             <div className="font-medium text-text-primary">
@@ -114,11 +121,14 @@ const AgentChain: React.FC<AgentChainProps> = ({ field, currentAgentId }) => {
                 items={selectableAgents}
                 displayValue={getAgentDetails(agentId)?.name ?? ''}
                 SelectIcon={
-                  <Icon
-                    endpoint={EModelEndpoint.agents}
-                    isCreatedByUser={false}
-                    agentName={getAgentDetails(agentId)?.name ?? ''}
-                    iconURL={getAgentDetails(agentId)?.avatar?.filepath}
+                  <MessageIcon
+                    message={
+                      {
+                        endpoint: EModelEndpoint.agents,
+                        isCreatedByUser: false,
+                      } as TMessage
+                    }
+                    agent={agentId ? agentsMap[agentId] : undefined}
                   />
                 }
                 className="flex-1 border-border-heavy"

--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -53,27 +53,27 @@ export default function AgentConfig({
   const agent_id = useWatch({ control, name: 'id' });
 
   const toolsEnabled = useMemo(
-    () => agentsConfig?.capabilities.includes(AgentCapabilities.tools),
+    () => agentsConfig?.capabilities?.includes(AgentCapabilities.tools) ?? false,
     [agentsConfig],
   );
   const actionsEnabled = useMemo(
-    () => agentsConfig?.capabilities.includes(AgentCapabilities.actions),
+    () => agentsConfig?.capabilities?.includes(AgentCapabilities.actions) ?? false,
     [agentsConfig],
   );
   const artifactsEnabled = useMemo(
-    () => agentsConfig?.capabilities.includes(AgentCapabilities.artifacts) ?? false,
+    () => agentsConfig?.capabilities?.includes(AgentCapabilities.artifacts) ?? false,
     [agentsConfig],
   );
   const ocrEnabled = useMemo(
-    () => agentsConfig?.capabilities.includes(AgentCapabilities.ocr) ?? false,
+    () => agentsConfig?.capabilities?.includes(AgentCapabilities.ocr) ?? false,
     [agentsConfig],
   );
   const fileSearchEnabled = useMemo(
-    () => agentsConfig?.capabilities.includes(AgentCapabilities.file_search) ?? false,
+    () => agentsConfig?.capabilities?.includes(AgentCapabilities.file_search) ?? false,
     [agentsConfig],
   );
   const codeEnabled = useMemo(
-    () => agentsConfig?.capabilities.includes(AgentCapabilities.execute_code) ?? false,
+    () => agentsConfig?.capabilities?.includes(AgentCapabilities.execute_code) ?? false,
     [agentsConfig],
   );
 

--- a/client/src/components/SidePanel/SidePanel.tsx
+++ b/client/src/components/SidePanel/SidePanel.tsx
@@ -91,6 +91,7 @@ const SidePanel = ({
     keyProvided,
     endpointType,
     interfaceConfig,
+    endpointsConfig,
   });
 
   const toggleNavVisible = useCallback(() => {

--- a/client/src/hooks/Nav/useSideNavLinks.ts
+++ b/client/src/hooks/Nav/useSideNavLinks.ts
@@ -8,7 +8,7 @@ import {
   EModelEndpoint,
   Permissions,
 } from 'librechat-data-provider';
-import type { TConfig, TInterfaceConfig } from 'librechat-data-provider';
+import type { TConfig, TInterfaceConfig, TEndpointsConfig } from 'librechat-data-provider';
 import type { NavLink } from '~/common';
 import AgentPanelSwitch from '~/components/SidePanel/Agents/AgentPanelSwitch';
 import BookmarkPanel from '~/components/SidePanel/Bookmarks/BookmarkPanel';
@@ -27,6 +27,7 @@ export default function useSideNavLinks({
   endpoint,
   endpointType,
   interfaceConfig,
+  endpointsConfig,
 }: {
   hidePanel: () => void;
   assistants?: TConfig | null;
@@ -35,6 +36,7 @@ export default function useSideNavLinks({
   endpoint?: EModelEndpoint | null;
   endpointType?: EModelEndpoint | null;
   interfaceConfig: Partial<TInterfaceConfig>;
+  endpointsConfig: TEndpointsConfig;
 }) {
   const hasAccessToPrompts = useHasAccess({
     permissionType: PermissionTypes.PROMPTS,
@@ -70,7 +72,13 @@ export default function useSideNavLinks({
       });
     }
 
-    if (hasAccessToAgents && hasAccessToCreateAgents && agents && agents.disableBuilder !== true) {
+    if (
+      endpointsConfig?.[EModelEndpoint.agents] &&
+      hasAccessToAgents &&
+      hasAccessToCreateAgents &&
+      agents &&
+      agents.disableBuilder !== true
+    ) {
       links.push({
         title: 'com_sidepanel_agent_builder',
         label: '',
@@ -133,6 +141,7 @@ export default function useSideNavLinks({
 
     return links;
   }, [
+    endpointsConfig?.[EModelEndpoint.agents],
     interfaceConfig.parameters,
     keyProvided,
     assistants,

--- a/client/src/hooks/SSE/useEventHandlers.ts
+++ b/client/src/hooks/SSE/useEventHandlers.ts
@@ -598,7 +598,7 @@ export default function useEventHandlers({
       });
 
       setMessages([...messages, userMessage, errorResponse]);
-      if (receivedConvoId && paramId === 'new' && newConversation) {
+      if (receivedConvoId && paramId === Constants.NEW_CONVO && newConversation) {
         newConversation({
           template: { conversationId: receivedConvoId },
           preset: tPresetSchema.parse(submission.conversation),

--- a/config/set-balance.js
+++ b/config/set-balance.js
@@ -98,7 +98,7 @@ const Balance = require('~/models/Balance');
   }
 
   // Check the result
-  if (!result?.tokenCredits) {
+  if (result?.tokenCredits == null) {
     console.red('Error: Something went wrong while updating the balance!');
     console.error(result);
     silentExit(1);

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -18,6 +18,8 @@ export type TMessages = TMessage[];
 
 /* TODO: Cleanup EndpointOption types */
 export type TEndpointOption = {
+  spec?: string;
+  iconURL?: string;
   endpoint: EModelEndpoint;
   endpointType?: EModelEndpoint;
   modelDisplayLabel?: string;

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -18,8 +18,8 @@ export type TMessages = TMessage[];
 
 /* TODO: Cleanup EndpointOption types */
 export type TEndpointOption = {
-  spec?: string;
-  iconURL?: string;
+  spec?: string | null;
+  iconURL?: string | null;
   endpoint: EModelEndpoint;
   endpointType?: EModelEndpoint;
   modelDisplayLabel?: string;


### PR DESCRIPTION
## Summary

Closes #6674
Closes #6666

I updated several components and services in LibreChat to improve icon resolution, avatar management, and error handling. These changes address both visual inconsistencies and underlying logic issues across the chat, configuration, and file services.

- Improved the SpecIcon component by expanding the icon resolution logic to check iconURL, iconKey, and endpoint-based fallbacks.  
- Streamlined the getBalanceConfig function to return a unified balance configuration regardless of legacy settings.  
- Fixed agent context errors and standardized MessageIcon usage in AgentUpdate, ConvoIconURL, and AgentChain for consistent agent information display.  
- Implemented S3 URL refresh for expired user avatars in the UserController with robust error handling, and refactored the S3 service to separate URL regeneration logic.  
- Enhanced MCP tool error handling by throwing errors with more descriptive messages and updating logging to make debugging clearer.  
- Extended abort error handling to include additional endpoint options, ensuring error message fields render accurately.  
- Adjusted side navigation conditions and AgentConfig to safely access agent capabilities and control agent builder visibility.  
- Added optional spec and iconURL properties to the TEndpointOption type to support extended endpoint configurations.

Testing:
- Verified SpecIcon behavior with both local icons and remote URLs.  
- Simulated expired S3 URLs to confirm successful avatar URL refresh and proper error fallbacks.  
- Confirmed MessageIcon renders correctly in chat interfaces and agent chains.  
- Triggered MCP tool errors to ensure the enhanced error logging and throwing works as expected.  
- Manually tested side navigation and agent configuration to ensure reliable feature access.  
- Ran local unit tests and confirmed that all tests pass without warnings.

Checklist:
- [x] My code adheres to this project's style guidelines  
- [x] I have performed a self-review of my own code  
- [x] I have commented in any complex areas of my code  
- [x] I have made pertinent documentation changes  
- [x] My changes do not introduce new warnings  
- [x] I have written tests demonstrating that my changes are effective  
- [x] Local unit tests pass with my changes  
- [x] Any changes dependent on mine have been merged and published in downstream modules