### PR TITLE
⏱️ refactor: Retry `/api/convos/gen_title` every 1s for up to 20s

### DIFF
--- a/api/server/routes/convos.js
+++ b/api/server/routes/convos.js
@@ -65,8 +65,14 @@ router.post('/gen_title', async (req, res) => {
   let title = await titleCache.get(key);
 
   if (!title) {
-    await sleep(2500);
-    title = await titleCache.get(key);
+    // Retry every 1s for up to 20s
+    for (let i = 0; i < 20; i++) {
+      await sleep(1000);
+      title = await titleCache.get(key);
+      if (title) {
+        break;
+      }
+    }
   }
 
   if (title) {


### PR DESCRIPTION
## Summary

Updates `/api/convos/gen_title` endpoint from 1 retry after 2.5s to up to 20 retries every second.
This makes the response both faster and more resilient as we've seen many instances, especially with agents, where the title generation API call would fail, leading to a degraded user experience and noisy 404 errors in logs.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Tested locally with title generation with agents.
Monitored the networking tab in Chrome to confirm that some requests that took more than 3s still succeeded when they would fail before.
![image](https://github.com/user-attachments/assets/3f6de324-ad73-4463-88d8-678306f642d8)

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
