### PR TITLE
🔌 fix: Shared MCP Server Connection Management

### DIFF
--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -442,10 +442,10 @@ async function getMCPSetupData(userId) {
   }
 
   const mcpManager = getMCPManager(userId);
-  /** @type {ReturnType<MCPManager['getAllConnections']>} */
+  /** @type {Map<string, import('@librechat/api').MCPConnection>} */
   let appConnections = new Map();
   try {
-    appConnections = (await mcpManager.getAllConnections()) || new Map();
+    appConnections = (await mcpManager.appConnections?.getAll()) || new Map();
   } catch (error) {
     logger.error(`[MCP][User: ${userId}] Error getting app connections:`, error);
   }

--- a/api/server/services/MCP.spec.js
+++ b/api/server/services/MCP.spec.js
@@ -123,7 +123,7 @@ describe('tests for the new helper functions used by the MCP connection status e
     beforeEach(() => {
       mockGetAppConfig = require('./Config').getAppConfig;
       mockGetMCPManager.mockReturnValue({
-        getAllConnections: jest.fn(() => new Map()),
+        appConnections: { getAll: jest.fn(() => new Map()) },
         getUserConnections: jest.fn(() => new Map()),
         getOAuthServers: jest.fn(() => new Set()),
       });
@@ -137,7 +137,7 @@ describe('tests for the new helper functions used by the MCP connection status e
       const mockOAuthServers = new Set(['server2']);
 
       const mockMCPManager = {
-        getAllConnections: jest.fn(() => mockAppConnections),
+        appConnections: { getAll: jest.fn(() => mockAppConnections) },
         getUserConnections: jest.fn(() => mockUserConnections),
         getOAuthServers: jest.fn(() => mockOAuthServers),
       };
@@ -147,7 +147,7 @@ describe('tests for the new helper functions used by the MCP connection status e
 
       expect(mockGetAppConfig).toHaveBeenCalled();
       expect(mockGetMCPManager).toHaveBeenCalledWith(mockUserId);
-      expect(mockMCPManager.getAllConnections).toHaveBeenCalled();
+      expect(mockMCPManager.appConnections.getAll).toHaveBeenCalled();
       expect(mockMCPManager.getUserConnections).toHaveBeenCalledWith(mockUserId);
       expect(mockMCPManager.getOAuthServers).toHaveBeenCalled();
 
@@ -168,7 +168,7 @@ describe('tests for the new helper functions used by the MCP connection status e
       mockGetAppConfig.mockResolvedValue({ mcpConfig: mockConfig.mcpServers });
 
       const mockMCPManager = {
-        getAllConnections: jest.fn(() => null),
+        appConnections: { getAll: jest.fn(() => null) },
         getUserConnections: jest.fn(() => null),
         getOAuthServers: jest.fn(() => null),
       };

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -29,7 +29,7 @@ async function reinitMCPServer({
   flowManager: _flowManager,
 }) {
   /** @type {MCPConnection | null} */
-  let userConnection = null;
+  let connection = null;
   /** @type {LCAvailableTools | null} */
   let availableTools = null;
   /** @type {ReturnType<MCPConnection['fetchTools']> | null} */
@@ -50,7 +50,7 @@ async function reinitMCPServer({
       });
 
     try {
-      userConnection = await mcpManager.getUserConnection({
+      connection = await mcpManager.getConnection({
         user,
         signal,
         forceNew,
@@ -70,7 +70,7 @@ async function reinitMCPServer({
 
       logger.info(`[MCP Reinitialize] Successfully established connection for ${serverName}`);
     } catch (err) {
-      logger.info(`[MCP Reinitialize] getUserConnection threw error: ${err.message}`);
+      logger.info(`[MCP Reinitialize] getConnection threw error: ${err.message}`);
       logger.info(
         `[MCP Reinitialize] OAuth state - oauthRequired: ${oauthRequired}, oauthUrl: ${oauthUrl ? 'present' : 'null'}`,
       );
@@ -95,8 +95,8 @@ async function reinitMCPServer({
       }
     }
 
-    if (userConnection && !oauthRequired) {
-      tools = await userConnection.fetchTools();
+    if (connection && !oauthRequired) {
+      tools = await connection.fetchTools();
       availableTools = await updateMCPServerTools({
         serverName,
         tools,
@@ -111,7 +111,7 @@ async function reinitMCPServer({
       if (oauthRequired) {
         return `MCP server '${serverName}' ready for OAuth authentication`;
       }
-      if (userConnection) {
+      if (connection) {
         return `MCP server '${serverName}' reinitialized successfully`;
       }
       return `Failed to reinitialize MCP server '${serverName}'`;
@@ -119,7 +119,7 @@ async function reinitMCPServer({
 
     const result = {
       availableTools,
-      success: Boolean((userConnection && !oauthRequired) || (oauthRequired && oauthUrl)),
+      success: Boolean((connection && !oauthRequired) || (oauthRequired && oauthUrl)),
       message: getResponseMessage(),
       oauthRequired,
       serverName,

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -4,6 +4,7 @@ import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
 import { MCPServersRegistry } from '~/mcp/MCPServersRegistry';
 import { MCPConnection } from './connection';
 import type * as t from './types';
+import { ConnectionsRepository } from '~/mcp/ConnectionsRepository';
 
 /**
  * Abstract base class for managing user-specific MCP connections with lifecycle management.
@@ -14,6 +15,9 @@ import type * as t from './types';
  */
 export abstract class UserConnectionManager {
   protected readonly serversRegistry: MCPServersRegistry;
+  // Connections shared by all users.
+  public appConnections: ConnectionsRepository | null = null;
+  // Connections per userId -> serverName -> connection
   protected userConnections: Map<string, Map<string, MCPConnection>> = new Map();
   /** Last activity timestamp for users (not per server) */
   protected userLastActivity: Map<string, number> = new Map();
@@ -58,6 +62,13 @@ export abstract class UserConnectionManager {
     const userId = user.id;
     if (!userId) {
       throw new McpError(ErrorCode.InvalidRequest, `[MCP] User object missing id property`);
+    }
+
+    if (this.appConnections!.has(serverName)) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `[MCP][User: ${userId}] Trying to create user-specific connection for app-level server "${serverName}"`,
+      );
     }
 
     const userServerMap = this.userConnections.get(userId);


### PR DESCRIPTION
In `reinitMCPServer`, a user-level connection is always created even when the server is app-level. When combined with memory-intensive stdio MCP servers, this causes severe memory issue for the LibreChat backend. This has happened before in the past where `MCPManager.callTool` always created a user-level connection.

This PR does not only attempt to fix this bug in `reinitMCPServer` but it will also prevent this from happening again in the future:
- Made MCPManager.getUserConnection to return an error if the connection is app-level
- Add MCPManager.getConnection to return either an app connection or a user connection based on the serverName
- Made MCPManager.appConnections public to avoid unnecessary wrapper methods.


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring 

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
