### PR TITLE
🔒 feat: Idempotency check for OAuth Flow Completion

### DIFF
--- a/packages/api/src/flow/manager.ts
+++ b/packages/api/src/flow/manager.ts
@@ -188,6 +188,46 @@ export class FlowStateManager<T = unknown> {
   }
 
   /**
+   * Checks if a flow is stale based on its age and status
+   * @param flowId - The flow identifier
+   * @param type - The flow type
+   * @param staleThresholdMs - Age in milliseconds after which a non-pending flow is considered stale (default: 2 minutes)
+   * @returns Object with isStale boolean and age in milliseconds
+   */
+  async isFlowStale(
+    flowId: string,
+    type: string,
+    staleThresholdMs: number = 2 * 60 * 1000,
+  ): Promise<{ isStale: boolean; age: number; status?: string }> {
+    const flowKey = this.getFlowKey(flowId, type);
+    const flowState = (await this.keyv.get(flowKey)) as FlowState<T> | undefined;
+
+    if (!flowState) {
+      return { isStale: false, age: 0 };
+    }
+
+    if (flowState.status === 'PENDING') {
+      return { isStale: false, age: 0, status: flowState.status };
+    }
+
+    const completedAt = flowState.completedAt || flowState.failedAt;
+    const createdAt = flowState.createdAt;
+
+    let flowAge = 0;
+    if (completedAt) {
+      flowAge = Date.now() - completedAt;
+    } else if (createdAt) {
+      flowAge = Date.now() - createdAt;
+    }
+
+    return {
+      isStale: flowAge > staleThresholdMs,
+      age: flowAge,
+      status: flowState.status,
+    };
+  }
+
+  /**
    * Marks a flow as failed
    */
   async failFlow(flowId: string, type: string, error: Error | string): Promise<boolean> {

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -7,9 +7,9 @@ import type { FlowMetadata } from '~/flow/types';
 import type * as t from './types';
 import { MCPTokenStorage, MCPOAuthHandler } from '~/mcp/oauth';
 import { sanitizeUrlForLogging } from './utils';
+import { withTimeout } from '~/utils/promise';
 import { MCPConnection } from './connection';
 import { processMCPEnv } from '~/utils';
-import { withTimeout } from '~/utils/promise';
 
 /**
  * Factory for creating MCP connections with optional OAuth authentication.
@@ -343,28 +343,48 @@ export class MCPConnectionFactory {
           `${this.logPrefix} OAuth flow completed, tokens received for ${this.serverName}`,
         );
 
-        // Re-fetch flow state after completion to get updated credentials
-        const updatedFlowState = await MCPOAuthHandler.getFlowState(
-          flowId,
-          this.flowManager as FlowStateManager<MCPOAuthTokens>,
-        );
-
-        /** Client information from the updated flow metadata */
+        /** Client information from the existing flow metadata */
         const existingMetadata = existingFlow.metadata as unknown as MCPOAuthFlowMetadata;
-        const clientInfo = updatedFlowState?.clientInfo || existingMetadata?.clientInfo;
+        const clientInfo = existingMetadata?.clientInfo;
 
         return { tokens, clientInfo };
       }
 
