### PR TITLE
feat: Adding code to call the rag_api simple reranker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
   - Search the internet and retrieve relevant information to enhance your AI context
   - Combines search providers, content scrapers, and result rerankers for optimal results
   - **Customizable Jina Reranking**: Configure custom Jina API URLs for reranking services
+  - Run local reranking with open source models through the rag_api.
   - **[Learn More →](https://www.librechat.ai/docs/features/web_search)**
 
 - 🪄 **Generative UI with Code Artifacts**:  

--- a/client/src/components/SidePanel/Agents/Search/ApiKeyDialog.tsx
+++ b/client/src/components/SidePanel/Agents/Search/ApiKeyDialog.tsx
@@ -117,6 +117,11 @@ export default function ApiKeyDialog({
         },
       },
     },
+    {
+      key: RerankerTypes.SIMPLE,
+      label: localize('com_ui_web_search_reranker_simple'),
+      inputs: {},
+    },
   ];
 
   const scraperOptions: DropdownOption[] = [

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1433,6 +1433,7 @@
   "com_ui_web_search_reranker_jina": "Jina AI",
   "com_ui_web_search_reranker_jina_key": "Get your Jina API key",
   "com_ui_web_search_reranker_jina_url_help": "Learn about Jina Rerank API",
+  "com_ui_web_search_reranker_simple": "Simple",
   "com_ui_web_search_scraper": "Scraper",
   "com_ui_web_search_scraper_firecrawl": "Firecrawl API",
   "com_ui_web_search_scraper_firecrawl_key": "Get your Firecrawl API key",

--- a/packages/api/src/web/web.ts
+++ b/packages/api/src/web/web.ts
@@ -120,7 +120,8 @@ export async function loadWebSearchAuth({
         }
       }
 
-      if (requiredKeys.length === 0) continue;
+      const simpleReRankerChosen = specificService && service === 'simple';
+      if (!simpleReRankerChosen && requiredKeys.length === 0) continue;
 
       const requiredAuthFields = extractWebSearchEnvVars({
         keys: requiredKeys,

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -818,6 +818,7 @@ export enum ScraperProviders {
 export enum RerankerTypes {
   JINA = 'jina',
   COHERE = 'cohere',
+  SIMPLE = 'simple',
 }
 
 export enum SafeSearchTypes {

--- a/packages/data-provider/src/types/web.ts
+++ b/packages/data-provider/src/types/web.ts
@@ -11,7 +11,7 @@ export enum DATE_RANGE {
 }
 
 export type SearchProvider = 'serper' | 'searxng';
-export type RerankerType = 'infinity' | 'jina' | 'cohere' | 'none';
+export type RerankerType = 'infinity' | 'jina' | 'cohere' | 'simple' | 'none';
 
 export interface Highlight {
   score: number;

--- a/packages/data-schemas/src/app/web.ts
+++ b/packages/data-schemas/src/app/web.ts
@@ -31,6 +31,7 @@ export const webSearchAuth = {
       jinaApiUrl: 0 as const,
     },
     cohere: { cohereApiKey: 1 as const },
+    simple: { },
   },
 };
 


### PR DESCRIPTION
## Summary

This pull request was originally introduced in 
https://github.com/danny-avila/LibreChat/discussions/9102

We are trying to use a local model to rerank search results using a Python library and implemented as a rest api in the rag_api repository:
https://github.com/danny-avila/rag_api/pull/190

Then we implement a caller in the agents repository:
https://github.com/danny-avila/agents/pull/33

Lastly, we have the code in this PR that will tie it all together.

We need a param in the webSearch configuration block in librechat.yaml

```
webSearch:
  rerankerType: "simple"
```

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

After this PR is added and the rag_api is started with our new function, and the configuration is done in rag and in this library, a web search should be able to be done without having an external ranker configured. 

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented on any complex areas of my code

## Extra remarks

I've run all test suites and linting and get 6k linting errors on my branch and a newly cloned repository.
I have not, to my knowledge, introduced any new errors in the tests, but I get the same errors on my branch and a newly cloned repository.