### PR TITLE
🔓 feat: Expose Env Field in Helm Deployment Template

### DIFF
--- a/helm/librechat/templates/deployment.yaml
+++ b/helm/librechat/templates/deployment.yaml
@@ -84,15 +84,9 @@ spec:
               name: {{ .Values.global.librechat.existingSecretName }}
               optional: true
           {{- end }}
-          {{- range .Values.global.librechat.extraSecretNames }}
-          - secretRef:
-              name: {{ . }}
-              optional: true
-          {{- end }}
-          {{- range .Values.global.librechat.extraConfigMapNames }}
-          - configMapRef:
-              name: {{ . }}
-              optional: true
+          {{- with .Values.global.librechat.env }}
+          env:
+          {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:
       {{- if or .Values.librechat.configYamlContent .Values.librechat.existingConfigYaml }}

--- a/helm/librechat/templates/deployment.yaml
+++ b/helm/librechat/templates/deployment.yaml
@@ -84,6 +84,16 @@ spec:
               name: {{ .Values.global.librechat.existingSecretName }}
               optional: true
           {{- end }}
+          {{- range .Values.global.librechat.extraSecretNames }}
+          - secretRef:
+              name: {{ . }}
+              optional: true
+          {{- end }}
+          {{- range .Values.global.librechat.extraConfigMapNames }}
+          - configMapRef:
+              name: {{ . }}
+              optional: true
+          {{- end }}
       volumes:
       {{- if or .Values.librechat.configYamlContent .Values.librechat.existingConfigYaml }}
       - name: config-yaml

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -7,14 +7,26 @@ replicaCount: 1
 
 
 global:
-   # existing Secret for all envs/ only Passwords. Can be locally generated with: kubectl create secret generic librechat-secret-envs --from-env-file=.env.example --dry-run=client -o yaml > secret-envs.yaml
+   # default Secret for envs/ only Passwords. Can be locally generated with: kubectl create secret generic librechat-secret-envs --from-env-file=.env.example --dry-run=client -o yaml > secret-envs.yaml
    # For better maintainabillity, you can put all vars directly in the config Section and only overwrite Secrets with this if nessesary.
    # Required Values:
+   # - CREDS_KEY
+   # - CREDS_IV
+   # - JWT_SECRET
+   # - JWT_REFRESH_SECRET
    # - MEILI_MASTER_KEY
   librechat:
     existingSecretName: "librechat-credentials-env"
     # Used for Setting the Right Key, can be something like AZURE_API_KEY, if Azure OpenAI is used
     existingSecretApiKey: OPENAI_API_KEY
+    # Optionally add names of extra secrets here. They will be merged with the default secret
+    # extraSecretNames:
+    #  - shared-secret
+    #  - extra-secret 
+    # Optioanlly add names of extra config maps here. They will be merged with the default config map
+    # extraConfigMapNames:
+    #  - librechat-extra-config
+    #  - shared-config
 
 librechat:
   configEnv:
@@ -27,12 +39,6 @@ librechat:
     JWT_REFRESH_SECRET: eaa5191f2914e30b9387fd84e254e4ba6fc51b4654968a9b0803b456a54b8418
     # Set Config Params here
     # ENV_NAME: env-value
-
-    # existing Secret for all envs/ only Passwords. Can be locally generated with: kubectl create secret generic librechat-secret-envs --from-env-file=.env.example --dry-run=client -o yaml > secret-envs.yaml
-    # For better maintainabillity, you can put all vars directly in the config Section and only overwrite Secrets with this if nessesary.
-    # Required Values:
-    # - MEILI_MASTER_KEY
-  existingSecretName: "librechat-credentials-env"
   
   # For adding a custom config yaml-file you can set the contents in this var. See https://www.librechat.ai/docs/configuration/librechat_yaml/example
   configYamlContent: ""

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -19,14 +19,18 @@ global:
     existingSecretName: "librechat-credentials-env"
     # Used for Setting the Right Key, can be something like AZURE_API_KEY, if Azure OpenAI is used
     existingSecretApiKey: OPENAI_API_KEY
-    # Optionally add names of extra secrets here. They will be merged with the default secret
-    # extraSecretNames:
-    #  - shared-secret
-    #  - extra-secret 
-    # Optioanlly add names of extra config maps here. They will be merged with the default config map
-    # extraConfigMapNames:
-    #  - librechat-extra-config
-    #  - shared-config
+    # Optionally add extra globally accessible environment variables here. These can be referenced under ConfigEnv to make them accessible inside LibreChat
+    # env:
+    #  - name: API_KEY
+    #    valueFrom:
+    #      secretKeyRef:
+    #        name: api_access
+    #        key: api_key
+    #  - name: CLIENT_ID
+    #    valueFrom:
+    #      secretKeyRef:
+    #        name: credentials
+    #        key: client_id
 
 librechat:
   configEnv:

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -43,6 +43,12 @@ librechat:
     JWT_REFRESH_SECRET: eaa5191f2914e30b9387fd84e254e4ba6fc51b4654968a9b0803b456a54b8418
     # Set Config Params here
     # ENV_NAME: env-value
+
+    # existing Secret for all envs/ only Passwords. Can be locally generated with: kubectl create secret generic librechat-secret-envs --from-env-file=.env.example --dry-run=client -o yaml > secret-envs.yaml
+    # For better maintainabillity, you can put all vars directly in the config Section and only overwrite Secrets with this if nessesary.
+    # Required Values:
+    # - MEILI_MASTER_KEY
+  existingSecretName: "librechat-credentials-env"
   
   # For adding a custom config yaml-file you can set the contents in this var. See https://www.librechat.ai/docs/configuration/librechat_yaml/example
   configYamlContent: ""


### PR DESCRIPTION
This PR adds support for specifying environment variables from secrets and config maps using the standard `env` field when using helm for deployment.

This is particularly useful in an enterprise setting where secrets and config may be spread over multiple resources and manually merging all of these into a new `librechat-credentials-env` secret is painful and error prone

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [X] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
