### PR TITLE
📑 refactor: Skip H1 Rendering for Falsy Header Values in `AuthLayout`

### DIFF
--- a/client/src/components/Auth/AuthLayout.tsx
+++ b/client/src/components/Auth/AuthLayout.tsx
@@ -75,7 +75,7 @@ function AuthLayout({
 
       <div className="flex flex-grow items-center justify-center">
         <div className="w-authPageWidth overflow-hidden bg-white px-6 py-4 dark:bg-gray-900 sm:max-w-md sm:rounded-lg">
-          {!hasStartupConfigError && !isFetching && (
+          {!hasStartupConfigError && !isFetching && header && (
             <h1
               className="mb-4 text-center text-3xl font-semibold text-black dark:text-white"
               style={{ userSelect: 'none' }}


### PR DESCRIPTION
## Description
Adds a check to prevent rendering an empty `<h1>` element in `AuthLayout` when the `header` prop is falsy (empty string, null, or undefined).

## Problem
Currently, the component renders `<h1></h1>` even when `header` is an empty string or falsy value, which:
- Creates unnecessary DOM elements
- Is not semantically correct HTML
- Limits flexibility for customizations where the header might be conditionally hidden

## Solution
Added `&& header` condition to the existing checks, ensuring the `<h1>` element is only rendered when there is actual content to display.

## Changes
- Modified `client/src/components/Auth/AuthLayout.tsx` to add `header` check to the conditional rendering

## Impact
- No breaking changes - existing functionality remains the same
- Improves semantic HTML structure
- Enables use cases where header might be intentionally omitted