### PR TITLE
🛠️ fix: Restrict Editable Content Types & Consolidate Typing

### DIFF
--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -336,6 +336,7 @@ export type TAskProps = {
 
 export type TOptions = {
   editedMessageId?: string | null;
+  editedContent?: t.TEditedContent;
   editedText?: string | null;
   isRegenerate?: boolean;
   isContinued?: boolean;

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -94,6 +94,12 @@ const ContentParts = memo(
               return null;
             }
 
+            const isToolCall =
+              part.type === ContentTypes.TOOL_CALL || part['tool_call_ids'] != null;
+            if (isToolCall) {
+              return null;
+            }
+
             return (
               <EditTextPart
                 index={idx}

--- a/client/src/components/Chat/Messages/Content/Parts/EditTextPart.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/EditTextPart.tsx
@@ -62,17 +62,26 @@ const EditTextPart = ({
     const messages = getMessages();
     const parentMessage = messages?.find((msg) => msg.messageId === message?.parentMessageId);
 
+    const editedContent =
+      part.type === ContentTypes.THINK
+        ? {
+            index,
+            type: ContentTypes.THINK as const,
+            [ContentTypes.THINK]: data.text,
+          }
+        : {
+            index,
+            type: ContentTypes.TEXT as const,
+            [ContentTypes.TEXT]: data.text,
+          };
+
     if (!parentMessage) {
       return;
     }
     ask(
       { ...parentMessage },
       {
-        editedContent: {
-          index,
-          text: data.text,
-          type: part.type,
-        },
+        editedContent,
         editedMessageId: messageId,
         isRegenerate: true,
         isEdited: true,

--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -267,13 +267,13 @@ export default function useChatFunctions({
 
       if (editedContent && latestMessage?.content) {
         initialResponse.content = cloneDeep(latestMessage.content);
-        const { index, text, type } = editedContent;
+        const { index, type, ...part } = editedContent;
         if (initialResponse.content && index >= 0 && index < initialResponse.content.length) {
           const contentPart = initialResponse.content[index];
           if (type === ContentTypes.THINK && contentPart.type === ContentTypes.THINK) {
-            contentPart[ContentTypes.THINK] = text;
+            contentPart[ContentTypes.THINK] = part[ContentTypes.THINK];
           } else if (type === ContentTypes.TEXT && contentPart.type === ContentTypes.TEXT) {
-            contentPart[ContentTypes.TEXT] = text;
+            contentPart[ContentTypes.TEXT] = part[ContentTypes.TEXT];
           }
         }
       } else {

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -109,11 +109,7 @@ export type TPayload = Partial<TMessage> &
     messages?: TMessages;
     isTemporary: boolean;
     ephemeralAgent?: TEphemeralAgent | null;
-    editedContent?: {
-      index: number;
-      text: string;
-      type: 'text' | 'think';
-    } | null;
+    editedContent?: TEditedContent | null;
   };
 
 export type TEditedContent =

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -11,6 +11,7 @@ import type {
 } from './schemas';
 import type { SettingDefinition } from './generate';
 import type { TMinimalFeedback } from './feedback';
+import type { ContentTypes } from './types/runs';
 import type { Agent } from './types/assistants';
 
 export * from './schemas';
@@ -115,6 +116,18 @@ export type TPayload = Partial<TMessage> &
     } | null;
   };
 
+export type TEditedContent =
+  | {
+      index: number;
+      type: ContentTypes.THINK;
+      [ContentTypes.THINK]: string;
+    }
+  | {
+      index: number;
+      type: ContentTypes.TEXT;
+      [ContentTypes.TEXT]: string;
+    };
+
 export type TSubmission = {
   plugin?: TResPlugin;
   plugins?: TResPlugin[];
@@ -129,11 +142,7 @@ export type TSubmission = {
   endpointOption: TEndpointOption;
   clientTimestamp?: string;
   ephemeralAgent?: TEphemeralAgent | null;
-  editedContent?: {
-    index: number;
-    text: string;
-    type: 'text' | 'think';
-  } | null;
+  editedContent?: TEditedContent | null;
 };
 
 export type EventSubmission = Omit<TSubmission, 'initialResponse'> & { initialResponse: TMessage };


### PR DESCRIPTION
## Summary

Closes #9160

I updated message content editing to restrict user edits to only valid content types, and refactored types for edited content throughout the application to ensure alignment and reduce type-related errors.

- Allowed editing exclusively for expected content types (text and think), blocking tool calls and other types from being editable in the UI.
- Centralized and standardized the `TEditedContent` type, updating both frontend and data layer to use the stricter definition.
- Updated the `ask` and chat function hooks to process only valid edited content objects, ensuring correct content update flow.
- Refined editing logic in `EditTextPart` to auto-select proper content type and consistently construct edit payloads.
- Improved the type system in TypeScript files for clarity and maintainability, reducing the risk of invalid payloads.
- Prevented UI rendering for edit options on tool calls or unsupported message content segments.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes