### PR TITLE
[WIP] Refactor: MCPToolBox

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -350,6 +350,7 @@ Current Date & Time: ${replaceSpecialVars({ text: '{{iso_datetime}}' })}
         /** Placeholder used for UI purposes */
         continue;
       }
+      //TODO: the config needs to be fetched from the registry
       if (serverName && options.req?.config?.mcpConfig?.[serverName] == null) {
         logger.warn(
           `MCP server "${serverName}" for "${toolName}" tool is not configured${agent?.id != null && agent.id ? ` but attached to "${agent.id}"` : ''}`,

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -41,7 +41,7 @@ export class MCPManager extends UserConnectionManager {
   /** Initializes the MCPManager by setting up server registry and app connections */
   public async initialize(configs: t.MCPServers) {
     await MCPServersInitializer.initialize(configs);
-    this.appConnections = new ConnectionsRepository(registry.sharedAppServers);
+    this.appConnections = new ConnectionsRepository(undefined);
   }
   /** update  config of an mcp server with possibility to change Server Tier based on whether it is private and or its configuration*/
   public async updateConfig(args: {

--- a/packages/api/src/mcp/MCPToolBox.ts
+++ b/packages/api/src/mcp/MCPToolBox.ts
@@ -1,0 +1,113 @@
+import { logger } from '@librechat/data-schemas';
+import { MCPToolsCacheFactory } from '~/mcp/registry/cache/toolsCache/MCPToolsCacheFactory';
+import { MCPServerInspector } from '~/mcp/registry/MCPServerInspector';
+import { mcpServersRegistry as registry } from '~/mcp/registry/MCPServersRegistry';
+import type { IMCPToolsCache } from '~/mcp/registry/cache/toolsCache/IMCPToolsCache';
+import type { MCPConnection } from '~/mcp/connection';
+import type * as t from './types';
+
+/**
+ * MCPToolBox manages per-user MCP tool caching with staleness detection.
+ *
+ * Architecture:
+ * - Follows same pattern as ConnectionsRepository
+ * - MCPManager holds Map<userId, MCPToolBox> (parallel to userConnections)
+ * - Cleaned up together with idle user connections
+ * - InMemory cache lives within toolbox instance, persists during session
+ *
+ * Staleness Detection:
+ * - Tools cached with timestamp (cachedAt)
+ * - On retrieval, compares cached.cachedAt vs config.cachedAt
+ * - Refetches if config was updated after tools were cached
+ * - Registry-aware: Only serves tools for servers user has access to
+ */
+export class MCPToolBox {
+  private readonly toolsCache: IMCPToolsCache;
+  private readonly ownerId: string | undefined;
+
+  constructor(ownerId?: string) {
+    this.ownerId = ownerId;
+    this.toolsCache = MCPToolsCacheFactory.create(ownerId || 'app');
+  }
+
+  /**
+   * Gets tools for a specific server with staleness detection.
+   * If cached tools are older than the server config, refetches from connection.
+   */
+  public async getToolsForServer(
+    serverName: string,
+    connection: MCPConnection,
+  ): Promise<t.LCAvailableTools> {
+    const serverConfig = await registry.getServerConfig(serverName, this.ownerId);
+    if (!serverConfig) {
+      const scope = this.ownerId ? `user ${this.ownerId}` : 'app-level';
+      throw new Error(`Server "${serverName}" not found in registry for ${scope}`);
+    }
+
+    const cached = await this.toolsCache.get(serverName);
+
+    const isStale = cached && serverConfig.cachedAt && cached.cachedAt < serverConfig.cachedAt;
+
+    if (isStale) {
+      logger.info(`[MCPToolBox] Tools stale for server "${serverName}", refetching`, {
+        ownerId: this.ownerId,
+        cachedAt: new Date(cached.cachedAt).toISOString(),
+        configCachedAt: serverConfig.cachedAt
+          ? new Date(serverConfig.cachedAt).toISOString()
+          : undefined,
+      });
+    }
+
+    if (!cached || isStale) {
+      const freshTools = await MCPServerInspector.getToolFunctions(serverName, connection);
+      if (cached) {
+        await this.toolsCache.update(serverName, freshTools);
+      } else {
+        await this.toolsCache.add(serverName, freshTools);
+      }
+      return freshTools;
+    }
+
+    return cached.tools;
+  }
+
+  /**
+   * Gets all available tools across all accessible servers.
+   * Only fetches tools for servers owner has access to via the registry.
+   */
+  public async getAllTools(connections: Map<string, MCPConnection>): Promise<t.LCAvailableTools> {
+    const allTools: t.LCAvailableTools = {};
+
+    const serverConfigs = await registry.getAllServerConfigs(this.ownerId);
+
+    for (const [serverName, connection] of connections.entries()) {
+      if (!serverConfigs[serverName]) {
+        continue;
+      }
+
+      try {
+        const tools = await this.getToolsForServer(serverName, connection);
+        Object.assign(allTools, tools);
+      } catch (error) {
+        logger.warn(`[MCPToolBox] Error fetching tools for server "${serverName}"`, error);
+      }
+    }
+
+    return allTools;
+  }
+
+  /**
+   * Removes tools from cache when server is removed or owner loses access.
+   */
+  public async removeServerTools(serverName: string): Promise<void> {
+    await this.toolsCache.remove(serverName);
+  }
+
+  /**
+   * Clears all cached tools for this owner.
+   * Called during cleanup when user connections are idle.
+   */
+  public async reset(): Promise<void> {
+    await this.toolsCache.reset();
+  }
+}

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -31,6 +31,8 @@ jest.mock('~/mcp/registry/MCPServersRegistry', () => ({
 jest.mock('~/mcp/registry/MCPServersInitializer', () => ({
   MCPServersInitializer: {
     initialize: jest.fn(),
+    reInitializeServer: jest.fn(),
+    initPrivateServers: jest.fn(),
   },
 }));
 
@@ -58,7 +60,7 @@ describe('MCPManager', () => {
     appConnectionsConfig: Partial<ConnectionsRepository>,
   ): jest.MockedClass<typeof ConnectionsRepository> {
     const mock = {
-      has: jest.fn().mockReturnValue(false),
+      has: jest.fn().mockResolvedValue(false),
       get: jest.fn().mockResolvedValue({} as unknown as MCPConnection),
       ...appConnectionsConfig,
     };
@@ -303,7 +305,7 @@ describe('MCPManager', () => {
       });
 
       mockAppConnections({
-        has: jest.fn().mockReturnValue(true),
+        has: jest.fn().mockResolvedValue(true),
       });
 
       const manager = await MCPManager.createInstance(newMCPServersConfig());
@@ -321,7 +323,7 @@ describe('MCPManager', () => {
       (MCPServerInspector.getToolFunctions as jest.Mock) = jest.fn().mockResolvedValue({});
 
       mockAppConnections({
-        has: jest.fn().mockReturnValue(false),
+        has: jest.fn().mockResolvedValue(false),
       });
 
       const manager = await MCPManager.createInstance(newMCPServersConfig());
@@ -357,7 +359,7 @@ describe('MCPManager', () => {
         .mockResolvedValue(expectedTools);
 
       mockAppConnections({
-        has: jest.fn().mockReturnValue(true),
+        has: jest.fn().mockResolvedValue(true),
       });
 
       const manager = await MCPManager.createInstance(newMCPServersConfig());
@@ -376,7 +378,7 @@ describe('MCPManager', () => {
       });
 
       mockAppConnections({
-        has: jest.fn().mockReturnValue(true),
+        has: jest.fn().mockResolvedValue(true),
       });
 
       const manager = await MCPManager.createInstance(newMCPServersConfig(specificServerName));

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -98,6 +98,12 @@ export class MCPConnection extends EventEmitter {
   timeout?: number;
   url?: string;
 
+  /**
+   * Timestamp when this connection was created.
+   * Used to detect if connection is stale compared to updated config.
+   */
+  public readonly createdAt: number;
+
   setRequestHeaders(headers: Record<string, string> | null): void {
     if (!headers) {
       return;
@@ -121,6 +127,7 @@ export class MCPConnection extends EventEmitter {
     this.iconPath = params.serverConfig.iconPath;
     this.timeout = params.serverConfig.timeout;
     this.lastPingTime = Date.now();
+    this.createdAt = Date.now(); // Record creation timestamp for staleness detection
     if (params.oauthTokens) {
       this.oauthTokens = params.oauthTokens;
     }
@@ -722,6 +729,17 @@ export class MCPConnection extends EventEmitter {
 
   public setOAuthTokens(tokens: MCPOAuthTokens): void {
     this.oauthTokens = tokens;
+  }
+
+  /**
+   * Check if this connection is stale compared to config update time.
+   * A connection is stale if it was created before the config was updated.
+   *
+   * @param configUpdatedAt - Unix timestamp (ms) when config was last updated
+   * @returns true if connection was created before config update, false otherwise
+   */
+  public isStale(configUpdatedAt: number): boolean {
+    return this.createdAt < configUpdatedAt;
   }
 
   private isOAuthError(error: unknown): boolean {

--- a/packages/api/src/mcp/registry/__tests__/MCPServersInitializer.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersInitializer.cache_integration.spec.ts
@@ -1,6 +1,8 @@
-import { expect } from '@playwright/test';
 import type * as t from '~/mcp/types';
 import type { MCPConnection } from '~/mcp/connection';
+const FIXED_TIME = 1699564800000;
+const originalDateNow = Date.now;
+Date.now = jest.fn(() => FIXED_TIME);
 
 // Mock isLeader to always return true to avoid lock contention during parallel operations
 jest.mock('~/cluster', () => ({
@@ -27,7 +29,7 @@ describe('MCPServersInitializer Redis Integration Tests', () => {
     },
     oauth_server: {
       type: 'streamable-http',
-      url: 'https://api.example.com/mcp',
+      url: 'https://api.example.com/mcp-oauth',
     },
     file_tools_server: {
       type: 'stdio',
@@ -51,7 +53,7 @@ describe('MCPServersInitializer Redis Integration Tests', () => {
     },
     oauth_server: {
       type: 'streamable-http',
-      url: 'https://api.example.com/mcp',
+      url: 'https://api.example.com/mcp-oauth',
       requiresOAuth: true,
     },
     file_tools_server: {
@@ -92,14 +94,30 @@ describe('MCPServersInitializer Redis Integration Tests', () => {
         },
       },
     },
+    remote_no_oauth_server: {
+      type: 'streamable-http',
+      url: 'https://api.example.com/mcp-no-auth',
+      requiresOAuth: false,
+    },
+  };
+
+  // Helper to determine requiresOAuth based on URL pattern
+  // URLs ending with '-oauth' require OAuth, others don't
+  const determineRequiresOAuth = (config: t.MCPOptions): boolean => {
+    if ('url' in config && config.url) {
+      return config.url.endsWith('-oauth');
+    }
+    return false;
   };
 
   beforeAll(async () => {
     // Set up environment variables for Redis (only if not already set)
     process.env.USE_REDIS = process.env.USE_REDIS ?? 'true';
     process.env.REDIS_URI = process.env.REDIS_URI ?? 'redis://127.0.0.1:6379';
+    // Use a unique prefix for each test run to avoid conflicts with parallel test executions
     process.env.REDIS_KEY_PREFIX =
-      process.env.REDIS_KEY_PREFIX ?? 'MCPServersInitializer-IntegrationTest';
+      process.env.REDIS_KEY_PREFIX ??
+      `MCPServersInitializer-IntegrationTest-${Date.now()}-${Math.random().toString(36).substring(7)}`;
 
     // Import modules after setting env vars
     const initializerModule = await import('../MCPServersInitializer');
@@ -127,6 +145,7 @@ describe('MCPServersInitializer Redis Integration Tests', () => {
     // Become leader so we can perform write operations
     leaderInstance = new LeaderElection();
     const isLeader = await leaderInstance.isLeader();
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(isLeader).toBe(true);
   });
 
@@ -137,13 +156,24 @@ describe('MCPServersInitializer Redis Integration Tests', () => {
       throw new Error('Lost leader status before test');
     }
 
+    // Reset caches first to ensure clean state
+    await registryStatusCache.reset();
+    await registry.reset();
+
     // Mock MCPServerInspector.inspect to return parsed config
-    jest.spyOn(MCPServerInspector, 'inspect').mockImplementation(async (serverName: string) => {
-      return {
-        ...testParsedConfigs[serverName],
-        _processedByInspector: true,
-      } as unknown as t.ParsedServerConfig;
-    });
+    // This mock inspects the actual rawConfig to determine requiresOAuth dynamically
+    jest
+      .spyOn(MCPServerInspector, 'inspect')
+      .mockImplementation(async (serverName: string, rawConfig: t.MCPOptions) => {
+        const baseConfig = testParsedConfigs[serverName] || {};
+        return {
+          ...baseConfig,
+          ...rawConfig,
+          // Override requiresOAuth based on the actual config being inspected
+          requiresOAuth: determineRequiresOAuth(rawConfig),
+          _processedByInspector: true,
+        } as unknown as t.ParsedServerConfig;
+      });
 
     // Mock MCPConnection
     const mockConnection = {
@@ -152,10 +182,6 @@ describe('MCPServersInitializer Redis Integration Tests', () => {
 
     // Mock MCPConnectionFactory
     jest.spyOn(MCPConnectionFactory, 'create').mockResolvedValue(mockConnection);
-
-    // Reset caches before each test
-    await registryStatusCache.reset();
-    await registry.reset();
   });
 
   afterEach(async () => {
@@ -173,6 +199,8 @@ describe('MCPServersInitializer Redis Integration Tests', () => {
   });
 
   afterAll(async () => {
+    Date.now = originalDateNow;
+
     // Resign as leader
     if (leaderInstance) await leaderInstance.resign();
 
@@ -296,6 +324,264 @@ describe('MCPServersInitializer Redis Integration Tests', () => {
       await MCPServersInitializer.initialize(testConfigs);
 
       expect(await registryStatusCache.isInitialized()).toBe(true);
+    });
+  });
+
+  describe('reInitializeServer()', () => {
+    it('should migrate server from sharedUserServers to sharedAppServers when OAuth requirement changes', async () => {
+      // Initial setup with OAuth server
+      await MCPServersInitializer.initialize({
+        oauth_server: {
+          type: 'streamable-http',
+          url: 'https://api.example.com/mcp-oauth',
+        },
+      });
+
+      // Verify server is in sharedUserServers
+      let serverInUserRegistry = await registry.sharedUserServers.get('oauth_server');
+      let serverInAppRegistry = await registry.sharedAppServers.get('oauth_server');
+      expect(serverInUserRegistry).toBeDefined();
+      expect(serverInUserRegistry?.requiresOAuth).toBe(true);
+      expect(serverInAppRegistry).toBeUndefined();
+
+      // Re-initialize with config that doesn't require OAuth
+      const updatedConfig: t.MCPOptions = {
+        type: 'streamable-http',
+        url: 'https://api.example.com/mcp-no-auth',
+      };
+
+      await MCPServersInitializer.reInitializeServer({
+        serverName: 'oauth_server',
+        config: updatedConfig,
+      });
+
+      // Verify server moved to sharedAppServers
+      serverInUserRegistry = await registry.sharedUserServers.get('oauth_server');
+      serverInAppRegistry = await registry.sharedAppServers.get('oauth_server');
+      expect(serverInUserRegistry).toBeUndefined();
+      expect(serverInAppRegistry).toBeDefined();
+      expect(serverInAppRegistry?.requiresOAuth).toBe(false);
+      expect(serverInAppRegistry?.url).toBe('https://api.example.com/mcp-no-auth');
+    });
+
+    it('should migrate server from private to shared when isPrivateServer changes to false', async () => {
+      const userId = 'redis-integration-user123';
+      const privateConfig: t.ParsedServerConfig = {
+        type: 'stdio',
+        command: 'node',
+        args: ['private-tools.js'],
+        requiresOAuth: false,
+      };
+
+      // Add private server first
+      await registry.addPrivateUserServer(userId, 'my_server', privateConfig);
+
+      // Verify server is in private registry
+      const privateServer = await registry.getPrivateServerConfig('my_server', userId);
+      expect(privateServer).toBeDefined();
+
+      // Re-initialize as shared server
+      const sharedConfig: t.MCPOptions = {
+        type: 'stdio',
+        command: 'node',
+        args: ['shared-tools.js'],
+      };
+
+      await MCPServersInitializer.reInitializeServer({
+        serverName: 'my_server',
+        config: sharedConfig,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        user: { id: userId } as any,
+        isPrivateServer: false,
+      });
+
+      // Verify server is now in shared registry
+      const sharedServer = await registry.sharedAppServers.get('my_server');
+      expect(sharedServer).toBeDefined();
+
+      // Verify server is NO LONGER in private registry
+      expect(await registry.getPrivateServerConfig('my_server', userId)).toBeUndefined();
+    });
+  });
+
+  describe('initPrivateServers()', () => {
+    const userId = 'user123';
+
+    it('should initialize multiple private servers for a user', async () => {
+      const privateConfigs: t.MCPServers = {
+        private_file_tools: {
+          type: 'stdio',
+          command: 'node',
+          args: ['private-file.js'],
+        },
+        private_search_tools: {
+          type: 'stdio',
+          command: 'node',
+          args: ['private-search.js'],
+        },
+      };
+
+      await MCPServersInitializer.initPrivateServers(privateConfigs, userId);
+
+      // Verify both servers were added to private registry
+      const fileTools = await registry.getPrivateServerConfig('private_file_tools', userId);
+      const searchTools = await registry.getPrivateServerConfig('private_search_tools', userId);
+
+      expect(fileTools).toBeDefined();
+      expect(searchTools).toBeDefined();
+      expect(fileTools?.type).toBe('stdio');
+      expect(searchTools?.type).toBe('stdio');
+    });
+
+    it('should skip initialization for already cached private servers', async () => {
+      const privateConfigs: t.MCPServers = {
+        cached_server: testConfigs.file_tools_server,
+      };
+
+      // Pre-add server to private cache
+      await registry.addPrivateUserServer(userId, 'cached_server', {
+        ...testParsedConfigs.file_tools_server,
+      });
+
+      // Get cached config before re-init
+      const cachedBefore = await registry.getPrivateServerConfig('cached_server', userId);
+      expect(cachedBefore).toBeDefined();
+
+      // Initialize again - should skip due to cache
+      await MCPServersInitializer.initPrivateServers(privateConfigs, userId);
+
+      // Verify server config hasn't changed (still cached)
+      const cachedAfter = await registry.getPrivateServerConfig('cached_server', userId);
+      expect(cachedAfter).toBeDefined();
+      expect(cachedAfter).toEqual(cachedBefore);
+    });
+
+    it('should handle private server initialization failures gracefully', async () => {
+      const privateConfigs: t.MCPServers = {
+        failing_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['failing.js'],
+        },
+        working_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['working.js'],
+        },
+      };
+
+      // Mock addPrivateUserServer to fail for one server
+      const originalAddPrivate = registry.addPrivateUserServer.bind(registry);
+      jest.spyOn(registry, 'addPrivateUserServer').mockImplementation(async (uid, name, config) => {
+        if (name === 'failing_server') {
+          throw new Error('Failed to add private server');
+        }
+        return originalAddPrivate(uid, name, config);
+      });
+
+      await MCPServersInitializer.initPrivateServers(privateConfigs, userId);
+
+      // Verify working server was still added
+      const workingServer = await registry.getPrivateServerConfig('working_server', userId);
+      expect(workingServer).toBeDefined();
+
+      // Verify failing server was not added
+      const failingServer = await registry.getPrivateServerConfig('failing_server', userId);
+      expect(failingServer).toBeUndefined();
+    });
+
+    it('should initialize private servers with user-specific cache isolation', async () => {
+      const user1 = 'user1';
+      const user2 = 'user2';
+
+      const privateConfigsUser1: t.MCPServers = {
+        user1_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['user1.js'],
+        },
+      };
+
+      const privateConfigsUser2: t.MCPServers = {
+        user2_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['user2.js'],
+        },
+      };
+
+      await MCPServersInitializer.initPrivateServers(privateConfigsUser1, user1);
+      await MCPServersInitializer.initPrivateServers(privateConfigsUser2, user2);
+
+      // Verify each user has their own server
+      const user1Server = await registry.getPrivateServerConfig('user1_server', user1);
+      const user2Server = await registry.getPrivateServerConfig('user2_server', user2);
+
+      expect(user1Server).toBeDefined();
+      expect(user2Server).toBeDefined();
+
+      // Verify servers are isolated - user2 can't see user1's server
+      const user1ServerFromUser2 = await registry.getPrivateServerConfig('user1_server', user2);
+      expect(user1ServerFromUser2).toBeUndefined();
+
+      // Verify servers are isolated - user1 can't see user2's server
+      const user2ServerFromUser1 = await registry.getPrivateServerConfig('user2_server', user1);
+      expect(user2ServerFromUser1).toBeUndefined();
+    });
+
+    it('should use Promise.allSettled for parallel initialization', async () => {
+      const allSettledSpy = jest.spyOn(Promise, 'allSettled');
+
+      const privateConfigs: t.MCPServers = {
+        server1: testConfigs.file_tools_server,
+        server2: testConfigs.search_tools_server,
+      };
+
+      await MCPServersInitializer.initPrivateServers(privateConfigs, userId);
+      expect(allSettledSpy).toHaveBeenCalledWith(expect.arrayContaining([expect.any(Promise)]));
+      expect(allSettledSpy).toHaveBeenCalledTimes(1);
+
+      allSettledSpy.mockRestore();
+    });
+
+    it('should allow same server name for different users', async () => {
+      const user1 = 'user1';
+      const user2 = 'user2';
+
+      const sharedServerName = 'my_tools_server';
+
+      const configUser1: t.MCPServers = {
+        [sharedServerName]: {
+          type: 'stdio',
+          command: 'node',
+          args: ['user1-tools.js'],
+        },
+      };
+
+      const configUser2: t.MCPServers = {
+        [sharedServerName]: {
+          type: 'stdio',
+          command: 'node',
+          args: ['user2-tools.js'],
+        },
+      };
+
+      await MCPServersInitializer.initPrivateServers(configUser1, user1);
+      await MCPServersInitializer.initPrivateServers(configUser2, user2);
+
+      // Verify each user has their own version with different args
+      const user1Server = await registry.getPrivateServerConfig(sharedServerName, user1);
+      const user2Server = await registry.getPrivateServerConfig(sharedServerName, user2);
+
+      expect(user1Server).toBeDefined();
+      expect(user2Server).toBeDefined();
+
+      if (user1Server && 'args' in user1Server) {
+        expect(user1Server.args).toEqual(['user1-tools.js']);
+      }
+      if (user2Server && 'args' in user2Server) {
+        expect(user2Server.args).toEqual(['user2-tools.js']);
+      }
     });
   });
 });

--- a/packages/api/src/mcp/registry/__tests__/MCPServersInitializer.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersInitializer.test.ts
@@ -6,6 +6,9 @@ import { MCPConnection } from '~/mcp/connection';
 import { registryStatusCache } from '~/mcp/registry/cache/RegistryStatusCache';
 import { MCPServerInspector } from '~/mcp/registry/MCPServerInspector';
 import { mcpServersRegistry as registry } from '~/mcp/registry/MCPServersRegistry';
+const FIXED_TIME = 1699564800000;
+const originalDateNow = Date.now;
+Date.now = jest.fn(() => FIXED_TIME);
 
 // Mock external dependencies
 jest.mock('../../MCPConnectionFactory');
@@ -31,6 +34,10 @@ const mockInspect = MCPServerInspector.inspect as jest.MockedFunction<
 describe('MCPServersInitializer', () => {
   let mockConnection: jest.Mocked<MCPConnection>;
 
+  afterAll(() => {
+    Date.now = originalDateNow;
+  });
+
   const testConfigs: t.MCPServers = {
     disabled_server: {
       type: 'stdio',
@@ -40,7 +47,7 @@ describe('MCPServersInitializer', () => {
     },
     oauth_server: {
       type: 'streamable-http',
-      url: 'https://api.example.com/mcp',
+      url: 'https://api.example.com/mcp-oauth',
     },
     file_tools_server: {
       type: 'stdio',
@@ -51,6 +58,10 @@ describe('MCPServersInitializer', () => {
       type: 'stdio',
       command: 'node',
       args: ['instructions.js'],
+    },
+    remote_no_oauth_server: {
+      type: 'streamable-http',
+      url: 'https://api.example.com/mcp-no-auth',
     },
   };
 
@@ -64,7 +75,7 @@ describe('MCPServersInitializer', () => {
     },
     oauth_server: {
       type: 'streamable-http',
-      url: 'https://api.example.com/mcp',
+      url: 'https://api.example.com/mcp-oauth',
       requiresOAuth: true,
     },
     file_tools_server: {
@@ -105,6 +116,21 @@ describe('MCPServersInitializer', () => {
         },
       },
     },
+    remote_no_oauth_server: {
+      type: 'streamable-http',
+      url: 'https://api.example.com/mcp-no-auth',
+      requiresOAuth: false,
+    },
+  };
+
+  // Helper to determine requiresOAuth based on URL pattern
+  // URLs ending with '-oauth' require OAuth, others don't
+  const determineRequiresOAuth = (config: t.MCPOptions): boolean => {
+    if ('url' in config && config.url) {
+      // If URL ends with '-oauth', requires OAuth
+      return config.url.endsWith('-oauth');
+    }
+    return false;
   };
 
   beforeEach(async () => {
@@ -117,9 +143,14 @@ describe('MCPServersInitializer', () => {
     (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(mockConnection);
 
     // Mock MCPServerInspector.inspect to return parsed config
-    mockInspect.mockImplementation(async (serverName: string) => {
+    // This mock inspects the actual rawConfig to determine requiresOAuth dynamically
+    mockInspect.mockImplementation(async (serverName: string, rawConfig: t.MCPOptions) => {
+      const baseConfig = testParsedConfigs[serverName] || {};
       return {
-        ...testParsedConfigs[serverName],
+        ...baseConfig,
+        ...rawConfig,
+        // Override requiresOAuth based on the actual config being inspected
+        requiresOAuth: determineRequiresOAuth(rawConfig),
         _processedByInspector: true,
       } as unknown as t.ParsedServerConfig;
     });
@@ -170,13 +201,17 @@ describe('MCPServersInitializer', () => {
       await MCPServersInitializer.initialize(testConfigs);
 
       // Verify all configs were processed by inspector (without connection parameter)
-      expect(mockInspect).toHaveBeenCalledTimes(4);
+      expect(mockInspect).toHaveBeenCalledTimes(5);
       expect(mockInspect).toHaveBeenCalledWith('disabled_server', testConfigs.disabled_server);
       expect(mockInspect).toHaveBeenCalledWith('oauth_server', testConfigs.oauth_server);
       expect(mockInspect).toHaveBeenCalledWith('file_tools_server', testConfigs.file_tools_server);
       expect(mockInspect).toHaveBeenCalledWith(
         'search_tools_server',
         testConfigs.search_tools_server,
+      );
+      expect(mockInspect).toHaveBeenCalledWith(
+        'remote_no_oauth_server',
+        testConfigs.remote_no_oauth_server,
       );
     });
 
@@ -232,12 +267,15 @@ describe('MCPServersInitializer', () => {
 
     it('should handle inspection failures gracefully', async () => {
       // Mock inspection failure for one server
-      mockInspect.mockImplementation(async (serverName: string) => {
+      mockInspect.mockImplementation(async (serverName: string, rawConfig: t.MCPOptions) => {
         if (serverName === 'file_tools_server') {
           throw new Error('Inspection failed');
         }
+        const baseConfig = testParsedConfigs[serverName] || {};
         return {
-          ...testParsedConfigs[serverName],
+          ...rawConfig,
+          ...baseConfig,
+          requiresOAuth: determineRequiresOAuth(rawConfig),
           _processedByInspector: true,
         } as unknown as t.ParsedServerConfig;
       });
@@ -287,6 +325,385 @@ describe('MCPServersInitializer', () => {
       await MCPServersInitializer.initialize(testConfigs);
 
       expect(await registryStatusCache.isInitialized()).toBe(true);
+    });
+  });
+
+  describe('reInitializeServer()', () => {
+    it('should migrate server from sharedUserServers to sharedAppServers when OAuth requirement changes', async () => {
+      await MCPServersInitializer.initialize(testConfigs);
+
+      // Verify server is in sharedUserServers
+      let serverInUserRegistry = await registry.sharedUserServers.get('oauth_server');
+      let serverInAppRegistry = await registry.sharedAppServers.get('oauth_server');
+      expect(serverInUserRegistry).toBeDefined();
+      expect(serverInUserRegistry?.requiresOAuth).toBe(true);
+      expect(serverInAppRegistry).toBeUndefined();
+
+      // Re-initialize with config that doesn't require OAuth
+      const updatedConfig: t.MCPOptions = {
+        type: 'streamable-http',
+        url: 'https://api.example.com/mcp-no-auth',
+      };
+
+      await MCPServersInitializer.reInitializeServer({
+        serverName: 'oauth_server',
+        config: updatedConfig,
+      });
+
+      // Verify server moved to sharedAppServers
+      serverInUserRegistry = await registry.sharedUserServers.get('oauth_server');
+      serverInAppRegistry = await registry.sharedAppServers.get('oauth_server');
+      expect(serverInUserRegistry).toBeUndefined();
+      expect(serverInAppRegistry).toBeDefined();
+      expect(serverInAppRegistry?.requiresOAuth).toBe(false);
+      expect(serverInAppRegistry?.url).toBe('https://api.example.com/mcp-no-auth');
+    });
+
+    it('should migrate server from sharedAppServers to sharedUserServers when OAuth is added', async () => {
+      await MCPServersInitializer.initialize(testConfigs);
+
+      // Verify server is in sharedAppServers (no OAuth required)
+      let serverInAppRegistry = await registry.sharedAppServers.get('remote_no_oauth_server');
+      let serverInUserRegistry = await registry.sharedUserServers.get('remote_no_oauth_server');
+      expect(serverInAppRegistry).toBeDefined();
+      expect(serverInAppRegistry?.requiresOAuth).toBe(false);
+      expect(serverInUserRegistry).toBeUndefined();
+
+      // Re-initialize with OAuth-required config (URL ending with -oauth)
+      const updatedConfig: t.MCPOptions = {
+        type: 'streamable-http',
+        url: 'https://api.example.com/protected-mcp-oauth',
+      };
+
+      await MCPServersInitializer.reInitializeServer({
+        serverName: 'remote_no_oauth_server',
+        config: updatedConfig,
+      });
+
+      // Verify server moved to sharedUserServers
+      serverInAppRegistry = await registry.sharedAppServers.get('remote_no_oauth_server');
+      serverInUserRegistry = await registry.sharedUserServers.get('remote_no_oauth_server');
+      expect(serverInAppRegistry).toBeUndefined();
+      expect(serverInUserRegistry).toBeDefined();
+      expect(serverInUserRegistry?.requiresOAuth).toBe(true);
+      expect(serverInUserRegistry?.url).toBe('https://api.example.com/protected-mcp-oauth');
+    });
+
+    it('should throw error when re-initializing private server without user', async () => {
+      await MCPServersInitializer.initialize(testConfigs);
+
+      const config: t.MCPOptions = {
+        type: 'stdio',
+        command: 'node',
+        args: ['tools.js'],
+      };
+
+      await expect(
+        MCPServersInitializer.reInitializeServer({
+          serverName: 'file_tools_server',
+          config,
+          isPrivateServer: true,
+        }),
+      ).rejects.toThrow('User must be provided for private server updates');
+    });
+
+    it('should throw error when user lacks id for private server', async () => {
+      await MCPServersInitializer.initialize(testConfigs);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const userWithoutId = { name: 'Test User' } as any;
+
+      await expect(
+        MCPServersInitializer.reInitializeServer({
+          serverName: 'file_tools_server',
+          config: testConfigs.file_tools_server,
+          user: userWithoutId,
+          isPrivateServer: true,
+        }),
+      ).rejects.toThrow('User must be provided for private server updates');
+    });
+
+    it('should migrate server from private to shared when isPrivateServer changes to false', async () => {
+      const userId = 'user123';
+      const privateConfig: t.ParsedServerConfig = {
+        type: 'stdio',
+        command: 'node',
+        args: ['private-tools.js'],
+        requiresOAuth: false,
+      };
+
+      // Add private server first
+      await registry.addPrivateUserServer(userId, 'my_server', privateConfig);
+
+      // Verify server is in private registry using the new helper method
+      const privateServer = await registry.getPrivateServerConfig('my_server', userId);
+      expect(privateServer).toBeDefined();
+      expect(privateServer?.type).toBe('stdio');
+      if (privateServer && 'args' in privateServer) {
+        expect(privateServer.args).toEqual(['private-tools.js']);
+      }
+
+      // Verify server is NOT in shared registries
+      expect(await registry.sharedAppServers.get('my_server')).toBeUndefined();
+      expect(await registry.sharedUserServers.get('my_server')).toBeUndefined();
+
+      // Re-initialize as shared server (isPrivateServer: false)
+      const sharedConfig: t.MCPOptions = {
+        type: 'stdio',
+        command: 'node',
+        args: ['shared-tools.js'],
+      };
+
+      await MCPServersInitializer.reInitializeServer({
+        serverName: 'my_server',
+        config: sharedConfig,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        user: { id: userId } as any,
+        isPrivateServer: false,
+      });
+
+      // Verify server is now in shared registry
+      const sharedServer = await registry.sharedAppServers.get('my_server');
+      expect(sharedServer).toBeDefined();
+      expect(sharedServer?.type).toBe('stdio');
+      if (sharedServer && 'args' in sharedServer) {
+        expect(sharedServer.args).toEqual(['shared-tools.js']);
+      }
+
+      // Verify server is NO LONGER in private registry
+      expect(await registry.getPrivateServerConfig('my_server', userId)).toBeUndefined();
+    });
+
+    it('should migrate server from shared to private when isPrivateServer changes to true', async () => {
+      const userId = 'user456';
+
+      // Initialize as shared server
+      await MCPServersInitializer.initialize({
+        my_shared_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['shared.js'],
+        },
+      });
+
+      // Verify server is in shared app registry
+      let sharedServer = await registry.sharedAppServers.get('my_shared_server');
+      expect(sharedServer).toBeDefined();
+      expect(sharedServer?.type).toBe('stdio');
+      if (sharedServer && 'args' in sharedServer) {
+        expect(sharedServer.args).toEqual(['shared.js']);
+      }
+
+      // Re-initialize as private server
+      const privateConfig: t.MCPOptions = {
+        type: 'stdio',
+        command: 'node',
+        args: ['private.js'],
+      };
+
+      await MCPServersInitializer.reInitializeServer({
+        serverName: 'my_shared_server',
+        config: privateConfig,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        user: { id: userId } as any,
+        isPrivateServer: true,
+      });
+
+      // Verify server is now in private registry using the new helper method
+      const privateServer = await registry.getPrivateServerConfig('my_shared_server', userId);
+      expect(privateServer).toBeDefined();
+      if (privateServer && 'args' in privateServer) {
+        expect(privateServer.args).toEqual(['private.js']);
+      }
+      // Verify server is NO LONGER in shared registry
+      sharedServer = await registry.sharedAppServers.get('my_shared_server');
+      expect(sharedServer).toBeUndefined();
+    });
+  });
+
+  describe('initPrivateServers()', () => {
+    const userId = 'user123';
+
+    it('should initialize multiple private servers for a user', async () => {
+      const privateConfigs: t.MCPServers = {
+        private_file_tools: {
+          type: 'stdio',
+          command: 'node',
+          args: ['private-file.js'],
+        },
+        private_search_tools: {
+          type: 'stdio',
+          command: 'node',
+          args: ['private-search.js'],
+        },
+      };
+
+      await MCPServersInitializer.initPrivateServers(privateConfigs, userId);
+
+      // Verify both servers were added to private registry
+      const fileTools = await registry.getPrivateServerConfig('private_file_tools', userId);
+      const searchTools = await registry.getPrivateServerConfig('private_search_tools', userId);
+
+      expect(fileTools).toBeDefined();
+      expect(searchTools).toBeDefined();
+      expect(fileTools?.type).toBe('stdio');
+      expect(searchTools?.type).toBe('stdio');
+    });
+
+    it('should skip initialization for already cached private servers', async () => {
+      const privateConfigs: t.MCPServers = {
+        cached_server: testConfigs.file_tools_server,
+      };
+
+      // Pre-add server to private cache
+      await registry.addPrivateUserServer(userId, 'cached_server', {
+        ...testParsedConfigs.file_tools_server,
+      });
+
+      jest.clearAllMocks();
+
+      // Initialize again - should skip due to cache
+      await MCPServersInitializer.initPrivateServers(privateConfigs, userId);
+
+      // Verify debug log was called (indicating cache hit)
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('[MCP][cached_server]'),
+      );
+      expect(mockLogger.debug).toHaveBeenCalledWith(expect.stringContaining('Using cached config'));
+    });
+
+    it('should handle private server initialization failures gracefully', async () => {
+      const privateConfigs: t.MCPServers = {
+        failing_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['failing.js'],
+        },
+        working_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['working.js'],
+        },
+      };
+
+      // Mock addPrivateUserServer to fail for one server
+      const originalAddPrivate = registry.addPrivateUserServer.bind(registry);
+      jest.spyOn(registry, 'addPrivateUserServer').mockImplementation(async (uid, name, config) => {
+        if (name === 'failing_server') {
+          throw new Error('Failed to add private server');
+        }
+        return originalAddPrivate(uid, name, config);
+      });
+
+      await MCPServersInitializer.initPrivateServers(privateConfigs, userId);
+
+      // Verify error was logged
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('[MCP][failing_server]'),
+        expect.any(Error),
+      );
+
+      // Verify working server was still added
+      const workingServer = await registry.getPrivateServerConfig('working_server', userId);
+      expect(workingServer).toBeDefined();
+
+      // Verify failing server was not added
+      const failingServer = await registry.getPrivateServerConfig('failing_server', userId);
+      expect(failingServer).toBeUndefined();
+    });
+
+    it('should initialize private servers with user-specific cache isolation', async () => {
+      const user1 = 'user1';
+      const user2 = 'user2';
+
+      const privateConfigsUser1: t.MCPServers = {
+        user1_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['user1.js'],
+        },
+      };
+
+      const privateConfigsUser2: t.MCPServers = {
+        user2_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['user2.js'],
+        },
+      };
+
+      await MCPServersInitializer.initPrivateServers(privateConfigsUser1, user1);
+      await MCPServersInitializer.initPrivateServers(privateConfigsUser2, user2);
+
+      // Verify each user has their own server
+      const user1Server = await registry.getPrivateServerConfig('user1_server', user1);
+      const user2Server = await registry.getPrivateServerConfig('user2_server', user2);
+
+      expect(user1Server).toBeDefined();
+      expect(user2Server).toBeDefined();
+
+      // Verify servers are isolated - user2 can't see user1's server
+      const user1ServerFromUser2 = await registry.getPrivateServerConfig('user1_server', user2);
+      expect(user1ServerFromUser2).toBeUndefined();
+
+      // Verify servers are isolated - user1 can't see user2's server
+      const user2ServerFromUser1 = await registry.getPrivateServerConfig('user2_server', user1);
+      expect(user2ServerFromUser1).toBeUndefined();
+    });
+
+    it('should use Promise.allSettled for parallel initialization', async () => {
+      const allSettledSpy = jest.spyOn(Promise, 'allSettled');
+
+      const privateConfigs: t.MCPServers = {
+        server1: testConfigs.file_tools_server,
+        server2: testConfigs.search_tools_server,
+      };
+
+      await MCPServersInitializer.initPrivateServers(privateConfigs, userId);
+
+      expect(allSettledSpy).toHaveBeenCalledWith(expect.arrayContaining([expect.any(Promise)]));
+      expect(allSettledSpy).toHaveBeenCalledTimes(1);
+
+      allSettledSpy.mockRestore();
+    });
+
+    it('should allow same server name for different users', async () => {
+      const user1 = 'user1';
+      const user2 = 'user2';
+
+      const sharedServerName = 'my_tools_server';
+
+      const configUser1: t.MCPServers = {
+        [sharedServerName]: {
+          type: 'stdio',
+          command: 'node',
+          args: ['user1-tools.js'],
+        },
+      };
+
+      const configUser2: t.MCPServers = {
+        [sharedServerName]: {
+          type: 'stdio',
+          command: 'node',
+          args: ['user2-tools.js'],
+        },
+      };
+
+      await MCPServersInitializer.initPrivateServers(configUser1, user1);
+      await MCPServersInitializer.initPrivateServers(configUser2, user2);
+
+      // Verify each user has their own version with different args
+      const user1Server = await registry.getPrivateServerConfig(sharedServerName, user1);
+      const user2Server = await registry.getPrivateServerConfig(sharedServerName, user2);
+
+      expect(user1Server).toBeDefined();
+      expect(user2Server).toBeDefined();
+
+      if (user1Server && 'args' in user1Server) {
+        expect(user1Server.args).toEqual(['user1-tools.js']);
+      }
+      if (user2Server && 'args' in user2Server) {
+        expect(user2Server.args).toEqual(['user2-tools.js']);
+      }
     });
   });
 });

--- a/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
@@ -160,13 +160,14 @@ describe('MCPServersRegistry Redis Integration Tests', () => {
       );
     });
 
-    it('should throw error when updating server for non-existent user', async () => {
+    it('should throw error when updating non-existent server (lazy-loads cache)', async () => {
       const userId = 'nonexistent_user';
       const serverName = 'private_server';
 
+      // With lazy-loading, cache is created but server doesn't exist in it
       await expect(
         registry.updatePrivateUserServer(userId, serverName, testParsedConfig),
-      ).rejects.toThrow('No private servers found for user "nonexistent_user".');
+      ).rejects.toThrow('Server "private_server" does not exist in cache. Use add() to create new configs.');
     });
   });
 
@@ -198,12 +199,12 @@ describe('MCPServersRegistry Redis Integration Tests', () => {
       );
     });
 
-    it('should throw error when user has no private server cache', async () => {
+    it('should return undefined when user has no private servers (lazy-loads cache)', async () => {
       const userId = 'user_with_no_cache';
 
-      await expect(registry.getPrivateServerConfig('server_name', userId)).rejects.toThrow(
-        'No private server cache found for user "user_with_no_cache"',
-      );
+      // With lazy-loading, cache is created but is empty
+      const config = await registry.getPrivateServerConfig('server_name', userId);
+      expect(config).toBeUndefined();
     });
 
     it('should isolate private servers between different users', async () => {

--- a/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.test.ts
@@ -107,13 +107,16 @@ describe('MCPServersRegistry', () => {
       );
     });
 
-    it('should throw error when updating server for non-existent user', async () => {
+    it('should throw error when updating non-existent server (lazy-loads cache)', async () => {
       const userId = 'nonexistent_user';
       const serverName = 'private_server';
 
+      // With lazy-loading, cache is created but server doesn't exist in it
       await expect(
         registry.updatePrivateUserServer(userId, serverName, testParsedConfig),
-      ).rejects.toThrow('No private servers found for user "nonexistent_user".');
+      ).rejects.toThrow(
+        'Server "private_server" does not exist in cache. Use add() to create new configs.',
+      );
     });
   });
 
@@ -145,12 +148,12 @@ describe('MCPServersRegistry', () => {
       );
     });
 
-    it('should throw error when user has no private server cache', async () => {
+    it('should return undefined when user has no private servers (lazy-loads cache)', async () => {
       const userId = 'user_with_no_cache';
 
-      await expect(registry.getPrivateServerConfig('server_name', userId)).rejects.toThrow(
-        'No private server cache found for user "user_with_no_cache"',
-      );
+      // With lazy-loading, cache is created but is empty
+      const config = await registry.getPrivateServerConfig('server_name', userId);
+      expect(config).toBeUndefined();
     });
 
     it('should isolate private servers between different users', async () => {

--- a/packages/api/src/mcp/registry/cache/ServerConfigsCacheInMemory.ts
+++ b/packages/api/src/mcp/registry/cache/ServerConfigsCacheInMemory.ts
@@ -15,7 +15,7 @@ export class ServerConfigsCacheInMemory {
       throw new Error(
         `Server "${serverName}" already exists in cache. Use update() to modify existing configs.`,
       );
-    this.cache.set(serverName, config);
+    this.cache.set(serverName, { ...config, cachedAt: Date.now() });
   }
 
   public async update(serverName: string, config: ParsedServerConfig): Promise<void> {
@@ -23,7 +23,7 @@ export class ServerConfigsCacheInMemory {
       throw new Error(
         `Server "${serverName}" does not exist in cache. Use add() to create new configs.`,
       );
-    this.cache.set(serverName, config);
+    this.cache.set(serverName, { ...config, cachedAt: Date.now() });
   }
 
   public async remove(serverName: string): Promise<void> {

--- a/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedis.ts
+++ b/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedis.ts
@@ -30,7 +30,7 @@ export class ServerConfigsCacheRedis extends BaseRegistryCache {
       throw new Error(
         `Server "${serverName}" already exists in cache. Use update() to modify existing configs.`,
       );
-    const success = await this.cache.set(serverName, config);
+    const success = await this.cache.set(serverName, { ...config, cachedAt: Date.now() });
     this.successCheck(`add ${this.owner} server "${serverName}"`, success);
   }
 
@@ -41,7 +41,7 @@ export class ServerConfigsCacheRedis extends BaseRegistryCache {
       throw new Error(
         `Server "${serverName}" does not exist in cache. Use add() to create new configs.`,
       );
-    const success = await this.cache.set(serverName, config);
+    const success = await this.cache.set(serverName, { ...config, cachedAt: Date.now() });
     this.successCheck(`update ${this.owner} server "${serverName}"`, success);
   }
 
@@ -68,9 +68,9 @@ export class ServerConfigsCacheRedis extends BaseRegistryCache {
         // Full key format: "prefix::namespace:keyName"
         const lastColonIndex = key.lastIndexOf(':');
         const keyName = key.substring(lastColonIndex + 1);
-        const value = await this.cache.get(keyName);
-        if (value) {
-          entries.push([keyName, value as ParsedServerConfig]);
+        const config = (await this.cache.get(keyName)) as ParsedServerConfig | undefined;
+        if (config) {
+          entries.push([keyName, config]);
         }
       }
     }

--- a/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheInMemory.test.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheInMemory.test.ts
@@ -1,5 +1,8 @@
 import { expect } from '@playwright/test';
 import { ParsedServerConfig } from '~/mcp/types';
+const FIXED_TIME = 1699564800000;
+const originalDateNow = Date.now;
+Date.now = jest.fn(() => FIXED_TIME);
 
 describe('ServerConfigsCacheInMemory Integration Tests', () => {
   let ServerConfigsCacheInMemory: typeof import('../ServerConfigsCacheInMemory').ServerConfigsCacheInMemory;
@@ -12,12 +15,14 @@ describe('ServerConfigsCacheInMemory Integration Tests', () => {
     command: 'node',
     args: ['server1.js'],
     env: { TEST: 'value1' },
+    cachedAt: FIXED_TIME,
   };
 
   const mockConfig2: ParsedServerConfig = {
     command: 'python',
     args: ['server2.py'],
     env: { TEST: 'value2' },
+    cachedAt: FIXED_TIME,
   };
 
   const mockConfig3: ParsedServerConfig = {
@@ -25,12 +30,17 @@ describe('ServerConfigsCacheInMemory Integration Tests', () => {
     args: ['server3.js'],
     url: 'http://localhost:3000',
     requiresOAuth: true,
+    cachedAt: FIXED_TIME,
   };
 
   beforeAll(async () => {
     // Import modules
     const cacheModule = await import('../ServerConfigsCacheInMemory');
     ServerConfigsCacheInMemory = cacheModule.ServerConfigsCacheInMemory;
+  });
+
+  afterAll(() => {
+    Date.now = originalDateNow;
   });
 
   beforeEach(() => {

--- a/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedis.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedis.cache_integration.spec.ts
@@ -1,5 +1,8 @@
 import { expect } from '@playwright/test';
 import { ParsedServerConfig } from '~/mcp/types';
+const FIXED_TIME = 1699564800000;
+const originalDateNow = Date.now;
+Date.now = jest.fn(() => FIXED_TIME);
 
 describe('ServerConfigsCacheRedis Integration Tests', () => {
   let ServerConfigsCacheRedis: typeof import('../ServerConfigsCacheRedis').ServerConfigsCacheRedis;
@@ -13,12 +16,14 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
     command: 'node',
     args: ['server1.js'],
     env: { TEST: 'value1' },
+    cachedAt: FIXED_TIME,
   };
 
   const mockConfig2: ParsedServerConfig = {
     command: 'python',
     args: ['server2.py'],
     env: { TEST: 'value2' },
+    cachedAt: FIXED_TIME,
   };
 
   const mockConfig3: ParsedServerConfig = {
@@ -26,6 +31,7 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
     args: ['server3.js'],
     url: 'http://localhost:3000',
     requiresOAuth: true,
+    cachedAt: FIXED_TIME,
   };
 
   beforeAll(async () => {
@@ -78,6 +84,8 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
   });
 
   afterAll(async () => {
+    Date.now = originalDateNow;
+
     // Clear leader key to allow other tests to become leader
     if (keyvRedisClient) await keyvRedisClient.del(LeaderElection.LEADER_KEY);
 

--- a/packages/api/src/mcp/registry/cache/toolsCache/IMCPToolsCache.ts
+++ b/packages/api/src/mcp/registry/cache/toolsCache/IMCPToolsCache.ts
@@ -1,0 +1,18 @@
+import { LCAvailableTools } from '~/mcp/types';
+
+/**
+ * Cached tools entry with timestamp for staleness detection
+ */
+export interface CachedTools {
+  tools: LCAvailableTools;
+  cachedAt: number;
+}
+
+export interface IMCPToolsCache {
+  add: (serverName: string, tools: LCAvailableTools) => Promise<void>;
+  update: (serverName: string, tools: LCAvailableTools) => Promise<void>;
+  remove: (serverName: string) => Promise<void>;
+  get: (serverName: string) => Promise<CachedTools | undefined>;
+  getAll: () => Promise<Record<string, CachedTools>>;
+  reset: () => Promise<void>;
+}

--- a/packages/api/src/mcp/registry/cache/toolsCache/MCPToolsCacheFactory.ts
+++ b/packages/api/src/mcp/registry/cache/toolsCache/MCPToolsCacheFactory.ts
@@ -1,0 +1,13 @@
+import { cacheConfig } from '~/cache';
+import { MCPToolsCacheInMemory } from './MCPToolsCacheInMemory';
+import { MCPToolsCacheRedis } from './MCPToolsCacheRedis';
+import { IMCPToolsCache } from './IMCPToolsCache';
+
+export class MCPToolsCacheFactory {
+  public static create(userId: string): IMCPToolsCache {
+    if (cacheConfig.USE_REDIS) {
+      return new MCPToolsCacheRedis(userId);
+    }
+    return new MCPToolsCacheInMemory();
+  }
+}

--- a/packages/api/src/mcp/registry/cache/toolsCache/MCPToolsCacheInMemory.ts
+++ b/packages/api/src/mcp/registry/cache/toolsCache/MCPToolsCacheInMemory.ts
@@ -1,0 +1,39 @@
+import { LCAvailableTools } from '~/mcp/types';
+import { IMCPToolsCache, CachedTools } from './IMCPToolsCache';
+
+export class MCPToolsCacheInMemory implements IMCPToolsCache {
+  private cache: Map<string, CachedTools> = new Map();
+
+  async add(serverName: string, tools: LCAvailableTools): Promise<void> {
+    this.cache.set(serverName, {
+      tools,
+      cachedAt: Date.now(),
+    });
+  }
+
+  async update(serverName: string, tools: LCAvailableTools): Promise<void> {
+    if (!this.cache.has(serverName)) {
+      throw new Error(`Server ${serverName} does not exist in cache.`);
+    }
+    this.cache.set(serverName, {
+      tools,
+      cachedAt: Date.now(),
+    });
+  }
+
+  async remove(serverName: string): Promise<void> {
+    this.cache.delete(serverName);
+  }
+
+  async get(serverName: string): Promise<CachedTools | undefined> {
+    return this.cache.get(serverName);
+  }
+
+  async getAll(): Promise<Record<string, CachedTools>> {
+    return Object.fromEntries(this.cache);
+  }
+
+  async reset(): Promise<void> {
+    this.cache.clear();
+  }
+}

--- a/packages/api/src/mcp/registry/cache/toolsCache/MCPToolsCacheRedis.ts
+++ b/packages/api/src/mcp/registry/cache/toolsCache/MCPToolsCacheRedis.ts
@@ -1,0 +1,82 @@
+import type Keyv from 'keyv';
+import { fromPairs } from 'lodash';
+import { LCAvailableTools } from '~/mcp/types';
+import { IMCPToolsCache, CachedTools } from './IMCPToolsCache';
+import { standardCache, keyvRedisClient } from '~/cache';
+import { BaseRegistryCache } from '../BaseRegistryCache';
+
+export class MCPToolsCacheRedis extends BaseRegistryCache implements IMCPToolsCache {
+  protected readonly cache: Keyv;
+  private readonly userId: string;
+  constructor(userId: string) {
+    super();
+    this.userId = userId;
+    this.cache = standardCache(`${this.PREFIX}::Tools::${userId}`);
+  }
+  async add(serverName: string, tools: LCAvailableTools): Promise<void> {
+    const exists = await this.cache.has(serverName);
+    if (exists) {
+      throw new Error(
+        `Server "${serverName}" already exists in cache that belongs to user with Id ${this.userId}. Use update() to modify existing tools.`,
+      );
+    }
+    const cachedTools: CachedTools = {
+      tools,
+      cachedAt: Date.now(),
+    };
+    const success = await this.cache.set(serverName, cachedTools);
+    this.successCheck(
+      `add server "${serverName}" tools into user's cache. User ID - "${this.userId}" `,
+      success,
+    );
+  }
+
+  async update(serverName: string, tools: LCAvailableTools): Promise<void> {
+    if (!(await this.cache.has(serverName))) {
+      throw new Error(`Server ${serverName} not found in tools cache. Use add() instead`);
+    }
+    const cachedTools: CachedTools = {
+      tools,
+      cachedAt: Date.now(),
+    };
+    const success = await this.cache.set(serverName, cachedTools);
+    this.successCheck(
+      `update server "${serverName}" tools into user's cache. User ID - "${this.userId}" `,
+      success,
+    );
+  }
+
+  async remove(serverName: string): Promise<void> {
+    const success = await this.cache.delete(serverName);
+    this.successCheck(
+      `remove server "${serverName}" tools from user's cache. User ID - "${this.userId}" `,
+      success,
+    );
+  }
+
+  async get(serverName: string): Promise<CachedTools | undefined> {
+    return this.cache.get(serverName);
+  }
+
+  async getAll(): Promise<Record<string, CachedTools>> {
+    const pattern = `*${this.cache.namespace}:*`;
+    const entries: Array<[string, CachedTools]> = [];
+
+    if (keyvRedisClient && 'scanIterator' in keyvRedisClient) {
+      for await (const key of keyvRedisClient.scanIterator({ MATCH: pattern })) {
+        const lastColonIndex = key.lastIndexOf(':');
+        const keyName = key.substring(lastColonIndex + 1);
+        const cachedTools = (await this.cache.get(keyName)) as CachedTools | undefined;
+        if (cachedTools) {
+          entries.push([keyName, cachedTools]);
+        }
+      }
+    }
+
+    return fromPairs(entries);
+  }
+
+  async reset(): Promise<void> {
+    this.cache.clear();
+  }
+}

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -153,6 +153,7 @@ export type ParsedServerConfig = MCPOptions & {
   tools?: string;
   toolFunctions?: LCAvailableTools;
   initDuration?: number;
+  cachedAt?: number;
 };
 
 export interface BasicConnectionOptions {


### PR DESCRIPTION
## Summary
Coming from this [discussion](https://github.com/danny-avila/LibreChat/discussions/9837)

Each user (or user group) should have their own set of MCP tools that are available to them. The tools should be dynamically loaded based on the MCP servers available to the users, and the tools each server provides for that user.

To find out which tools are available to a user, the application must first query the MCP Servers Registry to get the list of available MCP servers for that user, then query each server to get the list of tools it provides for that user. This process is expensive, so it should be cached for a reasonable amount of time.

The list of tools per user will be populated on-demand, instead of at startup.

### Technical details:
Add MCPToolBox to the MCP package with the ability to query the list of available tools for a specific user:
with caching per user per server, and with TTL.
must be aware of the changes in the MCPServersRegistry to add or remove tools as needed.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
