### PR TITLE
🗣️ feat: Language Support for OpenAI Speech-to-Text

### DIFF
--- a/client/src/hooks/Input/useSpeechToTextExternal.ts
+++ b/client/src/hooks/Input/useSpeechToTextExternal.ts
@@ -25,6 +25,7 @@ const useSpeechToTextExternal = (
 
   const [minDecibels] = useRecoilState(store.decibelValue);
   const [autoSendText] = useRecoilState(store.autoSendText);
+  const [languageSTT] = useRecoilState<string>(store.languageSTT);
   const [speechToText] = useRecoilState<boolean>(store.speechToText);
   const [autoTranscribeAudio] = useRecoilState<boolean>(store.autoTranscribeAudio);
 
@@ -121,6 +122,9 @@ const useSpeechToTextExternal = (
 
       const formData = new FormData();
       formData.append('audio', audioBlob, `audio.${fileExtension}`);
+      if (languageSTT) {
+        formData.append('language', languageSTT);
+      }
       setIsRequestBeingMade(true);
       cleanup();
       processAudio(formData);


### PR DESCRIPTION
## Summary

I added language support for OpenAI-like Speech-to-Text requests, enabling users to specify the transcription language for improved accuracy.

Closes #9440

- Added language parameter support in STTService for both OpenAI and Azure OpenAI providers
- Convert locale codes (e.g., "en-US") to ISO-639-1 format (e.g., "en") for API compatibility
- Modified sttRequest method to accept language parameter in the request data object
- Updated request handler to extract language from request body
- Integrated language preference from client state in useSpeechToTextExternal hook
- Append language parameter to FormData when making STT API requests from the client

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Test the language support by:
1. Configure STT with OpenAI or Azure OpenAI provider
2. Set a language preference in the application settings
3. Record audio and verify the transcription respects the selected language
4. Test with multiple languages to ensure proper ISO-639-1 conversion
5. Verify that requests without language specification continue to work as before

### **Test Configuration**:
- OpenAI API or Azure OpenAI API credentials
- Multiple language audio samples for testing
- Various STT language settings in the application

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings