### PR TITLE
Bug: Fix conversations reload on rename

### DIFF
--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -59,7 +59,10 @@ export const useUpdateConversationMutation = (
         queryClient.setQueryData([QueryKeys.conversation, id], updatedConvo);
         updateConvoInAllQueries(queryClient, id, () => updatedConvo);
         // Force a re-render of the conversation panel
-        queryClient.invalidateQueries([QueryKeys.allConversations]);
+        queryClient.invalidateQueries({
+          queryKey: [QueryKeys.allConversations],
+          refetchPage: (_, index) => index === 0,
+        });
         // We do not invalidate archived conversations because they cannot be updated while archived
       },
     },

--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -58,6 +58,9 @@ export const useUpdateConversationMutation = (
       onSuccess: (updatedConvo) => {
         queryClient.setQueryData([QueryKeys.conversation, id], updatedConvo);
         updateConvoInAllQueries(queryClient, id, () => updatedConvo);
+        // Force a re-render of the conversation panel
+        queryClient.invalidateQueries([QueryKeys.allConversations]);
+        // We do not invalidate archived conversations because they cannot be updated while archived
       },
     },
   );


### PR DESCRIPTION
## Summary

When renaming a conversation, the input field.closes but the conversation doesn't appear renamed.
Reopening the input field shows the old name.

The `useDeleteConversationMutation` invalidates both `QueryKeys.allConversations` and `QueryKeys.archivedConversations` but `useUpdateConversationMutation` (used by rename), doesn't call either.

https://github.com/danny-avila/LibreChat/blob/650e9b4f6c7e1ea063638ce10f95fbd53631f4bd/client/src/data-provider/mutations.ts#L516-L523

https://github.com/danny-avila/LibreChat/blob/650e9b4f6c7e1ea063638ce10f95fbd53631f4bd/client/src/data-provider/mutations.ts#L58-L61

**Before**
https://github.com/user-attachments/assets/1aca82d4-eebd-45b4-9d05-aea5fb46a05e

**After**
https://github.com/user-attachments/assets/9bf38f38-b781-4197-b848-9dbd999aad5b



## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

See video above for how to reproduce the issue and the fixed version.

I tried adding integration tests to conversations but the setup was getting too complicated, so I'm first submitting the fix only.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