-      // Clean up old completed flows: createFlow() may return cached results otherwise
+      // Clean up old completed/failed flows, but only if they're actually stale
+      // This prevents race conditions where we delete a flow that's still being processed
       if (existingFlow && existingFlow.status !== 'PENDING') {
-        try {
-          await this.flowManager.deleteFlow(flowId, 'mcp_oauth');
+        const completedAt = existingFlow.completedAt || existingFlow.failedAt;
+        const createdAt = existingFlow.createdAt;
+
+        let flowAge = 0;
+        if (completedAt) {
+          flowAge = Date.now() - completedAt;
+        } else if (createdAt) {
+          flowAge = Date.now() - createdAt;
+        }
+
+        /** Only delete flows older than 2 minutes to avoid race conditions with callback processing */
+        const STALE_FLOW_THRESHOLD = 2 * 60 * 1000; // 2 minutes
+
+        if (flowAge > STALE_FLOW_THRESHOLD) {
+          try {
+            await this.flowManager.deleteFlow(flowId, 'mcp_oauth');
+            logger.debug(
+              `${this.logPrefix} Cleared stale ${existingFlow.status} OAuth flow (age: ${Math.round(flowAge / 1000)}s)`,
+            );
+          } catch (error) {
+            logger.warn(`${this.logPrefix} Failed to clear stale OAuth flow`, error);
+          }
+        } else {
           logger.debug(
-            `${this.logPrefix} Cleared stale ${existingFlow.status} OAuth flow for ${flowId}`,
+            `${this.logPrefix} Skipping cleanup of recent ${existingFlow.status} flow (age: ${Math.round(flowAge / 1000)}s, threshold: ${STALE_FLOW_THRESHOLD / 1000}s)`,
           );
-        } catch (error) {
-          logger.warn(`${this.logPrefix} Failed to clear stale OAuth flow`, error);
+          // If flow is recent but not pending, something might be wrong
+          if (existingFlow.status === 'FAILED') {
+            logger.warn(
+              `${this.logPrefix} Recent OAuth flow failed, will retry after ${Math.round((STALE_FLOW_THRESHOLD - flowAge) / 1000)}s`,
+            );
+          }
         }
       }
 
@@ -402,15 +422,9 @@ export class MCPConnectionFactory {
       }
       logger.info(`${this.logPrefix} OAuth flow completed, tokens received for ${this.serverName}`);
 
-      // Re-fetch flow state after completion to get updated credentials
-      const updatedFlowState = await MCPOAuthHandler.getFlowState(
-        newFlowId,
-        this.flowManager as FlowStateManager<MCPOAuthTokens>,
-      );
-
-      /** Client information from the updated flow state */
-      const clientInfo = updatedFlowState?.clientInfo || flowMetadata?.clientInfo;
-      const metadata = updatedFlowState?.metadata || flowMetadata?.metadata;
+      /** Client information from the flow metadata */
+      const clientInfo = flowMetadata?.clientInfo;
+      const metadata = flowMetadata?.metadata;
 
       return {
         tokens,

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -445,6 +445,7 @@ export class MCPOAuthHandler {
         has_refresh_token: !!tokens.refresh_token,
         expires_in: tokens.expires_in,
         token_type: tokens.token_type,
+        scope: tokens.scope,
       });
 
       const mcpTokens: MCPOAuthTokens = {

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from 'crypto';
 import { logger } from '@librechat/data-schemas';
+import { FetchLike } from '@modelcontextprotocol/sdk/shared/transport';
+import { OAuthMetadataSchema } from '@modelcontextprotocol/sdk/shared/auth.js';
 import {
   registerClient,
   startAuthorization,
@@ -7,7 +9,6 @@ import {
   discoverAuthorizationServerMetadata,
   discoverOAuthProtectedResourceMetadata,
 } from '@modelcontextprotocol/sdk/client/auth.js';
-import { OAuthMetadataSchema } from '@modelcontextprotocol/sdk/shared/auth.js';
 import type { MCPOptions } from 'librechat-data-provider';
 import type { FlowStateManager } from '~/flow/manager';
 import type {
@@ -18,7 +19,6 @@ import type {
   OAuthMetadata,
 } from './types';
 import { sanitizeUrlForLogging } from '~/mcp/utils';
-import { FetchLike } from '@modelcontextprotocol/sdk/shared/transport';
 
 /** Type for the OAuth metadata from the SDK */
 type SDKOAuthMetadata = Parameters<typeof registerClient>[1]['metadata'];
@@ -439,12 +439,12 @@ export class MCPOAuthHandler {
         fetchFn: this.createOAuthFetch(oauthHeaders),
       });
 
-      logger.debug('[MCPOAuth] Raw tokens from exchange:', {
-        access_token: tokens.access_token ? '[REDACTED]' : undefined,
-        refresh_token: tokens.refresh_token ? '[REDACTED]' : undefined,
+      logger.debug('[MCPOAuth] Token exchange successful', {
+        flowId,
+        has_access_token: !!tokens.access_token,
+        has_refresh_token: !!tokens.refresh_token,
         expires_in: tokens.expires_in,
         token_type: tokens.token_type,
-        scope: tokens.scope,
       });
 
       const mcpTokens: MCPOAuthTokens = {


### PR DESCRIPTION
## Summary

I fixed potential OAuth flow issues in the MCP implementation by addressing race conditions in flow cleanup, removing credential re-fetch logic based on DCR, and adding idempotency protection to prevent duplicate token exchanges.

- Removed the re-fetch logic introduced in https://github.com/danny-avila/LibreChat/pull/10439 that attempted to capture DCR credential updates after token exchange, as the MCP SDK does not perform DCR during `exchangeAuthorization()` and flow metadata is never updated post-creation
- Fixed race condition in flow cleanup by implementing age-based deletion with a 2-minute threshold instead of immediately deleting completed flows, preventing "Flow state not found" errors during callback processing
- Added idempotency protection in the OAuth callback route to detect and prevent duplicate token exchange attempts, eliminating "authorization code does not exist" errors from browser retries
- Enhanced `FlowStateManager.completeFlow()` with duplicate completion checks and improved error logging for better debugging
- Simplified token storage to use original flow state credentials directly, removing unnecessary async operations
- Updated tests to validate actual OAuth flow behavior instead of artificially mocked scenarios that don't occur in production
- Cleaned up verbose diagnostic logging while retaining operationally useful logs for monitoring flow completion and cleanup decisions

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested the changes with Google Workspace MCP OAuth flow:

1. **Normal OAuth Flow**: Initiated MCP connection requiring OAuth, completed authorization in browser, verified successful token exchange and storage
2. **Idempotency Check**: Manually navigated to callback URL again with same authorization code, confirmed duplicate exchange was prevented
3. **Race Condition Prevention**: Triggered new connection attempt within 2 minutes of completion, verified stale flow was not prematurely deleted
4. **Token Persistence**: Restarted server and reconnected to MCP server, confirmed tokens were properly loaded from storage
5. **Unit Tests**: All updated tests pass, including new tests for idempotency protection and realistic credential storage

### **Test Configuration**:
- MCP Server: Google Workspace MCP with OAuth
- OAuth Provider: Google OAuth 2.0
- Flow completion time: ~6 seconds
- 84 tools successfully fetched after reconnection

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes