### PR TITLE
👁️ feat: Add Azure Mistral OCR strategy and endpoint integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ helm/**/.values.yaml
 
 # SAML Idp cert
 *.cert
+# dev files directory
+.devFiles/
+

--- a/api/server/services/Files/MistralOCR/crud.js
+++ b/api/server/services/Files/MistralOCR/crud.js
@@ -230,9 +230,105 @@ const uploadMistralOCR = async ({ req, file, file_id, entity_id }) => {
   }
 };
 
+/**
+ * Use Azure Mistral OCR API to processe the OCR result.
+ *
+ * @param {Object} params - The params object.
+ * @param {ServerRequest} params.req - The request object from Express. It should have a `user` property with an `id`
+ *                       representing the user
+ * @param {Express.Multer.File} params.file - The file object, which is part of the request. The file object should
+ *                                     have a `mimetype` property that tells us the file type
+ * @returns {Promise<{ filepath: string, bytes: number }>} - The result object containing the processed `text` and `images` (not currently used),
+ *                       along with the `filename` and `bytes` properties.
+ */
+const uploadAzureMistralOCR = async ({ req, file }) => {
+  try {
+    /** @type {TCustomConfig['ocr']} */
+    const ocrConfig = req.app.locals?.ocr;
+
+    const apiKeyConfig = ocrConfig.apiKey || '';
+    const baseURLConfig = ocrConfig.baseURL || '';
+
+    const isApiKeyEnvVar = envVarRegex.test(apiKeyConfig);
+    const isBaseURLEnvVar = envVarRegex.test(baseURLConfig);
+
+    const isApiKeyEmpty = !apiKeyConfig.trim();
+    const isBaseURLEmpty = !baseURLConfig.trim();
+
+    let apiKey, baseURL;
+
+    if (isApiKeyEnvVar || isBaseURLEnvVar || isApiKeyEmpty || isBaseURLEmpty) {
+      const apiKeyVarName = isApiKeyEnvVar ? extractVariableName(apiKeyConfig) : 'OCR_API_KEY';
+      const baseURLVarName = isBaseURLEnvVar ? extractVariableName(baseURLConfig) : 'OCR_BASEURL';
+
+      const authValues = await loadAuthValues({
+        userId: req.user.id,
+        authFields: [baseURLVarName, apiKeyVarName],
+        optional: new Set([baseURLVarName]),
+      });
+
+      apiKey = authValues[apiKeyVarName];
+      baseURL = authValues[baseURLVarName];
+    } else {
+      apiKey = apiKeyConfig;
+      baseURL = baseURLConfig;
+    }
+
+    const modelConfig = ocrConfig.mistralModel || '';
+    const model = envVarRegex.test(modelConfig)
+      ? extractEnvVariable(modelConfig)
+      : modelConfig.trim() || 'mistral-ocr-latest';
+
+    const mimetype = (file.mimetype || '').toLowerCase();
+    const originalname = file.originalname || '';
+    const isImage =
+      mimetype.startsWith('image') || /\.(png|jpe?g|gif|bmp|webp|tiff?)$/i.test(originalname);
+    const documentType = isImage ? 'image_url' : 'document_url';
+
+    const buffer = fs.readFileSync(file.path);
+    const base64 = buffer.toString('base64');
+    const ocrResult = await performOCR({
+      apiKey,
+      baseURL,
+      model,
+      url: `data:image/jpeg;base64,${base64}`,
+      documentType,
+    });
+
+    let aggregatedText = '';
+    const images = [];
+    ocrResult.pages.forEach((page, index) => {
+      if (ocrResult.pages.length > 1) {
+        aggregatedText += `# PAGE ${index + 1}\n`;
+      }
+
+      aggregatedText += page.markdown + '\n\n';
+
+      if (page.images && page.images.length > 0) {
+        page.images.forEach((image) => {
+          if (image.image_base64) {
+            images.push(image.image_base64);
+          }
+        });
+      }
+    });
+
+    return {
+      filename: file.originalname,
+      bytes: aggregatedText.length * 4,
+      filepath: FileSources.azure_mistral_ocr,
+      text: aggregatedText,
+      images,
+    };
+  } catch (error) {
+    const message = 'Error uploading document to Azure Mistral OCR API';
+    throw new Error(logAxiosError({ error, message }));
+  }
+};
 module.exports = {
   uploadDocumentToMistral,
   uploadMistralOCR,
+  uploadAzureMistralOCR,
   getSignedUrl,
   performOCR,
 };

