### PR TITLE
🔧 fix: MCP Selection Persist and UI Flicker Issues

### DIFF
--- a/client/src/Providers/MCPPanelContext.tsx
+++ b/client/src/Providers/MCPPanelContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import { Constants } from 'librechat-data-provider';
+import { useChatContext } from './ChatContext';
+
+interface MCPPanelContextValue {
+  conversationId: string;
+}
+
+const MCPPanelContext = createContext<MCPPanelContextValue | undefined>(undefined);
+
+export function MCPPanelProvider({ children }: { children: React.ReactNode }) {
+  const { conversation } = useChatContext();
+
+  /** Context value only created when conversationId changes */
+  const contextValue = useMemo<MCPPanelContextValue>(
+    () => ({
+      conversationId: conversation?.conversationId ?? Constants.NEW_CONVO,
+    }),
+    [conversation?.conversationId],
+  );
+
+  return <MCPPanelContext.Provider value={contextValue}>{children}</MCPPanelContext.Provider>;
+}
+
+export function useMCPPanelContext() {
+  const context = useContext(MCPPanelContext);
+  if (!context) {
+    throw new Error('useMCPPanelContext must be used within MCPPanelProvider');
+  }
+  return context;
+}

--- a/client/src/Providers/index.ts
+++ b/client/src/Providers/index.ts
@@ -23,6 +23,7 @@ export * from './SetConvoContext';
 export * from './SearchContext';
 export * from './BadgeRowContext';
 export * from './SidePanelContext';
+export * from './MCPPanelContext';
 export * from './ArtifactsContext';
 export * from './PromptGroupsContext';
 export { default as BadgeRowProvider } from './BadgeRowContext';

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -8,6 +8,11 @@ import type * as t from 'librechat-data-provider';
 import type { LucideIcon } from 'lucide-react';
 import type { TranslationKeys } from '~/hooks';
 
+export interface ConfigFieldDetail {
+  title: string;
+  description: string;
+}
+
 export type CodeBarProps = {
   lang: string;
   error?: boolean;

--- a/client/src/components/Chat/Input/BadgeRow.tsx
+++ b/client/src/components/Chat/Input/BadgeRow.tsx
@@ -368,7 +368,7 @@ function BadgeRow({
             <CodeInterpreter />
             <FileSearch />
             <Artifacts />
-            <MCPSelect />
+            <MCPSelect conversationId={conversationId} />
           </>
         )}
         {ghostBadge && (

--- a/client/src/components/Chat/Input/MCPConfigDialog.tsx
+++ b/client/src/components/Chat/Input/MCPConfigDialog.tsx
@@ -1,12 +1,8 @@
 import React, { useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { Button, Input, Label, OGDialog, OGDialogTemplate } from '@librechat/client';
+import type { ConfigFieldDetail } from '~/common';
 import { useLocalize } from '~/hooks';
-
-export interface ConfigFieldDetail {
-  title: string;
-  description: string;
-}
 
 interface MCPConfigDialogProps {
   isOpen: boolean;
@@ -34,7 +30,7 @@ export default function MCPConfigDialog({
     control,
     handleSubmit,
     reset,
-    formState: { errors, _ },
+    formState: { errors },
   } = useForm<Record<string, string>>({
     defaultValues: initialValues,
   });
@@ -56,14 +52,12 @@ export default function MCPConfigDialog({
   };
 
   const dialogTitle = localize('com_ui_configure_mcp_variables_for', { 0: serverName });
-  const dialogDescription = localize('com_ui_mcp_dialog_desc');
 
   return (
     <OGDialog open={isOpen} onOpenChange={onOpenChange}>
       <OGDialogTemplate
         className="sm:max-w-lg"
         title={dialogTitle}
-        description={dialogDescription}
         headerClassName="px-6 pt-6 pb-4"
         main={
           <form onSubmit={handleSubmit(onFormSubmit)} className="space-y-4 px-6 pb-2">

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -4,7 +4,7 @@ import MCPServerStatusIcon from '~/components/MCP/MCPServerStatusIcon';
 import { useMCPServerManager } from '~/hooks/MCP/useMCPServerManager';
 import MCPConfigDialog from '~/components/MCP/MCPConfigDialog';
 
-function MCPSelect() {
+function MCPSelect({ conversationId }: { conversationId?: string | null }) {
   const {
     configuredServers,
     mcpValues,
@@ -15,7 +15,7 @@ function MCPSelect() {
     getConfigDialogProps,
     isInitializing,
     localize,
-  } = useMCPServerManager();
+  } = useMCPServerManager({ conversationId });
 
   const renderSelectedValues = useCallback(
     (values: string[], placeholder?: string) => {
@@ -93,7 +93,9 @@ function MCPSelect() {
         selectItemsClassName="border border-blue-600/50 bg-blue-500/10 hover:bg-blue-700/10"
         selectClassName="group relative inline-flex items-center justify-center md:justify-start gap-1.5 rounded-full border border-border-medium text-sm font-medium transition-all md:w-full size-9 p-2 md:p-3 bg-transparent shadow-sm hover:bg-surface-hover hover:shadow-md active:shadow-inner"
       />
-      {configDialogProps && <MCPConfigDialog {...configDialogProps} />}
+      {configDialogProps && (
+        <MCPConfigDialog {...configDialogProps} conversationId={conversationId} />
+      )}
     </>
   );
 }

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -3,8 +3,11 @@ import { MultiSelect, MCPIcon } from '@librechat/client';
 import MCPServerStatusIcon from '~/components/MCP/MCPServerStatusIcon';
 import { useMCPServerManager } from '~/hooks/MCP/useMCPServerManager';
 import MCPConfigDialog from '~/components/MCP/MCPConfigDialog';
+import { useBadgeRowContext } from '~/Providers';
 
-function MCPSelect({ conversationId }: { conversationId?: string | null }) {
+type MCPSelectProps = { conversationId?: string | null };
+
+function MCPSelectContent({ conversationId }: MCPSelectProps) {
   const {
     configuredServers,
     mcpValues,
@@ -98,6 +101,12 @@ function MCPSelect({ conversationId }: { conversationId?: string | null }) {
       )}
     </>
   );
+}
+
+function MCPSelect(props: MCPSelectProps) {
+  const { mcpServerNames } = useBadgeRowContext();
+  if ((mcpServerNames?.length ?? 0) === 0) return null;
+  return <MCPSelectContent {...props} />;
 }
 
 export default memo(MCPSelect);

--- a/client/src/components/Chat/Input/MCPSubMenu.tsx
+++ b/client/src/components/Chat/Input/MCPSubMenu.tsx
@@ -9,10 +9,11 @@ import { cn } from '~/utils';
 
 interface MCPSubMenuProps {
   placeholder?: string;
+  conversationId?: string | null;
 }
 
 const MCPSubMenu = React.forwardRef<HTMLDivElement, MCPSubMenuProps>(
-  ({ placeholder, ...props }, ref) => {
+  ({ placeholder, conversationId, ...props }, ref) => {
     const {
       configuredServers,
       mcpValues,
@@ -23,7 +24,7 @@ const MCPSubMenu = React.forwardRef<HTMLDivElement, MCPSubMenuProps>(
       getServerStatusIconProps,
       getConfigDialogProps,
       isInitializing,
-    } = useMCPServerManager();
+    } = useMCPServerManager({ conversationId });
 
     const menuStore = Ariakit.useMenuStore({
       focusLoop: true,

--- a/client/src/components/Chat/Input/ToolsDropdown.tsx
+++ b/client/src/components/Chat/Input/ToolsDropdown.tsx
@@ -10,12 +10,12 @@ import {
   PermissionTypes,
   defaultAgentCapabilities,
 } from 'librechat-data-provider';
-import { useLocalize, useHasAccess, useAgentCapabilities, useMCPSelect } from '~/hooks';
+import { useLocalize, useHasAccess, useGetMCPTools, useAgentCapabilities } from '~/hooks';
 import ArtifactsSubMenu from '~/components/Chat/Input/ArtifactsSubMenu';
 import MCPSubMenu from '~/components/Chat/Input/MCPSubMenu';
+import { useGetStartupConfig } from '~/data-provider';
 import { useBadgeRowContext } from '~/Providers';
 import { cn } from '~/utils';
-import { useGetStartupConfig } from '~/data-provider';
 
 interface ToolsDropdownProps {
   disabled?: boolean;
@@ -30,11 +30,11 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
     artifacts,
     fileSearch,
     agentsConfig,
+    conversationId,
     codeApiKeyForm,
     codeInterpreter,
     searchApiKeyForm,
   } = useBadgeRowContext();
-  const mcpSelect = useMCPSelect();
   const { data: startupConfig } = useGetStartupConfig();
 
   const { codeEnabled, webSearchEnabled, artifactsEnabled, fileSearchEnabled } =
@@ -56,7 +56,6 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
   } = codeInterpreter;
   const { isPinned: isFileSearchPinned, setIsPinned: setIsFileSearchPinned } = fileSearch;
   const { isPinned: isArtifactsPinned, setIsPinned: setIsArtifactsPinned } = artifacts;
-  const { mcpServerNames } = mcpSelect;
 
   const canUseWebSearch = useHasAccess({
     permissionType: PermissionTypes.WEB_SEARCH,
@@ -287,10 +286,18 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
     });
   }
 
+  const { mcpToolDetails } = useGetMCPTools();
+
+  const mcpServerNames = useMemo(() => {
+    return (mcpToolDetails ?? []).map((tool) => tool.name);
+  }, [mcpToolDetails]);
+
   if (mcpServerNames && mcpServerNames.length > 0) {
     dropdownItems.push({
       hideOnClick: false,
-      render: (props) => <MCPSubMenu {...props} placeholder={mcpPlaceholder} />,
+      render: (props) => (
+        <MCPSubMenu {...props} placeholder={mcpPlaceholder} conversationId={conversationId} />
+      ),
     });
   }
 

--- a/client/src/components/Chat/Input/ToolsDropdown.tsx
+++ b/client/src/components/Chat/Input/ToolsDropdown.tsx
@@ -10,7 +10,7 @@ import {
   PermissionTypes,
   defaultAgentCapabilities,
 } from 'librechat-data-provider';
-import { useLocalize, useHasAccess, useGetMCPTools, useAgentCapabilities } from '~/hooks';
+import { useLocalize, useHasAccess, useAgentCapabilities } from '~/hooks';
 import ArtifactsSubMenu from '~/components/Chat/Input/ArtifactsSubMenu';
 import MCPSubMenu from '~/components/Chat/Input/MCPSubMenu';
 import { useGetStartupConfig } from '~/data-provider';
@@ -30,6 +30,7 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
     artifacts,
     fileSearch,
     agentsConfig,
+    mcpServerNames,
     conversationId,
     codeApiKeyForm,
     codeInterpreter,
@@ -285,12 +286,6 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
       ),
     });
   }
-
-  const { mcpToolDetails } = useGetMCPTools();
-
-  const mcpServerNames = useMemo(() => {
-    return (mcpToolDetails ?? []).map((tool) => tool.name);
-  }, [mcpToolDetails]);
 
   if (mcpServerNames && mcpServerNames.length > 0) {
     dropdownItems.push({

--- a/client/src/components/MCP/MCPConfigDialog.tsx
+++ b/client/src/components/MCP/MCPConfigDialog.tsx
@@ -8,14 +8,10 @@ import {
   OGDialogContent,
 } from '@librechat/client';
 import type { MCPServerStatus } from 'librechat-data-provider';
+import type { ConfigFieldDetail } from '~/common';
 import ServerInitializationSection from './ServerInitializationSection';
 import CustomUserVarsSection from './CustomUserVarsSection';
 import { useLocalize } from '~/hooks';
-
-export interface ConfigFieldDetail {
-  title: string;
-  description: string;
-}
 
 interface MCPConfigDialogProps {
   isOpen: boolean;

--- a/client/src/components/MCP/MCPConfigDialog.tsx
+++ b/client/src/components/MCP/MCPConfigDialog.tsx
@@ -27,6 +27,7 @@ interface MCPConfigDialogProps {
   onRevoke?: () => void;
   serverName: string;
   serverStatus?: MCPServerStatus;
+  conversationId?: string | null;
 }
 
 export default function MCPConfigDialog({
@@ -38,6 +39,7 @@ export default function MCPConfigDialog({
   onRevoke,
   serverName,
   serverStatus,
+  conversationId,
 }: MCPConfigDialogProps) {
   const localize = useLocalize();
 
@@ -126,6 +128,7 @@ export default function MCPConfigDialog({
         {/* Server Initialization Section */}
         <ServerInitializationSection
           serverName={serverName}
+          conversationId={conversationId}
           requiresOAuth={serverStatus?.requiresOAuth || false}
           hasCustomUserVars={fieldsSchema && Object.keys(fieldsSchema).length > 0}
         />

--- a/client/src/components/MCP/ServerInitializationSection.tsx
+++ b/client/src/components/MCP/ServerInitializationSection.tsx
@@ -71,13 +71,18 @@ export default function ServerInitializationSection({
   const isReinit = shouldShowReinit;
   const outerClass = isReinit ? 'flex justify-start' : 'flex justify-end';
   const buttonVariant = isReinit ? undefined : 'default';
-  const buttonText = isServerInitializing
-    ? localize('com_ui_loading')
-    : isReinit
-      ? localize('com_ui_reinitialize')
-      : requiresOAuth
-        ? localize('com_ui_authenticate')
-        : localize('com_ui_mcp_initialize');
+
+  let buttonText = '';
+  if (isServerInitializing) {
+    buttonText = localize('com_ui_loading');
+  } else if (isReinit) {
+    buttonText = localize('com_ui_reinitialize');
+  } else if (requiresOAuth) {
+    buttonText = localize('com_ui_authenticate');
+  } else {
+    buttonText = localize('com_ui_mcp_initialize');
+  }
+
   const icon = isServerInitializing ? (
     <Spinner className="h-4 w-4" />
   ) : (

--- a/client/src/components/MCP/ServerInitializationSection.tsx
+++ b/client/src/components/MCP/ServerInitializationSection.tsx
@@ -9,12 +9,14 @@ interface ServerInitializationSectionProps {
   serverName: string;
   requiresOAuth: boolean;
   hasCustomUserVars?: boolean;
+  conversationId?: string | null;
 }
 
 export default function ServerInitializationSection({
-  sidePanel = false,
   serverName,
   requiresOAuth,
+  conversationId,
+  sidePanel = false,
   hasCustomUserVars = false,
 }: ServerInitializationSectionProps) {
   const localize = useLocalize();
@@ -26,7 +28,7 @@ export default function ServerInitializationSection({
     isInitializing,
     isCancellable,
     getOAuthUrl,
-  } = useMCPServerManager();
+  } = useMCPServerManager({ conversationId });
 
   const serverStatus = connectionStatus[serverName];
   const isConnected = serverStatus?.connectionState === 'connected';

--- a/client/src/components/SidePanel/MCP/MCPPanel.tsx
+++ b/client/src/components/SidePanel/MCP/MCPPanel.tsx
@@ -8,15 +8,16 @@ import type { TUpdateUserPlugins } from 'librechat-data-provider';
 import ServerInitializationSection from '~/components/MCP/ServerInitializationSection';
 import { useMCPConnectionStatusQuery } from '~/data-provider/Tools/queries';
 import CustomUserVarsSection from '~/components/MCP/CustomUserVarsSection';
-import BadgeRowProvider from '~/Providers/BadgeRowContext';
+import { MCPPanelProvider, useMCPPanelContext } from '~/Providers';
 import { useGetStartupConfig } from '~/data-provider';
 import MCPPanelSkeleton from './MCPPanelSkeleton';
 import { useLocalize } from '~/hooks';
 
 function MCPPanelContent() {
   const localize = useLocalize();
-  const { showToast } = useToastContext();
   const queryClient = useQueryClient();
+  const { showToast } = useToastContext();
+  const { conversationId } = useMCPPanelContext();
   const { data: startupConfig, isLoading: startupConfigLoading } = useGetStartupConfig();
   const { data: connectionStatusData } = useMCPConnectionStatusQuery();
   const [selectedServerNameForEditing, setSelectedServerNameForEditing] = useState<string | null>(
@@ -153,6 +154,7 @@ function MCPPanelContent() {
 
         <ServerInitializationSection
           sidePanel={true}
+          conversationId={conversationId}
           serverName={selectedServerNameForEditing}
           requiresOAuth={serverStatus?.requiresOAuth || false}
           hasCustomUserVars={
@@ -204,8 +206,8 @@ function MCPPanelContent() {
 
 export default function MCPPanel() {
   return (
-    <BadgeRowProvider>
+    <MCPPanelProvider>
       <MCPPanelContent />
-    </BadgeRowProvider>
+    </MCPPanelProvider>
   );
 }

--- a/client/src/hooks/MCP/index.ts
+++ b/client/src/hooks/MCP/index.ts
@@ -1,1 +1,3 @@
+export * from './useMCPSelect';
+export * from './useGetMCPTools';
 export { useMCPServerManager } from './useMCPServerManager';

--- a/client/src/hooks/MCP/useGetMCPTools.ts
+++ b/client/src/hooks/MCP/useGetMCPTools.ts
@@ -5,7 +5,7 @@ import { useAvailableToolsQuery, useGetStartupConfig } from '~/data-provider';
 
 export function useGetMCPTools() {
   const { data: startupConfig } = useGetStartupConfig();
-  const { data: rawMcpTools, isFetched } = useAvailableToolsQuery(EModelEndpoint.agents, {
+  const { data: rawMcpTools } = useAvailableToolsQuery(EModelEndpoint.agents, {
     select: (data: TPlugin[]) => {
       const mcpToolsMap = new Map<string, TPlugin>();
       data.forEach((tool) => {
@@ -38,7 +38,6 @@ export function useGetMCPTools() {
   }, [rawMcpTools, startupConfig?.mcpServers]);
 
   return {
-    isFetched,
     mcpToolDetails,
   };
 }

--- a/client/src/hooks/MCP/useGetMCPTools.ts
+++ b/client/src/hooks/MCP/useGetMCPTools.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import { Constants, EModelEndpoint } from 'librechat-data-provider';
+import type { TPlugin } from 'librechat-data-provider';
+import { useAvailableToolsQuery, useGetStartupConfig } from '~/data-provider';
+
+export function useGetMCPTools() {
+  const { data: startupConfig } = useGetStartupConfig();
+  const { data: rawMcpTools, isFetched } = useAvailableToolsQuery(EModelEndpoint.agents, {
+    select: (data: TPlugin[]) => {
+      const mcpToolsMap = new Map<string, TPlugin>();
+      data.forEach((tool) => {
+        const isMCP = tool.pluginKey.includes(Constants.mcp_delimiter);
+        if (isMCP) {
+          const parts = tool.pluginKey.split(Constants.mcp_delimiter);
+          const serverName = parts[parts.length - 1];
+          if (!mcpToolsMap.has(serverName)) {
+            mcpToolsMap.set(serverName, {
+              name: serverName,
+              pluginKey: tool.pluginKey,
+              authConfig: tool.authConfig,
+              authenticated: tool.authenticated,
+            });
+          }
+        }
+      });
+      return Array.from(mcpToolsMap.values());
+    },
+  });
+
+  const mcpToolDetails = useMemo(() => {
+    if (!rawMcpTools || !startupConfig?.mcpServers) {
+      return rawMcpTools;
+    }
+    return rawMcpTools.filter((tool) => {
+      const serverConfig = startupConfig?.mcpServers?.[tool.name];
+      return serverConfig?.chatMenu !== false;
+    });
+  }, [rawMcpTools, startupConfig?.mcpServers]);
+
+  return {
+    isFetched,
+    mcpToolDetails,
+  };
+}

--- a/client/src/hooks/MCP/useMCPSelect.ts
+++ b/client/src/hooks/MCP/useMCPSelect.ts
@@ -22,8 +22,10 @@ const storageCondition = (value: unknown, rawCurrentValue?: string | null) => {
 export function useMCPSelect({ conversationId }: { conversationId?: string | null }) {
   const key = conversationId ?? Constants.NEW_CONVO;
   const hasSetFetched = useRef<string | null>(null);
+  const { isFetched, mcpToolDetails } = useGetMCPTools();
   const [ephemeralAgent, setEphemeralAgent] = useRecoilState(ephemeralAgentByConvoId(key));
 
+  const storageKey = `${LocalStorageKeys.LAST_MCP_}${key}`;
   const mcpState = useMemo(() => {
     return ephemeralAgent?.mcp ?? [];
   }, [ephemeralAgent?.mcp]);
@@ -45,7 +47,7 @@ export function useMCPSelect({ conversationId }: { conversationId?: string | nul
   );
 
   const [mcpValues, setMCPValuesRaw] = useLocalStorage<string[]>(
-    `${LocalStorageKeys.LAST_MCP_}${key}`,
+    storageKey,
     mcpState,
     setSelectedValues,
     storageCondition,
@@ -63,8 +65,6 @@ export function useMCPSelect({ conversationId }: { conversationId?: string | nul
     `${LocalStorageKeys.PIN_MCP_}${key}`,
     true,
   );
-
-  const { isFetched, mcpToolDetails } = useGetMCPTools();
 
   useEffect(() => {
     if (hasSetFetched.current === key) {

--- a/client/src/hooks/MCP/useMCPSelect.ts
+++ b/client/src/hooks/MCP/useMCPSelect.ts
@@ -1,9 +1,8 @@
-import { useRef, useEffect, useCallback, useMemo } from 'react';
+import { useRef, useCallback, useMemo } from 'react';
 import { useRecoilState } from 'recoil';
 import { Constants, LocalStorageKeys } from 'librechat-data-provider';
 import useLocalStorage from '~/hooks/useLocalStorageAlt';
 import { ephemeralAgentByConvoId } from '~/store';
-import { useGetMCPTools } from './useGetMCPTools';
 
 const storageCondition = (value: unknown, rawCurrentValue?: string | null) => {
   if (rawCurrentValue) {
@@ -21,8 +20,6 @@ const storageCondition = (value: unknown, rawCurrentValue?: string | null) => {
 
 export function useMCPSelect({ conversationId }: { conversationId?: string | null }) {
   const key = conversationId ?? Constants.NEW_CONVO;
-  const hasSetFetched = useRef<string | null>(null);
-  const { isFetched, mcpToolDetails } = useGetMCPTools();
   const [ephemeralAgent, setEphemeralAgent] = useRecoilState(ephemeralAgentByConvoId(key));
 
   const storageKey = `${LocalStorageKeys.LAST_MCP_}${key}`;
@@ -56,7 +53,7 @@ export function useMCPSelect({ conversationId }: { conversationId?: string | nul
   const setMCPValuesRawRef = useRef(setMCPValuesRaw);
   setMCPValuesRawRef.current = setMCPValuesRaw;
 
-  // Create a stable memoized setter to avoid re-creating it on every render and causing an infinite render loop
+  /** Create a stable memoized setter to avoid re-creating it on every render and causing an infinite render loop */
   const setMCPValues = useCallback((value: string[]) => {
     setMCPValuesRawRef.current(value);
   }, []);
@@ -66,33 +63,10 @@ export function useMCPSelect({ conversationId }: { conversationId?: string | nul
     true,
   );
 
-  useEffect(() => {
-    if (hasSetFetched.current === key) {
-      return;
-    }
-    if (!isFetched) {
-      return;
-    }
-    hasSetFetched.current = key;
-    if ((mcpToolDetails?.length ?? 0) > 0) {
-      setMCPValues(mcpValues.filter((mcp) => mcpToolDetails?.some((tool) => tool.name === mcp)));
-      return;
-    }
-    setMCPValues([]);
-  }, [isFetched, setMCPValues, mcpToolDetails, key, mcpValues]);
-
-  const mcpServerNames = useMemo(() => {
-    return (mcpToolDetails ?? []).map((tool) => tool.name);
-  }, [mcpToolDetails]);
-
   return {
     isPinned,
     mcpValues,
     setIsPinned,
     setMCPValues,
-    mcpServerNames,
-    ephemeralAgent,
-    mcpToolDetails,
-    setEphemeralAgent,
   };
 }

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -8,10 +8,10 @@ import {
   useReinitializeMCPServerMutation,
 } from 'librechat-data-provider/react-query';
 import type { TUpdateUserPlugins, TPlugin } from 'librechat-data-provider';
-import type { ConfigFieldDetail } from '~/components/MCP/MCPConfigDialog';
+import type { ConfigFieldDetail } from '~/common';
 import { useMCPConnectionStatusQuery } from '~/data-provider/Tools/queries';
+import { useLocalize, useMCPSelect, useGetMCPTools } from '~/hooks';
 import { useGetStartupConfig } from '~/data-provider';
-import { useLocalize, useMCPSelect } from '~/hooks';
 
 interface ServerState {
   isInitializing: boolean;
@@ -23,11 +23,12 @@ interface ServerState {
 
 export function useMCPServerManager({ conversationId }: { conversationId?: string | null }) {
   const localize = useLocalize();
+  const queryClient = useQueryClient();
   const { showToast } = useToastContext();
+  const { mcpToolDetails } = useGetMCPTools();
   const mcpSelect = useMCPSelect({ conversationId });
   const { data: startupConfig } = useGetStartupConfig();
-  const { mcpValues, setMCPValues, mcpToolDetails, isPinned, setIsPinned } = mcpSelect;
-  const queryClient = useQueryClient();
+  const { mcpValues, setMCPValues, isPinned, setIsPinned } = mcpSelect;
 
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const [selectedToolForConfig, setSelectedToolForConfig] = useState<TPlugin | null>(null);
@@ -500,12 +501,12 @@ export function useMCPServerManager({ conversationId }: { conversationId?: strin
       };
     },
     [
+      isCancellable,
       mcpToolDetails,
+      isInitializing,
+      cancelOAuthFlow,
       connectionStatus,
       startupConfig?.mcpServers,
-      isInitializing,
-      isCancellable,
-      cancelOAuthFlow,
     ],
   );
 
@@ -561,7 +562,6 @@ export function useMCPServerManager({ conversationId }: { conversationId?: strin
     mcpValues,
     setMCPValues,
 
-    mcpToolDetails,
     isPinned,
     setIsPinned,
     placeholderText,

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -90,7 +90,21 @@ export function useMCPServerManager({ conversationId }: { conversationId?: strin
     [connectionStatusData?.connectionStatus],
   );
 
+  /** Filter disconnected servers when values change, but only after initial load
+   This prevents clearing selections on page refresh when servers haven't connected yet
+   */
+  const hasInitialLoadCompleted = useRef(false);
+
   useEffect(() => {
+    if (!connectionStatusData || Object.keys(connectionStatus).length === 0) {
+      return;
+    }
+
+    if (!hasInitialLoadCompleted.current) {
+      hasInitialLoadCompleted.current = true;
+      return;
+    }
+
     if (!mcpValues?.length) return;
 
     const connectedSelected = mcpValues.filter(
@@ -100,7 +114,7 @@ export function useMCPServerManager({ conversationId }: { conversationId?: strin
     if (connectedSelected.length !== mcpValues.length) {
       setMCPValues(connectedSelected);
     }
-  }, [connectionStatus, mcpValues, setMCPValues]);
+  }, [connectionStatus, connectionStatusData, mcpValues, setMCPValues]);
 
   const updateServerState = useCallback((serverName: string, updates: Partial<ServerState>) => {
     setServerStates((prev) => {

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -21,10 +21,10 @@ interface ServerState {
   pollInterval: NodeJS.Timeout | null;
 }
 
-export function useMCPServerManager() {
+export function useMCPServerManager({ conversationId }: { conversationId?: string | null }) {
   const localize = useLocalize();
   const { showToast } = useToastContext();
-  const mcpSelect = useMCPSelect();
+  const mcpSelect = useMCPSelect({ conversationId });
   const { data: startupConfig } = useGetStartupConfig();
   const { mcpValues, setMCPValues, mcpToolDetails, isPinned, setIsPinned } = mcpSelect;
   const queryClient = useQueryClient();

--- a/client/src/hooks/Plugins/index.ts
+++ b/client/src/hooks/Plugins/index.ts
@@ -1,4 +1,3 @@
-export * from './useMCPSelect';
 export * from './useToolToggle';
 export { default as useAuthCodeTool } from './useAuthCodeTool';
 export { default as usePluginInstall } from './usePluginInstall';


### PR DESCRIPTION
## Summary

I fixed MCP selection clearing on page refresh and resolved UI flickering issues, potentially caused by improper hook usage patterns in the MCP management system. The flickering was likely due to components re-rendering unnecessarily when conversation context changed, especially when the hook was used to determine component rendering, as well as near-circular dependency of MCP-related hooks.

- Fixed clearing of MCP selections on page refresh by tracking initial load completion state before filtering disconnected servers
- Eliminated UI flicker by removing `useChatContext` dependency from `useMCPSelect` and passing `conversationId` as a prop instead
- Created `MCPPanelContext` provider to properly isolate conversation state management from selection logic
- Extracted MCP tools fetching into dedicated `useGetMCPTools` hook to prevent redundant data fetching across components
- Optimized `useLocalStorageAlt` performance by wrapping `setValueWrap` in `useCallback` to prevent unnecessary re-renders
- Streamlined `useMCPSelect` by removing unnecessary memoization that could trigger re-renders
- Improved `ServerInitializationSection` readability by replacing nested ternary with if-else statements
- Updated MCP components to receive `conversationId` as prop, preventing unnecessary context subscriptions

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes