### PR TITLE
🌘 fix: artifact of preview text is illegible in dark mode

### DIFF
--- a/client/src/mobile.css
+++ b/client/src/mobile.css
@@ -139,9 +139,9 @@
     z-index: 66;
     top: 0;
     max-width: 320px;
-  
+
     /* max-width: 260px; */
-  
+
     bottom: 0;
     right: 0
     /* opacity: 0; */
@@ -341,7 +341,7 @@
 
 div[role="tabpanel"][data-state="active"][data-orientation="horizontal"][aria-labelledby^="radix-"][id^="radix-"][id$="-content-preview"] {
   scrollbar-gutter: stable !important;
-  background-color: rgba(21, 21, 21, 0.5) !important;
+  background-color: rgba(205, 205, 205, 0.66) !important;
 }
 
 div[role="tabpanel"][data-state="active"][data-orientation="horizontal"][aria-labelledby^="radix-"][id^="radix-"][id$="-content-preview"]::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

The text in preview for artifacts is almost of the same color as the background in dark mode, making it impossible to read. The background is also too dark in light mode.

### Dark mode before and after:

![Screenshot 2025-05-15 at 10 54 35 AM](https://github.com/user-attachments/assets/a1037167-09ca-4c06-8a52-2db1a12c9906)


![Screenshot 2025-05-15 at 10 53 17 AM](https://github.com/user-attachments/assets/a5075201-7ae9-4a75-a4de-90dba689ebb1)


### Light mode before and after:

![Screenshot 2025-05-15 at 10 54 18 AM](https://github.com/user-attachments/assets/4c7813df-4ad2-4ebf-8449-9043ae5743d1)


![Screenshot 2025-05-15 at 10 53 36 AM](https://github.com/user-attachments/assets/8925df8b-34b7-46e2-bd43-d2b4f42e180e)


## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
