### PR TITLE
📦 chore: Bump `@librechat/agents` to v3.0.33

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -47,7 +47,7 @@
     "@langchain/google-genai": "^0.2.13",
     "@langchain/google-vertexai": "^0.2.13",
     "@langchain/textsplitters": "^0.1.0",
-    "@librechat/agents": "^3.0.32",
+    "@librechat/agents": "^3.0.33",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@langchain/google-genai": "^0.2.13",
         "@langchain/google-vertexai": "^0.2.13",
         "@langchain/textsplitters": "^0.1.0",
-        "@librechat/agents": "^3.0.32",
+        "@librechat/agents": "^3.0.33",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -16263,9 +16263,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.0.32",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.0.32.tgz",
-      "integrity": "sha512-6g7lLuEpot3vrHqgDZzPyrISvUshyWRINdnvkQsQf951QjdcFZuqmQ9mpUcaNQbczHBS4k5DLYIBUK+qzG/eiw==",
+      "version": "3.0.33",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.0.33.tgz",
+      "integrity": "sha512-Y/bobhsAPgffq2RGEQU542EJR0Va3yZEJLCEZWSG9BqgHS1ekhIiwxdD3UjhAv1Efh1J5BN3+NX+vyVuoZDjQQ==",
       "license": "MIT",
       "dependencies": {
         "@langchain/anthropic": "^0.3.26",
@@ -46140,7 +46140,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
@@ -46180,7 +46180,7 @@
         "@azure/storage-blob": "^12.27.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.79",
-        "@librechat/agents": "^3.0.32",
+        "@librechat/agents": "^3.0.33",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.21.0",
         "axios": "^1.12.1",
@@ -46246,7 +46246,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^29.0.0",
@@ -46485,7 +46485,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.020",
+      "version": "0.8.100",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.1",
@@ -46544,7 +46544,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.23",
+      "version": "0.0.30",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -84,7 +84,7 @@
     "@azure/storage-blob": "^12.27.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.79",
-    "@librechat/agents": "^3.0.32",
+    "@librechat/agents": "^3.0.33",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.21.0",
     "axios": "^1.12.1",


### PR DESCRIPTION
The commit https://github.com/danny-avila/agents/commit/06a332b8ad88a69925e57f0a2be59036e275d453 prevents [`EventStreamCallbackHandler`](https://github.com/langchain-ai/langchainjs/blob/6f8fa47388fd5c5d2bc8476e29349720d8fe7784/libs/langchain-core/src/tracers/event_stream.ts#L148) from throwing on custom events.

Adds `ignoreCustomEvent: true` to streamEvents options to prevent LangChain's `EventStreamCallbackHandler` from processing custom events.

Custom events are already routed through `createCustomEventCallback()` to the handlerRegistry, so `EventStreamCallbackHandler` doesn't need to handle them. Without this flag, it throws "Run ID not found in run map" errors during parallel execution or when custom events are dispatched after run cleanup.