### PR TITLE
📦 chore: bump `@librechat/agents` to to v2.4.61

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -48,7 +48,7 @@
     "@langchain/google-genai": "^0.2.13",
     "@langchain/google-vertexai": "^0.2.13",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^2.4.60",
+    "@librechat/agents": "^2.4.61",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@node-saml/passport-saml": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@langchain/google-genai": "^0.2.13",
         "@langchain/google-vertexai": "^0.2.13",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^2.4.60",
+        "@librechat/agents": "^2.4.61",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@node-saml/passport-saml": "^5.0.0",
@@ -19385,9 +19385,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "2.4.60",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.60.tgz",
-      "integrity": "sha512-rhZiQSm4wLXe738UdtxRY6zpQrpk+FVo6NUk5XfogtE8zE3C5AQap85PGxoNneYK39V9mCf1X4lwMHmLqHW7oA==",
+      "version": "2.4.61",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.61.tgz",
+      "integrity": "sha512-/05fUO+sYh4Xpj9k6UNwsKzV8UG25t3NbTCpvQdr1NWam56M2p1DWp4uqgqVZfJP2Lh4Dyprr4Erny3RaNhbBQ==",
       "license": "MIT",
       "dependencies": {
         "@langchain/anthropic": "^0.3.24",
@@ -46574,7 +46574,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "@librechat/agents": "^2.4.60",
+        "@librechat/agents": "^2.4.61",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.13.3",
         "axios": "^1.8.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -69,7 +69,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "@librechat/agents": "^2.4.60",
+    "@librechat/agents": "^2.4.61",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.13.3",
     "axios": "^1.8.2",


### PR DESCRIPTION
Closes #8407
Closes #8428 