### PR TITLE
🐳 chore: Update newer uv version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache python3 py3-pip uv
 ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
 
 # Add `uv` for extended MCP support
-COPY --from=ghcr.io/astral-sh/uv:0.6.13 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.9.5-python3.12-alpine /uv /uvx /bin/
 RUN uv --version
 
 RUN mkdir -p /app && chown node:node /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache python3 py3-pip uv
 ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
 
 # Add `uv` for extended MCP support
-COPY --from=ghcr.io/astral-sh/uv:0.9.5-python3.12-alpine /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.9.5-python3.12-alpine /usr/local/bin/uv /usr/local/bin/uvx /bin/
 RUN uv --version
 
 RUN mkdir -p /app && chown node:node /app


### PR DESCRIPTION
## Summary

This updates the uv binary to 0.9.5 with support for python 3.12 as the python version provided in alpine (node:20-alpine).

This to allow the ability to use any python version through uv on aarch64 as commented here: https://github.com/danny-avila/LibreChat/discussions/7984#discussioncomment-14763087

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Launch Librechat with this new Docker image and configure an MCP server with uv.

### **Test Configuration**:

```yaml
   mcpServers:
     time:
        type: stdio
        command: uvx
        args:
          - mcp-server-time
```

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
