### PR TITLE
🎨 feat: MCP UI basic integration

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -37,6 +37,7 @@
     "@headlessui/react": "^2.1.2",
     "@librechat/client": "*",
     "@marsidev/react-turnstile": "^1.1.0",
+    "@mcp-ui/client": "^5.7.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.2",
     "@radix-ui/react-checkbox": "^1.0.3",

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -625,3 +625,10 @@ declare global {
     google_tag_manager?: unknown;
   }
 }
+
+export type UIResource = {
+  uri: string;
+  mimeType: string;
+  text: string;
+  [key: string]: unknown;
+};

--- a/client/src/components/Chat/Messages/Content/UIResourceGrid.tsx
+++ b/client/src/components/Chat/Messages/Content/UIResourceGrid.tsx
@@ -1,0 +1,145 @@
+import { UIResourceRenderer } from '@mcp-ui/client';
+import type { UIResource } from '~/common';
+import React, { useState } from 'react';
+
+interface UIResourceGridProps {
+  uiResources: UIResource[];
+}
+
+const UIResourceGrid: React.FC<UIResourceGridProps> = React.memo(({ uiResources }) => {
+  const [showLeftArrow, setShowLeftArrow] = useState(false);
+  const [showRightArrow, setShowRightArrow] = useState(true);
+  const [isContainerHovered, setIsContainerHovered] = useState(false);
+  const scrollContainerRef = React.useRef<HTMLDivElement>(null);
+
+  const handleScroll = React.useCallback(() => {
+    if (!scrollContainerRef.current) return;
+
+    const { scrollLeft, scrollWidth, clientWidth } = scrollContainerRef.current;
+    setShowLeftArrow(scrollLeft > 0);
+    setShowRightArrow(scrollLeft < scrollWidth - clientWidth - 10);
+  }, []);
+
+  const scroll = React.useCallback((direction: 'left' | 'right') => {
+    if (!scrollContainerRef.current) return;
+
+    const viewportWidth = scrollContainerRef.current.clientWidth;
+    const scrollAmount = Math.floor(viewportWidth * 0.9);
+    const currentScroll = scrollContainerRef.current.scrollLeft;
+    const newScroll =
+      direction === 'left' ? currentScroll - scrollAmount : currentScroll + scrollAmount;
+
+    scrollContainerRef.current.scrollTo({
+      left: newScroll,
+      behavior: 'smooth',
+    });
+  }, []);
+
+  React.useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (container) {
+      container.addEventListener('scroll', handleScroll);
+      handleScroll();
+      return () => container.removeEventListener('scroll', handleScroll);
+    }
+  }, [handleScroll]);
+
+  if (uiResources.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="relative mb-4 pt-3"
+      onMouseEnter={() => setIsContainerHovered(true)}
+      onMouseLeave={() => setIsContainerHovered(false)}
+    >
+      <div
+        className={`pointer-events-none absolute left-0 top-0 z-10 h-full w-24 bg-gradient-to-r from-surface-primary to-transparent transition-opacity duration-500 ease-in-out ${
+          showLeftArrow ? 'opacity-100' : 'opacity-0'
+        }`}
+      />
+
+      <div
+        className={`pointer-events-none absolute right-0 top-0 z-10 h-full w-24 bg-gradient-to-l from-surface-primary to-transparent transition-opacity duration-500 ease-in-out ${
+          showRightArrow ? 'opacity-100' : 'opacity-0'
+        }`}
+      />
+
+      {showLeftArrow && (
+        <button
+          type="button"
+          onClick={() => scroll('left')}
+          className={`absolute left-2 top-1/2 z-20 -translate-y-1/2 rounded-xl bg-white p-2 text-gray-800 shadow-lg transition-all duration-200 hover:scale-110 hover:bg-gray-100 hover:shadow-xl active:scale-95 dark:bg-gray-200 dark:text-gray-800 dark:hover:bg-gray-300 ${
+            isContainerHovered ? 'opacity-100' : 'pointer-events-none opacity-0'
+          }`}
+          aria-label="Scroll left"
+        >
+          <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+        </button>
+      )}
+
+      <div
+        ref={scrollContainerRef}
+        className="hide-scrollbar flex gap-4 overflow-x-auto scroll-smooth"
+      >
+        {uiResources.map((uiResource, index) => {
+          const height = 360;
+          const width = 230;
+
+          return (
+            <div
+              key={index}
+              className="flex-shrink-0 transform-gpu transition-all duration-300 ease-out animate-in fade-in-0 slide-in-from-bottom-5"
+              style={{
+                width: `${width}px`,
+                minHeight: `${height}px`,
+                animationDelay: `${index * 100}ms`,
+              }}
+            >
+              <div className="flex h-full flex-col">
+                <UIResourceRenderer
+                  resource={{
+                    uri: uiResource.uri,
+                    mimeType: uiResource.mimeType,
+                    text: uiResource.text,
+                  }}
+                  onUIAction={async (result) => {
+                    console.log('Action:', result);
+                  }}
+                  htmlProps={{
+                    autoResizeIframe: { width: true, height: true },
+                  }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {showRightArrow && (
+        <button
+          type="button"
+          onClick={() => scroll('right')}
+          className={`absolute right-2 top-1/2 z-20 -translate-y-1/2 rounded-xl bg-white p-2 text-gray-800 shadow-lg transition-all duration-200 hover:scale-110 hover:bg-gray-100 hover:shadow-xl active:scale-95 dark:bg-gray-200 dark:text-gray-800 dark:hover:bg-gray-300 ${
+            isContainerHovered ? 'opacity-100' : 'pointer-events-none opacity-0'
+          }`}
+          aria-label="Scroll right"
+        >
+          <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+});
+
+export default UIResourceGrid;

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1195,6 +1195,7 @@
   "com_ui_travel": "Travel",
   "com_ui_trust_app": "I trust this application",
   "com_ui_try_adjusting_search": "Try adjusting your search terms",
+  "com_ui_ui_resources": "UI Resources",
   "com_ui_unarchive": "Unarchive",
   "com_ui_unarchive_error": "Failed to unarchive conversation",
   "com_ui_unknown": "Unknown",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2634,6 +2634,7 @@
         "@headlessui/react": "^2.1.2",
         "@librechat/client": "*",
         "@marsidev/react-turnstile": "^1.1.0",
+        "@mcp-ui/client": "^5.7.0",
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-alert-dialog": "^1.0.2",
         "@radix-ui/react-checkbox": "^1.0.3",
@@ -22547,6 +22548,21 @@
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0"
       }
     },
+    "node_modules/@mcp-ui/client": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@mcp-ui/client/-/client-5.7.0.tgz",
+      "integrity": "sha512-+HbPw3VS46WUSWmyJ34ZVnygb81QByA3luR6y0JDbyDZxjYtHw1FcIN7v9WbbE8PrfI0WcuWCSiNOO6sOGbwpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "*",
+        "@quilted/threads": "^3.1.3",
+        "@r2wc/react-to-web-component": "^2.0.4",
+        "@remote-dom/core": "^1.8.0",
+        "@remote-dom/react": "^1.2.2",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      }
+    },
     "node_modules/@microsoft/eslint-formatter-sarif": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@microsoft/eslint-formatter-sarif/-/eslint-formatter-sarif-3.1.0.tgz",
@@ -23230,6 +23246,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@preact/signals-core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.11.0.tgz",
+      "integrity": "sha512-jglbibeWHuFRzEWVFY/TT7wB1PppJxmcSfUHcK+2J9vBRtiooMfw6tAPttojNYrrpdGViqAYCbPpmWYlMm+eMQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -23283,6 +23309,57 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@quilted/events": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@quilted/events/-/events-2.1.3.tgz",
+      "integrity": "sha512-4fHaSLND8rmZ+tce9/4FNmG5UWTRpFtM54kOekf3tLON4ZLLnYzjjldELD35efd7+lT5+E3cdkacqc56d+kCrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.8.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@quilted/threads": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@quilted/threads/-/threads-3.3.1.tgz",
+      "integrity": "sha512-0ASnjTH+hOu1Qwzi9NnsVcsbMhWVx8pEE8SXIHknqcc/1rXAU0QlKw9ARq0W43FAdzyVeuXeXtZN27ZC0iALKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@quilted/events": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@preact/signals-core": "^1.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@preact/signals-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@r2wc/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@r2wc/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-vAfiuS5KywtV54SRzc4maEHcpdgeUyJzln+ATpNCOkO+ArIuOkTXd92b5YauVAd0A8B2rV/y9OeVW19vb73bUQ==",
+      "license": "MIT"
+    },
+    "node_modules/@r2wc/react-to-web-component": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@r2wc/react-to-web-component/-/react-to-web-component-2.0.4.tgz",
+      "integrity": "sha512-g1dtTTEGETNUimYldTW+2hxY3mmJZjzPEca0vqCutUht2GHmpK9mT5r/urmEI7uSbOkn6HaymosgVy26lvU1JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@r2wc/core": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -26885,6 +26962,61 @@
       "integrity": "sha512-HOil5aFtme37dVQTB6M34G95kPM3MMuqSmIRVCC52eKV+Y/tGSqw9P3rWhlAx6A+mz+MoX+XxsGsNJbaI5qCgQ==",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@remote-dom/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@remote-dom/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-h8OO2NRns2paXO/q5hkfXrwlZKq7oKj9XedGosi7J8OP3+aW7N2Gv4MBBVVQGCfOiZPkOj5m3sQH7FdyUWl7PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remote-dom/polyfill": "^1.4.4",
+        "htm": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@preact/signals-core": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@preact/signals-core": {
+          "optional": true
+        },
+        "preact": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remote-dom/polyfill": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@remote-dom/polyfill/-/polyfill-1.4.5.tgz",
+      "integrity": "sha512-V1qkKIl/wXyDO0I+tQDH06cBBNyyViZF3IYorkTTBf58dorqOP5Ta51vCCWeekPgdSOPuEKvHhvu6kAaKqVgww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@remote-dom/react": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@remote-dom/react/-/react-1.2.2.tgz",
+      "integrity": "sha512-PkvioODONTr1M0StGDYsR4Ssf5M0Rd4+IlWVvVoK3Zrw8nr7+5mJkgNofaj/z7i8Aep78L28PCW8/WduUt4unA==",
+      "license": "MIT",
+      "dependencies": {
+        "@remote-dom/core": "^1.7.0",
+        "@types/react": "^18.0.0",
+        "htm": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-alias": {
@@ -36610,6 +36742,12 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -45460,9 +45598,10 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -45531,15 +45670,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-flip-toolkit": {
@@ -47461,9 +47601,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -111,6 +111,7 @@ export function formatToolContent(
   const formattedContent: t.FormattedContent[] = [];
   const imageUrls: t.FormattedContent[] = [];
   let currentTextBlock = '';
+  let uiResources: t.UIResource[] = [];
 
   type ContentHandler = undefined | ((item: t.ToolContentPart) => void);
 
@@ -142,9 +143,14 @@ export function formatToolContent(
     },
 
     resource: (item) => {
+      if (item.resource.uri.startsWith('ui://')) {
+        uiResources.push(item.resource as t.UIResource);
+        return;
+      }
+
       const resourceText = [];
       if (item.resource.text != null && item.resource.text) {
-        resourceText.push(item.resource.text);
+        resourceText.push(`Resource Text: ${item.resource.text}`);
       }
       if (item.resource.uri.length) {
         resourceText.push(`Resource URI: ${item.resource.uri}`);
@@ -153,10 +159,10 @@ export function formatToolContent(
         resourceText.push(`Resource: ${item.resource.name}`);
       }
       if (item.resource.description) {
-        resourceText.push(`Description: ${item.resource.description}`);
+        resourceText.push(`Resource Description: ${item.resource.description}`);
       }
       if (item.resource.mimeType != null && item.resource.mimeType) {
-        resourceText.push(`Type: ${item.resource.mimeType}`);
+        resourceText.push(`Resource MIME Type: ${item.resource.mimeType}`);
       }
       currentTextBlock += (currentTextBlock ? '\n\n' : '') + resourceText.join('\n');
     },
@@ -174,6 +180,10 @@ export function formatToolContent(
 
   if (CONTENT_ARRAY_PROVIDERS.has(provider) && currentTextBlock) {
     formattedContent.push({ type: 'text', text: currentTextBlock });
+  }
+
+  if (uiResources.length) {
+    formattedContent.push({ type: 'text', metadata: 'ui_resources', text: btoa(JSON.stringify(uiResources))});
   }
 
   const artifacts = imageUrls.length ? { content: imageUrls } : undefined;

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -75,6 +75,7 @@ export type FormattedContent =
   | {
       type: 'text';
       text: string;
+      metadata?: string;
     }
   | {
       type: 'image';
@@ -102,6 +103,13 @@ export type FormattedContentResult = [
   string | FormattedContent[],
   undefined | { content: FormattedContent[] },
 ];
+
+export type UIResource = {
+  uri: string;
+  mimeType: string;
+  text: string;
+  [key: string]: unknown;
+}
 
 export type ImageFormatter = (item: ImageContent) => FormattedContent;
 


### PR DESCRIPTION
## Summary

Here's a [video](https://youtu.be/Sc7Y3LtgrRc) describing my intention.

There's a project called [MCP UI](https://github.com/idosal/mcp-ui). Its goal is to allow MCP server tool calls to send back not just text content to the client, but also UI elements in various forms (it could be HTML or URLs to embed as iFrames). That library also defines a way for the client and the iFrames elements to communicate through [message passing](https://github.com/idosal/mcp-ui?tab=readme-ov-file#ui-action).

Some popular clients like Postman (see [LinkedIn announcement](https://www.linkedin.com/posts/abhinavasthana_following-shopifys-support-for-mcp-ui-https-activity-7358623075334021120-OkbJ/)) and Goose by Block (see [blog post announcement](https://block.github.io/goose/blog/2025/08/11/mcp-ui-post-browser-world/)) have already built support.

A few weeks ago, Shopify announced agent-kit (see [tweet](https://x.com/tobi/status/1958244700189790549) by Tobi the CEO), which contains MCP servers serving UI resources so that any client can integrate Shopify commerce components into chat AI experiences. All the work on Shopify side to test these components was done on a branch on our local fork of LibreChat.

Now we want to make such integrations available to a wider public, so that any LibreChat user can start tinkering with MCP Servers sending back UI resources (coming from Shopify or elsewhere).

_Please note that I'm first waiting to have the general idea validated before writing detailed tests._

### Example of a MCP Server tool serving UI Resources as URL

If you use Anthropic's [MCP inspector](https://github.com/modelcontextprotocol/inspector), you can use the following public MCP Server:

- **Transport Type**: Streamable HTTP
- **URL**: https://mcpstorefront.com/?storedomain=allbirds.com

Connect to it, then go to the the tools, and make a query to `search_shop_catalog` and enter the following value in both the `query` and `context` parameters: "Looking for men's sneakers in red color under $200":

<img width="1509" height="626" alt="image" src="https://github.com/user-attachments/assets/b8d71a4e-7364-4e27-8f5a-5f2bbbe97344" />

You'll get [this](https://gist.github.com/samuelpath/b8701767dfb255f15f9fe7cae8f6696b) as full result.

We see that the content array contains one object of type `text` and then multiple objects of type `resource` (see the MCP docs on [Resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources)). Here's a sample one:

```json
{
  "type": "resource",
  "resource": {
    "uri": "ui://product/gid://shopify/Product/7009816019024",
    "mimeType": "text/uri-list",
    "text": "https://mcpstorefront.com/img/storefront/product.component.html?store_domain=allbirds.com&product_handle=womens-tree-toppers-natural-black-blizzard&product_id=gid://shopify/Product/7009816019024&mode=tool"
  }
}
```

The way these UI Resources are identified is by their `uri` starting with the `ui://` prefix.

### Example of a MCP Server tool serving UI Resources as HTML

Now in Anthropic's MCP Inspector, use the following [public MCP Server](https://mcp-aharvard.netlify.app/pick-seat/):

- **Transport Type**: Streamable HTTP
- **URL**: https://mcp-aharvard.netlify.app/mcp

Make a query to the `get-weather` tool:

<img width="1510" height="706" alt="image" src="https://github.com/user-attachments/assets/570941e7-220a-4acd-8d59-45c2216f7cc8" />

You'll get [this](https://gist.github.com/samuelpath/c61d9e7fced68d777c1341a41a81c451) as full result.

The UI Resource looks like this:

```json
{
  "type": "resource",
  "resource": {
    "uri": "ui://mcp-aharvard/weather-card",
    "mimeType": "text/html",
    "text": "<HTML CODE>"
  },
  // ...
}
```

So we see that we can have either `mimeType` as `text/uri-list` with the `text` property being a URL to embed, or `mimeType` as `text/html` having the `text` property as HTML code to render by the client.

### The current behaviour

So what happens before our changes if we connect LibreChat to that MCP server and make a request to that tool?

Let's add 2 MCP servers supporting UI Resources to the [Librechat.yaml](https://github.com/danny-avila/LibreChat/blob/main/librechat.example.yaml) configuration file:

```yaml
mcpServers:
  mcp-ui-allbirds:
    type: 'streamable-http'
    url: https://mcpstorefront.com/?storedomain=allbirds.com

  mcp-aharvard:
      type: 'streamable-http'
      url: https://mcp-aharvard.netlify.app/mcp
```

This is what we get in the section where we see the tool call details (see this [gist](https://gist.github.com/samuelpath/29848a768555604df982213b30983852) for the exact value):

<img width="1209" height="729" alt="image" src="https://github.com/user-attachments/assets/717ccb04-e704-41ca-960d-b3404777f9a2" />

If we replace the `\n` by actual line breaks, this is what we get:

```
https://mcpstorefront.com/img/storefront/product.component.html?store_domain=allbirds.com&product_handle=mens-tree-runner-go-blizzard-bold-red&product_id=gid://shopify/Product/7091625328720&mode=tool
Resource URI: ui://product/gid://shopify/Product/7091625328720
Type: text/uri-list

https://mcpstorefront.com/img/storefront/product.component.html?store_domain=allbirds.com&product_handle=mens-tree-runners-blizzard-bold-red&product_id=gid://shopify/Product/7091621527632&mode=tool
Resource URI: ui://product/gid://shopify/Product/7091621527632
Type: text/uri-list

# and so on…
```

This is coming from that following code in `packages/api/src/mcp/parsers.ts`:

https://github.com/danny-avila/LibreChat/blob/3ab1bd65e54d17ec545f59139a5a323f98e4c216/packages/api/src/mcp/parsers.ts#L143-L161

What the parser is currently doing is converting the UI resource coming from the MCP tool response into text content to be sent to the LLM, which simply doesn't know what to do about it currently.

### What we are changing

Now, when the backend receives such a [response](https://gist.github.com/samuelpath/b8701767dfb255f15f9fe7cae8f6696b) containing UI resources, we don't parse them as text elements with simple line breaks (which don't get rendered properly in the front-end anyway).

Instead, we accumulate them in an array, and then encode its value as b64 as an additional object in the `formattedContent` array with `metadata: 'ui_resources'` in order to identify it on the frontend.

This way, once the front-end receives that output, it can parse it back into UI resources more easily.

Another option we explored was to not use the text content at all but rather use the `artifact` variable, which Llangchain provides as a way to pass data down through the pipeline without sending it to the LLM and also without having to serialize and deserialize it. The logic is handled below:

https://github.com/danny-avila/LibreChat/blob/3ab1bd65e54d17ec545f59139a5a323f98e4c216/packages/api/src/mcp/parsers.ts#L178-L183

However, we realized that unlike what was described in the [Llangchain docs](https://js.langchain.com/docs/how_to/tool_artifacts/), the LibreChat agents library was parsing the artifacts as text to add them to the text content which is sent to the LLM. I proposed an [update](https://js.langchain.com/docs/how_to/tool_artifacts/) for that which was rejected since that approach was used as a workaround for other purposes. Also, getting the artifacts in the frontend where we also get the content wasn't straightforward, so it seemed easier for me here to use the existing data structure rather than sending the artifacts as such to the frontend rendering code.

Once the front-end receives the text output, it extracts then parses the encoded resources and removes them from the text output:

https://github.com/danny-avila/LibreChat/blob/87b95d825d8e39b1059e4998e6f6ff8cff130f80/client/src/components/Chat/Messages/Content/ToolCallInfo.tsx#L57-L70

It then displays the UI elements in MCP UI's `UIResourceRenderer` component, which abstracts away the the iFrame, if there is one UI resource, or in a custom `UIResourceGrid` component if there are multiple elements, which allows to display UI resources as a grid:

https://github.com/danny-avila/LibreChat/blob/9cb70b7cf76e1ecdb2da53abe3e37e54348aa814/client/src/components/Chat/Messages/Content/ToolCallInfo.tsx#L89-L106

We get something like this for multiple UI resources shared as embeddable URLs:

<img width="744" height="856" alt="image" src="https://github.com/user-attachments/assets/1237e3d6-9005-47e9-9c35-03b954a11f51" />

In this current iteration, when the user clicks on a UI element that should trigger an action, we simply log the intent in the console:

<img width="678" height="861" alt="image" src="https://github.com/user-attachments/assets/605cadae-ce9d-4ac3-90e9-73e73e8f414e" />

And we get something like this for a single UI Resource embedded as HTML rendered by the client:

<img width="737" height="674" alt="image" src="https://github.com/user-attachments/assets/306fa635-0b81-474d-aa92-8cd1d00291c3" />

### What we will do next

In a follow-up PR, we would like to:

- Add two new types of artifacts, one for a single UI element and one for multiple UI elements, using a syntax like the one below

```
:::artifact{identifier="p1" type="mcp-ui-single-element" title="Men's Court Graffik Shoes - Black/Red"}
https://cdn.shopify.com/storefront/product-catalog-details.component?store_domain=www.dcshoes.com&product_handle=dc-shoes-mens-court-graffik-shoes-blackred-blr
:::
```

- Update the prompt sent to the LLM when UI resources are present so that it knows it can use MCP UI artifacts in the response interspersed with text.
- Have the client handle the intent payload sent by the UI elements so that the LLM can trigger further actions, like other tool calls (for instance if the user clicks on `Add to cart`, 

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update (potentially, it could be nice to explicit this support)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes (I will do this once this PR is accepted, so as not to waste effort)
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works (I am working on it, but I'm already looking for feedback so as not to write tests for nothing)
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted (I will do this once this PR is accepted, so as not to waste effort)