### PR TITLE
Added the option to change the MCP Server Label

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -95,6 +95,7 @@ router.get('/', async function (req, res) {
       instanceProjectId: instanceProject._id.toString(),
       bundlerURL: process.env.SANDPACK_BUNDLER_URL,
       staticBundlerURL: process.env.SANDPACK_STATIC_BUNDLER_URL,
+      mcpPlaceholder: process.env.MCP_PLACEHOLDER,
     };
     /** @type {TCustomConfig['webSearch']} */
     const webSearchConfig = req.app.locals.webSearch;

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useRef, useMemo, useEffect, useCallback } from 'react';
 import { useRecoilState } from 'recoil';
 import { Constants, EModelEndpoint, LocalStorageKeys } from 'librechat-data-provider';
-import { useAvailableToolsQuery } from '~/data-provider';
+import { useAvailableToolsQuery, useGetStartupConfig } from '~/data-provider';
 import useLocalStorage from '~/hooks/useLocalStorageAlt';
 import MultiSelect from '~/components/ui/MultiSelect';
 import { ephemeralAgentByConvoId } from '~/store';
@@ -26,7 +26,7 @@ function MCPSelect({ conversationId }: { conversationId?: string | null }) {
   const localize = useLocalize();
   const key = conversationId ?? Constants.NEW_CONVO;
   const hasSetFetched = useRef<string | null>(null);
-
+  const { data: startupConfig } = useGetStartupConfig();
   const { data: mcpServerSet, isFetched } = useAvailableToolsQuery(EModelEndpoint.agents, {
     select: (data) => {
       const serverNames = new Set<string>();
@@ -104,6 +104,7 @@ function MCPSelect({ conversationId }: { conversationId?: string | null }) {
     return null;
   }
 
+  const placeholderText = startupConfig?.mcpPlaceholder || localize('com_ui_mcp_servers');
   return (
     <MultiSelect
       items={mcpServers ?? []}
@@ -111,7 +112,7 @@ function MCPSelect({ conversationId }: { conversationId?: string | null }) {
       setSelectedValues={setMCPValues}
       defaultSelectedValues={mcpValues ?? []}
       renderSelectedValues={renderSelectedValues}
-      placeholder={localize('com_ui_mcp_servers')}
+      placeholder={placeholderText}
       popoverClassName="min-w-fit"
       className="badge-icon min-w-fit"
       selectIcon={<MCPIcon className="icon-md text-text-primary" />}

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -588,6 +588,7 @@ export type TStartupConfig = {
     scraperType?: ScraperTypes;
     rerankerType?: RerankerTypes;
   };
+  mcpPlaceholder?: string;
 };
 
 export enum OCRStrategy {


### PR DESCRIPTION
## Summary

This gives the ability for customizing the label of the MCP server selector via environment variable. If the variable is not defined, a default localized label is used. 

## Change Type

Please delete any irrelevant options.

- [x] Feature (non-breaking change that adds functionality)
- [x] This change requires a documentation update

## Config Changes

There are two new environment variables:

| Key               | Type    | Description                                                    | Example |
|--------------------|----------|----------------------------------------------------------------|---------|
| MCP_PLACEHOLDER   | string  | Label shown in the MCP server MultiSelect component. If unset, a default will be used. | tools   |

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented on any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Any changes dependent on mine have been merged and published in downstream modules.