### PR TITLE
🕒 refactor: Use Legacy Content for Custom Endpoints and Azure Serverless for Improved Compatibility

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -26,7 +26,6 @@ const {
   VisionModes,
   ContentTypes,
   EModelEndpoint,
-  KnownEndpoints,
   PermissionTypes,
   isAgentsEndpoint,
   AgentCapabilities,
@@ -75,8 +74,6 @@ const payloadParser = ({ req, agent, endpoint }) => {
   }
   return req.body.endpointOption.model_parameters;
 };
-
-const legacyContentEndpoints = new Set([KnownEndpoints.groq, KnownEndpoints.deepseek]);
 
 const noSystemModelRegex = [/\b(o1-preview|o1-mini|amazon\.titan-text)\b/gi];
 
@@ -718,9 +715,6 @@ class AgentClient extends BaseClient {
         this.indexTokenCountMap,
         toolSet,
       );
-      if (legacyContentEndpoints.has(this.options.agent.endpoint?.toLowerCase())) {
-        initialMessages = formatContentStrings(initialMessages);
-      }
 
       /**
        *
@@ -784,6 +778,9 @@ class AgentClient extends BaseClient {
         }
 
         let messages = _messages;
+        if (agent.useLegacyContent === true) {
+          messages = formatContentStrings(messages);
+        }
         if (
           agent.model_parameters?.clientOptions?.defaultHeaders?.['anthropic-beta']?.includes(
             'prompt-caching',

--- a/api/server/services/Endpoints/agents/agent.js
+++ b/api/server/services/Endpoints/agents/agent.js
@@ -186,10 +186,11 @@ const initializeAgent = async ({
 
   return {
     ...agent,
+    tools,
     attachments,
     resendFiles,
     toolContextMap,
-    tools,
+    useLegacyContent: !!options.useLegacyContent,
     maxContextTokens: (agentMaxContextTokens - maxTokens) * 0.9,
   };
 };

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -139,7 +139,9 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
       );
       clientOptions.modelOptions.user = req.user.id;
       const options = getOpenAIConfig(apiKey, clientOptions, endpoint);
-      options.useLegacyContent = true;
+      if (options != null) {
+        options.useLegacyContent = true;
+      }
       if (!customOptions.streamRate) {
         return options;
       }

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -139,6 +139,7 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
       );
       clientOptions.modelOptions.user = req.user.id;
       const options = getOpenAIConfig(apiKey, clientOptions, endpoint);
+      options.useLegacyContent = true;
       if (!customOptions.streamRate) {
         return options;
       }
@@ -156,6 +157,7 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
     }
 
     return {
+      useLegacyContent: true,
       llmConfig: modelOptions,
     };
   }

--- a/api/server/services/Endpoints/openAI/initialize.js
+++ b/api/server/services/Endpoints/openAI/initialize.js
@@ -144,6 +144,9 @@ const initializeClient = async ({
     clientOptions = Object.assign({ modelOptions }, clientOptions);
     clientOptions.modelOptions.user = req.user.id;
     const options = getOpenAIConfig(apiKey, clientOptions);
+    if (serverless === true) {
+      options.useLegacyContent = true;
+    }
     const streamRate = clientOptions.streamRate;
     if (!streamRate) {
       return options;
@@ -153,9 +156,6 @@ const initializeClient = async ({
         handleLLMNewToken: createHandleLLMNewToken(streamRate),
       },
     ];
-    if (serverless === true) {
-      options.useLegacyContent = true;
-    }
     return options;
   }
 

--- a/api/server/services/Endpoints/openAI/initialize.js
+++ b/api/server/services/Endpoints/openAI/initialize.js
@@ -65,19 +65,20 @@ const initializeClient = async ({
   const isAzureOpenAI = endpoint === EModelEndpoint.azureOpenAI;
   /** @type {false | TAzureConfig} */
   const azureConfig = isAzureOpenAI && req.app.locals[EModelEndpoint.azureOpenAI];
-
+  let serverless = false;
   if (isAzureOpenAI && azureConfig) {
     const { modelGroupMap, groupMap } = azureConfig;
     const {
       azureOptions,
       baseURL,
       headers = {},
-      serverless,
+      serverless: _serverless,
     } = mapModelToAzureConfig({
       modelName,
       modelGroupMap,
       groupMap,
     });
+    serverless = _serverless;
 
     clientOptions.reverseProxyUrl = baseURL ?? clientOptions.reverseProxyUrl;
     clientOptions.headers = resolveHeaders(
@@ -152,6 +153,9 @@ const initializeClient = async ({
         handleLLMNewToken: createHandleLLMNewToken(streamRate),
       },
     ];
+    if (serverless === true) {
+      options.useLegacyContent = true;
+    }
     return options;
   }
 

--- a/api/server/services/Endpoints/openAI/initialize.js
+++ b/api/server/services/Endpoints/openAI/initialize.js
@@ -144,7 +144,7 @@ const initializeClient = async ({
     clientOptions = Object.assign({ modelOptions }, clientOptions);
     clientOptions.modelOptions.user = req.user.id;
     const options = getOpenAIConfig(apiKey, clientOptions);
-    if (serverless === true) {
+    if (options != null && serverless === true) {
       options.useLegacyContent = true;
     }
     const streamRate = clientOptions.streamRate;


### PR DESCRIPTION
## Summary

I refactored endpoint initialization and message handling logic to ensure legacy content formatting is used for custom endpoints and Azure serverless endpoints, improving compatibility with providers that require this format.

- Added the `useLegacyContent` property to client options for custom endpoints, always enabling legacy formatting for their messages
- Applied legacy content formatting to Azure serverless endpoints configured through the AI Foundry
- Updated message formatting logic in the agent client to dynamically use legacy content formatting based on the new `useLegacyContent` flag
- Modified endpoint initialization code in custom and OpenAI/Azure handlers to set `useLegacyContent` where appropriate
- Removed hardcoded legacy endpoint checks, adopting a more dynamic approach tied to endpoint config

## Change Type

- [x] Refactor (non-breaking change which improves code structure or compatibility)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes