### PR TITLE
📁 feat: Send Attachments Directly to Provider (OpenAI)

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -322,7 +322,8 @@ class AgentClient extends BaseClient {
         message.documents &&
         message.documents.length > 0 &&
         message.isCreatedByUser &&
-        this.options.agent.provider === EModelEndpoint.anthropic
+        (this.options.agent.provider === EModelEndpoint.anthropic ||
+          this.options.agent.provider === EModelEndpoint.openAI)
       ) {
         const contentParts = [];
         contentParts.push(...message.documents);

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -323,7 +323,8 @@ class AgentClient extends BaseClient {
         message.documents.length > 0 &&
         message.isCreatedByUser &&
         (this.options.agent.provider === EModelEndpoint.anthropic ||
-          this.options.agent.provider === EModelEndpoint.openAI)
+          this.options.agent.provider === EModelEndpoint.openAI ||
+          this.options.agent.provider === EModelEndpoint.azureOpenAI)
       ) {
         const contentParts = [];
         contentParts.push(...message.documents);

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -40,6 +40,7 @@ const {
   setMemory,
 } = require('~/models');
 const { getMCPAuthMap, checkCapability, hasCustomUserVars } = require('~/server/services/Config');
+const { encodeAndFormatDocuments } = require('~/server/services/Files/documents/encode');
 const { addCacheControl, createContextHandlers } = require('~/app/clients/prompts');
 const { initializeAgent } = require('~/server/services/Endpoints/agents/agent');
 const { spendTokens, spendStructuredTokens } = require('~/models/spendTokens');
@@ -227,12 +228,11 @@ class AgentClient extends BaseClient {
   }
 
   async addDocuments(message, attachments) {
-    const documentResult =
-      await require('~/server/services/Files/documents').encodeAndFormatDocuments(
-        this.options.req,
-        attachments,
-        this.options.agent.provider,
-      );
+    const documentResult = await encodeAndFormatDocuments(
+      this.options.req,
+      attachments,
+      this.options.agent.provider,
+    );
     message.documents =
       documentResult.documents && documentResult.documents.length
         ? documentResult.documents

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -32,6 +32,7 @@ const {
   AgentCapabilities,
   bedrockInputSchema,
   removeNullishValues,
+  isDocumentSupportedEndpoint,
 } = require('librechat-data-provider');
 const {
   findPluginAuthsByKeys,
@@ -322,9 +323,7 @@ class AgentClient extends BaseClient {
         message.documents &&
         message.documents.length > 0 &&
         message.isCreatedByUser &&
-        (this.options.agent.provider === EModelEndpoint.anthropic ||
-          this.options.agent.provider === EModelEndpoint.openAI ||
-          this.options.agent.provider === EModelEndpoint.azureOpenAI)
+        isDocumentSupportedEndpoint(this.options.agent.provider)
       ) {
         const contentParts = [];
         contentParts.push(...message.documents);

--- a/api/server/services/Files/documents/encode.js
+++ b/api/server/services/Files/documents/encode.js
@@ -73,7 +73,9 @@ async function encodeAndFormatDocuments(req, files, endpoint) {
 
     if (
       file.type !== 'application/pdf' ||
-      (endpoint !== EModelEndpoint.anthropic && endpoint !== EModelEndpoint.openAI)
+      (endpoint !== EModelEndpoint.anthropic &&
+        endpoint !== EModelEndpoint.openAI &&
+        endpoint !== EModelEndpoint.azureOpenAI)
     ) {
       continue;
     }

--- a/api/server/services/Files/documents/encode.js
+++ b/api/server/services/Files/documents/encode.js
@@ -1,6 +1,6 @@
 const { EModelEndpoint } = require('librechat-data-provider');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
-const { validateAnthropicPdf } = require('@librechat/api');
+const { validatePdf } = require('@librechat/api');
 
 /**
  * Converts a readable stream to a buffer.
@@ -132,9 +132,12 @@ async function encodeAndFormatDocuments(req, files, endpoint) {
       continue;
     }
 
-    if (file.type === 'application/pdf' && endpoint === EModelEndpoint.anthropic) {
+    if (
+      file.type === 'application/pdf' &&
+      (endpoint === EModelEndpoint.anthropic || endpoint === EModelEndpoint.openAI)
+    ) {
       const pdfBuffer = Buffer.from(content, 'base64');
-      const validation = await validateAnthropicPdf(pdfBuffer, pdfBuffer.length);
+      const validation = await validatePdf(pdfBuffer, pdfBuffer.length, endpoint);
 
       if (!validation.isValid) {
         throw new Error(`PDF validation failed: ${validation.error}`);

--- a/api/server/services/Files/documents/encode.js
+++ b/api/server/services/Files/documents/encode.js
@@ -71,7 +71,10 @@ async function encodeAndFormatDocuments(req, files, endpoint) {
     /** @type {FileSources} */
     const source = file.source ?? 'local';
 
-    if (file.type !== 'application/pdf' || endpoint !== EModelEndpoint.anthropic) {
+    if (
+      file.type !== 'application/pdf' ||
+      (endpoint !== EModelEndpoint.anthropic && endpoint !== EModelEndpoint.openAI)
+    ) {
       continue;
     }
 

--- a/api/server/services/Files/documents/encode.js
+++ b/api/server/services/Files/documents/encode.js
@@ -143,18 +143,27 @@ async function encodeAndFormatDocuments(req, files, endpoint) {
         throw new Error(`PDF validation failed: ${validation.error}`);
       }
 
-      const documentPart = {
-        type: 'document',
-        source: {
-          type: 'base64',
-          media_type: 'application/pdf',
-          data: content,
-        },
-        cache_control: { type: 'ephemeral' },
-        citations: { enabled: true },
-      };
+      if (endpoint === EModelEndpoint.anthropic) {
+        const documentPart = {
+          type: 'document',
+          source: {
+            type: 'base64',
+            media_type: 'application/pdf',
+            data: content,
+          },
+          cache_control: { type: 'ephemeral' },
+          citations: { enabled: true },
+        };
+        result.documents.push(documentPart);
+      } else if (endpoint === EModelEndpoint.openAI) {
+        const documentPart = {
+          type: 'input_file',
+          filename: file.filename,
+          file_data: `data:application/pdf;base64,${content}`,
+        };
+        result.documents.push(documentPart);
+      }
 
-      result.documents.push(documentPart);
       result.files.push(metadata);
     }
   }

--- a/api/server/services/Files/documents/encode.js
+++ b/api/server/services/Files/documents/encode.js
@@ -1,6 +1,6 @@
 const { EModelEndpoint } = require('librechat-data-provider');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
-const { validateAnthropicPdf } = require('../validation/pdfValidator');
+const { validateAnthropicPdf } = require('@librechat/api');
 
 /**
  * Converts a readable stream to a buffer.

--- a/api/server/services/Files/documents/encode.js
+++ b/api/server/services/Files/documents/encode.js
@@ -1,4 +1,4 @@
-const { EModelEndpoint } = require('librechat-data-provider');
+const { EModelEndpoint, isDocumentSupportedEndpoint } = require('librechat-data-provider');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { validatePdf } = require('@librechat/api');
 
@@ -71,12 +71,7 @@ async function encodeAndFormatDocuments(req, files, endpoint) {
     /** @type {FileSources} */
     const source = file.source ?? 'local';
 
-    if (
-      file.type !== 'application/pdf' ||
-      (endpoint !== EModelEndpoint.anthropic &&
-        endpoint !== EModelEndpoint.openAI &&
-        endpoint !== EModelEndpoint.azureOpenAI)
-    ) {
+    if (file.type !== 'application/pdf' || !isDocumentSupportedEndpoint(endpoint)) {
       continue;
     }
 
@@ -137,10 +132,7 @@ async function encodeAndFormatDocuments(req, files, endpoint) {
       continue;
     }
 
-    if (
-      file.type === 'application/pdf' &&
-      (endpoint === EModelEndpoint.anthropic || endpoint === EModelEndpoint.openAI)
-    ) {
+    if (file.type === 'application/pdf' && isDocumentSupportedEndpoint(endpoint)) {
       const pdfBuffer = Buffer.from(content, 'base64');
       const validation = await validatePdf(pdfBuffer, pdfBuffer.length, endpoint);
 

--- a/client/src/common/agents-types.ts
+++ b/client/src/common/agents-types.ts
@@ -21,7 +21,7 @@ export type TAgentCapabilities = {
   [AgentCapabilities.execute_code]: boolean;
   [AgentCapabilities.end_after_tools]?: boolean;
   [AgentCapabilities.hide_sequential_outputs]?: boolean;
-  [AgentCapabilities.direct_upload]?: boolean;
+  [AgentCapabilities.direct_attach]?: boolean;
 };
 
 export type AgentForm = {

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -98,9 +98,9 @@ const AttachFileMenu = ({
 
       // this is temporary until i add direct upload support for the other providers and can make a more robust solution
       const isAnthropicAgent = agent?.provider === 'anthropic';
-      const shouldShowDirectUpload = endpoint === EModelEndpoint.anthropic || isAnthropicAgent;
+      const shouldShowDirectAttach = endpoint === EModelEndpoint.anthropic || isAnthropicAgent;
 
-      if (!shouldShowDirectUpload) {
+      if (!shouldShowDirectAttach) {
         items.push({
           label: localize('com_ui_upload_image_input'),
           onClick: () => {
@@ -111,11 +111,11 @@ const AttachFileMenu = ({
         });
       }
 
-      if (shouldShowDirectUpload) {
+      if (shouldShowDirectAttach) {
         items.push({
           label: localize('com_ui_upload_provider'),
           onClick: () => {
-            setToolResource(EToolResources.direct_upload);
+            setToolResource(EToolResources.direct_attach);
             onAction('anthropic_multimodal');
           },
           icon: <FileImageIcon className="icon-md" />,

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -99,11 +99,14 @@ const AttachFileMenu = ({
       // this is temporary until i add direct upload support for the other providers and can make a more robust solution
       const isAnthropicAgent = agent?.provider === 'anthropic';
       const isOpenAIAgent = agent?.provider === 'openai';
+      const isAzureOpenAIAgent = agent?.provider === 'azureOpenAI';
       const shouldShowDirectAttach =
         endpoint === EModelEndpoint.anthropic ||
         endpoint === EModelEndpoint.openAI ||
+        endpoint === EModelEndpoint.azureOpenAI ||
         isAnthropicAgent ||
-        isOpenAIAgent;
+        isOpenAIAgent ||
+        isAzureOpenAIAgent;
 
       if (!shouldShowDirectAttach) {
         items.push({

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -103,17 +103,6 @@ const AttachFileMenu = ({
 
       const shouldShowDirectAttach = isDocumentSupportedEndpoint(agent?.provider ?? endpoint);
 
-      if (!shouldShowDirectAttach) {
-        items.push({
-          label: localize('com_ui_upload_image_input'),
-          onClick: () => {
-            setToolResource(undefined);
-            onAction('image');
-          },
-          icon: <ImageUpIcon className="icon-md" />,
-        });
-      }
-
       if (shouldShowDirectAttach) {
         items.push({
           label: localize('com_ui_upload_provider'),
@@ -122,6 +111,15 @@ const AttachFileMenu = ({
             onAction('anthropic_multimodal');
           },
           icon: <FileImageIcon className="icon-md" />,
+        });
+      } else {
+        items.push({
+          label: localize('com_ui_upload_image_input'),
+          onClick: () => {
+            setToolResource(undefined);
+            onAction('image');
+          },
+          icon: <ImageUpIcon className="icon-md" />,
         });
       }
 

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -98,7 +98,12 @@ const AttachFileMenu = ({
 
       // this is temporary until i add direct upload support for the other providers and can make a more robust solution
       const isAnthropicAgent = agent?.provider === 'anthropic';
-      const shouldShowDirectAttach = endpoint === EModelEndpoint.anthropic || isAnthropicAgent;
+      const isOpenAIAgent = agent?.provider === 'openai';
+      const shouldShowDirectAttach =
+        endpoint === EModelEndpoint.anthropic ||
+        endpoint === EModelEndpoint.openAI ||
+        isAnthropicAgent ||
+        isOpenAIAgent;
 
       if (!shouldShowDirectAttach) {
         items.push({

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -77,7 +77,7 @@ const AttachFileMenu = ({
    * */
   const capabilities = useAgentCapabilities(agentsConfig?.capabilities ?? defaultAgentCapabilities);
 
-  const handleUploadClick = (fileType?: 'image' | 'document' | 'anthropic_multimodal') => {
+  const handleUploadClick = (fileType?: 'image' | 'document' | 'multimodal') => {
     if (!inputRef.current) {
       return;
     }
@@ -86,7 +86,7 @@ const AttachFileMenu = ({
       inputRef.current.accept = 'image/*';
     } else if (fileType === 'document') {
       inputRef.current.accept = '.pdf,application/pdf';
-    } else if (fileType === 'anthropic_multimodal') {
+    } else if (fileType === 'multimodal') {
       inputRef.current.accept = 'image/*,.pdf,application/pdf';
     } else {
       inputRef.current.accept = '';
@@ -97,7 +97,7 @@ const AttachFileMenu = ({
 
   const dropdownItems = useMemo(() => {
     const createMenuItems = (
-      onAction: (fileType?: 'image' | 'document' | 'anthropic_multimodal') => void,
+      onAction: (fileType?: 'image' | 'document' | 'multimodal') => void,
     ) => {
       const items: MenuItemProps[] = [];
 
@@ -108,7 +108,7 @@ const AttachFileMenu = ({
           label: localize('com_ui_upload_provider'),
           onClick: () => {
             setToolResource(EToolResources.direct_attach);
-            onAction('anthropic_multimodal');
+            onAction('multimodal');
           },
           icon: <FileImageIcon className="icon-md" />,
         });

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -8,7 +8,12 @@ import {
   FileType2Icon,
   FileImageIcon,
 } from 'lucide-react';
-import { EToolResources, EModelEndpoint, defaultAgentCapabilities } from 'librechat-data-provider';
+import {
+  EToolResources,
+  EModelEndpoint,
+  defaultAgentCapabilities,
+  isDocumentSupportedEndpoint,
+} from 'librechat-data-provider';
 import {
   FileUpload,
   TooltipAnchor,
@@ -96,17 +101,7 @@ const AttachFileMenu = ({
     ) => {
       const items: MenuItemProps[] = [];
 
-      // this is temporary until i add direct upload support for the other providers and can make a more robust solution
-      const isAnthropicAgent = agent?.provider === 'anthropic';
-      const isOpenAIAgent = agent?.provider === 'openai';
-      const isAzureOpenAIAgent = agent?.provider === 'azureOpenAI';
-      const shouldShowDirectAttach =
-        endpoint === EModelEndpoint.anthropic ||
-        endpoint === EModelEndpoint.openAI ||
-        endpoint === EModelEndpoint.azureOpenAI ||
-        isAnthropicAgent ||
-        isOpenAIAgent ||
-        isAzureOpenAIAgent;
+      const shouldShowDirectAttach = isDocumentSupportedEndpoint(agent?.provider ?? endpoint);
 
       if (!shouldShowDirectAttach) {
         items.push({

--- a/client/src/hooks/Agents/useAgentCapabilities.ts
+++ b/client/src/hooks/Agents/useAgentCapabilities.ts
@@ -9,7 +9,7 @@ interface AgentCapabilitiesResult {
   fileSearchEnabled: boolean;
   webSearchEnabled: boolean;
   codeEnabled: boolean;
-  directUploadEnabled: boolean;
+  directAttachEnabled: boolean;
 }
 
 export default function useAgentCapabilities(
@@ -50,8 +50,8 @@ export default function useAgentCapabilities(
     [capabilities],
   );
 
-  const directUploadEnabled = useMemo(
-    () => capabilities?.includes(AgentCapabilities.direct_upload) ?? false,
+  const directAttachEnabled = useMemo(
+    () => capabilities?.includes(AgentCapabilities.direct_attach) ?? false,
     [capabilities],
   );
 
@@ -63,6 +63,6 @@ export default function useAgentCapabilities(
     artifactsEnabled,
     webSearchEnabled,
     fileSearchEnabled,
-    directUploadEnabled,
+    directAttachEnabled,
   };
 }

--- a/packages/api/src/files/index.ts
+++ b/packages/api/src/files/index.ts
@@ -1,1 +1,2 @@
 export * from './mistral/crud';
+export * from './validation';

--- a/packages/api/src/files/validation.ts
+++ b/packages/api/src/files/validation.ts
@@ -69,3 +69,17 @@ export async function validateAnthropicPdf(
     };
   }
 }
+
+export async function validateOpenAIPdf(
+  pdfBuffer: Buffer,
+  fileSize: number,
+): Promise<PDFValidationResult> {
+  if (fileSize > 10 * 1024 * 1024) {
+    return {
+      isValid: false,
+      error: "PDF file size exceeds OpenAI's 10MB limit",
+    };
+  }
+
+  return { isValid: true };
+}

--- a/packages/api/src/files/validation.ts
+++ b/packages/api/src/files/validation.ts
@@ -1,8 +1,24 @@
-import { anthropicPdfSizeLimit } from 'librechat-data-provider';
+import { anthropicPdfSizeLimit, EModelEndpoint } from 'librechat-data-provider';
 
 export interface PDFValidationResult {
   isValid: boolean;
   error?: string;
+}
+
+export async function validatePdf(
+  pdfBuffer: Buffer,
+  fileSize: number,
+  endpoint: EModelEndpoint,
+): Promise<PDFValidationResult> {
+  if (endpoint === EModelEndpoint.anthropic) {
+    return validateAnthropicPdf(pdfBuffer, fileSize);
+  }
+
+  if (endpoint === EModelEndpoint.openAI) {
+    return validateOpenAIPdf(fileSize);
+  }
+
+  return { isValid: true };
 }
 
 /**
@@ -11,7 +27,7 @@ export interface PDFValidationResult {
  * @param fileSize - The file size in bytes
  * @returns Promise that resolves to validation result
  */
-export async function validateAnthropicPdf(
+async function validateAnthropicPdf(
   pdfBuffer: Buffer,
   fileSize: number,
 ): Promise<PDFValidationResult> {
@@ -70,10 +86,7 @@ export async function validateAnthropicPdf(
   }
 }
 
-export async function validateOpenAIPdf(
-  pdfBuffer: Buffer,
-  fileSize: number,
-): Promise<PDFValidationResult> {
+async function validateOpenAIPdf(fileSize: number): Promise<PDFValidationResult> {
   if (fileSize > 10 * 1024 * 1024) {
     return {
       isValid: false,

--- a/packages/api/src/files/validation.ts
+++ b/packages/api/src/files/validation.ts
@@ -1,13 +1,20 @@
-const { logger } = require('~/config');
-const { anthropicPdfSizeLimit } = require('librechat-data-provider');
+import { anthropicPdfSizeLimit } from 'librechat-data-provider';
+
+export interface PDFValidationResult {
+  isValid: boolean;
+  error?: string;
+}
 
 /**
  * Validates if a PDF meets Anthropic's requirements
- * @param {Buffer} pdfBuffer - The PDF file as a buffer
- * @param {number} fileSize - The file size in bytes
- * @returns {Promise<{isValid: boolean, error?: string}>}
+ * @param pdfBuffer - The PDF file as a buffer
+ * @param fileSize - The file size in bytes
+ * @returns Promise that resolves to validation result
  */
-async function validateAnthropicPdf(pdfBuffer, fileSize) {
+export async function validateAnthropicPdf(
+  pdfBuffer: Buffer,
+  fileSize: number,
+): Promise<PDFValidationResult> {
   try {
     if (fileSize > anthropicPdfSizeLimit) {
       return {
@@ -53,20 +60,12 @@ async function validateAnthropicPdf(pdfBuffer, fileSize) {
       };
     }
 
-    logger.debug(
-      `PDF validation passed: ${Math.round(fileSize / 1024)}KB, ~${estimatedPages} pages`,
-    );
-
     return { isValid: true };
   } catch (error) {
-    logger.error('PDF validation error:', error);
+    console.error('PDF validation error:', error);
     return {
       isValid: false,
       error: 'Failed to validate PDF file',
     };
   }
 }
-
-module.exports = {
-  validateAnthropicPdf,
-};

--- a/packages/api/src/files/validation.ts
+++ b/packages/api/src/files/validation.ts
@@ -14,7 +14,7 @@ export async function validatePdf(
     return validateAnthropicPdf(pdfBuffer, fileSize);
   }
 
-  if (endpoint === EModelEndpoint.openAI) {
+  if (endpoint === EModelEndpoint.openAI || endpoint === EModelEndpoint.azureOpenAI) {
     return validateOpenAIPdf(fileSize);
   }
 

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -248,6 +248,7 @@ export const assistantEndpointSchema = baseEndpointSchema.merge(
 export type TAssistantEndpoint = z.infer<typeof assistantEndpointSchema>;
 
 export const defaultAgentCapabilities = [
+  AgentCapabilities.direct_attach,
   AgentCapabilities.execute_code,
   AgentCapabilities.file_search,
   AgentCapabilities.web_search,
@@ -256,7 +257,6 @@ export const defaultAgentCapabilities = [
   AgentCapabilities.tools,
   AgentCapabilities.chain,
   AgentCapabilities.ocr,
-  AgentCapabilities.direct_upload,
 ];
 
 export const agentsEndpointSchema = baseEndpointSchema

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -174,7 +174,7 @@ export enum Capabilities {
 export enum AgentCapabilities {
   hide_sequential_outputs = 'hide_sequential_outputs',
   end_after_tools = 'end_after_tools',
-  direct_upload = 'direct_upload',
+  direct_attach = 'direct_attach',
   execute_code = 'execute_code',
   file_search = 'file_search',
   web_search = 'web_search',

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -31,6 +31,19 @@ export enum EModelEndpoint {
   gptPlugins = 'gptPlugins',
 }
 
+/**
+ * Endpoints that support direct PDF processing in the agent system
+ */
+export const documentSupportedEndpoints = new Set<EModelEndpoint>([
+  EModelEndpoint.anthropic,
+  EModelEndpoint.openAI,
+  EModelEndpoint.azureOpenAI,
+]);
+
+export const isDocumentSupportedEndpoint = (endpoint: EModelEndpoint): boolean => {
+  return documentSupportedEndpoints.has(endpoint);
+};
+
 export const paramEndpoints = new Set<EModelEndpoint | string>([
   EModelEndpoint.agents,
   EModelEndpoint.openAI,

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -27,7 +27,7 @@ export enum Tools {
 
 export enum EToolResources {
   code_interpreter = 'code_interpreter',
-  direct_upload = 'direct_upload',
+  direct_attach = 'direct_attach',
   execute_code = 'execute_code',
   file_search = 'file_search',
   image_edit = 'image_edit',


### PR DESCRIPTION
## Summary

This pull request adds support for direct PDF attachment for OpenAI (and Azure OpenAI) Endpoints and agents, refactors the validation and formatting logic to now handle multiple endpoints more robustly, and refactors the naming pattern for the variables like `direct_attach`->`direct_upload` and `anthropic_multimodal`->`multimodal` to better reflect functionality. 

###### Note: In order for PDF attachments to work properly in OpenAI conversations, the 'Use Responses API' toggle should be enabled in the parameters panel.

**Backend enhancements and refactoring:**

- Added support for direct PDF attachment for OpenAI conversations by updating the `encodeAndFormatDocuments` function to handle both Anthropic and OpenAI endpoints, including appropriate document formatting for each provider. [[1]](diffhunk://#diff-8c99b1ddca0d7fa6758088ffec41bed3ff6ce185163505281c9e3de03450e8aaL325-R326) [[2]](diffhunk://#diff-19cccdec924feb0460ced2ee7de76f16395ae6ce6f776a27491d55451406c0c6L74-R77) [[3]](diffhunk://#diff-19cccdec924feb0460ced2ee7de76f16395ae6ce6f776a27491d55451406c0c6L135-R149) [[4]](diffhunk://#diff-19cccdec924feb0460ced2ee7de76f16395ae6ce6f776a27491d55451406c0c6L153-R169)
- Refactored PDF validation: moved and renamed the validator to `validatePdf`, and extended it to include OpenAI-specific file size checks. [[1]](diffhunk://#diff-19cccdec924feb0460ced2ee7de76f16395ae6ce6f776a27491d55451406c0c6L3-R3) [[2]](diffhunk://#diff-3811965631468b853e4a95644869bd2c2f40b20f7bffd527a4845d30a7b41456R2) [[3]](diffhunk://#diff-53d496901a1834a97e69ca47945a36412a23845084acde5325668e5229ed20e3L1-R33) [[4]](diffhunk://#diff-53d496901a1834a97e69ca47945a36412a23845084acde5325668e5229ed20e3L56-R98)
- Added isDocumentSupportedEndpoint to schemas.ts in order to consolidate the logic for whether or not to use direct PDF attachment in a single place so it is easier to add support for future endpoints. [[1]](diffhunk://#diff-fd8115c56ccc50dd947888341518234fbf336152586013254fedd6ba18aa35a5R34-R46)

**Frontend/UI improvements:**

- Updated the file attachment menu logic to show the direct attach option ('Upload to Provider') for OpenAI conversations, and switched UI logic and tool resource identifiers from `direct_upload` to `direct_attach`. [[1]](diffhunk://#diff-e91b10bc65bcfd3b507fcdfb876241fe9f3f7bb579d784c6b7625e32355aa125L101-R108) [[2]](diffhunk://#diff-e91b10bc65bcfd3b507fcdfb876241fe9f3f7bb579d784c6b7625e32355aa125L114-R123)
- Updated agent capability hooks and types to use `directAttachEnabled` instead of `directUploadEnabled`. [[1]](diffhunk://#diff-0df80e8f773444a3dc10c89fed57e293f34c932f11a67b26f44f0be02940f6e7L12-R12) [[2]](diffhunk://#diff-0df80e8f773444a3dc10c89fed57e293f34c932f11a67b26f44f0be02940f6e7L53-R54) [[3]](diffhunk://#diff-0df80e8f773444a3dc10c89fed57e293f34c932f11a67b26f44f0be02940f6e7L66-R66)

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Confirmed PDF validation logic working properly for openAI endpoints
Confirmed that multimodal attachments (Image + PDF) are recognized in chat and have content properly parsed
Confirmed no regressions with Upload Image functionality and UI for unsupported endpoints

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.
