### PR TITLE
🔨 fix: Add appConfig to uploadAzureMistralOCR

### DIFF
--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -605,7 +605,11 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
       const { handleFileUpload: uploadOCR } = getStrategyFunctions(
         appConfig?.ocr?.strategy ?? FileSources.mistral_ocr,
       );
-      const { text, bytes, filepath: ocrFileURL } = await uploadOCR({ req, file, loadAuthValues });
+      const {
+        text,
+        bytes,
+        filepath: ocrFileURL,
+      } = await uploadOCR({ req, file, loadAuthValues, appConfig });
       return await createTextFile({ text, bytes, filepath: ocrFileURL });
     }
 


### PR DESCRIPTION
## Summary

This pull request fixes a small error that was preventing OCR file uploads from happening. Resolved by adding in appConfig to the uploadOCR params so that context.appConfig is properly accessible in uploadAzureMistralOCR.


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Confirmed files destined for Azure Mistral OCR path now can be uploaded and referenced in chat and that the following error that prevented upload no longer occurs:

```
2025-08-28 23:13:23 error: [getUserPluginAuthValue] No plugin auth OCR_BASEURL found for user ...
2025-08-28 23:13:23 error: [getUserPluginAuthValue] No plugin auth OCR_API_KEY found for user ...
2025-08-28 23:13:23 error: Error uploading document to Azure Mistral OCR API: An error occurred while setting up the request: No plugin auth OCR_API_KEY found for user ...
2025-08-28 23:13:23 error: [/files] Error processing file: Error uploading document to Azure Mistral OCR API: An error occurred while setting up the request: No plugin auth OCR_API_KEY found for user ...

```


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] Local unit tests pass with my changes