### PR TITLE
🕒 feat: Track terms acceptance timestamp

### DIFF
--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -78,7 +78,10 @@ const getTermsStatusController = async (req, res) => {
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
     }
-    res.status(200).json({ termsAccepted: !!user.termsAccepted });
+    res.status(200).json({
+      termsAccepted: !!user.termsAccepted,
+      termsAcceptedAt: user.termsAcceptedAt || null,
+    });
   } catch (error) {
     logger.error('Error fetching terms acceptance status:', error);
     res.status(500).json({ message: 'Error fetching terms acceptance status' });
@@ -87,7 +90,14 @@ const getTermsStatusController = async (req, res) => {
 
 const acceptTermsController = async (req, res) => {
   try {
-    const user = await User.findByIdAndUpdate(req.user.id, { termsAccepted: true }, { new: true });
+    const user = await User.findByIdAndUpdate(
+      req.user.id,
+      {
+        termsAccepted: true,
+        termsAcceptedAt: new Date(),
+      },
+      { new: true },
+    );
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
     }

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -90,14 +90,10 @@ const getTermsStatusController = async (req, res) => {
 
 const acceptTermsController = async (req, res) => {
   try {
-    const user = await User.findByIdAndUpdate(
-      req.user.id,
-      {
-        termsAccepted: true,
-        termsAcceptedAt: new Date(),
-      },
-      { new: true },
-    );
+    const user = await updateUser(req.user.id, {
+      termsAccepted: true,
+      termsAcceptedAt: new Date(),
+    });
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
     }

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -97,7 +97,10 @@ const acceptTermsController = async (req, res) => {
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
     }
-    res.status(200).json({ message: 'Terms accepted successfully' });
+    res.status(200).json({
+      message: 'Terms accepted successfully',
+      termsAcceptedAt: user.termsAcceptedAt,
+    });
   } catch (error) {
     logger.error('Error accepting terms:', error);
     res.status(500).json({ message: 'Error accepting terms' });

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -102,6 +102,16 @@ const getTermsStatusController = async (req, res) => {
 
 const acceptTermsController = async (req, res) => {
   try {
+    const existing = await db.getUserById(req.user.id, 'termsAccepted termsAcceptedAt');
+    if (!existing) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    if (existing.termsAccepted && existing.termsAcceptedAt) {
+      return res.status(200).json({
+        message: 'Terms accepted successfully',
+        termsAcceptedAt: existing.termsAcceptedAt,
+      });
+    }
     const user = await db.updateUser(req.user.id, {
       termsAccepted: true,
       termsAcceptedAt: new Date(),

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -86,11 +86,14 @@ const getUserController = async (req, res) => {
 
 const getTermsStatusController = async (req, res) => {
   try {
-    const user = await db.getUserById(req.user.id, 'termsAccepted');
+    const user = await db.getUserById(req.user.id, 'termsAccepted termsAcceptedAt');
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
     }
-    res.status(200).json({ termsAccepted: !!user.termsAccepted });
+    res.status(200).json({
+      termsAccepted: !!user.termsAccepted,
+      termsAcceptedAt: user.termsAcceptedAt || null,
+    });
   } catch (error) {
     logger.error('Error fetching terms acceptance status:', error);
     res.status(500).json({ message: 'Error fetching terms acceptance status' });
@@ -99,7 +102,10 @@ const getTermsStatusController = async (req, res) => {
 
 const acceptTermsController = async (req, res) => {
   try {
-    const user = await db.updateUser(req.user.id, { termsAccepted: true });
+    const user = await db.updateUser(req.user.id, {
+      termsAccepted: true,
+      termsAcceptedAt: new Date(),
+    });
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
     }

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -102,20 +102,7 @@ const getTermsStatusController = async (req, res) => {
 
 const acceptTermsController = async (req, res) => {
   try {
-    const existing = await db.getUserById(req.user.id, 'termsAccepted termsAcceptedAt');
-    if (!existing) {
-      return res.status(404).json({ message: 'User not found' });
-    }
-    if (existing.termsAccepted && existing.termsAcceptedAt) {
-      return res.status(200).json({
-        message: 'Terms accepted successfully',
-        termsAcceptedAt: existing.termsAcceptedAt,
-      });
-    }
-    const user = await db.updateUser(req.user.id, {
-      termsAccepted: true,
-      termsAcceptedAt: new Date(),
-    });
+    const user = await db.acceptTerms(req.user.id);
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
     }

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -109,7 +109,10 @@ const acceptTermsController = async (req, res) => {
     if (!user) {
       return res.status(404).json({ message: 'User not found' });
     }
-    res.status(200).json({ message: 'Terms accepted successfully' });
+    res.status(200).json({
+      message: 'Terms accepted successfully',
+      termsAcceptedAt: user.termsAcceptedAt,
+    });
   } catch (error) {
     logger.error('Error accepting terms:', error);
     res.status(500).json({ message: 'Error accepting terms' });

--- a/api/server/controllers/UserController.spec.js
+++ b/api/server/controllers/UserController.spec.js
@@ -40,6 +40,7 @@ jest.mock('~/models', () => {
     deleteConvos: jest.fn().mockResolvedValue(undefined),
     deleteFiles: jest.fn().mockResolvedValue(undefined),
     updateUser: jest.fn(),
+    acceptTerms: jest.fn(),
     getUserById: jest.fn().mockResolvedValue(null),
     findToken: jest.fn(),
     getFiles: jest.fn().mockResolvedValue([]),
@@ -116,7 +117,7 @@ const {
   verifyEmailController,
 } = require('./UserController');
 const { Group } = require('~/db/models');
-const { deleteConvos, getUserById, updateUser } = require('~/models');
+const { deleteConvos, acceptTerms } = require('~/models');
 const { verifyEmail, resendVerificationEmail } = require('~/server/services/AuthService');
 
 describe('verifyEmailController', () => {
@@ -268,26 +269,22 @@ describe('acceptTermsController', () => {
   });
 
   it('returns 404 when the user does not exist', async () => {
-    getUserById.mockResolvedValueOnce(null);
+    acceptTerms.mockResolvedValueOnce(null);
 
     await acceptTermsController({ user: { id: 'missing-user' } }, mockRes);
 
+    expect(acceptTerms).toHaveBeenCalledWith('missing-user');
     expect(mockRes.status).toHaveBeenCalledWith(404);
     expect(mockRes.json).toHaveBeenCalledWith({ message: 'User not found' });
-    expect(updateUser).not.toHaveBeenCalled();
   });
 
-  it('records the acceptance timestamp on first acceptance', async () => {
+  it('returns the recorded acceptance timestamp on success', async () => {
     const acceptedAt = new Date('2026-06-14T10:00:00.000Z');
-    getUserById.mockResolvedValueOnce({ termsAccepted: false, termsAcceptedAt: null });
-    updateUser.mockResolvedValueOnce({ termsAccepted: true, termsAcceptedAt: acceptedAt });
+    acceptTerms.mockResolvedValueOnce({ termsAccepted: true, termsAcceptedAt: acceptedAt });
 
     await acceptTermsController({ user: { id: 'user-id' } }, mockRes);
 
-    expect(updateUser).toHaveBeenCalledWith('user-id', {
-      termsAccepted: true,
-      termsAcceptedAt: expect.any(Date),
-    });
+    expect(acceptTerms).toHaveBeenCalledWith('user-id');
     expect(mockRes.status).toHaveBeenCalledWith(200);
     expect(mockRes.json).toHaveBeenCalledWith({
       message: 'Terms accepted successfully',
@@ -295,39 +292,13 @@ describe('acceptTermsController', () => {
     });
   });
 
-  it('preserves the original timestamp when terms were already accepted', async () => {
-    const originalAcceptedAt = new Date('2026-01-01T00:00:00.000Z');
-    getUserById.mockResolvedValueOnce({
-      termsAccepted: true,
-      termsAcceptedAt: originalAcceptedAt,
-    });
+  it('returns 500 when the update throws', async () => {
+    acceptTerms.mockRejectedValueOnce(new Error('db down'));
 
     await acceptTermsController({ user: { id: 'user-id' } }, mockRes);
 
-    expect(updateUser).not.toHaveBeenCalled();
-    expect(mockRes.status).toHaveBeenCalledWith(200);
-    expect(mockRes.json).toHaveBeenCalledWith({
-      message: 'Terms accepted successfully',
-      termsAcceptedAt: originalAcceptedAt,
-    });
-  });
-
-  it('backfills a timestamp for legacy accepted users without one', async () => {
-    const backfilledAt = new Date('2026-06-14T12:00:00.000Z');
-    getUserById.mockResolvedValueOnce({ termsAccepted: true, termsAcceptedAt: null });
-    updateUser.mockResolvedValueOnce({ termsAccepted: true, termsAcceptedAt: backfilledAt });
-
-    await acceptTermsController({ user: { id: 'legacy-user' } }, mockRes);
-
-    expect(updateUser).toHaveBeenCalledWith('legacy-user', {
-      termsAccepted: true,
-      termsAcceptedAt: expect.any(Date),
-    });
-    expect(mockRes.status).toHaveBeenCalledWith(200);
-    expect(mockRes.json).toHaveBeenCalledWith({
-      message: 'Terms accepted successfully',
-      termsAcceptedAt: backfilledAt,
-    });
+    expect(mockRes.status).toHaveBeenCalledWith(500);
+    expect(mockRes.json).toHaveBeenCalledWith({ message: 'Error accepting terms' });
   });
 });
 

--- a/api/server/controllers/UserController.spec.js
+++ b/api/server/controllers/UserController.spec.js
@@ -111,11 +111,12 @@ afterEach(async () => {
 const {
   deleteUserController,
   getUserController,
+  acceptTermsController,
   resendVerificationController,
   verifyEmailController,
 } = require('./UserController');
 const { Group } = require('~/db/models');
-const { deleteConvos } = require('~/models');
+const { deleteConvos, getUserById, updateUser } = require('~/models');
 const { verifyEmail, resendVerificationEmail } = require('~/server/services/AuthService');
 
 describe('verifyEmailController', () => {
@@ -253,6 +254,80 @@ describe('getUserController', () => {
     expect(sentUser).not.toHaveProperty('openidTokens');
     expect(sentUser).not.toHaveProperty('tokenset');
     expect(sentUser).not.toHaveProperty('safeLookingRuntimeField');
+  });
+});
+
+describe('acceptTermsController', () => {
+  const mockRes = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 404 when the user does not exist', async () => {
+    getUserById.mockResolvedValueOnce(null);
+
+    await acceptTermsController({ user: { id: 'missing-user' } }, mockRes);
+
+    expect(mockRes.status).toHaveBeenCalledWith(404);
+    expect(mockRes.json).toHaveBeenCalledWith({ message: 'User not found' });
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  it('records the acceptance timestamp on first acceptance', async () => {
+    const acceptedAt = new Date('2026-06-14T10:00:00.000Z');
+    getUserById.mockResolvedValueOnce({ termsAccepted: false, termsAcceptedAt: null });
+    updateUser.mockResolvedValueOnce({ termsAccepted: true, termsAcceptedAt: acceptedAt });
+
+    await acceptTermsController({ user: { id: 'user-id' } }, mockRes);
+
+    expect(updateUser).toHaveBeenCalledWith('user-id', {
+      termsAccepted: true,
+      termsAcceptedAt: expect.any(Date),
+    });
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      message: 'Terms accepted successfully',
+      termsAcceptedAt: acceptedAt,
+    });
+  });
+
+  it('preserves the original timestamp when terms were already accepted', async () => {
+    const originalAcceptedAt = new Date('2026-01-01T00:00:00.000Z');
+    getUserById.mockResolvedValueOnce({
+      termsAccepted: true,
+      termsAcceptedAt: originalAcceptedAt,
+    });
+
+    await acceptTermsController({ user: { id: 'user-id' } }, mockRes);
+
+    expect(updateUser).not.toHaveBeenCalled();
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      message: 'Terms accepted successfully',
+      termsAcceptedAt: originalAcceptedAt,
+    });
+  });
+
+  it('backfills a timestamp for legacy accepted users without one', async () => {
+    const backfilledAt = new Date('2026-06-14T12:00:00.000Z');
+    getUserById.mockResolvedValueOnce({ termsAccepted: true, termsAcceptedAt: null });
+    updateUser.mockResolvedValueOnce({ termsAccepted: true, termsAcceptedAt: backfilledAt });
+
+    await acceptTermsController({ user: { id: 'legacy-user' } }, mockRes);
+
+    expect(updateUser).toHaveBeenCalledWith('legacy-user', {
+      termsAccepted: true,
+      termsAcceptedAt: expect.any(Date),
+    });
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.json).toHaveBeenCalledWith({
+      message: 'Terms accepted successfully',
+      termsAcceptedAt: backfilledAt,
+    });
   });
 });
 

--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -1043,7 +1043,7 @@ export const useAcceptTermsMutation = (
     onSuccess: (data, variables, context) => {
       queryClient.setQueryData<t.TUserTermsResponse>([QueryKeys.userTerms], {
         termsAccepted: true,
-        termsAcceptedAt: new Date().toISOString(),
+        termsAcceptedAt: data.termsAcceptedAt,
       });
       options?.onSuccess?.(data, variables, context);
     },

--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -1043,6 +1043,7 @@ export const useAcceptTermsMutation = (
     onSuccess: (data, variables, context) => {
       queryClient.setQueryData<t.TUserTermsResponse>([QueryKeys.userTerms], {
         termsAccepted: true,
+        termsAcceptedAt: new Date().toISOString(),
       });
       options?.onSuccess?.(data, variables, context);
     },

--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -1089,7 +1089,7 @@ export const useAcceptTermsMutation = (
     onSuccess: (data, variables, context) => {
       queryClient.setQueryData<t.TUserTermsResponse>([QueryKeys.userTerms], {
         termsAccepted: true,
-        termsAcceptedAt: new Date().toISOString(),
+        termsAcceptedAt: data.termsAcceptedAt,
       });
       options?.onSuccess?.(data, variables, context);
     },

--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -1,10 +1,10 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { dataService, MutationKeys, QueryKeys, defaultOrderQuery } from 'librechat-data-provider';
 import {
   Constants,
   defaultAssistantsVersion,
   ConversationListResponse,
 } from 'librechat-data-provider';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { dataService, MutationKeys, QueryKeys, defaultOrderQuery } from 'librechat-data-provider';
 import type { InfiniteData, UseMutationResult } from '@tanstack/react-query';
 import type * as t from 'librechat-data-provider';
 import {

--- a/client/src/data-provider/mutations.ts
+++ b/client/src/data-provider/mutations.ts
@@ -1089,6 +1089,7 @@ export const useAcceptTermsMutation = (
     onSuccess: (data, variables, context) => {
       queryClient.setQueryData<t.TUserTermsResponse>([QueryKeys.userTerms], {
         termsAccepted: true,
+        termsAcceptedAt: new Date().toISOString(),
       });
       options?.onSuccess?.(data, variables, context);
     },

--- a/config/list-users.js
+++ b/config/list-users.js
@@ -7,7 +7,10 @@ const connect = require('./connect');
 const listUsers = async () => {
   try {
     await connect();
-    const users = await User.find({}, 'email provider avatar username name createdAt');
+    const users = await User.find(
+      {},
+      'email provider avatar username name createdAt termsAccepted termsAcceptedAt',
+    );
 
     console.log('\nUser List:');
     console.log('----------------------------------------');
@@ -18,6 +21,10 @@ const listUsers = async () => {
       console.log(`Name: ${user.name || 'N/A'}`);
       console.log(`Provider: ${user.provider || 'email'}`);
       console.log(`Created: ${user.createdAt}`);
+      console.log(`Terms Accepted: ${user.termsAccepted ? 'Yes' : 'No'}`);
+      console.log(
+        `Terms Accepted At: ${user.termsAcceptedAt ? user.termsAcceptedAt.toISOString() : 'N/A'}`,
+      );
       console.log('----------------------------------------');
     });
 

--- a/config/migrate-terms-timestamp.js
+++ b/config/migrate-terms-timestamp.js
@@ -1,0 +1,100 @@
+const path = require('path');
+const mongoose = require('mongoose');
+const { User } = require('@librechat/data-schemas').createModels(mongoose);
+require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
+const { askQuestion, silentExit } = require('./helpers');
+const connect = require('./connect');
+
+/**
+ * Migration script for Terms Acceptance Timestamp Tracking
+ *
+ * This script migrates existing users who have termsAccepted: true but no termsAcceptedAt timestamp.
+ * For these users, it sets termsAcceptedAt to their account creation date (createdAt) as a fallback.
+ *
+ * Usage: npm run migrate:terms-timestamp
+ */
+(async () => {
+  await connect();
+
+  console.purple('--------------------------');
+  console.purple('Migrate Terms Acceptance Timestamps');
+  console.purple('--------------------------');
+
+  // Count users that need migration
+  const usersToMigrate = await User.countDocuments({
+    termsAccepted: true,
+    $or: [{ termsAcceptedAt: null }, { termsAcceptedAt: { $exists: false } }],
+  });
+
+  if (usersToMigrate === 0) {
+    console.green(
+      'No users need migration. All users with termsAccepted: true already have a termsAcceptedAt timestamp.',
+    );
+    silentExit(0);
+  }
+
+  console.yellow(
+    `Found ${usersToMigrate} user(s) with termsAccepted: true but no termsAcceptedAt timestamp.`,
+  );
+  console.yellow(
+    'These users will have their termsAcceptedAt set to their account creation date (createdAt).',
+  );
+
+  const confirm = await askQuestion('Are you sure you want to proceed? (y/n): ');
+
+  if (confirm.toLowerCase() !== 'y') {
+    console.yellow('Operation cancelled.');
+    silentExit(0);
+  }
+
+  try {
+    // Find all users that need migration and update them
+    const cursor = User.find({
+      termsAccepted: true,
+      $or: [{ termsAcceptedAt: null }, { termsAcceptedAt: { $exists: false } }],
+    }).cursor();
+
+    let migratedCount = 0;
+    let errorCount = 0;
+
+    for await (const user of cursor) {
+      try {
+        // Use createdAt as fallback for termsAcceptedAt
+        const termsAcceptedAt = user.createdAt || new Date();
+        await User.updateOne({ _id: user._id }, { $set: { termsAcceptedAt } });
+        migratedCount++;
+
+        if (migratedCount % 100 === 0) {
+          console.yellow(`Migrated ${migratedCount} users...`);
+        }
+      } catch (error) {
+        console.red(`Error migrating user ${user._id}: ${error.message}`);
+        errorCount++;
+      }
+    }
+
+    console.green(`Migration complete!`);
+    console.green(`Successfully migrated: ${migratedCount} user(s)`);
+    if (errorCount > 0) {
+      console.red(`Errors encountered: ${errorCount}`);
+    }
+  } catch (error) {
+    console.red('Error during migration:', error);
+    silentExit(1);
+  }
+
+  silentExit(0);
+})();
+
+process.on('uncaughtException', (err) => {
+  if (!err.message.includes('fetch failed')) {
+    console.error('There was an uncaught error:');
+    console.error(err);
+  }
+
+  if (err.message.includes('fetch failed')) {
+    return;
+  } else {
+    process.exit(1);
+  }
+});

--- a/config/migrate-terms-timestamp.js
+++ b/config/migrate-terms-timestamp.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const mongoose = require('mongoose');
 const { User } = require('@librechat/data-schemas').createModels(mongoose);
+const { countUsers } = require('@librechat/data-schemas').createMethods(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { askQuestion, silentExit } = require('./helpers');
 const connect = require('./connect');
@@ -21,7 +22,7 @@ const connect = require('./connect');
   console.purple('--------------------------');
 
   // Count users that need migration
-  const usersToMigrate = await User.countDocuments({
+  const usersToMigrate = await countUsers({
     termsAccepted: true,
     $or: [{ termsAcceptedAt: null }, { termsAcceptedAt: { $exists: false } }],
   });

--- a/config/migrate-terms-timestamp.js
+++ b/config/migrate-terms-timestamp.js
@@ -62,6 +62,9 @@ const connect = require('./connect');
       try {
         // Use createdAt as fallback for termsAcceptedAt
         const termsAcceptedAt = user.createdAt || new Date();
+        if (!user.createdAt) {
+          console.yellow(`Warning: User ${user._id} has no createdAt, using current date for termsAcceptedAt`);
+        }
         await User.updateOne({ _id: user._id }, { $set: { termsAcceptedAt } });
         migratedCount++;
 

--- a/config/migrate-terms-timestamp.js
+++ b/config/migrate-terms-timestamp.js
@@ -64,6 +64,7 @@ const connect = require('./connect');
       }).cursor();
 
       let migratedCount = 0;
+      let skippedCount = 0;
       let errorCount = 0;
 
       for await (const user of cursor) {
@@ -75,11 +76,24 @@ const connect = require('./connect');
               `Warning: User ${user._id} has no createdAt, using current date for termsAcceptedAt`,
             );
           }
-          await User.updateOne({ _id: user._id }, { $set: { termsAcceptedAt } });
-          migratedCount++;
+          // Only backfill while the timestamp is still missing. If the user
+          // accepted through the API between the cursor read and this write,
+          // the filter no longer matches and their real timestamp is kept.
+          const result = await User.updateOne(
+            {
+              _id: user._id,
+              $or: [{ termsAcceptedAt: null }, { termsAcceptedAt: { $exists: false } }],
+            },
+            { $set: { termsAcceptedAt } },
+          );
 
-          if (migratedCount % 100 === 0) {
-            console.yellow(`Migrated ${migratedCount} users...`);
+          if (result.modifiedCount > 0) {
+            migratedCount++;
+            if (migratedCount % 100 === 0) {
+              console.yellow(`Migrated ${migratedCount} users...`);
+            }
+          } else {
+            skippedCount++;
           }
         } catch (error) {
           console.red(`Error migrating user ${user._id}: ${error.message}`);
@@ -89,6 +103,11 @@ const connect = require('./connect');
 
       console.green(`Migration complete!`);
       console.green(`Successfully migrated: ${migratedCount} user(s)`);
+      if (skippedCount > 0) {
+        console.yellow(
+          `Skipped ${skippedCount} user(s) who accepted concurrently during migration.`,
+        );
+      }
       if (errorCount > 0) {
         console.red(`Errors encountered: ${errorCount}`);
         silentExit(1);

--- a/config/migrate-terms-timestamp.js
+++ b/config/migrate-terms-timestamp.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const mongoose = require('mongoose');
+const { runAsSystem } = require('@librechat/data-schemas');
 const { User } = require('@librechat/data-schemas').createModels(mongoose);
 const { countUsers } = require('@librechat/data-schemas').createMethods(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
@@ -21,11 +22,15 @@ const connect = require('./connect');
   console.purple('Migrate Terms Acceptance Timestamps');
   console.purple('--------------------------');
 
-  // Count users that need migration
-  const usersToMigrate = await countUsers({
-    termsAccepted: true,
-    $or: [{ termsAcceptedAt: null }, { termsAcceptedAt: { $exists: false } }],
-  });
+  // Count users that need migration. This script spans every tenant, so run
+  // it under system context or the tenant isolation plugin throws under
+  // TENANT_ISOLATION_STRICT=true and scopes to a non-existent tenant otherwise.
+  const usersToMigrate = await runAsSystem(() =>
+    countUsers({
+      termsAccepted: true,
+      $or: [{ termsAcceptedAt: null }, { termsAcceptedAt: { $exists: false } }],
+    }),
+  );
 
   if (usersToMigrate === 0) {
     console.green(
@@ -49,42 +54,46 @@ const connect = require('./connect');
   }
 
   try {
-    // Find all users that need migration and update them
-    const cursor = User.find({
-      termsAccepted: true,
-      $or: [{ termsAcceptedAt: null }, { termsAcceptedAt: { $exists: false } }],
-    }).cursor();
+    // Scan and update across every tenant under system context, matching the
+    // other cross-tenant migrations, so the tenant isolation plugin does not
+    // throw or scope queries to a non-existent tenant.
+    await runAsSystem(async () => {
+      const cursor = User.find({
+        termsAccepted: true,
+        $or: [{ termsAcceptedAt: null }, { termsAcceptedAt: { $exists: false } }],
+      }).cursor();
 
-    let migratedCount = 0;
-    let errorCount = 0;
+      let migratedCount = 0;
+      let errorCount = 0;
 
-    for await (const user of cursor) {
-      try {
-        // Use createdAt as fallback for termsAcceptedAt
-        const termsAcceptedAt = user.createdAt || new Date();
-        if (!user.createdAt) {
-          console.yellow(
-            `Warning: User ${user._id} has no createdAt, using current date for termsAcceptedAt`,
-          );
+      for await (const user of cursor) {
+        try {
+          // Use createdAt as fallback for termsAcceptedAt
+          const termsAcceptedAt = user.createdAt || new Date();
+          if (!user.createdAt) {
+            console.yellow(
+              `Warning: User ${user._id} has no createdAt, using current date for termsAcceptedAt`,
+            );
+          }
+          await User.updateOne({ _id: user._id }, { $set: { termsAcceptedAt } });
+          migratedCount++;
+
+          if (migratedCount % 100 === 0) {
+            console.yellow(`Migrated ${migratedCount} users...`);
+          }
+        } catch (error) {
+          console.red(`Error migrating user ${user._id}: ${error.message}`);
+          errorCount++;
         }
-        await User.updateOne({ _id: user._id }, { $set: { termsAcceptedAt } });
-        migratedCount++;
-
-        if (migratedCount % 100 === 0) {
-          console.yellow(`Migrated ${migratedCount} users...`);
-        }
-      } catch (error) {
-        console.red(`Error migrating user ${user._id}: ${error.message}`);
-        errorCount++;
       }
-    }
 
-    console.green(`Migration complete!`);
-    console.green(`Successfully migrated: ${migratedCount} user(s)`);
-    if (errorCount > 0) {
-      console.red(`Errors encountered: ${errorCount}`);
-      silentExit(1);
-    }
+      console.green(`Migration complete!`);
+      console.green(`Successfully migrated: ${migratedCount} user(s)`);
+      if (errorCount > 0) {
+        console.red(`Errors encountered: ${errorCount}`);
+        silentExit(1);
+      }
+    });
   } catch (error) {
     console.red('Error during migration:', error);
     silentExit(1);

--- a/config/migrate-terms-timestamp.js
+++ b/config/migrate-terms-timestamp.js
@@ -76,12 +76,13 @@ const connect = require('./connect');
               `Warning: User ${user._id} has no createdAt, using current date for termsAcceptedAt`,
             );
           }
-          // Only backfill while the timestamp is still missing. If the user
-          // accepted through the API between the cursor read and this write,
-          // the filter no longer matches and their real timestamp is kept.
+          // Only backfill users who are still accepted and have no timestamp.
+          // If they accept through the API or get reset between the cursor read
+          // and this write, the filter no longer matches and their state is kept.
           const result = await User.updateOne(
             {
               _id: user._id,
+              termsAccepted: true,
               $or: [{ termsAcceptedAt: null }, { termsAcceptedAt: { $exists: false } }],
             },
             { $set: { termsAcceptedAt } },
@@ -105,7 +106,7 @@ const connect = require('./connect');
       console.green(`Successfully migrated: ${migratedCount} user(s)`);
       if (skippedCount > 0) {
         console.yellow(
-          `Skipped ${skippedCount} user(s) who accepted concurrently during migration.`,
+          `Skipped ${skippedCount} user(s) whose terms state changed during migration.`,
         );
       }
       if (errorCount > 0) {

--- a/config/migrate-terms-timestamp.js
+++ b/config/migrate-terms-timestamp.js
@@ -63,7 +63,9 @@ const connect = require('./connect');
         // Use createdAt as fallback for termsAcceptedAt
         const termsAcceptedAt = user.createdAt || new Date();
         if (!user.createdAt) {
-          console.yellow(`Warning: User ${user._id} has no createdAt, using current date for termsAcceptedAt`);
+          console.yellow(
+            `Warning: User ${user._id} has no createdAt, using current date for termsAcceptedAt`,
+          );
         }
         await User.updateOne({ _id: user._id }, { $set: { termsAcceptedAt } });
         migratedCount++;
@@ -81,6 +83,7 @@ const connect = require('./connect');
     console.green(`Successfully migrated: ${migratedCount} user(s)`);
     if (errorCount > 0) {
       console.red(`Errors encountered: ${errorCount}`);
+      silentExit(1);
     }
   } catch (error) {
     console.red('Error during migration:', error);

--- a/config/reset-terms.js
+++ b/config/reset-terms.js
@@ -21,7 +21,10 @@ const connect = require('./connect');
   }
 
   try {
-    const result = await User.updateMany({}, { $set: { termsAccepted: false } });
+    const result = await User.updateMany(
+      {},
+      { $set: { termsAccepted: false, termsAcceptedAt: null } },
+    );
     console.green(`Updated ${result.modifiedCount} user(s).`);
   } catch (error) {
     console.red('Error resetting terms acceptance:', error);

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "b:balance": "bun config/add-balance.js",
     "b:list-balances": "bun config/list-balances.js",
     "reset-terms": "node config/reset-terms.js",
+    "migrate:terms-timestamp": "node config/migrate-terms-timestamp.js",
     "flush-cache": "node config/flush-cache.js",
     "migrate:agent-permissions:dry-run": "node config/migrate-agent-permissions.js --dry-run",
     "migrate:agent-permissions": "node config/migrate-agent-permissions.js",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "b:balance": "bun config/add-balance.js",
     "b:list-balances": "bun config/list-balances.js",
     "reset-terms": "node config/reset-terms.js",
+    "migrate:terms-timestamp": "node config/migrate-terms-timestamp.js",
     "flush-cache": "node config/flush-cache.js",
     "migrate:agent-permissions:dry-run": "node config/migrate-agent-permissions.js --dry-run",
     "migrate:agent-permissions": "node config/migrate-agent-permissions.js",

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -26,6 +26,7 @@ const ALLOWED_USER_FIELDS = [
   'emailVerified',
   'twoFactorEnabled',
   'termsAccepted',
+  'termsAcceptedAt',
 ] as const;
 
 type AllowedUserField = (typeof ALLOWED_USER_FIELDS)[number];

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -655,6 +655,7 @@ export type TCustomConfigSpeechResponse = { [key: string]: string };
 
 export type TUserTermsResponse = {
   termsAccepted: boolean;
+  termsAcceptedAt: Date | string | null;
 };
 
 export type TAcceptTermsResponse = {

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -659,7 +659,8 @@ export type TUserTermsResponse = {
 };
 
 export type TAcceptTermsResponse = {
-  success: boolean;
+  message: string;
+  termsAcceptedAt: Date | string;
 };
 
 export type TBannerResponse = TBanner | null;

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -714,6 +714,7 @@ export type TCustomConfigSpeechResponse = { [key: string]: string };
 
 export type TUserTermsResponse = {
   termsAccepted: boolean;
+  termsAcceptedAt: Date | string | null;
 };
 
 export type TAcceptTermsResponse = {

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -718,7 +718,8 @@ export type TUserTermsResponse = {
 };
 
 export type TAcceptTermsResponse = {
-  success: boolean;
+  message: string;
+  termsAcceptedAt: Date | string;
 };
 
 export type TBannerResponse = TBanner | null;

--- a/packages/data-schemas/src/methods/user.methods.spec.ts
+++ b/packages/data-schemas/src/methods/user.methods.spec.ts
@@ -1,9 +1,9 @@
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import type * as t from '~/types';
+import balanceSchema from '~/schema/balance';
 import { createUserMethods } from './user';
 import userSchema from '~/schema/user';
-import balanceSchema from '~/schema/balance';
 
 /** Mocking crypto for generateToken */
 jest.mock('~/crypto', () => ({
@@ -366,6 +366,63 @@ describe('User Methods - Database Tests', () => {
       const found = await methods.getUserById(fakeId.toString());
 
       expect(found).toBeNull();
+    });
+  });
+
+  describe('acceptTerms', () => {
+    test('sets termsAccepted and stamps termsAcceptedAt on first acceptance', async () => {
+      const user = await User.create({
+        name: 'Terms User',
+        email: 'terms@example.com',
+        provider: 'local',
+      });
+
+      const before = Date.now();
+      const updated = await methods.acceptTerms(user._id?.toString() ?? '');
+      const after = Date.now();
+
+      expect(updated?.termsAccepted).toBe(true);
+      expect(updated?.termsAcceptedAt).toBeInstanceOf(Date);
+      const stamped = (updated?.termsAcceptedAt as Date).getTime();
+      expect(stamped).toBeGreaterThanOrEqual(before - 1000);
+      expect(stamped).toBeLessThanOrEqual(after + 1000);
+    });
+
+    test('preserves the original termsAcceptedAt on repeat acceptance', async () => {
+      const originalAcceptedAt = new Date('2026-01-01T00:00:00.000Z');
+      const user = await User.create({
+        name: 'Repeat User',
+        email: 'repeat@example.com',
+        provider: 'local',
+        termsAccepted: true,
+        termsAcceptedAt: originalAcceptedAt,
+      });
+
+      const updated = await methods.acceptTerms(user._id?.toString() ?? '');
+
+      expect(updated?.termsAccepted).toBe(true);
+      expect((updated?.termsAcceptedAt as Date).getTime()).toBe(originalAcceptedAt.getTime());
+    });
+
+    test('backfills termsAcceptedAt for a legacy accepted user without a timestamp', async () => {
+      const user = await User.create({
+        name: 'Legacy User',
+        email: 'legacy@example.com',
+        provider: 'local',
+        termsAccepted: true,
+      });
+
+      const updated = await methods.acceptTerms(user._id?.toString() ?? '');
+
+      expect(updated?.termsAccepted).toBe(true);
+      expect(updated?.termsAcceptedAt).toBeInstanceOf(Date);
+    });
+
+    test('returns null for non-existent user', async () => {
+      const fakeId = new mongoose.Types.ObjectId();
+      const result = await methods.acceptTerms(fakeId.toString());
+
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/data-schemas/src/methods/user.ts
+++ b/packages/data-schemas/src/methods/user.ts
@@ -26,6 +26,7 @@ export function createUserMethods(mongoose: typeof import('mongoose')): {
     returnUser?: boolean,
   ) => Promise<mongoose.Types.ObjectId | Partial<IUser>>;
   updateUser: (userId: string, updateData: Partial<IUser>) => Promise<IUser | null>;
+  acceptTerms: (userId: string) => Promise<IUser | null>;
   searchUsers: ({
     searchPattern,
     limit,
@@ -251,6 +252,28 @@ export function createUserMethods(mongoose: typeof import('mongoose')): {
       new: true,
       runValidators: true,
     }).lean<IUser>();
+  }
+
+  /**
+   * Atomically records terms acceptance for a user.
+   * Sets termsAccepted and, only when no timestamp is already stored, stamps
+   * termsAcceptedAt with the server time so the first acceptance within a terms
+   * cycle is preserved across concurrent or repeated requests.
+   */
+  async function acceptTerms(userId: string): Promise<IUser | null> {
+    const User = mongoose.models.User;
+    return await User.findByIdAndUpdate(
+      userId,
+      [
+        {
+          $set: {
+            termsAccepted: true,
+            termsAcceptedAt: { $ifNull: ['$termsAcceptedAt', '$$NOW'] },
+          },
+        },
+      ],
+      { new: true, runValidators: true },
+    ).lean<IUser>();
   }
 
   /**
@@ -511,6 +534,7 @@ export function createUserMethods(mongoose: typeof import('mongoose')): {
     countUsers,
     createUser,
     updateUser,
+    acceptTerms,
     searchUsers,
     getUserById,
     generateToken,

--- a/packages/data-schemas/src/schema/user.ts
+++ b/packages/data-schemas/src/schema/user.ts
@@ -132,6 +132,10 @@ const userSchema = new Schema<IUser>(
       type: Boolean,
       default: false,
     },
+    termsAcceptedAt: {
+      type: Date,
+      default: null,
+    },
     personalization: {
       type: {
         memories: {

--- a/packages/data-schemas/src/schema/user.ts
+++ b/packages/data-schemas/src/schema/user.ts
@@ -127,6 +127,10 @@ const userSchema: Schema<IUser> = new Schema<IUser>(
       type: Boolean,
       default: false,
     },
+    termsAcceptedAt: {
+      type: Date,
+      default: null,
+    },
     personalization: {
       type: {
         memories: {

--- a/packages/data-schemas/src/types/user.ts
+++ b/packages/data-schemas/src/types/user.ts
@@ -31,6 +31,7 @@ export interface IUser extends Document {
   }>;
   expiresAt?: Date;
   termsAccepted?: boolean;
+  termsAcceptedAt?: Date | null;
   personalization?: {
     memories?: boolean;
   };
@@ -68,6 +69,7 @@ export interface UpdateUserRequest {
   plugins?: string[];
   twoFactorEnabled?: boolean;
   termsAccepted?: boolean;
+  termsAcceptedAt?: Date | null;
   personalization?: {
     memories?: boolean;
   };

--- a/packages/data-schemas/src/types/user.ts
+++ b/packages/data-schemas/src/types/user.ts
@@ -48,6 +48,7 @@ export interface IUser extends Document {
   }>;
   expiresAt?: Date;
   termsAccepted?: boolean;
+  termsAcceptedAt?: Date | null;
   personalization?: {
     memories?: boolean;
   };
@@ -93,6 +94,7 @@ export interface UpdateUserRequest {
   plugins?: string[];
   twoFactorEnabled?: boolean;
   termsAccepted?: boolean;
+  termsAcceptedAt?: Date | null;
   personalization?: {
     memories?: boolean;
   };


### PR DESCRIPTION
## Summary

This pull request introduces tracking for the timestamp when users accept the terms of service. It updates the user schema and related APIs to support a new `termsAcceptedAt` field, ensures this information is handled consistently across the backend and frontend, and provides migration and reset scripts to manage legacy and future user data

Closes #9350

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Tested on Firefox and Chrome

### **Test Configuration**:

- OS: WSL2
- npm Version: 11.5.2

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.