### PR TITLE
➕ style: Update "Copy Agent" Icon for Clearer Action

### DIFF
--- a/client/src/components/Conversations/ConvoOptions/ConvoOptions.tsx
+++ b/client/src/components/Conversations/ConvoOptions/ConvoOptions.tsx
@@ -2,7 +2,7 @@ import { useState, useId, useRef, memo, useCallback, useMemo } from 'react';
 import * as Menu from '@ariakit/react/menu';
 import { useParams, useNavigate } from 'react-router-dom';
 import { DropdownPopup, Spinner, useToastContext } from '@librechat/client';
-import { Ellipsis, Share2, Copy, Archive, Pen, Trash } from 'lucide-react';
+import { Ellipsis, Share2, CopyPlus, Archive, Pen, Trash } from 'lucide-react';
 import type { MouseEvent } from 'react';
 import {
   useDuplicateConversationMutation,
@@ -151,7 +151,7 @@ function ConvoOptions({
         icon: isDuplicateLoading ? (
           <Spinner className="size-4" />
         ) : (
-          <Copy className="icon-sm mr-2 text-text-primary" />
+          <CopyPlus className="icon-sm mr-2 text-text-primary" />
         ),
       },
       {

--- a/client/src/components/SidePanel/Agents/DuplicateAgent.tsx
+++ b/client/src/components/SidePanel/Agents/DuplicateAgent.tsx
@@ -1,4 +1,4 @@
-import { CopyIcon } from 'lucide-react';
+import { CopyPlus } from 'lucide-react';
 import { useToastContext, Button } from '@librechat/client';
 import { useDuplicateAgentMutation } from '~/data-provider';
 import { isEphemeralAgent } from '~/common';
@@ -41,7 +41,7 @@ export default function DuplicateAgent({ agent_id }: { agent_id: string }) {
       onClick={handleDuplicate}
     >
       <div className="flex w-full items-center justify-center gap-2 text-primary">
-        <CopyIcon className="size-4" />
+        <CopyPlus className="size-4" />
       </div>
     </Button>
   );


### PR DESCRIPTION
## Summary

This pull request updates the icon used for duplication actions across the application to improve consistency and clarity as suggested by @Pfaufisch. The `CopyPlus` icon from `lucide-react` replaces the previous `Copy` and `CopyIcon` icons in both conversation and agent duplication components

Closes #10645

## Change Type

- [x] Style update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
