### PR TITLE
🔒 fix: Email Domain Validation Order and Coverage

### DIFF
--- a/api/server/middleware/checkDomainAllowed.js
+++ b/api/server/middleware/checkDomainAllowed.js
@@ -11,18 +11,25 @@ const { getAppConfig } = require('~/server/services/Config');
  * @param {Object} res - Express response object.
  * @param {Function} next - Next middleware function.
  *
- * @returns {Promise<function|Object>} - Returns a Promise which when resolved calls next middleware if the domain's email is allowed
+ * @returns {Promise<void>} - Calls next middleware if the domain's email is allowed, otherwise redirects to login
  */
-const checkDomainAllowed = async (req, res, next = () => {}) => {
-  const email = req?.user?.email;
-  const appConfig = await getAppConfig({
-    role: req?.user?.role,
-  });
-  if (email && !isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {
-    logger.error(`[Social Login] [Social Login not allowed] [Email: ${email}]`);
-    return res.redirect('/login');
-  } else {
-    return next();
+const checkDomainAllowed = async (req, res, next) => {
+  try {
+    const email = req?.user?.email;
+    const appConfig = await getAppConfig({
+      role: req?.user?.role,
+    });
+
+    if (email && !isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {
+      logger.error(`[Social Login] [Social Login not allowed] [Email: ${email}]`);
+      res.redirect('/login');
+      return;
+    }
+
+    next();
+  } catch (error) {
+    logger.error('[checkDomainAllowed] Error checking domain:', error);
+    res.redirect('/login');
   }
 };
 

--- a/api/server/routes/oauth.js
+++ b/api/server/routes/oauth.js
@@ -26,9 +26,12 @@ const domains = {
 router.use(logHeaders);
 router.use(loginLimiter);
 
-const oauthHandler = async (req, res) => {
+const oauthHandler = async (req, res, next) => {
   try {
-    await checkDomainAllowed(req, res);
+    if (res.headersSent) {
+      return;
+    }
+
     await checkBan(req, res);
     if (req.banned) {
       return;
@@ -46,6 +49,7 @@ const oauthHandler = async (req, res) => {
     res.redirect(domains.client);
   } catch (err) {
     logger.error('Error in setting authentication tokens:', err);
+    next(err);
   }
 };
 
@@ -79,6 +83,7 @@ router.get(
     scope: ['openid', 'profile', 'email'],
   }),
   setBalanceConfig,
+  checkDomainAllowed,
   oauthHandler,
 );
 
@@ -104,6 +109,7 @@ router.get(
     profileFields: ['id', 'email', 'name'],
   }),
   setBalanceConfig,
+  checkDomainAllowed,
   oauthHandler,
 );
 
@@ -125,6 +131,7 @@ router.get(
     session: false,
   }),
   setBalanceConfig,
+  checkDomainAllowed,
   oauthHandler,
 );
 
@@ -148,6 +155,7 @@ router.get(
     scope: ['user:email', 'read:user'],
   }),
   setBalanceConfig,
+  checkDomainAllowed,
   oauthHandler,
 );
 
@@ -171,6 +179,7 @@ router.get(
     scope: ['identify', 'email'],
   }),
   setBalanceConfig,
+  checkDomainAllowed,
   oauthHandler,
 );
 
@@ -192,6 +201,7 @@ router.post(
     session: false,
   }),
   setBalanceConfig,
+  checkDomainAllowed,
   oauthHandler,
 );
 


### PR DESCRIPTION
## Summary

I reordered and expanded email domain validation to prevent user creation before domain validation, fixing a critical security gap where users could be created with disallowed email domains.

- Reorder domain validation to occur before user creation in all authentication strategies
- Add domain validation as middleware to OAuth callback routes (Google, Facebook, GitHub, Discord, OpenID, SAML)
- Move domain validation checks earlier in LDAP strategy before createUser call
- Implement domain validation in OpenID Connect strategy before user registration
- Add domain validation to SAML authentication strategy before createUser execution
- Enhance social login process to validate domains before calling createSocialUser
- Refactor checkDomainAllowed middleware with improved error handling and early return patterns
- Add proper error handling in OAuth handler to prevent response conflicts after redirect
- Include descriptive error messages for blocked registrations across all authentication methods

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

I tested the domain validation functionality across multiple authentication methods to ensure proper enforcement occurs before user creation and prevents unauthorized registrations.

### **Test Configuration**:
- Configure `DOMAIN_CLIENT` and `DOMAIN_SERVER` environment variables
- Set up `allowedDomains` in registration configuration with restricted domains
- Test OAuth providers (Google, GitHub, Facebook, Discord) with disallowed email domains
- Test LDAP authentication with blocked domains to verify no user creation
- Test SAML authentication with domain validation before registration
- Verify users are not created in database when domain validation fails
- Confirm proper error messages and redirect behavior for blocked domains

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes