### PR TITLE
👑 feat: Add OIDC Claim-Based Admin Role Assignment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -459,6 +459,9 @@ OPENID_CALLBACK_URL=/oauth/openid/callback
 OPENID_REQUIRED_ROLE=
 OPENID_REQUIRED_ROLE_TOKEN_KIND=
 OPENID_REQUIRED_ROLE_PARAMETER_PATH=
+OPENID_ADMIN_ROLE=
+OPENID_ADMIN_ROLE_PARAMETER_PATH=
+OPENID_ADMIN_ROLE_TOKEN_KIND=
 # Set to determine which user info property returned from OpenID Provider to store as the User's username
 OPENID_USERNAME_CLAIM=
 # Set to determine which user info property returned from OpenID Provider to store as the User's name

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -282,6 +282,34 @@ function convertToUsername(input, defaultValue = '') {
 }
 
 /**
+ * Retrieves a property from an object using a dot-separated path.
+ * If the property does not exist, it returns undefined.
+ * @param {Object} obj - The object from which to retrieve the property.
+ * @param {string} path - The dot-separated path to the property.
+ * @returns {*} The value of the property at the specified path, or undefined if it does not exist.
+ * @example
+ * const obj = { a: { b: { c: 42 } } };
+ * const value = getPropFromObject(obj, 'a.b.c'); // returns 42
+ * const missingValue = getPropFromObject(obj, 'a.b.x'); // returns undefined
+ * const undefinedValue = getPropFromObject(obj, 'a.b'); // returns { c: 42 }
+ * const emptyValue = getPropFromObject(obj, ''); // returns undefined
+ * const nullValue = getPropFromObject(null, 'a.b.c'); // returns undefined
+ * const undefinedValue = getPropFromObject(undefined, 'a.b.c'); // returns undefined
+ */
+function getPropertyFromObject(obj, path) {
+  if (!obj || !path) {
+    return undefined;
+  }
+  
+  const pathParts = path.split('.');
+  return pathParts.reduce((o, key) => {
+    if (o === null || o === undefined || !(key in o)) {
+      return undefined;
+    }
+    return o[key];
+  }, obj);
+}
+/**
  * Sets up the OpenID strategy for authentication.
  * This function configures the OpenID client, handles proxy settings,
  * and defines the OpenID strategy for Passport.js.
@@ -328,6 +356,12 @@ async function setupOpenId() {
         ? 'OPENID_GENERATE_NONCE=true - Will generate nonce and use explicit metadata for federated providers'
         : 'OPENID_GENERATE_NONCE=false - Standard flow without explicit nonce or metadata',
     });
+
+    // Set of env variables that specify how to set if a user is an admin
+    // If not set, all users will be treated as regular users
+    const adminRole = process.env.OPENID_ADMIN_ROLE;
+    const adminRoleParameterPath = process.env.OPENID_ADMIN_ROLE_PARAMETER_PATH;
+    const adminRoleTokenKind = process.env.OPENID_ADMIN_ROLE_TOKEN_KIND;
 
     const openidLogin = new CustomOpenIDStrategy(
       {
@@ -386,17 +420,9 @@ async function setupOpenId() {
             } else if (requiredRoleTokenKind === 'id') {
               decodedToken = jwtDecode(tokenset.id_token);
             }
-            const pathParts = requiredRoleParameterPath.split('.');
-            let found = true;
-            let roles = pathParts.reduce((o, key) => {
-              if (o === null || o === undefined || !(key in o)) {
-                found = false;
-                return [];
-              }
-              return o[key];
-            }, decodedToken);
 
-            if (!found) {
+            let roles = getPropertyFromObject(decodedToken, requiredRoleParameterPath);
+            if (!roles) {
               logger.error(
                 `[openidStrategy] Key '${requiredRoleParameterPath}' not found in ${requiredRoleTokenKind} token!`,
               );
@@ -444,6 +470,47 @@ async function setupOpenId() {
             if (userinfo.email && userinfo.email !== user.email) {
               user.email = userinfo.email;
               user.emailVerified = userinfo.email_verified || false;
+            }
+          }
+
+          if (adminRole && adminRoleParameterPath && adminRoleTokenKind) {
+            let adminRoleObject;
+            switch (adminRoleTokenKind) {
+              case 'access':
+                adminRoleObject = jwtDecode(tokenset.access_token);
+                break;
+              case 'id':
+                adminRoleObject = jwtDecode(tokenset.id_token);
+                break;
+              case 'userinfo':
+                adminRoleObject = userinfo;
+                break;
+              default:
+                logger.error(
+                  `[openidStrategy] Invalid admin role token kind: ${adminRoleTokenKind}. Must be one of 'access', 'id', or 'userinfo'.`,
+                );
+                return done(new Error('Invalid admin role token kind'));
+              }
+
+            const adminRoles = getPropertyFromObject(
+              adminRoleObject,
+              adminRoleParameterPath,
+            );
+
+            // Accept 3 types of values for the object extracted from adminRoleParameterPath:
+            // 1. A boolean value indicating if the user is an admin
+            // 2. A string with a single role name
+            // 3. An array of role names
+
+            if (adminRoles && (
+              adminRoles === true || 
+              adminRoles === adminRole ||
+              (Array.isArray(adminRoles) && adminRoles.includes(adminRole))
+            )) {
+              user.role = "ADMIN";
+              logger.info(
+                `[openidStrategy] User ${username} is an admin based on role: ${adminRole}`,
+              );
             }
           }
 

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -1,4 +1,5 @@
 const undici = require('undici');
+const { get } = require('lodash');
 const fetch = require('node-fetch');
 const passport = require('passport');
 const client = require('openid-client');
@@ -282,28 +283,6 @@ function convertToUsername(input, defaultValue = '') {
 }
 
 /**
- * Retrieves a property from an object using a dot-separated path.
- * If the property does not exist, it returns undefined.
- *
- * @param {Object} obj - The object from which to retrieve the property.
- * @param {string} path - The dot-separated path to the property.
- * @returns {*} The value of the property at the specified path, or undefined if it does not exist.
- */
-function getPropertyFromObject(obj, path) {
-  if (!obj || !path) {
-    return undefined;
-  }
-
-  const pathParts = path.split('.');
-  return pathParts.reduce((o, key) => {
-    if (o === null || o === undefined || !(key in o)) {
-      return undefined;
-    }
-    return o[key];
-  }, obj);
-}
-
-/**
  * Sets up the OpenID strategy for authentication.
  * This function configures the OpenID client, handles proxy settings,
  * and defines the OpenID strategy for Passport.js.
@@ -415,7 +394,7 @@ async function setupOpenId() {
               decodedToken = jwtDecode(tokenset.id_token);
             }
 
-            let roles = getPropertyFromObject(decodedToken, requiredRoleParameterPath);
+            let roles = get(decodedToken, requiredRoleParameterPath);
             if (!roles) {
               logger.error(
                 `[openidStrategy] Key '${requiredRoleParameterPath}' not found in ${requiredRoleTokenKind} token!`,
@@ -486,7 +465,7 @@ async function setupOpenId() {
                 return done(new Error('Invalid admin role token kind'));
             }
 
-            const adminRoles = getPropertyFromObject(adminRoleObject, adminRoleParameterPath);
+            const adminRoles = get(adminRoleObject, adminRoleParameterPath);
 
             // Accept 3 types of values for the object extracted from adminRoleParameterPath:
             // 1. A boolean value indicating if the user is an admin

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -284,23 +284,16 @@ function convertToUsername(input, defaultValue = '') {
 /**
  * Retrieves a property from an object using a dot-separated path.
  * If the property does not exist, it returns undefined.
+ * 
  * @param {Object} obj - The object from which to retrieve the property.
  * @param {string} path - The dot-separated path to the property.
  * @returns {*} The value of the property at the specified path, or undefined if it does not exist.
- * @example
- * const obj = { a: { b: { c: 42 } } };
- * const value = getPropFromObject(obj, 'a.b.c'); // returns 42
- * const missingValue = getPropFromObject(obj, 'a.b.x'); // returns undefined
- * const undefinedValue = getPropFromObject(obj, 'a.b'); // returns { c: 42 }
- * const emptyValue = getPropFromObject(obj, ''); // returns undefined
- * const nullValue = getPropFromObject(null, 'a.b.c'); // returns undefined
- * const undefinedValue = getPropFromObject(undefined, 'a.b.c'); // returns undefined
  */
 function getPropertyFromObject(obj, path) {
   if (!obj || !path) {
     return undefined;
   }
-  
+
   const pathParts = path.split('.');
   return pathParts.reduce((o, key) => {
     if (o === null || o === undefined || !(key in o)) {
@@ -309,6 +302,7 @@ function getPropertyFromObject(obj, path) {
     return o[key];
   }, obj);
 }
+
 /**
  * Sets up the OpenID strategy for authentication.
  * This function configures the OpenID client, handles proxy settings,
@@ -490,24 +484,22 @@ async function setupOpenId() {
                   `[openidStrategy] Invalid admin role token kind: ${adminRoleTokenKind}. Must be one of 'access', 'id', or 'userinfo'.`,
                 );
                 return done(new Error('Invalid admin role token kind'));
-              }
+            }
 
-            const adminRoles = getPropertyFromObject(
-              adminRoleObject,
-              adminRoleParameterPath,
-            );
+            const adminRoles = getPropertyFromObject(adminRoleObject, adminRoleParameterPath);
 
             // Accept 3 types of values for the object extracted from adminRoleParameterPath:
             // 1. A boolean value indicating if the user is an admin
             // 2. A string with a single role name
             // 3. An array of role names
 
-            if (adminRoles && (
-              adminRoles === true || 
-              adminRoles === adminRole ||
-              (Array.isArray(adminRoles) && adminRoles.includes(adminRole))
-            )) {
-              user.role = "ADMIN";
+            if (
+              adminRoles &&
+              (adminRoles === true ||
+                adminRoles === adminRole ||
+                (Array.isArray(adminRoles) && adminRoles.includes(adminRole)))
+            ) {
+              user.role = 'ADMIN';
               logger.info(
                 `[openidStrategy] User ${username} is an admin based on role: ${adminRole}`,
               );

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -399,6 +399,13 @@ async function setupOpenId() {
               logger.error(
                 `[openidStrategy] Key '${requiredRoleParameterPath}' not found in ${requiredRoleTokenKind} token!`,
               );
+              const rolesList =
+                requiredRoles.length === 1
+                  ? `"${requiredRoles[0]}"`
+                  : `one of: ${requiredRoles.map((r) => `"${r}"`).join(', ')}`;
+              return done(null, false, {
+                message: `You must have ${rolesList} role to log in.`,
+              });
             }
 
             if (!requiredRoles.some((role) => roles.includes(role))) {

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -284,7 +284,7 @@ function convertToUsername(input, defaultValue = '') {
 /**
  * Retrieves a property from an object using a dot-separated path.
  * If the property does not exist, it returns undefined.
- * 
+ *
  * @param {Object} obj - The object from which to retrieve the property.
  * @param {string} path - The dot-separated path to the property.
  * @returns {*} The value of the property at the specified path, or undefined if it does not exist.

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -395,9 +395,9 @@ async function setupOpenId() {
             }
 
             let roles = get(decodedToken, requiredRoleParameterPath);
-            if (!roles) {
+            if (!roles || (!Array.isArray(roles) && typeof roles !== 'string')) {
               logger.error(
-                `[openidStrategy] Key '${requiredRoleParameterPath}' not found in ${requiredRoleTokenKind} token!`,
+                `[openidStrategy] Key '${requiredRoleParameterPath}' not found or invalid type in ${requiredRoleTokenKind} token!`,
               );
               const rolesList =
                 requiredRoles.length === 1

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -489,6 +489,11 @@ async function setupOpenId() {
               logger.info(
                 `[openidStrategy] User ${username} is an admin based on role: ${adminRole}`,
               );
+            } else if (user.role === 'ADMIN') {
+              user.role = 'USER';
+              logger.info(
+                `[openidStrategy] User ${username} demoted from admin - role no longer present in token`,
+              );
             }
           }
 

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -125,6 +125,9 @@ describe('setupOpenId', () => {
     process.env.OPENID_REQUIRED_ROLE = 'requiredRole';
     process.env.OPENID_REQUIRED_ROLE_PARAMETER_PATH = 'roles';
     process.env.OPENID_REQUIRED_ROLE_TOKEN_KIND = 'id';
+    process.env.OPENID_ADMIN_ROLE = 'admin';
+    process.env.OPENID_ADMIN_ROLE_PARAMETER_PATH = 'permissions';
+    process.env.OPENID_ADMIN_ROLE_TOKEN_KIND = 'id';
     delete process.env.OPENID_USERNAME_CLAIM;
     delete process.env.OPENID_NAME_CLAIM;
     delete process.env.PROXY;
@@ -133,6 +136,7 @@ describe('setupOpenId', () => {
     // Default jwtDecode mock returns a token that includes the required role.
     jwtDecode.mockReturnValue({
       roles: ['requiredRole'],
+      permissions: ['admin'],
     });
 
     // By default, assume that no user is found, so createUser will be called
@@ -440,5 +444,27 @@ describe('setupOpenId', () => {
     const callOptions = OpenIDStrategy.mock.calls[OpenIDStrategy.mock.calls.length - 1][0];
     expect(callOptions.usePKCE).toBe(false);
     expect(callOptions.params?.code_challenge_method).toBeUndefined();
+  });
+
+  it('should set role to "ADMIN" if OPENID_ADMIN_ROLE is set and user has that role', async () => {
+    // Act
+    const { user } = await validate(tokenset);
+
+    // Assert – verify that the user role is set to "ADMIN"
+    expect(user.role).toBe('ADMIN');
+  });
+
+  it('should not set user role if OPENID_ADMIN_ROLE is set but the user does not have that role', async () => {
+    // Arrange – simulate a token without the admin permission
+    jwtDecode.mockReturnValue({
+      roles: ['requiredRole'],
+      permissions: ['not-admin'],
+    });
+
+    // Act
+    const { user } = await validate(tokenset);
+
+    // Assert – verify that the user role is not defined
+    expect(user.role).toBeUndefined();
   });
 });


### PR DESCRIPTION
# Pull Request Template

## Summary

This Pull Request implements #9167 .
The goal is to allow a user that logins OIDC to be an admin in LibreChat depending on a claim that can exist in either the access_token, id_token or it's user profile.

A PR for the documentation was also open, detailing 3 new env vars, similar to the ones already used to check required roles.

```env
OPENID_ADMIN_ROLE=
OPENID_ADMIN_ROLE_PARAMETER_PATH=
OPENID_ADMIN_ROLE_TOKEN_KIND=
```

## Change Type

Please delete any irrelevant options.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Testing

Depending on your OIDC provider configurations might be different.
If you have a claim in the `id_token` called `roles` that's an array, and an admin user must have a role called __admin__, the configuration would be the following:

```env
OPENID_ADMIN_ROLE=admin
OPENID_ADMIN_ROLE_PARAMETER_PATH=roles
OPENID_ADMIN_ROLE_TOKEN_KIND=id
```

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [X] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [X] Local unit tests pass with my changes
- [X] A pull request for updating the documentation has been submitted. https://github.com/LibreChat-AI/librechat.ai/pull/398
