### PR TITLE
🖊️ fix: Add left border accent to active conversation for WCAG 1.4.11 Compliance

### DIFF
--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -132,8 +132,10 @@ export default function Conversation({ conversation, retainView, toggleNav }: Co
   return (
     <div
       className={cn(
-        'group relative flex h-12 w-full items-center rounded-lg transition-colors duration-200 md:h-9',
-        isActiveConvo ? 'bg-surface-active-alt' : 'hover:bg-surface-active-alt',
+        'group relative flex h-12 w-full items-center border-l-2 transition-[background-color] duration-200 md:h-9',
+        isActiveConvo
+          ? 'rounded-r-lg border-l-border-xheavy bg-surface-active-alt'
+          : 'rounded-lg border-l-transparent hover:bg-surface-active-alt',
       )}
       role="button"
       tabIndex={renaming ? -1 : 0}

--- a/client/src/components/Conversations/ConvoLink.tsx
+++ b/client/src/components/Conversations/ConvoLink.tsx
@@ -30,10 +30,7 @@ const ConvoLink: React.FC<ConvoLinkProps> = ({
     >
       {children}
       <div
-        className={cn(
-          'relative flex-1 grow overflow-hidden whitespace-nowrap',
-          isActiveConvo && 'italic',
-        )}
+        className="relative flex-1 grow overflow-hidden whitespace-nowrap"
         style={{ textOverflow: 'clip' }}
         onDoubleClick={(e) => {
           if (isSmallScreen) {


### PR DESCRIPTION

The active conversation state previously failed WCAG 1.4.11 Non-text Contrast requirements (~1.2:1 contrast ratio). Added a left border indicator using border-xheavy which provides 6:1+ contrast in both light and dark modes.

- Add border-l-2 with border-xheavy color for active state
- Conditionally apply rounded-r-lg (active) vs rounded-lg (inactive)
- Use transition-[background-color] to prevent border/radius animation glitch
