### PR TITLE
🔧 fix: Plugin Method Undefined in Agent Tool Closure

### DIFF
--- a/api/server/services/Config/getCustomConfig.js
+++ b/api/server/services/Config/getCustomConfig.js
@@ -1,10 +1,9 @@
 const { logger } = require('@librechat/data-schemas');
-const { getUserMCPAuthMap } = require('@librechat/api');
+const { isEnabled, getUserMCPAuthMap } = require('@librechat/api');
 const { CacheKeys, EModelEndpoint } = require('librechat-data-provider');
-const { normalizeEndpointName, isEnabled } = require('~/server/utils');
+const { normalizeEndpointName } = require('~/server/utils');
 const loadCustomConfig = require('./loadCustomConfig');
 const { getCachedTools } = require('./getCachedTools');
-const { findPluginAuthsByKeys } = require('~/models');
 const getLogStores = require('~/cache/getLogStores');
 
 /**
@@ -55,46 +54,48 @@ const getCustomEndpointConfig = async (endpoint) => {
   );
 };
 
-async function createGetMCPAuthMap() {
+/**
+ * @param {Object} params
+ * @param {string} params.userId
+ * @param {GenericTool[]} [params.tools]
+ * @param {import('@librechat/data-schemas').PluginAuthMethods['findPluginAuthsByKeys']} params.findPluginAuthsByKeys
+ * @returns {Promise<Record<string, Record<string, string>> | undefined>}
+ */
+async function getMCPAuthMap({ userId, tools, findPluginAuthsByKeys }) {
+  try {
+    if (!tools || tools.length === 0) {
+      return;
+    }
+    const appTools = await getCachedTools({
+      userId,
+    });
+    return await getUserMCPAuthMap({
+      tools,
+      userId,
+      appTools,
+      findPluginAuthsByKeys,
+    });
+  } catch (err) {
+    logger.error(
+      `[api/server/controllers/agents/client.js #chatCompletion] Error getting custom user vars for agent`,
+      err,
+    );
+  }
+}
+
+/**
+ * @returns {Promise<boolean>}
+ */
+async function hasCustomUserVars() {
   const customConfig = await getCustomConfig();
   const mcpServers = customConfig?.mcpServers;
-  const hasCustomUserVars = Object.values(mcpServers ?? {}).some((server) => server.customUserVars);
-  if (!hasCustomUserVars) {
-    return;
-  }
-
-  /**
-   * @param {Object} params
-   * @param {GenericTool[]} [params.tools]
-   * @param {string} params.userId
-   * @returns {Promise<Record<string, Record<string, string>> | undefined>}
-   */
-  return async function ({ tools, userId }) {
-    try {
-      if (!tools || tools.length === 0) {
-        return;
-      }
-      const appTools = await getCachedTools({
-        userId,
-      });
-      return await getUserMCPAuthMap({
-        tools,
-        userId,
-        appTools,
-        findPluginAuthsByKeys,
-      });
-    } catch (err) {
-      logger.error(
-        `[api/server/controllers/agents/client.js #chatCompletion] Error getting custom user vars for agent`,
-        err,
-      );
-    }
-  };
+  return Object.values(mcpServers ?? {}).some((server) => server.customUserVars);
 }
 
 module.exports = {
+  getMCPAuthMap,
   getCustomConfig,
   getBalanceConfig,
-  createGetMCPAuthMap,
+  hasCustomUserVars,
   getCustomEndpointConfig,
 };

--- a/packages/api/src/agents/auth.ts
+++ b/packages/api/src/agents/auth.ts
@@ -76,6 +76,11 @@ export async function getPluginAuthMap({
     await Promise.all(decryptionPromises);
     return authMap;
   } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    const plugins = pluginKeys?.join(', ') ?? 'all requested';
+    logger.warn(
+      `[getPluginAuthMap] Failed to fetch auth values for userId ${userId}, plugins: ${plugins}: ${message}`,
+    );
     if (!throwError) {
       /** Empty objects for each plugin key on error */
       return pluginKeys.reduce((acc, key) => {
@@ -83,11 +88,6 @@ export async function getPluginAuthMap({
         return acc;
       }, {} as PluginAuthMap);
     }
-
-    const message = error instanceof Error ? error.message : 'Unknown error';
-    logger.error(
-      `[getPluginAuthMap] Failed to fetch auth values for userId ${userId}, plugins: ${pluginKeys.join(', ')}: ${message}`,
-    );
     throw error;
   }
 }


### PR DESCRIPTION
## Summary

Closes #8400

I fixed the plugin authorization method scope issue within agent client tool invocation, refactored the custom config logic for clarity, and improved plugin authentication error reporting.

- Refactored agent client to use direct method reference (`getMCPAuthMap`) instead of closure for plugin authorization mapping, preventing `undefined` in dynamic contexts
- Merged and simplified custom config utility functions into a clear `getMCPAuthMap` and `hasCustomUserVars` API
- Enhanced the plugin authentication error handling in the TypeScript agent layer by improving warning messages while reducing double-logging and unnecessary error propagation
- Improved dependency injection for plugin methods and clarified related imports/exports

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update 

## Testing

I tested these changes locally with agent toolchains using plugins that require credential mapping under various user contexts. To verify, exercise the plugin-enabled agents via chat, confirm valid plugin credential usage, and inspect server logs for accurate error messaging and absence of `undefined` closure errors. 

### Test Configuration:

- Node v20+
- Local MongoDB and Redis backend 
- Plugin agents configured with custom user variables and without

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes