### PR TITLE
🔄 fix: Update Agent Versioning to Include `agent_ids`

### DIFF
--- a/api/models/Agent.js
+++ b/api/models/Agent.js
@@ -170,7 +170,6 @@ const isDuplicateVersion = (updateData, currentData, versions, actionsHash = nul
     'created_at',
     'updated_at',
     '__v',
-    'agent_ids',
     'versions',
     'actionsHash', // Exclude actionsHash from direct comparison
   ];


### PR DESCRIPTION
## Summary

This PR updates the Agent model to properly track changes to the `agent_ids` field in the versioning system. Previously, changes to `agent_ids` were ignored when determining if a new version should be created, which could lead to lost history when agents were added or removed from the chain.

It was falsely identifying a new agent chain as a duplicate version.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

## Copilot Summary

This pull request introduces changes to the `Agent` model and its associated tests, focusing on the inclusion of the `agent_ids` field in version detection and handling. The updates ensure that changes to the `agent_ids` field are properly tracked, creating new versions when necessary, and include comprehensive test cases to validate this behavior.

### Changes to `Agent` model:

* Removed exclusion of the `agent_ids` field from version comparison, allowing updates to this field to trigger new versions. (`api/models/Agent.js`)

### Updates to `Agent` tests:

* Added initialization of the `Agent` model within multiple test suites to ensure proper setup. (`api/models/Agent.spec.js`) [[1]](diffhunk://#diff-5b35f88572ad9de90848bae7deaf749ab802b9471a4ea52007f97525299041c9R665) [[2]](diffhunk://#diff-5b35f88572ad9de90848bae7deaf749ab802b9471a4ea52007f97525299041c9R1327) [[3]](diffhunk://#diff-5b35f88572ad9de90848bae7deaf749ab802b9471a4ea52007f97525299041c9R1509) [[4]](diffhunk://#diff-5b35f88572ad9de90848bae7deaf749ab802b9471a4ea52007f97525299041c9R1803)
* Introduced a new test suite, "Agent IDs Field in Version Detection," which includes:
  - Validation that changes to `agent_ids` create new versions.
  - Detection of duplicate versions when `agent_ids` remains unchanged.
  - Handling of `agent_ids` updates alongside other fields.
  - Preservation of `agent_ids` in version history.
  - Support for empty `agent_ids` arrays and agents without the `agent_ids` field.
