### PR TITLE
🔗 fix: Add branch-specific shared links (targetMessageId)

### DIFF
--- a/api/server/routes/share.js
+++ b/api/server/routes/share.js
@@ -99,7 +99,8 @@ router.get('/link/:conversationId', requireJwtAuth, async (req, res) => {
 
 router.post('/:conversationId', requireJwtAuth, async (req, res) => {
   try {
-    const created = await createSharedLink(req.user.id, req.params.conversationId);
+    const { targetMessageId } = req.body;
+    const created = await createSharedLink(req.user.id, req.params.conversationId, targetMessageId);
     if (created) {
       res.status(200).json(created);
     } else {

--- a/client/src/components/Conversations/ConvoOptions/ShareButton.tsx
+++ b/client/src/components/Conversations/ConvoOptions/ShareButton.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
 import { QRCodeSVG } from 'qrcode.react';
 import { Copy, CopyCheck } from 'lucide-react';
 import { useGetSharedLinkQuery } from 'librechat-data-provider/react-query';
 import { OGDialogTemplate, Button, Spinner, OGDialog } from '@librechat/client';
 import { useLocalize, useCopyToClipboard } from '~/hooks';
 import SharedLinkButton from './SharedLinkButton';
-import { useChatContext } from '~/Providers';
 import { cn } from '~/utils';
+import store from '~/store';
 
 export default function ShareButton({
   conversationId,
@@ -22,12 +23,12 @@ export default function ShareButton({
   children?: React.ReactNode;
 }) {
   const localize = useLocalize();
-  const { latestMessage } = useChatContext();
   const [showQR, setShowQR] = useState(false);
   const [sharedLink, setSharedLink] = useState('');
   const [isCopying, setIsCopying] = useState(false);
-  const { data: share, isLoading } = useGetSharedLinkQuery(conversationId);
   const copyLink = useCopyToClipboard({ text: sharedLink });
+  const latestMessage = useRecoilValue(store.latestMessageFamily(0));
+  const { data: share, isLoading } = useGetSharedLinkQuery(conversationId);
 
   useEffect(() => {
     if (share?.shareId !== undefined) {

--- a/client/src/components/Conversations/ConvoOptions/ShareButton.tsx
+++ b/client/src/components/Conversations/ConvoOptions/ShareButton.tsx
@@ -4,8 +4,8 @@ import { Copy, CopyCheck } from 'lucide-react';
 import { useGetSharedLinkQuery } from 'librechat-data-provider/react-query';
 import { OGDialogTemplate, Button, Spinner, OGDialog } from '@librechat/client';
 import { useLocalize, useCopyToClipboard } from '~/hooks';
-import { useChatContext } from '~/Providers';
 import SharedLinkButton from './SharedLinkButton';
+import { useChatContext } from '~/Providers';
 import { cn } from '~/utils';
 
 export default function ShareButton({

--- a/client/src/components/Conversations/ConvoOptions/ShareButton.tsx
+++ b/client/src/components/Conversations/ConvoOptions/ShareButton.tsx
@@ -4,6 +4,7 @@ import { Copy, CopyCheck } from 'lucide-react';
 import { useGetSharedLinkQuery } from 'librechat-data-provider/react-query';
 import { OGDialogTemplate, Button, Spinner, OGDialog } from '@librechat/client';
 import { useLocalize, useCopyToClipboard } from '~/hooks';
+import { useChatContext } from '~/Providers';
 import SharedLinkButton from './SharedLinkButton';
 import { cn } from '~/utils';
 
@@ -21,6 +22,7 @@ export default function ShareButton({
   children?: React.ReactNode;
 }) {
   const localize = useLocalize();
+  const { latestMessage } = useChatContext();
   const [showQR, setShowQR] = useState(false);
   const [sharedLink, setSharedLink] = useState('');
   const [isCopying, setIsCopying] = useState(false);
@@ -39,6 +41,7 @@ export default function ShareButton({
       <SharedLinkButton
         share={share}
         conversationId={conversationId}
+        targetMessageId={latestMessage?.messageId}
         setShareDialogOpen={onOpenChange}
         showQR={showQR}
         setShowQR={setShowQR}

--- a/client/src/components/Conversations/ConvoOptions/SharedLinkButton.tsx
+++ b/client/src/components/Conversations/ConvoOptions/SharedLinkButton.tsx
@@ -21,6 +21,7 @@ import { useLocalize } from '~/hooks';
 export default function SharedLinkButton({
   share,
   conversationId,
+  targetMessageId,
   setShareDialogOpen,
   showQR,
   setShowQR,
@@ -28,6 +29,7 @@ export default function SharedLinkButton({
 }: {
   share: TSharedLinkGetResponse | undefined;
   conversationId: string;
+  targetMessageId?: string;
   setShareDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
   showQR: boolean;
   setShowQR: (showQR: boolean) => void;
@@ -86,7 +88,7 @@ export default function SharedLinkButton({
   };
 
   const createShareLink = async () => {
-    const share = await mutate({ conversationId });
+    const share = await mutate({ conversationId, targetMessageId });
     const newLink = generateShareLink(share.shareId);
     setSharedLink(newLink);
   };

--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -168,18 +168,26 @@ export const useArchiveConvoMutation = (
 };
 
 export const useCreateSharedLinkMutation = (
-  options?: t.MutationOptions<t.TCreateShareLinkRequest, { conversationId: string }>,
-): UseMutationResult<t.TSharedLinkResponse, unknown, { conversationId: string }, unknown> => {
+  options?: t.MutationOptions<
+    t.TCreateShareLinkRequest,
+    { conversationId: string; targetMessageId?: string }
+  >,
+): UseMutationResult<
+  t.TSharedLinkResponse,
+  unknown,
+  { conversationId: string; targetMessageId?: string },
+  unknown
+> => {
   const queryClient = useQueryClient();
 
   const { onSuccess, ..._options } = options || {};
   return useMutation(
-    ({ conversationId }: { conversationId: string }) => {
+    ({ conversationId, targetMessageId }: { conversationId: string; targetMessageId?: string }) => {
       if (!conversationId) {
         throw new Error('Conversation ID is required');
       }
 
-      return dataService.createSharedLink(conversationId);
+      return dataService.createSharedLink(conversationId, targetMessageId);
     },
     {
       onSuccess: (_data: t.TSharedLinkResponse, vars, context) => {

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -42,8 +42,11 @@ export function getSharedLink(conversationId: string): Promise<t.TSharedLinkGetR
   return request.get(endpoints.getSharedLink(conversationId));
 }
 
-export function createSharedLink(conversationId: string): Promise<t.TSharedLinkResponse> {
-  return request.post(endpoints.createSharedLink(conversationId));
+export function createSharedLink(
+  conversationId: string,
+  targetMessageId?: string,
+): Promise<t.TSharedLinkResponse> {
+  return request.post(endpoints.createSharedLink(conversationId), { targetMessageId });
 }
 
 export function updateSharedLink(shareId: string): Promise<t.TSharedLinkResponse> {

--- a/packages/data-schemas/src/schema/share.ts
+++ b/packages/data-schemas/src/schema/share.ts
@@ -6,6 +6,7 @@ export interface ISharedLink extends Document {
   user?: string;
   messages?: Types.ObjectId[];
   shareId?: string;
+  targetMessageId?: string;
   isPublic: boolean;
   createdAt?: Date;
   updatedAt?: Date;
@@ -30,6 +31,11 @@ const shareSchema: Schema<ISharedLink> = new Schema(
       type: String,
       index: true,
     },
+    targetMessageId: {
+      type: String,
+      required: false,
+      index: true,
+    },
     isPublic: {
       type: Boolean,
       default: true,
@@ -37,5 +43,8 @@ const shareSchema: Schema<ISharedLink> = new Schema(
   },
   { timestamps: true },
 );
+
+// Compound index to allow multiple shares per conversation based on different branches
+shareSchema.index({ conversationId: 1, user: 1, targetMessageId: 1 });
 
 export default shareSchema;

--- a/packages/data-schemas/src/schema/share.ts
+++ b/packages/data-schemas/src/schema/share.ts
@@ -44,7 +44,6 @@ const shareSchema: Schema<ISharedLink> = new Schema(
   { timestamps: true },
 );
 
-// Compound index to allow multiple shares per conversation based on different branches
 shareSchema.index({ conversationId: 1, user: 1, targetMessageId: 1 });
 
 export default shareSchema;

--- a/packages/data-schemas/src/types/share.ts
+++ b/packages/data-schemas/src/types/share.ts
@@ -8,6 +8,7 @@ export interface ISharedLink {
   user?: string;
   messages?: Types.ObjectId[];
   shareId?: string;
+  targetMessageId?: string;
   isPublic: boolean;
   createdAt?: Date;
   updatedAt?: Date;


### PR DESCRIPTION
## Summary

Add support for sharing a specific branch of a conversation by allowing users to generate shared links that reference a particular message (`targetMessageId`). Backend: added `targetMessageId` to the `ISharedLink` schema and model, introduced a compound index, updated `createSharedLink` and the API route to handle `targetMessageId` and filter messages up to the target. Frontend: updated `useCreateSharedLinkMutation` and `dataService.createSharedLink` to accept `targetMessageId`, and enhanced `ShareButton` / `SharedLinkButton` components to use the latest message's ID as `targetMessageId`

Closes: #10007 

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

started a new convo, shared it, loaded the shared convo, created a message branch, and refreshed the loaded convo (verified as working)

### **Test Configuration**:

- OS: WSL2
- npm Version: 11.5.2

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.