### PR TITLE
🤖 refactor: Improve Speech Settings Initialization

### DIFF
--- a/client/src/components/Nav/SettingsTabs/Speech/Speech.tsx
+++ b/client/src/components/Nav/SettingsTabs/Speech/Speech.tsx
@@ -76,16 +76,10 @@ function Speech() {
         playbackRate: { value: playbackRate, setFunc: setPlaybackRate },
       };
 
-      if (
-        (settings[key].value !== newValue || settings[key].value === newValue || !settings[key]) &&
-        settings[key].value === 'sttExternal' &&
-        settings[key].value === 'ttsExternal'
-      ) {
-        return;
-      }
-
       const setting = settings[key];
-      setting.setFunc(newValue);
+      if (setting) {
+        setting.setFunc(newValue);
+      }
     },
     [
       sttExternal,
@@ -130,13 +124,20 @@ function Speech() {
   useEffect(() => {
     if (data && data.message !== 'not_found') {
       Object.entries(data).forEach(([key, value]) => {
-        updateSetting(key, value);
+        // Only apply config values as defaults if no user preference exists in localStorage
+        const existingValue = localStorage.getItem(key);
+        if (existingValue === null && key !== 'sttExternal' && key !== 'ttsExternal') {
+          updateSetting(key, value);
+        } else if (key === 'sttExternal' || key === 'ttsExternal') {
+          updateSetting(key, value);
+        }
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data]);
 
   // Reset engineTTS if it is set to a removed/invalid value (e.g., 'edge')
+  // TODO: remove this once the 'edge' engine is fully deprecated
   useEffect(() => {
     const validEngines = ['browser', 'external'];
     if (!validEngines.includes(engineTTS)) {

--- a/client/src/hooks/Config/index.ts
+++ b/client/src/hooks/Config/index.ts
@@ -1,2 +1,3 @@
 export { default as useAppStartup } from './useAppStartup';
 export { default as useClearStates } from './useClearStates';
+export { default as useSpeechSettingsInit } from './useSpeechSettingsInit';

--- a/client/src/hooks/Config/useAppStartup.ts
+++ b/client/src/hooks/Config/useAppStartup.ts
@@ -5,6 +5,7 @@ import { LocalStorageKeys } from 'librechat-data-provider';
 import { useAvailablePluginsQuery } from 'librechat-data-provider/react-query';
 import type { TStartupConfig, TPlugin, TUser } from 'librechat-data-provider';
 import { mapPlugins, selectPlugins, processPlugins } from '~/utils';
+import useSpeechSettingsInit from './useSpeechSettingsInit';
 import store from '~/store';
 
 const pluginStore: TPlugin = {
@@ -30,6 +31,8 @@ export default function useAppStartup({
     enabled: !!user?.plugins,
     select: selectPlugins,
   });
+
+  useSpeechSettingsInit(!!user);
 
   /** Set the app title */
   useEffect(() => {

--- a/client/src/hooks/Config/useSpeechSettingsInit.ts
+++ b/client/src/hooks/Config/useSpeechSettingsInit.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { useGetCustomConfigSpeechQuery } from 'librechat-data-provider/react-query';
+import { logger } from '~/utils';
+import store from '~/store';
+
+/**
+ * Initializes speech-related Recoil values from the server-side custom
+ * configuration on first load (only when the user is authenticated)
+ */
+export default function useSpeechSettingsInit(isAuthenticated: boolean) {
+  const { data } = useGetCustomConfigSpeechQuery({ enabled: isAuthenticated });
+
+  const setters = useRef({
+    conversationMode: useSetRecoilState(store.conversationMode),
+    advancedMode: useSetRecoilState(store.advancedMode),
+    speechToText: useSetRecoilState(store.speechToText),
+    textToSpeech: useSetRecoilState(store.textToSpeech),
+    cacheTTS: useSetRecoilState(store.cacheTTS),
+    engineSTT: useSetRecoilState(store.engineSTT),
+    languageSTT: useSetRecoilState(store.languageSTT),
+    autoTranscribeAudio: useSetRecoilState(store.autoTranscribeAudio),
+    decibelValue: useSetRecoilState(store.decibelValue),
+    autoSendText: useSetRecoilState(store.autoSendText),
+    engineTTS: useSetRecoilState(store.engineTTS),
+    voice: useSetRecoilState(store.voice),
+    cloudBrowserVoices: useSetRecoilState(store.cloudBrowserVoices),
+    languageTTS: useSetRecoilState(store.languageTTS),
+    automaticPlayback: useSetRecoilState(store.automaticPlayback),
+    playbackRate: useSetRecoilState(store.playbackRate),
+  }).current;
+
+  useEffect(() => {
+    if (!isAuthenticated || !data || data.message === 'not_found') return;
+
+    logger.log('Initializing speech settings from config:', data);
+
+    Object.entries(data).forEach(([key, value]) => {
+      if (key === 'sttExternal' || key === 'ttsExternal') return;
+
+      if (localStorage.getItem(key) !== null) return;
+
+      const setter = (setters as Record<string, (v: any) => void>)[key];
+      if (setter) {
+        logger.log(`Setting default speech setting: ${key} = ${value}`);
+        setter(value as any);
+      }
+    });
+  }, [isAuthenticated, data]);
+}

--- a/client/src/hooks/Config/useSpeechSettingsInit.ts
+++ b/client/src/hooks/Config/useSpeechSettingsInit.ts
@@ -40,7 +40,7 @@ export default function useSpeechSettingsInit(isAuthenticated: boolean) {
 
       if (localStorage.getItem(key) !== null) return;
 
-      const setter = (setters as Record<string, (v: any) => void>)[key];
+      const setter = setters[key as keyof typeof setters];
       if (setter) {
         logger.log(`Setting default speech setting: ${key} = ${value}`);
         setter(value as any);

--- a/client/src/hooks/Config/useSpeechSettingsInit.ts
+++ b/client/src/hooks/Config/useSpeechSettingsInit.ts
@@ -46,5 +46,5 @@ export default function useSpeechSettingsInit(isAuthenticated: boolean) {
         setter(value as any);
       }
     });
-  }, [isAuthenticated, data]);
+  }, [isAuthenticated, data, setters]);
 }


### PR DESCRIPTION
## Summary

- Speech Settings Initialization:
  - 🛠️ Added `useSpeechSettingsInit` hook for initializing speech settings using server-side config when user is authenticated
  - 🔗 Integrated the new hook into `useAppStartup` to streamline initial setup
  - 🔒 Default values now only apply when user preferences are absent in localStorage
- Optimizations in `Speech` Component:
  - 🧹 Simplified `updateSetting` by removing redundant conditions; settings update only when valid
  - ⚡ Enhanced `useEffect` to apply config values as defaults with specific logic for `sttExternal` and `ttsExternal`
- Impact:
  - ✅ Ensures smoother initialization, reduces logic duplication, and improves UI clarity for speech

Closes #6168 #7856

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
