### PR TITLE
fix: include Claude 4 Sonnet and Opus in non-legacy output pattern

### DIFF
--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -119,7 +119,10 @@ class AnthropicClient extends BaseClient {
     this.isClaudeLatest =
       /claude-[3-9]/.test(modelMatch) || /claude-(?:sonnet|opus|haiku)-[4-9]/.test(modelMatch);
     this.isLegacyOutput = !(
-      /claude-3[-.]5-sonnet/.test(modelMatch) || /claude-3[-.]7/.test(modelMatch)
+      /claude-3[-.]5-sonnet/.test(modelMatch) ||
+      /claude-3[-.]7/.test(modelMatch) ||
+      /claude-sonnet-4/.test(modelMatch) ||
+      /claude-opus-4/.test(modelMatch)
     );
     this.supportsCacheControl = this.options.promptCache && checkPromptCacheSupport(modelMatch);
 

--- a/api/app/clients/specs/AnthropicClient.test.js
+++ b/api/app/clients/specs/AnthropicClient.test.js
@@ -570,8 +570,35 @@ describe('AnthropicClient', () => {
         anthropicSettings.legacy.maxOutputTokens.default,
       );
     });
-  });
 
+    it('should not cap maxOutputTokens for Claude 4 Sonnet models', () => {
+      const client = new AnthropicClient('test-api-key');
+      const highTokenValue = anthropicSettings.legacy.maxOutputTokens.default * 10; // 40,960 tokens
+
+      client.setOptions({
+        modelOptions: {
+          model: 'claude-sonnet-4-20250514',
+          maxOutputTokens: highTokenValue,
+        },
+      });
+
+      expect(client.modelOptions.maxOutputTokens).toBe(highTokenValue);
+    });
+
+    it('should not cap maxOutputTokens for Claude 4 Opus models', () => {
+      const client = new AnthropicClient('test-api-key');
+      const highTokenValue = anthropicSettings.legacy.maxOutputTokens.default * 6; // 24,576 tokens (under 32K limit)
+
+      client.setOptions({
+        modelOptions: {
+          model: 'claude-opus-4-20250514',
+          maxOutputTokens: highTokenValue,
+        },
+      });
+
+      expect(client.modelOptions.maxOutputTokens).toBe(highTokenValue);
+    });
+  });
   describe('topK/topP parameters for different models', () => {
     beforeEach(() => {
       // Mock the SplitStreamHandler


### PR DESCRIPTION
Fixes #7546

- Added Claude 4 Sonnet and Opus to isLegacyOutput exclusion regex
- Prevents these models from being capped at legacy 4096 token limit
- Allows proper use of their higher token limits (64K for Sonnet, 32K for Opus)
- Follows existing pattern used for Claude 3.5 and 3.7 models
- Added comprehensive test coverage for Claude 4 token limits


## Summary
Fixes #7546

Claude 4 Sonnet and Opus models are incorrectly treated as "legacy output" models in `AnthropicClient.js`, causing them to be capped at the legacy 4096 token limit instead of their proper higher limits (64K for Sonnet, 32K for Opus) or user-configured limits.

This fix adds Claude 4 Sonnet and Opus to the `isLegacyOutput` exclusion regex, following the same pattern used for Claude 3.5 and 3.7 models, and includes comprehensive test coverage to prevent regression.

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
**Test Process:**
1. Configured LibreChat with Claude Sonnet 4 model (`claude-sonnet-4-20250514`)
2. Set `maxOutputTokens: 16000` in LibreChat UI.
3. Made requests that should generate more than 4096 tokens
4. Verified responses are no longer capped at 4096 tokens
5. Added unit tests covering both Claude 4 Sonnet and Opus models
6. All existing tests pass with no regressions

**Added Test Coverage:**
- `should not cap maxOutputTokens for Claude 4 Sonnet models` 
- `should not cap maxOutputTokens for Claude 4 Opus models`


### **Test Configuration**:
- Model: `claude-sonnet-4-20250514`
- Configuration: `maxOutputTokens: 16000` in librechat.yaml
- Environment: Docker deployment with custom configuration
- All unit tests: `npm run test:api -- api/app/clients/specs/AnthropicClient.test.js`

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code (N/A - simple regex addition)
- [ ] I have made pertinent documentation changes (N/A - internal bug fix)
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules (N/A)
- [ ] A pull request for updating the documentation has been submitted (N/A - internal fix)

