### PR TITLE
Helm: Pass custom envFrom to deployments

### DIFF
--- a/helm/librechat-rag-api/Chart.yaml
+++ b/helm/librechat-rag-api/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/librechat-rag-api/templates/rag-deployment.yaml
+++ b/helm/librechat-rag-api/templates/rag-deployment.yaml
@@ -45,6 +45,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:
+          {{- with .Values.rag.envFrom }} 
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
           - configMapRef:
               name: {{ include "rag.fullname" $ }}-config
           {{- if .Values.rag.existingSecret }}

--- a/helm/librechat-rag-api/values.yaml
+++ b/helm/librechat-rag-api/values.yaml
@@ -3,6 +3,7 @@
 rag:
   enabled: true
   existingSecret: ''
+  envFrom: []
   configEnv:
     DB_PORT: '5432'
     EMBEDDINGS_PROVIDER: openai

--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -36,6 +36,6 @@ dependencies:
     condition: meilisearch.enabled
     repository: "https://meilisearch.github.io/meilisearch-kubernetes"
   - name: librechat-rag-api
-    version: "0.5.2"
+    version: "0.6.0"
     condition: librechat-rag-api.enabled
     repository: file://../librechat-rag-api

--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.9
+version: 1.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/librechat/templates/deployment.yaml
+++ b/helm/librechat/templates/deployment.yaml
@@ -65,6 +65,9 @@ spec:
           {{- toYaml .Values.volumeMounts | nindent 10 }}
           {{- end }}
           envFrom:
+          {{- with .Values.librechat.envFrom }}
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
           - configMapRef:
               name: {{ include "librechat.fullname" $ }}-configenv
           {{- if .Values.global.librechat.existingSecretName }}

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -17,6 +17,8 @@ global:
     existingSecretApiKey: OPENAI_API_KEY
 
 librechat:
+  envFrom: []
+
   configEnv:
     PLUGIN_MODELS: gpt-4,gpt-4-turbo-preview,gpt-4-0125-preview,gpt-4-1106-preview,gpt-4-0613,gpt-3.5-turbo,gpt-3.5-turbo-0125,gpt-3.5-turbo-1106,gpt-3.5-turbo-0613
     DEBUG_PLUGINS: "true"


### PR DESCRIPTION
## Summary
There are scenarios where a single source for environment variables isn’t enough. To accommodate deployments that need to pull variables from multiple places, this PR introduces global.librechat.envFrom in values.yaml. Chart users can now list any number of envFrom entries (ConfigMaps, Secrets, etc.) there, and the array is forwarded to the Deployment so the pod picks them up automatically.

## Change Type
- [x] New feature (non-breaking change which adds functionality)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:
- I configured test envFrom's in env and executed helm template.
Here's result in librechat Deployment:
<img width="622" alt="image" src="https://github.com/user-attachments/assets/f9a31cd4-f7ac-4ad8-bd8e-c51100476e0f" />

Here's result in librechat-librechat-rag-api-rag Deployment:
<img width="469" alt="image" src="https://github.com/user-attachments/assets/354ba6f1-78a0-4a4d-a1fc-b362daadbbce" />




## Checklist

Please delete any irrelevant options.

- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
