### PR TITLE
📎 fix: Document Uploads for Custom Endpoints

### DIFF
--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -117,8 +117,10 @@ const AttachFileMenu = ({
       const items: MenuItemProps[] = [];
 
       const currentProvider = provider || endpoint;
-      
-      if (isDocumentSupportedProvider(endpointType) || isDocumentSupportedProvider(currentProvider)) {
+      if (
+        isDocumentSupportedProvider(endpointType) ||
+        isDocumentSupportedProvider(currentProvider)
+      ) {
         items.push({
           label: localize('com_ui_upload_provider'),
           onClick: () => {

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -118,7 +118,7 @@ const AttachFileMenu = ({
 
       const currentProvider = provider || endpoint;
 
-      if (isDocumentSupportedProvider(currentProvider || endpointType)) {
+      if (isDocumentSupportedProvider(endpointType || currentProvider)) {
         items.push({
           label: localize('com_ui_upload_provider'),
           onClick: () => {

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -117,8 +117,8 @@ const AttachFileMenu = ({
       const items: MenuItemProps[] = [];
 
       const currentProvider = provider || endpoint;
-
-      if (isDocumentSupportedProvider(endpointType || currentProvider)) {
+      
+      if (isDocumentSupportedProvider(endpointType) || isDocumentSupportedProvider(currentProvider)) {
         items.push({
           label: localize('com_ui_upload_provider'),
           onClick: () => {

--- a/client/src/components/Chat/Input/Files/DragDropModal.tsx
+++ b/client/src/components/Chat/Input/Files/DragDropModal.tsx
@@ -57,7 +57,7 @@ const DragDropModal = ({ onOptionSelect, setShowModal, files, isVisible }: DragD
     const currentProvider = provider || endpoint;
 
     // Check if provider supports document upload
-    if (isDocumentSupportedProvider(currentProvider || endpointType)) {
+    if (isDocumentSupportedProvider(endpointType || currentProvider)) {
       const isGoogleProvider = currentProvider === EModelEndpoint.google;
       const validFileTypes = isGoogleProvider
         ? files.every(

--- a/client/src/components/Chat/Input/Files/DragDropModal.tsx
+++ b/client/src/components/Chat/Input/Files/DragDropModal.tsx
@@ -57,7 +57,7 @@ const DragDropModal = ({ onOptionSelect, setShowModal, files, isVisible }: DragD
     const currentProvider = provider || endpoint;
 
     // Check if provider supports document upload
-    if (isDocumentSupportedProvider(endpointType || currentProvider)) {
+    if (isDocumentSupportedProvider(endpointType) || isDocumentSupportedProvider(currentProvider)) {
       const isGoogleProvider = currentProvider === EModelEndpoint.google;
       const validFileTypes = isGoogleProvider
         ? files.every(

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
@@ -29,7 +29,7 @@ jest.mock('~/components/SharePoint', () => ({
 }));
 
 jest.mock('@librechat/client', () => {
-  const React = require('react');
+  const React = jest.requireActual('react');
   return {
     FileUpload: React.forwardRef(({ children, handleFileChange }: any, ref: any) => (
       <div data-testid="file-upload">
@@ -78,7 +78,9 @@ const mockUseAgentCapabilities = jest.requireMock('~/hooks').useAgentCapabilitie
 const mockUseGetAgentsConfig = jest.requireMock('~/hooks').useGetAgentsConfig;
 const mockUseFileHandling = jest.requireMock('~/hooks').useFileHandling;
 const mockUseLocalize = jest.requireMock('~/hooks').useLocalize;
-const mockUseSharePointFileHandling = jest.requireMock('~/hooks/Files/useSharePointFileHandling').default;
+const mockUseSharePointFileHandling = jest.requireMock(
+  '~/hooks/Files/useSharePointFileHandling',
+).default;
 const mockUseGetStartupConfig = jest.requireMock('~/data-provider').useGetStartupConfig;
 
 describe('AttachFileMenu', () => {
@@ -96,13 +98,13 @@ describe('AttachFileMenu', () => {
     // Default mock implementations
     mockUseLocalize.mockReturnValue((key: string) => {
       const translations: Record<string, string> = {
-        'com_ui_upload_provider': 'Upload to Provider',
-        'com_ui_upload_image_input': 'Upload Image',
-        'com_ui_upload_ocr_text': 'Upload OCR Text',
-        'com_ui_upload_file_search': 'Upload for File Search',
-        'com_ui_upload_code_files': 'Upload Code Files',
-        'com_sidepanel_attach_files': 'Attach Files',
-        'com_files_upload_sharepoint': 'Upload from SharePoint',
+        com_ui_upload_provider: 'Upload to Provider',
+        com_ui_upload_image_input: 'Upload Image',
+        com_ui_upload_ocr_text: 'Upload OCR Text',
+        com_ui_upload_file_search: 'Upload for File Search',
+        com_ui_upload_code_files: 'Upload Code Files',
+        com_sidepanel_attach_files: 'Attach Files',
+        com_files_upload_sharepoint: 'Upload from SharePoint',
       };
       return translations[key] || key;
     });
@@ -150,12 +152,9 @@ describe('AttachFileMenu', () => {
     return render(
       <QueryClientProvider client={queryClient}>
         <RecoilRoot>
-          <AttachFileMenu
-            conversationId="test-conversation"
-            {...props}
-          />
+          <AttachFileMenu conversationId="test-conversation" {...props} />
         </RecoilRoot>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
   };
 
@@ -553,6 +552,7 @@ describe('AttachFileMenu', () => {
       fireEvent.click(button);
 
       const uploadProviderButton = screen.getByText('Upload to Provider');
+      expect(uploadProviderButton).toBeInTheDocument();
       fireEvent.click(uploadProviderButton);
 
       // Implementation detail - multimodal type is used

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
@@ -126,5 +126,16 @@ describe('AttachFileMenu - Provider Detection', () => {
           isDocumentSupportedProvider(scenario.currentProvider),
       ).toBe(false);
     });
+    it('should handle agents endpoints with document supported providers', () => {
+      const scenario = {
+        currentProvider: EModelEndpoint.google,
+        endpointType: EModelEndpoint.agents,
+      };
+
+      expect(
+        isDocumentSupportedProvider(scenario.endpointType) ||
+          isDocumentSupportedProvider(scenario.currentProvider),
+      ).toBe(true);
+    });
   });
 });

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
@@ -1,0 +1,112 @@
+/**
+ * Tests for AttachFileMenu provider detection fix
+ *
+ * Issue: Custom endpoints (like LiteLLM) pointing to OpenAI models weren't showing
+ * "Upload to Provider" because currentProvider was checked before endpointType.
+ *
+ * Fix (line 121): Prioritize endpointType over currentProvider
+ * - Changed from: isDocumentSupportedProvider(currentProvider || endpointType)
+ * - Changed to:   isDocumentSupportedProvider(endpointType || currentProvider)
+ */
+
+import { EModelEndpoint, isDocumentSupportedProvider } from 'librechat-data-provider';
+
+describe('AttachFileMenu - Provider Detection', () => {
+  describe('endpointType priority over currentProvider', () => {
+    it('should show upload option for LiteLLM with OpenAI endpointType', () => {
+      const currentProvider = 'litellm'; // NOT in documentSupportedProviders
+      const endpointType = EModelEndpoint.openAI; // IS in documentSupportedProviders
+
+      // With fix: endpointType checked first = true
+      const withFix = isDocumentSupportedProvider(endpointType || currentProvider);
+      expect(withFix).toBe(true);
+
+      // Without fix: currentProvider checked first = false
+      const withoutFix = isDocumentSupportedProvider(currentProvider || endpointType);
+      expect(withoutFix).toBe(false);
+    });
+
+    it('should show upload option for any custom gateway with OpenAI endpointType', () => {
+      const currentProvider = 'my-custom-gateway';
+      const endpointType = EModelEndpoint.openAI;
+
+      const result = isDocumentSupportedProvider(endpointType || currentProvider);
+      expect(result).toBe(true);
+    });
+
+    it('should fallback to currentProvider when endpointType is undefined', () => {
+      const currentProvider = EModelEndpoint.openAI;
+      const endpointType = undefined;
+
+      const result = isDocumentSupportedProvider(endpointType || currentProvider);
+      expect(result).toBe(true);
+    });
+
+    it('should fallback to currentProvider when endpointType is null', () => {
+      const currentProvider = EModelEndpoint.anthropic;
+      const endpointType = null;
+
+      const result = isDocumentSupportedProvider((endpointType as any) || currentProvider);
+      expect(result).toBe(true);
+    });
+
+    it('should return false when neither provider supports documents', () => {
+      const currentProvider = 'unsupported-provider';
+      const endpointType = 'unsupported-endpoint' as any;
+
+      const result = isDocumentSupportedProvider(endpointType || currentProvider);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('supported providers', () => {
+    const supportedProviders = [
+      { name: 'OpenAI', value: EModelEndpoint.openAI },
+      { name: 'Anthropic', value: EModelEndpoint.anthropic },
+      { name: 'Google', value: EModelEndpoint.google },
+      { name: 'Azure OpenAI', value: EModelEndpoint.azureOpenAI },
+      { name: 'Custom', value: EModelEndpoint.custom },
+    ];
+
+    supportedProviders.forEach(({ name, value }) => {
+      it(`should recognize ${name} as supported`, () => {
+        expect(isDocumentSupportedProvider(value)).toBe(true);
+      });
+    });
+  });
+
+  describe('real-world scenarios', () => {
+    it('should handle LiteLLM gateway pointing to OpenAI', () => {
+      const scenario = {
+        currentProvider: 'litellm',
+        endpointType: EModelEndpoint.openAI,
+      };
+
+      expect(isDocumentSupportedProvider(scenario.endpointType || scenario.currentProvider)).toBe(
+        true,
+      );
+    });
+
+    it('should handle direct OpenAI connection', () => {
+      const scenario = {
+        currentProvider: EModelEndpoint.openAI,
+        endpointType: EModelEndpoint.openAI,
+      };
+
+      expect(isDocumentSupportedProvider(scenario.endpointType || scenario.currentProvider)).toBe(
+        true,
+      );
+    });
+
+    it('should handle unsupported custom endpoint without override', () => {
+      const scenario = {
+        currentProvider: 'my-unsupported-endpoint',
+        endpointType: undefined,
+      };
+
+      expect(isDocumentSupportedProvider(scenario.endpointType || scenario.currentProvider)).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
@@ -126,5 +126,16 @@ describe('DragDropModal - Provider Detection', () => {
           isDocumentSupportedProvider(scenario.currentProvider),
       ).toBe(false);
     });
+    it('should handle agents endpoints with document supported providers', () => {
+      const scenario = {
+        currentProvider: EModelEndpoint.google,
+        endpointType: EModelEndpoint.agents,
+      };
+
+      expect(
+        isDocumentSupportedProvider(scenario.endpointType) ||
+          isDocumentSupportedProvider(scenario.currentProvider),
+      ).toBe(true);
+    });
   });
 });

--- a/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
@@ -1,0 +1,112 @@
+/**
+ * Tests for DragDropModal provider detection fix
+ *
+ * Issue: Custom endpoints (like LiteLLM) pointing to OpenAI models weren't showing
+ * "Upload to Provider" because currentProvider was checked before endpointType.
+ *
+ * Fix (line 60): Prioritize endpointType over currentProvider
+ * - Changed from: isDocumentSupportedProvider(currentProvider || endpointType)
+ * - Changed to:   isDocumentSupportedProvider(endpointType || currentProvider)
+ */
+
+import { EModelEndpoint, isDocumentSupportedProvider } from 'librechat-data-provider';
+
+describe('DragDropModal - Provider Detection', () => {
+  describe('endpointType priority over currentProvider', () => {
+    it('should show upload option for LiteLLM with OpenAI endpointType', () => {
+      const currentProvider = 'litellm'; // NOT in documentSupportedProviders
+      const endpointType = EModelEndpoint.openAI; // IS in documentSupportedProviders
+
+      // With fix: endpointType checked first = true
+      const withFix = isDocumentSupportedProvider(endpointType || currentProvider);
+      expect(withFix).toBe(true);
+
+      // Without fix: currentProvider checked first = false
+      const withoutFix = isDocumentSupportedProvider(currentProvider || endpointType);
+      expect(withoutFix).toBe(false);
+    });
+
+    it('should show upload option for any custom gateway with OpenAI endpointType', () => {
+      const currentProvider = 'my-custom-gateway';
+      const endpointType = EModelEndpoint.openAI;
+
+      const result = isDocumentSupportedProvider(endpointType || currentProvider);
+      expect(result).toBe(true);
+    });
+
+    it('should fallback to currentProvider when endpointType is undefined', () => {
+      const currentProvider = EModelEndpoint.openAI;
+      const endpointType = undefined;
+
+      const result = isDocumentSupportedProvider(endpointType || currentProvider);
+      expect(result).toBe(true);
+    });
+
+    it('should fallback to currentProvider when endpointType is null', () => {
+      const currentProvider = EModelEndpoint.anthropic;
+      const endpointType = null;
+
+      const result = isDocumentSupportedProvider((endpointType as any) || currentProvider);
+      expect(result).toBe(true);
+    });
+
+    it('should return false when neither provider supports documents', () => {
+      const currentProvider = 'unsupported-provider';
+      const endpointType = 'unsupported-endpoint' as any;
+
+      const result = isDocumentSupportedProvider(endpointType || currentProvider);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('supported providers', () => {
+    const supportedProviders = [
+      { name: 'OpenAI', value: EModelEndpoint.openAI },
+      { name: 'Anthropic', value: EModelEndpoint.anthropic },
+      { name: 'Google', value: EModelEndpoint.google },
+      { name: 'Azure OpenAI', value: EModelEndpoint.azureOpenAI },
+      { name: 'Custom', value: EModelEndpoint.custom },
+    ];
+
+    supportedProviders.forEach(({ name, value }) => {
+      it(`should recognize ${name} as supported`, () => {
+        expect(isDocumentSupportedProvider(value)).toBe(true);
+      });
+    });
+  });
+
+  describe('real-world scenarios', () => {
+    it('should handle LiteLLM gateway pointing to OpenAI', () => {
+      const scenario = {
+        currentProvider: 'litellm',
+        endpointType: EModelEndpoint.openAI,
+      };
+
+      expect(isDocumentSupportedProvider(scenario.endpointType || scenario.currentProvider)).toBe(
+        true,
+      );
+    });
+
+    it('should handle direct OpenAI connection', () => {
+      const scenario = {
+        currentProvider: EModelEndpoint.openAI,
+        endpointType: EModelEndpoint.openAI,
+      };
+
+      expect(isDocumentSupportedProvider(scenario.endpointType || scenario.currentProvider)).toBe(
+        true,
+      );
+    });
+
+    it('should handle unsupported custom endpoint without override', () => {
+      const scenario = {
+        currentProvider: 'my-unsupported-endpoint',
+        endpointType: undefined,
+      };
+
+      expect(isDocumentSupportedProvider(scenario.endpointType || scenario.currentProvider)).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
@@ -1,23 +1,3 @@
-/**
- * Tests for DragDropModal provider detection fix
- *
- * Issue: Custom endpoints (like LiteLLM) pointing to OpenAI models weren't showing
- * "Upload to Provider" because currentProvider was checked before endpointType.
- *
- * Fix (line 60): Check both endpointType and currentProvider for document support
- * - Changed from: isDocumentSupportedProvider(currentProvider || endpointType)
- * - Changed to:   isDocumentSupportedProvider(endpointType) || isDocumentSupportedProvider(currentProvider)
- *
- * We need to check both because, for agents, the endpointType is populated as EModelEndpoint.agents
- * and the currentProvider is the actual provider (e.g. 'google'), so just shortcircuiting within the args
- * would fail to identify the provider as document supported since it would evaluate isDocumentSupportedProvider('agents') to false,
- * missing the correct provider information currentProvider: 'google' and not displaying the upload to provider option in the drag drop modal.
- *
- * Conversely, for an OpenAI-compatible gateway (e.g. 'litellm'), if the provider were shortcircuited in the args with currentProvider first,
- * it would not identify the provider as document supported since it would evaluate isDocumentSupportedProvider('litellm') to false,
- * missing the correct provider information endpointType: 'openai' and not displaying the upload to provider option in the drag drop modal.
- */
-
 import { EModelEndpoint, isDocumentSupportedProvider } from 'librechat-data-provider';
 
 describe('DragDropModal - Provider Detection', () => {

--- a/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
@@ -4,9 +4,18 @@
  * Issue: Custom endpoints (like LiteLLM) pointing to OpenAI models weren't showing
  * "Upload to Provider" because currentProvider was checked before endpointType.
  *
- * Fix (line 60): Prioritize endpointType over currentProvider
+ * Fix (line 60): Check both endpointType and currentProvider for document support
  * - Changed from: isDocumentSupportedProvider(currentProvider || endpointType)
- * - Changed to:   isDocumentSupportedProvider(endpointType || currentProvider)
+ * - Changed to:   isDocumentSupportedProvider(endpointType) || isDocumentSupportedProvider(currentProvider)
+ *
+ * We need to check both because, for agents, the endpointType is populated as EModelEndpoint.agents
+ * and the currentProvider is the actual provider (e.g. 'google'), so just shortcircuiting within the args
+ * would fail to identify the provider as document supported since it would evaluate isDocumentSupportedProvider('agents') to false,
+ * missing the correct provider information currentProvider: 'google' and not displaying the upload to provider option in the drag drop modal.
+ *
+ * Conversely, for an OpenAI-compatible gateway (e.g. 'litellm'), if the provider were shortcircuited in the args with currentProvider first,
+ * it would not identify the provider as document supported since it would evaluate isDocumentSupportedProvider('litellm') to false,
+ * missing the correct provider information endpointType: 'openai' and not displaying the upload to provider option in the drag drop modal.
  */
 
 import { EModelEndpoint, isDocumentSupportedProvider } from 'librechat-data-provider';
@@ -17,11 +26,12 @@ describe('DragDropModal - Provider Detection', () => {
       const currentProvider = 'litellm'; // NOT in documentSupportedProviders
       const endpointType = EModelEndpoint.openAI; // IS in documentSupportedProviders
 
-      // With fix: endpointType checked first = true
-      const withFix = isDocumentSupportedProvider(endpointType || currentProvider);
+      // With fix: endpointType checked
+      const withFix =
+        isDocumentSupportedProvider(endpointType) || isDocumentSupportedProvider(currentProvider);
       expect(withFix).toBe(true);
 
-      // Without fix: currentProvider checked first = false
+      // Without fix: only currentProvider checked = false
       const withoutFix = isDocumentSupportedProvider(currentProvider || endpointType);
       expect(withoutFix).toBe(false);
     });
@@ -30,7 +40,8 @@ describe('DragDropModal - Provider Detection', () => {
       const currentProvider = 'my-custom-gateway';
       const endpointType = EModelEndpoint.openAI;
 
-      const result = isDocumentSupportedProvider(endpointType || currentProvider);
+      const result =
+        isDocumentSupportedProvider(endpointType) || isDocumentSupportedProvider(currentProvider);
       expect(result).toBe(true);
     });
 
@@ -38,7 +49,8 @@ describe('DragDropModal - Provider Detection', () => {
       const currentProvider = EModelEndpoint.openAI;
       const endpointType = undefined;
 
-      const result = isDocumentSupportedProvider(endpointType || currentProvider);
+      const result =
+        isDocumentSupportedProvider(endpointType) || isDocumentSupportedProvider(currentProvider);
       expect(result).toBe(true);
     });
 
@@ -46,7 +58,9 @@ describe('DragDropModal - Provider Detection', () => {
       const currentProvider = EModelEndpoint.anthropic;
       const endpointType = null;
 
-      const result = isDocumentSupportedProvider((endpointType as any) || currentProvider);
+      const result =
+        isDocumentSupportedProvider(endpointType as any) ||
+        isDocumentSupportedProvider(currentProvider);
       expect(result).toBe(true);
     });
 
@@ -54,7 +68,8 @@ describe('DragDropModal - Provider Detection', () => {
       const currentProvider = 'unsupported-provider';
       const endpointType = 'unsupported-endpoint' as any;
 
-      const result = isDocumentSupportedProvider(endpointType || currentProvider);
+      const result =
+        isDocumentSupportedProvider(endpointType) || isDocumentSupportedProvider(currentProvider);
       expect(result).toBe(false);
     });
   });
@@ -82,9 +97,10 @@ describe('DragDropModal - Provider Detection', () => {
         endpointType: EModelEndpoint.openAI,
       };
 
-      expect(isDocumentSupportedProvider(scenario.endpointType || scenario.currentProvider)).toBe(
-        true,
-      );
+      expect(
+        isDocumentSupportedProvider(scenario.endpointType) ||
+          isDocumentSupportedProvider(scenario.currentProvider),
+      ).toBe(true);
     });
 
     it('should handle direct OpenAI connection', () => {
@@ -93,9 +109,10 @@ describe('DragDropModal - Provider Detection', () => {
         endpointType: EModelEndpoint.openAI,
       };
 
-      expect(isDocumentSupportedProvider(scenario.endpointType || scenario.currentProvider)).toBe(
-        true,
-      );
+      expect(
+        isDocumentSupportedProvider(scenario.endpointType) ||
+          isDocumentSupportedProvider(scenario.currentProvider),
+      ).toBe(true);
     });
 
     it('should handle unsupported custom endpoint without override', () => {
@@ -104,9 +121,10 @@ describe('DragDropModal - Provider Detection', () => {
         endpointType: undefined,
       };
 
-      expect(isDocumentSupportedProvider(scenario.endpointType || scenario.currentProvider)).toBe(
-        false,
-      );
+      expect(
+        isDocumentSupportedProvider(scenario.endpointType) ||
+          isDocumentSupportedProvider(scenario.currentProvider),
+      ).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes for the "Upload to Provider" option visibility for custom endpoints (like LiteLLM) that are OpenAI-compatible.

Fixes #10334

### Issue

Custom endpoints pointing to OpenAI-compatible models (e.g., LiteLLM gateways) were not showing the "Upload to Provider" option because the frontend was checking the custom endpoint name (`currentProvider`) before checking the backend's override (`endpointType`).

### Root Cause

In `AttachFileMenu.tsx` and `DragDropModal.tsx`, the provider detection logic was:

`isDocumentSupportedProvider(currentProvider || endpointType)`

This checked `currentProvider` (e.g., "litellm") first, which is not in the `documentSupportedProviders` set, causing the check to fail even though the backend correctly set `endpointType` to "openAI".

### Solution

Check both `endpointType` and `currentProvider`:

`isDocumentSupportedProvider(endpointType) || isDocumentSupportedProvider(currentProvider)`

Now the backend's override is checked first, allowing custom OpenAI-compatible endpoints to correctly display document upload capabilities.

### Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

### Testing

**Test Configuration:**

* **Browser:** Any
* **Custom Endpoint:** LiteLLM or any OpenAI-compatible gateway
* **Backend Configuration:** Custom endpoint with `overrideProvider = Providers.OPENAI`

### Test Steps:

1.  Configure a custom endpoint (e.g., LiteLLM) pointing to an OpenAI model
2.  Start a new conversation with that endpoint
3.  Click the attachment button
4.  **Expected:** "Upload to Provider" option should appear (allowing images and PDFs)
5.  **Before fix:** Only "Upload Image" appeared

### Unit Tests:

Added comprehensive unit tests in:
* `client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx` (13 tests)
* `client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx` (13 tests)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.