### PR TITLE
📝 feat: Add Prompt Parameter Support for Anthropic Custom Endpoints

### DIFF
--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -1,10 +1,12 @@
 import { ProxyAgent } from 'undici';
 import { Providers } from '@librechat/agents';
-import { KnownEndpoints, removeNullishValues } from 'librechat-data-provider';
+import { KnownEndpoints, removeNullishValues, EModelEndpoint } from 'librechat-data-provider';
 import type { BindToolsInput } from '@langchain/core/language_models/chat_models';
+import type { AnthropicClientOptions } from '@librechat/agents';
 import type { AzureOpenAIInput } from '@langchain/openai';
 import type { OpenAI } from 'openai';
 import type * as t from '~/types';
+import { getLLMConfig as getAnthropicLLMConfig } from '~/endpoints/anthropic/llm';
 import { sanitizeModelName, constructAzureURL } from '~/utils/azure';
 import { createFetch } from '~/utils/generators';
 import { isEnabled } from '~/utils/common';
@@ -233,12 +235,30 @@ export function getOpenAIConfig(
     dropParams,
   } = options;
 
-  const { llmConfig, tools } = getOpenAILLMConfig({
-    streaming,
-    modelOptions: _modelOptions,
-    addParams,
-    dropParams,
-  });
+  let llmConfig:
+    | (Partial<t.ClientOptions> & Partial<t.OpenAIParameters> & Partial<AzureOpenAIInput>)
+    | AnthropicClientOptions;
+  let tools: BindToolsInput[];
+
+  if (options.customParams?.defaultParamsEndpoint === EModelEndpoint.anthropic) {
+    const anthropicResult = getAnthropicLLMConfig(apiKey, {
+      modelOptions: _modelOptions,
+      userId: options.userId || '',
+      proxy: options.proxy,
+      reverseProxyUrl: options.reverseProxyUrl,
+    });
+    llmConfig = anthropicResult.llmConfig;
+    tools = anthropicResult.tools;
+  } else {
+    const openaiResult = getOpenAILLMConfig({
+      streaming,
+      modelOptions: _modelOptions,
+      addParams,
+      dropParams,
+    });
+    llmConfig = openaiResult.llmConfig;
+    tools = openaiResult.tools;
+  }
 
   let useOpenRouter = false;
   const configOptions: t.OpenAIConfiguration = {};

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -22,6 +22,10 @@ export interface OpenAIConfigOptions {
   streaming?: boolean;
   addParams?: Record<string, unknown>;
   dropParams?: string[];
+  customParams?: {
+    defaultParamsEndpoint?: string;
+  };
+  userId?: string;
 }
 
 export type OpenAIConfiguration = OpenAIClientOptions['configuration'];


### PR DESCRIPTION
## Summary

This pull request adds support for handling Anthropic model endpoints in the OpenAI configuration logic. The main changes involve updating the configuration selection process to dynamically use Anthropic-specific options when appropriate, along with related type and interface updates.

**Support for Anthropic endpoint configuration:**

* Added logic in `getOpenAIConfig` (in `llm.ts`) to detect when the `defaultParamsEndpoint` is set to Anthropic and, in that case, retrieve and use Anthropic-specific configuration and tools via `getAnthropicLLMConfig`.
* Imported `EModelEndpoint` and `getLLMConfig` from Anthropic-related modules to enable endpoint detection and configuration retrieval.

**Interface and type updates:**

* Updated the `OpenAIConfigOptions` interface (in `openai.ts`) to include `customParams` (with a `defaultParamsEndpoint` field) and a `userId` field, enabling the new endpoint selection logic.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Tests Pending 

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes