### PR TITLE
🩹 fix: Wrap Attempt to Reconnect OAuth MCP Servers

### DIFF
--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -116,11 +116,15 @@ const refreshController = async (req, res) => {
       const token = await setAuthTokens(userId, res, session);
 
       // trigger OAuth MCP server reconnection asynchronously (best effort)
-      void getOAuthReconnectionManager()
-        .reconnectServers(userId)
-        .catch((err) => {
-          logger.error('Error reconnecting OAuth MCP servers:', err);
-        });
+      try {
+        void getOAuthReconnectionManager()
+          .reconnectServers(userId)
+          .catch((err) => {
+            logger.error('[refreshController] Error reconnecting OAuth MCP servers:', err);
+          });
+      } catch (err) {
+        logger.warn(`[refreshController] Cannot attempt OAuth MCP servers reconnection:`, err);
+      }
 
       res.status(200).send({ token, user });
     } else if (req?.query?.retry) {


### PR DESCRIPTION
## Summary

This PR adjusts the OAuthReconnectionManager invocation so that if it's not initialized yet its best-effort call is wrapped in a try/catch.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual testing with artificially-slow initialization.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] Local unit tests pass with my changes
