### PR TITLE
🎪 refactor: Allow Last Model Spec Selection without Prioritizing

### DIFF
--- a/client/src/hooks/useNewConvo.ts
+++ b/client/src/hooks/useNewConvo.ts
@@ -265,7 +265,7 @@ const useNewConvo = (index = 0) => {
         preset = getModelSpecPreset(defaultModelSpec);
       }
 
-      if (conversation.conversationId === 'new' && !modelsData) {
+      if (conversation.conversationId === Constants.NEW_CONVO && !modelsData) {
         const filesToDelete = Array.from(files.values())
           .filter(
             (file) =>

--- a/client/src/hooks/useNewConvo.ts
+++ b/client/src/hooks/useNewConvo.ts
@@ -259,7 +259,7 @@ const useNewConvo = (index = 0) => {
         startupConfig &&
         (startupConfig.modelSpecs?.prioritize === true ||
           (startupConfig.interface?.modelSelect ?? true) !== true ||
-          (result?.last != null && _preset == null && Object.keys(_template).length === 0)) &&
+          (result?.last != null && Object.keys(_template).length === 0)) &&
         defaultModelSpec
       ) {
         preset = getModelSpecPreset(defaultModelSpec);

--- a/client/src/hooks/useNewConvo.ts
+++ b/client/src/hooks/useNewConvo.ts
@@ -252,12 +252,14 @@ const useNewConvo = (index = 0) => {
       };
 
       let preset = _preset;
-      const defaultModelSpec = getDefaultModelSpec(startupConfig);
+      const result = getDefaultModelSpec(startupConfig);
+      const defaultModelSpec = result?.default ?? result?.last;
       if (
         !preset &&
         startupConfig &&
         (startupConfig.modelSpecs?.prioritize === true ||
-          (startupConfig.interface?.modelSelect ?? true) !== true) &&
+          (startupConfig.interface?.modelSelect ?? true) !== true ||
+          (result?.last != null && _preset == null && Object.keys(_template).length === 0)) &&
         defaultModelSpec
       ) {
         preset = getModelSpecPreset(defaultModelSpec);

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -66,7 +66,8 @@ export default function ChatRoute() {
     }
 
     if (conversationId === Constants.NEW_CONVO && endpointsQuery.data && modelsQuery.data) {
-      const spec = getDefaultModelSpec(startupConfig);
+      const result = getDefaultModelSpec(startupConfig);
+      const spec = result?.default ?? result?.last;
       logger.log('conversation', 'ChatRoute, new convo effect', conversation);
       newConversation({
         modelsData: modelsQuery.data,
@@ -90,7 +91,8 @@ export default function ChatRoute() {
       assistantListMap[EModelEndpoint.assistants] &&
       assistantListMap[EModelEndpoint.azureAssistants]
     ) {
-      const spec = getDefaultModelSpec(startupConfig);
+      const result = getDefaultModelSpec(startupConfig);
+      const spec = result?.default ?? result?.last;
       logger.log('conversation', 'ChatRoute new convo, assistants effect', conversation);
       newConversation({
         modelsData: modelsQuery.data,

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -176,11 +176,17 @@ export function getConvoSwitchLogic(params: ConversationInitParams): InitiatedTe
   };
 }
 
-/** Gets the default spec by order.
- *
- * First, the admin defined default, then last selected spec, followed by first spec
+/**
+ * Gets default model spec from config and user preferences.
+ * Priority: admin default → last selected → first spec (when prioritize=true or modelSelect disabled).
+ * Otherwise: admin default or last conversation spec.
  */
-export function getDefaultModelSpec(startupConfig?: t.TStartupConfig) {
+export function getDefaultModelSpec(startupConfig?: t.TStartupConfig):
+  | {
+      default?: t.TModelSpec;
+      last?: t.TModelSpec;
+    }
+  | undefined {
   const { modelSpecs, interface: interfaceConfig } = startupConfig ?? {};
   const { list, prioritize } = modelSpecs ?? {};
   if (!list) {
@@ -190,9 +196,9 @@ export function getDefaultModelSpec(startupConfig?: t.TStartupConfig) {
   if (prioritize === true || !interfaceConfig?.modelSelect) {
     const lastSelectedSpecName = localStorage.getItem(LocalStorageKeys.LAST_SPEC);
     const lastSelectedSpec = list?.find((spec) => spec.name === lastSelectedSpecName);
-    return defaultSpec || lastSelectedSpec || list?.[0];
+    return { default: defaultSpec || lastSelectedSpec || list?.[0] };
   } else if (defaultSpec) {
-    return defaultSpec;
+    return { default: defaultSpec };
   }
   const lastConversationSetup = JSON.parse(
     localStorage.getItem(LocalStorageKeys.LAST_CONVO_SETUP + '_0') ?? '{}',
@@ -200,7 +206,7 @@ export function getDefaultModelSpec(startupConfig?: t.TStartupConfig) {
   if (!lastConversationSetup.spec) {
     return;
   }
-  return list?.find((spec) => spec.name === lastConversationSetup.spec);
+  return { last: list?.find((spec) => spec.name === lastConversationSetup.spec) };
 }
 
 export function getModelSpecPreset(modelSpec?: t.TModelSpec) {


### PR DESCRIPTION
# Summary

I refactored the default model spec retrieval logic to better handle last selected specs on new chats and replaced hardcoded conversation ID strings with constants for improved maintainability.

- Refactored `getDefaultModelSpec` to return an object containing both default and last selected specs, allowing more flexible spec selection logic
- Updated the spec selection logic to prioritize the last selected spec when starting a new chat if the last selection was a spec
- Modified `useNewConvo` and `ChatRoute` to use the new spec retrieval structure, defaulting to either the admin-defined default or the user's last selected spec
- Replaced hardcoded `'new'` conversation ID string with `Constants.NEW_CONVO` for better code consistency
- Added comprehensive documentation to `getDefaultModelSpec` explaining the priority order: admin default → last selected → first spec
- Enhanced the conditional logic to handle edge cases where users should see their last selected spec on new conversations

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes