### PR TITLE
🔐 feat: Add Explicit State Parameter For OIDC Compatibility

### DIFF
--- a/api/server/routes/oauth.js
+++ b/api/server/routes/oauth.js
@@ -1,6 +1,7 @@
 // file deepcode ignore NoRateLimitingForLogin: Rate limiting is handled by the `loginLimiter` middleware
 const express = require('express');
 const passport = require('passport');
+const client = require('openid-client');
 const {
   checkBan,
   logHeaders,
@@ -107,6 +108,7 @@ router.get(
   '/openid',
   passport.authenticate('openid', {
     session: false,
+    state: client.randomState(),
   }),
 );
 
@@ -115,6 +117,7 @@ router.get(
   passport.authenticate('openid', {
     failureRedirect: `${domains.client}/oauth/error`,
     failureMessage: true,
+    state: client.randomState(),
     session: false,
   }),
   setBalanceConfig,

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -28,6 +28,17 @@ class CustomOpenIDStrategy extends OpenIDStrategy {
     const hostAndProtocol = process.env.DOMAIN_SERVER;
     return new URL(`${hostAndProtocol}${req.originalUrl ?? req.url}`);
   }
+
+  /**
+   * Override to ensure proper authorization request parameters
+   */
+  authorizationRequestParams(req, options) {
+    const params = super.authorizationRequestParams?.(req, options) || {};
+    if (options?.state != null && options.state && !params.has('state')) {
+      params.set('state', options.state);
+    }
+    return params;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

I added explicit state parameter passing to the OpenID OAuth flow and implemented debounced context management to resolve compatibility issues with OIDC providers that require state parameters.

- Added explicit state parameter generation using `openid-client.randomState()` to both OpenID authentication routes since some OAuth/OIDC providers require it
- Imported the `openid-client` module in OAuth routes to support state parameter functionality
- Implemented custom `authorizationRequestParams` method in OpenID strategy to ensure state parameter inclusion when the latest version of openid-client doesn't provide it automatically
- Refactored `setUserContext` from a callback to a debounced function with 50ms delay to prevent race conditions during authentication
- Reorganized imports in AuthContext for better structure and added lodash debounce dependency
- Added state parameter validation in authorization request parameters to ensure proper OAuth flow compliance

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

I tested the OAuth flow with OIDC providers that require state parameters to ensure compatibility, and verified that the debounced setUserContext prevents race conditions during authentication state changes.

### **Test Configuration**:
- OIDC providers that explicitly require state parameters
- Multiple authentication attempts to test debouncing behavior
- State parameter presence validation in OAuth callback

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes