### PR TITLE
fix: no system message only for o1-preview and o1-mini

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -475,7 +475,9 @@ class OpenAIClient extends BaseClient {
       promptPrefix = this.augmentedPrompt + promptPrefix;
     }
 
-    if (promptPrefix && this.isOmni !== true) {
+    const noSysMsg = /\b(o1-preview|o1-mini)\b/i.test(this.modelOptions.model);
+
+    if (promptPrefix && !noSysMsg) {
       promptPrefix = `Instructions:\n${promptPrefix.trim()}`;
       instructions = {
         role: 'system',
@@ -503,7 +505,7 @@ class OpenAIClient extends BaseClient {
     };
 
     /** EXPERIMENTAL */
-    if (promptPrefix && this.isOmni === true) {
+    if (promptPrefix && noSysMsg) {
       const lastUserMessageIndex = payload.findLastIndex((message) => message.role === 'user');
       if (lastUserMessageIndex !== -1) {
         if (Array.isArray(payload[lastUserMessageIndex].content)) {


### PR DESCRIPTION
## Summary

Currently system messages are disabled for all omni models. However, only o1-preview and o1-mini don't support system messages. This pull request disables system messages only for those two models.

Then models like o3 and o4-mini can still use system messages. This closes #6192

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Tested system messages with o3 and o4-mini after and checked logs, worked.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
