### PR TITLE
🐳 fix: Add missing `uploads` directory to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN \
     # Allow mounting of these files, which have no default
     touch .env ; \
     # Create directories for the volumes to inherit the correct permissions
-    mkdir -p /app/client/public/images /app/api/logs ; \
+    mkdir -p /app/client/public/images /app/api/logs /app/uploads ; \
     npm config set fetch-retry-maxtimeout 600000 ; \
     npm config set fetch-retries 5 ; \
     npm config set fetch-retry-mintimeout 15000 ; \
@@ -43,8 +43,6 @@ RUN \
     NODE_OPTIONS="--max-old-space-size=2048" npm run frontend; \
     npm prune --production; \
     npm cache clean --force
-
-RUN mkdir -p /app/client/public/images /app/api/logs
 
 # Node API setup
 EXPOSE 3080


### PR DESCRIPTION
## Summary

We are using LibreChat with Docker named volumes. We noticed that the permissions are not set correctly for the `/app/uploads` directory in the Dockerfile. During runtime we encountered an `EACCES: permission denied` error during file upload.

The reason for this behavior is that, at container start the named volume is mounted to a new directory with owner `root:root`. The `/app/uploads` is thus not readable or writeable for the `node:node` user, with which the docker service runs.

Adding `/app/uploads` to the existing permission setup for `/app/client/public/images` and `/app/api/logs` in the Dockerfile fixes this issue. The directory `/app/uploads` is now created by the `node:node` user during docker build-time.

We also noticed that there is a duplicate line in the Dockerfile that creates the directories a second time. This duplicate line was removed.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

We tested the Dockerfile setup by building the image and running it with named docker volumes for the `/app/uploads` directory. Uploading of files is now functional.

```
# docker-compose.yml

services:
  api:
    (...)
    volumes:
      - librechat_images:/app/client/public/images
      - librechat_uploads:/app/uploads
      - librechat_logs:/app/api/logs
```

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
