### PR TITLE
🔁 feat: Allow "http" as Alias for "streamable-http" in MCP Options

### DIFF
--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -45,9 +45,12 @@ function isSSEOptions(options: t.MCPOptions): options is t.SSEOptions {
  * @returns True if options are for a streamable HTTP transport
  */
 function isStreamableHTTPOptions(options: t.MCPOptions): options is t.StreamableHTTPOptions {
-  if ('url' in options && options.type === 'streamable-http') {
-    const protocol = new URL(options.url).protocol;
-    return protocol !== 'ws:' && protocol !== 'wss:';
+  if ('url' in options && 'type' in options) {
+    const optionType = options.type as string;
+    if (optionType === 'streamable-http' || optionType === 'http') {
+      const protocol = new URL(options.url).protocol;
+      return protocol !== 'ws:' && protocol !== 'wss:';
+    }
   }
   return false;
 }
@@ -142,6 +145,7 @@ export class MCPConnection extends EventEmitter {
       } else if (isWebSocketOptions(options)) {
         type = 'websocket';
       } else if (isStreamableHTTPOptions(options)) {
+        // Could be either 'streamable-http' or 'http', normalize to 'streamable-http'
         type = 'streamable-http';
       } else if (isSSEOptions(options)) {
         type = 'sse';

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -125,7 +125,7 @@ export const SSEOptionsSchema = BaseOptionsSchema.extend({
 });
 
 export const StreamableHTTPOptionsSchema = BaseOptionsSchema.extend({
-  type: z.literal('streamable-http'),
+  type: z.union([z.literal('streamable-http'), z.literal('http')]),
   headers: z.record(z.string(), z.string()).optional(),
   url: z
     .string()


### PR DESCRIPTION
- Updated StreamableHTTPOptionsSchema to accept "http" alongside "streamable-http".
- Enhanced isStreamableHTTPOptions function to handle both types and validate URLs accordingly.
- Added tests to ensure correct processing of "http" type options and rejection of websocket URLs.
