### PR TITLE
🌐 fix: Support `global` location for Google VertexAI

### DIFF
--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -34,9 +34,8 @@ const BaseClient = require('./BaseClient');
 
 const loc = process.env.GOOGLE_LOC || 'us-central1';
 const publisher = 'google';
-const endpointPrefix = (loc === 'global')
-  ? 'aiplatform.googleapis.com'
-  : `${loc}-aiplatform.googleapis.com`;
+const endpointPrefix =
+  loc === 'global' ? 'aiplatform.googleapis.com' : `${loc}-aiplatform.googleapis.com`;
 
 const settings = endpointSettings[EModelEndpoint.google];
 const EXCLUDED_GENAI_MODELS = /gemini-(?:1\.0|1-0|pro)/;

--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -34,7 +34,9 @@ const BaseClient = require('./BaseClient');
 
 const loc = process.env.GOOGLE_LOC || 'us-central1';
 const publisher = 'google';
-const endpointPrefix = `${loc}-aiplatform.googleapis.com`;
+const endpointPrefix = (loc === 'global')
+  ? 'aiplatform.googleapis.com'
+  : `${loc}-aiplatform.googleapis.com`;
 
 const settings = endpointSettings[EModelEndpoint.google];
 const EXCLUDED_GENAI_MODELS = /gemini-(?:1\.0|1-0|pro)/;


### PR DESCRIPTION
## Summary

What is the problem?

The current logic for constructing the endpointPrefix incorrectly prepends the location variable in all cases. When process.env.GOOGLE_LOC is set to 'global', this creates an invalid endpoint: global-aiplatform.googleapis.com, which is not correct url per https://cloud.google.com/vertex-ai/docs/reference/rest

What is the solution?

If the location (loc) is 'global', it sets the endpointPrefix to the correct root domain: aiplatform.googleapis.com.
For all other locations, it maintains the existing behavior, prepending the location to the domain (e.g., us-central1-aiplatform.googleapis.com).

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Test it in my local env. Set process.env.GOOGLE_LOC = 'global'. The endpointPrefix should be aiplatform.googleapis.com.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
