### PR TITLE
✨ feat: Require login for accessing shared conversations

### DIFF
--- a/client/src/components/Nav/Nav.tsx
+++ b/client/src/components/Nav/Nav.tsx
@@ -199,6 +199,7 @@ const Nav = memo(
           style={{
             width: navVisible ? navWidth : '0px',
             transform: navVisible ? 'translateX(0)' : 'translateX(-100%)',
+            position: 'fixed',
           }}
         >
           <div className="h-full w-[320px] md:w-[260px]">

--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -62,7 +62,7 @@ function SharedView() {
   return (
     <ShareContext.Provider value={{ isSharedConvo: true }}>
       <main
-        className="relative flex w-full grow overflow-hidden dark:bg-surface-secondary"
+        className="relative flex w-full grow dark:bg-surface-secondary"
         style={{ paddingBottom: '50px' }}
       >
         <div className="transition-width relative flex h-full w-full flex-1 flex-col items-stretch overflow-hidden pt-0 dark:bg-surface-secondary">

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -72,9 +72,9 @@ export default function Root() {
             <PromptGroupsProvider>
               <Banner onHeightChange={setBannerHeight} />
               <div className="flex" style={{ height: `calc(100dvh - ${bannerHeight}px)` }}>
-                <div className="relative z-0 flex h-full w-full overflow-hidden">
+                <div className="relative z-0 flex h-full w-full">
                   <Nav navVisible={navVisible} setNavVisible={setNavVisible} />
-                  <div className="relative flex h-full max-w-full flex-1 flex-col overflow-hidden">
+                  <div className="relative flex h-full max-w-full flex-1 flex-col">
                     <MobileNav setNavVisible={setNavVisible} />
                     <Outlet context={{ navVisible, setNavVisible } satisfies ContextType} />
                   </div>

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -34,11 +34,6 @@ const baseHref = baseEl?.getAttribute('href') || '/';
 export const router = createBrowserRouter(
   [
     {
-      path: 'share/:shareId',
-      element: <ShareRoute />,
-      errorElement: <RouteErrorBoundary />,
-    },
-    {
       path: 'oauth',
       errorElement: <RouteErrorBoundary />,
       children: [
@@ -99,6 +94,11 @@ export const router = createBrowserRouter(
           path: '/',
           element: <Root />,
           children: [
+            {
+              path: 'share/:shareId',
+              element: <ShareRoute />,
+              errorElement: <RouteErrorBoundary />,
+            },
             {
               index: true,
               element: <Navigate to="/c/new" replace={true} />,


### PR DESCRIPTION
## Summary

Right now, shared conversations can be opened by anyone without authentication, which risks unintended information leaks. By requiring users to be logged in before accessing a shared conversation, we not only protect sensitive content but also ensure that sharing stays intentional, controlled, and traceable.

This change moves the `ShareRoute` behind roots so that accessibility of shared conversations can require a user login. The CSS related changes are for resolving scrolling issues after the view is moved inside root.

Fixes https://github.com/danny-avila/LibreChat/issues/9571

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Manual testing:

1. Create a shared convo
2. Open the shared convo in non-logged in status
3. User is redirect to login page
4. After loggin, the shared convo is accessible.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
