### PR TITLE
Fix env var redundnacy and update model names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,8 @@ MONGO_AUTO_INDEX=
 # Set to `false` to disable Mongoose automatically calling `createCollection()` on every model created on this connection. */
 MONGO_AUTO_CREATE=
 
-DOMAIN_CLIENT=http://localhost:3080
-DOMAIN_SERVER=http://localhost:3080
+DOMAIN_CLIENT=http://localhost:$PORT
+DOMAIN_SERVER=http://localhost:$PORT
 
 NO_INDEX=true
 # Use the address that is at most n number of hops away from the Express application.
@@ -109,7 +109,7 @@ PROXY=
 #============#
 
 ANTHROPIC_API_KEY=user_provided
-# ANTHROPIC_MODELS=claude-opus-4-20250514,claude-sonnet-4-20250514,claude-3-7-sonnet-20250219,claude-3-5-sonnet-20241022,claude-3-5-haiku-20241022,claude-3-opus-20240229,claude-3-sonnet-20240229,claude-3-haiku-20240307
+# ANTHROPIC_MODELS=claude-haiku-4-5-20251001,claude-sonnet-4-5-20250929,claude-opus-4-1-20250805,claude-3-5-haiku-20241022,,claude-3-haiku-20240307
 # ANTHROPIC_REVERSE_PROXY=
 
 #============#
@@ -201,10 +201,10 @@ OPENAI_API_KEY=user_provided
 DEBUG_OPENAI=false
 
 # TITLE_CONVO=false
-# OPENAI_TITLE_MODEL=gpt-4o-mini
+# OPENAI_TITLE_MODEL=gpt-5-nano
 
 # OPENAI_SUMMARIZE=true
-# OPENAI_SUMMARY_MODEL=gpt-4o-mini
+# OPENAI_SUMMARY_MODEL=gpt-5-nano
 
 # OPENAI_FORCE_PROMPT=true
 


### PR DESCRIPTION
Fixed 'PORT' env var redundancy, and updated model names for Anthropic and OpenAI.

## Summary

> Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

noticed that updating the port requires to update 3 separate variables, which is inefficient. updated the anthropic models to reflect new releases, since they cost the same, and still kept the 2 cheapest models for people who want to use them.

changed default `OPENAI_TITLE_MODEL` to be gpt-5-nano, as it's got the cheapest API pricing and should be more than sufficient.

## Change Type

- [x] This change requires a documentation update

i'm not sure which one was the best one to choose, but i'm updating the documentation so seemed the most appropriate.

## Testing

> Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

does not apply.

## Checklist

- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
