### PR TITLE
⚒️ fix: MCP Initialization Flows

### DIFF
--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -303,7 +303,7 @@ router.post('/oauth/cancel/:serverName', requireJwtAuth, async (req, res) => {
     }
 
     // Cancel the flow by marking it as failed
-    await flowManager.completeFlow(flowId, 'mcp_oauth', null, 'User cancelled OAuth flow');
+    await flowManager.failFlow(flowId, 'mcp_oauth', 'User cancelled OAuth flow');
 
     logger.info(`[MCP OAuth Cancel] Successfully cancelled OAuth flow for ${serverName}`);
 

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -463,7 +463,7 @@ router.post('/:serverName/reinitialize', requireJwtAuth, async (req, res) => {
     };
 
     res.json({
-      success: userConnection && !oauthRequired,
+      success: (userConnection && !oauthRequired) || (oauthRequired && oauthUrl),
       message: getResponseMessage(),
       serverName,
       oauthRequired,

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -13,6 +13,7 @@ function MCPSelect() {
     batchToggleServers,
     getServerStatusIconProps,
     getConfigDialogProps,
+    isInitializing,
     localize,
   } = useMCPServerManager();
 
@@ -32,14 +33,18 @@ function MCPSelect() {
   const renderItemContent = useCallback(
     (serverName: string, defaultContent: React.ReactNode) => {
       const statusIconProps = getServerStatusIconProps(serverName);
+      const isServerInitializing = isInitializing(serverName);
 
       // Common wrapper for the main content (check mark + text)
       // Ensures Check & Text are adjacent and the group takes available space.
       const mainContentWrapper = (
         <button
           type="button"
-          className="flex flex-grow items-center rounded bg-transparent p-0 text-left transition-colors focus:outline-none"
+          className={`flex flex-grow items-center rounded bg-transparent p-0 text-left transition-colors focus:outline-none ${
+            isServerInitializing ? 'opacity-50' : ''
+          }`}
           tabIndex={0}
+          disabled={isServerInitializing}
         >
           {defaultContent}
         </button>
@@ -58,7 +63,7 @@ function MCPSelect() {
 
       return mainContentWrapper;
     },
-    [getServerStatusIconProps],
+    [getServerStatusIconProps, isInitializing],
   );
 
   // Don't render if no servers are selected and not pinned

--- a/client/src/components/Chat/Input/MCPSubMenu.tsx
+++ b/client/src/components/Chat/Input/MCPSubMenu.tsx
@@ -22,6 +22,7 @@ const MCPSubMenu = React.forwardRef<HTMLDivElement, MCPSubMenuProps>(
       toggleServerSelection,
       getServerStatusIconProps,
       getConfigDialogProps,
+      isInitializing,
     } = useMCPServerManager();
 
     const menuStore = Ariakit.useMenuStore({
@@ -86,6 +87,7 @@ const MCPSubMenu = React.forwardRef<HTMLDivElement, MCPSubMenuProps>(
             {configuredServers.map((serverName) => {
               const statusIconProps = getServerStatusIconProps(serverName);
               const isSelected = mcpValues?.includes(serverName) ?? false;
+              const isServerInitializing = isInitializing(serverName);
 
               const statusIcon = statusIconProps && <MCPServerStatusIcon {...statusIconProps} />;
 
@@ -96,12 +98,15 @@ const MCPSubMenu = React.forwardRef<HTMLDivElement, MCPSubMenuProps>(
                     event.preventDefault();
                     toggleServerSelection(serverName);
                   }}
+                  disabled={isServerInitializing}
                   className={cn(
                     'flex items-center gap-2 rounded-lg px-2 py-1.5 text-text-primary hover:cursor-pointer',
                     'scroll-m-1 outline-none transition-colors',
                     'hover:bg-black/[0.075] dark:hover:bg-white/10',
                     'data-[active-item]:bg-black/[0.075] dark:data-[active-item]:bg-white/10',
                     'w-full min-w-0 justify-between text-sm',
+                    isServerInitializing &&
+                      'opacity-50 hover:bg-transparent dark:hover:bg-transparent',
                   )}
                 >
                   <div className="flex flex-grow items-center gap-2">

--- a/client/src/components/MCP/ServerInitializationSection.tsx
+++ b/client/src/components/MCP/ServerInitializationSection.tsx
@@ -34,7 +34,7 @@ export default function ServerInitializationSection({
   const serverOAuthUrl = getOAuthUrl(serverName);
 
   const handleInitializeClick = useCallback(() => {
-    initializeServer(serverName);
+    initializeServer(serverName, false);
   }, [initializeServer, serverName]);
 
   const handleCancelClick = useCallback(() => {

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -171,6 +171,7 @@ export function useMCPServerManager() {
               message: localize('com_ui_mcp_oauth_timeout', { 0: serverName }),
               status: 'error',
             });
+            clearInterval(pollInterval);
             cleanupServerState(serverName);
             return;
           }
@@ -180,10 +181,15 @@ export function useMCPServerManager() {
               message: localize('com_ui_mcp_init_failed'),
               status: 'error',
             });
+            clearInterval(pollInterval);
             cleanupServerState(serverName);
+            return;
           }
         } catch (error) {
           console.error(`[MCP Manager] Error polling server ${serverName}:`, error);
+          clearInterval(pollInterval);
+          cleanupServerState(serverName);
+          return;
         }
       }, 3500);
 

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -309,6 +309,10 @@ export function useMCPServerManager() {
       const disconnectedServers: string[] = [];
 
       serverNames.forEach((serverName) => {
+        if (isInitializing(serverName)) {
+          return;
+        }
+
         const serverStatus = connectionStatus[serverName];
         if (serverStatus?.connectionState === 'connected') {
           connectedServers.push(serverName);
@@ -323,11 +327,15 @@ export function useMCPServerManager() {
         initializeServer(serverName);
       });
     },
-    [connectionStatus, setMCPValues, initializeServer],
+    [connectionStatus, setMCPValues, initializeServer, isInitializing],
   );
 
   const toggleServerSelection = useCallback(
     (serverName: string) => {
+      if (isInitializing(serverName)) {
+        return;
+      }
+
       const currentValues = mcpValues ?? [];
       const isCurrentlySelected = currentValues.includes(serverName);
 
@@ -343,7 +351,7 @@ export function useMCPServerManager() {
         }
       }
     },
-    [mcpValues, setMCPValues, connectionStatus, initializeServer],
+    [mcpValues, setMCPValues, connectionStatus, initializeServer, isInitializing],
   );
 
   const handleConfigSave = useCallback(

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -201,7 +201,7 @@ export function useMCPServerManager() {
   );
 
   const initializeServer = useCallback(
-    async (serverName: string) => {
+    async (serverName: string, autoOpenOAuth: boolean = true) => {
       updateServerState(serverName, { isInitializing: true });
 
       try {
@@ -216,7 +216,9 @@ export function useMCPServerManager() {
               isInitializing: true,
             });
 
-            window.open(response.oauthUrl, '_blank', 'noopener,noreferrer');
+            if (autoOpenOAuth) {
+              window.open(response.oauthUrl, '_blank', 'noopener,noreferrer');
+            }
 
             startServerPolling(serverName);
           } else {


### PR DESCRIPTION
## Summary

This pull request fixes issues with MCP OAuth flows concerning cancellation handling, polling cleanup, UI state management during server initialization, and most critically resolving a bug introduced in #8718 which broke initial OAuth flows. 


### Backend Changes:

* [`api/server/routes/mcp.js`](diffhunk://#diff-441df2e5a900c841f39b9017188b25a4726e878ef4aa025f0866c20ca55e2616R306): 
  - **OAuth Cancellation**: Changed `completeFlow` to `failFlow` for proper cancellation state management, preventing stale client IDs and "Client ID mismatch" errors
  - **Reinitialize Success Logic**: Fixed success condition to properly handle OAuth-required servers (`success: (userConnection && !oauthRequired) || (oauthRequired && oauthUrl)`)

* [`api/server/services/MCP.js`](diffhunk://#diff-84b27c970a707cf337f1f7ddbcb6f15079209e91b870ff4d6cee17bac66a43a1L290-R309): 
  - **Cancellation vs Error Detection**: Added logic to differentiate between user-cancelled flows and actual OAuth failures
  - **UI Error Prevention**: Returns `hasFailedFlow: false` for cancelled flows to prevent error triangle display in UI

### Frontend Changes:

* [`client/src/hooks/MCP/useMCPServerManager.ts`](diffhunk://#diff-6c7b9353bafbb6c0b01552f4b078069ce4c47b77d2a0af46b1db3694d80417f4R174-R188):
  - **Polling Cleanup**: Added `clearInterval(pollInterval)` in error conditions and catch blocks to stop infinite polling
  - **OAuth Cancellation Flow**: Reordered cancellation to call backend first, then cleanup frontend state only on success
  - **Server Interaction Guards**: Added `isInitializing` checks to prevent server selection/toggling during initialization
  - **Auto-OAuth Parameter**: Added `autoOpenOAuth` parameter to `initializeServer` for better OAuth URL handling control

* [`client/src/components/Chat/Input/MCPSelect.tsx`](diffhunk://#diff-84b27c970a707cf337f1f7ddbcb6f15079209e91b870ff4d6cee17bac66a43a1L16-R20):
  - **Visual Feedback**: Added opacity styling and disabled state for initializing servers
  - **Interaction Prevention**: Disabled button clicks during server initialization

* [`client/src/components/Chat/Input/MCPSubMenu.tsx`](diffhunk://#diff-84b27c970a707cf337f1f7ddbcb6f15079209e91b870ff4d6cee17bac66a43a1L89-R103):
  - **Consistent Disabled State**: Applied same disabled/opacity styling as MCPSelect for initializing servers

* [`client/src/components/MCP/ServerInitializationSection.tsx`](diffhunk://#diff-84b27c970a707cf337f1f7ddbcb6f15079209e91b870ff4d6cee17bac66a43a1R37):
  - **OAuth Parameter Fix**: Updated `initializeServer` call to pass `autoOpenOAuth: false` for manual initialization


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual verification of MCP OAuth flow scenarios:
- OAuth flow initiation and completion
- OAuth flow cancellation at various stages  
- OAuth flow reinitialization and completion after cancellation
- Error handling during OAuth failures
- Server selection/deselection during initialization attempts
- Polling behavior after errors and cancellations
- UI state consistency across different cancellation scenarios
- Multiple server initialization attempts

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] A pull request for updating the documentation has been submitted.