### PR TITLE
🔢 refactor: Replace Stray ResourceType String Literals

### DIFF
--- a/client/src/components/Prompts/Groups/ChatGroupItem.tsx
+++ b/client/src/components/Prompts/Groups/ChatGroupItem.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, memo, useRef } from 'react';
+import { PermissionBits, ResourceType } from 'librechat-data-provider';
 import { Menu as MenuIcon, Edit as EditIcon, EarthIcon, TextSearch } from 'lucide-react';
 import {
   DropdownMenu,
@@ -7,7 +8,6 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from '@librechat/client';
-import { PermissionBits, ResourceType } from 'librechat-data-provider';
 import type { TPromptGroup } from 'librechat-data-provider';
 import { useLocalize, useSubmitMessage, useCustomLink, useResourcePermissions } from '~/hooks';
 import VariableDialog from '~/components/Prompts/Groups/VariableDialog';

--- a/client/src/components/Prompts/Groups/ChatGroupItem.tsx
+++ b/client/src/components/Prompts/Groups/ChatGroupItem.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from '@librechat/client';
-import { PermissionBits } from 'librechat-data-provider';
+import { PermissionBits, ResourceType } from 'librechat-data-provider';
 import type { TPromptGroup } from 'librechat-data-provider';
 import { useLocalize, useSubmitMessage, useCustomLink, useResourcePermissions } from '~/hooks';
 import VariableDialog from '~/components/Prompts/Groups/VariableDialog';
@@ -34,7 +34,7 @@ function ChatGroupItem({
   );
 
   // Check permissions for the promptGroup
-  const { hasPermission } = useResourcePermissions('promptGroup', group._id || '');
+  const { hasPermission } = useResourcePermissions(ResourceType.PROMPTGROUP, group._id || '');
   const canEdit = hasPermission(PermissionBits.EDIT);
 
   const triggerButtonRef = useRef<HTMLButtonElement | null>(null);

--- a/client/src/components/Prompts/Groups/DashGroupItem.tsx
+++ b/client/src/components/Prompts/Groups/DashGroupItem.tsx
@@ -1,7 +1,7 @@
 import { memo, useState, useRef, useMemo, useCallback, KeyboardEvent } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
-import { EarthIcon, Pen } from 'lucide-react';
 import { Trans } from 'react-i18next';
+import { EarthIcon, Pen } from 'lucide-react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { PermissionBits, ResourceType, type TPromptGroup } from 'librechat-data-provider';
 import {
   Input,

--- a/client/src/components/Prompts/Groups/DashGroupItem.tsx
+++ b/client/src/components/Prompts/Groups/DashGroupItem.tsx
@@ -1,8 +1,8 @@
 import { memo, useState, useRef, useMemo, useCallback, KeyboardEvent } from 'react';
-import { EarthIcon, Pen } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { EarthIcon, Pen } from 'lucide-react';
 import { Trans } from 'react-i18next';
-import { PermissionBits, type TPromptGroup } from 'librechat-data-provider';
+import { PermissionBits, ResourceType, type TPromptGroup } from 'librechat-data-provider';
 import {
   Input,
   Label,
@@ -29,7 +29,7 @@ function DashGroupItemComponent({ group, instanceProjectId }: DashGroupItemProps
   const blurTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [nameInputValue, setNameInputValue] = useState(group.name);
 
-  const { hasPermission } = useResourcePermissions('promptGroup', group._id || '');
+  const { hasPermission } = useResourcePermissions(ResourceType.PROMPTGROUP, group._id || '');
   const canEdit = hasPermission(PermissionBits.EDIT);
   const canDelete = hasPermission(PermissionBits.DELETE);
 


### PR DESCRIPTION
## Summary

This pull request updates how resource permissions are checked for prompt groups in the `ChatGroupItem` and `DashGroupItem` components. The main change is to use the `ResourceType.PROMPTGROUP` enum instead of the hardcoded string `'promptGroup'` when invoking the `useResourcePermissions` hook, ensuring consistency and type safety across the codebase.

**Resource permission handling improvements:**

* Updated both `ChatGroupItem.tsx` and `DashGroupItem.tsx` to use `ResourceType.PROMPTGROUP` instead of the string `'promptGroup'` when calling `useResourcePermissions`, improving maintainability and reducing risk of typos. [[1]](diffhunk://#diff-ff6ac4654d188c11b83e962f29291a34fe46d9023398f74cfff1fd0cc55ac4b7L37-R37) [[2]](diffhunk://#diff-f90f37cb51b42d4acf378ff51a35ebeced1c1b60961740b42784b7515d9b60e8L32-R32)

**Imports and type usage updates:**

* Added `ResourceType` to imports from `librechat-data-provider` in both files to support the new usage. [[1]](diffhunk://#diff-ff6ac4654d188c11b83e962f29291a34fe46d9023398f74cfff1fd0cc55ac4b7L10-R10) [[2]](diffhunk://#diff-f90f37cb51b42d4acf378ff51a35ebeced1c1b60961740b42784b7515d9b60e8L2-R5)
## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

N/A

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes