### PR TITLE
🪖 chore: bump helm app version to v0.7.8

### DIFF
--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.8
+version: 1.8.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -22,7 +22,7 @@ version: 1.8.8
 # It is recommended to use it with quotes.
 
 # renovate: image=ghcr.io/danny-avila/librechat
-appVersion: "v0.7.7"
+appVersion: "v0.7.8"
 
 home: https://www.librechat.ai
 


### PR DESCRIPTION
## Summary

The helm version is one behind the rc release version. Docker compose uses 0.7.8 and so should helm.

## Change Type

Chore: Bumping the container version to meet the recent release.

## Testing

I have deployed this in my local kubernetes cluster and compared it to my running docker compose. Everything is working as expected.

### **Test Configuration**:

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings

