### PR TITLE
🧱 fix: DALL-E Proxy Bypass

### DIFF
--- a/api/app/clients/tools/structured/DALLE3.js
+++ b/api/app/clients/tools/structured/DALLE3.js
@@ -1,9 +1,8 @@
 const { z } = require('zod');
 const path = require('path');
 const OpenAI = require('openai');
-const fetch = require('node-fetch');
 const { v4: uuidv4 } = require('uuid');
-const { ProxyAgent } = require('undici');
+const { ProxyAgent, fetch } = require('undici');
 const { Tool } = require('@langchain/core/tools');
 const { logger } = require('@librechat/data-schemas');
 const { getImageBasename } = require('@librechat/api');


### PR DESCRIPTION
## Summary

This PR fixes a proxy bypass by the DALL-E plugin. node-fetch is not supporting GET methods with undici. The fix uses the fetch from undici.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The enviroment for reproducing the error ist described in https://github.com/danny-avila/LibreChat/discussions/9037 

Testing was done in npm/Docker by changing old/new versions of DALLE3.js

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
