### PR TITLE
🏄‍♂️ fix: Handle SSE Stream Edge Case

### DIFF
--- a/client/src/hooks/Input/useAutoSave.ts
+++ b/client/src/hooks/Input/useAutoSave.ts
@@ -4,35 +4,10 @@ import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { LocalStorageKeys, Constants } from 'librechat-data-provider';
 import type { TFile } from 'librechat-data-provider';
 import type { ExtendedFile } from '~/common';
+import { clearDraft, decodeBase64, encodeBase64 } from '~/utils';
 import { useChatFormContext } from '~/Providers';
 import { useGetFiles } from '~/data-provider';
 import store from '~/store';
-
-const clearDraft = debounce((id?: string | null) => {
-  localStorage.removeItem(`${LocalStorageKeys.TEXT_DRAFT}${id ?? ''}`);
-}, 2500);
-
-const encodeBase64 = (plainText: string): string => {
-  try {
-    const textBytes = new TextEncoder().encode(plainText);
-    return btoa(String.fromCharCode(...textBytes));
-  } catch (e) {
-    return '';
-  }
-};
-
-const decodeBase64 = (base64String: string): string => {
-  try {
-    const bytes = atob(base64String);
-    const uint8Array = new Uint8Array(bytes.length);
-    for (let i = 0; i < bytes.length; i++) {
-      uint8Array[i] = bytes.charCodeAt(i);
-    }
-    return new TextDecoder().decode(uint8Array);
-  } catch (e) {
-    return '';
-  }
-};
 
 export const useAutoSave = ({
   isSubmitting,

--- a/client/src/hooks/SSE/useEventHandlers.ts
+++ b/client/src/hooks/SSE/useEventHandlers.ts
@@ -7,10 +7,10 @@ import {
   QueryKeys,
   Constants,
   EndpointURLs,
+  ContentTypes,
   tPresetSchema,
   tMessageSchema,
   tConvoUpdateSchema,
-  ContentTypes,
   isAssistantsEndpoint,
 } from 'librechat-data-provider';
 import type { TMessage, TConversation, EventSubmission } from 'librechat-data-provider';
@@ -21,6 +21,7 @@ import type { SetterOrUpdater, Resetter } from 'recoil';
 import type { ConversationCursorData } from '~/utils';
 import {
   logger,
+  setDraft,
   scrollToEnd,
   getAllContentText,
   addConvoToAllQueries,
@@ -457,6 +458,38 @@ export default function useEventHandlers({
       announcePolite({ message: 'end', isStatus: true });
       announcePolite({ message: getAllContentText(responseMessage) });
 
+      const isNewConvo = conversation.conversationId !== submissionConvo.conversationId;
+
+      const setFinalMessages = (id: string | null, _messages: TMessage[]) => {
+        setMessages(_messages);
+        queryClient.setQueryData<TMessage[]>([QueryKeys.messages, id], _messages);
+      };
+
+      /** Handle edge case where stream is cancelled before any response, which creates a blank page */
+      if (
+        !conversation.conversationId &&
+        responseMessage?.content?.[0]?.['text']?.value ===
+          submission.initialResponse?.content?.[0]?.['text']?.value
+      ) {
+        const currentConvoId =
+          (submissionConvo.conversationId ?? conversation.conversationId) || Constants.NEW_CONVO;
+        if (isNewConvo && submissionConvo.conversationId) {
+          removeConvoFromAllQueries(queryClient, submissionConvo.conversationId);
+        }
+
+        const isNewChat =
+          location.pathname === `/c/${Constants.NEW_CONVO}` &&
+          currentConvoId === Constants.NEW_CONVO;
+
+        setFinalMessages(currentConvoId, isNewChat ? [] : [...messages]);
+        setDraft({ id: currentConvoId, value: requestMessage?.text });
+        setIsSubmitting(false);
+        if (isNewChat) {
+          navigate(`/c/${Constants.NEW_CONVO}`, { replace: true, state: { focusChat: true } });
+        }
+        return;
+      }
+
       /* Update messages; if assistants endpoint, client doesn't receive responseMessage */
       let finalMessages: TMessage[] = [];
       if (runMessages) {
@@ -467,11 +500,7 @@ export default function useEventHandlers({
         finalMessages = [...messages, requestMessage, responseMessage];
       }
       if (finalMessages.length > 0) {
-        setMessages(finalMessages);
-        queryClient.setQueryData<TMessage[]>(
-          [QueryKeys.messages, conversation.conversationId],
-          finalMessages,
-        );
+        setFinalMessages(conversation.conversationId, finalMessages);
       } else if (
         isAssistantsEndpoint(submissionConvo.endpoint) &&
         (!submissionConvo.conversationId || submissionConvo.conversationId === Constants.NEW_CONVO)
@@ -482,9 +511,8 @@ export default function useEventHandlers({
         );
       }
 
-      const isNewConvo = conversation.conversationId !== submissionConvo.conversationId;
-      if (isNewConvo) {
-        removeConvoFromAllQueries(queryClient, submissionConvo.conversationId as string);
+      if (isNewConvo && submissionConvo.conversationId) {
+        removeConvoFromAllQueries(queryClient, submissionConvo.conversationId);
       }
 
       /* Refresh title */
@@ -527,7 +555,7 @@ export default function useEventHandlers({
           );
         }
 
-        if (location.pathname === '/c/new') {
+        if (location.pathname === `/c/${Constants.NEW_CONVO}`) {
           navigate(`/c/${conversation.conversationId}`, { replace: true });
         }
       }

--- a/client/src/utils/drafts.ts
+++ b/client/src/utils/drafts.ts
@@ -36,4 +36,4 @@ export const setDraft = ({ id, value }: { id: string; value?: string }) => {
 };
 
 export const getDraft = (id?: string): string | null =>
-  (localStorage.getItem(`${LocalStorageKeys.TEXT_DRAFT}${id ?? ''}`) ?? '') || '';
+  decodeBase64((localStorage.getItem(`${LocalStorageKeys.TEXT_DRAFT}${id ?? ''}`) ?? '') || '');

--- a/client/src/utils/drafts.ts
+++ b/client/src/utils/drafts.ts
@@ -26,3 +26,14 @@ export const decodeBase64 = (base64String: string): string => {
     return '';
   }
 };
+
+export const setDraft = ({ id, value }: { id: string; value?: string }) => {
+  if (value && value.length > 1) {
+    localStorage.setItem(`${LocalStorageKeys.TEXT_DRAFT}${id}`, encodeBase64(value));
+    return;
+  }
+  localStorage.removeItem(`${LocalStorageKeys.TEXT_DRAFT}${id}`);
+};
+
+export const getDraft = (id?: string): string | null =>
+  (localStorage.getItem(`${LocalStorageKeys.TEXT_DRAFT}${id ?? ''}`) ?? '') || '';

--- a/client/src/utils/drafts.ts
+++ b/client/src/utils/drafts.ts
@@ -1,0 +1,28 @@
+import debounce from 'lodash/debounce';
+import { LocalStorageKeys } from 'librechat-data-provider';
+
+export const clearDraft = debounce((id?: string | null) => {
+  localStorage.removeItem(`${LocalStorageKeys.TEXT_DRAFT}${id ?? ''}`);
+}, 2500);
+
+export const encodeBase64 = (plainText: string): string => {
+  try {
+    const textBytes = new TextEncoder().encode(plainText);
+    return btoa(String.fromCharCode(...textBytes));
+  } catch {
+    return '';
+  }
+};
+
+export const decodeBase64 = (base64String: string): string => {
+  try {
+    const bytes = atob(base64String);
+    const uint8Array = new Uint8Array(bytes.length);
+    for (let i = 0; i < bytes.length; i++) {
+      uint8Array[i] = bytes.charCodeAt(i);
+    }
+    return new TextDecoder().decode(uint8Array);
+  } catch {
+    return '';
+  }
+};

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -6,6 +6,7 @@ export * from './files';
 export * from './latex';
 export * from './theme';
 export * from './forms';
+export * from './drafts';
 export * from './convos';
 export * from './presets';
 export * from './prompts';


### PR DESCRIPTION
## Summary

I refactored the draft auto-save and restore logic to use dedicated utility functions, ensured proper draft encoding/decoding, and fixed a blank page issue when an SSE stream is cancelled before a response is received.

- Moved `encodeBase64`, `decodeBase64`, and `clearDraft` into a new `drafts.ts` utility file for modularity and reuse
- Updated `useAutoSave` hook to utilize the new draft utility functions, reducing redundant code and improving reliability
- Implemented `setDraft` and `getDraft` helpers; all draft-related logic and storage centralized for clarity
- Fixed `getDraft` to always decode stored draft values before returning them to avoid showing invalid base64 data in the input field
- Handled a specific edge case in `useEventHandlers` where stream cancellation before any response would previously result in a blank conversation page, now preventing navigation and properly restoring any previous or empty draft state
- Ensured conversation message state and draft input retain consistency in interrupted or failed conversations

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (code quality improvement, no behavior change)
- [x] Documentation update (added or improved inline comments)

## Testing

I manually tested the following scenarios in the LibreChat UI:

- Draft auto-saving and restoration when navigating between conversations and after refresh
- Cancelling a streaming response before any content arrives: confirmed the page does not go blank and past drafts/messages persist or reset as expected
- Draft text consistently appears decoded in the input field after reloads or navigation
- All storage relevant to draft content is encoded/decoded appropriately

**Test Configuration:**

- Latest LibreChat main branch
- Chrome browser
- Tested both new and existing conversations with and without SSE response interruptions

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works (manual verification for edge cases)
- [x] Local unit tests pass with my changes