### PR TITLE
👥 fix: Collaborative Check Flag for Shared Agent Files

### DIFF
--- a/api/models/File.js
+++ b/api/models/File.js
@@ -21,7 +21,7 @@ const findFileById = async (file_id, options = {}) => {
  * @param {string} agentId - The agent ID that might grant access
  * @returns {Promise<Map<string, boolean>>} Map of fileId to access status
  */
-const hasAccessToFilesViaAgent = async (userId, fileIds, agentId) => {
+const hasAccessToFilesViaAgent = async (userId, fileIds, agentId, checkCollaborative = true) => {
   const accessMap = new Map();
 
   // Initialize all files as no access
@@ -55,11 +55,11 @@ const hasAccessToFilesViaAgent = async (userId, fileIds, agentId) => {
     }
 
     // Agent is globally shared - check if it's collaborative
-    if (!agent.isCollaborative) {
+    if (checkCollaborative && !agent.isCollaborative) {
       return accessMap;
     }
 
-    // Agent is globally shared and collaborative - check which files are actually attached
+    // Check which files are actually attached
     const attachedFileIds = new Set();
     if (agent.tool_resources) {
       for (const [_resourceType, resource] of Object.entries(agent.tool_resources)) {
@@ -118,7 +118,12 @@ const getFiles = async (filter, _sortOptions, selectFields = { text: 0 }, option
 
     // Batch check access for all non-owned files
     const fileIds = filesToCheck.map((f) => f.file_id);
-    const accessMap = await hasAccessToFilesViaAgent(options.userId, fileIds, options.agentId);
+    const accessMap = await hasAccessToFilesViaAgent(
+      options.userId,
+      fileIds,
+      options.agentId,
+      false,
+    );
 
     // Filter files based on access
     const accessibleFiles = filesToCheck.filter((file) => accessMap.get(file.file_id));


### PR DESCRIPTION
## Summary

This PR fixes #8515 where shared, non-collaborative agents were unable to access their attached file search files when used by other users. The issue was caused by a check in the `hasAccessToFilesViaAgent` function that would immediately deny file access for any globally shared agent that wasn't collaborative.
This makes the `isCollaborative` check optional allows all globally shared agents to access their attached files while preventing users without authorization to delete those files.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The fix was tested by reproducing the exact steps from the issue:

1. **User A**: Created an agent with attached files for file search
2. **User A**: Shared the agent to all users with "Allow other users to edit your agent" disabled (non-collaborative)
3. **User B**: Selected the shared agent and asked questions about the attached files
4. **Result**: Agent can now successfully access and use the attached files to answer questions

Regression testing deletion of files:

1. **User B**: Try to delete the file
2. **Result**: Message `Delete operation is not allowed` is displayed
3. **User A**: Try to delete the file
4. **Result**: Message `Succesfully deleted` is displayed

### **Test Configuration**:

- Agent configured as globally shared with `isCollaborative: false`
- Files attached to the agent via file search functionality

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
