### PR TITLE
Fix: rag_api short lived token when using OpenID token reuse

### DIFF
--- a/api/app/clients/tools/util/fileSearch.js
+++ b/api/app/clients/tools/util/fileSearch.js
@@ -1,5 +1,6 @@
 const { z } = require('zod');
 const axios = require('axios');
+const jwt = require('jsonwebtoken');
 const { tool } = require('@langchain/core/tools');
 const { Tools, EToolResources } = require('librechat-data-provider');
 const { getFiles } = require('~/models/File');
@@ -59,7 +60,10 @@ const createFileSearchTool = async ({ req, files, entity_id }) => {
       if (files.length === 0) {
         return 'No files to search. Instruct the user to add files for the search.';
       }
-      const jwtToken = req.headers.authorization.split(' ')[1];
+      const jwtToken = jwt.sign({ id: req.user.id }, process.env.JWT_SECRET, {
+        expiresIn: '5m',
+        algorithm: 'HS256',
+      });
       if (!jwtToken) {
         return 'There was an error authenticating the file search request.';
       }

--- a/api/server/services/Files/VectorDB/crud.js
+++ b/api/server/services/Files/VectorDB/crud.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const jwt = require('jsonwebtoken');
 const axios = require('axios');
 const FormData = require('form-data');
 const { logAxiosError } = require('@librechat/api');
@@ -23,7 +24,10 @@ const deleteVectors = async (req, file) => {
     return;
   }
   try {
-    const jwtToken = req.headers.authorization.split(' ')[1];
+    const jwtToken = jwt.sign({ id: req.user.id }, process.env.JWT_SECRET, {
+      expiresIn: '5m',
+      algorithm: 'HS256',
+    });
     return await axios.delete(`${process.env.RAG_API_URL}/documents`, {
       headers: {
         Authorization: `Bearer ${jwtToken}`,
@@ -70,7 +74,10 @@ async function uploadVectors({ req, file, file_id, entity_id }) {
   }
 
   try {
-    const jwtToken = req.headers.authorization.split(' ')[1];
+    const jwtToken = jwt.sign({ id: req.user.id }, process.env.JWT_SECRET, {
+      expiresIn: '5m',
+      algorithm: 'HS256',
+    });
     const formData = new FormData();
     formData.append('file_id', file_id);
     formData.append('file', fs.createReadStream(file.path));


### PR DESCRIPTION
## Summary

This PR fixes an issue where rag_api will reject any interaction with it if LibreChat has been switched to OpenID Token Reuse, as it expects to receive a token encoded with HS256. We generate a short lived 5 minutes token to allow the JWT token exchange instead of sending the original token coming from Entra or other IDM platforms.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Enable OpenID token reuse and try to upload a file to rag_api, it will fail immediately complaining about the format of the token in the logs. 

### **Test Configuration**:

`# OpenID
OPENID_CLIENT_ID=client_id
OPENID_CLIENT_SECRET=secret
OPENID_ISSUER=https://login.microsoftonline.com/tenant-id/v2.0
OPENID_SESSION_SECRET=session_secret
OPENID_CALLBACK_URL=/oauth/openid/callback
OPENID_AUTO_REDIRECT=true

OPENID_REUSE_TOKENS=true
OPENID_JWKS_URL_CACHE_ENABLED=true
OPENID_JWKS_URL_CACHE_TIME=600000  # 10 minutes in milliseconds
OPENID_ON_BEHALF_FLOW_FOR_USERINFRO_REQUIRED=true
OPENID_ON_BEHALF_FLOW_USERINFRO_SCOPE=user.read
OPENID_USE_END_SESSION_ENDPOINT=true
OPENID_SCOPE="api://librechat/.default openid profile email offline_access"`

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
