### PR TITLE
🛠️ fix: resolve broken file downloads from assistants API (Web ReadableStream support)

### DIFF
--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -31,6 +31,7 @@ const { getAssistant } = require('~/models/Assistant');
 const { getAgent } = require('~/models/Agent');
 const { getLogStores } = require('~/cache');
 const { logger } = require('~/config');
+const { Readable } = require('stream');
 
 const router = express.Router();
 
@@ -323,11 +324,6 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
       res.setHeader('X-File-Metadata', JSON.stringify(file));
     };
 
-    /** @type {{ body: import('stream').PassThrough } | undefined} */
-    let passThrough;
-    /** @type {ReadableStream | undefined} */
-    let fileStream;
-
     if (checkOpenAIStorage(file.source)) {
       req.body = { model: file.model };
       const endpointMap = {
@@ -340,12 +336,19 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
         overrideEndpoint: endpointMap[file.source],
       });
       logger.debug(`Downloading file ${file_id} from OpenAI`);
-      passThrough = await getDownloadStream(file_id, openai);
+      const passThrough = await getDownloadStream(file_id, openai);
       setHeaders();
       logger.debug(`File ${file_id} downloaded from OpenAI`);
-      passThrough.body.pipe(res);
+
+      // Handle both Node.js and Web streams
+      const stream =
+        passThrough.body && typeof passThrough.body.getReader === 'function'
+          ? Readable.fromWeb(passThrough.body)
+          : passThrough.body;
+
+      stream.pipe(res);
     } else {
-      fileStream = await getDownloadStream(req, file.filepath);
+      const fileStream = await getDownloadStream(req, file.filepath);
 
       fileStream.on('error', (streamError) => {
         logger.error('[DOWNLOAD ROUTE] Stream error:', streamError);


### PR DESCRIPTION
## Summary

### Resolves file download failures for users of the OpenAI Assistants API

This PR updates the `/download/:userId/:file_id` route to correctly handle both Node.js `Readable` streams and Web API `ReadableStream` objects returned by some storage backends (e.g., OpenAI). Previously, the code assumed a Node.js stream and called `.pipe()` directly, which caused runtime errors when a Web API stream was returned (as it lacks `.pipe()`).  

The updated logic uses `Readable.fromWeb()` to convert a Web API stream to a Node.js stream when necessary, ensuring that the piping to the Express response works as expected.

### Impact

- **Urgency:** This is a blocking issue: all users leveraging the OpenAI Assistants API are currently unable to download generated files.
-  **Scope:** Impacts both new and existing deployments that rely on OpenAI.
- **User Experience:** Without this fix, users encounter unexplained download failures and server errors when attempting to download files generated by the Assistants API. Most users will simply see the following error message when they click the file download link in the conversation:

<img width="463" height="59" alt="assistants-api-file-download-error" src="https://github.com/user-attachments/assets/2366273e-4cc6-4eaf-a340-5417057dd9d5" />


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

**Test Process:**
- Verified file downloads from OpenAI Assistants API work as expected.
- Confirmed that file content is correctly streamed to the client.
- Tested with files of various sizes and types.
- Ensured no runtime errors occur when piping streams.

### **Test Configuration**:
- Node.js v20.x
- LibreChat server running locally
- Both OpenAI and local file storage strategies enabled

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
