### PR TITLE
feat: S3 support path style urls

### DIFF
--- a/api/server/services/Files/S3/crud.js
+++ b/api/server/services/Files/S3/crud.js
@@ -259,6 +259,7 @@ function extractKeyFromS3Url(fileUrlOrKey) {
 
     if (endpoint?.trim() && forcePathStyle) {
       const endpointUrl = new URL(endpoint);
+      
       const startPos = endpointUrl.pathname.length +
         (endpointUrl.pathname.endsWith('/') ? 2 : 1) +
         bucketName.length +

--- a/api/server/services/Files/S3/crud.js
+++ b/api/server/services/Files/S3/crud.js
@@ -269,12 +269,6 @@ function extractKeyFromS3Url(fileUrlOrKey) {
       return fileUrlOrKey;
     }
 
-    if (endpoint?.trim() && forcePathStyle) {
-      const endpointUrl = new URL(endpoint)
-      const startPos = endpointUrl.pathname.length + (endpointUrl.pathname.endsWith('/') ? 2 : 1) + bucketName.length + 1;
-      return fileUrlOrKey.substring(startPos);
-    }
-
     return fileUrlOrKey.startsWith('/') ? fileUrlOrKey.substring(1) : fileUrlOrKey;
   }
 }

--- a/api/server/services/Files/S3/crud.js
+++ b/api/server/services/Files/S3/crud.js
@@ -261,7 +261,7 @@ function extractKeyFromS3Url(fileUrlOrKey) {
       const endpointUrl = new URL(endpoint);
       const startPos =
         endpointUrl.pathname.length +
-        (endpointUrl.pathname.endsWith('/') ? 2 : 1) +
+        (endpointUrl.pathname.endsWith('/') ? 0 : 1) +
         bucketName.length +
         1;
 

--- a/api/server/services/Files/S3/crud.js
+++ b/api/server/services/Files/S3/crud.js
@@ -14,7 +14,9 @@ const {
 const endpoint = process.env.AWS_ENDPOINT_URL;
 const bucketName = process.env.AWS_BUCKET_NAME;
 const defaultBasePath = 'images';
-const forcePathStyle = ['1', 'true', 'yes'].includes((process.env.AWS_FORCE_PATH_STYLE ?? '').toLowerCase());
+const forcePathStyle = ['1', 'true', 'yes'].includes(
+  (process.env.AWS_FORCE_PATH_STYLE ?? '').toLowerCase().
+);
 
 let s3UrlExpirySeconds = 2 * 60; // 2 minutes
 let s3RefreshExpiryMs = null;
@@ -256,8 +258,11 @@ function extractKeyFromS3Url(fileUrlOrKey) {
     const url = new URL(fileUrlOrKey);
 
     if (endpoint?.trim() && forcePathStyle) {
-      const endpointUrl = new URL(endpoint)
-      const startPos = endpointUrl.pathname.length + (endpointUrl.pathname.endsWith('/') ? 2 : 1) + bucketName.length + 1;
+      const endpointUrl = new URL(endpoint);
+      const startPos = endpointUrl.pathname.length +
+        (endpointUrl.pathname.endsWith('/') ? 2 : 1) +
+        bucketName.length +
+        1;
       return url.pathname.substring(startPos);
     }
 

--- a/api/server/services/Files/S3/crud.js
+++ b/api/server/services/Files/S3/crud.js
@@ -259,11 +259,12 @@ function extractKeyFromS3Url(fileUrlOrKey) {
 
     if (endpoint?.trim() && forcePathStyle) {
       const endpointUrl = new URL(endpoint);
-      
-      const startPos = endpointUrl.pathname.length +
+      const startPos =
+        endpointUrl.pathname.length +
         (endpointUrl.pathname.endsWith('/') ? 2 : 1) +
         bucketName.length +
         1;
+
       return url.pathname.substring(startPos);
     }
 

--- a/api/server/services/Files/S3/crud.js
+++ b/api/server/services/Files/S3/crud.js
@@ -14,7 +14,7 @@ const {
 const endpoint = process.env.AWS_ENDPOINT_URL;
 const bucketName = process.env.AWS_BUCKET_NAME;
 const defaultBasePath = 'images';
-const forcePathStyle = ['1', 'true', 'yes'].includes(process.env.AWS_FORCE_PATH_STYLE?.toLowerCase());
+const forcePathStyle = ['1', 'true', 'yes'].includes((process.env.AWS_FORCE_PATH_STYLE ?? '').toLowerCase());
 
 let s3UrlExpirySeconds = 2 * 60; // 2 minutes
 let s3RefreshExpiryMs = null;

--- a/api/server/services/Files/S3/crud.js
+++ b/api/server/services/Files/S3/crud.js
@@ -15,7 +15,7 @@ const endpoint = process.env.AWS_ENDPOINT_URL;
 const bucketName = process.env.AWS_BUCKET_NAME;
 const defaultBasePath = 'images';
 const forcePathStyle = ['1', 'true', 'yes'].includes(
-  (process.env.AWS_FORCE_PATH_STYLE ?? '').toLowerCase().
+  (process.env.AWS_FORCE_PATH_STYLE ?? '').toLowerCase(),
 );
 
 let s3UrlExpirySeconds = 2 * 60; // 2 minutes

--- a/packages/api/src/cdn/s3.ts
+++ b/packages/api/src/cdn/s3.ts
@@ -34,7 +34,7 @@ export const initializeS3 = (): S3Client | null => {
 
   const config = {
     region,
-    forcePathStyle: forcePathStyle, // Enable path-style addressing
+    forcePathStyle, // Conditionally enable path-style addressing
     // Conditionally add the endpoint if it is provided
     ...(endpoint ? { endpoint } : {}),
   };

--- a/packages/api/src/cdn/s3.ts
+++ b/packages/api/src/cdn/s3.ts
@@ -28,7 +28,9 @@ export const initializeS3 = (): S3Client | null => {
   const endpoint = process.env.AWS_ENDPOINT_URL;
   const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
   const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
-  const forcePathStyle = ['1', 'true', 'yes'].includes((process.env.AWS_FORCE_PATH_STYLE ?? '').toLowerCase());
+  const forcePathStyle = ['1', 'true', 'yes'].includes(
+    (process.env.AWS_FORCE_PATH_STYLE ?? '').toLowerCase(),
+  );
 
   const config = {
     region,

--- a/packages/api/src/cdn/s3.ts
+++ b/packages/api/src/cdn/s3.ts
@@ -28,7 +28,7 @@ export const initializeS3 = (): S3Client | null => {
   const endpoint = process.env.AWS_ENDPOINT_URL;
   const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
   const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
-  const forcePathStyle = ['1', 'true', 'yes'].includes(process.env.AWS_FORCE_PATH_STYLE?.toLowerCase());
+  const forcePathStyle = ['1', 'true', 'yes'].includes((process.env.AWS_FORCE_PATH_STYLE ?? '').toLowerCase());
 
   const config = {
     region,

--- a/packages/api/src/cdn/s3.ts
+++ b/packages/api/src/cdn/s3.ts
@@ -28,9 +28,11 @@ export const initializeS3 = (): S3Client | null => {
   const endpoint = process.env.AWS_ENDPOINT_URL;
   const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
   const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+  const forcePathStyle = ['1', 'true', 'yes'].includes(process.env.AWS_FORCE_PATH_STYLE?.toLowerCase());
 
   const config = {
     region,
+    forcePathStyle: forcePathStyle, // Enable path-style addressing
     // Conditionally add the endpoint if it is provided
     ...(endpoint ? { endpoint } : {}),
   };


### PR DESCRIPTION
## Summary

Exposes the `forcePathStyle` [AWS S3 option](https://github.com/aws/aws-sdk-js-v3/blob/2a1737eb76705bcde9f3aa42cae89292ae7ad865/clients/client-s3/src/endpoint/EndpointParameters.ts#L12) via a new `AWS_FORCE_PATH_STYLE` environment variable. This allows configuring path-based access to AWS and non-AWS S3 services.

Fixes #10276 #11806

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Tested locally using minio, a custom S3 service, and we are running this in production in daily use by 1000+ users.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
