### PR TITLE
📻 feat: radio component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51506,7 +51506,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^25.0.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "React components for LibreChat",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/client/src/components/Radio.tsx
+++ b/packages/client/src/components/Radio.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useLayoutEffect, useCallback, memo } from 'react';
+import { useLocalize } from '~/hooks';
 
 interface Option {
   value: string;
@@ -13,6 +14,7 @@ interface RadioProps {
 }
 
 const Radio = memo(function Radio({ options, value, onChange, disabled = false }: RadioProps) {
+  const localize = useLocalize();
   const [currentValue, setCurrentValue] = useState<string>(value ?? '');
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const [backgroundStyle, setBackgroundStyle] = useState<React.CSSProperties>({});
@@ -55,7 +57,9 @@ const Radio = memo(function Radio({ options, value, onChange, disabled = false }
         className="relative inline-flex items-center rounded-lg bg-muted p-1 opacity-50"
         role="radiogroup"
       >
-        <span className="px-4 py-2 text-xs text-muted-foreground">No options available</span>
+        <span className="px-4 py-2 text-xs text-muted-foreground">
+          {localize('com_ui_no_options')}
+        </span>
       </div>
     );
   }

--- a/packages/client/src/components/Radio.tsx
+++ b/packages/client/src/components/Radio.tsx
@@ -1,0 +1,95 @@
+import React, { useState, useRef, useLayoutEffect, useCallback, memo } from 'react';
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface RadioProps {
+  options: Option[];
+  value?: string;
+  onChange?: (value: string) => void;
+  disabled?: boolean;
+}
+
+const Radio = memo(function Radio({ options, value, onChange, disabled = false }: RadioProps) {
+  const [currentValue, setCurrentValue] = useState<string>(value ?? '');
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [backgroundStyle, setBackgroundStyle] = useState<React.CSSProperties>({});
+
+  const handleChange = (newValue: string) => {
+    setCurrentValue(newValue);
+    onChange?.(newValue);
+  };
+
+  const updateBackgroundStyle = useCallback(() => {
+    const selectedIndex = options.findIndex((opt) => opt.value === currentValue);
+    if (selectedIndex >= 0 && buttonRefs.current[selectedIndex]) {
+      const selectedButton = buttonRefs.current[selectedIndex];
+      const container = selectedButton?.parentElement;
+      if (selectedButton && container) {
+        const containerRect = container.getBoundingClientRect();
+        const buttonRect = selectedButton.getBoundingClientRect();
+        const offsetLeft = buttonRect.left - containerRect.left - 4;
+        setBackgroundStyle({
+          width: `${buttonRect.width}px`,
+          transform: `translateX(${offsetLeft}px)`,
+        });
+      }
+    }
+  }, [currentValue, options]);
+
+  useLayoutEffect(() => {
+    updateBackgroundStyle();
+  }, [updateBackgroundStyle]);
+
+  useLayoutEffect(() => {
+    if (value !== undefined) {
+      setCurrentValue(value);
+    }
+  }, [value]);
+
+  if (options.length === 0) {
+    return (
+      <div
+        className="relative inline-flex items-center rounded-lg bg-muted p-1 opacity-50"
+        role="radiogroup"
+      >
+        <span className="px-4 py-2 text-xs text-muted-foreground">No options available</span>
+      </div>
+    );
+  }
+
+  const selectedIndex = options.findIndex((opt) => opt.value === currentValue);
+
+  return (
+    <div className="relative inline-flex items-center rounded-lg bg-muted p-1" role="radiogroup">
+      {selectedIndex >= 0 && (
+        <div
+          className="pointer-events-none absolute inset-y-1 rounded-md border border-border/50 bg-background shadow-sm transition-all duration-300 ease-out"
+          style={backgroundStyle}
+        />
+      )}
+      {options.map((option, index) => (
+        <button
+          key={option.value}
+          ref={(el) => {
+            buttonRefs.current[index] = el;
+          }}
+          type="button"
+          role="radio"
+          aria-checked={currentValue === option.value}
+          onClick={() => handleChange(option.value)}
+          disabled={disabled}
+          className={`relative z-10 flex h-[34px] items-center justify-center rounded-md px-4 text-sm font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+            currentValue === option.value ? 'text-foreground' : 'text-foreground'
+          } ${disabled ? 'cursor-not-allowed opacity-50' : ''}`}
+        >
+          <span className="whitespace-nowrap">{option.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+});
+
+export default Radio;

--- a/packages/client/src/components/index.ts
+++ b/packages/client/src/components/index.ts
@@ -30,6 +30,7 @@ export * from './Progress';
 export * from './InputOTP';
 export * from './MultiSearch';
 export * from './Resizable';
+export { default as Radio } from './Radio';
 export { default as Badge } from './Badge';
 export { default as Combobox } from './Combobox';
 export { default as Dropdown } from './Dropdown';

--- a/packages/client/src/locales/en/translation.json
+++ b/packages/client/src/locales/en/translation.json
@@ -1,3 +1,4 @@
 {
-  "com_ui_cancel": "Cancel"
+  "com_ui_cancel": "Cancel",
+  "com_ui_no_options": "No options available"
 }


### PR DESCRIPTION
# Summary

- 📻 Introduce a fully functional and accessible `Radio` component in the client package with customizable options and dynamic styling
- 🌐 Update localization files to include a message for scenarios when no options are available (`com_ui_no_options`)
- 🚀 Export the new `Radio` component for application-wide use
- 📦 Bump `@librechat/client` package version from `0.1.9` to `0.2.0` to reflect the addition of this new feature

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- ✅ Verified color contrast accessibility using [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
- 🔊 Tested screen reader compatibility using NVDA's Speech Viewer

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
