### PR TITLE
📂 refactor: Show File Search and Code File Upload Options Based on Agent Tools

### DIFF
--- a/client/src/components/Chat/Input/Files/AttachFileChat.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileChat.tsx
@@ -39,6 +39,7 @@ function AttachFileChat({
       <AttachFileMenu
         disabled={disableInputs}
         conversationId={conversationId}
+        agentId={conversation?.agent_id}
         endpointFileConfig={endpointFileConfig}
       />
     );

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -11,7 +11,13 @@ import {
   SharePointIcon,
 } from '@librechat/client';
 import type { EndpointFileConfig } from 'librechat-data-provider';
-import { useLocalize, useGetAgentsConfig, useFileHandling, useAgentCapabilities } from '~/hooks';
+import {
+  useAgentToolPermissions,
+  useAgentCapabilities,
+  useGetAgentsConfig,
+  useFileHandling,
+  useLocalize,
+} from '~/hooks';
 import useSharePointFileHandling from '~/hooks/Files/useSharePointFileHandling';
 import { SharePointPickerDialog } from '~/components/SharePoint';
 import { useGetStartupConfig } from '~/data-provider';
@@ -21,11 +27,17 @@ import { cn } from '~/utils';
 
 interface AttachFileMenuProps {
   conversationId: string;
+  agentId?: string | null;
   disabled?: boolean | null;
   endpointFileConfig?: EndpointFileConfig;
 }
 
-const AttachFileMenu = ({ disabled, conversationId, endpointFileConfig }: AttachFileMenuProps) => {
+const AttachFileMenu = ({
+  agentId,
+  disabled,
+  conversationId,
+  endpointFileConfig,
+}: AttachFileMenuProps) => {
   const localize = useLocalize();
   const isUploadDisabled = disabled ?? false;
   const inputRef = useRef<HTMLInputElement>(null);
@@ -51,6 +63,8 @@ const AttachFileMenu = ({ disabled, conversationId, endpointFileConfig }: Attach
    * Use definition for agents endpoint for ephemeral agents
    * */
   const capabilities = useAgentCapabilities(agentsConfig?.capabilities ?? defaultAgentCapabilities);
+
+  const { fileSearchAllowedByAgent, codeAllowedByAgent } = useAgentToolPermissions(agentId);
 
   const handleUploadClick = (isImage?: boolean) => {
     if (!inputRef.current) {
@@ -86,7 +100,7 @@ const AttachFileMenu = ({ disabled, conversationId, endpointFileConfig }: Attach
         });
       }
 
-      if (capabilities.fileSearchEnabled) {
+      if (capabilities.fileSearchEnabled && fileSearchAllowedByAgent) {
         items.push({
           label: localize('com_ui_upload_file_search'),
           onClick: () => {
@@ -101,7 +115,7 @@ const AttachFileMenu = ({ disabled, conversationId, endpointFileConfig }: Attach
         });
       }
 
-      if (capabilities.codeEnabled) {
+      if (capabilities.codeEnabled && codeAllowedByAgent) {
         items.push({
           label: localize('com_ui_upload_code_files'),
           onClick: () => {
@@ -142,6 +156,8 @@ const AttachFileMenu = ({ disabled, conversationId, endpointFileConfig }: Attach
     setToolResource,
     setEphemeralAgent,
     sharePointEnabled,
+    codeAllowedByAgent,
+    fileSearchAllowedByAgent,
     setIsSharePointDialogOpen,
   ]);
 

--- a/client/src/hooks/Agents/__tests__/useAgentToolPermissions.test.ts
+++ b/client/src/hooks/Agents/__tests__/useAgentToolPermissions.test.ts
@@ -1,0 +1,180 @@
+import { renderHook } from '@testing-library/react';
+import { Tools } from 'librechat-data-provider';
+import useAgentToolPermissions from '../useAgentToolPermissions';
+
+// Mock the dependencies
+jest.mock('~/data-provider', () => ({
+  useGetAgentByIdQuery: jest.fn(),
+}));
+
+jest.mock('~/Providers', () => ({
+  useAgentsMapContext: jest.fn(),
+}));
+
+const mockUseGetAgentByIdQuery = jest.requireMock('~/data-provider').useGetAgentByIdQuery;
+const mockUseAgentsMapContext = jest.requireMock('~/Providers').useAgentsMapContext;
+
+describe('useAgentToolPermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when no agentId is provided', () => {
+    it('should allow all tools for ephemeral agents', () => {
+      mockUseAgentsMapContext.mockReturnValue({});
+      mockUseGetAgentByIdQuery.mockReturnValue({ data: undefined });
+
+      const { result } = renderHook(() => useAgentToolPermissions(null));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(true);
+      expect(result.current.codeAllowedByAgent).toBe(true);
+      expect(result.current.tools).toBeUndefined();
+    });
+
+    it('should allow all tools when agentId is undefined', () => {
+      mockUseAgentsMapContext.mockReturnValue({});
+      mockUseGetAgentByIdQuery.mockReturnValue({ data: undefined });
+
+      const { result } = renderHook(() => useAgentToolPermissions(undefined));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(true);
+      expect(result.current.codeAllowedByAgent).toBe(true);
+      expect(result.current.tools).toBeUndefined();
+    });
+
+    it('should allow all tools when agentId is empty string', () => {
+      mockUseAgentsMapContext.mockReturnValue({});
+      mockUseGetAgentByIdQuery.mockReturnValue({ data: undefined });
+
+      const { result } = renderHook(() => useAgentToolPermissions(''));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(true);
+      expect(result.current.codeAllowedByAgent).toBe(true);
+      expect(result.current.tools).toBeUndefined();
+    });
+  });
+
+  describe('when agentId is provided but agent not found', () => {
+    it('should disallow all tools', () => {
+      mockUseAgentsMapContext.mockReturnValue({});
+      mockUseGetAgentByIdQuery.mockReturnValue({ data: undefined });
+
+      const { result } = renderHook(() => useAgentToolPermissions('non-existent-agent'));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(false);
+      expect(result.current.codeAllowedByAgent).toBe(false);
+      expect(result.current.tools).toBeUndefined();
+    });
+  });
+
+  describe('when agent is found with tools', () => {
+    it('should allow tools that are included in the agent tools array', () => {
+      const agentId = 'test-agent';
+      const agent = {
+        id: agentId,
+        tools: [Tools.file_search],
+      };
+
+      mockUseAgentsMapContext.mockReturnValue({ [agentId]: agent });
+      mockUseGetAgentByIdQuery.mockReturnValue({ data: undefined });
+
+      const { result } = renderHook(() => useAgentToolPermissions(agentId));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(true);
+      expect(result.current.codeAllowedByAgent).toBe(false);
+      expect(result.current.tools).toEqual([Tools.file_search]);
+    });
+
+    it('should allow both tools when both are included', () => {
+      const agentId = 'test-agent';
+      const agent = {
+        id: agentId,
+        tools: [Tools.file_search, Tools.execute_code],
+      };
+
+      mockUseAgentsMapContext.mockReturnValue({ [agentId]: agent });
+      mockUseGetAgentByIdQuery.mockReturnValue({ data: undefined });
+
+      const { result } = renderHook(() => useAgentToolPermissions(agentId));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(true);
+      expect(result.current.codeAllowedByAgent).toBe(true);
+      expect(result.current.tools).toEqual([Tools.file_search, Tools.execute_code]);
+    });
+
+    it('should use data from API query when available', () => {
+      const agentId = 'test-agent';
+      const agentMapData = {
+        id: agentId,
+        tools: [Tools.file_search],
+      };
+      const agentApiData = {
+        id: agentId,
+        tools: [Tools.execute_code, Tools.file_search],
+      };
+
+      mockUseAgentsMapContext.mockReturnValue({ [agentId]: agentMapData });
+      mockUseGetAgentByIdQuery.mockReturnValue({ data: agentApiData });
+
+      const { result } = renderHook(() => useAgentToolPermissions(agentId));
+
+      // API data should take precedence
+      expect(result.current.fileSearchAllowedByAgent).toBe(true);
+      expect(result.current.codeAllowedByAgent).toBe(true);
+      expect(result.current.tools).toEqual([Tools.execute_code, Tools.file_search]);
+    });
+
+    it('should fallback to agent map data when API data is not available', () => {
+      const agentId = 'test-agent';
+      const agentMapData = {
+        id: agentId,
+        tools: [Tools.execute_code],
+      };
+
+      mockUseAgentsMapContext.mockReturnValue({ [agentId]: agentMapData });
+      mockUseGetAgentByIdQuery.mockReturnValue({ data: undefined });
+
+      const { result } = renderHook(() => useAgentToolPermissions(agentId));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(false);
+      expect(result.current.codeAllowedByAgent).toBe(true);
+      expect(result.current.tools).toEqual([Tools.execute_code]);
+    });
+  });
+
+  describe('when agent has no tools', () => {
+    it('should disallow all tools with empty array', () => {
+      const agentId = 'test-agent';
+      const agent = {
+        id: agentId,
+        tools: [],
+      };
+
+      mockUseAgentsMapContext.mockReturnValue({ [agentId]: agent });
+      mockUseGetAgentByIdQuery.mockReturnValue({ data: undefined });
+
+      const { result } = renderHook(() => useAgentToolPermissions(agentId));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(false);
+      expect(result.current.codeAllowedByAgent).toBe(false);
+      expect(result.current.tools).toEqual([]);
+    });
+
+    it('should disallow all tools with undefined tools', () => {
+      const agentId = 'test-agent';
+      const agent = {
+        id: agentId,
+        tools: undefined,
+      };
+
+      mockUseAgentsMapContext.mockReturnValue({ [agentId]: agent });
+      mockUseGetAgentByIdQuery.mockReturnValue({ data: undefined });
+
+      const { result } = renderHook(() => useAgentToolPermissions(agentId));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(false);
+      expect(result.current.codeAllowedByAgent).toBe(false);
+      expect(result.current.tools).toBeUndefined();
+    });
+  });
+});

--- a/client/src/hooks/Agents/index.ts
+++ b/client/src/hooks/Agents/index.ts
@@ -5,3 +5,4 @@ export type { ProcessedAgentCategory } from './useAgentCategories';
 export { default as useAgentCapabilities } from './useAgentCapabilities';
 export { default as useGetAgentsConfig } from './useGetAgentsConfig';
 export { default as useAgentDefaultPermissionLevel } from './useAgentDefaultPermissionLevel';
+export { default as useAgentToolPermissions } from './useAgentToolPermissions';

--- a/client/src/hooks/Agents/useAgentToolPermissions.ts
+++ b/client/src/hooks/Agents/useAgentToolPermissions.ts
@@ -1,0 +1,65 @@
+import { useMemo } from 'react';
+import { Tools } from 'librechat-data-provider';
+import { useGetAgentByIdQuery } from '~/data-provider';
+import { useAgentsMapContext } from '~/Providers';
+
+interface AgentToolPermissionsResult {
+  fileSearchAllowedByAgent: boolean;
+  codeAllowedByAgent: boolean;
+  tools: string[] | undefined;
+}
+
+/**
+ * Hook to determine whether specific tools are allowed for a given agent.
+ *
+ * @param agentId - The ID of the agent. If null/undefined/empty, returns true for all tools (ephemeral agent behavior)
+ * @returns Object with boolean flags for file_search and execute_code permissions, plus the tools array
+ */
+export default function useAgentToolPermissions(
+  agentId: string | null | undefined,
+): AgentToolPermissionsResult {
+  const agentsMap = useAgentsMapContext();
+
+  // Get the agent from the map if available
+  const selectedAgent = useMemo(() => {
+    return agentId != null && agentId !== '' ? agentsMap?.[agentId] : undefined;
+  }, [agentId, agentsMap]);
+
+  // Query for agent data from the API
+  const { data: agentData } = useGetAgentByIdQuery(agentId ?? '', {
+    enabled: !!agentId,
+  });
+
+  // Get tools from either the API data or the agents map
+  const tools = useMemo(
+    () =>
+      (agentData?.tools as string[] | undefined) || (selectedAgent?.tools as string[] | undefined),
+    [agentData?.tools, selectedAgent?.tools],
+  );
+
+  // Determine if file_search is allowed
+  const fileSearchAllowedByAgent = useMemo(() => {
+    // If no agentId, allow for ephemeral agents
+    if (!agentId) return true;
+    // If agentId exists but agent not found, disallow
+    if (!selectedAgent) return false;
+    // Check if the agent has the file_search tool
+    return tools?.includes(Tools.file_search) ?? false;
+  }, [agentId, selectedAgent, tools]);
+
+  // Determine if execute_code is allowed
+  const codeAllowedByAgent = useMemo(() => {
+    // If no agentId, allow for ephemeral agents
+    if (!agentId) return true;
+    // If agentId exists but agent not found, disallow
+    if (!selectedAgent) return false;
+    // Check if the agent has the execute_code tool
+    return tools?.includes(Tools.execute_code) ?? false;
+  }, [agentId, selectedAgent, tools]);
+
+  return {
+    fileSearchAllowedByAgent,
+    codeAllowedByAgent,
+    tools,
+  };
+}


### PR DESCRIPTION
## Summary

I implemented a refactor to intelligently show file upload options based on an agent's configured tools, ensuring users only see relevant file handling options for their specific agent configurations.

- Added `useAgentToolPermissions` hook to evaluate tool permissions based on agent configuration
- Enhanced `AttachFileMenu` to conditionally display file search and code upload options based on agent tools
- Updated `DragDropModal` to respect agent tool restrictions when showing drag-and-drop file options
- Modified `useDragHelpers` to check agent tool permissions before displaying file handling modal
- Implemented comprehensive test coverage for the new agent tool permissions logic
- Passed agent ID through file attachment components to enable proper permission checking

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

I tested the implementation by configuring agents with different tool combinations and verifying that file upload options appear only when the corresponding tools are enabled. The tests cover ephemeral agents, agents with specific tool configurations, and edge cases with missing or undefined agent data.

### **Test Configuration**:
- Agents with file_search tool only
- Agents with execute_code tool only  
- Agents with both tools enabled
- Agents with no tools configured
- Ephemeral agents (no agent ID)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes