### PR TITLE
📦 chore: bump `@modelcontextprotocol/sdk` to `1.13.3` and cleanup `mcp/connection.ts`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20317,9 +20317,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.3.tgz",
-      "integrity": "sha512-DyVYSOafBvk3/j1Oka4z5BWT8o4AFmoNyZY9pALOm7Lh3GZglR71Co4r4dEUoqDWdDazIZQHBe7J2Nwkg6gHgQ==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.3.tgz",
+      "integrity": "sha512-bGwA78F/U5G2jrnsdRkPY3IwIwZeWUEfb5o764b79lb0rJmMT76TLwKhdNZOWakOQtedYefwIR4emisEMvInKA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -20328,6 +20328,7 @@
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
         "pkce-challenge": "^5.0.0",
@@ -46568,7 +46569,7 @@
       "peerDependencies": {
         "@librechat/agents": "^2.4.46",
         "@librechat/data-schemas": "*",
-        "@modelcontextprotocol/sdk": "^1.12.3",
+        "@modelcontextprotocol/sdk": "^1.13.3",
         "axios": "^1.8.2",
         "diff": "^7.0.0",
         "eventsource": "^3.0.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -71,7 +71,7 @@
   "peerDependencies": {
     "@librechat/agents": "^2.4.46",
     "@librechat/data-schemas": "*",
-    "@modelcontextprotocol/sdk": "^1.12.3",
+    "@modelcontextprotocol/sdk": "^1.13.3",
     "axios": "^1.8.2",
     "diff": "^7.0.0",
     "eventsource": "^3.0.2",


### PR DESCRIPTION
# Pull Request Template
## Summary

This PR updates `@modelcontextprotocol/sdk` to `>1.13.3`.
The main goal is to pick up [this change
](https://github.com/modelcontextprotocol/typescript-sdk/commit/9edb6196001fc6582c911f7c0650116161760fd5).
Without it, LibreChat's error handling in `packages/api/src/mcp/connection.ts` is inactive.
https://github.com/danny-avila/LibreChat/blob/main/packages/api/src/mcp/connection.ts#L209-L216

Because I was investigating `packages/api/src/mcp/connection.ts` for a fix, I also included some cleanup of unused code.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The best way to test is with a local MCP server that can be killed and restarted while the connection was established to ensure LibreChat recovers correctly.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
