### PR TITLE
🤖 fix: Remove `versions` and `__v` when Duplicating an Agent

### DIFF
--- a/api/server/controllers/agents/__tests__/v1.spec.js
+++ b/api/server/controllers/agents/__tests__/v1.spec.js
@@ -1,0 +1,195 @@
+const { duplicateAgent } = require('../v1');
+const { getAgent, createAgent } = require('~/models/Agent');
+const { getActions } = require('~/models/Action');
+const { nanoid } = require('nanoid');
+
+jest.mock('~/models/Agent');
+jest.mock('~/models/Action');
+jest.mock('nanoid');
+
+describe('duplicateAgent', () => {
+  let req, res;
+
+  beforeEach(() => {
+    req = {
+      params: { id: 'agent_123' },
+      user: { id: 'user_456' },
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    jest.clearAllMocks();
+  });
+
+  it('should duplicate an agent successfully', async () => {
+    const mockAgent = {
+      id: 'agent_123',
+      name: 'Test Agent',
+      description: 'Test Description',
+      instructions: 'Test Instructions',
+      provider: 'openai',
+      model: 'gpt-4',
+      tools: ['file_search'],
+      actions: [],
+      author: 'user_789',
+      versions: [{ name: 'Test Agent', version: 1 }],
+      __v: 0,
+    };
+
+    const mockNewAgent = {
+      id: 'agent_new_123',
+      name: 'Test Agent (1/2/23, 12:34)',
+      description: 'Test Description',
+      instructions: 'Test Instructions',
+      provider: 'openai',
+      model: 'gpt-4',
+      tools: ['file_search'],
+      actions: [],
+      author: 'user_456',
+      versions: [
+        {
+          name: 'Test Agent (1/2/23, 12:34)',
+          description: 'Test Description',
+          instructions: 'Test Instructions',
+          provider: 'openai',
+          model: 'gpt-4',
+          tools: ['file_search'],
+          actions: [],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    };
+
+    getAgent.mockResolvedValue(mockAgent);
+    getActions.mockResolvedValue([]);
+    nanoid.mockReturnValue('new_123');
+    createAgent.mockResolvedValue(mockNewAgent);
+
+    await duplicateAgent(req, res);
+
+    expect(getAgent).toHaveBeenCalledWith({ id: 'agent_123' });
+    expect(getActions).toHaveBeenCalledWith({ agent_id: 'agent_123' }, true);
+    expect(createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'agent_new_123',
+        author: 'user_456',
+        name: expect.stringContaining('Test Agent ('),
+        description: 'Test Description',
+        instructions: 'Test Instructions',
+        provider: 'openai',
+        model: 'gpt-4',
+        tools: ['file_search'],
+        actions: [],
+      }),
+    );
+
+    expect(createAgent).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        versions: expect.anything(),
+        __v: expect.anything(),
+      }),
+    );
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      agent: mockNewAgent,
+      actions: [],
+    });
+  });
+
+  it('should ensure duplicated agent has clean versions array without nested fields', async () => {
+    const mockAgent = {
+      id: 'agent_123',
+      name: 'Test Agent',
+      description: 'Test Description',
+      versions: [
+        {
+          name: 'Test Agent',
+          versions: [{ name: 'Nested' }],
+          __v: 1,
+        },
+      ],
+      __v: 2,
+    };
+
+    const mockNewAgent = {
+      id: 'agent_new_123',
+      name: 'Test Agent (1/2/23, 12:34)',
+      description: 'Test Description',
+      versions: [
+        {
+          name: 'Test Agent (1/2/23, 12:34)',
+          description: 'Test Description',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    };
+
+    getAgent.mockResolvedValue(mockAgent);
+    getActions.mockResolvedValue([]);
+    nanoid.mockReturnValue('new_123');
+    createAgent.mockResolvedValue(mockNewAgent);
+
+    await duplicateAgent(req, res);
+
+    expect(mockNewAgent.versions).toHaveLength(1);
+
+    const firstVersion = mockNewAgent.versions[0];
+    expect(firstVersion).not.toHaveProperty('versions');
+    expect(firstVersion).not.toHaveProperty('__v');
+
+    expect(mockNewAgent).not.toHaveProperty('__v');
+
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('should return 404 if agent not found', async () => {
+    getAgent.mockResolvedValue(null);
+
+    await duplicateAgent(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Agent not found',
+      status: 'error',
+    });
+  });
+
+  it('should handle tool_resources.ocr correctly', async () => {
+    const mockAgent = {
+      id: 'agent_123',
+      name: 'Test Agent',
+      tool_resources: {
+        ocr: { enabled: true, config: 'test' },
+        other: { should: 'not be copied' },
+      },
+    };
+
+    getAgent.mockResolvedValue(mockAgent);
+    getActions.mockResolvedValue([]);
+    nanoid.mockReturnValue('new_123');
+    createAgent.mockResolvedValue({ id: 'agent_new_123' });
+
+    await duplicateAgent(req, res);
+
+    expect(createAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool_resources: {
+          ocr: { enabled: true, config: 'test' },
+        },
+      }),
+    );
+  });
+
+  it('should handle errors gracefully', async () => {
+    getAgent.mockRejectedValue(new Error('Database error'));
+
+    await duplicateAgent(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Database error' });
+  });
+});

