### PR TITLE
🍞 feat: Add Toasts for Successful Conversation Deletion

### DIFF
--- a/client/src/components/Conversations/ConvoOptions/DeleteButton.tsx
+++ b/client/src/components/Conversations/ConvoOptions/DeleteButton.tsx
@@ -55,6 +55,11 @@ export function DeleteConversationDialog({
       }
       setMenuOpen?.(false);
       retainView();
+      showToast({
+        message: localize('com_ui_convo_delete_success'),
+        severity: NotificationSeverity.SUCCESS,
+        showIcon: true,
+      });
     },
     onError: () => {
       showToast({

--- a/client/src/components/Nav/SettingsTabs/General/ArchivedChatsTable.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/ArchivedChatsTable.tsx
@@ -93,6 +93,11 @@ export default function ArchivedChatsTable({
     onSuccess: async () => {
       setIsDeleteOpen(false);
       await refetch();
+      showToast({
+        message: localize('com_ui_convo_delete_success') as string,
+        severity: NotificationSeverity.SUCCESS,
+        showIcon: true,
+      });
     },
     onError: (error: unknown) => {
       showToast({

--- a/client/src/components/Nav/SettingsTabs/General/ArchivedChatsTable.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/ArchivedChatsTable.tsx
@@ -94,7 +94,7 @@ export default function ArchivedChatsTable({
       setIsDeleteOpen(false);
       await refetch();
       showToast({
-        message: localize('com_ui_convo_delete_success') as string,
+        message: localize('com_ui_convo_delete_success'),
         severity: NotificationSeverity.SUCCESS,
         showIcon: true,
       });

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -799,6 +799,7 @@
   "com_ui_continue_oauth": "Continue with OAuth",
   "com_ui_controls": "Controls",
   "com_ui_convo_delete_error": "Failed to delete conversation",
+  "com_ui_convo_delete_success": "Conversation successfully deleted",
   "com_ui_copied": "Copied!",
   "com_ui_copied_to_clipboard": "Copied to clipboard",
   "com_ui_copy_code": "Copy code",


### PR DESCRIPTION
## Summary

This pull request enhances user feedback when deleting conversations by adding a success notification. Now, users will see a confirmation toast after successfully deleting a conversation, both from the conversation options and the archived chats table.

**User Experience Improvements:**

* Added a success toast notification after deleting a conversation in `DeleteConversationDialog` (`DeleteButton.tsx`), providing immediate feedback to users.
* Added a success toast notification after deleting a conversation in `ArchivedChatsTable`, ensuring consistent feedback across different deletion flows.

**Localization Update:**

* Added a new localized string `com_ui_convo_delete_success` to `translation.json` for the success message.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Visual Confirmation

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes