### PR TITLE
🔍 refactor: OCR Fully Optional with Defaults for "Upload as Text"

### DIFF
--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -1,16 +1,12 @@
+const { FileSources, EModelEndpoint, getConfigDefaults } = require('librechat-data-provider');
 const {
   isEnabled,
+  loadOCRConfig,
   loadMemoryConfig,
   agentsConfigSetup,
   loadWebSearchConfig,
   loadDefaultInterface,
 } = require('@librechat/api');
-const {
-  FileSources,
-  loadOCRConfig,
-  EModelEndpoint,
-  getConfigDefaults,
-} = require('librechat-data-provider');
 const {
   checkWebSearchConfig,
   checkVariables,

--- a/api/server/services/AppService.spec.js
+++ b/api/server/services/AppService.spec.js
@@ -142,7 +142,6 @@ describe('AppService', () => {
         turnstileConfig: mockedTurnstileConfig,
         modelSpecs: undefined,
         paths: expect.anything(),
-        ocr: expect.anything(),
         imageOutputType: expect.any(String),
         fileConfig: undefined,
         secureImageLinks: undefined,

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -594,10 +594,9 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
 
     const fileConfig = mergeFileConfig(appConfig.fileConfig);
 
-    const shouldUseOCR = fileConfig.checkType(
-      file.mimetype,
-      fileConfig.ocr?.supportedMimeTypes || [],
-    );
+    const shouldUseOCR =
+      appConfig?.ocr != null &&
+      fileConfig.checkType(file.mimetype, fileConfig.ocr?.supportedMimeTypes || []);
 
     if (shouldUseOCR && !(await checkCapability(req, AgentCapabilities.ocr))) {
       throw new Error('OCR capability is not enabled for Agents');
@@ -626,7 +625,7 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
     );
 
     if (!shouldUseText) {
-      throw new Error(`File type ${file.mimetype} is not supported for OCR or text parsing`);
+      throw new Error(`File type ${file.mimetype} is not supported for text parsing.`);
     }
 
     const { text, bytes } = await parseText({ req, file, file_id });

--- a/packages/api/src/files/index.ts
+++ b/packages/api/src/files/index.ts
@@ -1,4 +1,5 @@
-export * from './mistral/crud';
 export * from './audio';
-export * from './text';
+export * from './mistral/crud';
+export * from './ocr';
 export * from './parse';
+export * from './text';

--- a/packages/api/src/files/mistral/crud.ts
+++ b/packages/api/src/files/mistral/crud.ts
@@ -303,7 +303,7 @@ async function loadAuthConfig(context: OCRContext): Promise<AuthConfig> {
 /**
  * Gets the model configuration
  */
-function getModelConfig(ocrConfig: TCustomConfig['ocr']): string {
+function getModelConfig(ocrConfig?: TCustomConfig['ocr']): string {
   const modelConfig = ocrConfig?.mistralModel || '';
 
   if (!modelConfig.trim()) {

--- a/packages/api/src/files/ocr.ts
+++ b/packages/api/src/files/ocr.ts
@@ -1,7 +1,8 @@
-import type { TCustomConfig } from '../src/config';
-import { OCRStrategy } from '../src/config';
+import { OCRStrategy } from 'librechat-data-provider';
+import type { TCustomConfig } from 'librechat-data-provider';
 
-export function loadOCRConfig(config: TCustomConfig['ocr']): TCustomConfig['ocr'] {
+export function loadOCRConfig(config?: TCustomConfig['ocr']): TCustomConfig['ocr'] | undefined {
+  if (!config) return;
   const baseURL = config?.baseURL ?? '';
   const apiKey = config?.apiKey ?? '';
   const mistralModel = config?.mistralModel ?? '';

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -133,7 +133,7 @@ export const defaultOCRMimeTypes = [
   /^application\/epub\+zip$/,
 ];
 
-export const defaultTextMimeTypes = [textMimeTypes];
+export const defaultTextMimeTypes = [/^[\w.-]+\/[\w.-]+$/];
 
 export const defaultSTTMimeTypes = [audioMimeTypes];
 

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -9,7 +9,6 @@ export * from './messages';
 export * from './artifacts';
 /* schema helpers  */
 export * from './parsers';
-export * from './ocr';
 /* custom/dynamic configurations  */
 export * from './generate';
 export * from './models';


### PR DESCRIPTION
## Summary

Made OCR capability fully optional when uploading files as text and using all default configurations for `fileConfig`, `ocr` (not provided), and `context` capability is enabled.

- Changed OCR capability check to properly verify that OCR configuration exists before attempting capability validation
- Updated defaultTextMimeTypes to support virtually all file types for text parsing using a universal regex pattern
- Moved loadOCRConfig function from packages/data-provider to packages/api and updated import in `AppService`
- Modified loadOCRConfig to return undefined when OCR is not explicitly configured instead of empty configuration
- Updated error message for unsupported file types to be more accurate and remove OCR reference when not applicable
- Added proper type annotation for optional OCR configuration parameter in getModelConfig function

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

I tested the changes by verifying that OCR capability checks work correctly when OCR is not configured, and that file uploads with various MIME types are properly handled during text parsing operations.

### **Test Configuration**:
- LibreChat development environment
- Various file types for upload testing
- OCR enabled/disabled configurations

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes