### PR TITLE
🔢 feat: Add Support for Integer and Float JSON Schema Types

### DIFF
--- a/packages/api/src/mcp/zod.ts
+++ b/packages/api/src/mcp/zod.ts
@@ -350,7 +350,7 @@ export function convertJsonSchemaToZod(
     } else {
       zodSchema = z.string();
     }
-  } else if (schema.type === 'number') {
+  } else if (schema.type === 'number' || schema.type === 'integer' || schema.type === 'float') {
     zodSchema = z.number();
   } else if (schema.type === 'boolean') {
     zodSchema = z.boolean();

--- a/packages/api/src/types/zod.ts
+++ b/packages/api/src/types/zod.ts
@@ -1,5 +1,5 @@
 export type JsonSchemaType = {
-  type: 'string' | 'number' | 'boolean' | 'array' | 'object';
+  type: 'string' | 'number' | 'integer' | 'float' | 'boolean' | 'array' | 'object';
   enum?: string[];
   items?: JsonSchemaType;
   properties?: Record<string, JsonSchemaType>;


### PR DESCRIPTION
## Summary

I added support for the `integer` JSON Schema type and the non-standard `float` type to handle MCP servers properly. While `integer` is a valid JSON Schema type according to the official specification, some implementations may not handle it correctly. The `float` type is not part of the JSON Schema spec (which uses `number` for floating-point values), but some MCP servers use it anyway, causing schema conversion failures.

- Extended `JsonSchemaType` to include 'integer' and 'float' as valid type options
- Modified `convertJsonSchemaToZod` function to handle integer and float types by mapping them to `z.number()`
- Added comprehensive test suite covering integer type conversion and ensuring it doesn't generate incorrect `anyOf` structures
- Verified that mixed number, integer, and float fields in object properties are handled correctly
- Ensured existing functionality for string, number, and boolean types remains intact

**Note**: `integer` is a standard JSON Schema type for validating whole numbers. `float` is not part of the official specification (the standard uses `number` with appropriate constraints), but this change accommodates MCP servers that use this non-standard type.

## Change Type

- [x] Feature (non-breaking change which adds functionality)

## Testing

I added extensive unit tests to verify the fix works correctly. The tests ensure that integer and float types are properly converted to Zod number schemas instead of falling through to incorrect anyOf structures. The tests also verify that optional integer fields in objects are handled correctly.

### **Test Configuration**:
- Framework: Jest
- Test files: `packages/api/src/mcp/__tests__/zod.spec.ts`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes