### PR TITLE
🗑️ a11y: Add Accessible Name to Button for File Attachment Removal

### DIFF
--- a/client/src/components/Chat/Input/Files/RemoveFile.tsx
+++ b/client/src/components/Chat/Input/Files/RemoveFile.tsx
@@ -1,11 +1,15 @@
+import { useLocalize } from '~/hooks';
+
 export default function RemoveFile({ onRemove }: { onRemove: () => void }) {
+  const localize = useLocalize();
   return (
     <button
       type="button"
       className="absolute right-1 top-1 -translate-y-1/2 translate-x-1/2 rounded-full bg-surface-secondary p-0.5 transition-colors duration-200 hover:bg-surface-primary"
       onClick={onRemove}
+      aria-label={localize('com_ui_attach_remove')}
     >
-      <span>
+      <span aria-hidden="true">
         <svg
           stroke="currentColor"
           fill="none"

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -509,6 +509,7 @@
   "com_ui_attach_error_openai": "Cannot attach Assistant files to other endpoints",
   "com_ui_attach_error_size": "File size limit exceeded for endpoint:",
   "com_ui_attach_error_type": "Unsupported file type for endpoint:",
+  "com_ui_attach_remove": "Remove file",
   "com_ui_attach_warn_endpoint": "Non-Assistant files may be ignored without a compatible tool",
   "com_ui_attachment": "Attachment",
   "com_ui_auth_type": "Auth Type",


### PR DESCRIPTION
Closes #5527 

## Summary

Added `aria-label`  that reads "remove file" to the button. The text was added to the English translation file. Also added `aria-hidden="true"` to the "x" icon.


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Translation update

## Testing

### **Test Configuration**:

- Browser: Chrome
- Screen Readers: VoiceOver
- Operating System: macOS Sequoia

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
