### PR TITLE
feat: send JWT token to custom endpoint when configured

### DIFF
--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -35,6 +35,10 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
     });
   }
 
+  if (endpointConfig.addUserToken) {
+    resolvedHeaders['X-Librechat-User'] = req.headers['authorization'];
+  }
+
   if (CUSTOM_API_KEY.match(envVarRegex)) {
     throw new Error(`Missing API Key for ${endpoint}.`);
   }

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -75,6 +75,7 @@ librechat:
   #       # OpenRouter.ai
   #       - name: "OpenRouter"
   #         apiKey: "${OPENROUTER_KEY}"
+  #         addUserToken: false
   #         baseURL: "https://openrouter.ai/api/v1"
   #         models:
   #           default: ["openai/gpt-3.5-turbo"]

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -285,6 +285,7 @@ export const endpointSchema = baseEndpointSchema.merge(
     summaryModel: z.string().optional(),
     forcePrompt: z.boolean().optional(),
     modelDisplayLabel: z.string().optional(),
+    addUserToken: z.string().optional(),
     headers: z.record(z.any()).optional(),
     addParams: z.record(z.any()).optional(),
     dropParams: z.array(z.string()).optional(),


### PR DESCRIPTION
- Closes: https://github.com/danny-avila/LibreChat/issues/7769

## Summary

This PR introduces support for sending the authorization token to custom APIs via the custom-endpoint routine:

1. librechat.yaml – Adds addUserToken as an optional parameter to allow custom endpoints to receive the user token (JWT).
2. helm/librechat/values.yaml – Includes the addUserToken property as a comment.
3. packages/data-provider/src/config.ts – Adds the addUserToken field to the endpoint schema.
4. api/server/services/Endpoints/custom/initialize.js – Sends the authorization token in requests to custom endpoints.

These changes allow custom endpoint APIs to handle the user token, enabling use cases such as token swapping when necessary.

## Change Type

Please delete any irrelevant options.
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Testing

1. In librechat.yaml, I set the addUserToken property to true.
![image](https://github.com/user-attachments/assets/ff15bdfc-1f9d-47f0-9120-3be073c13953)

3. On my backend, I manually verified that the X-Librechat-User token was correctly sent by LibreChat.
![image](https://github.com/user-attachments/assets/361fae17-2db5-4340-8b11-84114c432d5b)

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
- [X] Any changes dependent on mine have been merged and published in downstream modules.
- [] A pull request for updating the documentation has been submitted.

