### PR TITLE
🛣️ feat: `directEndpoint` Fetch Override for Custom Endpoints

### DIFF
--- a/api/server/services/Config/loadConfigModels.js
+++ b/api/server/services/Config/loadConfigModels.js
@@ -76,10 +76,11 @@ async function loadConfigModels(req) {
       fetchPromisesMap[uniqueKey] =
         fetchPromisesMap[uniqueKey] ||
         fetchModels({
-          user: req.user.id,
-          baseURL: BASE_URL,
-          apiKey: API_KEY,
           name,
+          apiKey: API_KEY,
+          baseURL: BASE_URL,
+          user: req.user.id,
+          direct: endpoint.directEndpoint,
           userIdQuery: models.userIdQuery,
         });
       uniqueKeyToEndpointsMap[uniqueKey] = uniqueKeyToEndpointsMap[uniqueKey] || [];

--- a/api/server/services/ModelService.js
+++ b/api/server/services/ModelService.js
@@ -34,6 +34,7 @@ const { openAIApiKey, userProvidedOpenAI } = require('./Config/EndpointService')
  * @param {string} params.apiKey - The API key for authentication with the API.
  * @param {string} params.baseURL - The base path URL for the API.
  * @param {string} [params.name='OpenAI'] - The name of the API; defaults to 'OpenAI'.
+ * @param {boolean} [params.direct=false] - Whether `directEndpoint` was configured
  * @param {boolean} [params.azure=false] - Whether to fetch models from Azure.
  * @param {boolean} [params.userIdQuery=false] - Whether to send the user ID as a query parameter.
  * @param {boolean} [params.createTokenConfig=true] - Whether to create a token configuration from the API response.
@@ -44,14 +45,16 @@ const { openAIApiKey, userProvidedOpenAI } = require('./Config/EndpointService')
 const fetchModels = async ({
   user,
   apiKey,
-  baseURL,
+  baseURL: _baseURL,
   name = EModelEndpoint.openAI,
+  direct,
   azure = false,
   userIdQuery = false,
   createTokenConfig = true,
   tokenKey,
 }) => {
   let models = [];
+  const baseURL = direct ? extractBaseURL(_baseURL) : _baseURL;
 
   if (!baseURL && !azure) {
     return models;

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -6,7 +6,10 @@ import type { AzureOpenAIInput } from '@langchain/openai';
 import type { OpenAI } from 'openai';
 import type * as t from '~/types';
 import { sanitizeModelName, constructAzureURL } from '~/utils/azure';
+import { createFetch } from '~/utils/generators';
 import { isEnabled } from '~/utils/common';
+
+type Fetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 export const knownOpenAIParams = new Set([
   // Constructor/Instance Parameters
@@ -92,6 +95,7 @@ export function getOpenAIConfig(
   const {
     modelOptions: _modelOptions = {},
     reverseProxyUrl,
+    directEndpoint,
     defaultQuery,
     headers,
     proxy,
@@ -309,6 +313,13 @@ export function getOpenAIConfig(
 
   if (hasModelKwargs) {
     llmConfig.modelKwargs = modelKwargs;
+  }
+
+  if (directEndpoint === true && configOptions?.baseURL != null) {
+    configOptions.fetch = createFetch({
+      directEndpoint: directEndpoint,
+      reverseProxyUrl: configOptions?.baseURL,
+    }) as unknown as Fetch;
   }
 
   const result: t.LLMConfigResult = {

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -12,6 +12,7 @@ export type OpenAIParameters = z.infer<typeof openAISchema>;
  */
 export interface OpenAIConfigOptions {
   modelOptions?: Partial<OpenAIParameters>;
+  directEndpoint?: boolean;
   reverseProxyUrl?: string;
   defaultQuery?: Record<string, string | undefined>;
   headers?: Record<string, string>;


### PR DESCRIPTION
## Summary

I added `directEndpoint` support across the model fetching and OpenAI API logic, enabling optional direct routing of requests and a custom fetch override. This enhancement allows for routing model and completion requests directly to given endpoints, bypassing the default `/chat/completions` URL when specified.

- Updated `OpenAIConfigOptions` to include a `directEndpoint` boolean property, enabling this new logic in type definitions.
- Modified `getOpenAIConfig` to override the fetch logic when `directEndpoint` is set, utilizing a custom fetch that respects the direct endpoint and `baseURL` configuration.
- Enhanced `fetchModels` and `loadConfigModels` to pass and utilize the `directEndpoint` flag and adjust base URL resolution accordingly.
- Adjusted model service logic so that when `directEndpoint` is enabled, requests automatically extract the base URL and bypass special handling.
- Verified the integration in the OpenAI endpoint backend to ensure proper fetch override behavior.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes