### PR TITLE
🎚️ feat: Custom Parameters

### DIFF
--- a/.github/workflows/i18n-unused-keys.yml
+++ b/.github/workflows/i18n-unused-keys.yml
@@ -22,7 +22,7 @@ jobs:
 
           # Define paths
           I18N_FILE="client/src/locales/en/translation.json"
-          SOURCE_DIRS=("client/src" "api")
+          SOURCE_DIRS=("client/src" "api" "packages/data-provider/src")
 
           # Check if translation file exists
           if [[ ! -f "$I18N_FILE" ]]; then

--- a/api/server/services/Config/getCustomConfig.js
+++ b/api/server/services/Config/getCustomConfig.js
@@ -10,17 +10,7 @@ const getLogStores = require('~/cache/getLogStores');
  * */
 async function getCustomConfig() {
   const cache = getLogStores(CacheKeys.CONFIG_STORE);
-  let customConfig = await cache.get(CacheKeys.CUSTOM_CONFIG);
-
-  if (!customConfig) {
-    customConfig = await loadCustomConfig();
-  }
-
-  if (!customConfig) {
-    return null;
-  }
-
-  return customConfig;
+  return (await cache.get(CacheKeys.CUSTOM_CONFIG)) || (await loadCustomConfig());
 }
 
 /**

--- a/api/server/services/Config/loadConfigEndpoints.js
+++ b/api/server/services/Config/loadConfigEndpoints.js
@@ -29,7 +29,14 @@ async function loadConfigEndpoints(req) {
 
     for (let i = 0; i < customEndpoints.length; i++) {
       const endpoint = customEndpoints[i];
-      const { baseURL, apiKey, name: configName, iconURL, modelDisplayLabel, customParams } = endpoint;
+      const {
+        baseURL,
+        apiKey,
+        name: configName,
+        iconURL,
+        modelDisplayLabel,
+        customParams,
+      } = endpoint;
       const name = normalizeEndpointName(configName);
 
       const resolvedApiKey = extractEnvVariable(apiKey);

--- a/api/server/services/Config/loadConfigEndpoints.js
+++ b/api/server/services/Config/loadConfigEndpoints.js
@@ -29,7 +29,7 @@ async function loadConfigEndpoints(req) {
 
     for (let i = 0; i < customEndpoints.length; i++) {
       const endpoint = customEndpoints[i];
-      const { baseURL, apiKey, name: configName, iconURL, modelDisplayLabel } = endpoint;
+      const { baseURL, apiKey, name: configName, iconURL, modelDisplayLabel, customParams } = endpoint;
       const name = normalizeEndpointName(configName);
 
       const resolvedApiKey = extractEnvVariable(apiKey);
@@ -41,6 +41,7 @@ async function loadConfigEndpoints(req) {
         userProvideURL: isUserProvided(resolvedBaseURL),
         modelDisplayLabel,
         iconURL,
+        customParams,
       };
     }
   }

--- a/api/server/services/Config/loadCustomConfig.js
+++ b/api/server/services/Config/loadCustomConfig.js
@@ -12,7 +12,7 @@ const loadYaml = require('~/utils/loadYaml');
 const { logger } = require('~/config');
 const axios = require('axios');
 const yaml = require('js-yaml');
-const _ = require('lodash');
+const { keyBy } = require('lodash');
 
 const projectRoot = path.resolve(__dirname, '..', '..', '..', '..');
 const defaultConfigPath = path.resolve(projectRoot, 'librechat.yaml');
@@ -135,7 +135,10 @@ function parseCustomParams(endpointName, customParams) {
   customParams.paramDefinitions = customParams.paramDefinitions || [];
 
   // Checks if `defaultParamsEndpoint` is a key in `paramSettings`.
-  const validEndpoints = new Set(_.keys(paramSettings).concat(_.keys(agentParamSettings)));
+  const validEndpoints = new Set([
+    ...Object.keys(paramSettings),
+    ...Object.keys(agentParamSettings),
+  ]);
   if (!validEndpoints.has(paramEndpoint)) {
     throw new Error(
       `defaultParamsEndpoint of "${endpointName}" endpoint is invalid. ` +
@@ -147,13 +150,13 @@ function parseCustomParams(endpointName, customParams) {
   const regularParams = paramSettings[paramEndpoint] ?? [];
   const agentParams = agentParamSettings[paramEndpoint] ?? [];
   const defaultParams = regularParams.concat(agentParams);
-  const defaultParamsMap = _.keyBy(defaultParams, 'key');
+  const defaultParamsMap = keyBy(defaultParams, 'key');
 
   // TODO: Remove this check once we support new parameters not part of default parameters.
   // Checks if every key in `paramDefinitions` is valid.
-  const validKeys = new Set(_.keys(defaultParamsMap));
+  const validKeys = new Set(Object.keys(defaultParamsMap));
   const paramKeys = customParams.paramDefinitions.map((param) => param.key);
-  if (_.some(paramKeys, (key) => !validKeys.has(key))) {
+  if (paramKeys.some((key) => !validKeys.has(key))) {
     throw new Error(
       `paramDefinitions of "${endpointName}" endpoint contains invalid key(s). ` +
         `Valid parameter keys are ${Array.from(validKeys).join(', ')}`,

--- a/api/server/services/Config/loadCustomConfig.js
+++ b/api/server/services/Config/loadCustomConfig.js
@@ -113,8 +113,9 @@ https://www.librechat.ai/docs/configuration/stt_tts`);
     logger.debug('Custom config:', customConfig);
   }
 
-  (customConfig.endpoints?.custom ?? []).filter((endpoint) => endpoint.customParams)
-    .forEach(endpoint => parseCustomParams(endpoint.name, endpoint.customParams));
+  (customConfig.endpoints?.custom ?? [])
+    .filter((endpoint) => endpoint.customParams)
+    .forEach((endpoint) => parseCustomParams(endpoint.name, endpoint.customParams));
 
   if (customConfig.cache) {
     const cache = getLogStores(CacheKeys.CONFIG_STORE);
@@ -136,8 +137,10 @@ function parseCustomParams(endpointName, customParams) {
   // Checks if `defaultParamsEndpoint` is a key in `paramSettings`.
   const validEndpoints = new Set(_.keys(paramSettings).concat(_.keys(agentParamSettings)));
   if (!validEndpoints.has(paramEndpoint)) {
-    throw new Error(`defaultParamsEndpoint of "${endpointName}" endpoint is invalid. ` +
-      `Valid options are ${Array.from(validEndpoints).join(', ')}`);
+    throw new Error(
+      `defaultParamsEndpoint of "${endpointName}" endpoint is invalid. ` +
+        `Valid options are ${Array.from(validEndpoints).join(', ')}`,
+    );
   }
 
   // creates default param maps
@@ -151,19 +154,23 @@ function parseCustomParams(endpointName, customParams) {
   const validKeys = new Set(_.keys(defaultParamsMap));
   const paramKeys = customParams.paramDefinitions.map((param) => param.key);
   if (_.some(paramKeys, (key) => !validKeys.has(key))) {
-    throw new Error(`paramDefinitions of "${endpointName}" endpoint contains invalid key(s). ` +
-    `Valid parameter keys are ${Array.from(validKeys).join(', ')}`);
+    throw new Error(
+      `paramDefinitions of "${endpointName}" endpoint contains invalid key(s). ` +
+        `Valid parameter keys are ${Array.from(validKeys).join(', ')}`,
+    );
   }
 
   // Fill out missing values for custom param definitions
-  customParams.paramDefinitions = customParams.paramDefinitions.map(param => {
+  customParams.paramDefinitions = customParams.paramDefinitions.map((param) => {
     return { ...defaultParamsMap[param.key], ...param, optionType: 'custom' };
   });
 
-  try{
+  try {
     validateSettingDefinitions(customParams.paramDefinitions);
-  } catch(e) {
-    throw new Error(`Custom parameter definitions for "${endpointName}" endpoint is malformed: ${e.message}`);
+  } catch (e) {
+    throw new Error(
+      `Custom parameter definitions for "${endpointName}" endpoint is malformed: ${e.message}`,
+    );
   }
 }
 

--- a/api/server/services/Config/loadCustomConfig.js
+++ b/api/server/services/Config/loadCustomConfig.js
@@ -12,7 +12,7 @@ const loadYaml = require('~/utils/loadYaml');
 const { logger } = require('~/config');
 const axios = require('axios');
 const yaml = require('js-yaml');
-const { keyBy } = require('lodash');
+const keyBy = require('lodash/keyBy');
 
 const projectRoot = path.resolve(__dirname, '..', '..', '..', '..');
 const defaultConfigPath = path.resolve(projectRoot, 'librechat.yaml');

--- a/api/server/services/Config/loadCustomConfig.js
+++ b/api/server/services/Config/loadCustomConfig.js
@@ -1,11 +1,10 @@
 const path = require('path');
-const { CacheKeys, configSchema, EImageOutputType, validateSettingDefinitions } = require('librechat-data-provider');
+const { CacheKeys, configSchema, EImageOutputType, validateSettingDefinitions, agentSettings } = require('librechat-data-provider');
 const getLogStores = require('~/cache/getLogStores');
 const loadYaml = require('~/utils/loadYaml');
 const { logger } = require('~/config');
 const axios = require('axios');
 const yaml = require('js-yaml');
-const { agentSettings } = require('@librechat/frontend/src/components/SidePanel/Parameters/settings');
 const _ = require('lodash');
 
 const projectRoot = path.resolve(__dirname, '..', '..', '..', '..');

--- a/api/server/services/Config/loadCustomConfig.spec.js
+++ b/api/server/services/Config/loadCustomConfig.spec.js
@@ -194,7 +194,7 @@ describe('loadCustomConfig', () => {
       },
     };
 
-    async function loadCustomParams (customParams) {
+    async function loadCustomParams(customParams) {
       mockConfig.endpoints.custom[0].customParams = customParams;
       loadYaml.mockReturnValue(mockConfig);
       return await loadCustomConfig();
@@ -213,10 +213,12 @@ describe('loadCustomConfig', () => {
     it('returns no error when customParams is valid', async () => {
       const result = await loadCustomParams({
         defaultParamsEndpoint: 'google',
-        paramDefinitions: [{
-          key: 'temperature',
-          default: 0.5,
-        }],
+        paramDefinitions: [
+          {
+            key: 'temperature',
+            default: 0.5,
+          },
+        ],
       });
       expect(result).toEqual(mockConfig);
     });
@@ -237,12 +239,14 @@ describe('loadCustomConfig', () => {
     it('throws an error when paramDefinitions is malformed', async () => {
       const malformedCustomParams = {
         defaultParamsEndpoint: 'google',
-        paramDefinitions: [{
-          key: 'temperature',
-          type: 'noomba',
-          component: 'inpoot',
-          optionType: 'custom',
-        }],
+        paramDefinitions: [
+          {
+            key: 'temperature',
+            type: 'noomba',
+            component: 'inpoot',
+            optionType: 'custom',
+          },
+        ],
       };
       await expect(loadCustomParams(malformedCustomParams)).rejects.toThrow(
         /Custom parameter definitions for "Google" endpoint is malformed:/,
@@ -267,30 +271,31 @@ describe('loadCustomConfig', () => {
 
       const parsedConfig = await loadCustomParams(customParams);
       const paramDefinitions = parsedConfig.endpoints.custom[0].customParams.paramDefinitions;
-      expect (paramDefinitions).toEqual([
+      expect(paramDefinitions).toEqual([
         {
-          'columnSpan': 1,
-          'component': 'slider',
-          'default': 0.7, // overridden
-          'includeInput': true,
-          'key': 'temperature',
-          'label': 'temperature',
-          'optionType': 'custom',
-          'range': { // overridden
-            'max': 0.9,
-            'min': 0.1,
-            'step': 0.1,
+          columnSpan: 1,
+          component: 'slider',
+          default: 0.7, // overridden
+          includeInput: true,
+          key: 'temperature',
+          label: 'temperature',
+          optionType: 'custom',
+          range: {
+            // overridden
+            max: 0.9,
+            min: 0.1,
+            step: 0.1,
           },
-          'type': 'number',
+          type: 'number',
         },
         {
-          'columnSpan': 1,
-          'component': 'textarea', // overridden
-          'key': 'pressure',
-          'label': 'pressure',
-          'optionType': 'custom',
-          'placeholder': '',
-          'type': 'string',
+          columnSpan: 1,
+          component: 'textarea', // overridden
+          key: 'pressure',
+          label: 'pressure',
+          optionType: 'custom',
+          placeholder: '',
+          type: 'string',
         },
       ]);
     });

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -105,6 +105,7 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
     headers: resolvedHeaders,
     addParams: endpointConfig.addParams,
     dropParams: endpointConfig.dropParams,
+    customParams: endpointConfig.customParams,
     titleConvo: endpointConfig.titleConvo,
     titleModel: endpointConfig.titleModel,
     forcePrompt: endpointConfig.forcePrompt,

--- a/client/src/components/Endpoints/Settings/Anthropic.tsx
+++ b/client/src/components/Endpoints/Settings/Anthropic.tsx
@@ -3,7 +3,7 @@ import { getSettingsKeys } from 'librechat-data-provider';
 import type { SettingDefinition } from 'librechat-data-provider';
 import type { TModelSelectProps } from '~/common';
 import { componentMapping } from '~/components/SidePanel/Parameters/components';
-import { presetSettings } from '~/components/SidePanel/Parameters/settings';
+import { presetSettings } from 'librechat-data-provider';
 
 export default function AnthropicSettings({
   conversation,

--- a/client/src/components/Endpoints/Settings/Bedrock.tsx
+++ b/client/src/components/Endpoints/Settings/Bedrock.tsx
@@ -3,7 +3,7 @@ import { getSettingsKeys } from 'librechat-data-provider';
 import type { SettingDefinition } from 'librechat-data-provider';
 import type { TModelSelectProps } from '~/common';
 import { componentMapping } from '~/components/SidePanel/Parameters/components';
-import { presetSettings } from '~/components/SidePanel/Parameters/settings';
+import { presetSettings } from 'librechat-data-provider';
 
 export default function BedrockSettings({
   conversation,

--- a/client/src/components/Endpoints/Settings/OpenAI.tsx
+++ b/client/src/components/Endpoints/Settings/OpenAI.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 import { getSettingsKeys } from 'librechat-data-provider';
-import type { SettingDefinition, DynamicSettingProps } from 'librechat-data-provider';
+import type { SettingDefinition } from 'librechat-data-provider';
 import type { TModelSelectProps } from '~/common';
 import { componentMapping } from '~/components/SidePanel/Parameters/components';
-import { presetSettings } from '~/components/SidePanel/Parameters/settings';
+import { presetSettings } from 'librechat-data-provider';
 
 export default function OpenAISettings({
   conversation,

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -15,7 +15,7 @@ import { useGetEndpointsQuery } from '~/data-provider';
 import { getEndpointField, cn } from '~/utils';
 import { useLocalize } from '~/hooks';
 import { Panel } from '~/common';
-import _ from 'lodash';
+import { keyBy } from 'lodash';
 
 export default function ModelPanel({
   setActivePanel,
@@ -75,7 +75,7 @@ export default function ModelPanel({
     const defaultParams =
       agentParamSettings[combinedKey] ?? agentParamSettings[overriddenEndpointKey] ?? [];
     const overriddenParams = endpointsConfig[provider]?.customParams?.paramDefinitions ?? [];
-    const overriddenParamsMap = _.keyBy(overriddenParams, 'key');
+    const overriddenParamsMap = keyBy(overriddenParams, 'key');
     return defaultParams.map(
       (param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param,
     );

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -1,7 +1,12 @@
 import React, { useMemo, useEffect } from 'react';
 import { ChevronLeft, RotateCcw } from 'lucide-react';
 import { useFormContext, useWatch, Controller } from 'react-hook-form';
-import { getSettingsKeys, alternateName, agentParamSettings, SettingDefinition } from 'librechat-data-provider';
+import {
+  getSettingsKeys,
+  alternateName,
+  agentParamSettings,
+  SettingDefinition,
+} from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { AgentForm, AgentModelPanelProps, StringOption } from '~/common';
 import { componentMapping } from '~/components/SidePanel/Parameters/components';
@@ -63,14 +68,17 @@ export default function ModelPanel({
     [provider, endpointsConfig],
   );
 
-  const parameters = useMemo(() : SettingDefinition[] => {
+  const parameters = useMemo((): SettingDefinition[] => {
     const customParams = endpointsConfig[provider]?.customParams ?? {};
     const [combinedKey, endpointKey] = getSettingsKeys(endpointType ?? provider, model ?? '');
     const overriddenEndpointKey = customParams.defaultParamsEndpoint ?? endpointKey;
-    const defaultParams = agentParamSettings[combinedKey] ?? agentParamSettings[overriddenEndpointKey] ?? [];
+    const defaultParams =
+      agentParamSettings[combinedKey] ?? agentParamSettings[overriddenEndpointKey] ?? [];
     const overriddenParams = endpointsConfig[provider]?.customParams?.paramDefinitions ?? [];
     const overriddenParamsMap = _.keyBy(overriddenParams, 'key');
-    return defaultParams.map(param => overriddenParamsMap[param.key] as SettingDefinition ?? param);
+    return defaultParams.map(
+      (param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param,
+    );
   }, [endpointType, endpointsConfig, model, provider]);
 
   const setOption = (optionKey: keyof t.AgentModelParameters) => (value: t.AgentParameterValue) => {

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -1,11 +1,10 @@
 import React, { useMemo, useEffect } from 'react';
 import { ChevronLeft, RotateCcw } from 'lucide-react';
 import { useFormContext, useWatch, Controller } from 'react-hook-form';
-import { getSettingsKeys, alternateName } from 'librechat-data-provider';
+import { getSettingsKeys, alternateName, agentSettings } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { AgentForm, AgentModelPanelProps, StringOption } from '~/common';
 import { componentMapping } from '~/components/SidePanel/Parameters/components';
-import { agentSettings } from '~/components/SidePanel/Parameters/settings';
 import ControlCombobox from '~/components/ui/ControlCombobox';
 import { useGetEndpointsQuery } from '~/data-provider';
 import { getEndpointField, cn } from '~/utils';

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -15,7 +15,7 @@ import { useGetEndpointsQuery } from '~/data-provider';
 import { getEndpointField, cn } from '~/utils';
 import { useLocalize } from '~/hooks';
 import { Panel } from '~/common';
-import { keyBy } from 'lodash';
+import keyBy from 'lodash/keyBy';
 
 export default function ModelPanel({
   setActivePanel,

--- a/client/src/components/SidePanel/Parameters/DynamicCheckbox.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicCheckbox.tsx
@@ -1,8 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { OptionTypes } from 'librechat-data-provider';
 import type { DynamicSettingProps } from 'librechat-data-provider';
 import { Label, Checkbox, HoverCard, HoverCardTrigger } from '~/components/ui';
-import { TranslationKeys, useLocalize, useParameterEffects } from '~/hooks';
+import { TranslationKeys, useLocalize, useDebouncedInput, useParameterEffects } from '~/hooks';
 import { useChatContext } from '~/Providers';
 import OptionHover from './OptionHover';
 import { ESide } from '~/common';
@@ -23,23 +23,20 @@ function DynamicCheckbox({
 }: DynamicSettingProps) {
   const localize = useLocalize();
   const { preset } = useChatContext();
-  const [inputValue, setInputValue] = useState<boolean>(!!(defaultValue as boolean | undefined));
+
+  const [setInputValue, inputValue, setLocalValue] = useDebouncedInput<boolean>({
+    optionKey: settingKey,
+    initialValue: optionType !== OptionTypes.Custom ? conversation?.[settingKey] : defaultValue,
+    setter: () => ({}),
+    setOption,
+  });
 
   const selectedValue = useMemo(() => {
-    if (optionType === OptionTypes.Custom) {
-      // TODO: custom logic, add to payload but not to conversation
-      return inputValue;
-    }
-
     return conversation?.[settingKey] ?? defaultValue;
-  }, [conversation, defaultValue, optionType, settingKey, inputValue]);
+  }, [conversation, defaultValue, settingKey]);
 
   const handleCheckedChange = (checked: boolean) => {
-    if (optionType === OptionTypes.Custom) {
-      // TODO: custom logic, add to payload but not to conversation
-      setInputValue(checked);
-      return;
-    }
+    setInputValue(checked);
     setOption(settingKey)(checked);
   };
 
@@ -49,8 +46,7 @@ function DynamicCheckbox({
     defaultValue,
     conversation,
     inputValue,
-    setInputValue,
-    preventDelayedUpdate: true,
+    setInputValue: setLocalValue,
   });
 
   return (

--- a/client/src/components/SidePanel/Parameters/DynamicCombobox.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicCombobox.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState, useCallback } from 'react';
-import { OptionTypes } from 'librechat-data-provider';
 import type { DynamicSettingProps } from 'librechat-data-provider';
 import { Label, HoverCard, HoverCardTrigger } from '~/components/ui';
 import ControlCombobox from '~/components/ui/ControlCombobox';
@@ -16,7 +15,6 @@ function DynamicCombobox({
   description = '',
   columnSpan,
   setOption,
-  optionType,
   options: _options,
   items: _items,
   showLabel = true,
@@ -36,11 +34,8 @@ function DynamicCombobox({
   const [inputValue, setInputValue] = useState<string | null>(null);
 
   const selectedValue = useMemo(() => {
-    if (optionType === OptionTypes.Custom) {
-      return inputValue;
-    }
     return conversation?.[settingKey] ?? defaultValue;
-  }, [conversation, defaultValue, optionType, settingKey, inputValue]);
+  }, [conversation, defaultValue, settingKey]);
 
   const items = useMemo(() => {
     if (_items != null) {
@@ -54,13 +49,10 @@ function DynamicCombobox({
 
   const handleChange = useCallback(
     (value: string) => {
-      if (optionType === OptionTypes.Custom) {
-        setInputValue(value);
-      } else {
-        setOption(settingKey)(value);
-      }
+      setInputValue(value);
+      setOption(settingKey)(value);
     },
-    [optionType, setOption, settingKey],
+    [setOption, settingKey],
   );
 
   useParameterEffects({

--- a/client/src/components/SidePanel/Parameters/DynamicInput.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicInput.tsx
@@ -12,7 +12,6 @@ function DynamicInput({
   settingKey,
   defaultValue,
   description = '',
-  type = 'string',
   columnSpan,
   setOption,
   optionType,
@@ -28,7 +27,7 @@ function DynamicInput({
   const { preset } = useChatContext();
 
   const [setInputValue, inputValue, setLocalValue] = useDebouncedInput<string | number>({
-    optionKey: optionType !== OptionTypes.Custom ? settingKey : undefined,
+    optionKey: settingKey,
     initialValue: optionType !== OptionTypes.Custom ? conversation?.[settingKey] : defaultValue,
     setter: () => ({}),
     setOption,
@@ -44,17 +43,7 @@ function DynamicInput({
   });
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    if (type !== 'number') {
-      setInputValue(e);
-      return;
-    }
-
-    if (value === '') {
-      setInputValue(e);
-    } else if (!isNaN(Number(value))) {
-      setInputValue(e, true);
-    }
+    setInputValue(e, !isNaN(Number(e.target.value)));
   };
 
   return (

--- a/client/src/components/SidePanel/Parameters/DynamicSlider.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicSlider.tsx
@@ -33,7 +33,7 @@ function DynamicSlider({
   );
 
   const [setInputValue, inputValue, setLocalValue] = useDebouncedInput<string | number>({
-    optionKey: optionType !== OptionTypes.Custom ? settingKey : undefined,
+    optionKey: settingKey,
     initialValue: optionType !== OptionTypes.Custom ? conversation?.[settingKey] : defaultValue,
     setter: () => ({}),
     setOption,

--- a/client/src/components/SidePanel/Parameters/DynamicSwitch.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicSwitch.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import type { DynamicSettingProps } from 'librechat-data-provider';
 import { Label, Switch, HoverCard, HoverCardTrigger } from '~/components/ui';
 import { TranslationKeys, useLocalize, useParameterEffects } from '~/hooks';
@@ -32,9 +32,7 @@ function DynamicSwitch({
     preventDelayedUpdate: true,
   });
 
-  const selectedValue = useMemo(() => {
-    return conversation?.[settingKey] ?? defaultValue;
-  }, [conversation, defaultValue, settingKey]);
+  const selectedValue = conversation?.[settingKey] ?? defaultValue;
 
   const handleCheckedChange = (checked: boolean) => {
     setInputValue(checked);
@@ -54,7 +52,7 @@ function DynamicSwitch({
               htmlFor={`${settingKey}-dynamic-switch`}
               className="text-left text-sm font-medium"
             >
-              {labelCode ? localize(label as TranslationKeys) ?? label : label || settingKey}{' '}
+              {labelCode ? (localize(label as TranslationKeys) ?? label) : label || settingKey}{' '}
               {showDefault && (
                 <small className="opacity-40">
                   ({localize('com_endpoint_default')}:{' '}
@@ -73,7 +71,11 @@ function DynamicSwitch({
         </HoverCardTrigger>
         {description && (
           <OptionHover
-            description={descriptionCode ? localize(description as TranslationKeys) ?? description : description}
+            description={
+              descriptionCode
+                ? (localize(description as TranslationKeys) ?? description)
+                : description
+            }
             side={ESide.Left}
           />
         )}

--- a/client/src/components/SidePanel/Parameters/DynamicSwitch.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicSwitch.tsx
@@ -1,5 +1,4 @@
 import { useState, useMemo } from 'react';
-import { OptionTypes } from 'librechat-data-provider';
 import type { DynamicSettingProps } from 'librechat-data-provider';
 import { Label, Switch, HoverCard, HoverCardTrigger } from '~/components/ui';
 import { TranslationKeys, useLocalize, useParameterEffects } from '~/hooks';
@@ -14,7 +13,6 @@ function DynamicSwitch({
   description = '',
   columnSpan,
   setOption,
-  optionType,
   readonly = false,
   showDefault = false,
   labelCode = false,
@@ -35,20 +33,11 @@ function DynamicSwitch({
   });
 
   const selectedValue = useMemo(() => {
-    if (optionType === OptionTypes.Custom) {
-      // TODO: custom logic, add to payload but not to conversation
-      return inputValue;
-    }
-
     return conversation?.[settingKey] ?? defaultValue;
-  }, [conversation, defaultValue, optionType, settingKey, inputValue]);
+  }, [conversation, defaultValue, settingKey]);
 
   const handleCheckedChange = (checked: boolean) => {
-    if (optionType === OptionTypes.Custom) {
-      // TODO: custom logic, add to payload but not to conversation
-      setInputValue(checked);
-      return;
-    }
+    setInputValue(checked);
     setOption(settingKey)(checked);
   };
 

--- a/client/src/components/SidePanel/Parameters/DynamicTags.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicTags.tsx
@@ -1,10 +1,9 @@
 import { useState, useMemo, useCallback, useRef } from 'react';
-import { OptionTypes } from 'librechat-data-provider';
 import type { DynamicSettingProps } from 'librechat-data-provider';
 import { Label, Input, HoverCard, HoverCardTrigger, Tag } from '~/components/ui';
 import { useChatContext, useToastContext } from '~/Providers';
 import { TranslationKeys, useLocalize, useParameterEffects } from '~/hooks';
-import { cn, defaultTextProps } from '~/utils';
+import { cn } from '~/utils';
 import OptionHover from './OptionHover';
 import { ESide } from '~/common';
 
@@ -15,7 +14,6 @@ function DynamicTags({
   description = '',
   columnSpan,
   setOption,
-  optionType,
   placeholder = '',
   readonly = false,
   showDefault = false,
@@ -38,14 +36,10 @@ function DynamicTags({
 
   const updateState = useCallback(
     (update: string[]) => {
-      if (optionType === OptionTypes.Custom) {
-        // TODO: custom logic, add to payload but not to conversation
-        setTags(update);
-        return;
-      }
+      setTags(update);
       setOption(settingKey)(update);
     },
-    [optionType, setOption, settingKey],
+    [setOption, settingKey],
   );
 
   const onTagClick = useCallback(() => {
@@ -54,18 +48,9 @@ function DynamicTags({
     }
   }, [inputRef]);
 
-  const currentTags: string[] | undefined = useMemo(() => {
-    if (optionType === OptionTypes.Custom) {
-      // TODO: custom logic, add to payload but not to conversation
-      return tags;
-    }
-
-    if (!conversation?.[settingKey]) {
-      return defaultValue ?? [];
-    }
-
-    return conversation[settingKey];
-  }, [conversation, defaultValue, optionType, settingKey, tags]);
+  const currentTags = useMemo(() => {
+    return conversation?.[settingKey] ?? defaultValue ?? [];
+  }, [conversation, defaultValue, settingKey]);
 
   const onTagRemove = useCallback(
     (indexToRemove: number) => {

--- a/client/src/components/SidePanel/Parameters/DynamicTags.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicTags.tsx
@@ -48,9 +48,10 @@ function DynamicTags({
     }
   }, [inputRef]);
 
+  const currentValue = conversation?.[settingKey];
   const currentTags = useMemo(() => {
-    return conversation?.[settingKey] ?? defaultValue ?? [];
-  }, [conversation, defaultValue, settingKey]);
+    return currentValue ?? defaultValue ?? [];
+  }, [currentValue, defaultValue]);
 
   const onTagRemove = useCallback(
     (indexToRemove: number) => {
@@ -60,7 +61,7 @@ function DynamicTags({
 
       if (minTags != null && currentTags.length <= minTags) {
         showToast({
-          message: localize('com_ui_min_tags',{ 0: minTags + '' }),
+          message: localize('com_ui_min_tags', { 0: minTags + '' }),
           status: 'warning',
         });
         return;
@@ -111,7 +112,7 @@ function DynamicTags({
               htmlFor={`${settingKey}-dynamic-input`}
               className="text-left text-sm font-medium"
             >
-              {labelCode ? localize(label as TranslationKeys) ?? label : label || settingKey}{' '}
+              {labelCode ? (localize(label as TranslationKeys) ?? label) : label || settingKey}{' '}
               {showDefault && (
                 <small className="opacity-40">
                   (
@@ -159,7 +160,11 @@ function DynamicTags({
                   }
                 }}
                 onChange={(e) => setTagText(e.target.value)}
-                placeholder={placeholderCode ? localize(placeholder as TranslationKeys) ?? placeholder : placeholder}
+                placeholder={
+                  placeholderCode
+                    ? (localize(placeholder as TranslationKeys) ?? placeholder)
+                    : placeholder
+                }
                 className={cn('flex h-10 max-h-10 border-none bg-surface-secondary px-3 py-2')}
               />
             </div>
@@ -167,7 +172,11 @@ function DynamicTags({
         </HoverCardTrigger>
         {description && (
           <OptionHover
-            description={descriptionCode ? localize(description as TranslationKeys) ?? description : description}
+            description={
+              descriptionCode
+                ? (localize(description as TranslationKeys) ?? description)
+                : description
+            }
             side={descriptionSide as ESide}
           />
         )}

--- a/client/src/components/SidePanel/Parameters/DynamicTextarea.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicTextarea.tsx
@@ -2,7 +2,7 @@ import { OptionTypes } from 'librechat-data-provider';
 import type { DynamicSettingProps } from 'librechat-data-provider';
 import { Label, TextareaAutosize, HoverCard, HoverCardTrigger } from '~/components/ui';
 import { useLocalize, useDebouncedInput, useParameterEffects, TranslationKeys } from '~/hooks';
-import { cn, defaultTextProps } from '~/utils';
+import { cn } from '~/utils';
 import { useChatContext } from '~/Providers';
 import OptionHover from './OptionHover';
 import { ESide } from '~/common';
@@ -27,7 +27,7 @@ function DynamicTextarea({
   const { preset } = useChatContext();
 
   const [setInputValue, inputValue, setLocalValue] = useDebouncedInput<string | null>({
-    optionKey: optionType !== OptionTypes.Custom ? settingKey : undefined,
+    optionKey: settingKey,
     initialValue:
       optionType !== OptionTypes.Custom
         ? (conversation?.[settingKey] as string)

--- a/client/src/components/SidePanel/Parameters/Panel.tsx
+++ b/client/src/components/SidePanel/Parameters/Panel.tsx
@@ -14,7 +14,7 @@ import { useGetEndpointsQuery } from '~/data-provider';
 import { getEndpointField, logger } from '~/utils';
 import { componentMapping } from './components';
 import { useChatContext } from '~/Providers';
-import { keyBy } from 'lodash';
+import keyBy from 'lodash/keyBy';
 
 export default function Parameters() {
   const localize = useLocalize();

--- a/client/src/components/SidePanel/Parameters/Panel.tsx
+++ b/client/src/components/SidePanel/Parameters/Panel.tsx
@@ -14,7 +14,7 @@ import { useGetEndpointsQuery } from '~/data-provider';
 import { getEndpointField, logger } from '~/utils';
 import { componentMapping } from './components';
 import { useChatContext } from '~/Providers';
-import _ from 'lodash';
+import { keyBy } from 'lodash';
 
 export default function Parameters() {
   const localize = useLocalize();
@@ -43,7 +43,7 @@ export default function Parameters() {
     const overriddenEndpointKey = customParams.defaultParamsEndpoint ?? endpointKey;
     const defaultParams = paramSettings[combinedKey] ?? paramSettings[overriddenEndpointKey] ?? [];
     const overriddenParams = endpointsConfig[provider]?.customParams?.paramDefinitions ?? [];
-    const overriddenParamsMap = _.keyBy(overriddenParams, 'key');
+    const overriddenParamsMap = keyBy(overriddenParams, 'key');
     return defaultParams.map(
       (param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param,
     );

--- a/client/src/components/SidePanel/Parameters/Panel.tsx
+++ b/client/src/components/SidePanel/Parameters/Panel.tsx
@@ -1,6 +1,6 @@
 import { RotateCcw } from 'lucide-react';
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
-import { excludedKeys, getSettingsKeys, tConvoUpdateSchema } from 'librechat-data-provider';
+import { excludedKeys, getSettingsKeys, tConvoUpdateSchema, settings } from 'librechat-data-provider';
 import type { TPreset } from 'librechat-data-provider';
 import { SaveAsPresetDialog } from '~/components/Endpoints';
 import { useSetIndexOptions, useLocalize } from '~/hooks';
@@ -8,7 +8,6 @@ import { useGetEndpointsQuery } from '~/data-provider';
 import { getEndpointField, logger } from '~/utils';
 import { componentMapping } from './components';
 import { useChatContext } from '~/Providers';
-import { settings } from './settings';
 
 export default function Parameters() {
   const localize = useLocalize();

--- a/client/src/components/SidePanel/Parameters/Panel.tsx
+++ b/client/src/components/SidePanel/Parameters/Panel.tsx
@@ -37,14 +37,16 @@ export default function Parameters() {
     [conversation?.endpoint, endpointsConfig],
   );
 
-  const parameters = useMemo(() : SettingDefinition[] => {
+  const parameters = useMemo((): SettingDefinition[] => {
     const customParams = endpointsConfig[provider]?.customParams ?? {};
     const [combinedKey, endpointKey] = getSettingsKeys(endpointType ?? provider, model);
     const overriddenEndpointKey = customParams.defaultParamsEndpoint ?? endpointKey;
     const defaultParams = paramSettings[combinedKey] ?? paramSettings[overriddenEndpointKey] ?? [];
     const overriddenParams = endpointsConfig[provider]?.customParams?.paramDefinitions ?? [];
     const overriddenParamsMap = _.keyBy(overriddenParams, 'key');
-    return defaultParams.map(param => overriddenParamsMap[param.key] as SettingDefinition ?? param);
+    return defaultParams.map(
+      (param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param,
+    );
   }, [endpointType, endpointsConfig, model, provider]);
 
   useEffect(() => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -279,7 +279,8 @@ export const endpointSchema = baseEndpointSchema.merge(
     addParams: z.record(z.any()).optional(),
     dropParams: z.array(z.string()).optional(),
     customParams: z.object({
-      includeDefaultParams: z.union([z.boolean(), z.array(z.string())]).default(true).optional(),
+      defaultParamsEndpoint: z.string().default('custom').optional(),
+      defaultParamsIncluded: z.union([z.boolean(), z.array(z.string())]).default(true).optional(),
       paramDefinitions: z.array(z.record(z.any())).optional(),
     }).strict(),
     customOrder: z.number().optional(),

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -279,8 +279,7 @@ export const endpointSchema = baseEndpointSchema.merge(
     addParams: z.record(z.any()).optional(),
     dropParams: z.array(z.string()).optional(),
     customParams: z.object({
-      defaultParamsEndpoint: z.string().default('custom').optional(),
-      defaultParamsIncluded: z.union([z.boolean(), z.array(z.string())]).default(true).optional(),
+      defaultParamsEndpoint: z.string().default('custom'),
       paramDefinitions: z.array(z.record(z.any())).optional(),
     }).strict(),
     customOrder: z.number().optional(),

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -278,15 +278,17 @@ export const endpointSchema = baseEndpointSchema.merge(
     headers: z.record(z.any()).optional(),
     addParams: z.record(z.any()).optional(),
     dropParams: z.array(z.string()).optional(),
-    customParams: z.object({
-      defaultParamsEndpoint: z.string().default('custom'),
-      paramDefinitions: z.array(z.record(z.any())).optional(),
-    }).strict(),
+    customParams: z
+      .object({
+        defaultParamsEndpoint: z.string().default('custom'),
+        paramDefinitions: z.array(z.record(z.any())).optional(),
+      })
+      .strict(),
     customOrder: z.number().optional(),
     directEndpoint: z.boolean().optional(),
     titleMessageRole: z.string().optional(),
   }),
-).strict();
+);
 
 export type TEndpoint = z.infer<typeof endpointSchema>;
 
@@ -616,7 +618,7 @@ export const configSchema = z.object({
       [EModelEndpoint.azureAssistants]: assistantEndpointSchema.optional(),
       [EModelEndpoint.assistants]: assistantEndpointSchema.optional(),
       [EModelEndpoint.agents]: agentsEndpointSChema.optional(),
-      [EModelEndpoint.custom]: z.array(endpointSchema.partial().strict()).optional(),
+      [EModelEndpoint.custom]: z.array(endpointSchema.partial()).optional(),
       [EModelEndpoint.bedrock]: baseEndpointSchema.optional(),
     })
     .strict()

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -278,11 +278,15 @@ export const endpointSchema = baseEndpointSchema.merge(
     headers: z.record(z.any()).optional(),
     addParams: z.record(z.any()).optional(),
     dropParams: z.array(z.string()).optional(),
+    customParams: z.object({
+      includeDefaultParams: z.union([z.boolean(), z.array(z.string())]).default(true).optional(),
+      paramDefinitions: z.array(z.record(z.any())).optional(),
+    }).strict(),
     customOrder: z.number().optional(),
     directEndpoint: z.boolean().optional(),
     titleMessageRole: z.string().optional(),
   }),
-);
+).strict();
 
 export type TEndpoint = z.infer<typeof endpointSchema>;
 
@@ -612,7 +616,7 @@ export const configSchema = z.object({
       [EModelEndpoint.azureAssistants]: assistantEndpointSchema.optional(),
       [EModelEndpoint.assistants]: assistantEndpointSchema.optional(),
       [EModelEndpoint.agents]: agentsEndpointSChema.optional(),
-      [EModelEndpoint.custom]: z.array(endpointSchema.partial()).optional(),
+      [EModelEndpoint.custom]: z.array(endpointSchema.partial().strict()).optional(),
       [EModelEndpoint.bedrock]: baseEndpointSchema.optional(),
     })
     .strict()

--- a/packages/data-provider/src/generate.ts
+++ b/packages/data-provider/src/generate.ts
@@ -466,7 +466,7 @@ export function validateSettingDefinitions(settings: SettingsConfiguration): voi
     }
 
     /* Default value checks */
