### PR TITLE
🛠️ feat: Add Config Validation Bypass & Improve Error Handling

### DIFF
--- a/api/server/services/Config/loadCustomConfig.js
+++ b/api/server/services/Config/loadCustomConfig.js
@@ -85,26 +85,32 @@ Please specify a correct \`imageOutputType\` value (case-sensitive).
     let errorMessage = `Invalid custom config file at ${configPath}:
 ${JSON.stringify(result.error, null, 2)}`;
 
-    if (i === 0) {
-      logger.error(errorMessage);
-      const speechError = result.error.errors.find(
-        (err) =>
-          err.code === 'unrecognized_keys' &&
-          (err.message?.includes('stt') || err.message?.includes('tts')),
-      );
+    logger.error(errorMessage);
+    const speechError = result.error.errors.find(
+      (err) =>
+        err.code === 'unrecognized_keys' &&
+        (err.message?.includes('stt') || err.message?.includes('tts')),
+    );
 
-      if (speechError) {
-        logger.warn(`
+    if (speechError) {
+      logger.warn(`
 The Speech-to-text and Text-to-speech configuration format has recently changed.
 If you're getting this error, please refer to the latest documentation:
 
 https://www.librechat.ai/docs/configuration/stt_tts`);
-      }
-
-      i++;
     }
 
-    return null;
+    if (process.env.CONFIG_BYPASS_VALIDATION === 'true') {
+      logger.warn(
+        'CONFIG_BYPASS_VALIDATION is enabled. Continuing with default configuration despite validation errors.',
+      );
+      return null;
+    }
+
+    logger.error(
+      'Exiting due to invalid configuration. Set CONFIG_BYPASS_VALIDATION=true to bypass this check.',
+    );
+    process.exit(1);
   } else {
     if (printConfig) {
       logger.info('Custom config file loaded:');


### PR DESCRIPTION
## Summary

This PR introduces a `CONFIG_BYPASS_VALIDATION` option that lets the app continue with defaults even when custom config validation fails. Validation errors now either trigger an explicit exit or fall back gracefully, and logging has been streamlined for clearer diagnostics.

https://github.com/LibreChat-AI/librechat.ai/pull/456

Closes #9561

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

checked with both a correct and invalid librechat.yaml

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
