### PR TITLE
🔧 refactor: `customUserVar` Error Normalization

### DIFF
--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -1,5 +1,5 @@
 const { logger } = require('@librechat/data-schemas');
-const { webSearchKeys, extractWebSearchEnvVars } = require('@librechat/api');
+const { webSearchKeys, extractWebSearchEnvVars, normalizeHttpError } = require('@librechat/api');
 const {
   getFiles,
   updateUser,
@@ -20,24 +20,6 @@ const { Transaction, Balance, User } = require('~/db/models');
 const { deleteToolCalls } = require('~/models/ToolCall');
 const { deleteAllSharedLinks } = require('~/models');
 const { getMCPManager } = require('~/config');
-
-/**
- * Normalizes an error-like object into an HTTP status and message.
- * Ensures we always respond with a valid numeric status to avoid UI hangs.
- */
-function normalizeHttpError(err, fallbackStatus = 400) {
-  let status = fallbackStatus;
-  if (typeof err?.status === 'number') {
-    status = err.status;
-  }
-
-  let message = 'An error occurred.';
-  if (typeof err?.message === 'string' && err.message.length > 0) {
-    message = err.message;
-  }
-
-  return { status, message };
-}
 
 const getUserController = async (req, res) => {
   /** @type {MongoUser} */

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -450,7 +450,7 @@
   "com_nav_maximize_chat_space": "Maximize chat space",
   "com_nav_mcp_configure_server": "Configure {{0}}",
   "com_nav_mcp_status_connecting": "{{0}} - Connecting",
-  "com_nav_mcp_vars_update_error": "Error updating MCP custom user variables: {{0}}",
+  "com_nav_mcp_vars_update_error": "Error updating MCP custom user variables",
   "com_nav_mcp_vars_updated": "MCP custom user variables updated successfully.",
   "com_nav_modular_chat": "Enable switching Endpoints mid-conversation",
   "com_nav_my_files": "My Files",

--- a/packages/api/src/utils/http.ts
+++ b/packages/api/src/utils/http.ts
@@ -1,0 +1,26 @@
+/**
+ * Normalizes an error-like object into an HTTP status and message.
+ * Ensures we always respond with a valid numeric status to avoid UI hangs.
+ */
+export function normalizeHttpError(
+  err: Error | { status?: number; message?: string } | unknown,
+  fallbackStatus = 400,
+) {
+  let status = fallbackStatus;
+  if (err && typeof err === 'object' && 'status' in err && typeof err.status === 'number') {
+    status = err.status;
+  }
+
+  let message = 'An error occurred.';
+  if (
+    err &&
+    typeof err === 'object' &&
+    'message' in err &&
+    typeof err.message === 'string' &&
+    err.message.length > 0
+  ) {
+    message = err.message;
+  }
+
+  return { status, message };
+}

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -12,3 +12,4 @@ export * from './openid';
 export * from './tempChatRetention';
 export { default as Tokenizer } from './tokenizer';
 export * from './yaml';
+export * from './http';


### PR DESCRIPTION
## Summary

This pull request normalizes error handling in `updateUserPluginsController`. It introduces a small helper to ensure a valid HTTP status and message are always returned (defaulting to 400 when missing), preventing the “Saving...” state from persisting when encountering errors (e.g., invalid `CREDS_KEY` length). Also updates a localization string which popped during these errors which had an unused template variable. 

Related to Discussion #8916

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Translation update

## Testing
- Configure an invalid `CREDS_KEY` (non-64 hex) to trigger an encryption error.
- In the UI, save MCP customUserVars.
- Confirm POST `/api/user/plugins` responds with 400 and an error message.


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes