### PR TITLE
fix: Don't ping meilisearch if search is disabled in configuration

### DIFF
--- a/api/server/routes/search.js
+++ b/api/server/routes/search.js
@@ -46,8 +46,7 @@ router.get('/enable', async function (req, res) {
     });
 
     const { status } = await client.health();
-    result = status === 'available' && !!process.env.SEARCH;
-    return res.send(result);
+    return res.send(status === 'available');
   } catch (error) {
     return res.send(false);
   }

--- a/api/server/routes/search.js
+++ b/api/server/routes/search.js
@@ -35,6 +35,10 @@ router.get('/test', async function (req, res) {
 
 router.get('/enable', async function (req, res) {
   let result = false;
+  if (process.env.SEARCH.toLowerCase() === 'false') {
+    return res.send(false);
+  }
+
   try {
     const client = new MeiliSearch({
       host: process.env.MEILI_HOST,


### PR DESCRIPTION
## Summary

When search is disabled in configuration, backend keeps pinging meilisearch via `/search/enable` endpoint.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
