### PR TITLE
🏷️ feat: Request Placeholders for Custom Endpoint & MCP Headers

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -37,6 +37,8 @@ class BaseClient {
     this.conversationId;
     /** @type {string} */
     this.responseMessageId;
+    /** @type {string} */
+    this.parentMessageId;
     /** @type {TAttachment[]} */
     this.attachments;
     /** The key for the usage object's input tokens
@@ -614,15 +616,19 @@ class BaseClient {
       this.currentMessages.push(userMessage);
     }
 
+    /**
+     * When the userMessage is pushed to currentMessages, the parentMessage is the userMessageId.
+     * this only matters when buildMessages is utilizing the parentMessageId, and may vary on implementation
+     */
+    const parentMessageId = isEdited ? head : userMessage.messageId;
+    this.parentMessageId = parentMessageId;
     let {
       prompt: payload,
       tokenCountMap,
       promptTokens,
     } = await this.buildMessages(
       this.currentMessages,
-      // When the userMessage is pushed to currentMessages, the parentMessage is the userMessageId.
-      // this only matters when buildMessages is utilizing the parentMessageId, and may vary on implementation
-      isEdited ? head : userMessage.messageId,
+      parentMessageId,
       this.getBuildMessagesOptions(opts),
       opts,
     );

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -652,10 +652,10 @@ class OpenAIClient extends BaseClient {
     const { headers } = this.options;
     if (headers && typeof headers === 'object' && !Array.isArray(headers)) {
       configOptions.baseOptions = {
-        headers: resolveHeaders({
+        headers: resolveHeaders({ headers: {
           ...headers,
           ...configOptions?.baseOptions?.headers,
-        }),
+        } }),
       };
     }
 
@@ -749,7 +749,7 @@ class OpenAIClient extends BaseClient {
         groupMap,
       });
 
-      this.options.headers = resolveHeaders(headers);
+      this.options.headers = resolveHeaders({ headers });
       this.options.reverseProxyUrl = baseURL ?? null;
       this.langchainProxy = extractBaseURL(this.options.reverseProxyUrl);
       this.apiKey = azureOptions.azureOpenAIApiKey;
@@ -1181,7 +1181,7 @@ ${convo}
           modelGroupMap,
           groupMap,
         });
-        opts.defaultHeaders = resolveHeaders(headers);
+        opts.defaultHeaders = resolveHeaders({ headers });
         this.langchainProxy = extractBaseURL(baseURL);
         this.apiKey = azureOptions.azureOpenAIApiKey;
 

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -652,10 +652,12 @@ class OpenAIClient extends BaseClient {
     const { headers } = this.options;
     if (headers && typeof headers === 'object' && !Array.isArray(headers)) {
       configOptions.baseOptions = {
-        headers: resolveHeaders({ headers: {
-          ...headers,
-          ...configOptions?.baseOptions?.headers,
-        } }),
+        headers: resolveHeaders({
+          headers: {
+            ...headers,
+            ...configOptions?.baseOptions?.headers,
+          },
+        }),
       };
     }
 

--- a/api/server/cleanup.js
+++ b/api/server/cleanup.js
@@ -1,6 +1,6 @@
-const { logger } = require('~/config');
+const { logger } = require('@librechat/data-schemas');
 
-// WeakMap to hold temporary data associated with requests
+/** WeakMap to hold temporary data associated with requests */
 const requestDataMap = new WeakMap();
 
 const FinalizationRegistry = global.FinalizationRegistry || null;
@@ -23,7 +23,7 @@ const clientRegistry = FinalizationRegistry
         } else {
           logger.debug('[FinalizationRegistry] Cleaning up client');
         }
-      } catch (e) {
+      } catch {
         // Ignore errors
       }
     })
@@ -54,6 +54,9 @@ function disposeClient(client) {
     }
     if (client.responseMessageId) {
       client.responseMessageId = null;
+    }
+    if (client.parentMessageId) {
+      client.parentMessageId = null;
     }
     if (client.message_file_map) {
       client.message_file_map = null;
@@ -334,7 +337,7 @@ function disposeClient(client) {
       }
     }
     client.options = null;
-  } catch (e) {
+  } catch {
     // Ignore errors during disposal
   }
 }

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -768,6 +768,11 @@ class AgentClient extends BaseClient {
           last_agent_index: this.agentConfigs?.size ?? 0,
           user_id: this.user ?? this.options.req.user?.id,
           hide_sequential_outputs: this.options.agent.hide_sequential_outputs,
+          requestBody: {
+            messageId: this.responseMessageId,
+            conversationId: this.conversationId,
+            parentMessageId: this.parentMessageId,
+          },
           user: this.options.req.user,
         },
         recursionLimit: agentsEConfig?.recursionLimit ?? 25,

--- a/api/server/services/Endpoints/azureAssistants/initialize.js
+++ b/api/server/services/Endpoints/azureAssistants/initialize.js
@@ -109,14 +109,14 @@ const initializeClient = async ({ req, res, version, endpointOption, initAppClie
 
     apiKey = azureOptions.azureOpenAIApiKey;
     opts.defaultQuery = { 'api-version': azureOptions.azureOpenAIApiVersion };
-    opts.defaultHeaders = resolveHeaders(
-      {
+    opts.defaultHeaders = resolveHeaders({
+      headers: {
         ...headers,
         'api-key': apiKey,
         'OpenAI-Beta': `assistants=${version}`,
       },
-      req.user,
-    );
+      user: req.user,
+    });
     opts.model = azureOptions.azureOpenAIApiDeploymentName;
 
     if (initAppClient) {

--- a/api/server/services/Endpoints/azureAssistants/initialize.js
+++ b/api/server/services/Endpoints/azureAssistants/initialize.js
@@ -116,7 +116,6 @@ const initializeClient = async ({ req, res, version, endpointOption, initAppClie
         'OpenAI-Beta': `assistants=${version}`,
       },
       user: req.user,
-      body: req.body,
     });
     opts.model = azureOptions.azureOpenAIApiDeploymentName;
 

--- a/api/server/services/Endpoints/azureAssistants/initialize.js
+++ b/api/server/services/Endpoints/azureAssistants/initialize.js
@@ -116,6 +116,7 @@ const initializeClient = async ({ req, res, version, endpointOption, initAppClie
         'OpenAI-Beta': `assistants=${version}`,
       },
       user: req.user,
+      body: req.body,
     });
     opts.model = azureOptions.azureOpenAIApiDeploymentName;
 

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -28,7 +28,11 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
   const CUSTOM_API_KEY = extractEnvVariable(endpointConfig.apiKey);
   const CUSTOM_BASE_URL = extractEnvVariable(endpointConfig.baseURL);
 
-  let resolvedHeaders = resolveHeaders({ headers: endpointConfig.headers, user: req.user, body: req.body });
+  let resolvedHeaders = resolveHeaders({
+    headers: endpointConfig.headers,
+    user: req.user,
+    body: req.body,
+  });
 
   if (CUSTOM_API_KEY.match(envVarRegex)) {
     throw new Error(`Missing API Key for ${endpoint}.`);

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -29,9 +29,22 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
   const CUSTOM_BASE_URL = extractEnvVariable(endpointConfig.baseURL);
 
   const customUserVars = {};
-  customUserVars.LIBRECHAT_CONVERSATION_ID = req.body.conversationId;
+  if (req.body.conversationId) {
+    customUserVars.LIBRECHAT_CONVERSATION_ID = req.body.conversationId;
+  }
 
   let resolvedHeaders = resolveHeaders(endpointConfig.headers, req.user, customUserVars);
+
+  // Filter out headers with unresolved placeholders
+  const filteredHeaders = {};
+  for (const [key, value] of Object.entries(resolvedHeaders)) {
+    if (typeof value === 'string' && value.includes('{{') && value.includes('}}')) {
+      continue;
+    }
+    filteredHeaders[key] = value;
+  }
+
+  resolvedHeaders = filteredHeaders;
 
   if (CUSTOM_API_KEY.match(envVarRegex)) {
     throw new Error(`Missing API Key for ${endpoint}.`);

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -28,7 +28,10 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
   const CUSTOM_API_KEY = extractEnvVariable(endpointConfig.apiKey);
   const CUSTOM_BASE_URL = extractEnvVariable(endpointConfig.baseURL);
 
-  let resolvedHeaders = resolveHeaders(endpointConfig.headers, req.user);
+  const customUserVars = {};
+  customUserVars.LIBRECHAT_CONVERSATION_ID = req.body.conversationId;
+
+  let resolvedHeaders = resolveHeaders(endpointConfig.headers, req.user, customUserVars);
 
   if (CUSTOM_API_KEY.match(envVarRegex)) {
     throw new Error(`Missing API Key for ${endpoint}.`);

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -28,7 +28,7 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
   const CUSTOM_API_KEY = extractEnvVariable(endpointConfig.apiKey);
   const CUSTOM_BASE_URL = extractEnvVariable(endpointConfig.baseURL);
 
-  let resolvedHeaders = resolveHeaders(endpointConfig.headers, req.user, undefined, req.body);
+  let resolvedHeaders = resolveHeaders({ headers: endpointConfig.headers, user: req.user, body: req.body });
 
   if (CUSTOM_API_KEY.match(envVarRegex)) {
     throw new Error(`Missing API Key for ${endpoint}.`);

--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -28,23 +28,7 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
   const CUSTOM_API_KEY = extractEnvVariable(endpointConfig.apiKey);
   const CUSTOM_BASE_URL = extractEnvVariable(endpointConfig.baseURL);
 
-  const customUserVars = {};
-  if (req.body.conversationId) {
-    customUserVars.LIBRECHAT_CONVERSATION_ID = req.body.conversationId;
-  }
-
-  let resolvedHeaders = resolveHeaders(endpointConfig.headers, req.user, customUserVars);
-
-  // Filter out headers with unresolved placeholders
-  const filteredHeaders = {};
-  for (const [key, value] of Object.entries(resolvedHeaders)) {
-    if (typeof value === 'string' && value.includes('{{') && value.includes('}}')) {
-      continue;
-    }
-    filteredHeaders[key] = value;
-  }
-
-  resolvedHeaders = filteredHeaders;
+  let resolvedHeaders = resolveHeaders(endpointConfig.headers, req.user, undefined, req.body);
 
   if (CUSTOM_API_KEY.match(envVarRegex)) {
     throw new Error(`Missing API Key for ${endpoint}.`);

--- a/api/server/services/Endpoints/custom/initialize.spec.js
+++ b/api/server/services/Endpoints/custom/initialize.spec.js
@@ -64,26 +64,14 @@ describe('custom/initializeClient', () => {
     jest.clearAllMocks();
   });
 
-  it('calls resolveHeaders with conversation ID when provided', async () => {
-    const { resolveHeaders } = require('@librechat/api');
-    const requestWithConversationId = {
-      ...mockRequest,
-      body: { ...mockRequest.body, conversationId: 'existing-conversation-123' },
-    };
-    await initializeClient({ req: requestWithConversationId, res: mockResponse, optionsOnly: true });
-    expect(resolveHeaders).toHaveBeenCalledWith(
-      { 'x-user': '{{LIBRECHAT_USER_ID}}', 'x-email': '{{LIBRECHAT_USER_EMAIL}}' },
-      { id: 'user-123', email: 'test@example.com' },
-      { LIBRECHAT_CONVERSATION_ID: 'existing-conversation-123' },
-    );
-  });
-
-  it('calls resolveHeaders with headers and user', async () => {
+  it('calls resolveHeaders with headers, user, and body for body placeholder support', async () => {
     const { resolveHeaders } = require('@librechat/api');
     await initializeClient({ req: mockRequest, res: mockResponse, optionsOnly: true });
     expect(resolveHeaders).toHaveBeenCalledWith(
       { 'x-user': '{{LIBRECHAT_USER_ID}}', 'x-email': '{{LIBRECHAT_USER_EMAIL}}' },
       { id: 'user-123', email: 'test@example.com' },
+      undefined, // customUserVars
+      { endpoint: 'test-endpoint' }, // body - supports {{LIBRECHAT_BODY_*}} placeholders
     );
   });
 

--- a/api/server/services/Endpoints/custom/initialize.spec.js
+++ b/api/server/services/Endpoints/custom/initialize.spec.js
@@ -64,6 +64,20 @@ describe('custom/initializeClient', () => {
     jest.clearAllMocks();
   });
 
+  it('calls resolveHeaders with conversation ID when provided', async () => {
+    const { resolveHeaders } = require('@librechat/api');
+    const requestWithConversationId = {
+      ...mockRequest,
+      body: { ...mockRequest.body, conversationId: 'existing-conversation-123' },
+    };
+    await initializeClient({ req: requestWithConversationId, res: mockResponse, optionsOnly: true });
+    expect(resolveHeaders).toHaveBeenCalledWith(
+      { 'x-user': '{{LIBRECHAT_USER_ID}}', 'x-email': '{{LIBRECHAT_USER_EMAIL}}' },
+      { id: 'user-123', email: 'test@example.com' },
+      { LIBRECHAT_CONVERSATION_ID: 'existing-conversation-123' },
+    );
+  });
+
   it('calls resolveHeaders with headers and user', async () => {
     const { resolveHeaders } = require('@librechat/api');
     await initializeClient({ req: mockRequest, res: mockResponse, optionsOnly: true });

--- a/api/server/services/Endpoints/custom/initialize.spec.js
+++ b/api/server/services/Endpoints/custom/initialize.spec.js
@@ -67,12 +67,11 @@ describe('custom/initializeClient', () => {
   it('calls resolveHeaders with headers, user, and body for body placeholder support', async () => {
     const { resolveHeaders } = require('@librechat/api');
     await initializeClient({ req: mockRequest, res: mockResponse, optionsOnly: true });
-    expect(resolveHeaders).toHaveBeenCalledWith(
-      { 'x-user': '{{LIBRECHAT_USER_ID}}', 'x-email': '{{LIBRECHAT_USER_EMAIL}}' },
-      { id: 'user-123', email: 'test@example.com' },
-      undefined, // customUserVars
-      { endpoint: 'test-endpoint' }, // body - supports {{LIBRECHAT_BODY_*}} placeholders
-    );
+    expect(resolveHeaders).toHaveBeenCalledWith({
+      headers: { 'x-user': '{{LIBRECHAT_USER_ID}}', 'x-email': '{{LIBRECHAT_USER_EMAIL}}' },
+      user: { id: 'user-123', email: 'test@example.com' },
+      body: { endpoint: 'test-endpoint' }, // body - supports {{LIBRECHAT_BODY_*}} placeholders
+    });
   });
 
   it('throws if endpoint config is missing', async () => {

--- a/api/server/services/Endpoints/openAI/initialize.js
+++ b/api/server/services/Endpoints/openAI/initialize.js
@@ -81,10 +81,10 @@ const initializeClient = async ({
     serverless = _serverless;
 
     clientOptions.reverseProxyUrl = baseURL ?? clientOptions.reverseProxyUrl;
-    clientOptions.headers = resolveHeaders(
-      { ...headers, ...(clientOptions.headers ?? {}) },
-      req.user,
-    );
+    clientOptions.headers = resolveHeaders({
+      headers: { ...headers, ...(clientOptions.headers ?? {}) },
+      user: req.user,
+    });
 
     clientOptions.titleConvo = azureConfig.titleConvo;
     clientOptions.titleModel = azureConfig.titleModel;

--- a/api/server/services/Endpoints/openAI/initialize.js
+++ b/api/server/services/Endpoints/openAI/initialize.js
@@ -84,7 +84,6 @@ const initializeClient = async ({
     clientOptions.headers = resolveHeaders({
       headers: { ...headers, ...(clientOptions.headers ?? {}) },
       user: req.user,
-      body: req.body,
     });
 
     clientOptions.titleConvo = azureConfig.titleConvo;

--- a/api/server/services/Endpoints/openAI/initialize.js
+++ b/api/server/services/Endpoints/openAI/initialize.js
@@ -84,6 +84,7 @@ const initializeClient = async ({
     clientOptions.headers = resolveHeaders({
       headers: { ...headers, ...(clientOptions.headers ?? {}) },
       user: req.user,
+      body: req.body,
     });
 
     clientOptions.titleConvo = azureConfig.titleConvo;

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -186,6 +186,7 @@ async function createMCPTool({ req, res, toolKey, provider: _provider }) {
           signal: derivedSignal,
         },
         user: config?.configurable?.user,
+        requestBody: config?.configurable?.requestBody,
         customUserVars,
         flowManager,
         tokenMethods: {

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -195,6 +195,7 @@ async function createMCPTool({ req, res, toolKey, provider: _provider }) {
         },
         oauthStart,
         oauthEnd,
+        body: req.body,
       });
 
       if (isAssistantsEndpoint(provider) && Array.isArray(result)) {

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -195,7 +195,6 @@ async function createMCPTool({ req, res, toolKey, provider: _provider }) {
         },
         oauthStart,
         oauthEnd,
-        body: req.body,
       });
 
       if (isAssistantsEndpoint(provider) && Array.isArray(result)) {

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -290,6 +290,8 @@ endpoints:
       # recommended environment variables:
       apiKey: '${OPENROUTER_KEY}'
       baseURL: 'https://openrouter.ai/api/v1'
+      headers:
+          x-librechat-body-parentmessageid: '{{LIBRECHAT_BODY_PARENTMESSAGEID}}'
       models:
         default: ['meta-llama/llama-3-70b-instruct']
         fetch: true

--- a/packages/api/src/endpoints/openai/initialize.ts
+++ b/packages/api/src/endpoints/openai/initialize.ts
@@ -87,10 +87,10 @@ export const initializeOpenAI = async ({
     });
 
     clientOptions.reverseProxyUrl = configBaseURL ?? clientOptions.reverseProxyUrl;
-    clientOptions.headers = resolveHeaders(
-      { ...headers, ...(clientOptions.headers ?? {}) },
-      req.user,
-    );
+    clientOptions.headers = resolveHeaders({
+      headers: { ...headers, ...(clientOptions.headers ?? {}) },
+      user: req.user,
+    });
 
     const groupName = modelGroupMap[modelName || '']?.group;
     if (groupName && groupMap[groupName]) {

--- a/packages/api/src/mcp/ConnectionsRepository.ts
+++ b/packages/api/src/mcp/ConnectionsRepository.ts
@@ -1,5 +1,5 @@
 import { logger } from '@librechat/data-schemas';
-import { MCPConnectionFactory, OAuthConnectionOptions } from '~/mcp/MCPConnectionFactory';
+import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
 import { MCPConnection } from './connection';
 import type * as t from './types';
 
@@ -10,9 +10,9 @@ import type * as t from './types';
 export class ConnectionsRepository {
   protected readonly serverConfigs: Record<string, t.MCPOptions>;
   protected connections: Map<string, MCPConnection> = new Map();
-  protected oauthOpts: OAuthConnectionOptions | undefined;
+  protected oauthOpts: t.OAuthConnectionOptions | undefined;
 
-  constructor(serverConfigs: t.MCPServers, oauthOpts?: OAuthConnectionOptions) {
+  constructor(serverConfigs: t.MCPServers, oauthOpts?: t.OAuthConnectionOptions) {
     this.serverConfigs = serverConfigs;
     this.oauthOpts = oauthOpts;
   }

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -43,6 +43,7 @@ export class MCPConnectionFactory {
       options: basic.serverConfig,
       user: oauth?.user,
       customUserVars: oauth?.customUserVars,
+      body: oauth?.requestBody,
     });
     this.serverName = basic.serverName;
     this.useOAuth = !!oauth?.useOAuth;

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -57,7 +57,11 @@ export class MCPConnectionFactory {
   }
 
   protected constructor(basic: BasicConnectionOptions, oauth?: OAuthConnectionOptions) {
-    this.serverConfig = processMCPEnv(basic.serverConfig, oauth?.user, oauth?.customUserVars);
+    this.serverConfig = processMCPEnv({
+      obj: basic.serverConfig,
+      user: oauth?.user,
+      customUserVars: oauth?.customUserVars,
+    });
     this.serverName = basic.serverName;
     this.useOAuth = !!oauth?.useOAuth;
     this.logPrefix = oauth?.user

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -1,7 +1,6 @@
 import { logger } from '@librechat/data-schemas';
 import type { OAuthClientInformation } from '@modelcontextprotocol/sdk/shared/auth.js';
 import type { TokenMethods } from '@librechat/data-schemas';
-import type { TUser } from 'librechat-data-provider';
 import type { MCPOAuthTokens, MCPOAuthFlowMetadata } from '~/mcp/oauth';
 import type { FlowStateManager } from '~/flow/manager';
 import type { FlowMetadata } from '~/flow/types';
@@ -9,23 +8,6 @@ import type * as t from './types';
 import { MCPTokenStorage, MCPOAuthHandler } from '~/mcp/oauth';
 import { MCPConnection } from './connection';
 import { processMCPEnv } from '~/utils';
-
-export interface BasicConnectionOptions {
-  serverName: string;
-  serverConfig: t.MCPOptions;
-}
-
-export interface OAuthConnectionOptions {
-  useOAuth: true;
-  user: TUser;
-  customUserVars?: Record<string, string>;
-  flowManager: FlowStateManager<MCPOAuthTokens | null>;
-  tokenMethods?: TokenMethods;
-  signal?: AbortSignal;
-  oauthStart?: (authURL: string) => Promise<void>;
-  oauthEnd?: () => Promise<void>;
-  returnOnOAuth?: boolean;
-}
 
 /**
  * Factory for creating MCP connections with optional OAuth authentication.
@@ -49,16 +31,16 @@ export class MCPConnectionFactory {
 
   /** Creates a new MCP connection with optional OAuth support */
   static async create(
-    basic: BasicConnectionOptions,
-    oauth?: OAuthConnectionOptions,
+    basic: t.BasicConnectionOptions,
+    oauth?: t.OAuthConnectionOptions,
   ): Promise<MCPConnection> {
     const factory = new this(basic, oauth);
     return factory.createConnection();
   }
 
-  protected constructor(basic: BasicConnectionOptions, oauth?: OAuthConnectionOptions) {
+  protected constructor(basic: t.BasicConnectionOptions, oauth?: t.OAuthConnectionOptions) {
     this.serverConfig = processMCPEnv({
-      obj: basic.serverConfig,
+      options: basic.serverConfig,
       user: oauth?.user,
       customUserVars: oauth?.customUserVars,
     });

--- a/packages/api/src/mcp/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/MCPServersRegistry.ts
@@ -30,7 +30,7 @@ export class MCPServersRegistry {
 
   constructor(configs: t.MCPServers) {
     this.rawConfigs = configs;
-    this.parsedConfigs = mapValues(configs, (con) => processMCPEnv(con));
+    this.parsedConfigs = mapValues(configs, (con) => processMCPEnv({ obj: con }));
     this.connections = new ConnectionsRepository(configs);
   }
 

--- a/packages/api/src/mcp/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/MCPServersRegistry.ts
@@ -30,7 +30,7 @@ export class MCPServersRegistry {
 
   constructor(configs: t.MCPServers) {
     this.rawConfigs = configs;
-    this.parsedConfigs = mapValues(configs, (con) => processMCPEnv({ obj: con }));
+    this.parsedConfigs = mapValues(configs, (con) => processMCPEnv({ options: con }));
     this.connections = new ConnectionsRepository(configs);
   }
 

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -7,6 +7,7 @@ import type { MCPOAuthTokens } from '~/mcp/oauth';
 import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
 import { MCPServersRegistry } from '~/mcp/MCPServersRegistry';
 import { MCPConnection } from './connection';
+import type { RequestBody } from '~/types';
 import type * as t from './types';
 
 /**
@@ -47,6 +48,7 @@ export abstract class UserConnectionManager {
     serverName,
     flowManager,
     customUserVars,
+    requestBody,
     tokenMethods,
     oauthStart,
     oauthEnd,
@@ -57,6 +59,7 @@ export abstract class UserConnectionManager {
     serverName: string;
     flowManager: FlowStateManager<MCPOAuthTokens | null>;
     customUserVars?: Record<string, string>;
+    requestBody?: RequestBody;
     tokenMethods?: TokenMethods;
     oauthStart?: (authURL: string) => Promise<void>;
     oauthEnd?: () => Promise<void>;
@@ -127,6 +130,7 @@ export abstract class UserConnectionManager {
           oauthStart: oauthStart,
           oauthEnd: oauthEnd,
           returnOnOAuth: returnOnOAuth,
+          requestBody: requestBody,
         },
       );
 

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -1,14 +1,15 @@
 import { logger } from '@librechat/data-schemas';
+import type { TokenMethods } from '@librechat/data-schemas';
 import type { TUser } from 'librechat-data-provider';
 import type { FlowStateManager } from '~/flow/manager';
 import type { MCPOAuthTokens } from '~/mcp/oauth';
-import { MCPConnectionFactory } from '../MCPConnectionFactory';
+import type * as t from '~/mcp/types';
+import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
+import { MCPConnection } from '~/mcp/connection';
 import { MCPOAuthHandler } from '~/mcp/oauth';
-import { MCPConnection } from '../connection';
 import { processMCPEnv } from '~/utils';
-import type * as t from '../types';
 
-jest.mock('../connection');
+jest.mock('~/mcp/connection');
 jest.mock('~/mcp/oauth');
 jest.mock('~/utils');
 jest.mock('@librechat/data-schemas', () => ({
@@ -74,7 +75,7 @@ describe('MCPConnectionFactory', () => {
       const connection = await MCPConnectionFactory.create(basicOptions);
 
       expect(connection).toBe(mockConnectionInstance);
-      expect(mockProcessMCPEnv).toHaveBeenCalledWith({ obj: mockServerConfig });
+      expect(mockProcessMCPEnv).toHaveBeenCalledWith({ options: mockServerConfig });
       expect(mockMCPConnection).toHaveBeenCalledWith({
         serverName: 'test-server',
         serverConfig: mockServerConfig,
@@ -115,7 +116,7 @@ describe('MCPConnectionFactory', () => {
       const connection = await MCPConnectionFactory.create(basicOptions, oauthOptions);
 
       expect(connection).toBe(mockConnectionInstance);
-      expect(mockProcessMCPEnv).toHaveBeenCalledWith({ obj: mockServerConfig, user: mockUser });
+      expect(mockProcessMCPEnv).toHaveBeenCalledWith({ options: mockServerConfig, user: mockUser });
       expect(mockMCPConnection).toHaveBeenCalledWith({
         serverName: 'test-server',
         serverConfig: mockServerConfig,
@@ -132,12 +133,12 @@ describe('MCPConnectionFactory', () => {
         serverConfig: mockServerConfig,
       };
 
-      const oauthOptions = {
+      const oauthOptions: t.OAuthConnectionOptions = {
         useOAuth: true as const,
         user: mockUser,
         flowManager: mockFlowManager,
         tokenMethods: {
-          findToken: undefined as unknown as () => Promise<any>,
+          findToken: undefined as unknown as TokenMethods['findToken'],
           createToken: jest.fn(),
           updateToken: jest.fn(),
           deleteTokens: jest.fn(),

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -74,7 +74,7 @@ describe('MCPConnectionFactory', () => {
       const connection = await MCPConnectionFactory.create(basicOptions);
 
       expect(connection).toBe(mockConnectionInstance);
-      expect(mockProcessMCPEnv).toHaveBeenCalledWith(mockServerConfig, undefined, undefined);
+      expect(mockProcessMCPEnv).toHaveBeenCalledWith({ obj: mockServerConfig });
       expect(mockMCPConnection).toHaveBeenCalledWith({
         serverName: 'test-server',
         serverConfig: mockServerConfig,
@@ -115,7 +115,7 @@ describe('MCPConnectionFactory', () => {
       const connection = await MCPConnectionFactory.create(basicOptions, oauthOptions);
 
       expect(connection).toBe(mockConnectionInstance);
-      expect(mockProcessMCPEnv).toHaveBeenCalledWith(mockServerConfig, mockUser, undefined);
+      expect(mockProcessMCPEnv).toHaveBeenCalledWith({ obj: mockServerConfig, user: mockUser });
       expect(mockMCPConnection).toHaveBeenCalledWith({
         serverName: 'test-server',
         serverConfig: mockServerConfig,

--- a/packages/api/src/mcp/__tests__/MCPServersRegistry.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPServersRegistry.test.ts
@@ -25,7 +25,7 @@ jest.mock('@librechat/data-schemas', () => ({
 // Mock processMCPEnv to verify it's called and adds a processed marker
 jest.mock('~/utils', () => ({
   ...jest.requireActual('~/utils'),
-  processMCPEnv: jest.fn((config) => ({
+  processMCPEnv: jest.fn(({ obj: config }) => ({
     ...config,
     _processed: true, // Simple marker to verify processing occurred
   })),

--- a/packages/api/src/mcp/__tests__/MCPServersRegistry.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPServersRegistry.test.ts
@@ -25,8 +25,8 @@ jest.mock('@librechat/data-schemas', () => ({
 // Mock processMCPEnv to verify it's called and adds a processed marker
 jest.mock('~/utils', () => ({
   ...jest.requireActual('~/utils'),
-  processMCPEnv: jest.fn(({ obj: config }) => ({
-    ...config,
+  processMCPEnv: jest.fn(({ options }) => ({
+    ...options,
     _processed: true, // Simple marker to verify processing occurred
   })),
 }));

--- a/packages/api/src/mcp/__tests__/mcp.spec.ts
+++ b/packages/api/src/mcp/__tests__/mcp.spec.ts
@@ -178,7 +178,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(originalObj);
+      const result = processMCPEnv({ obj: originalObj });
 
       // Verify it's not the same object reference
       expect(result).not.toBe(originalObj);
@@ -203,7 +203,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj);
+      const result = processMCPEnv({ obj });
 
       expect('env' in result && result.env).toEqual({
         API_KEY: 'test-api-key-value',
@@ -225,7 +225,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user);
+      const result = processMCPEnv({ obj, user });
 
       expect('headers' in result && result.headers).toEqual({
         Authorization: 'test-api-key-value',
@@ -236,9 +236,9 @@ describe('Environment Variable Extraction (MCP)', () => {
 
     it('should handle null or undefined input', () => {
       // @ts-ignore - Testing null/undefined handling
-      expect(processMCPEnv(null)).toBeNull();
+      expect(processMCPEnv({ obj: null })).toBeNull();
       // @ts-ignore - Testing null/undefined handling
-      expect(processMCPEnv(undefined)).toBeUndefined();
+      expect(processMCPEnv({ obj: undefined })).toBeUndefined();
     });
 
     it('should not modify objects without env or headers', () => {
@@ -248,7 +248,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         timeout: 5000,
       };
 
-      const result = processMCPEnv(obj);
+      const result = processMCPEnv({ obj });
 
       expect(result).toEqual(obj);
       expect(result).not.toBe(obj); // Still a different object (deep clone)
@@ -269,8 +269,8 @@ describe('Environment Variable Extraction (MCP)', () => {
       const user1 = createTestUser({ id: 'user-123' });
       const user2 = createTestUser({ id: 'user-456' });
 
-      const resultUser1 = processMCPEnv(baseConfig, user1);
-      const resultUser2 = processMCPEnv(baseConfig, user2);
+      const resultUser1 = processMCPEnv({ obj: baseConfig, user: user1 });
+      const resultUser2 = processMCPEnv({ obj: baseConfig, user: user2 });
 
       // Verify each has the correct user ID
       expect('headers' in resultUser1 && resultUser1.headers?.['User-Id']).toBe('user-123');
@@ -303,7 +303,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user);
+      const result = processMCPEnv({ obj, user });
 
       expect('headers' in result && result.headers).toEqual({
         Authorization: 'test-api-key-value',
@@ -318,7 +318,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         url: 'https://example.com/api',
       };
 
-      const result = processMCPEnv(obj);
+      const result = processMCPEnv({ obj });
 
       expect(result.type).toBe('streamable-http');
     });
@@ -329,7 +329,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         url: 'https://example.com/api',
       };
 
-      const result = processMCPEnv(obj as unknown as MCPOptions);
+      const result = processMCPEnv({ obj: obj as unknown as MCPOptions });
 
       expect(result.type).toBe('http');
     });
@@ -346,7 +346,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj as unknown as MCPOptions, user);
+      const result = processMCPEnv({ obj: obj as unknown as MCPOptions, user });
 
       expect('headers' in result && result.headers).toEqual({
         Authorization: 'test-api-key-value',
@@ -379,7 +379,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user);
+      const result = processMCPEnv({ obj, user });
 
       expect('headers' in result && result.headers).toEqual({
         'User-Email': 'test@example.com',
@@ -408,7 +408,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user);
+      const result = processMCPEnv({ obj, user });
 
       expect('headers' in result && result.headers).toEqual({
         'User-Email': 'test@example.com',
@@ -433,7 +433,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user);
+      const result = processMCPEnv({ obj, user });
 
       expect('env' in result && result.env).toEqual({
         USER_EMAIL: 'test@example.com',
@@ -452,7 +452,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         url: 'https://example.com/api/{{LIBRECHAT_USER_USERNAME}}/stream',
       };
 
-      const result = processMCPEnv(obj, user);
+      const result = processMCPEnv({ obj, user });
 
       expect('url' in result && result.url).toBe('https://example.com/api/testuser/stream');
     });
@@ -474,7 +474,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user);
+      const result = processMCPEnv({ obj, user });
 
       expect('headers' in result && result.headers).toEqual({
         'Email-Verified': 'true',
@@ -498,7 +498,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user);
+      const result = processMCPEnv({ obj, user });
 
       expect('headers' in result && result.headers).toEqual({
         'User-Email': 'test@example.com',
@@ -521,7 +521,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user);
+      const result = processMCPEnv({ obj, user });
 
       expect('headers' in result && result.headers).toEqual({
         'Primary-Email': 'test@example.com',
@@ -544,7 +544,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result1 = processMCPEnv(obj1, userWithId);
+      const result1 = processMCPEnv({ obj: obj1, user: userWithId });
       expect('headers' in result1 && result1.headers?.['User-Id']).toBe('user-123');
 
       // Test with '_id' property only (should not work since we only check 'id')
@@ -561,7 +561,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result2 = processMCPEnv(obj2, userWithUnderscore);
+      const result2 = processMCPEnv({ obj: obj2, user: userWithUnderscore });
       // Since we don't check _id, the placeholder should remain unchanged
       expect('headers' in result2 && result2.headers?.['User-Id']).toBe('{{LIBRECHAT_USER_ID}}');
 
@@ -579,7 +579,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result3 = processMCPEnv(obj3, userWithBoth);
+      const result3 = processMCPEnv({ obj: obj3, user: userWithBoth });
       expect('headers' in result3 && result3.headers?.['User-Id']).toBe('user-789');
     });
 
@@ -600,7 +600,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user, customUserVars);
+      const result = processMCPEnv({ obj, user, customUserVars });
 
       expect('env' in result && result.env).toEqual({
         VAR_A: 'custom-value-1',
@@ -627,7 +627,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user, customUserVars);
+      const result = processMCPEnv({ obj, user, customUserVars });
 
       expect('headers' in result && result.headers).toEqual({
         Authorization: 'Bearer user-specific-token',
@@ -648,7 +648,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         url: 'wss://example.com/{{TENANT_ID}}/api/{{API_VERSION}}?user={{LIBRECHAT_USER_ID}}&key=${TEST_API_KEY}',
       };
 
-      const result = processMCPEnv(obj, user, customUserVars);
+      const result = processMCPEnv({ obj, user, customUserVars });
 
       expect('url' in result && result.url).toBe(
         'wss://example.com/tenant123/api/v2?user=test-user-id&key=test-api-key-value',
@@ -680,7 +680,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         ],
       };
 
-      const result = processMCPEnv(obj, user, customUserVars);
+      const result = processMCPEnv({ obj, user, customUserVars });
 
       expect('args' in result && result.args).toEqual([
         '-y',
@@ -712,7 +712,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user, customUserVars);
+      const result = processMCPEnv({ obj, user, customUserVars });
       expect('headers' in result && result.headers?.['Test-Email']).toBe('custom-email-wins');
 
       // Clean up env var
@@ -732,7 +732,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user, customUserVars);
+      const result = processMCPEnv({ obj, user, customUserVars });
       expect('env' in result && result.env).toEqual({
         API_KEY: 'test-api-key-value',
       });
@@ -752,7 +752,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user, customUserVars);
+      const result = processMCPEnv({ obj, user, customUserVars });
       expect('headers' in result && result.headers).toEqual({
         'User-Email-Header': 'user-provided-email@example.com',
         'System-Key-Header': 'test-api-key-value',
@@ -792,7 +792,11 @@ describe('Environment Variable Extraction (MCP)', () => {
       // Cast obj to MCPOptions when calling processMCPEnv.
       // This acknowledges the object might not strictly conform to one schema in the union,
       // but we are testing the function's ability to handle these properties if present.
-      const result = processMCPEnv(obj as MCPOptions, user, allCustomVarsForCall);
+      const result = processMCPEnv({
+        obj: obj as MCPOptions,
+        user,
+        customUserVars: allCustomVarsForCall,
+      });
 
       expect('url' in result && result.url).toBe('https://ep123.example.com/users/john.doe');
       expect('headers' in result && result.headers).toEqual({
@@ -824,7 +828,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user, customUserVars);
+      const result = processMCPEnv({ obj, user, customUserVars });
 
       expect('headers' in result && result.headers).toEqual({
         Authorization: 'ghp_1234567890abcdef1234567890abcdef12345678',
@@ -847,7 +851,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv(obj, user);
+      const result = processMCPEnv({ obj, user });
 
       expect('headers' in result && result.headers).toEqual({
         Authorization: '{{PAT_TOKEN}}', // Should remain unchanged since no customUserVars provided

--- a/packages/api/src/mcp/__tests__/mcp.spec.ts
+++ b/packages/api/src/mcp/__tests__/mcp.spec.ts
@@ -178,7 +178,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj: originalObj });
+      const result = processMCPEnv({ options: originalObj });
 
       // Verify it's not the same object reference
       expect(result).not.toBe(originalObj);
@@ -192,7 +192,7 @@ describe('Environment Variable Extraction (MCP)', () => {
     });
 
     it('should process environment variables in env field', () => {
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         command: 'node',
         args: ['server.js'],
         env: {
@@ -203,7 +203,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj });
+      const result = processMCPEnv({ options });
 
       expect('env' in result && result.env).toEqual({
         API_KEY: 'test-api-key-value',
@@ -215,7 +215,7 @@ describe('Environment Variable Extraction (MCP)', () => {
 
     it('should process user ID in headers field', () => {
       const user = createTestUser({ id: 'test-user-123' });
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'sse',
         url: 'https://example.com',
         headers: {
@@ -225,7 +225,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user });
+      const result = processMCPEnv({ options, user });
 
       expect('headers' in result && result.headers).toEqual({
         Authorization: 'test-api-key-value',
@@ -236,22 +236,22 @@ describe('Environment Variable Extraction (MCP)', () => {
 
     it('should handle null or undefined input', () => {
       // @ts-ignore - Testing null/undefined handling
-      expect(processMCPEnv({ obj: null })).toBeNull();
+      expect(processMCPEnv({ options: null })).toBeNull();
       // @ts-ignore - Testing null/undefined handling
-      expect(processMCPEnv({ obj: undefined })).toBeUndefined();
+      expect(processMCPEnv({ options: undefined })).toBeUndefined();
     });
 
     it('should not modify objects without env or headers', () => {
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         command: 'node',
         args: ['server.js'],
         timeout: 5000,
       };
 
-      const result = processMCPEnv({ obj });
+      const result = processMCPEnv({ options });
 
-      expect(result).toEqual(obj);
-      expect(result).not.toBe(obj); // Still a different object (deep clone)
+      expect(result).toEqual(options);
+      expect(result).not.toBe(options); // Still a different object (deep clone)
     });
 
     it('should ensure different users with same starting config get separate values', () => {
@@ -269,8 +269,8 @@ describe('Environment Variable Extraction (MCP)', () => {
       const user1 = createTestUser({ id: 'user-123' });
       const user2 = createTestUser({ id: 'user-456' });
 
-      const resultUser1 = processMCPEnv({ obj: baseConfig, user: user1 });
-      const resultUser2 = processMCPEnv({ obj: baseConfig, user: user2 });
+      const resultUser1 = processMCPEnv({ options: baseConfig, user: user1 });
+      const resultUser2 = processMCPEnv({ options: baseConfig, user: user2 });
 
       // Verify each has the correct user ID
       expect('headers' in resultUser1 && resultUser1.headers?.['User-Id']).toBe('user-123');
@@ -293,7 +293,7 @@ describe('Environment Variable Extraction (MCP)', () => {
 
     it('should process headers in streamable-http options', () => {
       const user = createTestUser({ id: 'test-user-123' });
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'streamable-http',
         url: 'https://example.com',
         headers: {
@@ -303,7 +303,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user });
+      const result = processMCPEnv({ options, user });
 
       expect('headers' in result && result.headers).toEqual({
         Authorization: 'test-api-key-value',
@@ -313,12 +313,12 @@ describe('Environment Variable Extraction (MCP)', () => {
     });
 
     it('should maintain streamable-http type in processed options', () => {
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'streamable-http',
         url: 'https://example.com/api',
       };
 
-      const result = processMCPEnv({ obj });
+      const result = processMCPEnv({ options });
 
       expect(result.type).toBe('streamable-http');
     });
@@ -329,7 +329,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         url: 'https://example.com/api',
       };
 
-      const result = processMCPEnv({ obj: obj as unknown as MCPOptions });
+      const result = processMCPEnv({ options: obj as unknown as MCPOptions });
 
       expect(result.type).toBe('http');
     });
@@ -346,7 +346,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj: obj as unknown as MCPOptions, user });
+      const result = processMCPEnv({ options: obj as unknown as MCPOptions, user });
 
       expect('headers' in result && result.headers).toEqual({
         Authorization: 'test-api-key-value',
@@ -365,7 +365,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         emailVerified: true,
         role: 'admin',
       });
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'sse',
         url: 'https://example.com',
         headers: {
@@ -379,7 +379,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user });
+      const result = processMCPEnv({ options, user });
 
       expect('headers' in result && result.headers).toEqual({
         'User-Email': 'test@example.com',
@@ -398,7 +398,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         email: 'test@example.com',
         username: undefined, // explicitly set to undefined to test missing field
       });
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'sse',
         url: 'https://example.com',
         headers: {
@@ -408,7 +408,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user });
+      const result = processMCPEnv({ options, user });
 
       expect('headers' in result && result.headers).toEqual({
         'User-Email': 'test@example.com',
@@ -423,7 +423,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         email: 'test@example.com',
         ldapId: 'ldap-user-123',
       });
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         command: 'node',
         args: ['server.js'],
         env: {
@@ -433,7 +433,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user });
+      const result = processMCPEnv({ options, user });
 
       expect('env' in result && result.env).toEqual({
         USER_EMAIL: 'test@example.com',
@@ -447,12 +447,12 @@ describe('Environment Variable Extraction (MCP)', () => {
         id: 'user-123',
         username: 'testuser',
       });
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'sse',
         url: 'https://example.com/api/{{LIBRECHAT_USER_USERNAME}}/stream',
       };
 
-      const result = processMCPEnv({ obj, user });
+      const result = processMCPEnv({ options, user });
 
       expect('url' in result && result.url).toBe('https://example.com/api/testuser/stream');
     });
@@ -464,7 +464,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         twoFactorEnabled: false,
         termsAccepted: true,
       });
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'sse',
         url: 'https://example.com',
         headers: {
@@ -474,7 +474,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user });
+      const result = processMCPEnv({ options, user });
 
       expect('headers' in result && result.headers).toEqual({
         'Email-Verified': 'true',
@@ -489,7 +489,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         email: 'test@example.com',
         password: 'secret-password',
       });
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'sse',
         url: 'https://example.com',
         headers: {
@@ -498,7 +498,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user });
+      const result = processMCPEnv({ options, user });
 
       expect('headers' in result && result.headers).toEqual({
         'User-Email': 'test@example.com',
@@ -511,7 +511,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         id: 'user-123',
         email: 'test@example.com',
       });
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'sse',
         url: 'https://example.com',
         headers: {
@@ -521,7 +521,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user });
+      const result = processMCPEnv({ options, user });
 
       expect('headers' in result && result.headers).toEqual({
         'Primary-Email': 'test@example.com',
@@ -544,7 +544,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result1 = processMCPEnv({ obj: obj1, user: userWithId });
+      const result1 = processMCPEnv({ options: obj1, user: userWithId });
       expect('headers' in result1 && result1.headers?.['User-Id']).toBe('user-123');
 
       // Test with '_id' property only (should not work since we only check 'id')
@@ -561,7 +561,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result2 = processMCPEnv({ obj: obj2, user: userWithUnderscore });
+      const result2 = processMCPEnv({ options: obj2, user: userWithUnderscore });
       // Since we don't check _id, the placeholder should remain unchanged
       expect('headers' in result2 && result2.headers?.['User-Id']).toBe('{{LIBRECHAT_USER_ID}}');
 
@@ -579,7 +579,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result3 = processMCPEnv({ obj: obj3, user: userWithBoth });
+      const result3 = processMCPEnv({ options: obj3, user: userWithBoth });
       expect('headers' in result3 && result3.headers?.['User-Id']).toBe('user-789');
     });
 
@@ -589,7 +589,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         CUSTOM_VAR_1: 'custom-value-1',
         CUSTOM_VAR_2: 'custom-value-2',
       };
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         command: 'node',
         args: ['server.js'],
         env: {
@@ -600,7 +600,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user, customUserVars });
+      const result = processMCPEnv({ options, user, customUserVars });
 
       expect('env' in result && result.env).toEqual({
         VAR_A: 'custom-value-1',
@@ -616,7 +616,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         USER_TOKEN: 'user-specific-token',
         REGION: 'us-west-1',
       };
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'sse',
         url: 'https://example.com/api',
         headers: {
@@ -627,7 +627,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user, customUserVars });
+      const result = processMCPEnv({ options, user, customUserVars });
 
       expect('headers' in result && result.headers).toEqual({
         Authorization: 'Bearer user-specific-token',
@@ -643,12 +643,12 @@ describe('Environment Variable Extraction (MCP)', () => {
         API_VERSION: 'v2',
         TENANT_ID: 'tenant123',
       };
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'websocket',
         url: 'wss://example.com/{{TENANT_ID}}/api/{{API_VERSION}}?user={{LIBRECHAT_USER_ID}}&key=${TEST_API_KEY}',
       };
 
-      const result = processMCPEnv({ obj, user, customUserVars });
+      const result = processMCPEnv({ options, user, customUserVars });
 
       expect('url' in result && result.url).toBe(
         'wss://example.com/tenant123/api/v2?user=test-user-id&key=test-api-key-value',
@@ -664,7 +664,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         MY_API_KEY: 'user-provided-api-key-12345',
         PROFILE_NAME: 'production-profile',
       };
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         command: 'npx',
         args: [
           '-y',
@@ -680,7 +680,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         ],
       };
 
-      const result = processMCPEnv({ obj, user, customUserVars });
+      const result = processMCPEnv({ options, user, customUserVars });
 
       expect('args' in result && result.args).toEqual([
         '-y',
@@ -704,7 +704,7 @@ describe('Environment Variable Extraction (MCP)', () => {
       const customUserVars = {
         LIBRECHAT_USER_EMAIL: 'custom-email-wins',
       };
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'sse',
         url: 'https://example.com/api',
         headers: {
@@ -712,7 +712,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user, customUserVars });
+      const result = processMCPEnv({ options, user, customUserVars });
       expect('headers' in result && result.headers?.['Test-Email']).toBe('custom-email-wins');
 
       // Clean up env var
@@ -724,7 +724,7 @@ describe('Environment Variable Extraction (MCP)', () => {
       const customUserVars = {
         UNUSED_VAR: 'unused-value',
       };
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         command: 'node',
         args: ['server.js'],
         env: {
@@ -732,7 +732,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user, customUserVars });
+      const result = processMCPEnv({ options, user, customUserVars });
       expect('env' in result && result.env).toEqual({
         API_KEY: 'test-api-key-value',
       });
@@ -742,7 +742,7 @@ describe('Environment Variable Extraction (MCP)', () => {
       const user = createTestUser({ email: 'user-provided-email@example.com' });
       // No customUserVars provided or customUserVars is empty
       const customUserVars = {};
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'sse',
         url: 'https://example.com/api',
         headers: {
@@ -752,7 +752,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user, customUserVars });
+      const result = processMCPEnv({ options, user, customUserVars });
       expect('headers' in result && result.headers).toEqual({
         'User-Email-Header': 'user-provided-email@example.com',
         'System-Key-Header': 'test-api-key-value',
@@ -793,7 +793,7 @@ describe('Environment Variable Extraction (MCP)', () => {
       // This acknowledges the object might not strictly conform to one schema in the union,
       // but we are testing the function's ability to handle these properties if present.
       const result = processMCPEnv({
-        obj: obj as MCPOptions,
+        options: obj as MCPOptions,
         user,
         customUserVars: allCustomVarsForCall,
       });
@@ -818,7 +818,7 @@ describe('Environment Variable Extraction (MCP)', () => {
       };
 
       // Simulate the GitHub MCP server configuration from librechat.yaml
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'streamable-http',
         url: 'https://api.githubcopilot.com/mcp/',
         headers: {
@@ -828,7 +828,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user, customUserVars });
+      const result = processMCPEnv({ options, user, customUserVars });
 
       expect('headers' in result && result.headers).toEqual({
         Authorization: 'ghp_1234567890abcdef1234567890abcdef12345678',
@@ -842,7 +842,7 @@ describe('Environment Variable Extraction (MCP)', () => {
     it('should handle GitHub MCP server configuration without PAT_TOKEN (placeholder remains)', () => {
       const user = createTestUser({ id: 'github-user-123' });
       // No customUserVars provided - PAT_TOKEN should remain as placeholder
-      const obj: MCPOptions = {
+      const options: MCPOptions = {
         type: 'streamable-http',
         url: 'https://api.githubcopilot.com/mcp/',
         headers: {
@@ -851,7 +851,7 @@ describe('Environment Variable Extraction (MCP)', () => {
         },
       };
 
-      const result = processMCPEnv({ obj, user });
+      const result = processMCPEnv({ options, user });
 
       expect('headers' in result && result.headers).toEqual({
         Authorization: '{{PAT_TOKEN}}', // Should remain unchanged since no customUserVars provided

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -7,9 +7,12 @@ import {
   WebSocketOptionsSchema,
   StreamableHTTPOptionsSchema,
 } from 'librechat-data-provider';
+import type { TPlugin, TUser } from 'librechat-data-provider';
 import type * as t from '@modelcontextprotocol/sdk/types.js';
-import type { TPlugin } from 'librechat-data-provider';
+import type { TokenMethods } from '@librechat/data-schemas';
+import type { FlowStateManager } from '~/flow/manager';
 import type { JsonSchemaType } from '~/types/zod';
+import type * as o from '~/mcp/oauth/types';
 
 export type StdioOptions = z.infer<typeof StdioOptionsSchema>;
 export type WebSocketOptions = z.infer<typeof WebSocketOptionsSchema>;
@@ -113,3 +116,20 @@ export type ParsedServerConfig = MCPOptions & {
   capabilities?: string;
   tools?: string;
 };
+
+export interface BasicConnectionOptions {
+  serverName: string;
+  serverConfig: MCPOptions;
+}
+
+export interface OAuthConnectionOptions {
+  useOAuth: true;
+  user: TUser;
+  customUserVars?: Record<string, string>;
+  flowManager: FlowStateManager<o.MCPOAuthTokens | null>;
+  tokenMethods?: TokenMethods;
+  signal?: AbortSignal;
+  oauthStart?: (authURL: string) => Promise<void>;
+  oauthEnd?: () => Promise<void>;
+  returnOnOAuth?: boolean;
+}

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -12,6 +12,7 @@ import type * as t from '@modelcontextprotocol/sdk/types.js';
 import type { TokenMethods } from '@librechat/data-schemas';
 import type { FlowStateManager } from '~/flow/manager';
 import type { JsonSchemaType } from '~/types/zod';
+import type { RequestBody } from '~/types/http';
 import type * as o from '~/mcp/oauth/types';
 
 export type StdioOptions = z.infer<typeof StdioOptionsSchema>;
@@ -123,8 +124,9 @@ export interface BasicConnectionOptions {
 }
 
 export interface OAuthConnectionOptions {
-  useOAuth: true;
   user: TUser;
+  useOAuth: true;
+  requestBody?: RequestBody;
   customUserVars?: Record<string, string>;
   flowManager: FlowStateManager<o.MCPOAuthTokens | null>;
   tokenMethods?: TokenMethods;

--- a/packages/api/src/types/http.ts
+++ b/packages/api/src/types/http.ts
@@ -1,0 +1,11 @@
+import type { Request } from 'express';
+
+/**
+ * LibreChat-specific request body type that extends Express Request body
+ * (have to use type alias because you can't extend indexed access types like Request['body'])
+ */
+export type RequestBody = Request['body'] & {
+  parentMessageId: string;
+  messageId: string;
+  conversationId?: string;
+};

--- a/packages/api/src/types/http.ts
+++ b/packages/api/src/types/http.ts
@@ -1,11 +1,9 @@
-import type { Request } from 'express';
-
 /**
  * LibreChat-specific request body type that extends Express Request body
  * (have to use type alias because you can't extend indexed access types like Request['body'])
  */
-export type RequestBody = Request['body'] & {
-  parentMessageId: string;
-  messageId: string;
+export type RequestBody = {
+  messageId?: string;
   conversationId?: string;
+  parentMessageId?: string;
 };

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -3,6 +3,7 @@ export * from './balance';
 export * from './events';
 export * from './error';
 export * from './google';
+export * from './http';
 export * from './mistral';
 export * from './openai';
 export * from './prompts';

--- a/packages/api/src/utils/env.spec.ts
+++ b/packages/api/src/utils/env.spec.ts
@@ -36,7 +36,9 @@ describe('resolveHeaders', () => {
   });
 
   it('should return empty object when headers is null', () => {
-    const result = resolveHeaders({ headers: null as unknown as Record<string, string> | null });
+    const result = resolveHeaders({
+      headers: null as unknown as Record<string, string>,
+    });
     expect(result).toEqual({});
   });
 

--- a/packages/api/src/utils/env.spec.ts
+++ b/packages/api/src/utils/env.spec.ts
@@ -426,4 +426,11 @@ describe('resolveHeaders', () => {
     expect(result['X-Empty']).toBe('');
     expect(result['X-Boolean']).toBe('true');
   });
+
+  it('should process LIBRECHAT_BODY placeholders', () => {
+    const body = { conversationId: 'conv-123', parentMessageId: 'parent-456', messageId: 'msg-789' };
+    const headers = { 'X-Conversation': '{{LIBRECHAT_BODY_CONVERSATIONID}}' };
+    const result = resolveHeaders(headers, undefined, undefined, body);
+    expect(result['X-Conversation']).toBe('conv-123');
+  });
 });

--- a/packages/api/src/utils/env.spec.ts
+++ b/packages/api/src/utils/env.spec.ts
@@ -36,12 +36,12 @@ describe('resolveHeaders', () => {
   });
 
   it('should return empty object when headers is null', () => {
-    const result = resolveHeaders(null as unknown as Record<string, string> | undefined);
+    const result = resolveHeaders({ headers: null as unknown as Record<string, string> | null });
     expect(result).toEqual({});
   });
 
   it('should return empty object when headers is empty', () => {
-    const result = resolveHeaders({});
+    const result = resolveHeaders({ headers: {} });
     expect(result).toEqual({});
   });
 
@@ -52,7 +52,7 @@ describe('resolveHeaders', () => {
       'Content-Type': 'application/json',
     };
 
-    const result = resolveHeaders(headers);
+    const result = resolveHeaders({ headers });
 
     expect(result).toEqual({
       Authorization: 'test-api-key-value',
@@ -68,7 +68,7 @@ describe('resolveHeaders', () => {
       'Content-Type': 'application/json',
     };
 
-    const result = resolveHeaders(headers, user);
+    const result = resolveHeaders({ headers, user });
 
     expect(result).toEqual({
       'User-Id': 'test-user-123',
@@ -82,7 +82,7 @@ describe('resolveHeaders', () => {
       'Content-Type': 'application/json',
     };
 
-    const result = resolveHeaders(headers);
+    const result = resolveHeaders({ headers });
 
     expect(result).toEqual({
       'User-Id': '{{LIBRECHAT_USER_ID}}',
@@ -97,7 +97,7 @@ describe('resolveHeaders', () => {
       'Content-Type': 'application/json',
     };
 
-    const result = resolveHeaders(headers, user);
+    const result = resolveHeaders({ headers, user });
 
     expect(result).toEqual({
       'User-Id': '{{LIBRECHAT_USER_ID}}',
@@ -123,7 +123,7 @@ describe('resolveHeaders', () => {
       'Content-Type': 'application/json',
     };
 
-    const result = resolveHeaders(headers, user);
+    const result = resolveHeaders({ headers, user });
 
     expect(result).toEqual({
       'User-Email': 'test@example.com',
@@ -148,7 +148,7 @@ describe('resolveHeaders', () => {
       'Non-Existent': '{{LIBRECHAT_USER_NONEXISTENT}}',
     };
 
-    const result = resolveHeaders(headers, user);
+    const result = resolveHeaders({ headers, user });
 
     expect(result).toEqual({
       'User-Email': 'test@example.com',
@@ -171,7 +171,7 @@ describe('resolveHeaders', () => {
       'X-User-Id': '{{LIBRECHAT_USER_ID}}',
     };
 
-    const result = resolveHeaders(headers, user, customUserVars);
+    const result = resolveHeaders({ headers, user, customUserVars });
 
     expect(result).toEqual({
       Authorization: 'Bearer user-specific-token',
@@ -194,7 +194,7 @@ describe('resolveHeaders', () => {
       'Test-Email': '{{LIBRECHAT_USER_EMAIL}}',
     };
 
-    const result = resolveHeaders(headers, user, customUserVars);
+    const result = resolveHeaders({ headers, user, customUserVars });
 
     expect(result).toEqual({
       'Test-Email': 'custom-email@example.com',
@@ -213,7 +213,7 @@ describe('resolveHeaders', () => {
       'User-Id': '{{LIBRECHAT_USER_ID}}',
     };
 
-    const result = resolveHeaders(headers, user);
+    const result = resolveHeaders({ headers, user });
 
     expect(result).toEqual({
       'User-Role': 'admin',
@@ -233,7 +233,7 @@ describe('resolveHeaders', () => {
       'Backup-Email': '{{LIBRECHAT_USER_EMAIL}}',
     };
 
-    const result = resolveHeaders(headers, user);
+    const result = resolveHeaders({ headers, user });
 
     expect(result).toEqual({
       'Primary-Email': 'test@example.com',
@@ -259,7 +259,7 @@ describe('resolveHeaders', () => {
       'Content-Type': 'application/json',
     };
 
-    const result = resolveHeaders(headers, user, customUserVars);
+    const result = resolveHeaders({ headers, user, customUserVars });
 
     expect(result).toEqual({
       Authorization: 'Bearer secret-token',
@@ -277,7 +277,7 @@ describe('resolveHeaders', () => {
     };
     const user = { id: 'user-123' };
 
-    const result = resolveHeaders(originalHeaders, user);
+    const result = resolveHeaders({ headers: originalHeaders, user });
 
     // Verify the result is processed
     expect(result).toEqual({
@@ -306,7 +306,7 @@ describe('resolveHeaders', () => {
       'Dot-Header': '{{CUSTOM.VAR}}',
     };
 
-    const result = resolveHeaders(headers, user, customUserVars);
+    const result = resolveHeaders({ headers, user, customUserVars });
 
     expect(result).toEqual({
       'Dash-Header': 'dash-value',
@@ -357,7 +357,7 @@ describe('resolveHeaders', () => {
       'X-User-TermsAccepted': '{{LIBRECHAT_USER_TERMSACCEPTED}}',
     };
 
-    const result = resolveHeaders(headers, user);
+    const result = resolveHeaders({ headers, user });
 
     expect(result['X-User-ID']).toBe('abc');
     expect(result['X-User-Name']).toBe('Test User');
@@ -384,7 +384,7 @@ describe('resolveHeaders', () => {
       'X-Multi': 'User: {{LIBRECHAT_USER_ID}}, Env: ${TEST_API_KEY}, Custom: {{MY_CUSTOM}}',
     };
     const customVars = { MY_CUSTOM: 'custom-value' };
-    const result = resolveHeaders(headers, user, customVars);
+    const result = resolveHeaders({ headers, user, customUserVars: customVars });
     expect(result['X-Multi']).toBe('User: abc, Env: test-api-key-value, Custom: custom-value');
   });
 
@@ -394,7 +394,7 @@ describe('resolveHeaders', () => {
       'X-Unknown': '{{SOMETHING_NOT_RECOGNIZED}}',
       'X-Known': '{{LIBRECHAT_USER_ID}}',
     };
-    const result = resolveHeaders(headers, user);
+    const result = resolveHeaders({ headers, user });
     expect(result['X-Unknown']).toBe('{{SOMETHING_NOT_RECOGNIZED}}');
     expect(result['X-Known']).toBe('abc');
   });
@@ -416,7 +416,7 @@ describe('resolveHeaders', () => {
       'X-Boolean': '{{LIBRECHAT_USER_EMAILVERIFIED}}',
     };
     const customVars = { MY_CUSTOM: 'custom-value' };
-    const result = resolveHeaders(headers, user, customVars);
+    const result = resolveHeaders({ headers, user, customUserVars: customVars });
 
     expect(result['X-User']).toBe('abc');
     expect(result['X-Env']).toBe('test-api-key-value');
@@ -430,7 +430,7 @@ describe('resolveHeaders', () => {
   it('should process LIBRECHAT_BODY placeholders', () => {
     const body = { conversationId: 'conv-123', parentMessageId: 'parent-456', messageId: 'msg-789' };
     const headers = { 'X-Conversation': '{{LIBRECHAT_BODY_CONVERSATIONID}}' };
-    const result = resolveHeaders(headers, undefined, undefined, body);
+    const result = resolveHeaders({ headers, body });
     expect(result['X-Conversation']).toBe('conv-123');
   });
 });

--- a/packages/api/src/utils/env.spec.ts
+++ b/packages/api/src/utils/env.spec.ts
@@ -428,7 +428,11 @@ describe('resolveHeaders', () => {
   });
 
   it('should process LIBRECHAT_BODY placeholders', () => {
-    const body = { conversationId: 'conv-123', parentMessageId: 'parent-456', messageId: 'msg-789' };
+    const body = {
+      conversationId: 'conv-123',
+      parentMessageId: 'parent-456',
+      messageId: 'msg-789',
+    };
     const headers = { 'X-Conversation': '{{LIBRECHAT_BODY_CONVERSATIONID}}' };
     const result = resolveHeaders({ headers, body });
     expect(result['X-Conversation']).toBe('conv-123');

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -1,5 +1,6 @@
 import { extractEnvVariable } from 'librechat-data-provider';
-import type { TUser, MCPOptions, RequestBody } from 'librechat-data-provider';
+import type { TUser, MCPOptions } from 'librechat-data-provider';
+import type { RequestBody } from '~/types';
 
 /**
  * List of allowed user fields that can be used in MCP environment variables.

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -140,25 +140,25 @@ function processSingleValue({
 /**
  * Recursively processes an object to replace environment variables in string values
  * @param params - Processing parameters
- * @param params.obj - The object to process
+ * @param params.options - The MCP options to process
  * @param params.user - The user object containing all user fields
  * @param params.customUserVars - vars that user set in settings
  * @param params.body - the body of the request that is being processed
  * @returns - The processed object with environment variables replaced
  */
 export function processMCPEnv(params: {
-  obj: Readonly<MCPOptions>;
+  options: Readonly<MCPOptions>;
   user?: TUser;
   customUserVars?: Record<string, string>;
   body?: RequestBody;
 }): MCPOptions {
-  const { obj, user, customUserVars, body } = params;
+  const { options, user, customUserVars, body } = params;
 
-  if (obj === null || obj === undefined) {
-    return obj;
+  if (options === null || options === undefined) {
+    return options;
   }
 
-  const newObj: MCPOptions = structuredClone(obj);
+  const newObj: MCPOptions = structuredClone(options);
 
   if ('env' in newObj && newObj.env) {
     const processedEnv: Record<string, string> = {};

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -141,12 +141,14 @@ function processSingleValue({
  * @param obj - The object to process
  * @param user - The user object containing all user fields
  * @param customUserVars - vars that user set in settings
+ * @param body - the body of the request that is being processed
  * @returns - The processed object with environment variables replaced
  */
 export function processMCPEnv(
   obj: Readonly<MCPOptions>,
   user?: TUser,
   customUserVars?: Record<string, string>,
+  body?: RequestBody,
 ): MCPOptions {
   if (obj === null || obj === undefined) {
     return obj;
@@ -157,7 +159,7 @@ export function processMCPEnv(
   if ('env' in newObj && newObj.env) {
     const processedEnv: Record<string, string> = {};
     for (const [key, originalValue] of Object.entries(newObj.env)) {
-      processedEnv[key] = processSingleValue({ originalValue, customUserVars, user });
+      processedEnv[key] = processSingleValue({ originalValue, customUserVars, user, body });
     }
     newObj.env = processedEnv;
   }
@@ -165,7 +167,7 @@ export function processMCPEnv(
   if ('args' in newObj && newObj.args) {
     const processedArgs: string[] = [];
     for (const originalValue of newObj.args) {
-      processedArgs.push(processSingleValue({ originalValue, customUserVars, user }));
+      processedArgs.push(processSingleValue({ originalValue, customUserVars, user, body }));
     }
     newObj.args = processedArgs;
   }
@@ -175,14 +177,14 @@ export function processMCPEnv(
   if ('headers' in newObj && newObj.headers) {
     const processedHeaders: Record<string, string> = {};
     for (const [key, originalValue] of Object.entries(newObj.headers)) {
-      processedHeaders[key] = processSingleValue({ originalValue, customUserVars, user });
+      processedHeaders[key] = processSingleValue({ originalValue, customUserVars, user, body });
     }
     newObj.headers = processedHeaders;
   }
 
   // Process URL if it exists (for WebSocket, SSE, StreamableHTTP types)
   if ('url' in newObj && newObj.url) {
-    newObj.url = processSingleValue({ originalValue: newObj.url, customUserVars, user });
+    newObj.url = processSingleValue({ originalValue: newObj.url, customUserVars, user, body });
   }
 
   return newObj;

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -29,11 +29,7 @@ const ALLOWED_USER_FIELDS = [
  * List of allowed request body fields that can be used in header placeholders.
  * These are common fields from the request body that are safe to expose in headers.
  */
-const ALLOWED_BODY_FIELDS = [
-  'conversationId',
-  'parentMessageId',
-  'messageId'
-] as const;
+const ALLOWED_BODY_FIELDS = ['conversationId', 'parentMessageId', 'messageId'] as const;
 
 /**
  * Processes a string value to replace user field placeholders
@@ -81,7 +77,6 @@ function processUserPlaceholders(value: string, user?: TUser): string {
  * @returns The processed string with placeholders replaced
  */
 function processBodyPlaceholders(value: string, body: RequestBody): string {
-
   for (const field of ALLOWED_BODY_FIELDS) {
     const placeholder = `{{LIBRECHAT_BODY_${field.toUpperCase()}}}`;
     if (!value.includes(placeholder)) {
@@ -195,7 +190,7 @@ export function processMCPEnv(
 
 /**
  * Resolves header values by replacing user placeholders, body variables, custom variables, and environment variables.
- * 
+ *
  * @param options - Optional configuration object.
  * @param options.headers - The headers object to process.
  * @param options.user - Optional user object for replacing user field placeholders (can be partial with just id).

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -139,18 +139,21 @@ function processSingleValue({
 
 /**
  * Recursively processes an object to replace environment variables in string values
- * @param obj - The object to process
- * @param user - The user object containing all user fields
- * @param customUserVars - vars that user set in settings
- * @param body - the body of the request that is being processed
+ * @param params - Processing parameters
+ * @param params.obj - The object to process
+ * @param params.user - The user object containing all user fields
+ * @param params.customUserVars - vars that user set in settings
+ * @param params.body - the body of the request that is being processed
  * @returns - The processed object with environment variables replaced
  */
-export function processMCPEnv(
-  obj: Readonly<MCPOptions>,
-  user?: TUser,
-  customUserVars?: Record<string, string>,
-  body?: RequestBody,
-): MCPOptions {
+export function processMCPEnv(params: {
+  obj: Readonly<MCPOptions>;
+  user?: TUser;
+  customUserVars?: Record<string, string>;
+  body?: RequestBody;
+}): MCPOptions {
+  const { obj, user, customUserVars, body } = params;
+
   if (obj === null || obj === undefined) {
     return obj;
   }

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -25,7 +25,6 @@ export * from './types/mutations';
 export * from './types/queries';
 export * from './types/runs';
 export * from './types/web';
-export * from './types/http';
 export * from './types/graph';
 /* access permissions */
 export * from './accessPermissions';

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -25,6 +25,7 @@ export * from './types/mutations';
 export * from './types/queries';
 export * from './types/runs';
 export * from './types/web';
+export * from './types/http';
 export * from './types/graph';
 /* access permissions */
 export * from './accessPermissions';

--- a/packages/data-provider/src/types/http.ts
+++ b/packages/data-provider/src/types/http.ts
@@ -1,0 +1,7 @@
+export interface RequestBody {
+  parentMessageId: string;
+  messageId: string;
+  conversationId?: string;
+  [key: string]: unknown;
+}
+

--- a/packages/data-provider/src/types/http.ts
+++ b/packages/data-provider/src/types/http.ts
@@ -4,4 +4,3 @@ export interface RequestBody {
   conversationId?: string;
   [key: string]: unknown;
 }
-

--- a/packages/data-provider/src/types/http.ts
+++ b/packages/data-provider/src/types/http.ts
@@ -1,6 +1,0 @@
-export interface RequestBody {
-  parentMessageId: string;
-  messageId: string;
-  conversationId?: string;
-  [key: string]: unknown;
-}


### PR DESCRIPTION
## Summary

Originally #8601 

feat: add support for request body placeholders in custom endpoint headers

- Add {{LIBRECHAT_BODY_*}} placeholders for conversationId, parentMessageId, messageId

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

endpoints:
  custom:
    - name: 'customllm'
      apiKey: 'KEY'
      baseURL: 'http://host.docker.internal:8001/v1'
      models:
        default:
          [
            'mycustommodel'
          ]
        fetch: false
      titleConvo: true
      titleModel: 'current_model'
      modelDisplayLabel: 'mycustommodel'
      headers:
        X-Conversation-ID: "{{LIBRECHAT_BODY_CONVERSATIONID}}"
        
## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted. https://github.com/LibreChat-AI/librechat.ai/pull/386

