### PR TITLE
💾 feat: add prompt caching support for Claude models on custom endpoints

### DIFF
--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -695,6 +695,8 @@ const openAI: SettingsConfiguration = [
   librechat.fileTokenLimit,
 ];
 
+const customAnthropic: SettingsConfiguration = [...openAI, anthropic.promptCache];
+
 const openAICol1: SettingsConfiguration = [
   baseDefinitions.model as SettingDefinition,
   librechat.modelLabel,
@@ -882,6 +884,7 @@ export const paramSettings: Record<string, SettingsConfiguration | undefined> = 
   [EModelEndpoint.openAI]: openAI,
   [EModelEndpoint.azureOpenAI]: openAI,
   [EModelEndpoint.custom]: openAI,
+  [`${EModelEndpoint.custom}-anthropic`]: customAnthropic,
   [EModelEndpoint.anthropic]: anthropicConfig,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.Anthropic}`]: bedrockAnthropic,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.MistralAI}`]: bedrockMistral,

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -111,6 +111,9 @@ export const getModelKey = (endpoint: EModelEndpoint | string, model: string) =>
     );
     return (provider ?? parts[0]) as BedrockProviders;
   }
+  if (endpoint === EModelEndpoint.custom && model.toLowerCase().includes(Providers.ANTHROPIC)) {
+    return Providers.ANTHROPIC;
+  }
   return model;
 };
 
@@ -866,8 +869,9 @@ export const tQueryParamsSchema = tConversationSchema
     topK: true,
     /** @endpoints google, anthropic */
     maxOutputTokens: true,
-    /** @endpoints anthropic */
+    /** @endpoints anthropic, bedrock, custom */
     promptCache: true,
+    /** @endpoints anthropic, google, bedrock */
     thinking: true,
     thinkingBudget: true,
     /** @endpoints bedrock */


### PR DESCRIPTION
## Summary


**Relevant Discussion:** https://github.com/danny-avila/LibreChat/issues/3953
Also: https://github.com/danny-avila/LibreChat/issues/5661

# OpenRouter Prompt Caching Support

OpenRouter supports explicit prompt caching but LibreChat doesn't support this via OpenRouter.
Nova, Claude, and Gemini models all support explicit prompt caching.

Relevant OpenRouter docs:
https://openrouter.ai/docs/guides/best-practices/prompt-caching#anthropic-claude

https://openrouter.ai/docs/guides/best-practices/prompt-caching#how-gemini-prompt-caching-works-on-openrouter

This PR adds support for Anthropic models on custom endpoints (including OpenRouter).

**Why only Anthropic models?**

1. Nova

I could not find any info about Nova prompt caching support on OpenRouter. Presumably it's not supported via OpenRouter. LibreChat already supports Nova prompt caching when using Bedrock endpoint.

2. Gemini
Gemini 2.5 flash/pro and gemini 3 preview support both explicit and implicit caching: https://ai.google.dev/gemini-api/docs/caching

Which eliminates most of the value-add from bringing support for Gemini explicit prompt caching. But it could be done. You'd also have to add it to the LibreChat Gemini endpoint. This PR decides that Gemini implicit caching is good enough for now.

3. Claude

- Claude models support only explicit prompt caching (not implicit). The savings are huge (90%!).
- LibreChat already supports explicit prompt caching for Claude and Nova models via the native Anthropic and Bedrock endpoints.
- LibreChat did not support prompt caching for OpenRouter users. This PR fixes that.

# Implementation

## Frontend

The frontend needs to determine if the user is using a custom endpoint with an Anthropic model. If so, we show the prompt caching toggle.

This is done by extending the existing `getModelKey` function in `schemas.ts` to detect custom endpoints with Anthropic models:

```typescript
if (endpoint === EModelEndpoint.custom && model.toLowerCase().includes(Providers.ANTHROPIC)) {
  return Providers.ANTHROPIC;
}
```

This generates a settings key `custom-anthropic`, which maps to a new `customAnthropic` configuration in `paramSettings` that includes the `promptCache` toggle.

This follows the same pattern used for Bedrock endpoints (e.g., `bedrock-anthropic`).

## Backend

In `OpenAIClient.js`, when OpenRouter is detected with prompt caching enabled and a supported model:

1. Set `this.supportsCacheControl = true` in the constructor
2. In `chatCompletion`, apply:
   - `anthropic-beta` headers via `getClaudeHeaders()`
   - `cache_control` markers to messages via `addCacheControl()`

## Files Changed

- `packages/data-provider/src/schemas.ts` - `getModelKey` returns `Providers.ANTHROPIC` for custom + anthropic models
- `packages/data-provider/src/parameterSettings.ts` - Added `customAnthropic` config with promptCache toggle
- `api/app/clients/OpenAIClient.js` - Backend cache control logic for OpenRouter

## Limitations

1. **Toggle shown for all Anthropic models on custom endpoints.** This mirrors the behavior of the native Anthropic endpoint, which shows the toggle regardless of whether the specific model supports caching. The backend's `checkPromptCacheSupport()` handles the actual validation.

2. **Works for any custom endpoint with Anthropic models.** Not just OpenRouter - any custom endpoint using model names containing "anthropic" (e.g., `anthropic/claude-3-opus`) will see the toggle. This is maybe feature, not a limitation?

## Change Type

- [x] New feature (non-breaking change which adds functionality)


## Documentation

I dont believe this requires a documention update. This adds a toggle that users expect to already be there. I'm open to discussion on this point.
Existing prompt caching docs:

- https://www.librechat.ai/docs/configuration/librechat_yaml/object_structure/config
- https://www.librechat.ai/docs/features/url_query#model-parameters

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
