### PR TITLE
🔑 feat: add support for reverse proxy auth headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -392,6 +392,16 @@ ALLOW_PASSWORD_RESET=false
 # ALLOW_ACCOUNT_DELETION=true # note: enabled by default if omitted/commented out
 ALLOW_UNVERIFIED_EMAIL_LOGIN=true
 
+#============================#
+# Forwarded Authentication   #
+#============================#
+# Enable forwarded authentication using HTTP headers from a reverse proxy
+# FORWARD_AUTH_ENABLED=false
+# Required header containing the username (case-insensitive)
+# FORWARD_AUTH_USERNAME_HEADER=X-Forwarded-User
+# Optional header containing the user's email (case-insensitive)
+# FORWARD_AUTH_EMAIL_HEADER=X-Forwarded-Email
+
 SESSION_EXPIRY=1000 * 60 * 15
 REFRESH_TOKEN_EXPIRY=(1000 * 60 * 60 * 24) * 7
 

--- a/api/package.json
+++ b/api/package.json
@@ -98,6 +98,7 @@
     "openid-client": "^6.5.0",
     "passport": "^0.6.0",
     "passport-apple": "^2.0.2",
+    "passport-custom": "^1.1.1",
     "passport-discord": "^0.1.4",
     "passport-facebook": "^3.0.0",
     "passport-github2": "^0.1.12",

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -12,9 +12,8 @@ const { isEnabled } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const mongoSanitize = require('express-mongo-sanitize');
 const { connectDb, indexSync } = require('~/db');
-
 const validateImageRequest = require('./middleware/validateImageRequest');
-const { jwtLogin, ldapLogin, passportLogin } = require('~/strategies');
+const { jwtLogin, ldapLogin, passportLogin, forwardedAuthLogin } = require('~/strategies');
 const errorController = require('./controllers/ErrorController');
 const initializeMCP = require('./services/initializeMCP');
 const configureSocialLogins = require('./socialLogins');
