### PR TITLE
🛡️ fix: Title Generation Skip Logic Based On Endpoint Config

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1121,6 +1121,13 @@ class AgentClient extends BaseClient {
       );
     }
 
+    if (endpointConfig?.titleConvo === false) {
+      logger.debug(
+        `[api/server/controllers/agents/client.js #titleConvo] Title generation disabled for endpoint "${endpoint}"`,
+      );
+      return;
+    }
+
     if (endpointConfig?.titleEndpoint && endpointConfig.titleEndpoint !== endpoint) {
       try {
         titleProviderConfig = getProviderConfig({
@@ -1130,7 +1137,7 @@ class AgentClient extends BaseClient {
         endpoint = endpointConfig.titleEndpoint;
       } catch (error) {
         logger.warn(
-          `[api/server/controllers/agents/client.js #titleConvo] Error getting title endpoint config for ${endpointConfig.titleEndpoint}, falling back to default`,
+          `[api/server/controllers/agents/client.js #titleConvo] Error getting title endpoint config for "${endpointConfig.titleEndpoint}", falling back to default`,
           error,
         );
         // Fall back to original provider config

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -263,6 +263,125 @@ describe('AgentClient - titleConvo', () => {
       expect(result).toBeUndefined();
     });
 
+    it('should skip title generation when titleConvo is set to false', async () => {
+      // Set titleConvo to false in endpoint config
+      mockReq.config = {
+        endpoints: {
+          [EModelEndpoint.openAI]: {
+            titleConvo: false,
+            titleModel: 'gpt-3.5-turbo',
+            titlePrompt: 'Custom title prompt',
+            titleMethod: 'structured',
+            titlePromptTemplate: 'Template: {{content}}',
+          },
+        },
+      };
+
+      const text = 'Test conversation text';
+      const abortController = new AbortController();
+
+      const result = await client.titleConvo({ text, abortController });
+
+      // Should return undefined without generating title
+      expect(result).toBeUndefined();
+
+      // generateTitle should NOT have been called
+      expect(mockRun.generateTitle).not.toHaveBeenCalled();
+
+      // recordCollectedUsage should NOT have been called
+      expect(client.recordCollectedUsage).not.toHaveBeenCalled();
+    });
+
+    it('should skip title generation when titleConvo is false in all config', async () => {
+      // Set titleConvo to false in "all" config
+      mockReq.config = {
+        endpoints: {
+          all: {
+            titleConvo: false,
+            titleModel: 'gpt-4o-mini',
+            titlePrompt: 'All config title prompt',
+            titleMethod: 'completion',
+            titlePromptTemplate: 'All config template',
+          },
+        },
+      };
+
+      const text = 'Test conversation text';
+      const abortController = new AbortController();
+
+      const result = await client.titleConvo({ text, abortController });
+
+      // Should return undefined without generating title
+      expect(result).toBeUndefined();
+
+      // generateTitle should NOT have been called
+      expect(mockRun.generateTitle).not.toHaveBeenCalled();
+
+      // recordCollectedUsage should NOT have been called
+      expect(client.recordCollectedUsage).not.toHaveBeenCalled();
+    });
+
+    it('should skip title generation when titleConvo is false for custom endpoint scenario', async () => {
+      // This test validates the behavior when customEndpointConfig (retrieved via
+      // getProviderConfig for custom endpoints) has titleConvo: false.
+      //
+      // The code path is:
+      // 1. endpoints?.all is checked (undefined in this test)
+      // 2. endpoints?.[endpoint] is checked (our test config)
+      // 3. Would fall back to titleProviderConfig.customEndpointConfig (for real custom endpoints)
+      //
+      // We simulate a custom endpoint scenario using a dynamically named endpoint config
+
+      // Create a unique endpoint name that represents a custom endpoint
+      const customEndpointName = 'customEndpoint';
+
+      // Configure the endpoint to have titleConvo: false
+      // This simulates what would be in customEndpointConfig for a real custom endpoint
+      mockReq.config = {
+        endpoints: {
+          // No 'all' config - so it will check endpoints[endpoint]
+          // This config represents what customEndpointConfig would contain
+          [customEndpointName]: {
+            titleConvo: false,
+            titleModel: 'custom-model-v1',
+            titlePrompt: 'Custom endpoint title prompt',
+            titleMethod: 'completion',
+            titlePromptTemplate: 'Custom template: {{content}}',
+            baseURL: 'https://api.custom-llm.com/v1',
+            apiKey: 'test-custom-key',
+            // Additional custom endpoint properties
+            models: {
+              default: ['custom-model-v1', 'custom-model-v2'],
+            },
+          },
+        },
+      };
+
+      // Set up agent to use our custom endpoint
+      // Use openAI as base but override with custom endpoint name for this test
+      mockAgent.endpoint = EModelEndpoint.openAI;
+      mockAgent.provider = EModelEndpoint.openAI;
+
+      // Override the endpoint in the config to point to our custom config
+      mockReq.config.endpoints[EModelEndpoint.openAI] =
+        mockReq.config.endpoints[customEndpointName];
+      delete mockReq.config.endpoints[customEndpointName];
+
+      const text = 'Test custom endpoint conversation';
+      const abortController = new AbortController();
+
+      const result = await client.titleConvo({ text, abortController });
+
+      // Should return undefined without generating title because titleConvo is false
+      expect(result).toBeUndefined();
+
+      // generateTitle should NOT have been called
+      expect(mockRun.generateTitle).not.toHaveBeenCalled();
+
+      // recordCollectedUsage should NOT have been called
+      expect(client.recordCollectedUsage).not.toHaveBeenCalled();
+    });
+
     it('should pass titleEndpoint configuration to generateTitle', async () => {
       // Mock the API key just for this test
       const originalApiKey = process.env.ANTHROPIC_API_KEY;

--- a/api/server/services/Endpoints/agents/title.js
+++ b/api/server/services/Endpoints/agents/title.js
@@ -54,6 +54,11 @@ const addTitle = async (req, { text, response, client }) => {
       clearTimeout(timeoutId);
     }
 
+    if (!title) {
+      logger.debug(`[${key}] No title generated`);
+      return;
+    }
+
     await titleCache.set(key, title, 120000);
     await saveConvo(
       req,


### PR DESCRIPTION
## Summary

Closes #9802

I fixed the title generation logic to properly respect the `titleConvo` configuration setting and improved debugging output for the title generation process.

- Check for `titleConvo: false` in endpoint configuration before attempting title generation
- Return early when title generation is disabled to avoid unnecessary processing
- Add comprehensive test coverage for various scenarios where title generation should be skipped
- Improve error logging with clearer endpoint identification using quotes for better readability
- Add debug logging when no title is generated to aid in troubleshooting

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I added comprehensive test cases covering all scenarios where title generation should be skipped:

1. **Direct endpoint configuration**: When `titleConvo: false` is set in the specific endpoint config
2. **Global "all" configuration**: When `titleConvo: false` is set in the "all" endpoint config that applies to all endpoints
3. **Custom endpoint scenario**: When `titleConvo: false` is configured for custom endpoints through provider configuration

All tests verify that:
- `generateTitle` is not called when title generation is disabled
- `recordCollectedUsage` is not called when skipping title generation
- The function returns `undefined` as expected

### **Test Configuration**:
- Node.js test environment with Jest
- Mocked AgentClient dependencies and configurations
- AbortController simulation for request handling

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes