### PR TITLE
fix: handle YAML tokenConfig in custom endpoints properly

### DIFF
--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -109,6 +109,11 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
     endpointTokenConfig = await cache.get(tokenKey);
   }
 
+  // Handle YAML tokenConfig if present
+  if (endpointConfig.tokenConfig && !endpointTokenConfig) {
+    endpointTokenConfig = endpointConfig.tokenConfig;
+  }
+
   const customOptions = {
     headers: resolvedHeaders,
     addParams: endpointConfig.addParams,

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -316,6 +316,13 @@ export const endpointSchema = baseEndpointSchema.merge(
     customOrder: z.number().optional(),
     directEndpoint: z.boolean().optional(),
     titleMessageRole: z.string().optional(),
+    tokenConfig: z.record(
+      z.object({
+        prompt: z.number(),
+        completion: z.number(),
+        context: z.number(),
+      })
+    ).optional(),
   }),
 );
 


### PR DESCRIPTION
## Summary
  - Fixes custom endpoints ignoring YAML tokenConfig settings
  - Resolves issue where maxContextTokens defaults to 3686 instead of configured values
  - Ensures YAML tokenConfig is properly passed to endpoint initialization
  - Adds tokenConfig validation to endpointSchema for proper YAML parsing

  ## Problem
  When using MCP (Model Context Protocol) with Agents that route through custom endpoints, the YAML tokenConfig configuration was being completely ignored.

  This caused:
  - Token limits defaulting to 4096 instead of configured values (e.g., 200000 for qwen3:30b)
  - Message truncation due to incorrect maxContextTokens calculation (3686 = Math.round((4096 - 0) * 0.9))
  - Custom model configurations not being applied properly
  - YAML validation errors when tokenConfig was specified in librechat.yaml

  ## Root Cause
  1. In `/api/server/services/Endpoints/custom/initialize.js` lines 97-100:
     - Code checked `!endpointConfig.tokenConfig` to skip cache reading
     - But never assigned the YAML tokenConfig to endpointTokenConfig
     - This left endpointTokenConfig as undefined when YAML config was present

  2. In `/packages/data-provider/src/config.ts` endpointSchema:
     - Missing tokenConfig field in validation schema
     - YAML configurations with tokenConfig would fail validation

  ## Solution
  1. Added proper handling of YAML tokenConfig in initialize.js after line 110:
  ```javascript
  // Handle YAML tokenConfig if present
  if (endpointConfig.tokenConfig && !endpointTokenConfig) {
    endpointTokenConfig = endpointConfig.tokenConfig;
  }

  2. Added tokenConfig field to endpointSchema in config.ts:
  tokenConfig: z.record(
    z.object({
      prompt: z.number(),
      completion: z.number(),
      context: z.number(),
    })
  ).optional(),

  Test Plan

  - Verified fix resolves the 3686 token limit issue
  - Confirmed YAML tokenConfig is now properly applied
  - Tested with Ollama local models (qwen3:30b 256K context)
  - Verified YAML validation passes with tokenConfig specified
  - Confirmed TypeScript compilation succeeds with new schema

  Files Changed

  - api/server/services/Endpoints/custom/initialize.js - Runtime tokenConfig handling
  - packages/data-provider/src/config.ts - Schema validation for tokenConfig

  Fixes maxContextTokens calculation for large context models when using MCP routing through Agents.