### PR TITLE
feat: Add Message Feedback Configuration and Logic

### DIFF
--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -139,6 +139,7 @@ describe('AppService', () => {
         parameters: true,
         sidePanel: true,
         presets: true,
+        messageFeedback: true,
       }),
       mcpConfig: null,
       turnstileConfig: mockedTurnstileConfig,

--- a/api/server/services/start/interface.js
+++ b/api/server/services/start/interface.js
@@ -51,6 +51,7 @@ async function loadDefaultInterface(config, configDefaults, roleName = SystemRol
     runCode: interfaceConfig?.runCode ?? defaults.runCode,
     webSearch: interfaceConfig?.webSearch ?? defaults.webSearch,
     customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,
+    messageFeedback: interfaceConfig?.messageFeedback ?? defaults.messageFeedback,
   });
 
   await updateAccessPermissions(roleName, {

--- a/client/src/components/Chat/Messages/HoverButtons.tsx
+++ b/client/src/components/Chat/Messages/HoverButtons.tsx
@@ -1,13 +1,17 @@
 import React, { useState, useMemo, memo } from 'react';
 import { useRecoilState } from 'recoil';
 import type { TConversation, TMessage, TFeedback } from 'librechat-data-provider';
+import { getConfigDefaults } from 'librechat-data-provider';
 import { EditIcon, Clipboard, CheckMark, ContinueIcon, RegenerateIcon } from '~/components';
 import { useGenerationsByLatest, useLocalize } from '~/hooks';
 import { Fork } from '~/components/Conversations';
+import { useGetStartupConfig } from '~/data-provider';
 import MessageAudio from './MessageAudio';
 import Feedback from './Feedback';
 import { cn } from '~/utils';
 import store from '~/store';
+
+const defaultInterface = getConfigDefaults().interface;
 
 type THoverButtons = {
   isEditing: boolean;
@@ -123,6 +127,12 @@ const HoverButtons = ({
   const localize = useLocalize();
   const [isCopied, setIsCopied] = useState(false);
   const [TextToSpeech] = useRecoilState<boolean>(store.textToSpeech);
+  const { data: startupConfig } = useGetStartupConfig();
+
+  const interfaceConfig = useMemo(
+    () => startupConfig?.interface ?? defaultInterface,
+    [startupConfig],
+  );
 
   const endpoint = useMemo(() => {
     if (!conversation) {
@@ -238,7 +248,7 @@ const HoverButtons = ({
       />
 
       {/* Feedback Buttons */}
-      {!isCreatedByUser && (
+      {!isCreatedByUser && interfaceConfig?.messageFeedback !== false && (
         <Feedback handleFeedback={handleFeedback} feedback={message.feedback} isLast={isLast} />
       )}
 

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -73,6 +73,7 @@ interface:
   bookmarks: true
   multiConvo: true
   agents: true
+  messageFeedback: true
   # Temporary chat retention period in hours (default: 720, min: 1, max: 8760)
   # temporaryChatRetention: 1
 

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -513,6 +513,7 @@ export const intefaceSchema = z
     temporaryChatRetention: z.number().min(1).max(8760).optional(),
     runCode: z.boolean().optional(),
     webSearch: z.boolean().optional(),
+    messageFeedback: z.boolean().optional(),
   })
   .default({
     endpointsMenu: true,
@@ -528,6 +529,7 @@ export const intefaceSchema = z
     temporaryChat: true,
     runCode: true,
     webSearch: true,
+    messageFeedback: true,
   });
 
 export type TInterfaceConfig = z.infer<typeof intefaceSchema>;


### PR DESCRIPTION
## Summary

Currently, there is not a way to disable user feedback on responses (thumbs up/down) without making direct changes to the source code. Though some admins want to collect this type of user feedback, there are some admins that don't. This PR allows admins to have the option to either enable user feedback or to disable it entirely. 

## Change Type


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

I introduced a new configuration option in the interface settings that can control message feedback visibility. This can be configured in through `librechat.yaml` configuration:
```yaml
interface:
  messageFeedback: false
```
When this setting is `false`, the user feedback buttons (thumbs up/down) will be hidden from the chat UI. When this setting is either `true` or not set at all (default behavior), the feedback buttons will be visible for AI responses.

Screenshot below is when **messageFeedback: false** in `librechat.yaml`.

<img width="808" alt="image" src="https://github.com/user-attachments/assets/5ccb697a-9c68-40d6-b9ad-06d6f073ceaf" />

### **Test Configuration**:

1. Set `messageFeedback: false` in your `librechat.yaml` or set `INTERFACE_MESSAGE_FEEDBACK=false` in your `.env`
2. Start the application
3. Verify that no feedback buttons (thumbs up/down) appear on any AI messages
4. Set the value back to `true` or remove the configuration
5. Verify that feedback buttons reappear on AI messages

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.
