### PR TITLE
fix: add Claude 3.7 Sonnet max output token limit

### DIFF
--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -244,7 +244,7 @@ const anthropicMaxOutputs = {
   'claude-3-sonnet': 4096,
   'claude-3-opus': 4096,
   'claude-3.5-sonnet': 8192,
-  'claude-3-5-sonnet': 8192,
+  'claude-3-7-sonnet': 64000,
 };
 
 const maxOutputTokensMap = {


### PR DESCRIPTION
## Summary

Replaced duplicated Claude 3.5 Sonnet max output token entry with Claude 3.7 Sonnet max tokens (64k)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran existing unit tests
- npm run test:api
- npm run test:client

### **Test Configuration**:

Node.js v20.x

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
