### PR TITLE
🏷️ fix: Increment Tag Counters When Forking/Duplicating Conversations

### DIFF
--- a/api/server/utils/import/fork.spec.js
+++ b/api/server/utils/import/fork.spec.js
@@ -10,6 +10,10 @@ jest.mock('~/models/Message', () => ({
   bulkSaveMessages: jest.fn(),
 }));
 
+jest.mock('~/models/ConversationTag', () => ({
+  bulkIncrementTagCounts: jest.fn(),
+}));
+
 let mockIdCounter = 0;
 jest.mock('uuid', () => {
   return {
@@ -22,6 +26,7 @@ jest.mock('uuid', () => {
 
 const {
   forkConversation,
+  duplicateConversation,
   splitAtTargetLevel,
   getAllMessagesUpToParent,
   getMessagesUpToTargetLevel,
@@ -29,6 +34,7 @@ const {
 } = require('./fork');
 const { getConvo, bulkSaveConvos } = require('~/models/Conversation');
 const { getMessages, bulkSaveMessages } = require('~/models/Message');
+const { bulkIncrementTagCounts } = require('~/models/ConversationTag');
 const { createImportBatchBuilder } = require('./importBatchBuilder');
 const BaseClient = require('~/app/clients/BaseClient');
 
@@ -180,6 +186,120 @@ describe('forkConversation', () => {
         requestUserId: 'user1',
       }),
     ).rejects.toThrow('Failed to fetch messages');
+  });
+
+  test('should increment tag counts when forking conversation with tags', async () => {
+    const mockConvoWithTags = {
+      ...mockConversation,
+      tags: ['bookmark1', 'bookmark2'],
+    };
+    getConvo.mockResolvedValue(mockConvoWithTags);
+
+    await forkConversation({
+      originalConvoId: 'abc123',
+      targetMessageId: '3',
+      requestUserId: 'user1',
+      option: ForkOptions.DIRECT_PATH,
+    });
+
+    // Verify that bulkIncrementTagCounts was called with correct tags
+    expect(bulkIncrementTagCounts).toHaveBeenCalledWith('user1', ['bookmark1', 'bookmark2']);
+  });
+
+  test('should handle conversation without tags when forking', async () => {
+    const mockConvoWithoutTags = {
+      ...mockConversation,
+      // No tags field
+    };
+    getConvo.mockResolvedValue(mockConvoWithoutTags);
+
+    await forkConversation({
+      originalConvoId: 'abc123',
+      targetMessageId: '3',
+      requestUserId: 'user1',
+      option: ForkOptions.DIRECT_PATH,
+    });
+
+    // bulkIncrementTagCounts will be called with array containing undefined
+    expect(bulkIncrementTagCounts).toHaveBeenCalled();
+  });
+
+  test('should handle empty tags array when forking', async () => {
+    const mockConvoWithEmptyTags = {
+      ...mockConversation,
+      tags: [],
+    };
+    getConvo.mockResolvedValue(mockConvoWithEmptyTags);
+
+    await forkConversation({
+      originalConvoId: 'abc123',
+      targetMessageId: '3',
+      requestUserId: 'user1',
+      option: ForkOptions.DIRECT_PATH,
+    });
+
+    // bulkIncrementTagCounts will be called with empty array
+    expect(bulkIncrementTagCounts).toHaveBeenCalledWith('user1', []);
+  });
+});
+
+describe('duplicateConversation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIdCounter = 0;
+    getConvo.mockResolvedValue(mockConversation);
+    getMessages.mockResolvedValue(mockMessages);
+    bulkSaveConvos.mockResolvedValue(null);
+    bulkSaveMessages.mockResolvedValue(null);
+    bulkIncrementTagCounts.mockResolvedValue(null);
+  });
+
+  test('should duplicate conversation and increment tag counts', async () => {
+    const mockConvoWithTags = {
+      ...mockConversation,
+      tags: ['important', 'work', 'project'],
+    };
+    getConvo.mockResolvedValue(mockConvoWithTags);
+
+    await duplicateConversation({
+      userId: 'user1',
+      conversationId: 'abc123',
+    });
+
+    // Verify that bulkIncrementTagCounts was called with correct tags
+    expect(bulkIncrementTagCounts).toHaveBeenCalledWith('user1', ['important', 'work', 'project']);
+  });
+
+  test('should duplicate conversation without tags', async () => {
+    const mockConvoWithoutTags = {
+      ...mockConversation,
+      // No tags field
+    };
+    getConvo.mockResolvedValue(mockConvoWithoutTags);
+
+    await duplicateConversation({
+      userId: 'user1',
+      conversationId: 'abc123',
+    });
+
+    // bulkIncrementTagCounts will be called with array containing undefined
+    expect(bulkIncrementTagCounts).toHaveBeenCalled();
+  });
+
+  test('should handle empty tags array when duplicating', async () => {
+    const mockConvoWithEmptyTags = {
+      ...mockConversation,
+      tags: [],
+    };
+    getConvo.mockResolvedValue(mockConvoWithEmptyTags);
+
+    await duplicateConversation({
+      userId: 'user1',
+      conversationId: 'abc123',
+    });
+
+    // bulkIncrementTagCounts will be called with empty array
+    expect(bulkIncrementTagCounts).toHaveBeenCalledWith('user1', []);
   });
 });
 

--- a/api/server/utils/import/fork.spec.js
+++ b/api/server/utils/import/fork.spec.js
@@ -32,9 +32,9 @@ const {
   getMessagesUpToTargetLevel,
   cloneMessagesWithTimestamps,
 } = require('./fork');
+const { bulkIncrementTagCounts } = require('~/models/ConversationTag');
 const { getConvo, bulkSaveConvos } = require('~/models/Conversation');
 const { getMessages, bulkSaveMessages } = require('~/models/Message');
-const { bulkIncrementTagCounts } = require('~/models/ConversationTag');
 const { createImportBatchBuilder } = require('./importBatchBuilder');
 const BaseClient = require('~/app/clients/BaseClient');
 

--- a/api/server/utils/import/importBatchBuilder.js
+++ b/api/server/utils/import/importBatchBuilder.js
@@ -1,5 +1,6 @@
 const { v4: uuidv4 } = require('uuid');
 const { EModelEndpoint, Constants, openAISettings } = require('librechat-data-provider');
+const { bulkIncrementTagCounts } = require('~/models/ConversationTag');
 const { bulkSaveConvos } = require('~/models/Conversation');
 const { bulkSaveMessages } = require('~/models/Message');
 const { logger } = require('~/config');
@@ -93,13 +94,22 @@ class ImportBatchBuilder {
 
   /**
    * Saves the batch of conversations and messages to the DB.
+   * Also increments tag counts for any existing tags.
    * @returns {Promise<void>} A promise that resolves when the batch is saved.
    * @throws {Error} If there is an error saving the batch.
    */
   async saveBatch() {
     try {
-      await bulkSaveConvos(this.conversations);
-      await bulkSaveMessages(this.messages, true);
+      const promises = [];
+      promises.push(bulkSaveConvos(this.conversations));
+      promises.push(bulkSaveMessages(this.messages, true));
+      promises.push(
+        bulkIncrementTagCounts(
+          this.requestUserId,
+          this.conversations.flatMap((convo) => convo.tags),
+        ),
+      );
+      await Promise.all(promises);
       logger.debug(
         `user: ${this.requestUserId} | Added ${this.conversations.length} conversations and ${this.messages.length} messages to the DB.`,
       );

--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -96,7 +96,7 @@ export const useArchiveConvoMutation = (
   const queryClient = useQueryClient();
   const convoQueryKey = [QueryKeys.allConversations];
   const archivedConvoQueryKey = [QueryKeys.archivedConversations];
-  const { onMutate, onError, onSettled, onSuccess, ..._options } = options || {};
+  const { onMutate, onError, onSuccess, ..._options } = options || {};
 
   return useMutation(
     (payload: t.TArchiveConversationRequest) => dataService.archiveConversation(payload),
@@ -567,6 +567,19 @@ export const useDuplicateConversationMutation = (
         queryKey: [QueryKeys.allConversations],
         refetchPage: (_, index) => index === 0,
       });
+
+      if (duplicatedConversation.tags && duplicatedConversation.tags.length > 0) {
+        queryClient.setQueryData<t.TConversationTag[]>([QueryKeys.conversationTags], (oldTags) => {
+          if (!oldTags) return oldTags;
+          return oldTags.map((tag) => {
+            if (duplicatedConversation.tags?.includes(tag.tag)) {
+              return { ...tag, count: tag.count + 1 };
+            }
+            return tag;
+          });
+        });
+      }
+
       onSuccess?.(data, vars, context);
     },
     ..._options,
@@ -597,6 +610,19 @@ export const useForkConvoMutation = (
         queryKey: [QueryKeys.allConversations],
         refetchPage: (_, index) => index === 0,
       });
+
+      if (forkedConversation.tags && forkedConversation.tags.length > 0) {
+        queryClient.setQueryData<t.TConversationTag[]>([QueryKeys.conversationTags], (oldTags) => {
+          if (!oldTags) return oldTags;
+          return oldTags.map((tag) => {
+            if (forkedConversation.tags?.includes(tag.tag)) {
+              return { ...tag, count: tag.count + 1 };
+            }
+            return tag;
+          });
+        });
+      }
+
       onSuccess?.(data, vars, context);
     },
     ..._options,
@@ -871,7 +897,7 @@ export const useUploadAssistantAvatarMutation = (
   unknown // context
 > => {
   return useMutation([MutationKeys.assistantAvatarUpload], {
-    mutationFn: ({ postCreation, ...variables }: t.AssistantAvatarVariables) =>
+    mutationFn: ({ postCreation: _postCreation, ...variables }: t.AssistantAvatarVariables) =>
       dataService.uploadAssistantAvatar(variables),
     ...(options || {}),
   });


### PR DESCRIPTION
## Summary

Closes #9736

I implemented a fix for tag counter inconsistencies when forking or duplicating conversations with bookmarks, preventing negative tag counts during bookmark removal.

- Add `bulkIncrementTagCounts` function to efficiently update existing tag counts in batch operations
- Integrate tag count updates into `importBatchBuilder.saveBatch()` using `Promise.all` for concurrent execution
- Update frontend mutations to directly modify cache state instead of invalidating queries for better performance
- Optimize `bulkIncrementTagCounts` to skip unnecessary database queries when no tags need updating
- Ensure forked and duplicated conversations properly increment associated bookmark tag counters

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The fix addresses tag counter synchronization during conversation duplication and forking operations. Testing should verify that bookmark tag counts remain accurate across these operations.

### **Test Configuration**:
- Create conversations with bookmarks containing tags
- Fork/duplicate these conversations multiple times
- Verify tag counters increment correctly for each operation
- Remove bookmarks from duplicated conversations and confirm counters don't go negative

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes