### PR TITLE
Add agent count to user-stats script

### DIFF
--- a/config/user-stats.js
+++ b/config/user-stats.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { silentExit } = require('./helpers');
 const { User, Conversation, Message } = require('@librechat/data-schemas').createModels(mongoose);
+const { Agent } = require('~/db/models');
 const connect = require('./connect');
 
 (async () => {
@@ -20,12 +21,14 @@ const connect = require('./connect');
   for (const user of users) {
     let conversationsCount = (await Conversation.countDocuments({ user: user._id })) ?? 0;
     let messagesCount = (await Message.countDocuments({ user: user._id })) ?? 0;
+    let agentsCount = (await Agent.countDocuments({ author: user._id })) ?? 0;
 
     userData.push({
       User: user.name,
       Email: user.email,
       Conversations: conversationsCount,
       Messages: messagesCount,
+      Agents: agentsCount,
     });
   }
 
@@ -34,7 +37,11 @@ const connect = require('./connect');
       return b.Conversations - a.Conversations;
     }
 
-    return b.Messages - a.Messages;
+    if (a.Messages !== b.Messages) {
+      return b.Messages - a.Messages;
+    }
+
+    return b.Agents - a.Agents;
   });
 
   console.table(userData);


### PR DESCRIPTION
# Pull Request Template

## Summary

This is a small pull request which updates the user statistics script to include agent-related data for each user.. The changes ensure that the script now counts and displays the number of agents authored by each user, and sorts users by conversations, messages, and agents.



Is useful to add this information to track agent usage.

* Added the `Agent` model import from `~/db/models` to enable agent-related queries.
* Updated the statistics gathering logic to count the number of agents authored by each user and include this count in the output data.
* Modified the sorting logic to sort users first by conversations, then by messages, and finally by agents, ensuring the most active users appear at the top of the table.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

I haven't seen related tests to this script so I decided not to add them but let me know if you think it's relevant.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
