### PR TITLE
feat: Add File Search Default Enabled Configuration Option

### DIFF
--- a/client/src/Providers/BadgeRowContext.tsx
+++ b/client/src/Providers/BadgeRowContext.tsx
@@ -9,6 +9,7 @@ import {
   useCodeApiKeyForm,
   useToolToggle,
 } from '~/hooks';
+import { useGetStartupConfig } from '~/data-provider';
 import { getTimestampedValue, setTimestamp } from '~/utils/timestamps';
 import { ephemeralAgentByConvoId } from '~/store';
 
@@ -48,6 +49,7 @@ export default function BadgeRowProvider({
   const lastKeyRef = useRef<string>('');
   const hasInitializedRef = useRef(false);
   const { agentsConfig } = useGetAgentsConfig();
+  const { data: startupConfig } = useGetStartupConfig();
   const key = conversationId ?? Constants.NEW_CONVO;
 
   const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(key));
@@ -113,7 +115,7 @@ export default function BadgeRowProvider({
       const finalValues = {
         [Tools.execute_code]: initialValues[Tools.execute_code] ?? false,
         [Tools.web_search]: initialValues[Tools.web_search] ?? false,
-        [Tools.file_search]: initialValues[Tools.file_search] ?? false,
+        [Tools.file_search]: initialValues[Tools.file_search] ?? (startupConfig?.interface?.fileSearchDefaultEnabled ?? false),
         [AgentCapabilities.artifacts]: initialValues[AgentCapabilities.artifacts] ?? false,
       };
 

--- a/client/src/Providers/BadgeRowContext.tsx
+++ b/client/src/Providers/BadgeRowContext.tsx
@@ -54,6 +54,8 @@ export default function BadgeRowProvider({
 
   const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(key));
 
+  const interfaceConfig = startupConfig?.interface;
+
   /** Initialize ephemeralAgent from localStorage on mount and when conversation changes */
   useEffect(() => {
     if (isSubmitting) {
@@ -115,7 +117,8 @@ export default function BadgeRowProvider({
       const finalValues = {
         [Tools.execute_code]: initialValues[Tools.execute_code] ?? false,
         [Tools.web_search]: initialValues[Tools.web_search] ?? false,
-        [Tools.file_search]: initialValues[Tools.file_search] ?? (startupConfig?.interface?.fileSearchDefaultEnabled ?? false),
+        [Tools.file_search]:
+          initialValues[Tools.file_search] ?? interfaceConfig?.fileSearchDefaultEnabled ?? false,
         [AgentCapabilities.artifacts]: initialValues[AgentCapabilities.artifacts] ?? false,
       };
 
@@ -140,7 +143,7 @@ export default function BadgeRowProvider({
         }
       });
     }
-  }, [key, isSubmitting, setEphemeralAgent]);
+  }, [key, isSubmitting, setEphemeralAgent, interfaceConfig]);
 
   /** CodeInterpreter hooks */
   const codeApiKeyForm = useCodeApiKeyForm({});

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -32,6 +32,10 @@ interface:
   # Note: This setting does not disable the Agents File Search Capability.
   # To disable the Agents Capability, see the Agents Endpoint configuration instead.
   fileSearch: true
+  # Set whether file search is enabled by default in new conversations (default: false)
+  # When enabled, users won't need to manually toggle file search on for each conversation
+  # Users can still toggle it off, and their preference will be remembered per conversation
+  fileSearchDefaultEnabled: false
   # Privacy policy settings
   privacyPolicy:
     externalUrl: 'https://librechat.ai/privacy-policy'

--- a/packages/api/src/app/AppService.interface.spec.ts
+++ b/packages/api/src/app/AppService.interface.spec.ts
@@ -154,4 +154,27 @@ describe('AppService interface configuration', () => {
     // Verify that peoplePicker is undefined when not provided
     expect(result.interfaceConfig?.peoplePicker).toBeUndefined();
   });
+
+  it('should set fileSearchDefaultEnabled based on config with fallback to false', async () => {
+    // Test explicit true
+    let config = { interface: { fileSearchDefaultEnabled: true } };
+    let result = await AppService({ config });
+    expect(result.interfaceConfig).toEqual(
+      expect.objectContaining({ fileSearchDefaultEnabled: true }),
+    );
+
+    // Test explicit false
+    config = { interface: { fileSearchDefaultEnabled: false } };
+    result = await AppService({ config });
+    expect(result.interfaceConfig).toEqual(
+      expect.objectContaining({ fileSearchDefaultEnabled: false }),
+    );
+
+    // Test omitted (should default to false)
+    config = { interface: {} };
+    result = await AppService({ config });
+    expect(result.interfaceConfig).toEqual(
+      expect.objectContaining({ fileSearchDefaultEnabled: false }),
+    );
+  });
 });

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -559,6 +559,7 @@ export const interfaceSchema = z
       })
       .optional(),
     fileSearch: z.boolean().optional(),
+    fileSearchDefaultEnabled: z.boolean().optional(),
     fileCitations: z.boolean().optional(),
   })
   .default({
@@ -584,6 +585,7 @@ export const interfaceSchema = z
       use: false,
     },
     fileSearch: true,
+    fileSearchDefaultEnabled: false,
     fileCitations: true,
   });
 

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -52,6 +52,7 @@ export async function loadDefaultInterface({
     runCode: interfaceConfig?.runCode,
     webSearch: interfaceConfig?.webSearch,
     fileSearch: interfaceConfig?.fileSearch,
+    fileSearchDefaultEnabled: interfaceConfig?.fileSearchDefaultEnabled ?? defaults.fileSearchDefaultEnabled,
     fileCitations: interfaceConfig?.fileCitations,
     peoplePicker: interfaceConfig?.peoplePicker,
     marketplace: interfaceConfig?.marketplace,


### PR DESCRIPTION
## Summary

Added a new configuration option `interface.fileSearchDefaultEnabled` to control whether the File Search tool is enabled by default in new conversations.

### Motivation

Currently, users must manually enable the "File Search" tool before they can use the "Upload for File Search" feature. The toggle state is hardcoded to `false`, causing unnecessary confusion and friction for users who expect file search to be readily available and who were used to having it enabled by default prior to `v0.8.0`. We've received a large number of support requests/tickets due to this single UI change.

This PR adds a configuration option so admins can set file search to be enabled by default while still allowing users to toggle it off per conversation. User preferences are persisted in local storage and always override the config default (i.e. backwards compatible).

A more comprehensive solution could provide administrators with a way to set system-wide defaults that users could then override for their user account, which could then be toggled per conversation, but I think that should be considered in the context of the other tools that are available. So for that reason, this is intended as a more targeted change to address the immediate user support issue we're facing.

### Key Changes

- Added `fileSearchDefaultEnabled` to interface schema (`packages/data-provider/src/config.ts`)
- Exposed field through backend API (`packages/data-schemas/src/app/interface.ts`)
- Updated frontend to use config value instead of hardcoded default (`client/src/Providers/BadgeRowContext.tsx`)
- Added documentation to `librechat.example.yaml`


## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

### Test Configuration

```yaml
interface:
  fileSearch: true
  fileSearchDefaultEnabled: true  # Set to false (or omit) to test default behavior
```

### Test steps

1. Set config value in `librechat.yaml`
2. Rebuild packages: `npm run build:packages`
3. Restart backend and frontend
4. Create new conversation and verify default toggle state
5. Toggle manually, reload page, verify preference persists

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.
