### PR TITLE
🐳 feat: Add Jemalloc and UV to Docker Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@
 # Base node image
 FROM node:20-alpine AS node
 
-RUN apk --no-cache add curl
+# Add `uv` for extended MCP support
+COPY --from=ghcr.io/astral-sh/uv:0.6.13 /uv /uvx /bin/
+RUN uv --version
 
 RUN mkdir -p /app && chown node:node /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,12 @@
 # Base node image
 FROM node:20-alpine AS node
 
+# Install jemalloc
+RUN apk add --no-cache jemalloc
+
+# Set environment variable to use jemalloc
+ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
+
 # Add `uv` for extended MCP support
 COPY --from=ghcr.io/astral-sh/uv:0.6.13 /uv /uvx /bin/
 RUN uv --version

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -3,6 +3,10 @@
 
 # Base for all builds
 FROM node:20-alpine AS base-min
+# Install jemalloc
+RUN apk add --no-cache jemalloc
+# Set environment variable to use jemalloc
+ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
 WORKDIR /app
 RUN apk --no-cache add curl
 RUN npm config set fetch-retry-maxtimeout 600000 && \

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -50,6 +50,9 @@ RUN npm run build
 
 # API setup (including client dist)
 FROM base-min AS api-build
+# Add `uv` for extended MCP support
+COPY --from=ghcr.io/astral-sh/uv:0.6.13 /uv /uvx /bin/
+RUN uv --version
 WORKDIR /app
 # Install only production deps
 RUN npm ci --omit=dev


### PR DESCRIPTION
## Summary

I implemented enhancements in the Docker build files for LibreChat to optimize memory allocation and extend MCP support. I configured jemalloc and integrated the uv tool to replace the default curl installation.

- Install jemalloc in both Dockerfile and Dockerfile.multi using apk.
- Set the environment variable LD_PRELOAD to /usr/lib/libjemalloc.so.2 to enable jemalloc.
- Integrate uv by copying its binaries from ghcr.io/astral-sh/uv, replacing the prior curl installation steps, and validating with uv --version.
- Verify the Docker image builds to ensure proper functionality and performance improvements.

Motivations: 

- Ran memory tests and resulted in similar situation described here, for which jemalloc is suggested
- https://github.com/nodejs/help/issues/1518
- for `uv`, to broaden support of uv-based/python mcp servers to the docker builds

Change Type:
- [x] New feature (non-breaking change which adds functionality)

Testing:
I built the Docker images locally using both Dockerfile and Dockerfile.multi. I recommend running commands like “docker build -f Dockerfile .” and “docker build -f Dockerfile.multi .” and then verifying that uv is operational via “uv --version” to confirm the changes work as expected.

Checklist:
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules