### PR TITLE
🐋 fix: Improve Deepseek Compatbility

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -673,7 +673,7 @@ class AgentClient extends BaseClient {
         this.indexTokenCountMap,
         toolSet,
       );
-      if (legacyContentEndpoints.has(this.options.agent.endpoint)) {
+      if (legacyContentEndpoints.has(this.options.agent.endpoint?.toLowerCase())) {
         initialMessages = formatContentStrings(initialMessages);
       }
 

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -253,6 +253,8 @@ export const getResponseSender = (endpointOption: t.TEndpointOption): string => 
       return extractOmniVersion(model);
     } else if (model && (model.includes('mistral') || model.includes('codestral'))) {
       return 'Mistral';
+    } else if (model && model.includes('deepseek')) {
+      return 'Deepseek';
     } else if (model && model.includes('gpt-')) {
       const gptVersion = extractGPTVersion(model);
       return gptVersion || 'GPT';
@@ -289,6 +291,8 @@ export const getResponseSender = (endpointOption: t.TEndpointOption): string => 
       return extractOmniVersion(model);
     } else if (model && (model.includes('mistral') || model.includes('codestral'))) {
       return 'Mistral';
+    } else if (model && model.includes('deepseek')) {
+      return 'Deepseek';
     } else if (model && model.includes('gpt-')) {
       const gptVersion = extractGPTVersion(model);
       return gptVersion || 'GPT';


### PR DESCRIPTION
## Summary

- Added logic to the response sender to detect `deepseek` models and label their sender as "Deepseek"
- Normalized endpoint field to lowercase for proper matching in legacyContentEndpoints, fixing content handling problems with `deepseek-chat` agent followups
- Refactored the `convertJsonSchemaToZod` utility, ensuring all optional object properties are treated as `.optional().nullable()`
- Improved schema field dropping logic and nested property handling for robust schema transformations

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

I manually tested response sender outputs for Deepseek models and verified sender display in the UI. For schema changes, I ran existing schema conversion and validation unit tests and added test cases to validate optional fields work with `null` values. For the AgentClient fix, I confirmed followups for `deepseek-chat` execute without legacy content errors.

**Test Configuration:**
- Node.js v18+
- Manual agent interaction tests with `deepseek-chat`
- Schema conversion tests in `data-provider` package

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes