### PR TITLE
🔐 feat: Add Resource Parameter to OAuth Requests per MCP Spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20902,9 +20902,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.3.tgz",
-      "integrity": "sha512-bGwA78F/U5G2jrnsdRkPY3IwIwZeWUEfb5o764b79lb0rJmMT76TLwKhdNZOWakOQtedYefwIR4emisEMvInKA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.16.0.tgz",
+      "integrity": "sha512-8ofX7gkZcLj9H9rSd50mCgm3SSF8C7XoclxJuLoV0Cz3rEQ1tv9MZRYYvJtm9n1BiEQQMzSmE/w2AEkNacLYfg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -47093,7 +47093,7 @@
         "@langchain/core": "^0.3.62",
         "@librechat/agents": "^2.4.63",
         "@librechat/data-schemas": "*",
-        "@modelcontextprotocol/sdk": "^1.13.3",
+        "@modelcontextprotocol/sdk": "^1.16.0",
         "axios": "^1.8.2",
         "diff": "^7.0.0",
         "eventsource": "^3.0.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -72,7 +72,7 @@
     "@langchain/core": "^0.3.62",
     "@librechat/agents": "^2.4.63",
     "@librechat/data-schemas": "*",
-    "@modelcontextprotocol/sdk": "^1.13.3",
+    "@modelcontextprotocol/sdk": "^1.16.0",
     "axios": "^1.8.2",
     "diff": "^7.0.0",
     "eventsource": "^3.0.2",


### PR DESCRIPTION
Addresses this part of the spec https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#resource-parameter-implementation


MCP clients MUST implement Resource Indicators for OAuth 2.0 as defined in [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html) to explicitly specify the target resource for which the token is being requested. The resource parameter:

- **MUST** be included in both authorization requests and token requests.
- **MUST** identify the MCP server that the client intends to use the token with.
- **MUST** use the canonical URI of the MCP server as defined in [RFC 8707 Section 2](https://www.rfc-editor.org/rfc/rfc8707.html#name-access-token-request).