### PR TITLE
📖 feat: Word Wrapping for Text and Markdown Code Blocks

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1243,8 +1243,12 @@ pre {
     Ubuntu Mono,
     monospace !important;
 }
-code[class='language-plaintext'] {
-  white-space: pre-line;
+code.language-text,
+code.language-txt,
+code.language-plaintext,
+code.language-markdown,
+code.language-md {
+  white-space: pre-wrap !important;
 }
 code.hljs,
 code[class*='language-'],


### PR DESCRIPTION
## Summary

This PR improves readability of text content in code fences by enabling word wrapping for markdown and plaintext code blocks. Currently, long lines in text/markdown fences require horizontal scrolling, which is cumbersome when viewing prose content.

The change applies `white-space: pre-wrap` to code blocks with language types: text, txt, plaintext, markdown, and md. This allows text to wrap naturally while preserving formatting for actual code blocks.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Tested locally by creating messages with markdown/text code fences containing long lines, e.g.:

```markdown
# Header
This is a very long line of text that would normally require horizontal scrolling in a code fence but now wraps naturally for better readability. Often times when returning markdown snippets in larger contexts we'll see this occurring, and it's hell to read.
```

<img width="450" alt="screnshot" src="https://github.com/user-attachments/assets/2e733e92-1a6d-401a-8474-46e534c069f3" />


### **Test Configuration**:
- Browser: Chrome/Firefox
- Verified wrapping works correctly for all targeted language types
- Verified other code blocks (JavaScript, Python, etc.) remain unchanged with `white-space: pre`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.