### PR TITLE
PR FOR VISIBILITY: Generated artifacts in side panel - draft

### DIFF
--- a/client/src/components/SidePanel/GeneratedArtifacts/ArtifactsTable.tsx
+++ b/client/src/components/SidePanel/GeneratedArtifacts/ArtifactsTable.tsx
@@ -1,0 +1,178 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Table,
+  Input,
+  Button,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+  TableHeader,
+  OGDialog,
+  OGDialogTrigger,
+  OGDialogContent,
+  OGDialogTitle,
+  OGDialogClose,
+} from '@librechat/client';
+import { Eye, X } from 'lucide-react';
+import { useLocalize } from '~/hooks';
+import type { ExtractedArtifact } from '~/utils/extractArtifacts';
+import { CodeMarkdown } from '~/components/Artifacts/Code';
+
+type ArtifactsTableProps = {
+  artifacts: ExtractedArtifact[];
+};
+
+const pageSize = 10;
+
+export function ArtifactsTable({ artifacts }: ArtifactsTableProps) {
+  const localize = useLocalize();
+  const [pageIndex, setPageIndex] = useState(0);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const filtered = useMemo(() => {
+    const query = searchQuery.toLowerCase();
+    return artifacts.filter((a) =>
+      [a.title, a.type].some((v) => (v || '').toLowerCase().includes(query)),
+    );
+  }, [artifacts, searchQuery]);
+
+  const currentRows = useMemo(() => {
+    return filtered.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize);
+  }, [filtered, pageIndex]);
+
+  // language is computed upstream in extractArtifacts.ts and exposed on each artifact
+
+  return (
+    <div className="mt-2 space-y-2">
+      <div className="flex items-center gap-4">
+        <Input
+          placeholder="Filter artifacts..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          aria-label="Filter artifacts"
+        />
+      </div>
+
+      <div className="rounded-lg border border-border-light bg-transparent shadow-sm transition-colors">
+        <Table className="w-full table-fixed">
+          <TableHeader>
+            <TableRow className="border-b border-border-light">
+              <TableHead className="w-[45%] bg-surface-secondary py-3 text-left text-sm font-medium text-text-secondary">
+                <div>Title</div>
+              </TableHead>
+              <TableHead className="w-[25%] bg-surface-secondary py-3 text-left text-sm font-medium text-text-secondary">
+                <div>Type</div>
+              </TableHead>
+              <TableHead className="w-[30%] bg-surface-secondary py-3 text-left text-sm font-medium text-text-secondary">
+                <div>Preview</div>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {currentRows.length ? (
+              currentRows.map((artifact) => (
+                <TableRow
+                  key={artifact.id}
+                  className="border-b border-border-light hover:bg-surface-secondary"
+                >
+                  <TableCell className="w-[45%] px-4 py-3">
+                    <div
+                      className="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-text-primary"
+                      title={artifact.title}
+                    >
+                      {artifact.title}
+                    </div>
+                  </TableCell>
+                  <TableCell className="w-[25%] px-4 py-3">
+                    <div
+                      className="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-text-secondary"
+                      title={artifact.type}
+                    >
+                      {artifact.type}
+                    </div>
+                  </TableCell>
+                  <TableCell className="w-[30%] px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <OGDialog
+                        open={openId === artifact.id}
+                        onOpenChange={(o) => setOpenId(o ? artifact.id : null)}
+                      >
+                        <OGDialogTrigger asChild>
+                          <Button variant="ghost" size="sm" aria-label={localize('com_ui_preview')}>
+                            <Eye className="h-4 w-4" />
+                          </Button>
+                        </OGDialogTrigger>
+                        <OGDialogContent className="flex max-h-[80vh] max-w-full flex-col overflow-hidden rounded-lg bg-surface-primary p-0 md:max-w-[800px]">
+                          <div className="flex items-center justify-between border-b border-border-light px-4 py-3">
+                            <OGDialogTitle className="text-base font-medium">
+                              {artifact.title}
+                            </OGDialogTitle>
+                            <OGDialogClose asChild>
+                              <button aria-label="Close" className="text-text-secondary">
+                                <X className="h-4 w-4" />
+                              </button>
+                            </OGDialogClose>
+                          </div>
+                          <div className="max-h-[70vh] overflow-auto p-4">
+                            {(() => {
+                              const lang = artifact.language ?? '';
+                              const fenced = `\n\n\`\`\`${lang}\n${artifact.content ?? ''}\n\`\`\`\n`;
+                              return <CodeMarkdown content={fenced} isSubmitting={false} />;
+                            })()}
+                          </div>
+                        </OGDialogContent>
+                      </OGDialog>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={3} className="h-24 text-center text-sm text-text-secondary">
+                  {localize('com_files_no_results')}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {filtered.length > pageSize && (
+        <div
+          className="flex items-center justify-end gap-2"
+          role="navigation"
+          aria-label="Pagination"
+        >
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPageIndex((prev) => Math.max(prev - 1, 0))}
+            disabled={pageIndex === 0}
+            aria-label={localize('com_ui_prev')}
+          >
+            {localize('com_ui_prev')}
+          </Button>
+          <div
+            className="text-sm"
+            aria-live="polite"
+          >{`${pageIndex + 1} / ${Math.ceil(filtered.length / pageSize)}`}</div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              setPageIndex((prev) => ((prev + 1) * pageSize < filtered.length ? prev + 1 : prev))
+            }
+            disabled={(pageIndex + 1) * pageSize >= filtered.length}
+            aria-label={localize('com_ui_next')}
+          >
+            {localize('com_ui_next')}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ArtifactsTable;

--- a/client/src/components/SidePanel/GeneratedArtifacts/GeneratedArtifacts.tsx
+++ b/client/src/components/SidePanel/GeneratedArtifacts/GeneratedArtifacts.tsx
@@ -1,0 +1,46 @@
+import { TMessage } from 'librechat-data-provider';
+import { useParams } from 'react-router-dom';
+import { useGetMessagesByConvoId } from '../../../data-provider';
+import { extractArtifacts, type ExtractedArtifact } from '../../../utils/extractArtifacts';
+import ArtifactsTable from './ArtifactsTable';
+
+export default function GeneratedArtifacts() {
+  const { conversationId } = useParams();
+
+  const { data: artifacts = [], isLoading } = useGetMessagesByConvoId(conversationId ?? '', {
+    select: (data: TMessage[]) => {
+      // Filter only messages that contain artifacts
+      // DRAFT: only supports gemini artifacts
+      const artifacts = data.reduce((artifacts, message) => {
+        const content = message.content;
+        if (content) {
+          content.forEach((part) => {
+            if (
+              part.type === 'text' &&
+              typeof part.text === 'string' &&
+              part.text.includes(':::artifact')
+            ) {
+              artifacts.push(...extractArtifacts(part.text));
+            }
+          });
+        }
+        return artifacts;
+      }, [] as ExtractedArtifact[]);
+
+      return artifacts;
+    },
+    enabled: !!conversationId,
+  });
+
+  if (!artifacts || artifacts.length === 0) {
+    return <div>No artifacts found</div>;
+  }
+
+  return (
+    <div className="w-full pt-0 text-text-primary">
+      <div className="mt-2 space-y-2">
+        <ArtifactsTable artifacts={artifacts} />
+      </div>
+    </div>
+  );
+}

--- a/client/src/hooks/Nav/useSideNavLinks.ts
+++ b/client/src/hooks/Nav/useSideNavLinks.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Blocks, MCPIcon, AttachmentIcon } from '@librechat/client';
+import { Blocks, MCPIcon, AttachmentIcon, ArchiveIcon } from '@librechat/client';
 import { Database, Bookmark, Settings2, ArrowRightToLine, MessageSquareQuote } from 'lucide-react';
 import {
   Permissions,
@@ -19,6 +19,7 @@ import PromptsAccordion from '~/components/Prompts/PromptsAccordion';
 import Parameters from '~/components/SidePanel/Parameters/Panel';
 import FilesPanel from '~/components/SidePanel/Files/Panel';
 import MCPPanel from '~/components/SidePanel/MCP/MCPPanel';
+import GeneratedArtifacts from '~/components/SidePanel/GeneratedArtifacts/GeneratedArtifacts';
 import { useGetStartupConfig } from '~/data-provider';
 import { useHasAccess } from '~/hooks';
 
@@ -169,6 +170,14 @@ export default function useSideNavLinks({
         Component: MCPPanel,
       });
     }
+
+    links.push({
+      title: 'com_sidepanel_generated_artifacts',
+      label: '',
+      icon: ArchiveIcon,
+      id: 'generated-artifacts',
+      Component: GeneratedArtifacts,
+    });
 
     links.push({
       title: 'com_sidepanel_hide_panel',

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -600,6 +600,7 @@
   "com_sidepanel_manage_files": "Manage Files",
   "com_sidepanel_mcp_no_servers_with_vars": "No MCP servers with configurable variables.",
   "com_sidepanel_parameters": "Parameters",
+  "com_sidepanel_generated_artifacts": "Generated Artifacts",
   "com_sources_agent_file": "Source Document",
   "com_sources_agent_files": "Agent Files",
   "com_sources_download_aria_label": "Download {{filename}}{{status}}",

--- a/client/src/utils/extractArtifacts.ts
+++ b/client/src/utils/extractArtifacts.ts
@@ -1,0 +1,65 @@
+export type ExtractedArtifact = {
+  id: string;
+  type: string;
+  title: string;
+  content: string;
+  language?: string;
+};
+
+export const mimeToLang: Record<string, string> = {
+  'text/html': 'html',
+  'application/vnd.code-html': 'html',
+  'text/css': 'css',
+  'application/javascript': 'javascript',
+  'text/javascript': 'javascript',
+  'application/json': 'json',
+  'text/markdown': 'markdown',
+  'text/md': 'markdown',
+  'text/typescript': 'typescript',
+  'application/typescript': 'typescript',
+};
+
+export function extractArtifacts(text: string): ExtractedArtifact[] {
+  const artifacts: ExtractedArtifact[] = [];
+  // gemini returns artifacts wrapped in :::artifact{...}:::
+  const artifactMatches = text.match(/:::artifact\{([^}]+)\}([\s\S]*?):::/g);
+
+  artifactMatches?.forEach((match) => {
+    // extract the metadata and content from the artifact i.e.
+    // :::artifact{identifier="unique-identifier" type="mime-type" title="Artifact Title"}
+    // ```html
+    // <html>
+    // <body>
+    // <h1>Hello, world!</h1>
+    // </body>
+    // </html>
+    // ```
+    // :::
+    const headerMatch = match.match(/:::artifact\{([^}]+)\}/);
+    const contentMatch = match.match(/```[\s\S]*?```/);
+
+    if (headerMatch && contentMatch) {
+      const metadata = headerMatch[1];
+      const fenceLangMatch = contentMatch[0].match(/```(\w+)/);
+      const content = contentMatch[0].replace(/```\w*\n?/, '').replace(/\n?```$/, '');
+
+      const typeMatch = metadata.match(/type="([^"]+)"/);
+      const titleMatch = metadata.match(/title="([^"]+)"/);
+      const idMatch = metadata.match(/identifier="([^"]+)"/);
+      const type = typeMatch?.[1] || 'unknown';
+      const title = titleMatch?.[1] || 'Untitled';
+      const id = idMatch?.[1] || `artifact-${title}-${type}`;
+      let language = mimeToLang[type] || fenceLangMatch?.[1] || 'txt';
+
+      artifacts.push({
+        id,
+        type,
+        title,
+        content,
+        language,
+      });
+    }
+  });
+
+  return artifacts;
+}


### PR DESCRIPTION
I'd like to receive some feedback on the following feature I am proposing. 


In short, I've added a nav entry in the right sidebar called generated artifacts. The goal is to provide an easy way to preview all the artifacts the model generates in a given conversation, so the user doesn't have to scroll up or down to find the artifact they are looking for.

This is what it looks like:

<img width="2934" height="1428" alt="image (2)" src="https://github.com/user-attachments/assets/7901685c-faa4-4a89-98e1-cd23fe5e0fd9" />

ATM, I'm only supporting Gemini, as they label artifacts distinctively in their payloads, but I don't think it will be hard to also include other models.

What do you think? Should I go on implement this fully?

Thanks!