--- a/api/server/services/Files/strategies.js
+++ b/api/server/services/Files/strategies.js
@@ -46,7 +46,7 @@ const {
 const { uploadOpenAIFile, deleteOpenAIFile, getOpenAIFileStream } = require('./OpenAI');
 const { getCodeOutputDownloadStream, uploadCodeEnvFile } = require('./Code');
 const { uploadVectors, deleteVectors } = require('./VectorDB');
-const { uploadMistralOCR } = require('./MistralOCR');
+const { uploadMistralOCR, uploadAzureMistralOCR } = require('./MistralOCR');
 
 /**
  * Firebase Storage Strategy Functions
@@ -202,6 +202,26 @@ const mistralOCRStrategy = () => ({
   handleFileUpload: uploadMistralOCR,
 });
 
+const azureMistralOCRStrategy = () => ({
+  /** @type {typeof saveFileFromURL | null} */
+  saveURL: null,
+  /** @type {typeof getLocalFileURL | null} */
+  getFileURL: null,
+  /** @type {typeof saveLocalBuffer | null} */
+  saveBuffer: null,
+  /** @type {typeof processLocalAvatar | null} */
+  processAvatar: null,
+  /** @type {typeof uploadLocalImage | null} */
+  handleImageUpload: null,
+  /** @type {typeof prepareImagesLocal | null} */
+  prepareImagePayload: null,
+  /** @type {typeof deleteLocalFile | null} */
+  deleteFile: null,
+  /** @type {typeof getLocalFileStream | null} */
+  getDownloadStream: null,
+  handleFileUpload: uploadAzureMistralOCR,
+});
+
 // Strategy Selector
 const getStrategyFunctions = (fileSource) => {
   if (fileSource === FileSources.firebase) {
@@ -222,6 +242,8 @@ const getStrategyFunctions = (fileSource) => {
     return codeOutputStrategy();
   } else if (fileSource === FileSources.mistral_ocr) {
     return mistralOCRStrategy();
+  } else if (fileSource === FileSources.azure_mistral_ocr) {
+    return azureMistralOCRStrategy();
   } else {
     throw new Error('Invalid file source');
   }

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -586,6 +586,7 @@ export type TStartupConfig = {
 export enum OCRStrategy {
   MISTRAL_OCR = 'mistral_ocr',
   CUSTOM_OCR = 'custom_ocr',
+  AZURE_MISTRAL_OCR = 'azure_mistral_ocr',
 }
 
 export enum SearchCategories {

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -10,6 +10,7 @@ export enum FileSources {
   vectordb = 'vectordb',
   execute_code = 'execute_code',
   mistral_ocr = 'mistral_ocr',
+  azure_mistral_ocr = 'azure_mistral_ocr',
   text = 'text',
 }
 


### PR DESCRIPTION
This pull request introduces a new OCR strategy named azure_mistral_ocr, enabling support for Mistral OCR endpoints deployed on Azure. This allows seamless integration with Azure-hosted Mistral services, which currently do not support the default file upload API used by LibreChat.

To address this, the configuration, schema validations, and file handling logic have been updated to support this new strategy. It bypasses the default upload step and directly performs OCR through the Azure endpoint.

Fixes #6814


⚠️ Documentation Updates Notice:
The following configuration will need to be documented to enable users to adopt the new strategy:

```yaml
ocr:
  mistralModel: "mistral-ocr-2503"  # Optional: Specify Mistral model, defaults to "mistral-ocr-latest"
  apiKey: "${OCR_API_KEY}"        # Optional: Defaults to OCR_API_KEY env variable
  baseURL: "https://{azure_mistral_ocr_endpoint}/v1"
  strategy: azure_mistral_ocr
```

Once the PR is reviewed and approved, I’ll be happy to submit a separate PR to update the documentation accordingly.

## Summary

- Added a new OCR strategy: azure_mistral_ocr
- Added logic in api/server/services/Files/MistralOCR/crud.js to support Azure's behavior (bypassing pre-OCR file upload)
`api\server\services\Files\MistralOCR\crud.js`
- Extended schema and configuration validation to support the new strategy

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## Testing

- Set ocr.strategy to azure_mistral_ocr
- Use an mistral-ocr-2503 azure endpoint
- Upload a PDF or image using the Upload as Text option for an agent
- Send a query to the agent and verify the OCR output

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] ***A pull request for updating the documentation will submitted.
