### PR TITLE
🔐 refactor: Improve MCP Auth UX for Agent Panel

### DIFF
--- a/client/src/components/MCP/CustomUserVarsSection.tsx
+++ b/client/src/components/MCP/CustomUserVarsSection.tsx
@@ -66,7 +66,7 @@ function AuthField({ name, config, hasValue, control, errors }: AuthFieldProps) 
             placeholder={
               hasValue
                 ? localize('com_ui_mcp_update_var', { 0: config.title })
-                : localize('com_ui_mcp_enter_var', { 0: config.title })
+                : `${localize('com_ui_mcp_enter_var', { 0: config.title })} ${localize('com_ui_optional')}`
             }
             className="w-full rounded border border-border-medium bg-transparent px-2 py-1 text-text-primary placeholder:text-text-secondary focus:outline-none sm:text-sm"
           />

--- a/client/src/components/SidePanel/MCP/MCPPanel.tsx
+++ b/client/src/components/SidePanel/MCP/MCPPanel.tsx
@@ -31,9 +31,9 @@ function MCPPanelContent() {
       showToast({ message: localize('com_nav_mcp_vars_updated'), status: 'success' });
 
       await Promise.all([
-        queryClient.refetchQueries([QueryKeys.mcpTools]),
-        queryClient.refetchQueries([QueryKeys.mcpAuthValues]),
-        queryClient.refetchQueries([QueryKeys.mcpConnectionStatus]),
+        queryClient.invalidateQueries([QueryKeys.mcpTools]),
+        queryClient.invalidateQueries([QueryKeys.mcpAuthValues]),
+        queryClient.invalidateQueries([QueryKeys.mcpConnectionStatus]),
       ]);
     },
     onError: (error: unknown) => {

--- a/client/src/components/Tools/MCPToolSelectDialog.tsx
+++ b/client/src/components/Tools/MCPToolSelectDialog.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, useMemo } from 'react';
 import { Search, X } from 'lucide-react';
 import { useFormContext } from 'react-hook-form';
-import { Constants, EModelEndpoint } from 'librechat-data-provider';
+import { useQueryClient } from '@tanstack/react-query';
+import { Constants, EModelEndpoint, QueryKeys } from 'librechat-data-provider';
 import { Dialog, DialogPanel, DialogTitle, Description } from '@headlessui/react';
 import { useUpdateUserPluginsMutation } from 'librechat-data-provider/react-query';
 import type { TError, AgentToolType } from 'librechat-data-provider';
@@ -24,6 +25,7 @@ function MCPToolSelectDialog({
   endpoint: EModelEndpoint.agents;
 }) {
   const localize = useLocalize();
+  const queryClient = useQueryClient();
   const { initializeServer } = useMCPServerManager();
   const { getValues, setValue } = useFormContext<AgentForm>();
   const { mcpServersMap, startupConfig } = useAgentPanelContext();
@@ -31,6 +33,7 @@ function MCPToolSelectDialog({
     enabled: mcpServersMap.size > 0,
   });
 
+  const [isSavingCustomVars, setIsSavingCustomVars] = useState(false);
   const [isInitializing, setIsInitializing] = useState<string | null>(null);
   const [configuringServer, setConfiguringServer] = useState<string | null>(null);
 
@@ -67,9 +70,27 @@ function MCPToolSelectDialog({
     }, 5000);
   };
 
