### PR TITLE
🪙 refactor: Remove Use of `CHECK_BALANCE` in Balance Scripts

### DIFF
--- a/config/add-balance.js
+++ b/config/add-balance.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const mongoose = require('mongoose');
-const { isEnabled, getBalanceConfig } = require('@librechat/api');
+const { getBalanceConfig } = require('@librechat/api');
 const { User } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { createTransaction } = require('~/models/Transaction');
@@ -33,15 +33,12 @@ const connect = require('./connect');
     // console.purple(`[DEBUG] Args Length: ${process.argv.length}`);
   }
 
-  if (!process.env.CHECK_BALANCE) {
+  const appConfig = await getAppConfig();
+  const balanceConfig = getBalanceConfig(appConfig);
+
+  if (!balanceConfig?.enabled) {
     console.red(
-      'Error: CHECK_BALANCE environment variable is not set! Configure it to use it: `CHECK_BALANCE=true`',
-    );
-    silentExit(1);
-  }
-  if (isEnabled(process.env.CHECK_BALANCE) === false) {
-    console.red(
-      'Error: CHECK_BALANCE environment variable is set to `false`! Please configure: `CHECK_BALANCE=true`',
+      'Error: Balance is not enabled. Use librechat.yaml to enable it',
     );
     silentExit(1);
   }
@@ -80,8 +77,6 @@ const connect = require('./connect');
    */
   let result;
   try {
-    const appConfig = await getAppConfig();
-    const balanceConfig = getBalanceConfig(appConfig);
     result = await createTransaction({
       user: user._id,
       tokenType: 'credits',

--- a/config/set-balance.js
+++ b/config/set-balance.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const mongoose = require('mongoose');
-const { isEnabled } = require('@librechat/api');
+const { getBalanceConfig } = require('@librechat/api');
 const { User, Balance } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { askQuestion, silentExit } = require('./helpers');
@@ -31,15 +31,10 @@ const connect = require('./connect');
     // console.purple(`[DEBUG] Args Length: ${process.argv.length}`);
   }
 
-  if (!process.env.CHECK_BALANCE) {
+  const balanceConfig = getBalanceConfig();
+  if (!balanceConfig?.enabled) {
     console.red(
-      'Error: CHECK_BALANCE environment variable is not set! Configure it to use it: `CHECK_BALANCE=true`',
-    );
-    silentExit(1);
-  }
-  if (isEnabled(process.env.CHECK_BALANCE) === false) {
-    console.red(
-      'Error: CHECK_BALANCE environment variable is set to `false`! Please configure: `CHECK_BALANCE=true`',
+      'Error: Balance is not enabled. Use librechat.yaml to enable it',
     );
     silentExit(1);
   }


### PR DESCRIPTION
`config/set_balance.js` and `config/add_balance.js` still use the `CHECK_BALANCE` variable. This PR makes them use the `getBalanceConfig` from the api.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested on my local instance

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
