### PR TITLE
🪟 refactor: Portal Control for Shared View Settings and Google Balance Support

### DIFF
--- a/client/src/components/Nav/SettingsTabs/General/General.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/General.tsx
@@ -41,9 +41,11 @@ const toggleSwitchConfigs = [
 export const ThemeSelector = ({
   theme,
   onChange,
+  portal = true,
 }: {
   theme: string;
   onChange: (value: string) => void;
+  portal?: boolean;
 }) => {
   const localize = useLocalize();
 
@@ -67,6 +69,7 @@ export const ThemeSelector = ({
         testId="theme-selector"
         className="z-50"
         aria-labelledby={labelId}
+        portal={portal}
       />
     </div>
   );

--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -227,9 +227,13 @@ function ShareHeader({
                 <OGDialogTitle>{settingsLabel}</OGDialogTitle>
               </OGDialogHeader>
               <div className="flex flex-col gap-4 pt-2 text-sm">
-                <ThemeSelector theme={theme} onChange={onThemeChange} />
+                <div className="relative focus-within:z-[100]">
+                  <ThemeSelector theme={theme} onChange={onThemeChange} portal={false} />
+                </div>
                 <div className="bg-border-medium/60 h-px w-full" />
-                <LangSelector langcode={langcode} onChange={onLangChange} portal={false} />
+                <div className="relative focus-within:z-[100]">
+                  <LangSelector langcode={langcode} onChange={onLangChange} portal={false} />
+                </div>
               </div>
             </OGDialogContent>
           </OGDialog>

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1133,6 +1133,7 @@ export const supportsBalanceCheck = {
   [EModelEndpoint.azureAssistants]: true,
   [EModelEndpoint.azureOpenAI]: true,
   [EModelEndpoint.bedrock]: true,
+  [EModelEndpoint.google]: true,
 };
 
 export const visionModels = [


### PR DESCRIPTION
Closes #10781

## Summary

I added a portal prop to the ThemeSelector component and improved the dropdown behavior in the ShareView settings dialog, while also extending balance check support to the Google endpoint.

- Added optional `portal` prop to ThemeSelector component, defaulting to `true` for backward compatibility
- Set `portal={false}` for ThemeSelector in ShareView to keep dropdown within dialog bounds
- Wrapped ThemeSelector and LangSelector in ShareView with relative containers using `focus-within:z-[100]` for proper stacking context
- Added Google endpoint to the `supportsBalanceCheck` configuration in data-provider

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

1. Open a shared conversation view
2. Click the settings button to open the settings dialog
3. Verify the Theme selector dropdown renders correctly within the dialog (not portaled outside)
4. Verify the Language selector dropdown also renders correctly within the dialog
5. Confirm both dropdowns have proper z-index stacking when focused
6. Verify balance checking works for Google endpoint configurations

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes