### PR TITLE
🤖 feat: Add Z.AI GLM Context Window & Pricing

### DIFF
--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -157,6 +157,13 @@ const tokenValues = Object.assign(
     'gpt-oss-20b': { prompt: 0.05, completion: 0.2 },
     'gpt-oss:120b': { prompt: 0.15, completion: 0.6 },
     'gpt-oss-120b': { prompt: 0.15, completion: 0.6 },
+    // GLM models (Zhipu AI)
+    'glm-4': { prompt: 0.1, completion: 0.1 },
+    'glm-4-32b': { prompt: 0.1, completion: 0.1 },
+    'glm-4.5': { prompt: 0.35, completion: 1.55 },
+    'glm-4.5v': { prompt: 0.6, completion: 1.8 },
+    'glm-4.5-air': { prompt: 0.14, completion: 0.86 },
+    'glm-4.6': { prompt: 0.5, completion: 1.75 },
   },
   bedrockValues,
 );

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -158,6 +158,7 @@ const tokenValues = Object.assign(
     'gpt-oss:120b': { prompt: 0.15, completion: 0.6 },
     'gpt-oss-120b': { prompt: 0.15, completion: 0.6 },
     // GLM models (Zhipu AI)
+    glm4: { prompt: 0.1, completion: 0.1 },
     'glm-4': { prompt: 0.1, completion: 0.1 },
     'glm-4-32b': { prompt: 0.1, completion: 0.1 },
     'glm-4.5': { prompt: 0.35, completion: 1.55 },

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -404,6 +404,18 @@ describe('getMultiplier', () => {
       expect(getMultiplier({ model: key, tokenType: 'completion' })).toBe(expectedCompletion);
     });
   });
+
+  it('should return correct multipliers for GLM models', () => {
+    const models = ['glm-4.6', 'glm-4.5v', 'glm-4.5-air', 'glm-4.5', 'glm-4-32b', 'glm-4'];
+    models.forEach((key) => {
+      const expectedPrompt = tokenValues[key].prompt;
+      const expectedCompletion = tokenValues[key].completion;
+      expect(getMultiplier({ valueKey: key, tokenType: 'prompt' })).toBe(expectedPrompt);
+      expect(getMultiplier({ valueKey: key, tokenType: 'completion' })).toBe(expectedCompletion);
+      expect(getMultiplier({ model: key, tokenType: 'prompt' })).toBe(expectedPrompt);
+      expect(getMultiplier({ model: key, tokenType: 'completion' })).toBe(expectedCompletion);
+    });
+  });
 });
 
 describe('AWS Bedrock Model Tests', () => {
@@ -779,6 +791,104 @@ describe('Grok Model Tests - Pricing', () => {
         tokenValues['grok-4'].completion,
       );
     });
+  });
+});
+
+describe('GLM Model Tests', () => {
+  it('should return expected value keys for GLM models', () => {
+    expect(getValueKey('glm-4.6')).toBe('glm-4.6');
+    expect(getValueKey('glm-4.5')).toBe('glm-4.5');
+    expect(getValueKey('glm-4.5v')).toBe('glm-4.5v');
+    expect(getValueKey('glm-4.5-air')).toBe('glm-4.5-air');
+    expect(getValueKey('glm-4-32b')).toBe('glm-4-32b');
+    expect(getValueKey('glm-4')).toBe('glm-4');
+  });
+
+  it('should match GLM model variations with provider prefixes', () => {
+    expect(getValueKey('z-ai/glm-4.6')).toBe('glm-4.6');
+    expect(getValueKey('z-ai/glm-4.5')).toBe('glm-4.5');
+    expect(getValueKey('z-ai/glm-4.5-air')).toBe('glm-4.5-air');
+    expect(getValueKey('z-ai/glm-4.5v')).toBe('glm-4.5v');
+    expect(getValueKey('z-ai/glm-4-32b')).toBe('glm-4-32b');
+
+    expect(getValueKey('zai/glm-4.6')).toBe('glm-4.6');
+    expect(getValueKey('zai/glm-4.5')).toBe('glm-4.5');
+    expect(getValueKey('zai/glm-4.5-air')).toBe('glm-4.5-air');
+    expect(getValueKey('zai/glm-4.5v')).toBe('glm-4.5v');
+
+    expect(getValueKey('zai-org/GLM-4.6')).toBe('glm-4.6');
+    expect(getValueKey('zai-org/GLM-4.5')).toBe('glm-4.5');
+    expect(getValueKey('zai-org/GLM-4.5-Air')).toBe('glm-4.5-air');
+    expect(getValueKey('zai-org/GLM-4.5V')).toBe('glm-4.5v');
+    expect(getValueKey('zai-org/GLM-4-32B-0414')).toBe('glm-4-32b');
+  });
+
+  it('should match GLM model variations with suffixes', () => {
+    expect(getValueKey('glm-4.6-fp8')).toBe('glm-4.6');
+    expect(getValueKey('zai-org/GLM-4.6-FP8')).toBe('glm-4.6');
+    expect(getValueKey('zai-org/GLM-4.5-Air-FP8')).toBe('glm-4.5-air');
+  });
+
+  it('should prioritize more specific GLM model patterns', () => {
+    expect(getValueKey('glm-4.5-air-something')).toBe('glm-4.5-air');
+    expect(getValueKey('glm-4.5-something')).toBe('glm-4.5');
+    expect(getValueKey('glm-4.5v-something')).toBe('glm-4.5v');
+  });
+
+  it('should return correct multipliers for all GLM models', () => {
+    expect(getMultiplier({ model: 'glm-4.6', tokenType: 'prompt' })).toBe(
+      tokenValues['glm-4.6'].prompt,
+    );
+    expect(getMultiplier({ model: 'glm-4.6', tokenType: 'completion' })).toBe(
+      tokenValues['glm-4.6'].completion,
+    );
+
+    expect(getMultiplier({ model: 'glm-4.5v', tokenType: 'prompt' })).toBe(
+      tokenValues['glm-4.5v'].prompt,
+    );
+    expect(getMultiplier({ model: 'glm-4.5v', tokenType: 'completion' })).toBe(
+      tokenValues['glm-4.5v'].completion,
+    );
+
+    expect(getMultiplier({ model: 'glm-4.5-air', tokenType: 'prompt' })).toBe(
+      tokenValues['glm-4.5-air'].prompt,
+    );
+    expect(getMultiplier({ model: 'glm-4.5-air', tokenType: 'completion' })).toBe(
+      tokenValues['glm-4.5-air'].completion,
+    );
+
+    expect(getMultiplier({ model: 'glm-4.5', tokenType: 'prompt' })).toBe(
+      tokenValues['glm-4.5'].prompt,
+    );
+    expect(getMultiplier({ model: 'glm-4.5', tokenType: 'completion' })).toBe(
+      tokenValues['glm-4.5'].completion,
+    );
+
+    expect(getMultiplier({ model: 'glm-4-32b', tokenType: 'prompt' })).toBe(
+      tokenValues['glm-4-32b'].prompt,
+    );
+    expect(getMultiplier({ model: 'glm-4-32b', tokenType: 'completion' })).toBe(
+      tokenValues['glm-4-32b'].completion,
+    );
+
+    expect(getMultiplier({ model: 'glm-4', tokenType: 'prompt' })).toBe(
+      tokenValues['glm-4'].prompt,
+    );
+    expect(getMultiplier({ model: 'glm-4', tokenType: 'completion' })).toBe(
+      tokenValues['glm-4'].completion,
+    );
+  });
+
+  it('should return correct multipliers for GLM models with provider prefixes', () => {
+    expect(getMultiplier({ model: 'z-ai/glm-4.6', tokenType: 'prompt' })).toBe(
+      tokenValues['glm-4.6'].prompt,
+    );
+    expect(getMultiplier({ model: 'zai/glm-4.5-air', tokenType: 'completion' })).toBe(
+      tokenValues['glm-4.5-air'].completion,
+    );
+    expect(getMultiplier({ model: 'zai-org/GLM-4.5V', tokenType: 'prompt' })).toBe(
+      tokenValues['glm-4.5v'].prompt,
+    );
   });
 });
 

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -406,7 +406,7 @@ describe('getMultiplier', () => {
   });
 
   it('should return correct multipliers for GLM models', () => {
-    const models = ['glm-4.6', 'glm-4.5v', 'glm-4.5-air', 'glm-4.5', 'glm-4-32b', 'glm-4'];
+    const models = ['glm-4.6', 'glm-4.5v', 'glm-4.5-air', 'glm-4.5', 'glm-4-32b', 'glm-4', 'glm4'];
     models.forEach((key) => {
       const expectedPrompt = tokenValues[key].prompt;
       const expectedCompletion = tokenValues[key].completion;
@@ -802,6 +802,7 @@ describe('GLM Model Tests', () => {
     expect(getValueKey('glm-4.5-air')).toBe('glm-4.5-air');
     expect(getValueKey('glm-4-32b')).toBe('glm-4-32b');
     expect(getValueKey('glm-4')).toBe('glm-4');
+    expect(getValueKey('glm4')).toBe('glm4');
   });
 
   it('should match GLM model variations with provider prefixes', () => {
@@ -876,6 +877,11 @@ describe('GLM Model Tests', () => {
     );
     expect(getMultiplier({ model: 'glm-4', tokenType: 'completion' })).toBe(
       tokenValues['glm-4'].completion,
+    );
+
+    expect(getMultiplier({ model: 'glm4', tokenType: 'prompt' })).toBe(tokenValues['glm4'].prompt);
+    expect(getMultiplier({ model: 'glm4', tokenType: 'completion' })).toBe(
+      tokenValues['glm4'].completion,
     );
   });
 

--- a/api/package.json
+++ b/api/package.json
@@ -48,7 +48,7 @@
     "@langchain/google-genai": "^0.2.13",
     "@langchain/google-vertexai": "^0.2.13",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^2.4.82",
+    "@librechat/agents": "^2.4.83",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -418,6 +418,7 @@ describe('getModelMaxTokens', () => {
     expect(getModelMaxTokens('glm-4.5')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4.5']);
     expect(getModelMaxTokens('glm-4-32b')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4-32b']);
     expect(getModelMaxTokens('glm-4')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4']);
+    expect(getModelMaxTokens('glm4')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm4']);
   });
 
   test('should return correct tokens for GLM models with provider prefixes', () => {
@@ -932,6 +933,7 @@ describe('GLM Model Tests (Zhipu AI)', () => {
       expect(getModelMaxTokens('glm-4.5')).toBe(131000);
       expect(getModelMaxTokens('glm-4-32b')).toBe(128000);
       expect(getModelMaxTokens('glm-4')).toBe(128000);
+      expect(getModelMaxTokens('glm4')).toBe(128000);
     });
 
     test('should handle partial matches for GLM models with provider prefixes', () => {
@@ -974,6 +976,7 @@ describe('GLM Model Tests (Zhipu AI)', () => {
       expect(matchModelName('glm-4.5')).toBe('glm-4.5');
       expect(matchModelName('glm-4-32b')).toBe('glm-4-32b');
       expect(matchModelName('glm-4')).toBe('glm-4');
+      expect(matchModelName('glm4')).toBe('glm4');
     });
 
     test('should match GLM model variations with provider prefixes', () => {

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -409,6 +409,63 @@ describe('getModelMaxTokens', () => {
     });
   });
 
+  test('should return correct tokens for GLM models', () => {
+    expect(getModelMaxTokens('glm-4.6')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4.6']);
+    expect(getModelMaxTokens('glm-4.5v')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4.5v']);
+    expect(getModelMaxTokens('glm-4.5-air')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['glm-4.5-air'],
+    );
+    expect(getModelMaxTokens('glm-4.5')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4.5']);
+    expect(getModelMaxTokens('glm-4-32b')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4-32b']);
+    expect(getModelMaxTokens('glm-4')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4']);
+  });
+
+  test('should return correct tokens for GLM models with provider prefixes', () => {
+    expect(getModelMaxTokens('z-ai/glm-4.6')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4.6']);
+    expect(getModelMaxTokens('z-ai/glm-4.5')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4.5']);
+    expect(getModelMaxTokens('z-ai/glm-4.5-air')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['glm-4.5-air'],
+    );
+    expect(getModelMaxTokens('z-ai/glm-4.5v')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['glm-4.5v'],
+    );
+    expect(getModelMaxTokens('z-ai/glm-4-32b')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['glm-4-32b'],
+    );
+
+    expect(getModelMaxTokens('zai/glm-4.6')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4.6']);
+    expect(getModelMaxTokens('zai/glm-4.5-air')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['glm-4.5-air'],
+    );
+    expect(getModelMaxTokens('zai/glm-4.5v')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4.5v']);
+
+    expect(getModelMaxTokens('zai-org/GLM-4.6')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['glm-4.6'],
+    );
+    expect(getModelMaxTokens('zai-org/GLM-4.5')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['glm-4.5'],
+    );
+    expect(getModelMaxTokens('zai-org/GLM-4.5-Air')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['glm-4.5-air'],
+    );
+    expect(getModelMaxTokens('zai-org/GLM-4.5V')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['glm-4.5v'],
+    );
+    expect(getModelMaxTokens('zai-org/GLM-4-32B-0414')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['glm-4-32b'],
+    );
+  });
+
+  test('should return correct tokens for GLM models with suffixes', () => {
+    expect(getModelMaxTokens('glm-4.6-fp8')).toBe(maxTokensMap[EModelEndpoint.openAI]['glm-4.6']);
+    expect(getModelMaxTokens('zai-org/GLM-4.6-FP8')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['glm-4.6'],
+    );
+    expect(getModelMaxTokens('zai-org/GLM-4.5-Air-FP8')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['glm-4.5-air'],
+    );
+  });
+
   test('should return correct max output tokens for GPT-5 models', () => {
     const { getModelMaxOutputTokens } = require('@librechat/api');
     ['gpt-5', 'gpt-5-mini', 'gpt-5-nano'].forEach((model) => {
@@ -862,6 +919,92 @@ describe('Kimi Model Tests', () => {
       expect(matchModelName('kimi-k2-latest')).toBe('kimi');
       expect(matchModelName('kimi-vl-preview')).toBe('kimi');
       expect(matchModelName('kimi-2024')).toBe('kimi');
+    });
+  });
+});
+
+describe('GLM Model Tests (Zhipu AI)', () => {
+  describe('getModelMaxTokens', () => {
+    test('should return correct tokens for GLM models', () => {
+      expect(getModelMaxTokens('glm-4.6')).toBe(200000);
+      expect(getModelMaxTokens('glm-4.5v')).toBe(66000);
+      expect(getModelMaxTokens('glm-4.5-air')).toBe(131000);
+      expect(getModelMaxTokens('glm-4.5')).toBe(131000);
+      expect(getModelMaxTokens('glm-4-32b')).toBe(128000);
+      expect(getModelMaxTokens('glm-4')).toBe(128000);
+    });
+
+    test('should handle partial matches for GLM models with provider prefixes', () => {
+      expect(getModelMaxTokens('z-ai/glm-4.6')).toBe(200000);
+      expect(getModelMaxTokens('z-ai/glm-4.5')).toBe(131000);
+      expect(getModelMaxTokens('z-ai/glm-4.5-air')).toBe(131000);
+      expect(getModelMaxTokens('z-ai/glm-4.5v')).toBe(66000);
+      expect(getModelMaxTokens('z-ai/glm-4-32b')).toBe(128000);
+
+      expect(getModelMaxTokens('zai/glm-4.6')).toBe(200000);
+      expect(getModelMaxTokens('zai/glm-4.5')).toBe(131000);
+      expect(getModelMaxTokens('zai/glm-4.5-air')).toBe(131000);
+      expect(getModelMaxTokens('zai/glm-4.5v')).toBe(66000);
+
+      expect(getModelMaxTokens('zai-org/GLM-4.6')).toBe(200000);
+      expect(getModelMaxTokens('zai-org/GLM-4.5')).toBe(131000);
+      expect(getModelMaxTokens('zai-org/GLM-4.5-Air')).toBe(131000);
+      expect(getModelMaxTokens('zai-org/GLM-4.5V')).toBe(66000);
+      expect(getModelMaxTokens('zai-org/GLM-4-32B-0414')).toBe(128000);
+    });
+
+    test('should handle GLM model variations with suffixes', () => {
+      expect(getModelMaxTokens('glm-4.6-fp8')).toBe(200000);
+      expect(getModelMaxTokens('zai-org/GLM-4.6-FP8')).toBe(200000);
+      expect(getModelMaxTokens('zai-org/GLM-4.5-Air-FP8')).toBe(131000);
+    });
+
+    test('should prioritize more specific GLM patterns', () => {
+      expect(getModelMaxTokens('glm-4.5-air-custom')).toBe(131000);
+      expect(getModelMaxTokens('glm-4.5-custom')).toBe(131000);
+      expect(getModelMaxTokens('glm-4.5v-custom')).toBe(66000);
+    });
+  });
+
+  describe('matchModelName', () => {
+    test('should match exact GLM model names', () => {
+      expect(matchModelName('glm-4.6')).toBe('glm-4.6');
+      expect(matchModelName('glm-4.5v')).toBe('glm-4.5v');
+      expect(matchModelName('glm-4.5-air')).toBe('glm-4.5-air');
+      expect(matchModelName('glm-4.5')).toBe('glm-4.5');
+      expect(matchModelName('glm-4-32b')).toBe('glm-4-32b');
+      expect(matchModelName('glm-4')).toBe('glm-4');
+    });
+
+    test('should match GLM model variations with provider prefixes', () => {
+      expect(matchModelName('z-ai/glm-4.6')).toBe('glm-4.6');
+      expect(matchModelName('z-ai/glm-4.5')).toBe('glm-4.5');
+      expect(matchModelName('z-ai/glm-4.5-air')).toBe('glm-4.5-air');
+      expect(matchModelName('z-ai/glm-4.5v')).toBe('glm-4.5v');
+      expect(matchModelName('z-ai/glm-4-32b')).toBe('glm-4-32b');
+
+      expect(matchModelName('zai/glm-4.6')).toBe('glm-4.6');
+      expect(matchModelName('zai/glm-4.5')).toBe('glm-4.5');
+      expect(matchModelName('zai/glm-4.5-air')).toBe('glm-4.5-air');
+      expect(matchModelName('zai/glm-4.5v')).toBe('glm-4.5v');
+
+      expect(matchModelName('zai-org/GLM-4.6')).toBe('glm-4.6');
+      expect(matchModelName('zai-org/GLM-4.5')).toBe('glm-4.5');
+      expect(matchModelName('zai-org/GLM-4.5-Air')).toBe('glm-4.5-air');
+      expect(matchModelName('zai-org/GLM-4.5V')).toBe('glm-4.5v');
+      expect(matchModelName('zai-org/GLM-4-32B-0414')).toBe('glm-4-32b');
+    });
+
+    test('should match GLM model variations with suffixes', () => {
+      expect(matchModelName('glm-4.6-fp8')).toBe('glm-4.6');
+      expect(matchModelName('zai-org/GLM-4.6-FP8')).toBe('glm-4.6');
+      expect(matchModelName('zai-org/GLM-4.5-Air-FP8')).toBe('glm-4.5-air');
+    });
+
+    test('should handle case-insensitive matching for GLM models', () => {
+      expect(matchModelName('zai-org/GLM-4.6')).toBe('glm-4.6');
+      expect(matchModelName('zai-org/GLM-4.5V')).toBe('glm-4.5v');
+      expect(matchModelName('zai-org/GLM-4-32B-0414')).toBe('glm-4-32b');
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@langchain/google-genai": "^0.2.13",
         "@langchain/google-vertexai": "^0.2.13",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^2.4.82",
+        "@librechat/agents": "^2.4.83",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -21522,9 +21522,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "2.4.82",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.82.tgz",
-      "integrity": "sha512-KNz8L1H/IXE3hnOU27ElsGy+oWpZ7oYnrLXIoJUyoy/qWlAUzKkzbOHp4hkLIK3xB21ncVuSqKS0542W6MQkKQ==",
+      "version": "2.4.83",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-2.4.83.tgz",
+      "integrity": "sha512-xOspD4jegd7wpjWQhOieOso2LrXsNRyHNYEIIuCuk2eUZkxJU+1Rny0XzukhenTOG8P4bpne9XoVxxxZ0W5duA==",
       "license": "MIT",
       "dependencies": {
         "@langchain/anthropic": "^0.3.26",
@@ -51336,7 +51336,7 @@
         "@azure/storage-blob": "^12.27.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.62",
-        "@librechat/agents": "^2.4.82",
+        "@librechat/agents": "^2.4.83",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.17.1",
         "axios": "^1.12.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -80,7 +80,7 @@
     "@azure/storage-blob": "^12.27.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.62",
-    "@librechat/agents": "^2.4.82",
+    "@librechat/agents": "^2.4.83",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.17.1",
     "axios": "^1.12.1",

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -262,6 +262,13 @@ const aggregateModels = {
   'gpt-oss-20b': 131000,
   'gpt-oss:120b': 131000,
   'gpt-oss-120b': 131000,
+  // GLM models (Zhipu AI)
+  'glm-4': 128000,
+  'glm-4-32b': 128000,
+  'glm-4.5': 131000,
+  'glm-4.5-air': 131000,
+  'glm-4.5v': 66000,
+  'glm-4.6': 200000,
 };
 
 export const maxTokensMap = {
@@ -317,9 +324,10 @@ export function findMatchingPattern(
   tokensMap: Record<string, number> | EndpointTokenConfig,
 ): string | null {
   const keys = Object.keys(tokensMap);
+  const lowerModelName = modelName.toLowerCase();
   for (let i = keys.length - 1; i >= 0; i--) {
     const modelKey = keys[i];
-    if (modelName.includes(modelKey)) {
+    if (lowerModelName.includes(modelKey)) {
       return modelKey;
     }
   }

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -263,6 +263,7 @@ const aggregateModels = {
   'gpt-oss:120b': 131000,
   'gpt-oss-120b': 131000,
   // GLM models (Zhipu AI)
+  glm4: 128000,
   'glm-4': 128000,
   'glm-4-32b': 128000,
   'glm-4.5': 131000,


### PR DESCRIPTION
# Summary

I added comprehensive support for Zhipu AI's GLM model family, including context window configurations and pricing multipliers for all GLM variants.

- Added context window limits for all GLM models (glm-4, glm-4-32b, glm-4.5, glm-4.5-air, glm-4.5v, glm-4.6) ranging from 66K to 200K tokens
- Implemented pricing multipliers for prompt and completion tokens across all GLM model variants
- Enhanced model name matching to handle provider prefixes (z-ai/, zai/, zai-org/) and suffixes (-fp8, -FP8) with case-insensitive matching
- Refactored findMatchingPattern function to use case-insensitive comparison for improved pattern matching reliability
- Added comprehensive test coverage for GLM models including pattern matching, token limits, and pricing calculations across various naming conventions
- Updated @librechat/agents to v2.4.83 to address a reasoning edge case encountered with GLM models

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested GLM model support including context window limits, pricing calculations, and model name matching with various provider prefixes and suffixes. Verified case-insensitive matching works correctly and that all model variants return expected token limits and pricing multipliers.

### Test Configuration

- Node.js environment with Jest test runner
- Test cases cover exact model names, provider-prefixed names, case variations, and suffix variations
- Validated against tokenValues and maxTokensMap configurations

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules