### PR TITLE
📏 fix: `ModelSelector` Spacing Regression

### DIFF
--- a/client/src/components/Chat/Header.tsx
+++ b/client/src/components/Chat/Header.tsx
@@ -61,6 +61,7 @@ export default function Header() {
               className={cn(
                 'flex items-center gap-2',
                 !isSmallScreen ? 'transition-all duration-200 ease-in-out' : '',
+                !navVisible && !isSmallScreen ? 'pl-2' : '',
               )}
             >
               <ModelSelector startupConfig={startupConfig} />


### PR DESCRIPTION
## Summary

This pull request fixes a minor UI regression in the `Header` component. The change improves the layout by adding left padding when the navigation is hidden on non-small screens, ensuring consistent spacing.

* UI layout adjustment: Adds a `'pl-2'` class to the header container when `navVisible` is false and the screen is not small, improving spacing in the header. (`client/src/components/Chat/Header.tsx`)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before
<img width="1728" height="958" alt="Screenshot 2025-12-03 at 7 08 06 AM" src="https://github.com/user-attachments/assets/5550dd8e-a8ce-4cb6-af78-439fa6a6b20d" />

### After
<img width="1728" height="958" alt="Screenshot 2025-12-03 at 7 06 48 AM" src="https://github.com/user-attachments/assets/9dea1ba7-c0c8-48a4-a54e-b0a86dadcdae" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes