### PR TITLE
docs: clarify Azure instanceName format for speech services

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -136,6 +136,16 @@ registration:
 #       apiKey: '${TTS_API_KEY}'
 #       model: ''
 #       voices: ['']
+#     azureOpenAI:
+#       # instanceName: The <NAME> part of your Azure endpoint URL
+#       # For example, if your endpoint is: https://my-instance.cognitiveservices.azure.com
+#       # Then instanceName should be: 'my-instance' (not the full URL)
+#       instanceName: '${AZURE_TTS_INSTANCE_NAME}'
+#       apiKey: '${AZURE_TTS_API_KEY}'
+#       deploymentName: '${AZURE_TTS_DEPLOYMENT_NAME}'
+#       apiVersion: '2024-02-01'
+#       model: 'tts-1'
+#       voices: ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer']
 
 #
 #   stt:
@@ -143,6 +153,15 @@ registration:
 #       url: ''
 #       apiKey: '${STT_API_KEY}'
 #       model: ''
+#     azureOpenAI:
+#       # instanceName: The <NAME> part of your Azure endpoint URL
+#       # For example, if your endpoint is: https://my-instance.cognitiveservices.azure.com
+#       # Then instanceName should be: 'my-instance' (not the full URL)
+#       # Note: The code also supports full domain format for backward compatibility
+#       instanceName: '${AZURE_STT_INSTANCE_NAME}'
+#       apiKey: '${AZURE_STT_API_KEY}'
+#       deploymentName: '${AZURE_STT_DEPLOYMENT_NAME}'
+#       apiVersion: '2024-02-01'
 
 # rateLimits:
 #   fileUploads:


### PR DESCRIPTION
## Summary
 Adds Azure OpenAI Speech-to-Text (STT) and Text-to-Speech (TTS) configuration examples to `librechat.example.yaml` with clear documentation about the `instanceName` format.

  Clarifies that `instanceName` should be the `<NAME>` part only (e.g., `my-instance`), not the full URL (e.g., `my-instance.cognitiveservices.azure.com`), though the full domain
  format is still supported for backward compatibility.

  **Example:**
  ```yaml
  stt:
    azureOpenAI:
      # instanceName: The <NAME> part of your Azure endpoint URL
      # For example, if your endpoint is: https://my-instance.cognitiveservices.azure.com
      # Then instanceName should be: 'my-instance' (not the full URL)
      instanceName: '${AZURE_STT_INSTANCE_NAME}'
      apiKey: '${AZURE_STT_API_KEY}'
      deploymentName: '${AZURE_STT_DEPLOYMENT_NAME}'
      apiVersion: '2024-02-01'
```
  Related to #10283 and pointed out here: https://github.com/danny-avila/LibreChat/pull/10355
## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Translation update

## Testing

N/A

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
