### PR TITLE
🛠️ chore: Add `@radix-ui/react-tooltip` to Artifact Dependencies

### DIFF
--- a/client/src/utils/artifacts.ts
+++ b/client/src/utils/artifacts.ts
@@ -89,6 +89,7 @@ const standardDependencies = {
   '@radix-ui/react-slot': '^1.1.0',
   '@radix-ui/react-toggle': '^1.1.0',
   '@radix-ui/react-toggle-group': '^1.1.0',
+  '@radix-ui/react-tooltip': '^1.2.8',
   'embla-carousel-react': '^8.2.0',
   'react-day-picker': '^9.0.8',
   'dat.gui': '^0.7.9',


### PR DESCRIPTION
## Summary

`tooltip` in `packages/data-provider/src/artifacts.ts` (used in `client/src/utils/artifacts.ts` as `shadcnComponents.tooltip`)  imports `@radix-ui/react-tooltip`, but this was missing from the list of `standardDependencies`, resulting in a error with any artifacts that attempt to use that shadcn component. This PR fixes that.

I've checked the rest of the shadcn components, and this was the only missing dependency.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

