### PR TITLE
📱 fix: Improve Mobile Chat Focus Detection and Navigation

### DIFF
--- a/client/src/hooks/Chat/useFocusChatEffect.ts
+++ b/client/src/hooks/Chat/useFocusChatEffect.ts
@@ -12,12 +12,22 @@ export default function useFocusChatEffect(textAreaRef: React.RefObject<HTMLText
         `Focusing textarea on location state change: ${location.pathname}`,
       );
 
-      /** Check if the device is not a touchscreen */
-      if (!window.matchMedia?.('(pointer: coarse)').matches) {
-        textAreaRef.current?.focus();
+      const hasCoarsePointer = window.matchMedia?.('(pointer: coarse)').matches;
+      const hasHover = window.matchMedia?.('(hover: hover)').matches;
+
+      const path = `${location.pathname}${window.location.search ?? ''}`;
+      /* Early return if mobile-like: has coarse pointer OR lacks hover */
+      if (hasCoarsePointer || !hasHover) {
+        navigate(path, {
+          replace: true,
+          state: {},
+        });
+        return;
       }
 
-      navigate(`${location.pathname}${window.location.search ?? ''}`, {
+      textAreaRef.current?.focus();
+
+      navigate(path, {
         replace: true,
         state: {},
       });


### PR DESCRIPTION
# Summary

I refined the mobile device detection logic in the useFocusChatEffect hook to prevent unwanted focus behavior on mobile devices and ensure proper navigation state cleanup, given latest changes to Android and iOS.

- Enhanced mobile device detection by checking both coarse pointer capability and hover support instead of relying solely on pointer type
- Inverted the logic to handle mobile devices as the primary case, returning early when mobile-like behavior is detected
- Extracted the path construction into a reusable variable to eliminate duplication
- Preserved navigation state cleanup for both mobile and desktop cases while only focusing the textarea on true desktop devices
- Added clearer logic flow that treats devices with coarse pointers OR lacking hover capability as mobile

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Test the focus behavior across different device types to ensure the textarea only receives focus on desktop devices while navigation state is properly cleared on all platforms.

### **Test Configuration**:
- Desktop browser with mouse/trackpad
- Mobile device (iOS/Android)
- Tablet with touch input
- Desktop with touchscreen capability
- Browser responsive design mode

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes