### PR TITLE
fix: default values from customParams are not applied on the client

### DIFF
--- a/client/src/components/SidePanel/Parameters/Panel.tsx
+++ b/client/src/components/SidePanel/Parameters/Panel.tsx
@@ -50,6 +50,10 @@ export default function Parameters() {
       .map((param) => (overriddenParamsMap[param.key] as SettingDefinition) ?? param);
   }, [endpointType, endpointsConfig, model, provider]);
 
+  const overriddenParams = useMemo(() => {
+    return endpointsConfig[provider]?.customParams?.paramDefinitions ?? [];
+  }, [provider, endpointsConfig]);
+
   useEffect(() => {
     if (!parameters) {
       return;
@@ -98,11 +102,22 @@ export default function Parameters() {
         }
       });
 
+      // Apply default values for parameters that don't exist in the conversation yet
+      overriddenParams.forEach((overriddenValue) => {
+        const defaultValue = overriddenValue.default;
+        const key = overriddenValue.key;
+
+        if (key && paramKeys.has(key) && updatedConversation[key] == null && defaultValue != null) {
+          updatedKeys.push(key);
+          updatedConversation[key] = defaultValue;
+        }
+      });
+
       logger.log('parameters', 'parameters effect, updated keys:', updatedKeys);
 
       return updatedConversation;
     });
-  }, [parameters, setConversation]);
+  }, [parameters, setConversation, overriddenParams]);
 
   const resetParameters = useCallback(() => {
     setConversation((prev) => {


### PR DESCRIPTION
## Summary

when you have customParams defined in your librechat.yaml with the default values different from the system defaults, the message to the model will be sent without taking into account these new defaults. this pr fixes this behavior and makes sure the parameters with values that you override with are being included as a part of the payload to the model

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

to reproduce the bug you need to override of the parameter into your librechat.yaml. I used `useResponsesApi` as an example (system default is `false`):


```yaml
# your librechat.yaml
...
endpoints:
  custom:
    - name: Custom Params Test
      apiKey: nothing-important-here
      baseURL: ******
      models:
        default:
          - "Big Beautiful Model"
        fetch: false
      customParams:
        defaultParamsEndpoint: 'openAI'
        paramDefinitions:
          - key: useResponsesApi
            default: true
...
```

if you open the chat with this model and just send your first message, in the payload to `/api/agents/chat/your-model-name` you won't see `useResponsesApi: true` and it breaks the communication with the model that specifically needs responses api. 

without the fix the workaround is to toggle `useResponsesApi` in the Parameters section off and then on again - this way it will be imprinted in the payload for next requests.

after applying this fix the first message you send in the new chat will have `useResponsesApi: true` in its payload

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
