### PR TITLE
fix: remove conditional rendering of MCPPanel in SideNav based on presence of customUserVars

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -5,6 +5,7 @@ const { getCustomConfig } = require('~/server/services/Config/getCustomConfig');
 const { getLdapConfig } = require('~/server/services/Config/ldap');
 const { getProjectByName } = require('~/models/Project');
 const { isEnabled } = require('~/server/utils');
+const { getMCPManager } = require('~/config');
 const { getLogStores } = require('~/cache');
 
 const router = express.Router();
@@ -102,11 +103,14 @@ router.get('/', async function (req, res) {
     payload.mcpServers = {};
     const config = await getCustomConfig();
     if (config?.mcpServers != null) {
+      const mcpManager = getMCPManager();
+      const oauthServers = mcpManager.getOAuthServers();
       for (const serverName in config.mcpServers) {
         const serverConfig = config.mcpServers[serverName];
         payload.mcpServers[serverName] = {
           customUserVars: serverConfig?.customUserVars || {},
           chatMenu: serverConfig?.chatMenu,
+          isOAuth: oauthServers.has(serverName),
         };
       }
     }

--- a/client/src/hooks/Nav/useSideNavLinks.ts
+++ b/client/src/hooks/Nav/useSideNavLinks.ts
@@ -155,7 +155,9 @@ export default function useSideNavLinks({
     if (
       startupConfig?.mcpServers &&
       Object.values(startupConfig.mcpServers).some(
-        (server) => server.customUserVars && Object.keys(server.customUserVars).length > 0,
+        (server: any) =>
+          (server.customUserVars && Object.keys(server.customUserVars).length > 0) ||
+          server.isOAuth,
       )
     ) {
       links.push({

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -613,6 +613,7 @@ export type TStartupConfig = {
         }
       >;
       chatMenu?: boolean;
+      isOAuth?: boolean;
     }
   >;
   mcpPlaceholder?: string;


### PR DESCRIPTION
## Summary

This PR makes it so that the MCP settings panel renders even when no customUserVars are set for configured MCP servers. 

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual verification of MCPPanel in SideNav when no servers have been configured with customUserVars in the yaml.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
