### PR TITLE
feat: extraEnvFrom in helm chart

### DIFF
--- a/helm/librechat/templates/deployment.yaml
+++ b/helm/librechat/templates/deployment.yaml
@@ -91,6 +91,9 @@ spec:
               name: {{ .Values.global.librechat.existingSecretName }}
               optional: true
           {{- end }}
+          {{- with .Values.extraEnvFrom }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- with .Values.global.librechat.env }}
           env:
           {{- toYaml . | nindent 12 }}

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -49,7 +49,7 @@ librechat:
     # Required Values:
     # - MEILI_MASTER_KEY
   existingSecretName: "librechat-credentials-env"
-  
+
   # For adding a custom config yaml-file you can set the contents in this var. See https://www.librechat.ai/docs/configuration/librechat_yaml/example
   configYamlContent: ""
   # configYamlContent: |
@@ -69,7 +69,7 @@ librechat:
   #       openNewTab: true
 
   #   registration:
-  #     socialLogins: ["discord", "facebook", "github", "google", "openid"] 
+  #     socialLogins: ["discord", "facebook", "github", "google", "openid"]
   #   endpoints:
   #     azureOpenAI:
   #      # Endpoint-level configuration
@@ -110,7 +110,7 @@ librechat:
     enabled: true
     size: 10G
     accessModes: ReadWriteOnce
-    # storageClassName: 
+    # storageClassName:
 
 # only lite RAG is supported
 librechat-rag-api:
@@ -127,6 +127,7 @@ image:
   tag: ""
 
 
+extraEnvFrom: []
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -276,7 +277,7 @@ mongodb:
     enabled: false
   databases:
    - LibreChat
-#  persistence: 
+#  persistence:
 #    size: 8Gi
 
 
@@ -285,7 +286,7 @@ meilisearch:
   persistence:
     enabled: true
     storageClass: ""
-  image: 
+  image:
     tag: "v1.7.3"
   auth:
     # Use an existing Kubernetes secret for the MEILI_MASTER_KEY


### PR DESCRIPTION
Adds ability to add extraEnvFrom if you want to mount multiple separate secrets as env vars. Using this in my local fork of librechat chart.
