### PR TITLE
🛡️ fix: Preset and Validation Logic for URL Query Params

### DIFF
--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -535,6 +535,7 @@ export type NewConversationParams = {
   buildDefault?: boolean;
   keepLatestMessage?: boolean;
   keepAddedConvos?: boolean;
+  disableParams?: boolean;
 };
 
 export type ConvoGenerator = (params: NewConversationParams) => void | t.TConversation;

--- a/client/src/components/Chat/Input/HeaderOptions.tsx
+++ b/client/src/components/Chat/Input/HeaderOptions.tsx
@@ -79,19 +79,19 @@ export default function HeaderOptions({
               {!noSettings[endpoint] &&
                 interfaceConfig?.parameters === true &&
                 paramEndpoint === false && (
-                <TooltipAnchor
-                  id="parameters-button"
-                  aria-label={localize('com_ui_model_parameters')}
-                  description={localize('com_ui_model_parameters')}
-                  tabIndex={0}
-                  role="button"
-                  onClick={triggerAdvancedMode}
-                  data-testid="parameters-button"
-                  className="inline-flex size-10 items-center justify-center rounded-lg border border-border-light bg-transparent text-text-primary transition-all ease-in-out hover:bg-surface-tertiary disabled:pointer-events-none disabled:opacity-50 radix-state-open:bg-surface-tertiary"
-                >
-                  <Settings2 size={16} aria-label="Settings/Parameters Icon" />
-                </TooltipAnchor>
-              )}
+                  <TooltipAnchor
+                    id="parameters-button"
+                    aria-label={localize('com_ui_model_parameters')}
+                    description={localize('com_ui_model_parameters')}
+                    tabIndex={0}
+                    role="button"
+                    onClick={triggerAdvancedMode}
+                    data-testid="parameters-button"
+                    className="inline-flex size-10 items-center justify-center rounded-lg border border-border-light bg-transparent text-text-primary transition-all ease-in-out hover:bg-surface-tertiary disabled:pointer-events-none disabled:opacity-50 radix-state-open:bg-surface-tertiary"
+                  >
+                    <Settings2 size={16} aria-label="Settings/Parameters Icon" />
+                  </TooltipAnchor>
+                )}
             </div>
             {interfaceConfig?.parameters === true && paramEndpoint === false && (
               <OptionsPopover

--- a/client/src/hooks/Conversations/usePresets.ts
+++ b/client/src/hooks/Conversations/usePresets.ts
@@ -58,10 +58,11 @@ export default function usePresets() {
     }
     setDefaultPreset(defaultPreset);
     if (!conversation?.conversationId || conversation.conversationId === 'new') {
-      newConversation({ preset: defaultPreset, modelsData });
+      newConversation({ preset: defaultPreset, modelsData, disableParams: true });
     }
     hasLoaded.current = true;
     // dependencies are stable and only needed once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [presetsQuery.data, user, modelsData]);
 
   const setPresets = useCallback(

--- a/client/src/hooks/Conversations/usePresets.ts
+++ b/client/src/hooks/Conversations/usePresets.ts
@@ -103,7 +103,7 @@ export default function usePresets() {
       if (data.defaultPreset && data.presetId !== _defaultPreset?.presetId) {
         message = `${toastTitle} ${localize('com_endpoint_preset_default')}`;
         setDefaultPreset(data);
-        newConversation({ preset: data });
+        newConversation({ preset: data, disableParams: true });
       } else if (preset.defaultPreset === false) {
         setDefaultPreset(null);
         message = `${toastTitle} ${localize('com_endpoint_preset_default_removed')}`;
@@ -186,6 +186,7 @@ export default function usePresets() {
     newPreset.iconURL = newPreset.iconURL ?? null;
     newPreset.modelLabel = newPreset.modelLabel ?? null;
     const isModular = isCurrentModular && isNewModular && shouldSwitch;
+    const disableParams = newPreset.defaultPreset === true;
     if (isExistingConversation && isModular) {
       const currentConvo = getDefaultConversation({
         /* target endpointType is necessary to avoid endpoint mixing */
@@ -206,11 +207,12 @@ export default function usePresets() {
         preset: currentConvo,
         keepLatestMessage: true,
         keepAddedConvos: true,
+        disableParams,
       });
       return;
     }
 
-    newConversation({ preset: newPreset, keepAddedConvos: isModular });
+    newConversation({ preset: newPreset, keepAddedConvos: isModular, disableParams });
   };
 
   const onChangePreset = (preset: TPreset) => {

--- a/client/src/hooks/Input/useQueryParams.ts
+++ b/client/src/hooks/Input/useQueryParams.ts
@@ -167,7 +167,7 @@ export default function useQueryParams({
         template.iconURL = null;
         template.modelLabel = null;
         resetParams = { spec: null, iconURL: null, modelLabel: null };
-        newPreset = { ...newPreset, ...resetParams };
+        newPreset = { ...newPreset, ...resetParams, modelLabel: newPreset.modelLabel };
       }
 
       const isModular = isCurrentModular && isNewModular && shouldSwitch;
@@ -259,35 +259,6 @@ export default function useQueryParams({
   }, [methods, submitMessage, conversation]);
 
   useEffect(() => {
-    // Only proceed if we've already processed URL parameters but haven't yet handled submission
-    if (
-      !processedRef.current ||
-      submissionHandledRef.current ||
-      settingsAppliedRef.current ||
-      !validSettingsRef.current ||
-      !conversation
-    ) {
-      return;
-    }
-
-    const allSettingsApplied = areSettingsApplied();
-
-    if (allSettingsApplied) {
-      settingsAppliedRef.current = true;
-
-      if (pendingSubmitRef.current) {
-        if (settingsTimeoutRef.current) {
-          clearTimeout(settingsTimeoutRef.current);
-          settingsTimeoutRef.current = null;
-        }
-
-        console.log('Settings fully applied, processing submission');
-        processSubmission();
-      }
-    }
-  }, [conversation, processSubmission, areSettingsApplied]);
-
-  useEffect(() => {
     const processQueryParams = () => {
       const queryParams: Record<string, string> = {};
       searchParams.forEach((value, key) => {
@@ -332,14 +303,15 @@ export default function useQueryParams({
 
       /** Mark processing as complete and clean up as needed */
       const success = () => {
-        const currentParams = new URLSearchParams(searchParams.toString());
+        const paramString = searchParams.toString();
+        const currentParams = new URLSearchParams(paramString);
         currentParams.delete('prompt');
         currentParams.delete('q');
         currentParams.delete('submit');
 
         setSearchParams(currentParams, { replace: true });
         processedRef.current = true;
-        console.log('Parameters processed successfully');
+        console.log('Parameters processed successfully', paramString);
         clearInterval(intervalId);
 
         // Only clean URL if there's no pending submission
@@ -417,4 +389,33 @@ export default function useQueryParams({
     queryClient,
     processSubmission,
   ]);
+
+  useEffect(() => {
+    // Only proceed if we've already processed URL parameters but haven't yet handled submission
+    if (
+      !processedRef.current ||
+      submissionHandledRef.current ||
+      settingsAppliedRef.current ||
+      !validSettingsRef.current ||
+      !conversation
+    ) {
+      return;
+    }
+
+    const allSettingsApplied = areSettingsApplied();
+
+    if (allSettingsApplied) {
+      settingsAppliedRef.current = true;
+
+      if (pendingSubmitRef.current) {
+        if (settingsTimeoutRef.current) {
+          clearTimeout(settingsTimeoutRef.current);
+          settingsTimeoutRef.current = null;
+        }
+
+        console.log('Settings fully applied, processing submission');
+        processSubmission();
+      }
+    }
+  }, [conversation, processSubmission, areSettingsApplied]);
 }

--- a/client/src/hooks/Input/useQueryParams.ts
+++ b/client/src/hooks/Input/useQueryParams.ts
@@ -167,7 +167,7 @@ export default function useQueryParams({
         template.iconURL = null;
         template.modelLabel = null;
         resetParams = { spec: null, iconURL: null, modelLabel: null };
-        newPreset = { ...newPreset, ...resetParams, modelLabel: newPreset.modelLabel };
+        newPreset = { ...newPreset, ...resetParams };
       }
 
       const isModular = isCurrentModular && isNewModular && shouldSwitch;

--- a/client/src/hooks/Input/useSelectMention.ts
+++ b/client/src/hooks/Input/useSelectMention.ts
@@ -225,6 +225,7 @@ export default function useSelectMention({
       newPreset.iconURL = newPreset.iconURL ?? null;
       newPreset.modelLabel = newPreset.modelLabel ?? null;
       const isModular = isCurrentModular && isNewModular && shouldSwitch;
+      const disableParams = newPreset.defaultPreset === true;
       if (isExistingConversation && isModular) {
         template.endpointType = newEndpointType as EModelEndpoint | undefined;
         template.spec = null;
@@ -244,12 +245,17 @@ export default function useSelectMention({
           preset: newPreset,
           keepLatestMessage: true,
           keepAddedConvos: true,
+          disableParams,
         });
         return;
       }
 
       logger.info('conversation', 'Switching conversation to new preset', template);
-      newConversation({ preset: newPreset, keepAddedConvos: isModular });
+      newConversation({
+        preset: newPreset,
+        keepAddedConvos: isModular,
+        disableParams,
+      });
     },
     [
       modularChat,

--- a/client/src/hooks/useNewConvo.ts
+++ b/client/src/hooks/useNewConvo.ts
@@ -71,6 +71,7 @@ const useNewConvo = (index = 0) => {
         keepLatestMessage?: boolean,
         keepAddedConvos?: boolean,
         disableFocus?: boolean,
+        _disableParams?: boolean,
       ) => {
         const modelsConfig = modelsData ?? modelsQuery.data;
         const { endpoint = null } = conversation;
@@ -87,6 +88,7 @@ const useNewConvo = (index = 0) => {
             ? defaultPreset
             : preset;
 
+        const disableParams = _disableParams ?? activePreset?.presetId === defaultPreset?.presetId;
         if (buildDefaultConversation) {
           let defaultEndpoint = getDefaultEndpoint({
             convoSetup: activePreset ?? conversation,
@@ -148,6 +150,10 @@ const useNewConvo = (index = 0) => {
           });
         }
 
+        if (disableParams === true) {
+          conversation.disableParams = true;
+        }
+
         if (!(keepAddedConvos ?? false)) {
           clearAllConversations(true);
         }
@@ -160,7 +166,7 @@ const useNewConvo = (index = 0) => {
           );
           setConversation({
             ...conversation,
-            conversationId: 'new',
+            conversationId: Constants.NEW_CONVO as string,
           });
         } else {
           logger.log('conversation', 'Setting conversation from `useNewConvo`', conversation);
@@ -205,6 +211,7 @@ const useNewConvo = (index = 0) => {
       buildDefault = true,
       keepLatestMessage = false,
       keepAddedConvos = false,
+      disableParams,
     }: {
       template?: Partial<TConversation>;
       preset?: Partial<TPreset>;
@@ -213,6 +220,7 @@ const useNewConvo = (index = 0) => {
       disableFocus?: boolean;
       keepLatestMessage?: boolean;
       keepAddedConvos?: boolean;
+      disableParams?: boolean;
     } = {}) {
       pauseGlobalAudio();
       if (!saveBadgesState) {
@@ -282,17 +290,19 @@ const useNewConvo = (index = 0) => {
         keepLatestMessage,
         keepAddedConvos,
         disableFocus,
+        disableParams,
       );
     },
     [
-      pauseGlobalAudio,
-      startupConfig,
-      saveDrafts,
-      switchToConversation,
       files,
       setFiles,
+      saveDrafts,
       mutateAsync,
       resetBadges,
+      startupConfig,
+      saveBadgesState,
+      pauseGlobalAudio,
+      switchToConversation,
     ],
   );
 

--- a/client/src/hooks/useNewConvo.ts
+++ b/client/src/hooks/useNewConvo.ts
@@ -88,7 +88,12 @@ const useNewConvo = (index = 0) => {
             ? defaultPreset
             : preset;
 
-        const disableParams = _disableParams ?? activePreset?.presetId === defaultPreset?.presetId;
+        const disableParams =
+          _disableParams ??
+          (activePreset?.presetId != null &&
+            activePreset.presetId &&
+            activePreset.presetId === defaultPreset?.presetId);
+
         if (buildDefaultConversation) {
           let defaultEndpoint = getDefaultEndpoint({
             convoSetup: activePreset ?? conversation,

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -106,10 +106,13 @@ const conversationByIndex = atomFamily<TConversation | null, string | number>({
           JSON.stringify(newValue),
         );
 
+        const disableParams = newValue.disableParams === true;
         const shouldUpdateParams =
+          index === 0 &&
+          !disableParams &&
           newValue.createdAt === '' &&
           JSON.stringify(newValue) !== JSON.stringify(oldValue) &&
-          (oldValue as TConversation)?.conversationId === 'new';
+          (oldValue as TConversation)?.conversationId === Constants.NEW_CONVO;
 
         if (shouldUpdateParams) {
           const newParams = createChatSearchParams(newValue);

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -299,10 +299,10 @@ const conversationByKeySelector = selectorFamily({
   key: 'conversationByKeySelector',
   get:
     (index: string | number) =>
-      ({ get }) => {
-        const conversation = get(conversationByIndex(index));
-        return conversation;
-      },
+    ({ get }) => {
+      const conversation = get(conversationByIndex(index));
+      return conversation;
+    },
 });
 
 function useClearSubmissionState() {
@@ -361,24 +361,24 @@ const updateConversationSelector = selectorFamily({
   get: () => () => null as Partial<TConversation> | null,
   set:
     (conversationId: string) =>
-      ({ set, get }, newPartialConversation) => {
-        if (newPartialConversation instanceof DefaultValue) {
-          return;
-        }
+    ({ set, get }, newPartialConversation) => {
+      if (newPartialConversation instanceof DefaultValue) {
+        return;
+      }
 
-        const keys = get(conversationKeysAtom);
-        keys.forEach((key) => {
-          set(conversationByIndex(key), (prevConversation) => {
-            if (prevConversation && prevConversation.conversationId === conversationId) {
-              return {
-                ...prevConversation,
-                ...newPartialConversation,
-              };
-            }
-            return prevConversation;
-          });
+      const keys = get(conversationKeysAtom);
+      keys.forEach((key) => {
+        set(conversationByIndex(key), (prevConversation) => {
+          if (prevConversation && prevConversation.conversationId === conversationId) {
+            return {
+              ...prevConversation,
+              ...newPartialConversation,
+            };
+          }
+          return prevConversation;
         });
-      },
+      });
+    },
 });
 
 export default {

--- a/client/src/utils/createChatSearchParams.ts
+++ b/client/src/utils/createChatSearchParams.ts
@@ -1,6 +1,12 @@
-import { isAgentsEndpoint, isAssistantsEndpoint, Constants } from 'librechat-data-provider';
+import {
+  Constants,
+  isAgentsEndpoint,
+  tQueryParamsSchema,
+  isAssistantsEndpoint,
+} from 'librechat-data-provider';
 import type { TConversation, TPreset } from 'librechat-data-provider';
 
+const allowedParams = Object.keys(tQueryParamsSchema.shape);
 export default function createChatSearchParams(
   input: TConversation | TPreset | Record<string, string> | null,
 ): URLSearchParams {
@@ -9,25 +15,6 @@ export default function createChatSearchParams(
   }
 
   const params = new URLSearchParams();
-
-  const allowedParams = [
-    'endpoint',
-    'model',
-    'temperature',
-    'presence_penalty',
-    'frequency_penalty',
-    'stop',
-    'top_p',
-    'max_tokens',
-    'topP',
-    'topK',
-    'maxOutputTokens',
-    'promptCache',
-    'region',
-    'maxTokens',
-    'agent_id',
-    'assistant_id',
-  ];
 
   if (input && typeof input === 'object' && !('endpoint' in input) && !('model' in input)) {
     Object.entries(input as Record<string, string>).forEach(([key, value]) => {
@@ -64,20 +51,12 @@ export default function createChatSearchParams(
     params.set('model', conversation.model);
   }
 
-  const paramMap = {
-    temperature: conversation.temperature,
-    presence_penalty: conversation.presence_penalty,
-    frequency_penalty: conversation.frequency_penalty,
-    stop: conversation.stop,
-    top_p: conversation.top_p,
-    max_tokens: conversation.max_tokens,
-    topP: conversation.topP,
-    topK: conversation.topK,
-    maxOutputTokens: conversation.maxOutputTokens,
-    promptCache: conversation.promptCache,
-    region: conversation.region,
-    maxTokens: conversation.maxTokens,
-  };
+  const paramMap: Record<string, any> = {};
+  allowedParams.forEach((key) => {
+    if (key !== 'endpoint' && key !== 'model' && key in conversation) {
+      paramMap[key] = (conversation as any)[key];
+    }
+  });
 
   return Object.entries(paramMap).reduce((params, [key, value]) => {
     if (value != null) {

--- a/client/src/utils/createChatSearchParams.ts
+++ b/client/src/utils/createChatSearchParams.ts
@@ -53,7 +53,10 @@ export default function createChatSearchParams(
 
   const paramMap: Record<string, any> = {};
   allowedParams.forEach((key) => {
-    if (key !== 'endpoint' && key !== 'model' && key in conversation) {
+    if (key === 'agent_id' && conversation.agent_id === Constants.EPHEMERAL_AGENT_ID) {
+      return;
+    }
+    if (key !== 'endpoint' && key !== 'model') {
       paramMap[key] = (conversation as any)[key];
     }
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -45296,7 +45296,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.82",
+      "version": "0.7.83",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.8.2",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.82",
+  "version": "0.7.83",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -52,6 +52,7 @@ export const excludedKeys = new Set([
   'model',
   'files',
   'spec',
+  'disableParams',
 ]);
 
 export enum SettingsViews {

--- a/packages/data-provider/src/generate.ts
+++ b/packages/data-provider/src/generate.ts
@@ -358,7 +358,7 @@ export function validateSettingDefinitions(settings: SettingsConfiguration): voi
         // continue;
       }
       setting.includeInput =
-        setting.type === SettingTypes.Number ? setting.includeInput ?? true : false; // Default to true if type is number
+        setting.type === SettingTypes.Number ? (setting.includeInput ?? true) : false; // Default to true if type is number
     }
 
     if (setting.component === ComponentTypes.Slider && setting.type === SettingTypes.Number) {
@@ -445,7 +445,8 @@ export function validateSettingDefinitions(settings: SettingsConfiguration): voi
 
     // Validate optionType and conversation schema
     if (setting.optionType !== OptionTypes.Custom) {
-      const conversationSchema = tConversationSchema.shape[setting.key as keyof TConversation];
+      const conversationSchema =
+        tConversationSchema.shape[setting.key as keyof Omit<TConversation, 'disableParams'>];
       if (!conversationSchema) {
         errors.push({
           code: ZodIssueCode.custom,

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -750,6 +750,7 @@ export type TSetOption = (
 
 export type TConversation = z.infer<typeof tConversationSchema> & {
   presetOverride?: Partial<TPreset>;
+  disableParams?: boolean;
 };
 
 export const tSharedLinkSchema = z.object({

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -666,11 +666,6 @@ export const tQueryParamsSchema = tConversationSchema
     // librechat settings
     /** The model spec to be used */
     spec: true,
-    /**
-     * Legacy: The model label, if any, usually from a preset.
-     * Overrides the system-defined model label shown in AI messages.
-     * */
-    modelLabel: true,
     /** The AI context window, overrides the system-defined window as determined by `model` value */
     maxContextTokens: true,
     /**

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -666,6 +666,11 @@ export const tQueryParamsSchema = tConversationSchema
     // librechat settings
     /** The model spec to be used */
     spec: true,
+    /**
+     * Legacy: The model label, if any, usually from a preset.
+     * Overrides the system-defined model label shown in AI messages.
+     * */
+    modelLabel: true,
     /** The AI context window, overrides the system-defined window as determined by `model` value */
     maxContextTokens: true,
     /**


### PR DESCRIPTION
## Summary

This PR resolves URL Query Param processing logic conflicting and having race conditions with default presets. It was decided not to create query params when a default preset is applied.

Closes #7403

- Added `disableParams` property to `NewConversationParams`, `TConversation`, and related Redux/Recoil hooks to control parameter update behavior when loading a default preset
- Updated `usePresets`, `useNewConvo`, and `useSelectMention` hooks to set and respect `disableParams` in new conversations and preset changes
- Refined `createChatSearchParams` to ignore `agent_id` if set to `EPHEMERAL_AGENT_ID` and to use new typing for allowed query keys
- Reworked parameter processing in `useQueryParams` for improved clarity and maintainability, removing redundant timing logic and aligning with new state flow
- Changed validation flow in `validateSettingDefinitions` and updated conversation type and schema to include `disableParams`
- Applied linting and code style improvements across affected files

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

I tested the following:
- Switched between default and custom presets, ensuring URL search params only update when appropriate and are not overwritten on default preset load
- Verified that changing presets updates conversation state as expected, and that disabling params prevents query string changes
- Checked for correct reset/clearing of legacy query parameters and full functional preset/model switching without errors
- Confirmed edge cases where new conversations, especially using modular endpoints or ephemeral agents, behave predictably
- Ran local unit tests and manually validated state in browser tools

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules. 