### PR TITLE
🔐 fix: Resolve Env. Variables for MCP OAuth Manual Config

### DIFF
--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -191,6 +191,21 @@ export function processMCPEnv(params: {
     newObj.url = processSingleValue({ originalValue: newObj.url, customUserVars, user, body });
   }
 
+  // Process OAuth configuration if it exists (for all transport types)
+  if ('oauth' in newObj && newObj.oauth) {
+    const processedOAuth: Record<string, string | string[] | undefined> = {};
+    for (const [key, originalValue] of Object.entries(newObj.oauth)) {
+      // Only process string values for environment variables
+      // token_exchange_method is an enum and shouldn't be processed
+      if (typeof originalValue === 'string') {
+        processedOAuth[key] = processSingleValue({ originalValue, customUserVars, user, body });
+      } else {
+        processedOAuth[key] = originalValue;
+      }
+    }
+    newObj.oauth = processedOAuth;
+  }
+
   return newObj;
 }
 


### PR DESCRIPTION
## Summary

This PR (addresses issues raised in https://github.com/danny-avila/LibreChat/issues/9500) 
* Added functionality to process OAuth configuration within the MCP environment.
* Implemented handling for string values in OAuth settings, ensuring proper processing of environment variables.
* Maintained original structure for non-string values to preserve existing configurations.

**Context:** The `processMCPEnv` function was missing support for processing environment variables in OAuth configurations for MCP servers. This caused authentication failures when using environment variable references like `${JIRA_OAUTH_CLIENT_ID}` in `librechat.yaml` OAuth sections, as the variables remained as literal strings instead of being replaced with their actual values.

**Solution:** Extended the `processMCPEnv` function to iterate through OAuth configuration objects, processing only string values (which may contain environment variables) while preserving non-string values like enums and arrays unchanged. This follows the same pattern used for processing headers, env, and args fields.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The fix has been manually tested with relevant OAuth configuration scenarios.

### **Test Configuration**:

**Files Modified:**
- `packages/api/src/utils/env.ts` - Added OAuth processing logic

**Manual Testing:**
Configure an MCP server with OAuth environment variables in `librechat.yaml`:
```yaml
mcpServers:
  jira:
    url: ${JIRA_MCP_SERVICE_URL}
    type: streamable-http
    chatMenu: true
    timeout: 300000
    headers:
      Content-Type: 'application/json'
    oauth:
      authorization_url: 'https://auth.atlassian.com/authorize'
      token_url: 'https://auth.atlassian.com/oauth/token'
      client_id: '${JIRA_OAUTH_CLIENT_ID}'
      client_secret: '${JIRA_OAUTH_CLIENT_SECRET}'
      scope: 'read:jira-work read:jira-user'
      redirect_uri: 'http://localhost:3000/api/mcp/jira/oauth/callback'
```

Set environment variables and verify they are properly parsed during MCP server initialization.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted.