### PR TITLE
🎨 fix: Correct Read-Only State Logic in Code Editor

### DIFF
--- a/client/src/components/Artifacts/ArtifactCodeEditor.tsx
+++ b/client/src/components/Artifacts/ArtifactCodeEditor.tsx
@@ -179,9 +179,10 @@ export const ArtifactCodeEditor = function ({
       bundlerURL: template === 'static' ? config.staticBundlerURL : config.bundlerURL,
     };
   }, [config, template, fileKey]);
-  const [readOnly, setReadOnly] = useState(externalReadOnly ?? isSubmitting ?? false);
+  const initialReadOnly = (externalReadOnly ?? false) || (isSubmitting ?? false);
+  const [readOnly, setReadOnly] = useState(initialReadOnly);
   useEffect(() => {
-    setReadOnly(externalReadOnly ?? isSubmitting ?? false);
+    setReadOnly((externalReadOnly ?? false) || (isSubmitting ?? false));
   }, [isSubmitting, externalReadOnly]);
 
   if (Object.keys(files).length === 0) {

--- a/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
@@ -69,7 +69,7 @@ const Reasoning = memo(({ reasoning, isLast }: ReasoningProps) => {
   return (
     <div className="group/reasoning">
       <div className="group/thinking-container">
-        <div className="sticky top-0 z-10 mb-2 pb-2 pt-2">
+        <div className="sticky top-0 z-10 mb-2 bg-presentation pb-2 pt-2">
           <ThinkingButton
             isExpanded={isExpanded}
             onClick={handleClick}

--- a/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
@@ -148,7 +148,7 @@ const Thinking: React.ElementType = memo(({ children }: { children: React.ReactN
 
   return (
     <div className="group/thinking-container">
-      <div className="sticky top-0 z-10 mb-4 bg-surface-primary pb-2 pt-2">
+      <div className="sticky top-0 z-10 mb-4 bg-presentation pb-2 pt-2">
         <ThinkingButton
           isExpanded={isExpanded}
           onClick={handleClick}

--- a/client/src/components/Chat/Messages/MinimalHoverButtons.tsx
+++ b/client/src/components/Chat/Messages/MinimalHoverButtons.tsx
@@ -27,7 +27,11 @@ export default function MinimalHoverButtons({ message, searchResults }: THoverBu
           isCopied ? localize('com_ui_copied_to_clipboard') : localize('com_ui_copy_to_clipboard')
         }
       >
-        {isCopied ? <CheckMark className="h-[18px] w-[18px]" /> : <Clipboard size="19" />}
+        {isCopied ? (
+          <CheckMark className="h-[18px] w-[18px]" />
+        ) : (
+          <Clipboard className="h-[18px] w-[18px]" />
+        )}
       </button>
     </div>
   );

--- a/client/src/components/Chat/Messages/MinimalHoverButtons.tsx
+++ b/client/src/components/Chat/Messages/MinimalHoverButtons.tsx
@@ -28,9 +28,9 @@ export default function MinimalHoverButtons({ message, searchResults }: THoverBu
         }
       >
         {isCopied ? (
-          <CheckMark className="h-[18px] w-[18px]" />
+          <CheckMark className="h-[19px] w-[19px]" />
         ) : (
-          <Clipboard className="h-[18px] w-[18px]" />
+          <Clipboard className="h-[19px] w-[19px]" />
         )}
       </button>
     </div>


### PR DESCRIPTION
## Summary

This pull request contains a few small UI and logic improvements to the code editor and chat message components. The changes mainly address consistency in state initialization and UI styling

* Updated the sticky header in the `Reasoning` and `Thinking` component to include the `bg-presentation` class for consistent background styling while improving visibility
* Standardized the icon sizing in the `MinimalHoverButtons` component by adding explicit `h-[18px] w-[18px]` classes to both the `Clipboard` and `CheckMark` icons
* Refined the initialization and update logic for the `readOnly` state in the `ArtifactCodeEditor` component to ensure correct precedence between `externalReadOnly` and `isSubmitting`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
