### PR TITLE
fix: Add required OAuth metadata fields for pre-configured OAuth clients

### DIFF
--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -182,6 +182,9 @@ export class MCPOAuthHandler {
           token_endpoint: config.token_url,
           issuer: serverUrl,
           scopes_supported: config.scope?.split(' '),
+          response_types_supported: ['code'],
+          code_challenge_methods_supported: ['S256'],
+          grant_types_supported: ['authorization_code', 'refresh_token'],
         };
 
         const clientInfo: OAuthClientInformation = {


### PR DESCRIPTION
## Summary
When using pre-configured OAuth settings (client_id, authorization_url, token_url), the manually constructed metadata object was missing required fields that the MCP SDK validates in startAuthorization():

https://github.com/modelcontextprotocol/typescript-sdk/blob/31acdcbb189056ec83d14a4f7a37ae2b1c67680e/src/client/auth.ts#L820

Add the missing required fields with MCP-compliant values:
- response_types_supported: ['code']
- code_challenge_methods_supported: ['S256']
- grant_types_supported: ['authorization_code', 'refresh_token']

Dynamic discovery path is unaffected as discoverAuthorizationServerMetadata() returns complete metadata from the OAuth provider.


## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

```
mcpServers:
  telemetry:
    type: sse
    url: http://my.mcp.server/sse
    oauth:
      authorization_url: "https://accounts.google.com/o/oauth2/v2/auth"
      token_url: "https://oauth2.googleapis.com/token"
      client_id: redacted.apps.googleusercontent.com
      client_secret: GOCSPX-REDACTED
      scope: "openid email profile"
```

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
