### PR TITLE
✨ feat: Add MCP Reinitialization to MCPPanel

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -235,7 +235,7 @@ const loadTools = async ({
 
   /** @type {Record<string, string>} */
   const toolContextMap = {};
-  const appTools = (await getCachedTools({ includeGlobal: true })) ?? {};
+  const cachedTools = (await getCachedTools({ userId: user, includeGlobal: true })) ?? {};
 
   for (const tool of tools) {
     if (tool === Tools.execute_code) {
@@ -303,7 +303,7 @@ Current Date & Time: ${replaceSpecialVars({ text: '{{iso_datetime}}' })}
         });
       };
       continue;
-    } else if (tool && appTools[tool] && mcpToolPattern.test(tool)) {
+    } else if (tool && cachedTools && mcpToolPattern.test(tool)) {
       requestedTools[tool] = async () =>
         createMCPTool({
           req: options.req,

--- a/api/models/Agent.js
+++ b/api/models/Agent.js
@@ -61,7 +61,7 @@ const getAgent = async (searchParameter) => await Agent.findOne(searchParameter)
 const loadEphemeralAgent = async ({ req, agent_id, endpoint, model_parameters: _m }) => {
   const { model, ...model_parameters } = _m;
   /** @type {Record<string, FunctionTool>} */
-  const availableTools = await getCachedTools({ includeGlobal: true });
+  const availableTools = await getCachedTools({ userId: req.user.id, includeGlobal: true });
   /** @type {TEphemeralAgent | null} */
   const ephemeralAgent = req.body.ephemeralAgent;
   const mcpServers = new Set(ephemeralAgent?.mcp);

--- a/api/server/controllers/PluginController.js
+++ b/api/server/controllers/PluginController.js
@@ -146,11 +146,7 @@ const getAvailableTools = async (req, res) => {
     const userPlugins = convertMCPToolsToPlugins(cachedUserTools, customConfig);
 
     if (cachedToolsArray && userPlugins) {
-      const dedupedTools = [
-        ...new Map(
-          [...userPlugins, ...cachedToolsArray].map((tool) => [tool.pluginKey, tool]),
-        ).values(),
-      ];
+      const dedupedTools = filterUniquePlugins([...userPlugins, ...cachedToolsArray]);
       res.status(200).json(dedupedTools);
       return;
     }
@@ -230,9 +226,7 @@ const getAvailableTools = async (req, res) => {
     const finalTools = filterUniquePlugins(toolsOutput);
     await cache.set(CacheKeys.TOOLS, finalTools);
 
-    const dedupedTools = [
-      ...new Map([...userPlugins, ...finalTools].map((tool) => [tool.pluginKey, tool])).values(),
-    ];
+    const dedupedTools = filterUniquePlugins([...userPlugins, ...finalTools]);
 
     res.status(200).json(dedupedTools);
   } catch (error) {
@@ -295,8 +289,4 @@ function convertMCPToolsToPlugins(functionTools, customConfig) {
 module.exports = {
   getAvailableTools,
   getAvailablePluginsController,
-  filterUniquePlugins,
-  checkPluginAuth,
-  createServerToolsCallback,
-  createGetServerTools,
 };

--- a/api/server/controllers/PluginController.js
+++ b/api/server/controllers/PluginController.js
@@ -138,15 +138,25 @@ function createGetServerTools() {
  */
 const getAvailableTools = async (req, res) => {
   try {
+    const userId = req.user?.id;
+    const customConfig = await getCustomConfig();
     const cache = getLogStores(CacheKeys.CONFIG_STORE);
     const cachedToolsArray = await cache.get(CacheKeys.TOOLS);
-    if (cachedToolsArray) {
-      res.status(200).json(cachedToolsArray);
+    const cachedUserTools = await getCachedTools({ userId });
+    const userPlugins = convertMCPToolsToPlugins(cachedUserTools, customConfig);
+
+    if (cachedToolsArray && userPlugins) {
+      const dedupedTools = [
+        ...new Map(
+          [...userPlugins, ...cachedToolsArray].map((tool) => [tool.pluginKey, tool]),
+        ).values(),
+      ];
+      res.status(200).json(dedupedTools);
       return;
     }
 
+    // If not in cache, build from manifest
     let pluginManifest = availableTools;
-    const customConfig = await getCustomConfig();
     if (customConfig?.mcpServers != null) {
       const mcpManager = getMCPManager();
       const flowsCache = getLogStores(CacheKeys.FLOWS);
@@ -217,17 +227,76 @@ const getAvailableTools = async (req, res) => {
 
       toolsOutput.push(toolToAdd);
     }
-
     const finalTools = filterUniquePlugins(toolsOutput);
     await cache.set(CacheKeys.TOOLS, finalTools);
-    res.status(200).json(finalTools);
+
+    const dedupedTools = [
+      ...new Map([...userPlugins, ...finalTools].map((tool) => [tool.pluginKey, tool])).values(),
+    ];
+
+    res.status(200).json(dedupedTools);
   } catch (error) {
     logger.error('[getAvailableTools]', error);
     res.status(500).json({ message: error.message });
   }
 };
 
+/**
+ * Converts MCP function format tools to plugin format
+ * @param {Object} functionTools - Object with function format tools
+ * @param {Object} customConfig - Custom configuration for MCP servers
+ * @returns {Array} Array of plugin objects
+ */
+function convertMCPToolsToPlugins(functionTools, customConfig) {
+  const plugins = [];
+
+  for (const [toolKey, toolData] of Object.entries(functionTools)) {
+    if (!toolData.function || !toolKey.includes(Constants.mcp_delimiter)) {
+      continue;
+    }
+
+    const functionData = toolData.function;
+    const parts = toolKey.split(Constants.mcp_delimiter);
+    const serverName = parts[parts.length - 1];
+
+    const plugin = {
+      name: parts[0], // Use the tool name without server suffix
+      pluginKey: toolKey,
+      description: functionData.description || '',
+      authenticated: true,
+      icon: undefined,
+    };
+
+    // Build authConfig for MCP tools
+    const serverConfig = customConfig?.mcpServers?.[serverName];
+    if (!serverConfig?.customUserVars) {
+      plugin.authConfig = [];
+      plugins.push(plugin);
+      continue;
+    }
+
+    const customVarKeys = Object.keys(serverConfig.customUserVars);
+    if (customVarKeys.length === 0) {
+      plugin.authConfig = [];
+    } else {
+      plugin.authConfig = Object.entries(serverConfig.customUserVars).map(([key, value]) => ({
+        authField: key,
+        label: value.title || key,
+        description: value.description || '',
+      }));
+    }
+
+    plugins.push(plugin);
+  }
+
+  return plugins;
+}
+
 module.exports = {
   getAvailableTools,
   getAvailablePluginsController,
+  filterUniquePlugins,
+  checkPluginAuth,
+  createServerToolsCallback,
+  createGetServerTools,
 };

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -16,7 +16,7 @@ const { connectDb, indexSync } = require('~/db');
 const validateImageRequest = require('./middleware/validateImageRequest');
 const { jwtLogin, ldapLogin, passportLogin } = require('~/strategies');
 const errorController = require('./controllers/ErrorController');
-const initializeMCP = require('./services/initializeMCP');
+const initializeMCPs = require('./services/initializeMCPs');
 const configureSocialLogins = require('./socialLogins');
 const AppService = require('./services/AppService');
 const staticCache = require('./utils/staticCache');
@@ -146,7 +146,7 @@ const startServer = async () => {
       logger.info(`Server listening at http://${host == '0.0.0.0' ? 'localhost' : host}:${port}`);
     }
 
-    initializeMCP(app);
+    initializeMCPs(app);
   });
 };
 

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -104,7 +104,7 @@ function createAbortHandler({ userId, serverName, toolName, flowManager }) {
  * @returns { Promise<typeof tool | { _call: (toolInput: Object | string) => unknown}> } An object with `_call` method to execute the tool input.
  */
 async function createMCPTool({ req, res, toolKey, provider: _provider }) {
-  const availableTools = await getCachedTools({ includeGlobal: true });
+  const availableTools = await getCachedTools({ userId: req.user?.id, includeGlobal: true });
   const toolDefinition = availableTools?.[toolKey]?.function;
   if (!toolDefinition) {
     logger.error(`Tool ${toolKey} not found in available tools`);

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -226,7 +226,7 @@ async function processRequiredActions(client, requiredActions) {
     `[required actions] user: ${client.req.user.id} | thread_id: ${requiredActions[0].thread_id} | run_id: ${requiredActions[0].run_id}`,
     requiredActions,
   );
-  const toolDefinitions = await getCachedTools({ includeGlobal: true });
+  const toolDefinitions = await getCachedTools({ userId: client.req.user.id, includeGlobal: true });
   const seenToolkits = new Set();
   const tools = requiredActions
     .map((action) => {

--- a/api/server/services/initializeMCPs.js
+++ b/api/server/services/initializeMCPs.js
@@ -9,9 +9,24 @@ const { getLogStores } = require('~/cache');
  * Initialize MCP servers
  * @param {import('express').Application} app - Express app instance
  */
-async function initializeMCP(app) {
+async function initializeMCPs(app) {
   const mcpServers = app.locals.mcpConfig;
   if (!mcpServers) {
+    return;
+  }
+
+  // Filter out servers with startup: false
+  const filteredServers = {};
+  for (const [name, config] of Object.entries(mcpServers)) {
+    if (config.startup === false) {
+      logger.info(`Skipping MCP server '${name}' due to startup: false`);
+      continue;
+    }
+    filteredServers[name] = config;
+  }
+
+  if (Object.keys(filteredServers).length === 0) {
+    logger.info('[MCP] No MCP servers to initialize (all skipped or none configured)');
     return;
   }
 
@@ -21,8 +36,8 @@ async function initializeMCP(app) {
   const flowManager = flowsCache ? getFlowStateManager(flowsCache) : null;
 
   try {
-    await mcpManager.initializeMCP({
-      mcpServers,
+    await mcpManager.initializeMCPs({
+      mcpServers: filteredServers,
       flowManager,
       tokenMethods: {
         findToken,
@@ -44,13 +59,10 @@ async function initializeMCP(app) {
     await mcpManager.mapAvailableTools(toolsCopy, flowManager);
     await setCachedTools(toolsCopy, { isGlobal: true });
 
-    const cache = getLogStores(CacheKeys.CONFIG_STORE);
-    await cache.delete(CacheKeys.TOOLS);
-    logger.debug('Cleared tools array cache after MCP initialization');
     logger.info('MCP servers initialized successfully');
   } catch (error) {
     logger.error('Failed to initialize MCP servers:', error);
   }
 }
 
-module.exports = initializeMCP;
+module.exports = initializeMCPs;

--- a/api/server/services/initializeMCPs.js
+++ b/api/server/services/initializeMCPs.js
@@ -59,6 +59,10 @@ async function initializeMCPs(app) {
     await mcpManager.mapAvailableTools(toolsCopy, flowManager);
     await setCachedTools(toolsCopy, { isGlobal: true });
 
+    const cache = getLogStores(CacheKeys.CONFIG_STORE);
+    await cache.delete(CacheKeys.TOOLS);
+    logger.debug('Cleared tools array cache after MCP initialization');
+
     logger.info('MCP servers initialized successfully');
   } catch (error) {
     logger.error('Failed to initialize MCP servers:', error);

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -132,6 +132,8 @@ export const resendVerificationEmail = () => '/api/user/verify/resend';
 
 export const plugins = () => '/api/plugins';
 
+export const mcpReinitialize = (serverName: string) => `/api/mcp/${serverName}/reinitialize`;
+
 export const config = () => '/api/config';
 
 export const prompts = () => '/api/prompts';

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -141,6 +141,10 @@ export const updateUserPlugins = (payload: t.TUpdateUserPlugins) => {
   return request.post(endpoints.userPlugins(), payload);
 };
 
+export const reinitializeMCPServer = (serverName: string) => {
+  return request.post(endpoints.mcpReinitialize(serverName));
+};
+
 /* Config */
 
 export const getStartupConfig = (): Promise<

--- a/packages/data-provider/src/react-query/react-query-service.ts
+++ b/packages/data-provider/src/react-query/react-query-service.ts
@@ -316,6 +316,20 @@ export const useUpdateUserPluginsMutation = (
   });
 };
 
+export const useReinitializeMCPServerMutation = (): UseMutationResult<
+  { success: boolean; message: string; serverName: string },
+  unknown,
+  string,
+  unknown
+> => {
+  const queryClient = useQueryClient();
+  return useMutation((serverName: string) => dataService.reinitializeMCPServer(serverName), {
+    onSuccess: () => {
+      queryClient.refetchQueries([QueryKeys.tools]);
+    },
+  });
+};
+
 export const useGetCustomConfigSpeechQuery = (
   config?: UseQueryOptions<t.TCustomConfigSpeechResponse>,
 ): QueryObserverResult<t.TCustomConfigSpeechResponse> => {


### PR DESCRIPTION
## Summary

This PR introduces the ability to reinitialize MCP servers that utilize customUserVars and allows for flagging of MCP servers in `librechat.yaml` with the new `startup` property in order to skip app-level initialization for MCP servers which require user provided credentials for authentication, as well as improving the management of MCP servers, per-user tool caching, and user experience in the MCP panel:

- **User-Aware Tool Caching:** Tool caching logic has been refactored throughout the codebase to consistently include user identifiers. This ensures accurate retrieval of per-user tool results and prevents collisions or leaks between system/global and user-specific tool sets.
- **MCP Server Reinitialization:** A new backend endpoint and supporting logic have been added to dynamically reinitialize individual MCP servers. This allows servers to be reloaded (for example, after credential or config changes) without restarting the main process, and ensures user-scoped changes to tool availability occur immediately.
- **MCPManager Refactor:** The `MCPManager` service has been reorganized, splitting out complex logic for initializing one versus many MCP server connections. This clarifies startup flow and centralizes error handling and capability introspection for each MCP server.
- **Frontend UX – MCPPanel:** The MCP panel UI in the client is enhanced to offer a new "Reinitialize MCP server" button for each MCP server, with visual feedback (spinning icon, toast notifications) when a reload is triggered. This promotes better control and transparency for users and administrators monitoring plugin health.

---

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Translation update

---

## Details / Change Breakdown

### Tool Caching

- Calls to `getCachedTools` now include userIds where necessary to utilize user scoped tools.
- Backend endpoints and service logic updated for correct cache read/write paths for per-user and global tool sets.

### MCP Server Reinitialization

- New Endpoint: `POST /api/mcp/:serverName/reinitialize` with robust error handling.
- Reinitialization initiates a server disconnect, reloads user credentials, fetches available tools, and updates the user's cached tool list accordingly.

### Service & Manager Refactor

- The `MCPManager` now provides separate methods for initializing all servers or a specific server.
- Skipping of servers at startup (those marked `startup: false`) is respected and logged.

### Frontend – MCPPanel Improvements

- Added an async "reinitialize" button to each server row, providing a spinner while the request is in flight.
- User feedback given for both success and error via UI toast notifications.
- State is managed reactively using a `Set` to track which servers are currently reloading.

---

## Screenshots

<div align="center">

### MCP Panel – Server List with Reinitialize

https://github.com/user-attachments/assets/9e630f51-ed31-4a4e-8ef9-42d2b702c181

*This screencapture demonstrates the new reinitialize action beside each MCP server in the list.*

</div>

---

## Testing

**Backend**
- Manually verified cache contents before/after reinitialization for a user.
- Triggered server reinitialize endpoint for both configured and missing servers, checking error handling.
- Confirmed proper update of user tool set by inspecting tool cache and issuing tool-using requests.

**Frontend**
- Clicked the "Reinitialize" button for each MCP server and observed toast status, loading state, and tool effect.
- Disabled and re-enabled servers via config and confirmed list updates accordingly.

---

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes (if needed)
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
