### PR TITLE
👆🏼 fix: Agent Support for Upload to Provider in DragDropModal

### DIFF
--- a/client/src/components/Chat/Input/Files/DragDropModal.tsx
+++ b/client/src/components/Chat/Input/Files/DragDropModal.tsx
@@ -56,7 +56,7 @@ const DragDropModal = ({ onOptionSelect, setShowModal, files, isVisible }: DragD
     const currentProvider = provider || endpoint;
 
     // Check if provider supports document upload
-    if (isDocumentSupportedProvider(endpointType || currentProvider)) {
+    if (isDocumentSupportedProvider(currentProvider || endpointType)) {
       _options.push({
         label: localize('com_ui_upload_provider'),
         value: undefined,


### PR DESCRIPTION
## Summary

This pull request makes a minor update to the logic for checking if a provider supports document upload in the `DragDropModal` component by swapping the currentProvider and endpointType variable order so that currentProvider gets evaluated first prior to short-circuit. 

The change ensures that the correct provider value is used when calling `isDocumentSupportedProvider` in the context of an Agent conversation, where endpointType will contain the value 'agents', whereas provider will contain the actual expected provider value (ie 'google', 'openAI')

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verification of presence of Upload to Provider option for PDF filetype in DragDropModal after change, and absence of option in non-document supported endpoints.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes