### PR TITLE
✨ fix: Minor Menu Issues

### DIFF
--- a/client/src/components/Chat/ExportAndShareMenu.tsx
+++ b/client/src/components/Chat/ExportAndShareMenu.tsx
@@ -68,6 +68,7 @@ export default function ExportAndShareMenu({
   return (
     <>
       <DropdownPopup
+        portal={true}
         menuId={menuId}
         focusLoop={true}
         unmountOnHide={true}

--- a/client/src/components/Chat/Input/MCPSubMenu.tsx
+++ b/client/src/components/Chat/Input/MCPSubMenu.tsx
@@ -26,6 +26,7 @@ const MCPSubMenu = ({
   const localize = useLocalize();
 
   const menuStore = Ariakit.useMenuStore({
+    focusLoop: true,
     showTimeout: 100,
     placement: 'right',
   });
@@ -35,7 +36,13 @@ const MCPSubMenu = ({
       <Ariakit.MenuItem
         {...props}
         render={
-          <Ariakit.MenuButton className="flex w-full cursor-pointer items-center justify-between rounded-lg p-2 hover:bg-surface-hover" />
+          <Ariakit.MenuButton
+            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+              e.stopPropagation();
+              menuStore.toggle();
+            }}
+            className="flex w-full cursor-pointer items-center justify-between rounded-lg p-2 hover:bg-surface-hover"
+          />
         }
       >
         <div className="flex items-center gap-2">
@@ -62,10 +69,8 @@ const MCPSubMenu = ({
         </button>
       </Ariakit.MenuItem>
       <Ariakit.Menu
-        gutter={-4}
-        shift={-8}
-        unmountOnHide
         portal={true}
+        unmountOnHide={true}
         className={cn(
           'animate-popover-left z-50 ml-3 flex min-w-[200px] flex-col rounded-xl',
           'border border-border-light bg-surface-secondary p-1 shadow-lg',

--- a/client/src/components/Chat/Input/ToolsDropdown.tsx
+++ b/client/src/components/Chat/Input/ToolsDropdown.tsx
@@ -99,17 +99,7 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
   const mcpPlaceholder = startupConfig?.interface?.mcpServers?.placeholder;
 
   const dropdownItems = useMemo(() => {
-    const items: MenuItemProps[] = [
-      {
-        render: () => (
-          <div className="px-3 py-2 text-xs font-semibold text-text-secondary">
-            {localize('com_ui_tools')}
-          </div>
-        ),
-        hideOnClick: false,
-      },
-    ];
-
+    const items: MenuItemProps[] = [];
     items.push({
       onClick: handleFileSearchToggle,
       hideOnClick: false,


### PR DESCRIPTION
## Summary

I improved the user experience for dropdown and submenu components by fixing focus loop handling, removing an unnecessary "Tools" header, and enabling better menu portal support.

- Enabled the Ariakit menu focus loop in MCPSubMenu for seamless keyboard navigation
- Improved button interaction in MCPSubMenu by updating the onClick logic to prevent event bubbling and correctly toggle the menu
- Cleaned up MCPSubMenu properties, moved unmountOnHide to be explicit, and removed unused props for clarity
- Removed the "Tools" header from ToolsDropdown, providing a cleaner dropdown appearance
- Enabled portal support in ExportAndShareMenu to ensure modals render above all content and outside stacking context issues

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

I manually tested each dropdown menu (ToolsDropdown, ExportAndShareMenu, and MCPSubMenu) to confirm:
- Menus appear above overlays and are not clipped by boundaries
- Focus remains trapped within the menu while navigating with keyboard
- Submenus open and close as expected without activating unrelated dropdowns
- Clicking menu buttons prevents propagation, fixing unwanted parent toggling
- The ToolsDropdown no longer displays the "Tools" header

To validate changes, I recommend checking these menu components across different browsers and devices, using both mouse and keyboard navigation.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes