### PR TITLE
feat: privateAssistants and supportedIds

### DIFF
--- a/api/server/controllers/assistants/helpers.js
+++ b/api/server/controllers/assistants/helpers.js
@@ -250,7 +250,11 @@ const fetchAssistants = async ({ req, res, overrideEndpoint }) => {
 function filterAssistants({ assistants, userId, assistantsConfig }) {
   const { supportedIds, excludedIds, privateAssistants } = assistantsConfig;
   if (privateAssistants) {
-    return assistants.filter((assistant) => userId === assistant.metadata?.author);
+    return assistants.filter(
+      (assistant) =>
+        userId === assistant.metadata?.author ||
+        (supportedIds?.length && supportedIds.includes(assistant.id)),
+    );
   } else if (supportedIds?.length) {
     return assistants.filter((assistant) => supportedIds.includes(assistant.id));
   } else if (excludedIds?.length) {

--- a/api/server/services/start/assistants.js
+++ b/api/server/services/start/assistants.js
@@ -32,15 +32,6 @@ function assistantsConfigSetup(config, assistantsEndpoint, prevConfig = {}) {
       `Configuration conflict: The '${assistantsEndpoint}' endpoint has both 'supportedIds' and 'excludedIds' defined. The 'excludedIds' will be ignored.`,
     );
   }
-  if (
-    assistantsConfig.privateAssistants &&
-    (assistantsConfig.supportedIds?.length || assistantsConfig.excludedIds?.length)
-  ) {
-    logger.warn(
-      `Configuration conflict: The '${assistantsEndpoint}' endpoint has both 'privateAssistants' and 'supportedIds' or 'excludedIds' defined. The 'supportedIds' and 'excludedIds' will be ignored.`,
-    );
-  }
-
   return {
     ...prevConfig,
     retrievalModels: parsedConfig.retrievalModels,


### PR DESCRIPTION
## Summary
Currently, `privateAssistants: true` and `supportedIds` are mutually exclusive settings. When both are configured, the system issues a warning. This PR removes this limitation: Users can now have both private assistants (when `privateAssistants` is set to `true`) and specific admin-configured assistants (via `supportedIds`) simultaneously. This provides more flexibility in assistant configuration while maintaining clear access control.

## Change Type
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] A pull request for updating the documentation has been submitted.
