### PR TITLE
🛂 fix: Only Perform `allowedProviders` Validation for Agents

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -458,6 +458,12 @@ class AgentClient extends BaseClient {
       res: this.options.res,
       agent: prelimAgent,
       allowedProviders,
+      endpointOption: {
+        endpoint:
+          prelimAgent.id !== Constants.EPHEMERAL_AGENT_ID
+            ? EModelEndpoint.agents
+            : memoryConfig.agent?.provider,
+      },
     });
 
     if (!agent) {

--- a/api/server/services/Endpoints/agents/agent.js
+++ b/api/server/services/Endpoints/agents/agent.js
@@ -8,6 +8,7 @@ const {
   ErrorTypes,
   EModelEndpoint,
   EToolResources,
+  isAgentsEndpoint,
   replaceSpecialVars,
   providerEndpointMap,
 } = require('librechat-data-provider');
@@ -42,7 +43,11 @@ const initializeAgent = async ({
   allowedProviders,
   isInitialAgent = false,
 }) => {
-  if (allowedProviders.size > 0 && !allowedProviders.has(agent.provider)) {
+  if (
+    isAgentsEndpoint(endpointOption?.endpoint) &&
+    allowedProviders.size > 0 &&
+    !allowedProviders.has(agent.provider)
+  ) {
     throw new Error(
       `{ "type": "${ErrorTypes.INVALID_AGENT_PROVIDER}", "info": "${agent.provider}" }`,
     );


### PR DESCRIPTION
## Summary

I updated the provider validation logic to ensure `allowedProviders` checks only apply to agent-related endpoints, preventing erroneous validation attempts for non-agent providers.

- Updated the argument payload in `AgentClient` to supply a correct `endpointOption.endpoint` value based on agent type (ephemeral vs persistent).
- Modified the `initializeAgent` service to run `allowedProviders` validation strictly when called within an agent endpoint context, leveraging the new `isAgentsEndpoint` utility.
- Ensured graceful handling of validation to avoid improper errors when using endpoints not related to agents.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes