### PR TITLE
🔗 fix: Shared Links Accessibility Improvements

### DIFF
--- a/client/src/components/Nav/SettingsTabs/Data/SharedLinks.tsx
+++ b/client/src/components/Nav/SettingsTabs/Data/SharedLinks.tsx
@@ -21,6 +21,7 @@ import {
   useMediaQuery,
   OGDialogHeader,
   OGDialogTitle,
+  TooltipAnchor,
   DataTable,
   Spinner,
   Button,
@@ -259,30 +260,42 @@ export default function SharedLinks() {
         },
         cell: ({ row }) => (
           <div className="flex items-center gap-2">
-            <a
-              href={`/c/${row.original.conversationId}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex h-8 w-8 items-center justify-center rounded-md p-0 transition-colors hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-ring"
-              aria-label={`${localize('com_ui_view_source')} - ${row.original.title || localize('com_ui_untitled')}`}
-            >
-              <MessageSquare className="size-4" aria-hidden="true" />
-            </a>
-            <Button
-              variant="ghost"
-              className="h-8 w-8 p-0 hover:bg-surface-hover"
-              onClick={() => {
-                setDeleteRow(row.original);
-                setIsDeleteOpen(true);
-              }}
-              aria-label={localize('com_ui_delete_shared_link', {
-                title: row.original.title || localize('com_ui_untitled'),
-              })}
-              aria-haspopup="dialog"
-              aria-controls="delete-shared-link-dialog"
-            >
-              <TrashIcon className="size-4" aria-hidden="true" />
-            </Button>
+            <TooltipAnchor
+              description={localize('com_ui_open_source_chat_new_tab')}
+              render={
+                <a
+                  href={`/c/${row.original.conversationId}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex h-8 w-8 items-center justify-center rounded-md p-0 transition-colors hover:bg-surface-hover focus:outline-none focus:ring-2 focus:ring-ring"
+                  aria-label={localize('com_ui_open_source_chat_new_tab_title', {
+                    title: row.original.title || localize('com_ui_untitled'),
+                  })}
+                >
+                  <MessageSquare className="size-4" aria-hidden="true" />
+                </a>
+              }
+            />
+            <TooltipAnchor
+              description={localize('com_ui_delete_shared_link_heading')}
+              render={
+                <Button
+                  variant="ghost"
+                  className="h-8 w-8 p-0 hover:bg-surface-hover"
+                  onClick={() => {
+                    setDeleteRow(row.original);
+                    setIsDeleteOpen(true);
+                  }}
+                  aria-label={localize('com_ui_delete_shared_link', {
+                    title: row.original.title || localize('com_ui_untitled'),
+                  })}
+                  aria-haspopup="dialog"
+                  aria-controls="delete-shared-link-dialog"
+                >
+                  <TrashIcon className="size-4" aria-hidden="true" />
+                </Button>
+              }
+            />
           </div>
         ),
       },

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1361,6 +1361,8 @@
   "com_ui_versions": "Versions",
   "com_ui_view_memory": "View Memory",
   "com_ui_view_source": "View source chat - {{title}}",
+  "com_ui_open_source_chat_new_tab_title": "Open Source Chat in New Tab - {{title}}",
+  "com_ui_open_source_chat_new_tab": "Open Source Chat in New Tab",
   "com_ui_web_search": "Web Search",
   "com_ui_web_search_cohere_key": "Enter Cohere API Key",
   "com_ui_web_search_firecrawl_url": "Firecrawl API URL (optional)",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1360,7 +1360,6 @@
   "com_ui_version_var": "Version {{0}}",
   "com_ui_versions": "Versions",
   "com_ui_view_memory": "View Memory",
-  "com_ui_view_source": "View source chat - {{title}}",
   "com_ui_open_source_chat_new_tab_title": "Open Source Chat in New Tab - {{title}}",
   "com_ui_open_source_chat_new_tab": "Open Source Chat in New Tab",
   "com_ui_web_search": "Web Search",


### PR DESCRIPTION
## Summary

This pull request enhances the user experience for shared links in the Data settings tab by improving accessibility and clarity of actions. The most important changes include wrapping action buttons with tooltips for clearer descriptions and updating localization strings for better context in tooltips and aria labels. It also fixes an issue with title interpolation in Shared Links where the shared link title in the aria-label was not being properly interpolated for the View Source Chat button.

> Note: In order for this PR to not violate WCAG compliance standards, #10851 must first be merged in, so that the tooltips are dismissible with the Escape key on hover / focus without closing the entire modal.

**UI/Accessibility Improvements:**

* Wrapped the "open source chat" and "delete shared link" action buttons in the shared links table with the `TooltipAnchor` component, providing descriptive tooltips for each action. [[1]](diffhunk://#diff-43d7bd3c9192302385a4bb914ea48fb433ff73817013db6e25ad2a486f7f4db9R263-R281) [[2]](diffhunk://#diff-43d7bd3c9192302385a4bb914ea48fb433ff73817013db6e25ad2a486f7f4db9R297-R298)
* Updated the aria-label for the "open source chat" button to use a more descriptive, localized string including the conversation title.

**Localization Updates:**

* Added new localization strings `com_ui_open_source_chat_new_tab_title` and `com_ui_open_source_chat_new_tab` to provide clearer context for tooltips and aria labels. TooltipAnchor descriptions now say "Open Source Chat in New Tab" and "Delete Shared Link" to more explicitly describe the function of the buttons.

**Component Imports:**

* Imported the `TooltipAnchor` component to support the new tooltip functionality in the shared links table.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before

https://github.com/user-attachments/assets/1cad07e4-27ac-4d0e-b7ed-d92ba395458e

### After

https://github.com/user-attachments/assets/64ec0f47-4db5-4e4b-86c1-b3d8af623d43

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes