### PR TITLE
🔧 fix: Properly handle Token Expiry Defaults when Env Variable not set

### DIFF
--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -409,7 +409,9 @@ const setOpenIDAuthTokens = (tokenset, res) => {
       return;
     }
     const { REFRESH_TOKEN_EXPIRY } = process.env ?? {};
-    const expiryInMilliseconds = eval(REFRESH_TOKEN_EXPIRY) ?? 1000 * 60 * 60 * 24 * 7; // 7 days default
+    const expiryInMilliseconds = REFRESH_TOKEN_EXPIRY
+      ? eval(REFRESH_TOKEN_EXPIRY)
+      : 1000 * 60 * 60 * 24 * 7; // 7 days default
     const expirationDate = new Date(Date.now() + expiryInMilliseconds);
     if (tokenset == null) {
       logger.error('[setOpenIDAuthTokens] No tokenset found in request');

--- a/packages/data-schemas/src/methods/session.ts
+++ b/packages/data-schemas/src/methods/session.ts
@@ -13,7 +13,9 @@ export class SessionError extends Error {
 }
 
 const { REFRESH_TOKEN_EXPIRY } = process.env ?? {};
-const expires = eval(REFRESH_TOKEN_EXPIRY ?? '0') ?? 1000 * 60 * 60 * 24 * 7; // 7 days default
+const expires = REFRESH_TOKEN_EXPIRY
+  ? eval(REFRESH_TOKEN_EXPIRY)
+  : 1000 * 60 * 60 * 24 * 7; // 7 days default
 
 // Factory function that takes mongoose instance and returns the methods
 export function createSessionMethods(mongoose: typeof import('mongoose')) {


### PR DESCRIPTION
## Summary

The following line is not properly handling the use case where `REFRESH_TOKEN_EXPIRY` is not defined:

```js
eval(REFRESH_TOKEN_EXPIRY ?? '0') ?? 1000 * 60 * 60 * 24 * 7;
```

See what happens when `REFRESH_TOKEN_EXPIRY` is not defined:

<img width="440" alt="image" src="https://github.com/user-attachments/assets/c610dd3d-dce6-4049-9199-72716920ad2d" />

So `expires` or `expiryInMilliseconds` becomes zero, in which case we create a token which instantly expires, which is clearly not the expected behaviour.

This is because `eval(undefined ?? '0')` evaluates to `0`.
Then you have a [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) (`??`), but this operator only "returns its right-hand side operand when its left-hand side operand is [null](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/null) or [undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined), and otherwise returns its left-hand side operand."

This means that when `REFRESH_TOKEN_EXPIRY` is not defined, the right-hand side is never evaluated.

The nullish coalescing operator has a different behaviour than the logical OR (`||`) which evaluates the right-hand side operand when its left-hand side is _falsy_. In that case it would have worked since the number `0` is neither `undefined` nor `null` but it is falsy.

The way we've found this bug is when we merged from upstream on our Shopify fork then ran our internal server tests. Everything failed unless we manually added the `REFRESH_TOKEN_EXPIRY` environment variable in the tests, which should not have been the case since you have a default value.

The reason this bug was not caught upstream is that there are no tests testing this behaviour and that the original committer had the `REFRESH_TOKEN_EXPIRY` set in their development environment.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Simply try running the app without the `REFRESH_TOKEN_EXPIRY` environment variable set in your `.env` without this fix and you'll see that auth will simply not work.

Then test again on this branch still without the `REFRESH_TOKEN_EXPIRY` environment variable set in your `.env` and everything should work thanks to the default value now being applied.

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes