### PR TITLE
🚩 feat: Add `--provider` flag to create-user script

### DIFF
--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -176,7 +176,7 @@ const registerUser = async (user, additionalData = {}) => {
     return { status: 404, message: errorMessage };
   }
 
-  const { email, password, name, username } = user;
+  const { email, password, name, username, provider } = user;
 
   let newUserId;
   try {
@@ -207,7 +207,7 @@ const registerUser = async (user, additionalData = {}) => {
 
     const salt = bcrypt.genSaltSync(10);
     const newUserData = {
-      provider: 'local',
+      provider: provider ?? 'local',
       email,
       username,
       name,

--- a/config/create-user.js
+++ b/config/create-user.js
@@ -23,32 +23,32 @@ const connect = require('./connect');
     console.purple('--------------------------');
   }
 
-  let email = '';
-  let password = '';
-  let name = '';
-  let username = '';
-  let emailVerified = true;
-
   // Parse command line arguments
+  let email, password, name, username, emailVerified, provider;
   for (let i = 2; i < process.argv.length; i++) {
     if (process.argv[i].startsWith('--email-verified=')) {
       emailVerified = process.argv[i].split('=')[1].toLowerCase() !== 'false';
       continue;
     }
 
-    if (!email) {
+    if (process.argv[i].startsWith('--provider=')) {
+      provider = process.argv[i].split('=')[1];
+      continue;
+    }
+
+    if (email === undefined) {
       email = process.argv[i];
-    } else if (!name) {
+    } else if (name === undefined) {
       name = process.argv[i];
-    } else if (!username) {
+    } else if (username === undefined) {
       username = process.argv[i];
-    } else if (!password) {
+    } else if (password === undefined) {
       console.red('Warning: password passed in as argument, this is not secure!');
       password = process.argv[i];
     }
   }
 
-  if (!email) {
+  if (email === undefined) {
     email = await askQuestion('Email:');
   }
   if (!email.includes('@')) {
@@ -57,19 +57,19 @@ const connect = require('./connect');
   }
 
   const defaultName = email.split('@')[0];
-  if (!name) {
+  if (name === undefined) {
     name = await askQuestion('Name: (default is: ' + defaultName + ')');
     if (!name) {
       name = defaultName;
     }
   }
-  if (!username) {
+  if (username === undefined) {
     username = await askQuestion('Username: (default is: ' + defaultName + ')');
     if (!username) {
       username = defaultName;
     }
   }
-  if (!password) {
+  if (password === undefined) {
     password = await askQuestion('Password: (leave blank, to generate one)');
     if (!password) {
       password = Math.random().toString(36).slice(-18);
@@ -78,7 +78,7 @@ const connect = require('./connect');
   }
 
   // Only prompt for emailVerified if it wasn't set via CLI
-  if (!process.argv.some((arg) => arg.startsWith('--email-verified='))) {
+  if (emailVerified === undefined){
     const emailVerifiedInput = await askQuestion(`Email verified? (Y/n, default is Y):
 
 If \`y\`, the user's email will be considered verified.
@@ -99,7 +99,7 @@ or the user will need to attempt logging in to have a verification link sent to 
     silentExit(1);
   }
 
-  const user = { email, password, name, username, confirm_password: password };
+  const user = { email, password, name, username, confirm_password: password, provider };
   let result;
   try {
     result = await registerUser(user, { emailVerified });


### PR DESCRIPTION
As we're using google authentication without automatic sign-up, we need a way to pass the provider to the user creation.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

- Setup google authentication
- Create local user with `npm run create-user -- --provider=google`
- Log in

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code

Closes #10571 