### PR TITLE
📦 chore: bump `@librechat/agents` to v2.4.70

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -49,7 +49,7 @@
     "@langchain/google-vertexai": "^0.2.13",
     "@langchain/openai": "^0.5.18",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^2.4.69",
+    "@librechat/agents": "^2.4.70",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@langchain/google-vertexai": "^0.2.13",
         "@langchain/openai": "^0.5.18",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^2.4.69",
+        "@librechat/agents": "^2.4.70",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.17.1",
@@ -20124,9 +20124,9 @@
       }
     },
     "node_modules/@langchain/anthropic": {
-      "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-0.3.24.tgz",
-      "integrity": "sha512-Gi1TwXu5vkCxUMToiXaiwTTWq9v3WMyU3ldB/VEWjzbkr3nKF5kcp+HLqhvV7WWOFVTTNgG+pzfq8JALecq5MA==",
+      "version": "0.3.26",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-0.3.26.tgz",
+      "integrity": "sha512-IRCjkxsMx6MZUZmv/aYX5A9RdIduzdR0eeOc4rX8waBcYP7qmtA/CUTNmTtMSoXfOfJY4s3414bkVNBkmS0+5g==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.56.0",
@@ -21573,12 +21573,12 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "2.4.69",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.69.tgz",
-      "integrity": "sha512-Yt0rttqOaZQeZPIB68I8RdnU6SHeh0OJV5yEg8mx9EHTA7SnV/lOlDhn424aXdpMvYZYuxAt/Fev3jTC7qKiTg==",
+      "version": "2.4.70",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.70.tgz",
+      "integrity": "sha512-3FzKUd+VwAuPZBDYKPe707BNtnIsDVKGUpYgqjmnpSjDd5O5h1TUkcTjK36C68sNezsT6FJcDz1vozIEhN2aiA==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/anthropic": "^0.3.24",
+        "@langchain/anthropic": "^0.3.26",
         "@langchain/aws": "^0.1.12",
         "@langchain/community": "^0.3.47",
         "@langchain/core": "^0.3.62",
@@ -51414,7 +51414,7 @@
       },
       "peerDependencies": {
         "@langchain/core": "^0.3.62",
-        "@librechat/agents": "^2.4.69",
+        "@librechat/agents": "^2.4.70",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.17.1",
         "axios": "^1.8.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "@langchain/core": "^0.3.62",
-    "@librechat/agents": "^2.4.69",
+    "@librechat/agents": "^2.4.70",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.17.1",
     "axios": "^1.8.2",


### PR DESCRIPTION
Closes #8909 