### PR TITLE
🔧 refactor: Update Avatar component to improve file selection handling

### DIFF
--- a/client/src/components/Nav/SettingsTabs/Account/Avatar.tsx
+++ b/client/src/components/Nav/SettingsTabs/Account/Avatar.tsx
@@ -134,8 +134,13 @@ function Avatar() {
     e.preventDefault();
   }, []);
 
-  const openFileDialog = () => {
+  const openFileDialog = useCallback(() => {
     fileInputRef.current?.click();
+  }, []);
+
+  const handleSelectFileClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    openFileDialog();
   };
 
   const resetImage = useCallback(() => {
@@ -341,7 +346,7 @@ function Avatar() {
                       : '2MB',
                 })}
               </p>
-              <Button type="button" variant="secondary" onClick={openFileDialog}>
+              <Button type="button" variant="secondary" onClick={handleSelectFileClick}>
                 {localize('com_ui_select_file')}
               </Button>
               <input


### PR DESCRIPTION
## Summary

Fixes bug #10554: Avatar upload opens file picker twice when clicking "Select file" button.

**Problem**: When changing the profile picture via `Settings → Account → Change picture`, clicking the "Select file" button opened the OS file picker twice. The click event was bubbling up from the button to the parent drop-zone div, which also had an `onClick` handler calling `openFileDialog()`.

**Solution**: 
- Wrapped `openFileDialog` in `useCallback` for proper memoization
- Created a `handleSelectFileClick` handler that stops event propagation before opening the file dialog
- Updated the "Select file" button to use the new handler instead of calling `openFileDialog` directly

This ensures the file picker opens only once when clicking the button, while maintaining existing functionality for drag-and-drop and keyboard interactions.

**Related Issue**: #10554

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing

**Test Process**:
1. Logged in and navigated to Settings → Account
2. Clicked "Change picture" to open the avatar dialog
3. Clicked "Select file" button and selected an image file
4. Verified that the file picker opened only once (not twice)
5. Verified that the selected image loaded correctly in the editor


**Browsers Tested**:
- Chrome (Chromium-based)

### **Test Configuration**:
- No special configuration required
- Standard avatar upload flow

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings

