### PR TITLE
fix(i18n): change 'instruction' translation from '설명' to '지침'

### DIFF
--- a/client/src/locales/ko/translation.json
+++ b/client/src/locales/ko/translation.json
@@ -764,7 +764,7 @@
   "com_ui_import_conversation_success": "대화가 성공적으로 가져와졌습니다",
   "com_ui_include_shadcnui": "shadcn/ui 컴포넌트 설치 안내",
   "com_ui_input": "입력",
-  "com_ui_instructions": "설명",
+  "com_ui_instructions": "지침",
   "com_ui_key": "키",
   "com_ui_late_night": "늦은 밤에도 행복하세요",
   "com_ui_latest_footer": "모두를 위한 AI, 한곳에서",


### PR DESCRIPTION
Summary

This PR updates the Korean translation for the instruction label in the UI.
Previously, both instruction and description were translated as 설명, which caused confusion in the interface.
To clarify the distinction, the instruction label has been updated to 지침.

There are no code-level changes—only a translation file update.

Change Type
	•	Translation update

Testing

Test Configuration
	•	Locale: ko
	•	Target file: client/src/locales/ko/translation.json
	•	Confirmed the UI now renders '지침' instead of '설명' for the instruction field, and that it is visually distinct from the description label.

Checklist
	•	My code adheres to this project’s style guidelines
	•	I have performed a self-review of my own code
	•	I have commented in any complex areas of my code (not applicable)
	•	I have made pertinent documentation changes (not applicable)
	•	My changes do not introduce new warnings
	•	I have written tests demonstrating that my changes are effective or that my feature works (not applicable)
	•	Local unit tests pass with my changes
	•	Any changes dependent on mine have been merged and published in downstream modules (not applicable)
	•	A pull request for updating the documentation has been submitted (not applicable)