### PR TITLE
fix: OpenAI Convo Titler does not use OPENAI_REVERSE_PROXY

### DIFF
--- a/api/app/clients/llm/createLLM.js
+++ b/api/app/clients/llm/createLLM.js
@@ -34,6 +34,7 @@ function createLLM({
   let credentials = { openAIApiKey };
   let configuration = {
     apiKey: openAIApiKey,
+    ...(configOptions.basePath && { baseURL: configOptions.basePath }),
   };
 
   /**  @type {AzureOptions} */


### PR DESCRIPTION

## Summary

The OpenAI titler tries first to generate the title with a custom langchain call. When it fails it fallsback on "classic" completion which works correctly. The langchain calls fails if a baseURL must be configured, this is fixed in this PR.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Without the patch, the titler generates an error when OPENAI_REVERSE_PROXY is required for successful OpenAI completion:
```
[RunManager] handleLLMError: { "context":"title","tokenBuffer":150,"conversationId":"b5eff7a0-9144-420a-84c9-f279f3ad5b12"} 401 Incorrect API key provided: xxxx**** ...
```
It then falls back to the "completion" method and succeeds

With the patch it succeeds at first try.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My changes do not introduce new warnings

Actually it's documented that there are two methods for title generation in OpenAIClient.js / titleConvo , maybe the error and fallback is normal behavior. The patch avoids  invalid calls to OpenAI's backend and errors in the logs.
