### PR TITLE
✔️ fix: Resource field TypeError & Missing Role Permission Type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48815,7 +48815,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -342,9 +342,9 @@ export class MCPOAuthHandler {
         throw new Error('Invalid flow metadata');
       }
 
-      let resource;
+      let resource: URL | undefined;
       try {
-        if (metadata.resourceMetadata?.resource) {
+        if (metadata.resourceMetadata?.resource != null && metadata.resourceMetadata.resource) {
           resource = new URL(metadata.resourceMetadata.resource);
           logger.debug(`[MCPOAuth] Resource URL for flow ${flowId}: ${resource.toString()}`);
         }
@@ -357,12 +357,12 @@ export class MCPOAuthHandler {
       }
 
       const tokens = await exchangeAuthorization(metadata.serverUrl, {
+        redirectUri: metadata.clientInfo.redirect_uris?.[0] || this.getDefaultRedirectUri(),
         metadata: metadata.metadata as unknown as SDKOAuthMetadata,
         clientInformation: metadata.clientInfo,
-        authorizationCode,
         codeVerifier: metadata.codeVerifier,
-        redirectUri: metadata.clientInfo.redirect_uris?.[0] || this.getDefaultRedirectUri(),
-        resource: resource,
+        authorizationCode,
+        resource,
       });
 
       logger.debug('[MCPOAuth] Raw tokens from exchange:', {

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -269,18 +269,17 @@ export class MCPOAuthHandler {
         authorizationUrl.searchParams.set('state', flowId);
         logger.debug(`[MCPOAuth] Added state parameter to authorization URL`);
 
-        if (resourceMetadata?.resource) {
+        if (resourceMetadata?.resource != null && resourceMetadata.resource) {
           authorizationUrl.searchParams.set('resource', resourceMetadata.resource);
+          logger.debug(
+            `[MCPOAuth] Added resource parameter to authorization URL: ${resourceMetadata.resource}`,
+          );
         } else {
           logger.warn(
             `[MCPOAuth] Resource metadata missing 'resource' property for ${serverName}. ` +
               'This can cause issues with some Authorization Servers who expect a "resource" parameter.',
           );
         }
-
-        logger.debug(
-          `[MCPOAuth] Added resource parameter to authorization URL: ${resourceMetadata.resource}`,
-        );
       } catch (error) {
         logger.error(`[MCPOAuth] startAuthorization failed:`, error);
         throw error;

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/src/types/role.ts
+++ b/packages/data-schemas/src/types/role.ts
@@ -35,5 +35,8 @@ export interface IRole extends Document {
     [PermissionTypes.WEB_SEARCH]?: {
       [Permissions.USE]?: boolean;
     };
+    [PermissionTypes.FILE_SEARCH]?: {
+      [Permissions.USE]?: boolean;
+    };
   };
 }


### PR DESCRIPTION
## Summary

I resolved a TypeError related to undefined resource parameters in OAuth logging, added the missing FILE_SEARCH permission type to the IRole interface, and bumped the @librechat/data-schemas package version to 0.0.11.

- Fixed a bug in the MCPOAuthHandler that caused a TypeError when the resource parameter was undefined by adding a null and truthiness check before logging and setting the parameter
- Added the FILE_SEARCH permission type to the IRole interface to support granular permission handling
- Updated the version of @librechat/data-schemas to 0.0.11 for publishing consistency

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

I manually tested the OAuth flow to ensure the resource parameter is handled and logged correctly both when defined and undefined. I confirmed no TypeError occurs in log output. I verified the role type changes by ensuring the new FILE_SEARCH permission type is reflected in type usage and assignment. I recommend running unit and type checks across the packages that consume IRole and reviewing OAuth log output in development to confirm the absence of regressions and runtime errors.

### **Test Configuration**:
- Node 18.x
- Local MongoDB instance
- OAuth dev credentials

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes