### PR TITLE
🪣 feat: Init Containers and Custom ConfigMaps Support in Helm Chart

### DIFF
--- a/helm/librechat/templates/configmaps-additional.yaml
+++ b/helm/librechat/templates/configmaps-additional.yaml
@@ -1,0 +1,26 @@
+{{- range $key, $value := .Values.additionalConfigMaps }}
+{{- if or .data .binaryData }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "librechat.fullname" $ }}-{{ default "custom" $key }}
+  {{- with .labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with .data }}
+data:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .binaryData }}
+binaryData:
+  {{- toYaml . | nindent 2 }}
+immutable: {{ default false .immutable }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/librechat/templates/deployment.yaml
+++ b/helm/librechat/templates/deployment.yaml
@@ -51,6 +51,15 @@ spec:
       serviceAccountName: {{ include "librechat.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- range $key, $value := .Values.initContainers }}
+        {{- if . }}
+        - name: {{ $key }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: {{ include "librechat.fullname" $ }}
           securityContext:

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -219,6 +219,13 @@ readinessProbe:
     path: /health
     port: 3080
 
+# Additional init containers on the output Deployment definition.
+initContainers: {}
+#   foo: # the name of the init container
+#     image: busybox
+#     command: ['sh', '-c', 'echo The app is starting! && sleep 5']
+#   # ... add more init containers as needed
+
 # Additional volumes on the output Deployment definition.
 volumes: []
 # - name: foo
@@ -268,6 +275,16 @@ dnsConfig: {}
 # Strategy for LibreChat deployment updates
 updateStrategy:
   type: RollingUpdate
+
+# Extra ConfigMaps to be created alongside the main ones
+additionalConfigMaps: {}
+#   custom: # suffix of the ConfigMap name
+#     labels: {}
+#     annotations: {}
+#     data: {}
+#     binaryData: {}
+#     immutable: false
+#   # ... add more ConfigMaps as needed
 
 # MongoDB Parameters
 mongodb:


### PR DESCRIPTION
## Summary

The helm chart was extended with a support for custom init containers and custom configmaps.
The maps (instead of lists) for both the `initContainers:` and `additionalConfigMaps:` keys in the `values.yaml` were used on purpose. They will be better pickable (deterministically) by external orchestration tools, such as Terraform.
Resolves #10522 issue.

## Change Type

- New feature (non-breaking change which adds functionality)

## Testing

The changes in the `helm/librechat` helm chart were tested (including bleeding edge cases) with
```
helm template librechat .
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings