### PR TITLE
👫 fix: Entra ID group retrieval to use `getMemberGroups` and add pagination

### DIFF
--- a/api/server/services/GraphApiService.js
+++ b/api/server/services/GraphApiService.js
@@ -159,7 +159,7 @@ const searchEntraIdPrincipals = async (accessToken, sub, query, type = 'all', li
 
 /**
  * Get current user's Entra ID group memberships from Microsoft Graph
- * Uses /me/memberOf endpoint to get groups the user is a member of
+ * Uses /me/getMemberGroups endpoint to get transitive groups the user is a member of
  * @param {string} accessToken - OpenID Connect access token
  * @param {string} sub - Subject identifier
  * @returns {Promise<Array<string>>} Array of group ID strings (GUIDs)
@@ -167,10 +167,12 @@ const searchEntraIdPrincipals = async (accessToken, sub, query, type = 'all', li
 const getUserEntraGroups = async (accessToken, sub) => {
   try {
     const graphClient = await createGraphClient(accessToken, sub);
+    const response = await graphClient
+      .api('/me/getMemberGroups')
+      .post({ securityEnabledOnly: false });
 
-    const groupsResponse = await graphClient.api('/me/memberOf').select('id').get();
-
-    return (groupsResponse.value || []).map((group) => group.id);
+    const groupIds = Array.isArray(response?.value) ? response.value : [];
+    return [...new Set(groupIds.map((groupId) => String(groupId)))];
   } catch (error) {
     logger.error('[getUserEntraGroups] Error fetching user groups:', error);
     return [];
@@ -187,13 +189,22 @@ const getUserEntraGroups = async (accessToken, sub) => {
 const getUserOwnedEntraGroups = async (accessToken, sub) => {
   try {
     const graphClient = await createGraphClient(accessToken, sub);
+    const allGroupIds = [];
+    let nextLink = '/me/ownedObjects/microsoft.graph.group';
 
-    const groupsResponse = await graphClient
-      .api('/me/ownedObjects/microsoft.graph.group')
-      .select('id')
-      .get();
+    while (nextLink) {
+      const response = await graphClient.api(nextLink).select('id').top(999).get();
+      const groups = response?.value || [];
+      allGroupIds.push(...groups.map((group) => group.id));
 
-    return (groupsResponse.value || []).map((group) => group.id);
+      nextLink = response['@odata.nextLink']
+        ? response['@odata.nextLink']
+            .replace(/^https:\/\/graph\.microsoft\.com\/v1\.0/, '')
+            .trim() || null
+        : null;
+    }
+
+    return allGroupIds;
   } catch (error) {
     logger.error('[getUserOwnedEntraGroups] Error fetching user owned groups:', error);
     return [];
@@ -211,21 +222,27 @@ const getUserOwnedEntraGroups = async (accessToken, sub) => {
 const getGroupMembers = async (accessToken, sub, groupId) => {
   try {
     const graphClient = await createGraphClient(accessToken, sub);
-    const allMembers = [];
-    let nextLink = `/groups/${groupId}/members`;
+    const allMembers = new Set();
+    let nextLink = `/groups/${groupId}/transitiveMembers`;
 
     while (nextLink) {
       const membersResponse = await graphClient.api(nextLink).select('id').top(999).get();
 
-      const members = membersResponse.value || [];
-      allMembers.push(...members.map((member) => member.id));
+      const members = membersResponse?.value || [];
+      members.forEach((member) => {
+        if (typeof member?.id === 'string' && member['@odata.type'] === '#microsoft.graph.user') {
+          allMembers.add(member.id);
+        }
+      });
 
       nextLink = membersResponse['@odata.nextLink']
-        ? membersResponse['@odata.nextLink'].split('/v1.0')[1]
+        ? membersResponse['@odata.nextLink']
+            .replace(/^https:\/\/graph\.microsoft\.com\/v1\.0/, '')
+            .trim() || null
         : null;
     }
 
-    return allMembers;
+    return Array.from(allMembers);
   } catch (error) {
     logger.error('[getGroupMembers] Error fetching group members:', error);
     return [];


### PR DESCRIPTION
… pagination support

## Summary

Fixes Entra ID group membership retrieval to properly handle nested groups and large result sets by implementing transitive group queries and pagination support.

### **Problem**

The previous implementation had several limitations:

1. **No nested group support**  
   - Used `/me/memberOf`, which only returns direct group memberships.  
   - Missed users belonging via nested group hierarchies.

2. **Incomplete group member results**  
   - Used `/groups/{id}/members`, which excludes users in nested child groups.

3. **Missing pagination**  
   - Result sets beyond 100 items (default page size) were ignored.

4. **Duplicate results**  
   - No deduplication of group IDs or member IDs.

---

### **Solution**

#### **1. Transitive Group Membership (`getUserEntraGroups`)**

| Previous | Updated |
|----------|---------|
| `/me/memberOf` (direct only) | `/me/getMemberGroups` (transitive, includes nested groups) |

- Retrieves **all groups** a user is part of, including nested structures.
- Uses **POST** with `securityEnabledOnly: false` to include all group types.
- Implements **deduplication** of group IDs.

---

#### **2. Transitive Group Members (`getGroupMembers`)**

| Previous | Updated |
|----------|---------|
| `/groups/{id}/members` | `/groups/{id}/transitiveMembers` |

- Returns **all users**, whether directly in the group or via nested subgroups.
- Filters results to only include `#microsoft.graph.user` (excludes groups).
- Uses a **Set** for automatic deduplication of member IDs.

---

#### **3. Pagination Support**

Implemented in both `getUserOwnedEntraGroups` and `getGroupMembers`:

- Uses `.top(999)` to fetch the **maximum items per page** (Graph API limit).
- Handles `@odata.nextLink` for seamless pagination.
- Ensures **no missing results** regardless of dataset size.

---

### **Impact**

This update is important for organizations using nested Entra ID group structures for permissions and access control.

Without transitive queries:
- Users in nested groups would not be recognized correctly.
- This could lead to inaccurate permission checks and denial of access where it should be allowed.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Create an EntraID group called 'innergroup'
- Assign user A to innergroup
- Create an EntraID group called 'outergroup'
- Assign innergroup to outergroup
- Create an agent in LibreChat with User B
- Share the agent with outergroup
- Without this PR, user A won't get access to this agent, with the patch he will

For the other use-case it's difficult to test reliably, but it can be done:
- Have more than 1000 users available in Entra
- Assign them all directly to a test group
- Perform a graph query and follow the @odata.link to get the second page
- Pick a user from the second page, and try to login in librechat with it
- This user won't be able to access an agent shared with test group if he's beyond the 999th position in the graph query result, without this patch

**New test cases:**
1. getUserEntraGroups - 1 new test (deduplication test)
2. getUserOwnedEntraGroups - 2 new tests (pagination support, error handling)
3. getGroupMembers - 2 new tests (transitive members filtering, error handling)

Plus several modified existing tests to reflect the API change from /me/memberOf to /me/getMemberGroups.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
