### PR TITLE
🎨 fix: Update artifacts Tailwind to official CDN

### DIFF
--- a/client/src/utils/artifacts.ts
+++ b/client/src/utils/artifacts.ts
@@ -140,7 +140,7 @@ export function getProps(type: string): Partial<SandpackProviderProps> {
 }
 
 export const sharedOptions: SandpackProviderProps['options'] = {
-  externalResources: ['https://unpkg.com/@tailwindcss/ui/dist/tailwind-ui.min.css'],
+  externalResources: ['https://cdn.tailwindcss.com/3.4.17'],
 };
 
 export const sharedFiles = {
@@ -189,7 +189,7 @@ export const sharedFiles = {
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Document</title>
-        <script src="https://cdn.tailwindcss.com"></script>
+        <script src="https://cdn.tailwindcss.com/3.4.17"></script>
       </head>
       <body>
         <div id="root"></div>


### PR DESCRIPTION
## Summary

`https://unpkg.com/@tailwindcss/ui/dist/tailwind-ui.min.css` redirects to Tailwind v0.7.2 (`https://unpkg.com/@tailwindcss/ui@0.7.2/dist/tailwind-ui.min.css`), which is 7 years old. I don't think it used to point to that old version, but not sure how to check that.

Regardless, this PR updates the Tailwind version used by artifacts to v3.4.17, served by the official Tailwind CDN.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested rendering artifacts locally, works fine.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
