### PR TITLE
feat: configurable timers and number of retries for mcp reconnect

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -143,6 +143,9 @@ actions:
 #     # type: sse # type can optionally be omitted
 #     url: http://localhost:3001/sse
 #     timeout: 60000  # 1 minute timeout for this server, this is the default timeout for MCP servers.
+#     maxReconnectAttempts: 3   # retries in case of disconnection, default is 3
+#     maxBackoffMs: 30000       # max Backoff between reconnection attempts, default is 30000
+#     reconnectBackoffMs: 1000  # Initial backoff time between reconnection attemps, doubled until maxBackoffMs, default is 1000
 #   puppeteer:
 #     type: stdio
 #     command: npx

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -62,7 +62,6 @@ export class MCPConnection extends EventEmitter {
   private transport: Transport | null = null; // Make this nullable
   private connectionState: t.ConnectionState = 'disconnected';
   private connectPromise: Promise<void> | null = null;
-  private readonly MAX_RECONNECT_ATTEMPTS = 3;
   public readonly serverName: string;
   private shouldStopReconnecting = false;
   private isReconnecting = false;
@@ -108,6 +107,18 @@ export class MCPConnection extends EventEmitter {
   private getLogPrefix(): string {
     const userPart = this.userId ? `[User: ${this.userId}]` : '';
     return `[MCP]${userPart}[${this.serverName}]`;
+  }
+
+  private get maxReconnectAttempts(): number {
+    return this.options.maxReconnectAttempts ?? 3;
+  }
+
+  private get maxBackoffMs(): number {
+    return this.options.maxBackoffMs ?? 30000;
+  }
+
+  private get reconnectBackoffMs(): number {
+    return this.options.reconnectBackoffMs ?? 1000;
   }
 
   public static getInstance(
@@ -310,32 +321,49 @@ export class MCPConnection extends EventEmitter {
     }
 
     this.isReconnecting = true;
-    const backoffDelay = (attempt: number) => Math.min(1000 * Math.pow(2, attempt), 30000);
+    const backoffDelay = (attempt: number) =>
+      Math.min(this.reconnectBackoffMs * Math.pow(2, attempt), this.maxBackoffMs);
 
     try {
+      const maxAttempts = this.maxReconnectAttempts;
+      if (maxAttempts === 0) {
+        return;
+      }
+
       while (
-        this.reconnectAttempts < this.MAX_RECONNECT_ATTEMPTS &&
-        !(this.shouldStopReconnecting as boolean)
+        (maxAttempts === -1 || this.reconnectAttempts < maxAttempts) &&
+        !this.shouldStopReconnecting
       ) {
         this.reconnectAttempts++;
         const delay = backoffDelay(this.reconnectAttempts);
 
+        const maxAttemptsLabel = maxAttempts === -1 ? 'infinity' : maxAttempts;
         logger.info(
-          `${this.getLogPrefix()} Reconnecting ${this.reconnectAttempts}/${this.MAX_RECONNECT_ATTEMPTS} (delay: ${delay}ms)`,
+          `${this.getLogPrefix()} Reconnecting ${
+            this.reconnectAttempts
+          }/${maxAttemptsLabel} (delay: ${delay}ms)`,
         );
 
         await new Promise((resolve) => setTimeout(resolve, delay));
 
+        // Check if we should stop before attempting connection
+        if (this.shouldStopReconnecting) {
+          logger.info(`${this.getLogPrefix()} Reconnection cancelled during delay`);
+          return;
+        }
+
         try {
           await this.connect();
+          // Connection successful - reset attempts and exit
           this.reconnectAttempts = 0;
+          logger.info(`${this.getLogPrefix()} Reconnection successful`);
           return;
         } catch (error) {
           logger.error(`${this.getLogPrefix()} Reconnection attempt failed:`, error);
 
           if (
-            this.reconnectAttempts === this.MAX_RECONNECT_ATTEMPTS ||
-            (this.shouldStopReconnecting as boolean)
+            (maxAttempts !== -1 && this.reconnectAttempts >= maxAttempts) ||
+            this.shouldStopReconnecting
           ) {
             logger.error(`${this.getLogPrefix()} Stopping reconnection attempts`);
             return;
@@ -368,10 +396,16 @@ export class MCPConnection extends EventEmitter {
 
     this.emit('connectionChange', 'connecting');
 
+    // Reset reconnection flags when starting a new connection attempt
+    this.shouldStopReconnecting = false;
+
     this.connectPromise = (async () => {
       try {
+        logger.debug(`${this.getLogPrefix()} Starting connection process`);
+
         if (this.transport) {
           try {
+            logger.debug(`${this.getLogPrefix()} Closing existing transport`);
             await this.client.close();
             this.transport = null;
           } catch (error) {
@@ -379,10 +413,15 @@ export class MCPConnection extends EventEmitter {
           }
         }
 
+        logger.debug(`${this.getLogPrefix()} Constructing transport`);
         this.transport = this.constructTransport(this.options);
         this.setupTransportDebugHandlers();
 
         const connectTimeout = this.options.initTimeout ?? 120000;
+        logger.debug(
+          `${this.getLogPrefix()} Attempting client connection with timeout ${connectTimeout}ms`,
+        );
+
         await Promise.race([
           this.client.connect(this.transport),
           new Promise((_resolve, reject) =>
@@ -393,6 +432,9 @@ export class MCPConnection extends EventEmitter {
           ),
         ]);
 
+        logger.debug(
+          `${this.getLogPrefix()} Client connection successful, setting state to connected`,
+        );
         this.connectionState = 'connected';
         this.emit('connectionChange', 'connected');
         this.reconnectAttempts = 0;
@@ -509,7 +551,7 @@ export class MCPConnection extends EventEmitter {
 
   async connect(): Promise<void> {
     try {
-      await this.disconnect();
+      await this.disconnect(false); // Don't stop reconnection during connection setup
       await this.connectClient();
       if (!(await this.isConnected())) {
         throw new Error('Connection not established');
@@ -518,6 +560,12 @@ export class MCPConnection extends EventEmitter {
       logger.error(`${this.getLogPrefix()} Connection failed:`, error);
       throw error;
     }
+  }
+
+  /** Stop any ongoing reconnection attempts */
+  public stopReconnection(): void {
+    this.shouldStopReconnecting = true;
+    logger.info(`${this.getLogPrefix()} Reconnection attempts stopped`);
   }
 
   private setupTransportErrorHandlers(transport: Transport): void {
@@ -537,8 +585,13 @@ export class MCPConnection extends EventEmitter {
     };
   }
 
-  public async disconnect(): Promise<void> {
+  public async disconnect(stopReconnecting: boolean = true): Promise<void> {
     try {
+      // Only stop reconnection attempts if this is an intentional disconnect
+      if (stopReconnecting) {
+        this.shouldStopReconnecting = true;
+      }
+
       if (this.transport) {
         await this.client.close();
         this.transport = null;
@@ -586,12 +639,17 @@ export class MCPConnection extends EventEmitter {
   public async isConnected(): Promise<boolean> {
     // First check if we're in a connected state
     if (this.connectionState !== 'connected') {
+      logger.debug(
+        `${this.getLogPrefix()} Connection state is not 'connected': ${this.connectionState}`,
+      );
       return false;
     }
 
     try {
       // Try ping first as it's the lightest check
+      logger.debug(`${this.getLogPrefix()} Attempting ping to verify connection`);
       await this.client.ping();
+      logger.debug(`${this.getLogPrefix()} Ping successful`);
       return this.connectionState === 'connected';
     } catch (error) {
       // Check if the error is because ping is not supported (method not found)
@@ -614,10 +672,13 @@ export class MCPConnection extends EventEmitter {
       try {
         // Get server capabilities to verify connection is truly active
         const capabilities = this.client.getServerCapabilities();
+        logger.debug(`${this.getLogPrefix()} Server capabilities:`, capabilities);
 
         // If we have capabilities, try calling a supported method to verify connection
         if (capabilities?.tools) {
+          logger.debug(`${this.getLogPrefix()} Attempting listTools to verify connection`);
           await this.client.listTools();
+          logger.debug(`${this.getLogPrefix()} listTools successful`);
           return this.connectionState === 'connected';
         } else if (capabilities?.resources) {
           await this.client.listResources();

--- a/packages/api/src/mcp/manager.ts
+++ b/packages/api/src/mcp/manager.ts
@@ -435,7 +435,8 @@ export class MCPManager {
     config = { ...(processMCPEnv(config, user, customUserVars) ?? {}) };
     /** If no in-memory tokens, tokens from persistent storage */
     let tokens: MCPOAuthTokens | null = null;
-    if (tokenMethods?.findToken) {
+    // Only attempt to get OAuth tokens if the server has OAuth configuration
+    if (tokenMethods?.findToken && config.oauth) {
       try {
         /** Refresh function for user-specific connections */
         const refreshTokensFunction = async (
@@ -606,7 +607,7 @@ export class MCPManager {
     } catch (error) {
       logger.error(`[MCP][User: ${userId}][${serverName}] Failed to establish connection`, error);
       // Ensure partial connection state is cleaned up if initialization fails
-      await connection?.disconnect().catch((disconnectError) => {
+      await connection?.disconnect(false).catch((disconnectError) => {
         logger.error(
           `[MCP][User: ${userId}][${serverName}] Error during cleanup after failed connection`,
           disconnectError,

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -23,6 +23,9 @@ export type MCPOptions = z.infer<typeof MCPOptionsSchema> & {
       description: string;
     }
   >;
+  maxReconnectAttempts?: number;
+  maxBackoffMs?: number;
+  reconnectBackoffMs?: number;
 };
 export type MCPServers = z.infer<typeof MCPServersSchema>;
 export interface MCPResource {

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -6,6 +6,9 @@ const BaseOptionsSchema = z.object({
   iconPath: z.string().optional(),
   timeout: z.number().optional(),
   initTimeout: z.number().optional(),
+  maxReconnectAttempts: z.number().int().min(-1).optional(),
+  maxBackoffMs: z.number().int().min(0).optional(),
+  reconnectBackoffMs: z.number().int().min(0).optional(),
   /** Controls visibility in chat dropdown menu (MCPSelect) */
   chatMenu: z.boolean().optional(),
   /**


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Configure MCP re-connection parameters in librechat.yaml . Allows to retry more than 3 times in case of disconnection, it's useful with http servers which restart etc..
Currently we have to restart librechat if an MCP server is unavailable for more than 8 seconds, which is not very practical on a shared instance with several remote mcp server which can be unavailable for several minutes.

## Change Type

Please delete any irrelevant options.

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Translation update

## Testing

I have tested that
- without setting the new environment variables the behavior is the same as before.
- setting a big number of retries allows librechat to recover after longer disconnections
- the startup process is not affected ( it's always 3 restarts )

In my test setup I had 2 remote http mcp servers configured in librechat.yaml, one up and one down.


### **Test Configuration**:

Configure the librechat.yaml mcp server like this:

```
mcpServers:
     remote-mcp:
    type: streamable-http
    url: http://my.mcp.com/mcp
    headers:
      x-user-email: "{{LIBRECHAT_USER_EMAIL}}"
    maxReconnectAttempts: 10
    maxBackoffMs: 30000
    reconnectBackoffMs: 1000 
```
the default maxReconnectAttempts is 3


Configure one or several MCP servers in librechat.yaml

verify that:
  - the startup connection process succeeds or fails as before ( unreachable servers or ones requiring oauth are tried only thrice, then disabled )
  - once librechat is running, if you stop the one of the connected mcp server the number of retries performed by librechat follows the configuration

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.

I will update the documentation for the new options in the mcpServer section of librechat.yaml