### PR TITLE
⌚ fix: Debounce `setUserContext` and Default State Param for OpenID Auth

### DIFF
--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -74,9 +74,6 @@ class AnthropicClient extends BaseClient {
     /** Whether to use Messages API or Completions API
      * @type {boolean} */
     this.useMessages;
-    /** Whether or not the model is limited to the legacy amount of output tokens
-     * @type {boolean} */
-    this.isLegacyOutput;
     /** Whether or not the model supports Prompt Caching
      * @type {boolean} */
     this.supportsCacheControl;
@@ -118,13 +115,16 @@ class AnthropicClient extends BaseClient {
     const modelMatch = matchModelName(this.modelOptions.model, EModelEndpoint.anthropic);
     this.isClaudeLatest =
       /claude-[3-9]/.test(modelMatch) || /claude-(?:sonnet|opus|haiku)-[4-9]/.test(modelMatch);
-    this.isLegacyOutput = !(
-      /claude-3[-.]5-sonnet/.test(modelMatch) || /claude-3[-.]7/.test(modelMatch)
+    const isLegacyOutput = !(
+      /claude-3[-.]5-sonnet/.test(modelMatch) ||
+      /claude-3[-.]7/.test(modelMatch) ||
+      /claude-(?:sonnet|opus|haiku)-[4-9]/.test(modelMatch) ||
+      /claude-[4-9]/.test(modelMatch)
     );
     this.supportsCacheControl = this.options.promptCache && checkPromptCacheSupport(modelMatch);
 
     if (
-      this.isLegacyOutput &&
+      isLegacyOutput &&
       this.modelOptions.maxOutputTokens &&
       this.modelOptions.maxOutputTokens > legacy.maxOutputTokens.default
     ) {

--- a/api/app/clients/specs/AnthropicClient.test.js
+++ b/api/app/clients/specs/AnthropicClient.test.js
@@ -514,6 +514,34 @@ describe('AnthropicClient', () => {
       expect(client.modelOptions.maxOutputTokens).toBe(highTokenValue);
     });
 
+    it('should not cap maxOutputTokens for Claude 4 Sonnet models', () => {
+      const client = new AnthropicClient('test-api-key');
+      const highTokenValue = anthropicSettings.legacy.maxOutputTokens.default * 10; // 40,960 tokens
+
+      client.setOptions({
+        modelOptions: {
+          model: 'claude-sonnet-4-20250514',
+          maxOutputTokens: highTokenValue,
+        },
+      });
+
+      expect(client.modelOptions.maxOutputTokens).toBe(highTokenValue);
+    });
+
+    it('should not cap maxOutputTokens for Claude 4 Opus models', () => {
+      const client = new AnthropicClient('test-api-key');
+      const highTokenValue = anthropicSettings.legacy.maxOutputTokens.default * 6; // 24,576 tokens (under 32K limit)
+
+      client.setOptions({
+        modelOptions: {
+          model: 'claude-opus-4-20250514',
+          maxOutputTokens: highTokenValue,
+        },
+      });
+
+      expect(client.modelOptions.maxOutputTokens).toBe(highTokenValue);
+    });
+
     it('should cap maxOutputTokens for Claude 3.5 Haiku models', () => {
       const client = new AnthropicClient('test-api-key');
       const highTokenValue = anthropicSettings.legacy.maxOutputTokens.default * 2;

--- a/api/server/cleanup.js
+++ b/api/server/cleanup.js
@@ -140,9 +140,6 @@ function disposeClient(client) {
     if (client.useMessages !== undefined) {
       client.useMessages = null;
     }
-    if (client.isLegacyOutput !== undefined) {
-      client.isLegacyOutput = null;
-    }
     if (client.supportsCacheControl !== undefined) {
       client.supportsCacheControl = null;
     }

--- a/api/server/index.spec.js
+++ b/api/server/index.spec.js
@@ -4,6 +4,10 @@ const request = require('supertest');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const mongoose = require('mongoose');
 
+jest.mock('~/server/services/Config/loadCustomConfig', () => {
+  return jest.fn(() => Promise.resolve({}));
+});
+
 describe('Server Configuration', () => {
   // Increase the default timeout to allow for Mongo cleanup
   jest.setTimeout(30_000);

--- a/api/server/routes/oauth.js
+++ b/api/server/routes/oauth.js
@@ -104,13 +104,12 @@ router.get(
 /**
  * OpenID Routes
  */
-router.get(
-  '/openid',
-  passport.authenticate('openid', {
+router.get('/openid', (req, res, next) => {
+  return passport.authenticate('openid', {
     session: false,
     state: randomState(),
-  }),
-);
+  })(req, res, next);
+});
 
 router.get(
   '/openid/callback',

--- a/api/server/routes/oauth.js
+++ b/api/server/routes/oauth.js
@@ -1,6 +1,7 @@
 // file deepcode ignore NoRateLimitingForLogin: Rate limiting is handled by the `loginLimiter` middleware
 const express = require('express');
 const passport = require('passport');
+const client = require('openid-client');
 const {
   checkBan,
   logHeaders,
@@ -107,6 +108,7 @@ router.get(
   '/openid',
   passport.authenticate('openid', {
     session: false,
+    state: client.randomState(),
   }),
 );
 

--- a/api/server/routes/oauth.js
+++ b/api/server/routes/oauth.js
@@ -1,7 +1,7 @@
 // file deepcode ignore NoRateLimitingForLogin: Rate limiting is handled by the `loginLimiter` middleware
 const express = require('express');
 const passport = require('passport');
-const client = require('openid-client');
+const { randomState } = require('openid-client');
 const {
   checkBan,
   logHeaders,
@@ -10,8 +10,8 @@ const {
   checkDomainAllowed,
 } = require('~/server/middleware');
 const { setAuthTokens, setOpenIDAuthTokens } = require('~/server/services/AuthService');
-const { logger } = require('~/config');
 const { isEnabled } = require('~/server/utils');
+const { logger } = require('~/config');
 
 const router = express.Router();
 
@@ -108,7 +108,7 @@ router.get(
   '/openid',
   passport.authenticate('openid', {
     session: false,
-    state: client.randomState(),
+    state: randomState(),
   }),
 );
 

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -28,6 +28,13 @@ class CustomOpenIDStrategy extends OpenIDStrategy {
     const hostAndProtocol = process.env.DOMAIN_SERVER;
     return new URL(`${hostAndProtocol}${req.originalUrl ?? req.url}`);
   }
+  authorizationRequestParams(req, options) {
+    const params = super.authorizationRequestParams(req, options);
+    if (options?.state && !params.has('state')) {
+      params.set('state', options.state);
+    }
+    return params;
+  }
 }
 
 /**

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -211,7 +211,7 @@ export default function ModelPanel({
       {/* Model Parameters */}
       {parameters && (
         <div className="h-auto max-w-full overflow-x-hidden p-2">
-          <div className="grid grid-cols-4 gap-6">
+          <div className="grid grid-cols-2 gap-4">
             {/* This is the parent element containing all settings */}
             {/* Below is an example of an applied dynamic setting, each be contained by a div with the column span specified */}
             {parameters.map((setting) => {

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -2,10 +2,10 @@ import React, { useMemo, useEffect } from 'react';
 import { ChevronLeft, RotateCcw } from 'lucide-react';
 import { useFormContext, useWatch, Controller } from 'react-hook-form';
 import {
-  getSettingsKeys,
   alternateName,
-  agentParamSettings,
+  getSettingsKeys,
   SettingDefinition,
+  agentParamSettings,
 } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { AgentForm, AgentModelPanelProps, StringOption } from '~/common';

--- a/client/src/components/SidePanel/Parameters/Panel.tsx
+++ b/client/src/components/SidePanel/Parameters/Panel.tsx
@@ -2,10 +2,10 @@ import { RotateCcw } from 'lucide-react';
 import React, { useMemo, useState, useEffect, useCallback } from 'react';
 import {
   excludedKeys,
-  getSettingsKeys,
-  tConvoUpdateSchema,
   paramSettings,
+  getSettingsKeys,
   SettingDefinition,
+  tConvoUpdateSchema,
 } from 'librechat-data-provider';
 import type { TPreset } from 'librechat-data-provider';
 import { SaveAsPresetDialog } from '~/components/Endpoints';
@@ -140,7 +140,7 @@ export default function Parameters() {
 
   return (
     <div className="h-auto max-w-full overflow-x-hidden p-3">
-      <div className="grid grid-cols-4 gap-6">
+      <div className="grid grid-cols-2 gap-4">
         {' '}
         {/* This is the parent element containing all settings */}
         {/* Below is an example of an applied dynamic setting, each be contained by a div with the column span specified */}

--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -682,9 +682,9 @@ const bedrockGeneralColumns = {
 export const presetSettings: Record<
   string,
   | {
-  col1: SettingsConfiguration;
-  col2: SettingsConfiguration;
-}
+      col1: SettingsConfiguration;
+      col2: SettingsConfiguration;
+    }
   | undefined
 > = {
   [EModelEndpoint.openAI]: openAIColumns,


### PR DESCRIPTION
## Summary

- Refactored setUserContext from useCallback to useMemo with lodash debounce to prevent race conditions during rapid authentication state changes
- Added 50ms debounce delay to batch multiple authentication updates and improve stability
- Imported debounce from lodash and reorganized imports for better readability
- Added default random state parameter to OpenID auth request using `client.randomState()` for providers that require it
- Enhanced CustomOpenIDStrategy to properly handle state parameter by overriding authorizationRequestParams method
- Ensured passport strategy correctly uses the provided state parameter when making authorization requests

### Other Changes

- Fixes UI issue with Model Parameters using wrong amount of grid columns
- Closes #7546 

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

I tested the authentication flow to ensure the debouncing prevents race conditions during rapid authentication state changes and verified that OpenID authentication works properly with providers requiring state parameters.

### **Test Configuration**:
- Tested authentication context updates with rapid state changes
- Verified OpenID authentication flow with providers requiring state parameters
- Confirmed no breaking changes to existing authentication behavior

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes