### PR TITLE
♻️ fix: Correct Message ID Assignment Logic

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -197,6 +197,10 @@ class BaseClient {
       this.currentMessages[this.currentMessages.length - 1].messageId = head;
     }
 
+    if (opts.isRegenerate && responseMessageId.endsWith('_')) {
+      responseMessageId = crypto.randomUUID();
+    }
+
     this.responseMessageId = responseMessageId;
 
     return {

--- a/api/app/clients/specs/BaseClient.test.js
+++ b/api/app/clients/specs/BaseClient.test.js
@@ -422,6 +422,46 @@ describe('BaseClient', () => {
       expect(response).toEqual(expectedResult);
     });
 
+    test('should replace responseMessageId with new UUID when isRegenerate is true and messageId ends with underscore', async () => {
+      const mockCrypto = require('crypto');
+      const newUUID = 'new-uuid-1234';
+      jest.spyOn(mockCrypto, 'randomUUID').mockReturnValue(newUUID);
+
+      const opts = {
+        isRegenerate: true,
+        responseMessageId: 'existing-message-id_',
+      };
+
+      await TestClient.setMessageOptions(opts);
+
+      expect(TestClient.responseMessageId).toBe(newUUID);
+      expect(TestClient.responseMessageId).not.toBe('existing-message-id_');
+
+      mockCrypto.randomUUID.mockRestore();
+    });
+
+    test('should not replace responseMessageId when isRegenerate is false', async () => {
+      const opts = {
+        isRegenerate: false,
+        responseMessageId: 'existing-message-id_',
+      };
+
+      await TestClient.setMessageOptions(opts);
+
+      expect(TestClient.responseMessageId).toBe('existing-message-id_');
+    });
+
+    test('should not replace responseMessageId when it does not end with underscore', async () => {
+      const opts = {
+        isRegenerate: true,
+        responseMessageId: 'existing-message-id',
+      };
+
+      await TestClient.setMessageOptions(opts);
+
+      expect(TestClient.responseMessageId).toBe('existing-message-id');
+    });
+
     test('sendMessage should work with provided conversationId and parentMessageId', async () => {
       const userMessage = 'Second message in the conversation';
       const opts = {

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -12,6 +12,7 @@ const { saveMessage } = require('~/models');
 const AgentController = async (req, res, next, initializeClient, addTitle) => {
   let {
     text,
+    isRegenerate,
     endpointOption,
     conversationId,
     isContinued = false,
@@ -167,6 +168,7 @@ const AgentController = async (req, res, next, initializeClient, addTitle) => {
       onStart,
       getReqData,
       isContinued,
+      isRegenerate,
       editedContent,
       conversationId,
       parentMessageId,

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -345,9 +345,7 @@ export type TOptions = {
   isContinued?: boolean;
   isEdited?: boolean;
   overrideMessages?: t.TMessage[];
-  /** This value is only true when the user submits a message with "Save & Submit" for a user-created message */
-  isResubmission?: boolean;
-  /** Currently only utilized when `isResubmission === true`, uses that message's currently attached files */
+  /** Currently only utilized when resubmitting user-created message, uses that message's currently attached files */
   overrideFiles?: t.TMessage['files'];
 };
 

--- a/client/src/components/Chat/Messages/Content/EditMessage.tsx
+++ b/client/src/components/Chat/Messages/Content/EditMessage.tsx
@@ -60,7 +60,6 @@ const EditMessage = ({
           conversationId,
         },
         {
-          isResubmission: true,
           overrideFiles: message.files,
         },
       );

--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -230,7 +230,10 @@ export default function useChatFunctions({
     }
 
     const responseMessageId =
-      editedMessageId ?? (latestMessage?.messageId ? latestMessage?.messageId + '_' : null) ?? null;
+      editedMessageId ??
+      (latestMessage?.messageId && isRegenerate ? latestMessage?.messageId + '_' : null) ??
+      null;
+
     const initialResponse: TMessage = {
       sender: responseSender,
       text: '',

--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -83,7 +83,6 @@ export default function useChatFunctions({
     {
       editedContent = null,
       editedMessageId = null,
-      isResubmission = false,
       isRegenerate = false,
       isContinued = false,
       isEdited = false,
@@ -310,7 +309,6 @@ export default function useChatFunctions({
       isEdited: isEditOrContinue,
       isContinued,
       isRegenerate,
-      isResubmission,
       initialResponse,
       isTemporary,
       ephemeralAgent,

--- a/packages/data-provider/src/createPayload.ts
+++ b/packages/data-provider/src/createPayload.ts
@@ -4,14 +4,15 @@ import * as s from './schemas';
 
 export default function createPayload(submission: t.TSubmission) {
   const {
-    conversation,
-    userMessage,
-    endpointOption,
     isEdited,
+    userMessage,
     isContinued,
     isTemporary,
-    ephemeralAgent,
+    isRegenerate,
+    conversation,
     editedContent,
+    ephemeralAgent,
+    endpointOption,
   } = submission;
   const { conversationId } = s.tConvoUpdateSchema.parse(conversation);
   const { endpoint: _e, endpointType } = endpointOption as {
@@ -31,11 +32,12 @@ export default function createPayload(submission: t.TSubmission) {
     ...userMessage,
     ...endpointOption,
     endpoint,
-    ephemeralAgent: s.isAssistantsEndpoint(endpoint) ? undefined : ephemeralAgent,
-    isContinued: !!(isEdited && isContinued),
-    conversationId,
     isTemporary,
+    isRegenerate,
     editedContent,
+    conversationId,
+    isContinued: !!(isEdited && isContinued),
+    ephemeralAgent: s.isAssistantsEndpoint(endpoint) ? undefined : ephemeralAgent,
   };
 
   return { server, payload };

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -126,7 +126,6 @@ export type TSubmission = {
   isTemporary: boolean;
   messages: TMessage[];
   isRegenerate?: boolean;
-  isResubmission?: boolean;
   initialResponse?: TMessage;
   conversation: Partial<TConversation>;
   endpointOption: TEndpointOption;

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -105,6 +105,7 @@ export type TEphemeralAgent = {
 export type TPayload = Partial<TMessage> &
   Partial<TEndpointOption> & {
     isContinued: boolean;
+    isRegenerate?: boolean;
     conversationId: string | null;
     messages?: TMessages;
     isTemporary: boolean;


### PR DESCRIPTION

## Summary

Closes #8438

I addressed an issue with how regenerated chat response message IDs were handled by introducing the `isRegenerate` flag across the client, API, and data-provider layers. This change ensures that temporary response IDs created during regeneration are not saved to persistent storage. While doing so, I also removed the now-unused `isResubmission` flag from type definitions and function calls to streamline the submission logic.

- Added `isRegenerate` flag to chat payloads, backend controllers, and type definitions
- Updated regeneration logic to generate unique message IDs and avoid persisting temporary IDs
- Removed all references to `isResubmission` in both frontend and backend code
- Refactored payload generation, submission hooks, and types for improved clarity and reliability in edit/regenerate flows

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I manually tested message regeneration actions to ensure new responses don't retain temporary IDs and verified that regular editing and submission flows continue to work. I recommend testing:

- Regenerating a message and ensuring only the correct ID is saved
- Editing and resubmitting a message to confirm the removal of `isResubmission` does not affect functionality

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes