### PR TITLE
feat: add fileSearchSelected config option to control File search default state

### DIFF
--- a/client/src/Providers/BadgeRowContext.tsx
+++ b/client/src/Providers/BadgeRowContext.tsx
@@ -9,6 +9,7 @@ import {
   useCodeApiKeyForm,
   useToolToggle,
 } from '~/hooks';
+import { useGetStartupConfig } from '~/data-provider';
 import { getTimestampedValue, setTimestamp } from '~/utils/timestamps';
 import { ephemeralAgentByConvoId } from '~/store';
 
@@ -48,6 +49,7 @@ export default function BadgeRowProvider({
   const lastKeyRef = useRef<string>('');
   const hasInitializedRef = useRef(false);
   const { agentsConfig } = useGetAgentsConfig();
+  const { data: config } = useGetStartupConfig();
   const key = conversationId ?? Constants.NEW_CONVO;
 
   const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(key));
@@ -110,10 +112,12 @@ export default function BadgeRowProvider({
        * Always set values for all tools (use defaults if not in `localStorage`)
        * If `ephemeralAgent` is `null`, create a new object with just our tool values
        */
+      const fileSearchSelected = config?.interface?.fileSearchSelected ?? false;
+
       const finalValues = {
         [Tools.execute_code]: initialValues[Tools.execute_code] ?? false,
         [Tools.web_search]: initialValues[Tools.web_search] ?? false,
-        [Tools.file_search]: initialValues[Tools.file_search] ?? false,
+        [Tools.file_search]: initialValues[Tools.file_search] ?? fileSearchSelected,
         [AgentCapabilities.artifacts]: initialValues[AgentCapabilities.artifacts] ?? false,
       };
 

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -32,6 +32,10 @@ interface:
   # Note: This setting does not disable the Agents File Search Capability.
   # To disable the Agents Capability, see the Agents Endpoint configuration instead.
   fileSearch: true
+  # Enable/disable file search selected by default in new conversations (default: false)
+  # When true, the File search toggle will be enabled/checked by default for new conversations
+  # When false, users need to manually enable the File search toggle (current behavior)
+  fileSearchSelected: false
   # Privacy policy settings
   privacyPolicy:
     externalUrl: 'https://librechat.ai/privacy-policy'

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -32,9 +32,10 @@ interface:
   # Note: This setting does not disable the Agents File Search Capability.
   # To disable the Agents Capability, see the Agents Endpoint configuration instead.
   fileSearch: true
-  # Enable/disable file search selected by default in new conversations (default: false)
-  # When true, the File search toggle will be enabled/checked by default for new conversations
-  # When false, users need to manually enable the File search toggle (current behavior)
+  # Pre-select "File search" toggle in new conversations (default: false)
+  # When true: "File search" toggle is automatically selected in new conversations
+  # When false: Users must manually select "File search" toggle to upload files (current behavior)
+  # Only has effect when fileSearch is true
   fileSearchSelected: false
   # Privacy policy settings
   privacyPolicy:

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -234,13 +234,11 @@ endpoints:
       baseURL: 'https://api.groq.com/openai/v1/'
       models:
         default:
-          [
-            'llama3-70b-8192',
-            'llama3-8b-8192',
-            'llama2-70b-4096',
-            'mixtral-8x7b-32768',
-            'gemma-7b-it',
-          ]
+          - 'llama3-70b-8192'
+          - 'llama3-8b-8192'
+          - 'llama2-70b-4096'
+          - 'mixtral-8x7b-32768'
+          - 'gemma-7b-it'
         fetch: false
       titleConvo: true
       titleModel: 'mixtral-8x7b-32768'
@@ -325,6 +323,60 @@ endpoints:
       forcePrompt: false
       modelDisplayLabel: 'Portkey'
       iconURL: https://images.crunchbase.com/image/upload/c_pad,f_auto,q_auto:eco,dpr_1/rjqy7ghvjoiu4cd1xjbf
+# Example modelSpecs configuration showing grouping options
+# The 'group' field organizes model specs in the UI selector:
+# - If 'group' matches an endpoint name (e.g., "openAI", "groq"), the spec appears nested under that endpoint
+# - If 'group' is a custom name (doesn't match any endpoint), it creates a separate collapsible section
+# - If 'group' is omitted, the spec appears as a standalone item at the top level
+# modelSpecs:
+#   list:
+#     # Example 1: Nested under an endpoint (grouped with openAI endpoint)
+#     - name: "gpt-4o"
+#       label: "GPT-4 Optimized"
+#       description: "Most capable GPT-4 model with multimodal support"
+#       group: "openAI"  # String value matching the endpoint name
+#       preset:
+#         endpoint: "openAI"
+#         model: "gpt-4o"
+#
+#     # Example 2: Nested under a custom endpoint (grouped with groq endpoint)
+#     - name: "llama3-70b-8192"
+#       label: "Llama 3 70B"
+#       description: "Fastest inference available - great for quick responses"
+#       group: "groq"  # String value matching your custom endpoint name from endpoints.custom
+#       preset:
+#         endpoint: "groq"
+#         model: "llama3-70b-8192"
+#
+#     # Example 3: Custom group (creates a separate collapsible section)
+#     - name: "coding-assistant"
+#       label: "Coding Assistant"
+#       description: "Specialized for coding tasks"
+#       group: "my-assistants"  # Custom string - doesn't match any endpoint, so creates its own group
+#       preset:
+#         endpoint: "openAI"
+#         model: "gpt-4o"
+#         instructions: "You are an expert coding assistant..."
+#         temperature: 0.3
+#
+#     - name: "writing-assistant"
+#       label: "Writing Assistant"
+#       description: "Specialized for creative writing"
+#       group: "my-assistants"  # Same custom group name - both specs appear in same section
+#       preset:
+#         endpoint: "anthropic"
+#         model: "claude-sonnet-4"
+#         instructions: "You are a creative writing expert..."
+#
+#     # Example 4: Standalone (no group - appears at top level)
+#     - name: "general-assistant"
+#       label: "General Assistant"
+#       description: "General purpose assistant"
+#       # No 'group' field - appears as standalone item at top level (not nested)
+#       preset:
+#         endpoint: "openAI"
+#         model: "gpt-4o-mini"
+
 # fileConfig:
 #   endpoints:
 #     assistants:

--- a/packages/api/src/app/__tests__/fileSearchSelected.integration.test.ts
+++ b/packages/api/src/app/__tests__/fileSearchSelected.integration.test.ts
@@ -6,14 +6,12 @@ import { SystemRoles, Permissions, PermissionTypes } from 'librechat-data-provid
 
 // Mock the logger and memory modules
 jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
   logger: {
     error: jest.fn(),
     warn: jest.fn(),
     debug: jest.fn(),
   },
-}));
-
-jest.mock('@librechat/data-schemas/dist/app/memory', () => ({
   isMemoryEnabled: jest.fn(() => false),
 }));
 

--- a/packages/api/src/app/__tests__/fileSearchSelected.integration.test.ts
+++ b/packages/api/src/app/__tests__/fileSearchSelected.integration.test.ts
@@ -1,0 +1,376 @@
+import { loadDefaultInterface } from '../interface';
+import { updateInterfacePermissions } from '../permissions';
+import type { TCustomConfig, TConfigDefaults } from 'librechat-data-provider';
+import type { AppConfig } from '~/types/config';
+import { SystemRoles, Permissions, PermissionTypes } from 'librechat-data-provider';
+
+// Mock the logger and memory modules
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('~/memory/config', () => ({
+  isMemoryEnabled: jest.fn(() => false),
+}));
+
+describe('fileSearchSelected Integration Tests', () => {
+  const mockGetRoleByName = jest.fn();
+  const mockUpdateAccessPermissions = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetRoleByName.mockResolvedValue(null);
+  });
+
+  describe('End-to-end configuration flow', () => {
+    it('should handle complete flow when fileSearchSelected is true and fileSearch is true', async () => {
+      // Step 1: Configuration loading
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true,
+          prompts: true,
+          bookmarks: true,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: false,
+          prompts: false,
+          bookmarks: false,
+        },
+      };
+
+      // Step 2: Load interface configuration
+      const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+
+      // Verify interface config is correct
+      expect(interfaceConfig.fileSearch).toBe(true);
+      expect(interfaceConfig.fileSearchSelected).toBe(true);
+      expect(interfaceConfig.prompts).toBe(true);
+      expect(interfaceConfig.bookmarks).toBe(true);
+
+      // Step 3: Create app config and update permissions
+      const appConfig: AppConfig = {
+        config,
+        interfaceConfig,
+      } as AppConfig;
+
+      await updateInterfacePermissions({
+        appConfig,
+        getRoleByName: mockGetRoleByName,
+        updateAccessPermissions: mockUpdateAccessPermissions,
+      });
+
+      // Step 4: Verify permissions were updated correctly
+      expect(mockUpdateAccessPermissions).toHaveBeenCalledTimes(2);
+
+      // Check USER role permissions
+      const userCall = mockUpdateAccessPermissions.mock.calls.find(
+        (call) => call[0] === SystemRoles.USER,
+      );
+      expect(userCall[1][PermissionTypes.FILE_SEARCH]).toEqual({
+        [Permissions.USE]: true,
+      });
+
+      // Check ADMIN role permissions
+      const adminCall = mockUpdateAccessPermissions.mock.calls.find(
+        (call) => call[0] === SystemRoles.ADMIN,
+      );
+      expect(adminCall[1][PermissionTypes.FILE_SEARCH]).toEqual({
+        [Permissions.USE]: true,
+      });
+    });
+
+    it('should prevent configuration when fileSearch is false but fileSearchSelected is true', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: true,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: false,
+        },
+      };
+
+      // Should throw during interface loading
+      await expect(loadDefaultInterface({ config, configDefaults })).rejects.toThrow(
+        'Configuration error: fileSearchSelected cannot be enabled when fileSearch is disabled',
+      );
+
+      // Permissions should not be updated due to the error
+      expect(mockUpdateAccessPermissions).not.toHaveBeenCalled();
+    });
+
+    it('should handle complex configuration with modelSpecs and fileSearchSelected', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true,
+        },
+        modelSpecs: {
+          list: [
+            {
+              name: 'test-model',
+              preset: {
+                endpoint: 'openAI',
+                model: 'gpt-4',
+              },
+            },
+          ],
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: false,
+          endpointsMenu: true,
+          modelSelect: true,
+          parameters: true,
+          presets: true,
+        },
+      };
+
+      const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+
+      // ModelSpecs should affect other interface elements
+      expect(interfaceConfig.endpointsMenu).toBe(false);
+      expect(interfaceConfig.parameters).toBe(false);
+      expect(interfaceConfig.presets).toBe(false);
+
+      // But fileSearchSelected should preserve explicit configuration
+      expect(interfaceConfig.fileSearch).toBe(true);
+      expect(interfaceConfig.fileSearchSelected).toBe(true);
+    });
+
+    it('should handle memory configuration alongside fileSearchSelected', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true,
+          memories: true,
+        },
+        memory: {
+          agent: {
+            id: 'test-agent',
+          },
+          personalize: true,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: false,
+          memories: false,
+        },
+      };
+
+      const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+      const appConfig: AppConfig = {
+        config,
+        interfaceConfig,
+      } as AppConfig;
+
+      await updateInterfacePermissions({
+        appConfig,
+        getRoleByName: mockGetRoleByName,
+        updateAccessPermissions: mockUpdateAccessPermissions,
+      });
+
+      expect(mockUpdateAccessPermissions).toHaveBeenCalledTimes(2);
+
+      const userCall = mockUpdateAccessPermissions.mock.calls.find(
+        (call) => call[0] === SystemRoles.USER,
+      );
+
+      // Should have both file search and memory permissions
+      expect(userCall[1][PermissionTypes.FILE_SEARCH]).toEqual({
+        [Permissions.USE]: true,
+      });
+      expect(userCall[1][PermissionTypes.MEMORIES]).toBeDefined();
+    });
+
+    it('should handle edge case with defaults providing conflicting configuration', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: false, // Explicitly disabled
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: true, // Default tries to enable, but fileSearch is false
+        },
+      };
+
+      // Should throw because defaults create invalid configuration
+      await expect(loadDefaultInterface({ config, configDefaults })).rejects.toThrow(
+        'Configuration error: fileSearchSelected cannot be enabled when fileSearch is disabled',
+      );
+    });
+
+    it('should allow fileSearchSelected from defaults when fileSearch is true', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true, // Explicitly enabled
+          // fileSearchSelected not specified, should use default
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: true, // This should be used since fileSearch is true
+        },
+      };
+
+      const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+
+      expect(interfaceConfig.fileSearch).toBe(true);
+      expect(interfaceConfig.fileSearchSelected).toBe(true);
+    });
+
+    it('should handle minimal configuration', async () => {
+      const config: Partial<TCustomConfig> = {};
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: false,
+        },
+      };
+
+      const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+      const appConfig: AppConfig = {
+        config,
+        interfaceConfig,
+      } as AppConfig;
+
+      await updateInterfacePermissions({
+        appConfig,
+        getRoleByName: mockGetRoleByName,
+        updateAccessPermissions: mockUpdateAccessPermissions,
+      });
+
+      expect(mockUpdateAccessPermissions).toHaveBeenCalledTimes(2);
+      expect(interfaceConfig.fileSearch).toBe(true);
+      expect(interfaceConfig.fileSearchSelected).toBe(false);
+    });
+
+    it('should handle undefined configuration gracefully', async () => {
+      const config = undefined;
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true,
+        },
+      };
+
+      const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+      const appConfig: AppConfig = {
+        config: config as TCustomConfig,
+        interfaceConfig,
+      } as AppConfig;
+
+      await updateInterfacePermissions({
+        appConfig,
+        getRoleByName: mockGetRoleByName,
+        updateAccessPermissions: mockUpdateAccessPermissions,
+      });
+
+      expect(mockUpdateAccessPermissions).toHaveBeenCalledTimes(2);
+      expect(interfaceConfig.fileSearch).toBe(true);
+      expect(interfaceConfig.fileSearchSelected).toBe(true);
+    });
+  });
+
+  describe('Configuration precedence', () => {
+    it('should prioritize explicit config over defaults', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: false, // Explicit false
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true, // Default true, should be overridden
+        },
+      };
+
+      const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+
+      expect(interfaceConfig.fileSearch).toBe(true);
+      expect(interfaceConfig.fileSearchSelected).toBe(false); // Should use explicit config
+    });
+
+    it('should use defaults when config values are undefined', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          // fileSearchSelected is undefined, should use default
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: true, // Should be used
+        },
+      };
+
+      const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+
+      expect(interfaceConfig.fileSearch).toBe(true); // From config
+      expect(interfaceConfig.fileSearchSelected).toBe(true); // From defaults
+    });
+  });
+
+  describe('removeNullishValues behavior', () => {
+    it('should exclude fileSearchSelected when undefined', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          // fileSearchSelected undefined
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          // fileSearchSelected also undefined in defaults
+        },
+      };
+
+      const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+
+      expect(interfaceConfig).not.toHaveProperty('fileSearchSelected');
+      expect(interfaceConfig.fileSearch).toBe(true);
+    });
+
+    it('should include fileSearchSelected when false (not nullish)', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: false, // Explicit false should be included
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true,
+        },
+      };
+
+      const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+
+      expect(interfaceConfig).toHaveProperty('fileSearchSelected', false);
+      expect(interfaceConfig.fileSearch).toBe(true);
+    });
+  });
+});

--- a/packages/api/src/app/__tests__/fileSearchSelected.integration.test.ts
+++ b/packages/api/src/app/__tests__/fileSearchSelected.integration.test.ts
@@ -1,4 +1,4 @@
-import { loadDefaultInterface } from '../interface';
+import { loadDefaultInterface } from '@librechat/data-schemas';
 import { updateInterfacePermissions } from '../permissions';
 import type { TCustomConfig, TConfigDefaults } from 'librechat-data-provider';
 import type { AppConfig } from '~/types/config';
@@ -13,7 +13,7 @@ jest.mock('@librechat/data-schemas', () => ({
   },
 }));
 
-jest.mock('~/memory/config', () => ({
+jest.mock('@librechat/data-schemas/dist/app/memory', () => ({
   isMemoryEnabled: jest.fn(() => false),
 }));
 

--- a/packages/api/src/app/interface.test.ts
+++ b/packages/api/src/app/interface.test.ts
@@ -1,5 +1,4 @@
-import { logger } from '@librechat/data-schemas';
-import { loadDefaultInterface } from './interface';
+import { logger, loadDefaultInterface } from '@librechat/data-schemas';
 import type { TCustomConfig, TConfigDefaults } from 'librechat-data-provider';
 
 // Mock the logger
@@ -8,10 +7,11 @@ jest.mock('@librechat/data-schemas', () => ({
     error: jest.fn(),
     warn: jest.fn(),
   },
+  loadDefaultInterface: jest.requireActual('@librechat/data-schemas').loadDefaultInterface,
 }));
 
 // Mock isMemoryEnabled
-jest.mock('./memory', () => ({
+jest.mock('@librechat/data-schemas/dist/app/memory', () => ({
   isMemoryEnabled: jest.fn((config) => !!config?.agent),
 }));
 

--- a/packages/api/src/app/interface.test.ts
+++ b/packages/api/src/app/interface.test.ts
@@ -1,17 +1,13 @@
 import { logger, loadDefaultInterface } from '@librechat/data-schemas';
 import type { TCustomConfig, TConfigDefaults } from 'librechat-data-provider';
 
-// Mock the logger
+// Mock the logger and isMemoryEnabled
 jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
   logger: {
     error: jest.fn(),
     warn: jest.fn(),
   },
-  loadDefaultInterface: jest.requireActual('@librechat/data-schemas').loadDefaultInterface,
-}));
-
-// Mock isMemoryEnabled
-jest.mock('@librechat/data-schemas/dist/app/memory', () => ({
   isMemoryEnabled: jest.fn((config) => !!config?.agent),
 }));
 

--- a/packages/api/src/app/interface.test.ts
+++ b/packages/api/src/app/interface.test.ts
@@ -1,0 +1,369 @@
+import { logger } from '@librechat/data-schemas';
+import { loadDefaultInterface } from './interface';
+import type { TCustomConfig, TConfigDefaults } from 'librechat-data-provider';
+
+// Mock the logger
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+// Mock isMemoryEnabled
+jest.mock('./memory', () => ({
+  isMemoryEnabled: jest.fn((config) => !!config?.agent),
+}));
+
+describe('loadDefaultInterface', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fileSearchSelected configuration', () => {
+    it('should include fileSearchSelected when explicitly set to true', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: false,
+        },
+      };
+
+      const result = await loadDefaultInterface({ config, configDefaults });
+
+      expect(result.fileSearchSelected).toBe(true);
+    });
+
+    it('should include fileSearchSelected when explicitly set to false', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: false,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true,
+        },
+      };
+
+      const result = await loadDefaultInterface({ config, configDefaults });
+
+      expect(result.fileSearchSelected).toBe(false);
+    });
+
+    it('should not include fileSearchSelected when not configured', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+        },
+      };
+
+      const result = await loadDefaultInterface({ config, configDefaults });
+
+      expect(result.fileSearchSelected).toBeUndefined();
+    });
+
+    it('should handle fileSearchSelected when fileSearch is false', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: false,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: false,
+        },
+      };
+
+      const result = await loadDefaultInterface({ config, configDefaults });
+
+      expect(result.fileSearchSelected).toBe(false);
+    });
+  });
+
+  describe('fileSearchSelected validation', () => {
+    it('should throw error when fileSearch is false but fileSearchSelected is true', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: true,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: false,
+        },
+      };
+
+      await expect(loadDefaultInterface({ config, configDefaults })).rejects.toThrow(
+        'Configuration error: fileSearchSelected cannot be enabled when fileSearch is disabled',
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'Invalid configuration: fileSearchSelected cannot be true when fileSearch is false. ' +
+          'Either enable fileSearch or disable fileSearchSelected.',
+      );
+    });
+
+    it('should not throw error when fileSearch is true and fileSearchSelected is true', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: false,
+        },
+      };
+
+      await expect(loadDefaultInterface({ config, configDefaults })).resolves.not.toThrow();
+
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('should not throw error when fileSearch is true and fileSearchSelected is false', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: false,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true,
+        },
+      };
+
+      await expect(loadDefaultInterface({ config, configDefaults })).resolves.not.toThrow();
+
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('should not throw error when both fileSearch and fileSearchSelected are false', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: false,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: false,
+        },
+      };
+
+      await expect(loadDefaultInterface({ config, configDefaults })).resolves.not.toThrow();
+
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('should not throw error when fileSearch is undefined and fileSearchSelected is true', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearchSelected: true,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: false,
+        },
+      };
+
+      await expect(loadDefaultInterface({ config, configDefaults })).resolves.not.toThrow();
+
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when fileSearch is explicitly false and fileSearchSelected is true (from defaults)', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: false,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: false,
+          fileSearchSelected: true, // This should cause validation error
+        },
+      };
+
+      // Since fileSearchSelected comes from defaults but fileSearch is explicitly false in config,
+      // this should trigger validation error
+      await expect(loadDefaultInterface({ config, configDefaults })).rejects.toThrow(
+        'Configuration error: fileSearchSelected cannot be enabled when fileSearch is disabled',
+      );
+    });
+  });
+
+  describe('complex configuration scenarios', () => {
+    it('should handle complex interface configuration with fileSearchSelected', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          endpointsMenu: true,
+          modelSelect: true,
+          parameters: true,
+          fileSearch: true,
+          fileSearchSelected: true,
+          prompts: true,
+          bookmarks: true,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          endpointsMenu: false,
+          modelSelect: false,
+          parameters: false,
+          fileSearch: false,
+          fileSearchSelected: false,
+          prompts: false,
+          bookmarks: false,
+        },
+      };
+
+      const result = await loadDefaultInterface({ config, configDefaults });
+
+      expect(result.endpointsMenu).toBe(true);
+      expect(result.modelSelect).toBe(true);
+      expect(result.parameters).toBe(true);
+      expect(result.fileSearch).toBe(true);
+      expect(result.fileSearchSelected).toBe(true);
+      expect(result.prompts).toBe(true);
+      expect(result.bookmarks).toBe(true);
+    });
+
+    it('should use defaults when config is empty', async () => {
+      const config: Partial<TCustomConfig> = {};
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true,
+        },
+      };
+
+      const result = await loadDefaultInterface({ config, configDefaults });
+
+      expect(result.fileSearch).toBe(true);
+      expect(result.fileSearchSelected).toBe(true);
+    });
+
+    it('should handle undefined config', async () => {
+      const config = undefined;
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: false,
+        },
+      };
+
+      const result = await loadDefaultInterface({ config, configDefaults });
+
+      expect(result.fileSearch).toBe(true);
+      expect(result.fileSearchSelected).toBe(false);
+    });
+  });
+
+  describe('integration with modelSpecs', () => {
+    it('should respect modelSpecs settings while preserving fileSearchSelected', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true,
+        },
+        modelSpecs: {
+          list: [
+            {
+              name: 'test-spec',
+              preset: {
+                endpoint: 'openAI',
+                model: 'gpt-4',
+              },
+            },
+          ],
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          endpointsMenu: true,
+          modelSelect: true,
+          parameters: true,
+          presets: true,
+          fileSearch: false,
+          fileSearchSelected: false,
+        },
+      };
+
+      const result = await loadDefaultInterface({ config, configDefaults });
+
+      // These should be influenced by modelSpecs
+      expect(result.endpointsMenu).toBe(false);
+      expect(result.parameters).toBe(false);
+      expect(result.presets).toBe(false);
+
+      // These should preserve explicit configuration
+      expect(result.fileSearch).toBe(true);
+      expect(result.fileSearchSelected).toBe(true);
+    });
+  });
+
+  describe('removeNullishValues behavior', () => {
+    it('should exclude fileSearchSelected when it is undefined', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          // fileSearchSelected is undefined
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          // fileSearchSelected not in defaults either
+        },
+      };
+
+      const result = await loadDefaultInterface({ config, configDefaults });
+
+      expect(result).not.toHaveProperty('fileSearchSelected');
+    });
+
+    it('should include fileSearchSelected when it is false (not nullish)', async () => {
+      const config: Partial<TCustomConfig> = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: false,
+        },
+      };
+      const configDefaults: TConfigDefaults = {
+        interface: {
+          fileSearch: true,
+          fileSearchSelected: true,
+        },
+      };
+
+      const result = await loadDefaultInterface({ config, configDefaults });
+
+      expect(result).toHaveProperty('fileSearchSelected', false);
+    });
+  });
+});

--- a/packages/api/src/app/interface.ts
+++ b/packages/api/src/app/interface.ts
@@ -53,6 +53,7 @@ export async function loadDefaultInterface({
     runCode: interfaceConfig?.runCode,
     webSearch: interfaceConfig?.webSearch,
     fileSearch: interfaceConfig?.fileSearch,
+    fileSearchSelected: interfaceConfig?.fileSearchSelected,
     fileCitations: interfaceConfig?.fileCitations,
     peoplePicker: interfaceConfig?.peoplePicker,
     marketplace: interfaceConfig?.marketplace,

--- a/packages/api/src/app/interface.ts
+++ b/packages/api/src/app/interface.ts
@@ -101,6 +101,17 @@ export async function loadDefaultInterface({
     if (i === 0) i++;
   }
 
+  // Validate fileSearchSelected configuration
+  if (loadedInterface.fileSearch === false && loadedInterface.fileSearchSelected === true) {
+    logger.error(
+      'Invalid configuration: fileSearchSelected cannot be true when fileSearch is false. ' +
+        'Either enable fileSearch or disable fileSearchSelected.',
+    );
+    throw new Error(
+      'Configuration error: fileSearchSelected cannot be enabled when fileSearch is disabled',
+    );
+  }
+
   if (i > 0) {
     logSettings();
   }

--- a/packages/api/src/app/permissions.spec.ts
+++ b/packages/api/src/app/permissions.spec.ts
@@ -1,8 +1,8 @@
+import { loadDefaultInterface } from '@librechat/data-schemas';
 import { SystemRoles, Permissions, PermissionTypes, roleDefaults } from 'librechat-data-provider';
 import type { TConfigDefaults, TCustomConfig } from 'librechat-data-provider';
-import type { AppConfig } from '~/types/config';
+import type { AppConfig } from '@librechat/data-schemas';
 import { updateInterfacePermissions } from './permissions';
-import { loadDefaultInterface } from './interface';
 
 const mockUpdateAccessPermissions = jest.fn();
 const mockGetRoleByName = jest.fn();

--- a/packages/client/src/Providers/BadgeRowContext.test.tsx
+++ b/packages/client/src/Providers/BadgeRowContext.test.tsx
@@ -1,0 +1,386 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BadgeRowProvider, useBadgeRowContext } from './BadgeRowContext';
+import { useGetStartupConfig } from '~/data-provider';
+
+// Mock the hooks and utilities
+jest.mock('~/data-provider');
+jest.mock('~/hooks', () => ({
+  useMCPServerManager: jest.fn(() => ({})),
+  useSearchApiKeyForm: jest.fn(() => ({ setIsDialogOpen: jest.fn() })),
+  useGetAgentsConfig: jest.fn(() => ({ agentsConfig: null })),
+  useCodeApiKeyForm: jest.fn(() => ({ setIsDialogOpen: jest.fn() })),
+  useToolToggle: jest.fn((config) => ({
+    isEnabled: false,
+    setIsEnabled: jest.fn(),
+    ...config,
+  })),
+}));
+
+jest.mock('~/utils/timestamps', () => ({
+  getTimestampedValue: jest.fn(),
+  setTimestamp: jest.fn(),
+}));
+
+// Mock localStorage
+const mockLocalStorage = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn(),
+};
+Object.defineProperty(window, 'localStorage', {
+  value: mockLocalStorage,
+});
+
+// Test component to access context
+const TestComponent: React.FC = () => {
+  const context = useBadgeRowContext();
+  return (
+    <div data-testid="test-component">
+      <span data-testid="fileSearch-enabled">{context.fileSearch.isEnabled?.toString()}</span>
+    </div>
+  );
+};
+
+const renderWithProviders = (
+  children: React.ReactNode,
+  configData?: unknown,
+  conversationId?: string | null,
+) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  (useGetStartupConfig as jest.Mock).mockReturnValue({
+    data: configData,
+    isLoading: false,
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <BadgeRowProvider conversationId={conversationId}>{children}</BadgeRowProvider>
+      </RecoilRoot>
+    </QueryClientProvider>,
+  );
+};
+
+describe('BadgeRowProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLocalStorage.getItem.mockReturnValue(null);
+  });
+
+  describe('fileSearchSelected configuration', () => {
+    it('should initialize fileSearch toggle with fileSearchSelected=true from config', async () => {
+      const configData = {
+        interface: {
+          fileSearchSelected: true,
+        },
+      };
+
+      renderWithProviders(<TestComponent />, configData, 'test-convo-id');
+
+      await waitFor(() => {
+        // Verify that the configuration was used during initialization
+        expect(useGetStartupConfig).toHaveBeenCalled();
+      });
+    });
+
+    it('should initialize fileSearch toggle with fileSearchSelected=false from config', async () => {
+      const configData = {
+        interface: {
+          fileSearchSelected: false,
+        },
+      };
+
+      renderWithProviders(<TestComponent />, configData, 'test-convo-id');
+
+      await waitFor(() => {
+        expect(useGetStartupConfig).toHaveBeenCalled();
+      });
+    });
+
+    it('should use default false when fileSearchSelected is not configured', async () => {
+      const configData = {
+        interface: {
+          // fileSearchSelected not specified
+        },
+      };
+
+      renderWithProviders(<TestComponent />, configData, 'test-convo-id');
+
+      await waitFor(() => {
+        expect(useGetStartupConfig).toHaveBeenCalled();
+      });
+    });
+
+    it('should use default false when config is undefined', async () => {
+      renderWithProviders(<TestComponent />, undefined, 'test-convo-id');
+
+      await waitFor(() => {
+        expect(useGetStartupConfig).toHaveBeenCalled();
+      });
+    });
+
+    it('should use default false when interface config is undefined', async () => {
+      const configData = {
+        // interface not specified
+      };
+
+      renderWithProviders(<TestComponent />, configData, 'test-convo-id');
+
+      await waitFor(() => {
+        expect(useGetStartupConfig).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('localStorage interaction with fileSearchSelected', () => {
+    it('should use localStorage value when available, overriding config default', async () => {
+      const { getTimestampedValue } = await import('~/utils/timestamps');
+      getTimestampedValue.mockImplementation((key: string) => {
+        if (key.includes('fileSearch')) {
+          return 'true'; // localStorage has fileSearch enabled
+        }
+        return null;
+      });
+
+      const configData = {
+        interface: {
+          fileSearchSelected: false, // Config says false, but localStorage says true
+        },
+      };
+
+      renderWithProviders(<TestComponent />, configData, 'test-convo-id');
+
+      await waitFor(() => {
+        expect(getTimestampedValue).toHaveBeenCalledWith(expect.stringContaining('fileSearch'));
+      });
+    });
+
+    it('should fall back to config when localStorage is empty', async () => {
+      const { getTimestampedValue } = await import('~/utils/timestamps');
+      getTimestampedValue.mockReturnValue(null); // No localStorage value
+
+      const configData = {
+        interface: {
+          fileSearchSelected: true,
+        },
+      };
+
+      renderWithProviders(<TestComponent />, configData, 'test-convo-id');
+
+      await waitFor(() => {
+        expect(getTimestampedValue).toHaveBeenCalled();
+      });
+    });
+
+    it('should handle localStorage parsing errors gracefully', async () => {
+      const { getTimestampedValue } = await import('~/utils/timestamps');
+      getTimestampedValue.mockImplementation((key: string) => {
+        if (key.includes('fileSearch')) {
+          return 'invalid-json'; // This will cause JSON.parse to fail
+        }
+        return null;
+      });
+
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const configData = {
+        interface: {
+          fileSearchSelected: true,
+        },
+      };
+
+      renderWithProviders(<TestComponent />, configData, 'test-convo-id');
+
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Failed to parse file search toggle value:',
+          expect.any(Error),
+        );
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('conversation ID handling', () => {
+    it('should use NEW_CONVO constant when conversationId is null', async () => {
+      const configData = {
+        interface: {
+          fileSearchSelected: true,
+        },
+      };
+
+      renderWithProviders(<TestComponent />, configData, null);
+
+      await waitFor(() => {
+        expect(useGetStartupConfig).toHaveBeenCalled();
+      });
+    });
+
+    it('should use NEW_CONVO constant when conversationId is undefined', async () => {
+      const configData = {
+        interface: {
+          fileSearchSelected: true,
+        },
+      };
+
+      renderWithProviders(<TestComponent />, configData, undefined);
+
+      await waitFor(() => {
+        expect(useGetStartupConfig).toHaveBeenCalled();
+      });
+    });
+
+    it('should use provided conversationId when available', async () => {
+      const configData = {
+        interface: {
+          fileSearchSelected: true,
+        },
+      };
+
+      renderWithProviders(<TestComponent />, configData, 'specific-conversation-id');
+
+      await waitFor(() => {
+        expect(useGetStartupConfig).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('initialization behavior', () => {
+    it('should not reinitialize when isSubmitting is true', async () => {
+      const { setTimestamp } = await import('~/utils/timestamps');
+      const configData = {
+        interface: {
+          fileSearchSelected: true,
+        },
+      };
+
+      const { rerender } = renderWithProviders(<TestComponent />, configData, 'test-convo-id');
+
+      // Simulate isSubmitting=true
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <RecoilRoot>
+            <BadgeRowProvider conversationId="test-convo-id" isSubmitting={true}>
+              <TestComponent />
+            </BadgeRowProvider>
+          </RecoilRoot>
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        // Should not call setTimestamp when isSubmitting is true
+        expect(setTimestamp).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should initialize only once per conversation change', async () => {
+      const { setTimestamp } = await import('~/utils/timestamps');
+      const configData = {
+        interface: {
+          fileSearchSelected: true,
+        },
+      };
+
+      const { rerender } = renderWithProviders(<TestComponent />, configData, 'convo-1');
+
+      // Re-render with same conversation ID
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <RecoilRoot>
+            <BadgeRowProvider conversationId="convo-1">
+              <TestComponent />
+            </BadgeRowProvider>
+          </RecoilRoot>
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        // Should only initialize once for the same conversation
+        expect(setTimestamp).toHaveBeenCalledTimes(4); // Once for each tool type
+      });
+
+      // Change conversation ID
+      rerender(
+        <QueryClientProvider client={new QueryClient()}>
+          <RecoilRoot>
+            <BadgeRowProvider conversationId="convo-2">
+              <TestComponent />
+            </BadgeRowProvider>
+          </RecoilRoot>
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        // Should initialize again for new conversation
+        expect(setTimestamp).toHaveBeenCalledTimes(8); // Two sets of 4 calls
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle missing config gracefully', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      renderWithProviders(<TestComponent />, null, 'test-convo-id');
+
+      await waitFor(() => {
+        expect(useGetStartupConfig).toHaveBeenCalled();
+        // Should not throw errors
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should handle malformed config gracefully', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      const malformedConfig = {
+        interface: 'not-an-object', // This should be an object
+      };
+
+      renderWithProviders(<TestComponent />, malformedConfig, 'test-convo-id');
+
+      await waitFor(() => {
+        expect(useGetStartupConfig).toHaveBeenCalled();
+        // Should not throw errors even with malformed config
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('context provider', () => {
+    it('should throw error when useBadgeRowContext is used outside provider', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      expect(() => {
+        render(<TestComponent />);
+      }).toThrow('useBadgeRowContext must be used within a BadgeRowProvider');
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('should provide context successfully when used within provider', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      expect(() => {
+        renderWithProviders(<TestComponent />, {}, 'test-convo-id');
+      }).not.toThrow();
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -1,0 +1,73 @@
+import { removeNullishValues } from 'librechat-data-provider';
+import type { TCustomConfig, TConfigDefaults } from 'librechat-data-provider';
+import type { AppConfig } from '~/types/app';
+import logger from '../config/winston';
+import { isMemoryEnabled } from './memory';
+
+/**
+ * Loads the default interface object.
+ * @param params - The loaded custom configuration.
+ * @param params.config - The loaded custom configuration.
+ * @param params.configDefaults - The custom configuration default values.
+ * @returns default interface object.
+ */
+export async function loadDefaultInterface({
+  config,
+  configDefaults,
+}: {
+  config?: Partial<TCustomConfig>;
+  configDefaults: TConfigDefaults;
+}): Promise<AppConfig['interfaceConfig']> {
+  const { interface: interfaceConfig } = config ?? {};
+  const { interface: defaults } = configDefaults;
+  const hasModelSpecs = (config?.modelSpecs?.list?.length ?? 0) > 0;
+  const includesAddedEndpoints = (config?.modelSpecs?.addedEndpoints?.length ?? 0) > 0;
+
+  const memoryConfig = config?.memory;
+  const memoryEnabled = isMemoryEnabled(memoryConfig);
+  /** Only disable memories if memory config is present but disabled/invalid */
+  const shouldDisableMemories = memoryConfig && !memoryEnabled;
+
+  const loadedInterface: AppConfig['interfaceConfig'] = removeNullishValues({
+    // UI elements - use schema defaults
+    endpointsMenu:
+      interfaceConfig?.endpointsMenu ?? (hasModelSpecs ? false : defaults.endpointsMenu),
+    modelSelect:
+      interfaceConfig?.modelSelect ??
+      (hasModelSpecs ? includesAddedEndpoints : defaults.modelSelect),
+    parameters: interfaceConfig?.parameters ?? (hasModelSpecs ? false : defaults.parameters),
+    presets: interfaceConfig?.presets ?? (hasModelSpecs ? false : defaults.presets),
+    sidePanel: interfaceConfig?.sidePanel ?? defaults.sidePanel,
+    privacyPolicy: interfaceConfig?.privacyPolicy ?? defaults.privacyPolicy,
+    termsOfService: interfaceConfig?.termsOfService ?? defaults.termsOfService,
+    mcpServers: interfaceConfig?.mcpServers ?? defaults.mcpServers,
+    customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,
+
+    // Permissions - only include if explicitly configured
+    bookmarks: interfaceConfig?.bookmarks,
+    memories: shouldDisableMemories ? false : interfaceConfig?.memories,
+    prompts: interfaceConfig?.prompts,
+    multiConvo: interfaceConfig?.multiConvo,
+    agents: interfaceConfig?.agents,
+    temporaryChat: interfaceConfig?.temporaryChat,
+    runCode: interfaceConfig?.runCode,
+    webSearch: interfaceConfig?.webSearch,
+    fileSearch: interfaceConfig?.fileSearch,
+    fileSearchSelected: interfaceConfig?.fileSearchSelected,
+    fileCitations: interfaceConfig?.fileCitations,
+    peoplePicker: interfaceConfig?.peoplePicker,
+    marketplace: interfaceConfig?.marketplace,
+  });
+
+  // Validate fileSearchSelected configuration
+  if (loadedInterface.fileSearch === false && loadedInterface.fileSearchSelected === true) {
+    logger.error(
+      'Invalid configuration: fileSearchSelected cannot be true when fileSearch is false. ' +
+        'Either enable fileSearch or disable fileSearchSelected.',
+    );
+    throw new Error(
+      'Configuration error: fileSearchSelected cannot be enabled when fileSearch is disabled',
+    );
+  }
+  return loadedInterface;
+}


### PR DESCRIPTION
## Summary

This PR adds a new configuration option `fileSearchSelected` that allows LibreChat operators/administrators to pre-select the "File search" toggle in new conversations, improving user experience by eliminating the need to manually enable file uploads for each conversation.

## Problem

Currently, when LibreChat instances have file uploads enabled (`fileSearch: true`), users must manually select the "File search" toggle in every new conversation before they can upload files. If they forget to enable this toggle and try to drag-and-drop or upload files, they encounter the error: *"No capabilities enabled that support this file type."*

This creates friction for users who frequently need to upload files, as they must remember to enable file search in each new conversation.

## Solution

Added `fileSearchSelected` configuration option that allows administrators to pre-select the "File search" toggle in new conversations, so users can immediately upload files without manual configuration.

### Configuration

```yaml
interface:
  fileSearch: true          # Enables file upload capability for the instance (existing)
  fileSearchSelected: true  # Pre-selects "File search" toggle in new conversations (new)
```

### Behavior

- **`fileSearchSelected: true`** - "File search" toggle is automatically selected in new conversations
- **`fileSearchSelected: false`** - "File search" toggle starts unselected (current behavior - users must manually enable)
- **Defaults to `false`** for backward compatibility
- **Validation**: Throws configuration error if `fileSearchSelected: true` when `fileSearch: false`

## Use Cases

**Current User Experience (Before):**
1. User starts new conversation
2. User tries to upload file → **Error: "No capabilities enabled"**
3. User must manually click "File search" toggle
4. User can now upload files
5. Repeat for every new conversation

**Improved User Experience (With `fileSearchSelected: true`):**
1. User starts new conversation
2. "File search" toggle is already selected
3. User can immediately upload files
4. No manual configuration needed

## Changes

1. **Backend** (`packages/api/src/app/interface.ts`): 
   - Added `fileSearchSelected` to interface configuration loading
   - Added validation to prevent `fileSearchSelected: true` when `fileSearch: false`
2. **Frontend** (`client/src/Providers/BadgeRowContext.tsx`): 
   - Uses `fileSearchSelected` config value as default instead of hardcoded `false`
3. **Config** (`librechat.example.yaml`): Added documentation and examples

## Benefits

- ✅ **Improved UX**: Users can upload files immediately in new conversations
- ✅ **Operator Control**: Administrators can decide default behavior for their instance
- ✅ **Backward Compatible**: Existing behavior preserved (defaults to `false`)
- ✅ **Reduces User Friction**: Eliminates need to manually enable file uploads repeatedly
- ✅ **Configuration Validation**: Prevents invalid combinations

## Configuration Examples

```yaml
# Instance with file uploads enabled, but users must manually select in each conversation
interface:
  fileSearch: true
  fileSearchSelected: false  # Default behavior

# Instance with file uploads enabled and pre-selected for user convenience  
interface:
  fileSearch: true
  fileSearchSelected: true   # New capability

# Instance with file uploads completely disabled
interface:
  fileSearch: false
  # fileSearchSelected ignored when fileSearch is false
```

## Testing

- [x] Configuration validation prevents invalid combinations
- [x] Pre-commit hooks pass (prettier, eslint)
- [x] Backward compatibility maintained
- [x] Default behavior unchanged (`fileSearchSelected: false`)

## Related Issues

Improves user experience by allowing administrators to pre-select the "File search" toggle, eliminating the need for users to manually enable file uploads in every new conversation.