### PR TITLE
⬇️ refactor: Improve Conversation JSON Export

### DIFF
--- a/client/src/hooks/Conversations/useExportConversation.ts
+++ b/client/src/hooks/Conversations/useExportConversation.ts
@@ -103,7 +103,7 @@ export default function useExportConversation({
     if (content.type === ContentTypes.TEXT) {
       // TEXT
       const textPart = content[ContentTypes.TEXT];
-      const text = typeof textPart === 'string' ? textPart : textPart.value;
+      const text = typeof textPart === 'string' ? textPart : (textPart?.value ?? '');
       return [sender, text];
     }
 
@@ -365,12 +365,8 @@ export default function useExportConversation({
       data['messages'] = messages;
     }
 
-    exportFromJSON({
-      data: data,
-      fileName: filename,
-      extension: 'json',
-      exportType: exportFromJSON.types.json,
-    });
+    /** Use JSON.stringify without indentation to minimize file size for deeply nested recursive exports */
+    download(JSON.stringify(data), `${filename}.json`, 'application/json');
   };
 
   const exportConversation = () => {


### PR DESCRIPTION
Updated the export logic in the useExportConversation hook to use JSON.stringify without indentation, reducing file size for deeply nested exports. Additionally, ensured safe access to text content by providing a fallback for undefined values.