### PR TITLE
fix: add missing o3 support fixture

### DIFF
--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -180,6 +180,8 @@ const getValueKey = (model, endpoint) => {
     return 'gpt-3.5-turbo-1106';
   } else if (modelName.includes('gpt-3.5')) {
     return '4k';
+  } else if (modelName.includes('o3')) {
+    return 'o3';
   } else if (modelName.includes('o1-preview')) {
     return 'o1-preview';
   } else if (modelName.includes('o1-mini')) {


### PR DESCRIPTION
## Summary

After the most recent update, it looks like o4-mini is supported but there was a function that was missed to enable support for the full o3 model. I have confirmed adding this locally fixed the o3 requests.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
