### PR TITLE
📷 fix: Use 'media' type for Google multimodal attachments

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -47,7 +47,7 @@
     "@langchain/google-genai": "^0.2.13",
     "@langchain/google-vertexai": "^0.2.13",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^3.0.26",
+    "@librechat/agents": "^3.0.27",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "@langchain/google-genai": "^0.2.13",
         "@langchain/google-vertexai": "^0.2.13",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^3.0.26",
+        "@librechat/agents": "^3.0.27",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -16426,9 +16426,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.0.26",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.0.26.tgz",
-      "integrity": "sha512-ALJQlry68RjxHE6Jq1S7l8M3bmBTrikkT5C6NhN8SRgq1DFoov383wDiHqOs7WwxG29Zh2FmBEGKd23bkjiTcw==",
+      "version": "3.0.27",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.0.27.tgz",
+      "integrity": "sha512-4xMzWdPgzYhEkbgGgwYx9/fIpYa9CDEupyTvYllR1sZQ8inBeByA8sMW3aTnaC+euAHZP0oVYs4Uw3J1SB0Mag==",
       "license": "MIT",
       "dependencies": {
         "@langchain/anthropic": "^0.3.26",
@@ -47440,7 +47440,7 @@
         "@azure/storage-blob": "^12.27.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.79",
-        "@librechat/agents": "^3.0.26",
+        "@librechat/agents": "^3.0.27",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.21.0",
         "axios": "^1.12.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -84,7 +84,7 @@
     "@azure/storage-blob": "^12.27.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.79",
-    "@librechat/agents": "^3.0.26",
+    "@librechat/agents": "^3.0.27",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.21.0",
     "axios": "^1.12.1",

--- a/packages/api/src/files/encode/audio.ts
+++ b/packages/api/src/files/encode/audio.ts
@@ -75,7 +75,7 @@ export async function encodeAndFormatAudios(
 
     if (provider === Providers.GOOGLE || provider === Providers.VERTEXAI) {
       result.audios.push({
-        type: 'audio',
+        type: 'media',
         mimeType: file.type,
         data: content,
       });

--- a/packages/api/src/files/encode/document.ts
+++ b/packages/api/src/files/encode/document.ts
@@ -112,7 +112,7 @@ export async function encodeAndFormatDocuments(
         });
       } else if (provider === Providers.GOOGLE || provider === Providers.VERTEXAI) {
         result.documents.push({
-          type: 'document',
+          type: 'media',
           mimeType: 'application/pdf',
           data: content,
         });

--- a/packages/api/src/files/encode/video.ts
+++ b/packages/api/src/files/encode/video.ts
@@ -75,7 +75,7 @@ export async function encodeAndFormatVideos(
 
     if (provider === Providers.GOOGLE || provider === Providers.VERTEXAI) {
       result.videos.push({
-        type: 'video',
+        type: 'media',
         mimeType: file.type,
         data: content,
       });

--- a/packages/api/src/types/files.ts
+++ b/packages/api/src/types/files.ts
@@ -61,7 +61,7 @@ export interface AnthropicDocumentBlock {
 
 /** Google document block format */
 export interface GoogleDocumentBlock {
-  type: 'document';
+  type: 'media';
   mimeType: string;
   data: string;
 }


### PR DESCRIPTION
## Summary

This pull request standardizes the format for media files (audio, video, and documents) sent to Google and VertexAI providers by changing their type from specific values (`audio`, `video`, `document`) to a generic `media` type which flags it to be transformed in the agent repo. 

> Note: This is a sibling PR to [PR #34](https://github.com/danny-avila/agents/pull/34) in the LibreChat repository and depends on the changes in that PR in order to retain functionality

**Standardization of media type for Google and VertexAI providers:**

* Updated the type field from `'audio'` to `'media'` in the audio encoding function in `audio.ts` for Google and VertexAI providers.
* Updated the type field from `'video'` to `'media'` in the video encoding function in `video.ts` for Google and VertexAI providers.
* Updated the type field from `'document'` to `'media'` in the document encoding function in `document.ts` for Google and VertexAI providers.
* Changed the `type` property in the `GoogleDocumentBlock` interface from `'document'` to `'media'` in `files.ts` to align with the new format.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Confirmed multimodal uploads still functioned with this change for VertexAI

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes