### PR TITLE
🎚️ feat: Anthropic Parameter Set Support via Custom Endpoints

### DIFF
--- a/api/app/clients/AnthropicClient.js
+++ b/api/app/clients/AnthropicClient.js
@@ -10,7 +10,17 @@ const {
   validateVisionModel,
 } = require('librechat-data-provider');
 const { SplitStreamHandler: _Handler } = require('@librechat/agents');
-const { Tokenizer, createFetch, createStreamEventHandlers } = require('@librechat/api');
+const {
+  Tokenizer,
+  createFetch,
+  matchModelName,
+  getClaudeHeaders,
+  getModelMaxTokens,
+  configureReasoning,
+  checkPromptCacheSupport,
+  getModelMaxOutputTokens,
+  createStreamEventHandlers,
+} = require('@librechat/api');
 const {
   truncateText,
   formatMessage,
@@ -19,12 +29,6 @@ const {
   parseParamFromPrompt,
   createContextHandlers,
 } = require('./prompts');
-const {
-  getClaudeHeaders,
-  configureReasoning,
-  checkPromptCacheSupport,
-} = require('~/server/services/Endpoints/anthropic/helpers');
-const { getModelMaxTokens, getModelMaxOutputTokens, matchModelName } = require('~/utils');
 const { spendTokens, spendStructuredTokens } = require('~/models/spendTokens');
 const { encodeAndFormat } = require('~/server/services/Files/images/encode');
 const { sleep } = require('~/server/utils');

--- a/api/app/clients/GoogleClient.js
+++ b/api/app/clients/GoogleClient.js
@@ -1,4 +1,5 @@
 const { google } = require('googleapis');
+const { getModelMaxTokens } = require('@librechat/api');
 const { concat } = require('@langchain/core/utils/stream');
 const { ChatVertexAI } = require('@langchain/google-vertexai');
 const { Tokenizer, getSafetySettings } = require('@librechat/api');
@@ -21,7 +22,6 @@ const {
 } = require('librechat-data-provider');
 const { encodeAndFormat } = require('~/server/services/Files/images');
 const { spendTokens } = require('~/models/spendTokens');
-const { getModelMaxTokens } = require('~/utils');
 const { sleep } = require('~/server/utils');
 const { logger } = require('~/config');
 const {

--- a/api/app/clients/OpenAIClient.js
+++ b/api/app/clients/OpenAIClient.js
@@ -7,7 +7,9 @@ const {
   createFetch,
   resolveHeaders,
   constructAzureURL,
+  getModelMaxTokens,
   genAzureChatCompletion,
+  getModelMaxOutputTokens,
   createStreamEventHandlers,
 } = require('@librechat/api');
 const {
@@ -31,13 +33,13 @@ const {
   titleInstruction,
   createContextHandlers,
 } = require('./prompts');
-const { extractBaseURL, getModelMaxTokens, getModelMaxOutputTokens } = require('~/utils');
 const { encodeAndFormat } = require('~/server/services/Files/images/encode');
 const { addSpaceIfNeeded, sleep } = require('~/server/utils');
 const { spendTokens } = require('~/models/spendTokens');
 const { handleOpenAIErrors } = require('./tools/util');
 const { summaryBuffer } = require('./memory');
 const { runTitleChain } = require('./chains');
+const { extractBaseURL } = require('~/utils');
 const { tokenSplit } = require('./document');
 const BaseClient = require('./BaseClient');
 const { createLLM } = require('./llm');

--- a/api/app/clients/specs/FakeClient.js
+++ b/api/app/clients/specs/FakeClient.js
@@ -1,5 +1,5 @@
+const { getModelMaxTokens } = require('@librechat/api');
 const BaseClient = require('../BaseClient');
-const { getModelMaxTokens } = require('../../../utils');
 
 class FakeClient extends BaseClient {
   constructor(apiKey, options = {}) {

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -1,4 +1,4 @@
-const { matchModelName } = require('../utils/tokens');
+const { matchModelName } = require('@librechat/api');
 const defaultRate = 6;
 
 /**

--- a/api/package.json
+++ b/api/package.json
@@ -49,7 +49,7 @@
     "@langchain/google-vertexai": "^0.2.13",
     "@langchain/openai": "^0.5.18",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^2.4.78",
+    "@librechat/agents": "^2.4.79",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/package.json
+++ b/api/package.json
@@ -49,7 +49,7 @@
     "@langchain/google-vertexai": "^0.2.13",
     "@langchain/openai": "^0.5.18",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^2.4.77",
+    "@librechat/agents": "^2.4.78",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -872,11 +872,10 @@ class AgentClient extends BaseClient {
         if (agent.useLegacyContent === true) {
           messages = formatContentStrings(messages);
         }
-        if (
-          agent.model_parameters?.clientOptions?.defaultHeaders?.['anthropic-beta']?.includes(
-            'prompt-caching',
-          )
-        ) {
+        const defaultHeaders =
+          agent.model_parameters?.clientOptions?.defaultHeaders ??
+          agent.model_parameters?.configuration?.defaultHeaders;
+        if (defaultHeaders?.['anthropic-beta']?.includes('prompt-caching')) {
           messages = addCacheControl(messages);
         }
 

--- a/api/server/controllers/assistants/chatV1.js
+++ b/api/server/controllers/assistants/chatV1.js
@@ -1,7 +1,7 @@
 const { v4 } = require('uuid');
 const { sleep } = require('@librechat/agents');
 const { logger } = require('@librechat/data-schemas');
-const { sendEvent, getBalanceConfig } = require('@librechat/api');
+const { sendEvent, getBalanceConfig, getModelMaxTokens } = require('@librechat/api');
 const {
   Time,
   Constants,
@@ -34,7 +34,6 @@ const { checkBalance } = require('~/models/balanceMethods');
 const { getConvo } = require('~/models/Conversation');
 const getLogStores = require('~/cache/getLogStores');
 const { countTokens } = require('~/server/utils');
-const { getModelMaxTokens } = require('~/utils');
 const { getOpenAIClient } = require('./helpers');
 
 /**

--- a/api/server/controllers/assistants/chatV2.js
+++ b/api/server/controllers/assistants/chatV2.js
@@ -1,7 +1,7 @@
 const { v4 } = require('uuid');
 const { sleep } = require('@librechat/agents');
 const { logger } = require('@librechat/data-schemas');
-const { sendEvent, getBalanceConfig } = require('@librechat/api');
+const { sendEvent, getBalanceConfig, getModelMaxTokens } = require('@librechat/api');
 const {
   Time,
   Constants,
@@ -31,7 +31,6 @@ const { checkBalance } = require('~/models/balanceMethods');
 const { getConvo } = require('~/models/Conversation');
 const getLogStores = require('~/cache/getLogStores');
 const { countTokens } = require('~/server/utils');
-const { getModelMaxTokens } = require('~/utils');
 const { getOpenAIClient } = require('./helpers');
 
 /**

--- a/api/server/services/Endpoints/agents/agent.js
+++ b/api/server/services/Endpoints/agents/agent.js
@@ -1,6 +1,7 @@
 const { Providers } = require('@librechat/agents');
 const {
   primeResources,
+  getModelMaxTokens,
   extractLibreChatParams,
   optionalChainWithEmptyCheck,
 } = require('@librechat/api');
@@ -17,7 +18,6 @@ const { getProviderConfig } = require('~/server/services/Endpoints');
 const { processFiles } = require('~/server/services/Files/process');
 const { getFiles, getToolFilesByIds } = require('~/models/File');
 const { getConvoFiles } = require('~/models/Conversation');
-const { getModelMaxTokens } = require('~/utils');
 
 /**
  * @param {object} params

--- a/api/server/services/Endpoints/anthropic/initialize.js
+++ b/api/server/services/Endpoints/anthropic/initialize.js
@@ -1,6 +1,6 @@
+const { getLLMConfig } = require('@librechat/api');
 const { EModelEndpoint } = require('librechat-data-provider');
 const { getUserKey, checkUserKeyExpiry } = require('~/server/services/UserService');
-const { getLLMConfig } = require('~/server/services/Endpoints/anthropic/llm');
 const AnthropicClient = require('~/app/clients/AnthropicClient');
 
 const initializeClient = async ({ req, res, endpointOption, overrideModel, optionsOnly }) => {

--- a/api/server/services/Endpoints/anthropic/initialize.js
+++ b/api/server/services/Endpoints/anthropic/initialize.js
@@ -40,7 +40,6 @@ const initializeClient = async ({ req, res, endpointOption, overrideModel, optio
     clientOptions = Object.assign(
       {
         proxy: PROXY ?? null,
-        userId: req.user.id,
         reverseProxyUrl: ANTHROPIC_REVERSE_PROXY ?? null,
         modelOptions: endpointOption?.model_parameters ?? {},
       },
@@ -49,6 +48,7 @@ const initializeClient = async ({ req, res, endpointOption, overrideModel, optio
     if (overrideModel) {
       clientOptions.modelOptions.model = overrideModel;
     }
+    clientOptions.modelOptions.user = req.user.id;
     return getLLMConfig(anthropicApiKey, clientOptions);
   }
 

--- a/api/server/services/Endpoints/bedrock/initialize.js
+++ b/api/server/services/Endpoints/bedrock/initialize.js
@@ -1,3 +1,4 @@
+const { getModelMaxTokens } = require('@librechat/api');
 const { createContentAggregator } = require('@librechat/agents');
 const {
   EModelEndpoint,
@@ -7,7 +8,6 @@ const {
 const { getDefaultHandlers } = require('~/server/controllers/agents/callbacks');
 const getOptions = require('~/server/services/Endpoints/bedrock/options');
 const AgentClient = require('~/server/controllers/agents/client');
-const { getModelMaxTokens } = require('~/utils');
 
 const initializeClient = async ({ req, res, endpointOption }) => {
   if (!endpointOption) {

--- a/api/server/services/ModelService.js
+++ b/api/server/services/ModelService.js
@@ -1,13 +1,13 @@
 const axios = require('axios');
 const { Providers } = require('@librechat/agents');
-const { logAxiosError } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const { HttpsProxyAgent } = require('https-proxy-agent');
+const { logAxiosError, inputSchema, processModelData } = require('@librechat/api');
 const { EModelEndpoint, defaultModels, CacheKeys } = require('librechat-data-provider');
-const { inputSchema, extractBaseURL, processModelData } = require('~/utils');
 const { OllamaClient } = require('~/app/clients/OllamaClient');
 const { isUserProvided } = require('~/server/utils');
 const getLogStores = require('~/cache/getLogStores');
+const { extractBaseURL } = require('~/utils');
 
 /**
  * Splits a string by commas and trims each resulting value.

--- a/api/server/services/ModelService.spec.js
+++ b/api/server/services/ModelService.spec.js
@@ -11,8 +11,8 @@ const {
   getAnthropicModels,
 } = require('./ModelService');
 
-jest.mock('~/utils', () => {
-  const originalUtils = jest.requireActual('~/utils');
+jest.mock('@librechat/api', () => {
+  const originalUtils = jest.requireActual('@librechat/api');
   return {
     ...originalUtils,
     processModelData: jest.fn((...args) => {
@@ -108,7 +108,7 @@ describe('fetchModels with createTokenConfig true', () => {
 
   beforeEach(() => {
     // Clears the mock's history before each test
-    const _utils = require('~/utils');
+    const _utils = require('@librechat/api');
     axios.get.mockResolvedValue({ data });
   });
 
@@ -120,7 +120,7 @@ describe('fetchModels with createTokenConfig true', () => {
       createTokenConfig: true,
     });
 
-    const { processModelData } = require('~/utils');
+    const { processModelData } = require('@librechat/api');
     expect(processModelData).toHaveBeenCalled();
     expect(processModelData).toHaveBeenCalledWith(data);
   });

--- a/api/utils/deriveBaseURL.spec.js
+++ b/api/utils/deriveBaseURL.spec.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const deriveBaseURL = require('./deriveBaseURL');
-jest.mock('~/utils', () => {
-  const originalUtils = jest.requireActual('~/utils');
+jest.mock('@librechat/api', () => {
+  const originalUtils = jest.requireActual('@librechat/api');
   return {
     ...originalUtils,
     processModelData: jest.fn((...args) => {

--- a/api/utils/index.js
+++ b/api/utils/index.js
@@ -1,4 +1,3 @@
-const tokenHelpers = require('./tokens');
 const deriveBaseURL = require('./deriveBaseURL');
 const extractBaseURL = require('./extractBaseURL');
 const findMessageContent = require('./findMessageContent');
@@ -6,6 +5,5 @@ const findMessageContent = require('./findMessageContent');
 module.exports = {
   deriveBaseURL,
   extractBaseURL,
-  ...tokenHelpers,
   findMessageContent,
 };

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -1,12 +1,12 @@
 const { EModelEndpoint } = require('librechat-data-provider');
 const {
+  maxTokensMap,
+  matchModelName,
+  processModelData,
+  getModelMaxTokens,
   maxOutputTokensMap,
   findMatchingPattern,
-  getModelMaxTokens,
-  processModelData,
-  matchModelName,
-  maxTokensMap,
-} = require('./tokens');
+} = require('@librechat/api');
 
 describe('getModelMaxTokens', () => {
   test('should return correct tokens for exact match', () => {
@@ -394,7 +394,7 @@ describe('getModelMaxTokens', () => {
   });
 
   test('should return correct max output tokens for GPT-5 models', () => {
-    const { getModelMaxOutputTokens } = require('./tokens');
+    const { getModelMaxOutputTokens } = require('@librechat/api');
     ['gpt-5', 'gpt-5-mini', 'gpt-5-nano'].forEach((model) => {
       expect(getModelMaxOutputTokens(model)).toBe(maxOutputTokensMap[EModelEndpoint.openAI][model]);
       expect(getModelMaxOutputTokens(model, EModelEndpoint.openAI)).toBe(
@@ -407,7 +407,7 @@ describe('getModelMaxTokens', () => {
   });
 
   test('should return correct max output tokens for GPT-OSS models', () => {
-    const { getModelMaxOutputTokens } = require('./tokens');
+    const { getModelMaxOutputTokens } = require('@librechat/api');
     ['gpt-oss-20b', 'gpt-oss-120b'].forEach((model) => {
       expect(getModelMaxOutputTokens(model)).toBe(maxOutputTokensMap[EModelEndpoint.openAI][model]);
       expect(getModelMaxOutputTokens(model, EModelEndpoint.openAI)).toBe(

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@langchain/google-vertexai": "^0.2.13",
         "@langchain/openai": "^0.5.18",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^2.4.77",
+        "@librechat/agents": "^2.4.78",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -21909,9 +21909,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "2.4.77",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.77.tgz",
-      "integrity": "sha512-x7fWbbdJpy8VpIYJa7E0laBUmtgveTmTzYS8QFkXUMjzqSx7nN5ruM6rzmcodOWRXt7IrB12k4VehJ1zUnb29A==",
+      "version": "2.4.78",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.78.tgz",
+      "integrity": "sha512-E6AEkMm2wA3vyMGf8Eb0g8kJsptehUebVbFCXeUuNhb0zba15BTD2Et8gA+wkFVsCA68bGhK9lPAmBodyr4N/A==",
       "license": "MIT",
       "dependencies": {
         "@langchain/anthropic": "^0.3.26",
@@ -51744,7 +51744,7 @@
       },
       "peerDependencies": {
         "@langchain/core": "^0.3.62",
-        "@librechat/agents": "^2.4.77",
+        "@librechat/agents": "^2.4.78",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.17.1",
         "axios": "^1.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@langchain/google-vertexai": "^0.2.13",
         "@langchain/openai": "^0.5.18",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^2.4.78",
+        "@librechat/agents": "^2.4.79",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -21909,9 +21909,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "2.4.78",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.78.tgz",
-      "integrity": "sha512-E6AEkMm2wA3vyMGf8Eb0g8kJsptehUebVbFCXeUuNhb0zba15BTD2Et8gA+wkFVsCA68bGhK9lPAmBodyr4N/A==",
+      "version": "2.4.79",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.79.tgz",
+      "integrity": "sha512-Ha8tBPNy9ycPMH+GfBL8lUKz4vC3aXWSO1BZt7x9wDkfVLQBd3XhtkYv0xMvA8y7i6YMowBoyAkkWpX3R8DeJg==",
       "license": "MIT",
       "dependencies": {
         "@langchain/anthropic": "^0.3.26",
@@ -51744,7 +51744,7 @@
       },
       "peerDependencies": {
         "@langchain/core": "^0.3.62",
-        "@librechat/agents": "^2.4.78",
+        "@librechat/agents": "^2.4.79",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.17.1",
         "axios": "^1.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51711,7 +51711,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "@langchain/core": "^0.3.62",
-    "@librechat/agents": "^2.4.77",
+    "@librechat/agents": "^2.4.78",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.17.1",
     "axios": "^1.8.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.js",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "@langchain/core": "^0.3.62",
-    "@librechat/agents": "^2.4.78",
+    "@librechat/agents": "^2.4.79",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.17.1",
     "axios": "^1.8.2",

--- a/packages/api/src/endpoints/anthropic/helpers.ts
+++ b/packages/api/src/endpoints/anthropic/helpers.ts
@@ -1,13 +1,14 @@
-const { EModelEndpoint, anthropicSettings } = require('librechat-data-provider');
-const { matchModelName } = require('~/utils');
-const { logger } = require('~/config');
+import { logger } from '@librechat/data-schemas';
+import { AnthropicClientOptions } from '@librechat/agents';
+import { EModelEndpoint, anthropicSettings } from 'librechat-data-provider';
+import { matchModelName } from '~/utils/tokens';
 
 /**
  * @param {string} modelName
  * @returns {boolean}
  */
-function checkPromptCacheSupport(modelName) {
-  const modelMatch = matchModelName(modelName, EModelEndpoint.anthropic);
+function checkPromptCacheSupport(modelName: string): boolean {
+  const modelMatch = matchModelName(modelName, EModelEndpoint.anthropic) ?? '';
   if (
     modelMatch.includes('claude-3-5-sonnet-latest') ||
     modelMatch.includes('claude-3.5-sonnet-latest')
@@ -31,7 +32,10 @@ function checkPromptCacheSupport(modelName) {
  * @param {boolean} supportsCacheControl Whether the model supports cache control
  * @returns {AnthropicClientOptions['extendedOptions']['defaultHeaders']|undefined} The headers object or undefined if not applicable
  */
-function getClaudeHeaders(model, supportsCacheControl) {
+function getClaudeHeaders(
+  model: string,
+  supportsCacheControl: boolean,
+): Record<string, string> | undefined {
   if (!supportsCacheControl) {
     return undefined;
   }
@@ -72,9 +76,13 @@ function getClaudeHeaders(model, supportsCacheControl) {
  * @param {number|null} extendedOptions.thinkingBudget The token budget for thinking
  * @returns {Object} Updated request options
  */
-function configureReasoning(anthropicInput, extendedOptions = {}) {
+function configureReasoning(
+  anthropicInput: AnthropicClientOptions & { max_tokens?: number },
+  extendedOptions: { thinking?: boolean; thinkingBudget?: number | null } = {},
+): AnthropicClientOptions & { max_tokens?: number } {
   const updatedOptions = { ...anthropicInput };
   const currentMaxTokens = updatedOptions.max_tokens ?? updatedOptions.maxTokens;
+
   if (
     extendedOptions.thinking &&
     updatedOptions?.model &&
@@ -82,11 +90,16 @@ function configureReasoning(anthropicInput, extendedOptions = {}) {
       /claude-(?:sonnet|opus|haiku)-[4-9]/.test(updatedOptions.model))
   ) {
     updatedOptions.thinking = {
+      ...updatedOptions.thinking,
       type: 'enabled',
-    };
+    } as { type: 'enabled'; budget_tokens: number };
   }
 
-  if (updatedOptions.thinking != null && extendedOptions.thinkingBudget != null) {
+  if (
+    updatedOptions.thinking != null &&
+    extendedOptions.thinkingBudget != null &&
+    updatedOptions.thinking.type === 'enabled'
+  ) {
     updatedOptions.thinking = {
       ...updatedOptions.thinking,
       budget_tokens: extendedOptions.thinkingBudget,
@@ -95,9 +108,10 @@ function configureReasoning(anthropicInput, extendedOptions = {}) {
 
   if (
     updatedOptions.thinking != null &&
+    updatedOptions.thinking.type === 'enabled' &&
     (currentMaxTokens == null || updatedOptions.thinking.budget_tokens > currentMaxTokens)
   ) {
-    const maxTokens = anthropicSettings.maxOutputTokens.reset(updatedOptions.model);
+    const maxTokens = anthropicSettings.maxOutputTokens.reset(updatedOptions.model ?? '');
     updatedOptions.max_tokens = currentMaxTokens ?? maxTokens;
 
     logger.warn(
@@ -115,4 +129,4 @@ function configureReasoning(anthropicInput, extendedOptions = {}) {
   return updatedOptions;
 }
 
-module.exports = { checkPromptCacheSupport, getClaudeHeaders, configureReasoning };
+export { checkPromptCacheSupport, getClaudeHeaders, configureReasoning };

--- a/packages/api/src/endpoints/anthropic/index.ts
+++ b/packages/api/src/endpoints/anthropic/index.ts
@@ -1,0 +1,2 @@
+export * from './helpers';
+export * from './llm';

--- a/packages/api/src/endpoints/anthropic/llm.spec.ts
+++ b/packages/api/src/endpoints/anthropic/llm.spec.ts
@@ -1,4 +1,4 @@
-const { getLLMConfig } = require('~/server/services/Endpoints/anthropic/llm');
+import { getLLMConfig } from './llm';
 
 jest.mock('https-proxy-agent', () => ({
   HttpsProxyAgent: jest.fn().mockImplementation((proxy) => ({ proxy })),
@@ -25,9 +25,9 @@ describe('getLLMConfig', () => {
     });
 
     expect(result.llmConfig.clientOptions).toHaveProperty('fetchOptions');
-    expect(result.llmConfig.clientOptions.fetchOptions).toHaveProperty('dispatcher');
-    expect(result.llmConfig.clientOptions.fetchOptions.dispatcher).toBeDefined();
-    expect(result.llmConfig.clientOptions.fetchOptions.dispatcher.constructor.name).toBe(
+    expect(result.llmConfig.clientOptions?.fetchOptions).toHaveProperty('dispatcher');
+    expect(result.llmConfig.clientOptions?.fetchOptions?.dispatcher).toBeDefined();
+    expect(result.llmConfig.clientOptions?.fetchOptions?.dispatcher.constructor.name).toBe(
       'ProxyAgent',
     );
   });
@@ -93,9 +93,10 @@ describe('getLLMConfig', () => {
     };
     const result = getLLMConfig('test-key', { modelOptions });
     const clientOptions = result.llmConfig.clientOptions;
-    expect(clientOptions.defaultHeaders).toBeDefined();
-    expect(clientOptions.defaultHeaders).toHaveProperty('anthropic-beta');
-    expect(clientOptions.defaultHeaders['anthropic-beta']).toBe(
+    expect(clientOptions?.defaultHeaders).toBeDefined();
+    expect(clientOptions?.defaultHeaders).toHaveProperty('anthropic-beta');
+    const defaultHeaders = clientOptions?.defaultHeaders as Record<string, string>;
+    expect(defaultHeaders['anthropic-beta']).toBe(
       'prompt-caching-2024-07-31,context-1m-2025-08-07',
     );
   });
@@ -111,9 +112,10 @@ describe('getLLMConfig', () => {
       const modelOptions = { model, promptCache: true };
       const result = getLLMConfig('test-key', { modelOptions });
       const clientOptions = result.llmConfig.clientOptions;
-      expect(clientOptions.defaultHeaders).toBeDefined();
-      expect(clientOptions.defaultHeaders).toHaveProperty('anthropic-beta');
-      expect(clientOptions.defaultHeaders['anthropic-beta']).toBe(
+      expect(clientOptions?.defaultHeaders).toBeDefined();
+      expect(clientOptions?.defaultHeaders).toHaveProperty('anthropic-beta');
+      const defaultHeaders = clientOptions?.defaultHeaders as Record<string, string>;
+      expect(defaultHeaders['anthropic-beta']).toBe(
         'prompt-caching-2024-07-31,context-1m-2025-08-07',
       );
     });
@@ -211,13 +213,13 @@ describe('getLLMConfig', () => {
     it('should handle empty modelOptions', () => {
       expect(() => {
         getLLMConfig('test-api-key', {});
-      }).toThrow("Cannot read properties of undefined (reading 'thinking')");
+      }).toThrow('No modelOptions provided');
     });
 
     it('should handle no options parameter', () => {
       expect(() => {
         getLLMConfig('test-api-key');
-      }).toThrow("Cannot read properties of undefined (reading 'thinking')");
+      }).toThrow('No modelOptions provided');
     });
 
     it('should handle temperature, stop sequences, and stream settings', () => {
@@ -254,9 +256,9 @@ describe('getLLMConfig', () => {
       });
 
       expect(result.llmConfig.clientOptions).toHaveProperty('fetchOptions');
-      expect(result.llmConfig.clientOptions.fetchOptions).toHaveProperty('dispatcher');
-      expect(result.llmConfig.clientOptions.fetchOptions.dispatcher).toBeDefined();
-      expect(result.llmConfig.clientOptions.fetchOptions.dispatcher.constructor.name).toBe(
+      expect(result.llmConfig.clientOptions?.fetchOptions).toHaveProperty('dispatcher');
+      expect(result.llmConfig.clientOptions?.fetchOptions?.dispatcher).toBeDefined();
+      expect(result.llmConfig.clientOptions?.fetchOptions?.dispatcher.constructor.name).toBe(
         'ProxyAgent',
       );
       expect(result.llmConfig.clientOptions).toHaveProperty('baseURL', 'https://reverse-proxy.com');
@@ -272,7 +274,7 @@ describe('getLLMConfig', () => {
       });
 
       // claude-3-5-sonnet supports prompt caching and should get the appropriate headers
-      expect(result.llmConfig.clientOptions.defaultHeaders).toEqual({
+      expect(result.llmConfig.clientOptions?.defaultHeaders).toEqual({
         'anthropic-beta': 'max-tokens-3-5-sonnet-2024-07-15,prompt-caching-2024-07-31',
       });
     });

--- a/packages/api/src/endpoints/anthropic/llm.spec.ts
+++ b/packages/api/src/endpoints/anthropic/llm.spec.ts
@@ -362,9 +362,11 @@ describe('getLLMConfig', () => {
         // Simulate clientOptions from initialize.js
         const clientOptions = {
           proxy: null,
-          userId: 'test-user-id-123',
           reverseProxyUrl: null,
-          modelOptions: endpointOption.model_parameters,
+          modelOptions: {
+            ...endpointOption.model_parameters,
+            user: 'test-user-id-123',
+          },
           streamRate: 25,
           titleModel: 'claude-3-haiku',
         };
@@ -393,12 +395,12 @@ describe('getLLMConfig', () => {
         const anthropicApiKey = 'sk-ant-proxy-key';
         const clientOptions = {
           proxy: 'http://corporate-proxy:8080',
-          userId: 'proxy-user-456',
           reverseProxyUrl: null,
           modelOptions: {
             model: 'claude-3-opus',
             temperature: 0.3,
             maxOutputTokens: 2048,
+            user: 'proxy-user-456',
           },
         };
 
@@ -426,12 +428,12 @@ describe('getLLMConfig', () => {
         const reverseProxyUrl = 'https://api.custom-anthropic.com/v1';
         const clientOptions = {
           proxy: null,
-          userId: 'reverse-proxy-user',
           reverseProxyUrl: reverseProxyUrl,
           modelOptions: {
             model: 'claude-3-5-haiku',
             temperature: 0.5,
             stream: false,
+            user: 'reverse-proxy-user',
           },
         };
 
@@ -453,7 +455,6 @@ describe('getLLMConfig', () => {
     describe('Model-Specific Real Usage Scenarios', () => {
       it('should handle Claude-3.7 with thinking enabled like production', () => {
         const clientOptions = {
-          userId: 'thinking-user-789',
           modelOptions: {
             model: 'claude-3-7-sonnet',
             temperature: 0.4,
@@ -463,6 +464,7 @@ describe('getLLMConfig', () => {
             thinking: true,
             thinkingBudget: 3000,
             promptCache: true,
+            user: 'thinking-user-789',
           },
         };
 
@@ -490,12 +492,12 @@ describe('getLLMConfig', () => {
 
       it('should handle web search functionality like production', () => {
         const clientOptions = {
-          userId: 'websearch-user-303',
           modelOptions: {
             model: 'claude-3-5-sonnet-latest',
             temperature: 0.6,
             maxOutputTokens: 4096,
             web_search: true,
+            user: 'websearch-user-303',
           },
         };
 
@@ -519,7 +521,6 @@ describe('getLLMConfig', () => {
       it('should handle complex production configuration', () => {
         const clientOptions = {
           proxy: 'http://prod-proxy.company.com:3128',
-          userId: 'prod-user-enterprise-404',
           reverseProxyUrl: 'https://anthropic-gateway.company.com/v1',
           modelOptions: {
             model: 'claude-3-opus-20240229',
@@ -530,6 +531,7 @@ describe('getLLMConfig', () => {
             stop: ['\\n\\nHuman:', '\\n\\nAssistant:', 'END_CONVERSATION'],
             stream: true,
             promptCache: true,
+            user: 'prod-user-enterprise-404',
           },
           streamRate: 15, // Conservative stream rate
           titleModel: 'claude-3-haiku-20240307',
@@ -574,10 +576,10 @@ describe('getLLMConfig', () => {
           // Regular options that should remain
           topP: 0.9,
           topK: 40,
+          user: 'system-options-user',
         };
 
         const clientOptions = {
-          userId: 'system-options-user',
           modelOptions,
         };
 
@@ -595,13 +597,13 @@ describe('getLLMConfig', () => {
     });
 
     describe('Error Handling and Edge Cases from Real Usage', () => {
-      it('should handle missing userId gracefully', () => {
+      it('should handle missing `user` ID string gracefully', () => {
         const clientOptions = {
           modelOptions: {
             model: 'claude-3-haiku',
             temperature: 0.5,
+            // `user` is missing
           },
-          // userId is missing
         };
 
         const result = getLLMConfig('sk-ant-no-user-key', clientOptions);
@@ -618,6 +620,7 @@ describe('getLLMConfig', () => {
           maxOutputTokens: 4096,
           topP: 0.9,
           topK: 40,
+          user: 'performance-test-user',
         };
 
         // Add many additional properties to test performance
@@ -626,7 +629,6 @@ describe('getLLMConfig', () => {
         }
 
         const clientOptions = {
-          userId: 'performance-test-user',
           modelOptions: largeModelOptions,
           proxy: 'http://performance-proxy:8080',
           reverseProxyUrl: 'https://performance-reverse-proxy.com',
@@ -657,7 +659,6 @@ describe('getLLMConfig', () => {
 
         modelVariations.forEach((model) => {
           const clientOptions = {
-            userId: 'model-variation-user',
             modelOptions: {
               model,
               temperature: 0.5,
@@ -665,6 +666,7 @@ describe('getLLMConfig', () => {
               topK: 40,
               thinking: true,
               promptCache: true,
+              user: 'model-variation-user',
             },
           };
 

--- a/packages/api/src/endpoints/anthropic/llm.ts
+++ b/packages/api/src/endpoints/anthropic/llm.ts
@@ -1,30 +1,13 @@
 import { Dispatcher, ProxyAgent } from 'undici';
 import { AnthropicClientOptions } from '@librechat/agents';
 import { anthropicSettings, removeNullishValues } from 'librechat-data-provider';
-import type {
-  AnthropicConfigOptions,
-  AnthropicLLMConfigResult,
-  AnthropicParameters,
-} from '~/types/anthropic';
+import type { AnthropicLLMConfigResult, AnthropicConfigOptions } from '~/types/anthropic';
 import { checkPromptCacheSupport, getClaudeHeaders, configureReasoning } from './helpers';
 
 /**
  * Generates configuration options for creating an Anthropic language model (LLM) instance.
- *
  * @param apiKey - The API key for authentication with Anthropic.
  * @param options={} - Additional options for configuring the LLM.
- * @param options.modelOptions - Model-specific options.
- * @param options.modelOptions.model - The name of the model to use.
- * @param options.modelOptions.maxOutputTokens - The maximum number of tokens to generate.
- * @param options.modelOptions.temperature - Controls randomness in output generation.
- * @param options.modelOptions.topP - Controls diversity of output generation.
- * @param options.modelOptions.topK - Controls the number of top tokens to consider.
- * @param options.modelOptions.stop - Sequences where the API will stop generating further tokens.
- * @param options.modelOptions.stream - Whether to stream the response.
- * @param options.userId - The user ID for tracking and personalization.
- * @param options.proxy - Proxy server URL.
- * @param options.reverseProxyUrl - URL for a reverse proxy, if used.
- *
  * @returns Configuration options for creating an Anthropic LLM instance, with null and undefined values removed.
  */
 function getLLMConfig(
@@ -55,11 +38,7 @@ function getLLMConfig(
     stream: true,
   };
 
-  const mergedOptions = Object.assign(
-    defaultOptions,
-    options.modelOptions,
-  ) as typeof defaultOptions &
-    Partial<AnthropicParameters> & { stop?: string[]; web_search?: boolean };
+  const mergedOptions = Object.assign(defaultOptions, options.modelOptions);
 
   let requestOptions: AnthropicClientOptions & { stream?: boolean } = {
     apiKey,
@@ -72,7 +51,7 @@ function getLLMConfig(
     clientOptions: {},
     invocationKwargs: {
       metadata: {
-        user_id: options.userId,
+        user_id: mergedOptions.user,
       },
     },
   };

--- a/packages/api/src/endpoints/anthropic/llm.ts
+++ b/packages/api/src/endpoints/anthropic/llm.ts
@@ -1,4 +1,4 @@
-import { ProxyAgent } from 'undici';
+import { Dispatcher, ProxyAgent } from 'undici';
 import { AnthropicClientOptions } from '@librechat/agents';
 import { anthropicSettings, removeNullishValues } from 'librechat-data-provider';
 import type {
@@ -121,7 +121,7 @@ function getLLMConfig(
     /** @type {AnthropicClientOptions} */
     llmConfig: removeNullishValues(
       requestOptions as Record<string, unknown>,
-    ) as AnthropicClientOptions,
+    ) as AnthropicClientOptions & { clientOptions?: { fetchOptions?: { dispatcher: Dispatcher } } },
   };
 }
 

--- a/packages/api/src/endpoints/anthropic/llm.ts
+++ b/packages/api/src/endpoints/anthropic/llm.ts
@@ -11,21 +11,21 @@ import { checkPromptCacheSupport, getClaudeHeaders, configureReasoning } from '.
 /**
  * Generates configuration options for creating an Anthropic language model (LLM) instance.
  *
- * @param {string} apiKey - The API key for authentication with Anthropic.
- * @param {Object} [options={}] - Additional options for configuring the LLM.
- * @param {Object} [options.modelOptions] - Model-specific options.
- * @param {string} [options.modelOptions.model] - The name of the model to use.
- * @param {number} [options.modelOptions.maxOutputTokens] - The maximum number of tokens to generate.
- * @param {number} [options.modelOptions.temperature] - Controls randomness in output generation.
- * @param {number} [options.modelOptions.topP] - Controls diversity of output generation.
- * @param {number} [options.modelOptions.topK] - Controls the number of top tokens to consider.
- * @param {string[]} [options.modelOptions.stop] - Sequences where the API will stop generating further tokens.
- * @param {boolean} [options.modelOptions.stream] - Whether to stream the response.
- * @param {string} options.userId - The user ID for tracking and personalization.
- * @param {string} [options.proxy] - Proxy server URL.
- * @param {string} [options.reverseProxyUrl] - URL for a reverse proxy, if used.
+ * @param apiKey - The API key for authentication with Anthropic.
+ * @param options={} - Additional options for configuring the LLM.
+ * @param options.modelOptions - Model-specific options.
+ * @param options.modelOptions.model - The name of the model to use.
+ * @param options.modelOptions.maxOutputTokens - The maximum number of tokens to generate.
+ * @param options.modelOptions.temperature - Controls randomness in output generation.
+ * @param options.modelOptions.topP - Controls diversity of output generation.
+ * @param options.modelOptions.topK - Controls the number of top tokens to consider.
+ * @param options.modelOptions.stop - Sequences where the API will stop generating further tokens.
+ * @param options.modelOptions.stream - Whether to stream the response.
+ * @param options.userId - The user ID for tracking and personalization.
+ * @param options.proxy - Proxy server URL.
+ * @param options.reverseProxyUrl - URL for a reverse proxy, if used.
  *
- * @returns {Object} Configuration options for creating an Anthropic LLM instance, with null and undefined values removed.
+ * @returns Configuration options for creating an Anthropic LLM instance, with null and undefined values removed.
  */
 function getLLMConfig(
   apiKey?: string,
@@ -61,7 +61,6 @@ function getLLMConfig(
   ) as typeof defaultOptions &
     Partial<AnthropicParameters> & { stop?: string[]; web_search?: boolean };
 
-  /** @type {AnthropicClientOptions} */
   let requestOptions: AnthropicClientOptions & { stream?: boolean } = {
     apiKey,
     model: mergedOptions.model,
@@ -118,7 +117,6 @@ function getLLMConfig(
 
   return {
     tools,
-    /** @type {AnthropicClientOptions} */
     llmConfig: removeNullishValues(
       requestOptions as Record<string, unknown>,
     ) as AnthropicClientOptions & { clientOptions?: { fetchOptions?: { dispatcher: Dispatcher } } },

--- a/packages/api/src/endpoints/anthropic/llm.ts
+++ b/packages/api/src/endpoints/anthropic/llm.ts
@@ -1,6 +1,12 @@
-const { ProxyAgent } = require('undici');
-const { anthropicSettings, removeNullishValues } = require('librechat-data-provider');
-const { checkPromptCacheSupport, getClaudeHeaders, configureReasoning } = require('./helpers');
+import { ProxyAgent } from 'undici';
+import { AnthropicClientOptions } from '@librechat/agents';
+import { anthropicSettings, removeNullishValues } from 'librechat-data-provider';
+import type {
+  AnthropicConfigOptions,
+  AnthropicLLMConfigResult,
+  AnthropicParameters,
+} from '~/types/anthropic';
+import { checkPromptCacheSupport, getClaudeHeaders, configureReasoning } from './helpers';
 
 /**
  * Generates configuration options for creating an Anthropic language model (LLM) instance.
@@ -21,25 +27,42 @@ const { checkPromptCacheSupport, getClaudeHeaders, configureReasoning } = requir
  *
  * @returns {Object} Configuration options for creating an Anthropic LLM instance, with null and undefined values removed.
  */
-function getLLMConfig(apiKey, options = {}) {
+function getLLMConfig(
+  apiKey?: string,
+  options: AnthropicConfigOptions = {} as AnthropicConfigOptions,
+): AnthropicLLMConfigResult {
   const systemOptions = {
-    thinking: options.modelOptions.thinking ?? anthropicSettings.thinking.default,
-    promptCache: options.modelOptions.promptCache ?? anthropicSettings.promptCache.default,
-    thinkingBudget: options.modelOptions.thinkingBudget ?? anthropicSettings.thinkingBudget.default,
+    thinking: options.modelOptions?.thinking ?? anthropicSettings.thinking.default,
+    promptCache: options.modelOptions?.promptCache ?? anthropicSettings.promptCache.default,
+    thinkingBudget:
+      options.modelOptions?.thinkingBudget ?? anthropicSettings.thinkingBudget.default,
   };
-  for (let key in systemOptions) {
-    delete options.modelOptions[key];
+
+  /** Couldn't figure out a way to still loop through the object while deleting the overlapping keys when porting this
+   * over from javascript, so for now they are being deleted manually until a better way presents itself.
+   */
+  if (options.modelOptions) {
+    delete options.modelOptions.thinking;
+    delete options.modelOptions.promptCache;
+    delete options.modelOptions.thinkingBudget;
+  } else {
+    throw new Error('No modelOptions provided');
   }
+
   const defaultOptions = {
     model: anthropicSettings.model.default,
     maxOutputTokens: anthropicSettings.maxOutputTokens.default,
     stream: true,
   };
 
-  const mergedOptions = Object.assign(defaultOptions, options.modelOptions);
+  const mergedOptions = Object.assign(
+    defaultOptions,
+    options.modelOptions,
+  ) as typeof defaultOptions &
+    Partial<AnthropicParameters> & { stop?: string[]; web_search?: boolean };
 
   /** @type {AnthropicClientOptions} */
-  let requestOptions = {
+  let requestOptions: AnthropicClientOptions & { stream?: boolean } = {
     apiKey,
     model: mergedOptions.model,
     stream: mergedOptions.stream,
@@ -66,20 +89,20 @@ function getLLMConfig(apiKey, options = {}) {
   }
 
   const supportsCacheControl =
-    systemOptions.promptCache === true && checkPromptCacheSupport(requestOptions.model);
-  const headers = getClaudeHeaders(requestOptions.model, supportsCacheControl);
-  if (headers) {
+    systemOptions.promptCache === true && checkPromptCacheSupport(requestOptions.model ?? '');
+  const headers = getClaudeHeaders(requestOptions.model ?? '', supportsCacheControl);
+  if (headers && requestOptions.clientOptions) {
     requestOptions.clientOptions.defaultHeaders = headers;
   }
 
-  if (options.proxy) {
+  if (options.proxy && requestOptions.clientOptions) {
     const proxyAgent = new ProxyAgent(options.proxy);
     requestOptions.clientOptions.fetchOptions = {
       dispatcher: proxyAgent,
     };
   }
 
-  if (options.reverseProxyUrl) {
+  if (options.reverseProxyUrl && requestOptions.clientOptions) {
     requestOptions.clientOptions.baseURL = options.reverseProxyUrl;
     requestOptions.anthropicApiUrl = options.reverseProxyUrl;
   }
@@ -96,8 +119,10 @@ function getLLMConfig(apiKey, options = {}) {
   return {
     tools,
     /** @type {AnthropicClientOptions} */
-    llmConfig: removeNullishValues(requestOptions),
+    llmConfig: removeNullishValues(
+      requestOptions as Record<string, unknown>,
+    ) as AnthropicClientOptions,
   };
 }
 
-module.exports = { getLLMConfig };
+export { getLLMConfig };

--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -1,5 +1,5 @@
 import { Providers } from '@librechat/agents';
-import { googleSettings, AuthKeys } from 'librechat-data-provider';
+import { googleSettings, AuthKeys, removeNullishValues } from 'librechat-data-provider';
 import type { GoogleClientOptions, VertexAIClientOptions } from '@librechat/agents';
 import type { GoogleAIToolType } from '@langchain/google-common';
 import type * as t from '~/types';
@@ -112,11 +112,15 @@ export function getGoogleConfig(
     ...modelOptions
   } = options.modelOptions || {};
 
-  const llmConfig: GoogleClientOptions | VertexAIClientOptions = {
+  const llmConfig: GoogleClientOptions | VertexAIClientOptions = removeNullishValues({
     ...(modelOptions || {}),
     model: modelOptions?.model ?? '',
     maxRetries: 2,
-  };
+    topP: modelOptions?.topP ?? undefined,
+    topK: modelOptions?.topK ?? undefined,
+    temperature: modelOptions?.temperature ?? undefined,
+    maxOutputTokens: modelOptions?.maxOutputTokens ?? undefined,
+  });
 
   /** Used only for Safety Settings */
   llmConfig.safetySettings = getSafetySettings(llmConfig.model);

--- a/packages/api/src/endpoints/index.ts
+++ b/packages/api/src/endpoints/index.ts
@@ -1,3 +1,4 @@
 export * from './custom';
 export * from './google';
 export * from './openai';
+export * from './anthropic';

--- a/packages/api/src/endpoints/openai/config.anthropic.spec.ts
+++ b/packages/api/src/endpoints/openai/config.anthropic.spec.ts
@@ -1,0 +1,451 @@
+import { getOpenAIConfig } from './config';
+
+describe('getOpenAIConfig - Anthropic Compatibility', () => {
+  describe('Anthropic via LiteLLM', () => {
+    it('should handle basic Anthropic configuration with defaultParamsEndpoint', () => {
+      const apiKey = 'sk-xxxx';
+      const endpoint = 'Anthropic (via LiteLLM)';
+      const options = {
+        modelOptions: {
+          model: 'claude-sonnet-4',
+          user: 'some_user_id',
+        },
+        reverseProxyUrl: 'http://host.docker.internal:4000/v1',
+        proxy: '',
+        headers: {},
+        addParams: undefined,
+        dropParams: undefined,
+        customParams: {
+          defaultParamsEndpoint: 'anthropic',
+          paramDefinitions: [],
+        },
+        endpoint: 'Anthropic (via LiteLLM)',
+        endpointType: 'custom',
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          apiKey: 'sk-xxxx',
+          model: 'claude-sonnet-4',
+          stream: true,
+          maxTokens: 8192,
+          modelKwargs: {
+            metadata: {
+              user_id: 'some_user_id',
+            },
+            thinking: {
+              type: 'enabled',
+              budget_tokens: 2000,
+            },
+          },
+        },
+        configOptions: {
+          baseURL: 'http://host.docker.internal:4000/v1',
+          defaultHeaders: {
+            'anthropic-beta': 'prompt-caching-2024-07-31,context-1m-2025-08-07',
+          },
+        },
+        tools: [],
+      });
+    });
+
+    it('should handle Claude 3.7 model with thinking enabled', () => {
+      const apiKey = 'sk-yyyy';
+      const endpoint = 'Anthropic (via LiteLLM)';
+      const options = {
+        modelOptions: {
+          model: 'claude-3.7-sonnet-20241022',
+          user: 'user123',
+          temperature: 0.7,
+          thinking: true,
+          thinkingBudget: 3000,
+        },
+        reverseProxyUrl: 'http://localhost:4000/v1',
+        customParams: {
+          defaultParamsEndpoint: 'anthropic',
+        },
+        endpoint: 'Anthropic (via LiteLLM)',
+        endpointType: 'custom',
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          apiKey: 'sk-yyyy',
+          model: 'claude-3.7-sonnet-20241022',
+          stream: true,
+          temperature: 0.7,
+          maxTokens: 8192,
+          modelKwargs: {
+            metadata: {
+              user_id: 'user123',
+            },
+            thinking: {
+              type: 'enabled',
+              budget_tokens: 3000,
+            },
+          },
+        },
+        configOptions: {
+          baseURL: 'http://localhost:4000/v1',
+          defaultHeaders: {
+            'anthropic-beta':
+              'token-efficient-tools-2025-02-19,output-128k-2025-02-19,prompt-caching-2024-07-31',
+          },
+        },
+        tools: [],
+      });
+    });
+
+    it('should handle Claude 3.7 model with thinking disabled (topP and topK included)', () => {
+      const apiKey = 'sk-yyyy';
+      const endpoint = 'Anthropic (via LiteLLM)';
+      const options = {
+        modelOptions: {
+          model: 'claude-3.7-sonnet-20241022',
+          user: 'user123',
+          temperature: 0.7,
+          topP: 0.9,
+          topK: 50,
+          thinking: false,
+        },
+        reverseProxyUrl: 'http://localhost:4000/v1',
+        customParams: {
+          defaultParamsEndpoint: 'anthropic',
+        },
+        endpoint: 'Anthropic (via LiteLLM)',
+        endpointType: 'custom',
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          apiKey: 'sk-yyyy',
+          model: 'claude-3.7-sonnet-20241022',
+          stream: true,
+          temperature: 0.7,
+          topP: 0.9,
+          maxTokens: 8192,
+          modelKwargs: {
+            metadata: {
+              user_id: 'user123',
+            },
+            topK: 50,
+          },
+        },
+        configOptions: {
+          baseURL: 'http://localhost:4000/v1',
+          defaultHeaders: {
+            'anthropic-beta':
+              'token-efficient-tools-2025-02-19,output-128k-2025-02-19,prompt-caching-2024-07-31',
+          },
+        },
+        tools: [],
+      });
+    });
+
+    it('should handle Claude 3.5 sonnet with special headers', () => {
+      const apiKey = 'sk-zzzz';
+      const endpoint = 'Anthropic (via LiteLLM)';
+      const options = {
+        modelOptions: {
+          model: 'claude-3.5-sonnet-20240620',
+          user: 'user456',
+          maxOutputTokens: 4096,
+        },
+        reverseProxyUrl: 'https://api.anthropic.proxy.com/v1',
+        customParams: {
+          defaultParamsEndpoint: 'anthropic',
+        },
+        endpoint: 'Anthropic (via LiteLLM)',
+        endpointType: 'custom',
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          apiKey: 'sk-zzzz',
+          model: 'claude-3.5-sonnet-20240620',
+          stream: true,
+          maxTokens: 4096,
+          modelKwargs: {
+            metadata: {
+              user_id: 'user456',
+            },
+          },
+        },
+        configOptions: {
+          baseURL: 'https://api.anthropic.proxy.com/v1',
+          defaultHeaders: {
+            'anthropic-beta': 'max-tokens-3-5-sonnet-2024-07-15,prompt-caching-2024-07-31',
+          },
+        },
+        tools: [],
+      });
+    });
+
+    it('should apply anthropic-beta headers based on model pattern', () => {
+      const apiKey = 'sk-custom';
+      const endpoint = 'Anthropic (via LiteLLM)';
+      const options = {
+        modelOptions: {
+          model: 'claude-3-sonnet',
+        },
+        reverseProxyUrl: 'http://custom.proxy/v1',
+        headers: {
+          'Custom-Header': 'custom-value',
+          Authorization: 'Bearer custom-token',
+        },
+        customParams: {
+          defaultParamsEndpoint: 'anthropic',
+        },
+        endpoint: 'Anthropic (via LiteLLM)',
+        endpointType: 'custom',
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          apiKey: 'sk-custom',
+          model: 'claude-3-sonnet',
+          stream: true,
+          maxTokens: 8192,
+          modelKwargs: {
+            metadata: {
+              user_id: undefined,
+            },
+          },
+        },
+        configOptions: {
+          baseURL: 'http://custom.proxy/v1',
+          defaultHeaders: {
+            'Custom-Header': 'custom-value',
+            Authorization: 'Bearer custom-token',
+            'anthropic-beta': 'prompt-caching-2024-07-31',
+          },
+        },
+        tools: [],
+      });
+    });
+
+    it('should handle models that do not match Claude patterns', () => {
+      const apiKey = 'sk-other';
+      const endpoint = 'Anthropic (via LiteLLM)';
+      const options = {
+        modelOptions: {
+          model: 'gpt-4-turbo',
+          user: 'userGPT',
+          temperature: 0.8,
+        },
+        reverseProxyUrl: 'http://litellm:4000/v1',
+        customParams: {
+          defaultParamsEndpoint: 'anthropic',
+        },
+        endpoint: 'Anthropic (via LiteLLM)',
+        endpointType: 'custom',
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          apiKey: 'sk-other',
+          model: 'gpt-4-turbo',
+          stream: true,
+          temperature: 0.8,
+          maxTokens: 8192,
+          modelKwargs: {
+            metadata: {
+              user_id: 'userGPT',
+            },
+          },
+        },
+        configOptions: {
+          baseURL: 'http://litellm:4000/v1',
+        },
+        tools: [],
+      });
+    });
+
+    it('should handle dropParams only working in OpenAI path not Anthropic', () => {
+      const apiKey = 'sk-drop';
+      const endpoint = 'Anthropic (via LiteLLM)';
+      const options = {
+        modelOptions: {
+          model: 'claude-3-opus-20240229',
+          user: 'userDrop',
+          temperature: 0.5,
+          maxOutputTokens: 2048,
+          thinking: true,
+          thinkingBudget: 5000,
+        },
+        reverseProxyUrl: 'http://proxy.litellm/v1',
+        dropParams: ['temperature', 'user'],
+        customParams: {
+          defaultParamsEndpoint: 'anthropic',
+        },
+        endpoint: 'Anthropic (via LiteLLM)',
+        endpointType: 'custom',
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          apiKey: 'sk-drop',
+          model: 'claude-3-opus-20240229',
+          stream: true,
+          temperature: 0.5,
+          maxTokens: 2048,
+          modelKwargs: {
+            metadata: {
+              user_id: 'userDrop',
+            },
+          },
+        },
+        configOptions: {
+          baseURL: 'http://proxy.litellm/v1',
+          defaultHeaders: {
+            'anthropic-beta': 'prompt-caching-2024-07-31',
+          },
+        },
+        tools: [],
+      });
+    });
+
+    it('should handle empty user string', () => {
+      const apiKey = 'sk-edge';
+      const endpoint = 'Anthropic (via LiteLLM)';
+      const options = {
+        modelOptions: {
+          model: 'claude-2.1',
+          user: '',
+          temperature: 0,
+        },
+        reverseProxyUrl: 'http://litellm/v1',
+        customParams: {
+          defaultParamsEndpoint: 'anthropic',
+        },
+        endpoint: 'Anthropic (via LiteLLM)',
+        endpointType: 'custom',
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          apiKey: 'sk-edge',
+          model: 'claude-2.1',
+          stream: true,
+          temperature: 0,
+          maxTokens: 8192,
+          modelKwargs: {
+            metadata: {
+              user_id: '',
+            },
+          },
+        },
+        configOptions: {
+          baseURL: 'http://litellm/v1',
+        },
+        tools: [],
+      });
+    });
+
+    it('should handle web_search tool', () => {
+      const apiKey = 'sk-search';
+      const endpoint = 'Anthropic (via LiteLLM)';
+      const options = {
+        modelOptions: {
+          model: 'claude-3-opus-20240229',
+          user: 'searchUser',
+          web_search: true,
+        },
+        reverseProxyUrl: 'http://litellm/v1',
+        customParams: {
+          defaultParamsEndpoint: 'anthropic',
+        },
+        endpoint: 'Anthropic (via LiteLLM)',
+        endpointType: 'custom',
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          apiKey: 'sk-search',
+          model: 'claude-3-opus-20240229',
+          stream: true,
+          maxTokens: 8192,
+          modelKwargs: {
+            metadata: {
+              user_id: 'searchUser',
+            },
+          },
+        },
+        configOptions: {
+          baseURL: 'http://litellm/v1',
+          defaultHeaders: {
+            'anthropic-beta': 'prompt-caching-2024-07-31',
+          },
+        },
+        tools: [
+          {
+            type: 'web_search_20250305',
+            name: 'web_search',
+          },
+        ],
+      });
+    });
+
+    it('should properly transform Anthropic config with invocationKwargs', () => {
+      const apiKey = 'sk-test';
+      const endpoint = 'Anthropic (via LiteLLM)';
+      const options = {
+        modelOptions: {
+          model: 'claude-3.5-haiku-20241022',
+          user: 'testUser',
+          topP: 0.9,
+          topK: 40,
+        },
+        reverseProxyUrl: 'http://litellm/v1',
+        customParams: {
+          defaultParamsEndpoint: 'anthropic',
+        },
+        endpoint: 'Anthropic (via LiteLLM)',
+        endpointType: 'custom',
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          apiKey: 'sk-test',
+          model: 'claude-3.5-haiku-20241022',
+          stream: true,
+          topP: 0.9,
+          maxTokens: 8192,
+          modelKwargs: {
+            metadata: {
+              user_id: 'testUser',
+            },
+            topK: 40,
+          },
+        },
+        configOptions: {
+          baseURL: 'http://litellm/v1',
+          defaultHeaders: {
+            'anthropic-beta': 'prompt-caching-2024-07-31',
+          },
+        },
+        tools: [],
+      });
+    });
+  });
+});

--- a/packages/api/src/endpoints/openai/config.backward-compat.spec.ts
+++ b/packages/api/src/endpoints/openai/config.backward-compat.spec.ts
@@ -97,6 +97,260 @@ describe('getOpenAIConfig - Backward Compatibility', () => {
     });
   });
 
+  describe('Azure OpenAI endpoint', () => {
+    it('should handle basic Azure OpenAI configuration', () => {
+      const apiKey = 'some_key';
+      const endpoint = undefined;
+      const options = {
+        modelOptions: {
+          model: 'gpt-4o',
+          user: 'some_user_id',
+        },
+        reverseProxyUrl: null,
+        endpoint: 'azureOpenAI',
+        azure: {
+          azureOpenAIApiKey: 'some_azure_key',
+          azureOpenAIApiInstanceName: 'some_instance_name',
+          azureOpenAIApiDeploymentName: 'gpt-4o',
+          azureOpenAIApiVersion: '2024-02-15-preview',
+        },
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          streaming: true,
+          model: 'gpt-4o',
+          user: 'some_user_id',
+          azureOpenAIApiKey: 'some_azure_key',
+          azureOpenAIApiInstanceName: 'some_instance_name',
+          azureOpenAIApiDeploymentName: 'gpt-4o',
+          azureOpenAIApiVersion: '2024-02-15-preview',
+        },
+        configOptions: {},
+        tools: [],
+      });
+    });
+
+    it('should handle Azure OpenAI with Responses API and reasoning', () => {
+      const apiKey = 'some_azure_key';
+      const endpoint = undefined;
+      const options = {
+        modelOptions: {
+          model: 'gpt-5',
+          reasoning_effort: ReasoningEffort.high,
+          reasoning_summary: ReasoningSummary.detailed,
+          verbosity: Verbosity.high,
+          useResponsesApi: true,
+          user: 'some_user_id',
+        },
+        endpoint: 'azureOpenAI',
+        azure: {
+          azureOpenAIApiKey: 'some_azure_key',
+          azureOpenAIApiInstanceName: 'some_instance_name',
+          azureOpenAIApiDeploymentName: 'gpt-5',
+          azureOpenAIApiVersion: '2024-12-01-preview',
+        },
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          streaming: true,
+          model: 'gpt-5',
+          useResponsesApi: true,
+          user: 'some_user_id',
+          apiKey: 'some_azure_key',
+          reasoning: {
+            effort: ReasoningEffort.high,
+            summary: ReasoningSummary.detailed,
+          },
+          modelKwargs: {
+            text: {
+              verbosity: Verbosity.high,
+            },
+          },
+        },
+        configOptions: {
+          baseURL: 'https://some_instance_name.openai.azure.com/openai/v1',
+          defaultHeaders: {
+            'api-key': 'some_azure_key',
+          },
+          defaultQuery: {
+            'api-version': 'preview',
+          },
+        },
+        tools: [],
+      });
+    });
+
+    it('should handle Azure serverless configuration with dropParams', () => {
+      const apiKey = 'some_azure_key';
+      const endpoint = undefined;
+      const options = {
+        modelOptions: {
+          model: 'jais-30b-chat',
+          user: 'some_user_id',
+        },
+        reverseProxyUrl: 'https://some_endpoint_name.services.ai.azure.com/models',
+        endpoint: 'azureOpenAI',
+        headers: {
+          'api-key': 'some_azure_key',
+        },
+        dropParams: ['stream_options', 'user'],
+        azure: false as const,
+        defaultQuery: {
+          'api-version': '2024-05-01-preview',
+        },
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          streaming: true,
+          model: 'jais-30b-chat',
+          apiKey: 'some_azure_key',
+        },
+        configOptions: {
+          baseURL: 'https://some_endpoint_name.services.ai.azure.com/models',
+          defaultHeaders: {
+            'api-key': 'some_azure_key',
+          },
+          defaultQuery: {
+            'api-version': '2024-05-01-preview',
+          },
+        },
+        tools: [],
+      });
+    });
+
+    it('should handle Azure serverless with user-provided key configuration', () => {
+      const apiKey = 'some_azure_key';
+      const endpoint = undefined;
+      const options = {
+        modelOptions: {
+          model: 'grok-3',
+          user: 'some_user_id',
+        },
+        reverseProxyUrl: 'https://some_endpoint_name.services.ai.azure.com/models',
+        endpoint: 'azureOpenAI',
+        headers: {
+          'api-key': 'some_azure_key',
+        },
+        dropParams: ['stream_options', 'user'],
+        azure: false as const,
+        defaultQuery: {
+          'api-version': '2024-05-01-preview',
+        },
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          streaming: true,
+          model: 'grok-3',
+          apiKey: 'some_azure_key',
+        },
+        configOptions: {
+          baseURL: 'https://some_endpoint_name.services.ai.azure.com/models',
+          defaultHeaders: {
+            'api-key': 'some_azure_key',
+          },
+          defaultQuery: {
+            'api-version': '2024-05-01-preview',
+          },
+        },
+        tools: [],
+      });
+    });
+
+    it('should handle Azure serverless with Mistral model configuration', () => {
+      const apiKey = 'some_azure_key';
+      const endpoint = undefined;
+      const options = {
+        modelOptions: {
+          model: 'Mistral-Large-2411',
+          user: 'some_user_id',
+        },
+        reverseProxyUrl: 'https://some_endpoint_name.services.ai.azure.com/models',
+        endpoint: 'azureOpenAI',
+        headers: {
+          'api-key': 'some_azure_key',
+        },
+        dropParams: ['stream_options', 'user'],
+        azure: false as const,
+        defaultQuery: {
+          'api-version': '2024-05-01-preview',
+        },
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          streaming: true,
+          model: 'Mistral-Large-2411',
+          apiKey: 'some_azure_key',
+        },
+        configOptions: {
+          baseURL: 'https://some_endpoint_name.services.ai.azure.com/models',
+          defaultHeaders: {
+            'api-key': 'some_azure_key',
+          },
+          defaultQuery: {
+            'api-version': '2024-05-01-preview',
+          },
+        },
+        tools: [],
+      });
+    });
+
+    it('should handle Azure serverless with DeepSeek model without dropParams', () => {
+      const apiKey = 'some_azure_key';
+      const endpoint = undefined;
+      const options = {
+        modelOptions: {
+          model: 'DeepSeek-R1',
+          user: 'some_user_id',
+        },
+        reverseProxyUrl: 'https://some_endpoint_name.models.ai.azure.com/v1/',
+        endpoint: 'azureOpenAI',
+        headers: {
+          'api-key': 'some_azure_key',
+        },
+        azure: false as const,
+        defaultQuery: {
+          'api-version': '2024-08-01-preview',
+        },
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          streaming: true,
+          model: 'DeepSeek-R1',
+          user: 'some_user_id',
+          apiKey: 'some_azure_key',
+        },
+        configOptions: {
+          baseURL: 'https://some_endpoint_name.models.ai.azure.com/v1/',
+          defaultHeaders: {
+            'api-key': 'some_azure_key',
+          },
+          defaultQuery: {
+            'api-version': '2024-08-01-preview',
+          },
+        },
+        tools: [],
+      });
+    });
+  });
+
   describe('Custom endpoints', () => {
     it('should handle Groq custom endpoint configuration', () => {
       const apiKey = 'gsk_somekey';

--- a/packages/api/src/endpoints/openai/config.backward-compat.spec.ts
+++ b/packages/api/src/endpoints/openai/config.backward-compat.spec.ts
@@ -1,0 +1,177 @@
+import {
+  Verbosity,
+  EModelEndpoint,
+  ReasoningEffort,
+  ReasoningSummary,
+} from 'librechat-data-provider';
+import { getOpenAIConfig } from './config';
+
+describe('getOpenAIConfig - Backward Compatibility', () => {
+  describe('OpenAI endpoint', () => {
+    it('should handle GPT-5 model with reasoning and web search', () => {
+      const apiKey = 'sk-proj-somekey';
+      const endpoint = undefined;
+      const options = {
+        modelOptions: {
+          model: 'gpt-5-nano',
+          verbosity: Verbosity.high,
+          reasoning_effort: ReasoningEffort.high,
+          reasoning_summary: ReasoningSummary.detailed,
+          useResponsesApi: true,
+          web_search: true,
+          user: 'some-user',
+        },
+        proxy: '',
+        reverseProxyUrl: null,
+        endpoint: EModelEndpoint.openAI,
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          streaming: true,
+          model: 'gpt-5-nano',
+          useResponsesApi: true,
+          user: 'some-user',
+          apiKey: 'sk-proj-somekey',
+          reasoning: {
+            effort: ReasoningEffort.high,
+            summary: ReasoningSummary.detailed,
+          },
+          modelKwargs: {
+            text: {
+              verbosity: Verbosity.high,
+            },
+          },
+        },
+        configOptions: {},
+        tools: [
+          {
+            type: 'web_search_preview',
+          },
+        ],
+      });
+    });
+  });
+
+  describe('OpenRouter endpoint', () => {
+    it('should handle OpenRouter configuration with dropParams and custom headers', () => {
+      const apiKey = 'sk-xxxx';
+      const endpoint = 'OpenRouter';
+      const options = {
+        modelOptions: {
+          model: 'qwen/qwen3-max',
+          user: 'some-user',
+        },
+        reverseProxyUrl: 'https://gateway.ai.cloudflare.com/v1/account-id/gateway-id/openrouter',
+        headers: {
+          'x-librechat-thread-id': '{{LIBRECHAT_BODY_CONVERSATIONID}}',
+          'x-test-key': '{{TESTING_USER_VAR}}',
+        },
+        proxy: '',
+        dropParams: ['user'],
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          streaming: true,
+          model: 'qwen/qwen3-max',
+          include_reasoning: true,
+          apiKey: 'sk-xxxx',
+        },
+        configOptions: {
+          baseURL: 'https://gateway.ai.cloudflare.com/v1/account-id/gateway-id/openrouter',
+          defaultHeaders: {
+            'HTTP-Referer': 'https://librechat.ai',
+            'X-Title': 'LibreChat',
+            'x-librechat-thread-id': '{{LIBRECHAT_BODY_CONVERSATIONID}}',
+            'x-test-key': '{{TESTING_USER_VAR}}',
+          },
+        },
+        tools: [],
+        provider: 'openrouter',
+      });
+    });
+  });
+
+  describe('Custom endpoints', () => {
+    it('should handle Groq custom endpoint configuration', () => {
+      const apiKey = 'gsk_somekey';
+      const endpoint = 'groq';
+      const options = {
+        modelOptions: {
+          model: 'qwen/qwen3-32b',
+          user: 'some-user',
+        },
+        reverseProxyUrl: 'https://api.groq.com/openai/v1/',
+        proxy: '',
+        headers: {},
+        endpoint: 'groq',
+        endpointType: 'custom',
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          streaming: true,
+          model: 'qwen/qwen3-32b',
+          user: 'some-user',
+          apiKey: 'gsk_somekey',
+        },
+        configOptions: {
+          baseURL: 'https://api.groq.com/openai/v1/',
+          defaultHeaders: {},
+        },
+        tools: [],
+      });
+    });
+
+    it('should handle Cloudflare Workers AI with custom headers and addParams', () => {
+      const apiKey = 'someKey';
+      const endpoint = 'Cloudflare Workers AI';
+      const options = {
+        modelOptions: {
+          model: '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b',
+          user: 'some-user',
+        },
+        reverseProxyUrl:
+          'https://gateway.ai.cloudflare.com/v1/${CF_ACCOUNT_ID}/${CF_GATEWAY_ID}/workers-ai/v1',
+        proxy: '',
+        headers: {
+          'x-librechat-thread-id': '{{LIBRECHAT_BODY_CONVERSATIONID}}',
+          'x-test-key': '{{TESTING_USER_VAR}}',
+        },
+        addParams: {
+          disableStreaming: true,
+        },
+        endpoint: 'Cloudflare Workers AI',
+        endpointType: 'custom',
+      };
+
+      const result = getOpenAIConfig(apiKey, options, endpoint);
+
+      expect(result).toEqual({
+        llmConfig: {
+          streaming: true,
+          model: '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b',
+          user: 'some-user',
+          disableStreaming: true,
+          apiKey: 'someKey',
+        },
+        configOptions: {
+          baseURL:
+            'https://gateway.ai.cloudflare.com/v1/${CF_ACCOUNT_ID}/${CF_GATEWAY_ID}/workers-ai/v1',
+          defaultHeaders: {
+            'x-librechat-thread-id': '{{LIBRECHAT_BODY_CONVERSATIONID}}',
+            'x-test-key': '{{TESTING_USER_VAR}}',
+          },
+        },
+        tools: [],
+      });
+    });
+  });
+});

--- a/packages/api/src/endpoints/openai/config.spec.ts
+++ b/packages/api/src/endpoints/openai/config.spec.ts
@@ -1,7 +1,8 @@
 import { Verbosity, ReasoningEffort, ReasoningSummary } from 'librechat-data-provider';
 import type { RequestInit } from 'undici';
 import type { OpenAIParameters, AzureOptions } from '~/types';
-import { getOpenAIConfig, knownOpenAIParams } from './llm';
+import { getOpenAIConfig } from './config';
+import { knownOpenAIParams } from './llm';
 
 describe('getOpenAIConfig', () => {
   const mockApiKey = 'test-api-key';

--- a/packages/api/src/endpoints/openai/config.ts
+++ b/packages/api/src/endpoints/openai/config.ts
@@ -24,7 +24,6 @@ export function getOpenAIConfig(
 ): t.OpenAIConfigResult {
   const {
     proxy,
-    headers,
     addParams,
     dropParams,
     defaultQuery,
@@ -44,15 +43,22 @@ export function getOpenAIConfig(
     !isAnthropic;
 
   let azure = options.azure;
+  let headers = options.headers;
   if (isAnthropic) {
     const anthropicResult = getAnthropicLLMConfig(apiKey, {
       modelOptions,
-      userId: options.userId || '',
       proxy: options.proxy,
-      reverseProxyUrl: options.reverseProxyUrl,
+      userId: options.userId || '',
     });
-    llmConfig = transformToOpenAIConfig(anthropicResult.llmConfig);
+    const transformed = transformToOpenAIConfig({
+      llmConfig: anthropicResult.llmConfig,
+      fromEndpoint: EModelEndpoint.anthropic,
+    });
+    llmConfig = transformed.llmConfig;
     tools = anthropicResult.tools;
+    if (transformed.configOptions?.defaultHeaders) {
+      headers = Object.assign(headers ?? {}, transformed.configOptions?.defaultHeaders);
+    }
   } else {
     const openaiResult = getOpenAILLMConfig({
       azure,

--- a/packages/api/src/endpoints/openai/config.ts
+++ b/packages/api/src/endpoints/openai/config.ts
@@ -1,0 +1,173 @@
+import { ProxyAgent } from 'undici';
+import { Providers } from '@librechat/agents';
+import { KnownEndpoints, EModelEndpoint } from 'librechat-data-provider';
+import type { AnthropicClientOptions } from '@librechat/agents';
+import type { AzureOpenAIInput } from '@langchain/openai';
+import type * as t from '~/types';
+import { getLLMConfig as getAnthropicLLMConfig } from '~/endpoints/anthropic/llm';
+import { constructAzureURL } from '~/utils/azure';
+import { createFetch } from '~/utils/generators';
+import { getOpenAILLMConfig } from './llm';
+
+type Fetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+type SupportedLLMConfig =
+  | AnthropicClientOptions
+  | t.ClientOptions
+  | (t.ClientOptions &
+      AzureOpenAIInput & {
+        useResponsesApi?: boolean;
+        azureOpenAIApiKey?: string;
+      });
+
+/**
+ * Overload for Anthropic configuration
+ */
+export function getOpenAIConfig(
+  apiKey: string,
+  options: t.OpenAIConfigOptions & {
+    customParams: { defaultParamsEndpoint: typeof EModelEndpoint.anthropic };
+  },
+  endpoint?: string | null,
+): t.LLMConfigResult<AnthropicClientOptions>;
+
+/**
+ * Overload for OpenAI/Azure configuration
+ */
+export function getOpenAIConfig(
+  apiKey: string,
+  options?: t.OpenAIConfigOptions,
+  endpoint?: string | null,
+): t.LLMConfigResult<t.ClientOptions>;
+
+/**
+ * Generates configuration options for creating a language model (LLM) instance.
+ * @param apiKey - The API key for authentication.
+ * @param options - Additional options for configuring the LLM.
+ * @param endpoint - The endpoint name
+ * @returns Configuration options for creating an LLM instance.
+ */
+export function getOpenAIConfig(
+  apiKey: string,
+  options: t.OpenAIConfigOptions = {},
+  endpoint?: string | null,
+): t.LLMConfigResult<SupportedLLMConfig> {
+  const {
+    proxy,
+    headers,
+    addParams,
+    dropParams,
+    defaultQuery,
+    directEndpoint,
+    streaming = true,
+    modelOptions = {},
+    reverseProxyUrl: baseURL,
+  } = options;
+
+  let llmConfig: SupportedLLMConfig;
+  let tools: t.LLMConfigResult['tools'];
+  const isAnthropic = options.customParams?.defaultParamsEndpoint === EModelEndpoint.anthropic;
+
+  const useOpenRouter =
+    ((baseURL && baseURL.includes(KnownEndpoints.openrouter)) ||
+      (endpoint != null && endpoint.toLowerCase().includes(KnownEndpoints.openrouter))) &&
+    !isAnthropic;
+
+  let azure = options.azure;
+  if (isAnthropic) {
+    const anthropicResult = getAnthropicLLMConfig(apiKey, {
+      modelOptions,
+      userId: options.userId || '',
+      proxy: options.proxy,
+      reverseProxyUrl: options.reverseProxyUrl,
+    });
+    llmConfig = anthropicResult.llmConfig;
+    tools = anthropicResult.tools;
+  } else {
+    const openaiResult = getOpenAILLMConfig({
+      azure,
+      apiKey,
+      baseURL,
+      streaming,
+      addParams,
+      dropParams,
+      modelOptions,
+      useOpenRouter,
+    });
+    llmConfig = openaiResult.llmConfig;
+    azure = openaiResult.azure;
+    tools = openaiResult.tools;
+  }
+
+  const configOptions: t.OpenAIConfiguration = {};
+  if (baseURL) {
+    configOptions.baseURL = baseURL;
+  }
+  if (useOpenRouter) {
+    configOptions.defaultHeaders = Object.assign(
+      {
+        'HTTP-Referer': 'https://librechat.ai',
+        'X-Title': 'LibreChat',
+      },
+      headers,
+    );
+  } else if (headers) {
+    configOptions.defaultHeaders = headers;
+  }
+
+  if (defaultQuery) {
+    configOptions.defaultQuery = defaultQuery;
+  }
+
+  if (proxy) {
+    const proxyAgent = new ProxyAgent(proxy);
+    configOptions.fetchOptions = {
+      dispatcher: proxyAgent,
+    };
+  }
+
+  if (azure && !isAnthropic) {
+    const constructAzureResponsesApi = () => {
+      if (!(llmConfig as t.ClientOptions).useResponsesApi || !azure) {
+        return;
+      }
+
+      configOptions.baseURL = constructAzureURL({
+        baseURL: configOptions.baseURL || 'https://${INSTANCE_NAME}.openai.azure.com/openai/v1',
+        azureOptions: azure,
+      });
+
+      configOptions.defaultHeaders = {
+        ...configOptions.defaultHeaders,
+        'api-key': apiKey,
+      };
+      configOptions.defaultQuery = {
+        ...configOptions.defaultQuery,
+        'api-version': configOptions.defaultQuery?.['api-version'] ?? 'preview',
+      };
+    };
+
+    constructAzureResponsesApi();
+  }
+
+  if (process.env.OPENAI_ORGANIZATION && !isAnthropic) {
+    configOptions.organization = process.env.OPENAI_ORGANIZATION;
+  }
+
+  if (directEndpoint === true && configOptions?.baseURL != null) {
+    configOptions.fetch = createFetch({
+      directEndpoint: directEndpoint,
+      reverseProxyUrl: configOptions?.baseURL,
+    }) as unknown as Fetch;
+  }
+
+  const result: t.LLMConfigResult<SupportedLLMConfig> = {
+    llmConfig,
+    configOptions,
+    tools,
+  };
+  if (useOpenRouter) {
+    result.provider = Providers.OPENROUTER;
+  }
+  return result;
+}

--- a/packages/api/src/endpoints/openai/config.ts
+++ b/packages/api/src/endpoints/openai/config.ts
@@ -50,6 +50,8 @@ export function getOpenAIConfig(
       proxy: options.proxy,
     });
     const transformed = transformToOpenAIConfig({
+      addParams,
+      dropParams,
       llmConfig: anthropicResult.llmConfig,
       fromEndpoint: EModelEndpoint.anthropic,
     });

--- a/packages/api/src/endpoints/openai/config.ts
+++ b/packages/api/src/endpoints/openai/config.ts
@@ -38,9 +38,9 @@ export function getOpenAIConfig(
   const isAnthropic = options.customParams?.defaultParamsEndpoint === EModelEndpoint.anthropic;
 
   const useOpenRouter =
+    !isAnthropic &&
     ((baseURL && baseURL.includes(KnownEndpoints.openrouter)) ||
-      (endpoint != null && endpoint.toLowerCase().includes(KnownEndpoints.openrouter))) &&
-    !isAnthropic;
+      (endpoint != null && endpoint.toLowerCase().includes(KnownEndpoints.openrouter)));
 
   let azure = options.azure;
   let headers = options.headers;
@@ -48,7 +48,6 @@ export function getOpenAIConfig(
     const anthropicResult = getAnthropicLLMConfig(apiKey, {
       modelOptions,
       proxy: options.proxy,
-      userId: options.userId || '',
     });
     const transformed = transformToOpenAIConfig({
       llmConfig: anthropicResult.llmConfig,

--- a/packages/api/src/endpoints/openai/index.ts
+++ b/packages/api/src/endpoints/openai/index.ts
@@ -1,2 +1,3 @@
 export * from './llm';
+export * from './config';
 export * from './initialize';

--- a/packages/api/src/endpoints/openai/initialize.ts
+++ b/packages/api/src/endpoints/openai/initialize.ts
@@ -9,7 +9,7 @@ import { createHandleLLMNewToken } from '~/utils/generators';
 import { getAzureCredentials } from '~/utils/azure';
 import { isUserProvided } from '~/utils/common';
 import { resolveHeaders } from '~/utils/env';
-import { getOpenAIConfig } from './llm';
+import { getOpenAIConfig } from './config';
 
 /**
  * Initializes OpenAI options for agent usage. This function always returns configuration
@@ -115,7 +115,7 @@ export const initializeOpenAI = async ({
   } else if (isAzureOpenAI) {
     clientOptions.azure =
       userProvidesKey && userValues?.apiKey ? JSON.parse(userValues.apiKey) : getAzureCredentials();
-    apiKey = clientOptions.azure?.azureOpenAIApiKey;
+    apiKey = clientOptions.azure ? clientOptions.azure.azureOpenAIApiKey : undefined;
   }
 
   if (userProvidesKey && !apiKey) {

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -112,7 +112,7 @@ export function getOpenAILLMConfig({
       model: modelOptions.model ?? '',
     },
     modelOptions,
-  ) as Partial<t.ClientOptions> & Partial<t.OpenAIParameters> & Partial<AzureOpenAIInput>;
+  ) as Partial<t.OAIClientOptions> & Partial<t.OpenAIParameters> & Partial<AzureOpenAIInput>;
 
   if (frequency_penalty != null) {
     llmConfig.frequencyPenalty = frequency_penalty;
@@ -197,13 +197,13 @@ export function getOpenAILLMConfig({
 
     combinedDropParams.forEach((param) => {
       if (param in llmConfig) {
-        delete llmConfig[param as keyof t.ClientOptions];
+        delete llmConfig[param as keyof t.OAIClientOptions];
       }
     });
   } else if (dropParams && Array.isArray(dropParams)) {
     dropParams.forEach((param) => {
       if (param in llmConfig) {
-        delete llmConfig[param as keyof t.ClientOptions];
+        delete llmConfig[param as keyof t.OAIClientOptions];
       }
     });
   }

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -80,6 +80,134 @@ function hasReasoningParams({
   );
 }
 
+function getOpenAILLMConfig({
+  streaming,
+  modelOptions,
+  addParams,
+  dropParams,
+}: {
+  streaming: boolean;
+  modelOptions: Partial<t.OpenAIParameters>;
+  addParams?: Record<string, unknown>;
+  dropParams?: string[];
+}): {
+  llmConfig: Partial<t.ClientOptions> & Partial<t.OpenAIParameters> & Partial<AzureOpenAIInput>;
+  tools: BindToolsInput[];
+} {
+  const { reasoning_effort, reasoning_summary, verbosity, web_search, ...restModelOptions } =
+    modelOptions;
+
+  const llmConfig = Object.assign(
+    {
+      streaming,
+      model: restModelOptions.model ?? '',
+    },
+    restModelOptions,
+  ) as Partial<t.ClientOptions> & Partial<t.OpenAIParameters> & Partial<AzureOpenAIInput>;
+
+  const modelKwargs: Record<string, unknown> = {};
+  let hasModelKwargs = false;
+
+  if (verbosity != null && verbosity !== '') {
+    modelKwargs.verbosity = verbosity;
+    hasModelKwargs = true;
+  }
+
+  if (addParams && typeof addParams === 'object') {
+    for (const [key, value] of Object.entries(addParams)) {
+      if (knownOpenAIParams.has(key)) {
+        (llmConfig as Record<string, unknown>)[key] = value;
+      } else {
+        hasModelKwargs = true;
+        modelKwargs[key] = value;
+      }
+    }
+  }
+
+  if (
+    hasReasoningParams({ reasoning_effort, reasoning_summary }) &&
+    llmConfig.useResponsesApi === true
+  ) {
+    llmConfig.reasoning = removeNullishValues(
+      {
+        effort: reasoning_effort,
+        summary: reasoning_summary,
+      },
+      true,
+    ) as OpenAI.Reasoning;
+  } else if (hasReasoningParams({ reasoning_effort })) {
+    llmConfig.reasoning_effort = reasoning_effort;
+  }
+
+  if (llmConfig.max_tokens != null) {
+    llmConfig.maxTokens = llmConfig.max_tokens;
+    delete llmConfig.max_tokens;
+  }
+
+  const tools: BindToolsInput[] = [];
+
+  if (web_search) {
+    llmConfig.useResponsesApi = true;
+    tools.push({ type: 'web_search_preview' });
+  }
+
+  /**
+   * Note: OpenAI Web Search models do not support any known parameters besides `max_tokens`
+   */
+  if (modelOptions.model && /gpt-4o.*search/.test(modelOptions.model as string)) {
+    const searchExcludeParams = [
+      'frequency_penalty',
+      'presence_penalty',
+      'reasoning',
+      'reasoning_effort',
+      'temperature',
+      'top_p',
+      'top_k',
+      'stop',
+      'logit_bias',
+      'seed',
+      'response_format',
+      'n',
+      'logprobs',
+      'user',
+    ];
+
+    const updatedDropParams = dropParams || [];
+    const combinedDropParams = [...new Set([...updatedDropParams, ...searchExcludeParams])];
+
+    combinedDropParams.forEach((param) => {
+      if (param in llmConfig) {
+        delete llmConfig[param as keyof t.ClientOptions];
+      }
+    });
+  } else if (dropParams && Array.isArray(dropParams)) {
+    dropParams.forEach((param) => {
+      if (param in llmConfig) {
+        delete llmConfig[param as keyof t.ClientOptions];
+      }
+    });
+  }
+
+  if (modelKwargs.verbosity && llmConfig.useResponsesApi === true) {
+    modelKwargs.text = { verbosity: modelKwargs.verbosity };
+    delete modelKwargs.verbosity;
+  }
+
+  if (llmConfig.model && /\bgpt-[5-9]\b/i.test(llmConfig.model) && llmConfig.maxTokens != null) {
+    const paramName =
+      llmConfig.useResponsesApi === true ? 'max_output_tokens' : 'max_completion_tokens';
+    modelKwargs[paramName] = llmConfig.maxTokens;
+    delete llmConfig.maxTokens;
+    hasModelKwargs = true;
+  }
+
+  if (hasModelKwargs) {
+    llmConfig.modelKwargs = modelKwargs;
+  }
+
+  return { llmConfig, tools };
+}
+
 /**
  * Generates configuration options for creating a language model (LLM) instance.
  * @param apiKey - The API key for authentication.
@@ -104,49 +232,13 @@ export function getOpenAIConfig(
     addParams,
     dropParams,
   } = options;
-  const {
-    reasoning_effort,
-    reasoning_summary,
-    verbosity,
-    frequency_penalty,
-    presence_penalty,
-    ...modelOptions
-  } = _modelOptions;
-  const llmConfig: Partial<t.ClientOptions> &
-    Partial<t.OpenAIParameters> &
-    Partial<AzureOpenAIInput> = Object.assign(
-    {
-      streaming,
-      model: modelOptions.model ?? '',
-    },
-    modelOptions,
-  );
 
-  if (frequency_penalty != null) {
-    llmConfig.frequencyPenalty = frequency_penalty;
-  }
-  if (presence_penalty != null) {
-    llmConfig.presencePenalty = presence_penalty;
-  }
-
-  const modelKwargs: Record<string, unknown> = {};
-  let hasModelKwargs = false;
-
-  if (verbosity != null && verbosity !== '') {
-    modelKwargs.verbosity = verbosity;
-    hasModelKwargs = true;
-  }
-
-  if (addParams && typeof addParams === 'object') {
-    for (const [key, value] of Object.entries(addParams)) {
-      if (knownOpenAIParams.has(key)) {
-        (llmConfig as Record<string, unknown>)[key] = value;
-      } else {
-        hasModelKwargs = true;
-        modelKwargs[key] = value;
-      }
-    }
-  }
+  const { llmConfig, tools } = getOpenAILLMConfig({
+    streaming,
+    modelOptions: _modelOptions,
+    addParams,
+    dropParams,
+  });
 
   let useOpenRouter = false;
   const configOptions: t.OpenAIConfiguration = {};
@@ -246,87 +338,6 @@ export function getOpenAIConfig(
 
   if (process.env.OPENAI_ORGANIZATION && azure) {
     configOptions.organization = process.env.OPENAI_ORGANIZATION;
-  }
-
-  if (
-    hasReasoningParams({ reasoning_effort, reasoning_summary }) &&
-    (llmConfig.useResponsesApi === true || useOpenRouter)
-  ) {
-    llmConfig.reasoning = removeNullishValues(
-      {
-        effort: reasoning_effort,
-        summary: reasoning_summary,
-      },
-      true,
-    ) as OpenAI.Reasoning;
-  } else if (hasReasoningParams({ reasoning_effort })) {
-    llmConfig.reasoning_effort = reasoning_effort;
-  }
-
-  if (llmConfig.max_tokens != null) {
-    llmConfig.maxTokens = llmConfig.max_tokens;
-    delete llmConfig.max_tokens;
-  }
-
-  const tools: BindToolsInput[] = [];
-
-  if (modelOptions.web_search) {
-    llmConfig.useResponsesApi = true;
-    tools.push({ type: 'web_search_preview' });
-  }
-
-  /**
-   * Note: OpenAI Web Search models do not support any known parameters besides `max_tokens`
-   */
-  if (modelOptions.model && /gpt-4o.*search/.test(modelOptions.model)) {
-    const searchExcludeParams = [
-      'frequency_penalty',
-      'presence_penalty',
-      'reasoning',
-      'reasoning_effort',
-      'temperature',
-      'top_p',
-      'top_k',
-      'stop',
-      'logit_bias',
-      'seed',
-      'response_format',
-      'n',
-      'logprobs',
-      'user',
-    ];
-
-    const updatedDropParams = dropParams || [];
-    const combinedDropParams = [...new Set([...updatedDropParams, ...searchExcludeParams])];
-
-    combinedDropParams.forEach((param) => {
-      if (param in llmConfig) {
-        delete llmConfig[param as keyof t.ClientOptions];
-      }
-    });
-  } else if (dropParams && Array.isArray(dropParams)) {
-    dropParams.forEach((param) => {
-      if (param in llmConfig) {
-        delete llmConfig[param as keyof t.ClientOptions];
-      }
-    });
-  }
-
-  if (modelKwargs.verbosity && llmConfig.useResponsesApi === true) {
-    modelKwargs.text = { verbosity: modelKwargs.verbosity };
-    delete modelKwargs.verbosity;
-  }
-
-  if (llmConfig.model && /\bgpt-[5-9]\b/i.test(llmConfig.model) && llmConfig.maxTokens != null) {
-    const paramName =
-      llmConfig.useResponsesApi === true ? 'max_output_tokens' : 'max_completion_tokens';
-    modelKwargs[paramName] = llmConfig.maxTokens;
-    delete llmConfig.maxTokens;
-    hasModelKwargs = true;
-  }
-
-  if (hasModelKwargs) {
-    llmConfig.modelKwargs = modelKwargs;
   }
 
   if (directEndpoint === true && configOptions?.baseURL != null) {

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -1,10 +1,12 @@
 import { ProxyAgent } from 'undici';
 import { Providers } from '@librechat/agents';
-import { KnownEndpoints, removeNullishValues } from 'librechat-data-provider';
+import { KnownEndpoints, removeNullishValues, EModelEndpoint } from 'librechat-data-provider';
 import type { BindToolsInput } from '@langchain/core/language_models/chat_models';
+import type { AnthropicClientOptions } from '@librechat/agents';
 import type { AzureOpenAIInput } from '@langchain/openai';
 import type { OpenAI } from 'openai';
 import type * as t from '~/types';
+import { getLLMConfig as getAnthropicLLMConfig } from '~/endpoints/anthropic/llm';
 import { sanitizeModelName, constructAzureURL } from '~/utils/azure';
 import { createFetch } from '~/utils/generators';
 import { isEnabled } from '~/utils/common';
@@ -233,12 +235,30 @@ export function getOpenAIConfig(
     dropParams,
   } = options;
 
-  const { llmConfig, tools } = getOpenAILLMConfig({
-    streaming,
-    modelOptions: _modelOptions,
-    addParams,
-    dropParams,
-  });
+  let llmConfig:
+    | (Partial<t.ClientOptions> & Partial<t.OpenAIParameters> & Partial<AzureOpenAIInput>)
+    | AnthropicClientOptions;
+  let tools: BindToolsInput[];
+
+  if (options.customParams?.defaultParamsEndpoint === EModelEndpoint.anthropic) {
+    const anthropicResult = getAnthropicLLMConfig(apiKey, {
+      modelOptions: _modelOptions,
+      userId: options.userId || '',
+      proxy: options.proxy,
+      reverseProxyUrl: options.reverseProxyUrl,
+    });
+    llmConfig = anthropicResult.llmConfig;
+    tools = anthropicResult.tools;
+  } else {
+    const openaiResult = getOpenAILLMConfig({
+      streaming,
+      modelOptions: _modelOptions,
+      addParams,
+      dropParams,
+    });
+    llmConfig = openaiResult.llmConfig;
+    tools = openaiResult.tools;
+  }
 
   let useOpenRouter = false;
   const configOptions: t.OpenAIConfiguration = {};

--- a/packages/api/src/endpoints/openai/transform.ts
+++ b/packages/api/src/endpoints/openai/transform.ts
@@ -1,0 +1,32 @@
+import type { ClientOptions } from '@librechat/agents';
+import type * as t from '~/types';
+import { knownOpenAIParams } from './llm';
+
+/**
+ * Transforms an Non-OpenAI LLM config to an OpenAI-conformant config.
+ * Non-OpenAI parameters are moved to modelKwargs.
+ */
+export function transformToOpenAIConfig(llmConfig: ClientOptions): t.OAIClientOptions {
+  const openAIConfig: Partial<t.OAIClientOptions> = {};
+  const modelKwargs: Record<string, unknown> = {};
+  let hasModelKwargs = false;
+
+  for (const [key, value] of Object.entries(llmConfig)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (knownOpenAIParams.has(key)) {
+      (openAIConfig as Record<string, unknown>)[key] = value;
+    } else {
+      modelKwargs[key] = value;
+      hasModelKwargs = true;
+    }
+  }
+
+  if (hasModelKwargs) {
+    openAIConfig.modelKwargs = modelKwargs;
+  }
+
+  return openAIConfig;
+}

--- a/packages/api/src/endpoints/openai/transform.ts
+++ b/packages/api/src/endpoints/openai/transform.ts
@@ -9,11 +9,16 @@ const anthropicExcludeParams = new Set(['anthropicApiUrl']);
  * Transforms a Non-OpenAI LLM config to an OpenAI-conformant config.
  * Non-OpenAI parameters are moved to modelKwargs.
  * Also extracts configuration options that belong in configOptions.
+ * Handles addParams and dropParams for parameter customization.
  */
 export function transformToOpenAIConfig({
+  addParams,
+  dropParams,
   llmConfig,
   fromEndpoint,
 }: {
+  addParams?: Record<string, unknown>;
+  dropParams?: string[];
   llmConfig: ClientOptions;
   fromEndpoint: string;
 }): {
@@ -54,8 +59,33 @@ export function transformToOpenAIConfig({
     }
   }
 
+  if (addParams && typeof addParams === 'object') {
+    for (const [key, value] of Object.entries(addParams)) {
+      if (knownOpenAIParams.has(key)) {
+        (openAIConfig as Record<string, unknown>)[key] = value;
+      } else {
+        modelKwargs[key] = value;
+        hasModelKwargs = true;
+      }
+    }
+  }
+
   if (hasModelKwargs) {
     openAIConfig.modelKwargs = modelKwargs;
+  }
+
+  if (dropParams && Array.isArray(dropParams)) {
+    dropParams.forEach((param) => {
+      if (param in openAIConfig) {
+        delete openAIConfig[param as keyof t.OAIClientOptions];
+      }
+      if (openAIConfig.modelKwargs && param in openAIConfig.modelKwargs) {
+        delete openAIConfig.modelKwargs[param];
+        if (Object.keys(openAIConfig.modelKwargs).length === 0) {
+          delete openAIConfig.modelKwargs;
+        }
+      }
+    });
   }
 
   return {

--- a/packages/api/src/endpoints/openai/transform.ts
+++ b/packages/api/src/endpoints/openai/transform.ts
@@ -1,18 +1,48 @@
+import { EModelEndpoint } from 'librechat-data-provider';
 import type { ClientOptions } from '@librechat/agents';
 import type * as t from '~/types';
 import { knownOpenAIParams } from './llm';
 
+const anthropicExcludeParams = new Set(['anthropicApiUrl']);
+
 /**
- * Transforms an Non-OpenAI LLM config to an OpenAI-conformant config.
+ * Transforms a Non-OpenAI LLM config to an OpenAI-conformant config.
  * Non-OpenAI parameters are moved to modelKwargs.
+ * Also extracts configuration options that belong in configOptions.
  */
-export function transformToOpenAIConfig(llmConfig: ClientOptions): t.OAIClientOptions {
+export function transformToOpenAIConfig({
+  llmConfig,
+  fromEndpoint,
+}: {
+  llmConfig: ClientOptions;
+  fromEndpoint: string;
+}): {
+  llmConfig: t.OAIClientOptions;
+  configOptions: Partial<t.OpenAIConfiguration>;
+} {
   const openAIConfig: Partial<t.OAIClientOptions> = {};
-  const modelKwargs: Record<string, unknown> = {};
+  let configOptions: Partial<t.OpenAIConfiguration> = {};
+  let modelKwargs: Record<string, unknown> = {};
   let hasModelKwargs = false;
+
+  const isAnthropic = fromEndpoint === EModelEndpoint.anthropic;
+  const excludeParams = isAnthropic ? anthropicExcludeParams : new Set();
 
   for (const [key, value] of Object.entries(llmConfig)) {
     if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (excludeParams.has(key)) {
+      continue;
+    }
+
+    if (isAnthropic && key === 'clientOptions') {
+      configOptions = Object.assign({}, configOptions, value as Partial<t.OpenAIConfiguration>);
+      continue;
+    } else if (isAnthropic && key === 'invocationKwargs') {
+      modelKwargs = Object.assign({}, modelKwargs, value as Record<string, unknown>);
+      hasModelKwargs = true;
       continue;
     }
 
@@ -28,5 +58,8 @@ export function transformToOpenAIConfig(llmConfig: ClientOptions): t.OAIClientOp
     openAIConfig.modelKwargs = modelKwargs;
   }
 
-  return openAIConfig;
+  return {
+    llmConfig: openAIConfig as t.OAIClientOptions,
+    configOptions,
+  };
 }

--- a/packages/api/src/types/anthropic.ts
+++ b/packages/api/src/types/anthropic.ts
@@ -14,9 +14,9 @@ export interface AnthropicConfigOptions {
   /** The user ID for tracking and personalization */
   userId?: string;
   /** Proxy server URL */
-  proxy?: string;
+  proxy?: string | null;
   /** URL for a reverse proxy, if used */
-  reverseProxyUrl?: string;
+  reverseProxyUrl?: string | null;
 }
 
 /**

--- a/packages/api/src/types/anthropic.ts
+++ b/packages/api/src/types/anthropic.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { Dispatcher } from 'undici';
+import { anthropicSchema } from 'librechat-data-provider';
+import { AnthropicClientOptions } from '@librechat/agents';
+
+export type AnthropicParameters = z.infer<typeof anthropicSchema>;
+
+/**
+ * Configuration options for the getLLMConfig function
+ */
+export interface AnthropicConfigOptions {
+  modelOptions?: Partial<AnthropicParameters>;
+  /** The user ID for tracking and personalization */
+  userId?: string;
+  /** Proxy server URL */
+  proxy?: string;
+  /** URL for a reverse proxy, if used */
+  reverseProxyUrl?: string;
+}
+
+/**
+ * Return type for getLLMConfig function
+ */
+export interface AnthropicLLMConfigResult {
+  /** Configuration options for creating an Anthropic LLM instance */
+  llmConfig: AnthropicClientOptions & {
+    clientOptions?: {
+      fetchOptions?: { dispatcher: Dispatcher };
+    };
+  };
+  /** Array of tools to be used */
+  tools: Array<{
+    type: string;
+    name?: string;
+  }>;
+}

--- a/packages/api/src/types/anthropic.ts
+++ b/packages/api/src/types/anthropic.ts
@@ -42,6 +42,7 @@ export type ThinkingConfigParam = ThinkingConfigEnabled | ThinkingConfigDisabled
 
 export type AnthropicModelOptions = Partial<Omit<AnthropicParameters, 'thinking'>> & {
   thinking?: AnthropicParameters['thinking'] | null;
+  user?: string;
 };
 
 /**
@@ -49,8 +50,6 @@ export type AnthropicModelOptions = Partial<Omit<AnthropicParameters, 'thinking'
  */
 export interface AnthropicConfigOptions {
   modelOptions?: AnthropicModelOptions;
-  /** The user ID for tracking and personalization */
-  userId?: string;
   /** Proxy server URL */
   proxy?: string | null;
   /** URL for a reverse proxy, if used */

--- a/packages/api/src/types/anthropic.ts
+++ b/packages/api/src/types/anthropic.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import { Dispatcher } from 'undici';
 import { anthropicSchema } from 'librechat-data-provider';
-import { AnthropicClientOptions } from '@librechat/agents';
-import { BindToolsInput } from '@langchain/core/language_models/chat_models';
+import type { AnthropicClientOptions } from '@librechat/agents';
+import type { LLMConfigResult } from './openai';
 
 export type AnthropicParameters = z.infer<typeof anthropicSchema>;
 
@@ -60,14 +60,11 @@ export interface AnthropicConfigOptions {
 /**
  * Return type for getLLMConfig function
  */
-export interface AnthropicLLMConfigResult {
-  /** Configuration options for creating an Anthropic LLM instance */
-  llmConfig: AnthropicClientOptions & {
+export type AnthropicLLMConfigResult = LLMConfigResult<
+  AnthropicClientOptions & {
     clientOptions?: {
       fetchOptions?: { dispatcher: Dispatcher };
     };
     stream?: boolean;
-  };
-  /** Array of tools to be used */
-  tools?: BindToolsInput[];
-}
+  }
+>;

--- a/packages/api/src/types/anthropic.ts
+++ b/packages/api/src/types/anthropic.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { Dispatcher } from 'undici';
 import { anthropicSchema } from 'librechat-data-provider';
 import { AnthropicClientOptions } from '@librechat/agents';
+import { BindToolsInput } from '@langchain/core/language_models/chat_models';
 
 export type AnthropicParameters = z.infer<typeof anthropicSchema>;
 
@@ -29,8 +30,5 @@ export interface AnthropicLLMConfigResult {
     };
   };
   /** Array of tools to be used */
-  tools: Array<{
-    type: string;
-    name?: string;
-  }>;
+  tools?: BindToolsInput[];
 }

--- a/packages/api/src/types/anthropic.ts
+++ b/packages/api/src/types/anthropic.ts
@@ -6,11 +6,49 @@ import { BindToolsInput } from '@langchain/core/language_models/chat_models';
 
 export type AnthropicParameters = z.infer<typeof anthropicSchema>;
 
+export interface ThinkingConfigDisabled {
+  type: 'disabled';
+}
+
+export interface ThinkingConfigEnabled {
+  /**
+   * Determines how many tokens Claude can use for its internal reasoning process.
+   * Larger budgets can enable more thorough analysis for complex problems, improving
+   * response quality.
+   *
+   * Must be ≥1024 and less than `max_tokens`.
+   *
+   * See
+   * [extended thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking)
+   * for details.
+   */
+  budget_tokens: number;
+
+  type: 'enabled';
+}
+
+/**
+ * Configuration for enabling Claude's extended thinking.
+ *
+ * When enabled, responses include `thinking` content blocks showing Claude's
+ * thinking process before the final answer. Requires a minimum budget of 1,024
+ * tokens and counts towards your `max_tokens` limit.
+ *
+ * See
+ * [extended thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking)
+ * for details.
+ */
+export type ThinkingConfigParam = ThinkingConfigEnabled | ThinkingConfigDisabled;
+
+export type AnthropicModelOptions = Partial<Omit<AnthropicParameters, 'thinking'>> & {
+  thinking?: AnthropicParameters['thinking'] | null;
+};
+
 /**
  * Configuration options for the getLLMConfig function
  */
 export interface AnthropicConfigOptions {
-  modelOptions?: Partial<AnthropicParameters>;
+  modelOptions?: AnthropicModelOptions;
   /** The user ID for tracking and personalization */
   userId?: string;
   /** Proxy server URL */
@@ -28,6 +66,7 @@ export interface AnthropicLLMConfigResult {
     clientOptions?: {
       fetchOptions?: { dispatcher: Dispatcher };
     };
+    stream?: boolean;
   };
   /** Array of tools to be used */
   tools?: BindToolsInput[];

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -13,3 +13,4 @@ export * from './prompts';
 export * from './run';
 export * from './tools';
 export * from './zod';
+export * from './anthropic';

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -22,6 +22,10 @@ export interface OpenAIConfigOptions {
   streaming?: boolean;
   addParams?: Record<string, unknown>;
   dropParams?: string[];
+  customParams?: {
+    defaultParamsEndpoint?: string;
+  };
+  userId?: string;
 }
 
 export type OpenAIConfiguration = OpenAIClientOptions['configuration'];

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { openAISchema, EModelEndpoint } from 'librechat-data-provider';
-import type { TEndpointOption, TAzureConfig, TEndpoint } from 'librechat-data-provider';
+import type { TEndpointOption, TAzureConfig, TEndpoint, TConfig } from 'librechat-data-provider';
 import type { BindToolsInput } from '@langchain/core/language_models/chat_models';
 import type { OpenAIClientOptions, Providers } from '@librechat/agents';
 import type { AzureOptions } from './azure';
@@ -24,9 +24,7 @@ export interface OpenAIConfigOptions {
   streaming?: boolean;
   addParams?: Record<string, unknown>;
   dropParams?: string[];
-  customParams?: {
-    defaultParamsEndpoint?: string;
-  };
+  customParams?: TConfig['customParams'];
   userId?: string;
 }
 

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -24,7 +24,7 @@ export interface OpenAIConfigOptions {
   streaming?: boolean;
   addParams?: Record<string, unknown>;
   dropParams?: string[];
-  customParams?: TConfig['customParams'];
+  customParams?: Partial<TConfig['customParams']>;
 }
 
 export type OpenAIConfiguration = OpenAIClientOptions['configuration'];

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -8,11 +8,13 @@ import type { AppConfig } from './config';
 
 export type OpenAIParameters = z.infer<typeof openAISchema>;
 
+export type OpenAIModelOptions = Partial<OpenAIParameters>;
+
 /**
  * Configuration options for the getLLMConfig function
  */
 export interface OpenAIConfigOptions {
-  modelOptions?: Partial<OpenAIParameters>;
+  modelOptions?: OpenAIModelOptions;
   directEndpoint?: boolean;
   reverseProxyUrl?: string | null;
   defaultQuery?: Record<string, string | undefined>;
@@ -30,19 +32,22 @@ export interface OpenAIConfigOptions {
 
 export type OpenAIConfiguration = OpenAIClientOptions['configuration'];
 
-export type ClientOptions = OpenAIClientOptions & {
+export type OAIClientOptions = OpenAIClientOptions & {
   include_reasoning?: boolean;
 };
 
 /**
  * Return type for getLLMConfig function
  */
-export interface LLMConfigResult<T = ClientOptions> {
+export interface LLMConfigResult<T = OAIClientOptions> {
   llmConfig: T;
-  configOptions: OpenAIConfiguration;
-  tools?: BindToolsInput[];
   provider?: Providers;
+  tools?: BindToolsInput[];
 }
+
+export type OpenAIConfigResult = LLMConfigResult<OAIClientOptions> & {
+  configOptions?: OpenAIConfiguration;
+};
 
 /**
  * Interface for user values retrieved from the database

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import { openAISchema, EModelEndpoint } from 'librechat-data-provider';
+import type { AnthropicClientOptions, OpenAIClientOptions, Providers } from '@librechat/agents';
 import type { TEndpointOption, TAzureConfig, TEndpoint } from 'librechat-data-provider';
 import type { BindToolsInput } from '@langchain/core/language_models/chat_models';
-import type { OpenAIClientOptions, Providers } from '@librechat/agents';
 import type { AzureOptions } from './azure';
 import type { AppConfig } from './config';
 
@@ -38,7 +38,7 @@ export type ClientOptions = OpenAIClientOptions & {
  * Return type for getLLMConfig function
  */
 export interface LLMConfigResult {
-  llmConfig: ClientOptions;
+  llmConfig: ClientOptions | AnthropicClientOptions;
   configOptions: OpenAIConfiguration;
   tools?: BindToolsInput[];
   provider?: Providers;

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import { openAISchema, EModelEndpoint } from 'librechat-data-provider';
-import type { AnthropicClientOptions, OpenAIClientOptions, Providers } from '@librechat/agents';
 import type { TEndpointOption, TAzureConfig, TEndpoint } from 'librechat-data-provider';
 import type { BindToolsInput } from '@langchain/core/language_models/chat_models';
+import type { OpenAIClientOptions, Providers } from '@librechat/agents';
 import type { AzureOptions } from './azure';
 import type { AppConfig } from './config';
 
@@ -37,8 +37,8 @@ export type ClientOptions = OpenAIClientOptions & {
 /**
  * Return type for getLLMConfig function
  */
-export interface LLMConfigResult {
-  llmConfig: ClientOptions | AnthropicClientOptions;
+export interface LLMConfigResult<T = ClientOptions> {
+  llmConfig: T;
   configOptions: OpenAIConfiguration;
   tools?: BindToolsInput[];
   provider?: Providers;

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -25,7 +25,6 @@ export interface OpenAIConfigOptions {
   addParams?: Record<string, unknown>;
   dropParams?: string[];
   customParams?: TConfig['customParams'];
-  userId?: string;
 }
 
 export type OpenAIConfiguration = OpenAIClientOptions['configuration'];

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -15,3 +15,4 @@ export * from './text';
 export { default as Tokenizer } from './tokenizer';
 export * from './yaml';
 export * from './http';
+export * from './tokens';

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -1,5 +1,23 @@
-const z = require('zod');
-const { EModelEndpoint } = require('librechat-data-provider');
+import z from 'zod';
+import { EModelEndpoint } from 'librechat-data-provider';
+
+/** Configuration object mapping model keys to their respective prompt, completion rates, and context limit
+ *
+ * Note: the [key: string]: unknown is not in the original JSDoc typedef in /api/typedefs.js, but I've included it since
+ * getModelMaxOutputTokens calls getModelTokenValue with a key of 'output', which was not in the original JSDoc typedef,
+ * but would be referenced in a TokenConfig in the if(matchedPattern) portion of getModelTokenValue.
+ * So in order to preserve functionality for that case and any others which might reference an additional key I'm unaware of,
+ * I've included it here until the interface can be typed more tightly.
+ */
+export interface TokenConfig {
+  prompt: number;
+  completion: number;
+  context: number;
+  [key: string]: unknown;
+}
+
+/** An endpoint's config object mapping model keys to their respective prompt, completion rates, and context limit */
+export type EndpointTokenConfig = Record<string, TokenConfig>;
 
 const openAIModels = {
   'o4-mini': 200000,
@@ -287,10 +305,13 @@ const maxOutputTokensMap = {
 /**
  * Finds the first matching pattern in the tokens map.
  * @param {string} modelName
- * @param {Record<string, number>} tokensMap
+ * @param {Record<string, number> | EndpointTokenConfig} tokensMap
  * @returns {string|null}
  */
-function findMatchingPattern(modelName, tokensMap) {
+function findMatchingPattern(
+  modelName: string,
+  tokensMap: Record<string, number> | EndpointTokenConfig,
+): string | null {
   const keys = Object.keys(tokensMap);
   for (let i = keys.length - 1; i >= 0; i--) {
     const modelKey = keys[i];
@@ -310,27 +331,50 @@ function findMatchingPattern(modelName, tokensMap) {
  * @param {string} [key='context'] - The key to look up in the tokens map.
  * @returns {number|undefined} The token value for the given model or undefined if no match is found.
  */
-function getModelTokenValue(modelName, tokensMap, key = 'context') {
+function getModelTokenValue(
+  modelName: string,
+  tokensMap: EndpointTokenConfig | Record<string, number>,
+  key = 'context',
+): number | undefined {
   if (typeof modelName !== 'string' || !tokensMap) {
     return undefined;
   }
 
-  if (tokensMap[modelName]?.context) {
-    return tokensMap[modelName].context;
+  if (
+    tokensMap[modelName] &&
+    typeof tokensMap[modelName] === 'object' &&
+    'context' in (tokensMap[modelName] as object)
+  ) {
+    return (tokensMap[modelName] as TokenConfig).context;
   }
 
-  if (tokensMap[modelName]) {
-    return tokensMap[modelName];
+  if (tokensMap[modelName] && typeof tokensMap[modelName] === 'number') {
+    return tokensMap[modelName] as number;
   }
 
   const matchedPattern = findMatchingPattern(modelName, tokensMap);
 
   if (matchedPattern) {
     const result = tokensMap[matchedPattern];
-    return result?.[key] ?? result ?? tokensMap.system_default;
+    if (result && typeof result === 'object' && key in result) {
+      return (result as TokenConfig)[key as keyof TokenConfig] as number;
+    }
+    if (typeof result === 'number') {
+      return result;
+    }
   }
 
-  return tokensMap.system_default;
+  if (typeof tokensMap === 'object' && 'system_default' in tokensMap) {
+    return (tokensMap as Record<string, number>).system_default;
+  }
+
+  /** Remove this comment once confirmed this shares same functionality with original js version:
+   * returning undefined when
+   * tokenMaps[modelName] didn't exist,
+   * tokenMaps wasn't an object (EndpointTokenConfig),
+   * modelName didn't match any pattern in tokenMaps,
+   * and tokenMaps didn't have a system_default property */
+  return undefined;
 }
 
 /**
@@ -341,8 +385,12 @@ function getModelTokenValue(modelName, tokensMap, key = 'context') {
  * @param {EndpointTokenConfig} [endpointTokenConfig] - Token Config for current endpoint to use for max tokens lookup
  * @returns {number|undefined} The maximum tokens for the given model or undefined if no match is found.
  */
-function getModelMaxTokens(modelName, endpoint = EModelEndpoint.openAI, endpointTokenConfig) {
-  const tokensMap = endpointTokenConfig ?? maxTokensMap[endpoint];
+function getModelMaxTokens(
+  modelName: string,
+  endpoint = EModelEndpoint.openAI,
+  endpointTokenConfig?: EndpointTokenConfig,
+): number | undefined {
+  const tokensMap = endpointTokenConfig ?? maxTokensMap[endpoint as keyof typeof maxTokensMap];
   return getModelTokenValue(modelName, tokensMap);
 }
 
@@ -354,8 +402,13 @@ function getModelMaxTokens(modelName, endpoint = EModelEndpoint.openAI, endpoint
  * @param {EndpointTokenConfig} [endpointTokenConfig] - Token Config for current endpoint to use for max tokens lookup
  * @returns {number|undefined} The maximum output tokens for the given model or undefined if no match is found.
  */
-function getModelMaxOutputTokens(modelName, endpoint = EModelEndpoint.openAI, endpointTokenConfig) {
-  const tokensMap = endpointTokenConfig ?? maxOutputTokensMap[endpoint];
+function getModelMaxOutputTokens(
+  modelName: string,
+  endpoint = EModelEndpoint.openAI,
+  endpointTokenConfig?: EndpointTokenConfig,
+): number | undefined {
+  const tokensMap =
+    endpointTokenConfig ?? maxOutputTokensMap[endpoint as keyof typeof maxOutputTokensMap];
   return getModelTokenValue(modelName, tokensMap, 'output');
 }
 
@@ -372,12 +425,12 @@ function getModelMaxOutputTokens(modelName, endpoint = EModelEndpoint.openAI, en
  * matchModelName('gpt-4-32k-unknown'); // Returns 'gpt-4-32k'
  * matchModelName('unknown-model'); // Returns undefined
  */
-function matchModelName(modelName, endpoint = EModelEndpoint.openAI) {
+function matchModelName(modelName: string, endpoint = EModelEndpoint.openAI): string | undefined {
   if (typeof modelName !== 'string') {
     return undefined;
   }
 
-  const tokensMap = maxTokensMap[endpoint];
+  const tokensMap: Record<string, number> = maxTokensMap[endpoint as keyof typeof maxTokensMap];
   if (!tokensMap) {
     return modelName;
   }
@@ -408,7 +461,7 @@ const inputSchema = z.object({
  * @param {{ data: Array<z.infer<typeof modelSchema>> }} input The input object containing base URL and data fetched from the API.
  * @returns {EndpointTokenConfig} The processed model data.
  */
-function processModelData(input) {
+function processModelData(input: z.infer<typeof inputSchema>): EndpointTokenConfig {
   const validationResult = inputSchema.safeParse(input);
   if (!validationResult.success) {
     throw new Error('Invalid input data');
@@ -416,7 +469,7 @@ function processModelData(input) {
   const { data } = validationResult.data;
 
   /** @type {EndpointTokenConfig} */
-  const tokenConfig = {};
+  const tokenConfig: EndpointTokenConfig = {};
 
   for (const model of data) {
     const modelKey = model.id;
@@ -478,15 +531,15 @@ const tiktokenModels = new Set([
   'gpt-3.5-turbo-0301',
 ]);
 
-module.exports = {
+export {
   inputSchema,
   modelSchema,
   maxTokensMap,
   tiktokenModels,
-  maxOutputTokensMap,
   matchModelName,
   processModelData,
   getModelMaxTokens,
+  maxOutputTokensMap,
   getModelTokenValue,
   findMatchingPattern,
   getModelMaxOutputTokens,

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -619,14 +619,14 @@ export const tConversationSchema = z.object({
   userLabel: z.string().optional(),
   model: z.string().nullable().optional(),
   promptPrefix: z.string().nullable().optional(),
-  temperature: z.number().optional(),
+  temperature: z.number().nullable().optional(),
   topP: z.number().optional(),
   topK: z.number().optional(),
   top_p: z.number().optional(),
   frequency_penalty: z.number().optional(),
   presence_penalty: z.number().optional(),
   parentMessageId: z.string().optional(),
-  maxOutputTokens: coerceNumber.optional(),
+  maxOutputTokens: coerceNumber.nullable().optional(),
   maxContextTokens: coerceNumber.optional(),
   max_tokens: coerceNumber.optional(),
   /* Anthropic */
@@ -634,6 +634,7 @@ export const tConversationSchema = z.object({
   system: z.string().optional(),
   thinking: z.boolean().optional(),
   thinkingBudget: coerceNumber.optional(),
+  stream: z.boolean().optional(),
   /* artifacts */
   artifacts: z.string().optional(),
   /* google */
@@ -1152,6 +1153,8 @@ export const anthropicBaseSchema = tConversationSchema.pick({
   maxContextTokens: true,
   web_search: true,
   fileTokenLimit: true,
+  stop: true,
+  stream: true,
 });
 
 export const anthropicSchema = anthropicBaseSchema


### PR DESCRIPTION
## Summary

This pull request allows for prompt parameters to be passed to custom Anthropic endpoints as raised in #8933. This was achieved by modularizing the logic for fetching LLM specific configs in endpoints/openai/llm.ts with the new getOpenAILLMConfig, then migrating over the necessary Anthropic LLM Config counterpart, and finally introducing logic to differentiate between the endpoints via their configured defaultParamsEndpoint fields.

- [#9412]
- [#9413]
- [#9414]

## Change Type

- [x] New feature (non-breaking change which adds functionality)


## Testing

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes