### PR TITLE
🔑 fix: Gemini Custom Endpoint Auth. for OAI-Compatible API

### DIFF
--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -121,9 +121,12 @@ export function getSafetySettings(
 export function getGoogleConfig(
   credentials: string | t.GoogleCredentials | undefined,
   options: t.GoogleConfigOptions = {},
+  acceptRawApiKey = false,
 ) {
   let creds: t.GoogleCredentials = {};
-  if (typeof credentials === 'string') {
+  if (acceptRawApiKey && typeof credentials === 'string') {
+    creds[AuthKeys.GOOGLE_API_KEY] = credentials;
+  } else if (typeof credentials === 'string') {
     try {
       creds = JSON.parse(credentials);
     } catch (err: unknown) {

--- a/packages/api/src/endpoints/openai/config.google.spec.ts
+++ b/packages/api/src/endpoints/openai/config.google.spec.ts
@@ -69,6 +69,26 @@ describe('getOpenAIConfig - Google Compatibility', () => {
         expect(result.tools).toEqual([]);
       });
 
+      it('should filter out googleSearch when web_search is only in modelOptions (not explicitly in addParams/defaultParams)', () => {
+        const apiKey = JSON.stringify({ GOOGLE_API_KEY: 'test-google-key' });
+        const endpoint = 'Gemini (Custom)';
+        const options = {
+          modelOptions: {
+            model: 'gemini-2.0-flash-exp',
+            web_search: true,
+          },
+          customParams: {
+            defaultParamsEndpoint: 'google',
+          },
+          reverseProxyUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+        };
+
+        const result = getOpenAIConfig(apiKey, options, endpoint);
+
+        /** googleSearch should be filtered out since web_search was not explicitly added via addParams or defaultParams */
+        expect(result.tools).toEqual([]);
+      });
+
       it('should handle web_search with mixed Google and OpenAI params in addParams', () => {
         const apiKey = JSON.stringify({ GOOGLE_API_KEY: 'test-google-key' });
         const endpoint = 'Gemini (Custom)';

--- a/packages/api/src/endpoints/openai/config.ts
+++ b/packages/api/src/endpoints/openai/config.ts
@@ -77,23 +77,28 @@ export function getOpenAIConfig(
       headers = Object.assign(headers ?? {}, transformed.configOptions?.defaultHeaders);
     }
   } else if (isGoogle) {
-    const googleResult = getGoogleConfig(apiKey, {
-      modelOptions,
-      reverseProxyUrl: baseURL ?? undefined,
-      authHeader: true,
-      addParams,
-      dropParams,
-      defaultParams,
-    });
+    const googleResult = getGoogleConfig(
+      apiKey,
+      {
+        modelOptions,
+        reverseProxyUrl: baseURL ?? undefined,
+        authHeader: true,
+        addParams,
+        dropParams,
+        defaultParams,
+      },
+      true,
+    );
     /** Transform handles addParams/dropParams - it knows about OpenAI params */
     const transformed = transformToOpenAIConfig({
       addParams,
       dropParams,
+      tools: googleResult.tools,
       llmConfig: googleResult.llmConfig,
       fromEndpoint: EModelEndpoint.google,
     });
     llmConfig = transformed.llmConfig;
-    tools = googleResult.tools;
+    tools = transformed.tools;
   } else {
     const openaiResult = getOpenAILLMConfig({
       azure,

--- a/packages/api/src/endpoints/openai/config.ts
+++ b/packages/api/src/endpoints/openai/config.ts
@@ -93,6 +93,7 @@ export function getOpenAIConfig(
     const transformed = transformToOpenAIConfig({
       addParams,
       dropParams,
+      defaultParams,
       tools: googleResult.tools,
       llmConfig: googleResult.llmConfig,
       fromEndpoint: EModelEndpoint.google,


### PR DESCRIPTION

## Summary

config used:

```yaml
endpoints:
  custom:
    - name: "Gemini"
      apiKey: "${CUSTOM_GOOGLE_API_KEY}"
      iconURL: "google"
      baseURL: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
      directEndpoint: true
      models:
        default: ["gemini-2.5-pro","gemini-2.5-flash","gemini-2.5-flash-lite","gemini-2.0-flash","gemini-2.0-flash-lite"]
        fetch: false
      customParams:
        defaultParamsEndpoint: 'google'
      addParams:
        web_search: true
      titleConvo: true
      titleMethod: "completion"
      titleModel: "current_model"
      modelDisplayLabel: "Gemini"
```

I fixed authentication errors that occurred when using Gemini as a custom endpoint with an OpenAI-compatible API, along with improvements to the configuration transformation logic.

- Added support for raw API key authentication in the Google config by introducing an `acceptRawApiKey` parameter
- Fixed tool handling in the OpenAI transform by properly passing tools through the transformation pipeline
- Filtered out Google-specific tools (like `googleSearch`) that have no OpenAI-compatible equivalent
- Expanded the list of Google-specific parameters to exclude during transformation, including `thinkingConfig`, `thinkingBudget`, and `includeThoughts`
- Refactored the `authOptions` handling to be more concise

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

To test these changes:

1. Configure Gemini as a custom endpoint using an OpenAI-compatible API setup
2. Verify authentication succeeds with a raw API key
3. Test that Google-specific tools are properly filtered when using the OAI-compatible endpoint
4. Confirm that thinking configuration parameters don't cause issues during transformation

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings