### PR TITLE
✨ feat(agents): persist Marketplace agents via per-user Favorites in Model dropdown

### DIFF
--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -410,7 +410,7 @@ const deleteAgentHandler = async (req, res) => {
 const getListAgentsHandler = async (req, res) => {
   try {
     const userId = req.user.id;
-    const { category, search, limit, cursor, promoted } = req.query;
+    const { category, search, limit, cursor, promoted, ids } = req.query;
     let requiredPermission = req.query.requiredPermission;
     if (typeof requiredPermission === 'string') {
       requiredPermission = parseInt(requiredPermission, 10);
@@ -433,6 +433,17 @@ const getListAgentsHandler = async (req, res) => {
       filter.is_promoted = true;
     } else if (promoted === '0') {
       filter.is_promoted = { $ne: true };
+    }
+
+    // Handle IDs filter (comma-separated agent custom IDs)
+    if (ids && typeof ids === 'string' && ids.trim() !== '') {
+      const idsArr = ids
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      if (idsArr.length > 0) {
+        filter.id = { $in: idsArr };
+      }
     }
 
     // Handle search filter

--- a/api/server/routes/user.js
+++ b/api/server/routes/user.js
@@ -7,6 +7,9 @@ const {
   verifyEmailController,
   deleteUserController,
   getUserController,
+  getFavoriteAgents,
+  addFavoriteAgent,
+  removeFavoriteAgent,
 } = require('~/server/controllers/UserController');
 const { requireJwtAuth, canDeleteAccount, verifyEmailLimiter } = require('~/server/middleware');
 
@@ -16,6 +19,10 @@ router.get('/', requireJwtAuth, getUserController);
 router.get('/terms', requireJwtAuth, getTermsStatusController);
 router.post('/terms/accept', requireJwtAuth, acceptTermsController);
 router.post('/plugins', requireJwtAuth, updateUserPluginsController);
+/** Favorites: Agents */
+router.get('/favorites/agents', requireJwtAuth, getFavoriteAgents);
+router.post('/favorites/agents', requireJwtAuth, addFavoriteAgent);
+router.delete('/favorites/agents/:agent_id', requireJwtAuth, removeFavoriteAgent);
 router.delete('/delete', requireJwtAuth, canDeleteAccount, deleteUserController);
 router.post('/verify', verifyEmailController);
 router.post('/verify/resend', verifyEmailLimiter, resendVerificationController);

--- a/client/src/data-provider/Agents/queries.ts
+++ b/client/src/data-provider/Agents/queries.ts
@@ -60,6 +60,24 @@ export const useListAgentsQuery = <TData = t.AgentListResponse>(
   );
 };
 
+/** Favorites hooks */
+export const useFavoriteAgentsQuery = (
+  config?: UseQueryOptions<{ favoriteAgents: string[] }>,
+): QueryObserverResult<{ favoriteAgents: string[] }> => {
+  return useQuery<{ favoriteAgents: string[] }>(
+    [QueryKeys.user, 'favoriteAgents'],
+    () => dataService.getFavoriteAgents(),
+    {
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      refetchOnMount: false,
+      retry: false,
+      staleTime: 60 * 1000,
+      ...(config || {}),
+    },
+  );
+};
+
 /**
  * Hook for retrieving basic details about a single agent (VIEW permission)
  */

--- a/client/src/hooks/Agents/useAgentsMap.ts
+++ b/client/src/hooks/Agents/useAgentsMap.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { PermissionBits } from 'librechat-data-provider';
 import type { TAgentsMap } from 'librechat-data-provider';
 import { useListAgentsQuery } from '~/data-provider';
+import { useFavoriteAgentsQuery } from '~/data-provider/Agents/queries';
 import { mapAgents } from '~/utils';
 
 export default function useAgentsMap({
@@ -16,6 +17,9 @@ export default function useAgentsMap({
       enabled: isAuthenticated,
     },
   );
+
+  // Preload favorites into cache by requesting them; combining happens in UI layer
+  useFavoriteAgentsQuery({ enabled: isAuthenticated });
 
   const agentsMap = useMemo<TAgentsMap | undefined>(() => {
     return mappedAgents !== null ? mappedAgents : undefined;

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -41,6 +41,8 @@ const buildQuery = (params: Record<string, unknown>): string => {
 
 export const health = () => `${BASE_URL}/health`;
 export const user = () => `${BASE_URL}/api/user`;
+export const userFavoritesAgents = () => `${user()}/favorites/agents`;
+export const userFavoriteAgent = (agentId: string) => `${userFavoritesAgents()}/${agentId}`;
 
 export const balance = () => `${BASE_URL}/api/balance`;
 

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -459,6 +459,16 @@ export const listAgents = (params: a.AgentListParams): Promise<a.AgentListRespon
   );
 };
 
+/* Favorites */
+export const getFavoriteAgents = (): Promise<{ favoriteAgents: string[] }> =>
+  request.get(endpoints.userFavoritesAgents());
+
+export const addFavoriteAgent = (agent_id: string): Promise<{ favoriteAgents: string[] }> =>
+  request.post(endpoints.userFavoritesAgents(), { agent_id });
+
+export const removeFavoriteAgent = (agent_id: string): Promise<{ favoriteAgents: string[] }> =>
+  request.delete(endpoints.userFavoriteAgent(agent_id));
+
 export const revertAgentVersion = ({
   agent_id,
   version_index,

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -291,6 +291,8 @@ export type AgentListParams = {
   search?: string;
   cursor?: string;
   promoted?: 0 | 1;
+  /** Optional comma-separated list of agent IDs or string[] */
+  ids?: string | string[];
 };
 
 export type AgentListResponse = {

--- a/packages/data-schemas/src/schema/user.ts
+++ b/packages/data-schemas/src/schema/user.ts
@@ -138,6 +138,10 @@ const userSchema = new Schema<IUser>(
           type: Boolean,
           default: true,
         },
+        favoriteAgents: {
+          type: [String],
+          default: [],
+        },
       },
       default: {},
     },

--- a/packages/data-schemas/src/types/user.ts
+++ b/packages/data-schemas/src/types/user.ts
@@ -33,6 +33,7 @@ export interface IUser extends Document {
   termsAccepted?: boolean;
   personalization?: {
     memories?: boolean;
+    favoriteAgents?: string[];
   };
   createdAt?: Date;
   updatedAt?: Date;


### PR DESCRIPTION
## Summary

Addresses the request for Marketplace agents to persist in the Model dropdown across sessions without listing all public agents. #9482 

This PR introduces a per-user “Favorites” mechanism:

- Users can favorite/unfavorite agents from:
  - The Marketplace (star icon on agent cards)
  - The Model dropdown (star icon next to each agent)
- Favorite agents persist per user across sessions and appear in the Model dropdown even if the user lacks EDIT permissions for them.
- Dropdown composition:
  - Owner/Editor agents remain as-is.
  - Favorite agents are merged in and ordered first in the agents submenu.
- Permissions are respected; we only include favorites the user can VIEW.
- Minimal schema/API/UI changes, no migration required (optional user field with defaults).

Endpoints added:
- GET `/api/user/favorites/agents`
- POST `/api/user/favorites/agents` { agent_id }
- DELETE `/api/user/favorites/agents/:agent_id`

Agents listing now supports filtering by IDs:
- GET `/api/agents?requiredPermission=1&ids=agent_...,agent_...`

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

1) Marketplace favorites
- Go to Marketplace.
- Click the star on a public agent to favorite it.
- Log out, log back in, open the Model dropdown → the favorited agent appears under the agents endpoint (favorites are listed first).
- Unfavorite the agent from either the Marketplace or the dropdown and confirm it’s removed from the dropdown.

2) Owner/Editor behavior unchanged
- Ensure agents you own or can edit still appear as before.
- Confirm no non-favorited public agents are added to the dropdown.

3) Search and ordering
- Use search in the Model selector; both owned and favorited agents should be searchable.
- Favorites should be ordered first within the agents submenu.

4) Permissions checks
- Verify that only agents with VIEW access can be favorited and included.

5) API checks
- GET `/api/user/favorites/agents` returns the user’s favorite IDs.
- POST/DELETE update that list.
- GET `/api/agents?requiredPermission=1&ids=...` returns the specified agents (if viewable).

### Test Configuration:
- Ensure Marketplace permission is enabled for the user role.
- Seed a mix of public agents and user-owned agents.
- No DB migration required; `personalization.favoriteAgents` defaults to [].

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.

Impact summary:
- Backend: optional user field `personalization.favoriteAgents`; user favorites routes; agents list `ids` filter.
- Client: data-provider favorites endpoints/hook; merged favorites into dropdown; star toggles in Marketplace and dropdown.
- Backwards compatible; minimal UI changes; no migration needed.