### PR TITLE
🧰 chore: ESLint configuration to enforce Prettier formatting rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -101,6 +101,7 @@ export default [
     },
 
     rules: {
+      'prettier/prettier': 'error',
       'react/react-in-jsx-scope': 'off',
 
       '@typescript-eslint/ban-ts-comment': [
@@ -121,28 +122,6 @@ export default [
       // Also disable the core no-unused-vars rule globally.
       'no-unused-vars': 'warn',
 
-      indent: ['error', 2, { SwitchCase: 1 }],
-      'max-len': [
-        'error',
-        {
-          code: 120,
-          ignoreStrings: true,
-          ignoreTemplateLiterals: true,
-          ignoreComments: true,
-        },
-      ],
-      'linebreak-style': 0,
-      curly: ['error', 'all'],
-      semi: ['error', 'always'],
-      'object-curly-spacing': ['error', 'always'],
-      'no-multiple-empty-lines': [
-        'error',
-        {
-          max: 1,
-        },
-      ],
-      'no-trailing-spaces': 'error',
-      'comma-dangle': ['error', 'always-multiline'],
       'no-console': 'off',
       'import/no-cycle': 'error',
       'import/no-self-import': 'error',
@@ -153,8 +132,6 @@ export default [
       'no-restricted-syntax': 'off',
       'react/prop-types': 'off',
       'react/display-name': 'off',
-      quotes: ['error', 'single'],
-      'key-spacing': ['error', { beforeColon: false, afterColon: true }],
 
       // 'perfectionist/sort-imports': [
       //   'error',


### PR DESCRIPTION
## Summary

Separated Prettier (for style configurations) from ESLint (for enforcing coding rules). The ESLint contained conflicting rules that enforced stylistic choices, causing issues when both `lint:fix` and `format` scripts were run.

Added `'prettier/prettier': 'error'` to enforce Prettier's existing style rules through ESLint, eliminating conflicts and streamlining our formatting approach.

Most annoyingly, things like this which I run into often with my editor auto-correcting. 

https://github.com/user-attachments/assets/cd03ff7c-f3dd-4d91-98b2-346c8215f909

This was caused by:  `indent: ['error', 2, { SwitchCase: 1 }],` because ESLint seems to consider these switch statements.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code

## Copilot Summary
This pull request updates the ESLint configuration in `eslint.config.mjs` to simplify and streamline the rules. It adds a new rule for Prettier enforcement and removes several custom formatting rules, likely to delegate these responsibilities to Prettier.

### Additions:
* Added the `prettier/prettier` rule with an error level to enforce Prettier formatting.

### Removals:
* Removed custom formatting rules, including `indent`, `max-len`, `linebreak-style`, `curly`, `semi`, `object-curly-spacing`, `no-multiple-empty-lines`, `no-trailing-spaces`, `comma-dangle`, `quotes`, and `key-spacing`. These changes suggest a shift toward relying on Prettier for code style enforcement. [[1]](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2L124-L145) [[2]](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2L156-L157)