### PR TITLE
🔧 refactor: Consolidate MCP tool removal and Improve UX

### DIFF
--- a/client/src/components/SidePanel/Agents/UnconfiguredMCPTool.tsx
+++ b/client/src/components/SidePanel/Agents/UnconfiguredMCPTool.tsx
@@ -1,25 +1,12 @@
 import React, { useState } from 'react';
 import { CircleX } from 'lucide-react';
-import { useFormContext } from 'react-hook-form';
-import { Constants } from 'librechat-data-provider';
-import { useUpdateUserPluginsMutation } from 'librechat-data-provider/react-query';
-import {
-  Label,
-  OGDialog,
-  TrashIcon,
-  useToastContext,
-  OGDialogTrigger,
-  OGDialogTemplate,
-} from '@librechat/client';
-import type { AgentForm } from '~/common';
-import { useLocalize } from '~/hooks';
+import { Label, OGDialog, TrashIcon, OGDialogTrigger, OGDialogTemplate } from '@librechat/client';
+import { useLocalize, useRemoveMCPTool } from '~/hooks';
 import { cn } from '~/utils';
 
 export default function UnconfiguredMCPTool({ serverName }: { serverName?: string }) {
   const localize = useLocalize();
-  const { showToast } = useToastContext();
-  const updateUserPlugins = useUpdateUserPluginsMutation();
-  const { getValues, setValue } = useFormContext<AgentForm>();
+  const { removeTool } = useRemoveMCPTool();
 
   const [isFocused, setIsFocused] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
@@ -27,36 +14,6 @@ export default function UnconfiguredMCPTool({ serverName }: { serverName?: strin
   if (!serverName) {
     return null;
   }
-
-  const removeTool = () => {
-    updateUserPlugins.mutate(
-      {
-        pluginKey: `${Constants.mcp_prefix}${serverName}`,
-        action: 'uninstall',
-        auth: {},
-        isEntityTool: true,
-      },
-      {
-        onError: (error: unknown) => {
-          showToast({
-            message: localize('com_ui_delete_tool_error', { error: String(error) }),
-            status: 'error',
-          });
-        },
-        onSuccess: () => {
-          const currentTools = getValues('tools');
-          const remainingToolIds =
-            currentTools?.filter(
-              (currentToolId) =>
-                currentToolId !== serverName &&
-                !currentToolId.endsWith(`${Constants.mcp_delimiter}${serverName}`),
-            ) || [];
-          setValue('tools', remainingToolIds);
-          showToast({ message: localize('com_ui_delete_tool_success'), status: 'success' });
-        },
-      },
-    );
-  };
 
   return (
     <OGDialog>
@@ -116,7 +73,7 @@ export default function UnconfiguredMCPTool({ serverName }: { serverName?: strin
           </Label>
         }
         selection={{
-          selectHandler: () => removeTool(),
+          selectHandler: () => removeTool(serverName || ''),
           selectClasses:
             'bg-red-700 dark:bg-red-600 hover:bg-red-800 dark:hover:bg-red-800 transition-color duration-200 text-white',
           selectText: localize('com_ui_delete'),

--- a/client/src/hooks/MCP/index.ts
+++ b/client/src/hooks/MCP/index.ts
@@ -3,3 +3,4 @@ export * from './useMCPConnectionStatus';
 export * from './useMCPSelect';
 export * from './useVisibleTools';
 export { useMCPServerManager } from './useMCPServerManager';
+export { useRemoveMCPTool } from './useRemoveMCPTool';

--- a/client/src/hooks/MCP/useRemoveMCPTool.ts
+++ b/client/src/hooks/MCP/useRemoveMCPTool.ts
@@ -1,0 +1,61 @@
+import { useCallback } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { Constants } from 'librechat-data-provider';
+import { useToastContext } from '@librechat/client';
+import { useUpdateUserPluginsMutation } from 'librechat-data-provider/react-query';
+import type { AgentForm } from '~/common';
+import { useLocalize } from '~/hooks';
+
+/**
+ * Hook for removing MCP tools/servers from an agent
+ * Provides unified logic for MCPTool, UninitializedMCPTool, and UnconfiguredMCPTool components
+ */
+export function useRemoveMCPTool() {
+  const localize = useLocalize();
+  const { showToast } = useToastContext();
+  const updateUserPlugins = useUpdateUserPluginsMutation();
+  const { getValues, setValue } = useFormContext<AgentForm>();
+
+  const removeTool = useCallback(
+    (serverName: string) => {
+      if (!serverName) {
+        return;
+      }
+
+      updateUserPlugins.mutate(
+        {
+          pluginKey: `${Constants.mcp_prefix}${serverName}`,
+          action: 'uninstall',
+          auth: {},
+          isEntityTool: true,
+        },
+        {
+          onError: (error: unknown) => {
+            showToast({
+              message: localize('com_ui_delete_tool_error', { error: String(error) }),
+              status: 'error',
+            });
+          },
+          onSuccess: () => {
+            const currentTools = getValues('tools');
+            const remainingToolIds =
+              currentTools?.filter(
+                (currentToolId) =>
+                  currentToolId !== serverName &&
+                  !currentToolId.endsWith(`${Constants.mcp_delimiter}${serverName}`),
+              ) || [];
+            setValue('tools', remainingToolIds, { shouldDirty: true });
+
+            showToast({
+              message: localize('com_ui_delete_tool_save_reminder'),
+              status: 'warning',
+            });
+          },
+        },
+      );
+    },
+    [getValues, setValue, updateUserPlugins, showToast, localize],
+  );
+
+  return { removeTool };
+}

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -834,7 +834,6 @@
   "com_ui_delete_tool": "Delete Tool",
   "com_ui_delete_tool_confirm": "Are you sure you want to delete this tool?",
   "com_ui_delete_tool_error": "Error while deleting the tool: {{error}}",
-  "com_ui_delete_tool_success": "Tool deleted successfully",
   "com_ui_delete_tool_save_reminder": "Tool removed. Save the agent to apply changes.",
   "com_ui_deleted": "Deleted",
   "com_ui_deleting_file": "Deleting file...",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -835,6 +835,7 @@
   "com_ui_delete_tool_confirm": "Are you sure you want to delete this tool?",
   "com_ui_delete_tool_error": "Error while deleting the tool: {{error}}",
   "com_ui_delete_tool_success": "Tool deleted successfully",
+  "com_ui_delete_tool_save_reminder": "Tool removed. Save the agent to apply changes.",
   "com_ui_deleted": "Deleted",
   "com_ui_deleting_file": "Deleting file...",
   "com_ui_descending": "Desc",


### PR DESCRIPTION
- Removed redundant tool removal logic from MCPTool, UnconfiguredMCPTool, and UninitializedMCPTool components.
- Introduced `useRemoveMCPTool` hook to handle tool removal and toast notifications.
- Updated translation.json to include a reminder message for saving changes after tool removal.