### PR TITLE
👤 fix: Missing User Placeholder Fields for MCP Services

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -1,8 +1,13 @@
 const { logger } = require('@librechat/data-schemas');
 const { SerpAPI } = require('@langchain/community/tools/serpapi');
 const { Calculator } = require('@langchain/community/tools/calculator');
-const { mcpToolPattern, loadWebSearchAuth, checkAccess } = require('@librechat/api');
 const { EnvVar, createCodeExecutionTool, createSearchTool } = require('@librechat/agents');
+const {
+  checkAccess,
+  createSafeUser,
+  mcpToolPattern,
+  loadWebSearchAuth,
+} = require('@librechat/api');
 const {
   Tools,
   Constants,
@@ -410,6 +415,7 @@ Current Date & Time: ${replaceSpecialVars({ text: '{{iso_datetime}}' })}
   /** MCP server tools are initialized sequentially by server */
   let index = -1;
   const failedMCPServers = new Set();
+  const safeUser = createSafeUser(options.req?.user);
   for (const [serverName, toolConfigs] of Object.entries(requestedMCPTools)) {
     index++;
     /** @type {LCAvailableTools} */
@@ -420,14 +426,14 @@ Current Date & Time: ${replaceSpecialVars({ text: '{{iso_datetime}}' })}
           continue;
         }
         const mcpParams = {
-          res: options.res,
-          userId: user,
           index,
-          serverName: config.serverName,
-          userMCPAuthMap,
-          model: agent?.model ?? model,
-          provider: agent?.provider ?? endpoint,
           signal,
+          user: safeUser,
+          userMCPAuthMap,
+          res: options.res,
+          model: agent?.model ?? model,
+          serverName: config.serverName,
+          provider: agent?.provider ?? endpoint,
         };
 
         if (config.type === 'all' && toolConfigs.length === 1) {

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -7,7 +7,7 @@ const { getLogStores } = require('~/cache');
 
 /**
  * @param {Object} params
- * @param {string} params.userId
+ * @param {IUser} params.user - The user from the request object.
  * @param {string} params.serverName - The name of the MCP server
  * @param {boolean} params.returnOnOAuth - Whether to initiate OAuth and return, or wait for OAuth flow to finish
  * @param {AbortSignal} [params.signal] - The abort signal to handle cancellation.
@@ -18,7 +18,7 @@ const { getLogStores } = require('~/cache');
  * @param {Record<string, Record<string, string>>} [params.userMCPAuthMap]
  */
 async function reinitMCPServer({
-  userId,
+  user,
   signal,
   forceNew,
   serverName,
@@ -51,7 +51,7 @@ async function reinitMCPServer({
 
     try {
       userConnection = await mcpManager.getUserConnection({
-        user: { id: userId },
+        user,
         signal,
         forceNew,
         oauthStart,

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -1,5 +1,6 @@
 import { extractEnvVariable } from 'librechat-data-provider';
 import type { TUser, MCPOptions } from 'librechat-data-provider';
+import type { IUser } from '@librechat/data-schemas';
 import type { RequestBody } from '~/types';
 
 /**
@@ -25,6 +26,31 @@ const ALLOWED_USER_FIELDS = [
   'twoFactorEnabled',
   'termsAccepted',
 ] as const;
+
+type AllowedUserField = (typeof ALLOWED_USER_FIELDS)[number];
+type SafeUser = Pick<IUser, AllowedUserField>;
+
+/**
+ * Creates a safe user object containing only allowed fields.
+ * Optimized for performance while maintaining type safety.
+ *
+ * @param user - The user object to extract safe fields from
+ * @returns A new object containing only allowed fields
+ */
+export function createSafeUser(user: IUser | null | undefined): Partial<SafeUser> {
+  if (!user) {
+    return {};
+  }
+
+  const safeUser: Partial<SafeUser> = {};
+  for (const field of ALLOWED_USER_FIELDS) {
+    if (field in user) {
+      safeUser[field] = user[field];
+    }
+  }
+
+  return safeUser;
+}
 
 /**
  * List of allowed request body fields that can be used in header placeholders.


### PR DESCRIPTION
## Summary

I fixed user handling across MCP services by implementing proper user parameter passing and adding missing user placeholder field support throughout the MCP tooling system. This bug was introduced in 5b1a31ef4d18cb01f45f791a24e99d15ab7432c4

- Refactored `handleTools.js` to use `createSafeUser` utility and pass complete user objects instead of just user IDs to MCP tools
- Updated MCP route handlers to utilize safe user objects with proper user field extraction 
- Modified MCP service functions (`createMCPTools`, `createMCPTool`, `reconnectServer`) to accept full user objects instead of string user IDs
- Added comprehensive test coverage for user parameter passing integrity across MCP service functions
- Created `createSafeUser` utility function in `env.ts` to extract only allowed user fields for security while maintaining type safety
- Enhanced MCP server reinitialization to properly handle user context with complete user data
- Fixed OAuth flow handling to include proper user context throughout connection lifecycle

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Added tests to ensure user with more fields than just ID are passed

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.