### PR TITLE
Add support for restricting MCP server access by user

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -649,6 +649,7 @@ class AgentClient extends BaseClient {
           thread_id: this.conversationId,
           last_agent_index: this.agentConfigs?.size ?? 0,
           user_id: this.user ?? this.options.req.user?.id,
+          user_email: this.options.req.user?.email,
           hide_sequential_outputs: this.options.agent.hide_sequential_outputs,
         },
         recursionLimit: agentsEConfig?.recursionLimit,
@@ -656,6 +657,18 @@ class AgentClient extends BaseClient {
         streamMode: 'values',
         version: 'v2',
       };
+
+      // Filter MCP tools based on user access
+      if (
+        this.options.req.app.locals.filterMCPToolsByUser &&
+        this.options.agent.tools &&
+        this.options.req.user?.email
+      ) {
+        this.options.agent.tools = this.options.req.app.locals.filterMCPToolsByUser(
+          this.options.req.user.email,
+          this.options.agent.tools,
+        );
+      }
 
       const toolSet = new Set((this.options.agent.tools ?? []).map((tool) => tool && tool.name));
       let { messages: initialMessages, indexTokenCountMap } = formatAgentMessages(

--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -65,6 +65,22 @@ const AppService = async (app) => {
     directory: paths.structuredTools,
   });
 
+  // Filter function to track MCP server for tools
+  app.locals.filterMCPToolsByUser = (userEmail, tools) => {
+    if (!userEmail || !config.mcpServers || !tools) {
+      return tools;
+    }
+    const mcpManager = getMCPManager();
+    return tools.filter((tool) => {
+      // If not an MCP tool or no pluginKey, keep it
+      if (!tool.pluginKey || !tool.pluginKey.includes('__mcp_')) {
+        return true;
+      }
+      const [_, serverName] = tool.pluginKey.split('__mcp_');
+      return mcpManager.checkUserServerAccess(serverName, userEmail);
+    });
+  };
+
   if (config.mcpServers != null) {
     const mcpManager = getMCPManager();
     await mcpManager.initializeMCP(config.mcpServers, processMCPEnv);

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -61,6 +61,7 @@ async function createMCPTool({ req, toolKey, provider: _provider }) {
         toolArguments,
         options: {
           userId: config?.configurable?.user_id,
+          userEmail: config?.configurable?.user_email,
           signal: derivedSignal,
         },
       });

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -141,6 +141,8 @@ actions:
 #       - -y
 #       - "@modelcontextprotocol/server-puppeteer"
 #     timeout: 300000  # 5 minutes timeout for this server
+#     # Restrict access to specific users by email
+#     allowedUsers: ["admin@example.com", "developer@example.com"]
 #   filesystem:
 #     # type: stdio
 #     command: npx
@@ -149,12 +151,15 @@ actions:
 #       - "@modelcontextprotocol/server-filesystem"
 #       - /home/user/LibreChat/
 #     iconPath: /home/user/LibreChat/client/public/assets/logo.svg
+#     # Restrict access using a regex pattern (all users with company.com email domain)
+#     allowedUsers: ".*@company\\.com$"
 #   mcp-obsidian:
 #     command: npx
 #     args:
 #       - -y
 #       - "mcp-obsidian"
 #       - /path/to/obsidian/vault
+#     # This MCP server has no allowedUsers restriction, so all users can access it
 
 # Definition of custom endpoints
 endpoints:

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -7,6 +7,13 @@ const BaseOptionsSchema = z.object({
   initTimeout: z.number().optional(),
   /** Controls visibility in chat dropdown menu (MCPSelect) */
   chatMenu: z.boolean().optional(),
+  /** Restricts access to specific users by email */
+  allowedUsers: z
+    .union([
+      z.array(z.string().email()), // List of specific email addresses
+      z.string(), // Regular expression pattern for matching emails
+    ])
+    .optional(),
 });
 
 export const StdioOptionsSchema = BaseOptionsSchema.extend({


### PR DESCRIPTION
## Summary
This PR adds the ability to restrict access to specific MCP (Model Context Protocol) servers based on user email addresses. Administrators can now specify which users are allowed to access each MCP server through either explicit email lists or regex patterns, providing fine-grained access control for potentially sensitive tools.

## Changes
- Added an `allowedUsers` configuration option for MCP servers in the `librechat.yaml` file, which can be:
  - An array of specific email addresses (e.g., `["admin@example.com", "user@example.com"]`)
  - A regex pattern string (e.g., `".*@company\\.com$"`) to allow matching against email domains or patterns
- Modified the MCP manager to verify user access permissions when:
  - Creating connections to MCP servers
  - Loading available tools for a user
  - Executing agent requests with MCP tools
- Implemented per-user caching of available tools rather than global caching
- Added user email propagation throughout the relevant request chains
- Updated example configuration in `librechat.example.yaml` with documentation

## Motivation
Previously, all users had access to all configured MCP servers. This posed potential security and resource concerns for administrators who wanted to offer certain powerful tools (like filesystem access or specialized integrations) to only specific users while allowing everyone to access other MCP servers.

## How to Use

In your `librechat.yaml` configuration, you can now add an `allowedUsers` property to any MCP server definition:

```yaml
mcpServers:
  puppeteer:
    command: npx
    args:
      - -y
      - "@modelcontextprotocol/server-puppeteer"
    # Restrict to specific email addresses
    allowedUsers: ["admin@example.com", "developer@example.com"]
  
  filesystem:
    command: npx
    args:
      - -y
      - "@modelcontextprotocol/server-filesystem"
    # Restrict using a regex pattern (all users with company.com email domain)
    allowedUsers: ".*@company\\.com$"
  
  general-mcp-server:
    command: npx
    args:
      - -y
      - "some-mcp-server"
    # No allowedUsers property means all users can access this server
```
## Related Issues
[\[Enhancement\]: Multi-user setup with MCP tools for trusted infrastructure setup · Issue #6437 · danny-avila/LibreChat · GitHub](https://github.com/danny-avila/LibreChat/issues/6437)

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [ ] Translation update

## Testing

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.
