### PR TITLE
🛡️ fix: Deep Clone `MCPOptions` for User MCP Connections

### DIFF
--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -96,28 +96,30 @@ export type MCPOptions = z.infer<typeof MCPOptionsSchema>;
  * @param {string} [userId] - The user ID
  * @returns {MCPOptions} - The processed object with environment variables replaced
  */
-export function processMCPEnv(obj: MCPOptions, userId?: string): MCPOptions {
+export function processMCPEnv(obj: Readonly<MCPOptions>, userId?: string): MCPOptions {
   if (obj === null || obj === undefined) {
     return obj;
   }
 
-  if ('env' in obj && obj.env) {
+  const newObj: MCPOptions = structuredClone(obj);
+
+  if ('env' in newObj && newObj.env) {
     const processedEnv: Record<string, string> = {};
-    for (const [key, value] of Object.entries(obj.env)) {
+    for (const [key, value] of Object.entries(newObj.env)) {
       processedEnv[key] = extractEnvVariable(value);
     }
-    obj.env = processedEnv;
-  } else if ('headers' in obj && obj.headers) {
+    newObj.env = processedEnv;
+  } else if ('headers' in newObj && newObj.headers) {
     const processedHeaders: Record<string, string> = {};
-    for (const [key, value] of Object.entries(obj.headers)) {
+    for (const [key, value] of Object.entries(newObj.headers)) {
       if (value === '{{LIBRECHAT_USER_ID}}' && userId != null && userId) {
         processedHeaders[key] = userId;
         continue;
       }
       processedHeaders[key] = extractEnvVariable(value);
     }
-    obj.headers = processedHeaders;
+    newObj.headers = processedHeaders;
   }
 
-  return obj;
+  return newObj;
 }


### PR DESCRIPTION
## Summary

related to #6437 

This PR addresses an issue in the `processMCPEnv` function within the `packages/data-provider/src/mcp.ts` file. The function was modifying the original `MCPOptions` object, leading to unintended side effects where the `LIBRECHAT_USER_ID` could be incorrectly shared across different users. To resolve this, a deep clone of the `MCPOptions` object is now performed before processing, ensuring that modifications are isolated and do not affect other users. 

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

To verify the fix, the following steps were performed:

**Reproduction Steps:**

1.  Call the MCP server with one user.
2.  Call the MCP server with a different user.
3.  Observe that the `LIBRECHAT_USER_ID` is always the same as the first user's ID.

**Verification Steps:**

1.  Logged in as each user in separate browser instances (e.g., Chrome and Firefox).
2.  Utilized a simple `get_current_user` MCP function to verify the value of `LIBRECHAT_USER_ID` for each user.
3.  Confirmed that the `LIBRECHAT_USER_ID` was unique and correctly associated with each user, demonstrating that the side effect has been eliminated.

### **Test Configuration**:

*   Browsers: Chrome, Firefox
*   MCP Function: `get_current_user` (An easy route on fastapi\_mcp that prints the `Authorization: LIBRECHAT_USER_ID` header would work. The header name must use `Authorization`, as fastapi\_mcp won't forward other headers.)

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code

