### PR TITLE
👨‍🔧 fix: Direct Provider Attachment Support for Agents

### DIFF
--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -508,7 +508,10 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
   const { file } = req;
   const appConfig = req.config;
   const { agent_id, tool_resource, file_id, temp_file_id = null } = metadata;
-  if (agent_id && !tool_resource) {
+
+  let messageAttachment = !!metadata.message_file;
+
+  if (agent_id && !tool_resource && !messageAttachment) {
     throw new Error('No tool resource provided for agent file upload');
   }
 
@@ -516,7 +519,6 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
     throw new Error('Image uploads are not supported for file search tool resources');
   }
 
-  let messageAttachment = !!metadata.message_file;
   if (!messageAttachment && !agent_id) {
     throw new Error('No agent ID provided for agent file upload');
   }

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -118,7 +118,7 @@ const AttachFileMenu = ({
 
       const currentProvider = provider || endpoint;
 
-      if (isDocumentSupportedProvider(endpointType || currentProvider)) {
+      if (isDocumentSupportedProvider(currentProvider || endpointType)) {
         items.push({
           label: localize('com_ui_upload_provider'),
           onClick: () => {

--- a/client/src/hooks/Agents/useAgentToolPermissions.ts
+++ b/client/src/hooks/Agents/useAgentToolPermissions.ts
@@ -37,7 +37,10 @@ export default function useAgentToolPermissions(
     [agentData?.tools, selectedAgent?.tools],
   );
 
-  const provider = useMemo(() => selectedAgent?.provider, [selectedAgent?.provider]);
+  const provider = useMemo(
+    () => agentData?.provider || selectedAgent?.provider,
+    [agentData?.provider, selectedAgent?.provider],
+  );
 
   const fileSearchAllowedByAgent = useMemo(() => {
     // Check ephemeral agent settings


### PR DESCRIPTION
## Summary

This pull request adds support for **Upload to Provider** functionality in Agent conversations. The main focus is on ensuring correct validation for agent file uploads and making provider detection more robust across the UI and hooks. 

Prior to this fix, Agent conversations would erroneously not display the **Upload to Provider** option in the `AttachFileMenu` component, despite an Agent with a supported Endpoint type being selected. This was caused by the `provider` variable referenced from `useAgentToolPermissions` hook not being set, leaving the variable to default to "agents" when passed to `isDocumentSupportedProvider`, and thusly not pushing the **Upload to Provider** option to the list of displayed options in the attachment menu. This behavior was fixed by having the `provider` variable in the the hook first attempt to access `agentData.provider` (which held the correct provider for the agent i.e. 'google'), rather than `selectedAgent.provider`.

The second fix involved in adding support was simply adding a condition to the guard statement in `processAgentFileUpload` which was previously preventing Agent uploads from being handled if they did not have a set `tool_resource` (as is the case for **Upload to Provider** uploads). 


**Agent file upload validation:**

* Updated `processAgentFileUpload` in `process.js` to require a `tool_resource` only when the upload is not a message attachment, preventing errors for message file uploads where `tool_resource` is undefined, since the Direct Provider Attachment upload flow specifically sets `tool_resource` to undefined (following the precedent initially set by the handling for **Upload Image**).

**Provider selection logic improvements:**

* Modified `useAgentToolPermissions` to prioritize `agentData.provider` over `selectedAgent.provider` for determining the provider, ensuring the most up-to-date provider is used.
* Fixed provider selection in `AttachFileMenu.tsx` by passing `currentProvider || endpointType` to `isDocumentSupportedProvider`, improving compatibility with different endpoint types.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual verification of proper behavior in UI and testing proper responses with Agent/Endpoint conversations for Google, Anthropic, OpenAI, and groq (for negative control where **Upload to Provider** should not be shown)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
