### PR TITLE
🔧 refactor: Prevent Unnecessary Google Service Key Loading

### DIFF
--- a/api/server/services/Config/loadAsyncEndpoints.js
+++ b/api/server/services/Config/loadAsyncEndpoints.js
@@ -1,7 +1,7 @@
 const path = require('path');
-const { loadServiceKey } = require('@librechat/api');
+const { logger } = require('@librechat/data-schemas');
+const { loadServiceKey, isUserProvided } = require('@librechat/api');
 const { EModelEndpoint } = require('librechat-data-provider');
-const { isUserProvided } = require('~/server/utils');
 const { config } = require('./EndpointService');
 
 const { openAIApiKey, azureOpenAIApiKey, useAzurePlugins, userProvidedOpenAI, googleKey } = config;
@@ -11,28 +11,29 @@ const { openAIApiKey, azureOpenAIApiKey, useAzurePlugins, userProvidedOpenAI, go
  * @param {Express.Request} req - The request object
  */
 async function loadAsyncEndpoints(req) {
-  let i = 0;
   let serviceKey, googleUserProvides;
-  const serviceKeyPath =
-    process.env.GOOGLE_SERVICE_KEY_FILE_PATH ||
-    path.join(__dirname, '../../..', 'data', 'auth.json');
 
-  try {
-    serviceKey = await loadServiceKey(serviceKeyPath);
-  } catch {
-    if (i === 0) {
-      i++;
+  /** Check if GOOGLE_KEY is provided at all(including 'user_provided') */
+  const isGoogleKeyProvided = googleKey && googleKey.trim() !== '';
+
+  if (isGoogleKeyProvided) {
+    /** If GOOGLE_KEY is provided, check if it's user_provided */
+    googleUserProvides = isUserProvided(googleKey);
+  } else {
+    /** Only attempt to load service key if GOOGLE_KEY is not provided */
+    const serviceKeyPath =
+      process.env.GOOGLE_SERVICE_KEY_FILE_PATH ||
+      path.join(__dirname, '../../..', 'data', 'auth.json');
+
+    try {
+      serviceKey = await loadServiceKey(serviceKeyPath);
+    } catch (error) {
+      logger.error('Error loading service key', error);
+      serviceKey = null;
     }
   }
 
-  if (isUserProvided(googleKey)) {
-    googleUserProvides = true;
-    if (i <= 1) {
-      i++;
-    }
-  }
-
-  const google = serviceKey || googleKey ? { userProvide: googleUserProvides } : false;
+  const google = serviceKey || isGoogleKeyProvided ? { userProvide: googleUserProvides } : false;
 
   const useAzure = req.app.locals[EModelEndpoint.azureOpenAI]?.plugins;
   const gptPlugins =

--- a/api/server/services/Endpoints/google/initialize.js
+++ b/api/server/services/Endpoints/google/initialize.js
@@ -17,16 +17,24 @@ const initializeClient = async ({ req, res, endpointOption, overrideModel, optio
 
   let serviceKey = {};
 
-  try {
-    const serviceKeyPath =
-      process.env.GOOGLE_SERVICE_KEY_FILE_PATH ||
-      path.join(__dirname, '../../../..', 'data', 'auth.json');
-    serviceKey = await loadServiceKey(serviceKeyPath);
-    if (!serviceKey) {
+  /** Check if GOOGLE_KEY is provided at all (including 'user_provided') */
+  const isGoogleKeyProvided =
+    (GOOGLE_KEY && GOOGLE_KEY.trim() !== '') || (isUserProvided && userKey != null);
+
+  if (!isGoogleKeyProvided) {
+    /** Only attempt to load service key if GOOGLE_KEY is not provided */
+    try {
+      const serviceKeyPath =
+        process.env.GOOGLE_SERVICE_KEY_FILE_PATH ||
+        path.join(__dirname, '../../../..', 'data', 'auth.json');
+      serviceKey = await loadServiceKey(serviceKeyPath);
+      if (!serviceKey) {
+        serviceKey = {};
+      }
+    } catch (_e) {
+      // Service key loading failed, but that's okay if not required
       serviceKey = {};
     }
-  } catch (_e) {
-    // Do nothing
   }
 
   const credentials = isUserProvided


### PR DESCRIPTION
## Summary

I refined the Google service key handling logic to improve reliability and clarity in both `loadAsyncEndpoints` and the `initializeClient` function. These changes make key detection more robust and service key loading more predictable.

- Updated `loadAsyncEndpoints` to check if `GOOGLE_KEY` is present, including user-provided scenarios, before attempting to load the service key from file.
- Added `isUserProvided` logic to ensure consistency with user-supplied keys.
- Moved service key file loading to only happen when `GOOGLE_KEY` is not supplied, reducing unnecessary file reads.
- Enhanced error handling with logging for service key loading failures in `loadAsyncEndpoints`.
- Simplified initialization in `initializeClient` by clearly distinguishing between environment key usage and service key fallback.
- Ensured defaulting to empty objects or nulls to prevent runtime errors.

## Change Type

- [x] Refactor (enhancement to existing logic without new features)
- [x] Bug fix (resolved potential issues with service key loading)
- [x] Documentation update (improved code clarity)

## Testing

I manually tested authentication logic with various combinations:
- Provided `GOOGLE_KEY` (both valid and empty).
- Supplied user-provided keys.
- Removed env keys to force service key file loading.
- Intentionally corrupted file paths to confirm error handling and logging.
- Observed server output and endpoint initialization for each case.

### **Test Configuration**:
- Configured environment variables for Google key scenarios.
- Ran local server using different configurations.
- Verified log output for missing or erroneous keys.
- Checked endpoint availability and user experience in the frontend.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes