### PR TITLE
🔒 feat: MCP OAuth Config for Metadata Parameters

### DIFF
--- a/packages/api/src/mcp/oauth/handler.test.ts
+++ b/packages/api/src/mcp/oauth/handler.test.ts
@@ -1,0 +1,191 @@
+import { MCPOAuthHandler } from './handler';
+import type { MCPOptions } from 'librechat-data-provider';
+
+// Mock the external dependencies
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@modelcontextprotocol/sdk/client/auth.js', () => ({
+  startAuthorization: jest.fn(),
+}));
+
+import { startAuthorization } from '@modelcontextprotocol/sdk/client/auth.js';
+
+const mockStartAuthorization = startAuthorization as jest.MockedFunction<typeof startAuthorization>;
+
+describe('MCPOAuthHandler - Configurable OAuth Metadata', () => {
+  const mockServerName = 'test-server';
+  const mockServerUrl = 'https://example.com/mcp';
+  const mockUserId = 'user-123';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.DOMAIN_SERVER = 'http://localhost:3080';
+
+    // Mock startAuthorization to return a successful response
+    mockStartAuthorization.mockResolvedValue({
+      authorizationUrl: new URL('https://auth.example.com/oauth/authorize?client_id=test'),
+      codeVerifier: 'test-code-verifier',
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.DOMAIN_SERVER;
+  });
+
+  describe('Pre-configured OAuth Metadata Fields', () => {
+    const baseConfig: MCPOptions['oauth'] = {
+      authorization_url: 'https://auth.example.com/oauth/authorize',
+      token_url: 'https://auth.example.com/oauth/token',
+      client_id: 'test-client-id',
+      client_secret: 'test-client-secret',
+    };
+
+    it('should use default values when OAuth metadata fields are not configured', async () => {
+      await MCPOAuthHandler.initiateOAuthFlow(
+        mockServerName,
+        mockServerUrl,
+        mockUserId,
+        baseConfig,
+      );
+
+      expect(mockStartAuthorization).toHaveBeenCalledWith(
+        mockServerUrl,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            grant_types_supported: ['authorization_code', 'refresh_token'],
+            token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+            response_types_supported: ['code'],
+            code_challenge_methods_supported: ['S256', 'plain'],
+          }),
+        }),
+      );
+    });
+
+    it('should use custom grant_types_supported when provided', async () => {
+      const config = {
+        ...baseConfig,
+        grant_types_supported: ['authorization_code'],
+      };
+
+      await MCPOAuthHandler.initiateOAuthFlow(mockServerName, mockServerUrl, mockUserId, config);
+
+      expect(mockStartAuthorization).toHaveBeenCalledWith(
+        mockServerUrl,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            grant_types_supported: ['authorization_code'],
+          }),
+        }),
+      );
+    });
+
+    it('should use custom token_endpoint_auth_methods_supported when provided', async () => {
+      const config = {
+        ...baseConfig,
+        token_endpoint_auth_methods_supported: ['client_secret_post'],
+      };
+
+      await MCPOAuthHandler.initiateOAuthFlow(mockServerName, mockServerUrl, mockUserId, config);
+
+      expect(mockStartAuthorization).toHaveBeenCalledWith(
+        mockServerUrl,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            token_endpoint_auth_methods_supported: ['client_secret_post'],
+          }),
+        }),
+      );
+    });
+
+    it('should use custom response_types_supported when provided', async () => {
+      const config = {
+        ...baseConfig,
+        response_types_supported: ['code', 'token'],
+      };
+
+      await MCPOAuthHandler.initiateOAuthFlow(mockServerName, mockServerUrl, mockUserId, config);
+
+      expect(mockStartAuthorization).toHaveBeenCalledWith(
+        mockServerUrl,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            response_types_supported: ['code', 'token'],
+          }),
+        }),
+      );
+    });
+
+    it('should use custom code_challenge_methods_supported when provided', async () => {
+      const config = {
+        ...baseConfig,
+        code_challenge_methods_supported: ['S256'],
+      };
+
+      await MCPOAuthHandler.initiateOAuthFlow(mockServerName, mockServerUrl, mockUserId, config);
+
+      expect(mockStartAuthorization).toHaveBeenCalledWith(
+        mockServerUrl,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            code_challenge_methods_supported: ['S256'],
+          }),
+        }),
+      );
+    });
+
+    it('should use all custom OAuth metadata fields when provided together', async () => {
+      const config = {
+        ...baseConfig,
+        grant_types_supported: ['authorization_code', 'client_credentials'],
+        token_endpoint_auth_methods_supported: ['none'],
+        response_types_supported: ['code', 'token', 'id_token'],
+        code_challenge_methods_supported: ['S256'],
+      };
+
+      await MCPOAuthHandler.initiateOAuthFlow(mockServerName, mockServerUrl, mockUserId, config);
+
+      expect(mockStartAuthorization).toHaveBeenCalledWith(
+        mockServerUrl,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            grant_types_supported: ['authorization_code', 'client_credentials'],
+            token_endpoint_auth_methods_supported: ['none'],
+            response_types_supported: ['code', 'token', 'id_token'],
+            code_challenge_methods_supported: ['S256'],
+          }),
+        }),
+      );
+    });
+
+    it('should handle empty arrays as valid custom values', async () => {
+      const config = {
+        ...baseConfig,
+        grant_types_supported: [],
+        token_endpoint_auth_methods_supported: [],
+        response_types_supported: [],
+        code_challenge_methods_supported: [],
+      };
+
+      await MCPOAuthHandler.initiateOAuthFlow(mockServerName, mockServerUrl, mockUserId, config);
+
+      expect(mockStartAuthorization).toHaveBeenCalledWith(
+        mockServerUrl,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            grant_types_supported: [],
+            token_endpoint_auth_methods_supported: [],
+            response_types_supported: [],
+            code_challenge_methods_supported: [],
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/packages/api/src/mcp/oauth/handler.test.ts
+++ b/packages/api/src/mcp/oauth/handler.test.ts
@@ -1,7 +1,6 @@
 import { MCPOAuthHandler } from './handler';
 import type { MCPOptions } from 'librechat-data-provider';
 
-// Mock the external dependencies
 jest.mock('@librechat/data-schemas', () => ({
   logger: {
     debug: jest.fn(),

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -182,7 +182,6 @@ export class MCPOAuthHandler {
           token_endpoint: config.token_url,
           issuer: serverUrl,
           scopes_supported: config.scope?.split(' ') ?? [],
-          // Use config values or sensible defaults for the pre-configured path
           grant_types_supported: config?.grant_types_supported ?? [
             'authorization_code',
             'refresh_token',
@@ -197,7 +196,7 @@ export class MCPOAuthHandler {
             'plain',
           ],
         };
-        logger.debug(`Using metadata: ${JSON.stringify(metadata)}`);
+        logger.debug(`[MCPOAuth] metadata for "${serverName}": ${JSON.stringify(metadata)}`);
         const clientInfo: OAuthClientInformation = {
           client_id: config.client_id,
           client_secret: config.client_secret,

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -181,8 +181,14 @@ export class MCPOAuthHandler {
           authorization_endpoint: config.authorization_url,
           token_endpoint: config.token_url,
           issuer: serverUrl,
-          scopes_supported: config.scope?.split(' '),
+          scopes_supported: config.scope?.split(' ') ?? [],
+          // Add sensible defaults for the pre-configured path
+          grant_types_supported: ['authorization_code', 'refresh_token'],
+          token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
+          response_types_supported: ['code'],
+          code_challenge_methods_supported: ['S256', 'plain'],
         };
+        logger.info('Using metadata: ', metadata);
 
         const clientInfo: OAuthClientInformation = {
           client_id: config.client_id,

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -182,13 +182,22 @@ export class MCPOAuthHandler {
           token_endpoint: config.token_url,
           issuer: serverUrl,
           scopes_supported: config.scope?.split(' ') ?? [],
-          // Add sensible defaults for the pre-configured path
-          grant_types_supported: ['authorization_code', 'refresh_token'],
-          token_endpoint_auth_methods_supported: ['client_secret_basic', 'client_secret_post'],
-          response_types_supported: ['code'],
-          code_challenge_methods_supported: ['S256', 'plain'],
+          // Use config values or sensible defaults for the pre-configured path
+          grant_types_supported: config?.grant_types_supported ?? [
+            'authorization_code',
+            'refresh_token',
+          ],
+          token_endpoint_auth_methods_supported: config?.token_endpoint_auth_methods_supported ?? [
+            'client_secret_basic',
+            'client_secret_post',
+          ],
+          response_types_supported: config?.response_types_supported ?? ['code'],
+          code_challenge_methods_supported: config?.code_challenge_methods_supported ?? [
+            'S256',
+            'plain',
+          ],
         };
-
+        logger.debug(`Using metadata: ${JSON.stringify(metadata)}`);
         const clientInfo: OAuthClientInformation = {
           client_id: config.client_id,
           client_secret: config.client_secret,

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -188,7 +188,6 @@ export class MCPOAuthHandler {
           response_types_supported: ['code'],
           code_challenge_methods_supported: ['S256', 'plain'],
         };
-        logger.info('Using metadata: ', metadata);
 
         const clientInfo: OAuthClientInformation = {
           client_id: config.client_id,

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -36,6 +36,14 @@ const BaseOptionsSchema = z.object({
       redirect_uri: z.string().url().optional(),
       /** Token exchange method */
       token_exchange_method: z.nativeEnum(TokenExchangeMethodEnum).optional(),
+      /** Supported grant types (defaults to ['authorization_code', 'refresh_token']) */
+      grant_types_supported: z.array(z.string()).optional(),
+      /** Supported token endpoint authentication methods (defaults to ['client_secret_basic', 'client_secret_post']) */
+      token_endpoint_auth_methods_supported: z.array(z.string()).optional(),
+      /** Supported response types (defaults to ['code']) */
+      response_types_supported: z.array(z.string()).optional(),
+      /** Supported code challenge methods (defaults to ['S256', 'plain']) */
+      code_challenge_methods_supported: z.array(z.string()).optional(),
     })
     .optional(),
   customUserVars: z


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

This PR fixes a critical bug where MCP OAuth initialization consistently fails when using pre-configured OAuth settings in `librechat.yaml`. The error manifests as:

```
[MCPOAuth] Failed to initiate OAuth flow
Cannot read properties of undefined (reading 'includes')
```

**Root Cause:** The pre-configured OAuth path creates an incomplete `metadata` object missing required properties (`grant_types_supported`, `token_endpoint_auth_methods_supported`, etc.). When the MCP SDK calls `.includes()` on these undefined arrays, it crashes with a TypeError. Most likely this was not noticed due to the fact that most people probably use DCR instead of static client id & secret.

**Solution:** Added sensible default values for the missing OAuth metadata properties to ensure the metadata object is always complete and compatible with modern OAuth servers.

**Impact:** This affects **all new users** attempting to use MCP servers with OAuth authentication, making it a critical bug for production deployments. The fix enables reliable OAuth flows for all users and consistent behavior across Docker and local environments.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

**Test Process:**

1. **Reproduction Setup:**
   - Configure MCP server with pre-configured OAuth in `librechat.yaml`:
     ```yaml
     mcpServers:
       test-server:
         type: streamable-http
         url: https://example.com/mcp
         oauth:
           authorization_url: "https://auth.example.com/oauth/authorize"
           token_url: "https://auth.example.com/oauth/token"
           client_id: "test_client_id"
           client_secret: "test_secret"
     ```
   - Use fresh user account (without existing OAuth tokens)
   - Attempt to use MCP tool, triggering OAuth initialization

2. **Before Fix:**
   ```bash
   npm run backend:dev
   # Result: Consistent crash with "Cannot read properties of undefined (reading 'includes')"
   ```

3. **After Fix:**
   ```bash
   npm run build:api  # Rebuild with fix
   npm run backend:dev
   # Result: OAuth flow initiates correctly, redirects to authorization server
   ```

4. **Verification:**
   - Tested with Auth0 OAuth server
   - Verified PKCE compatibility (S256 and plain methods)
   - Confirmed backward compatibility with existing configurations
   - Tested both Docker and local development environments

### **Test Configuration**:

- **Environment:** Ubuntu Linux with Node.js v22.17.1
- **OAuth Provider:** Auth0 with OIDC conformance enabled
- **MCP Server:** Streamable HTTP transport
- **LibreChat Version:** v0.7.9 (main branch)
- **Test Scenarios:** 
  - Fresh user (no cached tokens)
  - Pre-configured OAuth settings
  - Docker deployment vs. local development

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.

## Additional Technical Details

**Files Changed:**
- `packages/api/src/mcp/oauth/handler.ts`: Added default metadata properties

**Default Values Added:**
- `grant_types_supported`: `['authorization_code', 'refresh_token']`
- `token_endpoint_auth_methods_supported`: `['client_secret_basic', 'client_secret_post']`
- `response_types_supported`: `['code']`
- `code_challenge_methods_supported`: `['S256', 'plain']`

**Backward Compatibility:**
- ✅ Fully backward compatible
- ✅ No breaking changes to configuration format
- ✅ Existing OAuth flows continue to work unchanged
- ✅ No external dependencies added

**Related Issues:**
This resolves OAuth initialization failures in Docker deployments and production environments with pre-configured OAuth settings. 