### PR TITLE
🔐 fix: MCP OAuth Token Persistence Race Condition and Refresh Auth Method

### DIFF
--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -504,6 +504,7 @@ export class MCPOAuthHandler {
         let authMethods: string[] | undefined;
         if (config?.token_url) {
           tokenUrl = config.token_url;
+          authMethods = config.token_endpoint_auth_methods_supported;
         } else if (!metadata.serverUrl) {
           throw new Error('No token URL available for refresh');
         } else {


### PR DESCRIPTION
## Summary

Two changes:
1. Fixes a bug in `packages/api/src/mcp/oauth/handler.ts` where `authMethods` wasn't set if a `token_url` exists, resulting in the refresh token flow always falling back to `client_secret_basic`.
2. Resolves #9772 by persisting OAuth tokens immediately after successful OAuth flow completion, before attempting MCP server reconnection. This prevents a race condition where reconnection attempts use stale/null credentials, causing unnecessary re-registration with DCR and token/client ID mismatches.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
