### PR TITLE
🔧 fix: File Deletion for Azure Assistants API

### DIFF
--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -121,6 +121,14 @@ router.delete('/', async (req, res) => {
       await processDeleteRequest({ req, files: assistantFiles });
       res.status(200).json({ message: 'File associations removed successfully from assistant' });
       return;
+    } else if (
+      req.body.assistant_id &&
+      req.body.files?.[0]?.filepath === EModelEndpoint.azureAssistants
+    ) {
+      await processDeleteRequest({ req, files: req.body.files });
+      return res
+        .status(200)
+        .json({ message: 'File associations removed successfully from Azure Assistant' });
     }
 
     await processDeleteRequest({ req, files: dbFiles });

--- a/api/server/services/Files/OpenAI/crud.js
+++ b/api/server/services/Files/OpenAI/crud.js
@@ -54,7 +54,7 @@ async function deleteOpenAIFile(req, file, openai) {
       throw new Error('OpenAI returned `false` for deleted status');
     }
     logger.debug(
-      `[deleteOpenAIFile] User ${req.user.id} successfully deleted ${file.file_id} from OpenAI`,
+      `[deleteOpenAIFile] User ${req.user.id} successfully deleted file "${file.file_id}" from OpenAI`,
     );
   } catch (error) {
     logger.error('[deleteOpenAIFile] Error deleting file from OpenAI: ' + error.message);

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -137,11 +137,13 @@ const processDeleteRequest = async ({ req, files }) => {
   /** @type {Record<string, OpenAI | undefined>} */
   const client = { [FileSources.openai]: undefined, [FileSources.azure]: undefined };
   const initializeClients = async () => {
-    const openAIClient = await getOpenAIClient({
-      req,
-      overrideEndpoint: EModelEndpoint.assistants,
-    });
-    client[FileSources.openai] = openAIClient.openai;
+    if (req.app.locals[EModelEndpoint.assistants]) {
+      const openAIClient = await getOpenAIClient({
+        req,
+        overrideEndpoint: EModelEndpoint.assistants,
+      });
+      client[FileSources.openai] = openAIClient.openai;
+    }
 
     if (!req.app.locals[EModelEndpoint.azureOpenAI]?.assistants) {
       return;


### PR DESCRIPTION
## Summary

- Updated the DELETE route for files to handle Azure Assistants specifically when deleting file associations, returning an appropriate success message.
- Improved client initialization logic in `processDeleteRequest` to only create OpenAI client when needed for the relevant endpoint, preventing mismatched client usage.
- Enhanced logging to clarify file deletion events on OpenAI, including file ID context in debug statements.
- Refactored the deletion handling code to distinguish between OpenAI Assistants and Azure Assistants for safer, more predictable file management.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested file deletion for both OpenAI and Azure Assistants APIs via API calls (using Postman/curl) and verified that:
- Files associated with an Azure Assistant are deleted and proper confirmation is returned.
- Files for OpenAI Assistants are unaffected by Azure-specific logic.
- Error handling and event logging work as expected.

**Test Configuration:**
- Node.js 20.x
- Both OpenAI and Azure API keys configured in `.env`
- Relevant endpoints accessible from the network environment

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes