### PR TITLE
🎯 refactor: Custom Endpoint Request-based Header Resolution

### DIFF
--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -36,10 +36,12 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
   const CUSTOM_API_KEY = extractEnvVariable(endpointConfig.apiKey);
   const CUSTOM_BASE_URL = extractEnvVariable(endpointConfig.baseURL);
 
+  /** Intentionally excludes passing `body`, i.e. `req.body`, as
+   *  values may not be accurate until `AgentClient` is initialized
+   */
   let resolvedHeaders = resolveHeaders({
     headers: endpointConfig.headers,
     user: req.user,
-    body: req.body,
   });
 
   if (CUSTOM_API_KEY.match(envVarRegex)) {

--- a/api/server/services/Endpoints/custom/initialize.spec.js
+++ b/api/server/services/Endpoints/custom/initialize.spec.js
@@ -76,7 +76,10 @@ describe('custom/initializeClient', () => {
     expect(resolveHeaders).toHaveBeenCalledWith({
       headers: { 'x-user': '{{LIBRECHAT_USER_ID}}', 'x-email': '{{LIBRECHAT_USER_EMAIL}}' },
       user: { id: 'user-123', email: 'test@example.com', role: 'user' },
+      /**
+       * Note: Request-based Header Resolution is deferred until right before LLM request is made
       body: { endpoint: 'test-endpoint' }, // body - supports {{LIBRECHAT_BODY_*}} placeholders
+       */
     });
   });
 


### PR DESCRIPTION
## Summary

I refactored the header resolution logic for custom endpoints to occur immediately before LLM requests rather than during client initialization.

- Moved header resolution from initialization phase to execution phase in both `AgentClient` run and title generation methods
- Added `resolveHeaders` calls with appropriate request body context right before `createRun` and `generateTitle` operations
- Removed `req.body` from initial header resolution in `initializeClient` since values may be inaccurate at initialization time
- Ensured request-specific data (messageId, conversationId, parentMessageId) is available when headers are resolved
- Added clarifying comments about the timing considerations and potential extension to non-custom endpoints

Motivation: https://github.com/danny-avila/LibreChat/discussions/8582#discussioncomment-14243552

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Test the header resolution by:
1. Configure a custom endpoint with dynamic headers that rely on request body values
2. Send messages through the custom endpoint and verify headers contain correct request-specific values
3. Test both agent runs and title generation flows
4. Confirm headers are properly resolved with messageId, conversationId, and parentMessageId

### **Test Configuration**:
- Custom endpoint with request-based headers configured
- Agent workflows enabled
- Title generation enabled

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings