### PR TITLE
Refactor: Enable DB Methods Access in MCP Package

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -10,8 +10,8 @@ const {
   createSafeUser,
   mcpToolPattern,
   loadWebSearchAuth,
-  mcpServersRegistry,
 } = require('@librechat/api');
+const { getMCPServersRegistry } = require('~/config');
 const {
   Tools,
   Constants,
@@ -340,7 +340,10 @@ Current Date & Time: ${replaceSpecialVars({ text: '{{iso_datetime}}' })}
         /** Placeholder used for UI purposes */
         continue;
       }
-      if (serverName && (await mcpServersRegistry.getServerConfig(serverName, user)) == undefined) {
+      if (
+        serverName &&
+        (await getMCPServersRegistry().getServerConfig(serverName, user)) == undefined
+      ) {
         logger.warn(
           `MCP server "${serverName}" for "${toolName}" tool is not configured${agent?.id != null && agent.id ? ` but attached to "${agent.id}"` : ''}`,
         );

--- a/api/config/index.js
+++ b/api/config/index.js
@@ -1,6 +1,11 @@
 const { EventSource } = require('eventsource');
 const { Time } = require('librechat-data-provider');
-const { MCPManager, FlowStateManager, OAuthReconnectionManager } = require('@librechat/api');
+const {
+  MCPManager,
+  FlowStateManager,
+  MCPServersRegistry,
+  OAuthReconnectionManager,
+} = require('@librechat/api');
 const logger = require('./winston');
 
 global.EventSource = EventSource;
@@ -23,6 +28,8 @@ function getFlowStateManager(flowsCache) {
 
 module.exports = {
   logger,
+  createMCPServersRegistry: MCPServersRegistry.createInstance,
+  getMCPServersRegistry: MCPServersRegistry.getInstance,
   createMCPManager: MCPManager.createInstance,
   getMCPManager: MCPManager.getInstance,
   getFlowStateManager,

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -3,7 +3,6 @@ const { Tools, CacheKeys, Constants, FileSources } = require('librechat-data-pro
 const {
   MCPOAuthHandler,
   MCPTokenStorage,
-  mcpServersRegistry,
   normalizeHttpError,
   extractWebSearchEnvVars,
 } = require('@librechat/api');
@@ -34,9 +33,9 @@ const {
 const { updateUserPluginAuth, deleteUserPluginAuth } = require('~/server/services/PluginService');
 const { updateUserPluginsService, deleteUserKey } = require('~/server/services/UserService');
 const { verifyEmail, resendVerificationEmail } = require('~/server/services/AuthService');
+const { getMCPManager, getFlowStateManager, getMCPServersRegistry } = require('~/config');
 const { needsRefresh, getNewS3URL } = require('~/server/services/Files/S3/crud');
 const { processDeleteRequest } = require('~/server/services/Files/process');
-const { getMCPManager, getFlowStateManager } = require('~/config');
 const { getAppConfig } = require('~/server/services/Config');
 const { deleteToolCalls } = require('~/models/ToolCall');
 const { deleteUserPrompts } = require('~/models/Prompt');
@@ -321,9 +320,9 @@ const maybeUninstallOAuthMCP = async (userId, pluginKey, appConfig) => {
 
   const serverName = pluginKey.replace(Constants.mcp_prefix, '');
   const serverConfig =
-    (await mcpServersRegistry.getServerConfig(serverName, userId)) ??
+    (await getMCPServersRegistry().getServerConfig(serverName, userId)) ??
     appConfig?.mcpServers?.[serverName];
-  const oauthServers = await mcpServersRegistry.getOAuthServers();
+  const oauthServers = await getMCPServersRegistry().getOAuthServers();
   if (!oauthServers.has(serverName)) {
     // this server does not use OAuth, so nothing to do here as well
     return;

--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -5,8 +5,7 @@
 const { logger } = require('@librechat/data-schemas');
 const { Constants } = require('librechat-data-provider');
 const { cacheMCPServerTools, getMCPServerTools } = require('~/server/services/Config');
-const { getMCPManager } = require('~/config');
-const { mcpServersRegistry } = require('@librechat/api');
+const { getMCPManager, getMCPServersRegistry } = require('~/config');
 
 /**
  * Get all MCP tools available to the user
@@ -19,7 +18,7 @@ const getMCPTools = async (req, res) => {
       return res.status(401).json({ message: 'Unauthorized' });
     }
 
-    const mcpConfig = await mcpServersRegistry.getAllServerConfigs(userId);
+    const mcpConfig = await getMCPServersRegistry().getAllServerConfigs(userId);
     const configuredServers = mcpConfig ? Object.keys(mcpConfig) : [];
 
     if (!mcpConfig || Object.keys(mcpConfig).length == 0) {
@@ -69,7 +68,7 @@ const getMCPTools = async (req, res) => {
 
         // Get server config once
         const serverConfig = mcpConfig[serverName];
-        const rawServerConfig = await mcpServersRegistry.getServerConfig(serverName, userId);
+        const rawServerConfig = await getMCPServersRegistry().getServerConfig(serverName, userId);
 
         // Initialize server object with all server-level data
         const server = {
@@ -137,7 +136,7 @@ const getMCPServersList = async (req, res) => {
     // TODO - Ensure DB servers loaded into registry (configs only)
 
     // 2. Get all server configs from registry (YAML + DB)
-    const serverConfigs = await mcpServersRegistry.getAllServerConfigs(userId);
+    const serverConfigs = await getMCPServersRegistry().getAllServerConfigs(userId);
 
     return res.json(serverConfigs);
   } catch (error) {

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -6,9 +6,13 @@ const {
   MCPOAuthHandler,
   MCPTokenStorage,
   getUserMCPAuthMap,
-  mcpServersRegistry,
 } = require('@librechat/api');
-const { getMCPManager, getFlowStateManager, getOAuthReconnectionManager } = require('~/config');
+const {
+  getMCPManager,
+  getFlowStateManager,
+  getOAuthReconnectionManager,
+  getMCPServersRegistry,
+} = require('~/config');
 const { getMCPSetupData, getServerConnectionStatus } = require('~/server/services/MCP');
 const { findToken, updateToken, createToken, deleteTokens } = require('~/models');
 const { getUserPluginAuthValue } = require('~/server/services/PluginService');
@@ -365,7 +369,7 @@ router.post('/:serverName/reinitialize', requireJwtAuth, async (req, res) => {
     logger.info(`[MCP Reinitialize] Reinitializing server: ${serverName}`);
 
     const mcpManager = getMCPManager();
-    const serverConfig = await mcpServersRegistry.getServerConfig(serverName, user.id);
+    const serverConfig = await getMCPServersRegistry().getServerConfig(serverName, user.id);
     if (!serverConfig) {
       return res.status(404).json({
         error: `MCP server '${serverName}' not found in configuration`,
@@ -516,7 +520,7 @@ router.get('/:serverName/auth-values', requireJwtAuth, async (req, res) => {
       return res.status(401).json({ error: 'User not authenticated' });
     }
 
-    const serverConfig = await mcpServersRegistry.getServerConfig(serverName, user.id);
+    const serverConfig = await getMCPServersRegistry().getServerConfig(serverName, user.id);
     if (!serverConfig) {
       return res.status(404).json({
         error: `MCP server '${serverName}' not found in configuration`,
@@ -556,7 +560,7 @@ router.get('/:serverName/auth-values', requireJwtAuth, async (req, res) => {
 });
 
 async function getOAuthHeaders(serverName, userId) {
-  const serverConfig = await mcpServersRegistry.getServerConfig(serverName, userId);
+  const serverConfig = await getMCPServersRegistry().getServerConfig(serverName, userId);
   return serverConfig?.oauth_headers ?? {};
 }
 /**

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -20,12 +20,15 @@ const {
   ContentTypes,
   isAssistantsEndpoint,
 } = require('librechat-data-provider');
-const { getMCPManager, getFlowStateManager, getOAuthReconnectionManager } = require('~/config');
+const {
+  getMCPManager,
+  getFlowStateManager,
+  getOAuthReconnectionManager,
+  getMCPServersRegistry,
+} = require('~/config');
 const { findToken, createToken, updateToken } = require('~/models');
 const { reinitMCPServer } = require('./Tools/mcp');
-const { getAppConfig } = require('./Config');
 const { getLogStores } = require('~/cache');
-const { mcpServersRegistry } = require('@librechat/api');
 
 /**
  * @param {object} params
@@ -435,7 +438,7 @@ function createToolInstance({ res, toolName, serverName, toolDefinition, provide
  * @returns {Object} Object containing mcpConfig, appConnections, userConnections, and oauthServers
  */
 async function getMCPSetupData(userId) {
-  const mcpConfig = await mcpServersRegistry.getAllServerConfigs(userId);
+  const mcpConfig = await getMCPServersRegistry().getAllServerConfigs(userId);
 
   if (!mcpConfig) {
     throw new Error('MCP config not found');
@@ -450,7 +453,7 @@ async function getMCPSetupData(userId) {
     logger.error(`[MCP][User: ${userId}] Error getting app connections:`, error);
   }
   const userConnections = mcpManager.getUserConnections(userId) || new Map();
-  const oauthServers = await mcpServersRegistry.getOAuthServers(userId);
+  const oauthServers = await getMCPServersRegistry().getOAuthServers(userId);
 
   return {
     mcpConfig,

--- a/api/server/services/initializeMCPs.js
+++ b/api/server/services/initializeMCPs.js
@@ -1,6 +1,7 @@
+const mongoose = require('mongoose');
 const { logger } = require('@librechat/data-schemas');
 const { mergeAppTools, getAppConfig } = require('./Config');
-const { createMCPManager } = require('~/config');
+const { createMCPServersRegistry, createMCPManager } = require('~/config');
 
 /**
  * Initialize MCP servers
@@ -11,6 +12,9 @@ async function initializeMCPs() {
   if (!mcpServers) {
     return;
   }
+
+  // Initialize MCPServersRegistry first (required for MCPManager)
+  createMCPServersRegistry(mongoose);
 
   const mcpManager = await createMCPManager(mcpServers);
 

--- a/packages/api/src/mcp/ConnectionsRepository.ts
+++ b/packages/api/src/mcp/ConnectionsRepository.ts
@@ -1,7 +1,7 @@
 import { logger } from '@librechat/data-schemas';
 import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
 import { MCPConnection } from './connection';
-import { mcpServersRegistry as registry } from '~/mcp/registry/MCPServersRegistry';
+import { MCPServersRegistry } from '~/mcp/registry/MCPServersRegistry';
 import type * as t from './types';
 
 /**
@@ -25,7 +25,7 @@ export class ConnectionsRepository {
 
   /** Checks whether this repository can connect to a specific server */
   async has(serverName: string): Promise<boolean> {
-    const config = await registry.getServerConfig(serverName, this.ownerId);
+    const config = await MCPServersRegistry.getInstance().getServerConfig(serverName, this.ownerId);
     const canConnect = !!config && this.isAllowedToConnectToServer(config);
     if (!canConnect) {
       //if connection is no longer possible we attempt to disconnect any leftover connections
@@ -36,7 +36,10 @@ export class ConnectionsRepository {
 
   /** Gets or creates a connection for the specified server with lazy loading */
   async get(serverName: string): Promise<MCPConnection | null> {
-    const serverConfig = await registry.getServerConfig(serverName, this.ownerId);
+    const serverConfig = await MCPServersRegistry.getInstance().getServerConfig(
+      serverName,
+      this.ownerId,
+    );
 
     const existingConnection = this.connections.get(serverName);
     if (!serverConfig || !this.isAllowedToConnectToServer(serverConfig)) {
@@ -94,7 +97,7 @@ export class ConnectionsRepository {
   async getAll(): Promise<Map<string, MCPConnection>> {
     //TODO in the future we should use a scoped config getter (APPLevel, UserLevel, Private)
     //for now the absent config will not throw error
-    const allConfigs = await registry.getAllServerConfigs(this.ownerId);
+    const allConfigs = await MCPServersRegistry.getInstance().getAllServerConfigs(this.ownerId);
     return this.getMany(Object.keys(allConfigs));
   }
 

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -11,7 +11,7 @@ import { UserConnectionManager } from './UserConnectionManager';
 import { ConnectionsRepository } from './ConnectionsRepository';
 import { MCPServerInspector } from './registry/MCPServerInspector';
 import { MCPServersInitializer } from './registry/MCPServersInitializer';
-import { mcpServersRegistry as registry } from './registry/MCPServersRegistry';
+import { MCPServersRegistry } from './registry/MCPServersRegistry';
 import { formatToolContent } from './parsers';
 import { MCPConnection } from './connection';
 import { processMCPEnv } from '~/utils/env';
@@ -69,7 +69,7 @@ export class MCPManager extends UserConnectionManager {
   /** Returns all available tool functions from app-level connections */
   public async getAppToolFunctions(): Promise<t.LCAvailableTools> {
     const toolFunctions: t.LCAvailableTools = {};
-    const configs = await registry.getAllServerConfigs();
+    const configs = await MCPServersRegistry.getInstance().getAllServerConfigs();
     for (const config of Object.values(configs)) {
       if (config.toolFunctions != null) {
         Object.assign(toolFunctions, config.toolFunctions);
@@ -115,7 +115,7 @@ export class MCPManager extends UserConnectionManager {
    */
   private async getInstructions(serverNames?: string[]): Promise<Record<string, string>> {
     const instructions: Record<string, string> = {};
-    const configs = await registry.getAllServerConfigs();
+    const configs = await MCPServersRegistry.getInstance().getAllServerConfigs();
     for (const [serverName, config] of Object.entries(configs)) {
       if (config.serverInstructions != null) {
         instructions[serverName] = config.serverInstructions as string;
@@ -216,7 +216,10 @@ Please follow these instructions when using tools from the respective MCP server
         );
       }
 
-      const rawConfig = (await registry.getServerConfig(serverName, userId)) as t.MCPOptions;
+      const rawConfig = (await MCPServersRegistry.getInstance().getServerConfig(
+        serverName,
+        userId,
+      )) as t.MCPOptions;
       const currentOptions = processMCPEnv({
         user,
         options: rawConfig,

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -1,7 +1,7 @@
 import { logger } from '@librechat/data-schemas';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
-import { mcpServersRegistry as serversRegistry } from '~/mcp/registry/MCPServersRegistry';
+import { MCPServersRegistry } from '~/mcp/registry/MCPServersRegistry';
 import { MCPConnection } from './connection';
 import type * as t from './types';
 import { ConnectionsRepository } from '~/mcp/ConnectionsRepository';
@@ -61,7 +61,7 @@ export abstract class UserConnectionManager {
       );
     }
 
-    const config = await serversRegistry.getServerConfig(serverName, userId);
+    const config = await MCPServersRegistry.getInstance().getServerConfig(serverName, userId);
 
     const userServerMap = this.userConnections.get(userId);
     let connection = forceNew ? undefined : userServerMap?.get(serverName);

--- a/packages/api/src/mcp/__tests__/ConnectionsRepository.test.ts
+++ b/packages/api/src/mcp/__tests__/ConnectionsRepository.test.ts
@@ -21,18 +21,21 @@ jest.mock('../MCPConnectionFactory', () => ({
 jest.mock('../connection');
 
 // Mock the registry
+const mockRegistryInstance = {
+  getServerConfig: jest.fn(),
+  getAllServerConfigs: jest.fn(),
+};
+
 jest.mock('../registry/MCPServersRegistry', () => ({
-  mcpServersRegistry: {
-    getServerConfig: jest.fn(),
-    getAllServerConfigs: jest.fn(),
+  MCPServersRegistry: {
+    getInstance: () => mockRegistryInstance,
   },
 }));
 
 const mockLogger = logger as jest.Mocked<typeof logger>;
 
-// Import mocked registry
-import { mcpServersRegistry as registry } from '../registry/MCPServersRegistry';
-const mockRegistry = registry as jest.Mocked<typeof registry>;
+// Use mocked registry instance
+const mockRegistry = mockRegistryInstance as jest.Mocked<typeof mockRegistryInstance>;
 
 describe('ConnectionsRepository', () => {
   let repository: ConnectionsRepository;

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -1,7 +1,6 @@
 import { logger } from '@librechat/data-schemas';
 import type * as t from '~/mcp/types';
 import { MCPManager } from '~/mcp/MCPManager';
-import { mcpServersRegistry } from '~/mcp/registry/MCPServersRegistry';
 import { MCPServersInitializer } from '~/mcp/registry/MCPServersInitializer';
 import { MCPServerInspector } from '~/mcp/registry/MCPServerInspector';
 import { ConnectionsRepository } from '~/mcp/ConnectionsRepository';
@@ -17,11 +16,15 @@ jest.mock('@librechat/data-schemas', () => ({
   },
 }));
 
+const mockRegistryInstance = {
+  getServerConfig: jest.fn(),
+  getAllServerConfigs: jest.fn(),
+  getOAuthServers: jest.fn(),
+};
+
 jest.mock('~/mcp/registry/MCPServersRegistry', () => ({
-  mcpServersRegistry: {
-    getServerConfig: jest.fn(),
-    getAllServerConfigs: jest.fn(),
-    getOAuthServers: jest.fn(),
+  MCPServersRegistry: {
+    getInstance: () => mockRegistryInstance,
   },
 }));
 
@@ -47,7 +50,7 @@ describe('MCPManager', () => {
 
     // Set up default mock implementations
     (MCPServersInitializer.initialize as jest.Mock).mockResolvedValue(undefined);
-    (mcpServersRegistry.getAllServerConfigs as jest.Mock).mockResolvedValue({});
+    (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({});
   });
 
   function mockAppConnections(
@@ -75,7 +78,7 @@ describe('MCPManager', () => {
 
   describe('getAppToolFunctions', () => {
     it('should return empty object when no servers have tool functions', async () => {
-      (mcpServersRegistry.getAllServerConfigs as jest.Mock).mockResolvedValue({
+      (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
         server1: { type: 'stdio', command: 'test', args: [] },
         server2: { type: 'stdio', command: 'test2', args: [] },
       });
@@ -109,7 +112,7 @@ describe('MCPManager', () => {
         },
       };
 
-      (mcpServersRegistry.getAllServerConfigs as jest.Mock).mockResolvedValue({
+      (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
         server1: {
           type: 'stdio',
           command: 'test',
@@ -145,7 +148,7 @@ describe('MCPManager', () => {
         },
       };
 
-      (mcpServersRegistry.getAllServerConfigs as jest.Mock).mockResolvedValue({
+      (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
         server1: {
           type: 'stdio',
           command: 'test',
@@ -174,7 +177,7 @@ describe('MCPManager', () => {
 
   describe('formatInstructionsForContext', () => {
     it('should return empty string when no servers have instructions', async () => {
-      (mcpServersRegistry.getAllServerConfigs as jest.Mock).mockResolvedValue({
+      (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
         server1: { type: 'stdio', command: 'test', args: [] },
         server2: { type: 'stdio', command: 'test2', args: [] },
       });
@@ -186,7 +189,7 @@ describe('MCPManager', () => {
     });
 
     it('should format instructions from multiple servers', async () => {
-      (mcpServersRegistry.getAllServerConfigs as jest.Mock).mockResolvedValue({
+      (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
         github: {
           type: 'sse',
           url: 'https://api.github.com',
@@ -211,7 +214,7 @@ describe('MCPManager', () => {
     });
 
     it('should filter instructions by server names when provided', async () => {
-      (mcpServersRegistry.getAllServerConfigs as jest.Mock).mockResolvedValue({
+      (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
         github: {
           type: 'sse',
           url: 'https://api.github.com',
@@ -243,7 +246,7 @@ describe('MCPManager', () => {
     });
 
     it('should handle servers with null or undefined instructions', async () => {
-      (mcpServersRegistry.getAllServerConfigs as jest.Mock).mockResolvedValue({
+      (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
         github: {
           type: 'sse',
           url: 'https://api.github.com',
@@ -272,7 +275,7 @@ describe('MCPManager', () => {
     });
 
     it('should return empty string when filtered servers have no instructions', async () => {
-      (mcpServersRegistry.getAllServerConfigs as jest.Mock).mockResolvedValue({
+      (mockRegistryInstance.getAllServerConfigs as jest.Mock).mockResolvedValue({
         github: {
           type: 'sse',
           url: 'https://api.github.com',

--- a/packages/api/src/mcp/oauth/OAuthReconnectionManager.ts
+++ b/packages/api/src/mcp/oauth/OAuthReconnectionManager.ts
@@ -4,7 +4,7 @@ import type { MCPOAuthTokens } from './types';
 import { OAuthReconnectionTracker } from './OAuthReconnectionTracker';
 import { FlowStateManager } from '~/flow/manager';
 import { MCPManager } from '~/mcp/MCPManager';
-import { mcpServersRegistry } from '~/mcp/registry/MCPServersRegistry';
+import { MCPServersRegistry } from '~/mcp/registry/MCPServersRegistry';
 
 const DEFAULT_CONNECTION_TIMEOUT_MS = 10_000; // ms
 
@@ -72,7 +72,7 @@ export class OAuthReconnectionManager {
 
     // 1. derive the servers to reconnect
     const serversToReconnect = [];
-    for (const serverName of await mcpServersRegistry.getOAuthServers()) {
+    for (const serverName of await MCPServersRegistry.getInstance().getOAuthServers()) {
       const canReconnect = await this.canReconnect(userId, serverName);
       if (canReconnect) {
         serversToReconnect.push(serverName);
@@ -104,7 +104,7 @@ export class OAuthReconnectionManager {
 
     logger.info(`${logPrefix} Attempting reconnection`);
 
-    const config = await mcpServersRegistry.getServerConfig(serverName, userId);
+    const config = await MCPServersRegistry.getInstance().getServerConfig(serverName, userId);
 
     const cleanupOnFailedReconnect = () => {
       this.reconnectionsTracker.setFailed(userId, serverName);

--- a/packages/api/src/mcp/registry/MCPServersInitializer.ts
+++ b/packages/api/src/mcp/registry/MCPServersInitializer.ts
@@ -5,7 +5,7 @@ import { logger } from '@librechat/data-schemas';
 import { ParsedServerConfig } from '~/mcp/types';
 import { sanitizeUrlForLogging } from '~/mcp/utils';
 import type * as t from '~/mcp/types';
-import { mcpServersRegistry as registry } from './MCPServersRegistry';
+import { MCPServersRegistry } from './MCPServersRegistry';
 
 const MCP_INIT_TIMEOUT_MS =
   process.env.MCP_INIT_TIMEOUT_MS != null ? parseInt(process.env.MCP_INIT_TIMEOUT_MS) : 30_000;
@@ -36,7 +36,7 @@ export class MCPServersInitializer {
     if (await isLeader()) {
       // Leader performs initialization
       await statusCache.reset();
-      await registry.reset();
+      await MCPServersRegistry.getInstance().reset();
       const serverNames = Object.keys(rawConfigs);
       await Promise.allSettled(
         serverNames.map((serverName) =>
@@ -59,7 +59,11 @@ export class MCPServersInitializer {
   /** Initializes a single server with all its metadata and adds it to appropriate collections */
   public static async initializeServer(serverName: string, rawConfig: t.MCPOptions): Promise<void> {
     try {
-      const config = await registry.addServer(serverName, rawConfig, 'CACHE');
+      const config = await MCPServersRegistry.getInstance().addServer(
+        serverName,
+        rawConfig,
+        'CACHE',
+      );
       MCPServersInitializer.logParsedConfig(serverName, config);
     } catch (error) {
       logger.error(`${MCPServersInitializer.prefix(serverName)} Failed to initialize:`, error);

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -14,13 +14,35 @@ import { IServerConfigsRepositoryInterface } from './ServerConfigsRepositoryInte
  *
  * Query priority: Cache configs are checked first, then DB configs.
  */
-class MCPServersRegistry {
+export class MCPServersRegistry {
+  private static instance: MCPServersRegistry;
+
   private readonly dbConfigsRepo: IServerConfigsRepositoryInterface;
   private readonly cacheConfigsRepo: IServerConfigsRepositoryInterface;
 
-  constructor() {
-    this.dbConfigsRepo = new ServerConfigsDB();
+  constructor(mongoose: typeof import('mongoose')) {
+    this.dbConfigsRepo = new ServerConfigsDB(mongoose);
     this.cacheConfigsRepo = ServerConfigsCacheFactory.create('App', false);
+  }
+
+  /** Creates and initializes the singleton MCPServersRegistry instance */
+  public static createInstance(mongoose: typeof import('mongoose')): MCPServersRegistry {
+    if (!mongoose) {
+      throw new Error('MCP Registry instance creation failed. mongoose is undefined');
+    }
+    if (MCPServersRegistry.instance) {
+      return MCPServersRegistry.instance;
+    }
+    MCPServersRegistry.instance = new MCPServersRegistry(mongoose);
+    return MCPServersRegistry.instance;
+  }
+
+  /** Returns the singleton MCPServersRegistry instance */
+  public static getInstance(): MCPServersRegistry {
+    if (!MCPServersRegistry.instance) {
+      throw new Error('MCPServersRegistry has not been initialized.');
+    }
+    return MCPServersRegistry.instance;
   }
 
   public async getServerConfig(
@@ -100,5 +122,3 @@ class MCPServersRegistry {
     }
   }
 }
-
-export const mcpServersRegistry = new MCPServersRegistry();

--- a/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
+++ b/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { ParsedServerConfig } from '~/mcp/types';
 import { IServerConfigsRepositoryInterface } from '../ServerConfigsRepositoryInterface';
-import { logger } from '@librechat/data-schemas';
+import { AllMethods, createMethods, logger } from '@librechat/data-schemas';
 
 /**
  * DB backed config storage
@@ -9,6 +9,11 @@ import { logger } from '@librechat/data-schemas';
  * Will handle Permission ACL
  */
 export class ServerConfigsDB implements IServerConfigsRepositoryInterface {
+  private _dbMethods: AllMethods;
+  constructor(mongoose: typeof import('mongoose')) {
+    this._dbMethods = createMethods(mongoose);
+  }
+
   public async add(serverName: string, config: ParsedServerConfig, userId?: string): Promise<void> {
     logger.debug('ServerConfigsDB add not yet implemented');
     return;
@@ -40,6 +45,9 @@ export class ServerConfigsDB implements IServerConfigsRepositoryInterface {
    */
   public async getAll(userId?: string): Promise<Record<string, ParsedServerConfig>> {
     logger.debug('ServerConfigsDB getAll not yet implemented');
+    const userInfo = await this._dbMethods.findUser({ _id: userId });
+    console.log(userInfo);
+    logger.debug('********DB Operation successful from MCP API PACKAGE********', userInfo);
     return {};
   }
 


### PR DESCRIPTION
## Motivation

The @librechat/api MCP package needs to consume database methods (like findUser, etc.) for the upcoming ServerConfigsDB implementation. Previously, MCPServersRegistry was a pre-instantiated singleton with no way to inject
the mongoose instance required to create these db methods.

## Solution

1. MCPServersRegistry Dependency Injection (packages/api/src/mcp/registry/MCPServersRegistry.ts)
- Changed from pre-instantiated singleton to createInstance(mongoose)/getInstance() pattern
- Passes mongoose to ServerConfigsDB, enabling db method access within the package

2. ServerConfigsDB Setup (packages/api/src/mcp/registry/db/ServerConfigsDB.ts)
- New repository class accepting mongoose in constructor
- Creates db methods via createMethods(mongoose) from @librechat/data-schemas
- **Placeholder CRUD methods ready for implementation of dynamic MCP server storage**
- As a proof of concept, I am fetching user object from db based on userId, and logging it in the console. 

3. API Consistency Updates
Replaced direct MCPServersRegistry.getInstance() calls with getMCPServersRegistry() from ~/config across all api/ folder files, matching the getMCPManager() pattern.

## Next Steps

Implement ServerConfigsDB CRUD methods for storing/retrieving dynamic MCP server configurations from the database.

## Change Type

Please delete any irrelevant options.

- [ ] New feature (non-breaking change which adds functionality)


## Testing

### Test Updates
- Added getMCPServersRegistry mock to test files.
- All tests are passing.


## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
