### PR TITLE
🐛 fix: Correct Next Refill Date Logic for Balance Settings

### DIFF
--- a/client/src/components/Nav/SettingsTabs/Balance/AutoRefillSettings.tsx
+++ b/client/src/components/Nav/SettingsTabs/Balance/AutoRefillSettings.tsx
@@ -47,6 +47,56 @@ const addIntervalToDate = (
   return result;
 };
 
+/**
+ * Calculates the next future refill date.
+ * This function determines how many intervals have passed since the base date
+ * and advances to the next eligible date. It correctly handles both fixed-duration
+ * intervals (e.g., days, weeks) and variable-duration intervals (e.g., months).
+ *
+ * @param {Date} baseDate - The starting date for the calculation (e.g., the last refill date).
+ * @param {number} value - The numeric value of the interval (e.g., 7 for 7 days).
+ * @param {'seconds'|'minutes'|'hours'|'days'|'weeks'|'months'} unit - The unit of time for the interval.
+ * @returns {Date} The next calculated future refill date.
+ */
+function getNextFutureInterval(
+  baseDate: Date,
+  value: number,
+  unit: 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks' | 'months',
+): Date {
+  const now = new Date();
+
+  if (baseDate > now) {
+    return addIntervalToDate(baseDate, value, unit);
+  }
+
+  if (unit === 'months') {
+    let nextRefillDate = new Date(baseDate);
+    while (nextRefillDate <= now) {
+      nextRefillDate = addIntervalToDate(nextRefillDate, value, unit);
+    }
+    return nextRefillDate;
+  }
+
+  const intervalInMs = {
+    seconds: value * 1000,
+    minutes: value * 1000 * 60,
+    hours: value * 1000 * 60 * 60,
+    days: value * 1000 * 60 * 60 * 24,
+    weeks: value * 1000 * 60 * 60 * 24 * 7,
+  }[unit];
+
+  if (intervalInMs <= 0) {
+    return addIntervalToDate(baseDate, value, unit);
+  }
+
+  const timeSinceBase = now.getTime() - baseDate.getTime();
+  const intervalsPassed = Math.floor(timeSinceBase / intervalInMs);
+  const intervalsToNext = intervalsPassed + 1;
+  const nextRefillTime = baseDate.getTime() + intervalsToNext * intervalInMs;
+
+  return new Date(nextRefillTime);
+}
+
 const AutoRefillSettings: React.FC<AutoRefillSettingsProps> = ({
   lastRefill,
   refillAmount,
@@ -57,7 +107,7 @@ const AutoRefillSettings: React.FC<AutoRefillSettingsProps> = ({
 
   const lastRefillDate = lastRefill ? new Date(lastRefill) : null;
   const nextRefill = lastRefillDate
-    ? addIntervalToDate(lastRefillDate, refillIntervalValue, refillIntervalUnit)
+    ? getNextFutureInterval(lastRefillDate, refillIntervalValue, refillIntervalUnit)
     : null;
 
   // Return the localized unit based on singular/plural values


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

This PR fixes the "Next Refill" date display in the balance settings. 

UI previously showed a stale date from the past if a refill was not triggered over multiple intervals.

New client-side logic in `AutoRefillSettings.tsx` now calculates the next upcoming refill date that is in the future. 

Backend logic that triggers a refill remains unchanged.


## Change Type

Please delete any irrelevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

I manually tested this change with the following steps:

1.  Navigate to **Settings → Balance**.
2.  Confirm the "Next Refill" date is a future date.
3.  To validate the logic, I set a user's `lastRefill` date to a past value in the database. After reloading the UI, the Balance settings correctly showed the next valid future date. See an example below, where current date is `8/18/2025`:
<img width="1325" height="466" alt="librecosts_4" src="https://github.com/user-attachments/assets/82624c21-ab72-44e9-871d-76e5ee2e9b90" />


### **Test Configuration**:
-   **Browser**: Safari
-   **Database**: MongoDB

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [X] My changes do not introduce new warnings