### PR TITLE
  fix: handle YAML tokenConfig in custom endpoints properlyfix: handle YAML tokenConfig in custom endpoints properly

### DIFF
--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -109,6 +109,11 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
     endpointTokenConfig = await cache.get(tokenKey);
   }
 
+  // Handle YAML tokenConfig if present
+  if (endpointConfig.tokenConfig && !endpointTokenConfig) {
+    endpointTokenConfig = endpointConfig.tokenConfig;
+  }
+
   const customOptions = {
     headers: resolvedHeaders,
     addParams: endpointConfig.addParams,


### PR DESCRIPTION
## Summary
  - Fixes custom endpoints ignoring YAML tokenConfig settings
  - Resolves issue where maxContextTokens defaults to 3686 instead of configured values
  - Ensures YAML tokenConfig is properly passed to endpoint initialization

  ## Problem
  When using MCP (Model Context Protocol) with Agents that route through custom endpoints, the YAML `tokenConfig` configuration was being completely ignored.
   This caused:

  1. Token limits defaulting to 4096 instead of configured values (e.g., 200000 for qwen3:30b)
  2. Message truncation due to incorrect maxContextTokens calculation (3686 = Math.round((4096 - 0) * 0.9))
  3. Custom model configurations not being applied properly

  ## Root Cause
  In `/api/server/services/Endpoints/custom/initialize.js` lines 97-100:
  - Code checked `!endpointConfig.tokenConfig` to skip cache reading
  - But never assigned the YAML tokenConfig to `endpointTokenConfig`
  - This left `endpointTokenConfig` as `undefined` when YAML config was present

  ## Solution
  Added proper handling of YAML tokenConfig after line 110:
  ```javascript
  // Handle YAML tokenConfig if present
  if (endpointConfig.tokenConfig && !endpointTokenConfig) {
    endpointTokenConfig = endpointConfig.tokenConfig;
  }

  Test Plan

  - Verified fix resolves the 3686 token limit issue
  - Confirmed YAML tokenConfig is now properly applied
  - Tested with Ollama local models (qwen3:30b 256K context)

  Fixes maxContextTokens calculation for large context models when using MCP routing through Agents.