### PR TITLE
feat: Add User Setting to disable Web Search

### DIFF
--- a/client/src/components/Chat/Input/WebSearch.tsx
+++ b/client/src/components/Chat/Input/WebSearch.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useRef, useMemo, useCallback } from 'react';
 import { Globe } from 'lucide-react';
 import debounce from 'lodash/debounce';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import {
   Tools,
   AuthType,
@@ -10,6 +10,7 @@ import {
   PermissionTypes,
   LocalStorageKeys,
 } from 'librechat-data-provider';
+import store from '~/store';
 import ApiKeyDialog from '~/components/SidePanel/Agents/Search/ApiKeyDialog';
 import { useLocalize, useHasAccess, useSearchApiKeyForm } from '~/hooks';
 import CheckboxButton from '~/components/ui/CheckboxButton';
@@ -36,6 +37,7 @@ function WebSearch({ conversationId }: { conversationId?: string | null }) {
   const localize = useLocalize();
   const key = conversationId ?? Constants.NEW_CONVO;
 
+  const webSearchEnabled = useRecoilValue(store.webSearchEnabled);
   const canUseWebSearch = useHasAccess({
     permissionType: PermissionTypes.WEB_SEARCH,
     permission: Permissions.USE,
@@ -90,7 +92,7 @@ function WebSearch({ conversationId }: { conversationId?: string | null }) {
     [handleChange],
   );
 
-  if (!canUseWebSearch) {
+  if (!webSearchEnabled || !canUseWebSearch) {
     return null;
   }
 

--- a/client/src/components/Nav/SettingsTabs/General/General.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/General.tsx
@@ -9,6 +9,13 @@ import store from '~/store';
 
 const toggleSwitchConfigs = [
   {
+    stateAtom: store.webSearchEnabled,
+    localizationKey: 'com_ui_web_search',
+    switchId: 'webSearchEnabled',
+    hoverCardText: 'com_ui_info_web_search',
+    key: 'webSearchEnabled',
+  },
+  {
     stateAtom: store.enableUserMsgMarkdown,
     localizationKey: 'com_nav_user_msg_markdown',
     switchId: 'enableUserMsgMarkdown',

--- a/client/src/locales/de/translation.json
+++ b/client/src/locales/de/translation.json
@@ -893,6 +893,7 @@
   "com_ui_versions": "Versionen",
   "com_ui_view_source": "Quell-Chat anzeigen",
   "com_ui_web_search": "Web-Suche",
+  "com_ui_info_web_search": "Wenn aktiviert, erscheint beim Chat-Prompt ein Button, um eine Web-Suche einzubeziehen. Die Nutzung setzt verschiedene API-Keys voraus.",
   "com_ui_web_search_api_subtitle": "Suche im Internet nach aktuellen Informationen",
   "com_ui_web_search_cohere_key": "Cohere API-Schlüssel eingeben",
   "com_ui_web_search_firecrawl_url": "Firecrawl API URL (optional)",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -944,6 +944,7 @@
   "com_ui_versions": "Versions",
   "com_ui_view_source": "View source chat",
   "com_ui_web_search": "Web Search",
+  "com_ui_info_web_search": "When enabled, a button appears at the chat prompt to include a web search. Usage requires various API keys.",
   "com_ui_web_search_api_subtitle": "Search the web for up-to-date information",
   "com_ui_web_search_cohere_key": "Enter Cohere API Key",
   "com_ui_web_search_firecrawl_url": "Firecrawl API URL (optional)",

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -22,6 +22,7 @@ const localStorageAtoms = {
   autoScroll: atomWithLocalStorage('autoScroll', false),
   hideSidePanel: atomWithLocalStorage('hideSidePanel', false),
   fontSize: atomWithLocalStorage('fontSize', 'text-base'),
+  webSearchEnabled: atomWithLocalStorage('webSearchEnabled', true),
   enableUserMsgMarkdown: atomWithLocalStorage<boolean>(
     LocalStorageKeys.ENABLE_USER_MSG_MARKDOWN,
     true,

--- a/packages/data-schemas/src/schema/user.ts
+++ b/packages/data-schemas/src/schema/user.ts
@@ -129,6 +129,10 @@ const userSchema = new Schema<IUser>(
       type: Boolean,
       default: false,
     },
+    webSearchEnabled: {
+      type: Boolean,
+      default: true,
+    },
   },
   { timestamps: true },
 );

--- a/packages/data-schemas/src/types/user.ts
+++ b/packages/data-schemas/src/types/user.ts
@@ -30,6 +30,7 @@ export interface IUser extends Document {
   }>;
   expiresAt?: Date;
   termsAccepted?: boolean;
+  webSearchEnabled?: boolean;
   createdAt?: Date;
   updatedAt?: Date;
 }


### PR DESCRIPTION
## Summary
This PR introduces a new user setting that allows disabling the web search functionality. The default setting maintains the current behavior (web search enabled) to preserve existing UI functionality.

## Motivation
- In larger organizations, not all three required API keys for web search can always be provided centrally
- Creating personal API keys for various services can be challenging, especially for non-technical users
- Providing a disable option serves as an interim solution until open-source/self-hosted alternatives become available

## Implementation
- Adds a toggle in user settings to enable/disable web search
- Default setting is 'enabled' to maintain backward compatibility
- No changes to existing UI unless explicitly disabled by user

## Change Type
- [x] New feature (non-breaking change which adds functionality)
- [ ] Translation update

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings

