### PR TITLE
fix(session): correct the logic for parsing expiration time

### DIFF
--- a/packages/data-schemas/src/methods/session.ts
+++ b/packages/data-schemas/src/methods/session.ts
@@ -13,7 +13,7 @@ export class SessionError extends Error {
 }
 
 const { REFRESH_TOKEN_EXPIRY } = process.env ?? {};
-const expires = eval(REFRESH_TOKEN_EXPIRY ?? '0') ?? 1000 * 60 * 60 * 24 * 7; // 7 days default
+const expires = parseInt(REFRESH_TOKEN_EXPIRY) || 1000 * 60 * 60 * 24 * 7; // 7 days default
 
 // Factory function that takes mongoose instance and returns the methods
 export function createSessionMethods(mongoose: typeof import('mongoose')) {


### PR DESCRIPTION
## Summary

* The eval() function is dangerous because it accepts arbitrary expressions.  
  ![CleanShot 2025-06-04 at 14 12 54@2x](https://github.com/user-attachments/assets/58f0638c-784b-493a-85aa-71b94094d37a)
* eval('0') ?? <default> always returns 0, since eval(0) is not `undefined`.
  ![CleanShot 2025-06-04 at 14 11 55@2x](https://github.com/user-attachments/assets/38106bcf-1910-4675-82d4-d8e7a599628a)

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

![CleanShot 2025-06-04 at 14 18 26@2x](https://github.com/user-attachments/assets/aafac0f6-0217-4426-a079-042cd28afa8d)

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
