### PR TITLE
🪂 refactor: MCP Server Init Fallback

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -30,11 +30,46 @@ const publicSharedLinksEnabled =
 const sharePointFilePickerEnabled = isEnabled(process.env.ENABLE_SHAREPOINT_FILEPICKER);
 const openidReuseTokens = isEnabled(process.env.OPENID_REUSE_TOKENS);
 
+/**
+ * Fetches MCP servers from registry and adds them to the payload.
+ * Registry now includes all configured servers (from YAML) plus inspection data when available.
+ * Always fetches fresh to avoid caching incomplete initialization state.
+ */
+const getMCPServers = async (payload, appConfig) => {
+  try {
+    if (appConfig?.mcpConfig == null) {
+      return;
+    }
+    const mcpManager = getMCPManager();
+    if (!mcpManager) {
+      return;
+    }
+    const mcpServers = await mcpServersRegistry.getAllServerConfigs();
+    if (!mcpServers) return;
+    for (const serverName in mcpServers) {
+      if (!payload.mcpServers) {
+        payload.mcpServers = {};
+      }
+      const serverConfig = mcpServers[serverName];
+      payload.mcpServers[serverName] = removeNullishValues({
+        startup: serverConfig?.startup,
+        chatMenu: serverConfig?.chatMenu,
+        isOAuth: serverConfig.requiresOAuth,
+        customUserVars: serverConfig?.customUserVars,
+      });
+    }
+  } catch (error) {
+    logger.error('Error loading MCP servers', error);
+  }
+};
+
 router.get('/', async function (req, res) {
   const cache = getLogStores(CacheKeys.CONFIG_STORE);
 
   const cachedStartupConfig = await cache.get(CacheKeys.STARTUP_CONFIG);
   if (cachedStartupConfig) {
+    const appConfig = await getAppConfig({ role: req.user?.role });
+    await getMCPServers(cachedStartupConfig, appConfig);
     res.send(cachedStartupConfig);
     return;
   }
@@ -126,35 +161,6 @@ router.get('/', async function (req, res) {
       payload.minPasswordLength = minPasswordLength;
     }
 
-    const getMCPServers = async () => {
-      try {
-        if (appConfig?.mcpConfig == null) {
-          return;
-        }
-        const mcpManager = getMCPManager();
-        if (!mcpManager) {
-          return;
-        }
-        const mcpServers = await mcpServersRegistry.getAllServerConfigs();
-        if (!mcpServers) return;
-        for (const serverName in mcpServers) {
-          if (!payload.mcpServers) {
-            payload.mcpServers = {};
-          }
-          const serverConfig = mcpServers[serverName];
-          payload.mcpServers[serverName] = removeNullishValues({
-            startup: serverConfig?.startup,
-            chatMenu: serverConfig?.chatMenu,
-            isOAuth: serverConfig.requiresOAuth,
-            customUserVars: serverConfig?.customUserVars,
-          });
-        }
-      } catch (error) {
-        logger.error('Error loading MCP servers', error);
-      }
-    };
-
-    await getMCPServers();
     const webSearchConfig = appConfig?.webSearch;
     if (
       webSearchConfig != null &&
@@ -184,6 +190,7 @@ router.get('/', async function (req, res) {
     }
 
     await cache.set(CacheKeys.STARTUP_CONFIG, payload);
+    await getMCPServers(payload, appConfig);
     return res.status(200).send(payload);
   } catch (err) {
     logger.error('Error in startup config', err);

--- a/packages/api/src/mcp/registry/MCPServersInitializer.ts
+++ b/packages/api/src/mcp/registry/MCPServersInitializer.ts
@@ -34,6 +34,9 @@ export class MCPServersInitializer {
   public static async initialize(rawConfigs: t.MCPServers): Promise<void> {
     if (await statusCache.isInitialized()) return;
 
+    /** Store raw configs immediately so they're available even if initialization fails/is slow */
+    registry.setRawConfigs(rawConfigs);
+
     if (await isLeader()) {
       // Leader performs initialization
       await statusCache.reset();

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -13,12 +13,22 @@ import {
  *
  * Provides a unified interface for retrieving server configs with proper fallback hierarchy:
  * checks shared app servers first, then shared user servers, then private user servers.
+ * Falls back to raw config when servers haven't been initialized yet or failed to initialize.
  * Handles server lifecycle operations including adding, removing, and querying configurations.
  */
 class MCPServersRegistry {
   public readonly sharedAppServers = ServerConfigsCacheFactory.create('App', false);
   public readonly sharedUserServers = ServerConfigsCacheFactory.create('User', false);
   private readonly privateUserServers: Map<string | undefined, ServerConfigsCache> = new Map();
+  private rawConfigs: t.MCPServers = {};
+
+  /**
+   * Stores the raw MCP configuration as a fallback when servers haven't been initialized yet.
+   * Should be called during initialization before inspecting servers.
+   */
+  public setRawConfigs(configs: t.MCPServers): void {
+    this.rawConfigs = configs;
+  }
 
   public async addPrivateUserServer(
     userId: string,
@@ -59,15 +69,32 @@ class MCPServersRegistry {
     const privateUserServer = await this.privateUserServers.get(userId)?.get(serverName);
     if (privateUserServer) return privateUserServer;
 
+    /** Fallback to raw config if server hasn't been initialized yet */
+    const rawConfig = this.rawConfigs[serverName];
+    if (rawConfig) return rawConfig as t.ParsedServerConfig;
+
     return undefined;
   }
 
   public async getAllServerConfigs(userId?: string): Promise<Record<string, t.ParsedServerConfig>> {
-    return {
+    const registryConfigs = {
       ...(await this.sharedAppServers.getAll()),
       ...(await this.sharedUserServers.getAll()),
       ...((await this.privateUserServers.get(userId)?.getAll()) ?? {}),
     };
+
+    /** Include all raw configs, but registry configs take precedence (they have inspection data) */
+    const allConfigs: Record<string, t.ParsedServerConfig> = {};
+    for (const serverName in this.rawConfigs) {
+      allConfigs[serverName] = this.rawConfigs[serverName] as t.ParsedServerConfig;
+    }
+
+    /** Override with registry configs where available (they have richer data) */
+    for (const serverName in registryConfigs) {
+      allConfigs[serverName] = registryConfigs[serverName];
+    }
+
+    return allConfigs;
   }
 
   // TODO: This is currently used to determine if a server requires OAuth. However, this info can


### PR DESCRIPTION
## Summary

I implemented a fallback mechanism to prevent MCP server configurations from being unavailable due to Redis cluster edge cases, but potentially also during application startup when initialization is slow or fails (mainly when using Redis clusters).

- Added raw config storage to MCPServersRegistry that preserves original YAML configuration before any async inspection occurs
- Implemented `setRawConfigs()` method to store configs immediately during initialization
- Modified `getServerConfig()` to fall back to raw configs when the registry hasn't been fully initialized yet
- Updated `getAllServerConfigs()` to merge raw configs with registry configs, with registry taking precedence for richer inspection data
- Stored raw configs immediately in MCPServersInitializer before any async inspection to ensure availability
- Moved `getMCPServers()` function outside the router handler scope in config.js for better reusability
- Fixed cache behavior to always fetch fresh MCP server data, preventing stale or incomplete initialization state from being served
- Added proper JSDoc documentation explaining the new fallback behavior and caching strategy
- Implemented Redis cluster support in flush-cache.js with proper node detection and iteration
- Enhanced console output to clearly distinguish between cluster and standalone Redis operations

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Tested with slow-initializing MCP servers and verified that configurations are immediately available from raw YAML while full inspection completes in the background. Confirmed that registry configs properly override raw configs once inspection finishes.

### **Test Configuration**:
- MCP servers with varying initialization speeds
- Redis standalone and cluster configurations
- Cache hit/miss scenarios during startup

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Any changes dependent on mine have been merged and published in downstream modules