### PR TITLE
🖼️ fix: Resolve stuck pixel animation during image generation

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
@@ -145,8 +145,7 @@ export default function OpenAIImageGen({
         clearInterval(intervalRef.current);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialProgress, quality]);
+  }, [isSubmitting, initialProgress, quality]);
 
   useEffect(() => {
     if (initialProgress >= 1 || cancelled) {


### PR DESCRIPTION
## Summary

This pull request fixes a missing `isSubmitting` dependency in the `useEffect` hook of the OpenAI image generation component. Without this dependency, the animation would sometimes get stuck because the effect didn't re-run when image generation started.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Visual confirmation that the pixel animation now consistently progresses during image generation.

**Before:** Animation stuck in early state with minimal pixels

https://github.com/user-attachments/assets/7db5464b-52f3-4780-8d60-b6551151eaf7



**After:** Animation properly progresses, gradually filling with more pixels

https://github.com/user-attachments/assets/c494e6b7-5ec1-42ec-a60a-32a3aff2be27



## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes

---

_Submitting this pull request on behalf of EPS Software Engineering AG. We appreciate all the hard work that has gone into this project — thank you for making LibreChat!_
