### PR TITLE
📢 fix: Better Prompt Search Result Announcements

### DIFF
--- a/client/src/components/Prompts/Groups/FilterPrompts.tsx
+++ b/client/src/components/Prompts/Groups/FilterPrompts.tsx
@@ -1,11 +1,10 @@
-import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useRecoilState } from 'recoil';
 import { ListFilter, User, Share2 } from 'lucide-react';
 import { SystemCategories } from 'librechat-data-provider';
 import { Dropdown, AnimatedSearchInput } from '@librechat/client';
 import type { Option } from '~/common';
-import type { TranslationKeys } from '~/hooks';
-import { useLocalize, useCategories } from '~/hooks';
+import { useLocalize, useCategories, useDebounce } from '~/hooks';
 import { usePromptGroupsContext } from '~/Providers';
 import { cn } from '~/utils';
 import store from '~/store';
@@ -14,10 +13,10 @@ export default function FilterPrompts({ className = '' }: { className?: string }
   const localize = useLocalize();
   const { name, setName, hasAccess, promptGroups } = usePromptGroupsContext();
   const { categories } = useCategories({ className: 'h-4 w-4', hasAccess });
-  const [displayName, setDisplayName] = useState(name || '');
-  const [isSearching, setIsSearching] = useState(false);
+  const [searchTerm, setSearchTerm] = useState(name || '');
   const [categoryFilter, setCategory] = useRecoilState(store.promptsCategory);
-  const [searchResultsAnnouncement, setSearchResultsAnnouncement] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm, 500);
+  const prevNameRef = useRef(name);
 
   const filterOptions = useMemo(() => {
     const baseOptions: Option[] = [
@@ -62,53 +61,35 @@ export default function FilterPrompts({ className = '' }: { className?: string }
     [setCategory],
   );
 
-  // Sync displayName with name prop when it changes externally
+  // Sync searchTerm with name prop when it changes externally
   useEffect(() => {
-    setDisplayName(name || '');
+    if (prevNameRef.current !== name) {
+      prevNameRef.current = name;
+      setSearchTerm(name || '');
+    }
   }, [name]);
 
   useEffect(() => {
-    if (displayName === '') {
-      // Clear immediately when empty
-      setName('');
-      setIsSearching(false);
-      return;
+    setName(debouncedSearchTerm);
+  }, [debouncedSearchTerm, setName]);
+
+  const handleSearchChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(e.target.value);
+  }, []);
+
+  const isSearching = searchTerm !== debouncedSearchTerm;
+
+  const resultCount = promptGroups?.length ?? 0;
+  const searchResultsAnnouncement = useMemo(() => {
+    if (!debouncedSearchTerm.trim()) {
+      return '';
     }
-
-    setIsSearching(true);
-    const timeout = setTimeout(() => {
-      setIsSearching(false);
-      setName(displayName); // Debounced setName call
-    }, 500);
-    return () => clearTimeout(timeout);
-  }, [displayName, setName]);
-
-  useEffect(() => {
-    if (!displayName.trim() || isSearching) {
-      setSearchResultsAnnouncement('');
-      return;
-    }
-
-    const resultCount = promptGroups?.length ?? 0;
-    const announcement =
-      resultCount === 1
-        ? localize('com_ui_result_found' as TranslationKeys, {
-            count: resultCount,
-          })
-        : localize('com_ui_results_found' as TranslationKeys, {
-            count: resultCount,
-          });
-
-    const timeout = setTimeout(() => {
-      setSearchResultsAnnouncement(announcement);
-    }, 300);
-
-    return () => clearTimeout(timeout);
-  }, [promptGroups?.length, displayName, isSearching, localize]);
+    return resultCount === 1 ? `${resultCount} result found` : `${resultCount} results found`;
+  }, [debouncedSearchTerm, resultCount]);
 
   return (
-    <div className={cn('flex w-full gap-2 text-text-primary', className)}>
-      <div aria-live="polite" className="sr-only">
+    <div role="search" className={cn('flex w-full gap-2 text-text-primary', className)}>
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
         {searchResultsAnnouncement}
       </div>
       <Dropdown
@@ -122,10 +103,8 @@ export default function FilterPrompts({ className = '' }: { className?: string }
         iconOnly
       />
       <AnimatedSearchInput
-        value={displayName}
-        onChange={(e) => {
-          setDisplayName(e.target.value);
-        }}
+        value={searchTerm}
+        onChange={handleSearchChange}
         isSearching={isSearching}
         placeholder={localize('com_ui_filter_prompts_name')}
       />


### PR DESCRIPTION
## Summary

This pull request addresses a circular dependency which was occurring within the search announcement logic of the Prompts page, causing max depth errors in the console. The prompt filtering logic in `FilterPrompts.tsx` has been refactored to fix this issue and to improve search accessibility. The main change is the introduction of debounced search input handling, which streamlines how search terms are managed and updates are propagated.

**Search input and debouncing improvements:**

* Replaced the previous `displayName` and manual debounce logic with a new `searchTerm` state and a `useDebounce` hook, ensuring smoother and more efficient search updates.
* Updated the effect logic to synchronize the search term with external changes to the `name` prop using a `useRef`, preventing unnecessary updates.

**Accessibility and UI enhancements:**

* Changed the container to use `role="search"` and improved the live region with `aria-atomic="true"` for better screen reader support.
* Simplified the search results announcement logic to use a memoized value, removing localization and providing a clearer result count message.

**Codebase cleanup:**

* Refactored the input handler to use a memoized callback and updated the `AnimatedSearchInput` to use the new `searchTerm` state and handler.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before
<img width="1725" height="956" alt="Screenshot 2025-12-08 at 8 36 38 AM" src="https://github.com/user-attachments/assets/7cfb7b6c-bfa8-4707-8d52-acd904332111" />

### After
<img width="1723" height="955" alt="Screenshot 2025-12-08 at 8 34 50 AM" src="https://github.com/user-attachments/assets/bf808994-97c6-448a-badc-fd8fbe0978b7" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes