### PR TITLE
🔧 chore: update pricing for OpenAI o3

### DIFF
--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -78,7 +78,7 @@ const tokenValues = Object.assign(
     'gpt-3.5-turbo-1106': { prompt: 1, completion: 2 },
     'o4-mini': { prompt: 1.1, completion: 4.4 },
     'o3-mini': { prompt: 1.1, completion: 4.4 },
-    o3: { prompt: 10, completion: 40 },
+    o3: { prompt: 2, completion: 8 },
     'o1-mini': { prompt: 1.1, completion: 4.4 },
     'o1-preview': { prompt: 15, completion: 60 },
     o1: { prompt: 15, completion: 60 },


### PR DESCRIPTION
## Summary

`o3` is now 80% cheaper, at $2/Mt input and $8/Mt output. https://openai.com/api/pricing/
## Change Type

## Testing

I have performed no testing and have full trust in blindly committing to your main branch, which hundreds of thousands of people depend on for their interactive AI chats.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
