### PR TITLE
📏 chore: Update ESLint Rules for Unused Variables

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -121,9 +121,14 @@ export default [
       // common rules
       'no-nested-ternary': 'warn',
       'no-constant-binary-expression': 'warn',
-      // Also disable the core no-unused-vars rule globally.
-      'no-unused-vars': 'warn',
-
+      'no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
       'no-console': 'off',
       'import/no-cycle': 'error',
       'import/no-self-import': 'error',
@@ -181,9 +186,6 @@ export default [
     files: ['api/**/*.js', 'config/**/*.js'],
     rules: {
       // API
-      // TODO: maybe later to error.
-      'no-unused-const': 'off',
-      'no-unused-vars': 'off',
       'no-async-promise-executor': 'off',
     },
   },
@@ -278,7 +280,14 @@ export default [
       ],
       //
       '@typescript-eslint/no-unused-expressions': 'off',
-      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unnecessary-condition': 'off',
       '@typescript-eslint/strict-boolean-expressions': 'off',


### PR DESCRIPTION
## Summary

I'm not sure the reason why this was turned off, but generally this is a good thing to have in case you create a variable and forget to use it as well as just keeping the code cleaner. 

It's just a warning, so it's not a blocking problem. 

As far as I can tell, `no-unused-const` isn't a rule that exists anywhere. 

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Copilot Summary

This pull request updates the ESLint configuration to improve code quality by enabling warnings for unused variables and introducing patterns to ignore specific cases.

### ESLint configuration updates:
* [`eslint.config.mjs`](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2L186-R193): Changed the `no-unused-vars` rule from `'off'` to `'warn'` and added ignore patterns for arguments, variables, and caught errors starting with an underscore (`^_`).