### PR TITLE
🔒 fix: Memory Disabled Config UI Permissions

### DIFF
--- a/packages/api/src/app/permissions.spec.ts
+++ b/packages/api/src/app/permissions.spec.ts
@@ -7,10 +7,6 @@ import { loadDefaultInterface } from './interface';
 const mockUpdateAccessPermissions = jest.fn();
 const mockGetRoleByName = jest.fn();
 
-jest.mock('~/memory', () => ({
-  isMemoryEnabled: jest.fn((config) => config?.enable === true),
-}));
-
 describe('updateInterfacePermissions - permissions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -58,6 +54,9 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -84,6 +83,9 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -160,6 +162,9 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: false },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: false,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: false },
@@ -186,6 +191,9 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: false },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: false,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: false },
@@ -262,6 +270,9 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -288,6 +299,9 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -377,6 +391,9 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: false },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -403,6 +420,9 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: false },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -479,6 +499,9 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -505,6 +528,9 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -587,6 +613,9 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -607,6 +636,9 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.BOOKMARKS]: { [Permissions.USE]: true },
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -702,6 +734,9 @@ describe('updateInterfacePermissions - permissions', () => {
       // All other permissions that don't exist in the database
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -725,6 +760,9 @@ describe('updateInterfacePermissions - permissions', () => {
       // All other permissions that don't exist in the database
       [PermissionTypes.MEMORIES]: {
         [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.READ]: true,
+        [Permissions.UPDATE]: true,
         [Permissions.OPT_OUT]: undefined,
       },
       [PermissionTypes.MULTI_CONVO]: { [Permissions.USE]: true },
@@ -926,11 +964,17 @@ describe('updateInterfacePermissions - permissions', () => {
     // Check MEMORIES permissions use role defaults
     expect(userCall[1][PermissionTypes.MEMORIES]).toEqual({
       [Permissions.USE]: true,
+      [Permissions.CREATE]: true,
+      [Permissions.READ]: true,
+      [Permissions.UPDATE]: true,
       [Permissions.OPT_OUT]: undefined,
     });
 
     expect(adminCall[1][PermissionTypes.MEMORIES]).toEqual({
       [Permissions.USE]: true,
+      [Permissions.CREATE]: true,
+      [Permissions.READ]: true,
+      [Permissions.UPDATE]: true,
       [Permissions.OPT_OUT]: undefined,
     });
   });
@@ -1155,5 +1199,115 @@ describe('updateInterfacePermissions - permissions', () => {
     // New permissions that didn't exist should still be added
     expect(userCall[1]).toHaveProperty(PermissionTypes.AGENTS);
     expect(userCall[1]).toHaveProperty(PermissionTypes.MULTI_CONVO);
+  });
+
+  it('should disable all memory permissions when memory.disabled is true', async () => {
+    const config = {
+      interface: {
+        // Even if memories is not explicitly set to false in interface
+        prompts: true,
+        bookmarks: true,
+      },
+      memory: {
+        disabled: true,
+        // Other memory config doesn't matter when disabled
+        agent: {
+          id: 'test-agent-id',
+        },
+        personalize: true,
+      } as unknown as TCustomConfig['memory'],
+    };
+    const configDefaults = {
+      interface: {
+        memories: true, // Default is true
+      },
+    } as TConfigDefaults;
+    const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+    const appConfig = { config, interfaceConfig } as unknown as AppConfig;
+
+    await updateInterfacePermissions({
+      appConfig,
+      getRoleByName: mockGetRoleByName,
+      updateAccessPermissions: mockUpdateAccessPermissions,
+    });
+
+    const expectedMemoryPermissions = {
+      [Permissions.USE]: false,
+      [Permissions.CREATE]: false,
+      [Permissions.READ]: false,
+      [Permissions.UPDATE]: false,
+      [Permissions.OPT_OUT]: false, // Even OPT_OUT should be false when memory is disabled
+    };
+
+    // Check USER role call
+    const userCall = mockUpdateAccessPermissions.mock.calls.find(
+      (call) => call[0] === SystemRoles.USER,
+    );
+    expect(userCall[1][PermissionTypes.MEMORIES]).toEqual(expectedMemoryPermissions);
+
+    // Check ADMIN role call
+    const adminCall = mockUpdateAccessPermissions.mock.calls.find(
+      (call) => call[0] === SystemRoles.ADMIN,
+    );
+    expect(adminCall[1][PermissionTypes.MEMORIES]).toEqual(expectedMemoryPermissions);
+  });
+
+  it('should enable memory permissions based on role defaults when memory is configured without disabled flag', async () => {
+    const config = {
+      interface: {
+        memories: true,
+      },
+      memory: {
+        // Memory is configured with an agent but not disabled
+        agent: {
+          provider: 'openai',
+          model: 'gpt-4',
+        },
+        personalize: true,
+      } as unknown as TCustomConfig['memory'],
+    };
+    const configDefaults = {
+      interface: {
+        memories: true,
+      },
+    } as TConfigDefaults;
+    const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+    const appConfig = { config, interfaceConfig } as unknown as AppConfig;
+
+    await updateInterfacePermissions({
+      appConfig,
+      getRoleByName: mockGetRoleByName,
+      updateAccessPermissions: mockUpdateAccessPermissions,
+    });
+
+    // Check USER role call - should use role defaults for non-USE permissions
+    const userCall = mockUpdateAccessPermissions.mock.calls.find(
+      (call) => call[0] === SystemRoles.USER,
+    );
+    expect(userCall[1][PermissionTypes.MEMORIES]).toEqual({
+      [Permissions.USE]: true,
+      [Permissions.CREATE]:
+        roleDefaults[SystemRoles.USER].permissions[PermissionTypes.MEMORIES]?.[Permissions.CREATE],
+      [Permissions.READ]:
+        roleDefaults[SystemRoles.USER].permissions[PermissionTypes.MEMORIES]?.[Permissions.READ],
+      [Permissions.UPDATE]:
+        roleDefaults[SystemRoles.USER].permissions[PermissionTypes.MEMORIES]?.[Permissions.UPDATE],
+      [Permissions.OPT_OUT]: true, // Should be true when personalize is enabled
+    });
+
+    // Check ADMIN role call
+    const adminCall = mockUpdateAccessPermissions.mock.calls.find(
+      (call) => call[0] === SystemRoles.ADMIN,
+    );
+    expect(adminCall[1][PermissionTypes.MEMORIES]).toEqual({
+      [Permissions.USE]: true,
+      [Permissions.CREATE]:
+        roleDefaults[SystemRoles.ADMIN].permissions[PermissionTypes.MEMORIES]?.[Permissions.CREATE],
+      [Permissions.READ]:
+        roleDefaults[SystemRoles.ADMIN].permissions[PermissionTypes.MEMORIES]?.[Permissions.READ],
+      [Permissions.UPDATE]:
+        roleDefaults[SystemRoles.ADMIN].permissions[PermissionTypes.MEMORIES]?.[Permissions.UPDATE],
+      [Permissions.OPT_OUT]: true, // Should be true when personalize is enabled
+    });
   });
 });

--- a/packages/api/src/app/permissions.ts
+++ b/packages/api/src/app/permissions.ts
@@ -69,6 +69,8 @@ export async function updateInterfacePermissions({
   const interfaceConfig = appConfig?.config?.interface;
   const memoryConfig = appConfig?.config?.memory;
   const memoryEnabled = isMemoryEnabled(memoryConfig);
+  /** Check if memory is explicitly disabled */
+  const isMemoryExplicitlyDisabled = memoryConfig && !memoryEnabled;
   /** Check if personalization is enabled (defaults to true if memory is configured and enabled) */
   const isPersonalizationEnabled =
     memoryConfig && memoryEnabled && memoryConfig.personalize !== false;
@@ -139,11 +141,28 @@ export async function updateInterfacePermissions({
         ),
       },
       [PermissionTypes.MEMORIES]: {
-        [Permissions.USE]: getPermissionValue(
-          loadedInterface.memories,
-          defaultPerms[PermissionTypes.MEMORIES]?.[Permissions.USE],
-          defaults.memories,
-        ),
+        [Permissions.USE]: isMemoryExplicitlyDisabled
+          ? false
+          : getPermissionValue(
+              loadedInterface.memories,
+              defaultPerms[PermissionTypes.MEMORIES]?.[Permissions.USE],
+              defaults.memories,
+            ),
+        ...(defaultPerms[PermissionTypes.MEMORIES]?.[Permissions.CREATE] !== undefined && {
+          [Permissions.CREATE]: isMemoryExplicitlyDisabled
+            ? false
+            : defaultPerms[PermissionTypes.MEMORIES][Permissions.CREATE],
+        }),
+        ...(defaultPerms[PermissionTypes.MEMORIES]?.[Permissions.READ] !== undefined && {
+          [Permissions.READ]: isMemoryExplicitlyDisabled
+            ? false
+            : defaultPerms[PermissionTypes.MEMORIES][Permissions.READ],
+        }),
+        ...(defaultPerms[PermissionTypes.MEMORIES]?.[Permissions.UPDATE] !== undefined && {
+          [Permissions.UPDATE]: isMemoryExplicitlyDisabled
+            ? false
+            : defaultPerms[PermissionTypes.MEMORIES][Permissions.UPDATE],
+        }),
         [Permissions.OPT_OUT]: isPersonalizationEnabled,
       },
       [PermissionTypes.MULTI_CONVO]: {


### PR DESCRIPTION
## Summary

I fixed a bug where setting `memory.disabled: true` in `librechat.yaml` had no effect on the UI, allowing memory functionality to remain visible and accessible in the sidepanel despite being explicitly disabled.

- Fixed the permission system in `packages/api/src/app/permissions.ts` to properly detect when memory is explicitly disabled via configuration
- Added logic to set all memory-related permissions (USE, CREATE, READ, UPDATE, OPT_OUT) to `false` when `memory.disabled: true`
- Enhanced the permission system to include all memory permissions defined in role defaults, not just a subset
- Updated existing unit tests to reflect the correct behavior where all memory permissions are properly handled
- Added comprehensive test cases to verify memory permissions are completely disabled when memory is explicitly disabled
- Added test case to verify memory permissions work correctly when memory is enabled with proper agent configuration
- Removed mocking of `isMemoryEnabled` function in tests to use the actual implementation for more accurate testing

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested the fix by implementing comprehensive unit tests that verify the memory permission system works correctly in both disabled and enabled states. The tests confirm that when `memory.disabled: true` is set in the configuration, all memory-related permissions are set to `false`, which prevents the memory functionality from appearing in the UI sidepanel.

### **Test Configuration**:
- Jest test suite with 16 test cases covering various permission scenarios
- Tests verify memory permissions for both USER and ADMIN roles
- Tests confirm memory functionality is completely disabled when `memory.disabled: true`
- Tests verify memory functionality works correctly when properly configured with agent settings

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes