### PR TITLE
🐛 fix: Display OAuth MCP servers according to Chat Menu Setting

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -106,6 +106,7 @@ router.get('/', async function (req, res) {
         const serverConfig = config.mcpServers[serverName];
         payload.mcpServers[serverName] = {
           customUserVars: serverConfig?.customUserVars || {},
+          chatMenu: serverConfig?.chatMenu,
         };
       }
     }

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -17,9 +17,14 @@ function MCPSelect() {
   const { mcpSelect, startupConfig } = useBadgeRowContext();
   const { mcpValues, setMCPValues, mcpToolDetails, isPinned } = mcpSelect;
 
-  // Get all configured MCP servers from config
+  // Get all configured MCP servers from config that allow chat menu
   const configuredServers = useMemo(() => {
-    return Object.keys(startupConfig?.mcpServers || {});
+    if (!startupConfig?.mcpServers) {
+      return [];
+    }
+    return Object.entries(startupConfig.mcpServers)
+      .filter(([, config]) => config.chatMenu !== false)
+      .map(([serverName]) => serverName);
   }, [startupConfig?.mcpServers]);
 
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);

--- a/client/src/hooks/Plugins/useMCPSelect.ts
+++ b/client/src/hooks/Plugins/useMCPSelect.ts
@@ -2,7 +2,7 @@ import { useRef, useEffect, useCallback, useMemo } from 'react';
 import { useRecoilState } from 'recoil';
 import { Constants, LocalStorageKeys, EModelEndpoint } from 'librechat-data-provider';
 import type { TPlugin } from 'librechat-data-provider';
-import { useAvailableToolsQuery } from '~/data-provider';
+import { useAvailableToolsQuery, useGetStartupConfig } from '~/data-provider';
 import useLocalStorage from '~/hooks/useLocalStorageAlt';
 import { ephemeralAgentByConvoId } from '~/store';
 
@@ -28,12 +28,13 @@ export function useMCPSelect({ conversationId }: UseMCPSelectOptions) {
   const key = conversationId ?? Constants.NEW_CONVO;
   const hasSetFetched = useRef<string | null>(null);
   const [ephemeralAgent, setEphemeralAgent] = useRecoilState(ephemeralAgentByConvoId(key));
-  const { data: mcpToolDetails, isFetched } = useAvailableToolsQuery(EModelEndpoint.agents, {
+  const { data: startupConfig } = useGetStartupConfig();
+  const { data: rawMcpTools, isFetched } = useAvailableToolsQuery(EModelEndpoint.agents, {
     select: (data: TPlugin[]) => {
       const mcpToolsMap = new Map<string, TPlugin>();
       data.forEach((tool) => {
         const isMCP = tool.pluginKey.includes(Constants.mcp_delimiter);
-        if (isMCP && tool.chatMenu !== false) {
+        if (isMCP) {
           const parts = tool.pluginKey.split(Constants.mcp_delimiter);
           const serverName = parts[parts.length - 1];
           if (!mcpToolsMap.has(serverName)) {
@@ -49,6 +50,16 @@ export function useMCPSelect({ conversationId }: UseMCPSelectOptions) {
       return Array.from(mcpToolsMap.values());
     },
   });
+
+  const mcpToolDetails = useMemo(() => {
+    if (!rawMcpTools || !startupConfig?.mcpServers) {
+      return rawMcpTools;
+    }
+    return rawMcpTools.filter((tool) => {
+      const serverConfig = startupConfig?.mcpServers?.[tool.name];
+      return serverConfig?.chatMenu !== false;
+    });
+  }, [rawMcpTools, startupConfig?.mcpServers]);
 
   const mcpState = useMemo(() => {
     return ephemeralAgent?.mcp ?? [];

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -612,6 +612,7 @@ export type TStartupConfig = {
           description: string;
         }
       >;
+      chatMenu?: boolean;
     }
   >;
   mcpPlaceholder?: string;


### PR DESCRIPTION
## Summary

This pull request fixes the behavior of MCPSelect and MCPSubMenu to now respect the chatMenu config option from `librechat.yaml`. Raised by #8642 

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing

Manual verification of presence/absence of servers in UI in accordance with chatMenu values.


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