-  const handleDirectAdd = async (serverName: string) => {
+  const handleDirectAdd = async (serverName: string, authData?: Record<string, string>) => {
     try {
       setIsInitializing(serverName);
+
+      // First, save auth if provided
+      if (authData && Object.keys(authData).length > 0) {
+        await updateUserPlugins.mutateAsync({
+          pluginKey: `${Constants.mcp_prefix}${serverName}`,
+          action: 'install',
+          auth: authData,
+          isEntityTool: true,
+        });
+
+        // Invalidate auth values query to ensure fresh data
+        await queryClient.invalidateQueries([QueryKeys.mcpAuthValues, serverName]);
+
+        // Small delay to ensure backend has processed the auth
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+
+      // Then initialize server if needed
       const serverInfo = mcpServersMap.get(serverName);
       if (!serverInfo?.isConnected) {
         const result = await initializeServer(serverName);
@@ -78,64 +99,65 @@ function MCPToolSelectDialog({
           return;
         }
       }
-      updateUserPlugins.mutate(
-        {
-          pluginKey: `${Constants.mcp_prefix}${serverName}`,
-          action: 'install',
-          auth: {},
-          isEntityTool: true,
-        },
-        {
-          onError: (error: unknown) => {
-            handleInstallError(error as TError);
-            setIsInitializing(null);
-          },
-          onSuccess: async () => {
-            const { data: updatedMCPData } = await refetchMCPTools();
 
-            const currentTools = getValues('tools') || [];
-            const toolsToAdd: string[] = [
-              `${Constants.mcp_server}${Constants.mcp_delimiter}${serverName}`,
-            ];
-
-            if (updatedMCPData?.servers?.[serverName]) {
-              const serverData = updatedMCPData.servers[serverName];
-              serverData.tools.forEach((tool) => {
-                toolsToAdd.push(tool.pluginKey);
-              });
-            }
-
-            const newTools = toolsToAdd.filter((tool) => !currentTools.includes(tool));
-            if (newTools.length > 0) {
-              setValue('tools', [...currentTools, ...newTools]);
-            }
-            setIsInitializing(null);
-          },
-        },
-      );
+      // Finally, add tools to form
+      await addToolsToForm(serverName);
+      setIsInitializing(null);
     } catch (error) {
       console.error('Error adding MCP server:', error);
+      handleInstallError(error as TError);
+      setIsInitializing(null);
+    }
+  };
+
+  const addToolsToForm = async (serverName: string) => {
+    const { data: updatedMCPData } = await refetchMCPTools();
+
+    const currentTools = getValues('tools') || [];
+    const toolsToAdd: string[] = [`${Constants.mcp_server}${Constants.mcp_delimiter}${serverName}`];
+
+    if (updatedMCPData?.servers?.[serverName]) {
+      const serverData = updatedMCPData.servers[serverName];
+      serverData.tools.forEach((tool) => {
+        toolsToAdd.push(tool.pluginKey);
+      });
+    }
+
+    const newTools = toolsToAdd.filter((tool) => !currentTools.includes(tool));
+    if (newTools.length > 0) {
+      setValue('tools', [...currentTools, ...newTools]);
     }
   };
 
   const handleSaveCustomVars = async (serverName: string, authData: Record<string, string>) => {
     try {
-      await updateUserPlugins.mutateAsync({
-        pluginKey: `${Constants.mcp_prefix}${serverName}`,
-        action: 'install',
-        auth: authData,
-        isEntityTool: true,
+      setIsSavingCustomVars(true);
+
+      // Filter out empty values to avoid overwriting existing values with empty ones
+      const filteredAuthData: Record<string, string> = {};
+      Object.entries(authData).forEach(([key, value]) => {
+        if (value && value.trim()) {
+          filteredAuthData[key] = value.trim();
+        }
       });
 
-      await handleDirectAdd(serverName);
-
+      // Always add the tool, but only pass auth data if there are values to save
+      // Empty auth data is fine - the tool can work without credentials
+      await handleDirectAdd(
+        serverName,
+        Object.keys(filteredAuthData).length > 0 ? filteredAuthData : undefined,
+      );
       setConfiguringServer(null);
     } catch (error) {
       console.error('Error saving custom vars:', error);
+      handleInstallError(error as TError);
+    } finally {
+      setIsSavingCustomVars(false);
     }
   };
 
   const handleRevokeCustomVars = (serverName: string) => {
+    setIsSavingCustomVars(true);
     updateUserPlugins.mutate(
       {
         pluginKey: `${Constants.mcp_prefix}${serverName}`,
@@ -144,9 +166,13 @@ function MCPToolSelectDialog({
         isEntityTool: true,
       },
       {
-        onError: (error: unknown) => handleInstallError(error as TError),
-        onSuccess: () => {
+        onError: (error: unknown) => {
+          handleInstallError(error as TError);
+          setIsSavingCustomVars(false);
+        },
+        onSuccess: async () => {
           setConfiguringServer(null);
+          setIsSavingCustomVars(false);
         },
       },
     );
@@ -170,26 +196,15 @@ function MCPToolSelectDialog({
     }
   };
 
+  /**
+   * Only remove from the form, don't delete auth credentials
+   */
   const onRemoveTool = (serverName: string) => {
-    updateUserPlugins.mutate(
-      {
-        pluginKey: `${Constants.mcp_prefix}${serverName}`,
-        action: 'uninstall',
-        auth: {},
-        isEntityTool: true,
-      },
-      {
-        onError: (error: unknown) => handleInstallError(error as TError),
-        onSuccess: () => {
-          const currentTools = getValues('tools') || [];
-          const remainingTools = currentTools.filter(
-            (tool) =>
-              tool !== serverName && !tool.endsWith(`${Constants.mcp_delimiter}${serverName}`),
-          );
-          setValue('tools', remainingTools);
-        },
-      },
+    const currentTools = getValues('tools') || [];
+    const remainingTools = currentTools.filter(
+      (tool) => tool !== serverName && !tool.endsWith(`${Constants.mcp_delimiter}${serverName}`),
     );
+    setValue('tools', remainingTools);
   };
 
   const installedToolsSet = useMemo(() => {
@@ -289,10 +304,10 @@ function MCPToolSelectDialog({
               </div>
               <CustomUserVarsSection
                 serverName={configuringServer}
+                isSubmitting={isSavingCustomVars}
                 fields={startupConfig?.mcpServers?.[configuringServer]?.customUserVars || {}}
                 onSave={(authData) => handleSaveCustomVars(configuringServer, authData)}
                 onRevoke={() => handleRevokeCustomVars(configuringServer)}
-                isSubmitting={updateUserPlugins.isLoading}
               />
             </div>
           )}

--- a/client/src/components/Tools/MCPToolSelectDialog.tsx
+++ b/client/src/components/Tools/MCPToolSelectDialog.tsx
@@ -7,7 +7,12 @@ import { Dialog, DialogPanel, DialogTitle, Description } from '@headlessui/react
 import { useUpdateUserPluginsMutation } from 'librechat-data-provider/react-query';
 import type { TError, AgentToolType } from 'librechat-data-provider';
 import type { AgentForm, TPluginStoreDialogProps } from '~/common';
-import { useLocalize, usePluginDialogHelpers, useMCPServerManager } from '~/hooks';
+import {
+  usePluginDialogHelpers,
+  useMCPServerManager,
+  useRemoveMCPTool,
+  useLocalize,
+} from '~/hooks';
 import CustomUserVarsSection from '~/components/MCP/CustomUserVarsSection';
 import { PluginPagination } from '~/components/Plugins/Store';
 import { useAgentPanelContext } from '~/Providers';
@@ -28,6 +33,7 @@ function MCPToolSelectDialog({
   const queryClient = useQueryClient();
   const { initializeServer } = useMCPServerManager();
   const { getValues, setValue } = useFormContext<AgentForm>();
+  const { removeTool } = useRemoveMCPTool({ showToast: false });
   const { mcpServersMap, startupConfig } = useAgentPanelContext();
   const { refetch: refetchMCPTools } = useMCPToolsQuery({
     enabled: mcpServersMap.size > 0,
@@ -196,17 +202,6 @@ function MCPToolSelectDialog({
     }
   };
 
-  /**
-   * Only remove from the form, don't delete auth credentials
-   */
-  const onRemoveTool = (serverName: string) => {
-    const currentTools = getValues('tools') || [];
-    const remainingTools = currentTools.filter(
-      (tool) => tool !== serverName && !tool.endsWith(`${Constants.mcp_delimiter}${serverName}`),
-    );
-    setValue('tools', remainingTools);
-  };
-
   const installedToolsSet = useMemo(() => {
     return new Set(mcpServerNames);
   }, [mcpServerNames]);
@@ -357,7 +352,7 @@ function MCPToolSelectDialog({
                         isConfiguring={isConfiguring}
                         isInitializing={isServerInitializing}
                         onAddTool={() => onAddTool(serverInfo.serverName)}
-                        onRemoveTool={() => onRemoveTool(serverInfo.serverName)}
+                        onRemoveTool={() => removeTool(serverInfo.serverName)}
                       />
                     );
                   })}

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -52,9 +52,9 @@ export function useMCPServerManager({ conversationId }: { conversationId?: strin
       showToast({ message: localize('com_nav_mcp_vars_updated'), status: 'success' });
 
       await Promise.all([
-        queryClient.refetchQueries([QueryKeys.mcpTools]),
-        queryClient.refetchQueries([QueryKeys.mcpAuthValues]),
-        queryClient.refetchQueries([QueryKeys.mcpConnectionStatus]),
+        queryClient.invalidateQueries([QueryKeys.mcpTools]),
+        queryClient.invalidateQueries([QueryKeys.mcpAuthValues]),
+        queryClient.invalidateQueries([QueryKeys.mcpConnectionStatus]),
       ]);
     },
     onError: (error: unknown) => {

--- a/client/src/hooks/MCP/useRemoveMCPTool.ts
+++ b/client/src/hooks/MCP/useRemoveMCPTool.ts
@@ -2,18 +2,17 @@ import { useCallback } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { Constants } from 'librechat-data-provider';
 import { useToastContext } from '@librechat/client';
-import { useUpdateUserPluginsMutation } from 'librechat-data-provider/react-query';
 import type { AgentForm } from '~/common';
 import { useLocalize } from '~/hooks';
 
 /**
  * Hook for removing MCP tools/servers from an agent
  * Provides unified logic for MCPTool, UninitializedMCPTool, and UnconfiguredMCPTool components
+ * Note: This only removes the tool from the form, it does not delete associated auth credentials
  */
 export function useRemoveMCPTool() {
   const localize = useLocalize();
   const { showToast } = useToastContext();
-  const updateUserPlugins = useUpdateUserPluginsMutation();
   const { getValues, setValue } = useFormContext<AgentForm>();
 
   const removeTool = useCallback(
@@ -22,39 +21,21 @@ export function useRemoveMCPTool() {
         return;
       }
 
-      updateUserPlugins.mutate(
-        {
-          pluginKey: `${Constants.mcp_prefix}${serverName}`,
-          action: 'uninstall',
-          auth: {},
-          isEntityTool: true,
-        },
-        {
-          onError: (error: unknown) => {
-            showToast({
-              message: localize('com_ui_delete_tool_error', { error: String(error) }),
-              status: 'error',
-            });
-          },
-          onSuccess: () => {
-            const currentTools = getValues('tools');
-            const remainingToolIds =
-              currentTools?.filter(
-                (currentToolId) =>
-                  currentToolId !== serverName &&
-                  !currentToolId.endsWith(`${Constants.mcp_delimiter}${serverName}`),
-              ) || [];
-            setValue('tools', remainingToolIds, { shouldDirty: true });
+      const currentTools = getValues('tools');
+      const remainingToolIds =
+        currentTools?.filter(
+          (currentToolId) =>
+            currentToolId !== serverName &&
+            !currentToolId.endsWith(`${Constants.mcp_delimiter}${serverName}`),
+        ) || [];
+      setValue('tools', remainingToolIds, { shouldDirty: true });
 
-            showToast({
-              message: localize('com_ui_delete_tool_save_reminder'),
-              status: 'warning',
-            });
-          },
-        },
-      );
+      showToast({
+        message: localize('com_ui_delete_tool_save_reminder'),
+        status: 'warning',
+      });
     },
-    [getValues, setValue, updateUserPlugins, showToast, localize],
+    [getValues, setValue, showToast, localize],
   );
 
   return { removeTool };

--- a/client/src/hooks/MCP/useRemoveMCPTool.ts
+++ b/client/src/hooks/MCP/useRemoveMCPTool.ts
@@ -10,10 +10,11 @@ import { useLocalize } from '~/hooks';
  * Provides unified logic for MCPTool, UninitializedMCPTool, and UnconfiguredMCPTool components
  * Note: This only removes the tool from the form, it does not delete associated auth credentials
  */
-export function useRemoveMCPTool() {
+export function useRemoveMCPTool(options?: { showToast?: boolean }) {
   const localize = useLocalize();
   const { showToast } = useToastContext();
   const { getValues, setValue } = useFormContext<AgentForm>();
+  const shouldShowToast = options?.showToast !== false;
 
   const removeTool = useCallback(
     (serverName: string) => {
@@ -30,12 +31,14 @@ export function useRemoveMCPTool() {
         ) || [];
       setValue('tools', remainingToolIds, { shouldDirty: true });
 
-      showToast({
-        message: localize('com_ui_delete_tool_save_reminder'),
-        status: 'warning',
-      });
+      if (shouldShowToast) {
+        showToast({
+          message: localize('com_ui_delete_tool_save_reminder'),
+          status: 'warning',
+        });
+      }
     },
-    [getValues, setValue, showToast, localize],
+    [getValues, setValue, showToast, localize, shouldShowToast],
   );
 
   return { removeTool };

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -834,7 +834,6 @@
   "com_ui_delete_success": "Successfully deleted",
   "com_ui_delete_tool": "Delete Tool",
   "com_ui_delete_tool_confirm": "Are you sure you want to delete this tool?",
-  "com_ui_delete_tool_error": "Error while deleting the tool: {{error}}",
   "com_ui_delete_tool_save_reminder": "Tool removed. Save the agent to apply changes.",
   "com_ui_deleted": "Deleted",
   "com_ui_deleting_file": "Deleting file...",

--- a/packages/api/src/flow/manager.ts
+++ b/packages/api/src/flow/manager.ts
@@ -74,7 +74,7 @@ export class FlowStateManager<T = unknown> {
       createdAt: Date.now(),
     };
 
-    logger.debug('Creating initial flow state:', flowKey);
+    logger.debug(`[${flowKey}] Creating initial flow state`);
     await this.keyv.set(flowKey, initialState, this.ttl);
     return this.monitorFlow(flowKey, type, signal);
   }

--- a/packages/data-provider/src/react-query/react-query-service.ts
+++ b/packages/data-provider/src/react-query/react-query-service.ts
@@ -343,7 +343,7 @@ export const useReinitializeMCPServerMutation = (): UseMutationResult<
   const queryClient = useQueryClient();
   return useMutation((serverName: string) => dataService.reinitializeMCPServer(serverName), {
     onSuccess: () => {
-      queryClient.refetchQueries([QueryKeys.mcpTools]);
+      queryClient.invalidateQueries([QueryKeys.mcpTools]);
     },
   });
 };

--- a/packages/data-provider/src/react-query/react-query-service.ts
+++ b/packages/data-provider/src/react-query/react-query-service.ts
@@ -320,6 +320,10 @@ export const useUpdateUserPluginsMutation = (
     onSuccess: (...args) => {
       queryClient.invalidateQueries([QueryKeys.user]);
       onSuccess?.(...args);
+      if (args[1]?.action === 'uninstall' && args[1]?.pluginKey?.startsWith(Constants.mcp_prefix)) {
+        const serverName = args[1]?.pluginKey?.substring(Constants.mcp_prefix.length);
+        queryClient.invalidateQueries([QueryKeys.mcpAuthValues, serverName]);
+      }
     },
   });
 };


### PR DESCRIPTION
## Summary

- Replace `refetchQueries` with `invalidateQueries` in MCPPanel and useMCPServerManager for better cache performance
- Update useReinitializeMCPServerMutation and useUpdateUserPluginsMutation to use invalidateQueries for MCP tools and auth values
- Enhance useUpdateUserPluginsMutation to automatically invalidate MCP auth values when uninstalling MCP servers
- Refactor MCPToolSelectDialog to streamline tool addition and removal with improved authentication data handling
- Introduce new `addToolsToForm` function to encapsulate form state management logic for better maintainability
- Add loading state management for custom variable saving operations to improve user feedback
- Simplify useRemoveMCPTool hook to focus solely on form state updates without backend mutations
- Update CustomUserVarsSection to include optional localization for placeholder text with better UX
- Enhance tool removal logic in MCPToolSelectDialog to utilize the refactored useRemoveMCPTool hook
- Improve error handling and user feedback throughout the MCP tool management flow
- Add proper filtering of empty authentication values to prevent overwriting existing credentials

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Please test the comprehensive MCP tool management functionality including:
- Adding and removing MCP servers from agents
- Saving and revoking custom authentication variables
- Verifying cache invalidation properly refreshes data across components
- Testing loading states during authentication operations
- Ensuring form state updates work correctly when adding/removing tools

### **Test Configuration**:
- Test with various MCP servers configured with different authentication requirements
- Verify authentication flow works correctly with both empty and populated credentials
- Check that cache updates reflect immediately in the UI without manual refresh
- Test error scenarios and ensure proper user feedback is displayed

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes