### PR TITLE
🔄 fix: Add Azure to Recognized and Content array providers for MCP Tool Calls

### DIFF
--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -3,13 +3,14 @@ const RECOGNIZED_PROVIDERS = new Set([
   'google',
   'anthropic',
   'openai',
+  'azureopenai',
   'openrouter',
   'xai',
   'deepseek',
   'ollama',
   'bedrock',
 ]);
-const CONTENT_ARRAY_PROVIDERS = new Set(['google', 'anthropic', 'openai']);
+const CONTENT_ARRAY_PROVIDERS = new Set(['google', 'anthropic', 'azureopenai', 'openai']);
 
 const imageFormatters: Record<string, undefined | t.ImageFormatter> = {
   // google: (item) => ({


### PR DESCRIPTION
Closes #9089