### PR TITLE
🪨 feat: Bedrock Support for Claude-4 Reasoning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,8 +52,9 @@ bower_components/
 *.d.ts
 !vite-env.d.ts
 
-# Cline
+# AI
 .clineignore
+.cursor
 
 # Floobits
 .floo

--- a/api/server/services/Endpoints/bedrock/options.js
+++ b/api/server/services/Endpoints/bedrock/options.js
@@ -25,10 +25,10 @@ const getOptions = async ({ req, overrideModel, endpointOption }) => {
   let credentials = isUserProvided
     ? await getUserKey({ userId: req.user.id, name: EModelEndpoint.bedrock })
     : {
-      accessKeyId: BEDROCK_AWS_ACCESS_KEY_ID,
-      secretAccessKey: BEDROCK_AWS_SECRET_ACCESS_KEY,
-      ...(BEDROCK_AWS_SESSION_TOKEN && { sessionToken: BEDROCK_AWS_SESSION_TOKEN }),
-    };
+        accessKeyId: BEDROCK_AWS_ACCESS_KEY_ID,
+        secretAccessKey: BEDROCK_AWS_SECRET_ACCESS_KEY,
+        ...(BEDROCK_AWS_SESSION_TOKEN && { sessionToken: BEDROCK_AWS_SESSION_TOKEN }),
+      };
 
   if (!credentials) {
     throw new Error('Bedrock credentials not provided. Please provide them again.');

--- a/packages/data-provider/specs/bedrock.spec.ts
+++ b/packages/data-provider/specs/bedrock.spec.ts
@@ -1,0 +1,114 @@
+import { bedrockInputParser } from '../src/bedrock';
+import type { BedrockConverseInput } from '../src/bedrock';
+
+describe('bedrockInputParser', () => {
+  describe('Model Matching for Reasoning Configuration', () => {
+    test('should match anthropic.claude-3-7-sonnet model', () => {
+      const input = {
+        model: 'anthropic.claude-3-7-sonnet',
+      };
+      const result = bedrockInputParser.parse(input) as BedrockConverseInput;
+      const additionalFields = result.additionalModelRequestFields as Record<string, unknown>;
+      expect(additionalFields.thinking).toBe(true);
+      expect(additionalFields.thinkingBudget).toBe(2000);
+      expect(additionalFields.anthropic_beta).toEqual(['output-128k-2025-02-19']);
+    });
+
+    test('should match anthropic.claude-sonnet-4 model', () => {
+      const input = {
+        model: 'anthropic.claude-sonnet-4',
+      };
+      const result = bedrockInputParser.parse(input) as BedrockConverseInput;
+      const additionalFields = result.additionalModelRequestFields as Record<string, unknown>;
+      expect(additionalFields.thinking).toBe(true);
+      expect(additionalFields.thinkingBudget).toBe(2000);
+      expect(additionalFields.anthropic_beta).toEqual(['output-128k-2025-02-19']);
+    });
+
+    test('should match anthropic.claude-opus-5 model', () => {
+      const input = {
+        model: 'anthropic.claude-opus-5',
+      };
+      const result = bedrockInputParser.parse(input) as BedrockConverseInput;
+      const additionalFields = result.additionalModelRequestFields as Record<string, unknown>;
+      expect(additionalFields.thinking).toBe(true);
+      expect(additionalFields.thinkingBudget).toBe(2000);
+      expect(additionalFields.anthropic_beta).toEqual(['output-128k-2025-02-19']);
+    });
+
+    test('should match anthropic.claude-haiku-6 model', () => {
+      const input = {
+        model: 'anthropic.claude-haiku-6',
+      };
+      const result = bedrockInputParser.parse(input) as BedrockConverseInput;
+      const additionalFields = result.additionalModelRequestFields as Record<string, unknown>;
+      expect(additionalFields.thinking).toBe(true);
+      expect(additionalFields.thinkingBudget).toBe(2000);
+      expect(additionalFields.anthropic_beta).toEqual(['output-128k-2025-02-19']);
+    });
+
+    test('should match anthropic.claude-4-sonnet model', () => {
+      const input = {
+        model: 'anthropic.claude-4-sonnet',
+      };
+      const result = bedrockInputParser.parse(input) as BedrockConverseInput;
+      const additionalFields = result.additionalModelRequestFields as Record<string, unknown>;
+      expect(additionalFields.thinking).toBe(true);
+      expect(additionalFields.thinkingBudget).toBe(2000);
+      expect(additionalFields.anthropic_beta).toEqual(['output-128k-2025-02-19']);
+    });
+
+    test('should match anthropic.claude-4.5-sonnet model', () => {
+      const input = {
+        model: 'anthropic.claude-4.5-sonnet',
+      };
+      const result = bedrockInputParser.parse(input) as BedrockConverseInput;
+      const additionalFields = result.additionalModelRequestFields as Record<string, unknown>;
+      expect(additionalFields.thinking).toBe(true);
+      expect(additionalFields.thinkingBudget).toBe(2000);
+      expect(additionalFields.anthropic_beta).toEqual(['output-128k-2025-02-19']);
+    });
+
+    test('should match anthropic.claude-4-7-sonnet model', () => {
+      const input = {
+        model: 'anthropic.claude-4-7-sonnet',
+      };
+      const result = bedrockInputParser.parse(input) as BedrockConverseInput;
+      const additionalFields = result.additionalModelRequestFields as Record<string, unknown>;
+      expect(additionalFields.thinking).toBe(true);
+      expect(additionalFields.thinkingBudget).toBe(2000);
+      expect(additionalFields.anthropic_beta).toEqual(['output-128k-2025-02-19']);
+    });
+
+    test('should not match non-Claude models', () => {
+      const input = {
+        model: 'some-other-model',
+      };
+      const result = bedrockInputParser.parse(input) as BedrockConverseInput;
+      expect(result.additionalModelRequestFields).toBeUndefined();
+    });
+
+    test('should respect explicit thinking configuration', () => {
+      const input = {
+        model: 'anthropic.claude-sonnet-4',
+        thinking: false,
+      };
+      const result = bedrockInputParser.parse(input) as BedrockConverseInput;
+      const additionalFields = result.additionalModelRequestFields as Record<string, unknown>;
+      expect(additionalFields.thinking).toBeUndefined();
+      expect(additionalFields.thinkingBudget).toBeUndefined();
+    });
+
+    test('should respect custom thinking budget', () => {
+      const input = {
+        model: 'anthropic.claude-sonnet-4',
+        thinking: true,
+        thinkingBudget: 3000,
+      };
+      const result = bedrockInputParser.parse(input) as BedrockConverseInput;
+      const additionalFields = result.additionalModelRequestFields as Record<string, unknown>;
+      expect(additionalFields.thinking).toBe(true);
+      expect(additionalFields.thinkingBudget).toBe(3000);
+    });
+  });
+});

--- a/packages/data-provider/src/bedrock.ts
+++ b/packages/data-provider/src/bedrock.ts
@@ -119,7 +119,10 @@ export const bedrockInputParser = s.tConversationSchema
     /** Default thinking and thinkingBudget for 'anthropic.claude-3-7-sonnet' models, if not defined */
     if (
       typeof typedData.model === 'string' &&
-      typedData.model.includes('anthropic.claude-3-7-sonnet')
+      (typedData.model.includes('anthropic.claude-3-7-sonnet') ||
+        /anthropic\.claude-(?:[4-9](?:\.\d+)?(?:-\d+)?-(?:sonnet|opus|haiku)|(?:sonnet|opus|haiku)-[4-9])/.test(
+          typedData.model,
+        ))
     ) {
       if (additionalFields.thinking === undefined) {
         additionalFields.thinking = true;


### PR DESCRIPTION
## Summary

Followup of #7512

- Extended the Bedrock input parser logic to include Claude-4, 4.5, and future models for automatic reasoning support.
- Added comprehensive unit tests to confirm that model matching and configuration of reasoning fields work as expected for all relevant Claude model patterns.
- Ensured explicit configuration for "thinking" and "thinkingBudget" is honored, providing flexibility for user overrides.
- Performed linting updates in `bedrock/options.js` to maintain code style consistency.
- Updated `.gitignore` entries to include AI development artifacts for better repo hygiene.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I wrote and ran new unit tests in `bedrock.spec.ts` covering model matching, reasoning field assignment, and override logic, verifying all cases pass with the current and expected future Anthropic Claude model naming patterns. I recommend manually verifying requests sent to Bedrock with new and future Claude models to ensure the "thinking" fields are applied as expected in live endpoints.

### **Test Configuration**:

- Node 20+
- Jest

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes