### PR TITLE
🐦 fix: Prioritize OIDC Username Claims to Prevent First Name Usernames

### DIFF
--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -353,7 +353,7 @@ async function setupOpenId() {
             username = userinfo[process.env.OPENID_USERNAME_CLAIM];
           } else {
             username = convertToUsername(
-              userinfo.username || userinfo.given_name || userinfo.email,
+              userinfo.preferred_username || userinfo.username || userinfo.email,
             );
           }
 


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Proposed fix for #8672 
Updated the OIDC claims used when creating a new user in LibreChat with social registration to use `preferred_username` first, followed by the nonstandard `username`, then the `email` claim, removed `given_name` from the mix so usernames don't end up being peoples' first names.

## Change Type
- [✅] Bug fix (non-breaking change which fixes an issue)

## Testing
Note that `email` is a required claim elsewhere in the code, so all tests must always include the `email` claim from OIDC.
- Configure a LibreChat installation with social registration turned on that points at a valid OIDC server.
- Log in as a user who has a claim for `preferred_username` provided by the OIDC server.
- Log in as a user who has a claim for `username` provided by the OIDC server.
- Log in as an additional user who provides neither of those claims.
- Verify the usernames of the created accounts correspond to `preferred_username`, `username`, and `email` values respectively.

### **Test Configuration**:
in environment:
```
ALLOW_SOCIAL_LOGIN=true
ALLOW_SOCIAL_REGISTRATION=true

# You also need to fill out these values to integrate with OpenID
OPENID_CLIENT_ID=
OPENID_CLIENT_SECRET=
OPENID_ISSUER=
OPENID_SESSION_SECRET=
```

You must also make sure that `OPENID_USERNAME_CLAIM` is not defined in your environment.

## Checklist
- [✅] My code adheres to this project's style guidelines
- [✅] I have performed a self-review of my own code
- [✅] Local unit tests pass with my changes
