### PR TITLE
🔗 fix: Correct `file_id` Extraction in Markdown File Download Links

### DIFF
--- a/client/src/components/Chat/Messages/Content/MarkdownComponents.tsx
+++ b/client/src/components/Chat/Messages/Content/MarkdownComponents.tsx
@@ -90,12 +90,13 @@ export const a: React.ElementType = memo(({ href, children }: TAnchorProps) => {
     if (match && match[0]) {
       const path = match[0];
       const parts = path.split('/');
-      const name = parts.pop();
-      const file_id = parts.pop();
-      return { file_id, filename: name, filepath: path };
+      // parts = ['files', userId, file_id] or ['outputs', userId, file_id]
+      const file_id = parts[2]; // Get the file_id (third element)
+      const filename = typeof children === 'string' ? children : file_id; // Use link text as filename
+      return { file_id, filename, filepath: path };
     }
     return { file_id: '', filename: '', filepath: '' };
-  }, [user?.id, href]);
+  }, [user?.id, href, children]);
 
   const { refetch: downloadFile } = useFileDownload(user?.id ?? '', file_id);
   const props: { target?: string; onClick?: React.MouseEventHandler } = { target: '_new' };

--- a/client/src/components/Chat/Messages/Content/__tests__/MarkdownComponents.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/MarkdownComponents.test.tsx
@@ -1,0 +1,229 @@
+/* eslint-disable i18next/no-literal-string */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { a } from '../MarkdownComponents';
+import * as useFileDownloadModule from '~/data-provider';
+import * as useToastContextModule from '@librechat/client';
+import * as useLocalizeModule from '~/hooks';
+import { dataService } from 'librechat-data-provider';
+
+// Mock all the complex dependencies
+jest.mock('~/components/Messages/Content/CodeBlock', () => ({
+  __esModule: true,
+  default: () => <div>CodeBlock</div>,
+}));
+
+jest.mock('~/hooks/Roles/useHasAccess', () => ({
+  __esModule: true,
+  default: jest.fn(() => true),
+}));
+
+jest.mock('~/Providers', () => ({
+  useCodeBlockContext: jest.fn(() => ({
+    getNextIndex: jest.fn(() => 0),
+    resetCounter: jest.fn(),
+  })),
+}));
+
+jest.mock('~/utils', () => ({
+  handleDoubleClick: jest.fn(),
+}));
+
+jest.mock('~/store', () => ({
+  user: null,
+}));
+
+jest.mock('~/data-provider', () => ({
+  useFileDownload: jest.fn(),
+}));
+
+jest.mock('@librechat/client', () => ({
+  useToastContext: jest.fn(),
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: jest.fn(),
+}));
+
+jest.mock('librechat-data-provider', () => ({
+  dataService: {
+    getDomainServerBaseUrl: jest.fn(),
+  },
+  PermissionTypes: {},
+  Permissions: {},
+  fileConfig: {
+    checkType: jest.fn(),
+  },
+}));
+
+jest.mock('recoil', () => ({
+  ...jest.requireActual('recoil'),
+  useRecoilValue: jest.fn(),
+}));
+
+import { useRecoilValue } from 'recoil';
+
+describe('MarkdownComponents - Link (a) Component', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const mockUser = {
+    id: 'user-123',
+    username: 'testuser',
+  };
+
+  const mockDownloadFile = jest.fn();
+  const mockShowToast = jest.fn();
+  const mockLocalize = jest.fn((key) => key);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup mocks
+    (useRecoilValue as jest.Mock).mockReturnValue(mockUser);
+    (useToastContextModule.useToastContext as jest.Mock).mockReturnValue({
+      showToast: mockShowToast,
+    });
+    (useLocalizeModule.useLocalize as jest.Mock).mockReturnValue(mockLocalize);
+    (dataService.getDomainServerBaseUrl as jest.Mock).mockReturnValue('http://localhost:3080');
+    (useFileDownloadModule.useFileDownload as jest.Mock).mockReturnValue({
+      refetch: mockDownloadFile,
+    });
+  });
+
+  /**
+   * This test verifies the file_id extraction bug in markdown file links.
+   *
+   * BUG: The current implementation uses .pop() twice which extracts values in reverse order:
+   *   - URL format: files/{userId}/{fileId}  (3 parts total)
+   *   - parts = ['files', 'user-123', 'file-abc-123']
+   *   - parts.pop() returns 'file-abc-123' (assigned to filename) - should be file_id!
+   *   - parts.pop() returns 'user-123' (assigned to file_id) - this is the userId!
+   *
+   * EXPECTED: useFileDownload should be called with file_id='file-abc-123'
+   * ACTUAL (BUG): useFileDownload is called with file_id='user-123' (the userId!)
+   *
+   * This test will FAIL with the current buggy code and PASS after the fix.
+   */
+  it('should extract correct file_id from markdown file link path', () => {
+    const testFileId = 'file-abc-123';
+    // The URL format is: files/{userId}/{fileId} - no separate filename!
+    const testHref = `files/${mockUser.id}/${testFileId}`;
+
+    const AnchorComponent = a as React.ComponentType<{ href: string; children: React.ReactNode }>;
+
+    render(
+      <RecoilRoot>
+        <QueryClientProvider client={queryClient}>
+          <AnchorComponent href={testHref}>Download Test File</AnchorComponent>
+        </QueryClientProvider>
+      </RecoilRoot>,
+    );
+
+    // Verify that useFileDownload was called with the CORRECT file_id
+    // Currently, the bug causes it to be called with userId instead
+    expect(useFileDownloadModule.useFileDownload).toHaveBeenCalledWith(
+      mockUser.id,
+      testFileId, // This is what we EXPECT (correct behavior)
+      // Currently the code passes userId here instead (bug!)
+    );
+  });
+
+  /**
+   * Additional test: Verify the download handler uses correct file_id
+   * This test verifies the bug from a different angle - checking the download function call
+   */
+  it('should use correct file_id when download is triggered', () => {
+    const testFileId = 'file-xyz-789';
+    const testHref = `files/${mockUser.id}/${testFileId}`;
+
+    const AnchorComponent = a as React.ComponentType<{ href: string; children: React.ReactNode }>;
+
+    render(
+      <RecoilRoot>
+        <QueryClientProvider client={queryClient}>
+          <AnchorComponent href={testHref}>Download File</AnchorComponent>
+        </QueryClientProvider>
+      </RecoilRoot>,
+    );
+
+    // Verify useFileDownload hook was initialized with correct file_id
+    expect(useFileDownloadModule.useFileDownload).toHaveBeenCalledWith(
+      mockUser.id,
+      testFileId, // Expected: correct file_id
+      // Bug: currently passes userId here
+    );
+  });
+
+  /**
+   * Test with 'outputs' prefix (alternative path format)
+   */
+  it('should extract correct file_id from outputs path', () => {
+    const testFileId = 'output-file-456';
+    const testHref = `outputs/${mockUser.id}/${testFileId}`;
+
+    const AnchorComponent = a as React.ComponentType<{ href: string; children: React.ReactNode }>;
+
+    render(
+      <RecoilRoot>
+        <QueryClientProvider client={queryClient}>
+          <AnchorComponent href={testHref}>Download Output</AnchorComponent>
+        </QueryClientProvider>
+      </RecoilRoot>,
+    );
+
+    expect(useFileDownloadModule.useFileDownload).toHaveBeenCalledWith(
+      mockUser.id,
+      testFileId, // Should be the actual file_id, not userId
+    );
+  });
+
+  /**
+   * Edge case: UUID-style file_id
+   */
+  it('should handle UUID-style file IDs', () => {
+    const testFileId = '550e8400-e29b-41d4-a716-446655440000';
+    const testHref = `files/${mockUser.id}/${testFileId}`;
+
+    const AnchorComponent = a as React.ComponentType<{ href: string; children: React.ReactNode }>;
+
+    render(
+      <RecoilRoot>
+        <QueryClientProvider client={queryClient}>
+          <AnchorComponent href={testHref}>Download</AnchorComponent>
+        </QueryClientProvider>
+      </RecoilRoot>,
+    );
+
+    expect(useFileDownloadModule.useFileDownload).toHaveBeenCalledWith(mockUser.id, testFileId);
+  });
+
+  /**
+   * Control test: Non-file links should not trigger file download logic
+   */
+  it('should not process regular external links', () => {
+    const testHref = 'https://example.com/page';
+
+    const AnchorComponent = a as React.ComponentType<{ href: string; children: React.ReactNode }>;
+
+    render(
+      <RecoilRoot>
+        <QueryClientProvider client={queryClient}>
+          <AnchorComponent href={testHref}>External Link</AnchorComponent>
+        </QueryClientProvider>
+      </RecoilRoot>,
+    );
+
+    // Should be called with empty strings for non-file links
+    expect(useFileDownloadModule.useFileDownload).toHaveBeenCalledWith(
+      mockUser.id,
+      '', // No file_id for regular links
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a critical bug in the markdown file download link handler that prevented files from being downloaded correctly through markdown links.

The issue occurred in `MarkdownComponents.tsx` where the `file_id` and `filename` were being extracted incorrectly from URLs in the format `files/{userId}/{file_id}`. The `.pop()` method was applied twice in reverse order, causing:
- The `userId` to be assigned to the `file_id` variable
- The actual `file_id` to be used as the `filename`

This resulted in download failures with 404 errors because the API endpoint was being called with `/api/files/download/{userId}/{userId}` instead of the correct `/api/files/download/{userId}/{file_id}`.

**Root cause:** When splitting the URL path and using `.pop()` twice, the values were extracted in reverse order (last element first, then second-to-last), inverting the userId and file_id.

**Solution:** 
- Changed to directly access `parts[2]` to get the correct `file_id`
- Use the markdown link text (`children`) as the filename for better UX
- Added `children` to the `useMemo` dependency array to properly track changes

This fix enables MCP tools and other integrations to serve files through LibreChat's download system using markdown links.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

### Test Process

1. Create a file in the uploads directory: `/app/uploads/{userId}/{filename}`
2. Create a corresponding MongoDB file record with:
   - `file_id`: UUID v4
   - `user`: MongoDB ObjectId matching the user
   - `filepath`: `/uploads/{userId}/{filename}`
   - `source`: `"local"`
3. Generate a markdown link in a chat message: `[filename.ext](files/{userId}/{file_id})`
4. Click the link
5. Verify the file downloads correctly

### **Test Configuration**:

- Browser: Chrome/Edge/Firefox
- LibreChat instance with local file storage
- MongoDB with file records
- Test file created via MCP tool or manual insertion

### Expected Behavior

**Before fix:**
- Click link → API call to `/api/files/download/{userId}/{userId}` → 404 error

**After fix:**
- Click link → API call to `/api/files/download/{userId}/{file_id}` → File downloads successfully

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules
- [ ] A pull request for updating the documentation has been submitted