### PR TITLE
📦 refactor: Request Message Sanitization for Smaller Final Response

### DIFF
--- a/api/server/middleware/abortMiddleware.js
+++ b/api/server/middleware/abortMiddleware.js
@@ -1,5 +1,5 @@
 const { logger } = require('@librechat/data-schemas');
-const { countTokens, isEnabled, sendEvent } = require('@librechat/api');
+const { countTokens, isEnabled, sendEvent, sanitizeMessageForTransmit } = require('@librechat/api');
 const { isAssistantsEndpoint, ErrorTypes, Constants } = require('librechat-data-provider');
 const { truncateText, smartTruncateText } = require('~/app/clients/prompts');
 const clearPendingReq = require('~/cache/clearPendingReq');
@@ -290,7 +290,7 @@ const createAbortController = (req, res, getAbortData, getReqData) => {
       title: conversation && !conversation.title ? null : conversation?.title || 'New Chat',
       final: true,
       conversation,
-      requestMessage: userMessage,
+      requestMessage: sanitizeMessageForTransmit(userMessage),
       responseMessage: responseMessage,
     };
   };

--- a/api/server/middleware/error.js
+++ b/api/server/middleware/error.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 const { logger } = require('@librechat/data-schemas');
 const { parseConvo } = require('librechat-data-provider');
-const { sendEvent, handleError } = require('@librechat/api');
+const { sendEvent, handleError, sanitizeMessageForTransmit } = require('@librechat/api');
 const { saveMessage, getMessages } = require('~/models/Message');
 const { getConvo } = require('~/models/Conversation');
 
