### PR TITLE
🛠️ fix: Conversation Navigation State

### DIFF
--- a/client/src/data-provider/queries.ts
+++ b/client/src/data-provider/queries.ts
@@ -30,6 +30,7 @@ import type {
   SharedLinksResponse,
 } from 'librechat-data-provider';
 import type { ConversationCursorData } from '~/utils/convos';
+import { findConversationInInfinite } from '~/utils';
 
 export const useGetPresetsQuery = (
   config?: UseQueryOptions<TPreset[]>,
@@ -68,14 +69,13 @@ export const useGetConvoIdQuery = (
     [QueryKeys.conversation, id],
     () => {
       // Try to find in all fetched infinite pages
-      const convosQuery = queryClient.getQueryData<InfiniteData<ConversationCursorData>>([
-        QueryKeys.allConversations,
-      ]);
-      const found = convosQuery?.pages
-        .flatMap((page) => page.conversations)
-        .find((c) => c.conversationId === id);
+      const convosQuery = queryClient.getQueryData<InfiniteData<ConversationCursorData>>(
+        [QueryKeys.allConversations],
+        { exact: false },
+      );
+      const found = findConversationInInfinite(convosQuery, id);
 
-      if (found) {
+      if (found && found.messages != null) {
         return found;
       }
       // Otherwise, fetch from API

--- a/client/src/hooks/Conversations/useNavigateToConvo.tsx
+++ b/client/src/hooks/Conversations/useNavigateToConvo.tsx
@@ -80,11 +80,11 @@ const useNavigateToConvo = (index = 0) => {
     }
     clearAllConversations(true);
     queryClient.setQueryData([QueryKeys.messages, currentConvoId], []);
-    setConversation(convo);
     if (convo.conversationId !== Constants.NEW_CONVO && convo.conversationId) {
       queryClient.invalidateQueries([QueryKeys.conversation, convo.conversationId]);
       fetchFreshData(convo);
     } else {
+      setConversation(convo);
       navigate(`/c/${convo.conversationId ?? Constants.NEW_CONVO}`, { state: { focusChat: true } });
     }
   };

--- a/client/src/hooks/Conversations/useNavigateToConvo.tsx
+++ b/client/src/hooks/Conversations/useNavigateToConvo.tsx
@@ -1,7 +1,7 @@
 import { useSetRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
-import { QueryKeys, Constants } from 'librechat-data-provider';
+import { QueryKeys, Constants, dataService } from 'librechat-data-provider';
 import type { TConversation, TEndpointsConfig, TModelsConfig } from 'librechat-data-provider';
 import { buildDefaultConvo, getDefaultEndpoint, getEndpointField, logger } from '~/utils';
 import store from '~/store';
@@ -13,6 +13,27 @@ const useNavigateToConvo = (index = 0) => {
   const setSubmission = useSetRecoilState(store.submissionByIndex(index));
   const clearAllLatestMessages = store.useClearLatestMessages(`useNavigateToConvo ${index}`);
   const { hasSetConversation, setConversation } = store.useCreateConversationAtom(index);
+
+  const fetchFreshData = async (conversation?: Partial<TConversation>) => {
+    const conversationId = conversation?.conversationId;
+    if (!conversationId) {
+      return;
+    }
+    try {
+      const data = await queryClient.fetchQuery([QueryKeys.conversation, conversationId], () =>
+        dataService.getConversationById(conversationId),
+      );
+      logger.log('conversation', 'Fetched fresh conversation data', data);
+      setConversation(data);
+      navigate(`/c/${conversationId ?? Constants.NEW_CONVO}`, { state: { focusChat: true } });
+    } catch (error) {
+      console.error('Error fetching conversation data on navigation', error);
+      if (conversation) {
+        setConversation(conversation as TConversation);
+        navigate(`/c/${conversationId}`, { state: { focusChat: true } });
+      }
+    }
+  };
 
   const navigateToConvo = (
     conversation?: TConversation | null,
@@ -58,9 +79,14 @@ const useNavigateToConvo = (index = 0) => {
       });
     }
     clearAllConversations(true);
-    setConversation(convo);
     queryClient.setQueryData([QueryKeys.messages, currentConvoId], []);
-    navigate(`/c/${convo.conversationId ?? Constants.NEW_CONVO}`, { state: { focusChat: true } });
+    setConversation(convo);
+    if (convo.conversationId !== Constants.NEW_CONVO && convo.conversationId) {
+      queryClient.invalidateQueries([QueryKeys.conversation, convo.conversationId]);
+      fetchFreshData(convo);
+    } else {
+      navigate(`/c/${convo.conversationId ?? Constants.NEW_CONVO}`, { state: { focusChat: true } });
+    }
   };
 
   return {

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -43,7 +43,8 @@ export default function ChatRoute() {
     refetchOnMount: 'always',
   });
   const initialConvoQuery = useGetConvoIdQuery(conversationId, {
-    enabled: isAuthenticated && conversationId !== Constants.NEW_CONVO,
+    enabled:
+      isAuthenticated && conversationId !== Constants.NEW_CONVO && !hasSetConversation.current,
   });
   const endpointsQuery = useGetEndpointsQuery({ enabled: isAuthenticated });
   const assistantListMap = useAssistantListMap();

--- a/client/src/utils/convos.spec.ts
+++ b/client/src/utils/convos.spec.ts
@@ -431,14 +431,14 @@ describe('Conversation Utilities', () => {
           pageParams: [],
         };
         const newConvo = makeConversation('new');
-        const updated = addConversationToInfinitePages(data, newConvo);
+        const updated = addConversationToInfinitePages(data, newConvo as TConversation);
         expect(updated.pages[0].conversations[0].conversationId).toBe('new');
         expect(updated.pages[0].conversations[1].conversationId).toBe('1');
       });
 
       it('creates new InfiniteData if data is undefined', () => {
         const newConvo = makeConversation('new');
-        const updated = addConversationToInfinitePages(undefined, newConvo);
+        const updated = addConversationToInfinitePages(undefined, newConvo as TConversation);
         expect(updated.pages[0].conversations[0].conversationId).toBe('new');
         expect(updated.pageParams).toEqual([undefined]);
       });
@@ -531,12 +531,12 @@ describe('Conversation Utilities', () => {
       it('stores model for endpoint', () => {
         const conversation = {
           conversationId: '1',
-          endpoint: 'openai',
+          endpoint: 'openAI',
           model: 'gpt-3',
         };
         storeEndpointSettings(conversation as any);
         const stored = JSON.parse(localStorage.getItem('lastModel') || '{}');
-        expect([undefined, 'gpt-3']).toContain(stored.openai);
+        expect([undefined, 'gpt-3']).toContain(stored.openAI);
       });
 
       it('stores secondaryModel for gptPlugins endpoint', () => {
@@ -574,14 +574,14 @@ describe('Conversation Utilities', () => {
           conversationId: 'a',
           updatedAt: '2024-01-01T12:00:00Z',
           createdAt: '2024-01-01T10:00:00Z',
-          endpoint: 'openai',
+          endpoint: 'openAI',
           model: 'gpt-3',
           title: 'Conversation A',
         } as TConversation;
         convoB = {
           conversationId: 'b',
           updatedAt: '2024-01-02T12:00:00Z',
-          endpoint: 'openai',
+          endpoint: 'openAI',
           model: 'gpt-3',
         } as TConversation;
         queryClient.setQueryData(['allConversations'], {

--- a/client/src/utils/convos.ts
+++ b/client/src/utils/convos.ts
@@ -280,11 +280,11 @@ export function updateConvoFieldsInfinite(
       pages: data.pages.map((page, pi) =>
         pi === pageIdx
           ? {
-            ...page,
-            conversations: page.conversations.map((c, ci) =>
-              ci === convoIdx ? { ...c, ...updatedConversation } : c,
-            ),
-          }
+              ...page,
+              conversations: page.conversations.map((c, ci) =>
+                ci === convoIdx ? { ...c, ...updatedConversation } : c,
+              ),
+            }
           : page,
       ),
     };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import typescriptEslintEslintPlugin from '@typescript-eslint/eslint-plugin';
 import { fixupConfigRules, fixupPluginRules } from '@eslint/compat';
 // import perfectionist from 'eslint-plugin-perfectionist';
 import reactHooks from 'eslint-plugin-react-hooks';
+import prettier from 'eslint-plugin-prettier';
 import tsParser from '@typescript-eslint/parser';
 import importPlugin from 'eslint-plugin-import';
 import { FlatCompat } from '@eslint/eslintrc';
@@ -62,6 +63,7 @@ export default [
       'import/parsers': tsParser,
       i18next,
       // perfectionist,
+      prettier: fixupPluginRules(prettier),
     },
 
     languageOptions: {


### PR DESCRIPTION
## Summary

Added back fetching conversation data on change, which was removed by #7118 to prevent double convo queries, but it was realized that the remaining conversation query data was not actually being used. To resolve this, the initialConvoQuery will now only be enabled on first page load as intended.

- Refactored `useNavigateToConvo` to set conversation state only via conversation intent, preventing duplicate message queries when navigating conversations
- Added logic to fetch fresh conversation data when navigating to a conversation and to handle errors gracefully, falling back to stale data if needed
- Improved initial conversation query condition in `ChatRoute` and `queries.ts` to avoid unnecessary network requests and enhance state management
- Updated `queries.ts` to utilize the `findConversationInInfinite` utility for better local state query logic
- Performed linting fixes and typing enhancements in `convos.spec.ts` and `convos.ts` for more robust test coverage
- Added Prettier plugin to ESLint setup to enforce code consistency

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change with no expected functional difference)
- [x] Documentation update

## Testing

I tested navigation between conversations in the chat application interface to ensure only a single query for messages occurs per navigation event and confirmed that fallback logic correctly loads local data on API errors. I ran unit and integration tests for conversation utility functions, verified state changes via React Query Devtools, and ensured new linting rules enforced stylistic consistency.

### **Test Configuration**:

- Ran the full test suite with `pnpm test`
- Manually navigated between multiple user conversations to monitor network queries
- Enabled development tools to inspect conversation state before and after navigation actions
- Confirmed no lint warnings after running `pnpm lint`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes