### PR TITLE
☰ fix: Side Panel Accessibility Improvements

### DIFF
--- a/client/src/components/Prompts/Groups/ChatGroupItem.tsx
+++ b/client/src/components/Prompts/Groups/ChatGroupItem.tsx
@@ -81,7 +81,7 @@ function ChatGroupItem({
                 ref={triggerButtonRef}
                 id={`prompt-actions-${group._id}`}
                 type="button"
-                aria-label={localize('com_ui_sr_actions_menu', { name: group.name })}
+                aria-label={localize('com_ui_sr_actions_menu', { 0: group.name })}
                 onClick={(e) => {
                   e.stopPropagation();
                 }}

--- a/client/src/components/Prompts/Groups/ChatGroupItem.tsx
+++ b/client/src/components/Prompts/Groups/ChatGroupItem.tsx
@@ -55,7 +55,7 @@ function ChatGroupItem({
 
   return (
     <>
-      <div className="relative my-2 items-stretch justify-between rounded-xl border border-border-light shadow-sm transition-all duration-300 ease-in-out hover:bg-surface-tertiary hover:shadow-lg">
+      <div className="relative my-2 items-stretch justify-between rounded-xl border border-border-light px-1 shadow-sm transition-all duration-300 ease-in-out hover:bg-surface-tertiary hover:shadow-lg">
         <ListCard
           name={group.name}
           category={group.category ?? ''}

--- a/client/src/components/Prompts/Groups/ChatGroupItem.tsx
+++ b/client/src/components/Prompts/Groups/ChatGroupItem.tsx
@@ -68,7 +68,10 @@ function ChatGroupItem({
         ></ListCard>
         {groupIsGlobal === true && (
           <div className="absolute right-14 top-[16px]">
-            <EarthIcon className="icon-md text-green-400" aria-label="Global prompt group" />
+            <EarthIcon
+              className="icon-md text-green-400"
+              aria-label={localize('com_ui_sr_global_prompt')}
+            />
           </div>
         )}
         <div className="absolute right-0 top-0 mr-1 mt-2.5 items-start pl-2">

--- a/client/src/components/Prompts/Groups/ChatGroupItem.tsx
+++ b/client/src/components/Prompts/Groups/ChatGroupItem.tsx
@@ -65,13 +65,12 @@ function ChatGroupItem({
               ? group.oneliner
               : (group.productionPrompt?.prompt ?? '')
           }
-        >
-          <div className="flex flex-row items-center gap-2">
-            {groupIsGlobal === true && (
-              <EarthIcon className="icon-md text-green-400" aria-label="Global prompt group" />
-            )}
+        ></ListCard>
+        {groupIsGlobal === true && (
+          <div className="absolute right-14 top-[16px]">
+            <EarthIcon className="icon-md text-green-400" aria-label="Global prompt group" />
           </div>
-        </ListCard>
+        )}
         <div className="absolute right-0 top-0 mr-1 mt-2.5 items-start pl-2">
           <DropdownMenu modal={false}>
             <DropdownMenuTrigger asChild>

--- a/client/src/components/Prompts/Groups/GroupSidePanel.tsx
+++ b/client/src/components/Prompts/Groups/GroupSidePanel.tsx
@@ -55,7 +55,7 @@ export default function GroupSidePanel({
           />
         </div>
       )}
-      <div className="flex flex-1 flex-col gap-2 overflow-y-auto">
+      <div className="flex flex-1 flex-col gap-2 overflow-visible">
         {children}
         <div className={cn('relative flex h-full flex-col', isChatRoute ? '' : 'px-2 md:px-0')}>
           <List

--- a/client/src/components/Prompts/Groups/ListCard.tsx
+++ b/client/src/components/Prompts/Groups/ListCard.tsx
@@ -50,7 +50,7 @@ export default function ListCard({
       </div>
       <div
         id={`card-snippet-${name}`}
-        className="ellipsis max-w-full select-none text-balance text-sm text-text-secondary"
+        className="ellipsis max-w-full select-none text-balance pt-1 text-sm text-text-secondary"
       >
         {snippet}
       </div>

--- a/client/src/components/SidePanel/Agents/AdminSettings.tsx
+++ b/client/src/components/SidePanel/Agents/AdminSettings.tsx
@@ -152,7 +152,7 @@ const AdminSettings = () => {
         <Button
           size={'sm'}
           variant={'outline'}
-          className="btn btn-neutral border-token-border-light relative h-9 w-full gap-1 rounded-lg font-medium"
+          className="btn btn-neutral border-token-border-light relative h-9 w-full gap-1 rounded-lg font-medium focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-primary"
           aria-label={localize('com_ui_admin_settings')}
         >
           <ShieldEllipsis className="cursor-pointer" aria-hidden="true" />
@@ -218,7 +218,7 @@ const AdminSettings = () => {
                 type="button"
                 onClick={handleSubmit(onSubmit)}
                 disabled={isSubmitting || isLoading}
-                className="btn rounded bg-green-500 font-bold text-white transition-all hover:bg-green-600"
+                className="btn rounded bg-green-500 font-bold text-white transition-all hover:bg-green-600 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring-primary"
               >
                 {localize('com_ui_save')}
               </button>

--- a/client/src/components/SidePanel/Agents/Advanced/AdvancedButton.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/AdvancedButton.tsx
@@ -15,7 +15,7 @@ const AdvancedButton: React.FC<AdvancedButtonProps> = ({ setActivePanel }) => {
     <Button
       size={'sm'}
       variant={'outline'}
-      className="btn btn-neutral border-token-border-light relative h-9 w-full gap-1 rounded-lg font-medium"
+      className="btn btn-neutral border-token-border-light relative h-9 w-full gap-1 rounded-lg font-medium focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-primary"
       onClick={() => setActivePanel(Panel.advanced)}
       aria-label={localize('com_ui_advanced')}
     >

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -476,7 +476,7 @@ export default function AgentPanel() {
     <FormProvider {...methods}>
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="scrollbar-gutter-stable h-auto w-full flex-shrink-0 overflow-x-hidden"
+        className="scrollbar-gutter-stable h-auto w-full flex-shrink-0 overflow-x-visible"
         aria-label="Agent configuration form"
       >
         <div className="mx-1 mt-2 flex w-full flex-wrap gap-2">

--- a/client/src/components/SidePanel/Bookmarks/BookmarkPanel.tsx
+++ b/client/src/components/SidePanel/Bookmarks/BookmarkPanel.tsx
@@ -6,7 +6,7 @@ const BookmarkPanel = () => {
   const { data } = useConversationTagsQuery();
 
   return (
-    <div className="h-auto max-w-full overflow-x-hidden">
+    <div className="h-auto max-w-full overflow-x-visible">
       <BookmarkContext.Provider value={{ bookmarks: data || [] }}>
         <BookmarkTable />
       </BookmarkContext.Provider>

--- a/client/src/components/SidePanel/Files/Panel.tsx
+++ b/client/src/components/SidePanel/Files/Panel.tsx
@@ -7,7 +7,7 @@ export default function FilesPanel() {
   const { data: files = [] } = useGetFiles<TFile[]>();
 
   return (
-    <div className="h-auto max-w-full overflow-x-hidden">
+    <div className="h-auto max-w-full overflow-x-visible">
       <DataTable columns={columns} data={files} />
     </div>
   );

--- a/client/src/components/SidePanel/Files/PanelTable.tsx
+++ b/client/src/components/SidePanel/Files/PanelTable.tsx
@@ -241,6 +241,11 @@ export default function DataTable<TData, TValue>({ columns, data }: DataTablePro
                             textOverflow: 'ellipsis',
                             whiteSpace: 'nowrap',
                           }}
+                          className={
+                            isFilenameCell
+                              ? 'focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-text-primary'
+                              : ''
+                          }
                           data-skip-refocus="true"
                           key={cell.id}
                           role={isFilenameCell ? 'button' : undefined}

--- a/client/src/components/SidePanel/MCPBuilder/MCPAdminSettings.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPAdminSettings.tsx
@@ -151,7 +151,8 @@ const MCPAdminSettings = () => {
         <Button
           size={'sm'}
           variant={'outline'}
-          className="btn btn-neutral border-token-border-light relative h-9 w-full gap-1 rounded-lg font-medium"
+          className="btn btn-neutral border-token-border-light relative h-9 w-full gap-1 rounded-lg font-medium focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-primary"
+          aria-label={localize('com_ui_admin_settings')}
         >
           <ShieldEllipsis className="cursor-pointer" aria-hidden="true" />
           {localize('com_ui_admin_settings')}
@@ -216,7 +217,7 @@ const MCPAdminSettings = () => {
                 type="button"
                 onClick={handleSubmit(onSubmit)}
                 disabled={isSubmitting || isLoading}
-                className="btn rounded bg-green-500 font-bold text-white transition-all hover:bg-green-600"
+                className="btn rounded bg-green-500 font-bold text-white transition-all hover:bg-green-600 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-primary"
               >
                 {localize('com_ui_save')}
               </button>

--- a/client/src/components/SidePanel/MCPBuilder/MCPBuilderPanel.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPBuilderPanel.tsx
@@ -22,7 +22,7 @@ export default function MCPBuilderPanel() {
   const configDialogProps = getConfigDialogProps();
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden">
+    <div className="flex h-full w-full flex-col overflow-visible">
       <div role="region" aria-label="MCP Builder" className="mt-2 space-y-2">
         {/* Admin Settings Button */}
         <MCPAdminSettings />

--- a/client/src/components/SidePanel/Memories/AdminSettings.tsx
+++ b/client/src/components/SidePanel/Memories/AdminSettings.tsx
@@ -141,7 +141,7 @@ const AdminSettings = () => {
         <Button
           size={'sm'}
           variant={'outline'}
-          className="btn btn-neutral border-token-border-light relative h-9 w-full gap-1 rounded-lg font-medium"
+          className="btn btn-neutral border-token-border-light relative h-9 w-full gap-1 rounded-lg font-medium focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-primary"
           aria-label={localize('com_ui_admin_settings')}
         >
           <ShieldEllipsis className="cursor-pointer" aria-hidden="true" />
@@ -206,7 +206,7 @@ const AdminSettings = () => {
               <button
                 type="submit"
                 disabled={isSubmitting || isLoading}
-                className="btn rounded bg-green-500 font-bold text-white transition-all hover:bg-green-600"
+                className="btn rounded bg-green-500 font-bold text-white transition-all hover:bg-green-600 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-primary"
               >
                 {localize('com_ui_save')}
               </button>

--- a/client/src/components/SidePanel/Memories/MemoryViewer.tsx
+++ b/client/src/components/SidePanel/Memories/MemoryViewer.tsx
@@ -239,7 +239,7 @@ export default function MemoryViewer() {
   }
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden">
+    <div className="flex h-full w-full flex-col">
       <div role="region" aria-label={localize('com_ui_memories')} className="mt-2 space-y-2">
         <div className="relative">
           <Input

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1283,6 +1283,7 @@
   "com_ui_special_variables_more_info": "You can select special variables from the dropdown: `{{current_date}}` (today's date and day of week), `{{current_datetime}}` (local date and time), `{{utc_iso_datetime}}` (UTC ISO datetime), and `{{current_user}}` (your account name).",
   "com_ui_speech_while_submitting": "Can't submit speech while a response is being generated",
   "com_ui_sr_actions_menu": "Open actions menu for \"{{0}}\" prompt",
+  "com_ui_sr_global_prompt": "Global prompt group",
   "com_ui_stack_trace": "Stack Trace",
   "com_ui_status_prefix": "Status:",
   "com_ui_stop": "Stop",

--- a/packages/client/src/components/Accordion.tsx
+++ b/packages/client/src/components/Accordion.tsx
@@ -39,7 +39,7 @@ const AccordionContent = React.forwardRef<
 >(({ className = '', children, ...props }, ref) => (
   <AccordionPrimitive.Content
     ref={ref}
-    className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    className="overflow-x-visible text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
     {...props}
   >
     <div className={cn('pb-4 pt-0', className)}>{children}</div>


### PR DESCRIPTION
## Summary

This pull request focuses on improving accessibility and user experience across several UI components within the right hand side panel by fixing clipped focus outlines, enhancing contrast for outlines which did not meet compliance standards for outline contrast thresholds, and addressing two regressions involving the positioning of the Global group icon for prompts being overlapped by the new absolute positioned menu button in the prompt list in the Prompts panel, and screen reader output for the same menu button not being a properly interpolated translation key. With the completion of this PR, all instances of clipping within the right hand side navigation panels should now be resolved as part of a larger effort to find and address instances of focus outline clipping throughout the application for improved accessibility.

**Accessibility improvements:**

* Fixed issues with focus outline clipping and contrast thresholds for buttons and interactive elements in `AdminSettings`, `AdvancedButton`, `MCPAdminSettings`, and DataTable filename cells to provide clear visual focus indicators for keyboard navigation. [[1]](diffhunk://#diff-fb4719b2bceca2ce9fe464e22dfd936c535544f688e05783d21c9ebe2fc86b26L155-R155) [[2]](diffhunk://#diff-fb4719b2bceca2ce9fe464e22dfd936c535544f688e05783d21c9ebe2fc86b26L221-R221) [[3]](diffhunk://#diff-a3f84bd058559756199ec37dc4ecbf3a614e6cd9e1113ea51a6d67e654fc2437L18-R18) [[4]](diffhunk://#diff-a94f0a958c28384060b37f37336b5ac80143a6b8364559784276cc4526e2833dL154-R155) [[5]](diffhunk://#diff-a94f0a958c28384060b37f37336b5ac80143a6b8364559784276cc4526e2833dL219-R220) [[6]](diffhunk://#diff-82b7eb1fccbef06d80b0d1530f45dec9f6a56463575d232c5e31b81169fa191bL144-R144) [[7]](diffhunk://#diff-82b7eb1fccbef06d80b0d1530f45dec9f6a56463575d232c5e31b81169fa191bL209-R209) [[8]](diffhunk://#diff-fc4d58c1169b81e3d63bd027612f839038db5094119a66165317696219c09027R244-R248)

**Overflow behavior adjustments:**

* Changed various panels and containers (`GroupSidePanel`, `AgentPanel`, `BookmarkPanel`, `FilesPanel`, `MCPBuilderPanel`, `MemoryViewer`, and `AccordionContent`) from `overflow-hidden` or `overflow-x-hidden` to `overflow-visible` or `overflow-x-visible` to prevent content from being clipped and improve layout flexibility. [[1]](diffhunk://#diff-ebb45c472c5663bf7b07b983357514c263148995be958a682f572ccf1a6d69b6L58-R58) [[2]](diffhunk://#diff-6017fc59e7c6a4cd75e96a4ffee2b76e07a3dcbd5a606f1fbd8b2ad7a0e720baL479-R479) [[3]](diffhunk://#diff-e2018017994ae0cf041ba5ee624a2d422cdc0900c617d670b10ddb831c48cb24L9-R9) [[4]](diffhunk://#diff-88eaa4237b70ea95a2030c0c03bbe1e2153f57b00793b5e5c10fb2d3d247d26eL10-R10) [[5]](diffhunk://#diff-94f4587c47bf06d640ead34615bef32c4fb8fc92982965ebe50c1a9dd7776161L25-R25) [[6]](diffhunk://#diff-5bca0c6b6b27b935801e6225475fa79150531a10a01f7da2e7b415d52968586aL242-R242) [[7]](diffhunk://#diff-24bd612efee2d8125da13938a213969b6216f7d17c65f042f20107580df7ac7aL42-R42)

**Minor UI enhancements:**

* Added padding-top to the snippet text in `ListCard` for improved spacing.
* Added horizontal padding to the chat group item container for better alignment.

These updates collectively enhance accessibility for keyboard users and improve the overall visual consistency of the application's UI.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified proper outline rendering for each affected button as changes were implemented, as well as confirming the screen reader output now properly announces the title of the related prompt for the menu dropdown button and the positioning of the globe icon alongside the menu dropdown button.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes