### PR TITLE
🐛 fix: Improve Error Handling when Adding MCP Server Fails

### DIFF
--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -235,7 +235,7 @@ const updateMCPServerController = async (req, res) => {
     res.status(200).json(parsedConfig);
   } catch (error) {
     logger.error('[updateMCPServer]', error);
-    if (error.message?.includes('MCP_INSPECTION_FAILED')) {
+    if (error.message?.startsWith('MCP_INSPECTION_FAILED:')) {
       return res.status(400).json({
         error: 'MCP_INSPECTION_FAILED',
         message: error.message,

--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -175,7 +175,7 @@ const createMCPServerController = async (req, res) => {
     });
   } catch (error) {
     logger.error('[createMCPServer]', error);
-    if (error.message?.includes('MCP_INSPECTION_FAILED')) {
+    if (error.message?.startsWith('MCP_INSPECTION_FAILED')) {
       return res.status(400).json({
         error: 'MCP_INSPECTION_FAILED',
         message: error.message,

--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -175,6 +175,12 @@ const createMCPServerController = async (req, res) => {
     });
   } catch (error) {
     logger.error('[createMCPServer]', error);
+    if (error.message?.includes('MCP_INSPECTION_FAILED')) {
+      return res.status(400).json({
+        error: 'MCP_INSPECTION_FAILED',
+        message: error.message,
+      });
+    }
     res.status(500).json({ message: error.message });
   }
 };
@@ -229,6 +235,12 @@ const updateMCPServerController = async (req, res) => {
     res.status(200).json(parsedConfig);
   } catch (error) {
     logger.error('[updateMCPServer]', error);
+    if (error.message?.includes('MCP_INSPECTION_FAILED')) {
+      return res.status(400).json({
+        error: 'MCP_INSPECTION_FAILED',
+        message: error.message,
+      });
+    }
     res.status(500).json({ message: error.message });
   }
 };

--- a/client/src/components/SidePanel/MCPBuilder/MCPServerDialog.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPServerDialog.tsx
@@ -280,7 +280,9 @@ export default function MCPServerDialog({
 
       if (error && typeof error === 'object' && 'response' in error) {
         const axiosError = error as any;
-        if (axiosError.response?.data?.error) {
+        if (axiosError.response?.data?.error === 'MCP_INSPECTION_FAILED') {
+          errorMessage = localize('com_ui_mcp_server_connection_failed');
+        } else if (axiosError.response?.data?.error) {
           errorMessage = axiosError.response.data.error;
         }
       } else if (error.message) {

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -633,6 +633,7 @@
   "com_ui_add_first_mcp_server": "Create your first MCP server to get started",
   "com_ui_mcp_server_created": "MCP server created successfully",
   "com_ui_mcp_server_updated": "MCP server updated successfully",
+  "com_ui_mcp_server_connection_failed": "Connection attempt to the provided MCP server failed. Please make sure the URL, the server type, and any authentication configuration are correct, then try again. Also ensure the URL is reachable.",
   "com_ui_add_model_preset": "Add a model or preset for an additional response",
   "com_ui_add_multi_conversation": "Add multi-conversation",
   "com_ui_add_special_variables": "Add Special Variables",

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -78,7 +78,13 @@ export class MCPServersRegistry {
     userId?: string,
   ): Promise<t.AddServerResult> {
     const configRepo = this.getConfigRepository(storageLocation);
-    const parsedConfig = await MCPServerInspector.inspect(serverName, config);
+    let parsedConfig: t.ParsedServerConfig;
+    try {
+      parsedConfig = await MCPServerInspector.inspect(serverName, config);
+    } catch (error) {
+      logger.error(`[MCPServersRegistry] Failed to inspect server "${serverName}":`, error);
+      throw new Error(`MCP_INSPECTION_FAILED: Failed to connect to MCP server "${serverName}"`);
+    }
     return await configRepo.add(serverName, parsedConfig, userId);
   }
 
@@ -89,7 +95,13 @@ export class MCPServersRegistry {
     userId?: string,
   ): Promise<t.ParsedServerConfig> {
     const configRepo = this.getConfigRepository(storageLocation);
-    const parsedConfig = await MCPServerInspector.inspect(serverName, config);
+    let parsedConfig: t.ParsedServerConfig;
+    try {
+      parsedConfig = await MCPServerInspector.inspect(serverName, config);
+    } catch (error) {
+      logger.error(`[MCPServersRegistry] Failed to inspect server "${serverName}":`, error);
+      throw new Error(`MCP_INSPECTION_FAILED: Failed to connect to MCP server "${serverName}"`);
+    }
     await configRepo.update(serverName, parsedConfig, userId);
     return parsedConfig;
   }


### PR DESCRIPTION
## Summary

- Add specific error handling when MCP server inspection/connection fails during create or update
- Log original errors for debugging while showing user-friendly localized message on frontend
- Return structured error response with `MCP_INSPECTION_FAILED` code

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

- [x] Try to create an MCP server with an invalid/unreachable URL
- [x] Verify the localized error message is displayed: "Connection attempt to the provided MCP server failed..."
- [x] Verify the original error is logged in server logs with `[MCPServersRegistry]` prefix
- [x] Try to update an existing MCP server with an invalid URL and verify same behavior


## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
