### PR TITLE
🔐 feat: Prioritize Provider ID Over Email for Social Login

### DIFF
--- a/api/strategies/appleStrategy.test.js
+++ b/api/strategies/appleStrategy.test.js
@@ -304,6 +304,7 @@ describe('Apple Login Strategy', () => {
           fileStrategy: 'local',
           balance: { enabled: false },
         }),
+        'jane.doe@example.com',
       );
     });
 

--- a/api/strategies/process.test.js
+++ b/api/strategies/process.test.js
@@ -167,4 +167,76 @@ describe('handleExistingUser', () => {
     // This should throw an error when trying to access oldUser._id
     await expect(handleExistingUser(null, avatarUrl)).rejects.toThrow();
   });
+
+  it('should update email when it has changed', async () => {
+    const oldUser = {
+      _id: 'user123',
+      email: 'old@example.com',
+      avatar: 'https://example.com/avatar.png?manual=true',
+    };
+    const avatarUrl = 'https://example.com/avatar.png';
+    const newEmail = 'new@example.com';
+
+    await handleExistingUser(oldUser, avatarUrl, {}, newEmail);
+
+    expect(updateUser).toHaveBeenCalledWith('user123', { email: 'new@example.com' });
+  });
+
+  it('should update both avatar and email when both have changed', async () => {
+    const oldUser = {
+      _id: 'user123',
+      email: 'old@example.com',
+      avatar: null,
+    };
+    const avatarUrl = 'https://example.com/new-avatar.png';
+    const newEmail = 'new@example.com';
+
+    await handleExistingUser(oldUser, avatarUrl, {}, newEmail);
+
+    expect(updateUser).toHaveBeenCalledWith('user123', {
+      avatar: avatarUrl,
+      email: 'new@example.com',
+    });
+  });
+
+  it('should not update email when it has not changed', async () => {
+    const oldUser = {
+      _id: 'user123',
+      email: 'same@example.com',
+      avatar: 'https://example.com/avatar.png?manual=true',
+    };
+    const avatarUrl = 'https://example.com/avatar.png';
+    const sameEmail = 'same@example.com';
+
+    await handleExistingUser(oldUser, avatarUrl, {}, sameEmail);
+
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  it('should trim email before comparison and update', async () => {
+    const oldUser = {
+      _id: 'user123',
+      email: 'test@example.com',
+      avatar: 'https://example.com/avatar.png?manual=true',
+    };
+    const avatarUrl = 'https://example.com/avatar.png';
+    const newEmailWithSpaces = '  newemail@example.com  ';
+
+    await handleExistingUser(oldUser, avatarUrl, {}, newEmailWithSpaces);
+
+    expect(updateUser).toHaveBeenCalledWith('user123', { email: 'newemail@example.com' });
+  });
+
+  it('should not update when email parameter is not provided', async () => {
+    const oldUser = {
+      _id: 'user123',
+      email: 'test@example.com',
+      avatar: 'https://example.com/avatar.png?manual=true',
+    };
+    const avatarUrl = 'https://example.com/avatar.png';
+
+    await handleExistingUser(oldUser, avatarUrl, {});
+
+    expect(updateUser).not.toHaveBeenCalled();
+  });
 });

