### PR TITLE
📦 chore: Bump `@librechat/agents` to v2.4.73

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -49,7 +49,7 @@
     "@langchain/google-vertexai": "^0.2.13",
     "@langchain/openai": "^0.5.18",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^2.4.72",
+    "@librechat/agents": "^2.4.73",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.17.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@langchain/google-vertexai": "^0.2.13",
         "@langchain/openai": "^0.5.18",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^2.4.72",
+        "@librechat/agents": "^2.4.73",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.17.1",
@@ -21527,9 +21527,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "2.4.72",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.72.tgz",
-      "integrity": "sha512-4AaTN3JcPa0hdIsMlGDOm6nT1YkFByo/P9i2V9ji1nlrgcamL2PTMrUPcLB3QFmnNupHFxb62/3t3GaviZ94Bw==",
+      "version": "2.4.73",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.73.tgz",
+      "integrity": "sha512-LRVKN9WIgVXJC+KFAZIRiOXOOtatDHKS5w/nFzf19kEVrR7TOhBiKhLH11gpvtE4heBLLTag5M1keMy4f1s75Q==",
       "license": "MIT",
       "dependencies": {
         "@langchain/anthropic": "^0.3.26",
@@ -51378,7 +51378,7 @@
       },
       "peerDependencies": {
         "@langchain/core": "^0.3.62",
-        "@librechat/agents": "^2.4.72",
+        "@librechat/agents": "^2.4.73",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.17.1",
         "axios": "^1.8.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "@langchain/core": "^0.3.62",
-    "@librechat/agents": "^2.4.72",
+    "@librechat/agents": "^2.4.73",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.17.1",
     "axios": "^1.8.2",


### PR DESCRIPTION
Closes #8939