### PR TITLE
⏳ fix: Async Model End Events, Await Tool Call and Dispatch Handling

### DIFF
--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -39,9 +39,9 @@ class ModelEndHandler {
    * @param {ModelEndData | undefined} data
    * @param {Record<string, unknown> | undefined} metadata
    * @param {StandardGraph} graph
-   * @returns
+   * @returns {Promise<void>}
    */
-  handle(event, data, metadata, graph) {
+  async handle(event, data, metadata, graph) {
     if (!graph || !metadata) {
       console.warn(`Graph or metadata not found in ${event} event`);
       return;
@@ -79,7 +79,7 @@ class ModelEndHandler {
         }
       }
       if (isGoogle || streamingDisabled || hasUnprocessedToolCalls) {
-        handleToolCalls(toolCalls, metadata, graph);
+        await handleToolCalls(toolCalls, metadata, graph);
       }
 
       const usage = data?.output?.usage_metadata;
@@ -101,7 +101,7 @@ class ModelEndHandler {
       const stepKey = graph.getStepKey(metadata);
       const message_id = getMessageId(stepKey, graph) ?? '';
       if (message_id) {
-        graph.dispatchRunStep(stepKey, {
+        await graph.dispatchRunStep(stepKey, {
           type: StepTypes.MESSAGE_CREATION,
           message_creation: {
             message_id,
@@ -111,7 +111,7 @@ class ModelEndHandler {
       const stepId = graph.getStepIdByKey(stepKey);
       const content = data.output.content;
       if (typeof content === 'string') {
-        graph.dispatchMessageDelta(stepId, {
+        await graph.dispatchMessageDelta(stepId, {
           content: [
             {
               type: 'text',
@@ -120,7 +120,7 @@ class ModelEndHandler {
           ],
         });
       } else if (content.every((c) => c.type?.startsWith('text'))) {
-        graph.dispatchMessageDelta(stepId, {
+        await graph.dispatchMessageDelta(stepId, {
           content,
         });
       }


### PR DESCRIPTION
## Summary

I fixed a concurrency issue in the Model End Event Handler by converting the handle method to be asynchronous and ensuring all async operations are properly awaited.

- Converted the `ModelEndHandler.handle()` method to async and updated its JSDoc return type to `Promise<void>`
- Added await to the `handleToolCalls()` invocation to ensure tool calls are fully processed before proceeding
- Added await to `graph.dispatchRunStep()` to guarantee proper message creation step sequencing
- Added await to both `graph.dispatchMessageDelta()` calls to ensure message content updates are dispatched in the correct order

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested the agent callback flow with tool calls and verified that:
- Tool calls are processed completely before message creation steps
- Graph dispatches occur in the proper sequence
- Message deltas are sent to the frontend in the correct order
- No race conditions occur when handling model end events

### **Test Configuration**:
- Tested with agents using tool calls
- Verified with both Google models and standard models
- Tested with streaming enabled and disabled

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Any changes dependent on mine have been merged and published in downstream modules