### PR TITLE
🌐 feat: Configurable Domain and Port for Vite Dev Server

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react';
+// @ts-ignore
 import path from 'path';
 import type { Plugin } from 'vite';
 import { defineConfig } from 'vite';
@@ -7,19 +8,23 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vitejs.dev/config/
+const backendPort = process.env.BACKEND_PORT && Number(process.env.BACKEND_PORT) || 3080;
+const backendURL = process.env.HOST ? `http://${process.env.HOST}:${backendPort}` : `http://localhost:${backendPort}`;
+
 export default defineConfig(({ command }) => ({
   base: '',
   server: {
-    host: 'localhost',
-    port: 3090,
+    allowedHosts: process.env.VITE_ALLOWED_HOSTS && process.env.VITE_ALLOWED_HOSTS.split(',') || [],
+    host: process.env.HOST || 'localhost',
+    port: process.env.PORT && Number(process.env.PORT) || 3090,
     strictPort: false,
     proxy: {
       '/api': {
-        target: 'http://localhost:3080',
+        target: backendURL,
         changeOrigin: true,
       },
       '/oauth': {
-        target: 'http://localhost:3080',
+        target: backendURL,
         changeOrigin: true,
       },
     },
@@ -259,6 +264,7 @@ export default defineConfig(({ command }) => ({
 interface SourcemapExclude {
   excludeNodeModules?: boolean;
 }
+
 export function sourcemapExclude(opts?: SourcemapExclude): Plugin {
   return {
     name: 'sourcemap-exclude',


### PR DESCRIPTION
## Summary

This PR allows configuring Vite so the exposed hot-reload frontend can be ran on a custom domain and port.
Added environment variable support:
| Variable name | Description |
|---|---|
| HOST | Shared host for frontend and backend/api |
| PORT | Port for the frontend server |
| BACKEND_PORT | Port for the backend/api sevrer|
| VITE_ALLOWED_HOSTS | List of allowed hosts, needed when customizing the host|

Allowing these configurations make running multiple instances locally more convenient as well as running them being a reverse proxy for instance.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

### **Test Configuration**:

```
# Example command
HOST=foo.dev BACKEND_PORT=1234 PORT=5678 VITE_ALLOWED_HOSTS=foo.dev npm run frontend:dev
```

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
