### PR TITLE
🔑 fix: Update Conversation Mutation to use ID from Payload

### DIFF
--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -55,9 +55,10 @@ export const useUpdateConversationMutation = (
   return useMutation(
     (payload: t.TUpdateConversationRequest) => dataService.updateConversation(payload),
     {
-      onSuccess: (updatedConvo) => {
-        queryClient.setQueryData([QueryKeys.conversation, id], updatedConvo);
-        updateConvoInAllQueries(queryClient, id, () => updatedConvo);
+      onSuccess: (updatedConvo, payload) => {
+        const targetId = payload.conversationId || id;
+        queryClient.setQueryData([QueryKeys.conversation, targetId], updatedConvo);
+        updateConvoInAllQueries(queryClient, targetId, () => updatedConvo);
       },
     },
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -51804,7 +51804,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.7.902",
+      "version": "0.7.903",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.8.2",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.7.902",
+  "version": "0.7.903",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
## Summary


- 🐛 Bug Fix: Updated `useUpdateConversationMutation`'s `onSuccess` callback to correctly handle `conversationId` from payload, ensuring the right conversation ID is used to update query data
- 📦 Version Update: Incremented `librechat-data-provider` package version from `0.7.902` to `0.7.903`

from #8750:
> When renaming a conversation, the input field.closes but the conversation doesn't appear renamed.
> Reopening the input field shows the old name

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested by creating, updating and deleting mutiple conversations

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
