### PR TITLE
📋 feat: Support Custom Content-Types in Action Descriptors

### DIFF
--- a/packages/data-provider/specs/actions.spec.ts
+++ b/packages/data-provider/specs/actions.spec.ts
@@ -15,6 +15,7 @@ import {
   getWeatherOpenapiSpec,
   whimsicalOpenapiSpec,
   scholarAIOpenapiSpec,
+  formOpenAPISpec,
   swapidev,
 } from './openapiSpecs';
 import { AuthorizationTypeEnum, AuthTypeEnum } from '../src/types/agents';
@@ -960,6 +961,34 @@ describe('openapiToFunction', () => {
 
     expect(requestBuilders).toHaveProperty('GetCurrentWeather');
     expect(requestBuilders.GetCurrentWeather).toBeInstanceOf(ActionRequest);
+    expect(requestBuilders.GetCurrentWeather.contentType).toBe('application/json');
+  });
+
+  it('preserves OpenAPI spec content-type', () => {
+    const { functionSignatures, requestBuilders } = openapiToFunction(formOpenAPISpec);
+    expect(functionSignatures.length).toBe(1);
+    expect(functionSignatures[0].name).toBe('SubmitForm');
+
+    const parameters = functionSignatures[0].parameters as ParametersSchema & {
+      properties: {
+        'entry.123': {
+          type: 'string';
+        };
+        'entry.456': {
+          type: 'string';
+        };
+      };
+    };
+
+    expect(parameters).toBeDefined();
+    expect(parameters.properties['entry.123']).toBeDefined();
+    expect(parameters.properties['entry.123'].type).toBe('string');
+    expect(parameters.properties['entry.456']).toBeDefined();
+    expect(parameters.properties['entry.456'].type).toBe('string');
+
+    expect(requestBuilders).toHaveProperty('SubmitForm');
+    expect(requestBuilders.SubmitForm).toBeInstanceOf(ActionRequest);
+    expect(requestBuilders.SubmitForm.contentType).toBe('application/x-www-form-urlencoded');
   });
 
   describe('openapiToFunction with $ref resolution', () => {

--- a/packages/data-provider/specs/openapiSpecs.ts
+++ b/packages/data-provider/specs/openapiSpecs.ts
@@ -162,6 +162,53 @@ export const whimsicalOpenapiSpec: OpenAPIV3.Document = {
   },
 };
 
+export const formOpenAPISpec: OpenAPIV3.Document = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Submit Google Form',
+    description: 'Submit data to a Google Forms',
+    version: 'v1.0.0',
+  },
+  servers: [
+    {
+      url: 'https://docs.google.com/forms',
+    },
+  ],
+  paths: {
+    '/formResponse': {
+      post: {
+        description: 'Submit a Google Form',
+        operationId: 'SubmitForm',
+        requestBody: {
+          required: true,
+          content: {
+            'application/x-www-form-urlencoded': {
+              schema: {
+                type: 'object',
+                properties: {
+                  'entry.123': {
+                    type: 'string',
+                    description: 'Name',
+                  },
+                  'entry.456': {
+                    type: 'string',
+                    description: 'Address',
+                  },
+                },
+              },
+            },
+          },
+        },
+        deprecated: false,
+        responses: {},
+      },
+    },
+  },
+  components: {
+    schemas: {},
+  },
+};
+
 export const scholarAIOpenapiSpec = `
 openapi: 3.0.1
 info:

--- a/packages/data-provider/src/actions.ts
+++ b/packages/data-provider/src/actions.ts
@@ -500,10 +500,11 @@ export function openapiToFunction(
         }
       }
 
+      let contentType = '';
       if (operationObj.requestBody) {
         const requestBody = operationObj.requestBody as RequestBodyObject;
         const content = requestBody.content;
-        const contentType = Object.keys(content ?? {})[0];
+        contentType = Object.keys(content ?? {})[0];
         const schema = content?.[contentType]?.schema;
         const resolvedSchema = resolveRef(
           schema as OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject,
@@ -522,6 +523,8 @@ export function openapiToFunction(
             paramLocations[key] = 'body';
           }
         }
+
+        contentType = contentType ?? 'application/json';
       }
 
       const functionSignature = new FunctionSignature(
@@ -538,7 +541,7 @@ export function openapiToFunction(
         method,
         operationId,
         !!(operationObj['x-openai-isConsequential'] ?? false),
-        operationObj.requestBody ? 'application/json' : '',
+        contentType,
         paramLocations,
       );
 


### PR DESCRIPTION
## Summary

Respect the content-type from actions descriptors to allow other types than `application/json`.
This can be helpful to let an agent submit Google Form entries for instance, which require `application/x-www-form-urlencoded`


## Change Type
- [x] New feature (non-breaking change which adds functionality)

## Testing

- Added unit tests
- For manual testing with Google Form for instance, an action descriptor like the following should work:
 ```yaml
openapi: 3.0.3
info:
  title: Google Forms Submission API
  description: API for submitting response to a specific Google Form.
  version: 1.0.0
servers:
  - url: https://docs.google.com
paths:
  /forms/u/0/d/e/${REPLACE_WITH_FORM_ID}/formResponse:
    post:      
      summary: Save the result
      operationId: saveResults
      requestBody:
        required: true
        content:
          application/x-www-form-urlencoded:
            schema:
              type: object
              properties:
                # replace with form field id
                entry.0123456789:
                  description: Name
                  type: string
                # replace with form field id
                entry.9876543210:
                  description: Question ID
                  type: string
              required:
                - entry.0123456789
                - entry.9876543210
      responses:
        '200':
          description: Form response successfully submitted.
```

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
