### PR TITLE
🔐 fix: Respect Server's Token Endpoint Auth Methods for MCP OAuth Refresh

### DIFF
--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -44,7 +44,7 @@ async function reinitMCPServer({
     const oauthStart =
       _oauthStart ??
       (async (authURL) => {
-        logger.info(`[MCP Reinitialize] OAuth URL received: ${authURL}`);
+        logger.info(`[MCP Reinitialize] OAuth URL received for ${serverName}`);
         oauthUrl = authURL;
         oauthRequired = true;
       });


### PR DESCRIPTION
### Summary

Closes #9705

I fixed a bug in MCP OAuth token refresh handling.

- Fixed OAuth token refresh to respect server's advertised `token_endpoint_auth_methods_supported` instead of always defaulting to Basic Auth
- Added proper detection and handling of `client_secret_post` method for servers like FastMCP that require client credentials in the request body
- Implemented fallback logic that defaults to `client_secret_basic` when no authentication methods are specified, per RFC 8414
- Added comprehensive test coverage for different authentication method scenarios including public clients
- Removed sensitive OAuth URL logging from MCP server reinitialization to prevent token leakage in logs
- Enhanced debug logging to show which authentication method is being used for troubleshooting

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested with FastMCP server that only supports `client_secret_post` authentication method. Previously failed with "refresh_token.client_id: Field required" error, now properly includes client credentials in the request body. Also verified backwards compatibility with servers supporting `client_secret_basic`.

### **Test Configuration**:
- FastMCP server with `client_secret_post` only
- Standard OAuth servers with Basic Auth support
- Public clients without client secrets
- Servers with no advertised authentication methods

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes