### PR TITLE
⚙️ feat: Add configurable trust checkbox labels for MCP Server Dialog

### DIFF
--- a/client/src/components/SidePanel/MCPBuilder/MCPServerDialog.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPServerDialog.tsx
@@ -22,7 +22,8 @@ import {
 } from '~/data-provider/MCP';
 import MCPAuth, { type AuthConfig, AuthTypeEnum, AuthorizationTypeEnum } from './MCPAuth';
 import MCPIcon from '~/components/SidePanel/Agents/MCPIcon';
-import { useLocalize } from '~/hooks';
+import { useLocalize, useLocalizedConfig } from '~/hooks';
+import { useGetStartupConfig } from '~/data-provider';
 import { cn } from '~/utils';
 import {
   SystemRoles,
@@ -69,6 +70,8 @@ export default function MCPServerDialog({
 }: MCPServerDialogProps) {
   const localize = useLocalize();
   const { showToast } = useToastContext();
+  const { data: startupConfig } = useGetStartupConfig();
+  const getLocalizedValue = useLocalizedConfig();
 
   // Mutations
   const createMutation = useCreateMCPServerMutation();
@@ -575,13 +578,38 @@ export default function MCPServerDialog({
                   <Label
                     id="trust-this-mcp-label"
                     htmlFor="trust"
-                    className="flex cursor-pointer flex-col text-sm font-medium"
+                    className="flex cursor-pointer flex-col break-words text-sm font-medium"
                   >
                     <span>
-                      {localize('com_ui_trust_app')} <span className="text-red-500">*</span>
+                      {startupConfig?.interface?.mcpServers?.trustCheckbox?.label ? (
+                        <span
+                          /** No sanitization required. trusted admin-controlled source (yml)  */
+                          dangerouslySetInnerHTML={{
+                            __html: getLocalizedValue(
+                              startupConfig.interface.mcpServers.trustCheckbox.label,
+                              localize('com_ui_trust_app'),
+                            ),
+                          }}
+                        />
+                      ) : (
+                        localize('com_ui_trust_app')
+                      )}{' '}
+                      <span className="text-red-500">*</span>
                     </span>
                     <span className="text-xs font-normal text-text-secondary">
-                      {localize('com_agents_mcp_trust_subtext')}
+                      {startupConfig?.interface?.mcpServers?.trustCheckbox?.subLabel ? (
+                        <span
+                          /** No sanitization required. trusted admin-controlled source (yml)  */
+                          dangerouslySetInnerHTML={{
+                            __html: getLocalizedValue(
+                              startupConfig.interface.mcpServers.trustCheckbox.subLabel,
+                              localize('com_agents_mcp_trust_subtext'),
+                            ),
+                          }}
+                        />
+                      ) : (
+                        localize('com_agents_mcp_trust_subtext')
+                      )}
                     </span>
                   </Label>
                 </div>

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -34,3 +34,4 @@ export { default as useSpeechToText } from './Input/useSpeechToText';
 export { default as useTextToSpeech } from './Input/useTextToSpeech';
 export { default as useGenerationsByLatest } from './useGenerationsByLatest';
 export { useResourcePermissions } from './useResourcePermissions';
+export { default as useLocalizedConfig } from './useLocalizedConfig';

--- a/client/src/hooks/useLocalizedConfig.ts
+++ b/client/src/hooks/useLocalizedConfig.ts
@@ -1,0 +1,36 @@
+import { useRecoilValue } from 'recoil';
+import store from '~/store';
+
+type LocalizedValue = string | Record<string, string> | undefined;
+
+/**
+ * Hook to resolve localized config values based on current user language.
+ * Automatically retrieves the current language from Recoil state.
+ *
+ * @returns A function to resolve localized values
+ */
+export default function useLocalizedConfig() {
+  const lang = useRecoilValue(store.lang);
+
+  /**
+   * Resolves a localized config value.
+   * @param value - Either a string or object with language codes as keys
+   * @param fallback - Fallback value if config is undefined or language not found
+   * @returns The resolved string value
+   */
+  return (value: LocalizedValue, fallback: string): string => {
+    if (value === undefined) {
+      return fallback;
+    }
+    if (typeof value === 'string') {
+      return value;
+    }
+    // Extract base language code (e.g., 'de' from 'de-DE')
+    const baseLang = lang?.split('-')[0] ?? 'en';
+
+    // Try exact locale (de-DE), then base language (de), then 'en', then first available
+    return (
+      (lang && value[lang]) || value[baseLang] || value['en'] || Object.values(value)[0] || fallback
+    );
+  };
+}

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -105,6 +105,18 @@ interface:
     use: false
     create: false
     share: false
+    # Creation / edit MCP server config Dialog config example
+    # trustCheckbox:
+    #   label:
+    #     en: 'I understand and I want to continue'
+    #     de: 'Ich verstehe und möchte fortfahren'
+    #     de-DE: 'Ich verstehe und möchte fortfahren' # You can narrow translation to regions like (de-DE or de-CH)
+    #   subLabel:
+    #     en: |
+    #       Librechat hasn't reviewed this MCP server. Attackers may attempt to steal your data or trick the model into taking unintended actions, including destroying data. <a href="https://google.de" target="_blank"><strong>Learn more.</strong></a>
+    #     de: |
+    #       LibreChat hat diesen MCP-Server nicht überprüft. Angreifer könnten versuchen, Ihre Daten zu stehlen oder das Modell zu unbeabsichtigten Aktionen zu verleiten, einschließlich der Zerstörung von Daten. <a href="https://google.de" target="_blank"><strong>Mehr erfahren.</strong></a>
+
   # Temporary chat retention period in hours (default: 720, min: 1, max: 8760)
   # temporaryChatRetention: 1
 

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -516,12 +516,22 @@ const termsOfServiceSchema = z.object({
 
 export type TTermsOfService = z.infer<typeof termsOfServiceSchema>;
 
+// Schema for localized string (either simple string or language-keyed object)
+const localizedStringSchema = z.union([z.string(), z.record(z.string())]);
+export type LocalizedString = z.infer<typeof localizedStringSchema>;
+
 const mcpServersSchema = z
   .object({
     placeholder: z.string().optional(),
     use: z.boolean().optional(),
     create: z.boolean().optional(),
     share: z.boolean().optional(),
+    trustCheckbox: z
+      .object({
+        label: localizedStringSchema.optional(),
+        subLabel: localizedStringSchema.optional(),
+      })
+      .optional(),
   })
   .optional();
 


### PR DESCRIPTION
## Summary
 This PR makes the trust checkbox label in the MCP Server Dialog configurable via librechat.yaml. Administrators can now customize the label and sublabel text with support for HTML content and multi-language localization.

<img width="842" height="708" alt="image" src="https://github.com/user-attachments/assets/5989a755-5645-48d9-9d01-8d355f50dc2a" />

## Changes

- Added trustCheckbox configuration option under interface.mcpServers in the YAML schema
- Created useLocalizedConfig hook to resolve localized config values based on user's language
- Updated MCPServerDialog to render configurable labels with HTML support

| Cohort / File(s) | Summary |
|---|---|
| **New Localization Hook** <br> `client/src/hooks/useLocalizedConfig.ts` | Implements a React hook that resolves localized config values based on current language state. Returns a resolver function supporting exact locale, base language, English fallback, and custom fallbacks. Handles string, object, and undefined input types. |
| **Hook Export** <br> `client/src/hooks/index.ts` | Re-exports the new `useLocalizedConfig` hook as a default export to expand the public API. |
| **Config Schema Extensions** <br> `packages/data-provider/src/config.ts` | Adds `LocalizedString` type (string \| object with string values) and schema. Extends `mcpServersSchema` with optional `trustCheckbox` field containing localized `label` and `subLabel` fields. |
| **Dialog Component Updates** <br> `client/src/components/SidePanel/MCPBuilder/MCPServerDialog.tsx` | Integrates `useGetStartupConfig` and `useLocalizedConfig` hooks to conditionally render admin-provided HTML-enabled labels for trust dialog text. Falls back to existing localized strings when startup config values are unavailable. Updates trust label container for long text wrapping. |

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing
Manuel testing:

- Simple string (same for all languages)
```yaml
  interface:
    mcpServers:
      trustCheckbox:
        label: "<strong>I trust this MCP server</strong>"
        subLabel: "By checking this box, you acknowledge the risks."
```
- Localized by language code
```yaml
  interface:
    mcpServers:
      trustCheckbox:
        label:
          en: "I trust this MCP server"
          de: "Ich vertraue diesem MCP-Server"
          de-DE: "Ich vertraue diesem MCP-Server (Deutschland)"
        subLabel:
          en: "By checking this box, you acknowledge the risks."
          de: "Durch Aktivieren bestätigen Sie die Risiken."
```
### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