--- a/api/strategies/socialLogin.test.js
+++ b/api/strategies/socialLogin.test.js
@@ -1,0 +1,276 @@
+const { logger } = require('@librechat/data-schemas');
+const { ErrorTypes } = require('librechat-data-provider');
+const { createSocialUser, handleExistingUser } = require('./process');
+const socialLogin = require('./socialLogin');
+const { findUser } = require('~/models');
+
+jest.mock('@librechat/data-schemas', () => {
+  const actualModule = jest.requireActual('@librechat/data-schemas');
+  return {
+    ...actualModule,
+    logger: {
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  };
+});
+
+jest.mock('./process', () => ({
+  createSocialUser: jest.fn(),
+  handleExistingUser: jest.fn(),
+}));
+
+jest.mock('@librechat/api', () => ({
+  ...jest.requireActual('@librechat/api'),
+  isEnabled: jest.fn().mockReturnValue(true),
+  isEmailDomainAllowed: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('~/models', () => ({
+  findUser: jest.fn(),
+}));
+
+jest.mock('~/server/services/Config', () => ({
+  getAppConfig: jest.fn().mockResolvedValue({
+    fileStrategy: 'local',
+    balance: { enabled: false },
+  }),
+}));
+
+describe('socialLogin', () => {
+  const mockGetProfileDetails = ({ profile }) => ({
+    email: profile.emails[0].value,
+    id: profile.id,
+    avatarUrl: profile.photos?.[0]?.value || null,
+    username: profile.name?.givenName || 'user',
+    name: `${profile.name?.givenName || ''} ${profile.name?.familyName || ''}`.trim(),
+    emailVerified: profile.emails[0].verified || false,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Finding users by provider ID', () => {
+    it('should find user by provider ID (googleId) when email has changed', async () => {
+      const provider = 'google';
+      const googleId = 'google-user-123';
+      const oldEmail = 'old@example.com';
+      const newEmail = 'new@example.com';
+
+      const existingUser = {
+        _id: 'user123',
+        email: oldEmail,
+        provider: 'google',
+        googleId: googleId,
+      };
+
+      /** Mock findUser to return user on first call (by googleId), null on second call */
+      findUser
+        .mockResolvedValueOnce(existingUser) // First call: finds by googleId
+        .mockResolvedValueOnce(null); // Second call would be by email, but won't be reached
+
+      const mockProfile = {
+        id: googleId,
+        emails: [{ value: newEmail, verified: true }],
+        photos: [{ value: 'https://example.com/avatar.png' }],
+        name: { givenName: 'John', familyName: 'Doe' },
+      };
+
+      const loginFn = socialLogin(provider, mockGetProfileDetails);
+      const callback = jest.fn();
+
+      await loginFn(null, null, null, mockProfile, callback);
+
+      /** Verify it searched by googleId first */
+      expect(findUser).toHaveBeenNthCalledWith(1, { googleId: googleId });
+
+      /** Verify it did NOT search by email (because it found user by googleId) */
+      expect(findUser).toHaveBeenCalledTimes(1);
+
+      /** Verify handleExistingUser was called with the new email */
+      expect(handleExistingUser).toHaveBeenCalledWith(
+        existingUser,
+        'https://example.com/avatar.png',
+        expect.any(Object),
+        newEmail,
+      );
+
+      /** Verify callback was called with success */
+      expect(callback).toHaveBeenCalledWith(null, existingUser);
+    });
+
+    it('should find user by provider ID (facebookId) when using Facebook', async () => {
+      const provider = 'facebook';
+      const facebookId = 'fb-user-456';
+      const email = 'user@example.com';
+
+      const existingUser = {
+        _id: 'user456',
+        email: email,
+        provider: 'facebook',
+        facebookId: facebookId,
+      };
+
+      findUser.mockResolvedValue(existingUser); // Always returns user
+
+      const mockProfile = {
+        id: facebookId,
+        emails: [{ value: email, verified: true }],
+        photos: [{ value: 'https://example.com/fb-avatar.png' }],
+        name: { givenName: 'Jane', familyName: 'Smith' },
+      };
+
+      const loginFn = socialLogin(provider, mockGetProfileDetails);
+      const callback = jest.fn();
+
+      await loginFn(null, null, null, mockProfile, callback);
+
+      /** Verify it searched by facebookId first */
+      expect(findUser).toHaveBeenCalledWith({ facebookId: facebookId });
+      expect(findUser.mock.calls[0]).toEqual([{ facebookId: facebookId }]);
+
+      expect(handleExistingUser).toHaveBeenCalledWith(
+        existingUser,
+        'https://example.com/fb-avatar.png',
+        expect.any(Object),
+        email,
+      );
+
+      expect(callback).toHaveBeenCalledWith(null, existingUser);
+    });
+
+    it('should fallback to finding user by email if not found by provider ID', async () => {
+      const provider = 'google';
+      const googleId = 'google-user-789';
+      const email = 'user@example.com';
+
+      const existingUser = {
+        _id: 'user789',
+        email: email,
+        provider: 'google',
+        googleId: 'old-google-id', // Different googleId (edge case)
+      };
+
+      /** First call (by googleId) returns null, second call (by email) returns user */
+      findUser
+        .mockResolvedValueOnce(null) // By googleId
+        .mockResolvedValueOnce(existingUser); // By email
+
+      const mockProfile = {
+        id: googleId,
+        emails: [{ value: email, verified: true }],
+        photos: [{ value: 'https://example.com/avatar.png' }],
+        name: { givenName: 'Bob', familyName: 'Johnson' },
+      };
+
+      const loginFn = socialLogin(provider, mockGetProfileDetails);
+      const callback = jest.fn();
+
+      await loginFn(null, null, null, mockProfile, callback);
+
+      /** Verify both searches happened */
+      expect(findUser).toHaveBeenNthCalledWith(1, { googleId: googleId });
+      expect(findUser).toHaveBeenNthCalledWith(2, { email: email });
+      expect(findUser).toHaveBeenCalledTimes(2);
+
+      /** Verify warning log */
+      expect(logger.warn).toHaveBeenCalledWith(
+        `[${provider}Login] User found by email: ${email} but not by ${provider}Id`,
+      );
+
+      expect(handleExistingUser).toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledWith(null, existingUser);
+    });
+
+    it('should create new user if not found by provider ID or email', async () => {
+      const provider = 'google';
+      const googleId = 'google-new-user';
+      const email = 'newuser@example.com';
+
+      const newUser = {
+        _id: 'newuser123',
+        email: email,
+        provider: 'google',
+        googleId: googleId,
+      };
+
+      /** Both searches return null */
+      findUser.mockResolvedValue(null);
+      createSocialUser.mockResolvedValue(newUser);
+
+      const mockProfile = {
+        id: googleId,
+        emails: [{ value: email, verified: true }],
+        photos: [{ value: 'https://example.com/avatar.png' }],
+        name: { givenName: 'New', familyName: 'User' },
+      };
+
+      const loginFn = socialLogin(provider, mockGetProfileDetails);
+      const callback = jest.fn();
+
+      await loginFn(null, null, null, mockProfile, callback);
+
+      /** Verify both searches happened */
+      expect(findUser).toHaveBeenCalledTimes(2);
+
+      /** Verify createSocialUser was called */
+      expect(createSocialUser).toHaveBeenCalledWith({
+        email: email,
+        avatarUrl: 'https://example.com/avatar.png',
+        provider: provider,
+        providerKey: 'googleId',
+        providerId: googleId,
+        username: 'New',
+        name: 'New User',
+        emailVerified: true,
+        appConfig: expect.any(Object),
+      });
+
+      expect(callback).toHaveBeenCalledWith(null, newUser);
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should return error if user exists with different provider', async () => {
+      const provider = 'google';
+      const googleId = 'google-user-123';
+      const email = 'user@example.com';
+
+      const existingUser = {
+        _id: 'user123',
+        email: email,
+        provider: 'local', // Different provider
+      };
+
+      findUser
+        .mockResolvedValueOnce(null) // By googleId
+        .mockResolvedValueOnce(existingUser); // By email
+
+      const mockProfile = {
+        id: googleId,
+        emails: [{ value: email, verified: true }],
+        photos: [{ value: 'https://example.com/avatar.png' }],
+        name: { givenName: 'John', familyName: 'Doe' },
+      };
+
+      const loginFn = socialLogin(provider, mockGetProfileDetails);
+      const callback = jest.fn();
+
+      await loginFn(null, null, null, mockProfile, callback);
+
+      /** Verify error callback */
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: ErrorTypes.AUTH_FAILED,
+          provider: 'local',
+        }),
+      );
+
+      expect(logger.info).toHaveBeenCalledWith(
+        `[${provider}Login] User ${email} already exists with provider local`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

I implemented a more robust social login flow that prioritizes provider-specific IDs (e.g., googleId, facebookId) over email addresses when authenticating users, and added email update functionality for existing users.

- Modified the social login process to first attempt user lookup by provider ID before falling back to email lookup
- Added email update capability to handle cases where a user's email has changed (e.g., Google Workspace email changes)
- Implemented comprehensive test coverage for the new provider ID-first lookup strategy
- Added warning logs when users are found by email but not by provider ID to track potential edge cases
- Enhanced `handleExistingUser` to update both avatar and email when either has changed
- Added email trimming and validation to ensure data consistency during updates
- Implemented proper handling for cases where users exist with different providers

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I wrote comprehensive unit tests covering all new functionality and edge cases:

- Verified user lookup prioritizes provider ID (googleId, facebookId) before email
- Tested email update functionality when user email changes
- Confirmed fallback to email lookup when provider ID is not found
- Validated new user creation when neither provider ID nor email matches
- Tested error handling for users with different providers
- Verified email trimming and comparison logic
- Ensured backward compatibility with existing login flows

All tests pass locally and verify the new authentication flow works correctly.

### **Test Configuration**:
- Node.js environment with Jest testing framework
- Mocked dependencies: findUser, createSocialUser, handleExistingUser
- Test cases cover Google, Facebook, and Apple social login providers

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules