### PR TITLE
fix: ModelSpecs Display Agents Without Proper ACL Permission Filtering

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
@@ -59,7 +59,21 @@ export function ModelSelectorProvider({ children, startupConfig }: ModelSelector
   const { data: endpointsConfig } = useGetEndpointsQuery();
   const { endpoint, model, spec, agent_id, assistant_id, newConversation } =
     useModelSelectorChatContext();
-  const modelSpecs = useMemo(() => startupConfig?.modelSpecs?.list ?? [], [startupConfig]);
+  const modelSpecs = useMemo(() => {
+    const specs = startupConfig?.modelSpecs?.list ?? [];
+    if (!agentsMap) {
+      return [];
+    }
+
+    // Filter modelSpecs to only include agents the user has access to
+    // Use agentsMap which already contains permission-filtered agents (consistent with other components)
+    return specs.filter(spec => {
+      if (spec.preset?.endpoint === 'agents' && spec.preset?.agent_id) {
+        return spec.preset.agent_id in agentsMap;
+      }
+      return true; // Keep non-agent modelSpecs
+    });
+  }, [startupConfig, agentsMap]);
   const permissionLevel = useAgentDefaultPermissionLevel();
   const { data: agents = null } = useListAgentsQuery(
     { requiredPermission: permissionLevel },


### PR DESCRIPTION
## Summary
Fixed ModelSpecs displaying agents without proper ACL permission filtering
This PR resolves an issue where ModelSpecs were displaying all configured agents in the UI regardless of user ACL permissions. Users could see and attempt to select agents they didn't have access to, resulting in "Something went wrong" errors when the backend correctly enforced permissions.

**Root Cause:** The `ModelSelectorContext.tsx` was loading ModelSpecs directly from `startupConfig?.modelSpecs?.list` without filtering based on user's accessible agents, while other agent-related components properly used permission-filtered agent lists.
Solution: Modified the modelSpecs filtering logic to use the existing agentsMap (which is already permission-filtered with PermissionBits.VIEW) to maintain consistency with other components in the codebase.

Related Issue: Fixes #9395 
## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
