### PR TITLE
🛠️ refactor: Only Show Agents MCP UI When Configured

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -122,7 +122,6 @@ router.get('/', async function (req, res) {
       payload.minPasswordLength = minPasswordLength;
     }
 
-    payload.mcpServers = {};
     const getMCPServers = () => {
       try {
         if (appConfig?.mcpConfig == null) {
@@ -136,6 +135,9 @@ router.get('/', async function (req, res) {
         if (!mcpServers) return;
         const oauthServers = mcpManager.getOAuthServers();
         for (const serverName in mcpServers) {
+          if (!payload.mcpServers) {
+            payload.mcpServers = {};
+          }
           const serverConfig = mcpServers[serverName];
           payload.mcpServers[serverName] = removeNullishValues({
             startup: serverConfig?.startup,

--- a/client/src/Providers/AgentPanelContext.tsx
+++ b/client/src/Providers/AgentPanelContext.tsx
@@ -140,6 +140,7 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
     pluginTools,
     activePanel,
     agentsConfig,
+    startupConfig,
     setActivePanel,
     endpointsConfig,
     setCurrentAgentId,

--- a/client/src/common/types.ts
+++ b/client/src/common/types.ts
@@ -239,6 +239,7 @@ export type AgentPanelContextType = {
   setActivePanel: React.Dispatch<React.SetStateAction<Panel>>;
   setCurrentAgentId: React.Dispatch<React.SetStateAction<string | undefined>>;
   agent_id?: string;
+  startupConfig?: t.TStartupConfig | null;
   agentsConfig?: t.TAgentsEndpoint | null;
   endpointsConfig?: t.TEndpointsConfig | null;
   /** Pre-computed MCP server information indexed by server key */

--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -49,6 +49,7 @@ export default function AgentConfig({ createMutation }: Pick<AgentPanelProps, 'c
     actions,
     setAction,
     agentsConfig,
+    startupConfig,
     mcpServersMap,
     setActivePanel,
     endpointsConfig,
@@ -308,6 +309,14 @@ export default function AgentConfig({ createMutation }: Pick<AgentPanelProps, 'c
             {fileSearchEnabled && <FileSearch agent_id={agent_id} files={knowledge_files} />}
           </div>
         )}
+        {/* MCP Section */}
+        {startupConfig?.mcpServers != null && (
+          <MCPTools
+            agentId={agent_id}
+            mcpServerNames={mcpServerNames}
+            setShowMCPToolDialog={setShowMCPToolDialog}
+          />
+        )}
         {/* Agent Tools & Actions */}
         <div className="mb-4">
           <label className={labelClass}>
@@ -375,12 +384,6 @@ export default function AgentConfig({ createMutation }: Pick<AgentPanelProps, 'c
             </div>
           </div>
         </div>
-        {/* MCP Section */}
-        <MCPTools
-          agentId={agent_id}
-          mcpServerNames={mcpServerNames}
-          setShowMCPToolDialog={setShowMCPToolDialog}
-        />
         {/* Support Contact (Optional) */}
         <div className="mb-4">
           <div className="mb-1.5 flex items-center gap-2">


### PR DESCRIPTION
## Summary

I refactored the MCP (Model Context Protocol) UI visibility logic to conditionally display the interface only when MCP servers are configured, and ensured the backend doesn't send empty configuration objects.

- Modified the config route to conditionally initialize `mcpServers` object only when actual server configurations exist
- Added `startupConfig` to the AgentPanelContext provider's value for component access
- Included `startupConfig` type definition in the AgentPanelContextType interface
- Relocated MCP Tools section in AgentConfig component to appear after Knowledge section
- Wrapped MCP Tools component with conditional rendering based on `startupConfig?.mcpServers` existence
- Prevented sending empty MCP configuration objects from the backend when no servers are configured

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Test the changes by:
1. Starting the application with no MCP servers configured in the environment
2. Verify that the MCP Tools section doesn't appear in the Agent configuration panel
3. Configure MCP servers in your environment/config
4. Restart the application and verify the MCP Tools section now appears
5. Check the network response from `/api/config` to ensure `mcpServers` field is absent when no servers are configured

### **Test Configuration**:
- Test with and without MCP server configurations
- Verify UI rendering in Agent panel for both scenarios

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings