### PR TITLE
🫴 refactor: Broader Support for GPT-OSS Naming

### DIFF
--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -152,7 +152,10 @@ const tokenValues = Object.assign(
     'ministral-8b': { prompt: 0.1, completion: 0.1 },
     'ministral-3b': { prompt: 0.04, completion: 0.04 },
     // GPT-OSS models
+    'gpt-oss': { prompt: 0.05, completion: 0.2 },
+    'gpt-oss:20b': { prompt: 0.05, completion: 0.2 },
     'gpt-oss-20b': { prompt: 0.05, completion: 0.2 },
+    'gpt-oss:120b': { prompt: 0.15, completion: 0.6 },
     'gpt-oss-120b': { prompt: 0.15, completion: 0.6 },
   },
   bedrockValues,

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -184,6 +184,16 @@ describe('getValueKey', () => {
     expect(getValueKey('claude-3.5-haiku-turbo')).toBe('claude-3.5-haiku');
     expect(getValueKey('claude-3.5-haiku-0125')).toBe('claude-3.5-haiku');
   });
+
+  it('should return expected value keys for "gpt-oss" models', () => {
+    expect(getValueKey('openai/gpt-oss-120b')).toBe('gpt-oss-120b');
+    expect(getValueKey('openai/gpt-oss:120b')).toBe('gpt-oss:120b');
+    expect(getValueKey('openai/gpt-oss-570b')).toBe('gpt-oss');
+    expect(getValueKey('gpt-oss-570b')).toBe('gpt-oss');
+    expect(getValueKey('groq/gpt-oss-1080b')).toBe('gpt-oss');
+    expect(getValueKey('gpt-oss-20b')).toBe('gpt-oss-20b');
+    expect(getValueKey('oai/gpt-oss:20b')).toBe('gpt-oss:20b');
+  });
 });
 
 describe('getMultiplier', () => {

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -396,8 +396,15 @@ describe('getModelMaxTokens', () => {
   });
 
   test('should return correct tokens for GPT-OSS models', () => {
-    const expected = maxTokensMap[EModelEndpoint.openAI]['gpt-oss-20b'];
-    ['gpt-oss-20b', 'gpt-oss-120b', 'openai/gpt-oss-20b', 'openai/gpt-oss-120b'].forEach((name) => {
+    const expected = maxTokensMap[EModelEndpoint.openAI]['gpt-oss'];
+    [
+      'gpt-oss:20b',
+      'gpt-oss-20b',
+      'gpt-oss-120b',
+      'openai/gpt-oss-20b',
+      'openai/gpt-oss-120b',
+      'openai/gpt-oss:120b',
+    ].forEach((name) => {
       expect(getModelMaxTokens(name)).toBe(expected);
     });
   });

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -257,7 +257,10 @@ const aggregateModels = {
   // misc.
   kimi: 131000,
   // GPT-OSS
+  'gpt-oss': 131000,
+  'gpt-oss:20b': 131000,
   'gpt-oss-20b': 131000,
+  'gpt-oss:120b': 131000,
   'gpt-oss-120b': 131000,
 };
 


### PR DESCRIPTION
## Summary

I expanded support for GPT-OSS model naming conventions to handle colon-separated variant syntax alongside the existing dash-separated format.

- Added token pricing configurations for colon-separated GPT-OSS variants (`gpt-oss:20b`, `gpt-oss:120b`)
- Included base `gpt-oss` model pricing as a fallback for unrecognized variants
- Updated token limit mappings in `aggregateModels` to support the new naming patterns
- Enhanced test coverage in `tx.spec.js` to validate `getValueKey` behavior for both colon and dash naming formats
- Extended `tokens.spec.js` tests to verify `getModelMaxTokens` correctly handles prefixed model names with both separators
- Ensured pricing consistency across all GPT-OSS model variants regardless of naming convention

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

I verified the changes through unit tests covering both the token pricing and max token retrieval logic for GPT-OSS models.

### **Test Configuration**:
- Ran existing test suites in `tx.spec.js` and `tokens.spec.js`
- Validated that both `gpt-oss:20b`/`gpt-oss:120b` and `gpt-oss-20b`/`gpt-oss-120b` formats return correct values
- Confirmed fallback to base `gpt-oss` pricing for unrecognized variants like `gpt-oss-570b`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes