### PR TITLE
🕸️ fix: Upload to Provider Filetype Filtering for DragDropModal

### DIFF
--- a/client/src/components/Chat/Input/Files/DragDropModal.tsx
+++ b/client/src/components/Chat/Input/Files/DragDropModal.tsx
@@ -3,6 +3,7 @@ import { useRecoilValue } from 'recoil';
 import { OGDialog, OGDialogTemplate } from '@librechat/client';
 import {
   EToolResources,
+  EModelEndpoint,
   defaultAgentCapabilities,
   isDocumentSupportedProvider,
 } from 'librechat-data-provider';
@@ -57,11 +58,22 @@ const DragDropModal = ({ onOptionSelect, setShowModal, files, isVisible }: DragD
 
     // Check if provider supports document upload
     if (isDocumentSupportedProvider(currentProvider || endpointType)) {
+      const isGoogleProvider = currentProvider === EModelEndpoint.google;
+      const validFileTypes = isGoogleProvider
+        ? files.every(
+            (file) =>
+              file.type?.startsWith('image/') ||
+              file.type?.startsWith('video/') ||
+              file.type?.startsWith('audio/') ||
+              file.type === 'application/pdf',
+          )
+        : files.every((file) => file.type?.startsWith('image/') || file.type === 'application/pdf');
+
       _options.push({
         label: localize('com_ui_upload_provider'),
         value: undefined,
         icon: <FileImageIcon className="icon-md" />,
-        condition: true, // Allow for both images and documents
+        condition: validFileTypes,
       });
     } else {
       // Only show image upload option if all files are images and provider doesn't support documents


### PR DESCRIPTION
## Summary

This pull request updates the `DragDropModal` component to improve file type validation when uploading files, so that the **Upload to Provider** option is only shown for supported filetype/endpoint combinations when drag-and-drop uploading files. (i.e. **Upload to Provider** option shown on video filetype drag and drop upload when in a conversation with the `google` endpoint, but not for one with`openAI`, since `openAI` endpoint doesn't currently support direct file attachments for video files)

**File upload validation improvements:**

* Added `EModelEndpoint` import and logic to detect if the current provider is Google, allowing Google to accept images, videos, audio files, and PDFs, while other providers only accept images and PDFs for document uploads (`DragDropModal.tsx`). [[1]](diffhunk://#diff-9a5f36c5cb42cc48b8bff66aca8fa8bde9ece4098f46f96f96016f26f32519a4R6) [[2]](diffhunk://#diff-9a5f36c5cb42cc48b8bff66aca8fa8bde9ece4098f46f96f96016f26f32519a4R61-R76)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verify correct presence/absence of **Upload to Provider** option in DragDropModal for different endpoint/filetype combinations

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes