### PR TITLE
⚙️ fix: Dynamic HPA API Version Selection for K8s Compatibility

### DIFF
--- a/helm/librechat/templates/_helpers.tpl
+++ b/helm/librechat/templates/_helpers.tpl
@@ -63,3 +63,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define apiVersion of HorizontalPodAutoscaler
+*/}}
+{{- define "librechat.hpa.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2" -}}
+{{- print "autoscaling/v2" -}}
+{{- else if .Capabilities.APIVersions.Has "autoscaling/v2beta2" -}}
+{{- print "autoscaling/v2beta2" -}}
+{{- else -}}
+{{- print "autoscaling/v2beta1" -}}
+{{- end -}}
+{{- end -}}

--- a/helm/librechat/templates/hpa.yaml
+++ b/helm/librechat/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "librechat.hpa.apiVersion" $ }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "librechat.fullname" $ }}


### PR DESCRIPTION
## Summary

Support for HorizontalPodAutoscaler apiVersion `autoscaling/v2beta1` was dropped in kubernetes version 1.25

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v125

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
