### PR TITLE
🔐 refactor: Improve MCP User Variable Description Rendering

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -64,6 +64,7 @@
     "copy-to-clipboard": "^3.3.3",
     "cross-env": "^7.0.3",
     "date-fns": "^3.3.1",
+    "dompurify": "^3.3.0",
     "downloadjs": "^1.4.7",
     "export-from-json": "^1.7.2",
     "filenamify": "^6.0.0",

--- a/client/src/components/MCP/CustomUserVarsSection.tsx
+++ b/client/src/components/MCP/CustomUserVarsSection.tsx
@@ -94,7 +94,7 @@ function AuthField({ name, config, hasValue, control, errors }: AuthFieldProps) 
       />
       {sanitizedDescription && (
         <p
-          className="text-xs text-text-secondary [&_a]:text-text-primary [&_a]:underline [&_a]:transition-colors hover:[&_a]:text-text-secondary-alt"
+          className="text-xs text-text-secondary [&_a]:text-blue-500 [&_a]:hover:underline"
           dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
         />
       )}

--- a/client/src/components/MCP/CustomUserVarsSection.tsx
+++ b/client/src/components/MCP/CustomUserVarsSection.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
+import DOMPurify from 'dompurify';
 import { useForm, Controller } from 'react-hook-form';
-import { Input, Label, Button, TooltipAnchor, CircleHelpIcon } from '@librechat/client';
+import { Input, Label, Button } from '@librechat/client';
 import { useMCPAuthValuesQuery } from '~/data-provider/Tools/queries';
 import { useLocalize } from '~/hooks';
 
@@ -27,21 +28,40 @@ interface AuthFieldProps {
 function AuthField({ name, config, hasValue, control, errors }: AuthFieldProps) {
   const localize = useLocalize();
 
+  const sanitizer = useMemo(() => {
+    const instance = DOMPurify();
+    instance.addHook('afterSanitizeAttributes', (node) => {
+      if (node.tagName && node.tagName === 'A') {
+        node.setAttribute('target', '_blank');
+        node.setAttribute('rel', 'noopener noreferrer');
+      }
+    });
+    return instance;
+  }, []);
+
+  const sanitizedDescription = useMemo(() => {
+    if (!config.description) {
+      return '';
+    }
+    try {
+      return sanitizer.sanitize(config.description, {
+        ALLOWED_TAGS: ['a', 'strong', 'b', 'em', 'i', 'br', 'code'],
+        ALLOWED_ATTR: ['href', 'class', 'target', 'rel'],
+        ALLOW_DATA_ATTR: false,
+        ALLOW_ARIA_ATTR: false,
+      });
+    } catch (error) {
+      console.error('Sanitization failed', error);
+      return config.description;
+    }
+  }, [config.description, sanitizer]);
+
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <TooltipAnchor
-          enableHTML={true}
-          description={config.description || ''}
-          render={
-            <div className="flex items-center gap-2">
-              <Label htmlFor={name} className="text-sm font-medium">
-                {config.title}
-              </Label>
-              <CircleHelpIcon className="h-6 w-6 cursor-help text-text-secondary transition-colors hover:text-text-primary" />
-            </div>
-          }
-        />
+        <Label htmlFor={name} className="text-sm font-medium">
+          {config.title}
+        </Label>
         {hasValue ? (
           <div className="flex min-w-fit items-center gap-2 whitespace-nowrap rounded-full border border-border-light px-2 py-0.5 text-xs font-medium text-text-secondary">
             <div className="h-1.5 w-1.5 rounded-full bg-green-500" />
@@ -66,12 +86,18 @@ function AuthField({ name, config, hasValue, control, errors }: AuthFieldProps) 
             placeholder={
               hasValue
                 ? localize('com_ui_mcp_update_var', { 0: config.title })
-                : `${localize('com_ui_mcp_enter_var', { 0: config.title })} ${localize('com_ui_optional')}`
+                : localize('com_ui_mcp_enter_var', { 0: config.title })
             }
             className="w-full rounded border border-border-medium bg-transparent px-2 py-1 text-text-primary placeholder:text-text-secondary focus:outline-none sm:text-sm"
           />
         )}
       />
+      {sanitizedDescription && (
+        <p
+          className="text-xs text-text-secondary [&_a]:text-text-primary [&_a]:underline [&_a]:transition-colors hover:[&_a]:text-text-secondary-alt"
+          dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
+        />
+      )}
       {errors[name] && <p className="text-xs text-red-500">{errors[name]?.message}</p>}
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -484,6 +484,7 @@
         "copy-to-clipboard": "^3.3.3",
         "cross-env": "^7.0.3",
         "date-fns": "^3.3.1",
+        "dompurify": "^3.3.0",
         "downloadjs": "^1.4.7",
         "export-from-json": "^1.7.2",
         "filenamify": "^6.0.0",
@@ -28441,11 +28442,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
+      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -46398,7 +46398,7 @@
         "@tanstack/react-virtual": "^3.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "dompurify": "^3.2.6",
+        "dompurify": "^3.3.0",
         "framer-motion": "^12.23.6",
         "i18next": "^24.2.2 || ^25.3.2",
         "i18next-browser-languagedetector": "^8.2.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -51,7 +51,7 @@
     "@tanstack/react-virtual": "^3.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "dompurify": "^3.2.6",
+    "dompurify": "^3.3.0",
     "framer-motion": "^12.23.6",
     "i18next": "^24.2.2 || ^25.3.2",
     "i18next-browser-languagedetector": "^8.2.0",


### PR DESCRIPTION
## Summary

I improved how user variable descriptions are displayed in the MCP CustomUserVarsSection component by replacing tooltip-based descriptions with inline text below inputs and adding proper HTML sanitization.

- Added DOMPurify to sanitize HTML content in user variable descriptions, allowing safe rendering of links and basic formatting tags
- Replaced TooltipAnchor with direct Label rendering for cleaner UI
- Added inline description display below input fields with styled link support
- Updated link styles to use blue color with hover underline for better visibility
- Updated DOMPurify to v3.3.0 across package dependencies for consistency
- Removed "(Optional)" text from placeholder for cleaner input appearance

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verify that MCP server user variable descriptions render correctly below their input fields, with any HTML links properly sanitized and styled.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings