### PR TITLE
⚖️ fix: Add Configurable File Size Cap for Conversation Imports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -650,6 +650,12 @@ HELP_AND_FAQ_URL=https://librechat.ai
 # Google tag manager id
 #ANALYTICS_GTM_ID=user provided google tag manager id
 
+# limit conversation file imports to a certain number of bytes in size to avoid the container
+# maxing out memory limitations by unremarking this line and supplying a file size in bytes
+# such as the below example of 250 mib
+# CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES=262144000
+
+
 #===============#
 # REDIS Options #
 #===============#

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -115,6 +115,9 @@ router.get('/', async function (req, res) {
       sharePointPickerGraphScope: process.env.SHAREPOINT_PICKER_GRAPH_SCOPE,
       sharePointPickerSharePointScope: process.env.SHAREPOINT_PICKER_SHAREPOINT_SCOPE,
       openidReuseTokens,
+      conversationImportMaxFileSize: process.env.CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES
+        ? parseInt(process.env.CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES, 10)
+        : 0,
     };
 
     const minPasswordLength = parseInt(process.env.MIN_PASSWORD_LENGTH, 10);

--- a/api/server/utils/import/importConversations.js
+++ b/api/server/utils/import/importConversations.js
@@ -10,6 +10,15 @@ const importConversations = async (job) => {
   const { filepath, requestUserId } = job;
   try {
     logger.debug(`user: ${requestUserId} | Importing conversation(s) from file...`);
+
+    /* error if file is too large */
+    const fileInfo = await fs.stat(filepath);
+    if (fileInfo.size > process.env.CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES) {
+      throw new Error(
+        `File size is ${fileInfo.size} bytes.  It exceeds the maximum limit of ${process.env.CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES} bytes.`,
+      );
+    }
+
     const fileData = await fs.readFile(filepath, 'utf8');
     const jsonData = JSON.parse(fileData);
     const importer = getImporter(jsonData);
@@ -17,6 +26,7 @@ const importConversations = async (job) => {
     logger.debug(`user: ${requestUserId} | Finished importing conversations`);
   } catch (error) {
     logger.error(`user: ${requestUserId} | Failed to import conversation: `, error);
+    throw error; // throw error all the way up so request does not return success
   } finally {
     try {
       await fs.unlink(filepath);

--- a/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
+++ b/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
@@ -1,5 +1,7 @@
 import { useState, useRef, useCallback } from 'react';
 import { Import } from 'lucide-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { QueryKeys, TStartupConfig } from 'librechat-data-provider';
 import { Spinner, useToastContext, Label, Button } from '@librechat/client';
 import { useUploadConversationsMutation } from '~/data-provider';
 import { NotificationSeverity } from '~/common';
@@ -51,6 +53,17 @@ function ImportConversations() {
   const handleFileUpload = useCallback(
     async (file: File) => {
       try {
+        const maxFileSize = (startupConfig as any)?.conversationImportMaxFileSize;
+        if (maxFileSize && file.size > maxFileSize) {
+          const size = (maxFileSize / (1024 * 1024)).toFixed(2);
+          showToast({
+            message: localize('com_error_files_upload_too_large', { 0: size }),
+            status: NotificationSeverity.ERROR,
+          });
+          setIsUploading(false);
+          return;
+        }
+
         const formData = new FormData();
         formData.append('file', file, encodeURIComponent(file.name || 'File'));
         uploadFile.mutate(formData);
@@ -63,13 +76,14 @@ function ImportConversations() {
         });
       }
     },
-    [uploadFile, showToast, localize],
+    [uploadFile, showToast, localize, startupConfig],
   );
 
   const handleFileChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
       if (file) {
+        setIsUploading(true);
         handleFileUpload(file);
       }
       event.target.value = '';

--- a/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
+++ b/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
@@ -7,6 +7,8 @@ import { useLocalize } from '~/hooks';
 import { cn, logger } from '~/utils';
 
 function ImportConversations() {
+  const queryClient = useQueryClient();
+  const startupConfig = queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]);
   const localize = useLocalize();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { showToast } = useToastContext();

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -365,6 +365,7 @@
   "com_error_files_process": "An error occurred while processing the file.",
   "com_error_files_upload": "An error occurred while uploading the file.",
   "com_error_files_upload_canceled": "The file upload request was canceled. Note: the file upload may still be processing and will need to be manually deleted.",
+  "com_error_files_upload_too_large": "The file is too large.  Please upload a file smaller than {{0}} MB",
   "com_error_files_validation": "An error occurred while validating the file.",
   "com_error_google_tool_conflict": "Usage of built-in Google tools are not supported with external tools. Please disable either the built-in tools or the external tools.",
   "com_error_heic_conversion": "Failed to convert HEIC image to JPEG. Please try converting the image manually or use a different format.",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -669,6 +669,7 @@ export type TStartupConfig = {
     }
   >;
   mcpPlaceholder?: string;
+  conversationImportMaxFileSize?: number;
 };
 
 export enum OCRStrategy {


### PR DESCRIPTION

# Pull Request Template

## Summary

Implement a max size for conversations imports to prevent bringing down the application by uploading a large file.  Also modified import endpoint such that if any error does occur, it bubbles the error up and the front end displays an error message.  Before this fix, it returns a 200 and the front end says the import was successful when an error occurs.

Addresses issue:   https://github.com/danny-avila/LibreChat/issues/10011

## Change Type

- Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

- tested manually that the CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES env file defaults to 0 which allows all files to be uploaded
- tested manually that the CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES when set to a number prevents a file from being uploaded in the front end code if it exceeds the number in bytes
- tested manually that the CONVERSATION_IMPORT_MAX_FILE_SIZE_BYTES will prevent the file from being parsed in the BACK END)  if a file is uploaded that exceeds the number of bytes.  This is of course to prevent malicious attempts of uploading a large file by bypassing the front end check

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [X] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [X] Local unit tests pass with my changes
- [X] A pull request for updating the documentation has been submitted.  (https://github.com/LibreChat-AI/librechat.ai/pull/425)
