### PR TITLE
🔍 feat: `DEBUG_MESSAGE_LENGTH` Environment Variable (pt. 2)

### DIFF
--- a/packages/data-schemas/src/config/parsers.ts
+++ b/packages/data-schemas/src/config/parsers.ts
@@ -7,6 +7,7 @@ const SPLAT_SYMBOL = Symbol.for('splat');
 const MESSAGE_SYMBOL = Symbol.for('message');
 const CONSOLE_JSON_STRING_LENGTH: number =
   parseInt(process.env.CONSOLE_JSON_STRING_LENGTH || '', 10) || 255;
+const DEBUG_MESSAGE_LENGTH: number = parseInt(process.env.DEBUG_MESSAGE_LENGTH || '', 10) || 150;
 
 const sensitiveKeys: RegExp[] = [
   /^(sk-)[^\s]+/, // OpenAI API key pattern
@@ -125,7 +126,7 @@ const debugTraverse = winston.format.printf(
     }
 
     const msgParts: string[] = [
-      `${timestamp} ${level}: ${truncateLongStrings(message.trim(), 150)}`,
+      `${timestamp} ${level}: ${truncateLongStrings(message.trim(), DEBUG_MESSAGE_LENGTH)}`,
     ];
 
     try {


### PR DESCRIPTION
# Summary

Closes #10470

I added configurable control over debug message truncation length through a new environment variable.

- Introduced `DEBUG_MESSAGE_LENGTH` environment variable to replace hardcoded 150-character truncation limit
- Implemented parsing logic with fallback to 150 characters as the default value
- Applied the configurable length to the `debugTraverse` format function for dynamic message truncation in logging
- Maintained consistency with existing `CONSOLE_JSON_STRING_LENGTH` implementation pattern

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

I verified that the DEBUG_MESSAGE_LENGTH environment variable correctly controls message truncation in debug logs, and that the default value of 150 characters is used when the variable is not set.

### **Test Configuration**:
- Tested with DEBUG_MESSAGE_LENGTH unset (defaults to 150)
- Tested with DEBUG_MESSAGE_LENGTH set to custom values (e.g., 200, 300)
- Verified log output reflects the configured truncation length

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Any changes dependent on mine have been merged and published in downstream modules