### PR TITLE
🔧 fix: User Placeholders in Headers for Custom Endpoints

### DIFF
--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -4,10 +4,9 @@ const {
   envVarRegex,
   FetchTokenConfig,
   extractEnvVariable,
-  resolveHeaders,
 } = require('librechat-data-provider');
 const { Providers } = require('@librechat/agents');
-const { getOpenAIConfig, createHandleLLMNewToken } = require('@librechat/api');
+const { getOpenAIConfig, createHandleLLMNewToken, resolveHeaders } = require('@librechat/api');
 const { getUserKeyValues, checkUserKeyExpiry } = require('~/server/services/UserService');
 const { getCustomEndpointConfig } = require('~/server/services/Config');
 const { fetchModels } = require('~/server/services/ModelService');

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -4,6 +4,7 @@ const {
   envVarRegex,
   FetchTokenConfig,
   extractEnvVariable,
+  resolveHeaders,
 } = require('librechat-data-provider');
 const { Providers } = require('@librechat/agents');
 const { getOpenAIConfig, createHandleLLMNewToken } = require('@librechat/api');
@@ -28,12 +29,7 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
   const CUSTOM_API_KEY = extractEnvVariable(endpointConfig.apiKey);
   const CUSTOM_BASE_URL = extractEnvVariable(endpointConfig.baseURL);
 
-  let resolvedHeaders = {};
-  if (endpointConfig.headers && typeof endpointConfig.headers === 'object') {
-    Object.keys(endpointConfig.headers).forEach((key) => {
-      resolvedHeaders[key] = extractEnvVariable(endpointConfig.headers[key]);
-    });
-  }
+  let resolvedHeaders = resolveHeaders(endpointConfig.headers, req.user);
 
   if (CUSTOM_API_KEY.match(envVarRegex)) {
     throw new Error(`Missing API Key for ${endpoint}.`);


### PR DESCRIPTION
## Summary
Fixed custom endpoint headers not actually resolving user placeholders due to forgetting to swap out `extractEnvVariable` for `resolveHeaders` function in `initialize.js` for custom endpoints.

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Verified fix by configuring Portkey custom endpoint with `{{LIBRECHAT_USER_EMAIL}}` and `{{LIBRECHAT_USER_ID}}` placeholder and confirming in Portkey dashboard analytics that actual user details are being sent instead of placeholder strings once the change was made.
<div align=center>
<img width="496" alt="Screenshot 2025-06-24 at 12 04 49 AM" src="https://github.com/user-attachments/assets/517a148f-346a-4ae2-8dfc-54e6357b81fb" />
<p><em>Portkey Analytics dashboard reflecting the previously unresolved and now correctly resolved user placeholders being passed in headers</em></p>
</div>

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes