### PR TITLE
🔤 fix: Replace Translation Keys with Localized Text

### DIFF
--- a/client/src/components/SidePanel/Parameters/DynamicSwitch.tsx
+++ b/client/src/components/SidePanel/Parameters/DynamicSwitch.tsx
@@ -56,7 +56,7 @@ function DynamicSwitch({
               {showDefault && (
                 <small className="opacity-40">
                   ({localize('com_endpoint_default')}:{' '}
-                  {defaultValue != null ? 'com_ui_on' : 'com_ui_off'})
+                  {defaultValue != null ? localize('com_ui_on') : localize('com_ui_off')})
                 </small>
               )}
             </Label>


### PR DESCRIPTION
## Summary

An easy fix for the UI label placeholder. on a side bar in the Parameters section when you're using `customParams` with `showDefault: true`, in the UI the label is not properly rendered:

<img width="160" height="99" alt="image" src="https://github.com/user-attachments/assets/af6d11c3-7319-49e7-96e5-036107f7b189" />

the fix gets it properly rendered:
<img width="162" height="106" alt="Screenshot 2025-11-13 at 11 59 33 AM" src="https://github.com/user-attachments/assets/517d0070-3d31-43b6-bb72-215e5e022deb" />

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing


The config which helps to reproduce the bug:

```yaml
# your librechat.yaml
...
endpoints:
  custom:
    - name: Custom Params Test
      apiKey: nothing-important-here
      baseURL: ******
      models:
        default:
          - "Big Beautiful Model"
        fetch: false
      customParams:
        defaultParamsEndpoint: 'openAI'
        paramDefinitions:
          - key: useResponsesApi
            default: true
            showDefault: true
...
```

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
