### PR TITLE
🏷️ refactor: Normalize Request Headers in `setRequestHeaders`

### DIFF
--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -88,8 +88,17 @@ export class MCPConnection extends EventEmitter {
   url?: string;
 
   setRequestHeaders(headers: Record<string, string> | null): void {
-    logger.debug(`${this.getLogPrefix()} Setting request headers: ${JSON.stringify(headers)}`);
-    this.requestHeaders = headers;
+    if (!headers) {
+      return;
+    }
+    const normalizedHeaders: Record<string, string> = {};
+    for (const [key, value] of Object.entries(headers)) {
+      normalizedHeaders[key.toLowerCase()] = value;
+    }
+    logger.debug(
+      `${this.getLogPrefix()} Setting request headers: ${JSON.stringify(normalizedHeaders)}`,
+    );
+    this.requestHeaders = normalizedHeaders;
   }
 
   getRequestHeaders(): Record<string, string> | null | undefined {


### PR DESCRIPTION
## Summary

I updated the `setRequestHeaders` method in `MCPConnection` to ensure all request header keys are normalized to lowercase before assignment. This change improves consistency when handling HTTP headers within the connection utility.

- Added normalization logic to convert all header keys to lowercase in `setRequestHeaders`
- Modified debug logging to print the normalized headers for easier troubleshooting
- Prevented assignment of null headers to avoid accidental overwrites

HTTP/2 spec requires all header names to be lowercase. Since these headers are applied right before the HTTP request is made, normalizing them here prevents request failures in HTTP/2 environments where mixed-case headers would be rejected.

## Change Type

- [x] Refactor (code change that neither fixes a bug nor adds a feature)

## Testing

I confirmed proper header normalization by manually initializing `MCPConnection` with mixed-case headers and inspecting the resulting output. The debug logs reflected the correct, lowercased header keys. 

**Test Configuration**:
- Node.js v20
- Manual method invocation in local dev environment

To further verify, I recommend writing unit tests that invoke `setRequestHeaders` with various header key cases, ensuring the internal `requestHeaders` property always stores keys in lowercase.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes