### PR TITLE
🔑 feat: Base64 Google Service Keys and Reliable Private Key Formats

### DIFF
--- a/packages/api/src/utils/key.ts
+++ b/packages/api/src/utils/key.ts
@@ -29,8 +29,20 @@ export async function loadServiceKey(keyPath: string): Promise<GoogleServiceKey 
 
   let serviceKey: unknown;
 
+  // Check if it's base64 encoded (common pattern for storing in env vars)
+  if (keyPath.trim().match(/^[A-Za-z0-9+/]+=*$/)) {
+    try {
+      const decoded = Buffer.from(keyPath.trim(), 'base64').toString('utf-8');
+      // Try to parse the decoded string as JSON
+      serviceKey = JSON.parse(decoded);
+    } catch {
+      // Not base64 or not valid JSON after decoding, continue with other methods
+      // Silent failure - not critical
+    }
+  }
+
   // Check if it's a stringified JSON (starts with '{')
-  if (keyPath.trim().startsWith('{')) {
+  if (!serviceKey && keyPath.trim().startsWith('{')) {
     try {
       serviceKey = JSON.parse(keyPath);
     } catch (error) {
@@ -39,7 +51,7 @@ export async function loadServiceKey(keyPath: string): Promise<GoogleServiceKey 
     }
   }
   // Check if it's a URL
-  else if (/^https?:\/\//.test(keyPath)) {
+  else if (!serviceKey && /^https?:\/\//.test(keyPath)) {
     try {
       const response = await axios.get(keyPath);
       serviceKey = response.data;
@@ -47,7 +59,7 @@ export async function loadServiceKey(keyPath: string): Promise<GoogleServiceKey 
       logger.error(`Failed to fetch the service key from URL: ${keyPath}`, error);
       return null;
     }
-  } else {
+  } else if (!serviceKey) {
     // It's a file path
     try {
       const absolutePath = path.isAbsolute(keyPath) ? keyPath : path.resolve(keyPath);
@@ -75,5 +87,30 @@ export async function loadServiceKey(keyPath: string): Promise<GoogleServiceKey 
     return null;
   }
 
-  return serviceKey as GoogleServiceKey;
+  // Fix private key formatting if needed
+  const key = serviceKey as GoogleServiceKey;
+  if (key.private_key && typeof key.private_key === 'string') {
+    // Replace escaped newlines with actual newlines
+    // When JSON.parse processes "\\n", it becomes "\n" (single backslash + n)
+    // When JSON.parse processes "\n", it becomes an actual newline character
+    key.private_key = key.private_key.replace(/\\n/g, '\n');
+
+    // Also handle the String.raw`\n` case mentioned in Stack Overflow
+    key.private_key = key.private_key.split(String.raw`\n`).join('\n');
+
+    // Ensure proper PEM format
+    if (!key.private_key.includes('\n')) {
+      // If no newlines are present, try to format it properly
+      const privateKeyMatch = key.private_key.match(
+        /^(-----BEGIN [A-Z ]+-----)(.*)(-----END [A-Z ]+-----)$/,
+      );
+      if (privateKeyMatch) {
+        const [, header, body, footer] = privateKeyMatch;
+        // Add newlines after header and before footer
+        key.private_key = `${header}\n${body}\n${footer}`;
+      }
+    }
+  }
+
+  return key;
 }


### PR DESCRIPTION
## Summary

I improved the loadServiceKey utility to support base64-encoded keys, robust private key formatting, and expanded corresponding unit tests. 

- Add detection and parsing for base64-encoded service keys, enabling secret management compatibility
- Ensure private_key fields are converted from escaped newlines (\n, \\n) to actual newlines for PEM compliance
- Implement fallback formatting for private keys without newlines, restoring valid PEM structure
- Expand key.test.ts with new scenarios: escaped/double-escaped newlines, base64 inputs, proper/poor formatting, and invalid cases for greater test coverage
- Maintain backward compatibility for all existing uses of loadServiceKey

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

I added unit tests covering all new branches, including various newline encodings, malformed and well-formed base64 payloads, valid/invalid formatting, and legacy-support edge cases. Run `pnpm run test` in the api package to confirm comprehensive coverage. You can also set a base64-encoded credential in the environment to verify live usage.

### **Test Configuration:**
- Node.js v20 LTS
- pnpm 8.x
- Run in packages/api: `pnpm run test`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes