### PR TITLE
🔍 fix: Race Condition in Search Bar Clear Text Handler

### DIFF
--- a/client/src/components/Nav/SearchBar.tsx
+++ b/client/src/components/Nav/SearchBar.tsx
@@ -24,35 +24,45 @@ const SearchBar = forwardRef((props: SearchBarProps, ref: React.Ref<HTMLDivEleme
   const inputRef = useRef<HTMLInputElement>(null);
   const [showClearIcon, setShowClearIcon] = useState(false);
 
-  const { newConversation } = useNewConvo();
+  const { newConversation: newConvo } = useNewConvo();
   const [search, setSearchState] = useRecoilState(store.search);
 
-  const clearSearch = useCallback(() => {
-    if (location.pathname.includes('/search')) {
-      newConversation({ disableFocus: true });
-      navigate('/c/new', { replace: true });
-    }
-  }, [newConversation, location.pathname, navigate]);
+  const clearSearch = useCallback(
+    (pathname?: string) => {
+      if (pathname?.includes('/search') || pathname === '/c/new') {
+        queryClient.removeQueries([QueryKeys.messages]);
+        newConvo({ disableFocus: true });
+        navigate('/c/new');
+      }
+    },
+    [newConvo, navigate, queryClient],
+  );
 
-  const clearText = useCallback(() => {
-    setShowClearIcon(false);
-    setText('');
-    setSearchState((prev) => ({
-      ...prev,
-      query: '',
-      debouncedQuery: '',
-      isTyping: false,
-    }));
-    clearSearch();
-    inputRef.current?.focus();
-  }, [setSearchState, clearSearch]);
+  const clearText = useCallback(
+    (pathname?: string) => {
+      setShowClearIcon(false);
+      setText('');
+      setSearchState((prev) => ({
+        ...prev,
+        query: '',
+        debouncedQuery: '',
+        isTyping: false,
+      }));
+      clearSearch(pathname);
+      inputRef.current?.focus();
+    },
+    [setSearchState, clearSearch],
+  );
 
-  const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    const { value } = e.target as HTMLInputElement;
-    if (e.key === 'Backspace' && value === '') {
-      clearText();
-    }
-  };
+  const handleKeyUp = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      const { value } = e.target as HTMLInputElement;
+      if (e.key === 'Backspace' && value === '') {
+        clearText(location.pathname);
+      }
+    },
+    [clearText, location.pathname],
+  );
 
   const sendRequest = useCallback(
     (value: string) => {
@@ -85,8 +95,6 @@ const SearchBar = forwardRef((props: SearchBarProps, ref: React.Ref<HTMLDivEleme
     debouncedSetDebouncedQuery(value);
     if (value.length > 0 && location.pathname !== '/search') {
       navigate('/search', { replace: true });
-    } else if (value.length === 0 && location.pathname === '/search') {
-      navigate('/c/new', { replace: true });
     }
   };
 
@@ -132,7 +140,7 @@ const SearchBar = forwardRef((props: SearchBarProps, ref: React.Ref<HTMLDivEleme
           showClearIcon ? 'opacity-100' : 'opacity-0',
           isSmallScreen === true ? 'right-[16px]' : '',
         )}
-        onClick={clearText}
+        onClick={() => clearText(location.pathname)}
         tabIndex={showClearIcon ? 0 : -1}
         disabled={!showClearIcon}
       >


### PR DESCRIPTION
## Summary

I fixed a race condition in the SearchBar component's clearText function with the input change handler and improved message query data clearing.

- Fix race condition by passing pathname parameter to clearText function instead of accessing location state during callback execution
- Add queryClient.removeQueries for messages when clearing search to properly clean up cached data
- Wrap handleKeyUp in useCallback with proper dependencies to prevent unnecessary re-renders
- Remove redundant navigation logic that was causing conflicts with the clear functionality
- Add pathname checks for both '/search' and '/c/new' routes to handle edge cases in clearSearch
- Update clearText onClick handler to pass current pathname directly

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested the search functionality by entering search queries, clearing them with the clear button, and using backspace to clear empty searches. I verified that message query data is properly cleared and navigation works correctly without race conditions.

### **Test Configuration**:
- Browser: Chrome/Firefox
- Route transitions between /search and /c/new
- Search input interactions (typing, clearing, backspace)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes