### PR TITLE
👓 a11y: Add Solid Marker to Improve Visibility in LLM Menu

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx
@@ -159,7 +159,7 @@ export const CustomMenuItem = React.forwardRef<HTMLDivElement, CustomMenuItemPro
       blurOnHoverEnd: false,
       ...props,
       className: cn(
-        'flex cursor-default items-center gap-2 rounded-lg p-2 outline-none! scroll-m-1 scroll-mt-[calc(var(--combobox-height,0px)+var(--label-height,4px))] aria-disabled:opacity-25 data-[active-item]:bg-black/[0.075] data-[active-item]:text-black dark:data-[active-item]:bg-white/10 dark:data-[active-item]:text-white sm:py-1 sm:text-sm min-w-0 w-full',
+        'flex cursor-default items-center gap-2 rounded-lg p-2 outline-none! scroll-m-1 scroll-mt-[calc(var(--combobox-height,0px)+var(--label-height,4px))] aria-disabled:opacity-25 data-[active-item]:border-l-2 data-[active-item]:rounded-l-none data-[active-item]:border-black data-[active-item]:bg-black/[0.075] data-[active-item]:text-black dark:data-[active-item]:bg-white/10 dark:data-[active-item]:text-white dark:data-[active-item]:border-white sm:py-1 sm:text-sm min-w-0 w-full',
         props.className,
       ),
     };

--- a/client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx
@@ -159,7 +159,7 @@ export const CustomMenuItem = React.forwardRef<HTMLDivElement, CustomMenuItemPro
       blurOnHoverEnd: false,
       ...props,
       className: cn(
-        'flex cursor-default items-center gap-2 rounded-lg p-2 outline-none! scroll-m-1 scroll-mt-[calc(var(--combobox-height,0px)+var(--label-height,4px))] aria-disabled:opacity-25 data-[active-item]:border-l-2 data-[active-item]:rounded-l-none data-[active-item]:border-black data-[active-item]:bg-black/[0.075] data-[active-item]:text-black dark:data-[active-item]:bg-white/10 dark:data-[active-item]:text-white dark:data-[active-item]:border-white sm:py-1 sm:text-sm min-w-0 w-full',
+        'flex cursor-default items-center gap-2 rounded-lg p-2 outline-none! scroll-m-1 scroll-mt-[calc(var(--combobox-height,0px)+var(--label-height,4px))] aria-disabled:opacity-25 border-l-2 border-transparent data-[active-item]:border-black data-[active-item]:rounded-l-none data-[active-item]:bg-black/[0.075] data-[active-item]:text-black dark:data-[active-item]:bg-white/10 dark:data-[active-item]:text-white dark:data-[active-item]:border-white sm:py-1 sm:text-sm min-w-0 w-full',
         props.className,
       ),
     };


### PR DESCRIPTION
## Summary

Originally #7686

In testing we found that users who have low visions and use assistive technology had trouble identifying the correct LLM models in the submenu due to the low contrast between the active-item and surrounding background color. This PR adds a solid black indicator to the left border edge to indicate the current active item in sub-menus to add another visual cue to support people with low vision and making it easier to distinguish the current active item in the menu from other items. 

[Screen Recording of the submenu chages in dark and light mode.](https://share.zight.com/d5uk2X5Z)

This pull request addresses issue #7608 with the style outlined in the issue and in discussion of PR #6645.

Files touched:
client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx @ line 162.

Added Tailwind classes:
`data-[active-item]:border-l-2` -- left border, 2px width
`data-[active-item]:rounded-l-none` -- no border-radius on left
`data-[active-item]:border-black` -- border color is black
`dark:data-[active-item]:border-white` - change border color for dark mode

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

## Testing

Manual keyboard testing. 

### **Test Configuration**:
MacOS Sequoia 15.3.2
Chrome/Safari/Firefox

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
