### PR TITLE
fix: extract text from MCP content array for custom endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ coordination/orchestration/*
 claude-flow
 # Removed Windows wrapper files per user request
 hive-mind-prompt-*.txt
+__pycache__

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,113 @@
+# LibreChat OpenShift Deployment Makefile
+# Usage: make deploy NAMESPACE=librechat-fips
+
+NAMESPACE ?= librechat-fips
+CLUSTER_DOMAIN ?= $(shell oc whoami --show-server 2>/dev/null | sed 's|https://api\.||' | sed 's|:6443||')
+ROUTE_HOST = librechat-$(NAMESPACE).apps.$(CLUSTER_DOMAIN)
+
+.PHONY: help deploy undeploy status logs update-config port-forward clean check-prereqs
+
+help: ## Show this help
+	@echo "LibreChat OpenShift Deployment"
+	@echo ""
+	@echo "Usage: make <target> [NAMESPACE=librechat-fips]"
+	@echo ""
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-20s %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Examples:"
+	@echo "  make deploy                    # Deploy to default namespace"
+	@echo "  make deploy NAMESPACE=myns     # Deploy to custom namespace"
+	@echo "  make status                    # Check deployment status"
+	@echo "  make logs                      # View application logs"
+
+check-prereqs: ## Check prerequisites (oc, helm, .env)
+	@command -v oc >/dev/null 2>&1 || { echo "Error: oc CLI not found"; exit 1; }
+	@command -v helm >/dev/null 2>&1 || { echo "Error: helm CLI not found"; exit 1; }
+	@oc whoami >/dev/null 2>&1 || { echo "Error: Not logged into OpenShift"; exit 1; }
+	@test -f .env || { echo "Error: .env file not found"; exit 1; }
+	@echo "Prerequisites OK"
+	@echo "  Cluster: $(CLUSTER_DOMAIN)"
+	@echo "  Namespace: $(NAMESPACE)"
+
+deploy: check-prereqs ## Deploy LibreChat to OpenShift
+	@./deploy-openshift.sh $(NAMESPACE) $(CLUSTER_DOMAIN)
+
+undeploy: ## Remove LibreChat deployment
+	@echo "Uninstalling LibreChat from $(NAMESPACE)..."
+	-helm uninstall librechat -n $(NAMESPACE) --wait
+	-oc delete route librechat -n $(NAMESPACE)
+	-oc delete configmap librechat-config -n $(NAMESPACE)
+	-oc delete secret librechat-credentials-env -n $(NAMESPACE)
+	-oc delete pvc --all -n $(NAMESPACE)
+	@echo "Uninstall complete. Namespace $(NAMESPACE) retained."
+
+clean: undeploy ## Full cleanup including namespace
+	@echo "Deleting namespace $(NAMESPACE)..."
+	-oc delete project $(NAMESPACE)
+	@echo "Cleanup complete."
+
+status: ## Show deployment status
+	@echo "=== Namespace: $(NAMESPACE) ==="
+	@echo ""
+	@echo "Pods:"
+	@oc get pods -n $(NAMESPACE) 2>/dev/null || echo "  No pods found"
+	@echo ""
+	@echo "Services:"
+	@oc get svc -n $(NAMESPACE) 2>/dev/null || echo "  No services found"
+	@echo ""
+	@echo "Routes:"
+	@oc get route -n $(NAMESPACE) 2>/dev/null || echo "  No routes found"
+	@echo ""
+	@echo "PVCs:"
+	@oc get pvc -n $(NAMESPACE) 2>/dev/null || echo "  No PVCs found"
+
+logs: ## View LibreChat application logs
+	oc logs -f deployment/librechat-librechat -n $(NAMESPACE)
+
+logs-mcp: ## View MCP-related logs
+	oc logs deployment/librechat-librechat -n $(NAMESPACE) | grep -i '\[MCP\]' | tail -50
+
+logs-mongodb: ## View MongoDB logs
+	oc logs -f deployment/librechat-mongodb -n $(NAMESPACE)
+
+update-config: ## Update librechat.yaml configuration
+	@./update-librechat-config.sh $(NAMESPACE) ./librechat.yaml
+
+port-forward: ## Forward port 3080 locally
+	@echo "Forwarding https://localhost:3080 -> LibreChat"
+	@echo "Press Ctrl+C to stop"
+	oc port-forward deployment/librechat-librechat 3080:3080 -n $(NAMESPACE)
+
+restart: ## Restart the LibreChat deployment
+	oc rollout restart deployment/librechat-librechat -n $(NAMESPACE)
+	oc rollout status deployment/librechat-librechat -n $(NAMESPACE) --timeout=180s
+
+scale: ## Scale deployment (usage: make scale REPLICAS=2)
+	@if [ -z "$(REPLICAS)" ]; then echo "Usage: make scale REPLICAS=2"; exit 1; fi
+	oc scale deployment/librechat-librechat --replicas=$(REPLICAS) -n $(NAMESPACE)
+
+url: ## Print the application URL
+	@echo "https://$(shell oc get route librechat -n $(NAMESPACE) -o jsonpath='{.spec.host}' 2>/dev/null || echo '$(ROUTE_HOST)')"
+
+test-health: ## Test the health endpoint
+	@curl -s -o /dev/null -w "%{http_code}" https://$(shell oc get route librechat -n $(NAMESPACE) -o jsonpath='{.spec.host}')/health && echo " OK" || echo " FAILED"
+
+# === Migration targets ===
+
+export-agents: ## Export agents from current cluster (run on SOURCE cluster)
+	@echo "Exporting agents from $(NAMESPACE)..."
+	@mkdir -p migration
+	@POD=$$(oc get pods -n $(NAMESPACE) -l app.kubernetes.io/name=mongodb -o jsonpath='{.items[0].metadata.name}'); \
+	oc exec $$POD -n $(NAMESPACE) -c mongodb -- mongosh --quiet --eval "JSON.stringify(db.agents.find().toArray())" LibreChat > migration/agents-export.json; \
+	oc exec $$POD -n $(NAMESPACE) -c mongodb -- mongosh --quiet --eval "JSON.stringify(db.aclentries.find().toArray())" LibreChat > migration/aclentries-export.json
+	@echo "Exported to migration/agents-export.json"
+
+import-agents: ## Import agents to current cluster (usage: make import-agents EMAIL=user@example.com)
+	@if [ -z "$(EMAIL)" ]; then echo "Usage: make import-agents EMAIL=user@example.com [NAME='Display Name'] [PUBLIC=true]"; exit 1; fi
+	@if [ ! -f migration/agents-export.json ]; then echo "Error: migration/agents-export.json not found. Run 'make export-agents' on source cluster first."; exit 1; fi
+	python3 scripts/migrate-agents.py \
+		--agents migration/agents-export.json \
+		--new-user-email "$(EMAIL)" \
+		$(if $(NAME),--new-user-name "$(NAME)") \
+		$(if $(PUBLIC),--make-public) \
+		--target-namespace $(NAMESPACE)

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -387,6 +387,11 @@ function createToolInstance({ res, toolName, serverName, toolDefinition, provide
       if (isGoogle && Array.isArray(result[0]) && result[0][0]?.type === ContentTypes.TEXT) {
         return [result[0][0].text, result[1]];
       }
+      // For custom endpoints (vLLM/Mistral), extract text from MCP content array
+      // MCP returns [{type: "text", text: "..."}] but vLLM expects plain string for tool content
+      if (Array.isArray(result) && Array.isArray(result[0]) && result[0][0]?.type === ContentTypes.TEXT) {
+        return [result[0][0].text, result[1]];
+      }
       return result;
     } catch (error) {
       logger.error(

--- a/deploy-openshift.sh
+++ b/deploy-openshift.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Deploy LibreChat to OpenShift
+# Usage: ./deploy-openshift.sh [namespace] [cluster-domain]
+#
+# Prerequisites:
+# - oc CLI logged into the cluster
+# - helm CLI installed
+# - .env file with API keys in the project root
+
+set -e
+
+# Configuration
+NAMESPACE="${1:-librechat-fips}"
+CLUSTER_DOMAIN="${2:-$(oc whoami --show-server | sed 's|https://api\.||' | sed 's|:6443||')}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${YELLOW}LibreChat OpenShift Deployment${NC}"
+echo "================================"
+echo "Namespace: $NAMESPACE"
+echo "Cluster: $CLUSTER_DOMAIN"
+echo ""
+
+# Verify prerequisites
+if ! oc whoami &>/dev/null; then
+    echo -e "${RED}Error: Not logged into OpenShift cluster${NC}"
+    exit 1
+fi
+
+if ! command -v helm &>/dev/null; then
+    echo -e "${RED}Error: helm CLI not found${NC}"
+    exit 1
+fi
+
+if [ ! -f "$SCRIPT_DIR/.env" ]; then
+    echo -e "${RED}Error: .env file not found${NC}"
+    echo "Create .env with required API keys (see .env.example)"
+    exit 1
+fi
+
+# Load environment variables
+source "$SCRIPT_DIR/.env"
+
+# Step 1: Create namespace if it doesn't exist
+echo -e "${YELLOW}Step 1: Creating namespace...${NC}"
+if oc get namespace "$NAMESPACE" &>/dev/null; then
+    echo "Namespace $NAMESPACE already exists"
+else
+    oc new-project "$NAMESPACE" --display-name="LibreChat FIPS" --description="LibreChat with FIPS compliance"
+fi
+
+# Step 2: Grant anyuid SCC to service accounts
+echo -e "${YELLOW}Step 2: Granting anyuid SCC...${NC}"
+for sa in default librechat-librechat librechat-mongodb librechat-meilisearch; do
+    oc adm policy add-scc-to-user anyuid -z "$sa" -n "$NAMESPACE" 2>/dev/null || true
+done
+echo -e "${GREEN}SCC permissions granted${NC}"
+
+# Step 3: Create or update credentials secret
+echo -e "${YELLOW}Step 3: Creating credentials secret...${NC}"
+oc delete secret librechat-credentials-env -n "$NAMESPACE" 2>/dev/null || true
+oc create secret generic librechat-credentials-env -n "$NAMESPACE" \
+    --from-literal=CREDS_KEY="${CREDS_KEY}" \
+    --from-literal=CREDS_IV="${CREDS_IV}" \
+    --from-literal=JWT_SECRET="${JWT_SECRET}" \
+    --from-literal=JWT_REFRESH_SECRET="${JWT_REFRESH_SECRET}" \
+    --from-literal=MEILI_MASTER_KEY="${MEILI_MASTER_KEY}" \
+    --from-literal=OPENROUTER_KEY="${OPENROUTER_KEY:-dummy}" \
+    --from-literal=VLLM_API_KEY="${VLLM_API_KEY:-dummy}" \
+    --from-literal=VLLM_API_URL="${VLLM_API_URL:-http://localhost}" \
+    --from-literal=ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-dummy}" \
+    --from-literal=OPENAI_API_KEY="${OPENAI_API_KEY:-dummy}"
+echo -e "${GREEN}Secret created${NC}"
+
+# Step 4: Create or update ConfigMap with librechat.yaml
+echo -e "${YELLOW}Step 4: Creating librechat config...${NC}"
+oc delete configmap librechat-config -n "$NAMESPACE" 2>/dev/null || true
+oc create configmap librechat-config --from-file=librechat.yaml="$SCRIPT_DIR/librechat.yaml" -n "$NAMESPACE"
+echo -e "${GREEN}ConfigMap created${NC}"
+
+# Step 5: Update values file with cluster domain
+echo -e "${YELLOW}Step 5: Preparing Helm values...${NC}"
+ROUTE_HOST="librechat-${NAMESPACE}.apps.${CLUSTER_DOMAIN}"
+VALUES_FILE="$SCRIPT_DIR/helm/librechat/values-openshift.yaml"
+
+# Create a temporary values file with updated domain
+TMP_VALUES=$(mktemp)
+sed "s|DOMAIN_SERVER:.*|DOMAIN_SERVER: \"https://${ROUTE_HOST}\"|g" "$VALUES_FILE" | \
+sed "s|DOMAIN_CLIENT:.*|DOMAIN_CLIENT: \"https://${ROUTE_HOST}\"|g" > "$TMP_VALUES"
+
+# Step 6: Deploy with Helm
+echo -e "${YELLOW}Step 6: Installing/Upgrading Helm release...${NC}"
+if helm list -n "$NAMESPACE" | grep -q librechat; then
+    helm upgrade librechat "$SCRIPT_DIR/helm/librechat" -f "$TMP_VALUES" -n "$NAMESPACE" --timeout 10m
+else
+    helm install librechat "$SCRIPT_DIR/helm/librechat" -f "$TMP_VALUES" -n "$NAMESPACE" --timeout 10m
+fi
+
+rm -f "$TMP_VALUES"
+
+# Step 7: Create route if it doesn't exist
+echo -e "${YELLOW}Step 7: Creating route...${NC}"
+if oc get route librechat -n "$NAMESPACE" &>/dev/null; then
+    echo "Route already exists"
+else
+    oc create route edge librechat --service=librechat-librechat --port=3080 -n "$NAMESPACE"
+fi
+
+# Step 8: Wait for pods and verify
+echo -e "${YELLOW}Step 8: Waiting for pods to be ready...${NC}"
+oc rollout status deployment/librechat-librechat -n "$NAMESPACE" --timeout=180s
+
+# Get the actual route
+ROUTE_URL=$(oc get route librechat -n "$NAMESPACE" -o jsonpath='{.spec.host}')
+
+echo ""
+echo -e "${GREEN}Deployment complete!${NC}"
+echo "================================"
+echo -e "URL: ${GREEN}https://${ROUTE_URL}${NC}"
+echo ""
+echo "Useful commands:"
+echo "  View pods:    oc get pods -n $NAMESPACE"
+echo "  View logs:    oc logs -f deployment/librechat-librechat -n $NAMESPACE"
+echo "  Update config: ./update-librechat-config.sh $NAMESPACE"

--- a/helm/librechat/values-openshift.yaml
+++ b/helm/librechat/values-openshift.yaml
@@ -1,0 +1,144 @@
+# OpenShift deployment values for LibreChat-FIPS
+# Cluster: cluster-kbm2h.kbm2h.sandbox5350.opentlc.com
+
+replicaCount: 1
+
+global:
+  librechat:
+    existingSecretName: "librechat-credentials-env"
+    existingSecretApiKey: OPENAI_API_KEY
+    env:
+      - name: OPENROUTER_KEY
+        valueFrom:
+          secretKeyRef:
+            name: librechat-credentials-env
+            key: OPENROUTER_KEY
+      - name: VLLM_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: librechat-credentials-env
+            key: VLLM_API_KEY
+      - name: VLLM_API_URL
+        valueFrom:
+          secretKeyRef:
+            name: librechat-credentials-env
+            key: VLLM_API_URL
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: librechat-credentials-env
+            key: ANTHROPIC_API_KEY
+      - name: OPENAI_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: librechat-credentials-env
+            key: OPENAI_API_KEY
+
+librechat:
+  configEnv:
+    # DEBUG settings
+    DEBUG_PLUGINS: "true"
+    # Feature flags
+    ALLOW_REGISTRATION: "true"
+    ALLOW_SOCIAL_LOGIN: "false"
+    ALLOW_UNVERIFIED_EMAIL_LOGIN: "true"
+    # MongoDB connection (uses Helm chart internal service)
+    MONGO_URI: "mongodb://librechat-mongodb:27017/LibreChat"
+    # Meilisearch connection
+    MEILI_HOST: "http://librechat-meilisearch:7700"
+    # Domain settings (will be set after route is created)
+    DOMAIN_SERVER: "https://librechat-librechat-fips.apps.cluster-kbm2h.kbm2h.sandbox5350.opentlc.com"
+    DOMAIN_CLIENT: "https://librechat-librechat-fips.apps.cluster-kbm2h.kbm2h.sandbox5350.opentlc.com"
+
+  existingSecretName: "librechat-credentials-env"
+
+  # Reference existing ConfigMap with librechat.yaml
+  existingConfigYaml: "librechat-config"
+
+  imageVolume:
+    enabled: true
+    size: 10Gi
+    accessModes: ReadWriteOnce
+
+# RAG API disabled for initial deployment
+librechat-rag-api:
+  enabled: false
+
+image:
+  repository: danny-avila/librechat
+  registry: ghcr.io
+  pullPolicy: IfNotPresent
+  tag: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+# OpenShift security context - with anyuid SCC, use chart defaults
+podSecurityContext:
+  fsGroup: 1000
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 3080
+  targetPort: 3080
+  containerPort: 3080
+  annotations: {}
+
+# Disable Ingress - use OpenShift Route instead
+ingress:
+  enabled: false
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 3080
+  initialDelaySeconds: 30
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 3080
+  initialDelaySeconds: 10
+  periodSeconds: 5
+
+# MongoDB configuration - with anyuid SCC, enable security contexts
+mongodb:
+  enabled: true
+  auth:
+    enabled: false
+  databases:
+    - LibreChat
+  image:
+    registry: docker.io
+    repository: bitnami/mongodb
+    tag: "latest"
+  persistence:
+    enabled: true
+    size: 8Gi
+
+# Meilisearch configuration - with anyuid SCC, use defaults
+meilisearch:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 5Gi
+    storageClass: ""
+  image:
+    tag: "v1.7.3"
+  auth:
+    existingMasterKeySecret: "librechat-credentials-env"

--- a/scripts/import-large-agent.py
+++ b/scripts/import-large-agent.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Import large agents via file copy to pod.
+Handles agents that are too large for command-line mongosh.
+"""
+
+import json
+import subprocess
+import sys
+from datetime import datetime
+import tempfile
+import os
+
+
+def run_cmd(cmd):
+    """Run a shell command and return output."""
+    result = subprocess.run(cmd, capture_output=True, text=True, shell=isinstance(cmd, str))
+    if result.returncode != 0:
+        raise Exception(f"Command failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+def import_large_agent(namespace: str, pod_name: str, agent: dict, new_author_id: str,
+                       new_author_name: str, make_public: bool = False):
+    """Import a single large agent via file transfer."""
+
+    agent_name = agent.get("name", "Unknown")
+    agent_id = agent.get("id")
+    now = datetime.utcnow().isoformat() + "Z"
+
+    # Prepare the document
+    doc = {
+        "id": agent["id"],
+        "name": agent.get("name", ""),
+        "description": agent.get("description", ""),
+        "instructions": agent.get("instructions", ""),
+        "avatar": agent.get("avatar"),
+        "provider": agent.get("provider", ""),
+        "model": agent.get("model", ""),
+        "model_parameters": agent.get("model_parameters", {}),
+        "artifacts": agent.get("artifacts", ""),
+        "tools": agent.get("tools", []),
+        "tool_kwargs": agent.get("tool_kwargs", []),
+        "actions": agent.get("actions", []),
+        "author": {"$oid": new_author_id},
+        "authorName": new_author_name,
+        "agent_ids": [],
+        "edges": agent.get("edges", []),
+        "isCollaborative": agent.get("isCollaborative", False),
+        "conversation_starters": agent.get("conversation_starters", []),
+        "tool_resources": agent.get("tool_resources", {}),
+        "projectIds": [],
+        "versions": agent.get("versions", []),
+        "category": agent.get("category", "general"),
+        "is_promoted": agent.get("is_promoted", False),
+        "createdAt": {"$date": now},
+        "updatedAt": {"$date": now}
+    }
+
+    # Write to temp file
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump(doc, f)
+        temp_file = f.name
+
+    try:
+        # Copy file to pod
+        remote_path = f"/tmp/agent-{agent_id}.json"
+        run_cmd(["oc", "cp", temp_file, f"{pod_name}:{remote_path}", "-n", namespace, "-c", "mongodb"])
+
+        # Import using mongoimport
+        import_cmd = f"mongoimport --db LibreChat --collection agents --file {remote_path}"
+        run_cmd(["oc", "exec", pod_name, "-n", namespace, "-c", "mongodb", "--", "sh", "-c", import_cmd])
+
+        # Cleanup remote file
+        run_cmd(["oc", "exec", pod_name, "-n", namespace, "-c", "mongodb", "--", "rm", remote_path])
+
+        print(f"  Imported: {agent_name} ({agent_id})")
+
+        # Make public if requested
+        if make_public:
+            # Get the inserted document's _id
+            get_id_cmd = f'''mongosh --quiet --eval "JSON.stringify(db.agents.findOne({{id: '{agent_id}'}}, {{_id: 1}}))" LibreChat'''
+            result = run_cmd(["oc", "exec", pod_name, "-n", namespace, "-c", "mongodb", "--", "sh", "-c", get_id_cmd])
+
+            if result and result != "null":
+                result_data = json.loads(result)
+                agent_oid = result_data.get("_id", {}).get("$oid")
+
+                if agent_oid:
+                    # Create public ACL entry
+                    acl_doc = {
+                        "principalType": "public",
+                        "resourceType": "agent",
+                        "resourceId": {"$oid": agent_oid},
+                        "permBits": 1,
+                        "grantedBy": {"$oid": new_author_id},
+                        "grantedAt": {"$date": now},
+                        "createdAt": {"$date": now},
+                        "updatedAt": {"$date": now}
+                    }
+
+                    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+                        json.dump(acl_doc, f)
+                        acl_file = f.name
+
+                    try:
+                        acl_remote = f"/tmp/acl-{agent_id}.json"
+                        run_cmd(["oc", "cp", acl_file, f"{pod_name}:{acl_remote}", "-n", namespace, "-c", "mongodb"])
+                        acl_import_cmd = f"mongoimport --db LibreChat --collection aclentries --file {acl_remote}"
+                        run_cmd(["oc", "exec", pod_name, "-n", namespace, "-c", "mongodb", "--", "sh", "-c", acl_import_cmd])
+                        run_cmd(["oc", "exec", pod_name, "-n", namespace, "-c", "mongodb", "--", "rm", acl_remote])
+                        print(f"    Made public: {agent_id}")
+                    finally:
+                        os.unlink(acl_file)
+
+        return True
+
+    finally:
+        os.unlink(temp_file)
+
+
+def main():
+    if len(sys.argv) < 5:
+        print("Usage: python3 import-large-agent.py <namespace> <pod> <agents.json> <author_id> [author_name] [--public]")
+        sys.exit(1)
+
+    namespace = sys.argv[1]
+    pod_name = sys.argv[2]
+    agents_file = sys.argv[3]
+    author_id = sys.argv[4]
+    author_name = sys.argv[5] if len(sys.argv) > 5 and not sys.argv[5].startswith("--") else "Admin"
+    make_public = "--public" in sys.argv
+
+    # Load agents
+    with open(agents_file) as f:
+        agents = json.load(f)
+
+    # Filter to failed agents (the ones with long instructions)
+    failed_names = [
+        "ServiceNow Chat",
+        "FBI - Crime Stats Chat",
+        "Public Health Researcher",
+        "FAA Agent",
+        "USAF - Findings Analyst"
+    ]
+
+    large_agents = [a for a in agents if a.get("name") in failed_names]
+
+    print(f"Found {len(large_agents)} large agents to import")
+
+    for agent in large_agents:
+        try:
+            import_large_agent(namespace, pod_name, agent, author_id, author_name, make_public)
+        except Exception as e:
+            print(f"  Error importing {agent.get('name')}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate-agents.py
+++ b/scripts/migrate-agents.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+LibreChat Agent Migration Script
+
+Migrates agents from one LibreChat MongoDB instance to another,
+updating ownership and optionally making them publicly accessible.
+
+Usage:
+    # Export from source cluster (run this first)
+    oc exec <mongodb-pod> -n <namespace> -- mongosh --quiet \
+        --eval "JSON.stringify(db.agents.find().toArray())" LibreChat > agents-export.json
+    oc exec <mongodb-pod> -n <namespace> -- mongosh --quiet \
+        --eval "JSON.stringify(db.aclentries.find().toArray())" LibreChat > aclentries-export.json
+
+    # Then run migration against target cluster
+    python3 migrate-agents.py --agents agents-export.json \
+        --new-user-email admin@example.com \
+        --make-public \
+        --target-namespace librechat-fips
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from typing import Optional
+import uuid
+
+
+def generate_object_id() -> str:
+    """Generate a MongoDB-style ObjectId (24 hex chars)."""
+    import time
+    timestamp = int(time.time())
+    random_part = uuid.uuid4().hex[:16]
+    return f"{timestamp:08x}{random_part}"
+
+
+def run_mongosh(namespace: str, pod_name: str, command: str) -> str:
+    """Run a mongosh command in the target MongoDB pod."""
+    cmd = [
+        "oc", "exec", pod_name, "-n", namespace, "--",
+        "mongosh", "--quiet", "--eval", command, "LibreChat"
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise Exception(f"mongosh failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+def get_mongodb_pod(namespace: str) -> str:
+    """Get the MongoDB pod name in the target namespace."""
+    cmd = ["oc", "get", "pods", "-n", namespace, "-l", "app.kubernetes.io/name=mongodb",
+           "-o", "jsonpath={.items[0].metadata.name}"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0 or not result.stdout.strip():
+        # Try alternate label
+        cmd = ["oc", "get", "pods", "-n", namespace,
+               "-o", "jsonpath={.items[?(@.metadata.name contains 'mongodb')].metadata.name}"]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0 or not result.stdout.strip():
+            raise Exception(f"Could not find MongoDB pod in namespace {namespace}")
+    return result.stdout.strip().split()[0]
+
+
+def get_or_create_user(namespace: str, pod_name: str, email: str, name: Optional[str] = None) -> dict:
+    """Get existing user by email or create a new admin user."""
+    # Check if user exists
+    check_cmd = f'db.users.findOne({{email: "{email}"}})'
+    result = run_mongosh(namespace, pod_name, check_cmd)
+
+    if result and result != "null":
+        user_data = json.loads(result.replace("ObjectId(", '"').replace(")", '"')
+                              .replace("ISODate(", '"').replace(")", '"'))
+        print(f"Found existing user: {email}")
+        return user_data
+
+    # Create new user
+    user_id = generate_object_id()
+    username = email.split("@")[0]
+    display_name = name or username
+    now = datetime.utcnow().isoformat() + "Z"
+
+    create_cmd = f'''db.users.insertOne({{
+        _id: ObjectId("{user_id}"),
+        name: "{display_name}",
+        username: "{username}",
+        email: "{email}",
+        role: "ADMIN",
+        provider: "local",
+        createdAt: ISODate("{now}"),
+        updatedAt: ISODate("{now}")
+    }})'''
+
+    run_mongosh(namespace, pod_name, create_cmd)
+    print(f"Created new admin user: {email} with ID: {user_id}")
+
+    return {"_id": user_id, "email": email, "name": display_name}
+
+
+def import_agents(namespace: str, pod_name: str, agents: list, new_author_id: str,
+                  new_author_name: str, make_public: bool = False) -> dict:
+    """Import agents with updated ownership."""
+    results = {"imported": 0, "skipped": 0, "errors": []}
+
+    for agent in agents:
+        agent_id = agent.get("id")
+        agent_name = agent.get("name", "Unknown")
+
+        # Check if agent already exists
+        check_cmd = f'db.agents.findOne({{id: "{agent_id}"}})'
+        existing = run_mongosh(namespace, pod_name, check_cmd)
+
+        if existing and existing != "null":
+            print(f"  Skipping existing agent: {agent_name} ({agent_id})")
+            results["skipped"] += 1
+            continue
+
+        try:
+            # Prepare agent document for insertion
+            # Remove MongoDB-specific fields that will be regenerated
+            agent_copy = {k: v for k, v in agent.items() if k not in ["_id", "__v"]}
+
+            # Update ownership
+            agent_copy["author"] = f'ObjectId("{new_author_id}")'
+            agent_copy["authorName"] = new_author_name
+
+            # Clear project associations (they won't exist in new cluster)
+            agent_copy["projectIds"] = []
+
+            # Convert to mongosh-compatible format
+            now = datetime.utcnow().isoformat() + "Z"
+
+            # Handle arrays and nested objects - use json.dumps for safe escaping
+            tools_str = json.dumps(agent_copy.get("tools", []))
+            tool_kwargs_str = json.dumps(agent_copy.get("tool_kwargs", []))
+            actions_str = json.dumps(agent_copy.get("actions", []))
+            starters_str = json.dumps(agent_copy.get("conversation_starters", []))
+            versions_str = json.dumps(agent_copy.get("versions", []))
+            model_params_str = json.dumps(agent_copy.get("model_parameters", {}))
+            tool_resources_str = json.dumps(agent_copy.get("tool_resources", {}))
+            edges_str = json.dumps(agent_copy.get("edges", []))
+
+            # Handle string fields - use json.dumps for safe escaping
+            agent_id_str = agent_copy['id']
+            name_str = json.dumps(agent_copy.get('name', ''))
+            desc_str = json.dumps(agent_copy.get('description', ''))
+            instr_str = json.dumps(agent_copy.get('instructions', ''))
+            provider_str = agent_copy.get('provider', '')
+            model_str = agent_copy.get('model', '')
+            artifacts_str = agent_copy.get('artifacts', '')
+            category_str = agent_copy.get('category', 'general')
+
+            # Handle avatar
+            avatar = agent_copy.get("avatar")
+            avatar_str = json.dumps(avatar) if avatar else "null"
+
+            # Handle booleans
+            is_collab = str(agent_copy.get('isCollaborative', False)).lower()
+            is_promo = str(agent_copy.get('is_promoted', False)).lower()
+
+            insert_cmd = f'''db.agents.insertOne({{
+                id: "{agent_id_str}",
+                name: {name_str},
+                description: {desc_str},
+                instructions: {instr_str},
+                avatar: {avatar_str},
+                provider: "{provider_str}",
+                model: "{model_str}",
+                model_parameters: {model_params_str},
+                artifacts: "{artifacts_str}",
+                tools: {tools_str},
+                tool_kwargs: {tool_kwargs_str},
+                actions: {actions_str},
+                author: ObjectId("{new_author_id}"),
+                authorName: "{new_author_name}",
+                agent_ids: [],
+                edges: {edges_str},
+                isCollaborative: {is_collab},
+                conversation_starters: {starters_str},
+                tool_resources: {tool_resources_str},
+                projectIds: [],
+                versions: {versions_str},
+                category: "{category_str}",
+                is_promoted: {is_promo},
+                createdAt: ISODate("{now}"),
+                updatedAt: ISODate("{now}")
+            }})'''
+
+            run_mongosh(namespace, pod_name, insert_cmd)
+            print(f"  Imported: {agent_name} ({agent_id})")
+            results["imported"] += 1
+
+            # Make public if requested
+            if make_public:
+                create_public_acl(namespace, pod_name, agent_id, new_author_id)
+
+        except Exception as e:
+            print(f"  Error importing {agent_name}: {e}")
+            results["errors"].append({"agent": agent_name, "error": str(e)})
+
+    return results
+
+
+def create_public_acl(namespace: str, pod_name: str, agent_id: str, granted_by: str):
+    """Create a public ACL entry for an agent."""
+    now = datetime.utcnow().isoformat() + "Z"
+
+    # First get the agent's _id
+    get_id_cmd = f'db.agents.findOne({{id: "{agent_id}"}}, {{_id: 1}})'
+    result = run_mongosh(namespace, pod_name, get_id_cmd)
+
+    if not result or result == "null":
+        print(f"    Warning: Could not find agent {agent_id} for ACL creation")
+        return
+
+    # Parse the ObjectId from the result
+    # Result looks like: { _id: ObjectId('...') }
+    import re
+    match = re.search(r"ObjectId\(['\"]([^'\"]+)['\"]\)", result)
+    if not match:
+        print(f"    Warning: Could not parse agent _id from: {result}")
+        return
+
+    agent_object_id = match.group(1)
+
+    # Create public ACL entry with VIEW permission (permBits: 1)
+    acl_cmd = f'''db.aclentries.insertOne({{
+        principalType: "public",
+        resourceType: "agent",
+        resourceId: ObjectId("{agent_object_id}"),
+        permBits: 1,
+        grantedBy: ObjectId("{granted_by}"),
+        grantedAt: ISODate("{now}"),
+        createdAt: ISODate("{now}"),
+        updatedAt: ISODate("{now}")
+    }})'''
+
+    run_mongosh(namespace, pod_name, acl_cmd)
+    print(f"    Made public: {agent_id}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Migrate LibreChat agents between MongoDB instances"
+    )
+    parser.add_argument("--agents", required=True, help="Path to agents JSON export file")
+    parser.add_argument("--aclentries", help="Path to ACL entries JSON export file (optional)")
+    parser.add_argument("--new-user-email", required=True, help="Email for the new owner")
+    parser.add_argument("--new-user-name", help="Display name for new owner")
+    parser.add_argument("--make-public", action="store_true", help="Make all agents publicly viewable")
+    parser.add_argument("--target-namespace", default="librechat-fips", help="Target OpenShift namespace")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
+
+    args = parser.parse_args()
+
+    # Load agents
+    print(f"Loading agents from {args.agents}...")
+    with open(args.agents, "r") as f:
+        agents = json.load(f)
+    print(f"Found {len(agents)} agents to migrate")
+
+    if args.dry_run:
+        print("\n=== DRY RUN MODE ===")
+        for agent in agents:
+            print(f"  Would import: {agent.get('name')} ({agent.get('id')})")
+            if args.make_public:
+                print(f"    Would make public")
+        return
+
+    # Get MongoDB pod
+    print(f"\nConnecting to MongoDB in namespace {args.target_namespace}...")
+    pod_name = get_mongodb_pod(args.target_namespace)
+    print(f"Found MongoDB pod: {pod_name}")
+
+    # Get or create user
+    print(f"\nSetting up owner user: {args.new_user_email}...")
+    user = get_or_create_user(
+        args.target_namespace,
+        pod_name,
+        args.new_user_email,
+        args.new_user_name
+    )
+
+    # Extract user ID (handle both string and dict formats)
+    if isinstance(user.get("_id"), dict):
+        user_id = user["_id"].get("$oid", str(user["_id"]))
+    else:
+        user_id = str(user["_id"]).replace("ObjectId('", "").replace("')", "")
+
+    user_name = user.get("name", args.new_user_email.split("@")[0])
+
+    # Import agents
+    print(f"\nImporting agents...")
+    results = import_agents(
+        args.target_namespace,
+        pod_name,
+        agents,
+        user_id,
+        user_name,
+        args.make_public
+    )
+
+    # Summary
+    print(f"\n=== Migration Complete ===")
+    print(f"Imported: {results['imported']}")
+    print(f"Skipped (already exist): {results['skipped']}")
+    if results['errors']:
+        print(f"Errors: {len(results['errors'])}")
+        for err in results['errors']:
+            print(f"  - {err['agent']}: {err['error']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/update-librechat-config.sh
+++ b/update-librechat-config.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Update LibreChat configuration and restart deployment
+# Usage: ./update-librechat-config.sh [namespace] [config-file]
+
+set -e
+
+NAMESPACE="${1:-librechat-fips}"
+CONFIG_FILE="${2:-./librechat.yaml}"
+DEPLOYMENT="librechat-librechat"
+CONFIGMAP="librechat-config"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}LibreChat Config Updater${NC}"
+echo "========================="
+echo "Namespace: $NAMESPACE"
+echo "Config file: $CONFIG_FILE"
+echo ""
+
+# Verify config file exists
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo -e "${RED}Error: Config file '$CONFIG_FILE' not found${NC}"
+    exit 1
+fi
+
+# Verify we can access the cluster
+if ! oc whoami &>/dev/null; then
+    echo -e "${RED}Error: Not logged into OpenShift cluster${NC}"
+    exit 1
+fi
+
+# Verify namespace exists
+if ! oc get namespace "$NAMESPACE" &>/dev/null; then
+    echo -e "${RED}Error: Namespace '$NAMESPACE' does not exist${NC}"
+    exit 1
+fi
+
+# Step 1: Update ConfigMap
+echo -e "${YELLOW}Step 1: Updating ConfigMap...${NC}"
+oc delete configmap "$CONFIGMAP" -n "$NAMESPACE" 2>/dev/null || true
+oc create configmap "$CONFIGMAP" --from-file=librechat.yaml="$CONFIG_FILE" -n "$NAMESPACE"
+echo -e "${GREEN}✓ ConfigMap updated${NC}"
+
+# Step 2: Scale down to release PVC (avoids stuck ContainerCreating)
+echo -e "${YELLOW}Step 2: Scaling down deployment...${NC}"
+oc scale deployment/"$DEPLOYMENT" -n "$NAMESPACE" --replicas=0
+echo "Waiting for pods to terminate..."
+sleep 15
+
+# Step 3: Scale up with new config
+echo -e "${YELLOW}Step 3: Scaling up deployment...${NC}"
+oc scale deployment/"$DEPLOYMENT" -n "$NAMESPACE" --replicas=1
+
+# Step 4: Wait for rollout
+echo -e "${YELLOW}Step 4: Waiting for rollout to complete...${NC}"
+if oc rollout status deployment/"$DEPLOYMENT" -n "$NAMESPACE" --timeout=180s; then
+    echo -e "${GREEN}✓ Deployment rolled out successfully${NC}"
+else
+    echo -e "${RED}✗ Rollout timed out${NC}"
+    echo "Check pod status with: oc get pods -n $NAMESPACE"
+    exit 1
+fi
+
+# Step 5: Verify MCP connections
+echo ""
+echo -e "${YELLOW}Step 5: Checking MCP server connections...${NC}"
+sleep 10  # Give servers time to initialize
+echo ""
+oc logs deployment/"$DEPLOYMENT" -n "$NAMESPACE" --tail=100 | grep -E "\[MCP\].*(-{2,}|Tools:|URL:|Connection failed|Failed)" | tail -30
+echo ""
+
+echo -e "${GREEN}Done! LibreChat config has been updated.${NC}"
+echo ""
+echo "Useful commands:"
+echo "  View logs: oc logs -f deployment/$DEPLOYMENT -n $NAMESPACE"
+echo "  Check MCP: oc logs deployment/$DEPLOYMENT -n $NAMESPACE | grep '\[MCP\]'"
+echo "  Get route: oc get route -n $NAMESPACE"


### PR DESCRIPTION
 ## Summary

  Fixes MCP tool content format compatibility with custom endpoints (vLLM/Mistral).

  MCP servers return tool results in array format `[{type: "text", text: "..."}]`, but vLLM/Mistral endpoints expect tool content as a plain string. This causes
  400 errors when LibreChat passes the array directly to vLLM.

  This fix extracts the text content for custom endpoints, matching the existing handling pattern already used for Google endpoints.

  **Tested with:**
  - Ministral-8B-Instruct-2410 via vLLM 0.6.6
  - MCP weather server returning structured JSON

  ## Change Type

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## Testing

  1. Deploy vLLM with a Mistral model (e.g., Ministral-8B) with tool calling enabled
  2. Configure LibreChat with a custom endpoint pointing to vLLM
  3. Add an MCP server (e.g., weather-mcp)
  4. Create an agent using the Mistral model with MCP tools
  5. Send a query that triggers tool use (e.g., "What's the weather in Seattle?")

  **Before fix:** 400 error - `messages.X.tool.content - Input should be a valid string`
  **After fix:** Tool result properly passed, model generates response

  ### Test Configuration:
  - vLLM 0.6.6 with `--tool-call-parser=mistral`
  - Ministral-8B-Instruct-2410
  - LibreChat v0.8.1-rc1

  ## Checklist

  - [x] My code adheres to this project's style guidelines
  - [x] I have performed a self-review of my own code
  - [x] I have commented in any complex areas of my code
  - [x] My changes do not introduce new warnings