### PR TITLE
📃 fix: Ensure MCP Resources Pass Name and Description Fields to LLM

### DIFF
--- a/packages/mcp/src/parsers.ts
+++ b/packages/mcp/src/parsers.ts
@@ -57,6 +57,12 @@ function parseAsString(result: t.MCPToolCallResponse): string {
         if (item.resource.uri) {
           resourceText.push(`Resource URI: ${item.resource.uri}`);
         }
+        if (item.resource.name) {
+          resourceText.push(`Resource: ${item.resource.name}`);
+        }
+        if (item.resource.description) {
+          resourceText.push(`Description: ${item.resource.description}`);
+        }
         if (item.resource.mimeType != null && item.resource.mimeType) {
           resourceText.push(`Type: ${item.resource.mimeType}`);
         }
@@ -140,6 +146,12 @@ export function formatToolContent(
       }
       if (item.resource.uri.length) {
         resourceText.push(`Resource URI: ${item.resource.uri}`);
+      }
+      if (item.resource.name) {
+        resourceText.push(`Resource: ${item.resource.name}`);
+      }
+      if (item.resource.description) {
+        resourceText.push(`Description: ${item.resource.description}`);
       }
       if (item.resource.mimeType != null && item.resource.mimeType) {
         resourceText.push(`Type: ${item.resource.mimeType}`);


### PR DESCRIPTION
## Summary

This pull request fixes an issue where MCP resources were not properly passing the `name` and `description` fields to the LLM, despite these fields being defined in the MCPResource interface. The resource handlers in the parsers have been updated to include all relevant fields (`uri`, `name`, `description`, `mimeType`).  
Motivation: Ensures the LLM receives complete context about resources, improving accuracy and usability.  
Related issue: Fixes #7441 
No additional dependencies are required for these changes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested with an MCP server that provides resources with `name` and `description` fields. Confirmed that all fields are now properly passed to the LLM.

### **Test Configuration**:

- LibreChat Version: latest
- Install Method: docker-compose
- OS: Linux
- Browser: Firefox
- MCP server configuration in librechat.yaml

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