-    if (setting.type === SettingTypes.Number && isNaN(setting.default as number)) {
+    if (setting.type === SettingTypes.Number && isNaN(setting.default as number)  && setting.default != null) {
       errors.push({
         code: ZodIssueCode.custom,
         message: `Invalid default value for setting ${setting.key}. Must be a number.`,
@@ -474,7 +474,7 @@ export function validateSettingDefinitions(settings: SettingsConfiguration): voi
       });
     }
 
-    if (setting.type === SettingTypes.Boolean && typeof setting.default !== 'boolean') {
+    if (setting.type === SettingTypes.Boolean && typeof setting.default !== 'boolean' && setting.default != null) {
       errors.push({
         code: ZodIssueCode.custom,
         message: `Invalid default value for setting ${setting.key}. Must be a boolean.`,
@@ -484,7 +484,7 @@ export function validateSettingDefinitions(settings: SettingsConfiguration): voi
 
     if (
       (setting.type === SettingTypes.String || setting.type === SettingTypes.Enum) &&
-      typeof setting.default !== 'string'
+      typeof setting.default !== 'string' && setting.default != null
     ) {
       errors.push({
         code: ZodIssueCode.custom,

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -36,3 +36,4 @@ import * as dataService from './data-service';
 export * from './utils';
 export * from './actions';
 export { default as createPayload } from './createPayload';
+export * from './parameterSettings';

--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -6,8 +6,8 @@ import {
   ReasoningEffort,
   BedrockProviders,
   anthropicSettings,
-} from 'librechat-data-provider';
-import type { SettingsConfiguration, SettingDefinition } from 'librechat-data-provider';
+} from './types';
+import { SettingDefinition, SettingsConfiguration } from './generate';
 
 // Base definitions
 const baseDefinitions: Record<string, SettingDefinition> = {
@@ -682,9 +682,9 @@ const bedrockGeneralColumns = {
 export const presetSettings: Record<
   string,
   | {
-      col1: SettingsConfiguration;
-      col2: SettingsConfiguration;
-    }
+  col1: SettingsConfiguration;
+  col2: SettingsConfiguration;
+}
   | undefined
 > = {
   [EModelEndpoint.openAI]: openAIColumns,
@@ -718,7 +718,7 @@ export const presetSettings: Record<
 
 export const agentSettings: Record<string, SettingsConfiguration | undefined> = Object.entries(
   presetSettings,
-).reduce((acc, [key, value]) => {
+).reduce<Record<string, SettingsConfiguration | undefined>>((acc, [key, value]) => {
   if (value) {
     acc[key] = value.col2;
   }

--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -654,7 +654,7 @@ const bedrockGeneralCol2: SettingsConfiguration = [
   bedrock.region,
 ];
 
-export const settings: Record<string, SettingsConfiguration | undefined> = {
+export const paramSettings: Record<string, SettingsConfiguration | undefined> = {
   [EModelEndpoint.openAI]: openAI,
   [EModelEndpoint.azureOpenAI]: openAI,
   [EModelEndpoint.custom]: openAI,
@@ -716,7 +716,7 @@ export const presetSettings: Record<
   },
 };
 
-export const agentSettings: Record<string, SettingsConfiguration | undefined> = Object.entries(
+export const agentParamSettings: Record<string, SettingsConfiguration | undefined> = Object.entries(
   presetSettings,
 ).reduce<Record<string, SettingsConfiguration | undefined>>((acc, [key, value]) => {
   if (value) {

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -10,6 +10,7 @@ import type {
   TConversationTag,
   TBanner,
 } from './schemas';
+import { SettingDefinition } from './generate';
 export type TOpenAIMessage = OpenAI.Chat.ChatCompletionMessageParam;
 
 export * from './schemas';
@@ -270,7 +271,7 @@ export type TConfig = {
   capabilities?: string[];
   customParams?: {
     defaultParamsEndpoint?: string;
-    paramDefinitions?: Array<object>;
+    paramDefinitions?: SettingDefinition[];
   };
 };
 

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -268,6 +268,27 @@ export type TConfig = {
   disableBuilder?: boolean;
   retrievalModels?: string[];
   capabilities?: string[];
+  customParams?: {
+    includeDefaultParams?: boolean | string[];
+    paramDefinitions?: Array<{
+      key: string;
+      type: string;
+      component: string;
+      optionType: string;
+      default?: any;
+      label?: string;
+      description?: string;
+      min?: number;
+      max?: number;
+      step?: number;
+      columnSpan?: number;
+      options?: Array<{
+        value: string;
+        label: string;
+      }>;
+      [key: string]: any;
+    }>;
+  };
 };
 
 export type TEndpointsConfig =

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -269,25 +269,8 @@ export type TConfig = {
   retrievalModels?: string[];
   capabilities?: string[];
   customParams?: {
-    includeDefaultParams?: boolean | string[];
-    paramDefinitions?: Array<{
-      key: string;
-      type: string;
-      component: string;
-      optionType: string;
-      default?: any;
-      label?: string;
-      description?: string;
-      min?: number;
-      max?: number;
-      step?: number;
-      columnSpan?: number;
-      options?: Array<{
-        value: string;
-        label: string;
-      }>;
-      [key: string]: any;
-    }>;
+    defaultParamsEndpoint?: string;
+    paramDefinitions?: Array<object>;
   };
 };
 


### PR DESCRIPTION
This pull request introduces support for custom parameters in configuration endpoints, refactors existing code for simplification, and updates the client-side components to handle dynamic settings more effectively.

This PR is accompanied by this [Documentation update](https://github.com/LibreChat-AI/librechat.ai/pull/297).

## Summary
### New Feature: Picking A Default Parameters Set
By default, when you specify a custom endpoint in `librechat.yaml` config file, it will use the default parameters of the OpenAI API. However, you can override these defaults by specifying the `customParams.defaultParamsEndpoint` field within the definition of your custom endpoint. For example, to use Google parameters for your custom endpoint:

```yaml
endpoints:
  custom:
    - name: 'Google Gemini'
      apiKey: ...
      baseURL: ...
      customParams:
        defaultParamsEndpoint: 'google'
 ```
Your “Google Gemini” endpoint will now display parameters for Google API when you create a new agent or preset.

### New Feature: Overriding Parameter Definitions

On top of that, you can also fine tune the parameters provided for your custom endpoint. For example, if you want to limit the range of the `temperature` parameter to a range between `0.0` and `0.7` with step of `0.1` and default of `0.5`, your `librechat.yaml` file would look like this:

```yaml
endpoints:
  custom:
    - name: 'Google Gemini'
      apiKey: ...
      baseURL: ...
      customParams:
        defaultParamsEndpoint: 'google'
        paramDefinitions:
          - key: temperature
            range:
              min: 0
              max: 0.7
              step: 0.1
            default: 0.5
```

![Screenshot 2025-05-12 at 4 32 07 PM](https://github.com/user-attachments/assets/3284adac-f826-456c-b484-486ac4f5b030)

### Refactor:
- moved `Parameters/settings.ts` into `data-provider` so that both frontend and backend code can use it.
- simplified `getCustomConfig` function

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted.
