### PR TITLE
🪙 fix: Max Output Tokens Refactor for Responses API

### DIFF
--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -1222,7 +1222,9 @@ ${convo}
       }
 
       if (this.isOmni === true && modelOptions.max_tokens != null) {
-        modelOptions.max_completion_tokens = modelOptions.max_tokens;
+        const paramName =
+          modelOptions.useResponsesApi === true ? 'max_output_tokens' : 'max_completion_tokens';
+        modelOptions[paramName] = modelOptions.max_tokens;
         delete modelOptions.max_tokens;
       }
       if (this.isOmni === true && modelOptions.temperature != null) {

--- a/packages/api/src/agents/__tests__/memory.test.ts
+++ b/packages/api/src/agents/__tests__/memory.test.ts
@@ -398,4 +398,72 @@ describe('processMemory - GPT-5+ handling', () => {
       }),
     );
   });
+
+  it('should use max_output_tokens when useResponsesApi is true', async () => {
+    await processMemory({
+      res: mockRes as Response,
+      userId: 'test-user',
+      setMemory: mockSetMemory,
+      deleteMemory: mockDeleteMemory,
+      messages: [],
+      memory: 'Test memory',
+      messageId: 'msg-123',
+      conversationId: 'conv-123',
+      instructions: 'Test instructions',
+      llmConfig: {
+        provider: Providers.OPENAI,
+        model: 'gpt-5',
+        maxTokens: 1000,
+        useResponsesApi: true,
+      },
+    });
+
+    const { Run } = jest.requireMock('@librechat/agents');
+    expect(Run.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        graphConfig: expect.objectContaining({
+          llmConfig: expect.objectContaining({
+            model: 'gpt-5',
+            modelKwargs: {
+              max_output_tokens: 1000,
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('should use max_completion_tokens when useResponsesApi is false or undefined', async () => {
+    await processMemory({
+      res: mockRes as Response,
+      userId: 'test-user',
+      setMemory: mockSetMemory,
+      deleteMemory: mockDeleteMemory,
+      messages: [],
+      memory: 'Test memory',
+      messageId: 'msg-123',
+      conversationId: 'conv-123',
+      instructions: 'Test instructions',
+      llmConfig: {
+        provider: Providers.OPENAI,
+        model: 'gpt-5',
+        maxTokens: 1000,
+        useResponsesApi: false,
+      },
+    });
+
+    const { Run } = jest.requireMock('@librechat/agents');
+    expect(Run.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        graphConfig: expect.objectContaining({
+          llmConfig: expect.objectContaining({
+            model: 'gpt-5',
+            modelKwargs: {
+              max_completion_tokens: 1000,
+            },
+          }),
+        }),
+      }),
+    );
+  });
 });

--- a/packages/api/src/agents/memory.ts
+++ b/packages/api/src/agents/memory.ts
@@ -352,7 +352,11 @@ ${memory ?? 'No existing memories'}`;
       // Move maxTokens to modelKwargs for GPT-5+ models
       if ('maxTokens' in finalLLMConfig && finalLLMConfig.maxTokens != null) {
         const modelKwargs = (finalLLMConfig as OpenAIClientOptions).modelKwargs ?? {};
-        modelKwargs.max_completion_tokens = finalLLMConfig.maxTokens;
+        const paramName =
+          (finalLLMConfig as OpenAIClientOptions).useResponsesApi === true
+            ? 'max_output_tokens'
+            : 'max_completion_tokens';
+        modelKwargs[paramName] = finalLLMConfig.maxTokens;
         delete finalLLMConfig.maxTokens;
         (finalLLMConfig as OpenAIClientOptions).modelKwargs = modelKwargs;
       }

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -373,7 +373,7 @@ describe('getOpenAIConfig', () => {
       text: {
         verbosity: Verbosity.medium,
       },
-      max_completion_tokens: 1500,
+      max_output_tokens: 1500,
     });
   });
 

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -300,7 +300,9 @@ export function getOpenAIConfig(
   }
 
   if (llmConfig.model && /\bgpt-[5-9]\b/i.test(llmConfig.model) && llmConfig.maxTokens != null) {
-    modelKwargs.max_completion_tokens = llmConfig.maxTokens;
+    const paramName =
+      llmConfig.useResponsesApi === true ? 'max_output_tokens' : 'max_completion_tokens';
+    modelKwargs[paramName] = llmConfig.maxTokens;
     delete llmConfig.maxTokens;
     hasModelKwargs = true;
   }


### PR DESCRIPTION
## Summary

This pull request fixes an error raised in #8966 stemming from how the `maxTokens` parameter is mapped for the new models, ensuring that when the `useResponsesApi` flag is enabled, `maxTokens` is moved to `max_output_tokens` instead of `max_completion_tokens`.


* Updated `OpenAIClient.js`, `memory.ts`, and `llm.ts` to set `max_output_tokens` (instead of `max_completion_tokens`) when `useResponsesApi` is true, and to use `max_completion_tokens` otherwise. This ensures consistent parameter mapping for GPT-5+ models. [[1]](diffhunk://#diff-57fec0f69b440d2f183ed19685acf911b55ed6d6388fe164faad61ee5cd4fa0bL1225-R1227) [[2]](diffhunk://#diff-9e323913c7896d2ce82c27a66371c08510dc41bb273e54625687f08fac1b9b83L355-R359) [[3]](diffhunk://#diff-10de0bb5fa754973cb85cba455d1a1e269a0ab9688f1f74af1e2a16b31d988f4L303-R305)

Testing and validation:

* Added and modified tests in `client.test.js` to verify that `maxTokens` is correctly moved to either `max_output_tokens` or `max_completion_tokens` depending on the model and `useResponsesApi` flag. Tests also confirm that only GPT-5+ models are affected by this logic. [[1]](diffhunk://#diff-9d2da21face1fb7e391361cf9944510fe71fee63ed3b39c39baeaaa842dbbdeeR789-R810) [[2]](diffhunk://#diff-9d2da21face1fb7e391361cf9944510fe71fee63ed3b39c39baeaaa842dbbdeeR891-R929)
* Added tests in `memory.test.ts` to ensure the correct parameter (`max_output_tokens` or `max_completion_tokens`) is set in the LLM config passed to the agent runner, based on the value of `useResponsesApi`.
* Updated `llm.spec.ts` to expect `max_output_tokens` instead of `max_completion_tokens` when `useResponsesApi` is true.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified absence of error when receiving responses in conversations with gpt-5 as a model and max token params set. 
Confirmed no regression with earlier models and non Responses API requests using gpt-4o.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
