### PR TITLE
🐋 feat: Add python to Dockerfile for increased MCP compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM node:20-alpine AS node
 
 # Install jemalloc
 RUN apk add --no-cache jemalloc
+RUN apk add --no-cache python3 py3-pip uv
 
 # Set environment variable to use jemalloc
 ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2


### PR DESCRIPTION
## Summary

Without this, it's not possible to run any MCPs that use python, only node.

So, add these to enable using things that use `uvx` similar to what the documentation already talks about for `npx`.

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

```yaml
mcpServers:
  fetch:
    type: stdio
    command: uvx
    args:
      - "mcp-server-fetch"

  time:
    type: stdio
    command: uvx
    args:
      - "mcp-server-time"
      - "--local-timezone"
      - "America/New_York"
```

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
