### PR TITLE
🔗 fix: Resolve Bedrock Tool Call Streaming "Content Type Mismatch"

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -47,7 +47,7 @@
     "@langchain/google-genai": "^0.2.13",
     "@langchain/google-vertexai": "^0.2.13",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^3.0.30",
+    "@librechat/agents": "^3.0.32",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@langchain/google-genai": "^0.2.13",
         "@langchain/google-vertexai": "^0.2.13",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^3.0.30",
+        "@librechat/agents": "^3.0.32",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -16263,9 +16263,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.0.30",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.0.30.tgz",
-      "integrity": "sha512-EJLo6GqXH0tefpdrhMnoiVwhFupS3K9I0xXAKCn+6greIhdZV1IlsYRxu+NXoK+xaFJBJeMkAb0E9Oih61NxoA==",
+      "version": "3.0.32",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.0.32.tgz",
+      "integrity": "sha512-6g7lLuEpot3vrHqgDZzPyrISvUshyWRINdnvkQsQf951QjdcFZuqmQ9mpUcaNQbczHBS4k5DLYIBUK+qzG/eiw==",
       "license": "MIT",
       "dependencies": {
         "@langchain/anthropic": "^0.3.26",
@@ -46180,7 +46180,7 @@
         "@azure/storage-blob": "^12.27.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.79",
-        "@librechat/agents": "^3.0.30",
+        "@librechat/agents": "^3.0.32",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.21.0",
         "axios": "^1.12.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -84,7 +84,7 @@
     "@azure/storage-blob": "^12.27.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.79",
-    "@librechat/agents": "^3.0.30",
+    "@librechat/agents": "^3.0.32",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.21.0",
     "axios": "^1.12.1",


### PR DESCRIPTION
## Summary

I fixed issues with AWS Bedrock Converse API streaming that caused multiple errors during tool call execution and conversation history replay. The problems stemmed from Bedrock's unique streaming behavior where it sends the same `contentBlockIndex` for different content types, and from our tool call handling creating empty content blocks that providers reject.

- Created `CustomChatBedrockConverse` wrapper class in `src/llm/bedrock/index.ts` that intercepts Bedrock stream chunks and recursively strips `contentBlockIndex` from `response_metadata` to prevent LangChain's merge logic from encountering duplicate keys with mismatched types
- Fixed tool call step creation timing in `src/tools/handlers.ts` (`handleToolCallChunks` function) to create the tool_calls step immediately upon receiving the first chunk, ensuring deltas are dispatched to the correct step instead of the message_creation step
- Removed dispatching of empty text blocks with `tool_call_ids` from both `handleToolCallChunks` and `handleToolCalls` functions in `src/tools/handlers.ts`, eliminating the root cause of "messages must have non-empty content" errors during conversation history replay
- Updated provider configuration in `src/llm/providers.ts` to use `CustomChatBedrockConverse` instead of the standard `ChatBedrockConverse` from `@langchain/aws`
- Updated type definitions in `src/types/llm.ts` to reflect the new custom Bedrock wrapper class in the `ChatModelMap` type

**Root Causes:**

1. **contentBlockIndex conflicts**: Bedrock sends the same `contentBlockIndex` value for both text and tool_use content blocks. LangChain's `AIMessageChunk.concat()` merge logic (`_mergeDicts` in `@langchain/core/dist/messages/base.js:293`) fails when encountering duplicate keys with different value types, logging "field[contentBlockIndex] already exists in this message chunk and value has unsupported type"

2. **Step association mismatch**: Tool call delta events were being dispatched to message_creation steps before dedicated tool_calls steps were created, causing the content aggregator to attempt merging TEXT and TOOL_CALL content at the same index, resulting in "Content type mismatch" warnings

3. **Empty content validation**: Empty text blocks containing only `tool_call_ids` metadata were stored in conversation history and rejected by both Anthropic ("messages must have non-empty content except for the optional final assistant message") and Bedrock ("The content field in the Message object at messages.X is empty") when replayed in subsequent conversation turns

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested with the tools.ts script using Bedrock provider with tool call streaming and verified all error messages are eliminated.

### **Test Configuration**:

npm run tool  # Uses Bedrock with Calculator tool**Verified fixes for:**
- ✅ Zero "Content type mismatch" errors (previously ~18 per run)
- ✅ Zero "field[contentBlockIndex] already exists" errors (previously ~18 per run) 
- ✅ Tool call streaming works correctly with multiple sequential tool invocations
- ✅ Conversation history replay works without empty content validation errors
- ✅ Multiple parallel tool calls execute successfully
- ✅ Content aggregation produces correct output structure

**Test output shows:**
- Successful calculator tool invocations with streaming deltas
- Proper step sequencing (message_creation at index 0, tool_calls at index 1, etc.)
- Clean final content aggregation with text and tool_call parts at different indices
- Complete multi-turn conversation with calculations

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes