### PR TITLE
🧹 chore: Remove Unused Cache Configuration Keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -690,8 +690,8 @@ HELP_AND_FAQ_URL=https://librechat.ai
 # REDIS_PING_INTERVAL=300
 
 # Force specific cache namespaces to use in-memory storage even when Redis is enabled
-# Comma-separated list of CacheKeys (e.g., STATIC_CONFIG,ROLES,MESSAGES)
-# FORCED_IN_MEMORY_CACHE_NAMESPACES=STATIC_CONFIG,ROLES
+# Comma-separated list of CacheKeys (e.g., ROLES,MESSAGES)
+# FORCED_IN_MEMORY_CACHE_NAMESPACES=ROLES,MESSAGES
 
 #==================================================#
 #                      Others                      #

--- a/api/cache/cacheConfig.spec.js
+++ b/api/cache/cacheConfig.spec.js
@@ -157,12 +157,11 @@ describe('cacheConfig', () => {
 
   describe('FORCED_IN_MEMORY_CACHE_NAMESPACES validation', () => {
     test('should parse comma-separated cache keys correctly', () => {
-      process.env.FORCED_IN_MEMORY_CACHE_NAMESPACES = ' ROLES, STATIC_CONFIG ,MESSAGES ';
+      process.env.FORCED_IN_MEMORY_CACHE_NAMESPACES = ' ROLES, MESSAGES ';
 
       const { cacheConfig } = require('./cacheConfig');
       expect(cacheConfig.FORCED_IN_MEMORY_CACHE_NAMESPACES).toEqual([
         'ROLES',
-        'STATIC_CONFIG',
         'MESSAGES',
       ]);
     });

--- a/api/cache/getLogStores.js
+++ b/api/cache/getLogStores.js
@@ -32,7 +32,6 @@ const namespaces = {
 
   [CacheKeys.ROLES]: standardCache(CacheKeys.ROLES),
   [CacheKeys.CONFIG_STORE]: standardCache(CacheKeys.CONFIG_STORE),
-  [CacheKeys.STATIC_CONFIG]: standardCache(CacheKeys.STATIC_CONFIG),
   [CacheKeys.PENDING_REQ]: standardCache(CacheKeys.PENDING_REQ),
   [CacheKeys.ENCODED_DOMAINS]: new Keyv({ store: keyvMongo, namespace: CacheKeys.ENCODED_DOMAINS }),
   [CacheKeys.ABORT_KEYS]: standardCache(CacheKeys.ABORT_KEYS, Time.TEN_MINUTES),

--- a/api/server/services/Config/loadCustomConfig.js
+++ b/api/server/services/Config/loadCustomConfig.js
@@ -119,10 +119,6 @@ https://www.librechat.ai/docs/configuration/stt_tts`);
     .filter((endpoint) => endpoint.customParams)
     .forEach((endpoint) => parseCustomParams(endpoint.name, endpoint.customParams));
 
-  if (customConfig.cache) {
-    const cache = getLogStores(CacheKeys.STATIC_CONFIG);
-    await cache.set(CacheKeys.LIBRECHAT_YAML_CONFIG, customConfig);
-  }
 
   if (result.data.modelSpecs) {
     customConfig.modelSpecs = result.data.modelSpecs;

--- a/api/server/services/Config/loadCustomConfig.spec.js
+++ b/api/server/services/Config/loadCustomConfig.spec.js
@@ -48,16 +48,11 @@ const axios = require('axios');
 const { loadYaml } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const loadCustomConfig = require('./loadCustomConfig');
-const getLogStores = require('~/cache/getLogStores');
 
 describe('loadCustomConfig', () => {
-  const mockSet = jest.fn();
-  const mockCache = { set: mockSet };
-
   beforeEach(() => {
     jest.resetAllMocks();
     delete process.env.CONFIG_PATH;
-    getLogStores.mockReturnValue(mockCache);
   });
 
   it('should return null and log error if remote config fetch fails', async () => {
@@ -94,7 +89,6 @@ describe('loadCustomConfig', () => {
     const result = await loadCustomConfig();
 
     expect(result).toEqual(mockConfig);
-    expect(mockSet).toHaveBeenCalledWith(expect.anything(), mockConfig);
   });
 
   it('should return null and log if config schema validation fails', async () => {
@@ -134,7 +128,6 @@ describe('loadCustomConfig', () => {
     axios.get.mockResolvedValue({ data: mockConfig });
     const result = await loadCustomConfig();
     expect(result).toEqual(mockConfig);
-    expect(mockSet).toHaveBeenCalledWith(expect.anything(), mockConfig);
   });
 
   it('should return null if the remote config file is not found', async () => {
@@ -168,7 +161,6 @@ describe('loadCustomConfig', () => {
     process.env.CONFIG_PATH = 'validConfig.yaml';
     loadYaml.mockReturnValueOnce(mockConfig);
     await loadCustomConfig();
-    expect(mockSet).not.toHaveBeenCalled();
   });
 
   it('should log the loaded custom config', async () => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1220,14 +1220,6 @@ export enum CacheKeys {
    */
   TOKEN_CONFIG = 'TOKEN_CONFIG',
   /**
-   * Key for the librechat yaml config cache.
-   */
-  LIBRECHAT_YAML_CONFIG = 'LIBRECHAT_YAML_CONFIG',
-  /**
-   * Key for the static config namespace.
-   */
-  STATIC_CONFIG = 'STATIC_CONFIG',
-  /**
    * Key for the app config namespace.
    */
   APP_CONFIG = 'APP_CONFIG',


### PR DESCRIPTION
These cache keys were identified as dead code - they were being written to but never read from anywhere in the codebase after a recent refactor:

- STATIC_CONFIG was used as a cache namespace that stored configuration data
- LIBRECHAT_YAML_CONFIG was the key used within that namespace to store parsed YAML config
- The cache.set() operation in loadCustomConfig.js stored the config but no cache.get() operations retrieved it
- Configuration data is already handled through other mechanisms without caching

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
