### PR TITLE
📍 feat: Preserve Deep Link Destinations Through the Auth Redirect Flow

### DIFF
--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import { debounce } from 'lodash';
 import { useRecoilState } from 'recoil';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { setTokenHeader, SystemRoles } from 'librechat-data-provider';
 import type { ReactNode } from 'react';
 import type * as t from 'librechat-data-provider';
@@ -48,7 +48,6 @@ const AuthContextProvider = ({
   });
 
   const navigate = useNavigate();
-  const location = useLocation();
 
   const setUserContext = useMemo(
     () =>
@@ -60,7 +59,7 @@ const AuthContextProvider = ({
         setTokenHeader(token);
         setIsAuthenticated(isAuthenticated);
 
-        const searchParams = new URLSearchParams(location.search);
+        const searchParams = new URLSearchParams(window.location.search);
         const postLoginRedirect = getPostLoginRedirect(searchParams);
 
         const logoutRedirect = logoutRedirectRef.current;
@@ -77,7 +76,7 @@ const AuthContextProvider = ({
 
         navigate(finalRedirect, { replace: true });
       }, 50),
-    [navigate, setUser, location.search],
+    [navigate, setUser],
   );
   const doSetError = useTimeout({ callback: (error) => setError(error as string | undefined) });
 
@@ -94,7 +93,7 @@ const AuthContextProvider = ({
     onError: (error: TResError | unknown) => {
       const resError = error as TResError;
       doSetError(resError.message);
-      const redirectTo = new URLSearchParams(location.search).get('redirect_to');
+      const redirectTo = new URLSearchParams(window.location.search).get('redirect_to');
       const loginPath = redirectTo ? `/login?redirect_to=${redirectTo}` : '/login';
       navigate(loginPath, { replace: true });
     },

--- a/client/src/routes/Layouts/Startup.tsx
+++ b/client/src/routes/Layouts/Startup.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import type { TStartupConfig } from 'librechat-data-provider';
+import { TranslationKeys, useLocalize } from '~/hooks';
 import { useGetStartupConfig } from '~/data-provider';
 import AuthLayout from '~/components/Auth/AuthLayout';
-import { TranslationKeys, useLocalize } from '~/hooks';
+import { REDIRECT_PARAM, SESSION_KEY } from '~/utils';
 
 const headerMap: Record<string, TranslationKeys> = {
   '/login': 'com_auth_welcome_back',
@@ -30,7 +31,12 @@ export default function StartupLayout({ isAuthenticated }: { isAuthenticated?: b
 
   useEffect(() => {
     if (isAuthenticated) {
-      navigate('/c/new', { replace: true });
+      const hasPendingRedirect =
+        new URLSearchParams(window.location.search).has(REDIRECT_PARAM) ||
+        sessionStorage.getItem(SESSION_KEY) != null;
+      if (!hasPendingRedirect) {
+        navigate('/c/new', { replace: true });
+      }
     }
     if (data) {
       setStartupConfig(data);

--- a/client/src/routes/Layouts/Startup.tsx
+++ b/client/src/routes/Layouts/Startup.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Outlet, useNavigate, useLocation, useSearchParams } from 'react-router-dom';
+import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import type { TStartupConfig } from 'librechat-data-provider';
 import { useGetStartupConfig } from '~/data-provider';
 import AuthLayout from '~/components/Auth/AuthLayout';
@@ -27,33 +27,15 @@ export default function StartupLayout({ isAuthenticated }: { isAuthenticated?: b
   const localize = useLocalize();
   const navigate = useNavigate();
   const location = useLocation();
-  const [searchParams, setSearchParams] = useSearchParams();
 
   useEffect(() => {
     if (isAuthenticated) {
-      // If a redirect_to param or stored redirect exists, navigate there after login page mounts
-      const encoded = searchParams.get('redirect_to');
-      const urlRedirect = encoded ? decodeURIComponent(encoded) : null;
-      const storedRedirect = sessionStorage.getItem('post_login_redirect_to');
-
-      const finalRedirect = urlRedirect || storedRedirect;
-      if (finalRedirect) {
-        if (storedRedirect) sessionStorage.removeItem('post_login_redirect_to');
-        // Clean the query param from URL
-        if (encoded) {
-          const params = new URLSearchParams(searchParams);
-          params.delete('redirect_to');
-          setSearchParams(params, { replace: true });
-        }
-        navigate(finalRedirect, { replace: true });
-        return;
-      }
       navigate('/c/new', { replace: true });
     }
     if (data) {
       setStartupConfig(data);
     }
-  }, [isAuthenticated, navigate, data, searchParams, setSearchParams]);
+  }, [isAuthenticated, navigate, data]);
 
   useEffect(() => {
     document.title = startupConfig?.appTitle || 'LibreChat';

--- a/client/src/routes/__tests__/StartupLayout.spec.tsx
+++ b/client/src/routes/__tests__/StartupLayout.spec.tsx
@@ -1,0 +1,128 @@
+/* eslint-disable i18next/no-literal-string */
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { SESSION_KEY } from '~/utils';
+import StartupLayout from '../Layouts/Startup';
+
+if (typeof Request === 'undefined') {
+  global.Request = class Request {
+    constructor(
+      public url: string,
+      public init?: RequestInit,
+    ) {}
+  } as any;
+}
+
+jest.mock('~/data-provider', () => ({
+  useGetStartupConfig: jest.fn(() => ({
+    data: null,
+    isFetching: false,
+    error: null,
+  })),
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: jest.fn(() => (key: string) => key),
+  TranslationKeys: {},
+}));
+
+jest.mock('~/components/Auth/AuthLayout', () => {
+  return function MockAuthLayout({ children }: { children: React.ReactNode }) {
+    return <div data-testid="auth-layout">{children}</div>;
+  };
+});
+
+function ChildRoute() {
+  return <div data-testid="child-route">Child</div>;
+}
+
+function NewConversation() {
+  return <div data-testid="new-conversation">New Conversation</div>;
+}
+
+const createTestRouter = (initialEntry: string, isAuthenticated: boolean) =>
+  createMemoryRouter(
+    [
+      {
+        path: '/login',
+        element: <StartupLayout isAuthenticated={isAuthenticated} />,
+        children: [{ index: true, element: <ChildRoute /> }],
+      },
+      {
+        path: '/c/new',
+        element: <NewConversation />,
+      },
+    ],
+    { initialEntries: [initialEntry] },
+  );
+
+describe('StartupLayout — redirect race condition', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+    jest.restoreAllMocks();
+  });
+
+  it('navigates to /c/new when authenticated with no pending redirect', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, search: '' },
+      writable: true,
+    });
+
+    const router = createTestRouter('/login', true);
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/c/new');
+    });
+  });
+
+  it('does NOT navigate to /c/new when redirect_to URL param is present', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, search: '?redirect_to=%2Fc%2Fabc123' },
+      writable: true,
+    });
+
+    const router = createTestRouter('/login?redirect_to=%2Fc%2Fabc123', true);
+    render(<RouterProvider router={router} />);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(router.state.location.pathname).toBe('/login');
+  });
+
+  it('does NOT navigate to /c/new when sessionStorage redirect is present', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, search: '' },
+      writable: true,
+    });
+    sessionStorage.setItem(SESSION_KEY, '/c/abc123');
+
+    const router = createTestRouter('/login', true);
+    render(<RouterProvider router={router} />);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(router.state.location.pathname).toBe('/login');
+  });
+
+  it('does NOT navigate when not authenticated', async () => {
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, search: '' },
+      writable: true,
+    });
+
+    const router = createTestRouter('/login', false);
+    render(<RouterProvider router={router} />);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(router.state.location.pathname).toBe('/login');
+  });
+});

--- a/client/src/routes/useAuthRedirect.ts
+++ b/client/src/routes/useAuthRedirect.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { buildLoginRedirectUrl } from '~/utils';
 import { useAuthContext } from '~/hooks';
 
 export default function useAuthRedirect() {
@@ -9,17 +10,18 @@ export default function useAuthRedirect() {
 
   useEffect(() => {
     const timeout = setTimeout(() => {
-      if (!isAuthenticated) {
-        // Preserve intended destination (path + query + hash) when redirecting to login
-        const currentPath = `${location.pathname}${location.search}${location.hash}`;
-        // Avoid redirect loop from the login page itself
-        if (location.pathname.startsWith('/login')) {
-          navigate('/login', { replace: true });
-          return;
-        }
-        const redirectTo = encodeURIComponent(currentPath || '/');
-        navigate(`/login?redirect_to=${redirectTo}`, { replace: true });
+      if (isAuthenticated) {
+        return;
       }
+
+      if (location.pathname.startsWith('/login')) {
+        navigate('/login', { replace: true });
+        return;
+      }
+
+      navigate(buildLoginRedirectUrl(location.pathname, location.search, location.hash), {
+        replace: true,
+      });
     }, 300);
 
     return () => {

--- a/client/src/routes/useAuthRedirect.ts
+++ b/client/src/routes/useAuthRedirect.ts
@@ -1,22 +1,31 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuthContext } from '~/hooks';
 
 export default function useAuthRedirect() {
   const { user, roles, isAuthenticated } = useAuthContext();
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     const timeout = setTimeout(() => {
       if (!isAuthenticated) {
-        navigate('/login', { replace: true });
+        // Preserve intended destination (path + query + hash) when redirecting to login
+        const currentPath = `${location.pathname}${location.search}${location.hash}`;
+        // Avoid redirect loop from the login page itself
+        if (location.pathname.startsWith('/login')) {
+          navigate('/login', { replace: true });
+          return;
+        }
+        const redirectTo = encodeURIComponent(currentPath || '/');
+        navigate(`/login?redirect_to=${redirectTo}`, { replace: true });
       }
     }, 300);
 
     return () => {
       clearTimeout(timeout);
     };
-  }, [isAuthenticated, navigate]);
+  }, [isAuthenticated, navigate, location]);
 
   return {
     user,

--- a/client/src/utils/__tests__/redirect.test.ts
+++ b/client/src/utils/__tests__/redirect.test.ts
@@ -1,0 +1,197 @@
+import {
+  isSafeRedirect,
+  buildLoginRedirectUrl,
+  getPostLoginRedirect,
+  persistRedirectToSession,
+  SESSION_KEY,
+} from '../redirect';
+
+describe('isSafeRedirect', () => {
+  it('accepts a simple relative path', () => {
+    expect(isSafeRedirect('/c/new')).toBe(true);
+  });
+
+  it('accepts a path with query params and hash', () => {
+    expect(isSafeRedirect('/c/new?q=hello&submit=true#section')).toBe(true);
+  });
+
+  it('accepts a nested path', () => {
+    expect(isSafeRedirect('/dashboard/settings/profile')).toBe(true);
+  });
+
+  it('rejects an absolute http URL', () => {
+    expect(isSafeRedirect('https://evil.com')).toBe(false);
+  });
+
+  it('rejects an absolute http URL with path', () => {
+    expect(isSafeRedirect('https://evil.com/phishing')).toBe(false);
+  });
+
+  it('rejects a protocol-relative URL', () => {
+    expect(isSafeRedirect('//evil.com')).toBe(false);
+  });
+
+  it('rejects a bare domain', () => {
+    expect(isSafeRedirect('evil.com')).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    expect(isSafeRedirect('')).toBe(false);
+  });
+
+  it('rejects /login to prevent redirect loops', () => {
+    expect(isSafeRedirect('/login')).toBe(false);
+  });
+
+  it('rejects /login with query params', () => {
+    expect(isSafeRedirect('/login?redirect_to=/c/new')).toBe(false);
+  });
+
+  it('rejects /login sub-paths', () => {
+    expect(isSafeRedirect('/login/2fa')).toBe(false);
+  });
+
+  it('rejects /login with hash', () => {
+    expect(isSafeRedirect('/login#foo')).toBe(false);
+  });
+
+  it('accepts the root path', () => {
+    expect(isSafeRedirect('/')).toBe(true);
+  });
+});
+
+describe('buildLoginRedirectUrl', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/c/abc123', search: '?model=gpt-4', hash: '#msg-5' },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+  });
+
+  it('builds a login URL from explicit args', () => {
+    const result = buildLoginRedirectUrl('/c/new', '?q=hello', '');
+    expect(result).toBe('/login?redirect_to=%2Fc%2Fnew%3Fq%3Dhello');
+  });
+
+  it('encodes complex paths with query and hash', () => {
+    const result = buildLoginRedirectUrl('/c/new', '?q=hello&submit=true', '#section');
+    expect(result).toContain('redirect_to=');
+    const encoded = result.split('redirect_to=')[1];
+    expect(decodeURIComponent(encoded)).toBe('/c/new?q=hello&submit=true#section');
+  });
+
+  it('falls back to window.location when no args provided', () => {
+    const result = buildLoginRedirectUrl();
+    const encoded = result.split('redirect_to=')[1];
+    expect(decodeURIComponent(encoded)).toBe('/c/abc123?model=gpt-4#msg-5');
+  });
+
+  it('falls back to "/" when all location parts are empty', () => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '', search: '', hash: '' },
+      writable: true,
+    });
+    const result = buildLoginRedirectUrl();
+    expect(result).toBe('/login?redirect_to=%2F');
+  });
+});
+
+describe('getPostLoginRedirect', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('returns the redirect_to param when valid', () => {
+    const params = new URLSearchParams('redirect_to=%2Fc%2Fnew');
+    expect(getPostLoginRedirect(params)).toBe('/c/new');
+  });
+
+  it('falls back to sessionStorage when no URL param', () => {
+    sessionStorage.setItem(SESSION_KEY, '/c/abc123');
+    const params = new URLSearchParams();
+    expect(getPostLoginRedirect(params)).toBe('/c/abc123');
+  });
+
+  it('prefers URL param over sessionStorage', () => {
+    sessionStorage.setItem(SESSION_KEY, '/c/old');
+    const params = new URLSearchParams('redirect_to=%2Fc%2Fnew');
+    expect(getPostLoginRedirect(params)).toBe('/c/new');
+  });
+
+  it('clears sessionStorage after reading', () => {
+    sessionStorage.setItem(SESSION_KEY, '/c/abc123');
+    const params = new URLSearchParams();
+    getPostLoginRedirect(params);
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+
+  it('returns null when no redirect source exists', () => {
+    const params = new URLSearchParams();
+    expect(getPostLoginRedirect(params)).toBeNull();
+  });
+
+  it('rejects an absolute URL from params', () => {
+    const params = new URLSearchParams('redirect_to=https%3A%2F%2Fevil.com');
+    expect(getPostLoginRedirect(params)).toBeNull();
+  });
+
+  it('rejects a protocol-relative URL from params', () => {
+    const params = new URLSearchParams('redirect_to=%2F%2Fevil.com');
+    expect(getPostLoginRedirect(params)).toBeNull();
+  });
+
+  it('rejects an absolute URL from sessionStorage', () => {
+    sessionStorage.setItem(SESSION_KEY, 'https://evil.com');
+    const params = new URLSearchParams();
+    expect(getPostLoginRedirect(params)).toBeNull();
+  });
+
+  it('rejects /login redirect to prevent loops', () => {
+    const params = new URLSearchParams('redirect_to=%2Flogin');
+    expect(getPostLoginRedirect(params)).toBeNull();
+  });
+
+  it('rejects /login sub-path redirect', () => {
+    const params = new URLSearchParams('redirect_to=%2Flogin%2F2fa');
+    expect(getPostLoginRedirect(params)).toBeNull();
+  });
+
+  it('still clears sessionStorage even when target is unsafe', () => {
+    sessionStorage.setItem(SESSION_KEY, 'https://evil.com');
+    const params = new URLSearchParams();
+    getPostLoginRedirect(params);
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+});
+
+describe('persistRedirectToSession', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('stores a valid relative path', () => {
+    persistRedirectToSession('/c/new?q=hello');
+    expect(sessionStorage.getItem(SESSION_KEY)).toBe('/c/new?q=hello');
+  });
+
+  it('rejects an absolute URL', () => {
+    persistRedirectToSession('https://evil.com');
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+
+  it('rejects a protocol-relative URL', () => {
+    persistRedirectToSession('//evil.com');
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+
+  it('rejects /login paths', () => {
+    persistRedirectToSession('/login?redirect_to=/c/new');
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+});

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -13,6 +13,7 @@ export * from './agents';
 export * from './drafts';
 export * from './convos';
 export * from './routes';
+export * from './redirect';
 export * from './presets';
 export * from './prompts';
 export * from './textarea';

--- a/client/src/utils/redirect.ts
+++ b/client/src/utils/redirect.ts
@@ -3,7 +3,11 @@ const SESSION_KEY = 'post_login_redirect_to';
 
 /** Validates that a redirect target is a safe relative path (not an absolute or protocol-relative URL) */
 function isSafeRedirect(url: string): boolean {
-  return url.startsWith('/') && !url.startsWith('//');
+  if (!url.startsWith('/') || url.startsWith('//')) {
+    return false;
+  }
+  const path = url.split('?')[0].split('#')[0];
+  return !path.startsWith('/login');
 }
 
 /** Builds a `/login?redirect_to=...` URL, reading from window.location when no args are provided */

--- a/client/src/utils/redirect.ts
+++ b/client/src/utils/redirect.ts
@@ -1,0 +1,54 @@
+const REDIRECT_PARAM = 'redirect_to';
+const SESSION_KEY = 'post_login_redirect_to';
+
+/** Validates that a redirect target is a safe relative path (not an absolute or protocol-relative URL) */
+function isSafeRedirect(url: string): boolean {
+  return url.startsWith('/') && !url.startsWith('//');
+}
+
+/** Builds a `/login?redirect_to=...` URL, reading from window.location when no args are provided */
+function buildLoginRedirectUrl(pathname?: string, search?: string, hash?: string): string {
+  const p = pathname ?? window.location.pathname;
+  const s = search ?? window.location.search;
+  const h = hash ?? window.location.hash;
+  const currentPath = `${p}${s}${h}`;
+  const encoded = encodeURIComponent(currentPath || '/');
+  return `/login?${REDIRECT_PARAM}=${encoded}`;
+}
+
+/**
+ * Resolves the post-login redirect from URL params and sessionStorage,
+ * cleans up both sources, and returns the validated target (or null).
+ */
+function getPostLoginRedirect(searchParams: URLSearchParams): string | null {
+  const encoded = searchParams.get(REDIRECT_PARAM);
+  const urlRedirect = encoded ? decodeURIComponent(encoded) : null;
+  const storedRedirect = sessionStorage.getItem(SESSION_KEY);
+
+  const target = urlRedirect ?? storedRedirect;
+
+  if (storedRedirect) {
+    sessionStorage.removeItem(SESSION_KEY);
+  }
+
+  if (target == null || !isSafeRedirect(target)) {
+    return null;
+  }
+
+  return target;
+}
+
+function persistRedirectToSession(value: string): void {
+  if (isSafeRedirect(value)) {
+    sessionStorage.setItem(SESSION_KEY, value);
+  }
+}
+
+export {
+  SESSION_KEY,
+  REDIRECT_PARAM,
+  isSafeRedirect,
+  persistRedirectToSession,
+  buildLoginRedirectUrl,
+  getPostLoginRedirect,
+};


### PR DESCRIPTION
## Summary

Fix for #10057 

Modified the authentication redirect logic to preserve the complete destination URL including query parameters throughout the login flow.

1. Auth Flow Updates

Updated all authentication redirects to carry redirect_to parameter with the full destination URL (including query string)
Modified login success handler to prioritize redirect_to parameter over the default /c/new destination

2. Files Modified

Authentication middleware/guards to append redirect_to when forcing navigation to /login
Login component to read and utilize redirect_to parameter after successful authentication
Logout flow to properly clear any stale redirect parameters

Works with both password and OAuth login methods

## Change Type

New feature (non-breaking change which adds functionality)

## Testing

Log out of the application
Navigate to /c/new?q=hello&submit=true
Verify redirect to /login?redirect_to=... with encoded URL
Complete login (password or OAuth)
Verify final destination is /c/new?q=hello&submit=true

### **Test Configuration**:

Normal

## Checklist


- [x] I agree to follow this project's Code of Conduct
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
