### PR TITLE
🚮 fix: Remove Filtering Logic Before MCP Initialization

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -111,17 +111,20 @@ router.get('/', async function (req, res) {
     payload.mcpServers = {};
     const config = await getCustomConfig();
     if (config?.mcpServers != null) {
-      const mcpManager = getMCPManager();
-      const oauthServers = mcpManager.getOAuthServers();
-
-      for (const serverName in config.mcpServers) {
-        const serverConfig = config.mcpServers[serverName];
-        payload.mcpServers[serverName] = {
-          startup: serverConfig?.startup,
-          chatMenu: serverConfig?.chatMenu,
-          isOAuth: oauthServers?.has(serverName),
-          customUserVars: serverConfig?.customUserVars || {},
-        };
+      try {
+        const mcpManager = getMCPManager();
+        const oauthServers = mcpManager.getOAuthServers();
+        for (const serverName in config.mcpServers) {
+          const serverConfig = config.mcpServers[serverName];
+          payload.mcpServers[serverName] = {
+            startup: serverConfig?.startup,
+            chatMenu: serverConfig?.chatMenu,
+            isOAuth: oauthServers?.has(serverName),
+            customUserVars: serverConfig?.customUserVars || {},
+          };
+        }
+      } catch (err) {
+        logger.error('Error loading MCP servers', err);
       }
     }
 

--- a/api/server/services/initializeMCPs.js
+++ b/api/server/services/initializeMCPs.js
@@ -14,22 +14,6 @@ async function initializeMCPs(app) {
     return;
   }
 
-  /** Servers filtered with `startup: false` */
-  const filteredServers = {};
-  for (const [name, config] of Object.entries(mcpServers)) {
-    if (config.startup === false) {
-      logger.info(`Skipping MCP server '${name}' due to startup: false`);
-      continue;
-    }
-    filteredServers[name] = config;
-  }
-
-  if (Object.keys(filteredServers).length === 0) {
-    logger.info('[MCP] No MCP servers to initialize (all skipped or none configured)');
-    return;
-  }
-
-  logger.info('Initializing MCP servers...');
   const mcpManager = await createMCPManager(mcpServers);
 
   try {


### PR DESCRIPTION
## Summary

I removed redundant filtering of MCP servers with the startup flag before manager initialization, simplifying the MCP loading process and aligning data exposure with server initialization.

- Deleted pre-initialization filtering for MCP servers based on `startup: false` in `initializeMCPs.js`
- Relied on the MCP Manager to handle server eligibility and OAuth detection instead of manual route filtering
- Simplified `/config` route logic and improved error reporting when loading MCP servers
- Enhanced maintainability by delegating initialization concerns to the MCP Manager

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes