### PR TITLE
🪄 fix: MCP UI Renders for OAuth and Custom User Vars Servers

### DIFF
--- a/client/src/Providers/BadgeRowContext.tsx
+++ b/client/src/Providers/BadgeRowContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { createContext, useContext, useEffect, useRef } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { Tools, Constants, LocalStorageKeys, AgentCapabilities } from 'librechat-data-provider';
 import type { TAgentsEndpoint } from 'librechat-data-provider';
@@ -7,7 +7,6 @@ import {
   useSearchApiKeyForm,
   useGetAgentsConfig,
   useCodeApiKeyForm,
-  useGetMCPTools,
   useToolToggle,
 } from '~/hooks';
 import { getTimestampedValue, setTimestamp } from '~/utils/timestamps';
@@ -15,7 +14,6 @@ import { ephemeralAgentByConvoId } from '~/store';
 
 interface BadgeRowContextType {
   conversationId?: string | null;
-  mcpServerNames?: string[] | null;
   agentsConfig?: TAgentsEndpoint | null;
   webSearch: ReturnType<typeof useToolToggle>;
   artifacts: ReturnType<typeof useToolToggle>;
@@ -49,7 +47,6 @@ export default function BadgeRowProvider({
 }: BadgeRowProviderProps) {
   const lastKeyRef = useRef<string>('');
   const hasInitializedRef = useRef(false);
-  const { mcpToolDetails } = useGetMCPTools();
   const { agentsConfig } = useGetAgentsConfig();
   const key = conversationId ?? Constants.NEW_CONVO;
 
@@ -191,16 +188,11 @@ export default function BadgeRowProvider({
 
   const mcpServerManager = useMCPServerManager({ conversationId });
 
-  const mcpServerNames = useMemo(() => {
-    return (mcpToolDetails ?? []).map((tool) => tool.name);
-  }, [mcpToolDetails]);
-
   const value: BadgeRowContextType = {
     webSearch,
     artifacts,
     fileSearch,
     agentsConfig,
-    mcpServerNames,
     conversationId,
     codeApiKeyForm,
     codeInterpreter,

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -8,7 +8,6 @@ function MCPSelectContent() {
   const { conversationId, mcpServerManager } = useBadgeRowContext();
   const {
     localize,
-    isPinned,
     mcpValues,
     isInitializing,
     placeholderText,
@@ -69,14 +68,6 @@ function MCPSelectContent() {
     [getServerStatusIconProps, isInitializing],
   );
 
-  if ((!mcpValues || mcpValues.length === 0) && !isPinned) {
-    return null;
-  }
-
-  if (!configuredServers || configuredServers.length === 0) {
-    return null;
-  }
-
   const configDialogProps = getConfigDialogProps();
 
   return (
@@ -102,8 +93,13 @@ function MCPSelectContent() {
 }
 
 function MCPSelect() {
-  const { mcpServerNames } = useBadgeRowContext();
-  if ((mcpServerNames?.length ?? 0) === 0) return null;
+  const { mcpServerManager } = useBadgeRowContext();
+  const { configuredServers } = mcpServerManager;
+
+  if (!configuredServers || configuredServers.length === 0) {
+    return null;
+  }
+
   return <MCPSelectContent />;
 }
 

--- a/client/src/components/Chat/Input/ToolsDropdown.tsx
+++ b/client/src/components/Chat/Input/ToolsDropdown.tsx
@@ -30,7 +30,7 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
     artifacts,
     fileSearch,
     agentsConfig,
-    mcpServerNames,
+    mcpServerManager,
     codeApiKeyForm,
     codeInterpreter,
     searchApiKeyForm,
@@ -286,7 +286,8 @@ const ToolsDropdown = ({ disabled }: ToolsDropdownProps) => {
     });
   }
 
-  if (mcpServerNames && mcpServerNames.length > 0) {
+  const { configuredServers } = mcpServerManager;
+  if (configuredServers && configuredServers.length > 0) {
     dropdownItems.push({
       hideOnClick: false,
       render: (props) => <MCPSubMenu {...props} placeholder={mcpPlaceholder} />,


### PR DESCRIPTION
## Summary

This pull request changes the behavior of the MCP UI elements in chat so that they will now always appear if there are any MCP servers configured in `librechat.yaml` that do not have chatMenu set to false in order to address the issue raised in [[Enhancement]: Stop hiding MCP Servers badge when all servers are "oauth" or "customUserVars" ](https://github.com/danny-avila/LibreChat/issues/9552)

Previously, `startup: false` and OAuth servers would not cause the MCP UI to render on their own, requiring users to initialize them in the MCP Settings Panel before the badge / tools dropdown would appear. In order to accomplish this change, the `mcpServerNames` property has been removed from the context in favor of using the more comprehensive `mcpServerManager`, which provides access to `configuredServers` directly. This has the added benefit of streamlining server configuration checks and improving maintainability. 

**Context refactoring:**

* Removed the `mcpServerNames` property and its associated logic from `BadgeRowContext.tsx`, replacing it with `mcpServerManager` for more robust server configuration handling. [[1]](diffhunk://#diff-a8407f75a4bfed14b0e2c07ccef4087ceea0cc9915f29ac947029c2b64d4798aL1-R1) [[2]](diffhunk://#diff-a8407f75a4bfed14b0e2c07ccef4087ceea0cc9915f29ac947029c2b64d4798aL10-L18) [[3]](diffhunk://#diff-a8407f75a4bfed14b0e2c07ccef4087ceea0cc9915f29ac947029c2b64d4798aL52) [[4]](diffhunk://#diff-a8407f75a4bfed14b0e2c07ccef4087ceea0cc9915f29ac947029c2b64d4798aL194-L203)

**Component updates for server configuration:**

* Updated `MCPSelect.tsx` and `ToolsDropdown.tsx` components to use `configuredServers` from `mcpServerManager` instead of relying on `mcpServerNames`, ensuring consistent server availability checks and rendering logic. [[1]](diffhunk://#diff-ab0adb5d5b0b02ce788946826e9175384beb81199bc036641f03ad9a34faeafbL105-R102) [[2]](diffhunk://#diff-46f37c8e45d8fb3cdb3b4b0fcf9a4feded46e0a5d883b10e74bb1ab747dbbd85L33-R33) [[3]](diffhunk://#diff-46f37c8e45d8fb3cdb3b4b0fcf9a4feded46e0a5d883b10e74bb1ab747dbbd85L289-R290)

* Simplified conditional rendering in `MCPSelectContent` by removing checks for `isPinned` and `mcpValues`, relying solely on `configuredServers` for display logic. [[1]](diffhunk://#diff-ab0adb5d5b0b02ce788946826e9175384beb81199bc036641f03ad9a34faeafbL11) [[2]](diffhunk://#diff-ab0adb5d5b0b02ce788946826e9175384beb81199bc036641f03ad9a34faeafbL72-L79)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified absence of MCPSelect and ToolsDropdown when only github-mcp with startup: false or spotify mcp server (OAuth) configured in YAML

Verified presence of aforementioned elements with same YAML configuration after changes

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes