### PR TITLE
refactor: Enhance URL parameter persistence during navigation

### DIFF
--- a/client/src/components/SidePanel/Parameters/DynamicCombobox.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicCombobox.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useCallback } from 'react';
 import { OptionTypes } from 'librechat-data-provider';
-import type { DynamicSettingProps } from 'librechat-data-provider';
+import type { DynamicSettingProps, TConversation } from 'librechat-data-provider';
 import { Label, HoverCard, HoverCardTrigger } from '~/components/ui';
 import ControlCombobox from '~/components/ui/ControlCombobox';
 import { TranslationKeys, useLocalize, useParameterEffects } from '~/hooks';
@@ -32,8 +32,19 @@ function DynamicCombobox({
   searchPlaceholder = '',
 }: DynamicSettingProps & { isCollapsed?: boolean; SelectIcon?: React.ReactNode }) {
   const localize = useLocalize();
-  const { preset } = useChatContext();
+  const { preset, updateSearchParams } = useChatContext();
   const [inputValue, setInputValue] = useState<string | null>(null);
+
+  const updateUrlParams = useCallback(
+    (value: string) => {
+      if (conversation && updateSearchParams) {
+        const updatedConvo = { ...conversation } as TConversation;
+        updatedConvo[settingKey as keyof TConversation] = value as never;
+        updateSearchParams(updatedConvo);
+      }
+    },
+    [conversation, updateSearchParams, settingKey],
+  );
 
   const selectedValue = useMemo(() => {
     if (optionType === OptionTypes.Custom) {
@@ -58,9 +69,10 @@ function DynamicCombobox({
         setInputValue(value);
       } else {
         setOption(settingKey)(value);
+        updateUrlParams(value);
       }
     },
-    [optionType, setOption, settingKey],
+    [optionType, setOption, settingKey, updateUrlParams],
   );
 
   useParameterEffects({

--- a/client/src/components/SidePanel/Parameters/DynamicInput.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicInput.tsx
@@ -1,5 +1,5 @@
 import { OptionTypes } from 'librechat-data-provider';
-import type { DynamicSettingProps } from 'librechat-data-provider';
+import type { DynamicSettingProps, TConversation } from 'librechat-data-provider';
 import { useLocalize, useDebouncedInput, useParameterEffects, TranslationKeys } from '~/hooks';
 import { Label, Input, HoverCard, HoverCardTrigger } from '~/components/ui';
 import { useChatContext } from '~/Providers';
@@ -25,7 +25,16 @@ function DynamicInput({
   conversation,
 }: DynamicSettingProps) {
   const localize = useLocalize();
-  const { preset } = useChatContext();
+  const { preset, updateSearchParams } = useChatContext();
+
+  // Create a custom setter that also updates URL parameters
+  const updateUrlParams = (value: string | number) => {
+    if (conversation && updateSearchParams) {
+      const updatedConvo = { ...conversation } as TConversation;
+      updatedConvo[settingKey as keyof TConversation] = value as never;
+      updateSearchParams(updatedConvo);
+    }
+  };
 
   const [setInputValue, inputValue, setLocalValue] = useDebouncedInput<string | number>({
     optionKey: optionType !== OptionTypes.Custom ? settingKey : undefined,
@@ -45,15 +54,20 @@ function DynamicInput({
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
+
     if (type !== 'number') {
       setInputValue(e);
+      updateUrlParams(value);
       return;
     }
 
     if (value === '') {
       setInputValue(e);
+      updateUrlParams('');
     } else if (!isNaN(Number(value))) {
+      const numValue = Number(value);
       setInputValue(e, true);
+      updateUrlParams(numValue);
     }
   };
 

--- a/client/src/components/SidePanel/Parameters/DynamicTags.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicTags.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useRef } from 'react';
 import { OptionTypes } from 'librechat-data-provider';
-import type { DynamicSettingProps } from 'librechat-data-provider';
+import type { DynamicSettingProps, TConversation } from 'librechat-data-provider';
 import { Label, Input, HoverCard, HoverCardTrigger, Tag } from '~/components/ui';
 import { useChatContext, useToastContext } from '~/Providers';
 import { TranslationKeys, useLocalize, useParameterEffects } from '~/hooks';
@@ -28,7 +28,7 @@ function DynamicTags({
   maxTags,
 }: DynamicSettingProps) {
   const localize = useLocalize();
-  const { preset } = useChatContext();
+  const { preset, updateSearchParams } = useChatContext();
   const { showToast } = useToastContext();
   const inputRef = useRef<HTMLInputElement>(null);
   const [tagText, setTagText] = useState<string>('');
@@ -44,8 +44,15 @@ function DynamicTags({
         return;
       }
       setOption(settingKey)(update);
+
+      // Update URL parameters when tags change
+      if (conversation && updateSearchParams) {
+        const updatedConvo = { ...conversation } as TConversation;
+        updatedConvo[settingKey as keyof TConversation] = update as never;
+        updateSearchParams(updatedConvo);
+      }
     },
-    [optionType, setOption, settingKey],
+    [optionType, setOption, settingKey, conversation, updateSearchParams],
   );
 
   const onTagClick = useCallback(() => {

--- a/client/src/hooks/Chat/useChatHelpers.ts
+++ b/client/src/hooks/Chat/useChatHelpers.ts
@@ -7,6 +7,7 @@ import type { TMessage } from 'librechat-data-provider';
 import useChatFunctions from '~/hooks/Chat/useChatFunctions';
 import { useAuthContext } from '~/hooks/AuthContext';
 import useNewConvo from '~/hooks/useNewConvo';
+import { useUpdateSearchParams } from '~/hooks/Input';
 import store from '~/store';
 
 // this to be set somewhere else
@@ -19,6 +20,7 @@ export default function useChatHelpers(index = 0, paramId?: string) {
   const { isAuthenticated } = useAuthContext();
 
   const { newConversation } = useNewConvo(index);
+  const updateSearchParams = useUpdateSearchParams();
   const { useCreateConversationAtom } = store;
   const { conversation, setConversation } = useCreateConversationAtom(index);
   const { conversationId } = conversation ?? {};
@@ -173,5 +175,6 @@ export default function useChatHelpers(index = 0, paramId?: string) {
     setFiles,
     filesLoading,
     setFilesLoading,
+    updateSearchParams,
   };
 }

--- a/client/src/hooks/Input/index.ts
+++ b/client/src/hooks/Input/index.ts
@@ -10,3 +10,4 @@ export { default as useMultipleKeys } from './useMultipleKeys';
 export { default as useSpeechToText } from './useSpeechToText';
 export { default as useTextToSpeech } from './useTextToSpeech';
 export { default as useGetAudioSettings } from './useGetAudioSettings';
+export { default as useUpdateSearchParams } from './useUpdateSearchParams';

--- a/client/src/hooks/Input/useUpdateSearchParams.ts
+++ b/client/src/hooks/Input/useUpdateSearchParams.ts
@@ -1,0 +1,91 @@
+import { useCallback, useRef } from 'react';
+import { useSearchParams, useLocation } from 'react-router-dom';
+import type { TConversation } from 'librechat-data-provider';
+
+export const useUpdateSearchParams = () => {
+  const lastParamsRef = useRef<Record<string, string>>({});
+  const [, setSearchParams] = useSearchParams();
+  const location = useLocation();
+
+  const updateSearchParams = useCallback(
+    (conversation: TConversation) => {
+      // Only update search params when we're on a new conversation route
+      if (location.pathname !== '/c/new') {
+        return;
+      }
+
+      setSearchParams(
+        (params) => {
+          const currentParams = Object.fromEntries(params.entries());
+          const newSearchParams = conversationToSearchParams(conversation);
+          const newParams = Object.fromEntries(newSearchParams.entries());
+
+          if (JSON.stringify(lastParamsRef.current) === JSON.stringify(newParams)) {
+            return currentParams;
+          }
+
+          lastParamsRef.current = { ...newParams };
+          return newParams;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams, location.pathname],
+  );
+
+  return updateSearchParams;
+};
+
+// Utility function to convert conversation parameters to URL search params
+export function conversationToSearchParams(conversation: TConversation): URLSearchParams {
+  const params = new URLSearchParams();
+
+  if (conversation.endpoint) {
+    params.set('endpoint', conversation.endpoint);
+  }
+  if (conversation.model) {
+    params.set('model', conversation.model);
+  }
+
+  if (conversation.agent_id) {
+    params.set('agent_id', String(conversation.agent_id));
+    return params;
+  }
+  if (conversation.assistant_id) {
+    params.set('assistant_id', String(conversation.assistant_id));
+    return params;
+  }
+
+  const paramMap = {
+    temperature: conversation.temperature,
+    presence_penalty: conversation.presence_penalty,
+    frequency_penalty: conversation.frequency_penalty,
+    stop: conversation.stop,
+    top_p: conversation.top_p,
+    max_tokens: conversation.max_tokens,
+    topP: conversation.topP,
+    topK: conversation.topK,
+    maxOutputTokens: conversation.maxOutputTokens,
+    promptCache: conversation.promptCache,
+    region: conversation.region,
+    maxTokens: conversation.maxTokens,
+  };
+
+  Object.entries(paramMap).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      if (Array.isArray(value)) {
+        if (key === 'stop') {
+          params.set(key, value.join(','));
+        } else {
+          params.set(key, JSON.stringify(value));
+        }
+      } else {
+        params.set(key, String(value));
+      }
+    }
+  });
+
+  return params;
+}
+
+export default useUpdateSearchParams;


### PR DESCRIPTION
## NOTE

Moving this into draft. There is a bug where the first message fails, which you can see in the first demo video. I thought this was related to some other configuration I had, but just confirmed it doesn't exist on main.

## Summary

Closes: https://github.com/danny-avila/LibreChat/issues/6980
Closes: https://github.com/danny-avila/LibreChat/discussions/7008

This PR enhances URL parameter handling with two main changes:

1. **New Feature**: Implemented dynamic URL updating that reflects the current chat configuration as users make selections. When a user selects an endpoint, model, or adjusts parameters (temperature, top_p, etc.), the URL automatically updates to include these selections using replaceState. This makes chat configurations shareable via URL.
2. **Bug Fix**: Fixed a race condition in the useQueryParams hook where using submit=true in the URL could trigger message submission before the model parameter was fully applied to the conversation state.

These improvements make the chat interface more user-friendly by improving shareability and allowing users to bookmark specific configurations for future use.

**NOTE**: `prompt`, `q`, and `submit` are the only parameters cleared out from `/c/new` to avoid unintended side effects or overloading the url. 

Agent and Assistant will only display the agent or assistant id and not the other endpoint or model based params.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

1. Verifying that URL parameters are dynamically updated when making configuration changes through the UI
2. Testing with various URL parameters to ensure they're correctly applied and persisted
3. Testing parameter persistence during navigation between pages
4. Verifying that URLs can be shared and load the correct configuration when opened
5. Testing the submit=true parameter with model selection to verify the race condition fix

### **Test Configuration**:

- Browser: Chrome
  - URL Parameters Tested:
    - Basic: endpoint, model, prompt/q, submit
    - OpenAI/Azure: temperature, presence_penalty, frequency_penalty, stop, top_p, max_tokens
    - Google/Anthropic: topP, topK, maxOutputTokens
    - Anthropic specific: promptCache
    - Special endpoints: agent_id, assistant_id
  - Test URLs:
    - `/c/new?endpoint=anthropic&model=claude-3-7-sonnet-20250219&topP=0.8&topK=10&promptCache=true`
    - `/c/new?endpoint=openAI&model=gpt-4o&temperature=0.7&top_p=0.9&presence_penalty=0.5&frequency_penalty=0.2&stop=end,stop`
    - `/c/new?endpoint=ollama&model=llama3%3Alatest&submit=true&prompt=hello`
    
### Demo

**Updating most params:**

https://github.com/user-attachments/assets/d85c6787-e94a-468e-ad42-40e7031b395f

**Updating params on an existing conversation doesn't change anything:**

https://github.com/user-attachments/assets/b6e76365-a26f-4d6f-8671-4f2e95e55cf1

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works _(not needed I don't think? I looked at the tests and there weren't any related to this)_
- [x] Local unit tests pass with my changes
