### PR TITLE
🛂 refactor: Centralize `fileStrategy` Resolution for OpenID, SAML, and Social Logins

### DIFF
--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -398,6 +398,7 @@ async function setupOpenId() {
             );
           }
 
+          const appConfig = await getAppConfig();
           if (!user) {
             user = {
               provider: 'openid',
@@ -409,7 +410,6 @@ async function setupOpenId() {
               idOnTheSource: userinfo.oid,
             };
 
-            const appConfig = await getAppConfig();
             const balanceConfig = getBalanceConfig(appConfig);
             user = await createUser(user, balanceConfig, true, true);
           } else {
@@ -438,7 +438,9 @@ async function setupOpenId() {
               userinfo.sub,
             );
             if (imageBuffer) {
-              const { saveBuffer } = getStrategyFunctions(process.env.CDN_PROVIDER);
+              const { saveBuffer } = getStrategyFunctions(
+                appConfig?.fileStrategy ?? process.env.CDN_PROVIDER,
+              );
               const imagePath = await saveBuffer({
                 fileName,
                 userId: user._id.toString(),

--- a/api/strategies/samlStrategy.js
+++ b/api/strategies/samlStrategy.js
@@ -220,6 +220,7 @@ async function setupSaml() {
             getUserName(profile) || getGivenName(profile) || getEmail(profile),
           );
 
+          const appConfig = await getAppConfig();
           if (!user) {
             user = {
               provider: 'saml',
@@ -229,7 +230,6 @@ async function setupSaml() {
               emailVerified: true,
               name: fullName,
             };
-            const appConfig = await getAppConfig();
             const balanceConfig = getBalanceConfig(appConfig);
             user = await createUser(user, balanceConfig, true, true);
           } else {
@@ -250,7 +250,9 @@ async function setupSaml() {
                 fileName = profile.nameID + '.png';
               }
 
-              const { saveBuffer } = getStrategyFunctions(process.env.CDN_PROVIDER);
+              const { saveBuffer } = getStrategyFunctions(
+                appConfig?.fileStrategy ?? process.env.CDN_PROVIDER,
+              );
               const imagePath = await saveBuffer({
                 fileName,
                 userId: user._id.toString(),

--- a/api/strategies/socialLogin.js
+++ b/api/strategies/socialLogin.js
@@ -2,6 +2,7 @@ const { isEnabled } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const { ErrorTypes } = require('librechat-data-provider');
 const { createSocialUser, handleExistingUser } = require('./process');
+const { getAppConfig } = require('~/server/services/Config');
 const { findUser } = require('~/models');
 
 const socialLogin =
@@ -12,11 +13,12 @@ const socialLogin =
         profile,
       });
 
+      const appConfig = await getAppConfig();
       const existingUser = await findUser({ email: email.trim() });
       const ALLOW_SOCIAL_REGISTRATION = isEnabled(process.env.ALLOW_SOCIAL_REGISTRATION);
 
       if (existingUser?.provider === provider) {
-        await handleExistingUser(existingUser, avatarUrl);
+        await handleExistingUser(existingUser, avatarUrl, appConfig);
         return cb(null, existingUser);
       } else if (existingUser) {
         logger.info(
@@ -38,6 +40,7 @@ const socialLogin =
           username,
           name,
           emailVerified,
+          appConfig,
         });
         return cb(null, newUser);
       }


### PR DESCRIPTION
## Summary

I refactored the file strategy resolution across OpenID, SAML, and social login implementations to use the application configuration's `fileStrategy` value instead of directly accessing the `CDN_PROVIDER` environment variable.

- Modified `openidStrategy.js` to retrieve `appConfig` earlier and use its `fileStrategy` value with a fallback to `process.env.CDN_PROVIDER`
- Updated `handleExistingUser` function to accept `appConfig` parameter for consistent file strategy resolution
- Modified `createSocialUser` function to accept `appConfig` parameter and use it for both balance configuration and file strategy determination
- Updated `samlStrategy.js` to retrieve `appConfig` once and use its `fileStrategy` value consistently
- Modified `socialLogin.js` to fetch `appConfig` and pass it to both `handleExistingUser` and `createSocialUser` functions
- Ensured all file strategy resolutions follow the pattern: `appConfig?.fileStrategy ?? process.env.CDN_PROVIDER`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

## Testing

Test the authentication flows with different file storage strategies:

1. Configure the application with a custom `fileStrategy` in the app configuration
2. Test OpenID login with profile picture retrieval
3. Test SAML authentication with avatar support
4. Test social login (Google/GitHub/Discord) with profile pictures
5. Verify fallback to `CDN_PROVIDER` environment variable when `fileStrategy` is not set in config

### **Test Configuration**:
- File strategies: local, s3, cloudinary, firebase
- Authentication providers: OpenID, SAML, Google, GitHub, Discord
- Test both with and without `fileStrategy` in app configuration

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules