### PR TITLE
🔀 feat: `moonshotai/kimi` Context and OpenRouter Endpoint Token Config

### DIFF
--- a/api/server/services/Endpoints/agents/agent.js
+++ b/api/server/services/Endpoints/agents/agent.js
@@ -131,7 +131,7 @@ const initializeAgent = async ({
   );
   const agentMaxContextTokens = optionalChainWithEmptyCheck(
     maxContextTokens,
-    getModelMaxTokens(tokensModel, providerEndpointMap[provider]),
+    getModelMaxTokens(tokensModel, providerEndpointMap[provider], options.endpointTokenConfig),
     4096,
   );
 
@@ -191,7 +191,7 @@ const initializeAgent = async ({
     resendFiles,
     toolContextMap,
     useLegacyContent: !!options.useLegacyContent,
-    maxContextTokens: (agentMaxContextTokens - maxTokens) * 0.9,
+    maxContextTokens: Math.round((agentMaxContextTokens - maxTokens) * 0.9),
   };
 };
 

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -141,8 +141,9 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
       const options = getOpenAIConfig(apiKey, clientOptions, endpoint);
       if (options != null) {
         options.useLegacyContent = true;
+        options.endpointTokenConfig = endpointTokenConfig;
       }
-      if (!customOptions.streamRate) {
+      if (!clientOptions.streamRate) {
         return options;
       }
       options.llmConfig.callbacks = [

--- a/api/utils/tokens.js
+++ b/api/utils/tokens.js
@@ -226,7 +226,14 @@ const xAIModels = {
   'grok-4': 256000, // 256K context
 };
 
-const aggregateModels = { ...openAIModels, ...googleModels, ...bedrockModels, ...xAIModels };
+const aggregateModels = {
+  ...openAIModels,
+  ...googleModels,
+  ...bedrockModels,
+  ...xAIModels,
+  // misc.
+  kimi: 131000,
+};
 
 const maxTokensMap = {
   [EModelEndpoint.azureOpenAI]: openAIModels,

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -714,3 +714,45 @@ describe('Claude Model Tests', () => {
     });
   });
 });
+
+describe('Kimi Model Tests', () => {
+  describe('getModelMaxTokens', () => {
+    test('should return correct tokens for Kimi models', () => {
+      expect(getModelMaxTokens('kimi')).toBe(131000);
+      expect(getModelMaxTokens('kimi-k2')).toBe(131000);
+      expect(getModelMaxTokens('kimi-vl')).toBe(131000);
+    });
+
+    test('should return correct tokens for Kimi models with provider prefix', () => {
+      expect(getModelMaxTokens('moonshotai/kimi-k2')).toBe(131000);
+      expect(getModelMaxTokens('moonshotai/kimi')).toBe(131000);
+      expect(getModelMaxTokens('moonshotai/kimi-vl')).toBe(131000);
+    });
+
+    test('should handle partial matches for Kimi models', () => {
+      expect(getModelMaxTokens('kimi-k2-latest')).toBe(131000);
+      expect(getModelMaxTokens('kimi-vl-preview')).toBe(131000);
+      expect(getModelMaxTokens('kimi-2024')).toBe(131000);
+    });
+  });
+
+  describe('matchModelName', () => {
+    test('should match exact Kimi model names', () => {
+      expect(matchModelName('kimi')).toBe('kimi');
+      expect(matchModelName('kimi-k2')).toBe('kimi');
+      expect(matchModelName('kimi-vl')).toBe('kimi');
+    });
+
+    test('should match Kimi model variations with provider prefix', () => {
+      expect(matchModelName('moonshotai/kimi')).toBe('kimi');
+      expect(matchModelName('moonshotai/kimi-k2')).toBe('kimi');
+      expect(matchModelName('moonshotai/kimi-vl')).toBe('kimi');
+    });
+
+    test('should match Kimi model variations with suffixes', () => {
+      expect(matchModelName('kimi-k2-latest')).toBe('kimi');
+      expect(matchModelName('kimi-vl-preview')).toBe('kimi');
+      expect(matchModelName('kimi-2024')).toBe('kimi');
+    });
+  });
+});

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -466,7 +466,6 @@
   "com_nav_send_message": "Send message",
   "com_nav_setting_account": "Account",
   "com_nav_setting_balance": "Balance",
-  "com_nav_setting_beta": "Beta features",
   "com_nav_setting_chat": "Chat",
   "com_nav_setting_data": "Data controls",
   "com_nav_setting_general": "General",


### PR DESCRIPTION
## Summary

- Added the `kimi` model with its max context window to the aggregate models in the token utility
- Enhanced logic to identify Kimi and Moonshot model variations, including those with prefixes, suffixes, or partial matches
- Created comprehensive tests validating detection and max token retrieval for Kimi/Moonshot model variants
- Modified agent initialization to accept endpoint token configuration and supply it to token computation
- Used `Math.round` to ensure the agent's context token budget is always an integer, improving consistency
- Fixed logic to ensure endpoint-specific token overrides propagate correctly through initialization routines