### PR TITLE
🛠️ chore: Typing and Remove Comments

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
@@ -70,7 +70,7 @@ const ImageAttachment = memo(({ attachment }: { attachment: TAttachment }) => {
       }}
     >
       <Image
-        altText={attachment.filename}
+        altText={attachment.filename || 'attachment image'}
         imagePath={filepath ?? ''}
         height={height ?? 0}
         width={width ?? 0}
@@ -89,8 +89,9 @@ export default function Attachment({ attachment }: { attachment?: TAttachment })
   }
 
   const { width, height, filepath = null } = attachment as TFile & TAttachmentMetadata;
-  const isImage =
-    imageExtRegex.test(attachment.filename) && width != null && height != null && filepath != null;
+  const isImage = attachment.filename
+    ? imageExtRegex.test(attachment.filename) && width != null && height != null && filepath != null
+    : false;
 
   if (isImage) {
     return <ImageAttachment attachment={attachment} />;
@@ -110,11 +111,12 @@ export function AttachmentGroup({ attachments }: { attachments?: TAttachment[] }
 
   attachments.forEach((attachment) => {
     const { width, height, filepath = null } = attachment as TFile & TAttachmentMetadata;
-    const isImage =
-      imageExtRegex.test(attachment.filename) &&
-      width != null &&
-      height != null &&
-      filepath != null;
+    const isImage = attachment.filename
+      ? imageExtRegex.test(attachment.filename) &&
+        width != null &&
+        height != null &&
+        filepath != null
+      : false;
 
     if (isImage) {
       imageAttachments.push(attachment);

--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -83,20 +83,12 @@ function parseAsString(result: t.MCPToolCallResponse): string {
 
 /**
  * Converts MCPToolCallResponse content into recognized content block types
- * Recognized types: "image", "image_url", "text", "json"
- *
- * @param {t.MCPToolCallResponse} result - The MCPToolCallResponse object
- * @param {string} provider - The provider name (google, anthropic, openai)
- * @returns {Array<Object>} Formatted content blocks
- */
-/**
- * Converts MCPToolCallResponse content into recognized content block types
  * First element: string or formatted content (excluding image_url)
- * Second element: image_url content if any
+ * Second element: Recognized types - "image", "image_url", "text", "json"
  *
- * @param {t.MCPToolCallResponse} result - The MCPToolCallResponse object
- * @param {string} provider - The provider name (google, anthropic, openai)
- * @returns {t.FormattedContentResult} Tuple of content and image_urls
+ * @param  result - The MCPToolCallResponse object
+ * @param provider - The provider name (google, anthropic, openai)
+ * @returns Tuple of content and image_urls
  */
 export function formatToolContent(
   result: t.MCPToolCallResponse,


### PR DESCRIPTION
## Summary

I fixed TypeScript type errors in the Attachment component by adding null checks for the filename property and updated JSDoc documentation in the formatToolContent function.

- Add null checks for `attachment.filename` to prevent type errors when the filename is undefined
- Provide fallback alt text "attachment image" for image attachments without filenames  
- Update image detection logic to safely handle undefined filenames using conditional checks
- Remove duplicate JSDoc comments and type annotations from formatToolContent function
- Simplify documentation format by removing redundant parameter type information

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

I tested these changes by verifying that TypeScript compilation passes without errors and that the attachment rendering works correctly with both valid filenames and undefined filename cases.

### **Test Configuration**:
- TypeScript compiler validation
- Component rendering with various attachment scenarios

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes