### PR TITLE
🔃 refactor: `AgentFooter` to conditionally render buttons based on `activePanel`

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentFooter.tsx
+++ b/client/src/components/SidePanel/Agents/AgentFooter.tsx
@@ -50,10 +50,12 @@ export default function AgentFooter({
     return localize('com_ui_create');
   };
 
+  const showButtons = activePanel === Panel.builder;
+
   return (
     <div className="mx-1 mb-1 flex w-full flex-col gap-2">
-      {activePanel !== Panel.advanced && <AdvancedButton setActivePanel={setActivePanel} />}
-      {user?.role === SystemRoles.ADMIN && <AdminSettings />}
+      {showButtons && <AdvancedButton setActivePanel={setActivePanel} />}
+      {user?.role === SystemRoles.ADMIN && showButtons && <AdminSettings />}
       {/* Context Button */}
       <div className="flex items-center justify-end gap-2">
         <DeleteButton
@@ -63,13 +65,13 @@ export default function AgentFooter({
         />
         {(agent?.author === user?.id || user?.role === SystemRoles.ADMIN) &&
           hasAccessToShareAgents && (
-          <ShareAgent
-            agent_id={agent_id}
-            agentName={agent?.name ?? ''}
-            projectIds={agent?.projectIds ?? []}
-            isCollaborative={agent?.isCollaborative}
-          />
-        )}
+            <ShareAgent
+              agent_id={agent_id}
+              agentName={agent?.name ?? ''}
+              projectIds={agent?.projectIds ?? []}
+              isCollaborative={agent?.isCollaborative}
+            />
+          )}
         {agent && agent.author === user?.id && <DuplicateAgent agent_id={agent_id} />}
         {/* Submit Button */}
         <button


### PR DESCRIPTION
## Summary

Fixed an issue with the Admin and Advanced buttons for Agents showing up at the bottom of every panel, instead of just the main panel. This was a little confusing and I don't think it was intended. 

Original: 

https://github.com/user-attachments/assets/ebfbf373-dc2e-42c3-a5f6-23a7537a898c

New Change:

https://github.com/user-attachments/assets/6a86f476-71e9-4ea7-9bb8-a07c446b1fee

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Copilot Summary

This pull request introduces a small improvement to the `AgentFooter` component by adding a `showButtons` variable to simplify and clarify conditional rendering logic.

* [`client/src/components/SidePanel/Agents/AgentFooter.tsx`](diffhunk://#diff-5396f62d2d4bd5fe0753d4f7c5175f1f604ff00f0f37b63f66ced29aa4b96532R53-R58): Introduced the `showButtons` variable to consolidate the condition `activePanel === Panel.builder`, ensuring that buttons are only displayed when this condition is met. This change improves readability and maintainability.
