### PR TITLE
📌 fix: Exclude Pinned Keys from Cleanup and Fix MCP Pin State

### DIFF
--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -69,7 +69,7 @@ function MCPSelectContent() {
     [getServerStatusIconProps, isInitializing],
   );
 
-  if (!isPinned && mcpValues.length === 0) {
+  if (!isPinned && mcpValues?.length === 0) {
     return null;
   }
 

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -8,6 +8,7 @@ function MCPSelectContent() {
   const { conversationId, mcpServerManager } = useBadgeRowContext();
   const {
     localize,
+    isPinned,
     mcpValues,
     isInitializing,
     placeholderText,
@@ -67,6 +68,10 @@ function MCPSelectContent() {
     },
     [getServerStatusIconProps, isInitializing],
   );
+
+  if (!isPinned && mcpValues.length === 0) {
+    return null;
+  }
 
   const configDialogProps = getConfigDialogProps();
 

--- a/client/src/utils/timestamps.ts
+++ b/client/src/utils/timestamps.ts
@@ -84,7 +84,9 @@ export function cleanupTimestampedStorage(): void {
       }
 
       // Check if this key should be timestamped
-      const isTimestampedKey = TIMESTAMPED_KEYS.some((prefix) => key.startsWith(prefix));
+      const isTimestampedKey = TIMESTAMPED_KEYS.some(
+        (prefix) => key.startsWith(prefix) && !key.includes('pinned'),
+      );
 
       if (isTimestampedKey && !key.endsWith(TIMESTAMP_SUFFIX)) {
         const timestampKey = `${key}${TIMESTAMP_SUFFIX}`;


### PR DESCRIPTION
## Summary

- Exclude pinned storage keys from timestamped storage cleanup logic to preserve user-pinned data
- Prevent MCPSelect component from rendering when not pinned and no values are available
- Modify the `isTimestampedKey` check to filter out keys containing 'pinned' in the cleanup function
- Add early return in MCPSelectContent when component should not be displayed
- Ensure pinned items are preserved during cleanup operations while maintaining proper UI state

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested these changes by verifying that pinned storage items persist through cleanup cycles and that the MCPSelect component properly hides when it has no content to display and is not pinned.

### **Test Configuration**:
- Verified pinned storage keys remain intact during cleanup
- Confirmed MCPSelect renders only when appropriate (pinned or has values)
- Tested storage cleanup functionality with mixed pinned/unpinned keys

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes