### PR TITLE
feat: increase sonnet 4 context window to 1M tokens - adding beta header context-1m-2025-08-07 

### DIFF
--- a/api/app/clients/specs/AnthropicClient.test.js
+++ b/api/app/clients/specs/AnthropicClient.test.js
@@ -245,7 +245,7 @@ describe('AnthropicClient', () => {
     });
 
     describe('Claude 4 model headers', () => {
-      it('should add "prompt-caching" beta header for claude-sonnet-4 model', () => {
+      it('should add "prompt-caching" and "context-1m" beta headers for claude-sonnet-4 model', () => {
         const client = new AnthropicClient('test-api-key');
         const modelOptions = {
           model: 'claude-sonnet-4-20250514',
@@ -255,28 +255,34 @@ describe('AnthropicClient', () => {
         expect(anthropicClient._options.defaultHeaders).toBeDefined();
         expect(anthropicClient._options.defaultHeaders).toHaveProperty('anthropic-beta');
         expect(anthropicClient._options.defaultHeaders['anthropic-beta']).toBe(
-          'prompt-caching-2024-07-31',
+          'prompt-caching-2024-07-31,context-1m-2025-08-07',
         );
       });
+
+      it('should add "prompt-caching" and "context-1m" beta headers for claude-sonnet-4 model formats', () => {
+        const client = new AnthropicClient('test-api-key');
+        const modelVariations = [
+          'claude-sonnet-4-20250514',
+          'claude-sonnet-4-latest',
+          'anthropic/claude-sonnet-4-20250514',
+        ];
+
+        modelVariations.forEach(model => {
+          const modelOptions = { model };
+          client.setOptions({ modelOptions, promptCache: true });
+          const anthropicClient = client.getClient(modelOptions);
+          expect(anthropicClient._options.defaultHeaders).toBeDefined();
+          expect(anthropicClient._options.defaultHeaders).toHaveProperty('anthropic-beta');
+          expect(anthropicClient._options.defaultHeaders['anthropic-beta']).toBe(
+            'prompt-caching-2024-07-31,context-1m-2025-08-07',
+          );
+        });
+      });	    
 
       it('should add "prompt-caching" beta header for claude-opus-4 model', () => {
         const client = new AnthropicClient('test-api-key');
         const modelOptions = {
           model: 'claude-opus-4-20250514',
-        };
-        client.setOptions({ modelOptions, promptCache: true });
-        const anthropicClient = client.getClient(modelOptions);
-        expect(anthropicClient._options.defaultHeaders).toBeDefined();
-        expect(anthropicClient._options.defaultHeaders).toHaveProperty('anthropic-beta');
-        expect(anthropicClient._options.defaultHeaders['anthropic-beta']).toBe(
-          'prompt-caching-2024-07-31',
-        );
-      });
-
-      it('should add "prompt-caching" beta header for claude-4-sonnet model', () => {
-        const client = new AnthropicClient('test-api-key');
-        const modelOptions = {
-          model: 'claude-4-sonnet-20250514',
         };
         client.setOptions({ modelOptions, promptCache: true });
         const anthropicClient = client.getClient(modelOptions);

--- a/api/server/services/Endpoints/anthropic/helpers.js
+++ b/api/server/services/Endpoints/anthropic/helpers.js
@@ -45,6 +45,10 @@ function getClaudeHeaders(model, supportsCacheControl) {
       'anthropic-beta':
         'token-efficient-tools-2025-02-19,output-128k-2025-02-19,prompt-caching-2024-07-31',
     };
+  } else if (/claude-sonnet-4-/.test(model)) {
+    return {
+      'anthropic-beta': 'prompt-caching-2024-07-31,context-1m-2025-08-07',
+    };
   } else if (
     /claude-(?:sonnet|opus|haiku)-[4-9]/.test(model) ||
     /claude-[4-9]-(?:sonnet|opus|haiku)?/.test(model) ||


### PR DESCRIPTION
adding beta header context-1m-2025-08-07 to claude sonnet 4  to increase context window to 1M tokens

## Summary

https://www.anthropic.com/news/1m-context 
Claude Sonnet 4 now supports up to 1 million tokens of context on the Anthropic API—a 5x increase that lets you process entire codebases with over 75,000 lines of code or dozens of research papers in a single request.
Long context support for Sonnet 4 is now in public beta on the Anthropic API and in Amazon Bedrock, with Google Cloud’s Vertex AI coming soon.

## Change Type

Please delete any irrelevant options.

- [ x ] New feature (non-breaking change which adds functionality)


