### PR TITLE
🔧 chore: Upgrade Meilisearch to version 1.28.2

### DIFF
--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -53,7 +53,7 @@ services:
     command: mongod --noauth
   meilisearch:
     container_name: chat-meilisearch
-    image: getmeili/meilisearch:v1.12.3
+    image: getmeili/meilisearch:v1.28.2
     restart: always
     # ports: # Uncomment this to access meilisearch from outside docker
     #   - 7700:7700 # if exposing these ports, make sure your master key is not the default value
@@ -63,7 +63,7 @@ services:
       - MEILI_HOST=http://meilisearch:7700
       - MEILI_NO_ANALYTICS=true
     volumes:
-      - ./meili_data_v1.12:/meili_data
+      - ./meili_data_v1.28:/meili_data
   vectordb:
     image: pgvector/pgvector:0.8.0-pg15-trixie
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     command: mongod --noauth
   meilisearch:
     container_name: chat-meilisearch
-    image: getmeili/meilisearch:v1.12.3
+    image: getmeili/meilisearch:v1.28.2
     restart: always
     user: "${UID}:${GID}"
     environment:
@@ -45,7 +45,7 @@ services:
       - MEILI_NO_ANALYTICS=true
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
     volumes:
-      - ./meili_data_v1.12:/meili_data
+      - ./meili_data_v1.28:/meili_data
   vectordb:
     container_name: vectordb
     image: pgvector/pgvector:0.8.0-pg15-trixie


### PR DESCRIPTION
# Pull Request Template

## Summary

This pull request updates the Meilisearch service configuration in both `deploy-compose.yml` and `docker-compose.yml` files to use a newer version and a new data volume. This change is intended to resolve the following:

- curl           8.11.1-r0   8.12.0-r0   apk   CVE-2025-0665   Critical  14.0% (94th)   13.2
- libcurl        8.11.1-r0   8.12.0-r0   apk   CVE-2025-0665   Critical  14.0% (94th)   13.2

(by severity: 2 critical, 11 high, 15 medium, 8 low, 0 negligible)

After upgrade - by severity: 0 critical, 0 high, 1 medium, 6 low, 0 negligible

## Change Type

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Note that by breaking change, LibreChat docs already include proper instructions for the fix: https://www.librechat.ai/docs/configuration/meilisearch#9-resetting-meilisearch-synchronization

## Testing

Automated tests, ensured that searching still works on existing and new chats.

## Checklist

- [X] I have performed a self-review of my own code
- [X] My changes do not introduce new warnings
- [X] Local unit tests pass with my changes
