### PR TITLE
✨ feat: Configurable MCP Dropdown Placeholder

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -97,6 +97,7 @@ router.get('/', async function (req, res) {
       instanceProjectId: instanceProject._id.toString(),
       bundlerURL: process.env.SANDPACK_BUNDLER_URL,
       staticBundlerURL: process.env.SANDPACK_STATIC_BUNDLER_URL,
+      mcpPlaceholder: process.env.MCP_PLACEHOLDER,
     };
 
     payload.mcpServers = {};

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -97,7 +97,6 @@ router.get('/', async function (req, res) {
       instanceProjectId: instanceProject._id.toString(),
       bundlerURL: process.env.SANDPACK_BUNDLER_URL,
       staticBundlerURL: process.env.SANDPACK_STATIC_BUNDLER_URL,
-      mcpPlaceholder: process.env.MCP_PLACEHOLDER,
     };
 
     payload.mcpServers = {};

--- a/api/server/services/start/interface.js
+++ b/api/server/services/start/interface.js
@@ -41,6 +41,7 @@ async function loadDefaultInterface(config, configDefaults, roleName = SystemRol
     sidePanel: interfaceConfig?.sidePanel ?? defaults.sidePanel,
     privacyPolicy: interfaceConfig?.privacyPolicy ?? defaults.privacyPolicy,
     termsOfService: interfaceConfig?.termsOfService ?? defaults.termsOfService,
+    mcpServers: interfaceConfig?.mcpServers ?? defaults.mcpServers,
     bookmarks: interfaceConfig?.bookmarks ?? defaults.bookmarks,
     memories: shouldDisableMemories ? false : (interfaceConfig?.memories ?? defaults.memories),
     prompts: interfaceConfig?.prompts ?? defaults.prompts,

--- a/client/src/Providers/BadgeRowContext.tsx
+++ b/client/src/Providers/BadgeRowContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext } from 'react';
 import { Tools, LocalStorageKeys } from 'librechat-data-provider';
 import { useMCPSelect, useToolToggle, useCodeApiKeyForm, useSearchApiKeyForm } from '~/hooks';
+import { useGetStartupConfig } from '~/data-provider';
 
 interface BadgeRowContextType {
   conversationId?: string | null;
@@ -10,6 +11,7 @@ interface BadgeRowContextType {
   fileSearch: ReturnType<typeof useToolToggle>;
   codeApiKeyForm: ReturnType<typeof useCodeApiKeyForm>;
   searchApiKeyForm: ReturnType<typeof useSearchApiKeyForm>;
+  startupConfig: ReturnType<typeof useGetStartupConfig>['data'];
 }
 
 const BadgeRowContext = createContext<BadgeRowContextType | undefined>(undefined);
@@ -28,6 +30,9 @@ interface BadgeRowProviderProps {
 }
 
 export default function BadgeRowProvider({ children, conversationId }: BadgeRowProviderProps) {
+  /** Startup config */
+  const { data: startupConfig } = useGetStartupConfig();
+
   /** MCPSelect hook */
   const mcpSelect = useMCPSelect({ conversationId });
 
@@ -73,6 +78,7 @@ export default function BadgeRowProvider({ children, conversationId }: BadgeRowP
     mcpSelect,
     webSearch,
     fileSearch,
+    startupConfig,
     conversationId,
     codeApiKeyForm,
     codeInterpreter,

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -130,7 +130,8 @@ function MCPSelect() {
     return null;
   }
 
-  const placeholderText = startupConfig?.mcpPlaceholder || localize('com_ui_mcp_servers');
+  const placeholderText =
+    startupConfig?.interface?.mcpServers?.placeholder || localize('com_ui_mcp_servers');
   return (
     <>
       <MultiSelect

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -5,7 +5,7 @@ import { useUpdateUserPluginsMutation } from 'librechat-data-provider/react-quer
 import type { TUpdateUserPlugins } from 'librechat-data-provider';
 import type { McpServerInfo } from '~/hooks/Plugins/useMCPSelect';
 import MCPConfigDialog, { type ConfigFieldDetail } from '~/components/ui/MCPConfigDialog';
-import { useToastContext, useBadgeRowContext } from '~/Providers';
+import { useToastContext, useBadgeRowContext, useGetStartupConfig } from '~/Providers';
 import MultiSelect from '~/components/ui/MultiSelect';
 import { MCPIcon } from '~/components/svg';
 import { useLocalize } from '~/hooks';
@@ -21,6 +21,7 @@ function MCPSelect() {
   const { mcpSelect } = useBadgeRowContext();
   const { mcpValues, setMCPValues, mcpServerNames, mcpToolDetails, isPinned } = mcpSelect;
 
+  const { data: startupConfig } = useGetStartupConfig();
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const [selectedToolForConfig, setSelectedToolForConfig] = useState<McpServerInfo | null>(null);
 
@@ -129,6 +130,7 @@ function MCPSelect() {
     return null;
   }
 
+  const placeholderText = startupConfig?.mcpPlaceholder || localize('com_ui_mcp_servers');
   return (
     <>
       <MultiSelect
@@ -138,7 +140,7 @@ function MCPSelect() {
         defaultSelectedValues={mcpValues ?? []}
         renderSelectedValues={renderSelectedValues}
         renderItemContent={renderItemContent}
-        placeholder={localize('com_ui_mcp_servers')}
+        placeholder={placeholderText}
         popoverClassName="min-w-fit"
         className="badge-icon min-w-fit"
         selectIcon={<MCPIcon className="icon-md text-text-primary" />}

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -2,10 +2,10 @@ import React, { memo, useCallback, useState } from 'react';
 import { SettingsIcon } from 'lucide-react';
 import { Constants } from 'librechat-data-provider';
 import { useUpdateUserPluginsMutation } from 'librechat-data-provider/react-query';
-import type { TUpdateUserPlugins } from 'librechat-data-provider';
-import type { McpServerInfo } from '~/hooks/Plugins/useMCPSelect';
+import type { TUpdateUserPlugins, TPlugin } from 'librechat-data-provider';
 import MCPConfigDialog, { type ConfigFieldDetail } from '~/components/ui/MCPConfigDialog';
-import { useToastContext, useBadgeRowContext, useGetStartupConfig } from '~/Providers';
+import { useToastContext, useBadgeRowContext } from '~/Providers';
+import { useGetStartupConfig } from '~/data-provider';
 import MultiSelect from '~/components/ui/MultiSelect';
 import { MCPIcon } from '~/components/svg';
 import { useLocalize } from '~/hooks';
@@ -23,7 +23,7 @@ function MCPSelect() {
 
   const { data: startupConfig } = useGetStartupConfig();
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
-  const [selectedToolForConfig, setSelectedToolForConfig] = useState<McpServerInfo | null>(null);
+  const [selectedToolForConfig, setSelectedToolForConfig] = useState<TPlugin | null>(null);
 
   const updateUserPluginsMutation = useUpdateUserPluginsMutation({
     onSuccess: () => {

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -5,7 +5,6 @@ import { useUpdateUserPluginsMutation } from 'librechat-data-provider/react-quer
 import type { TUpdateUserPlugins, TPlugin } from 'librechat-data-provider';
 import MCPConfigDialog, { type ConfigFieldDetail } from '~/components/ui/MCPConfigDialog';
 import { useToastContext, useBadgeRowContext } from '~/Providers';
-import { useGetStartupConfig } from '~/data-provider';
 import MultiSelect from '~/components/ui/MultiSelect';
 import { MCPIcon } from '~/components/svg';
 import { useLocalize } from '~/hooks';
@@ -18,10 +17,9 @@ const getBaseMCPPluginKey = (fullPluginKey: string): string => {
 function MCPSelect() {
   const localize = useLocalize();
   const { showToast } = useToastContext();
-  const { mcpSelect } = useBadgeRowContext();
+  const { mcpSelect, startupConfig } = useBadgeRowContext();
   const { mcpValues, setMCPValues, mcpServerNames, mcpToolDetails, isPinned } = mcpSelect;
 
-  const { data: startupConfig } = useGetStartupConfig();
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const [selectedToolForConfig, setSelectedToolForConfig] = useState<TPlugin | null>(null);
 

--- a/client/src/components/Chat/Input/MCPSubMenu.tsx
+++ b/client/src/components/Chat/Input/MCPSubMenu.tsx
@@ -11,6 +11,7 @@ interface MCPSubMenuProps {
   mcpValues?: string[];
   mcpServerNames: string[];
   handleMCPToggle: (serverName: string) => void;
+  placeholder?: string;
 }
 
 const MCPSubMenu = ({
@@ -19,6 +20,7 @@ const MCPSubMenu = ({
   mcpServerNames,
   setIsMCPPinned,
   handleMCPToggle,
+  placeholder,
   ...props
 }: MCPSubMenuProps) => {
   const localize = useLocalize();
@@ -38,7 +40,7 @@ const MCPSubMenu = ({
       >
         <div className="flex items-center gap-2">
           <MCPIcon className="icon-md" />
-          <span>{localize('com_ui_mcp_servers')}</span>
+          <span>{placeholder || localize('com_ui_mcp_servers')}</span>
           <ChevronRight className="ml-auto h-3 w-3" />
         </div>
         <button

--- a/client/src/components/Chat/Input/ToolsDropdown.tsx
+++ b/client/src/components/Chat/Input/ToolsDropdown.tsx
@@ -8,7 +8,6 @@ import MCPSubMenu from '~/components/Chat/Input/MCPSubMenu';
 import { PinIcon, VectorIcon } from '~/components/svg';
 import { useLocalize, useHasAccess } from '~/hooks';
 import { useBadgeRowContext } from '~/Providers';
-import { useGetStartupConfig } from '~/data-provider';
 import { cn } from '~/utils';
 
 interface ToolsDropdownProps {
@@ -18,10 +17,16 @@ interface ToolsDropdownProps {
 const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
   const localize = useLocalize();
   const isDisabled = disabled ?? false;
-  const { data: startupConfig } = useGetStartupConfig();
   const [isPopoverActive, setIsPopoverActive] = useState(false);
-  const { webSearch, codeInterpreter, fileSearch, mcpSelect, searchApiKeyForm, codeApiKeyForm } =
-    useBadgeRowContext();
+  const {
+    webSearch,
+    mcpSelect,
+    fileSearch,
+    startupConfig,
+    codeApiKeyForm,
+    codeInterpreter,
+    searchApiKeyForm,
+  } = useBadgeRowContext();
   const { setIsDialogOpen: setIsCodeDialogOpen, menuTriggerRef: codeMenuTriggerRef } =
     codeApiKeyForm;
   const { setIsDialogOpen: setIsSearchDialogOpen, menuTriggerRef: searchMenuTriggerRef } =
@@ -90,6 +95,8 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
     },
     [mcpSelect],
   );
+
+  const mcpPlaceholder = startupConfig?.interface?.mcpServers?.placeholder;
 
   const dropdownItems = useMemo(() => {
     const items: MenuItemProps[] = [
@@ -248,11 +255,11 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
           <MCPSubMenu
             {...props}
             mcpValues={mcpValues}
-            mcpServerNames={mcpServerNames}
             isMCPPinned={isMCPPinned}
+            placeholder={mcpPlaceholder}
+            mcpServerNames={mcpServerNames}
             setIsMCPPinned={setIsMCPPinned}
             handleMCPToggle={handleMCPToggle}
-            placeholder={startupConfig?.interface?.mcpServers?.placeholder}
           />
         ),
       });
@@ -265,6 +272,7 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
     canRunCode,
     isMCPPinned,
     isCodePinned,
+    mcpPlaceholder,
     mcpServerNames,
     isSearchPinned,
     setIsMCPPinned,
@@ -283,7 +291,6 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
     setIsSearchDialogOpen,
     handleFileSearchToggle,
     handleCodeInterpreterToggle,
-    startupConfig,
   ]);
 
   const menuTrigger = (

--- a/client/src/components/Chat/Input/ToolsDropdown.tsx
+++ b/client/src/components/Chat/Input/ToolsDropdown.tsx
@@ -8,6 +8,7 @@ import MCPSubMenu from '~/components/Chat/Input/MCPSubMenu';
 import { PinIcon, VectorIcon } from '~/components/svg';
 import { useLocalize, useHasAccess } from '~/hooks';
 import { useBadgeRowContext } from '~/Providers';
+import { useGetStartupConfig } from '~/data-provider';
 import { cn } from '~/utils';
 
 interface ToolsDropdownProps {
@@ -17,6 +18,7 @@ interface ToolsDropdownProps {
 const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
   const localize = useLocalize();
   const isDisabled = disabled ?? false;
+  const { data: startupConfig } = useGetStartupConfig();
   const [isPopoverActive, setIsPopoverActive] = useState(false);
   const { webSearch, codeInterpreter, fileSearch, mcpSelect, searchApiKeyForm, codeApiKeyForm } =
     useBadgeRowContext();
@@ -250,6 +252,7 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
             isMCPPinned={isMCPPinned}
             setIsMCPPinned={setIsMCPPinned}
             handleMCPToggle={handleMCPToggle}
+            placeholder={startupConfig?.interface?.mcpServers?.placeholder}
           />
         ),
       });
@@ -280,6 +283,7 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
     setIsSearchDialogOpen,
     handleFileSearchToggle,
     handleCodeInterpreterToggle,
+    startupConfig,
   ]);
 
   const menuTrigger = (

--- a/client/src/hooks/Plugins/useMCPSelect.ts
+++ b/client/src/hooks/Plugins/useMCPSelect.ts
@@ -1,7 +1,7 @@
 import { useRef, useEffect, useCallback, useMemo } from 'react';
 import { useRecoilState } from 'recoil';
 import { Constants, LocalStorageKeys, EModelEndpoint } from 'librechat-data-provider';
-import type { TPlugin, TPluginAuthConfig } from 'librechat-data-provider';
+import type { TPlugin } from 'librechat-data-provider';
 import { useAvailableToolsQuery } from '~/data-provider';
 import useLocalStorage from '~/hooks/useLocalStorageAlt';
 import { ephemeralAgentByConvoId } from '~/store';
@@ -24,20 +24,13 @@ interface UseMCPSelectOptions {
   conversationId?: string | null;
 }
 
-export interface McpServerInfo {
-  name: string;
-  pluginKey: string;
-  authConfig?: TPluginAuthConfig[];
-  authenticated?: boolean;
-}
-
 export function useMCPSelect({ conversationId }: UseMCPSelectOptions) {
   const key = conversationId ?? Constants.NEW_CONVO;
   const hasSetFetched = useRef<string | null>(null);
   const [ephemeralAgent, setEphemeralAgent] = useRecoilState(ephemeralAgentByConvoId(key));
   const { data: mcpToolDetails, isFetched } = useAvailableToolsQuery(EModelEndpoint.agents, {
     select: (data: TPlugin[]) => {
-      const mcpToolsMap = new Map<string, McpServerInfo>();
+      const mcpToolsMap = new Map<string, TPlugin>();
       data.forEach((tool) => {
         const isMCP = tool.pluginKey.includes(Constants.mcp_delimiter);
         if (isMCP && tool.chatMenu !== false) {
@@ -109,13 +102,13 @@ export function useMCPSelect({ conversationId }: UseMCPSelectOptions) {
   }, [mcpToolDetails]);
 
   return {
+    isPinned,
     mcpValues,
+    setIsPinned,
     setMCPValues,
     mcpServerNames,
     ephemeralAgent,
     mcpToolDetails,
     setEphemeralAgent,
-    isPinned,
-    setIsPinned,
   };
 }

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -13,6 +13,9 @@ cache: true
 # Custom interface configuration
 interface:
   customWelcome: "Welcome to LibreChat! Enjoy your experience."
+  # MCP Servers UI configuration
+  mcpServers:
+    placeholder: 'MCP Servers'
   # Privacy policy settings
   privacyPolicy:
     externalUrl: 'https://librechat.ai/privacy-policy'

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -482,6 +482,12 @@ const termsOfServiceSchema = z.object({
 
 export type TTermsOfService = z.infer<typeof termsOfServiceSchema>;
 
+const mcpServersSchema = z.object({
+  placeholder: z.string().optional(),
+});
+
+export type TMcpServersConfig = z.infer<typeof mcpServersSchema>;
+
 export const intefaceSchema = z
   .object({
     privacyPolicy: z
@@ -492,11 +498,7 @@ export const intefaceSchema = z
       .optional(),
     termsOfService: termsOfServiceSchema.optional(),
     customWelcome: z.string().optional(),
-    mcpServers: z
-      .object({
-        placeholder: z.string().optional(),
-      })
-      .optional(),
+    mcpServers: mcpServersSchema.optional(),
     endpointsMenu: z.boolean().optional(),
     modelSelect: z.boolean().optional(),
     parameters: z.boolean().optional(),

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -492,6 +492,11 @@ export const intefaceSchema = z
       .optional(),
     termsOfService: termsOfServiceSchema.optional(),
     customWelcome: z.string().optional(),
+    mcpServers: z
+      .object({
+        placeholder: z.string().optional(),
+      })
+      .optional(),
     endpointsMenu: z.boolean().optional(),
     modelSelect: z.boolean().optional(),
     parameters: z.boolean().optional(),

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -600,6 +600,7 @@ export type TStartupConfig = {
       >;
     }
   >;
+  mcpPlaceholder?: string;
 };
 
 export enum OCRStrategy {

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -400,7 +400,7 @@ export type TPluginAuthConfig = z.infer<typeof tPluginAuthConfigSchema>;
 export const tPluginSchema = z.object({
   name: z.string(),
   pluginKey: z.string(),
-  description: z.string(),
+  description: z.string().optional(),
   icon: z.string().optional(),
   authConfig: z.array(tPluginAuthConfigSchema).optional(),
   authenticated: z.boolean().optional(),


### PR DESCRIPTION
Related to #7964 

## Summary

This PR **introduces support for configuring the default MCP server selection label** via the `librechat.yaml` interface configuration (using a new `mcpServers.placeholder` field). This enables the MCPSelect label to be customized directly through YAML-based configuration, supporting better flexibility and future enhancements to MCP server UI configuration.

### Changes:

- **Added** `mcpServers.placeholder` to the interface schema (`packages/data-provider/src/config.ts`)
- **Expanded** `librechat.example.yaml` with a new section for MCP server UI configuration
- **Included** `mcpServers` in the interface configuration loaded by `api/server/services/start/interface.js`
- **Updated** `client/src/components/Chat/Input/MCPSelect.tsx` to use `startupConfig?.interface?.mcpServers?.placeholder`

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Translation update

## Testing

### **Test Configuration**:

**Test Steps:**
1. Add the following to your `librechat.yaml` interface section:
   ```yaml
   interface:
     mcpServers:
       placeholder: "Custom Label"
   ```

2. Start the LibreChat server
3. Navigate to a conversation with MCP servers available
4. Verify that the MCP dropdown shows "Custom Label" instead of the default "MCP Servers"

**Fallback Testing:**
1. Remove the `mcpServers` configuration from the YAML
2. Restart the server
3. Verify that the MCP dropdown falls back to the localized "MCP Servers" text

**Configuration Validation:**
- The YAML configuration should validate correctly without errors
- The interface configuration should be properly loaded and passed to the frontend

## Checklist


- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings