### PR TITLE
🔄 refactor: Default Completion Title Prompt and Title Model Selection

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -49,7 +49,7 @@
     "@langchain/google-vertexai": "^0.2.13",
     "@langchain/openai": "^0.5.18",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^2.4.67",
+    "@librechat/agents": "^2.4.68",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@node-saml/passport-saml": "^5.0.0",

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1022,7 +1022,7 @@ class AgentClient extends BaseClient {
     /** @type {import('@librechat/agents').ClientOptions} */
     let clientOptions = {
       maxTokens: 75,
-      model: agent.model_parameters.model,
+      model: agent.model || agent.model_parameters.model,
     };
 
     let titleProviderConfig = await getProviderConfig(endpoint);

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@langchain/google-vertexai": "^0.2.13",
         "@langchain/openai": "^0.5.18",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^2.4.67",
+        "@librechat/agents": "^2.4.68",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@node-saml/passport-saml": "^5.0.0",
@@ -21468,9 +21468,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "2.4.67",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.67.tgz",
-      "integrity": "sha512-GHGTdRmBTpfI/Ps3/is1h4hTEX0rijFdhj6LIqXQzHx6Nnv2nNIIK8tMW/0oPVHcdKuRGrR6Nt6BLpAJMfckgg==",
+      "version": "2.4.68",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.68.tgz",
+      "integrity": "sha512-05UhnUJJ6/I8KVkhJ9NrQcm3UKhA/cXG8yT2VU+QQRJoDf7qnt47DRBP87ZEWRGMLh2civq1OWQPW2BHf2eL4A==",
       "license": "MIT",
       "dependencies": {
         "@langchain/anthropic": "^0.3.24",
@@ -48617,7 +48617,7 @@
       },
       "peerDependencies": {
         "@langchain/core": "^0.3.62",
-        "@librechat/agents": "^2.4.67",
+        "@librechat/agents": "^2.4.68",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.16.0",
         "axios": "^1.8.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "@langchain/core": "^0.3.62",
-    "@librechat/agents": "^2.4.67",
+    "@librechat/agents": "^2.4.68",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.16.0",
     "axios": "^1.8.2",


### PR DESCRIPTION
## Summary

I updated the @librechat/agents package to version 2.4.68 to leverage the new default title prompt for the completion title method. I also refactored model selection in the agent client to prefer agent.model (the user-facing model value), falling back to agent.model_parameters.model to ensure correct Azure mapping.

- Bumped @librechat/agents to 2.4.68 in api/package.json for improved title prompt functionality
- Modified AgentClient to select agent.model first before agent.model_parameters.model for better Azure compatibility

## Change Type

- [x] Chore (dependency update)
- [x] Refactor (non-breaking change which improves code quality or maintainability)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes