### PR TITLE
🪪 fix: Preserve Existing Interface Permissions When Updating Config

### DIFF
--- a/api/server/services/start/interface.js
+++ b/api/server/services/start/interface.js
@@ -138,9 +138,6 @@ async function loadDefaultInterface(config, configDefaults) {
           defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.USE],
           defaults.prompts,
         ),
-        [Permissions.SHARED_GLOBAL]:
-          defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.SHARED_GLOBAL],
-        [Permissions.CREATE]: defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.CREATE],
       },
       [PermissionTypes.BOOKMARKS]: {
         [Permissions.USE]: getPermissionValue(
@@ -155,9 +152,6 @@ async function loadDefaultInterface(config, configDefaults) {
           defaultPerms[PermissionTypes.MEMORIES]?.[Permissions.USE],
           defaults.memories,
         ),
-        [Permissions.CREATE]: defaultPerms[PermissionTypes.MEMORIES]?.[Permissions.CREATE],
-        [Permissions.UPDATE]: defaultPerms[PermissionTypes.MEMORIES]?.[Permissions.UPDATE],
-        [Permissions.READ]: defaultPerms[PermissionTypes.MEMORIES]?.[Permissions.READ],
         [Permissions.OPT_OUT]: isPersonalizationEnabled,
       },
       [PermissionTypes.MULTI_CONVO]: {
@@ -173,9 +167,6 @@ async function loadDefaultInterface(config, configDefaults) {
           defaultPerms[PermissionTypes.AGENTS]?.[Permissions.USE],
           defaults.agents,
         ),
-        [Permissions.SHARED_GLOBAL]:
-          defaultPerms[PermissionTypes.AGENTS]?.[Permissions.SHARED_GLOBAL],
-        [Permissions.CREATE]: defaultPerms[PermissionTypes.AGENTS]?.[Permissions.CREATE],
       },
       [PermissionTypes.TEMPORARY_CHAT]: {
         [Permissions.USE]: getPermissionValue(

--- a/api/server/services/start/interface.spec.js
+++ b/api/server/services/start/interface.spec.js
@@ -54,22 +54,15 @@ describe('loadDefaultInterface', () => {
     const expectedPermissionsForUser = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: false,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
       [PermissionTypes.AGENTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: false,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.TEMPORARY_CHAT]: { [Permissions.USE]: true },
       [PermissionTypes.RUN_CODE]: { [Permissions.USE]: true },
@@ -87,22 +80,15 @@ describe('loadDefaultInterface', () => {
     const expectedPermissionsForAdmin = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: true,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
       [PermissionTypes.AGENTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: true,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.TEMPORARY_CHAT]: { [Permissions.USE]: true },
       [PermissionTypes.RUN_CODE]: { [Permissions.USE]: true },
@@ -164,22 +150,15 @@ describe('loadDefaultInterface', () => {
     const expectedPermissionsForUser = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: false,
-        [Permissions.SHARED_GLOBAL]: false,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: false },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: false,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: false },
       [PermissionTypes.AGENTS]: {
         [Permissions.USE]: false,
-        [Permissions.SHARED_GLOBAL]: false,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.TEMPORARY_CHAT]: { [Permissions.USE]: false },
       [PermissionTypes.RUN_CODE]: { [Permissions.USE]: false },
@@ -197,22 +176,15 @@ describe('loadDefaultInterface', () => {
     const expectedPermissionsForAdmin = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: false,
-        [Permissions.SHARED_GLOBAL]: true,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: false },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: false,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: false },
       [PermissionTypes.AGENTS]: {
         [Permissions.USE]: false,
-        [Permissions.SHARED_GLOBAL]: true,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.TEMPORARY_CHAT]: { [Permissions.USE]: false },
       [PermissionTypes.RUN_CODE]: { [Permissions.USE]: false },
@@ -274,22 +246,15 @@ describe('loadDefaultInterface', () => {
     const expectedPermissionsForUser = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: false,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
       [PermissionTypes.AGENTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: false,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.TEMPORARY_CHAT]: { [Permissions.USE]: true },
       [PermissionTypes.RUN_CODE]: { [Permissions.USE]: true },
@@ -307,22 +272,15 @@ describe('loadDefaultInterface', () => {
     const expectedPermissionsForAdmin = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: true,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
       [PermissionTypes.AGENTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: true,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.TEMPORARY_CHAT]: { [Permissions.USE]: true },
       [PermissionTypes.RUN_CODE]: { [Permissions.USE]: true },
@@ -397,22 +355,15 @@ describe('loadDefaultInterface', () => {
     const expectedPermissionsForUser = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: false,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: false },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
       [PermissionTypes.AGENTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: false,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.TEMPORARY_CHAT]: { [Permissions.USE]: true },
       [PermissionTypes.RUN_CODE]: { [Permissions.USE]: false },
@@ -430,22 +381,15 @@ describe('loadDefaultInterface', () => {
     const expectedPermissionsForAdmin = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: true,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: false },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
       [PermissionTypes.AGENTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: true,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.TEMPORARY_CHAT]: { [Permissions.USE]: true },
       [PermissionTypes.RUN_CODE]: { [Permissions.USE]: false },
@@ -507,22 +451,15 @@ describe('loadDefaultInterface', () => {
     const expectedPermissionsForUser = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: false,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
       [PermissionTypes.AGENTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: false,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.TEMPORARY_CHAT]: { [Permissions.USE]: true },
       [PermissionTypes.RUN_CODE]: { [Permissions.USE]: true },
@@ -540,22 +477,15 @@ describe('loadDefaultInterface', () => {
     const expectedPermissionsForAdmin = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: true,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
       [PermissionTypes.AGENTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: true,
-        [Permissions.CREATE]: true,
       },
       [PermissionTypes.TEMPORARY_CHAT]: { [Permissions.USE]: true },
       [PermissionTypes.RUN_CODE]: { [Permissions.USE]: true },
@@ -627,9 +557,6 @@ describe('loadDefaultInterface', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -650,9 +577,6 @@ describe('loadDefaultInterface', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -738,15 +662,10 @@ describe('loadDefaultInterface', () => {
     const expectedPermissionsForUser = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: false,
-        [Permissions.CREATE]: true,
       }, // Explicitly configured
       // All other permissions that don't exist in the database
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -766,15 +685,10 @@ describe('loadDefaultInterface', () => {
     const expectedPermissionsForAdmin = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
-        [Permissions.SHARED_GLOBAL]: true,
-        [Permissions.CREATE]: true,
       }, // Explicitly configured
       // All other permissions that don't exist in the database
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        [Permissions.UPDATE]: true,
-        [Permissions.READ]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -888,43 +802,29 @@ describe('loadDefaultInterface', () => {
     // Check PROMPTS permissions use role defaults
     expect(userCall[1][PermissionTypes.PROMPTS]).toEqual({
       [Permissions.USE]: true,
-      [Permissions.SHARED_GLOBAL]: false,
-      [Permissions.CREATE]: true,
     });
 
     expect(adminCall[1][PermissionTypes.PROMPTS]).toEqual({
       [Permissions.USE]: true,
-      [Permissions.SHARED_GLOBAL]: true,
-      [Permissions.CREATE]: true,
     });
 
     // Check AGENTS permissions use role defaults
     expect(userCall[1][PermissionTypes.AGENTS]).toEqual({
       [Permissions.USE]: true,
-      [Permissions.SHARED_GLOBAL]: false,
-      [Permissions.CREATE]: true,
     });
 
     expect(adminCall[1][PermissionTypes.AGENTS]).toEqual({
       [Permissions.USE]: true,
-      [Permissions.SHARED_GLOBAL]: true,
-      [Permissions.CREATE]: true,
     });
 
     // Check MEMORIES permissions use role defaults
     expect(userCall[1][PermissionTypes.MEMORIES]).toEqual({
       [Permissions.USE]: true,
-      [Permissions.CREATE]: true,
-      [Permissions.UPDATE]: true,
-      [Permissions.READ]: true,
       [Permissions.OPT_OUT]: undefined,
     });
 
     expect(adminCall[1][PermissionTypes.MEMORIES]).toEqual({
       [Permissions.USE]: true,
-      [Permissions.CREATE]: true,
-      [Permissions.UPDATE]: true,
-      [Permissions.READ]: true,
       [Permissions.OPT_OUT]: undefined,
     });
   });
@@ -1164,12 +1064,6 @@ describe('loadDefaultInterface', () => {
     // Explicitly configured permissions should be updated
     expect(userCall[1][PermissionTypes.PROMPTS]).toEqual({
       [Permissions.USE]: true,
-      [Permissions.SHARED_GLOBAL]:
-        roleDefaults[SystemRoles.USER].permissions[PermissionTypes.PROMPTS][
-          Permissions.SHARED_GLOBAL
-        ],
-      [Permissions.CREATE]:
-        roleDefaults[SystemRoles.USER].permissions[PermissionTypes.PROMPTS][Permissions.CREATE],
     });
     expect(userCall[1][PermissionTypes.BOOKMARKS]).toEqual({ [Permissions.USE]: true });
     expect(userCall[1][PermissionTypes.MARKETPLACE]).toEqual({ [Permissions.USE]: true });


### PR DESCRIPTION
## Summary

Closes  #9193

I updated the default interface settings logic to stop unnecessarily overwriting existing interface-level permissions when updating settings, and removed stale and redundant permission checks in both implementation and its test suite.

- Removed assignment of default values to permission keys not present in config, preventing overwriting of existing interface permissions (e.g., CREATE, READ, SHARED_GLOBAL on PROMPTS, MEMORIES, and AGENTS)
- Cleaned up interface.spec.js by deleting outdated and now-invalid assertions that were tightly coupled to those overwritten permissions, resulting in large test simplification and deletion
- Ensured more predictable and stable permission handling across config reloads and updates

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update (test code and config type usage)


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes