### PR TITLE
fix(agents): persist Marketplace agents in Model dropdown across sessions

### DIFF
--- a/client/src/components/Agents/AgentDetail.tsx
+++ b/client/src/components/Agents/AgentDetail.tsx
@@ -45,14 +45,19 @@ const AgentDetail: React.FC<AgentDetailProps> = ({ agent, isOpen, onClose }) => 
    */
   const handleStartChat = () => {
     if (agent) {
-      const keys = [QueryKeys.agents, { requiredPermission: PermissionBits.EDIT }];
-      const listResp = queryClient.getQueryData<AgentListResponse>(keys);
-      if (listResp != null) {
-        if (!listResp.data.some((a) => a.id === agent.id)) {
+      const editKey = [QueryKeys.agents, { requiredPermission: PermissionBits.EDIT }];
+      const viewKey = [QueryKeys.agents, { requiredPermission: PermissionBits.VIEW }];
+
+      const maybeAddAgent = (key: any) => {
+        const listResp = queryClient.getQueryData<AgentListResponse>(key);
+        if (listResp != null && !listResp.data.some((a) => a.id === agent.id)) {
           const currentAgents = [agent, ...JSON.parse(JSON.stringify(listResp.data))];
-          queryClient.setQueryData<AgentListResponse>(keys, { ...listResp, data: currentAgents });
+          queryClient.setQueryData<AgentListResponse>(key, { ...listResp, data: currentAgents });
         }
-      }
+      };
+
+      maybeAddAgent(editKey);
+      maybeAddAgent(viewKey);
 
       localStorage.setItem(`${LocalStorageKeys.AGENT_ID_PREFIX}0`, agent.id);
 

--- a/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
@@ -1,14 +1,9 @@
 import debounce from 'lodash/debounce';
 import React, { createContext, useContext, useState, useMemo } from 'react';
-import { EModelEndpoint, isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
+import { EModelEndpoint, isAgentsEndpoint, isAssistantsEndpoint, PermissionBits } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { Endpoint, SelectedValues } from '~/common';
-import {
-  useAgentDefaultPermissionLevel,
-  useSelectorEffects,
-  useKeyDialog,
-  useEndpoints,
-} from '~/hooks';
+import { useSelectorEffects, useKeyDialog, useEndpoints } from '~/hooks';
 import { useAgentsMapContext, useAssistantsMapContext } from '~/Providers';
 import { useGetEndpointsQuery, useListAgentsQuery } from '~/data-provider';
 import { useModelSelectorChatContext } from './ModelSelectorChatContext';
@@ -78,9 +73,8 @@ export function ModelSelectorProvider({ children, startupConfig }: ModelSelector
     });
   }, [startupConfig, agentsMap]);
 
-  const permissionLevel = useAgentDefaultPermissionLevel();
   const { data: agents = null } = useListAgentsQuery(
-    { requiredPermission: permissionLevel },
+    { requiredPermission: PermissionBits.VIEW },
     {
       select: (data) => data?.data,
     },


### PR DESCRIPTION
## Summary
- Fixes a bug where agents added from the Marketplace disappear from the Model dropdown after logout/browser close and re-login.
- Root cause: The dropdown queried agents using EDIT permission when Marketplace is enabled, excluding public agents that users can view but not edit. Additionally, starting a chat injected only the EDIT agents list into cache for the session.
- Changes:
  - Query agents with VIEW permission in `ModelSelectorContext.tsx`.
  - Inject selected agent into both VIEW and EDIT agent lists in the query cache in `AgentDetail.tsx`.

Fixes #9480 

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing
- Steps:
  1. Add an agent from the Marketplace.
  2. Start a chat with the agent.
  3. Log out or close the browser.
  4. Log back in and open the Model dropdown.
  5. Confirm the agent persists without re-adding.
- Browsers: Chrome, Firefox, Safari, Edge
- Notes: No API changes. Behavior validated via manual testing. Lint checks pass locally.

### Test Configuration:
- N/A (no environment changes required)

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.