### PR TITLE
🪄 style: Improved Input Collapse UI

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -260,36 +260,49 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
             <FileFormChat conversation={conversation} />
             {endpoint && (
               <div className={cn('flex', isRTL ? 'flex-row-reverse' : 'flex-row')}>
-                <TextareaAutosize
-                  {...registerProps}
-                  ref={(e) => {
-                    ref(e);
-                    (textAreaRef as React.MutableRefObject<HTMLTextAreaElement | null>).current = e;
-                  }}
-                  disabled={disableInputs || isNotAppendable}
-                  onPaste={handlePaste}
-                  onKeyDown={handleKeyDown}
-                  onKeyUp={handleKeyUp}
-                  onCompositionStart={handleCompositionStart}
-                  onCompositionEnd={handleCompositionEnd}
-                  id={mainTextareaId}
-                  tabIndex={0}
-                  data-testid="text-input"
-                  rows={1}
-                  onFocus={() => {
-                    handleFocusOrClick();
-                    setIsTextAreaFocused(true);
-                  }}
-                  onBlur={setIsTextAreaFocused.bind(null, false)}
-                  aria-label={localize('com_ui_message_input')}
-                  onClick={handleFocusOrClick}
-                  style={{ height: 44, overflowY: 'auto' }}
-                  className={cn(
-                    baseClasses,
-                    removeFocusRings,
-                    'transition-[max-height] duration-200 disabled:cursor-not-allowed',
+                <div className="relative flex-1">
+                  <TextareaAutosize
+                    {...registerProps}
+                    ref={(e) => {
+                      ref(e);
+                      (textAreaRef as React.MutableRefObject<HTMLTextAreaElement | null>).current =
+                        e;
+                    }}
+                    disabled={disableInputs || isNotAppendable}
+                    onPaste={handlePaste}
+                    onKeyDown={handleKeyDown}
+                    onKeyUp={handleKeyUp}
+                    onCompositionStart={handleCompositionStart}
+                    onCompositionEnd={handleCompositionEnd}
+                    id={mainTextareaId}
+                    tabIndex={0}
+                    data-testid="text-input"
+                    rows={1}
+                    onFocus={() => {
+                      handleFocusOrClick();
+                      setIsTextAreaFocused(true);
+                    }}
+                    onBlur={setIsTextAreaFocused.bind(null, false)}
+                    aria-label={localize('com_ui_message_input')}
+                    onClick={handleFocusOrClick}
+                    style={{ height: 44, overflowY: 'auto' }}
+                    className={cn(
+                      baseClasses,
+                      removeFocusRings,
+                      'transition-[max-height] duration-200 disabled:cursor-not-allowed',
+                    )}
+                  />
+                  {isCollapsed && (
+                    <div
+                      className="pointer-events-none absolute bottom-0 left-0 right-0 h-8"
+                      style={{
+                        background: isTemporary
+                          ? 'linear-gradient(to top, rgba(139, 92, 246, 0.1) 0%, rgba(139, 92, 246, 0.08) 20%, rgba(139, 92, 246, 0.05) 60%, transparent 80%)'
+                          : 'linear-gradient(to top, var(--surface-chat) 0%, var(--surface-chat) 20%, transparent 80%)',
+                      }}
+                    />
                   )}
-                />
+                </div>
                 <div className="flex flex-col items-start justify-start pr-2.5 pt-1.5">
                   <CollapseChat
                     isCollapsed={isCollapsed}

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -297,7 +297,7 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
                       className="pointer-events-none absolute bottom-0 left-0 right-0 h-8"
                       style={{
                         background: isTemporary
-                          ? 'linear-gradient(to top, rgba(139, 92, 246, 0.1) 0%, rgba(139, 92, 246, 0.08) 20%, rgba(139, 92, 246, 0.05) 60%, transparent 80%)'
+                          ? 'linear-gradient(to top, #E8E6EF 0%, #E8E6EF 20%, transparent 80%)'
                           : 'linear-gradient(to top, var(--surface-chat) 0%, var(--surface-chat) 20%, transparent 80%)',
                       }}
                     />

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useMemo, useEffect, useState, useCallback, useContext } from 'react';
+import { memo, useRef, useMemo, useEffect, useState, useCallback } from 'react';
 import { useWatch } from 'react-hook-form';
 import { TextareaAutosize } from '@librechat/client';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -34,15 +34,12 @@ import EditBadges from './EditBadges';
 import BadgeRow from './BadgeRow';
 import Mention from './Mention';
 import store from '~/store';
-import { ThemeContext, isDark } from '@librechat/client';
 
 const ChatForm = memo(({ index = 0 }: { index?: number }) => {
   const submitButtonRef = useRef<HTMLButtonElement>(null);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   useFocusChatEffect(textAreaRef);
   const localize = useLocalize();
-  const { theme } = useContext(ThemeContext);
-  const isThemeDark = isDark(theme);
 
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [, setIsScrollable] = useState(false);
@@ -297,11 +294,11 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
                   />
                   {isCollapsed && (
                     <div
-                      className="transition-200 pointer-events-none absolute bottom-0 left-0 right-0 h-8"
+                      className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 transition-all duration-200"
                       style={{
-                        background: isTemporary
-                          ? `linear-gradient(to top, ${isThemeDark ? '#212029' : '#E8E6EF'} 0%, ${isThemeDark ? '#212029' : '#E8E6EF'} 20%, transparent 70%)`
-                          : 'linear-gradient(to top, var(--surface-chat) 0%, var(--surface-chat) 20%, transparent 80%)',
+                        backdropFilter: 'blur(2px)',
+                        WebkitMaskImage: 'linear-gradient(to top, black 15%, transparent 75%)',
+                        maskImage: 'linear-gradient(to top, black 15%, transparent 75%)',
                       }}
                     />
                   )}

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -290,7 +290,7 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
                     'transition-[max-height] duration-200 disabled:cursor-not-allowed',
                   )}
                 />
-                <div className="flex flex-col items-start justify-start pt-1.5">
+                <div className="flex flex-col items-start justify-start pr-2.5 pt-1.5">
                   <CollapseChat
                     isCollapsed={isCollapsed}
                     isScrollable={isMoreThanThreeRows}

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useMemo, useEffect, useState, useCallback } from 'react';
+import { memo, useRef, useMemo, useEffect, useState, useCallback, useContext } from 'react';
 import { useWatch } from 'react-hook-form';
 import { TextareaAutosize } from '@librechat/client';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -34,12 +34,15 @@ import EditBadges from './EditBadges';
 import BadgeRow from './BadgeRow';
 import Mention from './Mention';
 import store from '~/store';
+import { ThemeContext, isDark } from '@librechat/client';
 
 const ChatForm = memo(({ index = 0 }: { index?: number }) => {
   const submitButtonRef = useRef<HTMLButtonElement>(null);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   useFocusChatEffect(textAreaRef);
   const localize = useLocalize();
+  const { theme } = useContext(ThemeContext);
+  const isThemeDark = isDark(theme);
 
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [, setIsScrollable] = useState(false);
@@ -294,10 +297,10 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
                   />
                   {isCollapsed && (
                     <div
-                      className="pointer-events-none absolute bottom-0 left-0 right-0 h-8"
+                      className="transition-200 pointer-events-none absolute bottom-0 left-0 right-0 h-8"
                       style={{
                         background: isTemporary
-                          ? 'linear-gradient(to top, #E8E6EF 0%, #E8E6EF 20%, transparent 80%)'
+                          ? `linear-gradient(to top, ${isThemeDark ? '#212029' : '#E8E6EF'} 0%, ${isThemeDark ? '#212029' : '#E8E6EF'} 20%, transparent 70%)`
                           : 'linear-gradient(to top, var(--surface-chat) 0%, var(--surface-chat) 20%, transparent 80%)',
                       }}
                     />

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -289,7 +289,7 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
                     className={cn(
                       baseClasses,
                       removeFocusRings,
-                      'transition-[max-height] duration-200 disabled:cursor-not-allowed',
+                      'scrollbar-hover transition-[max-height] duration-200 disabled:cursor-not-allowed',
                     )}
                   />
                   {isCollapsed && (

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1487,6 +1487,35 @@ button {
   background-color: transparent;
 }
 
+/* Show scrollbar only on hover */
+.scrollbar-hover {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.scrollbar-hover:hover {
+  scrollbar-color: var(--border-medium) transparent;
+}
+
+.dark .scrollbar-hover:hover {
+  scrollbar-color: var(--border-medium) transparent;
+}
+
+.scrollbar-hover::-webkit-scrollbar-thumb {
+  background-color: transparent;
+  transition: background-color 0.3s ease 0.5s;
+}
+
+.scrollbar-hover:hover::-webkit-scrollbar-thumb {
+  background-color: var(--border-medium);
+  transition-delay: 0s;
+}
+
+.dark .scrollbar-hover:hover::-webkit-scrollbar-thumb {
+  background-color: var(--border-medium);
+  transition-delay: 0s;
+}
+
 body,
 html {
   height: 100%;

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1497,21 +1497,12 @@ button {
   scrollbar-color: var(--border-medium) transparent;
 }
 
-.dark .scrollbar-hover:hover {
-  scrollbar-color: var(--border-medium) transparent;
-}
-
 .scrollbar-hover::-webkit-scrollbar-thumb {
   background-color: transparent;
   transition: background-color 0.3s ease 0.5s;
 }
 
 .scrollbar-hover:hover::-webkit-scrollbar-thumb {
-  background-color: var(--border-medium);
-  transition-delay: 0s;
-}
-
-.dark .scrollbar-hover:hover::-webkit-scrollbar-thumb {
   background-color: var(--border-medium);
   transition-delay: 0s;
 }


### PR DESCRIPTION
## Summary

This pull request improves the chat input UI by giving the collapse button chevron which appears when inputs exceed two lines a bit more padding away from the edge of the div, making the textarea scrollbar disappear when not needed, and adds a gradient blur to the bottom of the div to smooth the transition of overflowed text. 

### Reposition collapse chevron
- Moved the collapse button from outside the textarea container into the flex layout alongside the textarea for better visual integration.

### Add overflow gradient
- Implemented a gradient overlay at the bottom of collapsed textarea to smoothly fade overflowing text instead of showing a hard cutoff.

### Add hover-based scrollbar
- Created `.scrollbar-hover` CSS class that hides the scrollbar by default and reveals it on hover with a 0.5s delay and 0.3s fade transition.

## Screenshots

### Before
![Image 11-24-25 at 10 28 PM](https://github.com/user-attachments/assets/024c71e8-8346-4365-982b-e22a1a9ec266)
---
### After
![Image 11-24-25 at 10 26 PM](https://github.com/user-attachments/assets/8c7e8d65-7525-4982-b72d-eba01f5810b8)
---

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Manual Visual Testing in UI

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes