### PR TITLE
🗄️ refactor: Make `APP_CONFIG` a Dedicated Cache Store

### DIFF
--- a/api/cache/getLogStores.js
+++ b/api/cache/getLogStores.js
@@ -31,6 +31,7 @@ const namespaces = {
   [CacheKeys.SAML_SESSION]: sessionCache(CacheKeys.SAML_SESSION),
 
   [CacheKeys.ROLES]: standardCache(CacheKeys.ROLES),
+  [CacheKeys.APP_CONFIG]: standardCache(CacheKeys.APP_CONFIG),
   [CacheKeys.CONFIG_STORE]: standardCache(CacheKeys.CONFIG_STORE),
   [CacheKeys.STATIC_CONFIG]: standardCache(CacheKeys.STATIC_CONFIG),
   [CacheKeys.PENDING_REQ]: standardCache(CacheKeys.PENDING_REQ),

--- a/api/server/services/Config/app.js
+++ b/api/server/services/Config/app.js
@@ -4,6 +4,8 @@ const AppService = require('~/server/services/AppService');
 const { setCachedTools } = require('./getCachedTools');
 const getLogStores = require('~/cache/getLogStores');
 
+const BASE_CONFIG_KEY = '_BASE_';
+
 /**
  * Get the app configuration based on user context
  * @param {Object} [options]
@@ -14,8 +16,8 @@ const getLogStores = require('~/cache/getLogStores');
 async function getAppConfig(options = {}) {
   const { role, refresh } = options;
 
-  const cache = getLogStores(CacheKeys.CONFIG_STORE);
-  const cacheKey = role ? `${CacheKeys.APP_CONFIG}:${role}` : CacheKeys.APP_CONFIG;
+  const cache = getLogStores(CacheKeys.APP_CONFIG);
+  const cacheKey = role ? role : BASE_CONFIG_KEY;
 
   if (!refresh) {
     const cached = await cache.get(cacheKey);
@@ -24,7 +26,7 @@ async function getAppConfig(options = {}) {
     }
   }
 
-  let baseConfig = await cache.get(CacheKeys.APP_CONFIG);
+  let baseConfig = await cache.get(BASE_CONFIG_KEY);
   if (!baseConfig) {
     logger.info('[getAppConfig] App configuration not initialized. Initializing AppService...');
     baseConfig = await AppService();
@@ -37,7 +39,7 @@ async function getAppConfig(options = {}) {
       await setCachedTools(baseConfig.availableTools, { isGlobal: true });
     }
 
-    await cache.set(CacheKeys.APP_CONFIG, baseConfig);
+    await cache.set(BASE_CONFIG_KEY, baseConfig);
   }
 
   // For now, return the base config


### PR DESCRIPTION
- This allows use APP_CONFIG in FORCED_IN_MEMORY_CACHE_NAMESPACES
- Remove the complexity of nested namespace (e.g. we no longer have to worry about the prefix of every role key)

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
