### PR TITLE
⏱️ fix: Increase RAG API Text Parsing Timeout

### DIFF
--- a/packages/api/src/files/text.spec.ts
+++ b/packages/api/src/files/text.spec.ts
@@ -50,8 +50,9 @@ import { parseTextNative, parseText } from './text';
 import fs, { ReadStream } from 'fs';
 import axios from 'axios';
 import FormData from 'form-data';
-import { generateShortLivedToken } from '../crypto/jwt';
-import { readFileAsString } from '../utils';
+import type { ServerRequest } from '~/types';
+import { generateShortLivedToken } from '~/crypto/jwt';
+import { readFileAsString } from '~/utils';
 
 const mockedFs = fs as jest.Mocked<typeof fs>;
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -77,7 +78,7 @@ describe('text', () => {
 
   const mockReq = {
     user: { id: 'user123' },
-  };
+  } as ServerRequest;
 
   const mockFileId = 'file123';
 
@@ -228,6 +229,13 @@ describe('text', () => {
         file_id: mockFileId,
       });
 
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://rag-api.test/text',
+        expect.any(Object),
+        expect.objectContaining({
+          timeout: 300000,
+        }),
+      );
       expect(result).toEqual({
         text: '',
         bytes: 0,
@@ -278,7 +286,7 @@ describe('text', () => {
       });
 
       const result = await parseText({
-        req: { user: undefined },
+        req: { user: undefined } as ServerRequest,
         file: mockFile,
         file_id: mockFileId,
       });

--- a/packages/api/src/files/text.ts
+++ b/packages/api/src/files/text.ts
@@ -65,7 +65,7 @@ export async function parseText({
         accept: 'application/json',
         ...formHeaders,
       },
-      timeout: 30000,
+      timeout: 300000,
     });
 
     const responseData = response.data;


### PR DESCRIPTION
## Summary

This PR increases the RAG API text parsing timeout from 30 seconds to 5 minutes (300,000ms) to properly handle large file processing.

**Problem**: The previous 30-second timeout was insufficient for processing large files through the RAG API text endpoint, causing timeouts and fallback to native parsing for files that could have been successfully processed with more time.

**Solution**: Increased the timeout to 5 minutes to accommodate:
- Large PDF documents with many pages
- Complex document formats (Word, Excel, etc.) requiring extensive parsing
- Network latency when uploading large files to the RAG API

The health check timeout remains at 10 seconds as it only validates API availability and doesn't process file content.

**Files Changed**: `packages/api/src/files/text.ts`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### **Test Configuration**:

**Environment**:
- RAG_API_URL configured and pointing to a running RAG API instance
- Test files of various sizes (small, medium, and large)

**Test Process**:
1. Upload a small text file (< 1MB) - should complete quickly
2. Upload a medium-sized PDF (5-10MB) - should complete within the new timeout
3. Upload a large PDF or Word document (20-50MB) - should complete within 5 minutes instead of timing out at 30 seconds
4. Monitor server logs to confirm RAG API is being used instead of falling back to native parsing
5. Verify that the health check still uses the 10-second timeout

**Expected Results**:
- Large files that previously timed out and fell back to native parsing should now successfully parse through the RAG API
- No impact on small file processing speed
- Health check remains responsive with 10s timeout

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.