### PR TITLE
feat: Allow openid accounts with no email address

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -488,7 +488,8 @@ OPENID_ON_BEHALF_FLOW_FOR_USERINFO_REQUIRED=
 OPENID_ON_BEHALF_FLOW_USERINFO_SCOPE="user.read" # example for Scope Needed for Microsoft Graph API
 # Set to true to use the OpenID Connect end session endpoint for logout
 OPENID_USE_END_SESSION_ENDPOINT=
-
+# Set to true to make email claim optional
+OPENID_OPTIONAL_EMAIL=
 #========================#
 # SharePoint Integration #
 #========================#

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -356,6 +356,11 @@ async function setupOpenId() {
             ...(await getUserInfo(openidConfig, tokenset.access_token, claims.sub)),
           };
 
+          // some openid providers don't return email by default, so use the preferred_username claim as fallback
+          if (isEnabled(process.env.OPENID_OPTIONAL_EMAIL)) {
+            userinfo.email = userinfo.email || userinfo.preferred_username;
+          }
+
           const appConfig = await getAppConfig();
           if (!isEmailDomainAllowed(userinfo.email, appConfig?.registration?.allowedDomains)) {
             logger.error(


### PR DESCRIPTION
## Summary

Adds a fallback to use the upn claim for the user's email. This handles cases where certain OpenID providers, like Microsoft Entra ID, may return a null email value. The behavior is enabled by the OPENID_OPTIONAL_EMAIL feature flag.

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

## Testing

I tested the login flow using a Microsoft Entra ID account that has a null email attribute but a valid upn.

Configuration: The OPENID_OPTIONAL_EMAIL environment variable was enabled.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted.
