### PR TITLE
🔧 fix: MCP Queries and Connections

### DIFF
--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -81,7 +81,9 @@ export function useMCPServerManager() {
     return initialStates;
   });
 
-  const { data: connectionStatusData } = useMCPConnectionStatusQuery();
+  const { data: connectionStatusData } = useMCPConnectionStatusQuery({
+    enabled: !!startupConfig?.mcpServers && Object.keys(startupConfig.mcpServers).length > 0,
+  });
   const connectionStatus = useMemo(
     () => connectionStatusData?.connectionStatus || {},
     [connectionStatusData?.connectionStatus],

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -160,7 +160,7 @@ export function useMCPServerManager() {
               setMCPValues([...currentValues, serverName]);
             }
 
-            await queryClient.refetchQueries([QueryKeys.tools]);
+            await queryClient.invalidateQueries([QueryKeys.tools]);
 
             // This delay is to ensure UI has updated with new connection status before cleanup
             // Otherwise servers will show as disconnected for a second after OAuth flow completes

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -158,6 +158,8 @@ export function useMCPServerManager() {
               setMCPValues([...currentValues, serverName]);
             }
 
+            await queryClient.refetchQueries([QueryKeys.tools]);
+
             // This delay is to ensure UI has updated with new connection status before cleanup
             // Otherwise servers will show as disconnected for a second after OAuth flow completes
             setTimeout(() => {


### PR DESCRIPTION
## Summary

This pull request changes the behavior of the `useMCPServerManager` hook to only query for connection status if mcpServers are enabled and ensures the ToolSelectDialog updates after a successful MCP server connection. 
Related to #8863 and [Enabling balance does not properly initialize balances for users](https://discord.com/channels/1086345563026489514/1401563956383973447)

Query optimization:

* The `useMCPConnectionStatusQuery` is now only enabled if there are MCP servers present in the `startupConfig`, preventing unnecessary queries when no servers exist.

Data consistency after server changes:

* After adding a new MCP server, the hook now explicitly refetches the tools query using `queryClient.refetchQueries([QueryKeys.tools])` to ensure the latest tool data is available in the UI.
## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Confirmed absence of 'status' request for MCP connections (and absence of subsequent 404 errors) in Network tab when mcpServers not configured in `librechat.yaml`
- [x] Confirmed presence of 'paypal' MCP after successful OAuth connection in ToolSelectDialog without hard refresh

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
