### PR TITLE
🐞 fix: Prevent Type Error in Successful Bookmark Deletion

### DIFF
--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -388,43 +388,57 @@ export const useDeleteTagInConversations = () => {
       QueryKeys.allConversations,
     ]);
 
+    // If there is no conversations cache yet, nothing to update
+    if (!data || !Array.isArray(data.pages) || data.pages.length === 0) {
+      return;
+    }
+
     const conversationIdsWithTag: string[] = [];
 
-    // Remove deleted tag from conversations
-    const newData = JSON.parse(JSON.stringify(data)) as InfiniteData<ConversationListResponse>;
-    for (let pageIndex = 0; pageIndex < newData.pages.length; pageIndex++) {
-      const page = newData.pages[pageIndex];
-      page.conversations = page.conversations.map((conversation) => {
-        if (
-          conversation.conversationId &&
-          'tags' in conversation &&
-          Array.isArray(conversation.tags) &&
-          conversation.tags.includes(deletedTag)
-        ) {
-          conversationIdsWithTag.push(conversation.conversationId);
-          conversation.tags = conversation.tags.filter((tag: string) => tag !== deletedTag);
-        }
-        return conversation;
-      });
-    }
+    // Create an updated copy of the infinite query data without mutating the cache directly
+    const updatedData: InfiniteData<ConversationListResponse> = {
+      pageParams: Array.isArray(data.pageParams) ? [...data.pageParams] : [],
+      pages: data.pages.map((page) => ({
+        ...page,
+        conversations: page.conversations.map((conversation) => {
+          if (
+            conversation.conversationId &&
+            'tags' in conversation &&
+            Array.isArray((conversation as unknown as { tags?: string[] }).tags) &&
+            (conversation as unknown as { tags: string[] }).tags.includes(deletedTag)
+          ) {
+            conversationIdsWithTag.push(conversation.conversationId);
+            return {
+              ...conversation,
+              tags: (conversation as unknown as { tags: string[] }).tags.filter(
+                (tag: string) => tag !== deletedTag,
+              ),
+            } as t.TConversation;
+          }
+          return conversation as t.TConversation;
+        }),
+      })),
+    };
+
     queryClient.setQueryData<InfiniteData<ConversationListResponse>>(
       [QueryKeys.allConversations],
-      newData,
+      updatedData,
     );
 
-    // Remove the deleted tag from the cache of each conversation
+    // Remove the deleted tag from the cache of each individual conversation
     for (let i = 0; i < conversationIdsWithTag.length; i++) {
       const conversationId = conversationIdsWithTag[i];
       const conversationData = queryClient.getQueryData<t.TConversation>([
         QueryKeys.conversation,
         conversationId,
       ]);
-      if (conversationData && 'tags' in conversationData && Array.isArray(conversationData.tags)) {
-        conversationData.tags = conversationData.tags.filter((tag: string) => tag !== deletedTag);
-        queryClient.setQueryData<t.TConversation>(
-          [QueryKeys.conversation, conversationId],
-          conversationData,
-        );
+      if (conversationData && Array.isArray((conversationData as { tags?: string[] }).tags)) {
+        queryClient.setQueryData<t.TConversation>([QueryKeys.conversation, conversationId], {
+          ...conversationData,
+          tags: (conversationData as { tags: string[] }).tags.filter(
+            (tag: string) => tag !== deletedTag,
+          ),
+        });
       }
     }
   };


### PR DESCRIPTION
## Summary
Fixes a bug where an error toast (“There was an error deleting the bookmark”) appears after successfully deleting a bookmark. The issue was caused by the cache updater attempting to deep-clone a possibly undefined `allConversations` infinite query via `JSON.parse(JSON.stringify(data))`, which can throw and trigger the error toast even though deletion succeeds.
![error](https://github.com/user-attachments/assets/16a956f6-d415-4871-b75f-71660f5fe185)

- Change: Safely guard when the conversations cache is absent and perform immutable updates.
- Affected file: `client/src/data-provider/mutations.ts`
- Linked issue: Fixes #9013 

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing
Manual verification:
1. Create a bookmark.
2. Delete the bookmark from the bookmarks table.
3. Confirm: no error toast appears; success toast shows; bookmark is removed from UI and caches.
<img width="348" height="155" alt="image" src="https://github.com/user-attachments/assets/cd2d1657-a5aa-4d00-8486-1733f871b55e" />

### Test Configuration
- Node.js 20.x
- Browser(s): Chrome/Firefox
- Commit: `42d9cf22d8a25fd5b279dd7559f972b142c3d45e`

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.