### PR TITLE
🗨️ refactor: Only Allow Prompt Queries with Access

### DIFF
--- a/client/src/components/Chat/Input/PromptsCommand.tsx
+++ b/client/src/components/Chat/Input/PromptsCommand.tsx
@@ -2,14 +2,13 @@ import { useState, useRef, useEffect, useMemo, memo, useCallback } from 'react';
 import { AutoSizer, List } from 'react-virtualized';
 import { Spinner, useCombobox } from '@librechat/client';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
-import { PermissionTypes, Permissions } from 'librechat-data-provider';
 import type { TPromptGroup } from 'librechat-data-provider';
 import type { PromptOption } from '~/common';
 import { removeCharIfLast, detectVariables } from '~/utils';
 import VariableDialog from '~/components/Prompts/Groups/VariableDialog';
 import { usePromptGroupsContext } from '~/Providers';
-import { useLocalize, useHasAccess } from '~/hooks';
 import MentionItem from './MentionItem';
+import { useLocalize } from '~/hooks';
 import store from '~/store';
 
 const commandChar = '/';
@@ -54,12 +53,7 @@ function PromptsCommand({
   submitPrompt: (textPrompt: string) => void;
 }) {
   const localize = useLocalize();
-  const hasAccess = useHasAccess({
-    permissionType: PermissionTypes.PROMPTS,
-    permission: Permissions.USE,
-  });
-
-  const { allPromptGroups } = usePromptGroupsContext();
+  const { allPromptGroups, hasAccess } = usePromptGroupsContext();
   const { data, isLoading } = allPromptGroups;
 
   const [activeIndex, setActiveIndex] = useState(0);

--- a/client/src/components/Prompts/Groups/CategorySelector.tsx
+++ b/client/src/components/Prompts/Groups/CategorySelector.tsx
@@ -6,6 +6,7 @@ import { LocalStorageKeys } from 'librechat-data-provider';
 import { useFormContext, Controller } from 'react-hook-form';
 import type { MenuItemProps } from '@librechat/client';
 import type { ReactNode } from 'react';
+import { usePromptGroupsContext } from '~/Providers';
 import { useCategories } from '~/hooks';
 import { cn } from '~/utils';
 
@@ -22,8 +23,9 @@ const CategorySelector: React.FC<CategorySelectorProps> = ({
 }) => {
   const { t } = useTranslation();
   const formContext = useFormContext();
-  const { categories, emptyCategory } = useCategories();
   const [isOpen, setIsOpen] = useState(false);
+  const { hasAccess } = usePromptGroupsContext();
+  const { categories, emptyCategory } = useCategories({ hasAccess });
 
   const control = formContext?.control;
   const watch = formContext?.watch;

--- a/client/src/components/Prompts/Groups/CreatePromptForm.tsx
+++ b/client/src/components/Prompts/Groups/CreatePromptForm.tsx
@@ -7,6 +7,7 @@ import CategorySelector from '~/components/Prompts/Groups/CategorySelector';
 import VariablesDropdown from '~/components/Prompts/VariablesDropdown';
 import PromptVariables from '~/components/Prompts/PromptVariables';
 import Description from '~/components/Prompts/Description';
+import { usePromptGroupsContext } from '~/Providers';
 import { useLocalize, useHasAccess } from '~/hooks';
 import Command from '~/components/Prompts/Command';
 import { useCreatePrompt } from '~/data-provider';
@@ -37,10 +38,12 @@ const CreatePromptForm = ({
 }) => {
   const localize = useLocalize();
   const navigate = useNavigate();
-  const hasAccess = useHasAccess({
+  const { hasAccess: hasUseAccess } = usePromptGroupsContext();
+  const hasCreateAccess = useHasAccess({
     permissionType: PermissionTypes.PROMPTS,
     permission: Permissions.CREATE,
   });
+  const hasAccess = hasUseAccess && hasCreateAccess;
 
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout>;

--- a/client/src/components/Prompts/Groups/FilterPrompts.tsx
+++ b/client/src/components/Prompts/Groups/FilterPrompts.tsx
@@ -11,8 +11,8 @@ import store from '~/store';
 
 export default function FilterPrompts({ className = '' }: { className?: string }) {
   const localize = useLocalize();
-  const { name, setName } = usePromptGroupsContext();
-  const { categories } = useCategories('h-4 w-4');
+  const { name, setName, hasAccess } = usePromptGroupsContext();
+  const { categories } = useCategories({ className: 'h-4 w-4', hasAccess });
   const [displayName, setDisplayName] = useState(name || '');
   const [isSearching, setIsSearching] = useState(false);
   const [categoryFilter, setCategory] = useRecoilState(store.promptsCategory);

--- a/client/src/components/Prompts/PromptForm.tsx
+++ b/client/src/components/Prompts/PromptForm.tsx
@@ -167,6 +167,7 @@ const PromptForm = () => {
   const params = useParams();
   const localize = useLocalize();
   const { showToast } = useToastContext();
+  const { hasAccess } = usePromptGroupsContext();
   const alwaysMakeProd = useRecoilValue(store.alwaysMakeProd);
   const promptId = params.promptId || '';
 
@@ -179,10 +180,12 @@ const PromptForm = () => {
   const [showSidePanel, setShowSidePanel] = useState(false);
   const sidePanelWidth = '320px';
 
-  const { data: group, isLoading: isLoadingGroup } = useGetPromptGroup(promptId);
+  const { data: group, isLoading: isLoadingGroup } = useGetPromptGroup(promptId, {
+    enabled: hasAccess && !!promptId,
+  });
   const { data: prompts = [], isLoading: isLoadingPrompts } = useGetPrompts(
     { groupId: promptId },
-    { enabled: !!promptId },
+    { enabled: hasAccess && !!promptId },
   );
 
   const { hasPermission, isLoading: permissionsLoading } = useResourcePermissions(

--- a/client/src/hooks/Prompts/useCategories.tsx
+++ b/client/src/hooks/Prompts/useCategories.tsx
@@ -1,6 +1,6 @@
-import { useGetCategories } from '~/data-provider';
 import CategoryIcon from '~/components/Prompts/Groups/CategoryIcon';
 import { useLocalize, TranslationKeys } from '~/hooks';
+import { useGetCategories } from '~/data-provider';
 
 const loadingCategories: { label: TranslationKeys; value: string }[] = [
   {
@@ -14,9 +14,17 @@ const emptyCategory: { label: TranslationKeys; value: string } = {
   value: '',
 };
 
-const useCategories = (className = '') => {
+const useCategories = ({
+  className = '',
+  hasAccess = true,
+}: {
+  className?: string;
+  hasAccess?: boolean;
+}) => {
   const localize = useLocalize();
+
   const { data: categories = loadingCategories } = useGetCategories({
+    enabled: hasAccess,
     select: (data) =>
       data.map((category) => ({
         label: localize(category.label as TranslationKeys),


### PR DESCRIPTION
## Summary

I refactored the prompts system to enforce access control by preventing API queries when users lack proper permissions, improving security and reducing unnecessary network requests.

- Added access control checks throughout the prompts context and components
- Modified PromptGroupsContext to check for USE permission and conditionally enable queries
- Updated usePromptGroupsNav hook to accept hasAccess parameter and disable operations when access is denied
- Enhanced CategorySelector and FilterPrompts components to respect access permissions
- Modified CreatePromptForm to combine both USE and CREATE permission checks
- Updated PromptForm to conditionally enable queries based on access permissions
- Refactored useCategories hook to accept hasAccess parameter with proper query enabling
- Removed redundant permission checks from PromptsCommand component by leveraging context access state

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Testing should focus on verifying that users without proper permissions cannot access prompts functionality and that no unnecessary API calls are made.

### **Test Configuration**:
- Test with users having different permission levels (no access, USE only, CREATE only, both permissions)
- Verify that components render appropriately based on access levels
- Confirm that API queries are only triggered when users have proper permissions
- Test navigation and filtering functionality with and without access

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes