### PR TITLE
🛠️ fix: Agent Tools Modal on First-Time Agent Creation

### DIFF
--- a/client/src/Providers/AgentPanelContext.tsx
+++ b/client/src/Providers/AgentPanelContext.tsx
@@ -35,9 +35,7 @@ export function AgentPanelProvider({ children }: { children: React.ReactNode }) 
     enabled: !isEphemeralAgent(agent_id),
   });
 
-  const { data: regularTools } = useAvailableToolsQuery(EModelEndpoint.agents, {
-    enabled: !isEphemeralAgent(agent_id),
-  });
+  const { data: regularTools } = useAvailableToolsQuery(EModelEndpoint.agents);
 
   const { data: mcpData } = useMCPToolsQuery({
     enabled: !isEphemeralAgent(agent_id) && startupConfig?.mcpServers != null,


### PR DESCRIPTION
## Summary

When first opening the agent panel to create an agent, the agent tools are empty.
The tools get populated if the agent is saved or another saved is loaded.

This PR fixes the loading of the tools for new agents.

**Before**
https://github.com/user-attachments/assets/3aec19e2-1883-4f1c-b080-0d2bb9133e07

**After**
https://github.com/user-attachments/assets/2ee3e6ef-e628-4a8c-9c94-ce79631b37e6


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Reload the page
- Open the agent creation panel
- Click on "Add Tools"

Before: "Agent Tools" modal is empty
After: "Agent Tools" modal shows the configured tools

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