@@ -80,6 +79,7 @@ const startServer = async () => {
   app.use(passport.initialize());
   passport.use(jwtLogin());
   passport.use(passportLogin());
+  passport.use('forwardedAuth', forwardedAuthLogin());
 
   /* LDAP Auth */
   if (process.env.LDAP_URL && process.env.LDAP_USER_SEARCH_BASE) {
@@ -92,6 +92,11 @@ const startServer = async () => {
 
   app.use('/oauth', routes.oauth);
   /* API Endpoints */
+  // Apply forwarded auth middleware globally if enabled
+  if (process.env.FORWARD_AUTH_ENABLED === 'true') {
+    app.use(require('~/server/middleware/requireForwardedAuth'));
+  }
+
   app.use('/api/auth', routes.auth);
   app.use('/api/actions', routes.actions);
   app.use('/api/keys', routes.keys);

--- a/api/server/middleware/index.js
+++ b/api/server/middleware/index.js
@@ -13,6 +13,7 @@ const requireLdapAuth = require('./requireLdapAuth');
 const abortMiddleware = require('./abortMiddleware');
 const checkInviteUser = require('./checkInviteUser');
 const requireJwtAuth = require('./requireJwtAuth');
+const requireForwardedAuth = require('./requireForwardedAuth');
 const validateModel = require('./validateModel');
 const moderateText = require('./moderateText');
 const logHeaders = require('./logHeaders');
@@ -40,6 +41,7 @@ module.exports = {
   checkInviteUser,
   requireLdapAuth,
   requireLocalAuth,
+  requireForwardedAuth,
   canDeleteAccount,
   validateEndpoint,
   setBalanceConfig,

--- a/api/server/middleware/requireForwardedAuth.js
+++ b/api/server/middleware/requireForwardedAuth.js
@@ -1,0 +1,51 @@
+const passport = require('passport');
+const { setAuthTokens } = require('~/server/services/AuthService');
+const { logger } = require('~/config');
+
+/**
+ * Middleware that attempts to authenticate using forwarded HTTP headers
+ * Silently continues to the next middleware if authentication fails
+ * Sets req.user on success
+ *
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ * @param {Function} next - Express next function
+ */
+const requireForwardedAuth = (req, res, next) => {
+  // Skip if forward auth is not enabled
+  if (process.env.FORWARD_AUTH_ENABLED !== 'true') {
+    return next();
+  }
+
+  // Authenticate using the forwardedAuth strategy
+  passport.authenticate('forwardedAuth', { session: false }, async (err, user) => {
+    if (err) {
+      logger.error('[requireForwardedAuth] Error during authentication:', err);
+      return next(err);
+    }
+
+    if (!user) {
+      // No user found, continue to next middleware
+      return next();
+    }
+
+    // Set the authenticated user in the request
+    req.user = user;
+
+    // Generate JWT and cookies for the authenticated user
+    try {
+      const token = await setAuthTokens(user._id, res);
+      // Store token in request for potential use by other middleware
+      req.authToken = token;
+    } catch (tokenErr) {
+      logger.error('[requireForwardedAuth] Error generating auth tokens:', tokenErr);
+      return next(tokenErr);
+    }
+
+    logger.debug(`[requireForwardedAuth] User ${user.username}
+      authenticated via forwarded headers`);
+    next();
+  })(req, res, next);
+};
+
+module.exports = requireForwardedAuth;

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -97,6 +97,7 @@ router.get('/', async function (req, res) {
       instanceProjectId: instanceProject._id.toString(),
       bundlerURL: process.env.SANDPACK_BUNDLER_URL,
       staticBundlerURL: process.env.SANDPACK_STATIC_BUNDLER_URL,
+      forwardedAuthEnabled: isEnabled(process.env.FORWARD_AUTH_ENABLED),
     };
 
     payload.mcpServers = {};

--- a/api/strategies/forwardedAuthStrategy.js
+++ b/api/strategies/forwardedAuthStrategy.js
@@ -1,0 +1,98 @@
+const { SystemRoles } = require('librechat-data-provider');
+const passportCustom = require('passport-custom');
+const { getUserById, updateUser, findUser, createUser, countUsers } = require('~/models');
+const { logger } = require('~/config');
+
+/**
+ * Strategy for authentication using forwarded HTTP headers from a reverse proxy
+ * @returns {passportCustom.Strategy} A custom Passport.js strategy
+ */
+const forwardedAuthStrategy = () => {
+  return new passportCustom.Strategy(async (req, done) => {
+    try {
+      // Skip if forward auth is not enabled
+      if (process.env.FORWARD_AUTH_ENABLED !== 'true') {
+        return done(null, false);
+      }
+
+      // Get username header name from environment variable
+      const usernameHeader = process.env.FORWARD_AUTH_USERNAME_HEADER;
+      const emailHeader = process.env.FORWARD_AUTH_EMAIL_HEADER;
+
+      // Username header is required
+      if (!usernameHeader) {
+        logger.error('[forwardedAuthStrategy] FORWARD_AUTH_USERNAME_HEADER not configured');
+        return done(null, false);
+      }
+
+      // Extract username from header
+      const username = req.headers[usernameHeader.toLowerCase()];
+      if (!username) {
+        logger.debug(`[forwardedAuthStrategy] No username found in header ${usernameHeader}`);
+        return done(null, false);
+      }
+
+      // Extract email from header if configured
+      const email = emailHeader ? req.headers[emailHeader.toLowerCase()] : null;
+
+      // Try to find user by email first if email is available
+      let user = null;
+      if (email) {
+        user = await findUser({ email }, '-password -__v -totpSecret');
+      }
+
+      // If user not found by email, try to find by username
+      if (!user) {
+        user = await findUser({ username }, '-password -__v -totpSecret');
+      }
+
+      // If user exists, update the provider to forwardedAuth
+      if (user) {
+        const updates = { provider: 'forwardedAuth' };
+
+        // Update email if it was provided in the header and is different
+        if (email && user.email !== email) {
+          updates.email = email;
+        }
+
+        // Apply updates if there are any changes needed
+        if (Object.keys(updates).length > 0) {
+          user = await updateUser(user._id, updates);
+        }
+      } else {
+        // User doesn't exist, create a new one
+        logger.info(`[forwardedAuthStrategy] Creating new user with username: ${username}`);
+
+        // Check if this is the first user to register
+        const isFirstRegisteredUser = (await countUsers()) === 0;
+
+        // Create new user
+        const newUserData = {
+          provider: 'forwardedAuth',
+          username,
+          name: username,
+          emailVerified: true, // Auto-verify email for forwarded auth
+          role: isFirstRegisteredUser ? SystemRoles.ADMIN : SystemRoles.USER,
+        };
+
+        // Add email if provided
+        if (email) {
+          newUserData.email = email;
+        }
+
+        const newUserId = await createUser(newUserData);
+        user = await getUserById(newUserId, '-password -__v -totpSecret');
+      }
+
+      // Add id property for consistency with other auth strategies
+      user.id = user._id.toString();
+
+      return done(null, user);
+    } catch (err) {
+      logger.error('[forwardedAuthStrategy] Error:', err);
+      return done(err);
+    }
+  });
+};
+
+module.exports = forwardedAuthStrategy;

--- a/api/strategies/index.js
+++ b/api/strategies/index.js
@@ -9,6 +9,7 @@ const jwtLogin = require('./jwtStrategy');
 const ldapLogin = require('./ldapStrategy');
 const { setupSaml } = require('./samlStrategy');
 const openIdJwtLogin = require('./openIdJwtStrategy');
+const forwardedAuthLogin = require('./forwardedAuthStrategy');
 
 module.exports = {
   appleLogin,
@@ -23,4 +24,5 @@ module.exports = {
   ldapLogin,
   setupSaml,
   openIdJwtLogin,
+  forwardedAuthLogin,
 };

--- a/client/src/components/Auth/Login.tsx
+++ b/client/src/components/Auth/Login.tsx
@@ -45,7 +45,10 @@ function Login() {
     }
   }, [shouldAutoRedirect, startupConfig]);
 
-  // Render fallback UI if auto-redirect is active.
+  // Check if forwarded auth is enabled
+  const isForwardedAuthEnabled = startupConfig?.forwardedAuthEnabled;
+
+  // Render fallback UI if auto-redirect is active
   if (shouldAutoRedirect) {
     return (
       <div className="flex min-h-screen flex-col items-center justify-center p-4">
@@ -69,6 +72,16 @@ function Login() {
             id="openid"
           />
         </div>
+      </div>
+    );
+  }
+
+  // Render fallback UI if forwarded auth is enabled
+  if (isForwardedAuthEnabled) {
+    window.location.href = '/'; // Redirect to home page, which will trigger the forwarded auth
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center p-4">
+        <p className="text-lg font-semibold">{localize('com_auth_authenticating')}</p>
       </div>
     );
   }

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1,6 +1,7 @@
 {
   "chat_direction_left_to_right": "something needs to go here. was empty",
   "chat_direction_right_to_left": "something needs to go here. was empty",
+  "com_auth_authenticating": "Authenticating...",
   "com_a11y_ai_composing": "The AI is still composing.",
   "com_a11y_end": "The AI has finished their reply.",
   "com_a11y_start": "The AI has started their reply.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,7 @@
         "openid-client": "^6.5.0",
         "passport": "^0.6.0",
         "passport-apple": "^2.0.2",
+        "passport-custom": "^1.1.1",
         "passport-discord": "^0.1.4",
         "passport-facebook": "^3.0.0",
         "passport-github2": "^0.1.12",
@@ -38998,6 +38999,18 @@
       "dependencies": {
         "jsonwebtoken": "^9.0.0",
         "passport-oauth2": "^1.6.1"
+      }
+    },
+    "node_modules/passport-custom": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/passport-custom/-/passport-custom-1.1.1.tgz",
+      "integrity": "sha512-/2m7jUGxmCYvoqenLB9UrmkCgPt64h8ZtV+UtuQklZ/Tn1NpKBeOorCYkB/8lMRoiZ5hUrCoMmDtxCS/d38mlg==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/passport-discord": {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -575,6 +575,8 @@ export type TStartupConfig = {
     /** Whether LDAP uses username vs. email */
     username?: boolean;
   };
+  /** Forwarded Auth Configuration */
+  forwardedAuthEnabled?: boolean;
   serverDomain: string;
   emailLoginEnabled: boolean;
   registrationEnabled: boolean;


### PR DESCRIPTION
## Summary

Add support for authentication via forwarded HTTP headers, which is useful when you have a reverse proxy (like Nginx, Traefik, or Caddy) that handles authentication before the request reaches LibreChat. Closes #1856 

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Translation update

## Testing

Tested with Traefik and Authelia as reverse proxy in front of LibreChat.

## Checklist

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [X] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
- [X] Any changes dependent on mine have been merged and published in downstream modules.
- [X] A pull request for updating the documentation has been submitted (https://github.com/LibreChat-AI/librechat.ai/pull/362)