--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -242,6 +242,8 @@ const duplicateAgentHandler = async (req, res) => {
       createdAt: _createdAt,
       updatedAt: _updatedAt,
       tool_resources: _tool_resources = {},
+      versions: _versions,
+      __v: _v,
       ...cloneData
     } = agent;
     cloneData.name = `${agent.name} (${new Date().toLocaleString('en-US', {


### PR DESCRIPTION
## Summary

Fixed an issue where duplicating an agent would incorrectly include the original agent's version history (`versions` array) and Mongoose version key (`__v`) in the duplicated agent's data. This caused a nested version structure where the new agent's first version entry contained the entire version history from the original agent.

The fix ensures that when duplicating an agent, the `versions` and `__v` fields are properly excluded from the cloned data, allowing the new agent to start with a clean version history.

Reference discussion comment: https://github.com/danny-avila/LibreChat/discussions/8053#discussioncomment-13577157

cc: @benverhees 

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Create an agent with version history:
  - Create a new agent in the UI
  - Make several edits to the agent (change name, description, model, etc.) to build up version history
  - Note the agent's current version number
2. Duplicate the agent:
  - In the Agents side panel, locate your agent
  - Click the duplicate/copy icon button (only visible if you're the agent's author)
  - The duplicated agent should appear with a timestamp appended to its name
3. Verify the fix:
  - Open the duplicated agent's settings
  - Make a change (e.g., update the description) to create a new version
  - Check that the agent's version history shows only the `versions` created after duplication
  - The duplicated agent should start fresh without inheriting the original's version history
4. Database verification (optional):
  - Query the agents collection in MongoDB
  - Verify the duplicated agent has a clean versions array with no nested version data
  - Confirm there's no `__v` field nested within the version entries

### Expected behavior:
- Duplicated agents start with a clean version history
- No nested `versions` or `__v` fields in the version entries
- Version count starts fresh for the duplicated agent

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

## Copilot Summary

This pull request introduces a new test suite for the `duplicateAgent` function and includes a minor adjustment to the `duplicateAgentHandler` function to ensure proper handling of agent versions during duplication. The changes focus on improving test coverage, ensuring data consistency, and handling edge cases.

### New test suite for `duplicateAgent`:

* Added a comprehensive test suite in `api/server/controllers/agents/__tests__/v1.spec.js` to validate the behavior of the `duplicateAgent` function. Tests cover successful duplication, handling of nested fields in agent versions, error scenarios (e.g., agent not found, database errors), and proper copying of specific fields like `tool_resources.ocr`.

### Adjustment to `duplicateAgentHandler`:

* Updated the destructuring in `duplicateAgentHandler` (`api/server/controllers/agents/v1.js`) to explicitly exclude `_versions` and `_v` fields from the cloned agent data, ensuring these fields are not inadvertently carried over during duplication.