### PR TITLE
🧠 fix: Agent Title Config & Resource Handling

### DIFF
--- a/api/app/clients/tools/structured/OpenAIImageTools.js
+++ b/api/app/clients/tools/structured/OpenAIImageTools.js
@@ -107,6 +107,12 @@ const getImageEditPromptDescription = () => {
   return process.env.IMAGE_EDIT_OAI_PROMPT_DESCRIPTION || DEFAULT_IMAGE_EDIT_PROMPT_DESCRIPTION;
 };
 
+function createAbortHandler() {
+  return function () {
+    logger.debug('[ImageGenOAI] Image generation aborted');
+  };
+}
+
 /**
  * Creates OpenAI Image tools (generation and editing)
  * @param {Object} fields - Configuration fields
@@ -201,10 +207,18 @@ function createOpenAIImageTools(fields = {}) {
       }
 
       let resp;
+      /** @type {AbortSignal} */
+      let derivedSignal = null;
+      /** @type {() => void} */
+      let abortHandler = null;
+
       try {
-        const derivedSignal = runnableConfig?.signal
-          ? AbortSignal.any([runnableConfig.signal])
-          : undefined;
+        if (runnableConfig?.signal) {
+          derivedSignal = AbortSignal.any([runnableConfig.signal]);
+          abortHandler = createAbortHandler();
+          derivedSignal.addEventListener('abort', abortHandler, { once: true });
+        }
+
         resp = await openai.images.generate(
           {
             model: 'gpt-image-1',
@@ -228,6 +242,10 @@ function createOpenAIImageTools(fields = {}) {
         logAxiosError({ error, message });
         return returnValue(`Something went wrong when trying to generate the image. The OpenAI API may be unavailable:
 Error Message: ${error.message}`);
+      } finally {
+        if (abortHandler && derivedSignal) {
+          derivedSignal.removeEventListener('abort', abortHandler);
+        }
       }
 
       if (!resp) {
@@ -409,10 +427,17 @@ Error Message: ${error.message}`);
         headers['Authorization'] = `Bearer ${apiKey}`;
       }
 
+      /** @type {AbortSignal} */
+      let derivedSignal = null;
+      /** @type {() => void} */
+      let abortHandler = null;
+
       try {
-        const derivedSignal = runnableConfig?.signal
-          ? AbortSignal.any([runnableConfig.signal])
-          : undefined;
+        if (runnableConfig?.signal) {
+          derivedSignal = AbortSignal.any([runnableConfig.signal]);
+          abortHandler = createAbortHandler();
+          derivedSignal.addEventListener('abort', abortHandler, { once: true });
+        }
 
         /** @type {import('axios').AxiosRequestConfig} */
         const axiosConfig = {
@@ -467,6 +492,10 @@ Error Message: ${error.message}`);
         logAxiosError({ error, message });
         return returnValue(`Something went wrong when trying to edit the image. The OpenAI API may be unavailable:
 Error Message: ${error.message || 'Unknown error'}`);
+      } finally {
+        if (abortHandler && derivedSignal) {
+          derivedSignal.removeEventListener('abort', abortHandler);
+        }
       }
     },
     {

--- a/api/models/File.js
+++ b/api/models/File.js
@@ -1,5 +1,5 @@
 const { logger } = require('@librechat/data-schemas');
-const { EToolResources } = require('librechat-data-provider');
+const { EToolResources, FileContext } = require('librechat-data-provider');
 const { File } = require('~/db/models');
 
 /**
@@ -32,26 +32,24 @@ const getFiles = async (filter, _sortOptions, selectFields = { text: 0 }) => {
  * @returns {Promise<Array<MongoFile>>} Files that match the criteria
  */
 const getToolFilesByIds = async (fileIds, toolResourceSet) => {
-  if (!fileIds || !fileIds.length) {
+  if (!fileIds || !fileIds.length || !toolResourceSet?.size) {
     return [];
   }
 
   try {
     const filter = {
       file_id: { $in: fileIds },
+      $or: [],
     };
 
-    if (toolResourceSet.size) {
-      filter.$or = [{ text: { $exists: true, $ne: null } }];
-
-      if (toolResourceSet.has(EToolResources.file_search)) {
-        filter.$or.push({ embedded: true });
-      }
-      if (toolResourceSet.has(EToolResources.execute_code)) {
-        filter.$or.push({ 'metadata.fileIdentifier': { $exists: true } });
-      }
-    } else {
-      filter.text = { $exists: true, $ne: null };
+    if (toolResourceSet.has(EToolResources.ocr)) {
+      filter.$or.push({ text: { $exists: true, $ne: null }, context: FileContext.agents });
+    }
+    if (toolResourceSet.has(EToolResources.file_search)) {
+      filter.$or.push({ embedded: true });
+    }
+    if (toolResourceSet.has(EToolResources.execute_code)) {
+      filter.$or.push({ 'metadata.fileIdentifier': { $exists: true } });
     }
 
     const selectFields = { text: 0 };

--- a/api/models/File.js
+++ b/api/models/File.js
@@ -42,14 +42,16 @@ const getToolFilesByIds = async (fileIds, toolResourceSet) => {
     };
 
     if (toolResourceSet.size) {
-      filter.$or = [];
-    }
+      filter.$or = [{ text: { $exists: true, $ne: null } }];
 
-    if (toolResourceSet.has(EToolResources.file_search)) {
-      filter.$or.push({ embedded: true });
-    }
-    if (toolResourceSet.has(EToolResources.execute_code)) {
-      filter.$or.push({ 'metadata.fileIdentifier': { $exists: true } });
+      if (toolResourceSet.has(EToolResources.file_search)) {
+        filter.$or.push({ embedded: true });
+      }
+      if (toolResourceSet.has(EToolResources.execute_code)) {
+        filter.$or.push({ 'metadata.fileIdentifier': { $exists: true } });
+      }
+    } else {
+      filter.text = { $exists: true, $ne: null };
     }
 
     const selectFields = { text: 0 };

--- a/api/package.json
+++ b/api/package.json
@@ -48,7 +48,7 @@
     "@langchain/google-genai": "^0.2.13",
     "@langchain/google-vertexai": "^0.2.13",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^2.4.41",
+    "@librechat/agents": "^2.4.42",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@node-saml/passport-saml": "^5.0.0",

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1014,6 +1014,7 @@ class AgentClient extends BaseClient {
       optionsOnly: true,
       overrideEndpoint: endpoint,
       overrideModel: clientOptions.model,
+      endpointOption: { model_parameters: clientOptions },
     });
 
     let provider = options.provider ?? overrideProvider ?? agent.provider;

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -677,7 +677,7 @@ class AgentClient extends BaseClient {
           hide_sequential_outputs: this.options.agent.hide_sequential_outputs,
           user: this.options.req.user,
         },
-        recursionLimit: agentsEConfig?.recursionLimit,
+        recursionLimit: agentsEConfig?.recursionLimit ?? 25,
         signal: abortController.signal,
         streamMode: 'values',
         version: 'v2',
@@ -989,6 +989,21 @@ class AgentClient extends BaseClient {
     let clientOptions = {
       maxTokens: 75,
     };
+
+    const agentModelParams = this.options.agent.model_parameters || {};
+
+    if (agentModelParams.clientOptions) {
+      clientOptions.clientOptions = { ...agentModelParams.clientOptions };
+    }
+
+    if (agentModelParams.apiKey) {
+      clientOptions.apiKey = agentModelParams.apiKey;
+    }
+
+    if (agentModelParams.anthropicApiUrl) {
+      clientOptions.anthropicApiUrl = agentModelParams.anthropicApiUrl;
+    }
+
     let endpointConfig = req.app.locals[endpoint];
     if (!endpointConfig) {
       try {

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -283,7 +283,10 @@ router.post('/', async (req, res) => {
       message += ': ' + error.message;
     }
 
-    if (error.message?.includes('Invalid file format')) {
+    if (
+      error.message?.includes('Invalid file format') ||
+      error.message?.includes('No OCR result')
+    ) {
       message = error.message;
     }
 

--- a/api/server/services/Config/getCustomConfig.js
+++ b/api/server/services/Config/getCustomConfig.js
@@ -40,6 +40,7 @@ async function getBalanceConfig() {
 /**
  *
  * @param {string | EModelEndpoint} endpoint
+ * @returns {Promise<TEndpoint | undefined>}
  */
 const getCustomEndpointConfig = async (endpoint) => {
   const customConfig = await getCustomConfig();

--- a/api/server/services/Endpoints/agents/title.js
+++ b/api/server/services/Endpoints/agents/title.js
@@ -23,7 +23,7 @@ const addTitle = async (req, { text, response, client }) => {
   let timeoutId;
   try {
     const timeoutPromise = new Promise((_, reject) => {
-      timeoutId = setTimeout(() => reject(new Error('Title generation timeout')), 25000);
+      timeoutId = setTimeout(() => reject(new Error('Title generation timeout')), 45000);
     }).catch((error) => {
       logger.error('Title error:', error);
     });

--- a/api/server/services/Endpoints/anthropic/initialize.js
+++ b/api/server/services/Endpoints/anthropic/initialize.js
@@ -41,7 +41,7 @@ const initializeClient = async ({ req, res, endpointOption, overrideModel, optio
       {
         reverseProxyUrl: ANTHROPIC_REVERSE_PROXY ?? null,
         proxy: PROXY ?? null,
-        modelOptions: endpointOption.model_parameters,
+        modelOptions: endpointOption?.model_parameters ?? {},
       },
       clientOptions,
     );

--- a/api/server/services/Endpoints/anthropic/llm.js
+++ b/api/server/services/Endpoints/anthropic/llm.js
@@ -75,6 +75,7 @@ function getLLMConfig(apiKey, options = {}) {
 
   if (options.reverseProxyUrl) {
     requestOptions.clientOptions.baseURL = options.reverseProxyUrl;
+    requestOptions.anthropicApiUrl = options.reverseProxyUrl;
   }
 
   return {

--- a/api/server/services/Endpoints/anthropic/llm.spec.js
+++ b/api/server/services/Endpoints/anthropic/llm.spec.js
@@ -252,7 +252,12 @@ describe('getLLMConfig', () => {
         reverseProxyUrl: 'https://reverse-proxy.com',
       });
 
-      expect(result.llmConfig.clientOptions).toHaveProperty('httpAgent');
+      expect(result.llmConfig.clientOptions).toHaveProperty('fetchOptions');
+      expect(result.llmConfig.clientOptions.fetchOptions).toHaveProperty('dispatcher');
+      expect(result.llmConfig.clientOptions.fetchOptions.dispatcher).toBeDefined();
+      expect(result.llmConfig.clientOptions.fetchOptions.dispatcher.constructor.name).toBe(
+        'ProxyAgent',
+      );
       expect(result.llmConfig.clientOptions).toHaveProperty('baseURL', 'https://reverse-proxy.com');
       expect(result.llmConfig).toHaveProperty('anthropicApiUrl', 'https://reverse-proxy.com');
     });

--- a/api/server/services/Endpoints/anthropic/llm.spec.js
+++ b/api/server/services/Endpoints/anthropic/llm.spec.js
@@ -1,11 +1,45 @@
-const { anthropicSettings } = require('librechat-data-provider');
+const { anthropicSettings, removeNullishValues } = require('librechat-data-provider');
 const { getLLMConfig } = require('~/server/services/Endpoints/anthropic/llm');
+const { checkPromptCacheSupport, getClaudeHeaders, configureReasoning } = require('./helpers');
 
 jest.mock('https-proxy-agent', () => ({
   HttpsProxyAgent: jest.fn().mockImplementation((proxy) => ({ proxy })),
 }));
 
+jest.mock('./helpers', () => ({
+  checkPromptCacheSupport: jest.fn(),
+  getClaudeHeaders: jest.fn(),
+  configureReasoning: jest.fn((requestOptions) => requestOptions),
+}));
+
+jest.mock('librechat-data-provider', () => ({
+  anthropicSettings: {
+    model: { default: 'claude-3-opus-20240229' },
+    maxOutputTokens: { default: 4096, reset: jest.fn(() => 4096) },
+    thinking: { default: false },
+    promptCache: { default: false },
+    thinkingBudget: { default: null },
+  },
+  removeNullishValues: jest.fn((obj) => {
+    const result = {};
+    for (const key in obj) {
+      if (obj[key] !== null && obj[key] !== undefined) {
+        result[key] = obj[key];
+      }
+    }
+    return result;
+  }),
+}));
+
 describe('getLLMConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    checkPromptCacheSupport.mockReturnValue(false);
+    getClaudeHeaders.mockReturnValue(undefined);
+    configureReasoning.mockImplementation((requestOptions) => requestOptions);
+    anthropicSettings.maxOutputTokens.reset.mockReturnValue(4096);
+  });
+
   it('should create a basic configuration with default values', () => {
     const result = getLLMConfig('test-api-key', { modelOptions: {} });
 
@@ -36,6 +70,7 @@ describe('getLLMConfig', () => {
     });
 
     expect(result.llmConfig.clientOptions).toHaveProperty('baseURL', 'http://reverse-proxy');
+    expect(result.llmConfig).toHaveProperty('anthropicApiUrl', 'http://reverse-proxy');
   });
 
   it('should include topK and topP for non-Claude-3.7 models', () => {
@@ -65,6 +100,11 @@ describe('getLLMConfig', () => {
   });
 
   it('should NOT include topK and topP for Claude-3-7 models (hyphen notation)', () => {
+    configureReasoning.mockImplementation((requestOptions) => {
+      requestOptions.thinking = { type: 'enabled' };
+      return requestOptions;
+    });
+
     const result = getLLMConfig('test-api-key', {
       modelOptions: {
         model: 'claude-3-7-sonnet',
@@ -78,6 +118,11 @@ describe('getLLMConfig', () => {
   });
 
   it('should NOT include topK and topP for Claude-3.7 models (decimal notation)', () => {
+    configureReasoning.mockImplementation((requestOptions) => {
+      requestOptions.thinking = { type: 'enabled' };
+      return requestOptions;
+    });
+
     const result = getLLMConfig('test-api-key', {
       modelOptions: {
         model: 'claude-3.7-sonnet',
@@ -153,5 +198,156 @@ describe('getLLMConfig', () => {
 
     expect(result3.llmConfig).toHaveProperty('topK', 10);
     expect(result3.llmConfig).toHaveProperty('topP', 0.9);
+  });
+
+  describe('Edge cases', () => {
+    it('should handle missing apiKey', () => {
+      const result = getLLMConfig(undefined, { modelOptions: {} });
+      expect(result.llmConfig).not.toHaveProperty('apiKey');
+    });
+
+    it('should handle empty modelOptions', () => {
+      expect(() => {
+        getLLMConfig('test-api-key', {});
+      }).toThrow("Cannot read properties of undefined (reading 'thinking')");
+    });
+
+    it('should handle no options parameter', () => {
+      expect(() => {
+        getLLMConfig('test-api-key');
+      }).toThrow("Cannot read properties of undefined (reading 'thinking')");
+    });
+
+    it('should handle temperature, stop sequences, and stream settings', () => {
+      const result = getLLMConfig('test-api-key', {
+        modelOptions: {
+          temperature: 0.7,
+          stop: ['\n\n', 'END'],
+          stream: false,
+        },
+      });
+
+      expect(result.llmConfig).toHaveProperty('temperature', 0.7);
+      expect(result.llmConfig).toHaveProperty('stopSequences', ['\n\n', 'END']);
+      expect(result.llmConfig).toHaveProperty('stream', false);
+    });
+
+    it('should handle maxOutputTokens when explicitly set to falsy value', () => {
+      anthropicSettings.maxOutputTokens.reset.mockReturnValue(8192);
+      const result = getLLMConfig('test-api-key', {
+        modelOptions: {
+          model: 'claude-3-opus',
+          maxOutputTokens: null,
+        },
+      });
+
+      expect(anthropicSettings.maxOutputTokens.reset).toHaveBeenCalledWith('claude-3-opus');
+      expect(result.llmConfig).toHaveProperty('maxTokens', 8192);
+    });
+
+    it('should handle both proxy and reverseProxyUrl', () => {
+      const result = getLLMConfig('test-api-key', {
+        modelOptions: {},
+        proxy: 'http://proxy:8080',
+        reverseProxyUrl: 'https://reverse-proxy.com',
+      });
+
+      expect(result.llmConfig.clientOptions).toHaveProperty('httpAgent');
+      expect(result.llmConfig.clientOptions).toHaveProperty('baseURL', 'https://reverse-proxy.com');
+      expect(result.llmConfig).toHaveProperty('anthropicApiUrl', 'https://reverse-proxy.com');
+    });
+
+    it('should handle prompt cache with supported model', () => {
+      checkPromptCacheSupport.mockReturnValue(true);
+      getClaudeHeaders.mockReturnValue({ 'anthropic-beta': 'prompt-caching-2024-07-31' });
+
+      const result = getLLMConfig('test-api-key', {
+        modelOptions: {
+          model: 'claude-3-5-sonnet',
+          promptCache: true,
+        },
+      });
+
+      expect(checkPromptCacheSupport).toHaveBeenCalledWith('claude-3-5-sonnet');
+      expect(getClaudeHeaders).toHaveBeenCalledWith('claude-3-5-sonnet', true);
+      expect(result.llmConfig.clientOptions.defaultHeaders).toEqual({
+        'anthropic-beta': 'prompt-caching-2024-07-31',
+      });
+    });
+
+    it('should handle thinking and thinkingBudget options', () => {
+      configureReasoning.mockImplementation((requestOptions, systemOptions) => {
+        if (systemOptions.thinking) {
+          requestOptions.thinking = { type: 'enabled' };
+        }
+        if (systemOptions.thinkingBudget) {
+          requestOptions.thinking = {
+            ...requestOptions.thinking,
+            budget_tokens: systemOptions.thinkingBudget,
+          };
+        }
+        return requestOptions;
+      });
+
+      getLLMConfig('test-api-key', {
+        modelOptions: {
+          model: 'claude-3-7-sonnet',
+          thinking: true,
+          thinkingBudget: 5000,
+        },
+      });
+
+      expect(configureReasoning).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          thinking: true,
+          promptCache: false,
+          thinkingBudget: 5000,
+        }),
+      );
+    });
+
+    it('should remove system options from modelOptions', () => {
+      const modelOptions = {
+        model: 'claude-3-opus',
+        thinking: true,
+        promptCache: true,
+        thinkingBudget: 1000,
+        temperature: 0.5,
+      };
+
+      getLLMConfig('test-api-key', { modelOptions });
+
+      expect(modelOptions).not.toHaveProperty('thinking');
+      expect(modelOptions).not.toHaveProperty('promptCache');
+      expect(modelOptions).not.toHaveProperty('thinkingBudget');
+      expect(modelOptions).toHaveProperty('temperature', 0.5);
+    });
+
+    it('should handle all nullish values removal', () => {
+      removeNullishValues.mockImplementation((obj) => {
+        const cleaned = {};
+        Object.entries(obj).forEach(([key, value]) => {
+          if (value !== null && value !== undefined) {
+            cleaned[key] = value;
+          }
+        });
+        return cleaned;
+      });
+
+      const result = getLLMConfig('test-api-key', {
+        modelOptions: {
+          temperature: null,
+          topP: undefined,
+          topK: 0,
+          stop: [],
+        },
+      });
+
+      expect(result.llmConfig).not.toHaveProperty('temperature');
+      expect(result.llmConfig).not.toHaveProperty('topP');
+      expect(result.llmConfig).toHaveProperty('topK', 0);
+      expect(result.llmConfig).toHaveProperty('stopSequences', []);
+    });
   });
 });

--- a/api/server/services/Endpoints/bedrock/options.js
+++ b/api/server/services/Endpoints/bedrock/options.js
@@ -64,7 +64,7 @@ const getOptions = async ({ req, overrideModel, endpointOption }) => {
 
   /** @type {BedrockClientOptions} */
   const requestOptions = {
-    model: overrideModel ?? endpointOption.model,
+    model: overrideModel ?? endpointOption?.model,
     region: BEDROCK_AWS_DEFAULT_REGION,
   };
 
@@ -76,7 +76,7 @@ const getOptions = async ({ req, overrideModel, endpointOption }) => {
 
   const llmConfig = bedrockOutputParser(
     bedrockInputParser.parse(
-      removeNullishValues(Object.assign(requestOptions, endpointOption.model_parameters)),
+      removeNullishValues(Object.assign(requestOptions, endpointOption?.model_parameters ?? {})),
     ),
   );
 

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -134,7 +134,7 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
   };
 
   if (optionsOnly) {
-    const modelOptions = endpointOption.model_parameters;
+    const modelOptions = endpointOption?.model_parameters ?? {};
     if (endpoint !== Providers.OLLAMA) {
       clientOptions = Object.assign(
         {

--- a/api/server/services/Endpoints/google/initialize.js
+++ b/api/server/services/Endpoints/google/initialize.js
@@ -18,7 +18,7 @@ const initializeClient = async ({ req, res, endpointOption, overrideModel, optio
   let serviceKey = {};
   try {
     serviceKey = require('~/data/auth.json');
-  } catch (e) {
+  } catch (_e) {
     // Do nothing
   }
 
@@ -58,7 +58,7 @@ const initializeClient = async ({ req, res, endpointOption, overrideModel, optio
   if (optionsOnly) {
     clientOptions = Object.assign(
       {
-        modelOptions: endpointOption.model_parameters,
+        modelOptions: endpointOption?.model_parameters ?? {},
       },
       clientOptions,
     );

--- a/api/server/services/Endpoints/index.js
+++ b/api/server/services/Endpoints/index.js
@@ -1,0 +1,58 @@
+const { Providers } = require('@librechat/agents');
+const { EModelEndpoint } = require('librechat-data-provider');
+const initAnthropic = require('~/server/services/Endpoints/anthropic/initialize');
+const getBedrockOptions = require('~/server/services/Endpoints/bedrock/options');
+const initOpenAI = require('~/server/services/Endpoints/openAI/initialize');
+const initCustom = require('~/server/services/Endpoints/custom/initialize');
+const initGoogle = require('~/server/services/Endpoints/google/initialize');
+const { getCustomEndpointConfig } = require('~/server/services/Config');
+
+const providerConfigMap = {
+  [Providers.XAI]: initCustom,
+  [Providers.OLLAMA]: initCustom,
+  [Providers.DEEPSEEK]: initCustom,
+  [Providers.OPENROUTER]: initCustom,
+  [EModelEndpoint.openAI]: initOpenAI,
+  [EModelEndpoint.google]: initGoogle,
+  [EModelEndpoint.azureOpenAI]: initOpenAI,
+  [EModelEndpoint.anthropic]: initAnthropic,
+  [EModelEndpoint.bedrock]: getBedrockOptions,
+};
+
+/**
+ * Get the provider configuration and override endpoint based on the provider string
+ * @param {string} provider - The provider string
+ * @returns {Promise<{
+ * getOptions: Function,
+ * overrideProvider?: string,
+ * customEndpointConfig?: TEndpoint
+ * }>}
+ */
+async function getProviderConfig(provider) {
+  let getOptions = providerConfigMap[provider];
+  let overrideProvider;
+  /** @type {TEndpoint | undefined} */
+  let customEndpointConfig;
+
+  if (!getOptions && providerConfigMap[provider.toLowerCase()] != null) {
+    overrideProvider = provider.toLowerCase();
+    getOptions = providerConfigMap[overrideProvider];
+  } else if (!getOptions) {
+    customEndpointConfig = await getCustomEndpointConfig(provider);
+    if (!customEndpointConfig) {
+      throw new Error(`Provider ${provider} not supported`);
+    }
+    getOptions = initCustom;
+    overrideProvider = Providers.OPENAI;
+  }
+
+  return {
+    getOptions,
+    overrideProvider,
+    customEndpointConfig,
+  };
+}
+
+module.exports = {
+  getProviderConfig,
+};

--- a/api/server/services/Endpoints/openAI/initialize.js
+++ b/api/server/services/Endpoints/openAI/initialize.js
@@ -138,7 +138,7 @@ const initializeClient = async ({
   }
 
   if (optionsOnly) {
-    const modelOptions = endpointOption.model_parameters;
+    const modelOptions = endpointOption?.model_parameters ?? {};
     modelOptions.model = modelName;
     clientOptions = Object.assign({ modelOptions }, clientOptions);
     clientOptions.modelOptions.user = req.user.id;

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@langchain/google-genai": "^0.2.13",
         "@langchain/google-vertexai": "^0.2.13",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^2.4.41",
+        "@librechat/agents": "^2.4.42",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@node-saml/passport-saml": "^5.0.0",
@@ -1349,6 +1349,33 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "api/node_modules/@librechat/agents": {
+      "version": "2.4.42",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.42.tgz",
+      "integrity": "sha512-52ux2PeEAV79yr6/h6GN3omlpqX6H0FYl6qwjJ6gT04MMko/imnLd3bQrX0gm3i0KL5ygHbRjQeonONKjJayHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@langchain/anthropic": "^0.3.23",
+        "@langchain/aws": "^0.1.11",
+        "@langchain/community": "^0.3.47",
+        "@langchain/core": "^0.3.60",
+        "@langchain/deepseek": "^0.0.2",
+        "@langchain/google-genai": "^0.2.13",
+        "@langchain/google-vertexai": "^0.2.13",
+        "@langchain/langgraph": "^0.3.4",
+        "@langchain/mistralai": "^0.2.1",
+        "@langchain/ollama": "^0.2.3",
+        "@langchain/openai": "^0.5.14",
+        "@langchain/xai": "^0.0.3",
+        "cheerio": "^1.0.0",
+        "dotenv": "^16.4.7",
+        "https-proxy-agent": "^7.0.6",
+        "nanoid": "^3.3.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "api/node_modules/@smithy/abort-controller": {
@@ -19440,6 +19467,7 @@
       "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.41.tgz",
       "integrity": "sha512-kYmdk5WVRp0qZxTx6BuGCs4l0Ir9iBLLx4ZY4/1wxr80al5/vq3P8wbgGdKMeO2qTu4ZaT4RyWRQYWBg5HDkUQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@langchain/anthropic": "^0.3.23",
         "@langchain/aws": "^0.1.11",
@@ -19467,6 +19495,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.3.47.tgz",
       "integrity": "sha512-Vo42kAfkXpTFSevhEkeqqE55az8NyQgDktCbitXYuhipNbFYx08XVvqEDkFkB20MM/Z7u+cvLb+DxCqnKuH0CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@langchain/openai": ">=0.2.0 <0.6.0",
         "@langchain/weaviate": "^0.2.0",
@@ -19992,6 +20021,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.5.14.tgz",
       "integrity": "sha512-0GEj5K/qi1MRuZ4nE7NvyI4jTG+RSewLZqsExUwRukWdeqmkPNHGrogTa5ZDt7eaJxAaY7EgLC5ZnvCM3L1oug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "js-tiktoken": "^1.0.12",
         "openai": "^5.3.0",
@@ -20009,6 +20039,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -20018,6 +20049,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -20031,6 +20063,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-5.5.1.tgz",
       "integrity": "sha512-5i19097mGotHA1eFsM6Tjd/tJ8uo9sa5Ysv4Q6bKJ2vtN6rc0MzMrUefXnLXYAJcmMQrC1Efhj0AvfIkXrQamw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -20056,6 +20089,7 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/packages/api/src/files/mistral/crud.ts
+++ b/packages/api/src/files/mistral/crud.ts
@@ -353,7 +353,11 @@ export const uploadMistralOCR = async (context: OCRContext): Promise<MistralOCRU
       documentType,
     });
 
-    // Process result
+    if (!ocrResult || !ocrResult.pages || ocrResult.pages.length === 0) {
+      throw new Error(
+        'No OCR result returned from service, may be down or the file is not supported.',
+      );
+    }
     const { text, images } = processOCRResult(ocrResult);
 
     return {
@@ -400,6 +404,12 @@ export const uploadAzureMistralOCR = async (
       url: `${base64Prefix}${base64}`,
       documentType,
     });
+
+    if (!ocrResult || !ocrResult.pages || ocrResult.pages.length === 0) {
+      throw new Error(
+        'No OCR result returned from service, may be down or the file is not supported.',
+      );
+    }
 
     const { text, images } = processOCRResult(ocrResult);
 

--- a/packages/api/src/files/mistral/crud.ts
+++ b/packages/api/src/files/mistral/crud.ts
@@ -368,7 +368,7 @@ export const uploadMistralOCR = async (context: OCRContext): Promise<MistralOCRU
       images,
     };
   } catch (error) {
-    throw createOCRError(error, 'Error uploading document to Mistral OCR API');
+    throw createOCRError(error, 'Error uploading document to Mistral OCR API:');
   }
 };
 
@@ -421,6 +421,6 @@ export const uploadAzureMistralOCR = async (
       images,
     };
   } catch (error) {
-    throw createOCRError(error, 'Error uploading document to Azure Mistral OCR API');
+    throw createOCRError(error, 'Error uploading document to Azure Mistral OCR API:');
   }
 };


### PR DESCRIPTION
## Summary

Closes #7162


- Refactored agent endpoint/provider backend selection logic by introducing a centralized getProviderConfig utility.
- Streamlined AgentClient configuration for title generation, ensuring correct handling of client options and model parameters.
- Updated @librechat/agents to ^2.4.42 for up-to-date agent features.
  - includes consolidated structured output for title generation to limit amount of LLM calls
- Improved test coverage for `getLLMConfig` including additional edge cases, property assertions for fetchOptions and dispatcher, and prompt cache support.


### Other Changes
- Increased title generation timeout from 25s to 45s
- Added abort handler using AbortSignal for both OpenAI image generation and image editing, ensuring proper cleanup of listeners.
- Updated endpoint initializations to use optional chaining and default empty objects for modelOptions, reducing potential runtime errors.
- fixed an issue where openai style usage metadata was not applying correctly after title generations
- Added type annotation for getCustomEndpointConfig for clarity.
- Improved Mistral OCR error messages served to frontend
- Fixed an issue with tool resource file querying via `getToolFilesByIds` where non-resource files were being fetched for resource handling
   - This led to an edge case where OCR files were completely ignored.
   - also caused image files to always be attached to the latest message

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Chore (dependency/version update, code quality improvements)
- [x] Refactor (code update for clarity or maintainability)
- [x] Test (increases coverage or improves reliability)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes