### PR TITLE
🔖 fix: Custom Headers for Initial MCP SSE Connection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44008,7 +44008,7 @@
     },
     "packages/mcp": {
       "name": "librechat-mcp",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.js",

--- a/packages/mcp/src/connection.ts
+++ b/packages/mcp/src/connection.ts
@@ -68,7 +68,7 @@ export class MCPConnection extends EventEmitter {
     this.client = new Client(
       {
         name: 'librechat-mcp-client',
-        version: '1.2.0',
+        version: '1.2.1',
       },
       {
         capabilities: {},

--- a/packages/mcp/src/connection.ts
+++ b/packages/mcp/src/connection.ts
@@ -159,6 +159,15 @@ export class MCPConnection extends EventEmitter {
               headers: options.headers,
               signal: abortController.signal,
             },
+            eventSourceInit: {
+              fetch: (url, init) => {
+                const headers = new Headers(Object.assign({}, init?.headers, options.headers));
+                return fetch(url, {
+                  ...init,
+                  headers,
+                });
+              },
+            },
           });
 
           transport.onclose = () => {


### PR DESCRIPTION
## Summary

I bumped the MCP client version to 1.2.1 and refactored the connection logic to support including custom headers in the initial connection request, which is necessary as a workaround for specific integration needs.

- Updated the version to 1.2.1 in both `package.json` and initialization inside `MCPConnection`
- Refactored the connection to allow passing custom headers on initial connection requests
- Implemented an `eventSourceInit` fetch override in `connection.ts` to merge user-passed headers for custom integrations

Relevant github links:
- https://github.com/modelcontextprotocol/typescript-sdk/issues/436#issuecomment-2844816448
- https://github.com/danny-avila/LibreChat/issues/6437#issuecomment-2854383744
- https://github.com/danny-avila/LibreChat/discussions/7155#discussioncomment-13049614

## Change Type

- [x] Chore (maintenance tasks such as version bumps)
- [x] Refactor (code improvement with no user-facing changes)

## Testing

I manually validated the updated headers were present during Connect and that no regressions were introduced by the version bump. To further ensure reliability, run automated tests in `packages/mcp` and test header propagation with a custom header in a real integration scenario.

### Test Configuration:
- Node.js v20.x
- npm install and local builds
- Custom header validation with test requests

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes