### PR TITLE
👟 fix: Edge Case of Azure Provider Assignment for Title Run

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1048,6 +1048,12 @@ class AgentClient extends BaseClient {
       options.llmConfig?.azureOpenAIApiInstanceName == null
     ) {
       provider = Providers.OPENAI;
+    } else if (
+      endpoint === EModelEndpoint.azureOpenAI &&
+      options.llmConfig?.azureOpenAIApiInstanceName != null &&
+      provider !== Providers.AZURE
+    ) {
+      provider = Providers.AZURE;
     }
 
     /** @type {import('@librechat/agents').ClientOptions} */


### PR DESCRIPTION
Fixes an edge case identified when using a non-serverless model for title runs following serverless chat run.