### PR TITLE
🌐 feat: Configurable Redis Cluster Mode with Single URI Support

### DIFF
--- a/api/cache/cacheConfig.js
+++ b/api/cache/cacheConfig.js
@@ -52,7 +52,8 @@ const cacheConfig = {
   REDIS_CONNECT_TIMEOUT: math(process.env.REDIS_CONNECT_TIMEOUT, 10000),
   /** Queue commands when disconnected */
   REDIS_ENABLE_OFFLINE_QUEUE: isEnabled(process.env.REDIS_ENABLE_OFFLINE_QUEUE ?? 'true'),
-
+  /** Enable redis cluster without the need of multiple URIs */
+  USE_REDIS_CLUSTER: isEnabled(process.env.USE_REDIS_CLUSTER ?? 'false'),
   CI: isEnabled(process.env.CI),
   DEBUG_MEMORY_CACHE: isEnabled(process.env.DEBUG_MEMORY_CACHE),
 

--- a/api/cache/cacheConfig.spec.js
+++ b/api/cache/cacheConfig.spec.js
@@ -132,7 +132,6 @@ describe('cacheConfig', () => {
       expect(cacheConfig.USE_REDIS).toBe(true);
       expect(cacheConfig.REDIS_URI).toBe('redis://localhost:6379');
     });
-
   });
 
   describe('REDIS_CA file reading', () => {

--- a/api/cache/cacheConfig.spec.js
+++ b/api/cache/cacheConfig.spec.js
@@ -14,6 +14,7 @@ describe('cacheConfig', () => {
     delete process.env.REDIS_KEY_PREFIX_VAR;
     delete process.env.REDIS_KEY_PREFIX;
     delete process.env.USE_REDIS;
+    delete process.env.USE_REDIS_CLUSTER;
     delete process.env.REDIS_PING_INTERVAL;
     delete process.env.FORCED_IN_MEMORY_CACHE_NAMESPACES;
 
@@ -99,6 +100,39 @@ describe('cacheConfig', () => {
         require('./cacheConfig');
       }).toThrow('USE_REDIS is enabled but REDIS_URI is not set.');
     });
+  });
+
+  describe('USE_REDIS_CLUSTER configuration', () => {
+    test('should default to false when USE_REDIS_CLUSTER is not set', () => {
+      const { cacheConfig } = require('./cacheConfig');
+      expect(cacheConfig.USE_REDIS_CLUSTER).toBe(false);
+    });
+
+    test('should be false when USE_REDIS_CLUSTER is set to false', () => {
+      process.env.USE_REDIS_CLUSTER = 'false';
+
+      const { cacheConfig } = require('./cacheConfig');
+      expect(cacheConfig.USE_REDIS_CLUSTER).toBe(false);
+    });
+
+    test('should be true when USE_REDIS_CLUSTER is set to true', () => {
+      process.env.USE_REDIS_CLUSTER = 'true';
+
+      const { cacheConfig } = require('./cacheConfig');
+      expect(cacheConfig.USE_REDIS_CLUSTER).toBe(true);
+    });
+
+    test('should work with USE_REDIS enabled and REDIS_URI set', () => {
+      process.env.USE_REDIS_CLUSTER = 'true';
+      process.env.USE_REDIS = 'true';
+      process.env.REDIS_URI = 'redis://localhost:6379';
+
+      const { cacheConfig } = require('./cacheConfig');
+      expect(cacheConfig.USE_REDIS_CLUSTER).toBe(true);
+      expect(cacheConfig.USE_REDIS).toBe(true);
+      expect(cacheConfig.REDIS_URI).toBe('redis://localhost:6379');
+    });
+
   });
 
   describe('REDIS_CA file reading', () => {

--- a/api/cache/redisClients.js
+++ b/api/cache/redisClients.js
@@ -48,7 +48,7 @@ if (cacheConfig.USE_REDIS) {
   };
 
   ioredisClient =
-    urls.length === 1
+    urls.length === 1 && !cacheConfig.USE_REDIS_CLUSTER
       ? new IoRedis(cacheConfig.REDIS_URI, redisOptions)
       : new IoRedis.Cluster(
           urls.map((url) => ({ host: url.hostname, port: parseInt(url.port, 10) || 6379 })),
@@ -148,7 +148,7 @@ if (cacheConfig.USE_REDIS) {
   };
 
   keyvRedisClient =
-    urls.length === 1
+    urls.length === 1 && !cacheConfig.USE_REDIS_CLUSTER
       ? createClient({ url: cacheConfig.REDIS_URI, ...redisOptions })
       : createCluster({
           rootNodes: urls.map((url) => ({ url: url.href })),


### PR DESCRIPTION
# Summary
This PR enhances Redis client initialization to support cluster configuration without requiring multiple URIs, and adds comprehensive test coverage for the new USE_REDIS_CLUSTER configuration option.

## 🔧 Changes Made
1. New Configuration Option ([cacheConfig.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
	- Added USE_REDIS_CLUSTER environment variable support
	- Defaults to false for backward compatibility
	- Allows forcing cluster mode even with a single Redis URI
2. Enhanced Redis Client Logic ([redisClients.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
	- Modified client initialization to respect USE_REDIS_CLUSTER flag
	- Both IoRedis and KeyV Redis clients now check for cluster configuration
	- Updated condition from urls.length === 1 to urls.length === 1 && !cacheConfig.USE_REDIS_CLUSTER
3. Comprehensive Test Coverage ([cacheConfig.spec.js](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))
	- Added test suite for USE_REDIS_CLUSTER configuration
	- Tests cover default behavior, explicit true/false values, and integration with existing Redis settings
	- Ensures proper cleanup of environment variables
### 🎯 Why Single URI Cluster Support is Needed
For example, when using Google Cloud Platform's Memorystore for Redis Cluster, you typically receive:
- A single discovery endpoint (e.g., redis://my-cluster.abc123.cache.googleapis.com:6379)
- The cluster topology is automatically discovered through this single URI
- No need to specify individual node addresses upfront

## 🧪 Testing
The new test suite validates:
- Default behavior (cluster disabled)
- Explicit enable/disable functionality
- Integration with existing Redis configuration
- Proper environment variable handling

## 🔒 Backward Compatibility
- Existing configurations continue to work unchanged
- USE_REDIS_CLUSTER defaults to false
- Multiple URI configurations still trigger cluster mode automatically

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [X] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [X] A pull request for updating the documentation has been submitted. (see [PR](https://github.com/LibreChat-AI/librechat.ai/pull/392))
