### PR TITLE
🔑 refactor: MCP Settings Rendering Logic for OAuth Servers

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -3,9 +3,9 @@ const { logger } = require('@librechat/data-schemas');
 const { CacheKeys, defaultSocialLogins, Constants } = require('librechat-data-provider');
 const { getCustomConfig } = require('~/server/services/Config/getCustomConfig');
 const { getLdapConfig } = require('~/server/services/Config/ldap');
+const { getMCPManager } = require('~/config');
 const { getProjectByName } = require('~/models/Project');
 const { isEnabled } = require('~/server/utils');
-const { getMCPManager } = require('~/config');
 const { getLogStores } = require('~/cache');
 
 const router = express.Router();
@@ -105,12 +105,14 @@ router.get('/', async function (req, res) {
     if (config?.mcpServers != null) {
       const mcpManager = getMCPManager();
       const oauthServers = mcpManager.getOAuthServers();
+
       for (const serverName in config.mcpServers) {
         const serverConfig = config.mcpServers[serverName];
         payload.mcpServers[serverName] = {
           customUserVars: serverConfig?.customUserVars || {},
           chatMenu: serverConfig?.chatMenu,
           isOAuth: oauthServers.has(serverName),
+          startup: serverConfig?.startup,
         };
       }
     }

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -5,6 +5,7 @@ const { getCustomConfig } = require('~/server/services/Config/getCustomConfig');
 const { getLdapConfig } = require('~/server/services/Config/ldap');
 const { getProjectByName } = require('~/models/Project');
 const { isEnabled } = require('~/server/utils');
+const { getMCPManager } = require('~/config');
 const { getLogStores } = require('~/cache');
 
 const router = express.Router();
@@ -102,11 +103,14 @@ router.get('/', async function (req, res) {
     payload.mcpServers = {};
     const config = await getCustomConfig();
     if (config?.mcpServers != null) {
+      const mcpManager = getMCPManager();
+      const oauthServers = mcpManager.getOAuthServers();
       for (const serverName in config.mcpServers) {
         const serverConfig = config.mcpServers[serverName];
         payload.mcpServers[serverName] = {
           customUserVars: serverConfig?.customUserVars || {},
           chatMenu: serverConfig?.chatMenu,
+          isOAuth: oauthServers.has(serverName),
         };
       }
     }

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -1,11 +1,11 @@
 const express = require('express');
+const { isEnabled } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const { CacheKeys, defaultSocialLogins, Constants } = require('librechat-data-provider');
 const { getCustomConfig } = require('~/server/services/Config/getCustomConfig');
 const { getLdapConfig } = require('~/server/services/Config/ldap');
-const { getMCPManager } = require('~/config');
 const { getProjectByName } = require('~/models/Project');
-const { isEnabled } = require('~/server/utils');
+const { getMCPManager } = require('~/config');
 const { getLogStores } = require('~/cache');
 
 const router = express.Router();

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -452,11 +452,19 @@ router.post('/:serverName/reinitialize', requireJwtAuth, async (req, res) => {
       `[MCP Reinitialize] Sending response for ${serverName} - oauthRequired: ${oauthRequired}, oauthUrl: ${oauthUrl ? 'present' : 'null'}`,
     );
 
+    const getResponseMessage = () => {
+      if (oauthRequired) {
+        return `MCP server '${serverName}' ready for OAuth authentication`;
+      }
+      if (userConnection) {
+        return `MCP server '${serverName}' reinitialized successfully`;
+      }
+      return `Failed to reinitialize MCP server '${serverName}'`;
+    };
+
     res.json({
-      success: true,
-      message: oauthRequired
-        ? `MCP server '${serverName}' ready for OAuth authentication`
-        : `MCP server '${serverName}' reinitialized successfully`,
+      success: userConnection && !oauthRequired,
+      message: getResponseMessage(),
       serverName,
       oauthRequired,
       oauthUrl,

--- a/client/src/components/MCP/CustomUserVarsSection.tsx
+++ b/client/src/components/MCP/CustomUserVarsSection.tsx
@@ -110,11 +110,9 @@ export default function CustomUserVarsSection({
 
   const handleRevokeClick = () => {
     onRevoke();
-    // Reset form after revoke
     reset();
   };
 
-  // Show message if no fields to configure
   if (!fields || Object.keys(fields).length === 0) {
     return (
       <div className="p-4 text-center text-sm text-gray-500">

--- a/client/src/components/MCP/CustomUserVarsSection.tsx
+++ b/client/src/components/MCP/CustomUserVarsSection.tsx
@@ -114,9 +114,13 @@ export default function CustomUserVarsSection({
     reset();
   };
 
-  // Don't render if no fields to configure
+  // Show message if no fields to configure
   if (!fields || Object.keys(fields).length === 0) {
-    return null;
+    return (
+      <div className="p-4 text-center text-sm text-gray-500">
+        {localize('com_sidepanel_mcp_no_custom_vars', { '0': serverName })}
+      </div>
+    );
   }
 
   return (

--- a/client/src/components/MCP/MCPConfigDialog.tsx
+++ b/client/src/components/MCP/MCPConfigDialog.tsx
@@ -132,6 +132,7 @@ export default function MCPConfigDialog({
         <ServerInitializationSection
           serverName={serverName}
           requiresOAuth={serverStatus?.requiresOAuth || false}
+          hasCustomUserVars={fieldsSchema && Object.keys(fieldsSchema).length > 0}
         />
       </OGDialogContent>
     </OGDialog>

--- a/client/src/components/MCP/ServerInitializationSection.tsx
+++ b/client/src/components/MCP/ServerInitializationSection.tsx
@@ -63,10 +63,10 @@ export default function ServerInitializationSection({
   }
 
   return (
-    <div className="rounded-lg border border-[#991b1b] bg-[#2C1315] p-4">
+    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-700 dark:bg-amber-900/20">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-red-700 dark:text-red-300">
+          <span className="text-sm font-medium text-amber-800 dark:text-amber-200">
             {requiresOAuth
               ? localize('com_ui_mcp_not_authenticated', { 0: serverName })
               : localize('com_ui_mcp_not_initialized', { 0: serverName })}
@@ -77,7 +77,7 @@ export default function ServerInitializationSection({
           <Button
             onClick={handleInitializeClick}
             disabled={isServerInitializing}
-            className="flex items-center gap-2 bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 dark:hover:bg-blue-800"
+            className="btn btn-primary focus:shadow-outline flex w-full items-center justify-center px-4 py-2 font-semibold text-white hover:bg-green-600 focus:border-green-500"
           >
             {isServerInitializing ? (
               <>
@@ -110,7 +110,7 @@ export default function ServerInitializationSection({
           <div className="flex items-center gap-2">
             <Button
               onClick={() => window.open(serverOAuthUrl, '_blank', 'noopener,noreferrer')}
-              className="flex-1 bg-blue-600 text-white hover:bg-blue-700 dark:hover:bg-blue-800"
+              className="flex-1 bg-green-600 text-white hover:bg-green-700 dark:hover:bg-green-800"
             >
               {localize('com_ui_continue_oauth')}
             </Button>

--- a/client/src/components/MCP/ServerInitializationSection.tsx
+++ b/client/src/components/MCP/ServerInitializationSection.tsx
@@ -7,11 +7,13 @@ import { useLocalize } from '~/hooks';
 interface ServerInitializationSectionProps {
   serverName: string;
   requiresOAuth: boolean;
+  hasCustomUserVars?: boolean;
 }
 
 export default function ServerInitializationSection({
   serverName,
   requiresOAuth,
+  hasCustomUserVars = false,
 }: ServerInitializationSectionProps) {
   const localize = useLocalize();
 
@@ -39,8 +41,8 @@ export default function ServerInitializationSection({
     cancelOAuthFlow(serverName);
   }, [cancelOAuthFlow, serverName]);
 
-  // Show subtle reinitialize option if connected
-  if (isConnected) {
+  // Show subtle reinitialize option if connected AND server has OAuth or custom user vars
+  if (isConnected && (requiresOAuth || hasCustomUserVars)) {
     return (
       <div className="flex justify-start">
         <button
@@ -53,6 +55,11 @@ export default function ServerInitializationSection({
         </button>
       </div>
     );
+  }
+
+  // Don't show anything for connected servers that don't need OAuth or custom vars
+  if (isConnected) {
+    return null;
   }
 
   return (

--- a/client/src/components/MCP/ServerInitializationSection.tsx
+++ b/client/src/components/MCP/ServerInitializationSection.tsx
@@ -41,7 +41,6 @@ export default function ServerInitializationSection({
     cancelOAuthFlow(serverName);
   }, [cancelOAuthFlow, serverName]);
 
-  // Show subtle reinitialize option if connected AND server has OAuth or custom user vars
   if (isConnected && (requiresOAuth || hasCustomUserVars)) {
     return (
       <div className="flex justify-start">
@@ -57,7 +56,6 @@ export default function ServerInitializationSection({
     );
   }
 
-  // Don't show anything for connected servers that don't need OAuth or custom vars
   if (isConnected) {
     return null;
   }

--- a/client/src/components/SidePanel/MCP/MCPPanel.tsx
+++ b/client/src/components/SidePanel/MCP/MCPPanel.tsx
@@ -141,33 +141,31 @@ function MCPPanelContent() {
           {localize('com_sidepanel_mcp_variables_for', { '0': serverBeingEdited.serverName })}
         </h3>
 
-        {/* Server Initialization Section */}
         <div className="mb-4">
-          <ServerInitializationSection
+          <CustomUserVarsSection
             serverName={selectedServerNameForEditing}
-            requiresOAuth={serverStatus?.requiresOAuth || false}
-            hasCustomUserVars={
-              serverBeingEdited.config.customUserVars &&
-              Object.keys(serverBeingEdited.config.customUserVars).length > 0
-            }
+            fields={serverBeingEdited.config.customUserVars}
+            onSave={(authData) => {
+              if (selectedServerNameForEditing) {
+                handleConfigSave(selectedServerNameForEditing, authData);
+              }
+            }}
+            onRevoke={() => {
+              if (selectedServerNameForEditing) {
+                handleConfigRevoke(selectedServerNameForEditing);
+              }
+            }}
+            isSubmitting={updateUserPluginsMutation.isLoading}
           />
         </div>
 
-        {/* Custom User Variables Section */}
-        <CustomUserVarsSection
+        <ServerInitializationSection
           serverName={selectedServerNameForEditing}
-          fields={serverBeingEdited.config.customUserVars}
-          onSave={(authData) => {
-            if (selectedServerNameForEditing) {
-              handleConfigSave(selectedServerNameForEditing, authData);
-            }
-          }}
-          onRevoke={() => {
-            if (selectedServerNameForEditing) {
-              handleConfigRevoke(selectedServerNameForEditing);
-            }
-          }}
-          isSubmitting={updateUserPluginsMutation.isLoading}
+          requiresOAuth={serverStatus?.requiresOAuth || false}
+          hasCustomUserVars={
+            serverBeingEdited.config.customUserVars &&
+            Object.keys(serverBeingEdited.config.customUserVars).length > 0
+          }
         />
       </div>
     );

--- a/client/src/components/SidePanel/MCP/MCPPanel.tsx
+++ b/client/src/components/SidePanel/MCP/MCPPanel.tsx
@@ -146,6 +146,10 @@ function MCPPanelContent() {
           <ServerInitializationSection
             serverName={selectedServerNameForEditing}
             requiresOAuth={serverStatus?.requiresOAuth || false}
+            hasCustomUserVars={
+              serverBeingEdited.config.customUserVars &&
+              Object.keys(serverBeingEdited.config.customUserVars).length > 0
+            }
           />
         </div>
 

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -234,6 +234,12 @@ export function useMCPServerManager() {
 
             cleanupServerState(serverName);
           }
+        } else {
+          showToast({
+            message: localize('com_ui_mcp_init_failed', { 0: serverName }),
+            status: 'error',
+          });
+          cleanupServerState(serverName);
         }
       } catch (error) {
         console.error(`[MCP Manager] Failed to initialize ${serverName}:`, error);

--- a/client/src/hooks/Nav/useSideNavLinks.ts
+++ b/client/src/hooks/Nav/useSideNavLinks.ts
@@ -155,7 +155,9 @@ export default function useSideNavLinks({
     if (
       startupConfig?.mcpServers &&
       Object.values(startupConfig.mcpServers).some(
-        (server) => server.customUserVars && Object.keys(server.customUserVars).length > 0,
+        (server: any) =>
+          (server.customUserVars && Object.keys(server.customUserVars).length > 0) ||
+          server.isOAuth,
       )
     ) {
       links.push({

--- a/client/src/hooks/Nav/useSideNavLinks.ts
+++ b/client/src/hooks/Nav/useSideNavLinks.ts
@@ -157,7 +157,8 @@ export default function useSideNavLinks({
       Object.values(startupConfig.mcpServers).some(
         (server: any) =>
           (server.customUserVars && Object.keys(server.customUserVars).length > 0) ||
-          server.isOAuth,
+          server.isOAuth ||
+          server.startup === false,
       )
     ) {
       links.push({

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -506,6 +506,7 @@
   "com_sidepanel_hide_panel": "Hide Panel",
   "com_sidepanel_manage_files": "Manage Files",
   "com_sidepanel_mcp_no_servers_with_vars": "No MCP servers with configurable variables.",
+  "com_sidepanel_mcp_no_custom_vars": "No custom user variables set for {{0}}",
   "com_sidepanel_mcp_variables_for": "MCP Variables for {{0}}",
   "com_sidepanel_parameters": "Parameters",
   "com_sources_image_alt": "Search result image",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -851,7 +851,6 @@
   "com_ui_mcp_authenticated_success": "MCP server '{{0}}' authenticated successfully",
   "com_ui_mcp_dialog_desc": "Please enter the necessary information below.",
   "com_ui_mcp_enter_var": "Enter value for {{0}}",
-  "com_ui_mcp_init_cancelled": "MCP server '{{0}}' initialization was cancelled due to simultaneous request",
   "com_ui_mcp_init_failed": "Failed to initialize MCP server",
   "com_ui_mcp_initialize": "Initialize",
   "com_ui_mcp_initialized_success": "MCP server '{{0}}' initialized successfully",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -614,6 +614,7 @@ export type TStartupConfig = {
       >;
       chatMenu?: boolean;
       isOAuth?: boolean;
+      startup?: boolean;
     }
   >;
   mcpPlaceholder?: string;

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -613,6 +613,7 @@ export type TStartupConfig = {
         }
       >;
       chatMenu?: boolean;
+      isOAuth?: boolean;
     }
   >;
   mcpPlaceholder?: string;


### PR DESCRIPTION
## Summary

This pull request enhances the MCP Settings panel rendering logic to show when servers need user interaction for configuration, authentication, or initialization. The panel will now render if a server is detected that:
- has CustomUserVars 
- was detected as an OAuth server during startup
- has `startup: false` configured in `librechat.yaml`

This replaces the previous filtering logic which only checked for customUserVars.

### Server-side changes:

* [`api/server/routes/config.js`](diffhunk://#diff-441df2e5a900c841f39b9017188b25a4726e878ef4aa025f0866c20ca55e2616R8): Added dependency on `getMCPManager` and updated the route handler to include three new properties in the payload:
  - `isOAuth`: Determines if server requires OAuth by checking `getMCPManager().getOAuthServers()`
  - `startup`: Includes the startup configuration flag from server config

### Client-side changes:

* [`client/src/hooks/Nav/useSideNavLinks.ts`](diffhunk://#diff-84b27c970a707cf337f1f7ddbcb6f15079209e91b870ff4d6cee17bac66a43a1L158-R160): Updated navigation logic to render MCPPanel when servers meet any of the previously mentioned criteria.

* [`client/src/locales/en/translation.json`](diffhunk://#diff-c0fa59f8385909de9f593c765770ac70cec3d86cbfc11c3e2e4749ecc5c0f476L854): Added new localization string for empty state handling: `com_sidepanel_mcp_no_custom_vars`

### Configuration updates:

* [`packages/data-provider/src/config.ts`](diffhunk://#diff-6c7b9353bafbb6c0b01552f4b078069ce4c47b77d2a0af46b1db3694d80417f4R616): Added new optional properties to `TStartupConfig` type:
  - `isOAuth`: Boolean indicating OAuth requirement detection
  - `startup`: Boolean reflecting server startup configuration

### UX/UI Improvements:

* **Enhanced empty state handling**: `CustomUserVarsSection` now displays "No custom user variables set for {serverName}" instead of rendering nothing when no variables are configured.

* **Improved section organization**: Reordered MCP panel sections to show Custom User Variables first, followed by Server Initialization, creating a more logical user flow.

* **Better visual design**: Updated `ServerInitializationSection` styling:
  - Changed from red-themed alert styling to amber background (better semantic meaning)
  - Updated action buttons from blue to green (follows app design patterns)
  - Improved contrast and accessibility in light / dark modes

* **Smarter initialization controls**: The subtle reinitialize button now only appears for connected servers that actually need it (servers with OAuth requirements or custom user variables), preventing unnecessary UI clutter.

### Bug Fixes:

* **Fixed reinitialize endpoint**: Corrected improper handling of failure states in the MCP server reinitialize endpoint to prevent misleading success toasts.

* **Enhanced component props**: Added `hasCustomUserVars` prop to `ServerInitializationSection` to enable conditional rendering of initialization controls.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

Manual verification of MCP Settings Panel presence/absence in SideNav with various MCP server configurations:
- Servers with customUserVars
- OAuth-required servers 
- Servers with `startup: false`
- Servers without any configuration needs
- Mixed combinations of the above
- Empty state handling for servers without custom variables
- Visual styling across light and dark modes

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] A pull request for updating the documentation has been submitted.