### PR TITLE
Fix/MIA-113 - keyboard hides input field android edge

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -121,6 +121,41 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
     }
   }, [isCollapsed]);
 
+  /**
+   * HOTFIX: Android Edge Browser Keyboard Overlay Fix
+   *
+   * Problem: On Android Edge browser, the virtual keyboard covers the input field
+   * when it appears, making it impossible to see what the user is typing.
+   *
+   * Solution: When the textarea gains focus, push the form up by adding
+   * margin-bottom to make the input field visible above the keyboard.
+   */
+  const handleAndroidEdgeKeyboardFocusFix = useCallback(() => {
+    if (isAndroidEdgeBrowser()) {
+      const formElement = document.querySelector('form');
+      if (formElement) {
+        // Add margin-bottom to push the form up by the keyboard height
+        formElement.style.marginBottom = `240px`;
+      }
+    }
+  }, []);
+
+  /**
+   * HOTFIX: Android Edge Browser Keyboard Overlay Fix - Restore Position
+   *
+   * When the textarea loses focus (keyboard hides), restore the original
+   * form position by removing the margin-bottom.
+   */
+  const handleAndroidEdgeKeyboardBlurFix = useCallback(() => {
+    if (isAndroidEdgeBrowser()) {
+      const formElement = document.querySelector('form');
+      if (formElement) {
+        // Remove margin-bottom to restore original form position
+        formElement.style.marginBottom = `0px`;
+      }
+    }
+  }, []);
+
   useAutoSave({
     files,
     setFiles,
@@ -274,9 +309,13 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
                   rows={1}
                   onFocus={() => {
                     handleFocusOrClick();
+                    handleAndroidEdgeKeyboardFocusFix();
                     setIsTextAreaFocused(true);
                   }}
-                  onBlur={setIsTextAreaFocused.bind(null, false)}
+                  onBlur={() => {
+                    handleAndroidEdgeKeyboardBlurFix();
+                    setIsTextAreaFocused(false);
+                  }}
                   onClick={handleFocusOrClick}
                   style={{ height: 44, overflowY: 'auto' }}
                   className={cn(
@@ -343,5 +382,15 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
     </form>
   );
 });
+
+/**
+ * Needed for HOTFIX: Android Edge Browser Keyboard Overlay Fix (can be removed when Edge Android is fixed)
+ * @returns true if the browser is Android Edge, false otherwise
+ */
+function isAndroidEdgeBrowser(): boolean {
+  // https://learn.microsoft.com/de-de/microsoft-edge/web-platform/user-agent-guidance#identifiers-for-microsoft-edge-on-various-platforms
+  // EdgA -> Edge Android
+  return navigator.userAgent.includes('EdgA');
+}
 
 export default ChatForm;

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -131,11 +131,14 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
    * margin-bottom to make the input field visible above the keyboard.
    */
   const handleAndroidEdgeKeyboardFocusFix = useCallback(() => {
-    if (isAndroidEdgeBrowser()) {
+    const ANDROID_EDGE_HOTFIX_KEYBOARD_OVERLAY_HEIGHT = '240px';
+
+    // Only apply fix for Android Edge version 141 or greater
+    if (isAndroidEdgeWithVersion141OrGreater()) {
       const formElement = document.querySelector('form');
       if (formElement) {
         // Add margin-bottom to push the form up by the keyboard height
-        formElement.style.marginBottom = `240px`;
+        formElement.style.marginBottom = ANDROID_EDGE_HOTFIX_KEYBOARD_OVERLAY_HEIGHT;
       }
     }
   }, []);
@@ -147,7 +150,8 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
    * form position by removing the margin-bottom.
    */
   const handleAndroidEdgeKeyboardBlurFix = useCallback(() => {
-    if (isAndroidEdgeBrowser()) {
+    // Only apply fix for Android Edge version 141 or greater
+    if (isAndroidEdgeWithVersion141OrGreater()) {
       const formElement = document.querySelector('form');
       if (formElement) {
         // Remove margin-bottom to restore original form position
@@ -384,13 +388,42 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
 });
 
 /**
- * Needed for HOTFIX: Android Edge Browser Keyboard Overlay Fix (can be removed when Edge Android is fixed)
- * @returns true if the browser is Android Edge, false otherwise
+ * Get the Edge browser version from user agent string
+ * @returns the version number (e.g., 141) or null if not Edge
  */
-function isAndroidEdgeBrowser(): boolean {
+function getEdgeVersion(): number | null {
+  const userAgent = navigator.userAgent;
+
+  // Edge on Android pattern: "EdgA/141.0.0.0"
+  const edgeAndroidMatch = userAgent.match(/EdgA\/(\d+)/);
+  if (edgeAndroidMatch) {
+    return parseInt(edgeAndroidMatch[1], 10);
+  }
+
+  return null;
+}
+
+/**
+ * HOTFIX: Android Edge Browser Keyboard Overlay Fix
+ *
+ * Problem: On Android Edge browser, the virtual keyboard covers the input field
+ * when it appears, making it impossible to see what the user is typing.
+ *
+ * Solution: When the textarea gains focus, push the form up by adding
+ * margin-bottom to make the input field visible above the keyboard.
+ *
+ * This can be reproduced on  Edge Version 141 or greater
+ *
+ * Check if browser is Android Edge with version 141 or greater
+ * @returns true if Android Edge version >= 141, false otherwise
+ */
+function isAndroidEdgeWithVersion141OrGreater(): boolean {
   // https://learn.microsoft.com/de-de/microsoft-edge/web-platform/user-agent-guidance#identifiers-for-microsoft-edge-on-various-platforms
   // EdgA -> Edge Android
-  return navigator.userAgent.includes('EdgA');
+  const isAndroidEdge = navigator.userAgent.includes('EdgA');
+  const version = getEdgeVersion();
+
+  return isAndroidEdge && version !== null && version >= 141;
 }
 
 export default ChatForm;


### PR DESCRIPTION
## Summary

Hotfix Android Edge (Version 141 and greater) Keyboard Overlay Bug: https://github.com/danny-avila/LibreChat/issues/10074

⚠️ This hotfix should be removed when the bug is officially fixed by Microsoft Edge!

This Pull Request addresses an issue with the Android Edge browser where the virtual keyboard, when appearing, overlaps and hides the input field in the chat interface. The root cause of the problem is that, upon focusing on the input field, the form stays in its original position without being pushed above the keyboard.

The fix introduces a hotfix that dynamically adjusts the layout when the input field gains or loses focus. Specifically, a fixed margin-bottom of 240px is added to the form to ensure the input field stays visible above the keyboard and is restored to its original position when the keyboard disappears. This solution is specifically applied to the Edge browser on Android devices with version 141 or greater, as identified via the user agent string.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue) #10074 

## Testing

To verify the fix, the following steps were conducted:

1. Launch LibreChat in the Edge browser on an Android device.
2. Navigate to a chat and focus on the input text area to display the virtual keyboard.
3. Confirm that the input text area is pushed above the keyboard and remains visible at all times.
4. Remove the focus from the input text area (e.g., tap outside the form) to hide the virtual keyboard.
5. Confirm that the layout of the form is restored to its original position without additional spacing.

### **Test Configuration**:

- **Browser**: Microsoft Edge (Android version 141 or greater)
-   **OS:** Android

**Steps to Reproduce Issue**:
   1. Open LibreChat in Edge on an Android device.
   2. Start a chat.
   3. Focus on the input text area to trigger the virtual keyboard.
   4. Observe that the keyboard overlaps the input text area (issue).

**Steps to Test Fix**:
1. Open LibreChat with the updated code in Edge on an Android device.
2. Start a chat.
3. Focus on the input text area to trigger the virtual keyboard.
4. Verify that the input text area is visible above the keyboard (fixed).
5. Tap outside of the input text area to dismiss the keyboard.
6. Verify that the margin-bottom is removed, and the layout is restored.


This hotfix includes compatibility checks for the specific Edge browser version and only applies the layout adjustments when required, ensuring minimal impact on other environments.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works (tested it manually on a real device and on Browserstack real devices)
- [x] Local unit tests pass with my changes (on dev branch without my changes 4 tests are currently failing --> `Tests:       4 failed, 596 passed, 600 total` and with my changes 1 is failing --> `1 failed, 629 passed, 630 total` so maybe the tests are flaky?)

