### PR TITLE
🔢 fix: Unescape LaTeX Numbers in Artifact Content Edit

### DIFF
--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { unescapeLaTeX } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const { ContentTypes } = require('librechat-data-provider');
 const {
@@ -134,17 +135,32 @@ router.post('/artifact/:messageId', async (req, res) => {
       return res.status(400).json({ error: 'Artifact index out of bounds' });
     }
 
+    // Unescape LaTeX preprocessing done by the frontend
+    // The frontend escapes $ signs for display, but the database has unescaped versions
+    const unescapedOriginal = unescapeLaTeX(original);
+    const unescapedUpdated = unescapeLaTeX(updated);
+
     const targetArtifact = artifacts[index];
     let updatedText = null;
 
     if (targetArtifact.source === 'content') {
       const part = message.content[targetArtifact.partIndex];
-      updatedText = replaceArtifactContent(part.text, targetArtifact, original, updated);
+      updatedText = replaceArtifactContent(
+        part.text,
+        targetArtifact,
+        unescapedOriginal,
+        unescapedUpdated,
+      );
       if (updatedText) {
         part.text = updatedText;
       }
     } else {
-      updatedText = replaceArtifactContent(message.text, targetArtifact, original, updated);
+      updatedText = replaceArtifactContent(
+        message.text,
+        targetArtifact,
+        unescapedOriginal,
+        unescapedUpdated,
+      );
       if (updatedText) {
         message.text = updatedText;
       }

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -7,6 +7,7 @@ export * from './events';
 export * from './files';
 export * from './generators';
 export * from './key';
+export * from './latex';
 export * from './llm';
 export * from './math';
 export * from './openid';

--- a/packages/api/src/utils/latex.spec.ts
+++ b/packages/api/src/utils/latex.spec.ts
@@ -1,0 +1,122 @@
+import { unescapeLaTeX } from './latex';
+
+describe('unescapeLaTeX', () => {
+  describe('currency dollar signs', () => {
+    it('should unescape single backslash dollar signs', () => {
+      const input = 'Price: \\$14';
+      const expected = 'Price: $14';
+      expect(unescapeLaTeX(input)).toBe(expected);
+    });
+
+    it('should unescape double backslash dollar signs', () => {
+      const input = 'Price: \\\\$14';
+      const expected = 'Price: $14';
+      expect(unescapeLaTeX(input)).toBe(expected);
+    });
+
+    it('should unescape multiple currency values', () => {
+      const input = '**Crispy Calamari** - *\\\\$14*\n**Truffle Fries** - *\\\\$12*';
+      const expected = '**Crispy Calamari** - *$14*\n**Truffle Fries** - *$12*';
+      expect(unescapeLaTeX(input)).toBe(expected);
+    });
+
+    it('should handle currency with commas and decimals', () => {
+      const input = 'Total: \\\\$1,234.56';
+      const expected = 'Total: $1,234.56';
+      expect(unescapeLaTeX(input)).toBe(expected);
+    });
+  });
+
+  describe('mhchem notation', () => {
+    it('should unescape mhchem ce notation', () => {
+      const input = '$$\\\\ce{H2O}$$';
+      const expected = '$\\ce{H2O}$';
+      expect(unescapeLaTeX(input)).toBe(expected);
+    });
+
+    it('should unescape mhchem pu notation', () => {
+      const input = '$$\\\\pu{123 kJ/mol}$$';
+      const expected = '$\\pu{123 kJ/mol}$';
+      expect(unescapeLaTeX(input)).toBe(expected);
+    });
+
+    it('should handle multiple mhchem expressions', () => {
+      const input = '$$\\\\ce{H2O}$$ and $$\\\\ce{CO2}$$';
+      const expected = '$\\ce{H2O}$ and $\\ce{CO2}$';
+      expect(unescapeLaTeX(input)).toBe(expected);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty string', () => {
+      expect(unescapeLaTeX('')).toBe('');
+    });
+
+    it('should handle null', () => {
+      expect(unescapeLaTeX(null)).toBe(null);
+    });
+
+    it('should handle undefined', () => {
+      expect(unescapeLaTeX(undefined)).toBe(undefined);
+    });
+
+    it('should handle string with no dollar signs', () => {
+      const input = 'Hello world';
+      expect(unescapeLaTeX(input)).toBe(input);
+    });
+
+    it('should handle mixed escaped and unescaped content', () => {
+      const input = 'Price \\\\$14 and some text';
+      const expected = 'Price $14 and some text';
+      expect(unescapeLaTeX(input)).toBe(expected);
+    });
+  });
+
+  describe('real-world example from bug report', () => {
+    it('should correctly unescape restaurant menu content', () => {
+      const input = `# The Golden Spoon
+## *Contemporary American Cuisine*
+
+---
+
+### STARTERS
+
+**Crispy Calamari** - *\\\\$14*  
+Lightly fried, served with marinara & lemon aioli
+
+**Truffle Fries** - *\\\\$12*  
+Hand-cut fries, parmesan, truffle oil, fresh herbs
+
+**Burrata & Heirloom Tomatoes** - *\\\\$16*  
+Fresh burrata, basil pesto, balsamic reduction, grilled sourdough
+
+**Thai Chicken Lettuce Wraps** - *\\\\$13*  
+Spicy ground chicken, water chestnuts, ginger-soy glaze
+
+**Soup of the Day** - *\\\\$9`;
+
+      const expected = `# The Golden Spoon
+## *Contemporary American Cuisine*
+
+---
+
+### STARTERS
+
+**Crispy Calamari** - *$14*  
+Lightly fried, served with marinara & lemon aioli
+
+**Truffle Fries** - *$12*  
+Hand-cut fries, parmesan, truffle oil, fresh herbs
+
+**Burrata & Heirloom Tomatoes** - *$16*  
+Fresh burrata, basil pesto, balsamic reduction, grilled sourdough
+
+**Thai Chicken Lettuce Wraps** - *$13*  
+Spicy ground chicken, water chestnuts, ginger-soy glaze
+
+**Soup of the Day** - *$9`;
+
+      expect(unescapeLaTeX(input)).toBe(expected);
+    });
+  });
+});

--- a/packages/api/src/utils/latex.ts
+++ b/packages/api/src/utils/latex.ts
@@ -1,0 +1,27 @@
+/**
+ * Unescapes LaTeX preprocessing done by the frontend preprocessLaTeX function.
+ * This reverses the escaping of currency dollar signs and other LaTeX transformations.
+ *
+ * The frontend escapes dollar signs for proper LaTeX rendering (e.g., $14 → \\$14),
+ * but the database stores the original unescaped versions. This function reverses
+ * that transformation to match database content.
+ *
+ * @param text - The escaped text from the frontend
+ * @returns The unescaped text matching the database format
+ */
+export function unescapeLaTeX(text: string | null | undefined): string | null | undefined {
+  if (!text || typeof text !== 'string') {
+    return text;
+  }
+
+  // Unescape currency dollar signs (\\$ or \$ → $)
+  // This is the main transformation done by preprocessLaTeX for currency
+  let result = text.replace(/\\\\?\$/g, '$');
+
+  // Unescape mhchem notation if present
+  // Convert $$\\ce{...}$$ back to $\ce{...}$
+  result = result.replace(/\$\$\\\\ce\{([^}]*)\}\$\$/g, '$\\ce{$1}$');
+  result = result.replace(/\$\$\\\\pu\{([^}]*)\}\$\$/g, '$\\pu{$1}$');
+
+  return result;
+}


### PR DESCRIPTION
#  Summary

I fixed a bug where editing artifacts containing escaped dollar signs (like currency values) would fail to match the original content in the database. The frontend escapes dollar signs for LaTeX rendering, but the database stores unescaped versions, causing mismatches during content replacement.

- Added `unescapeLaTeX` utility function to reverse frontend LaTeX preprocessing
- Implemented preprocessing of `original` and `updated` content before artifact replacement in the messages route
- Created comprehensive test suite covering currency signs, mhchem notation, edge cases, and real-world scenarios
- Exported the new utility function from the API package index
- Ensured artifact edits now correctly match database content by unescaping both single and double backslash dollar sign patterns

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested this fix by creating artifacts with currency values (e.g., restaurant menus with prices like $14) and editing them through the artifact editor. Previously, these edits would fail silently because the escaped frontend content (`\\$14`) wouldn't match the unescaped database content (`$14`). After implementing the fix, edits work correctly.

### **Test Configuration**:
- Created artifacts containing escaped dollar signs
- Edited artifact content through the UI
- Verified successful content replacement in database
- Ran unit tests covering various LaTeX escape patterns

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes