### PR TITLE
🛂 fix: Reuse OpenID Auth Tokens with Proxy Setup

### DIFF
--- a/api/strategies/openIdJwtStrategy.js
+++ b/api/strategies/openIdJwtStrategy.js
@@ -15,17 +15,16 @@ const { isEnabled } = require('~/server/utils');
  * The JWT is then verified using the signing key, and the user is retrieved from the database.
  */
 const openIdJwtLogin = (openIdConfig) => {
-
   let jwksRsaOptions = {
     cache: isEnabled(process.env.OPENID_JWKS_URL_CACHE_ENABLED) || true,
     cacheMaxAge: process.env.OPENID_JWKS_URL_CACHE_TIME
-        ? eval(process.env.OPENID_JWKS_URL_CACHE_TIME)
-        : 60000,
+      ? eval(process.env.OPENID_JWKS_URL_CACHE_TIME)
+      : 60000,
     jwksUri: openIdConfig.serverMetadata().jwks_uri,
   };
 
   if (process.env.PROXY) {
-    jwksRsaOptions.requestAgent = new HttpsProxyAgent(process.env.PROXY)
+    jwksRsaOptions.requestAgent = new HttpsProxyAgent(process.env.PROXY);
   }
 
   return new JwtStrategy(
@@ -56,6 +55,6 @@ const openIdJwtLogin = (openIdConfig) => {
       }
     },
   );
-}
+};
 
 module.exports = openIdJwtLogin;

--- a/api/strategies/openIdJwtStrategy.js
+++ b/api/strategies/openIdJwtStrategy.js
@@ -1,4 +1,5 @@
 const { SystemRoles } = require('librechat-data-provider');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 const { Strategy: JwtStrategy, ExtractJwt } = require('passport-jwt');
 const { updateUser, findUser } = require('~/models');
 const { logger } = require('~/config');
@@ -13,17 +14,24 @@ const { isEnabled } = require('~/server/utils');
  * The strategy extracts the JWT from the Authorization header as a Bearer token.
  * The JWT is then verified using the signing key, and the user is retrieved from the database.
  */
-const openIdJwtLogin = (openIdConfig) =>
-  new JwtStrategy(
+const openIdJwtLogin = (openIdConfig) => {
+
+  let jwksRsaOptions = {
+    cache: isEnabled(process.env.OPENID_JWKS_URL_CACHE_ENABLED) || true,
+    cacheMaxAge: process.env.OPENID_JWKS_URL_CACHE_TIME
+        ? eval(process.env.OPENID_JWKS_URL_CACHE_TIME)
+        : 60000,
+    jwksUri: openIdConfig.serverMetadata().jwks_uri,
+  };
+
+  if (process.env.PROXY) {
+    jwksRsaOptions.requestAgent = new HttpsProxyAgent(process.env.PROXY)
+  }
+
+  return new JwtStrategy(
     {
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKeyProvider: jwksRsa.passportJwtSecret({
-        cache: isEnabled(process.env.OPENID_JWKS_URL_CACHE_ENABLED) || true,
-        cacheMaxAge: process.env.OPENID_JWKS_URL_CACHE_TIME
-          ? eval(process.env.OPENID_JWKS_URL_CACHE_TIME)
-          : 60000,
-        jwksUri: openIdConfig.serverMetadata().jwks_uri,
-      }),
+      secretOrKeyProvider: jwksRsa.passportJwtSecret(jwksRsaOptions),
     },
     async (payload, done) => {
       try {
@@ -48,5 +56,6 @@ const openIdJwtLogin = (openIdConfig) =>
       }
     },
   );
+}
 
 module.exports = openIdJwtLogin;

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -49,7 +49,7 @@ async function customFetch(url, options) {
       logger.info(`[openidStrategy] proxy agent configured: ${process.env.PROXY}`);
       fetchOptions = {
         ...options,
-        dispatcher: new HttpsProxyAgent(process.env.PROXY),
+        dispatcher: new undici.ProxyAgent(process.env.PROXY),
       };
     }
 


### PR DESCRIPTION

## Summary

Provides proxy support for jwt token reuse.

- fixes the openid Strategy
- fixes the openid jwt strategy (jwksRsa fetching in a proxy environment)


## Change Type

Please delete any irrelevant options.

- Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

Local test via docker-compose.


## Checklist

Please delete any irrelevant options.

- My code adheres to this project's style guidelines
- I have performed a self-review of my own code
- My changes do not introduce new warnings