@@ -71,7 +71,7 @@ const sendError = async (req, res, options, callback) => {
 
     return sendEvent(res, {
       final: true,
-      requestMessage: query?.[0] ? query[0] : requestMessage,
+      requestMessage: sanitizeMessageForTransmit(query?.[0] ?? requestMessage),
       responseMessage: errorMessage,
       conversation: convo,
     });

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -21,3 +21,4 @@ export { default as Tokenizer, countTokens } from './tokenizer';
 export * from './yaml';
 export * from './http';
 export * from './tokens';
+export * from './message';

--- a/packages/api/src/utils/message.spec.ts
+++ b/packages/api/src/utils/message.spec.ts
@@ -94,15 +94,17 @@ describe('sanitizeMessageForTransmit', () => {
     expect(result.text).toBe('Hello');
   });
 
-  it('should handle message with empty files array', () => {
+  it('should preserve empty files array (short-circuits mapping for empty arrays)', () => {
     const message = {
       messageId: 'msg-123',
-      files: [],
+      files: [] as { file_id: string }[],
     };
 
     const result = sanitizeMessageForTransmit(message);
 
     expect(result.files).toEqual([]);
+    // Shallow copy behavior: empty arrays skip the map operation, keeping same reference
+    expect(result.files).toBe(message.files);
   });
 
   it('should not modify original message object', () => {

--- a/packages/api/src/utils/message.spec.ts
+++ b/packages/api/src/utils/message.spec.ts
@@ -94,7 +94,7 @@ describe('sanitizeMessageForTransmit', () => {
     expect(result.text).toBe('Hello');
   });
 
-  it('should preserve empty files array (short-circuits mapping for empty arrays)', () => {
+  it('should create new array reference for empty files array (immutability)', () => {
     const message = {
       messageId: 'msg-123',
       files: [] as { file_id: string }[],
@@ -103,8 +103,8 @@ describe('sanitizeMessageForTransmit', () => {
     const result = sanitizeMessageForTransmit(message);
 
     expect(result.files).toEqual([]);
-    // Shallow copy behavior: empty arrays skip the map operation, keeping same reference
-    expect(result.files).toBe(message.files);
+    // New array reference ensures full immutability even for empty arrays
+    expect(result.files).not.toBe(message.files);
   });
 
   it('should not modify original message object', () => {

--- a/packages/api/src/utils/message.spec.ts
+++ b/packages/api/src/utils/message.spec.ts
@@ -1,0 +1,120 @@
+import { sanitizeFileForTransmit, sanitizeMessageForTransmit } from './message';
+
+describe('sanitizeFileForTransmit', () => {
+  it('should remove text field from file', () => {
+    const file = {
+      file_id: 'test-123',
+      filename: 'test.txt',
+      text: 'This is a very long text content that should be stripped',
+      bytes: 1000,
+    };
+
+    const result = sanitizeFileForTransmit(file);
+
+    expect(result.file_id).toBe('test-123');
+    expect(result.filename).toBe('test.txt');
+    expect(result.bytes).toBe(1000);
+    expect(result).not.toHaveProperty('text');
+  });
+
+  it('should remove _id and __v fields', () => {
+    const file = {
+      file_id: 'test-123',
+      _id: 'mongo-id',
+      __v: 0,
+      filename: 'test.txt',
+    };
+
+    const result = sanitizeFileForTransmit(file);
+
+    expect(result.file_id).toBe('test-123');
+    expect(result).not.toHaveProperty('_id');
+    expect(result).not.toHaveProperty('__v');
+  });
+
+  it('should not modify original file object', () => {
+    const file = {
+      file_id: 'test-123',
+      text: 'original text',
+    };
+
+    sanitizeFileForTransmit(file);
+
+    expect(file.text).toBe('original text');
+  });
+});
+
+describe('sanitizeMessageForTransmit', () => {
+  it('should remove fileContext from message', () => {
+    const message = {
+      messageId: 'msg-123',
+      text: 'Hello world',
+      fileContext: 'This is a very long context that should be stripped',
+    };
+
+    const result = sanitizeMessageForTransmit(message);
+
+    expect(result.messageId).toBe('msg-123');
+    expect(result.text).toBe('Hello world');
+    expect(result).not.toHaveProperty('fileContext');
+  });
+
+  it('should sanitize files array', () => {
+    const message = {
+      messageId: 'msg-123',
+      files: [
+        { file_id: 'file-1', text: 'long text 1', filename: 'a.txt' },
+        { file_id: 'file-2', text: 'long text 2', filename: 'b.txt' },
+      ],
+    };
+
+    const result = sanitizeMessageForTransmit(message);
+
+    expect(result.files).toHaveLength(2);
+    expect(result.files?.[0].file_id).toBe('file-1');
+    expect(result.files?.[0].filename).toBe('a.txt');
+    expect(result.files?.[0]).not.toHaveProperty('text');
+    expect(result.files?.[1]).not.toHaveProperty('text');
+  });
+
+  it('should handle null/undefined message', () => {
+    expect(sanitizeMessageForTransmit(null as unknown as object)).toBeNull();
+    expect(sanitizeMessageForTransmit(undefined as unknown as object)).toBeUndefined();
+  });
+
+  it('should handle message without files', () => {
+    const message = {
+      messageId: 'msg-123',
+      text: 'Hello',
+    };
+
+    const result = sanitizeMessageForTransmit(message);
+
+    expect(result.messageId).toBe('msg-123');
+    expect(result.text).toBe('Hello');
+  });
+
+  it('should handle message with empty files array', () => {
+    const message = {
+      messageId: 'msg-123',
+      files: [],
+    };
+
+    const result = sanitizeMessageForTransmit(message);
+
+    expect(result.files).toEqual([]);
+  });
+
+  it('should not modify original message object', () => {
+    const message = {
+      messageId: 'msg-123',
+      fileContext: 'original context',
+      files: [{ file_id: 'file-1', text: 'original text' }],
+    };
+
+    sanitizeMessageForTransmit(message);
+
+    expect(message.fileContext).toBe('original context');
+    expect(message.files[0].text).toBe('original text');
+  });
+});

--- a/packages/api/src/utils/message.ts
+++ b/packages/api/src/utils/message.ts
@@ -1,0 +1,66 @@
+import type { TFile, TMessage } from 'librechat-data-provider';
+
+/** Fields to strip from files before client transmission */
+const FILE_STRIP_FIELDS = ['text', '_id', '__v'] as const;
+
+/** Fields to strip from messages before client transmission */
+const MESSAGE_STRIP_FIELDS = ['fileContext'] as const;
+
+/**
+ * Strips large/unnecessary fields from a file object before transmitting to client.
+ * Use this within existing loops when building file arrays to avoid extra iterations.
+ *
+ * @param file - The file object to sanitize
+ * @returns A new file object without the stripped fields
+ *
+ * @example
+ * // Use in existing file processing loop:
+ * for (const attachment of client.options.attachments) {
+ *   if (messageFiles.has(attachment.file_id)) {
+ *     userMessage.files.push(sanitizeFileForTransmit(attachment));
+ *   }
+ * }
+ */
+export function sanitizeFileForTransmit<T extends Partial<TFile>>(
+  file: T,
+): Omit<T, (typeof FILE_STRIP_FIELDS)[number]> {
+  const sanitized = { ...file };
+  for (const field of FILE_STRIP_FIELDS) {
+    delete sanitized[field as keyof typeof sanitized];
+  }
+  return sanitized;
+}
+
+/**
+ * Sanitizes a message object before transmitting to client.
+ * Removes large fields like `fileContext` and strips `text` from embedded files.
+ *
+ * @param message - The message object to sanitize
+ * @returns A new message object safe for client transmission
+ *
+ * @example
+ * sendEvent(res, {
+ *   final: true,
+ *   requestMessage: sanitizeMessageForTransmit(userMessage),
+ *   responseMessage: response,
+ * });
+ */
+export function sanitizeMessageForTransmit<T extends Partial<TMessage>>(message: T): T {
+  if (!message) {
+    return message;
+  }
+
+  const sanitized = { ...message };
+
+  // Remove message-level fields
+  for (const field of MESSAGE_STRIP_FIELDS) {
+    delete sanitized[field as keyof typeof sanitized];
+  }
+
+  // Sanitize files array if present
+  if (Array.isArray(sanitized.files) && sanitized.files.length > 0) {
+    sanitized.files = sanitized.files.map((file) => sanitizeFileForTransmit(file));
+  }
+
+  return sanitized;
+}

--- a/packages/api/src/utils/message.ts
+++ b/packages/api/src/utils/message.ts
@@ -45,9 +45,11 @@ export function sanitizeFileForTransmit<T extends Partial<TFile>>(
  *   responseMessage: response,
  * });
  */
-export function sanitizeMessageForTransmit<T extends Partial<TMessage>>(message: T): T {
+export function sanitizeMessageForTransmit<T extends Partial<TMessage>>(
+  message: T,
+): Omit<T, (typeof MESSAGE_STRIP_FIELDS)[number]> {
   if (!message) {
-    return message;
+    return message as Omit<T, (typeof MESSAGE_STRIP_FIELDS)[number]>;
   }
 
   const sanitized = { ...message };
@@ -57,7 +59,7 @@ export function sanitizeMessageForTransmit<T extends Partial<TMessage>>(message:
     delete sanitized[field as keyof typeof sanitized];
   }
 
-  // Sanitize files array if present
+  // Explicitly replace the files array with a new sanitized array to avoid mutating nested objects
   if (Array.isArray(sanitized.files) && sanitized.files.length > 0) {
     sanitized.files = sanitized.files.map((file) => sanitizeFileForTransmit(file));
   }

--- a/packages/api/src/utils/message.ts
+++ b/packages/api/src/utils/message.ts
@@ -59,8 +59,8 @@ export function sanitizeMessageForTransmit<T extends Partial<TMessage>>(
     delete sanitized[field as keyof typeof sanitized];
   }
 
-  // Explicitly replace the files array with a new sanitized array to avoid mutating nested objects
-  if (Array.isArray(sanitized.files) && sanitized.files.length > 0) {
+  // Always create a new array when files exist to maintain full immutability
+  if (Array.isArray(sanitized.files)) {
     sanitized.files = sanitized.files.map((file) => sanitizeFileForTransmit(file));
   }
 


### PR DESCRIPTION
## Summary

I implemented `sanitizeFileForTransmit` and `sanitizeMessageForTransmit` utility functions to reduce payload sizes when transmitting data to the client.

- Added `sanitizeFileForTransmit` function that strips `text`, `_id`, and `__v` fields from file objects before transmission
- Added `sanitizeMessageForTransmit` function that removes `fileContext` from messages and sanitizes embedded file arrays
- Applied sanitization in the agents request controller when processing attachments and sending final events
- Updated `abortMiddleware` to sanitize user messages before transmission
- Updated error middleware to sanitize request messages in error responses
- Added comprehensive unit tests covering edge cases including null/undefined handling, empty arrays, and immutability verification

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Verified the new utility functions work correctly through unit tests that cover:
- Removal of specified fields from file objects
- Removal of `fileContext` from messages
- Proper sanitization of nested file arrays within messages
- Handling of null/undefined inputs
- Confirmation that original objects remain unmodified (immutability)

### Test Configuration
- Unit tests located in `packages/api/src/utils/message.spec.ts`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules