### PR TITLE
❇️ feat: Add Gemini 2.5 Default Models & Pricing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -163,10 +163,10 @@ GOOGLE_KEY=user_provided
 # GOOGLE_AUTH_HEADER=true
 
 # Gemini API (AI Studio)
-# GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.5-flash-lite-preview-06-17,gemini-2.0-flash,gemini-2.0-flash-lite
+# GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash,gemini-2.0-flash-lite
 
 # Vertex AI
-# GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.5-flash-lite-preview-06-17,gemini-2.0-flash-001,gemini-2.0-flash-lite-001
+# GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001
 
 # GOOGLE_TITLE_MODEL=gemini-2.0-flash-lite-001
 

--- a/.env.example
+++ b/.env.example
@@ -163,10 +163,10 @@ GOOGLE_KEY=user_provided
 # GOOGLE_AUTH_HEADER=true
 
 # Gemini API (AI Studio)
-# GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite-preview-06-17,gemini-2.0-flash,gemini-2.0-flash-lite
+# GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.5-flash-lite-preview-06-17,gemini-2.0-flash,gemini-2.0-flash-lite
 
 # Vertex AI
-# GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite-preview-06-17,gemini-2.0-flash-001,gemini-2.0-flash-lite-001
+# GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.5-flash-lite-preview-06-17,gemini-2.0-flash-001,gemini-2.0-flash-lite-001
 
 # GOOGLE_TITLE_MODEL=gemini-2.0-flash-lite-001
 

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -124,7 +124,8 @@ const tokenValues = Object.assign(
     'gemini-2.0-flash': { prompt: 0.1, completion: 0.4 },
     'gemini-2.0': { prompt: 0, completion: 0 }, // https://ai.google.dev/pricing
     'gemini-2.5-pro': { prompt: 1.25, completion: 10 },
-    'gemini-2.5-flash': { prompt: 0.15, completion: 3.5 },
+    'gemini-2.5-flash': { prompt: 0.3, completion: 2.5 },
+    'gemini-2.5-flash-lite': { prompt: 0.075, completion: 0.4 },
     'gemini-2.5': { prompt: 0, completion: 0 }, // Free for a period of time
     'gemini-1.5-flash-8b': { prompt: 0.075, completion: 0.3 },
     'gemini-1.5-flash': { prompt: 0.15, completion: 0.6 },

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -571,6 +571,9 @@ describe('getCacheMultiplier', () => {
 
 describe('Google Model Tests', () => {
   const googleModels = [
+    'gemini-2.5-pro',
+    'gemini-2.5-flash',
+    'gemini-2.5-flash-lite',
     'gemini-2.5-pro-preview-05-06',
     'gemini-2.5-flash-preview-04-17',
     'gemini-2.5-exp',
@@ -611,6 +614,9 @@ describe('Google Model Tests', () => {
 
   it('should map to the correct model keys', () => {
     const expected = {
+      'gemini-2.5-pro': 'gemini-2.5-pro',
+      'gemini-2.5-flash': 'gemini-2.5-flash',
+      'gemini-2.5-flash-lite': 'gemini-2.5-flash-lite',
       'gemini-2.5-pro-preview-05-06': 'gemini-2.5-pro',
       'gemini-2.5-flash-preview-04-17': 'gemini-2.5-flash',
       'gemini-2.5-exp': 'gemini-2.5',

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -262,6 +262,15 @@ describe('getModelMaxTokens', () => {
     expect(getModelMaxTokens('gemini-1.5-pro-preview-0409', EModelEndpoint.google)).toBe(
       maxTokensMap[EModelEndpoint.google]['gemini-1.5'],
     );
+    expect(getModelMaxTokens('gemini-2.5-pro', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google]['gemini-2.5-pro'],
+    );
+    expect(getModelMaxTokens('gemini-2.5-flash', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google]['gemini-2.5-flash'],
+    );
+    expect(getModelMaxTokens('gemini-2.5-flash-lite', EModelEndpoint.google)).toBe(
+      maxTokensMap[EModelEndpoint.google]['gemini-2.5-flash-lite'],
+    );
     expect(getModelMaxTokens('gemini-pro-vision', EModelEndpoint.google)).toBe(
       maxTokensMap[EModelEndpoint.google]['gemini-pro-vision'],
     );

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -91,6 +91,7 @@ const googleModels = {
   'gemini-2.5': 1000000, // 1M input tokens, 64k output tokens
   'gemini-2.5-pro': 1000000,
   'gemini-2.5-flash': 1000000,
+  'gemini-2.5-flash-lite': 1000000,
   'gemini-2.0': 2000000,
   'gemini-2.0-flash': 1000000,
   'gemini-2.0-flash-lite': 1000000,

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1019,16 +1019,7 @@ export const defaultModels = {
     'gemini-2.5-flash-lite',
     // Gemini 2.0 Models
     'gemini-2.0-flash-001',
-    'gemini-2.0-flash-exp',
     'gemini-2.0-flash-lite',
-    'gemini-2.0-pro-exp-02-05',
-    // Gemini 1.5 Models
-    'gemini-1.5-flash-001',
-    'gemini-1.5-flash-002',
-    'gemini-1.5-pro-001',
-    'gemini-1.5-pro-002',
-    // Gemini 1.0 Models
-    'gemini-1.0-pro-001',
   ],
   [EModelEndpoint.anthropic]: sharedAnthropicModels,
   [EModelEndpoint.openAI]: [

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1013,6 +1013,10 @@ export const defaultModels = {
   [EModelEndpoint.assistants]: [...sharedOpenAIModels, 'chatgpt-4o-latest'],
   [EModelEndpoint.agents]: sharedOpenAIModels, // TODO: Add agent models (agentsModels)
   [EModelEndpoint.google]: [
+    // Gemini 2.5 Models
+    'gemini-2.5-pro',
+    'gemini-2.5-flash',
+    'gemini-2.5-flash-lite',
     // Gemini 2.0 Models
     'gemini-2.0-flash-001',
     'gemini-2.0-flash-exp',
@@ -1107,6 +1111,7 @@ export const visionModels = [
   'gemini-exp',
   'gemini-1.5',
   'gemini-2',
+  'gemini-2.5',
   'gemini-3',
   'moondream',
   'llama3.2-vision',


### PR DESCRIPTION
## Summary

- **Added three new Gemini 2.5 models**: `gemini-2.5-pro`, `gemini-2.5-flash`, and `gemini-2.5-flash-lite`
- **Removed deprecated Gemini 1.5 and experimental models** that have been retired by [Google documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions)
- **Updated token pricing configuration** with accurate pricing for the new models
- **Updated environment configuration examples** to include only current models


## Change Type

- [x] New feature (non-breaking change which adds functionality)


## Testing

The changes have been tested by:

``` bash
cd api
npm test api/models/tx.spec.js
npm test api/utils/tokens.spec.js
```

Experiments conducted on September 30, 2025, across both Vertex AI and AI Studio are summarized below:

| Model | Vertex AI | AI Studio |
| --- | ---: | ---: |
| gemini-2.5-pro | ✅ | ✅ |
| gemini-2.5-flash | ✅ | ✅ |
| gemini-2.5-flash-lite | ✅ | ✅ |
| gemini-2.0-flash | ✅ | ✅ |
| gemini-2.0-flash-001 | ✅ | ✅ |
| gemini-2.0-flash-lite | ✅ | ✅ |
| gemini-2.0-flash-lite-001 | ✅ | ✅ |
| gemini-2.0-flash-exp | ✅ | ✅ |
| gemini-2.0-pro-exp-02-05 | ❌ | ❌ (Too Many Requests) |
| gemini-1.5-flash-002 | ❌ | ❌ |
| gemini-2.5-flash-lite-preview-06-17 | ❌ | ✅ |
| gemini-2.5-flash-lite-preview-09-2025 | ❌ | ✅ |


## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes`