### PR TITLE
📄 feat: Context Field for Anthropic Documents (PDF)

### DIFF
--- a/packages/api/src/files/encode/document.ts
+++ b/packages/api/src/files/encode/document.ts
@@ -2,7 +2,7 @@ import { Providers } from '@librechat/agents';
 import { isOpenAILikeProvider, isDocumentSupportedProvider } from 'librechat-data-provider';
 import type { IMongoFile } from '@librechat/data-schemas';
 import type { Request } from 'express';
-import type { StrategyFunctions, DocumentResult } from '~/types/files';
+import type { StrategyFunctions, DocumentResult, AnthropicDocumentBlock } from '~/types/files';
 import { validatePdf } from '~/files/validation';
 import { getFileStream } from './utils';
 
@@ -69,7 +69,7 @@ export async function encodeAndFormatDocuments(
       }
 
       if (provider === Providers.ANTHROPIC) {
-        result.documents.push({
+        const document: AnthropicDocumentBlock = {
           type: 'document',
           source: {
             type: 'base64',
@@ -77,7 +77,13 @@ export async function encodeAndFormatDocuments(
             data: content,
           },
           citations: { enabled: true },
-        });
+        };
+
+        if (file.filename) {
+          document.context = `File: "${file.filename}"`;
+        }
+
+        result.documents.push(document);
       } else if (useResponsesApi) {
         result.documents.push({
           type: 'input_file',

--- a/packages/api/src/files/encode/document.ts
+++ b/packages/api/src/files/encode/document.ts
@@ -76,7 +76,6 @@ export async function encodeAndFormatDocuments(
             media_type: 'application/pdf',
             data: content,
           },
-          cache_control: { type: 'ephemeral' },
           citations: { enabled: true },
         });
       } else if (useResponsesApi) {

--- a/packages/api/src/types/files.ts
+++ b/packages/api/src/types/files.ts
@@ -46,29 +46,51 @@ export interface VideoResult {
   }>;
 }
 
+/** Anthropic document block format */
+export interface AnthropicDocumentBlock {
+  type: 'document';
+  source: {
+    type: string;
+    media_type: string;
+    data: string;
+  };
+  context?: string;
+  title?: string;
+  cache_control?: { type: string };
+  citations?: { enabled: boolean };
+}
+
+/** Google document block format */
+export interface GoogleDocumentBlock {
+  type: 'document';
+  mimeType: string;
+  data: string;
+}
+
+/** OpenAI file block format */
+export interface OpenAIFileBlock {
+  type: 'file';
+  file: {
+    filename: string;
+    file_data: string;
+  };
+}
+
+/** OpenAI Responses API file format */
+export interface OpenAIInputFileBlock {
+  type: 'input_file';
+  filename: string;
+  file_data: string;
+}
+
+export type DocumentBlock =
+  | AnthropicDocumentBlock
+  | GoogleDocumentBlock
+  | OpenAIFileBlock
+  | OpenAIInputFileBlock;
+
 export interface DocumentResult {
-  documents: Array<{
-    type: 'document' | 'file' | 'input_file';
-    /** Anthropic File Format, `document` */
-    source?: {
-      type: string;
-      media_type: string;
-      data: string;
-    };
-    cache_control?: { type: string };
-    citations?: { enabled: boolean };
-    /** Google File Format, `document` */
-    mimeType?: string;
-    data?: string;
-    /** OpenAI File Format, `file` */
-    file?: {
-      filename?: string;
-      file_data?: string;
-    };
-    /** OpenAI Responses API File Format, `input_file` */
-    filename?: string;
-    file_data?: string;
-  }>;
+  documents: DocumentBlock[];
   files: Array<{
     file_id?: string;
     temp_file_id?: string;


### PR DESCRIPTION
## Summary

I added support for including filenames as context in Anthropic document blocks and refactored the document type definitions for better type safety and maintainability.

- Added optional `context` field to Anthropic document blocks to include the filename when available
- Removed the `cache_control` field from the default Anthropic document structure, allowing it to be set optionally
- Created dedicated TypeScript interfaces for each provider's document format: `AnthropicDocumentBlock`, `GoogleDocumentBlock`, `OpenAIFileBlock`, and `OpenAIInputFileBlock`
- Introduced a union type `DocumentBlock` to represent all possible document formats
- Refactored the `DocumentResult` interface to use the new strongly typed `DocumentBlock[]` instead of an inline type definition
- Improved code maintainability by separating provider-specific document formats into distinct, well-documented interfaces

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

I tested the changes by uploading PDF documents through the Anthropic provider and verifying that the filename appears correctly in the document context field. I also confirmed that existing functionality for other providers (Google, OpenAI) remains unaffected.

### **Test Configuration**:
- Provider: Anthropic Claude
- File type: PDF documents
- Verified context field population with filename
- Verified backward compatibility with existing document handling

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules