### PR TITLE
🪙 fix: Use Fallback Token Transaction if No Collected Usage

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -108,12 +108,15 @@ class BaseClient {
   /**
    * Abstract method to record token usage. Subclasses must implement this method.
    * If a correction to the token usage is needed, the method should return an object with the corrected token counts.
+   * Should only be used if `recordCollectedUsage` was not used instead.
+   * @param {string} [model]
    * @param {number} promptTokens
    * @param {number} completionTokens
    * @returns {Promise<void>}
    */
-  async recordTokenUsage({ promptTokens, completionTokens }) {
+  async recordTokenUsage({ model, promptTokens, completionTokens }) {
     logger.debug('[BaseClient] `recordTokenUsage` not implemented.', {
+      model,
       promptTokens,
       completionTokens,
     });
@@ -741,9 +744,13 @@ class BaseClient {
       } else {
         responseMessage.tokenCount = this.getTokenCountForResponse(responseMessage);
         completionTokens = responseMessage.tokenCount;
+        await this.recordTokenUsage({
+          usage,
+          promptTokens,
+          completionTokens,
+          model: responseMessage.model,
+        });
       }
-
-      await this.recordTokenUsage({ promptTokens, completionTokens, usage });
     }
 
     if (userMessagePromise) {


### PR DESCRIPTION
## Summary

I addressed an issue where token usage transactions were not recorded if collected usage data was unavailable by implementing a fallback to `recordTokenUsage`. This ensures token usage is accurately tracked even in the absence of collected usage metrics.

- Updated `BaseClient.recordTokenUsage` to accept `model` as an argument and improved debug logging for clarity
- Modified the control flow in `BaseClient` to ensure `recordTokenUsage` is called only when `recordCollectedUsage` is not used
- Refactored `AgentClient.recordTokenUsage` to handle recording both standard and "reasoning" token usage, using the appropriate context parameter for secondary transactions
- Enhanced error handling and logging for better visibility in the event of token usage recording failures


Closes https://github.com/danny-avila/LibreChat/issues/8428

**Change Type**
- [x] Bug fix (non-breaking change which fixes an issue)

**Testing**

To test these changes, I ran chat message flows where collected usage is both present and absent, verified that token transactions are logged as expected, and confirmed fallback behavior triggers the correct API call. I recommend additional local tests with both default and custom endpoints that do not provide pre-aggregated usage data to validate the fallback and error handling logic.

**Checklist**

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes