### PR TITLE
feat: Add deno runtime to docker image (#8715)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
 COPY --from=ghcr.io/astral-sh/uv:0.6.13 /uv /uvx /bin/
 RUN uv --version
 
+# Add `deno` for better MCP isolation
+RUN apk add --no-cache deno
+RUN deno --version
+
 RUN mkdir -p /app && chown node:node /app
 WORKDIR /app
 

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -58,6 +58,9 @@ FROM base-min AS api-build
 # Add `uv` for extended MCP support
 COPY --from=ghcr.io/astral-sh/uv:0.6.13 /uv /uvx /bin/
 RUN uv --version
+# Add `deno` for better MCP isolation
+RUN apk add --no-cache deno
+RUN deno --version
 WORKDIR /app
 # Install only production deps
 RUN npm ci --omit=dev


### PR DESCRIPTION
## Summary

Adds the Deno runtime to the docker image, allowing consumers of the image to run MCP servers based on JSR packages and benefit from better runtime isolation.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] A pull request for updating the documentation has been submitted.
