### PR TITLE
Feat: support data retention for normal chats

### DIFF
--- a/api/models/Conversation.js
+++ b/api/models/Conversation.js
@@ -2,6 +2,7 @@ const { logger } = require('@librechat/data-schemas');
 const { createTempChatExpirationDate } = require('@librechat/api');
 const { getMessages, deleteMessages } = require('./Message');
 const { Conversation } = require('~/db/models');
+const { RetentionMode } = require('librechat-data-provider');
 
 /**
  * Searches for a conversation by conversationId and returns a lean document with only conversationId and user.
@@ -100,6 +101,15 @@ module.exports = {
       }
 
       if (req?.body?.isTemporary) {
+        update.isTemporary = true;
+      } else {
+        update.isTemporary = false;
+      }
+
+      if (
+        req?.body?.isTemporary ||
+        req?.config?.interfaceConfig.retentionMode === RetentionMode.ALL
+      ) {
         try {
           const appConfig = req.config;
           update.expiredAt = createTempChatExpirationDate(appConfig?.interfaceConfig);
@@ -178,7 +188,9 @@ module.exports = {
       filters.push({ tags: { $in: tags } });
     }
 
-    filters.push({ $or: [{ expiredAt: null }, { expiredAt: { $exists: false } }] });
+    filters.push({
+      $or: [{ isTemporary: false }, { expiredAt: { $exists: false } }, { expiredAt: null }],
+    });
 
     if (search) {
       try {
@@ -276,7 +288,7 @@ module.exports = {
       const results = await Conversation.find({
         user,
         conversationId: { $in: conversationIds },
-        $or: [{ expiredAt: { $exists: false } }, { expiredAt: null }],
+        $or: [{ isTemporary: false }, { expiredAt: { $exists: false } }, { expiredAt: null }],
       }).lean();
 
       results.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));

--- a/api/models/Conversation.spec.js
+++ b/api/models/Conversation.spec.js
@@ -323,13 +323,24 @@ describe('Conversation Operations', () => {
       expect(secondSave.expiredAt).toBeNull();
     });
 
-    it('should filter out expired conversations in getConvosByCursor', async () => {
+    it('should filter out temporary conversations in getConvosByCursor', async () => {
       // Create some test conversations
-      const nonExpiredConvo = await Conversation.create({
+      const newNonTemporaryConvo = await Conversation.create({
         conversationId: uuidv4(),
         user: 'user123',
-        title: 'Non-expired',
+        title: 'New Non-temporary Conversation',
         endpoint: EModelEndpoint.openAI,
+        isTemporary: false,
+        expiredAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        updatedAt: new Date(),
+      });
+
+      const oldNonTemporaryConvo = await Conversation.create({
+        conversationId: uuidv4(),
+        user: 'user123',
+        title: 'Old Non-Temporary Conversation',
+        endpoint: EModelEndpoint.openAI,
+        isTemporary: undefined,
         expiredAt: null,
         updatedAt: new Date(),
       });
@@ -337,9 +348,10 @@ describe('Conversation Operations', () => {
       await Conversation.create({
         conversationId: uuidv4(),
         user: 'user123',
-        title: 'Future expired',
+        title: 'Temporary conversation',
         endpoint: EModelEndpoint.openAI,
-        expiredAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours from now
+        isTemporary: true,
+        expiredAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
         updatedAt: new Date(),
       });
 
@@ -348,41 +360,61 @@ describe('Conversation Operations', () => {
 
       const result = await getConvosByCursor('user123');
 
-      // Should only return conversations with null or non-existent expiredAt
-      expect(result.conversations).toHaveLength(1);
-      expect(result.conversations[0].conversationId).toBe(nonExpiredConvo.conversationId);
+      // Should return both non-temporary conversations, not the temporary one
+      expect(result.conversations).toHaveLength(2);
+      const convoIds = result.conversations.map((c) => c.conversationId);
+      expect(convoIds).toContain(newNonTemporaryConvo.conversationId);
+      expect(convoIds).toContain(oldNonTemporaryConvo.conversationId);
     });
 
     it('should filter out expired conversations in getConvosQueried', async () => {
-      // Create test conversations
-      const nonExpiredConvo = await Conversation.create({
+      const newNonTemporaryConvo = await Conversation.create({
         conversationId: uuidv4(),
         user: 'user123',
-        title: 'Non-expired',
+        title: 'New Non-temporary Conversation',
         endpoint: EModelEndpoint.openAI,
-        expiredAt: null,
+        isTemporary: false,
+        expiredAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        updatedAt: new Date(),
       });
 
-      const expiredConvo = await Conversation.create({
+      const oldNonTemporaryConvo = await Conversation.create({
         conversationId: uuidv4(),
         user: 'user123',
-        title: 'Expired',
+        title: 'Old Non-Temporary Conversation',
         endpoint: EModelEndpoint.openAI,
+        isTemporary: undefined,
+        expiredAt: null,
+        updatedAt: new Date(),
+      });
+
+      const tempConvo = await Conversation.create({
+        conversationId: uuidv4(),
+        user: 'user123',
+        title: 'Temporary conversation',
+        endpoint: EModelEndpoint.openAI,
+        isTemporary: true,
         expiredAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        updatedAt: new Date(),
       });
 
       const convoIds = [
-        { conversationId: nonExpiredConvo.conversationId },
-        { conversationId: expiredConvo.conversationId },
+        { conversationId: newNonTemporaryConvo.conversationId },
+        { conversationId: oldNonTemporaryConvo.conversationId },
+        { conversationId: tempConvo.conversationId },
       ];
 
       const result = await getConvosQueried('user123', convoIds);
 
       // Should only return the non-expired conversation
-      expect(result.conversations).toHaveLength(1);
-      expect(result.conversations[0].conversationId).toBe(nonExpiredConvo.conversationId);
-      expect(result.convoMap[nonExpiredConvo.conversationId]).toBeDefined();
-      expect(result.convoMap[expiredConvo.conversationId]).toBeUndefined();
+      expect(result.conversations).toHaveLength(2);
+
+      const resultIds = result.conversations.map((c) => c.conversationId);
+      expect(resultIds).toContain(newNonTemporaryConvo.conversationId);
+      expect(resultIds).toContain(oldNonTemporaryConvo.conversationId);
+      expect(result.convoMap[newNonTemporaryConvo.conversationId]).toBeDefined();
+      expect(result.convoMap[oldNonTemporaryConvo.conversationId]).toBeDefined();
+      expect(result.convoMap[tempConvo.conversationId]).toBeUndefined();
     });
   });
 

--- a/api/models/Message.js
+++ b/api/models/Message.js
@@ -4,6 +4,7 @@ const { createTempChatExpirationDate } = require('@librechat/api');
 const { Message } = require('~/db/models');
 
 const idSchema = z.string().uuid();
+const { RetentionMode } = require('librechat-data-provider');
 
 /**
  * Saves a message in the database.
@@ -54,7 +55,10 @@ async function saveMessage(req, params, metadata) {
       messageId: params.newMessageId || params.messageId,
     };
 
-    if (req?.body?.isTemporary) {
+    if (
+      req?.body?.isTemporary ||
+      req?.config?.interfaceConfig.retentionMode === RetentionMode.ALL
+    ) {
       try {
         const appConfig = req.config;
         update.expiredAt = createTempChatExpirationDate(appConfig?.interfaceConfig);

--- a/client/src/components/Chat/Menus/BookmarkMenu.tsx
+++ b/client/src/components/Chat/Menus/BookmarkMenu.tsx
@@ -26,8 +26,9 @@ const BookmarkMenu: FC = () => {
   const conversationId = conversation?.conversationId ?? '';
   const updateConvoTags = useBookmarkSuccess(conversationId);
   const tags = conversation?.tags;
-  const isTemporary = conversation?.expiredAt != null;
-
+  const isTemporary =
+    conversation.isTemporary ||
+    (conversation.isTemporary === undefined && conversation.expiredAt != null);
   const menuId = useId();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -45,7 +45,10 @@ export default function ChatRoute() {
   const endpointsQuery = useGetEndpointsQuery({ enabled: isAuthenticated });
   const assistantListMap = useAssistantListMap();
 
-  const isTemporaryChat = conversation && conversation.expiredAt ? true : false;
+  const isTemporaryChat =
+    conversation &&
+    (conversation.isTemporary ||
+      (conversation.isTemporary === undefined && conversation.expiredAt != null));
 
   useEffect(() => {
     if (conversationId === Constants.NEW_CONVO) {

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -119,6 +119,7 @@ interface:
 
   # Temporary chat retention period in hours (default: 720, min: 1, max: 8760)
   # temporaryChatRetention: 1
+  retentionMode: "temporary"
 
 # Example Cloudflare turnstile (optional)
 #turnstile:

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -43,6 +43,7 @@ export const excludedKeys = new Set([
   'createdAt',
   'updatedAt',
   'expiredAt',
+  'isTemporary',
   'messages',
   'isArchived',
   'tags',
@@ -537,6 +538,11 @@ const mcpServersSchema = z
 
 export type TMcpServersConfig = z.infer<typeof mcpServersSchema>;
 
+export enum RetentionMode {
+  ALL = 'all',
+  TEMPORARY = 'temporary',
+}
+
 export const interfaceSchema = z
   .object({
     privacyPolicy: z
@@ -560,6 +566,7 @@ export const interfaceSchema = z
     agents: z.boolean().optional(),
     temporaryChat: z.boolean().optional(),
     temporaryChatRetention: z.number().min(1).max(8760).optional(),
+    retentionMode: z.nativeEnum(RetentionMode).default(RetentionMode.TEMPORARY),
     runCode: z.boolean().optional(),
     webSearch: z.boolean().optional(),
     peoplePicker: z

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -721,6 +721,7 @@ export const tConversationSchema = z.object({
   iconURL: z.string().nullable().optional(),
   /* temporary chat */
   expiredAt: z.string().nullable().optional(),
+  isTemporary: z.boolean().optional(),
   /* file token limits */
   fileTokenLimit: coerceNumber.optional(),
   /** @deprecated */

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -49,6 +49,8 @@ export async function loadDefaultInterface({
     multiConvo: interfaceConfig?.multiConvo,
     agents: interfaceConfig?.agents,
     temporaryChat: interfaceConfig?.temporaryChat,
+    temporaryChatRetention: interfaceConfig?.temporaryChatRetention,
+    retentionMode: interfaceConfig?.retentionMode,
     runCode: interfaceConfig?.runCode,
     webSearch: interfaceConfig?.webSearch,
     fileSearch: interfaceConfig?.fileSearch,

--- a/packages/data-schemas/src/schema/convo.ts
+++ b/packages/data-schemas/src/schema/convo.ts
@@ -22,6 +22,10 @@ const convoSchema: Schema<IConversation> = new Schema(
       meiliIndex: true,
     },
     messages: [{ type: Schema.Types.ObjectId, ref: 'Message' }],
+    isTemporary: {
+      type: Boolean,
+      default: false,
+    },
     ...conversationPreset,
     agent_id: {
       type: String,

--- a/packages/data-schemas/src/types/convo.ts
+++ b/packages/data-schemas/src/types/convo.ts
@@ -6,6 +6,7 @@ export interface IConversation extends Document {
   title?: string;
   user?: string;
   messages?: Types.ObjectId[];
+  isTemporary?: boolean;
   // Fields provided by conversationPreset (adjust types as needed)
   endpoint?: string;
   endpointType?: string;


### PR DESCRIPTION
This PR adds a new config variable `retentionMode` which supports two values: `all` and `temporary`. When `temporary` is set, data retention works the same way as now. When `all` is set, data retention applies to all chats, not just temporary chats. 

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X ] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
- [X] Any changes dependent on mine have been merged and published in downstream modules.
- [X] A pull request for updating the documentation has been submitted.
