### PR TITLE
🐛 fix: Support Bedrock Provider for MCP Image Content Rendering

### DIFF
--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -7,6 +7,7 @@ const RECOGNIZED_PROVIDERS = new Set([
   'xai',
   'deepseek',
   'ollama',
+  'bedrock',
 ]);
 const CONTENT_ARRAY_PROVIDERS = new Set(['google', 'anthropic', 'openai']);
 


### PR DESCRIPTION
## Summary

This PR fixes MCP image content rendering for 'bedrock' provider. Without the fix the image content is rendered as plaintext since for unknown providers the formatToolContent function just [fallbacks to stringifying](https://github.com/danny-avila/LibreChat/blob/0587a1cc7ca7c9d206e5402ca46fc201cfe081bd/packages/api/src/mcp/parsers.ts#L101) whatever it gets.

Just adding bedrock as known [recognized provider](https://github.com/danny-avila/LibreChat/blob/0587a1cc7ca7c9d206e5402ca46fc201cfe081bd/packages/api/src/mcp/parsers.ts#L2) fixes image content formatting and rendering in UI.

This is also related to conversation #7798 

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Used whichever MCP server that generates image content according to [MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts#image-content), like [pupeteer](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/puppeteer) .

### **Test Configuration**:

- Anthropic's Claude 3 Haiku through AWS Bedrock
- MCP server providing image content

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
