### PR TITLE
ℹ️ feat: Scrollable `InfoHoverCard` Content

### DIFF
--- a/packages/client/src/components/InfoHoverCard.tsx
+++ b/packages/client/src/components/InfoHoverCard.tsx
@@ -24,7 +24,7 @@ const InfoHoverCard = ({ side, text }: InfoHoverCardProps) => {
       </HoverCardTrigger>
       <HoverCardPortal>
         <HoverCardContent side={side} className="z-[999] w-80">
-          <div className="space-y-2">
+          <div className="max-h-[80vh] space-y-2 overflow-y-auto">
             <span className="text-sm text-text-secondary">{text}</span>
           </div>
         </HoverCardContent>


### PR DESCRIPTION
## Summary

This pull request includes a small UI improvement to the `InfoHoverCard` component. The change ensures that the hover card content is scrollable if it exceeds 80% of the viewport height, preventing overflow issues.

* Made the hover card content in `InfoHoverCard.tsx` scrollable with a maximum height of 80vh to handle long content gracefully.

## Screenshots

### Before
<img width="1497" height="959" alt="Screenshot 2025-11-26 at 2 54 45 PM" src="https://github.com/user-attachments/assets/780ee4b8-b2a6-4078-9aac-dc25560fca80" />

> Note the content clips off the page and is not scrollable

---
<img width="1728" height="959" alt="Screenshot 2025-11-26 at 11 54 36 AM" src="https://github.com/user-attachments/assets/d52c906e-dae1-43da-8d00-1386b4e4a09f" />

> Entire page extends downward to accommodate the hovercard

### After
<img width="1497" height="959" alt="Screenshot 2025-11-26 at 2 52 45 PM" src="https://github.com/user-attachments/assets/aa7aacbb-2cf4-4c9a-b69f-c258459fd5bb" />

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Verification of proper behavior in UI with MCP Tool info hovercard for sequentialthinking tool in sequential-thinking MCP server (has very long description to showcase scrolling and max height behavior 

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes