### PR TITLE
🔗 chore: Remove `<link href='#' />` from `index.html`

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,7 +8,6 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="description" content="LibreChat - An open source chat application with support for multiple AI models" />
     <title>LibreChat</title>
-    <link rel="shortcut icon" href="#" />
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon-180x180.png" />


### PR DESCRIPTION
## Summary

I noticed we were making two requests to the index page. One was for the document and one was for an image:

Before:
<img width="2210" height="1692" alt="CleanShot 2025-08-22 at 17 26 55@2x" src="https://github.com/user-attachments/assets/88660b3f-c950-46ce-8daa-ff41d856adfa" />

which was just returning back the document. 

We're using page loads to track visits, so this was leading to double counts.

After:
<img width="1472" height="1222" alt="CleanShot 2025-08-22 at 18 01 57@2x" src="https://github.com/user-attachments/assets/380d599f-89cc-49f7-86b2-c8d1521c965d" />

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

1. Made the change
2. Ran npm run frontend
3. Started the docker compose script

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
