### PR TITLE
🧠 fix: Prevent Memory Errors with Buffer String

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -525,7 +525,10 @@ class AgentClient extends BaseClient {
           messagesToProcess = [...messages.slice(-messageWindowSize)];
         }
       }
-      return await this.processMemory(messagesToProcess);
+
+      const bufferString = getBufferString(messagesToProcess);
+      const bufferMessage = new HumanMessage(`# Current Chat:\n\n${bufferString}`);
+      return await this.processMemory([bufferMessage]);
     } catch (error) {
       logger.error('Memory Agent failed to process memory', error);
     }


### PR DESCRIPTION
## Summary

I resolved memory-related errors by using a buffer string when processing messages for agent memory routines.

- Constructed a buffer string from the list of recent messages using `getBufferString`
- Created a single `HumanMessage` containing the current chat history as a string, ensuring consistent input formatting
- Updated call to `processMemory` to accept a single buffer message array, reducing risk of malformed memory input exceptions

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes