### PR TITLE
🔨 fix: Update `expiresAt` timestamp for tokens

### DIFF
--- a/packages/data-schemas/src/methods/token.spec.ts
+++ b/packages/data-schemas/src/methods/token.spec.ts
@@ -418,6 +418,41 @@ describe('Token Methods - Detailed Tests', () => {
 
       expect(updated).toBeNull();
     });
+
+    test('should update expiresAt when expiresIn is provided', async () => {
+      const beforeUpdate = Date.now();
+      const newExpiresIn = 7200;
+
+      const updated = await methods.updateToken(
+        { token: 'update-token' },
+        { expiresIn: newExpiresIn },
+      );
+
+      const afterUpdate = Date.now();
+
+      expect(updated).toBeDefined();
+      expect(updated?.expiresAt).toBeDefined();
+
+      const expectedMinExpiry = beforeUpdate + newExpiresIn * 1000;
+      const expectedMaxExpiry = afterUpdate + newExpiresIn * 1000;
+
+      expect(updated!.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMinExpiry);
+      expect(updated!.expiresAt.getTime()).toBeLessThanOrEqual(expectedMaxExpiry);
+    });
+
+    test('should not modify expiresAt when expiresIn is not provided', async () => {
+      const original = await Token.findOne({ token: 'update-token' });
+      const originalExpiresAt = original!.expiresAt.getTime();
+
+      const updated = await methods.updateToken(
+        { token: 'update-token' },
+        { email: 'changed@example.com' },
+      );
+
+      expect(updated).toBeDefined();
+      expect(updated?.email).toBe('changed@example.com');
+      expect(updated!.expiresAt.getTime()).toBe(originalExpiresAt);
+    });
   });
 
   describe('deleteTokens', () => {

--- a/packages/data-schemas/src/methods/token.ts
+++ b/packages/data-schemas/src/methods/token.ts
@@ -35,7 +35,13 @@ export function createTokenMethods(mongoose: typeof import('mongoose')) {
   ): Promise<IToken | null> {
     try {
       const Token = mongoose.models.Token;
-      return await Token.findOneAndUpdate(query, updateData, { new: true });
+
+      const dataToUpdate = { ...updateData };
+      if (updateData?.expiresIn !== undefined) {
+        dataToUpdate.expiresAt = new Date(Date.now() + updateData.expiresIn * 1000);
+      }
+
+      return await Token.findOneAndUpdate(query, dataToUpdate, { new: true });
     } catch (error) {
       logger.debug('An error occurred while updating token:', error);
       throw error;

--- a/packages/data-schemas/src/types/token.ts
+++ b/packages/data-schemas/src/types/token.ts
@@ -34,6 +34,7 @@ export interface TokenUpdateData {
   identifier?: string;
   token?: string;
   expiresAt?: Date;
+  expiresIn?: number;
   metadata?: Map<string, unknown>;
 }
 


### PR DESCRIPTION
## Summary

This pull request fixes a bug in the `updateToken` method where the `expiresAt` timestamp was not being updated when tokens were refreshed.

The `storeTokens` function in `tokens.ts` passes `expiresIn` to `updateToken`, but the method was passing this directly to MongoDB without calculating the new `expiresAt` date.

The fix adds logic to calculate `expiresAt` from `expiresIn` in the `updateToken` method, similar to how `createToken` already handles this.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Added two unit tests in `token.spec.ts` to verify the fix
- Manually verified that the `expiresAt` value is correctly updated in MongoDB

**Before:** `updateToken` received `expiresIn` but `expiresAt` remained unchanged at its old value in the database

**After:** `expiresAt` is now calculated from `expiresIn` and persisted to the database

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

---

_Submitting this pull request on behalf of EPS Software Engineering AG_