### PR TITLE
🛂 fix: Address Accessibility Issues - Axe Rating: Moderate

### DIFF
--- a/client/src/components/Auth/AuthLayout.tsx
+++ b/client/src/components/Auth/AuthLayout.tsx
@@ -73,7 +73,7 @@ function AuthLayout({
         <ThemeSelector />
       </div>
 
-      <div className="flex flex-grow items-center justify-center">
+      <main className="flex flex-grow items-center justify-center">
         <div className="w-authPageWidth overflow-hidden bg-white px-6 py-4 dark:bg-gray-900 sm:max-w-md sm:rounded-lg">
           {!hasStartupConfigError && !isFetching && (
             <h1
@@ -89,7 +89,7 @@ function AuthLayout({
               <SocialLoginRender startupConfig={startupConfig} />
             )}
         </div>
-      </div>
+      </main>
       <Footer startupConfig={startupConfig} />
     </div>
   );

--- a/client/src/components/Bookmarks/BookmarkItem.tsx
+++ b/client/src/components/Bookmarks/BookmarkItem.tsx
@@ -40,10 +40,10 @@ const BookmarkItem: FC<MenuItemProps> = ({ tag, selected, handleSubmit, icon, ..
     }
 
     if (selected) {
-      return <BookmarkFilledIcon className="size-4" />;
+      return <BookmarkFilledIcon aria-hidden="true" className="size-4" />;
     }
 
-    return <BookmarkIcon className="size-4" />;
+    return <BookmarkIcon aria-hidden="true" className="size-4" />;
   };
 
   return (

--- a/client/src/components/Chat/AddMultiConvo.tsx
+++ b/client/src/components/Chat/AddMultiConvo.tsx
@@ -43,7 +43,7 @@ function AddMultiConvo() {
       data-testid="parameters-button"
       className="inline-flex size-10 flex-shrink-0 items-center justify-center rounded-xl border border-border-light bg-transparent text-text-primary transition-all ease-in-out hover:bg-surface-tertiary disabled:pointer-events-none disabled:opacity-50 radix-state-open:bg-surface-tertiary"
     >
-      <PlusCircle size={16} aria-label="Plus Icon" />
+      <PlusCircle size={16} aria-hidden="true" />
     </TooltipAnchor>
   );
 }

--- a/client/src/components/Chat/Footer.tsx
+++ b/client/src/components/Chat/Footer.tsx
@@ -20,6 +20,9 @@ export default function Footer({ className }: { className?: string }) {
       rel="noreferrer"
     >
       {localize('com_ui_privacy_policy')}
+      {privacyPolicy.openNewTab === true && (
+        <span className="sr-only">{' ' + localize('com_ui_opens_new_tab')}</span>
+      )}
     </a>
   );
 
@@ -31,6 +34,9 @@ export default function Footer({ className }: { className?: string }) {
       rel="noreferrer"
     >
       {localize('com_ui_terms_of_service')}
+      {termsOfService.openNewTab === true && (
+        <span className="sr-only">{' ' + localize('com_ui_opens_new_tab')}</span>
+      )}
     </a>
   );
 
@@ -66,6 +72,7 @@ export default function Footer({ className }: { className?: string }) {
                 {...otherProps}
               >
                 {children}
+                <span className="sr-only">{' ' + localize('com_ui_opens_new_tab')}</span>
               </a>
             );
           },

--- a/client/src/components/Chat/Input/Files/Table/Columns.tsx
+++ b/client/src/components/Chat/Input/Files/Table/Columns.tsx
@@ -79,7 +79,7 @@ export const columns: ColumnDef<TFile>[] = [
           <div className="flex gap-2">
             <ImagePreview
               url={file.filepath}
-              className="relative h-10 w-10 shrink-0 overflow-hidden rounded-md"
+              className="relative h-10 w-10 shrink-0 overflow-visible rounded-md"
               source={file.source}
             />
             <span className="self-center truncate">{file.filename}</span>

--- a/client/src/components/Chat/Input/Files/Table/DataTable.tsx
+++ b/client/src/components/Chat/Input/Files/Table/DataTable.tsx
@@ -158,8 +158,8 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
                 {headerGroup.headers.map((header, index) => {
                   const style: Style = {};
                   if (index === 0 && header.id === 'select') {
-                    style.width = '35px';
-                    style.minWidth = '35px';
+                    style.width = '36px';
+                    style.minWidth = '36px';
                   } else if (header.id === 'filename') {
                     style.width = isSmallScreen ? '60%' : '40%';
                   } else {
@@ -204,7 +204,10 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
                     return (
                       <TableCell
                         key={cell.id}
-                        className="align-start overflow-x-auto px-2 py-1 text-xs sm:px-4 sm:py-2 sm:text-sm [tr[data-disabled=true]_&]:opacity-50"
+                        className={cn(
+                          'align-start px-2 py-1 text-xs sm:px-4 sm:py-2 sm:text-sm [tr[data-disabled=true]_&]:opacity-50',
+                          cell.column.id === 'select' ? 'overflow-visible' : 'overflow-x-auto',
+                        )}
                         style={style}
                       >
                         {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/client/src/components/Chat/Menus/OpenSidebar.tsx
+++ b/client/src/components/Chat/Menus/OpenSidebar.tsx
@@ -30,7 +30,7 @@ export default function OpenSidebar({
             })
           }
         >
-          <Sidebar />
+          <Sidebar aria-hidden="true" />
         </Button>
       }
     />

--- a/client/src/components/Chat/TemporaryChat.tsx
+++ b/client/src/components/Chat/TemporaryChat.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { motion } from 'framer-motion';
 import { TooltipAnchor } from '@librechat/client';
 import { MessageCircleDashed } from 'lucide-react';
 import { useRecoilState, useRecoilCallback } from 'recoil';
@@ -43,6 +42,7 @@ export function TemporaryChat() {
           <button
             onClick={handleBadgeToggle}
             aria-label={localize(temporaryBadge.label)}
+            aria-pressed={isTemporary}
             className={cn(
               'inline-flex size-10 flex-shrink-0 items-center justify-center rounded-xl border border-border-light text-text-primary transition-all ease-in-out hover:bg-surface-tertiary',
               isTemporary

--- a/client/src/components/Conversations/ConvoLink.tsx
+++ b/client/src/components/Conversations/ConvoLink.tsx
@@ -30,7 +30,10 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
     >
       {children}
       <div
-        className="relative flex-1 grow overflow-hidden whitespace-nowrap"
+        className={cn(
+          'relative flex-1 grow overflow-hidden whitespace-nowrap',
+          isActiveConvo && 'italic',
+        )}
         style={{ textOverflow: 'clip' }}
         onDoubleClick={(e) => {
           if (isSmallScreen) {

--- a/client/src/components/Nav/Bookmarks/BookmarkNav.tsx
+++ b/client/src/components/Nav/Bookmarks/BookmarkNav.tsx
@@ -42,9 +42,9 @@ const BookmarkNav: FC<BookmarkNavProps> = ({ tags, setTags, isSmallScreen }: Boo
                 data-testid="bookmark-menu"
               >
                 {tags.length > 0 ? (
-                  <BookmarkFilledIcon className="icon-lg text-text-primary" aria-hidden="true" />
+                  <BookmarkFilledIcon aria-hidden="true" className="icon-lg text-text-primary" />
                 ) : (
-                  <BookmarkIcon className="icon-lg text-text-primary" aria-hidden="true" />
+                  <BookmarkIcon aria-hidden="true" className="icon-lg text-text-primary" />
                 )}
               </MenuButton>
             }

--- a/client/src/components/Nav/Bookmarks/BookmarkNavItems.tsx
+++ b/client/src/components/Nav/Bookmarks/BookmarkNavItems.tsx
@@ -41,7 +41,7 @@ const BookmarkNavItems: FC<{
           data-testid="bookmark-item-clear"
           handleSubmit={clear}
           selected={false}
-          icon={<CrossCircledIcon className="size-4" />}
+          icon={<CrossCircledIcon aria-hidden="true" className="size-4" />}
         />
         <BookmarkItem
           tag={localize('com_ui_no_bookmarks')}
@@ -65,7 +65,7 @@ const BookmarkNavItems: FC<{
             data-testid="bookmark-item-clear"
             handleSubmit={clear}
             selected={false}
-            icon={<CrossCircledIcon className="size-4" />}
+            icon={<CrossCircledIcon aria-hidden="true" className="size-4" />}
           />
         }
       />

--- a/client/src/components/Nav/NewChat.tsx
+++ b/client/src/components/Nav/NewChat.tsx
@@ -59,8 +59,11 @@ export default function NewChat({
               className="rounded-full border-none bg-transparent p-2 hover:bg-surface-hover md:rounded-xl"
               onClick={toggleNav}
             >
-              <Sidebar className="max-md:hidden" />
-              <MobileSidebar className="m-1 inline-flex size-10 items-center justify-center md:hidden" />
+              <Sidebar aria-hidden="true" className="max-md:hidden" />
+              <MobileSidebar
+                aria-hidden="true"
+                className="m-1 inline-flex size-10 items-center justify-center md:hidden"
+              />
             </Button>
           }
         />

--- a/client/src/components/Nav/SearchBar.tsx
+++ b/client/src/components/Nav/SearchBar.tsx
@@ -110,7 +110,7 @@ const SearchBar = forwardRef((props: SearchBarProps, ref: React.Ref<HTMLDivEleme
     <div
       ref={ref}
       className={cn(
-        'group relative mt-1 flex h-10 cursor-pointer items-center gap-3 rounded-lg border-border-medium px-3 py-2 text-text-primary transition-colors duration-200 focus-within:bg-surface-hover hover:bg-surface-hover',
+        'group relative mt-1 flex h-10 cursor-pointer items-center gap-3 rounded-lg border-2 border-transparent px-3 py-2 text-text-primary transition-all duration-200 focus-within:border-ring-primary focus-within:bg-surface-hover hover:bg-surface-hover',
         isSmallScreen === true ? 'mb-2 h-14 rounded-xl' : '',
       )}
     >

--- a/client/src/components/Nav/SearchBar.tsx
+++ b/client/src/components/Nav/SearchBar.tsx
@@ -114,7 +114,10 @@ const SearchBar = forwardRef((props: SearchBarProps, ref: React.Ref<HTMLDivEleme
         isSmallScreen === true ? 'mb-2 h-14 rounded-xl' : '',
       )}
     >
-      <Search className="absolute left-3 h-4 w-4 text-text-secondary group-focus-within:text-text-primary group-hover:text-text-primary" />
+      <Search
+        aria-hidden="true"
+        className="absolute left-3 h-4 w-4 text-text-secondary group-focus-within:text-text-primary group-hover:text-text-primary"
+      />
       <input
         type="text"
         ref={inputRef}

--- a/client/src/components/Nav/SettingsTabs/General/ArchivedChatsTable.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/ArchivedChatsTable.tsx
@@ -224,6 +224,7 @@ export default function ArchivedChatsTable({
                       })
                     }
                     title={localize('com_ui_unarchive')}
+                    aria-label={localize('com_ui_unarchive')}
                     disabled={unarchiveMutation.isLoading}
                   >
                     {unarchiveMutation.isLoading ? (
@@ -245,6 +246,7 @@ export default function ArchivedChatsTable({
                       setIsDeleteOpen(true);
                     }}
                     title={localize('com_ui_delete')}
+                    aria-label={localize('com_ui_delete')}
                   >
                     <TrashIcon className="size-4" />
                   </Button>

--- a/client/src/components/Prompts/AdvancedSwitch.tsx
+++ b/client/src/components/Prompts/AdvancedSwitch.tsx
@@ -30,6 +30,8 @@ const AdvancedSwitch = () => {
             setAlwaysMakeProd(true);
             setMode(PromptsEditorMode.SIMPLE);
           }}
+          aria-pressed={mode === PromptsEditorMode.SIMPLE}
+          aria-label={localize('com_ui_simple')}
           className={`relative z-10 flex-1 rounded-xl px-3 py-2 text-sm font-medium transition-all duration-300 md:px-6 ${
             mode === PromptsEditorMode.SIMPLE
               ? 'text-text-primary'
@@ -43,6 +45,8 @@ const AdvancedSwitch = () => {
         <button
           type="button"
           onClick={() => setMode(PromptsEditorMode.ADVANCED)}
+          aria-pressed={mode === PromptsEditorMode.ADVANCED}
+          aria-label={localize('com_ui_advanced')}
           className={`relative z-10 flex-1 rounded-xl px-3 py-2 text-sm font-medium transition-all duration-300 md:px-6 ${
             mode === PromptsEditorMode.ADVANCED
               ? 'text-text-primary'

--- a/client/src/components/Prompts/Groups/PanelNavigation.tsx
+++ b/client/src/components/Prompts/Groups/PanelNavigation.tsx
@@ -23,7 +23,7 @@ function PanelNavigation({
 
   return (
     <div className="flex items-center justify-between">
-      <div className="flex gap-2">
+      <div className="flex gap-2 pl-1">
         {!isChatRoute && <ThemeSelector returnThemeOnly={true} />}
         {children}
       </div>

--- a/client/src/components/Prompts/PromptEditor.tsx
+++ b/client/src/components/Prompts/PromptEditor.tsx
@@ -55,7 +55,8 @@ const PromptEditor: React.FC<Props> = ({ name, isEditing, setIsEditing }) => {
 
   return (
     <div className="flex max-h-[85vh] flex-col sm:max-h-[85vh]">
-      <h2 className="flex items-center justify-between rounded-t-xl border border-border-light py-1.5 pl-3 text-sm font-semibold text-text-primary sm:py-2 sm:pl-4 sm:text-base">
+      <h2 className="sr-only">{localize('com_ui_control_bar')}</h2>
+      <div className="flex items-center justify-between rounded-t-xl border border-border-light py-1.5 pl-3 text-sm font-semibold text-text-primary sm:py-2 sm:pl-4 sm:text-base">
         <span className="max-w-[200px] truncate sm:max-w-none">
           {localize('com_ui_prompt_text')}
         </span>
@@ -78,7 +79,7 @@ const PromptEditor: React.FC<Props> = ({ name, isEditing, setIsEditing }) => {
             />
           </button>
         </div>
-      </h2>
+      </div>
       <div
         role="button"
         className={cn(

--- a/client/src/components/Prompts/PromptForm.tsx
+++ b/client/src/components/Prompts/PromptForm.tsx
@@ -387,6 +387,7 @@ const PromptForm = () => {
   return (
     <FormProvider {...methods}>
       <form className="mt-4 flex w-full" onSubmit={handleSubmit((data) => onSave(data.prompt))}>
+        <h1 className="sr-only">{localize('com_ui_edit_prompt_page')}</h1>
         <div className="relative w-full">
           <div
             className="h-full w-full"

--- a/client/src/components/Prompts/PromptVersions.tsx
+++ b/client/src/components/Prompts/PromptVersions.tsx
@@ -51,7 +51,7 @@ const VersionTags = ({ tags }: { tags: string[] }) => {
               className={cn(
                 'w-24 justify-center border border-transparent',
                 tag === 'production'
-                  ? 'bg-green-100 text-green-500 dark:border-green-500 dark:bg-transparent dark:text-green-500'
+                  ? 'bg-green-100 text-green-700 dark:border-green-400 dark:bg-transparent dark:text-green-400'
                   : 'bg-blue-100 text-blue-500 dark:border-blue-500 dark:bg-transparent dark:text-blue-500',
               )}
               labelClassName="flex items-center m-0 justify-center gap-1"

--- a/client/src/components/Prompts/PromptVersions.tsx
+++ b/client/src/components/Prompts/PromptVersions.tsx
@@ -52,7 +52,7 @@ const VersionTags = ({ tags }: { tags: string[] }) => {
                 'w-24 justify-center border border-transparent',
                 tag === 'production'
                   ? 'bg-green-100 text-green-700 dark:border-green-400 dark:bg-transparent dark:text-green-400'
-                  : 'bg-blue-100 text-blue-500 dark:border-blue-500 dark:bg-transparent dark:text-blue-500',
+                  : 'bg-blue-100 text-blue-700 dark:border-blue-400 dark:bg-transparent dark:text-blue-400',
               )}
               labelClassName="flex items-center m-0 justify-center gap-1"
               LabelNode={(() => {
@@ -105,7 +105,7 @@ const VersionCard = ({
       className={cn(
         'group relative w-full rounded-lg border border-border-light p-4 transition-all duration-300',
         isSelected
-          ? 'bg-surface-hover shadow-xl'
+          ? 'bg-surface-secondary shadow-xl ring-2 ring-gray-400'
           : 'bg-surface-primary shadow-sm hover:bg-surface-secondary',
       )}
       onClick={onClick}

--- a/client/src/components/SidePanel/Memories/MemoryViewer.tsx
+++ b/client/src/components/SidePanel/Memories/MemoryViewer.tsx
@@ -236,13 +236,21 @@ export default function MemoryViewer() {
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
       <div role="region" aria-label={localize('com_ui_memories')} className="mt-2 space-y-2">
-        <div className="flex items-center gap-4">
+        <div className="relative">
           <Input
-            placeholder={localize('com_ui_memories_filter')}
+            id="memory-search"
+            placeholder=" "
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             aria-label={localize('com_ui_memories_filter')}
+            className="peer"
           />
+          <Label
+            htmlFor="memory-search"
+            className="pointer-events-none absolute -top-1 left-3 w-auto origin-[0] translate-y-3 scale-100 rounded bg-background px-1 text-base text-text-secondary transition-transform duration-200 peer-placeholder-shown:translate-y-3 peer-placeholder-shown:scale-100 peer-focus:-translate-y-2 peer-focus:scale-75 peer-focus:text-text-primary peer-[:not(:placeholder-shown)]:-translate-y-2 peer-[:not(:placeholder-shown)]:scale-75"
+          >
+            {localize('com_ui_memories_filter')}
+          </Label>
         </div>
         {/* Memory Usage and Toggle Display */}
         {(memData?.tokenLimit || hasOptOutAccess) && (

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -796,6 +796,7 @@
   "com_ui_context": "Context",
   "com_ui_continue": "Continue",
   "com_ui_continue_oauth": "Continue with OAuth",
+  "com_ui_control_bar": "Control bar",
   "com_ui_controls": "Controls",
   "com_ui_convo_delete_error": "Failed to delete conversation",
   "com_ui_copied": "Copied!",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -881,6 +881,7 @@
   "com_ui_edit_editing_image": "Editing image",
   "com_ui_edit_mcp_server": "Edit MCP Server",
   "com_ui_edit_memory": "Edit Memory",
+  "com_ui_edit_prompt_page": "Edit Prompt Page",
   "com_ui_editable_message": "Editable Message",
   "com_ui_editor_instructions": "Drag the image to reposition • Use zoom slider or buttons to adjust size",
   "com_ui_empty_category": "-",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1239,6 +1239,7 @@
   "com_ui_temporary": "Temporary Chat",
   "com_ui_terms_and_conditions": "Terms and Conditions",
   "com_ui_terms_of_service": "Terms of service",
+  "com_ui_opens_new_tab": "(opens in new tab)",
   "com_ui_thinking": "Thinking...",
   "com_ui_thoughts": "Thoughts",
   "com_ui_token": "token",

--- a/packages/client/src/components/Toast.tsx
+++ b/packages/client/src/components/Toast.tsx
@@ -7,7 +7,7 @@ export function Toast() {
   const severityClassName = {
     [NotificationSeverity.INFO]: 'border-gray-500 bg-gray-500',
     [NotificationSeverity.SUCCESS]: 'border-green-500 bg-green-500',
-    [NotificationSeverity.WARNING]: 'border-orange-500 bg-orange-500',
+    [NotificationSeverity.WARNING]: 'border-orange-600 bg-orange-600',
     [NotificationSeverity.ERROR]: 'border-red-500 bg-red-500',
   };
 


### PR DESCRIPTION
## Summary

This PR addresses the following moderate accessibility issues as identified by axe Auditor:

---

### Page missing Main landmark
_(Skip Navigation, Headings or Landmarks 2.4.1.a)_

- [439: Login Page](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/73d12d6a-8a83-11f0-8ad9-3fcb92dad186)

---

### State of active component lacks 3 to 1 contrast ratio
_(Non-Text Contrast - States of User Interface Components 1.4.11.b)_

- [562: Chat History Nav](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/e318b79a-8cc9-11f0-96bc-7fa1909e94ab)

---

### Graphical object with text lacks 3 to 1 contrast ratio
_(Non-Text Contrast - Graphical Objects 1.4.11.c)_

- [577: Chat History Nav](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/f4b1b65a-8cec-11f0-89f4-6bb83e8f71ba)

---

### SVG not hidden – decorative
_(Alternative Text (Decorative Images) 1.1.1.d)_

- [578: Chat History Nav](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/8d5318c2-8ced-11f0-b0b5-23b6e5c748dd)

---

### Focus indicator can be improved
_(Focus Visible 2.4.7.a)_

- [593: My Files Modal](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/75d61692-8d81-11f0-9c7d-1b59a3643250)

---

### Toggle button missing programmatic state
_(Name, Role, Value 4.1.2.a)_

- [606: Main Chat Interface](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/ad8f46fe-8d99-11f0-8f38-c708aa9e969e)
- [765: Edit Prompt Page](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/694e3274-97c2-11f0-857b-87456f383126)

---

### Links opens new window without warning
_(Context Changes (on Input) 3.2.2.a)_

- [611: Main Chat Interface](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/69419bec-8db1-11f0-99db-bb3a11ff4c19)

---

### Missing H1 heading
_(Headings 1.3.1.e)_

- [776: Edit Prompt Page](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/6d2d5ec8-97c8-11f0-b648-0370cb9a9a62)

---

### Text content lacks 4.5:1 contrast ratio
_(Color Contrast (regular text) 1.4.3.a)_

- [773: Create Prompt Page](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/18b18502-9270-11f0-90e1-477e675b4a77)
- [725: Bookmarks](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/966af5d8-9409-11f0-9e13-7f940182cb2a)

---

### Control text lacks 4.5:1 contrast ratio on hover or focus
_(Color Contrast (regular text) 1.4.3.a)_

- [770: Edit Prompt Page](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/951bb49c-97c4-11f0-b70a-e3e2d15b0da0)

---

### Text should not be marked as a heading
_(Headings 1.3.1.e)_

- [768: Edit Prompt Page](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/990508b6-97c3-11f0-b9a4-e76e94aa6fd2)

---

### Modal is closed, focus is not returned to trigger
_(Focus Order 2.4.3.a)_

- [717: Attach Files](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/e210a874-9405-11f0-ab77-37f6b1617128)

---

### Decorative image is not hidden from screen readers
_(Alternative Text (Decorative Images) 1.1.1.d)_

- [708: Main Chat Interface](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/2359386e-93f7-11f0-b753-2bdedc41b1d0)

---



## **Implementation Details:**

* Added `aria-hidden="true"` to decorative icons in components such as `BookmarkItem`, `BookmarkNav`, `BookmarkNavItems`, `Sidebar`, `MobileSidebar`, and `SearchBar` to ensure they are ignored by screen readers. Also added `aria-label` and `aria-pressed` to interactive buttons, such as those in `AdvancedSwitch`, `TemporaryChat`, and `ArchivedChatsTable`, for better accessibility. [[1]](diffhunk://#diff-02d15e8bca4cf749ce1e41d4304fb8be0a77fc739b9961c001ae9acdc289fc76L43-R46) [[2]](diffhunk://#diff-280e7aadecaa0d00917e720be1864035b1cf7839430ca719d958310be1d2057fL45-R47) [[3]](diffhunk://#diff-7de7215da7f05b2aa68af0a6ac297743ae8f64cea0f0c3a767fb425245a77974L44-R44) [[4]](diffhunk://#diff-7de7215da7f05b2aa68af0a6ac297743ae8f64cea0f0c3a767fb425245a77974L68-R68) [[5]](diffhunk://#diff-b942da77786dab87bdec866dedaae848fcfbd33f0d175113e6c1ae3f9712cb1cL62-R66) [[6]](diffhunk://#diff-7f38a70d8920ac72d818285e6d5ab23797c4719b9b7ab072763ba5014f3ca03aL113-R120) [[7]](diffhunk://#diff-0425cdef968b029dee9226ba9c61a03336a94f0aedd81c1d6cdd50dac6f2d2b1R33-R34) [[8]](diffhunk://#diff-0425cdef968b029dee9226ba9c61a03336a94f0aedd81c1d6cdd50dac6f2d2b1R48-R49) [[9]](diffhunk://#diff-7577c6932d9e076229df3b57c2e600813f6225bd3f177011eacdfc602e40ab19R45) [[10]](diffhunk://#diff-3b2da294b28349bd23748a1f878d255bd07fc71d61c505e3afafd53992ba70f4R227) [[11]](diffhunk://#diff-3b2da294b28349bd23748a1f878d255bd07fc71d61c505e3afafd53992ba70f4R249) [[12]](diffhunk://#diff-4a10a5c9c83b86c4023d38b0afe5e6e138c585ad6cee21ce3c95c3f72df60722L33-R33) [[13]](diffhunk://#diff-d9353c0049a8e80e7713661355b79e7234e20aa2756b625bd19854642cce1e90L46-R46)
* Improved screen reader experience in the `Footer` component by adding visually hidden text to indicate when links open in a new tab. [[1]](diffhunk://#diff-7b58757c87dce4c00b620edee7de05af6b26ef029af2c327c44646269b43fb8bR23-R25) [[2]](diffhunk://#diff-7b58757c87dce4c00b620edee7de05af6b26ef029af2c327c44646269b43fb8bR37-R39) [[3]](diffhunk://#diff-7b58757c87dce4c00b620edee7de05af6b26ef029af2c327c44646269b43fb8bR75)
* Updated the `PromptEditor` control bar heading to be screen reader only for better semantic structure.

**Keyboard Navigation and Focus Management:**

* Refactored the `ImagePreview` modal to use a button ref for returning focus after closing, replacing previous logic that tracked the active element. This ensures smoother keyboard navigation and focus restoration. [[1]](diffhunk://#diff-515b16f93f30dd71391631a65a651c03e9fbbf1ed93b6b1251938d6ec6abb616L1-R1) [[2]](diffhunk://#diff-515b16f93f30dd71391631a65a651c03e9fbbf1ed93b6b1251938d6ec6abb616L16-L20) [[3]](diffhunk://#diff-515b16f93f30dd71391631a65a651c03e9fbbf1ed93b6b1251938d6ec6abb616L38-R58) [[4]](diffhunk://#diff-515b16f93f30dd71391631a65a651c03e9fbbf1ed93b6b1251938d6ec6abb616R94) [[5]](diffhunk://#diff-515b16f93f30dd71391631a65a651c03e9fbbf1ed93b6b1251938d6ec6abb616L161-R136)

**UI and Layout Adjustments:**

* Changed layout elements from `div` to `main` in `AuthLayout` for better semantic HTML structure. [[1]](diffhunk://#diff-0d07e8462cbaa92e332105d442862ffe8a1f8815f8c2a48c2c28fa8e8b3f17beL76-R76) [[2]](diffhunk://#diff-0d07e8462cbaa92e332105d442862ffe8a1f8815f8c2a48c2c28fa8e8b3f17beL92-R92)
* Minor style and layout tweaks, including padding adjustments in `PanelNavigation`, updating overflow behavior in file tables, and making active conversation links italic for improved clarity. [[1]](diffhunk://#diff-95302dbb42d91bf45d2f518ef167e308701b795d7bb9d9c7b7f206412a3194c4L26-R26) [[2]](diffhunk://#diff-12dbb75b582ebee9fc5fbfda02676fe37d686341f7f57f9fbd7f72a49153cd49L82-R82) [[3]](diffhunk://#diff-2e0b5812cda843daff74a1cab203d355446f76ecd837329df146ed70e025e7c2L161-R162) [[4]](diffhunk://#diff-2e0b5812cda843daff74a1cab203d355446f76ecd837329df146ed70e025e7c2L207-R210) [[5]](diffhunk://#diff-72c67cfacc4c84ed8ef05b2206fa3345721eb9eb264c9255b451a8e0574b2d73L33-R36)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Confirmation of compliance with Colour Contrast Analyzer for contrast thresholds, macOS VoiceOver for screen-reader issues, and Chrome Web Inspector Accessibility Panel details for remaining confirmations. 

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes