### PR TITLE
feat: Add defaultPinMcp configuration option to interface settings

### DIFF
--- a/api/server/services/start/interface.js
+++ b/api/server/services/start/interface.js
@@ -78,6 +78,7 @@ async function loadDefaultInterface(config, configDefaults) {
     termsOfService: interfaceConfig?.termsOfService ?? defaults.termsOfService,
     mcpServers: interfaceConfig?.mcpServers ?? defaults.mcpServers,
     customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,
+    defaultPinMcp: interfaceConfig?.defaultPinMcp ?? defaults.defaultPinMcp,
 
     // Permissions - only include if explicitly configured
     bookmarks: interfaceConfig?.bookmarks,

--- a/client/src/hooks/Plugins/useMCPSelect.ts
+++ b/client/src/hooks/Plugins/useMCPSelect.ts
@@ -101,7 +101,7 @@ export function useMCPSelect() {
 
   const [isPinned, setIsPinned] = useLocalStorage<boolean>(
     `${LocalStorageKeys.PIN_MCP_}${key}`,
-    true,
+    startupConfig?.interface?.defaultPinMcp ?? true,
   );
 
   useEffect(() => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -545,6 +545,7 @@ export const interfaceSchema = z
       })
       .optional(),
     fileSearch: z.boolean().optional(),
+    defaultPinMcp: z.boolean().optional(),
     fileCitations: z.boolean().optional(),
   })
   .default({
@@ -570,6 +571,7 @@ export const interfaceSchema = z
       use: false,
     },
     fileSearch: true,
+    defaultPinMcp: true,
     fileCitations: true,
   });
 


### PR DESCRIPTION
## Summary
This PR introduces a new configuration option defaultPinMcp to the interface settings in Librechat.yaml, allowing administrators to control the default pinned state of MCP servers in the chat interface across all users. 

## Change Type
- [x] New feature (non-breaking change which adds functionality)

## Testing
### **Manual Test Configuration**:
- [x] Tested with defaultPinMcp: true (default behavior maintained)
- [x] Tested with defaultPinMcp: false (MCP servers unpinned by default)
- [x] Verified that existing user preferences are preserved when the setting is changed
- [x] Confirmed that the setting properly initializes the useMCPSelect hook's local storage value

## Test Process:
Set defaultPinMcp: false in the interface configuration
Verify that new users see MCP servers unpinned by default
Set defaultPinMcp: true and confirm MCP servers are pinned by default
Verify that existing user preferences stored in localStorage are not affected by configuration changes

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] My changes are backward compatible and maintain existing functionality
