### PR TITLE
Show agent avatars in chat history nav

### DIFF
--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 import { Constants } from 'librechat-data-provider';
 import type { TConversation } from 'librechat-data-provider';
 import { useNavigateToConvo, useMediaQuery, useLocalize } from '~/hooks';
+import { useListAgentsQuery } from '~/data-provider/Agents';
 import { useUpdateConversationMutation } from '~/data-provider';
 import EndpointIcon from '~/components/Endpoints/EndpointIcon';
 import { useGetEndpointsQuery } from '~/data-provider';
@@ -33,6 +34,16 @@ export default function Conversation({
   const { showToast } = useToastContext();
   const { navigateToConvo } = useNavigateToConvo();
   const { data: endpointsConfig } = useGetEndpointsQuery();
+  const { data: agentsData } = useListAgentsQuery();
+  const agentsMap = useMemo(() => {
+    if (!agentsData?.data) {
+      return {};
+    }
+    return agentsData.data.reduce((acc, agent) => {
+      acc[agent.id] = agent;
+      return acc;
+    }, {} as Record<string, any>);
+  }, [agentsData?.data]);
   const currentConvoId = useMemo(() => params.conversationId, [params.conversationId]);
   const updateConvoMutation = useUpdateConversationMutation(currentConvoId ?? '');
   const activeConvos = useRecoilValue(store.allConversationsSelector);
@@ -180,6 +191,7 @@ export default function Conversation({
           <EndpointIcon
             conversation={conversation}
             endpointsConfig={endpointsConfig}
+            agentsMap={agentsMap}
             size={20}
             context="menu-item"
           />

--- a/client/src/components/Endpoints/ConvoIconURL.tsx
+++ b/client/src/components/Endpoints/ConvoIconURL.tsx
@@ -67,6 +67,7 @@ const ConvoIconURL: React.FC<ConvoIconURLProps> = ({
           iconURL={endpointIconURL}
           assistantName={assistantName}
           avatar={assistantAvatar || agentAvatar}
+          agentAvatar={agentAvatar}
         />
       )}
     </div>

--- a/client/src/components/Endpoints/EndpointIcon.tsx
+++ b/client/src/components/Endpoints/EndpointIcon.tsx
@@ -1,9 +1,10 @@
-import { isAssistantsEndpoint } from 'librechat-data-provider';
+import { isAssistantsEndpoint, isAgentsEndpoint } from 'librechat-data-provider';
 import type {
   TConversation,
   TEndpointsConfig,
   TPreset,
   TAssistantsMap,
+  TAgentsMap,
 } from 'librechat-data-provider';
 import ConvoIconURL from '~/components/Endpoints/ConvoIconURL';
 import MinimalIcon from '~/components/Endpoints/MinimalIcon';
@@ -14,6 +15,7 @@ export default function EndpointIcon({
   endpointsConfig,
   className = 'mr-0',
   assistantMap,
+  agentsMap,
   context,
 }: {
   conversation: TConversation | TPreset | null;
@@ -21,6 +23,7 @@ export default function EndpointIcon({
   containerClassName?: string;
   context?: 'message' | 'nav' | 'landing' | 'menu-item';
   assistantMap?: TAssistantsMap;
+  agentsMap?: TAgentsMap;
   className?: string;
   size?: number;
 }) {
@@ -34,10 +37,15 @@ export default function EndpointIcon({
   const assistant = isAssistantsEndpoint(endpoint)
     ? assistantMap?.[endpoint]?.[conversation?.assistant_id ?? '']
     : null;
+  const agent = isAgentsEndpoint(endpoint)
+    ? agentsMap?.[conversation?.agent_id ?? '']
+    : null;
   const assistantAvatar = (assistant && (assistant.metadata?.avatar as string)) || '';
   const assistantName = assistant && (assistant.name ?? '');
+  const agentAvatar = agent?.avatar?.filepath || '';
+  const agentName = agent?.name || '';
 
-  const iconURL = assistantAvatar || convoIconURL;
+  const iconURL = agentAvatar || assistantAvatar || convoIconURL;
 
   if (iconURL && (iconURL.includes('http') || iconURL.startsWith('/images/'))) {
     return (
@@ -48,6 +56,8 @@ export default function EndpointIcon({
         endpointIconURL={endpointIconURL}
         assistantAvatar={assistantAvatar}
         assistantName={assistantName ?? ''}
+        agentAvatar={agentAvatar}
+        agentName={agentName}
       />
     );
   } else {
@@ -63,6 +73,9 @@ export default function EndpointIcon({
         isCreatedByUser={false}
         chatGptLabel={undefined}
         modelLabel={undefined}
+        assistantName={assistantName}
+        agentName={agentName}
+        agentAvatar={agentAvatar}
       />
     );
   }

--- a/client/src/components/Endpoints/MinimalIcon.tsx
+++ b/client/src/components/Endpoints/MinimalIcon.tsx
@@ -16,7 +16,7 @@ import { IconProps } from '~/common';
 import { cn } from '~/utils';
 
 const MinimalIcon: React.FC<IconProps> = (props) => {
-  const { size = 30, iconURL = '', iconClassName, error } = props;
+  const { size = 30, iconURL = '', iconClassName, error, agentAvatar, agentName } = props;
 
   let endpoint = 'default'; // Default value for endpoint
 
@@ -47,8 +47,16 @@ const MinimalIcon: React.FC<IconProps> = (props) => {
     [EModelEndpoint.assistants]: { icon: <Sparkles className="icon-sm" />, name: 'Assistant' },
     [EModelEndpoint.azureAssistants]: { icon: <Sparkles className="icon-sm" />, name: 'Assistant' },
     [EModelEndpoint.agents]: {
-      icon: <Feather className="icon-sm" />,
-      name: props.modelLabel ?? alternateName[EModelEndpoint.agents],
+      icon: agentAvatar ? (
+        <img
+          src={agentAvatar}
+          alt={agentName || 'Agent'}
+          className="h-full w-full rounded-full object-cover"
+        />
+      ) : (
+        <Feather className="icon-sm" />
+      ),
+      name: agentName || props.modelLabel || alternateName[EModelEndpoint.agents],
     },
     [EModelEndpoint.bedrock]: {
       icon: <BedrockIcon className="icon-xl text-text-primary" />,
@@ -73,6 +81,8 @@ const MinimalIcon: React.FC<IconProps> = (props) => {
       style={{
         width: size,
         height: size,
+        borderRadius: endpoint === EModelEndpoint.agents && agentAvatar ? '50%' : undefined,
+        overflow: endpoint === EModelEndpoint.agents && agentAvatar ? 'hidden' : undefined,
       }}
       className={cn(
         'relative flex items-center justify-center rounded-sm text-text-secondary',


### PR DESCRIPTION
This change displays agent avatars in the chat history navigation list instead of using the generic feather icon for all agents. It improves the visual identification of different agents in the conversation list.

The PR adds the following improvements:
- Display agent avatars in the chat history sidebar instead of the generic feather icon
- Properly handle agent data in the conversation components
- Add styling for rounded avatar images
- Maintain backward compatibility with existing code

This PR helps users visually identify different agents in their conversation history.