### PR TITLE
🧹 chore: [stripe] remove dangerously set html

### DIFF
--- a/client/src/components/Plugins/Store/PluginTooltip.tsx
+++ b/client/src/components/Plugins/Store/PluginTooltip.tsx
@@ -12,7 +12,7 @@ function PluginTooltip({ content, position }: TPluginTooltipProps) {
       <HoverCardContent side={position} className="w-80 ">
         <div className="space-y-2">
           <div className="text-sm text-gray-600 dark:text-gray-300">
-            <div dangerouslySetInnerHTML={{ __html: content }} />
+            {content}
           </div>
         </div>
       </HoverCardContent>


### PR DESCRIPTION
# Pull Request Template

## Summary

Remove use of `dangerouslySetInnerHTML` as it is a security risk

This is only used in
[PluginAuthForm](https://github.com/danny-avila/LibreChat/blob/9dbf153489a2b1b9f8f8c0caaa9a3f4995dfa472/client/src/components/Plugins/Store/PluginAuthForm.tsx#L69)
which passes a [string](https://github.com/danny-avila/LibreChat/blob/9dbf153489a2b1b9f8f8c0caaa9a3f4995dfa472/packages/data-provider/src/schemas.ts#L428) as content. There is no need for dangerously set html.

Is an HTML string possible?

Moreover plugins seem to be deprecated so is this being used anywhere?


## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

1. Made the change
1. Ran npm run frontend
1. Started the docker compose script

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
