### PR TITLE
fix: Remove direct assignment of promptPrefix

### DIFF
--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -51,7 +51,7 @@ export default function useChatFunctions({
   getMessages,
   setMessages,
   isSubmitting,
-  conversation,
+  conversation: immutableConversation,
   latestMessage,
   setSubmission,
   setLatestMessage,
@@ -81,6 +81,7 @@ export default function useChatFunctions({
   const customPromptMode = useRecoilValue(store.customPromptMode);
   const setShowStopButton = useSetRecoilState(store.showStopButtonByIndex(index));
   const resetLatestMultiMessage = useResetRecoilState(store.latestMessageFamily(index + 1));
+  const conversation = { ...immutableConversation };
 
   const ask: TAskFunction = (
     {


### PR DESCRIPTION
## Summary

The `useChatFunctions` had a bug where, when a `promptPrefix` was included for the conversation, an error would be logged and the message would refuse to send. This issue has affected several people in this discussion: https://github.com/danny-avila/LibreChat/discussions/7698

This meant you couldn't use Model Specs that included a `promptPrefix` as part of the preset (https://www.librechat.ai/docs/configuration/librechat_yaml/object_structure/model_specs#promptprefix); as far as I'm aware messages would fail to send 100% of the time in these cases.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added the following to `librechat.yaml`:
```
modelSpecs:
  enforce: true
  prioritize: true
  addedEndpoints: ["openAI"]
  list:
    - name: "test"
      label: "test"
      default: true
      preset:
        endpoint: "openAI"
        model: "gpt-4"
        promptPrefix: "This is my prompt prefix."
```
Then selected the "test" model from the client. Prior to the fix, attempting to send a message would fail, and the following error would be logged to the console:
```
Uncaught (in promise) TypeError: Cannot assign to read only property 'promptPrefix' of object '#<Object>'
    at ask (useChatFunctions.ts:136:20)
    at useSubmitMessage.ts:49:7
```

Following the fix, messages would send successfully and incorporate the indicated `promptPrefix`.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
