### PR TITLE
🐛 fix: Memories Key Updates

### DIFF
--- a/client/src/components/SidePanel/Memories/MemoryCreateDialog.tsx
+++ b/client/src/components/SidePanel/Memories/MemoryCreateDialog.tsx
@@ -52,6 +52,10 @@ export default function MemoryCreateDialog({
           if (axiosError.response?.status === 409 || errorMessage.includes('already exists')) {
             errorMessage = localize('com_ui_memory_key_exists');
           }
+          // Check for key validation error (lowercase and underscores only)
+          else if (errorMessage.includes('lowercase letters and underscores')) {
+            errorMessage = localize('com_ui_memory_key_validation');
+          }
         }
       } else if (error.message) {
         errorMessage = error.message;

--- a/client/src/components/SidePanel/Memories/MemoryEditDialog.tsx
+++ b/client/src/components/SidePanel/Memories/MemoryEditDialog.tsx
@@ -44,9 +44,29 @@ export default function MemoryEditDialog({
         status: 'success',
       });
     },
-    onError: () => {
+    onError: (error: Error) => {
+      let errorMessage = localize('com_ui_error');
+
+      if (error && typeof error === 'object' && 'response' in error) {
+        const axiosError = error as any;
+        if (axiosError.response?.data?.error) {
+          errorMessage = axiosError.response.data.error;
+
+          // Check for duplicate key error
+          if (axiosError.response?.status === 409 || errorMessage.includes('already exists')) {
+            errorMessage = localize('com_ui_memory_key_exists');
+          }
+          // Check for key validation error (lowercase and underscores only)
+          else if (errorMessage.includes('lowercase letters and underscores')) {
+            errorMessage = localize('com_ui_memory_key_validation');
+          }
+        }
+      } else if (error.message) {
+        errorMessage = error.message;
+      }
+
       showToast({
-        message: localize('com_ui_error'),
+        message: errorMessage,
         status: 'error',
       });
     },

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -856,6 +856,7 @@
   "com_ui_memory_deleted": "Memory deleted",
   "com_ui_memory_deleted_items": "Deleted Memories",
   "com_ui_memory_key_exists": "A memory with this key already exists. Please use a different key.",
+  "com_ui_memory_key_validation": "Memory key must only contain lowercase letters and underscores.",
   "com_ui_memory_updated": "Updated saved memory",
   "com_ui_memory_updated_items": "Updated Memories",
   "com_ui_mention": "Mention an endpoint, assistant, or preset to quickly switch to it",


### PR DESCRIPTION
## Summary 

This change fixes a bug in the Memories panel where editing a key in an existing memory appears to save your change, but actually does not make that change in the database. Also enhances error toast explanations for memory edits.

* Updated the PATCH /memories/:key endpoint to allow key changes while ensuring no duplicate keys exist.
* Improved error handling in MemoryCreateDialog and MemoryEditDialog for key validation and duplication scenarios.
* Added a new translation for memory key validation error in translation.json.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manually verified in the UI that the Key field was now saving properly when edited.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
