### PR TITLE
🗑️ fix: Delete Conversation Titling Regression from #10650

### DIFF
--- a/client/src/components/Conversations/ConvoOptions/DeleteButton.tsx
+++ b/client/src/components/Conversations/ConvoOptions/DeleteButton.tsx
@@ -91,7 +91,7 @@ export function DeleteConversationDialog({
       <div id="delete-conversation-dialog" className="w-full truncate">
         <Trans
           i18nKey="com_ui_delete_confirm_strong"
-          values={{ item: title }}
+          values={{ title }}
           components={{ strong: <strong /> }}
         />
       </div>


### PR DESCRIPTION
## Summary

This pull request makes a small change to the `DeleteConversationDialog` component in `DeleteButton.tsx`. The change updates the way the conversation title is passed to the translation function, removing the `item` key and just passing `title` directly, which allows the value to be properly parsed and rendered rather than incorrectly rendered as '{{ title }}'.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Visual confirmation of proper titling in Delete modal and review of other potentially affected files (`DashGroupItem.tsx` and `ArchivedChatsTable.tsx`) to confirm no regression occurred within their usage of the Trans component

## Screenshots

### Before
<img width="1509" height="956" alt="Screenshot 2025-12-01 at 7 28 37 AM" src="https://github.com/user-attachments/assets/3ff6f14f-4d49-4963-bd0f-85c9c78bb2ca" />

### After
<img width="1509" height="956" alt="Screenshot 2025-12-01 at 7 28 13 AM" src="https://github.com/user-attachments/assets/7b797f70-97a5-449f-ba2f-fc76136933c6" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes