### PR TITLE
🪟 fix: Auto-fetch agents to fill Viewport in Marketplace Scroll

### DIFF
--- a/client/src/components/Agents/AgentGrid.tsx
+++ b/client/src/components/Agents/AgentGrid.tsx
@@ -13,7 +13,7 @@ interface AgentGridProps {
   category: string; // Currently selected category
   searchQuery: string; // Current search query
   onSelectAgent: (agent: t.Agent) => void; // Callback when agent is selected
-  scrollElement?: HTMLElement | null; // Parent scroll container for infinite scroll
+  scrollElementRef?: React.RefObject<HTMLElement>; // Parent scroll container ref for infinite scroll
 }
 
 /**
@@ -23,7 +23,7 @@ const AgentGrid: React.FC<AgentGridProps> = ({
   category,
   searchQuery,
   onSelectAgent,
-  scrollElement,
+  scrollElementRef,
 }) => {
   const localize = useLocalize();
 
@@ -87,7 +87,7 @@ const AgentGrid: React.FC<AgentGridProps> = ({
   // Set up infinite scroll
   const { setScrollElement } = useInfiniteScroll({
     hasNextPage,
-    isFetchingNextPage,
+    isLoading: isFetching || isFetchingNextPage,
     fetchNextPage: () => {
       if (hasNextPage && !isFetching) {
         fetchNextPage();
@@ -99,10 +99,11 @@ const AgentGrid: React.FC<AgentGridProps> = ({
 
   // Connect the scroll element when it's provided
   useEffect(() => {
+    const scrollElement = scrollElementRef?.current;
     if (scrollElement) {
       setScrollElement(scrollElement);
     }
-  }, [scrollElement, setScrollElement]);
+  }, [scrollElementRef, setScrollElement]);
 
   /**
    * Get category display name from API data or use fallback

--- a/client/src/components/Agents/Marketplace.tsx
+++ b/client/src/components/Agents/Marketplace.tsx
@@ -427,7 +427,7 @@ const AgentMarketplace: React.FC<AgentMarketplaceProps> = ({ className = '' }) =
                       category={displayCategory}
                       searchQuery={searchQuery}
                       onSelectAgent={handleAgentSelect}
-                      scrollElement={scrollContainerRef.current}
+                      scrollElementRef={scrollContainerRef}
                     />
                   </div>
 
@@ -507,7 +507,7 @@ const AgentMarketplace: React.FC<AgentMarketplaceProps> = ({ className = '' }) =
                         category={nextCategory}
                         searchQuery={searchQuery}
                         onSelectAgent={handleAgentSelect}
-                        scrollElement={scrollContainerRef.current}
+                        scrollElementRef={scrollContainerRef}
                       />
                     </div>
                   )}


### PR DESCRIPTION
## Summary

Infinite scrolling has agents marketplace has a few issues:
- if the viewport is tall enough by default to show more than 6 items (and there is no scrollbar), there is no way to get more items to show
- when the window is resized to become bigger, and could potentially show more agents, the agents are not shown
- when switching between category tabs before scrolling, he infinite scroll does not work on the other categories.

This PR fixes all these issues. Check the videos for before / after.

**Before**

https://github.com/user-attachments/assets/313e9185-84dd-439f-9f5d-cd8d43626b2d


**After**

https://github.com/user-attachments/assets/b3747566-d5e0-42bc-877d-17ce8c51084d


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Follow the 3 different scenarios described in the summary or in the video.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
