### PR TITLE
🔧 fix: Import Path for Custom Configuration Loading

### DIFF
--- a/api/models/Conversation.js
+++ b/api/models/Conversation.js
@@ -1,6 +1,6 @@
 const { logger } = require('@librechat/data-schemas');
 const { createTempChatExpirationDate } = require('@librechat/api');
-const getCustomConfig = require('~/server/services/Config/loadCustomConfig');
+const getCustomConfig = require('~/server/services/Config/getCustomConfig');
 const { getMessages, deleteMessages } = require('./Message');
 const { Conversation } = require('~/db/models');
 

--- a/api/models/Message.js
+++ b/api/models/Message.js
@@ -1,7 +1,7 @@
 const { z } = require('zod');
 const { logger } = require('@librechat/data-schemas');
 const { createTempChatExpirationDate } = require('@librechat/api');
-const getCustomConfig = require('~/server/services/Config/loadCustomConfig');
+const getCustomConfig = require('~/server/services/Config/getCustomConfig');
 const { Message } = require('~/db/models');
 
 const idSchema = z.string().uuid();


### PR DESCRIPTION
Update import path for custom configuration loading to use the cache instead of reading and parsing the config file every time a message is saved.

## Summary

Both `Conversation.js` and `Message.js` used `loadCustomConfig` function to retrieve configuration of the app. This resulted in the config file to be read and parsed every time a message is saved, which is not performant and it also caused MCP tool lists to change unpredictably.

This fix will make those files get the info from the cache instead.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Run `npm run backend` and interact with any LLM model, you will see the config being printed out every a message is sent. This print out is called from the `loadCustomConfig` function.


## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
