### PR TITLE
fix: Add tokenConfig validation and fix YAML tokenConfig handling in custom endpoints

### DIFF
--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -109,6 +109,11 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
     endpointTokenConfig = await cache.get(tokenKey);
   }
 
+  // Handle YAML tokenConfig if present
+  if (endpointConfig.tokenConfig && !endpointTokenConfig) {
+    endpointTokenConfig = endpointConfig.tokenConfig;
+  }
+
   const customOptions = {
     headers: resolvedHeaders,
     addParams: endpointConfig.addParams,

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -316,6 +316,13 @@ export const endpointSchema = baseEndpointSchema.merge(
     customOrder: z.number().optional(),
     directEndpoint: z.boolean().optional(),
     titleMessageRole: z.string().optional(),
+    tokenConfig: z.record(
+      z.object({
+        prompt: z.number(),
+        completion: z.number(),
+        context: z.number(),
+      })
+    ).optional(),
   }),
 );
 


### PR DESCRIPTION
Summary
* Fixes custom endpoints ignoring YAML tokenConfig settings
* Resolves issue where maxContextTokens defaults to 3686 instead of configured values
* Ensures YAML tokenConfig is properly passed to endpoint initialization
* Adds tokenConfig validation to endpointSchema for proper YAML parsing
* Fixes maxContextTokens calculation for large context models when using MCP routing through Agents

Problem
When using MCP (Model Context Protocol) with Agents that route through custom endpoints, the YAML tokenConfig configuration was being completely ignored.
This issue specifically affects users running large context models (like qwen3:30b with 200K+ tokens) through MCP Agents with custom endpoints.

This caused:
* Token limits defaulting to 4096 instead of configured values (e.g., 200000 for qwen3:30b)
* Message truncation due to incorrect maxContextTokens calculation (3686 = Math.round((4096 - 0) * 0.9))
* Custom model configurations not being applied properly
* YAML validation errors when tokenConfig was specified in librechat.yaml

Example YAML configuration that was failing:
```yaml
endpoints:
  custom:
    - name: "ollama-local"
      apiKey: "ollama"
      baseURL: "http://localhost:11434/v1"
      models:
        default: ["qwen2.5:32b"]
      tokenConfig:
        "qwen2.5:32b":
          prompt: 200000
          completion: 200000
          context: 200000
```

Root Cause
1. In /api/server/services/Endpoints/custom/initialize.js lines 97-100:
    * Code checked !endpointConfig.tokenConfig to skip cache reading
    * But never assigned the YAML tokenConfig to endpointTokenConfig
    * This left endpointTokenConfig as undefined when YAML config was present
2. In /packages/data-provider/src/config.ts endpointSchema:
    * Missing tokenConfig field in validation schema
    * YAML configurations with tokenConfig would fail validation

Solution
1. Added proper handling of YAML tokenConfig in initialize.js after line 110:
// Handle YAML tokenConfig if present
if (endpointConfig.tokenConfig && !endpointTokenConfig) {
  endpointTokenConfig = endpointConfig.tokenConfig;
}

2. Added tokenConfig field to endpointSchema in config.ts:
tokenConfig: z.record(
  z.object({
    prompt: z.number(),
    completion: z.number(),
    context: z.number(),
  })
).optional(),

Test Plan
- Verified fix resolves the 3686 token limit issue
- Confirmed YAML tokenConfig is now properly applied
- Tested with Ollama local models (qwen3:30b 256K context)
- Verified YAML validation passes with tokenConfig specified
- Confirmed TypeScript compilation succeeds with new schema

Files Changed
- api/server/services/Endpoints/custom/initialize.js - Runtime tokenConfig handling
- packages/data-provider/src/config.ts - Schema validation for tokenConfig