### PR TITLE
Feat/customizable cookie domanin

### DIFF
--- a/README.md.v0.8.1-rc1
+++ b/README.md.v0.8.1-rc1
@@ -1,0 +1,5 @@
+This change intrduces a new env variable `COOKIE_DOMAIN`. This is exposes the domain in which authorization cookies are set.
+
+## Motivation
+
+I've talked about motivatin in [\[Enhancement\]: Customizable cookie domain #10416](https://github.com/danny-avila/LibreChat/discussions/10416).

--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -29,6 +29,9 @@ const domains = {
   server: process.env.DOMAIN_SERVER,
 };
 
+let COOKIE_DOMAIN = process.env['COOKIE_DOMAIN'] ?? '';
+logger.info(`[AuthService] cookies are set to domain ${COOKIE_DOMAIN || domains.server}`);
+
 const isProduction = process.env.NODE_ENV === 'production';
 const genericVerificationMessage = 'Please check your email to verify your email address.';
 
@@ -388,12 +391,14 @@ const setAuthTokens = async (userId, res, _session = null) => {
       httpOnly: true,
       secure: isProduction,
       sameSite: 'strict',
+      domain: COOKIE_DOMAIN,
     });
     res.cookie('token_provider', 'librechat', {
       expires: new Date(refreshTokenExpires),
       httpOnly: true,
       secure: isProduction,
       sameSite: 'strict',
+      domain: COOKIE_DOMAIN,
     });
     return token;
   } catch (error) {


### PR DESCRIPTION
Small change that enables setting a different cookie domain for authentication cookies. This is useful for when you want to set cookies to root domain.

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

I've mentioned the motivation for this commit in [Customizable cookie domain #10416](https://github.com/danny-avila/LibreChat/discussions/10416)

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

I've mentioned the motivation for this change in discussions  #10416

## Change Type

Please delete any irrelevant options.

- [*] New feature (non-breaking change which adds functionality)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [*] My code adheres to this project's style guidelines
- [*] I have performed a self-review of my own code
- [*] My changes do not introduce new warnings
- [*] Local unit tests pass with my changes

