### PR TITLE
🔐 fix: persist new MCP oauth tokens properly

### DIFF
--- a/packages/api/src/mcp/oauth/tokens.ts
+++ b/packages/api/src/mcp/oauth/tokens.ts
@@ -217,7 +217,11 @@ export class MCPTokenStorage {
         }
       }
 
-      logger.debug(`${logPrefix} Stored OAuth tokens`);
+      logger.debug(`${logPrefix} Stored OAuth tokens`, {
+        client_id: clientInfo?.client_id,
+        has_refresh_token: !!tokens.refresh_token,
+        expires_at: 'expires_at' in tokens ? tokens.expires_at : 'N/A',
+      });
     } catch (error) {
       const logPrefix = this.getLogPrefix(userId, serverName);
       logger.error(`${logPrefix} Failed to store tokens`, error);


### PR DESCRIPTION
## Summary

If MCP Oauth flow triggers a DCR re-registration (like if the client or refresh tokens we have are no longer valid), the new tokens are not properly persisted to the database.
This PR fixes that by getting an updated flow state with the newly issued tokens before persisting them to the database.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added one test to confirm that flow state is updated and updated tokens are persisted.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
