### PR TITLE
feat: update terms pop-up to include a `Don't show again` checkbox

### DIFF
--- a/client/src/components/ui/TermsAndConditionsModal.tsx
+++ b/client/src/components/ui/TermsAndConditionsModal.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import type { TTermsOfService } from 'librechat-data-provider';
 import MarkdownLite from '~/components/Chat/Messages/Content/MarkdownLite';
 import DialogTemplate from '~/components/ui/DialogTemplate';
 import { useAcceptTermsMutation } from '~/data-provider';
 import { useToastContext } from '~/Providers';
-import { OGDialog } from '~/components/ui';
+import { OGDialog, Checkbox } from '~/components/ui';
 import { useLocalize } from '~/hooks';
 
 const TermsAndConditionsModal = ({
@@ -25,6 +25,8 @@ const TermsAndConditionsModal = ({
 }) => {
   const localize = useLocalize();
   const { showToast } = useToastContext();
+  const [dontShowAgain, setDontShowAgain] = useState(false);
+
   const acceptTermsMutation = useAcceptTermsMutation({
     onSuccess: () => {
       onAccept();
@@ -36,7 +38,10 @@ const TermsAndConditionsModal = ({
   });
 
   const handleAccept = () => {
-    acceptTermsMutation.mutate();
+    if (dontShowAgain) {
+      acceptTermsMutation.mutate();
+    }
+    onOpenChange(false);
   };
 
   const handleDecline = () => {
@@ -101,6 +106,15 @@ const TermsAndConditionsModal = ({
             >
               {localize('com_ui_accept')}
             </button>
+            <Checkbox
+              id="dont-show-again"
+              checked={dontShowAgain}
+              onCheckedChange={(value) => setDontShowAgain(value === true)}
+              className="mt-4 flex items-center"
+            />
+            <label htmlFor="dont-show-again" className="text-sm mt-2 flex items-center text-gray-600 dark:text-gray-200">
+              {localize('com_ui_dont_show')}
+            </label>
           </>
         }
       />

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -710,6 +710,7 @@
   "com_ui_deselect_all": "Deselect All",
   "com_ui_detailed": "Detailed",
   "com_ui_disabling": "Disabling...",
+  "com_ui_dont_show": "Don’t show again",
   "com_ui_download": "Download",
   "com_ui_download_artifact": "Download Artifact",
   "com_ui_download_backup": "Download Backup Codes",


### PR DESCRIPTION
## Summary

Enhanced the Terms pop-up functionality with the following updates:

- Added a “**Don’t show again**” checkbox.
- Updated button behavior:
    - "**I do not accept**" = Logout and display pop-up on next login.
    - "**I accept**" = Close pop-up, reappears on next login.
    - "**I accept" + "Don't show again**" checkbox = Permanently dismiss pop-up.

<img src="https://github.com/user-attachments/assets/7bbe7e9f-a8b0-4722-b2b4-dcf1bf783238" alt="image" width=65%/>

---
We use the Terms pop-up not only for the Terms of Service but also to communicate important updates, such as new features, model changes, or version upgrades. This change allows users to control whether they want to see the pop-up again in future sessions.

If users have already read and acknowledged the content, they can choose not to be prompted repeatedly by selecting “**Don’t show again**”. On the other hand, users who wish to revisit important updates can simply leave the box unchecked to receive the reminder again at their next login.

This flexibility has been especially useful for many of our users, including those at educational institutions, who appreciate having control over how often they’re shown these updates.


## Change Type

Please delete any irrelevant options.


- [x] New feature (non-breaking change which adds functionality)
- [x] Translation update

## Testing

Manually tested by clicking through all combinations of buttons and checkbox states to ensure expected behavior is applied on the next login.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
