### PR TITLE
🎙️ fix: Azure OpenAI Speech-to-Text 400 Bad Request Error

### DIFF
--- a/api/server/services/Files/Audio/STTService.js
+++ b/api/server/services/Files/Audio/STTService.js
@@ -227,7 +227,6 @@ class STTService {
     }
 
     const headers = {
-      'Content-Type': 'multipart/form-data',
       ...(apiKey && { 'api-key': apiKey }),
     };
 

--- a/packages/api/src/utils/azure.ts
+++ b/packages/api/src/utils/azure.ts
@@ -25,6 +25,12 @@ export const genAzureEndpoint = ({
   azureOpenAIApiInstanceName: string;
   azureOpenAIApiDeploymentName: string;
 }): string => {
+  // Support both old (.openai.azure.com) and new (.cognitiveservices.azure.com) endpoint formats
+  // If instanceName already includes a full domain, use it as-is
+  if (azureOpenAIApiInstanceName.includes('.azure.com')) {
+    return `https://${azureOpenAIApiInstanceName}/openai/deployments/${azureOpenAIApiDeploymentName}`;
+  }
+  // Legacy format for backward compatibility
   return `https://${azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments/${azureOpenAIApiDeploymentName}`;
 };
 


### PR DESCRIPTION
Resolves https://github.com/danny-avila/LibreChat/issues/10283

## Summary

This PR fixes two critical bugs in the Azure OpenAI STT implementation that were causing transcription requests to fail:

### Bug 1: Malformed Multipart Form-Data Header

The code was manually setting `Content-Type: multipart/form-data` without the required `boundary` parameter. This caused Azure to reject requests with a 400 error.

**Before**:
```javascript
const headers = {
  'Content-Type': 'multipart/form-data',  // ❌ Missing boundary parameter
  ...(apiKey && { 'api-key': apiKey }),
};
return [url, formData, { ...headers, ...formData.getHeaders() }];
```

**After**:
```javascript
const headers = {
  ...(apiKey && { 'api-key': apiKey }),
};
return [url, formData, { ...headers, ...formData.getHeaders() }];  // ✅ FormData provides correct header with boundary
```

### Bug 2: Azure Endpoint Domain Format

The `genAzureEndpoint()` function only supported the legacy `.openai.azure.com` domain format. Azure has introduced a new `.cognitiveservices.azure.com` domain format that was not supported.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Before

https://github.com/user-attachments/assets/a27150a4-eb5a-4433-82f9-fd7646123665

---

After

https://github.com/user-attachments/assets/02a4c551-fd41-4f09-85fb-a634f6aafba6

---

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
