### PR TITLE
🗣 feat: MCP Status Accessibility Improvements

### DIFF
--- a/client/src/components/MCP/CustomUserVarsSection.tsx
+++ b/client/src/components/MCP/CustomUserVarsSection.tsx
@@ -26,6 +26,7 @@ interface AuthFieldProps {
 
 function AuthField({ name, config, hasValue, control, errors }: AuthFieldProps) {
   const localize = useLocalize();
+  const statusText = hasValue ? localize('com_ui_set') : localize('com_ui_unset');
 
   return (
     <div className="space-y-2">
@@ -36,23 +37,25 @@ function AuthField({ name, config, hasValue, control, errors }: AuthFieldProps) 
           render={
             <div className="flex items-center gap-2">
               <Label htmlFor={name} className="text-sm font-medium">
-                {config.title}
+                {config.title} <span className="sr-only">({statusText})</span>
               </Label>
               <CircleHelpIcon className="h-6 w-6 cursor-help text-text-secondary transition-colors hover:text-text-primary" />
             </div>
           }
         />
-        {hasValue ? (
-          <div className="flex min-w-fit items-center gap-2 whitespace-nowrap rounded-full border border-border-light px-2 py-0.5 text-xs font-medium text-text-secondary">
-            <div className="h-1.5 w-1.5 rounded-full bg-green-500" />
-            <span>{localize('com_ui_set')}</span>
-          </div>
-        ) : (
-          <div className="flex min-w-fit items-center gap-2 whitespace-nowrap rounded-full border border-border-light px-2 py-0.5 text-xs font-medium text-text-secondary">
-            <div className="h-1.5 w-1.5 rounded-full border border-border-medium" />
-            <span>{localize('com_ui_unset')}</span>
-          </div>
-        )}
+        <div aria-hidden="true">
+          {hasValue ? (
+            <div className="flex min-w-fit items-center gap-2 whitespace-nowrap rounded-full border border-border-light px-2 py-0.5 text-xs font-medium text-text-secondary">
+              <div className="h-1.5 w-1.5 rounded-full bg-green-500" />
+              <span>{localize('com_ui_set')}</span>
+            </div>
+          ) : (
+            <div className="flex min-w-fit items-center gap-2 whitespace-nowrap rounded-full border border-border-light px-2 py-0.5 text-xs font-medium text-text-secondary">
+              <div className="h-1.5 w-1.5 rounded-full border border-border-medium" />
+              <span>{localize('com_ui_unset')}</span>
+            </div>
+          )}
+        </div>
       </div>
       <Controller
         name={name}

--- a/client/src/components/MCP/MCPConfigDialog.tsx
+++ b/client/src/components/MCP/MCPConfigDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { KeyRound, PlugZap, AlertTriangle } from 'lucide-react';
 import {
   Spinner,
@@ -44,24 +44,32 @@ export default function MCPConfigDialog({
     ? localize('com_ui_configure_mcp_variables_for', { 0: serverName })
     : `${serverName} MCP Server`;
 
-  const getStatusText = () => {
-    if (!serverStatus) return '';
-    const { connectionState, requiresOAuth } = serverStatus;
-
-    if (connectionState === 'connecting') return localize('com_ui_connecting');
-    if (connectionState === 'error') return localize('com_ui_error');
-    if (connectionState === 'connected') return localize('com_ui_active');
-    if (connectionState === 'disconnected') {
-      return requiresOAuth ? localize('com_ui_oauth') : localize('com_ui_offline');
+  const fullTitle = useMemo(() => {
+    if (!serverStatus) {
+      return localize('com_ui_mcp_dialog_title', {
+        serverName,
+        status: '',
+      });
     }
-    return '';
-  };
 
-  const statusText = getStatusText();
-  const fullTitle = localize('com_ui_mcp_dialog_title', {
-    serverName,
-    status: statusText,
-  });
+    const { connectionState, requiresOAuth } = serverStatus;
+    let statusText = '';
+
+    if (connectionState === 'connecting') {
+      statusText = localize('com_ui_connecting');
+    } else if (connectionState === 'error') {
+      statusText = localize('com_ui_error');
+    } else if (connectionState === 'connected') {
+      statusText = localize('com_ui_active');
+    } else if (connectionState === 'disconnected') {
+      statusText = requiresOAuth ? localize('com_ui_oauth') : localize('com_ui_offline');
+    }
+
+    return localize('com_ui_mcp_dialog_title', {
+      serverName,
+      status: statusText,
+    });
+  }, [serverStatus, serverName, localize]);
 
   // Helper function to render status badge based on connection state
   const renderStatusBadge = () => {

--- a/client/src/components/MCP/MCPConfigDialog.tsx
+++ b/client/src/components/MCP/MCPConfigDialog.tsx
@@ -44,6 +44,25 @@ export default function MCPConfigDialog({
     ? localize('com_ui_configure_mcp_variables_for', { 0: serverName })
     : `${serverName} MCP Server`;
 
+  const getStatusText = () => {
+    if (!serverStatus) return '';
+    const { connectionState, requiresOAuth } = serverStatus;
+
+    if (connectionState === 'connecting') return localize('com_ui_connecting');
+    if (connectionState === 'error') return localize('com_ui_error');
+    if (connectionState === 'connected') return localize('com_ui_active');
+    if (connectionState === 'disconnected') {
+      return requiresOAuth ? localize('com_ui_oauth') : localize('com_ui_offline');
+    }
+    return '';
+  };
+
+  const statusText = getStatusText();
+  const fullTitle = localize('com_ui_mcp_dialog_title', {
+    serverName,
+    status: statusText,
+  });
+
   // Helper function to render status badge based on connection state
   const renderStatusBadge = () => {
     if (!serverStatus) {
@@ -102,7 +121,10 @@ export default function MCPConfigDialog({
 
   return (
     <OGDialog open={isOpen} onOpenChange={onOpenChange}>
-      <OGDialogContent className="flex max-h-screen w-11/12 max-w-lg flex-col space-y-2">
+      <OGDialogContent
+        className="flex max-h-screen w-11/12 max-w-lg flex-col space-y-2"
+        title={fullTitle}
+      >
         <OGDialogHeader>
           <div className="flex items-center gap-3">
             <OGDialogTitle className="text-xl">

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -789,6 +789,7 @@
   "com_ui_complete_setup": "Complete Setup",
   "com_ui_concise": "Concise",
   "com_ui_configure_mcp_variables_for": "Configure Variables for {{0}}",
+  "com_ui_mcp_dialog_title": "Configure Variables for {{serverName}}. Server Status: {{status}}",
   "com_ui_confirm": "Confirm",
   "com_ui_confirm_action": "Confirm Action",
   "com_ui_confirm_admin_use_change": "Changing this setting will block access for admins, including yourself. Are you sure you want to proceed?",

--- a/packages/client/src/components/MultiSelect.tsx
+++ b/packages/client/src/components/MultiSelect.tsx
@@ -82,7 +82,7 @@ export default function MultiSelect<T extends string>({
           className={cn(
             'flex items-center justify-between gap-2 rounded-xl px-3 py-2 text-sm',
             'bg-surface-tertiary text-text-primary shadow-sm hover:cursor-pointer hover:bg-surface-hover',
-            'outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75',
+            'outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white',
             selectClassName,
             selectedValues.length > 0 && selectItemsClassName != null && selectItemsClassName,
           )}


### PR DESCRIPTION
## Summary

This pull request enhances the MCP configuration dialog and custom user variable section with improved accessibility, clearer status indicators, and more informative dialog titles. The changes focus on making server connection status more understandable for visually impaired users.

**Accessibility and Status Display Improvements:**

* Added a screen-reader-only status indicator to the `Label` in `AuthField` to clarify whether a customUserVar value is set or unset, so that visually impaired users do not have to rely solely on the set/unset badge for user variable fields. (`client/src/components/MCP/CustomUserVarsSection.tsx`) [[1]](diffhunk://#diff-2e21b7c04e320fc4abe0b69cea733b8172f429857bdac28445106166ab9b07d1R29) [[2]](diffhunk://#diff-2e21b7c04e320fc4abe0b69cea733b8172f429857bdac28445106166ab9b07d1L39-R46) [[3]](diffhunk://#diff-2e21b7c04e320fc4abe0b69cea733b8172f429857bdac28445106166ab9b07d1R59)

**MCP Dialog Title and Status Enhancements:**

* Implemented a new function to generate localized server status text, and updated the dialog's title announcement to include both the server name and its current status for better context. (`client/src/components/MCP/MCPConfigDialog.tsx`, `client/src/locales/en/translation.json`) [[1]](diffhunk://#diff-a4c402b12a6534bb25cac1179ef280015085f09bd9f321f9f38eee409550a65bR47-R65) [[2]](diffhunk://#diff-a4c402b12a6534bb25cac1179ef280015085f09bd9f321f9f38eee409550a65bL105-R127) [[3]](diffhunk://#diff-c0fa59f8385909de9f593c765770ac70cec3d86cbfc11c3e2e4749ecc5c0f476R792)

**UI Consistency:**

* Removed anomalous `focus-visible:ring-opacity-75` from the `MultiSelect` component for more consistent focus styling alongside the other focus outlines in the chat input's badge bar. (`packages/client/src/components/MultiSelect.tsx`)

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Verification of proper announcements for an active MCP server (filesystem), with a set and unset custom user variable (API Key)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes