### PR TITLE
🔄 refactor: Google `grounding` field to `web_search` for Consistency

### DIFF
--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -106,7 +106,7 @@ export function getGoogleConfig(
   const authHeader = options.authHeader;
 
   const {
-    grounding,
+    web_search,
     thinking = googleSettings.thinking.default,
     thinkingBudget = googleSettings.thinkingBudget.default,
     ...modelOptions
@@ -191,7 +191,7 @@ export function getGoogleConfig(
 
   const tools: GoogleAIToolType[] = [];
 
-  if (grounding) {
+  if (web_search) {
     tools.push({ googleSearch: {} });
   }
 

--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -550,8 +550,8 @@ const google: Record<string, SettingDefinition> = {
     optionType: 'conversation',
     columnSpan: 2,
   },
-  grounding: {
-    key: 'grounding',
+  web_search: {
+    key: 'web_search',
     label: 'com_endpoint_use_search_grounding',
     labelCode: true,
     description: 'com_endpoint_google_use_search_grounding',
@@ -576,7 +576,7 @@ const googleConfig: SettingsConfiguration = [
   librechat.resendFiles,
   google.thinking,
   google.thinkingBudget,
-  google.grounding,
+  google.web_search,
 ];
 
 const googleCol1: SettingsConfiguration = [
@@ -594,7 +594,7 @@ const googleCol2: SettingsConfiguration = [
   librechat.resendFiles,
   google.thinking,
   google.thinkingBudget,
-  google.grounding,
+  google.web_search,
 ];
 
 const openAI: SettingsConfiguration = [

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -634,10 +634,8 @@ export const tConversationSchema = z.object({
   reasoning_summary: eReasoningSummarySchema.optional().nullable(),
   /* OpenAI: use Responses API */
   useResponsesApi: z.boolean().optional(),
-  /* OpenAI: use Responses API with Web Search */
+  /* OpenAI, Google: use Web Search */
   web_search: z.boolean().optional(),
-  /* Google: use Search Grounding */
-  grounding: z.boolean().optional(),
   /* assistant */
   assistant_id: z.string().optional(),
   /* agents */
@@ -741,7 +739,7 @@ export const tQueryParamsSchema = tConversationSchema
     /** @endpoints openAI, custom, azureOpenAI */
     useResponsesApi: true,
     /** @endpoints google */
-    grounding: true,
+    web_search: true,
     /** @endpoints google, anthropic, bedrock */
     topP: true,
     /** @endpoints google, anthropic */
@@ -824,7 +822,7 @@ export const googleBaseSchema = tConversationSchema.pick({
   topK: true,
   thinking: true,
   thinkingBudget: true,
-  grounding: true,
+  web_search: true,
   iconURL: true,
   greeting: true,
   spec: true,
@@ -856,7 +854,7 @@ export const googleGenConfigSchema = z
         thinkingBudget: coerceNumber.optional(),
       })
       .optional(),
-    grounding: z.boolean().optional(),
+    web_search: z.boolean().optional(),
   })
   .strip()
   .optional();

--- a/packages/data-schemas/src/types/convo.ts
+++ b/packages/data-schemas/src/types/convo.ts
@@ -48,7 +48,6 @@ export interface IConversation extends Document {
   reasoning_summary?: string;
   useResponsesApi?: boolean;
   web_search?: boolean;
-  grounding?: boolean;
   // Additional fields
   files?: string[];
   expiredAt?: Date;


### PR DESCRIPTION
### Summary
This change refactors Google's `grounding` parameter to utilize existing `web_search` field in order to reduce redundant database fields.

- Updated the Google configuration and related schemas to replace 'grounding' with 'web_search' for consistency.
- Adjusted the logic in the getGoogleConfig function to reflect the new naming convention.
- Ensured all references in parameter settings and conversation schemas are updated accordingly.