### PR TITLE
🔥 feat: Add Firecrawl Scraper Configurability

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -1,14 +1,9 @@
-const { mcpToolPattern } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const { SerpAPI } = require('@langchain/community/tools/serpapi');
 const { Calculator } = require('@langchain/community/tools/calculator');
+const { mcpToolPattern, loadWebSearchAuth } = require('@librechat/api');
 const { EnvVar, createCodeExecutionTool, createSearchTool } = require('@librechat/agents');
-const {
-  Tools,
-  EToolResources,
-  loadWebSearchAuth,
-  replaceSpecialVars,
-} = require('librechat-data-provider');
+const { Tools, EToolResources, replaceSpecialVars } = require('librechat-data-provider');
 const {
   availableTools,
   manifestToolMap,

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -1,11 +1,5 @@
-const {
-  Tools,
-  Constants,
-  FileSources,
-  webSearchKeys,
-  extractWebSearchEnvVars,
-} = require('librechat-data-provider');
 const { logger } = require('@librechat/data-schemas');
+const { webSearchKeys, extractWebSearchEnvVars } = require('@librechat/api');
 const {
   getFiles,
   updateUser,
@@ -20,6 +14,7 @@ const { updateUserPluginAuth, deleteUserPluginAuth } = require('~/server/service
 const { updateUserPluginsService, deleteUserKey } = require('~/server/services/UserService');
 const { verifyEmail, resendVerificationEmail } = require('~/server/services/AuthService');
 const { needsRefresh, getNewS3URL } = require('~/server/services/Files/S3/crud');
+const { Tools, Constants, FileSources } = require('librechat-data-provider');
 const { processDeleteRequest } = require('~/server/services/Files/process');
 const { Transaction, Balance, User } = require('~/db/models');
 const { deleteToolCalls } = require('~/models/ToolCall');

--- a/api/server/controllers/tools.js
+++ b/api/server/controllers/tools.js
@@ -1,14 +1,13 @@
 const { nanoid } = require('nanoid');
 const { EnvVar } = require('@librechat/agents');
-const { checkAccess } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
+const { checkAccess, loadWebSearchAuth } = require('@librechat/api');
 const {
   Tools,
   AuthType,
   Permissions,
   ToolCallTypes,
   PermissionTypes,
-  loadWebSearchAuth,
 } = require('librechat-data-provider');
 const { processFileURL, uploadImageBuffer } = require('~/server/services/Files/process');
 const { processCodeOutput } = require('~/server/services/Files/Code/process');

--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -1,12 +1,11 @@
+const { agentsConfigSetup, loadWebSearchConfig } = require('@librechat/api');
 const {
   FileSources,
   loadOCRConfig,
   EModelEndpoint,
   loadMemoryConfig,
   getConfigDefaults,
-  loadWebSearchConfig,
 } = require('librechat-data-provider');
-const { agentsConfigSetup } = require('@librechat/api');
 const {
   checkHealth,
   checkConfig,

--- a/api/server/services/start/checks.js
+++ b/api/server/services/start/checks.js
@@ -1,6 +1,6 @@
+const { webSearchKeys } = require('@librechat/api');
 const {
   Constants,
-  webSearchKeys,
   deprecatedAzureVariables,
   conflictingAzureVariables,
   extractVariableName,

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -20,6 +20,8 @@ export * from './agents';
 export * from './endpoints';
 /* Files */
 export * from './files';
+/* web search */
+export * from './web';
 /* types */
 export type * from './mcp/types';
 export type * from './flow/types';

--- a/packages/api/src/web/index.ts
+++ b/packages/api/src/web/index.ts
@@ -1,0 +1,1 @@
+export * from './web';

--- a/packages/api/src/web/web.spec.ts
+++ b/packages/api/src/web/web.spec.ts
@@ -4,13 +4,12 @@ import type {
   RerankerTypes,
   SearchProviders,
   TWebSearchConfig,
-} from '../src/config';
-import { webSearchAuth, loadWebSearchAuth, extractWebSearchEnvVars } from '../src/web';
-import { SafeSearchTypes } from '../src/config';
-import { AuthType } from '../src/schemas';
+} from 'librechat-data-provider';
+import { webSearchAuth, loadWebSearchAuth, extractWebSearchEnvVars } from './web';
+import { SafeSearchTypes, AuthType } from 'librechat-data-provider';
 
 // Mock the extractVariableName function
-jest.mock('../src/utils', () => ({
+jest.mock('../utils', () => ({
   extractVariableName: (value: string) => {
     if (!value || typeof value !== 'string') return null;
     const match = value.match(/^\${(.+)}$/);
@@ -77,6 +76,8 @@ describe('web.ts', () => {
       // Initialize a basic webSearchConfig
       webSearchConfig = {
         serperApiKey: '${SERPER_API_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
         firecrawlApiKey: '${FIRECRAWL_API_KEY}',
         firecrawlApiUrl: '${FIRECRAWL_API_URL}',
         jinaApiKey: '${JINA_API_KEY}',
@@ -89,7 +90,7 @@ describe('web.ts', () => {
       // Mock successful authentication for all services
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           result[field] =
             field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
         });
@@ -124,9 +125,9 @@ describe('web.ts', () => {
       // Mock authentication failure for the providers category
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           // Only provide values for scrapers and rerankers, not for providers
-          if (field !== 'SERPER_API_KEY') {
+          if (field !== 'SERPER_API_KEY' && field !== 'SEARXNG_INSTANCE_URL') {
             result[field] =
               field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
           }
@@ -174,7 +175,7 @@ describe('web.ts', () => {
       // Mock loadAuthValues to return different values for some keys
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           if (field === 'SERPER_API_KEY') {
             // This matches the system env var
             result[field] = 'system-api-key';
@@ -220,7 +221,7 @@ describe('web.ts', () => {
 
       mockLoadAuthValues.mockImplementation(({ authFields, optional }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           // Don't provide values for optional fields
           if (!optional?.has(field)) {
             result[field] = 'test-api-key';
@@ -245,7 +246,7 @@ describe('web.ts', () => {
       // Mock successful authentication
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           result[field] = 'test-api-key';
         });
         return Promise.resolve(result);
@@ -270,7 +271,7 @@ describe('web.ts', () => {
       // Mock successful authentication
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           result[field] =
             field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
         });
@@ -294,6 +295,8 @@ describe('web.ts', () => {
       // Initialize a webSearchConfig without specific services
       const webSearchConfig: TCustomConfig['webSearch'] = {
         serperApiKey: '${SERPER_API_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
         firecrawlApiKey: '${FIRECRAWL_API_KEY}',
         firecrawlApiUrl: '${FIRECRAWL_API_URL}',
         jinaApiKey: '${JINA_API_KEY}',
@@ -304,7 +307,7 @@ describe('web.ts', () => {
       // Mock successful authentication
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           result[field] =
             field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
         });
@@ -343,6 +346,8 @@ describe('web.ts', () => {
       // Initialize webSearchConfig with environment variable references
       const webSearchConfig: TCustomConfig['webSearch'] = {
         serperApiKey: '${SERPER_API_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
         firecrawlApiKey: '${FIRECRAWL_API_KEY}',
         firecrawlApiUrl: '${FIRECRAWL_API_URL}',
         jinaApiKey: '${JINA_API_KEY}',
@@ -357,7 +362,7 @@ describe('web.ts', () => {
       // Mock loadAuthValues to return the actual values
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           if (field === 'SERPER_API_KEY') {
             result[field] = 'system-serper-key';
           } else if (field === 'FIRECRAWL_API_KEY') {
@@ -432,6 +437,8 @@ describe('web.ts', () => {
       // Initialize webSearchConfig with custom variable names
       const webSearchConfig: TCustomConfig['webSearch'] = {
         serperApiKey: '${CUSTOM_SERPER_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
         firecrawlApiKey: '${CUSTOM_FIRECRAWL_KEY}',
         firecrawlApiUrl: '${CUSTOM_FIRECRAWL_URL}',
         jinaApiKey: '${CUSTOM_JINA_KEY}',
@@ -446,7 +453,7 @@ describe('web.ts', () => {
       // Mock loadAuthValues to return the actual values
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           if (field === 'CUSTOM_SERPER_KEY') {
             result[field] = 'custom-serper-key';
           } else if (field === 'CUSTOM_FIRECRAWL_KEY') {
@@ -500,6 +507,8 @@ describe('web.ts', () => {
       // Initialize webSearchConfig with environment variable references
       const webSearchConfig: TCustomConfig['webSearch'] = {
         serperApiKey: '${SERPER_API_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
         firecrawlApiKey: '${FIRECRAWL_API_KEY}',
         firecrawlApiUrl: '${FIRECRAWL_API_URL}',
         jinaApiKey: '${JINA_API_KEY}',
@@ -510,7 +519,7 @@ describe('web.ts', () => {
       // Mock loadAuthValues to return values
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           result[field] = field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-key';
         });
         return Promise.resolve(result);
@@ -559,6 +568,8 @@ describe('web.ts', () => {
       // Initialize webSearchConfig with environment variable references
       const webSearchConfig: TCustomConfig['webSearch'] = {
         serperApiKey: '${SERPER_API_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
         firecrawlApiKey: '${FIRECRAWL_API_KEY}',
         firecrawlApiUrl: '${FIRECRAWL_API_URL}',
         jinaApiKey: '${JINA_API_KEY}',
@@ -569,7 +580,7 @@ describe('web.ts', () => {
       // Mock loadAuthValues to return partial values
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           if (field === 'SERPER_API_KEY') {
             result[field] = 'test-key';
           }
@@ -666,6 +677,8 @@ describe('web.ts', () => {
       // Initialize a webSearchConfig with a specific searchProvider
       const webSearchConfig: TCustomConfig['webSearch'] = {
         serperApiKey: '${SERPER_API_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
         firecrawlApiKey: '${FIRECRAWL_API_KEY}',
         firecrawlApiUrl: '${FIRECRAWL_API_URL}',
         jinaApiKey: '${JINA_API_KEY}',
@@ -677,7 +690,7 @@ describe('web.ts', () => {
       // Mock successful authentication
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           result[field] =
             field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
         });
@@ -704,6 +717,8 @@ describe('web.ts', () => {
       // Initialize a webSearchConfig with a specific scraperType
       const webSearchConfig: TCustomConfig['webSearch'] = {
         serperApiKey: '${SERPER_API_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
         firecrawlApiKey: '${FIRECRAWL_API_KEY}',
         firecrawlApiUrl: '${FIRECRAWL_API_URL}',
         jinaApiKey: '${JINA_API_KEY}',
@@ -715,7 +730,7 @@ describe('web.ts', () => {
       // Mock successful authentication
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           result[field] =
             field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
         });
@@ -742,6 +757,8 @@ describe('web.ts', () => {
       // Initialize a webSearchConfig with a specific rerankerType
       const webSearchConfig: TCustomConfig['webSearch'] = {
         serperApiKey: '${SERPER_API_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
         firecrawlApiKey: '${FIRECRAWL_API_KEY}',
         firecrawlApiUrl: '${FIRECRAWL_API_URL}',
         jinaApiKey: '${JINA_API_KEY}',
@@ -753,7 +770,7 @@ describe('web.ts', () => {
       // Mock successful authentication
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           result[field] =
             field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
         });
@@ -786,6 +803,8 @@ describe('web.ts', () => {
       // Initialize a webSearchConfig with an invalid searchProvider
       const webSearchConfig: TCustomConfig['webSearch'] = {
         serperApiKey: '${SERPER_API_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
         firecrawlApiKey: '${FIRECRAWL_API_KEY}',
         firecrawlApiUrl: '${FIRECRAWL_API_URL}',
         jinaApiKey: '${JINA_API_KEY}',
@@ -797,7 +816,7 @@ describe('web.ts', () => {
       // Mock successful authentication
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           result[field] =
             field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
         });
@@ -818,6 +837,8 @@ describe('web.ts', () => {
       // Initialize a webSearchConfig with a specific rerankerType (jina)
       const webSearchConfig: TCustomConfig['webSearch'] = {
         serperApiKey: '${SERPER_API_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
         firecrawlApiKey: '${FIRECRAWL_API_KEY}',
         firecrawlApiUrl: '${FIRECRAWL_API_URL}',
         jinaApiKey: '${JINA_API_KEY}',
@@ -829,7 +850,7 @@ describe('web.ts', () => {
       // Mock authentication where cohere is authenticated but jina is not
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           // Authenticate all fields except JINA_API_KEY
           if (field !== 'JINA_API_KEY') {
             result[field] =
@@ -866,6 +887,8 @@ describe('web.ts', () => {
       // Initialize a webSearchConfig without specific services
       const webSearchConfig: TCustomConfig['webSearch'] = {
         serperApiKey: '${SERPER_API_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
         firecrawlApiKey: '${FIRECRAWL_API_KEY}',
         firecrawlApiUrl: '${FIRECRAWL_API_URL}',
         jinaApiKey: '${JINA_API_KEY}',
@@ -876,7 +899,7 @@ describe('web.ts', () => {
       // Mock successful authentication
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
-        authFields.forEach((field) => {
+        authFields.forEach((field: string) => {
           result[field] =
             field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
         });
@@ -898,6 +921,290 @@ describe('web.ts', () => {
       expect(result.authResult.searchProvider).toBeDefined();
       expect(result.authResult.scraperType).toBeDefined();
       expect(result.authResult.rerankerType).toBeDefined();
+    });
+
+    it('should handle firecrawlOptions properties', async () => {
+      // Initialize a webSearchConfig with comprehensive firecrawlOptions
+      const webSearchConfig: TCustomConfig['webSearch'] = {
+        serperApiKey: '${SERPER_API_KEY}',
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        jinaApiKey: '${JINA_API_KEY}',
+        cohereApiKey: '${COHERE_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        firecrawlOptions: {
+          formats: ['markdown', 'html'],
+          includeTags: ['img', 'p', 'h1'],
+          excludeTags: ['script', 'style'],
+          headers: { 'User-Agent': 'TestBot' },
+          waitFor: 2000,
+          timeout: 15000,
+          maxAge: 3600,
+          mobile: true,
+          skipTlsVerification: false,
+          blockAds: true,
+          removeBase64Images: false,
+          parsePDF: true,
+          storeInCache: false,
+          zeroDataRetention: true,
+          location: {
+            country: 'US',
+            languages: ['en'],
+          },
+          onlyMainContent: true,
+          changeTrackingOptions: {
+            modes: ['diff'],
+            schema: { title: 'string' },
+            prompt: 'Track changes',
+            tag: 'test-tag',
+          },
+        },
+      };
+
+      // Mock successful authentication
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          result[field] =
+            field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authenticated).toBe(true);
+      expect(result.authResult.firecrawlOptions).toEqual(webSearchConfig.firecrawlOptions);
+      expect(result.authResult.scraperTimeout).toBe(15000); // Should use firecrawlOptions.timeout
+    });
+
+    it('should use scraperTimeout when both scraperTimeout and firecrawlOptions.timeout are provided', async () => {
+      // Initialize a webSearchConfig with both scraperTimeout and firecrawlOptions.timeout
+      const webSearchConfig = {
+        serperApiKey: '${SERPER_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        jinaApiKey: '${JINA_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        scraperTimeout: 15000, // This should take priority
+        firecrawlOptions: {
+          timeout: 10000, // This should be ignored
+          includeTags: ['p'],
+          formats: ['markdown'],
+        },
+      } as TCustomConfig['webSearch'];
+
+      // Mock successful authentication
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          result[field] =
+            field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authenticated).toBe(true);
+      expect(result.authResult.scraperTimeout).toBe(15000); // Should use explicit scraperTimeout
+      expect(result.authResult.firecrawlOptions).toEqual({
+        timeout: 10000,
+        includeTags: ['p'],
+        formats: ['markdown'],
+      });
+    });
+
+    it('should fallback to default timeout when neither scraperTimeout nor firecrawlOptions.timeout are provided', async () => {
+      // Initialize a webSearchConfig without timeout values
+      const webSearchConfig = {
+        serperApiKey: '${SERPER_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        jinaApiKey: '${JINA_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        firecrawlOptions: {
+          includeTags: ['p'],
+          formats: ['markdown'],
+        },
+      } as TCustomConfig['webSearch'];
+
+      // Mock successful authentication
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          result[field] =
+            field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authenticated).toBe(true);
+      expect(result.authResult.scraperTimeout).toBe(7500); // Should use default timeout
+      expect(result.authResult.firecrawlOptions).toEqual({
+        includeTags: ['p'],
+        formats: ['markdown'],
+      });
+    });
+
+    it('should use firecrawlOptions.timeout when only firecrawlOptions.timeout is provided', async () => {
+      // Initialize a webSearchConfig with only firecrawlOptions.timeout
+      const webSearchConfig = {
+        serperApiKey: '${SERPER_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        jinaApiKey: '${JINA_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        firecrawlOptions: {
+          timeout: 12000, // Only timeout provided
+        },
+      } as TCustomConfig['webSearch'];
+
+      // Mock successful authentication
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          result[field] =
+            field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authenticated).toBe(true);
+      expect(result.authResult.scraperTimeout).toBe(12000); // Should use firecrawlOptions.timeout
+      expect(result.authResult.firecrawlOptions).toEqual({
+        timeout: 12000,
+      });
+    });
+
+    it('should handle firecrawlOptions.formats when only formats is provided', async () => {
+      // Initialize a webSearchConfig with only firecrawlOptions.formats
+      const webSearchConfig = {
+        serperApiKey: '${SERPER_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        jinaApiKey: '${JINA_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        firecrawlOptions: {
+          formats: ['html', 'markdown'], // Only formats provided
+        },
+      } as TCustomConfig['webSearch'];
+
+      // Mock successful authentication
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          result[field] =
+            field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authenticated).toBe(true);
+      expect(result.authResult.scraperTimeout).toBe(7500); // Should use default timeout
+      expect(result.authResult.firecrawlOptions).toEqual({
+        formats: ['html', 'markdown'],
+      });
+    });
+
+    it('should handle firecrawlOptions without formats property', async () => {
+      // Initialize a webSearchConfig with firecrawlOptions but no formats
+      const webSearchConfig = {
+        serperApiKey: '${SERPER_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        jinaApiKey: '${JINA_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        firecrawlOptions: {
+          timeout: 8000,
+          includeTags: ['p', 'h1'],
+          // formats is intentionally missing
+        },
+      } as TCustomConfig['webSearch'];
+
+      // Mock successful authentication
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          result[field] =
+            field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authenticated).toBe(true);
+      expect(result.authResult.scraperTimeout).toBe(8000); // Should use firecrawlOptions.timeout
+      expect(result.authResult.firecrawlOptions).toEqual({
+        timeout: 8000,
+        includeTags: ['p', 'h1'],
+        // formats should be undefined/missing
+      });
+    });
+
+    it('should handle webSearchConfig without firecrawlOptions at all', async () => {
+      // Initialize a webSearchConfig without any firecrawlOptions
+      const webSearchConfig = {
+        serperApiKey: '${SERPER_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        jinaApiKey: '${JINA_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        // firecrawlOptions is intentionally missing
+      } as TCustomConfig['webSearch'];
+
+      // Mock successful authentication
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          result[field] =
+            field === 'FIRECRAWL_API_URL' ? 'https://api.firecrawl.dev' : 'test-api-key';
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authenticated).toBe(true);
+      expect(result.authResult.scraperTimeout).toBe(7500); // Should use default timeout
+      expect(result.authResult.firecrawlOptions).toBeUndefined(); // Should be undefined
     });
   });
 });

--- a/packages/api/src/web/web.ts
+++ b/packages/api/src/web/web.ts
@@ -4,10 +4,13 @@ import type {
   TCustomConfig,
   SearchProviders,
   TWebSearchConfig,
-} from './config';
-import { SearchCategories, SafeSearchTypes } from './config';
-import { extractVariableName } from './utils';
-import { AuthType } from './schemas';
+} from 'librechat-data-provider';
+import {
+  SearchCategories,
+  SafeSearchTypes,
+  extractVariableName,
+  AuthType,
+} from 'librechat-data-provider';
 
 export function loadWebSearchConfig(
   config: TCustomConfig['webSearch'],
@@ -278,7 +281,9 @@ export async function loadWebSearchAuth({
   }
 
   authResult.safeSearch = webSearchConfig?.safeSearch ?? SafeSearchTypes.MODERATE;
-  authResult.scraperTimeout = webSearchConfig?.scraperTimeout ?? 7500;
+  authResult.scraperTimeout =
+    webSearchConfig?.scraperTimeout ?? webSearchConfig?.firecrawlOptions?.timeout ?? 7500;
+  authResult.firecrawlOptions = webSearchConfig?.firecrawlOptions;
 
   return {
     authTypes,

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -658,6 +658,39 @@ export const webSearchSchema = z.object({
   rerankerType: z.nativeEnum(RerankerTypes).optional(),
   scraperTimeout: z.number().optional(),
   safeSearch: z.nativeEnum(SafeSearchTypes).default(SafeSearchTypes.MODERATE),
+  firecrawlOptions: z
+    .object({
+      formats: z.array(z.string()).optional(),
+      includeTags: z.array(z.string()).optional(),
+      excludeTags: z.array(z.string()).optional(),
+      headers: z.record(z.string()).optional(),
+      waitFor: z.number().optional(),
+      timeout: z.number().optional(),
+      maxAge: z.number().optional(),
+      mobile: z.boolean().optional(),
+      skipTlsVerification: z.boolean().optional(),
+      blockAds: z.boolean().optional(),
+      removeBase64Images: z.boolean().optional(),
+      parsePDF: z.boolean().optional(),
+      storeInCache: z.boolean().optional(),
+      zeroDataRetention: z.boolean().optional(),
+      location: z
+        .object({
+          country: z.string().optional(),
+          languages: z.array(z.string()).optional(),
+        })
+        .optional(),
+      onlyMainContent: z.boolean().optional(),
+      changeTrackingOptions: z
+        .object({
+          modes: z.array(z.string()).optional(),
+          schema: z.record(z.unknown()).optional(),
+          prompt: z.string().optional(),
+          tag: z.string().nullable().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 
 export type TWebSearchConfig = z.infer<typeof webSearchSchema>;

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -13,8 +13,6 @@ export * from './generate';
 export * from './models';
 /* mcp */
 export * from './mcp';
-/* web search */
-export * from './web';
 /* memory */
 export * from './memory';
 /* RBAC */

--- a/packages/data-provider/src/types/web.ts
+++ b/packages/data-provider/src/types/web.ts
@@ -101,7 +101,33 @@ export interface ProcessSourcesConfig {
 export interface FirecrawlConfig {
   firecrawlApiKey?: string;
   firecrawlApiUrl?: string;
-  firecrawlFormats?: string[];
+  firecrawlOptions?: {
+    formats?: string[];
+    includeTags?: string[];
+    excludeTags?: string[];
+    headers?: Record<string, string>;
+    waitFor?: number;
+    timeout?: number;
+    maxAge?: number;
+    mobile?: boolean;
+    skipTlsVerification?: boolean;
+    blockAds?: boolean;
+    removeBase64Images?: boolean;
+    parsePDF?: boolean;
+    storeInCache?: boolean;
+    zeroDataRetention?: boolean;
+    location?: {
+      country?: string;
+      languages?: string[];
+    };
+    onlyMainContent?: boolean;
+    changeTrackingOptions?: {
+      modes?: string[];
+      schema?: Record<string, unknown>;
+      prompt?: string;
+      tag?: string | null;
+    };
+  };
 }
 
 export interface ScraperContentResult {


### PR DESCRIPTION
## Summary

**Adds advanced configurability for Firecrawl web scraping and refactors web search config/auth logic for future extensibility.**

This PR introduces a new `firecrawlOptions` configuration field to `librechat.yaml`, allowing users to fine-tune Firecrawl scraper behavior with a flexible schema (e.g. custom formats, headers, timeout, caching, content targeting, and more). In addition, core `web.ts` logic was moved from `packages/data-provider` to `packages/api`, and all relevant imports have been updated accordingly. The Firecrawl type in `FirecrawlConfig` has been expanded to include the new configurable options

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Translation update

## Details & Change Breakdown

### 1. Firecrawl Option Schema & Configuration

- **`firecrawlOptions` added to `webSearchSchema` in `packages/data-provider/src/config.ts`**:
  - Now supports configurable formats, include/exclude tags, custom headers, waiting, timeouts, mobile rendering, TLS and ads, parsePDF, cache control, content targeting, and change tracking.
- **Expanded `FirecrawlConfig` Type:**  
  - `firecrawlOptions` type in `packages/data-provider/src/types/web.ts` added that matches new schema 

### 2. Codebase Structure Refactor

- **Moved all `web.ts` logic from `data-provider` to `packages/api/src/web/web.ts`**
  - Test file moved likewise (`web.spec.ts`)
  - Updated all imports to reference new module locations (`@librechat/api`)

### 3. Integration & Propagation

- **`firecrawlOptions` is now passed through the web search auth loading function:**
  - Included in `loadWebSearchAuth` and returned for use in payload construction through authResults.

### 4. Test & Validation

- **Tests moved and updated:**  
  - `web.spec.ts` relocated, enhanced to test integration of new firecrawl options

## Testing

**Manual and unit test coverage:**

- Added unit tests for the expanded Firecrawl/web config logic in `packages/api/src/web/web.spec.ts`
- Manual:
  1. Populated `firecrawlOptions` in `librechat.yaml` with advanced settings (e.g. custom headers, enabled markdown, altered timeouts)
  2. Restarted backend
  3. Initiated chat session using Firecrawl scraping with SearXNG instance
  4. Confirmed settings are respected in outgoing Firecrawl payload and scraper result and that chat web search functionality was intact
  5. Repeated for different configurations as well as for when firecrawlOptions is absent to ensure default values were working

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.