### PR TITLE
removes react-interactions chunk

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -122,9 +122,6 @@ export default defineConfig(({ command }) => ({
             if (id.includes('@dicebear')) {
               return 'avatars';
             }
-            if (id.includes('react-dnd') || id.includes('react-flip-toolkit')) {
-              return 'react-interactions';
-            }
             if (id.includes('react-hook-form')) {
               return 'forms';
             }


### PR DESCRIPTION
## Summary

Currently when loading LibreChat after a frontend build, an error is thrown in the `react-interactions.js` chunk: 
```
Uncaught TypeError: Cannot read properties of undefined (reading 'createContext')
```  

Which is caused by `react-dnd` attempting to `React.createContext`. It would appear to be related to module load order but order cannot be overridden in any way. Instead we can have the modules loaded alongside React (i.e. in `vendor.js`). 

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

```
$ npm run frontend
$ npm run backend
```

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
