### PR TITLE
🔐 fix: Secure `iconURL` Handling

### DIFF
--- a/api/server/middleware/buildEndpointOption.js
+++ b/api/server/middleware/buildEndpointOption.js
@@ -61,17 +61,23 @@ async function buildEndpointOption(req, res, next) {
 
     try {
       currentModelSpec.preset.spec = spec;
-      if (currentModelSpec.iconURL != null && currentModelSpec.iconURL !== '') {
-        currentModelSpec.preset.iconURL = currentModelSpec.iconURL;
-      }
       parsedBody = parseCompactConvo({
         endpoint,
         endpointType,
         conversation: currentModelSpec.preset,
       });
+      if (currentModelSpec.iconURL != null && currentModelSpec.iconURL !== '') {
+        parsedBody.iconURL = currentModelSpec.iconURL;
+      }
     } catch (error) {
       logger.error(`Error parsing model spec for endpoint ${endpoint}`, error);
       return handleError(res, { text: 'Error parsing model spec' });
+    }
+  } else if (parsedBody.spec && appConfig.modelSpecs?.list) {
+    // Non-enforced mode: if spec is selected, derive iconURL from model spec
+    const modelSpec = appConfig.modelSpecs.list.find((s) => s.name === parsedBody.spec);
+    if (modelSpec?.iconURL) {
+      parsedBody.iconURL = modelSpec.iconURL;
     }
   }
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -269,6 +269,16 @@ export default [
         project: './packages/data-provider/tsconfig.json',
       },
     },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+    },
   },
   {
     files: ['./api/demo/**/*.ts'],

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -343,7 +343,11 @@ export const parseCompactConvo = ({
     throw new Error(`Unknown endpointType: ${endpointType}`);
   }
 
-  const convo = schema.parse(conversation) as s.TConversation | null;
+  // Strip iconURL from input before parsing - it should only be derived server-side
+  // from model spec configuration, not accepted from client requests
+  const { iconURL: _clientIconURL, ...conversationWithoutIconURL } = conversation;
+
+  const convo = schema.parse(conversationWithoutIconURL) as s.TConversation | null;
   // const { models, secondaryModels } = possibleValues ?? {};
   const { models } = possibleValues ?? {};
 


### PR DESCRIPTION
## Summary

I implemented security improvements for `iconURL` handling in conversation parsing and added a new ESLint rule to improve code quality.

- Updated the `buildEndpointOption` middleware to derive `iconURL` exclusively from model specs when not provided by the client, preventing potential malicious URL injection.
- Modified the `parseCompactConvo` function to strip `iconURL` from client-provided conversation inputs, ensuring this field is only set server-side.
- Added comprehensive tests validating the stripping of `iconURL` across OpenAI, Anthropic, Google, Agents, and Assistants endpoint types.
- Introduced an ESLint rule to warn about unused variables in the `data-provider` package, with patterns to ignore variables prefixed with underscores.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Verified that the new ESLint configuration correctly warns about unused variables while ignoring underscore-prefixed ones. Ran the new `parseCompactConvo` test suite to confirm `iconURL` is properly stripped from all endpoint types while preserving other conversation properties.

### **Test Configuration**:
- Node.js with Jest for unit testing
- ESLint with TypeScript plugin

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes