### PR TITLE
🔄 refactor: OAI Image Edit Proxy, Speech Settings Handling, Import Query Data Usage

### DIFF
--- a/api/app/clients/tools/structured/OpenAIImageTools.js
+++ b/api/app/clients/tools/structured/OpenAIImageTools.js
@@ -5,6 +5,7 @@ const FormData = require('form-data');
 const { ProxyAgent } = require('undici');
 const { tool } = require('@langchain/core/tools');
 const { logger } = require('@librechat/data-schemas');
+const { HttpsProxyAgent } = require('https-proxy-agent');
 const { logAxiosError, oaiToolkit } = require('@librechat/api');
 const { ContentTypes, EImageOutputType } = require('librechat-data-provider');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
@@ -348,16 +349,7 @@ Error Message: ${error.message}`);
         };
 
         if (process.env.PROXY) {
-          try {
-            const url = new URL(process.env.PROXY);
-            axiosConfig.proxy = {
-              host: url.hostname.replace(/^\[|\]$/g, ''),
-              port: url.port ? parseInt(url.port, 10) : undefined,
-              protocol: url.protocol.replace(':', ''),
-            };
-          } catch (error) {
-            logger.error('Error parsing proxy URL:', error);
-          }
+          axiosConfig.httpsAgent = new HttpsProxyAgent(process.env.PROXY);
         }
 
         if (process.env.IMAGE_GEN_OAI_AZURE_API_VERSION && process.env.IMAGE_GEN_OAI_BASEURL) {

--- a/api/server/services/Files/Audio/getCustomConfigSpeech.js
+++ b/api/server/services/Files/Audio/getCustomConfigSpeech.js
@@ -42,18 +42,26 @@ async function getCustomConfigSpeech(req, res) {
       settings.advancedMode = speechTab.advancedMode;
     }
 
-    if (speechTab.speechToText) {
-      for (const key in speechTab.speechToText) {
-        if (speechTab.speechToText[key] !== undefined) {
-          settings[key] = speechTab.speechToText[key];
+    if (speechTab.speechToText !== undefined) {
+      if (typeof speechTab.speechToText === 'boolean') {
+        settings.speechToText = speechTab.speechToText;
+      } else {
+        for (const key in speechTab.speechToText) {
+          if (speechTab.speechToText[key] !== undefined) {
+            settings[key] = speechTab.speechToText[key];
+          }
         }
       }
     }
 
-    if (speechTab.textToSpeech) {
-      for (const key in speechTab.textToSpeech) {
-        if (speechTab.textToSpeech[key] !== undefined) {
-          settings[key] = speechTab.textToSpeech[key];
+    if (speechTab.textToSpeech !== undefined) {
+      if (typeof speechTab.textToSpeech === 'boolean') {
+        settings.textToSpeech = speechTab.textToSpeech;
+      } else {
+        for (const key in speechTab.textToSpeech) {
+          if (speechTab.textToSpeech[key] !== undefined) {
+            settings[key] = speechTab.textToSpeech[key];
+          }
         }
       }
     }

--- a/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
+++ b/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
@@ -9,12 +9,10 @@ import { useLocalize } from '~/hooks';
 import { cn, logger } from '~/utils';
 
 function ImportConversations() {
-  const queryClient = useQueryClient();
-  const startupConfig = queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]);
   const localize = useLocalize();
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
   const { showToast } = useToastContext();
-
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [isUploading, setIsUploading] = useState(false);
 
   const handleSuccess = useCallback(() => {
@@ -53,7 +51,8 @@ function ImportConversations() {
   const handleFileUpload = useCallback(
     async (file: File) => {
       try {
-        const maxFileSize = (startupConfig as any)?.conversationImportMaxFileSize;
+        const startupConfig = queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]);
+        const maxFileSize = startupConfig?.conversationImportMaxFileSize;
         if (maxFileSize && file.size > maxFileSize) {
           const size = (maxFileSize / (1024 * 1024)).toFixed(2);
           showToast({
@@ -76,7 +75,7 @@ function ImportConversations() {
         });
       }
     },
-    [uploadFile, showToast, localize, startupConfig],
+    [uploadFile, showToast, localize, queryClient],
   );
 
   const handleFileChange = useCallback(


### PR DESCRIPTION
## Summary

Closes #10277
Closes #10150

- Simplified proxy configuration in OpenAI Image Edits by replacing manual URL parsing with HttpsProxyAgent
- Enhanced getCustomConfigSpeech to properly handle boolean values for speechToText and textToSpeech settings
- Fixed startupConfig retrieval in ImportConversations by moving it from component initialization to the actual usage point within the callback
- Removed unnecessary try-catch block around proxy URL parsing since HttpsProxyAgent handles this internally
- Added type checking to distinguish between boolean and object configurations for speech settings

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring (non-breaking change which improves code quality)

## Testing

I tested these changes by:
- Verifying proxy configuration works correctly with OpenAI Image Edit requests when PROXY environment variable is set
- Testing speech settings with both boolean and object configurations to ensure proper processing
- Confirming conversation imports properly access startupConfig at the correct time

### **Test Configuration**:
- Environment with PROXY variable configured
- Custom configuration with various speech settings combinations
- File import testing with size limits

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes