### PR TITLE
feat: add preventFileVersionHistory agent option

### DIFF
--- a/api/models/Agent.js
+++ b/api/models/Agent.js
@@ -460,6 +460,7 @@ const addAgentResourceFile = async ({ req, agent_id, tool_resource, file_id }) =
 
   const updatedAgent = await updateAgent(searchParameter, updateData, {
     updatingUserId: req?.user?.id,
+    skipVersioning: req?.config?.agents?.preventFileVersionHistory,
   });
   if (updatedAgent) {
     return updatedAgent;

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -836,6 +836,11 @@ export const configSchema = z.object({
       allowedDomains: z.array(z.string()).optional(),
     })
     .optional(),
+  agents: z
+    .object({
+      preventFileVersionHistory: z.boolean().optional(),
+    })
+    .optional(),
   registration: z
     .object({
       socialLogins: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

This PR introduces a new configuration option `agents.preventFileVersionHistory` in `librechat.yaml`.

When enabled, this option prevents the creation of a new Agent version snapshot each time a file is attached to an Agent.

**Motivation:**
This is particularly useful for RAG use cases where an Agent might have dozens or hundreds of documents attached over time. Currently, each file attachment triggers `updateAgent`, which creates a full duplicate of the Agent's state (including the growing file list) in the `versions` array. This leads to significant database document growth and can cause the Agent document to hit the `16MB` MongoDB document size limit.

Related docs PR: [LibreChat-AI/librechat.ai#446](https://github.com/LibreChat-AI/librechat.ai/pull/446)

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

1. Enable the setting in `librechat.yaml`:
   ```yaml
   agents:
     preventFileVersionHistory: true
   ```
2. Start the application.
3. Create or select an Agent.
4. Upload and attach a file to the Agent (e.g., via File Search / RAG).
5. Inspect the database or Agent Version history in the UI.
   * **Expected:** The file is attached successfully, but the version count/list does not increment for this specific action.
6. Disable the setting (or remove it).
7. Attach another file.
   * **Expected:** A new version snapshot is created.

### Test Configuration
- `librechat.yaml` configured with `agents.preventFileVersionHistory: true`

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating this feature