### PR TITLE
feat: eliciting user input

### DIFF
--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -38,6 +38,7 @@ const {
   updateMCPServerController,
   deleteMCPServerController,
 } = require('~/server/controllers/mcp');
+const elicitationRouter = require('./mcp/elicitation');
 
 const router = Router();
 
@@ -679,5 +680,8 @@ router.delete(
   }),
   deleteMCPServerController,
 );
+
+// Mount elicitation routes
+router.use('/elicitations', elicitationRouter);
 
 module.exports = router;

--- a/api/server/routes/mcp/elicitation.js
+++ b/api/server/routes/mcp/elicitation.js
@@ -1,0 +1,49 @@
+const express = require('express');
+const { getMCPManager } = require('~/config');
+const { requireJwtAuth } = require('../../middleware');
+const { logger } = require('@librechat/data-schemas');
+
+const router = express.Router();
+
+/**
+ * POST /api/mcp/elicitations/:id/respond
+ * Respond to an elicitation request
+ */
+router.post('/:id/respond', requireJwtAuth, async (req, res) => {
+  try {
+    const { id: elicitationId } = req.params;
+    const { action, content } = req.body;
+    const userId = req.user.id;
+
+    // Validate the response
+    if (!['accept', 'decline', 'cancel'].includes(action)) {
+      return res.status(400).json({ error: 'Invalid action. Must be accept, decline, or cancel' });
+    }
+
+    const mcpManager = getMCPManager();
+
+    // Verify the elicitation belongs to the user
+    const elicitation = mcpManager.getElicitationState(elicitationId);
+    if (!elicitation) {
+      return res.status(404).json({ error: 'Elicitation not found' });
+    }
+
+    if (elicitation.userId !== userId) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    // Respond to the elicitation
+    const success = mcpManager.respondToElicitation(elicitationId, { action, content });
+
+    if (!success) {
+      return res.status(400).json({ error: 'Failed to respond to elicitation' });
+    }
+
+    res.json({ success: true, message: 'Response sent successfully' });
+  } catch (error) {
+    logger.error('[MCP] Error responding to elicitation:', error);
+    res.status(500).json({ error: 'Failed to respond to elicitation' });
+  }
+});
+
+module.exports = router;

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -401,11 +401,12 @@ async function createMCPTool({
     });
     toolDefinition = result?.availableTools?.[toolKey]?.function;
   }
-
   if (!toolDefinition) {
     logger.warn(`[MCP][${serverName}][${toolName}] Tool definition not found, cannot create tool.`);
     return;
   }
+
+  logger.debug(`createMCPTool(${toolKey})`);
 
   return createToolInstance({
     res,
@@ -482,6 +483,7 @@ function createToolInstance({
       const customUserVars =
         config?.configurable?.userMCPAuthMap?.[`${Constants.mcp_prefix}${serverName}`];
 
+      const toolCallId = toolCall?.id || toolCall?.tool_call_id || toolCall?.tool_call_ids?.[0];
       const result = await mcpManager.callTool({
         serverName,
         toolName,
@@ -489,6 +491,7 @@ function createToolInstance({
         toolArguments,
         options: {
           signal: derivedSignal,
+          tool_call_id: toolCallId,
         },
         user: config?.configurable?.user,
         requestBody: config?.configurable?.requestBody,

--- a/client/src/components/Chat/Messages/Content/ElicitationForm.tsx
+++ b/client/src/components/Chat/Messages/Content/ElicitationForm.tsx
@@ -1,0 +1,249 @@
+import React, { useState, useCallback } from 'react';
+import { useForm } from 'react-hook-form';
+import { Button } from '@librechat/client';
+import { useLocalize } from '~/hooks';
+
+interface ElicitationPropertySchema {
+  type: 'string' | 'number' | 'integer' | 'boolean';
+  title?: string;
+  description?: string;
+  minLength?: number;
+  maxLength?: number;
+  minimum?: number;
+  maximum?: number;
+  format?: 'email' | 'uri' | 'date' | 'date-time';
+  default?: string | number | boolean;
+  enum?: string[];
+  enumNames?: string[];
+}
+
+interface ElicitationRequestSchema {
+  type: 'object';
+  properties: Record<string, ElicitationPropertySchema>;
+  required?: string[];
+}
+
+interface ElicitationRequest {
+  message: string;
+  requestedSchema: ElicitationRequestSchema;
+}
+
+interface ElicitationFormProps {
+  request: ElicitationRequest;
+  serverName: string;
+  onAccept: (data: Record<string, unknown>) => void;
+  onDecline: () => void;
+  onCancel: () => void;
+}
+
+export default function ElicitationForm({
+  request,
+  serverName,
+  onAccept,
+  onDecline,
+  onCancel,
+}: ElicitationFormProps) {
+  const localize = useLocalize();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setValue,
+  } = useForm<Record<string, unknown>>();
+
+  // Set default values
+  React.useEffect(() => {
+    Object.entries(request.requestedSchema.properties).forEach(([key, property]) => {
+      if (property.default !== undefined) {
+        setValue(key, property.default);
+      }
+    });
+  }, [request.requestedSchema.properties, setValue]);
+
+  const onSubmit = useCallback(
+    async (data: Record<string, unknown>) => {
+      setIsSubmitting(true);
+      try {
+        onAccept(data);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [onAccept],
+  );
+
+  const renderField = (key: string, property: ElicitationPropertySchema) => {
+    const isRequired = request.requestedSchema.required?.includes(key) ?? false;
+    const fieldId = `elicitation-${key}`;
+
+    // Validation rules
+    const validationRules: Record<string, unknown> = {
+      required: isRequired ? `${property.title || key} is required` : false,
+    };
+
+    if (property.type === 'string') {
+      if (property.minLength)
+        validationRules.minLength = {
+          value: property.minLength,
+          message: `Minimum length is ${property.minLength}`,
+        };
+      if (property.maxLength)
+        validationRules.maxLength = {
+          value: property.maxLength,
+          message: `Maximum length is ${property.maxLength}`,
+        };
+      if (property.format === 'email')
+        validationRules.pattern = {
+          value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+          message: 'Please enter a valid email address',
+        };
+    }
+
+    if (property.type === 'number' || property.type === 'integer') {
+      if (property.minimum !== undefined)
+        validationRules.min = {
+          value: property.minimum,
+          message: `Minimum value is ${property.minimum}`,
+        };
+      if (property.maximum !== undefined)
+        validationRules.max = {
+          value: property.maximum,
+          message: `Maximum value is ${property.maximum}`,
+        };
+    }
+
+    const renderInput = () => {
+      if (property.enum) {
+        return (
+          <select
+            id={fieldId}
+            {...register(key, validationRules)}
+            className="w-full rounded border border-border-medium bg-surface-primary px-3 py-2 text-text-primary focus:border-border-heavy focus:outline-none"
+          >
+            <option value="">{localize('com_ui_select')}</option>
+            {property.enum.map((option, index) => (
+              <option key={option} value={option}>
+                {property.enumNames?.[index] || option}
+              </option>
+            ))}
+          </select>
+        );
+      }
+
+      if (property.type === 'boolean') {
+        return (
+          <div className="flex items-center">
+            <input
+              id={fieldId}
+              type="checkbox"
+              {...register(key, validationRules)}
+              className="h-4 w-4 rounded border-border-medium text-blue-600 focus:ring-blue-500"
+            />
+            <label htmlFor={fieldId} className="ml-2 text-sm text-text-primary">
+              {property.title || key}
+            </label>
+          </div>
+        );
+      }
+
+      if (property.type === 'number' || property.type === 'integer') {
+        return (
+          <input
+            id={fieldId}
+            type="number"
+            step={property.type === 'integer' ? '1' : 'any'}
+            {...register(key, {
+              ...validationRules,
+              valueAsNumber: true,
+            })}
+            className="w-full rounded border border-border-medium bg-surface-primary px-3 py-2 text-text-primary focus:border-border-heavy focus:outline-none"
+          />
+        );
+      }
+
+      let inputType = 'text';
+      if (property.format === 'email') {
+        inputType = 'email';
+      } else if (property.format === 'date') {
+        inputType = 'date';
+      } else if (property.format === 'date-time') {
+        inputType = 'datetime-local';
+      }
+
+      return (
+        <input
+          id={fieldId}
+          type={inputType}
+          {...register(key, validationRules)}
+          className="w-full rounded border border-border-medium bg-surface-primary px-3 py-2 text-text-primary focus:border-border-heavy focus:outline-none"
+        />
+      );
+    };
+
+    return (
+      <div key={key} className="mb-4">
+        <label htmlFor={fieldId} className="mb-2 block text-sm font-medium text-text-primary">
+          {property.title || key}
+          {isRequired && <span className="ml-1 text-red-500">*</span>}
+        </label>
+
+        {property.description && (
+          <p className="mb-2 whitespace-pre-line text-xs text-text-secondary">
+            {property.description}
+          </p>
+        )}
+
+        {renderInput()}
+
+        {errors[key] && (
+          <p className="mt-1 text-xs text-red-500">{errors[key]?.message as string}</p>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl rounded-lg border border-border-medium bg-surface-primary p-6 shadow-sm">
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-text-primary">{localize('com_ui_input')}</h3>
+        <span className="rounded bg-surface-secondary px-2 py-1 text-xs text-text-secondary">
+          {serverName}
+        </span>
+      </div>
+
+      <p className="mb-6 whitespace-pre-line text-text-primary">{request.message}</p>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        {Object.entries(request.requestedSchema.properties).map(([key, property]) =>
+          renderField(key, property),
+        )}
+
+        <div className="flex justify-end space-x-3 pt-4">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={isSubmitting}
+            className="px-4 py-2"
+          >
+            {localize('com_ui_cancel')}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onDecline}
+            disabled={isSubmitting}
+            className="px-4 py-2"
+          >
+            {localize('com_ui_decline')}
+          </Button>
+          <Button type="submit" variant="default" disabled={isSubmitting} className="px-4 py-2">
+            {isSubmitting ? localize('com_ui_submit') : localize('com_ui_accept')}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -146,6 +146,7 @@ const Part = memo(
             attachments={attachments}
             auth={toolCall.auth}
             expires_at={toolCall.expires_at}
+            tool_call_id={toolCall.id}
             isLast={isLast}
           />
         );
@@ -195,6 +196,7 @@ const Part = memo(
             args={toolCall.function.arguments as string}
             name={toolCall.function.name}
             output={toolCall.function.output}
+            tool_call_id={toolCall.id}
             isLast={isLast}
           />
         );

--- a/client/src/hooks/Chat/useElicitation.ts
+++ b/client/src/hooks/Chat/useElicitation.ts
@@ -1,0 +1,71 @@
+import { useCallback } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import {
+  respondToElicitation as apiRespondToElicitation,
+  ElicitationResponse,
+  ElicitationState,
+} from 'librechat-data-provider';
+import { activeElicitationsState, elicitationDataState } from '~/store';
+
+export function useElicitation(toolCallId?: string) {
+  const activeElicitations = useRecoilValue(activeElicitationsState);
+  const elicitationData = useRecoilValue(elicitationDataState);
+  const setActiveElicitations = useSetRecoilState(activeElicitationsState);
+  const setElicitationData = useSetRecoilState(elicitationDataState);
+
+  // Get active elicitation for a specific tool call
+  const getElicitationForToolCall = useCallback(
+    (tcId?: string) => {
+      if (tcId) {
+        const activeElicitation = activeElicitations[tcId];
+        if (activeElicitation) {
+          return elicitationData[activeElicitation.id] || null;
+        }
+      }
+
+      return null;
+    },
+    [activeElicitations, elicitationData],
+  );
+
+  const respondToElicitation = useCallback(
+    async (elicitationId: string, response: ElicitationResponse) => {
+      try {
+        await apiRespondToElicitation(elicitationId, response);
+
+        // Manually remove the elicitation from state since we don't have an SSE event for responses
+        setElicitationData((prev) => {
+          const newState = { ...prev };
+          delete newState[elicitationId];
+          return newState;
+        });
+
+        // Remove from active elicitations
+        setActiveElicitations((prev) => {
+          const newState = { ...prev };
+          // Find and remove the elicitation from active state
+          Object.keys(newState).forEach((key) => {
+            if (newState[key].id === elicitationId) {
+              delete newState[key];
+            }
+          });
+          return newState;
+        });
+      } catch (error) {
+        console.error('Failed to respond to elicitation:', error);
+        throw error;
+      }
+    },
+    [setElicitationData, setActiveElicitations],
+  );
+
+  // Get the current elicitation for this tool call
+  const currentElicitation = getElicitationForToolCall(toolCallId) as ElicitationState | null;
+
+  return {
+    activeElicitation: currentElicitation,
+    hasActiveElicitation: !!currentElicitation,
+    respondToElicitation,
+    getElicitationForToolCall,
+  };
+}

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -20,7 +20,7 @@ import { useGetStartupConfig, useGetUserBalance, queueTitleGeneration } from '~/
 import type { ActiveJobsResponse } from '~/data-provider';
 import { useAuthContext } from '~/hooks/AuthContext';
 import useEventHandlers from './useEventHandlers';
-import store from '~/store';
+import store, { activeElicitationsState, elicitationDataState } from '~/store';
 
 const clearDraft = (conversationId?: string | null) => {
   if (conversationId) {
@@ -94,6 +94,8 @@ export default function useResumableSSE(
   const [streamId, setStreamId] = useState<string | null>(null);
   const setAbortScroll = useSetRecoilState(store.abortScrollFamily(runIndex));
   const setShowStopButton = useSetRecoilState(store.showStopButtonByIndex(runIndex));
+  const setActiveElicitations = useSetRecoilState(activeElicitationsState);
+  const setElicitationData = useSetRecoilState(elicitationDataState);
 
   const sseRef = useRef<SSE | null>(null);
   const reconnectAttemptRef = useRef(0);
@@ -215,6 +217,26 @@ export default function useResumableSSE(
               data: data.data,
               submission: currentSubmission as EventSubmission,
             });
+            return;
+          }
+
+          if (data.type === 'elicitation_created' && data.elicitationData) {
+            const elicitationData = data.elicitationData;
+            setElicitationData((prev) => ({
+              ...prev,
+              [elicitationData.id]: elicitationData,
+            }));
+            if (elicitationData.tool_call_id) {
+              setActiveElicitations((prev) => {
+                const newState = {
+                  ...prev,
+                  [elicitationData.tool_call_id]: {
+                    ...elicitationData,
+                  },
+                };
+                return newState;
+              });
+            }
             return;
           }
 
@@ -543,6 +565,8 @@ export default function useResumableSSE(
       startupConfig?.balance?.enabled,
       balanceQuery,
       removeActiveJob,
+      setActiveElicitations,
+      setElicitationData,
     ],
   );
 

--- a/client/src/store/elicitation.ts
+++ b/client/src/store/elicitation.ts
@@ -1,0 +1,25 @@
+import type { ElicitationState } from 'librechat-data-provider';
+import { atom } from 'recoil';
+
+export interface ActiveElicitation {
+  id: string;
+  tool_call_id?: string;
+  timestamp: number;
+}
+
+/**
+ * Stores active elicitations keyed by tool_call_id
+ * This allows the UI to show elicitations only for specific tool calls
+ */
+export const activeElicitationsState = atom<Record<string, ActiveElicitation>>({
+  key: 'activeElicitations',
+  default: {},
+});
+
+/**
+ * Stores detailed elicitation data keyed by elicitation ID
+ */
+export const elicitationDataState = atom<Record<string, ElicitationState>>({
+  key: 'elicitationData',
+  default: {},
+});

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -15,6 +15,7 @@ import isTemporary from './temporary';
 export * from './agents';
 export * from './mcp';
 export * from './favorites';
+export * from './elicitation';
 
 export default {
   ...artifacts,

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -16,11 +16,18 @@ import type {
   TextContent,
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
-import type { SearchResultData, UIResource, TPlugin } from 'librechat-data-provider';
+import type { SearchResultData, UIResource, TPlugin, ElicitationRequestSchema } from 'librechat-data-provider';
 import type { TokenMethods, JsonSchemaType, IUser } from '@librechat/data-schemas';
 import type { FlowStateManager } from '~/flow/manager';
 import type { RequestBody } from '~/types/http';
 import type * as o from '~/mcp/oauth/types';
+import {
+  ElicitationActionSchema,
+  ElicitationRequestSchemaSchema,
+  ElicitationCreateRequestSchema,
+  ElicitationResponseSchema,
+  ElicitationStateSchema,
+} from '../zod';
 
 export type StdioOptions = z.infer<typeof StdioOptionsSchema>;
 export type WebSocketOptions = z.infer<typeof WebSocketOptionsSchema>;
@@ -185,3 +192,45 @@ export interface OAuthConnectionOptions {
   returnOnOAuth?: boolean;
   connectionTimeout?: number;
 }
+
+// Elicitation types
+export type ElicitationAction = 'accept' | 'decline' | 'cancel';
+
+// Import elicitation types from data-provider to avoid duplication
+export type { ElicitationRequestSchema as ElicitationRequestSchemaInterface } from 'librechat-data-provider';
+
+// Zod inferred types
+export type ElicitationActionType = z.infer<typeof ElicitationActionSchema>;
+export type ElicitationRequestSchemaType = z.infer<typeof ElicitationRequestSchemaSchema>;
+export type ElicitationCreateRequestType = z.infer<typeof ElicitationCreateRequestSchema>;
+export type ElicitationResponseType = z.infer<typeof ElicitationResponseSchema>;
+export type ElicitationStateType = z.infer<typeof ElicitationStateSchema>;
+
+export interface ElicitationCreateRequest {
+  message: string;
+  requestedSchema: ElicitationRequestSchema;
+  tool_call_id?: string;
+}
+
+export interface ElicitationResponse {
+  action: ElicitationAction;
+  content?: Record<string, unknown>;
+}
+
+export interface ElicitationState {
+  id: string;
+  serverName: string;
+  userId: string;
+  request: ElicitationCreateRequest;
+  tool_call_id?: string;
+  timestamp: number;
+}
+
+// Export Zod schemas
+export {
+  ElicitationActionSchema,
+  ElicitationRequestSchemaSchema,
+  ElicitationCreateRequestSchema,
+  ElicitationResponseSchema,
+  ElicitationStateSchema,
+};

--- a/packages/api/src/mcp/types/request.ts
+++ b/packages/api/src/mcp/types/request.ts
@@ -1,0 +1,5 @@
+import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
+
+export interface CallToolRequestOptions extends RequestOptions {
+  tool_call_id?: string;
+}

--- a/packages/api/src/mcp/zod.ts
+++ b/packages/api/src/mcp/zod.ts
@@ -484,3 +484,50 @@ export function convertWithResolvedRefs(
   const resolved = resolveJsonSchemaRefs(schema);
   return convertJsonSchemaToZod(resolved, options);
 }
+
+// Elicitation Zod schemas
+export const ElicitationActionSchema = z.enum(['accept', 'decline', 'cancel']);
+
+export const ElicitationPropertySchema = z.object({
+  type: z.enum(['string', 'number', 'integer', 'boolean']),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  minLength: z.number().optional(),
+  maxLength: z.number().optional(),
+  minimum: z.number().optional(),
+  maximum: z.number().optional(),
+  format: z.enum(['email', 'uri', 'date', 'date-time']).optional(),
+  default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+  enum: z.array(z.string()).optional(),
+  enumNames: z.array(z.string()).optional(),
+});
+
+export const ElicitationRequestSchemaSchema = z.object({
+  type: z.literal('object'),
+  properties: z.record(z.string(), ElicitationPropertySchema),
+  required: z.array(z.string()).optional(),
+});
+
+export const ElicitationCreateRequestSchema = z.object({
+  message: z.string(),
+  requestedSchema: ElicitationRequestSchemaSchema,
+});
+
+export const ElicitationResponseSchema = z.object({
+  action: ElicitationActionSchema,
+  content: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const ElicitationStateSchema = z.object({
+  id: z.string(),
+  serverName: z.string(),
+  userId: z.string(),
+  request: ElicitationCreateRequestSchema,
+  timestamp: z.number(),
+});
+
+// MCP Request schema for elicitation/create
+export const ElicitationCreateMethodSchema = z.object({
+  method: z.literal('elicitation/create'),
+  params: ElicitationCreateRequestSchema,
+});

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -12,6 +12,7 @@ import request from './request';
 import * as s from './schemas';
 import * as r from './roles';
 import * as permissions from './accessPermissions';
+import * as mc from './types/mcp';
 
 export function revokeUserKey(name: string): Promise<unknown> {
   return request.delete(endpoints.revokeUserKey(name));
@@ -1051,4 +1052,11 @@ export interface ActiveJobsResponse {
 
 export const getActiveJobs = (): Promise<ActiveJobsResponse> => {
   return request.get(endpoints.activeJobs());
+};
+
+export const respondToElicitation = (
+  elicitationId: string,
+  response: mc.ElicitationResponse,
+): Promise<{ success: boolean; message: string }> => {
+  return request.post(`/api/mcp/elicitations/${elicitationId}/respond`, response);
 };

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -9,6 +9,7 @@ export * from './messages';
 export * from './artifacts';
 /* schema helpers  */
 export * from './parsers';
+export * from './schemas';
 /* custom/dynamic configurations  */
 export * from './generate';
 export * from './models';
@@ -30,6 +31,7 @@ export * from './types/web';
 export * from './types/graph';
 /* access permissions */
 export * from './accessPermissions';
+export * from './types/mcp';
 /* query/mutation keys */
 export * from './keys';
 /* api call helpers */
@@ -37,6 +39,7 @@ export * from './headers-helpers';
 export { loginPage, registerPage, apiBaseUrl } from './api-endpoints';
 export { default as request } from './request';
 export { dataService };
+export { respondToElicitation } from './data-service';
 import * as dataService from './data-service';
 /* general helpers */
 export * from './utils';

--- a/packages/data-provider/src/types/mcp.ts
+++ b/packages/data-provider/src/types/mcp.ts
@@ -1,0 +1,38 @@
+export interface ElicitationPropertySchema {
+  type: 'string' | 'number' | 'integer' | 'boolean';
+  title?: string;
+  description?: string;
+  minLength?: number;
+  maxLength?: number;
+  minimum?: number;
+  maximum?: number;
+  format?: 'email' | 'uri' | 'date' | 'date-time';
+  default?: string | number | boolean;
+  enum?: string[];
+  enumNames?: string[];
+}
+
+export interface ElicitationRequestSchema {
+  type: 'object';
+  properties: Record<string, ElicitationPropertySchema>;
+  required?: string[];
+}
+
+export interface ElicitationRequest {
+  message: string;
+  requestedSchema: ElicitationRequestSchema;
+}
+
+export interface ElicitationState {
+  id: string;
+  serverName: string;
+  userId: string;
+  request: ElicitationRequest;
+  timestamp: number;
+  tool_call_id?: string;
+}
+
+export interface ElicitationResponse {
+  action: 'accept' | 'decline' | 'cancel';
+  content?: Record<string, unknown>;
+}


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

This is a proposal for https://github.com/danny-avila/LibreChat/discussions/8681
With this PR Librechat's MCP client supports elicitations so MCP servers can  push them and require "human in the loop" confirmation for specific actions.

https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

## Testing

You need an MCP server able to generate "elecitInputs".
When the server generates this kind of event during tool execution:
- the librechat client will receive it
- it will propagate via SSE to the frontend
- the frontend will display a form requiring the user to accept / decline / cancel the MCP server action, and eventually also provide data via a form for action completion.
- 

### **Test Configuration**:

Configure an MCP server supporting elicitation, for example:
https://github.com/modelcontextprotocol/servers/tree/main/src/everything

   server-everything:
    command: npx
    args:
      - -y
      - "@modelcontextprotocol/server-everything
      
Unfortunately, as of 2025/07/26 the released npm package    does not have the latest tool "startElicitation", so you have to

```
 git clone https://github.com/modelcontextprotocol/servers.git  
 cd servers/src/everything/
 npm install
 npm run start:streamableHttp

```

And configure:
```
   server-everything:
    type: streamable-http
    url: http://<your ip address reachable by librechat>:3001/mcp   
```

Then you can ask your favorite llm to "execute the startElicitation tool" and you can test:

<img width="890" height="748" alt="image" src="https://github.com/user-attachments/assets/a652e2ab-8b8c-4d97-a99b-af45a15629a2" />

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.

I am not sure this requires much documentation change as nothing has to be done in the configuration, librechat MCP client will just advertise the elicitation capability to MCP servers.

