### PR TITLE
☀️ a11y: Add Missing Focus to Model Selector in Light Mode

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx
@@ -44,7 +44,7 @@ export const CustomMenu = React.forwardRef<HTMLDivElement, CustomMenuProps>(func
         {...props}
         className={cn(
           !parent &&
-            'flex h-10 w-full items-center justify-center gap-2 rounded-xl border border-border-light px-3 py-2 text-sm text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white',
+            'flex h-10 w-full items-center justify-center gap-2 rounded-xl border border-border-light px-3 py-2 text-sm text-text-primary',
           menuStore.useState('open')
             ? 'bg-surface-tertiary hover:bg-surface-tertiary'
             : 'bg-surface-secondary hover:bg-surface-tertiary',

--- a/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
@@ -52,7 +52,7 @@ function ModelSelectorContent() {
 
   const trigger = (
     <button
-      className="my-1 flex h-10 w-full max-w-[70vw] items-center justify-center gap-2 rounded-xl border border-border-light bg-surface-secondary px-3 py-2 text-sm text-text-primary hover:bg-surface-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+      className="my-1 flex h-10 w-full max-w-[70vw] items-center justify-center gap-2 rounded-xl border border-border-light bg-surface-secondary px-3 py-2 text-sm text-text-primary hover:bg-surface-tertiary"
       aria-label={localize('com_ui_select_model')}
     >
       {selectedIcon && React.isValidElement(selectedIcon) && (


### PR DESCRIPTION
## Summary

This PR addresses the accessibility issue identified in #6638. With the introduction of the new ARIAKit LLM Menu, there was a regression in that the focus indicator was no longer showing up in light mode. This PR adds focus back to the main LLM menu in lightmode. The focus-visible classes of the component were interfering with the applications own focus-visible styles in styles.css

Issue as seen in the current version: [missing focus](https://share.zight.com/X6uL7XKQ)
Suggested fix in the PR request: [focus on LLM menu](https://share.zight.com/E0uBLJXw)

Changed files:

- client/components/Chat/Menus/Endpoints/CustomMenu.tsx@line 47 - Remove focus-visible classes from Ariakit.MenuButton
- client/components/Chat/Menus/Endpoints/ModelSelector.tsx @ line 55 - Remove focus-visible classes from button element

**NOTE**: This partially replaces PR #6645 to immediately meet the [WCAG SC 2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html) and allowing more time to work on the other issue in the PR #6645 which I made its own issue #7608, to improve the visibility of the submenu's active items.

## Change Type

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual keyboard testing: In light mode, use the tab key to ove keyboard focus to the LLM menu. The black focus outline around the menu button should be visible and match the focus style of other interactive elements (black, solid, 2px).

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] Local unit tests pass with my changes

