### PR TITLE
ℹ️ fix: Add back Removed Icons for MCP Servers in Tools Dialog

### DIFF
--- a/api/server/controllers/PluginController.js
+++ b/api/server/controllers/PluginController.js
@@ -253,16 +253,17 @@ function convertMCPToolsToPlugins(functionTools, customConfig) {
     const parts = toolKey.split(Constants.mcp_delimiter);
     const serverName = parts[parts.length - 1];
 
+    const serverConfig = customConfig?.mcpServers?.[serverName];
+
     const plugin = {
       name: parts[0], // Use the tool name without server suffix
       pluginKey: toolKey,
       description: functionData.description || '',
       authenticated: true,
-      icon: undefined,
+      icon: serverConfig?.iconPath,
     };
 
     // Build authConfig for MCP tools
-    const serverConfig = customConfig?.mcpServers?.[serverName];
     if (!serverConfig?.customUserVars) {
       plugin.authConfig = [];
       plugins.push(plugin);

--- a/api/server/controllers/PluginController.spec.js
+++ b/api/server/controllers/PluginController.spec.js
@@ -1,0 +1,89 @@
+const { Constants } = require('librechat-data-provider');
+const { getCustomConfig, getCachedTools } = require('~/server/services/Config');
+const { getLogStores } = require('~/cache');
+
+// Mock the dependencies
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('~/server/services/Config', () => ({
+  getCustomConfig: jest.fn(),
+  getCachedTools: jest.fn(),
+}));
+
+jest.mock('~/server/services/ToolService', () => ({
+  getToolkitKey: jest.fn(),
+}));
+
+jest.mock('~/config', () => ({
+  getMCPManager: jest.fn(() => ({
+    loadManifestTools: jest.fn().mockResolvedValue([]),
+  })),
+  getFlowStateManager: jest.fn(),
+}));
+
+jest.mock('~/app/clients/tools', () => ({
+  availableTools: [],
+}));
+
+jest.mock('~/cache', () => ({
+  getLogStores: jest.fn(),
+}));
+
+// Import the actual module with the function we want to test
+const { getAvailableTools } = require('./PluginController');
+
+describe('PluginController', () => {
+  describe('plugin.icon behavior', () => {
+    let mockReq, mockRes, mockCache;
+
+    const callGetAvailableToolsWithMCPServer = async (mcpServers) => {
+      mockCache.get.mockResolvedValue(null);
+      getCustomConfig.mockResolvedValue({ mcpServers });
+
+      const functionTools = {
+        [`test-tool${Constants.mcp_delimiter}test-server`]: {
+          function: { name: 'test-tool', description: 'A test tool' },
+        },
+      };
+      getCachedTools.mockResolvedValueOnce(functionTools);
+      getCachedTools.mockResolvedValueOnce({
+        [`test-tool${Constants.mcp_delimiter}test-server`]: true,
+      });
+
+      await getAvailableTools(mockReq, mockRes);
+      const responseData = mockRes.json.mock.calls[0][0];
+      return responseData.find((tool) => tool.name === 'test-tool');
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockReq = { user: { id: 'test-user-id' } };
+      mockRes = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+      mockCache = { get: jest.fn(), set: jest.fn() };
+      getLogStores.mockReturnValue(mockCache);
+    });
+
+    it('should set plugin.icon when iconPath is defined', async () => {
+      const mcpServers = {
+        'test-server': {
+          iconPath: '/path/to/icon.png',
+        },
+      };
+      const testTool = await callGetAvailableToolsWithMCPServer(mcpServers);
+      expect(testTool.icon).toBe('/path/to/icon.png');
+    });
+
+    it('should set plugin.icon to undefined when iconPath is not defined', async () => {
+      const mcpServers = {
+        'test-server': {},
+      };
+      const testTool = await callGetAvailableToolsWithMCPServer(mcpServers);
+      expect(testTool.icon).toBeUndefined();
+    });
+  });
+});

--- a/api/test/jestSetup.js
+++ b/api/test/jestSetup.js
@@ -10,3 +10,4 @@ process.env.JWT_SECRET = 'test';
 process.env.JWT_REFRESH_SECRET = 'test';
 process.env.CREDS_KEY = 'test';
 process.env.CREDS_IV = 'test';
+process.env.OPENAI_API_KEY = 'test';


### PR DESCRIPTION
# Pull Request Template

## Summary

MCP servers allow defining an `iconPath` such as:
```yaml
mcpServers:
  my_mcp_server:
    type: 'streamable-http'
    url: https://example.com/mcp
    iconPath: '/assets/mcpmy_mcp_server.png'
```

However, the current code hard-code the icon to `undefined` so all MCP servers appear with the default icon
<img width="309" height="211" alt="image" src="https://github.com/user-attachments/assets/0bdd360b-7d37-442c-ad88-0f62b019f4f8" />

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

Added unit tests to cover this behavior only.
The file did not have any tests so adding all coverage here would be messy.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
