### PR TITLE
🖼️ chore: Linting & Transition Styling in UI Components

### DIFF
--- a/client/src/components/Chat/Input/Files/FileRow.tsx
+++ b/client/src/components/Chat/Input/Files/FileRow.tsx
@@ -75,20 +75,20 @@ export default function FileRow({
   const renderFiles = () => {
     const rowStyle = isRTL
       ? {
-        display: 'flex',
-        flexDirection: 'row-reverse',
-        flexWrap: 'wrap',
-        gap: '4px',
-        width: '100%',
-        maxWidth: '100%',
-      }
+          display: 'flex',
+          flexDirection: 'row-reverse',
+          flexWrap: 'wrap',
+          gap: '4px',
+          width: '100%',
+          maxWidth: '100%',
+        }
       : {
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: '4px',
-        width: '100%',
-        maxWidth: '100%',
-      };
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '4px',
+          width: '100%',
+          maxWidth: '100%',
+        };
 
     return (
       <div style={rowStyle as React.CSSProperties}>

--- a/client/src/components/Chat/Messages/Content/DialogImage.tsx
+++ b/client/src/components/Chat/Messages/Content/DialogImage.tsx
@@ -8,7 +8,7 @@ export default function DialogImage({ isOpen, onOpenChange, src = '', downloadIm
         showCloseButton={false}
         className="h-full w-full rounded-none bg-transparent"
         disableScroll={false}
-        overlayClassName="bg-surface-secondary"
+        overlayClassName="bg-surface-primary opacity-95 z-50"
       >
         <div className="absolute left-0 right-0 top-0 flex items-center justify-between p-4">
           <Button

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
@@ -194,8 +194,8 @@ export default function OpenAIImageGen({
           <Image
             altText={filename}
             imagePath={filepath ?? ''}
-            width={dimensions.width}
-            height={dimensions.height}
+            width={Number(dimensions.width?.split('px')[0])}
+            height={Number(dimensions.height?.split('px')[0])}
             placeholderDimensions={{ width: dimensions.width, height: dimensions.height }}
           />
         </div>

--- a/client/src/components/ui/PixelCard.tsx
+++ b/client/src/components/ui/PixelCard.tsx
@@ -350,12 +350,13 @@ export default function PixelCard({
     >
       <div
         className={cn(
-          'ease-[cubic-bezier(0.5,1,0.89,1)] relative isolate grid select-none place-items-center overflow-hidden rounded-lg border border-border-light shadow-md transition-colors duration-200',
+          'relative isolate grid select-none place-items-center overflow-hidden rounded-lg border border-border-light shadow-md transition-colors duration-200 ease-in-out',
           className,
         )}
         style={{
           width: '100%',
           height: '100%',
+          transitionTimingFunction: 'cubic-bezier(0.5, 1, 0.89, 1)',
         }}
         onMouseEnter={hoverIn}
         onMouseLeave={hoverOut}


### PR DESCRIPTION
## Summary

I updated the OpenAIImageGen component to ensure image dimensions are parsed correctly, improved overlay visibility in DialogImage, updated the PixelCard transition behavior to use style props, and applied linting fixes in FileRow.

- Corrected parsing of width and height for images in the OpenAIImageGen component to ensure numeric values are used when passing to the Image component.
- Enhanced overlay visibility for DialogImage by updating its overlay class to use `bg-surface-primary` with increased opacity and `z-50` for stacking.
- Updated the PixelCard component transition timing to rely on the `transitionTimingFunction` style prop, replacing the tailwind class for consistency and style flexibility.
- Performed linting cleanup in the FileRow component to improve readability and maintain coding standards.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Style update (non-breaking UI improvement)
- [x] Chore

## Testing

I manually verified image rendering in the OpenAIImageGen component to confirm numerical dimension extraction and correct sizing in the UI. Confirmed that DialogImage overlays now appear with the intended background and opacity during modal display. Checked PixelCard transitions for smooth animations and consistent timing behavior. Ensured linted FileRow still displays file items as expected in both LTR and RTL scenarios.

### **Test Configuration**:

- Browser: Chrome, Firefox
- Node: v20.x
- OS: macOS Ventura

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes