### PR TITLE
⬆️ refactor: Enable File Search from Upload Option

### DIFF
--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -91,6 +91,10 @@ const AttachFileMenu = ({ disabled, conversationId, endpointFileConfig }: Attach
           label: localize('com_ui_upload_file_search'),
           onClick: () => {
             setToolResource(EToolResources.file_search);
+            setEphemeralAgent((prev) => ({
+              ...prev,
+              [EToolResources.file_search]: true,
+            }));
             onAction();
           },
           icon: <FileSearch className="icon-md" />,


### PR DESCRIPTION
### Summary
- Align File Search upload behavior with Code Interpreter.
- When a user selects “Upload for File Search,” the File Search badge/tool is now auto-activated in the chat input.

- Affected file: `client/src/components/Chat/Input/Files/AttachFileMenu.tsx`
  - Change: set the ephemeral agent flag for File Search on selection.
  - Before: File Search badge did not activate after upload (except first message).
  - After: File Search badge activates immediately after selecting “Upload for File Search.”

- Closes: #9424 

### Change Type
- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

#### Steps to verify
1. Start a new conversation.
2. Click the attachment icon to open the file menu.
3. Choose “Upload for File Search” and select a non-image, supported file.
4. Observe the badge row:
   - File Search badge becomes active immediately.
5. Send a message; confirm File Search remains active for the message where the file is attached.
6. Repeat in an existing conversation to ensure consistent behavior beyond the first message.

#### Regression checks
- Choose “Code files” upload; confirm Code Interpreter badge still auto-activates.
- Upload an image; ensure no unintended toggles for File Search.
- Ensure no errors in the console during uploads.

### Test Configuration
- OS: Linux (kernel 6.8.x)
- Browsers: Chrome, Firefox
- From source (git): `4f2b4c330305cf9f576c5db56ec9a8cb0c9a53b2`

### Implementation Notes
- Updated File Search menu action to mirror Code Interpreter’s activation:
  - Set `[EToolResources.file_search] = true` on selection in `AttachFileMenu.tsx`.
- No server-side changes required; upload flow remains unchanged.

### Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit/build checks pass for the touched workspace
- [x] I have added tests or verified existing tests still pass
- [x] A documentation update is not required for this change
