### PR TITLE
Fix: Skip transaction creation when balance feature is disabled

### DIFF
--- a/api/models/Transaction.js
+++ b/api/models/Transaction.js
@@ -193,15 +193,15 @@ async function createTransaction(_txData) {
   if (txData.rawAmount != null && isNaN(txData.rawAmount)) {
     return;
   }
+  if (!balance?.enabled) {
+    return;
+  }
 
   const transaction = new Transaction(txData);
   transaction.endpointTokenConfig = txData.endpointTokenConfig;
   calculateTokenValue(transaction);
 
   await transaction.save();
-  if (!balance?.enabled) {
-    return;
-  }
 
   let incrementValue = transaction.tokenValue;
   const balanceResponse = await updateBalance({
@@ -223,6 +223,11 @@ async function createTransaction(_txData) {
  */
 async function createStructuredTransaction(_txData) {
   const { balance, ...txData } = _txData;
+
+  if (!balance?.enabled) {
+    return;
+  }
+
   const transaction = new Transaction({
     ...txData,
     endpointTokenConfig: txData.endpointTokenConfig,
@@ -231,10 +236,6 @@ async function createStructuredTransaction(_txData) {
   calculateStructuredTokenValue(transaction);
 
   await transaction.save();
-
-  if (!balance?.enabled) {
-    return;
-  }
 
   let incrementValue = transaction.tokenValue;
 

--- a/api/models/Transaction.spec.js
+++ b/api/models/Transaction.spec.js
@@ -1,10 +1,13 @@
 const mongoose = require('mongoose');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const { spendTokens, spendStructuredTokens } = require('./spendTokens');
-
 const { getMultiplier, getCacheMultiplier } = require('./tx');
-const { createTransaction } = require('./Transaction');
-const { Balance } = require('~/db/models');
+const {
+  createTransaction,
+  createStructuredTransaction,
+  createAutoRefillTransaction,
+} = require('./Transaction');
+const { Balance, Transaction } = require('~/db/models');
 
 let mongoServer;
 beforeAll(async () => {
@@ -378,5 +381,153 @@ describe('NaN Handling Tests', () => {
     expect(result).toBeUndefined();
     const balance = await Balance.findOne({ user: userId });
     expect(balance.tokenCredits).toBe(initialBalance);
+  });
+});
+
+describe('Balance Disabled Tests', () => {
+  test('createTransaction should not save transaction when balance is disabled', async () => {
+    // Arrange
+    const userId = new mongoose.Types.ObjectId();
+    const initialBalance = 10000000;
+    await Balance.create({ user: userId, tokenCredits: initialBalance });
+
+    const model = 'gpt-3.5-turbo';
+    const txData = {
+      user: userId,
+      conversationId: 'test-conversation-id',
+      model,
+      context: 'test',
+      endpointTokenConfig: null,
+      rawAmount: -100,
+      tokenType: 'prompt',
+      balance: { enabled: false },
+    };
+
+    // Act
+    const result = await createTransaction(txData);
+
+    // Assert: No transaction should be created, no result returned, and balance unchanged
+    expect(result).toBeUndefined();
+    const transactions = await Transaction.find({ user: userId });
+    expect(transactions).toHaveLength(0);
+    const balance = await Balance.findOne({ user: userId });
+    expect(balance.tokenCredits).toBe(initialBalance);
+  });
+
+  test('createStructuredTransaction should not save transaction when balance is disabled', async () => {
+    // Arrange
+    const userId = new mongoose.Types.ObjectId();
+    const initialBalance = 10000000;
+    await Balance.create({ user: userId, tokenCredits: initialBalance });
+
+    const model = 'claude-3-5-sonnet';
+    const txData = {
+      user: userId,
+      conversationId: 'test-conversation-id',
+      model,
+      context: 'message',
+      tokenType: 'prompt',
+      inputTokens: -10,
+      writeTokens: -100,
+      readTokens: -5,
+      balance: { enabled: false },
+    };
+
+    // Act
+    const result = await createStructuredTransaction(txData);
+
+    // Assert: No transaction should be created, no result returned, and balance unchanged
+    expect(result).toBeUndefined();
+    const transactions = await Transaction.find({ user: userId });
+    expect(transactions).toHaveLength(0);
+    const balance = await Balance.findOne({ user: userId });
+    expect(balance.tokenCredits).toBe(initialBalance);
+  });
+
+  test('createTransaction should save transaction when balance is enabled', async () => {
+    // Arrange
+    const userId = new mongoose.Types.ObjectId();
+    const initialBalance = 10000000;
+    await Balance.create({ user: userId, tokenCredits: initialBalance });
+
+    const model = 'gpt-3.5-turbo';
+    const txData = {
+      user: userId,
+      conversationId: 'test-conversation-id',
+      model,
+      context: 'test',
+      endpointTokenConfig: null,
+      rawAmount: -100,
+      tokenType: 'prompt',
+      balance: { enabled: true },
+    };
+
+    // Act
+    const result = await createTransaction(txData);
+
+    // Assert: Transaction should be created and balance updated
+    expect(result).toBeDefined();
+    expect(result.balance).toBeLessThan(initialBalance);
+    const transactions = await Transaction.find({ user: userId });
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0].rawAmount).toBe(-100);
+  });
+
+  test('createStructuredTransaction should save transaction when balance is enabled', async () => {
+    // Arrange
+    const userId = new mongoose.Types.ObjectId();
+    const initialBalance = 10000000;
+    await Balance.create({ user: userId, tokenCredits: initialBalance });
+
+    const model = 'claude-3-5-sonnet';
+    const txData = {
+      user: userId,
+      conversationId: 'test-conversation-id',
+      model,
+      context: 'message',
+      tokenType: 'prompt',
+      inputTokens: -10,
+      writeTokens: -100,
+      readTokens: -5,
+      balance: { enabled: true },
+    };
+
+    // Act
+    const result = await createStructuredTransaction(txData);
+
+    // Assert: Transaction should be created and balance updated
+    expect(result).toBeDefined();
+    expect(result.balance).toBeLessThan(initialBalance);
+    const transactions = await Transaction.find({ user: userId });
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0].inputTokens).toBe(-10);
+    expect(transactions[0].writeTokens).toBe(-100);
+    expect(transactions[0].readTokens).toBe(-5);
+  });
+
+  test('createAutoRefillTransaction should create transaction and update balance', async () => {
+    // Arrange
+    const userId = new mongoose.Types.ObjectId();
+    const initialBalance = 10000000;
+    await Balance.create({ user: userId, tokenCredits: initialBalance });
+
+    const txData = {
+      user: userId,
+      tokenType: 'credits',
+      context: 'autoRefill',
+      rawAmount: 5000000,
+    };
+
+    // Act
+    const result = await createAutoRefillTransaction(txData);
+
+    // Assert: Transaction should be created and balance updated
+    expect(result).toBeDefined();
+    expect(result.balance).toBeGreaterThan(initialBalance);
+    expect(result.transaction).toBeDefined();
+    const transactions = await Transaction.find({ user: userId });
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0].rawAmount).toBe(5000000);
+    expect(transactions[0].context).toBe('autoRefill');
   });
 });

--- a/api/models/spendTokens.spec.js
+++ b/api/models/spendTokens.spec.js
@@ -156,9 +156,9 @@ describe('spendTokens', () => {
 
     await spendTokens(txData, tokenUsage);
 
-    // Verify transactions were created
+    // Verify transactions were not created
     const transactions = await Transaction.find({ user: userId });
-    expect(transactions).toHaveLength(2);
+    expect(transactions).toHaveLength(0);
 
     // Verify balance was not updated (should still be 10000)
     const balance = await Balance.findOne({ user: userId });


### PR DESCRIPTION
## Summary

This PR prevents creating new objects in the `transactions` collection the balance feature is disabled. 
Without enabling balance, it seems transactions have no purpose but they consume a non negligible amount of space in the database.

Note: if there are still reasons to keep populating the `transactions` collection when balance is disable, we can add another configuration for it, but otherwise I think linking them together is simpler.


## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added unit tests and tested manually that new objects are not being created anymore.

### **Test Configuration**:
```yaml
#librechat.yaml
balance:
  enabled: false
```

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
