### PR TITLE
📨 feat: Pass Custom Headers to Model Discovery (`v1/models`)

### DIFF
--- a/api/server/services/ModelService.js
+++ b/api/server/services/ModelService.js
@@ -80,7 +80,9 @@ const fetchModels = async ({
 
   try {
     const options = {
-      headers: {},
+      headers: {
+        ...(headers ?? {}),
+      },
       timeout: 5000,
     };
 


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

I want to setup a custom endpoint for an OpenAI compatible API but the model discovery fails with an authentication error. To authenticate to the endpoint, I need to had a specific Header wich was not pass to the request even if it is in the confuguration

This PR adds the headers to the request.

See https://github.com/danny-avila/LibreChat/issues/10561

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. add this configuration:

```yaml
endpoints:
  custom:
    - name: "Custom endpoint"
      apiKey: "my-api-key"
      headers:
        my-custom-header: "value"
      baseURL: "https://my-endpoint/v1"
      models:
        default:
          - "demo-model"
        fetch: true
      titleConvo: true
      modelDisplayLabel: "Custom endpoint"
```
2. start librechat

Result:
The server is called on https://my-endpoint/v1/models with the my-custom-header header


### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
