### PR TITLE
🧩 refactor: File Upload Options based on Ephemeral Agent

### DIFF
--- a/client/src/Providers/DragDropContext.tsx
+++ b/client/src/Providers/DragDropContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import { useChatContext } from './ChatContext';
+
+interface DragDropContextValue {
+  conversationId: string | null | undefined;
+  agentId: string | null | undefined;
+}
+
+const DragDropContext = createContext<DragDropContextValue | undefined>(undefined);
+
+export function DragDropProvider({ children }: { children: React.ReactNode }) {
+  const { conversation } = useChatContext();
+
+  /** Context value only created when conversation fields change */
+  const contextValue = useMemo<DragDropContextValue>(
+    () => ({
+      conversationId: conversation?.conversationId,
+      agentId: conversation?.agent_id,
+    }),
+    [conversation?.conversationId, conversation?.agent_id],
+  );
+
+  return <DragDropContext.Provider value={contextValue}>{children}</DragDropContext.Provider>;
+}
+
+export function useDragDropContext() {
+  const context = useContext(DragDropContext);
+  if (!context) {
+    throw new Error('useDragDropContext must be used within DragDropProvider');
+  }
+  return context;
+}

--- a/client/src/Providers/index.ts
+++ b/client/src/Providers/index.ts
@@ -23,6 +23,7 @@ export * from './SetConvoContext';
 export * from './SearchContext';
 export * from './BadgeRowContext';
 export * from './SidePanelContext';
+export * from './DragDropContext';
 export * from './MCPPanelContext';
 export * from './ArtifactsContext';
 export * from './PromptGroupsContext';

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useMemo } from 'react';
 import * as Ariakit from '@ariakit/react';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { FileSearch, ImageUpIcon, TerminalSquareIcon, FileType2Icon } from 'lucide-react';
 import { EToolResources, EModelEndpoint, defaultAgentCapabilities } from 'librechat-data-provider';
 import {
@@ -42,7 +42,9 @@ const AttachFileMenu = ({
   const isUploadDisabled = disabled ?? false;
   const inputRef = useRef<HTMLInputElement>(null);
   const [isPopoverActive, setIsPopoverActive] = useState(false);
-  const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(conversationId));
+  const [ephemeralAgent, setEphemeralAgent] = useRecoilState(
+    ephemeralAgentByConvoId(conversationId),
+  );
   const [toolResource, setToolResource] = useState<EToolResources | undefined>();
   const { handleFileChange } = useFileHandling({
     overrideEndpoint: EModelEndpoint.agents,
@@ -64,7 +66,10 @@ const AttachFileMenu = ({
    * */
   const capabilities = useAgentCapabilities(agentsConfig?.capabilities ?? defaultAgentCapabilities);
 
-  const { fileSearchAllowedByAgent, codeAllowedByAgent } = useAgentToolPermissions(agentId);
+  const { fileSearchAllowedByAgent, codeAllowedByAgent } = useAgentToolPermissions(
+    agentId,
+    ephemeralAgent,
+  );
 
   const handleUploadClick = (isImage?: boolean) => {
     if (!inputRef.current) {

--- a/client/src/components/Chat/Input/Files/DragDropModal.tsx
+++ b/client/src/components/Chat/Input/Files/DragDropModal.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useRecoilValue } from 'recoil';
 import { OGDialog, OGDialogTemplate } from '@librechat/client';
 import { ImageUpIcon, FileSearch, TerminalSquareIcon, FileType2Icon } from 'lucide-react';
 import { EToolResources, defaultAgentCapabilities } from 'librechat-data-provider';
@@ -8,6 +9,7 @@ import {
   useGetAgentsConfig,
   useLocalize,
 } from '~/hooks';
+import { ephemeralAgentByConvoId } from '~/store';
 import { useChatContext } from '~/Providers';
 
 interface DragDropModalProps {
@@ -33,8 +35,12 @@ const DragDropModal = ({ onOptionSelect, setShowModal, files, isVisible }: DragD
    * */
   const capabilities = useAgentCapabilities(agentsConfig?.capabilities ?? defaultAgentCapabilities);
   const { conversation } = useChatContext();
+  const ephemeralAgent = useRecoilValue(
+    ephemeralAgentByConvoId(conversation?.conversationId ?? ''),
+  );
   const { fileSearchAllowedByAgent, codeAllowedByAgent } = useAgentToolPermissions(
     conversation?.agent_id,
+    ephemeralAgent,
   );
 
   const options = useMemo(() => {

--- a/client/src/components/Chat/Input/Files/DragDropModal.tsx
+++ b/client/src/components/Chat/Input/Files/DragDropModal.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 import { OGDialog, OGDialogTemplate } from '@librechat/client';
-import { ImageUpIcon, FileSearch, TerminalSquareIcon, FileType2Icon } from 'lucide-react';
 import { EToolResources, defaultAgentCapabilities } from 'librechat-data-provider';
+import { ImageUpIcon, FileSearch, TerminalSquareIcon, FileType2Icon } from 'lucide-react';
 import {
   useAgentToolPermissions,
   useAgentCapabilities,
@@ -10,7 +10,7 @@ import {
   useLocalize,
 } from '~/hooks';
 import { ephemeralAgentByConvoId } from '~/store';
-import { useChatContext } from '~/Providers';
+import { useDragDropContext } from '~/Providers';
 
 interface DragDropModalProps {
   onOptionSelect: (option: EToolResources | undefined) => void;
@@ -34,12 +34,10 @@ const DragDropModal = ({ onOptionSelect, setShowModal, files, isVisible }: DragD
    * Use definition for agents endpoint for ephemeral agents
    * */
   const capabilities = useAgentCapabilities(agentsConfig?.capabilities ?? defaultAgentCapabilities);
-  const { conversation } = useChatContext();
-  const ephemeralAgent = useRecoilValue(
-    ephemeralAgentByConvoId(conversation?.conversationId ?? ''),
-  );
+  const { conversationId, agentId } = useDragDropContext();
+  const ephemeralAgent = useRecoilValue(ephemeralAgentByConvoId(conversationId ?? ''));
   const { fileSearchAllowedByAgent, codeAllowedByAgent } = useAgentToolPermissions(
-    conversation?.agent_id,
+    agentId,
     ephemeralAgent,
   );
 

--- a/client/src/components/Chat/Input/Files/DragDropWrapper.tsx
+++ b/client/src/components/Chat/Input/Files/DragDropWrapper.tsx
@@ -1,6 +1,7 @@
 import { useDragHelpers } from '~/hooks';
 import DragDropOverlay from '~/components/Chat/Input/Files/DragDropOverlay';
 import DragDropModal from '~/components/Chat/Input/Files/DragDropModal';
+import { DragDropProvider } from '~/Providers';
 import { cn } from '~/utils';
 
 interface DragDropWrapperProps {
@@ -19,12 +20,14 @@ export default function DragDropWrapper({ children, className }: DragDropWrapper
       {children}
       {/** Always render overlay to avoid mount/unmount overhead */}
       <DragDropOverlay isActive={isActive} />
-      <DragDropModal
-        files={draggedFiles}
-        isVisible={showModal}
-        setShowModal={setShowModal}
-        onOptionSelect={handleOptionSelect}
-      />
+      <DragDropProvider>
+        <DragDropModal
+          files={draggedFiles}
+          isVisible={showModal}
+          setShowModal={setShowModal}
+          onOptionSelect={handleOptionSelect}
+        />
+      </DragDropProvider>
     </div>
   );
 }

--- a/client/src/hooks/Agents/__tests__/useAgentToolPermissions.render.test.ts
+++ b/client/src/hooks/Agents/__tests__/useAgentToolPermissions.render.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react';
-import { Tools, Constants } from 'librechat-data-provider';
+import { Tools, Constants, EToolResources } from 'librechat-data-provider';
+import type { TEphemeralAgent } from 'librechat-data-provider';
 import useAgentToolPermissions from '../useAgentToolPermissions';
 
 // Mock dependencies
@@ -15,56 +16,165 @@ jest.mock('~/Providers', () => ({
 import { useGetAgentByIdQuery } from '~/data-provider';
 import { useAgentsMapContext } from '~/Providers';
 
+type HookProps = {
+  agentId?: string | null;
+  ephemeralAgent?: TEphemeralAgent | null;
+};
+
 describe('useAgentToolPermissions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('Ephemeral Agent Scenarios', () => {
-    it('should return true for all tools when agentId is null', () => {
+  describe('Ephemeral Agent Scenarios (without ephemeralAgent parameter)', () => {
+    it('should return false for all tools when agentId is null and no ephemeralAgent provided', () => {
       (useAgentsMapContext as jest.Mock).mockReturnValue({});
       (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ data: undefined });
 
       const { result } = renderHook(() => useAgentToolPermissions(null));
 
-      expect(result.current.fileSearchAllowedByAgent).toBe(true);
-      expect(result.current.codeAllowedByAgent).toBe(true);
+      expect(result.current.fileSearchAllowedByAgent).toBe(false);
+      expect(result.current.codeAllowedByAgent).toBe(false);
       expect(result.current.tools).toBeUndefined();
     });
 
-    it('should return true for all tools when agentId is undefined', () => {
+    it('should return false for all tools when agentId is undefined and no ephemeralAgent provided', () => {
       (useAgentsMapContext as jest.Mock).mockReturnValue({});
       (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ data: undefined });
 
       const { result } = renderHook(() => useAgentToolPermissions(undefined));
 
-      expect(result.current.fileSearchAllowedByAgent).toBe(true);
-      expect(result.current.codeAllowedByAgent).toBe(true);
+      expect(result.current.fileSearchAllowedByAgent).toBe(false);
+      expect(result.current.codeAllowedByAgent).toBe(false);
       expect(result.current.tools).toBeUndefined();
     });
 
-    it('should return true for all tools when agentId is empty string', () => {
+    it('should return false for all tools when agentId is empty string and no ephemeralAgent provided', () => {
       (useAgentsMapContext as jest.Mock).mockReturnValue({});
       (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ data: undefined });
 
       const { result } = renderHook(() => useAgentToolPermissions(''));
 
+      expect(result.current.fileSearchAllowedByAgent).toBe(false);
+      expect(result.current.codeAllowedByAgent).toBe(false);
+      expect(result.current.tools).toBeUndefined();
+    });
+
+    it('should return false for all tools when agentId is EPHEMERAL_AGENT_ID and no ephemeralAgent provided', () => {
+      (useAgentsMapContext as jest.Mock).mockReturnValue({});
+      (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ data: undefined });
+
+      const { result } = renderHook(() => useAgentToolPermissions(Constants.EPHEMERAL_AGENT_ID));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(false);
+      expect(result.current.codeAllowedByAgent).toBe(false);
+      expect(result.current.tools).toBeUndefined();
+    });
+  });
+
+  describe('Ephemeral Agent with Tool Settings', () => {
+    it('should return true for file_search when ephemeralAgent has file_search enabled', () => {
+      (useAgentsMapContext as jest.Mock).mockReturnValue({});
+      (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ data: undefined });
+
+      const ephemeralAgent = {
+        [EToolResources.file_search]: true,
+      };
+
+      const { result } = renderHook(() => useAgentToolPermissions(null, ephemeralAgent));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(true);
+      expect(result.current.codeAllowedByAgent).toBe(false);
+      expect(result.current.tools).toBeUndefined();
+    });
+
+    it('should return true for execute_code when ephemeralAgent has execute_code enabled', () => {
+      (useAgentsMapContext as jest.Mock).mockReturnValue({});
+      (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ data: undefined });
+
+      const ephemeralAgent = {
+        [EToolResources.execute_code]: true,
+      };
+
+      const { result } = renderHook(() => useAgentToolPermissions(undefined, ephemeralAgent));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(false);
+      expect(result.current.codeAllowedByAgent).toBe(true);
+      expect(result.current.tools).toBeUndefined();
+    });
+
+    it('should return true for both tools when ephemeralAgent has both enabled', () => {
+      (useAgentsMapContext as jest.Mock).mockReturnValue({});
+      (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ data: undefined });
+
+      const ephemeralAgent = {
+        [EToolResources.file_search]: true,
+        [EToolResources.execute_code]: true,
+      };
+
+      const { result } = renderHook(() => useAgentToolPermissions('', ephemeralAgent));
+
       expect(result.current.fileSearchAllowedByAgent).toBe(true);
       expect(result.current.codeAllowedByAgent).toBe(true);
       expect(result.current.tools).toBeUndefined();
     });
 
-    it('should return true for all tools when agentId is EPHEMERAL_AGENT_ID', () => {
+    it('should return false for tools when ephemeralAgent has them explicitly disabled', () => {
       (useAgentsMapContext as jest.Mock).mockReturnValue({});
       (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ data: undefined });
 
-      const { result } = renderHook(() => 
-        useAgentToolPermissions(Constants.EPHEMERAL_AGENT_ID)
+      const ephemeralAgent = {
+        [EToolResources.file_search]: false,
+        [EToolResources.execute_code]: false,
+      };
+
+      const { result } = renderHook(() =>
+        useAgentToolPermissions(Constants.EPHEMERAL_AGENT_ID, ephemeralAgent),
       );
 
-      expect(result.current.fileSearchAllowedByAgent).toBe(true);
-      expect(result.current.codeAllowedByAgent).toBe(true);
+      expect(result.current.fileSearchAllowedByAgent).toBe(false);
+      expect(result.current.codeAllowedByAgent).toBe(false);
       expect(result.current.tools).toBeUndefined();
+    });
+
+    it('should handle ephemeralAgent with ocr property without affecting other tools', () => {
+      (useAgentsMapContext as jest.Mock).mockReturnValue({});
+      (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ data: undefined });
+
+      const ephemeralAgent = {
+        [EToolResources.ocr]: true,
+        [EToolResources.file_search]: true,
+      };
+
+      const { result } = renderHook(() => useAgentToolPermissions(null, ephemeralAgent));
+
+      expect(result.current.fileSearchAllowedByAgent).toBe(true);
+      expect(result.current.codeAllowedByAgent).toBe(false);
+      expect(result.current.tools).toBeUndefined();
+    });
+
+    it('should not affect regular agents when ephemeralAgent is provided', () => {
+      const agentId = 'regular-agent';
+      const mockAgent = {
+        id: agentId,
+        tools: [Tools.file_search],
+      };
+
+      (useAgentsMapContext as jest.Mock).mockReturnValue({
+        [agentId]: mockAgent,
+      });
+      (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ data: undefined });
+
+      const ephemeralAgent = {
+        [EToolResources.execute_code]: true,
+      };
+
+      const { result } = renderHook(() => useAgentToolPermissions(agentId, ephemeralAgent));
+
+      // Should use regular agent's tools, not ephemeralAgent
+      expect(result.current.fileSearchAllowedByAgent).toBe(true);
+      expect(result.current.codeAllowedByAgent).toBe(false);
+      expect(result.current.tools).toEqual([Tools.file_search]);
     });
   });
 
@@ -300,7 +410,7 @@ describe('useAgentToolPermissions', () => {
       expect(firstResult.codeAllowedByAgent).toBe(secondResult.codeAllowedByAgent);
       // Tools array reference should be the same since it comes from useMemo
       expect(firstResult.tools).toBe(secondResult.tools);
-      
+
       // Verify the actual values are correct
       expect(secondResult.fileSearchAllowedByAgent).toBe(true);
       expect(secondResult.codeAllowedByAgent).toBe(false);
@@ -318,10 +428,9 @@ describe('useAgentToolPermissions', () => {
       (useAgentsMapContext as jest.Mock).mockReturnValue(mockAgents);
       (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ data: undefined });
 
-      const { result, rerender } = renderHook(
-        ({ agentId }) => useAgentToolPermissions(agentId),
-        { initialProps: { agentId: agentId1 } }
-      );
+      const { result, rerender } = renderHook(({ agentId }) => useAgentToolPermissions(agentId), {
+        initialProps: { agentId: agentId1 },
+      });
 
       expect(result.current.fileSearchAllowedByAgent).toBe(true);
       expect(result.current.codeAllowedByAgent).toBe(false);
@@ -345,24 +454,34 @@ describe('useAgentToolPermissions', () => {
       });
       (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ data: undefined });
 
+      const ephemeralAgent = {
+        [EToolResources.file_search]: true,
+        [EToolResources.execute_code]: true,
+      };
+
       const { result, rerender } = renderHook(
-        ({ agentId }) => useAgentToolPermissions(agentId),
-        { initialProps: { agentId: null } }
+        ({ agentId, ephemeralAgent }) => useAgentToolPermissions(agentId, ephemeralAgent),
+        { initialProps: { agentId: null, ephemeralAgent } as HookProps },
       );
 
-      // Start with ephemeral agent (null)
+      // Start with ephemeral agent (null) with tools enabled
       expect(result.current.fileSearchAllowedByAgent).toBe(true);
       expect(result.current.codeAllowedByAgent).toBe(true);
 
       // Switch to regular agent
-      rerender({ agentId: regularAgentId });
+      rerender({ agentId: regularAgentId, ephemeralAgent });
       expect(result.current.fileSearchAllowedByAgent).toBe(false);
       expect(result.current.codeAllowedByAgent).toBe(false);
 
       // Switch back to ephemeral
-      rerender({ agentId: '' });
+      rerender({ agentId: '', ephemeralAgent });
       expect(result.current.fileSearchAllowedByAgent).toBe(true);
       expect(result.current.codeAllowedByAgent).toBe(true);
+
+      // Switch to ephemeral without tools
+      rerender({ agentId: null, ephemeralAgent: undefined });
+      expect(result.current.fileSearchAllowedByAgent).toBe(false);
+      expect(result.current.codeAllowedByAgent).toBe(false);
     });
   });
 
@@ -403,9 +522,9 @@ describe('useAgentToolPermissions', () => {
 
     it('should handle query loading state', () => {
       const agentId = 'loading-agent';
-      
+
       (useAgentsMapContext as jest.Mock).mockReturnValue({});
-      (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ 
+      (useGetAgentByIdQuery as jest.Mock).mockReturnValue({
         data: undefined,
         isLoading: true,
         error: null,
@@ -421,9 +540,9 @@ describe('useAgentToolPermissions', () => {
 
     it('should handle query error state', () => {
       const agentId = 'error-agent';
-      
+
       (useAgentsMapContext as jest.Mock).mockReturnValue({});
-      (useGetAgentByIdQuery as jest.Mock).mockReturnValue({ 
+      (useGetAgentByIdQuery as jest.Mock).mockReturnValue({
         data: undefined,
         isLoading: false,
         error: new Error('Failed to fetch agent'),

--- a/client/src/hooks/Agents/useAgentToolPermissions.ts
+++ b/client/src/hooks/Agents/useAgentToolPermissions.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
-import { Tools, Constants } from 'librechat-data-provider';
+import { Tools, Constants, EToolResources } from 'librechat-data-provider';
+import type { TEphemeralAgent } from 'librechat-data-provider';
 import { useGetAgentByIdQuery } from '~/data-provider';
 import { useAgentsMapContext } from '~/Providers';
 
@@ -16,11 +17,13 @@ function isEphemeralAgent(agentId: string | null | undefined): boolean {
 /**
  * Hook to determine whether specific tools are allowed for a given agent.
  *
- * @param agentId - The ID of the agent. If null/undefined/empty, returns true for all tools (ephemeral agent behavior)
+ * @param agentId - The ID of the agent. If null/undefined/empty, checks ephemeralAgent settings
+ * @param ephemeralAgent - Optional ephemeral agent settings for tool permissions
  * @returns Object with boolean flags for file_search and execute_code permissions, plus the tools array
  */
 export default function useAgentToolPermissions(
   agentId: string | null | undefined,
+  ephemeralAgent?: TEphemeralAgent | null,
 ): AgentToolPermissionsResult {
   const agentsMap = useAgentsMapContext();
 
@@ -37,22 +40,26 @@ export default function useAgentToolPermissions(
   );
 
   const fileSearchAllowedByAgent = useMemo(() => {
-    // Allow for ephemeral agents
-    if (isEphemeralAgent(agentId)) return true;
+    // Check ephemeral agent settings
+    if (isEphemeralAgent(agentId)) {
+      return ephemeralAgent?.[EToolResources.file_search] ?? false;
+    }
     // If agentId exists but agent not found, disallow
     if (!selectedAgent) return false;
     // Check if the agent has the file_search tool
     return tools?.includes(Tools.file_search) ?? false;
-  }, [agentId, selectedAgent, tools]);
+  }, [agentId, selectedAgent, tools, ephemeralAgent]);
 
   const codeAllowedByAgent = useMemo(() => {
-    // Allow for ephemeral agents
-    if (isEphemeralAgent(agentId)) return true;
+    // Check ephemeral agent settings
+    if (isEphemeralAgent(agentId)) {
+      return ephemeralAgent?.[EToolResources.execute_code] ?? false;
+    }
     // If agentId exists but agent not found, disallow
     if (!selectedAgent) return false;
     // Check if the agent has the execute_code tool
     return tools?.includes(Tools.execute_code) ?? false;
-  }, [agentId, selectedAgent, tools]);
+  }, [agentId, selectedAgent, tools, ephemeralAgent]);
 
   return {
     fileSearchAllowedByAgent,


### PR DESCRIPTION
## Summary

- Implement `DragDropContext` to provide isolated drag-drop state management and reduce dependency on `useChatContext`
- Wrap `DragDropModal` with `DragDropProvider` to create a focused context boundary
- Extract only necessary conversation fields (conversationId, agentId) in `DragDropContext` with memoized value
- Rename test files from `.test.tsx` to `.render.test.ts` for better test categorization
- Enhance `useAgentToolPermissions` hook to accept optional `ephemeralAgent` parameter
- Add comprehensive test coverage for ephemeral agent scenarios with tool permission configurations
- Update components to pass ephemeral agent state to tool permission hooks
- Refactor tool permission logic to check specific ephemeral agent settings instead of blanket allowances
- Add proper TypeScript typing for ephemeral agent parameters and hook props
- Fix permissions for ephemeral agents to properly respect individual tool settings rather than allowing all tools by default

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested the drag-drop functionality to ensure the new context properly isolates state management and validated that agent tool permissions correctly respect ephemeral agent configurations. The comprehensive test suite covers various scenarios including ephemeral agents with different tool combinations and ensures backwards compatibility with existing agent configurations.

### **Test Configuration**:
- Verified UI components render correctly with the new context structure
- Tested drag-drop operations with different agent configurations
- Validated ephemeral agent tool permissions across multiple scenarios
- Confirmed test file renaming doesn't break CI pipeline

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes