### PR TITLE
🛠️ fix: Workaround for Federated OpenID Nonce Validation Issues

### DIFF
--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -58,6 +58,7 @@ async function customFetch(url, options) {
     if (debugOpenId) {
       logger.debug(`[openidStrategy] Response status: ${response.status} ${response.statusText}`);
       logger.debug(`[openidStrategy] Response headers: ${logHeaders(response.headers)}`);
+      
     }
 
     if (response.status === 200 && response.headers.has('www-authenticate')) {
@@ -99,6 +100,7 @@ class CustomOpenIDStrategy extends OpenIDStrategy {
     const hostAndProtocol = process.env.DOMAIN_SERVER;
     return new URL(`${hostAndProtocol}${req.originalUrl ?? req.url}`);
   }
+  
   authorizationRequestParams(req, options) {
     const params = super.authorizationRequestParams(req, options);
     if (options?.state && !params.has('state')) {
@@ -111,9 +113,20 @@ class CustomOpenIDStrategy extends OpenIDStrategy {
         `[openidStrategy] Adding audience to authorization request: ${process.env.OPENID_AUDIENCE}`,
       );
     }
+    
+    // Generate nonce for federated providers that require it
+    const shouldGenerateNonce = isEnabled(process.env.OPENID_GENERATE_NONCE);
+    if (shouldGenerateNonce && !params.has('nonce') && this._sessionKey) {
+      const crypto = require('crypto');
+      const nonce = crypto.randomBytes(16).toString('hex');
+      params.set('nonce', nonce);
+      logger.debug('[openidStrategy] Generated nonce for federated provider:', nonce);
+    }
 
     return params;
   }
+
+
 }
 
 /**
@@ -276,11 +289,20 @@ function convertToUsername(input, defaultValue = '') {
  */
 async function setupOpenId() {
   try {
+    const shouldGenerateNonce = isEnabled(process.env.OPENID_GENERATE_NONCE);
+    
     /** @type {ClientMetadata} */
     const clientMetadata = {
       client_id: process.env.OPENID_CLIENT_ID,
       client_secret: process.env.OPENID_CLIENT_SECRET,
     };
+    
+    // Add explicit validation settings for federated providers that need them
+    if (shouldGenerateNonce) {
+      clientMetadata.response_types = ['code'];
+      clientMetadata.grant_types = ['authorization_code'];
+      clientMetadata.token_endpoint_auth_method = 'client_secret_post';
+    }
 
     /** @type {Configuration} */
     openidConfig = await client.discovery(
@@ -297,11 +319,19 @@ async function setupOpenId() {
     const requiredRoleParameterPath = process.env.OPENID_REQUIRED_ROLE_PARAMETER_PATH;
     const requiredRoleTokenKind = process.env.OPENID_REQUIRED_ROLE_TOKEN_KIND;
     const usePKCE = isEnabled(process.env.OPENID_USE_PKCE);
+    logger.info(`[openidStrategy] OpenID authentication configuration`, {
+      generateNonce: shouldGenerateNonce,
+      reason: shouldGenerateNonce 
+        ? 'OPENID_GENERATE_NONCE=true - Will generate nonce and use explicit metadata for federated providers'
+        : 'OPENID_GENERATE_NONCE=false - Standard flow without explicit nonce or metadata'
+    });
+    
     const openidLogin = new CustomOpenIDStrategy(
       {
         config: openidConfig,
         scope: process.env.OPENID_SCOPE,
         callbackURL: process.env.DOMAIN_SERVER + process.env.OPENID_CALLBACK_URL,
+        clockTolerance: process.env.OPENID_CLOCK_TOLERANCE || 300,
         usePKCE,
       },
       async (tokenset, done) => {

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -58,7 +58,6 @@ async function customFetch(url, options) {
     if (debugOpenId) {
       logger.debug(`[openidStrategy] Response status: ${response.status} ${response.statusText}`);
       logger.debug(`[openidStrategy] Response headers: ${logHeaders(response.headers)}`);
-      
     }
 
     if (response.status === 200 && response.headers.has('www-authenticate')) {
@@ -100,7 +99,7 @@ class CustomOpenIDStrategy extends OpenIDStrategy {
     const hostAndProtocol = process.env.DOMAIN_SERVER;
     return new URL(`${hostAndProtocol}${req.originalUrl ?? req.url}`);
   }
-  
+
   authorizationRequestParams(req, options) {
     const params = super.authorizationRequestParams(req, options);
     if (options?.state && !params.has('state')) {
@@ -113,7 +112,7 @@ class CustomOpenIDStrategy extends OpenIDStrategy {
         `[openidStrategy] Adding audience to authorization request: ${process.env.OPENID_AUDIENCE}`,
       );
     }
-    
+
     // Generate nonce for federated providers that require it
     const shouldGenerateNonce = isEnabled(process.env.OPENID_GENERATE_NONCE);
     if (shouldGenerateNonce && !params.has('nonce') && this._sessionKey) {
@@ -125,8 +124,6 @@ class CustomOpenIDStrategy extends OpenIDStrategy {
 
     return params;
   }
-
-
 }
 
 /**
@@ -290,13 +287,13 @@ function convertToUsername(input, defaultValue = '') {
 async function setupOpenId() {
   try {
     const shouldGenerateNonce = isEnabled(process.env.OPENID_GENERATE_NONCE);
-    
+
     /** @type {ClientMetadata} */
     const clientMetadata = {
       client_id: process.env.OPENID_CLIENT_ID,
       client_secret: process.env.OPENID_CLIENT_SECRET,
     };
-    
+
     // Add explicit validation settings for federated providers that need them
     if (shouldGenerateNonce) {
       clientMetadata.response_types = ['code'];
@@ -321,11 +318,11 @@ async function setupOpenId() {
     const usePKCE = isEnabled(process.env.OPENID_USE_PKCE);
     logger.info(`[openidStrategy] OpenID authentication configuration`, {
       generateNonce: shouldGenerateNonce,
-      reason: shouldGenerateNonce 
+      reason: shouldGenerateNonce
         ? 'OPENID_GENERATE_NONCE=true - Will generate nonce and use explicit metadata for federated providers'
-        : 'OPENID_GENERATE_NONCE=false - Standard flow without explicit nonce or metadata'
+        : 'OPENID_GENERATE_NONCE=false - Standard flow without explicit nonce or metadata',
     });
-    
+
     const openidLogin = new CustomOpenIDStrategy(
       {
         config: openidConfig,

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -113,7 +113,7 @@ class CustomOpenIDStrategy extends OpenIDStrategy {
       );
     }
 
-    // Generate nonce for federated providers that require it
+    /** Generate nonce for federated providers that require it */
     const shouldGenerateNonce = isEnabled(process.env.OPENID_GENERATE_NONCE);
     if (shouldGenerateNonce && !params.has('nonce') && this._sessionKey) {
       const crypto = require('crypto');
@@ -294,7 +294,6 @@ async function setupOpenId() {
       client_secret: process.env.OPENID_CLIENT_SECRET,
     };
 
-    // Add explicit validation settings for federated providers that need them
     if (shouldGenerateNonce) {
       clientMetadata.response_types = ['code'];
       clientMetadata.grant_types = ['authorization_code'];


### PR DESCRIPTION
# Patch: Add workaround for federated OpenID nonce issues

## Problem

When using federated identity setups like AWS Cognito with Microsoft Entra ID (Azure AD), authentication fails with `OAUTH_JWT_CLAIM_COMPARISON_FAILED` error. This occurs because:

1. LibreChat uses authorization code flow (`response_type=code`) which doesn't generate a nonce
2. Cognito adds a nonce when federating to Entra ID for security
3. The JWT returns with a nonce that doesn't match the session (null vs actual value)
4. openid-client validation fails: `null !== "actual_nonce_value"`

## Temporary Solution

This PR adds a **temporary workaround** via `OPENID_GENERATE_NONCE` environment variable that when enabled:

- **Generates a nonce** in the authorization request to match what federated providers expect
- **Adds explicit client metadata** for better compatibility with federated flows
- **Is opt-in** - default behavior unchanged for standard OpenID flows
- **Should be considered a patch** until LibreChat properly handles federated identity scenarios

⚠️ **Note**: This is a workaround, not a proper architectural fix. The ideal solution would be for LibreChat to automatically detect and handle federated identity scenarios without requiring manual configuration.

## Changes

### Environment Variable
```env
# Generate nonce for federated identity providers that require it
# Set to true when using federated identity where the IdP expects nonces
OPENID_GENERATE_NONCE=true
```

### Code Changes
- Added nonce generation in `authorizationRequestParams()` when flag is enabled
- Added conditional client metadata (response_types, grant_types, token_endpoint_auth_method) for federated compatibility
- Added logging to clearly indicate when federated mode is active

## Testing

- ✅ Tested with AWS Cognito + Entra ID federation
- ✅ Authentication now succeeds with proper nonce validation
- ✅ Maintains backward compatibility (default: false)
- ✅ Standard OpenID flows unaffected

## Security

This workaround:
- ✅ Maintains existing security (PKCE, state validation, etc.)
- ✅ Enables nonce validation in federated scenarios where it's currently broken
- ⚠️ Requires manual configuration to work properly
- ⚠️ Not a comprehensive solution for all federated identity edge cases

## Use Cases

**Enable `OPENID_GENERATE_NONCE=true` as a temporary fix when:**
- Using AWS Cognito with federated identity providers (Entra ID, Google, etc.)
- Getting `OAUTH_JWT_CLAIM_COMPARISON_FAILED` errors
- You need authentication to work while waiting for a proper fix

**Keep `OPENID_GENERATE_NONCE=false` (default) when:**
- Using direct OpenID Connect integration (no federation)
- Standard OpenID flows work without issues

## Future Work

This patch should eventually be replaced with:
- Automatic detection of federated identity scenarios
- Proper handling of different identity provider chains
- Comprehensive solution that doesn't require manual configuration

## Files Changed
- `api/strategies/openidStrategy.js` - Added conditional nonce generation and metadata

**This is a temporary patch to unblock federated identity authentication until a proper architectural solution is implemented.**