### PR TITLE
🏷️ chore: update OpenAI models list in `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,7 +196,7 @@ GOOGLE_KEY=user_provided
 #============#
 
 OPENAI_API_KEY=user_provided
-# OPENAI_MODELS=o1,o1-mini,o1-preview,gpt-4o,gpt-4.5-preview,chatgpt-4o-latest,gpt-4o-mini,gpt-3.5-turbo-0125,gpt-3.5-turbo-0301,gpt-3.5-turbo,gpt-4,gpt-4-0613,gpt-4-vision-preview,gpt-3.5-turbo-0613,gpt-3.5-turbo-16k-0613,gpt-4-0125-preview,gpt-4-turbo-preview,gpt-4-1106-preview,gpt-3.5-turbo-1106,gpt-3.5-turbo-instruct,gpt-3.5-turbo-instruct-0914,gpt-3.5-turbo-16k
+# OPENAI_MODELS=gpt-5,gpt-5-codex,gpt-5-mini,gpt-5-nano,o3-pro,o3,o4-mini,gpt-4.1,gpt-4.1-mini,gpt-4.1-nano,o3-mini,o1-pro,o1,gpt-4o,gpt-4o-mini
 
 DEBUG_OPENAI=false
 


### PR DESCRIPTION
Remove deprecated OpenAI models and add latest GPT-5, o3/o4, and GPT-4.1 series models based on current API offerings as of October 2025.

Removed deprecated models:

- gpt-4.5-preview (deprecated July 2025)
- o1-preview, o1-mini (deprecated July/October 2025)
- gpt-4-vision-preview (shut down December 2024)
- Dated GPT-3.5 and GPT-4 variants (consolidated into base versions)


Added new flagship models:

- GPT-5 series: gpt-5, gpt-5-mini, gpt-5-nano
- o3/o4 reasoning models: o3, o4-mini, o3-pro, o3-mini
- GPT-4.1 series: gpt-4.1, gpt-4.1-mini, gpt-4.1-nano
- Reorganized list with newest models first for better discoverability.

References:

https://platform.openai.com/docs/models
https://platform.openai.com/docs/deprecations