### PR TITLE
feat(helm): add service.loadBalancerClass support

### DIFF
--- a/helm/librechat/templates/service.yaml
+++ b/helm/librechat/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass | quote }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -169,6 +169,7 @@ securityContext:
 
 service:
   type: ClusterIP # LoadBalancer, NodePort, ClusterIP
+  loadBalancerClass: ""
   port: 3080
   targetPort: 3080
   containerPort: 3080


### PR DESCRIPTION
## Summary

Adds support for the optional Kubernetes `service.loadBalancerClass` field in the LibreChat Helm chart. This enables deployments that rely on custom or multiple load balancer controllers (e.g., Tailscale, Cilium, AKS custom LBs) to explicitly direct which controller provisions the LoadBalancer. The change is fully optional and preserves existing behavior when the field is not set.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

1. Helm template using the new feature:
```
service:
  type: LoadBalancer
  loadBalancerClass: tailscale
````
- [X] Verify the new Service definition includes `loadBalancerClass`.

2. Helm template using the old setup:
```
service:
  type: LoadBalancer
````
  And:
```
service:
  type: ClusterIP
````
- [X] Verify that in both scenarios, Service definition unchanged and no sign for: `loadBalancerClass`.

### **Test Configuration**:

* Chart version tested: 1.9.3
* Helm version: v4.0.1

## Checklist

- [ X] My code adheres to this project's style guidelines
- [ X] I have performed a self-review of my own code
- [ X] My changes do not introduce new warnings

