### PR TITLE
🚇 chore: Remove Overridden Transport Error Listener

### DIFF
--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -211,11 +211,6 @@ export class MCPConnection extends EventEmitter {
             this.emit('connectionChange', 'disconnected');
           };
 
-          transport.onerror = (error) => {
-            logger.error(`${this.getLogPrefix()} SSE transport error:`, error);
-            this.emitError(error, 'SSE transport error:');
-          };
-
           transport.onmessage = (message) => {
             logger.info(`${this.getLogPrefix()} Message received: ${JSON.stringify(message)}`);
           };
@@ -251,11 +246,6 @@ export class MCPConnection extends EventEmitter {
           transport.onclose = () => {
             logger.info(`${this.getLogPrefix()} Streamable-http transport closed`);
             this.emit('connectionChange', 'disconnected');
-          };
-
-          transport.onerror = (error: Error | unknown) => {
-            logger.error(`${this.getLogPrefix()} Streamable-http transport error:`, error);
-            this.emitError(error, 'Streamable-http transport error:');
           };
 
           transport.onmessage = (message: JSONRPCMessage) => {


### PR DESCRIPTION
## Summary
In `packages/api/src/mcp/connection.ts`, `setupTransportErrorHandlers` re-defines the `onerror` behavior that is already defined for Streamable-http and SSE transports a few line above.

Deleting the overridden code for clarity.

https://github.com/danny-avila/LibreChat/blob/365e3bca95aca100eb103a39c615a1a71b816ca8/packages/api/src/mcp/connection.ts#L214-L223

https://github.com/danny-avila/LibreChat/blob/365e3bca95aca100eb103a39c615a1a71b816ca8/packages/api/src/mcp/connection.ts#L533-L548

## Change Type

- [x] Re-factoring

## Testing

No behavior change.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
