### PR TITLE
🟢 fix: Incorrect `customUserVars` Set States

### DIFF
--- a/packages/data-schemas/src/methods/pluginAuth.ts
+++ b/packages/data-schemas/src/methods/pluginAuth.ts
@@ -10,15 +10,20 @@ import type {
 // Factory function that takes mongoose instance and returns the methods
 export function createPluginAuthMethods(mongoose: typeof import('mongoose')) {
   /**
-   * Finds a single plugin auth entry by userId and authField
+   * Finds a single plugin auth entry by userId and authField (and optionally pluginKey)
    */
   async function findOnePluginAuth({
     userId,
     authField,
+    pluginKey,
   }: FindPluginAuthParams): Promise<IPluginAuth | null> {
     try {
       const PluginAuth: Model<IPluginAuth> = mongoose.models.PluginAuth;
-      return await PluginAuth.findOne({ userId, authField }).lean();
+      return await PluginAuth.findOne({
+        userId,
+        authField,
+        ...(pluginKey && { pluginKey }),
+      }).lean();
     } catch (error) {
       throw new Error(
         `Failed to find plugin auth: ${error instanceof Error ? error.message : 'Unknown error'}`,

--- a/packages/data-schemas/src/types/pluginAuth.ts
+++ b/packages/data-schemas/src/types/pluginAuth.ts
@@ -18,6 +18,7 @@ export interface PluginAuthQuery {
 export interface FindPluginAuthParams {
   userId: string;
   authField: string;
+  pluginKey?: string;
 }
 
 export interface FindPluginAuthsByKeysParams {


### PR DESCRIPTION
## Summary

This pull request resolves a bug raised in #8731 and [Revoke not updating Set Indicator](https://discord.com/channels/1086345563026489514/1402799992716132515) where the Set/Unset indicators in `CustomUserVarsSection` would not correctly reflect the state of saved/revoked customUserVars. The previous behavior was matching to any authField which shared the same name, rather than being properly scoped to their respective pluginKeys.

Enhancements to plugin authentication querying:

* Updated the `FindPluginAuthParams` interface to include an optional `pluginKey` parameter, allowing queries to specify a plugin key if needed.
* Modified the `findOnePluginAuth` method in `createPluginAuthMethods` to accept the optional `pluginKey` and include it in the query if provided.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Replicated bug and traced through with debugger to confirm behavior when customUserVars shared names across multiple MCP servers.

Confirmed proper indication of customUserVars state after patch was applied.


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
