### PR TITLE
✨ feat: Add Support for `customUserVar` Replacement in 'args' Field

### DIFF
--- a/packages/api/src/mcp/mcp.spec.ts
+++ b/packages/api/src/mcp/mcp.spec.ts
@@ -655,6 +655,47 @@ describe('Environment Variable Extraction (MCP)', () => {
       );
     });
 
+    it('should process customUserVars in args field', () => {
+      const user = createTestUser({
+        id: 'user-123',
+        email: 'test@example.com',
+      });
+      const customUserVars = {
+        MY_API_KEY: 'user-provided-api-key-12345',
+        PROFILE_NAME: 'production-profile',
+      };
+      const obj: MCPOptions = {
+        command: 'npx',
+        args: [
+          '-y',
+          '@smithery/cli@latest',
+          'run',
+          '@upstash/context7-mcp',
+          '--key',
+          '{{MY_API_KEY}}',
+          '--profile',
+          '{{PROFILE_NAME}}',
+          '--user',
+          '{{LIBRECHAT_USER_EMAIL}}',
+        ],
+      };
+
+      const result = processMCPEnv(obj, user, customUserVars);
+
+      expect('args' in result && result.args).toEqual([
+        '-y',
+        '@smithery/cli@latest',
+        'run',
+        '@upstash/context7-mcp',
+        '--key',
+        'user-provided-api-key-12345',
+        '--profile',
+        'production-profile',
+        '--user',
+        'test@example.com',
+      ]);
+    });
+
     it('should prioritize customUserVars over user fields and system env vars if placeholders are the same (though not recommended)', () => {
       // This tests the order of operations: customUserVars -> userFields -> systemEnv
       // BUt it's generally not recommended to have overlapping placeholder names.

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -124,6 +124,14 @@ export function processMCPEnv(
     newObj.env = processedEnv;
   }
 
+  if ('args' in newObj && newObj.args) {
+    const processedArgs: string[] = [];
+    for (const originalValue of newObj.args) {
+      processedArgs.push(processSingleValue({ originalValue, customUserVars, user }));
+    }
+    newObj.args = processedArgs;
+  }
+
   // Process headers if they exist (for WebSocket, SSE, StreamableHTTP types)
   // Note: `env` and `headers` are on different branches of the MCPOptions union type.
   if ('headers' in newObj && newObj.headers) {


### PR DESCRIPTION
## Summary

This pull request adds support for custom user variables (e.g., `{{MY_API_KEY}}`) substitution in MCP server command arguments during reinitialization. Previously, The `processMCPEnv` function was only processing `env`, `headers`, and `url` fields but did not handle the `args` field used by MCP servers such as those generated by Smithery. During MCP server reinitialization through the UI, custom user variables in command arguments remained as unsubstituted placeholders (e.g., `'{{MY_API_KEY}}'` instead of the actual API key value), causing HTTP 401 authentication errors. Related to discussion #8731 

Example Use Case:
```yaml
mcpServers:
  context7-mcp:
    command: npx
    args:
      - '-y'
      - '@smithery/cli@latest'
      - run
      - '@author/servername-mcp'
      - '--key'
      - "{{MY_API_KEY}}" 
      - '--profile'
      - <redacted>
    customUserVars:
      MY_API_KEY:
        title: "API Key"
        description: "Enter your personal API key from <a href='https://smithery.ai/' target='_blank'>your account settings</a>"
    startup: false
```

### Backend Changes:

* [`packages/api/src/utils/env.ts`](diffhunk://#diff-packages/api/src/utils/env.ts): 
  - **Args Field Processing**: Added processing for the `args` field in `processMCPEnv` function to handle custom user variable substitution in MCP server command arguments by iterating through the command arguments and replacing placeholders like `{{MY_API_KEY}}` with user-provided values.

* [`packages/api/src/mcp/mcp.spec.ts`](diffhunk://#diff-packages/api/src/mcp/mcp.spec.ts):
  - **Test Coverage**: Added test case `"should process customUserVars in args field"` to verify that custom user variables are now substituted properly in the args field

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

* Added unit test covering custom user variables substitution for the args field
* Verified all existing MCP environment variable tests continue to pass
* Manual testing of MCP server reinitialization with custom user variables

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] A pull request for updating the documentation has been submitted.