### PR TITLE
🔧 fix: Format file_search Error

### DIFF
--- a/api/app/clients/tools/util/fileSearch.js
+++ b/api/app/clients/tools/util/fileSearch.js
@@ -78,11 +78,11 @@ const createFileSearchTool = async ({ userId, files, entity_id, fileCitations = 
   return tool(
     async ({ query }) => {
       if (files.length === 0) {
-        return 'No files to search. Instruct the user to add files for the search.';
+        return ['No files to search. Instruct the user to add files for the search.', {}];
       }
       const jwtToken = generateShortLivedToken(userId);
       if (!jwtToken) {
-        return 'There was an error authenticating the file search request.';
+        return ['There was an error authenticating the file search request.', {}];
       }
 
       /**
@@ -122,7 +122,7 @@ const createFileSearchTool = async ({ userId, files, entity_id, fileCitations = 
       const validResults = results.filter((result) => result !== null);
 
       if (validResults.length === 0) {
-        return 'No results found or errors occurred while searching the files.';
+        return ['No results found or errors occurred while searching the files.', {}];
       }
 
       const formattedResults = validResults


### PR DESCRIPTION
## Summary

This pull request updates the return values in the `createFileSearchTool` function to standardize the response format. Instead of returning strings for error cases, the function now returns a tuple containing the error message and an empty object. This change ensures consistent handling of responses throughout the codebase.

Error handling improvements:

* Updated all error return statements in `createFileSearchTool` to return a tuple of `[error message, {}]`, ensuring a consistent response format for cases when there are no files to search, authentication errors, or no search results. (`api/app/clients/tools/util/fileSearch.js`) [[1]](diffhunk://#diff-7bf3382dd191c8bace03c7b579b1897ed09f2619790669d7118a1bbf6d7dc2deL81-R85) [[2]](diffhunk://#diff-7bf3382dd191c8bace03c7b579b1897ed09f2619790669d7118a1bbf6d7dc2deL125-R125)
## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified presence / absence of error before and after implementing fix:

### Before
<img width="822" height="206" alt="Screenshot 2025-11-17 at 9 24 09 AM" src="https://github.com/user-attachments/assets/4cf5d369-5275-4711-94c1-ca28a3f26366" />

### After
<img width="822" height="220" alt="Screenshot 2025-11-17 at 9 24 19 AM" src="https://github.com/user-attachments/assets/c7366837-76ce-4c53-a79d-819cbe17702d" />

### **Test Configuration**:

Requires file_search to be enabled as a capability in `librechat.yaml`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes