### PR TITLE
feat: Add serviceAccount support for librechat helm chart

### DIFF
--- a/helm/librechat/templates/deployment.yaml
+++ b/helm/librechat/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ include "librechat.fullname" $ }}-sa
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/librechat/templates/serviceAccount.yaml
+++ b/helm/librechat/templates/serviceAccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken | default true }}
+kind: ServiceAccount
+metadata:
+  name:  {{ include "librechat.fullname" $ }}-sa
+  annotations:
+{{- range $key, $value := .Values.serviceAccount.annotations }}
+    {{ $key }}: {{ $value }}
+{{- end }}

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -88,6 +88,14 @@ librechat:
 
   # name of existing Yaml configmap, key must be librechat.yaml
   existingConfigYaml: ""
+  serviceAccount:
+    # If you want to disable the automountServiceAccountToken, set it to false
+    automountServiceAccountToken: true
+    # If you want to add annotations to the service account, you can do so here
+    # Example:
+    # annotations:
+    # - iam.amazonaws.com/role: arn:aws:iam::<account_id>:role/<role_name>
+    annotations: {}
 
   # Volume used to store image Files uploaded to the Web UI
   imageVolume:


### PR DESCRIPTION
## Summary

Librechat supports for access id and access keys. Would like to use IRSA. However, librechat helm chart does not have service account variables on templates. In order to use serviceAccounts for cloud provided services librechat helm chart needed some modifications.

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

I modified deployment manifest to add serviceAccount on my EKS kubernetes cluster. I was able to use aws bedrock and s3 with IRSA.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
