### PR TITLE
🐍 fix: Use Standard Mongoose Module Resolution in Config Scripts

### DIFF
--- a/config/add-balance.js
+++ b/config/add-balance.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 const { User } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { askQuestion, silentExit } = require('./helpers');

--- a/config/ban-user.js
+++ b/config/ban-user.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 const { User } = require('@librechat/data-schemas').createModels(mongoose);
 const { ViolationTypes } = require('librechat-data-provider');
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });

--- a/config/create-user.js
+++ b/config/create-user.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 const { User } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { registerUser } = require('~/server/services/AuthService');

--- a/config/delete-banner.js
+++ b/config/delete-banner.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 const { Banner } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { askQuestion, silentExit } = require('./helpers');

--- a/config/delete-user.js
+++ b/config/delete-user.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const path = require('path');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 const {
   User,
   Agent,

--- a/config/invite-user.js
+++ b/config/invite-user.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 const { User } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { sendEmail, checkEmailConfig } = require('~/server/utils');

--- a/config/list-balances.js
+++ b/config/list-balances.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 const { User, Balance } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { silentExit } = require('./helpers');

--- a/config/list-users.js
+++ b/config/list-users.js
@@ -1,6 +1,6 @@
 const path = require('path');
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 const { User } = require('@librechat/data-schemas').createModels(mongoose);
 const connect = require('./connect');
 

--- a/config/reset-meili-sync.js
+++ b/config/reset-meili-sync.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { askQuestion, silentExit } = require('./helpers');
 const connect = require('./connect');

--- a/config/reset-password.js
+++ b/config/reset-password.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const bcrypt = require('bcryptjs');
 const readline = require('readline');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 const { User } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const connect = require('./connect');

--- a/config/reset-terms.js
+++ b/config/reset-terms.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 const { User } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { askQuestion, silentExit } = require('./helpers');

--- a/config/set-balance.js
+++ b/config/set-balance.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 const { User, Balance } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { askQuestion, silentExit } = require('./helpers');

--- a/config/update-banner.js
+++ b/config/update-banner.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 const { v5: uuidv5 } = require('uuid');
 const { Banner } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });

--- a/config/user-stats.js
+++ b/config/user-stats.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const mongoose = require(path.resolve(__dirname, '..', 'api', 'node_modules', 'mongoose'));
+const mongoose = require('mongoose');
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { silentExit } = require('./helpers');
 const { User, Conversation, Message } = require('@librechat/data-schemas').createModels(mongoose);


### PR DESCRIPTION
# Pull Request Template

## Summary

his MR updates the commands in config/ scripts to use the standard Node.js module resolution for mongoose.
Previously, the scripts could fail due to a hardcoded path: #9139
Now, require('mongoose')]is used, ensuring compatibility with dependency deduplication and all supported package managers.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
npm run list-users

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings

