### PR TITLE
✂️ feat: Configurable File Token Limits and Truncation

### DIFF
--- a/api/server/services/Endpoints/anthropic/build.js
+++ b/api/server/services/Endpoints/anthropic/build.js
@@ -6,6 +6,7 @@ const buildOptions = (endpoint, parsedBody) => {
     modelLabel,
     promptPrefix,
     maxContextTokens,
+    fileTokenLimit,
     resendFiles = anthropicSettings.resendFiles.default,
     promptCache = anthropicSettings.promptCache.default,
     thinking = anthropicSettings.thinking.default,
@@ -29,6 +30,7 @@ const buildOptions = (endpoint, parsedBody) => {
     greeting,
     spec,
     maxContextTokens,
+    fileTokenLimit,
     modelOptions,
   });
 

--- a/api/server/services/Endpoints/bedrock/build.js
+++ b/api/server/services/Endpoints/bedrock/build.js
@@ -6,6 +6,7 @@ const buildOptions = (endpoint, parsedBody) => {
     modelLabel: name,
     promptPrefix,
     maxContextTokens,
+    fileTokenLimit,
     resendFiles = true,
     imageDetail,
     iconURL,
@@ -24,6 +25,7 @@ const buildOptions = (endpoint, parsedBody) => {
     spec,
     promptPrefix,
     maxContextTokens,
+    fileTokenLimit,
     model_parameters,
   });
 

--- a/api/server/services/Endpoints/custom/build.js
+++ b/api/server/services/Endpoints/custom/build.js
@@ -7,6 +7,7 @@ const buildOptions = (endpoint, parsedBody, endpointType) => {
     chatGptLabel,
     promptPrefix,
     maxContextTokens,
+    fileTokenLimit,
     resendFiles = true,
     imageDetail,
     iconURL,
@@ -27,6 +28,7 @@ const buildOptions = (endpoint, parsedBody, endpointType) => {
     greeting,
     spec,
     maxContextTokens,
+    fileTokenLimit,
     modelOptions,
   });
 

--- a/api/server/services/Endpoints/google/build.js
+++ b/api/server/services/Endpoints/google/build.js
@@ -12,6 +12,7 @@ const buildOptions = (endpoint, parsedBody) => {
     spec,
     artifacts,
     maxContextTokens,
+    fileTokenLimit,
     ...modelOptions
   } = parsedBody;
   const endpointOption = removeNullishValues({
@@ -24,6 +25,7 @@ const buildOptions = (endpoint, parsedBody) => {
     greeting,
     spec,
     maxContextTokens,
+    fileTokenLimit,
     modelOptions,
   });
 

--- a/api/server/services/Endpoints/openAI/build.js
+++ b/api/server/services/Endpoints/openAI/build.js
@@ -7,6 +7,7 @@ const buildOptions = (endpoint, parsedBody) => {
     chatGptLabel,
     promptPrefix,
     maxContextTokens,
+    fileTokenLimit,
     resendFiles = true,
     imageDetail,
     iconURL,
@@ -27,6 +28,7 @@ const buildOptions = (endpoint, parsedBody) => {
     greeting,
     spec,
     maxContextTokens,
+    fileTokenLimit,
     modelOptions,
   });
 

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -10,5 +10,6 @@ export * from './llm';
 export * from './math';
 export * from './openid';
 export * from './tempChatRetention';
+export * from './textTokenLimiter';
 export { default as Tokenizer } from './tokenizer';
 export * from './yaml';

--- a/packages/api/src/utils/llm.test.ts
+++ b/packages/api/src/utils/llm.test.ts
@@ -7,6 +7,7 @@ describe('extractLibreChatParams', () => {
     expect(result.resendFiles).toBe(true);
     expect(result.promptPrefix).toBeUndefined();
     expect(result.maxContextTokens).toBeUndefined();
+    expect(result.fileTokenLimit).toBeUndefined();
     expect(result.modelLabel).toBeUndefined();
     expect(result.modelOptions).toEqual({});
   });
@@ -17,6 +18,7 @@ describe('extractLibreChatParams', () => {
     expect(result.resendFiles).toBe(true);
     expect(result.promptPrefix).toBeUndefined();
     expect(result.maxContextTokens).toBeUndefined();
+    expect(result.fileTokenLimit).toBeUndefined();
     expect(result.modelLabel).toBeUndefined();
     expect(result.modelOptions).toEqual({});
   });
@@ -26,6 +28,7 @@ describe('extractLibreChatParams', () => {
       resendFiles: false,
       promptPrefix: 'You are a helpful assistant',
       maxContextTokens: 4096,
+      fileTokenLimit: 50000,
       modelLabel: 'GPT-4',
       model: 'gpt-4',
       temperature: 0.7,
@@ -37,6 +40,7 @@ describe('extractLibreChatParams', () => {
     expect(result.resendFiles).toBe(false);
     expect(result.promptPrefix).toBe('You are a helpful assistant');
     expect(result.maxContextTokens).toBe(4096);
+    expect(result.fileTokenLimit).toBe(50000);
     expect(result.modelLabel).toBe('GPT-4');
     expect(result.modelOptions).toEqual({
       model: 'gpt-4',
@@ -50,6 +54,7 @@ describe('extractLibreChatParams', () => {
       resendFiles: true,
       promptPrefix: null,
       maxContextTokens: 2048,
+      fileTokenLimit: undefined,
       modelLabel: null,
       model: 'claude-3',
     };
@@ -59,6 +64,7 @@ describe('extractLibreChatParams', () => {
     expect(result.resendFiles).toBe(true);
     expect(result.promptPrefix).toBeNull();
     expect(result.maxContextTokens).toBe(2048);
+    expect(result.fileTokenLimit).toBeUndefined();
     expect(result.modelLabel).toBeNull();
     expect(result.modelOptions).toEqual({
       model: 'claude-3',
@@ -77,6 +83,7 @@ describe('extractLibreChatParams', () => {
     expect(result.resendFiles).toBe(true); // Should use default
     expect(result.promptPrefix).toBe('Test prefix');
     expect(result.maxContextTokens).toBeUndefined();
+    expect(result.fileTokenLimit).toBeUndefined();
     expect(result.modelLabel).toBeUndefined();
     expect(result.modelOptions).toEqual({
       model: 'gpt-3.5-turbo',
@@ -90,6 +97,7 @@ describe('extractLibreChatParams', () => {
     expect(result.resendFiles).toBe(true); // Should use default
     expect(result.promptPrefix).toBeUndefined();
     expect(result.maxContextTokens).toBeUndefined();
+    expect(result.fileTokenLimit).toBeUndefined();
     expect(result.modelLabel).toBeUndefined();
     expect(result.modelOptions).toEqual({});
   });
@@ -99,6 +107,7 @@ describe('extractLibreChatParams', () => {
       resendFiles: false,
       promptPrefix: 'Custom prompt',
       maxContextTokens: 8192,
+      fileTokenLimit: 25000,
       modelLabel: 'Custom Model',
       // Model options
       model: 'gpt-4',
@@ -117,6 +126,7 @@ describe('extractLibreChatParams', () => {
     expect(result.resendFiles).toBe(false);
     expect(result.promptPrefix).toBe('Custom prompt');
     expect(result.maxContextTokens).toBe(8192);
+    expect(result.fileTokenLimit).toBe(25000);
     expect(result.modelLabel).toBe('Custom Model');
 
     // Model options should include everything else

--- a/packages/api/src/utils/llm.ts
+++ b/packages/api/src/utils/llm.ts
@@ -8,6 +8,7 @@ type LibreChatParams = {
   resendFiles: boolean;
   promptPrefix?: string | null;
   maxContextTokens?: number;
+  fileTokenLimit?: number;
   modelLabel?: string | null;
 };
 
@@ -32,6 +33,7 @@ export function extractLibreChatParams(
     (librechat.resendFiles.default as boolean);
   const promptPrefix = (delete modelOptions.promptPrefix, options.promptPrefix);
   const maxContextTokens = (delete modelOptions.maxContextTokens, options.maxContextTokens);
+  const fileTokenLimit = (delete modelOptions.fileTokenLimit, options.fileTokenLimit);
   const modelLabel = (delete modelOptions.modelLabel, options.modelLabel);
 
   return {
@@ -40,6 +42,7 @@ export function extractLibreChatParams(
       LibreChatKeys
     >,
     maxContextTokens,
+    fileTokenLimit,
     promptPrefix,
     resendFiles,
     modelLabel,

--- a/packages/api/src/utils/textTokenLimiter.ts
+++ b/packages/api/src/utils/textTokenLimiter.ts
@@ -1,0 +1,61 @@
+import { logger } from '@librechat/data-schemas';
+
+/**
+ * Processes text content by counting tokens and truncating if it exceeds the specified limit.
+ * @param text - The text content to process
+ * @param tokenLimit - The maximum number of tokens allowed (0 = no limit)
+ * @param tokenCountFn - Function to count tokens (defaults to TokenizerSingleton.getTokenCount)
+ * @returns Promise resolving to object with processed text, token count, and truncation status
+ */
+export async function processTextWithTokenLimit(
+  text: string,
+  tokenLimit: number,
+  tokenCountFn: (text: string) => number,
+): Promise<{ text: string; tokenCount: number; wasTruncated: boolean }> {
+  const originalTokenCount = await tokenCountFn(text);
+
+  if (originalTokenCount <= tokenLimit) {
+    return {
+      text,
+      tokenCount: originalTokenCount,
+      wasTruncated: false,
+    };
+  }
+
+  /**
+   * Doing binary search here to find the truncation point efficiently
+   * (May be a better way to go about this)
+   */
+  let low = 0;
+  let high = text.length;
+  let bestText = '';
+
+  logger.debug(
+    `[textTokenLimiter] Text content exceeds token limit: ${originalTokenCount} > ${tokenLimit}, truncating...`,
+  );
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const truncatedText = text.substring(0, mid);
+    const tokenCount = await tokenCountFn(truncatedText);
+
+    if (tokenCount <= tokenLimit) {
+      bestText = truncatedText;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  const finalTokenCount = await tokenCountFn(bestText);
+
+  logger.warn(
+    `[textTokenLimiter] Text truncated from ${originalTokenCount} to ${finalTokenCount} tokens (limit: ${tokenLimit})`,
+  );
+
+  return {
+    text: bestText,
+    tokenCount: finalTokenCount,
+    wasTruncated: true,
+  };
+}

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -185,6 +185,7 @@ export const megabyte = 1024 * 1024;
 export const mbToBytes = (mb: number): number => mb * megabyte;
 
 const defaultSizeLimit = mbToBytes(512);
+const defaultTokenLimit = 100000;
 const assistantsFileConfig = {
   fileLimit: 10,
   fileSizeLimit: defaultSizeLimit,
@@ -208,6 +209,7 @@ export const fileConfig = {
   },
   serverFileSizeLimit: defaultSizeLimit,
   avatarSizeLimit: mbToBytes(2),
+  fileTokenLimit: defaultTokenLimit,
   clientImageResize: {
     enabled: false,
     maxWidth: 1900,
@@ -257,6 +259,7 @@ export const fileConfigSchema = z.object({
   endpoints: z.record(endpointFileConfigSchema).optional(),
   serverFileSizeLimit: z.number().min(0).optional(),
   avatarSizeLimit: z.number().min(0).optional(),
+  fileTokenLimit: z.number().min(0).optional(),
   imageGeneration: z
     .object({
       percentage: z.number().min(0).max(100).optional(),

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -309,6 +309,10 @@ export function mergeFileConfig(dynamic: z.infer<typeof fileConfigSchema> | unde
       ...fileConfig.textParsing,
       supportedMimeTypes: fileConfig.textParsing?.supportedMimeTypes || [],
     },
+    stt: {
+      ...fileConfig.stt,
+      supportedMimeTypes: fileConfig.stt?.supportedMimeTypes || [],
+    },
   };
   if (!dynamic) {
     return mergedConfig;

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -326,6 +326,10 @@ export function mergeFileConfig(dynamic: z.infer<typeof fileConfigSchema> | unde
     mergedConfig.avatarSizeLimit = mbToBytes(dynamic.avatarSizeLimit);
   }
 
+  if (dynamic.fileTokenLimit !== undefined) {
+    mergedConfig.fileTokenLimit = dynamic.fileTokenLimit;
+  }
+
   // Merge clientImageResize configuration
   if (dynamic.clientImageResize !== undefined) {
     mergedConfig.clientImageResize = {

--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -9,7 +9,6 @@ import {
   anthropicSettings,
 } from './types';
 import { SettingDefinition, SettingsConfiguration } from './generate';
-import { fileConfig } from './file-config';
 
 // Base definitions
 const baseDefinitions: Record<string, SettingDefinition> = {
@@ -150,7 +149,6 @@ export const librechat = {
     type: 'number',
     component: 'input',
     columnSpan: 2,
-    default: fileConfig.fileTokenLimit,
   } as const,
 };
 

--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -9,6 +9,7 @@ import {
   anthropicSettings,
 } from './types';
 import { SettingDefinition, SettingsConfiguration } from './generate';
+import { fileConfig } from './file-config';
 
 // Base definitions
 const baseDefinitions: Record<string, SettingDefinition> = {
@@ -149,6 +150,7 @@ export const librechat = {
     type: 'number',
     component: 'input',
     columnSpan: 2,
+    default: fileConfig.fileTokenLimit,
   } as const,
 };
 

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -47,6 +47,7 @@ export type FileConfig = {
   endpoints: {
     [key: string]: EndpointFileConfig;
   };
+  fileTokenLimit?: number;
   serverFileSizeLimit?: number;
   avatarSizeLimit?: number;
   clientImageResize?: {


### PR DESCRIPTION
## Summary

This pull request adds a configurable runtime token limit for attached text content that is included in prompts. Oversized text is truncated to the configured limit just before prompt construction, leaving uploads/parsing unaffected. System param `fileTokenLimit` is extracted server‑side and not sent to providers.

**Text file token limiting and truncation (runtime):**
* Updated `api/server/services/Files/images/encode.js` to apply token‑aware truncation for `FileSources.text` using `processTextWithTokenLimit` and model‑aware `countTokens`. [[1]](diffhunk://#diff-efd34a23d9981d4b88013f1095a3fc71695454f5549f0c8c9b39469f1729f461L2-R12) [[2]](diffhunk://#diff-efd34a23d9981d4b88013f1095a3fc71695454f5549f0c8c9b39469f1729f461R107-R128) [[3]](diffhunk://#diff-0182e32591ec330924ecbf517ca2f3548a7495a471f363cca4a07ab3bfff47fdR1-R61)

**Endpoint and parameter propagation:**
* Added `fileTokenLimit` plumbed through endpoint build options for Anthropic, Bedrock, Custom, Google, and OpenAI so the runtime has access to the limit per request. [[1]](diffhunk://#diff-44c517b6025f1f63db0f0c01bc9d48945c1f6b2eb586921eefe278a320a60a06R9) [[2]](diffhunk://#diff-44c517b6025f1f63db0f0c01bc9d48945c1f6b2eb586921eefe278a320a60a06R33) [[3]](diffhunk://#diff-fe98a0f420746307a3a1671aa3f2b3c8cc0d5cba4557c1ae29bb1e97f1edd91eR9) [[4]](diffhunk://#diff-fe98a0f420746307a3a1671aa3f2b3c8cc0d5cba4557c1ae29bb1e97f1edd91eR28) [[5]](diffhunk://#diff-f75720cfb1f369660618aea7834035179edef778d612951b656af5104ada205fR10) [[6]](diffhunk://#diff-f75720cfb1f369660618aea7834035179edef778d612951b656af5104ada205fR31) [[7]](diffhunk://#diff-3da80754770799778b6d5ed3668396184f6ce305581bd37a578e6caf773756f5R15) [[8]](diffhunk://#diff-3da80754770799778b6d5ed3668396184f6ce305581bd37a578e6caf773756f5R28) [[9]](diffhunk://#diff-eb4a2f2ace4449909bbeb39c3b69dd2d0cbbd1a18bdb24b42406d316bc6935c4R10) [[10]](diffhunk://#diff-eb4a2f2ace4449909bbeb39c3b69dd2d0cbbd1a18bdb24b42406d316bc6935c4R31)

**Configuration and defaults:**
* Introduced top‑level `fileTokenLimit` (default: `100000`) in `fileConfig`; added schema + merge logic to accept YAML overrides. [[1]](diffhunk://#diff-4651a0cd00135da416be0578563c6da6f2bba3dcd2740ccb113f5b66ddd08cfbR188) [[2]](diffhunk://#diff-4651a0cd00135da416be0578563c6da6f2bba3dcd2740ccb113f5b66ddd08cfbR212) [[3]](diffhunk://#diff-4651a0cd00135da416be0578563c6da6f2bba3dcd2740ccb113f5b66ddd08cfbR262) [[4]](diffhunk://#diff-4651a0cd00135da416be0578563c6da6f2bba3dcd2740ccb113f5b66ddd08cfbR329-R332) [[5]](diffhunk://#diff-a4f095765fb2a97a09c33f7d6a235e70b4abcce450fd36ac285776c62fef3873R50)

**Utils and extractions:**
* Added `processTextWithTokenLimit` in `packages/api/src/utils/textTokenLimiter.ts` and exported through utils index. [[1]](diffhunk://#diff-feea02395888d8a36b16c9b592b85e69dd4bcfc56066c86c6c5e4417599b160fR10)
* Updated `extractLibreChatParams` to include `fileTokenLimit` and expanded tests to cover extraction/defaults. [[1]](diffhunk://#diff-b8832013c028015f1bc569b6fd140e9c114588228de5c42722e618f5b02a3233R11) [[2]](diffhunk://#diff-b8832013c028015f1bc569b6fd140e9c114588228de5c42722e618f5b02a3233R36) [[3]](diffhunk://#diff-b8832013c028015f1bc569b6fd140e9c114588228de5c42722e618f5b02a3233R45) [[4]](diffhunk://#diff-3fe919c67e74e4e3bc4c72ee05751f3c7212e9c21884e37c80eb7187333f01c7R13) [[5]](diffhunk://#diff-feea02395888d8a36b16c9b592b85e69dd4bcfc56066c86c6c5e4417599b160fR21) [[6]](diffhunk://#diff-feea02395888d8a36b16c9b592b85e69dd4bcfc56066c86c6c5e4417599b160fR31) [[7]](diffhunk://#diff-feea02395888d8a36b16c9b592b85e69dd4bcfc56066c86c6c5e4417599b160fR43) [[8]](diffhunk://#diff-feea02395888d8a36b16c9b592b85e69dd4bcfc56066c86c6c5e4417599b160fR57) [[9]](diffhunk://#diff-feea02395888d8a36b16c9b592b85e69dd4bcfc56066c86c6c5e4417599b160fR67) [[10]](diffhunk://#diff-feea02395888d8a36b16c9b592b85e69dd4bcfc56066c86c6c5e4417599b160fR86) [[11]](diffhunk://#diff-feea02395888d8a36b16c9b592b85e69dd4bcfc56066c86c6c5e4417599b160fR100) [[12]](diffhunk://#diff-feea02395888d8a36b16c9b592b85e69dd4bcfc56066c86c6c5e4417599b160fR110) [[13]](diffhunk://#diff-feea02395888d8a36b16c9b592b85e69dd4bcfc56066c86c6c5e4417599b160fR129)

**System parameter filtering:**
* `fileTokenLimit` is extracted and not included in provider payloads via endpoint build functions and `extractLibreChatParams`. [[1]](diffhunk://#diff-b8832013c028015f1bc569b6fd140e9c114588228de5c42722e618f5b02a3233R36) [[2]](diffhunk://#diff-44c517b6025f1f63db0f0c01bc9d48945c1f6b2eb586921eefe278a320a60a06R33) [[3]](diffhunk://#diff-fe98a0f420746307a3a1671aa3f2b3c8cc0d5cba4557c1ae29bb1e97f1edd91eR28) [[4]](diffhunk://#diff-f75720cfb1f369660618aea7834035179edef778d612951b656af5104ada205fR31) [[5]](diffhunk://#diff-3da80754770799778b6d5ed3668396184f6ce305581bd37a578e6caf773756f5R28) [[6]](diffhunk://#diff-eb4a2f2ace4449909bbeb39c3b69dd2d0cbbd1a18bdb24b42406d316bc6935c4R31)

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- Verified YAML default: removed `fileTokenLimit` and confirmed runtime default `100000` is used.
- Verified YAML override: set `fileTokenLimit: 25000`, attached a large text file, observed truncation logs and prompt includes truncated text.
- Verified request override: provided `fileTokenLimit` in request; it takes precedence over YAML default.
- Confirmed `fileTokenLimit` are not present in provider payloads.
- Unit tests updated in `packages/api/src/utils/llm.test.ts` to cover extraction and defaults.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted.