### PR TITLE
🔧 chore: Bump Data Provider and Custom Config Versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45218,7 +45218,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.84",
+      "version": "0.7.85",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.8.2",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.84",
+  "version": "0.7.85",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1313,7 +1313,7 @@ export enum Constants {
   /** Key for the app's version. */
   VERSION = 'v0.7.8',
   /** Key for the Custom Config's version (librechat.yaml). */
-  CONFIG_VERSION = '1.2.5',
+  CONFIG_VERSION = '1.2.6',
   /** Standard value for the first message's `parentMessageId` value, to indicate no parent exists. */
   NO_PARENT = '00000000-0000-0000-0000-000000000000',
   /** Standard value for the initial conversationId before a request is sent */


### PR DESCRIPTION
## Summary

I updated the `librechat-data-provider` package version to 0.7.85 and increased the `CONFIG_VERSION` constant to 1.2.6 for consistency with recent internal changes.

- Updated the `version` field in `librechat-data-provider/package.json` from 0.7.84 to 0.7.85 to reflect a new package release.
- Changed `CONFIG_VERSION` in `src/config.ts` from '1.2.5' to '1.2.6' for up-to-date configuration tracking.

## Change Type

- [x] Documentation update

## Testing

I verified the updates by rebuilding the data-provider package and ensuring that the version is reflected properly in builds. I recommend running a fresh install (`pnpm i` or `npm install`) and ensuring the application starts with the new configuration version, checking logs or UI where version data is surfaced.

### **Test Configuration**:

- Node.js 20.x
- pnpm 8.x
- LibreChat monorepo structure

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes