### PR TITLE
🧹 chore: Cleanup base64 Handling for Azure Mistral OCR

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -330,7 +330,7 @@ class AgentClient extends BaseClient {
 
     if (mcpServers.length > 0) {
       try {
-        const mcpInstructions = await getMCPManager().formatInstructionsForContext(mcpServers);
+        const mcpInstructions = getMCPManager().formatInstructionsForContext(mcpServers);
         if (mcpInstructions) {
           systemContent = [systemContent, mcpInstructions].filter(Boolean).join('\n\n');
           logger.debug('[AgentClient] Injected MCP instructions for servers:', mcpServers);

--- a/packages/api/src/files/mistral/crud.spec.ts
+++ b/packages/api/src/files/mistral/crud.spec.ts
@@ -1421,7 +1421,7 @@ describe('MistralOCR Service', () => {
         expect.objectContaining({
           document: expect.objectContaining({
             type: 'document_url',
-            document_url: expect.stringMatching(/^data:image\/jpeg;base64,/),
+            document_url: expect.stringMatching(/^data:application\/pdf;base64,/),
           }),
         }),
         expect.any(Object),


### PR DESCRIPTION
## Summary

- Uses the actual file mimetype with `'image/jpeg'` as a fallback to improve compatibility

### Other Changes
- Removed extraneous inline comments from `crud.ts` for better code clarity
- Remove unnecessary await from MCP instructions formatting in AgentClient

## Change Type

- [x] Chore (maintenance or refactor with no user-facing impact)

## Testing

I verified that uploading files via the Azure/Mistral OCR endpoint produces correct base64 encoding and successful OCR results. I recommend testing with various file types and mimetypes to confirm both functionality and fallback behavior.

### **Test Configuration**:

- Local dev environment with LibreChat API running
- Multiple images and document files uploaded through the OCR endpoint
- Confirmed proper base64 data URL format and working OCR response

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings