### PR TITLE
🎵 feat: Cumulative Transcription Support for External STT

### DIFF
--- a/api/server/services/Files/Audio/STTService.js
+++ b/api/server/services/Files/Audio/STTService.js
@@ -109,9 +109,11 @@ class STTService {
    * @throws {Error} If no STT schema is set, multiple providers are set, or no provider is set.
    */
   async getProviderSchema(req) {
-    const appConfig = await getAppConfig({
-      role: req?.user?.role,
-    });
+    const appConfig =
+      req.config ??
+      (await getAppConfig({
+        role: req?.user?.role,
+      }));
     const sttSchema = appConfig?.speech?.stt;
     if (!sttSchema) {
       throw new Error(

--- a/client/src/components/Prompts/AdminSettings.tsx
+++ b/client/src/components/Prompts/AdminSettings.tsx
@@ -153,7 +153,7 @@ const AdminSettings = () => {
             <span className="hidden sm:flex">{localize('com_ui_admin')}</span>
           </Button>
         </OGDialogTrigger>
-        <OGDialogContent className="max-w-lg border-border-light bg-surface-primary text-text-primary md:w-1/4">
+        <OGDialogContent className="max-w-lg border-border-light bg-surface-primary text-text-primary lg:w-1/4">
           <OGDialogTitle>
             {`${localize('com_ui_admin_settings')} - ${localize('com_ui_prompts')}`}
           </OGDialogTitle>

--- a/client/src/components/Sharing/PeoplePickerAdminSettings.tsx
+++ b/client/src/components/Sharing/PeoplePickerAdminSettings.tsx
@@ -163,7 +163,7 @@ const PeoplePickerAdminSettings = () => {
           {localize('com_ui_admin_settings')}
         </Button>
       </OGDialogTrigger>
-      <OGDialogContent className="w-full border-border-light bg-surface-primary text-text-primary md:w-1/4">
+      <OGDialogContent className="w-full border-border-light bg-surface-primary text-text-primary lg:w-1/4">
         <OGDialogTitle>{`${localize('com_ui_admin_settings')} - ${localize(
           'com_ui_people_picker',
         )}`}</OGDialogTitle>

--- a/client/src/components/SidePanel/Agents/AdminSettings.tsx
+++ b/client/src/components/SidePanel/Agents/AdminSettings.tsx
@@ -157,7 +157,7 @@ const AdminSettings = () => {
           {localize('com_ui_admin_settings')}
         </Button>
       </OGDialogTrigger>
-      <OGDialogContent className="border-border-light bg-surface-primary text-text-primary md:w-1/4">
+      <OGDialogContent className="border-border-light bg-surface-primary text-text-primary lg:w-1/4">
         <OGDialogTitle>{`${localize('com_ui_admin_settings')} - ${localize(
           'com_ui_agents',
         )}`}</OGDialogTitle>

--- a/client/src/components/SidePanel/Memories/AdminSettings.tsx
+++ b/client/src/components/SidePanel/Memories/AdminSettings.tsx
@@ -146,7 +146,7 @@ const AdminSettings = () => {
           {localize('com_ui_admin_settings')}
         </Button>
       </OGDialogTrigger>
-      <OGDialogContent className="border-border-light bg-surface-primary text-text-primary md:w-1/4">
+      <OGDialogContent className="border-border-light bg-surface-primary text-text-primary lg:w-1/4">
         <OGDialogTitle>{`${localize('com_ui_admin_settings')} - ${localize(
           'com_ui_memories',
         )}`}</OGDialogTitle>


### PR DESCRIPTION
## Summary

Closes #9306

Continues #9316 

I implemented cumulative transcription support for external Speech-to-Text providers and fixed configuration retrieval in TTS and STT services.

- Added logic to handle cumulative transcription for external STT providers in the AudioRecorder component
- Modified text concatenation behavior to distinguish between external and browser-based STT implementations
- Updated the stop recording handler to preserve existing text for external STT while clearing it for browser STT
- Refactored `getProviderSchema` and `getProvider` methods to accept an optional `appConfig` parameter for flexible configuration retrieval
- Fixed TTS and STT services to properly utilize AppConfig from request objects when available
- Improved error handling by validating app configuration before accessing TTS and STT schemas
- Enhanced `processTextToSpeech` and `streamAudio` methods to use the updated configuration parameter

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Test the cumulative transcription feature by:
1. Configure an external STT provider in librechat.yaml
2. Start audio recording and speak multiple sentences with pauses
3. Verify that transcriptions accumulate correctly without duplicating text
4. Test with browser-based STT to ensure existing behavior remains unchanged
5. Verify TTS functionality continues working with the configuration changes

### **Test Configuration**:
- External STT provider (e.g., Whisper API)
- Browser-based STT (Web Speech API)
- TTS provider configuration in librechat.yaml

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes