### PR TITLE
🌐 fix: Prevent MCP Body/Header Timeouts at 5-Minute mark

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -7,11 +7,12 @@ const {
   createRun,
   Tokenizer,
   checkAccess,
+  logAxiosError,
   resolveHeaders,
   getBalanceConfig,
-  getTransactionsConfig,
   memoryInstructions,
   formatContentStrings,
+  getTransactionsConfig,
   createMemoryProcessor,
 } = require('@librechat/api');
 const {
@@ -88,11 +89,10 @@ function createTokenCounter(encoding) {
 }
 
 function logToolError(graph, error, toolId) {
-  logger.error(
-    '[api/server/controllers/agents/client.js #chatCompletion] Tool Error',
+  logAxiosError({
     error,
-    toolId,
-  );
+    message: `[api/server/controllers/agents/client.js #chatCompletion] Tool Error "${toolId}"`,
+  });
 }
 
 class AgentClient extends BaseClient {

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -280,6 +280,7 @@ Please follow these instructions when using tools from the respective MCP server
         CallToolResultSchema,
         {
           timeout: connection.timeout,
+          resetTimeoutOnProgress: true,
           ...options,
         },
       );


### PR DESCRIPTION
## Summary

I fixed a critical timeout issue affecting MCP server connections by replacing the native fetch implementation with undici's fetch and configuring an agent to prevent body/header timeouts that were occurring at the 5-minute mark, when tool requests run for a long time.

- Added undici fetch as the primary fetch method for all MCP connections
- Configured Agent with `bodyTimeout: 0` and `headersTimeout: 0` to disable timeout limits
- Updated the `createFetchFunction` method to use undici's fetch with the custom agent
- Modified SSE transport initialization to include the undici agent and fetch implementation
- Added `resetTimeoutOnProgress: true` option to the tool calling mechanism in MCPManager
- Integrated proper type definitions for undici's RequestInit, RequestInfo, and Response interfaces
- Applied the timeout fix consistently across both SSE and WebSocket transport methods

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested the changes by running MCP server connections that previously failed after 5 minutes due to timeout issues. The connections now maintain stability beyond the 5-minute threshold without experiencing body or header timeouts.

### **Test Configuration**:
- MCP servers with long-running operations
- Connection duration tests exceeding 5 minutes
- Various MCP transport methods (SSE and WebSocket)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes