### PR TITLE
🔄 refactor: Return OpenRouter Provider in LLMConfig Based on `baseURL`

### DIFF
--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -1,4 +1,5 @@
 import { ProxyAgent } from 'undici';
+import { Providers } from '@librechat/agents';
 import { KnownEndpoints, removeNullishValues } from 'librechat-data-provider';
 import type { BindToolsInput } from '@langchain/core/language_models/chat_models';
 import type { AzureOpenAIInput } from '@langchain/openai';
@@ -222,9 +223,13 @@ export function getOpenAIConfig(
     });
   }
 
-  return {
+  const result: t.LLMConfigResult = {
     llmConfig,
     configOptions,
     tools,
   };
+  if (useOpenRouter) {
+    result.provider = Providers.OPENROUTER;
+  }
+  return result;
 }

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { openAISchema, EModelEndpoint } from 'librechat-data-provider';
 import type { TEndpointOption, TAzureConfig, TEndpoint } from 'librechat-data-provider';
 import type { BindToolsInput } from '@langchain/core/language_models/chat_models';
-import type { OpenAIClientOptions } from '@librechat/agents';
+import type { OpenAIClientOptions, Providers } from '@librechat/agents';
 import type { AzureOptions } from './azure';
 
 export type OpenAIParameters = z.infer<typeof openAISchema>;
@@ -35,6 +35,7 @@ export interface LLMConfigResult {
   llmConfig: ClientOptions;
   configOptions: OpenAIConfiguration;
   tools?: BindToolsInput[];
+  provider?: Providers;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #8874 

I updated the OpenAI config and types so that the LLM config result now includes a `provider` field when the OpenRouter provider is selected based on the endpoint's `baseURL`. This enables dynamic downstream handling and better downstream type clarity.

- Modified `getOpenAIConfig` to add a `provider` property as `Providers.OPENROUTER` when OpenRouter is selected
- Extended the `LLMConfigResult` type to optionally include a `provider` field of type `Providers`
- Ensured type imports for `Providers` are consistent in type definitions
- Improved flexibility for OpenRouter-based endpoint configuration and usage

## Change Type

- [x] Refactor (code change that neither fixes a bug nor adds a feature)

## Testing

I verified these changes by configuring endpoints with both standard OpenAI and OpenRouter-style base URLs, confirming that the `provider` is correctly set in the config result. If possible, also test LLM provider instantiation and request flow with OpenRouter and non-OpenRouter endpoints to ensure the updated `provider` logic does not cause regressions.

### **Test Configuration**:

- Custom endpoints in `baseURL` settings
- Console output and breakpoints to check returned `provider` values

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes