### PR TITLE
🔧 fix: Specify Endpoints for Responses API Auto-Enable Logic

### DIFF
--- a/client/src/hooks/Conversations/useSetIndexOptions.ts
+++ b/client/src/hooks/Conversations/useSetIndexOptions.ts
@@ -1,5 +1,11 @@
 import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { TPreset, TPlugin, TConversation, tConvoUpdateSchema } from 'librechat-data-provider';
+import {
+  TPreset,
+  TPlugin,
+  TConversation,
+  tConvoUpdateSchema,
+  EModelEndpoint,
+} from 'librechat-data-provider';
 import type { TSetExample, TSetOption, TSetOptionsPayload } from '~/common';
 import usePresetIndexOptions from './usePresetIndexOptions';
 import { useChatContext } from '~/Providers/ChatContext';
@@ -30,11 +36,19 @@ const useSetIndexOptions: TUseSetOptions = (preset = false) => {
       };
     }
 
-    // Auto-enable Responses API when web search is enabled
+    // Auto-enable Responses API when web search is enabled (only for OpenAI/Azure/Custom endpoints)
     if (param === 'web_search' && newValue === true) {
-      const currentUseResponsesApi = conversation?.useResponsesApi ?? false;
-      if (!currentUseResponsesApi) {
-        update['useResponsesApi'] = true;
+      const currentEndpoint = conversation?.endpoint;
+      const isOpenAICompatible =
+        currentEndpoint === EModelEndpoint.openAI ||
+        currentEndpoint === EModelEndpoint.azureOpenAI ||
+        currentEndpoint === EModelEndpoint.custom;
+
+      if (isOpenAICompatible) {
+        const currentUseResponsesApi = conversation?.useResponsesApi ?? false;
+        if (!currentUseResponsesApi) {
+          update['useResponsesApi'] = true;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Updated the logic to auto-enable the Responses API when web search is enabled, specifically for OpenAI, Azure, and Custom endpoints.
- Added import for EModelEndpoint to facilitate endpoint compatibility checks.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual verification via absence of url query params for non-applicable endpoints when enabling web_search.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings

