### PR TITLE
🧮 fix: Properly Escape Currency and Prevent Code Block LaTeX Bugs

### DIFF
--- a/client/src/utils/latex.spec.ts
+++ b/client/src/utils/latex.spec.ts
@@ -219,4 +219,18 @@ y$ which spans lines`;
     const expected = 'Use $$x + y$$ in math but `$lookup` in code';
     expect(preprocessLaTeX(content)).toBe(expected);
   });
+
+  test('escapes currency amounts without commas', () => {
+    const content =
+      'The total amount invested is $1157.90 (existing amount) + $500 (new investment) = $1657.90.';
+    const expected =
+      'The total amount invested is \\$1157.90 (existing amount) + \\$500 (new investment) = \\$1657.90.';
+    expect(preprocessLaTeX(content)).toBe(expected);
+  });
+
+  test('handles large currency amounts', () => {
+    const content = 'You can win $1000000 or even $9999999.99!';
+    const expected = 'You can win \\$1000000 or even \\$9999999.99!';
+    expect(preprocessLaTeX(content)).toBe(expected);
+  });
 });

--- a/client/src/utils/latex.spec.ts
+++ b/client/src/utils/latex.spec.ts
@@ -233,4 +233,10 @@ y$ which spans lines`;
     const expected = 'You can win \\$1000000 or even \\$9999999.99!';
     expect(preprocessLaTeX(content)).toBe(expected);
   });
+
+  test('escapes currency with many decimal places', () => {
+    const content = 'Bitcoin: $0.00001234, Gas: $3.999, Rate: $1.234567890';
+    const expected = 'Bitcoin: \\$0.00001234, Gas: \\$3.999, Rate: \\$1.234567890';
+    expect(preprocessLaTeX(content)).toBe(expected);
+  });
 });

--- a/client/src/utils/latex.spec.ts
+++ b/client/src/utils/latex.spec.ts
@@ -207,4 +207,16 @@ y$ which spans lines`;
     const expected = 'Set $$\\{x | x > \\$0\\}$$ for positive prices';
     expect(preprocessLaTeX(content)).toBe(expected);
   });
+
+  test('does not convert when closing dollar is preceded by backtick', () => {
+    const content = 'The error "invalid $lookup namespace" occurs when using `$lookup` operator';
+    const expected = 'The error "invalid $lookup namespace" occurs when using `$lookup` operator';
+    expect(preprocessLaTeX(content)).toBe(expected);
+  });
+
+  test('handles mixed backtick and non-backtick cases', () => {
+    const content = 'Use $x + y$ in math but `$lookup` in code';
+    const expected = 'Use $$x + y$$ in math but `$lookup` in code';
+    expect(preprocessLaTeX(content)).toBe(expected);
+  });
 });

--- a/client/src/utils/latex.ts
+++ b/client/src/utils/latex.ts
@@ -5,7 +5,7 @@ const MHCHEM_CE_ESCAPED_REGEX = /\$\\\\ce\{[^}]*\}\$/g;
 const MHCHEM_PU_ESCAPED_REGEX = /\$\\\\pu\{[^}]*\}\$/g;
 const CURRENCY_REGEX =
   /(?<![\\$])\$(?!\$)(?=\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?(?:\s|$|[^a-zA-Z\d]))/g;
-const SINGLE_DOLLAR_REGEX = /(?<!\\)\$(?!\$)((?:[^$\n]|\\[$])+?)(?<!\\)\$(?!\$)/g;
+const SINGLE_DOLLAR_REGEX = /(?<!\\)\$(?!\$)((?:[^$\n]|\\[$])+?)(?<!\\)(?<!`)\$(?!\$)/g;
 
 /**
  * Escapes mhchem package notation in LaTeX by converting single dollar delimiters to double dollars

--- a/client/src/utils/latex.ts
+++ b/client/src/utils/latex.ts
@@ -3,8 +3,7 @@ const MHCHEM_CE_REGEX = /\$\\ce\{/g;
 const MHCHEM_PU_REGEX = /\$\\pu\{/g;
 const MHCHEM_CE_ESCAPED_REGEX = /\$\\\\ce\{[^}]*\}\$/g;
 const MHCHEM_PU_ESCAPED_REGEX = /\$\\\\pu\{[^}]*\}\$/g;
-const CURRENCY_REGEX =
-  /(?<![\\$])\$(?!\$)(?=\d{1,3}(?:,\d{3})*(?:\.\d{1,2})?(?:\s|$|[^a-zA-Z\d]))/g;
+const CURRENCY_REGEX = /(?<![\\$])\$(?!\$)(?=\d+(?:,\d{3})*(?:\.\d{1,2})?(?:\s|$|[^a-zA-Z\d]))/g;
 const SINGLE_DOLLAR_REGEX = /(?<!\\)\$(?!\$)((?:[^$\n]|\\[$])+?)(?<!\\)(?<!`)\$(?!\$)/g;
 
 /**

--- a/client/src/utils/latex.ts
+++ b/client/src/utils/latex.ts
@@ -3,7 +3,7 @@ const MHCHEM_CE_REGEX = /\$\\ce\{/g;
 const MHCHEM_PU_REGEX = /\$\\pu\{/g;
 const MHCHEM_CE_ESCAPED_REGEX = /\$\\\\ce\{[^}]*\}\$/g;
 const MHCHEM_PU_ESCAPED_REGEX = /\$\\\\pu\{[^}]*\}\$/g;
-const CURRENCY_REGEX = /(?<![\\$])\$(?!\$)(?=\d+(?:,\d{3})*(?:\.\d{1,2})?(?:\s|$|[^a-zA-Z\d]))/g;
+const CURRENCY_REGEX = /(?<![\\$])\$(?!\$)(?=\d+(?:,\d{3})*(?:\.\d+)?(?:\s|$|[^a-zA-Z\d]))/g;
 const SINGLE_DOLLAR_REGEX = /(?<!\\)\$(?!\$)((?:[^$\n]|\\[$])+?)(?<!\\)(?<!`)\$(?!\$)/g;
 
 /**


### PR DESCRIPTION
## Summary

I improved LaTeX preprocessing to robustly escape all currency values and prevent code block parsing errors.

- Updated currency regex to support unlimited decimal places and large numbers without commas
- Fixed LaTeX regex to skip closing $ preceded by backtick, avoiding code block issues
- Added and updated tests for edge cases with currency and inline code

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added comprehensive tests in `latex.spec.ts` for multi-decimal, large, and code block currency scenarios. Run `npm run test` in the client to verify all cases pass.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes