### PR TITLE
🔑 fix: use `apiKey` instead of `openAIApiKey` in OpenAI-like Config

### DIFF
--- a/api/server/services/Endpoints/openAI/llm.js
+++ b/api/server/services/Endpoints/openAI/llm.js
@@ -136,7 +136,7 @@ function getLLMConfig(apiKey, options = {}, endpoint = null) {
     Object.assign(llmConfig, azure);
     llmConfig.model = llmConfig.azureOpenAIApiDeploymentName;
   } else {
-    llmConfig.openAIApiKey = apiKey;
+    llmConfig.apiKey = apiKey;
     // Object.assign(llmConfig, {
     //   configuration: { apiKey },
     // });


### PR DESCRIPTION
## Summary

- Changed the configuration object in the OpenAI endpoint service to assign the API key to `apiKey` as `openAIApiKey` is deprecated and causing issues with specific providers like Deepseek
- Improved compatibility with expected downstream consumers that rely on the `apiKey` property
- Enhanced code clarity by aligning property names with the expected configuration interface

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I manually tested OpenAI-like endpoint requests use the correct API key value as user-provided. Testing included:

- Sending requests using custom endpoints with different API keys, set to `user_provided`
- Verifying correct API key usage in outgoing requests

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes