### PR TITLE
📛 refactor: Decouple MCP Dialog UI from `BadgeRowContext`

### DIFF
--- a/client/src/Providers/BadgeRowContext.tsx
+++ b/client/src/Providers/BadgeRowContext.tsx
@@ -2,27 +2,18 @@ import React, { createContext, useContext, useEffect, useRef } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { Tools, Constants, LocalStorageKeys, AgentCapabilities } from 'librechat-data-provider';
 import type { TAgentsEndpoint } from 'librechat-data-provider';
-import {
-  useSearchApiKeyForm,
-  useGetAgentsConfig,
-  useCodeApiKeyForm,
-  useToolToggle,
-  useMCPSelect,
-} from '~/hooks';
-import { useGetStartupConfig } from '~/data-provider';
+import { useSearchApiKeyForm, useGetAgentsConfig, useCodeApiKeyForm, useToolToggle } from '~/hooks';
 import { ephemeralAgentByConvoId } from '~/store';
 
 interface BadgeRowContextType {
   conversationId?: string | null;
   agentsConfig?: TAgentsEndpoint | null;
-  mcpSelect: ReturnType<typeof useMCPSelect>;
   webSearch: ReturnType<typeof useToolToggle>;
   artifacts: ReturnType<typeof useToolToggle>;
   fileSearch: ReturnType<typeof useToolToggle>;
   codeInterpreter: ReturnType<typeof useToolToggle>;
   codeApiKeyForm: ReturnType<typeof useCodeApiKeyForm>;
   searchApiKeyForm: ReturnType<typeof useSearchApiKeyForm>;
-  startupConfig: ReturnType<typeof useGetStartupConfig>['data'];
 }
 
 const BadgeRowContext = createContext<BadgeRowContextType | undefined>(undefined);
@@ -119,12 +110,6 @@ export default function BadgeRowProvider({
     }
   }, [key, isSubmitting, setEphemeralAgent]);
 
-  /** Startup config */
-  const { data: startupConfig } = useGetStartupConfig();
-
-  /** MCPSelect hook */
-  const mcpSelect = useMCPSelect({ conversationId });
-
   /** CodeInterpreter hooks */
   const codeApiKeyForm = useCodeApiKeyForm({});
   const { setIsDialogOpen: setCodeDialogOpen } = codeApiKeyForm;
@@ -172,12 +157,10 @@ export default function BadgeRowProvider({
   });
 
   const value: BadgeRowContextType = {
-    mcpSelect,
     webSearch,
     artifacts,
     fileSearch,
     agentsConfig,
-    startupConfig,
     conversationId,
     codeApiKeyForm,
     codeInterpreter,

--- a/client/src/components/Chat/Input/ToolsDropdown.tsx
+++ b/client/src/components/Chat/Input/ToolsDropdown.tsx
@@ -10,11 +10,12 @@ import {
   PermissionTypes,
   defaultAgentCapabilities,
 } from 'librechat-data-provider';
-import { useLocalize, useHasAccess, useAgentCapabilities } from '~/hooks';
+import { useLocalize, useHasAccess, useAgentCapabilities, useMCPSelect } from '~/hooks';
 import ArtifactsSubMenu from '~/components/Chat/Input/ArtifactsSubMenu';
 import MCPSubMenu from '~/components/Chat/Input/MCPSubMenu';
 import { useBadgeRowContext } from '~/Providers';
 import { cn } from '~/utils';
+import { useGetStartupConfig } from '~/data-provider';
 
 interface ToolsDropdownProps {
   disabled?: boolean;
@@ -26,15 +27,16 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
   const [isPopoverActive, setIsPopoverActive] = useState(false);
   const {
     webSearch,
-    mcpSelect,
     artifacts,
     fileSearch,
     agentsConfig,
-    startupConfig,
     codeApiKeyForm,
     codeInterpreter,
     searchApiKeyForm,
   } = useBadgeRowContext();
+  const mcpSelect = useMCPSelect();
+  const { data: startupConfig } = useGetStartupConfig();
+
   const { codeEnabled, webSearchEnabled, artifactsEnabled, fileSearchEnabled } =
     useAgentCapabilities(agentsConfig?.capabilities ?? defaultAgentCapabilities);
 

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -10,8 +10,8 @@ import {
 import type { TUpdateUserPlugins, TPlugin } from 'librechat-data-provider';
 import type { ConfigFieldDetail } from '~/components/MCP/MCPConfigDialog';
 import { useMCPConnectionStatusQuery } from '~/data-provider/Tools/queries';
-import { useBadgeRowContext } from '~/Providers';
-import { useLocalize } from '~/hooks';
+import { useLocalize, useMCPSelect } from '~/hooks';
+import { useGetStartupConfig } from '../../data-provider';
 
 interface ServerState {
   isInitializing: boolean;
@@ -24,7 +24,8 @@ interface ServerState {
 export function useMCPServerManager() {
   const localize = useLocalize();
   const { showToast } = useToastContext();
-  const { mcpSelect, startupConfig } = useBadgeRowContext();
+  const mcpSelect = useMCPSelect();
+  const { data: startupConfig } = useGetStartupConfig();
   const { mcpValues, setMCPValues, mcpToolDetails, isPinned, setIsPinned } = mcpSelect;
   const queryClient = useQueryClient();
 

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -10,8 +10,8 @@ import {
 import type { TUpdateUserPlugins, TPlugin } from 'librechat-data-provider';
 import type { ConfigFieldDetail } from '~/components/MCP/MCPConfigDialog';
 import { useMCPConnectionStatusQuery } from '~/data-provider/Tools/queries';
+import { useGetStartupConfig } from '~/data-provider';
 import { useLocalize, useMCPSelect } from '~/hooks';
-import { useGetStartupConfig } from '../../data-provider';
 
 interface ServerState {
   isInitializing: boolean;

--- a/client/src/hooks/Plugins/useMCPSelect.ts
+++ b/client/src/hooks/Plugins/useMCPSelect.ts
@@ -5,6 +5,7 @@ import type { TPlugin } from 'librechat-data-provider';
 import { useAvailableToolsQuery, useGetStartupConfig } from '~/data-provider';
 import useLocalStorage from '~/hooks/useLocalStorageAlt';
 import { ephemeralAgentByConvoId } from '~/store';
+import { useChatContext } from '../../Providers';
 
 const storageCondition = (value: unknown, rawCurrentValue?: string | null) => {
   if (rawCurrentValue) {
@@ -20,12 +21,14 @@ const storageCondition = (value: unknown, rawCurrentValue?: string | null) => {
   return Array.isArray(value) && value.length > 0;
 };
 
-interface UseMCPSelectOptions {
-  conversationId?: string | null;
-}
+export function useMCPSelect() {
+  const { conversation } = useChatContext();
 
-export function useMCPSelect({ conversationId }: UseMCPSelectOptions) {
-  const key = conversationId ?? Constants.NEW_CONVO;
+  const key = useMemo(
+    () => conversation?.conversationId ?? Constants.NEW_CONVO,
+    [conversation?.conversationId],
+  );
+
   const hasSetFetched = useRef<string | null>(null);
   const [ephemeralAgent, setEphemeralAgent] = useRecoilState(ephemeralAgentByConvoId(key));
   const { data: startupConfig } = useGetStartupConfig();

--- a/client/src/hooks/Plugins/useMCPSelect.ts
+++ b/client/src/hooks/Plugins/useMCPSelect.ts
@@ -5,7 +5,7 @@ import type { TPlugin } from 'librechat-data-provider';
 import { useAvailableToolsQuery, useGetStartupConfig } from '~/data-provider';
 import useLocalStorage from '~/hooks/useLocalStorageAlt';
 import { ephemeralAgentByConvoId } from '~/store';
-import { useChatContext } from '../../Providers';
+import { useChatContext } from '~/Providers';
 
 const storageCondition = (value: unknown, rawCurrentValue?: string | null) => {
   if (rawCurrentValue) {


### PR DESCRIPTION
## Summary

It would be useful to be able to use the `MCPConfigDialog` standalone, but currently it's not possible since it's tightly coupled with `BadgeRowContext` (via `useMCPServerManager` and its internal `useBadgeRowContext` usage).

Decoupling them would allow the component and its logic to be used anywhere they can be needed (while still inside a `ChatContext`), e.g. in the agent tools selection dialog for MCP servers that require OAuth.

This PR implements such decoupling in (I hope!) the least impactful way possible.

Note: I think that a nice incremental PR would be to introduce a consistent helper (possibly a hook) to replace `conversation?.conversationId ?? Constants.NEW_CONVO`, but I left it out of this PR to keep its scope small.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Testing this kind of refactor is a bit tricky since no logic changes are introduced, but an example of the manual tests I made was having a button outside of the `BadgeRowContext` to programmatically control the dialog.

E.g.:

```tsx
<button
  className="..."
  onClick={openMCPDialog}
>
  {'mcp dialog'}
</button>

// ...

<MCPConfigDialog
  // ...
  serverName="fake-mcp"
  serverStatus={connectionStatus['fake-mcp']}
/>
```

https://github.com/user-attachments/assets/5675d577-9c54-424c-9a13-b00614b678fa

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
