### PR TITLE
ℹ️ feat: Dismissible Tooltips in Modals

### DIFF
--- a/packages/client/src/components/OriginalDialog.tsx
+++ b/packages/client/src/components/OriginalDialog.tsx
@@ -66,28 +66,71 @@ type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, overlayClassName, showCloseButton = true, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay className={overlayClassName} />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'max-w-11/12 fixed left-[50%] top-[50%] z-50 grid max-h-[90vh] w-full translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-2xl bg-background p-6 text-text-primary shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      {showCloseButton && (
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-ring-primary ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-          <X className="h-6 w-6" />
-          {/* eslint-disable-next-line i18next/no-literal-string */}
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
-      )}
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
+>(
+  (
+    {
+      className,
+      overlayClassName,
+      showCloseButton = true,
+      children,
+      onEscapeKeyDown: propsOnEscapeKeyDown,
+      ...props
+    },
+    ref,
+  ) => {
+    /* Handle Escape key to prevent closing dialog if a tooltip is open 
+    (this is a workaround in order to achieve WCAG compliance which requires
+    that our tooltips be dismissable with Escape key) */
+    const handleEscapeKeyDown = React.useCallback(
+      (event: KeyboardEvent) => {
+        const tooltips = document.querySelectorAll('.tooltip');
+
+        for (const tooltip of Array.from(tooltips)) {
+          const computedStyle = window.getComputedStyle(tooltip);
+          const opacity = parseFloat(computedStyle.opacity);
+
+          if (
+            tooltip.parentElement &&
+            computedStyle.display !== 'none' &&
+            computedStyle.visibility !== 'hidden' &&
+            opacity > 0
+          ) {
+            event.preventDefault();
+            return;
+          }
+        }
+
+        // Call the original handler if it exists
+        propsOnEscapeKeyDown?.(event);
+      },
+      [propsOnEscapeKeyDown],
+    );
+
+    return (
+      <DialogPortal>
+        <DialogOverlay className={overlayClassName} />
+        <DialogPrimitive.Content
+          ref={ref}
+          onEscapeKeyDown={handleEscapeKeyDown}
+          className={cn(
+            'max-w-11/12 fixed left-[50%] top-[50%] z-50 grid max-h-[90vh] w-full translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-2xl bg-background p-6 text-text-primary shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
+            className,
+          )}
+          {...props}
+        >
+          {children}
+          {showCloseButton && (
+            <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-ring-primary ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+              <X className="h-6 w-6" />
+              {/* eslint-disable-next-line i18next/no-literal-string */}
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          )}
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    );
+  },
+);
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (


### PR DESCRIPTION
## Summary

This pull request updates the `DialogContent` component in `OriginalDialog.tsx` to improve accessibility and handle keyboard events more robustly. The main change is the addition of custom logic to prevent the dialog from closing when the Escape key is pressed if a tooltip is currently open, addressing a WCAG compliance requirement.

Accessibility and keyboard handling improvements:

* Added a custom `handleEscapeKeyDown` function to `DialogContent` that checks for visible tooltips and prevents the dialog from closing via Escape if any are open, ensuring tooltips remain dismissible with Escape as required by WCAG guidelines. (`packages/client/src/components/OriginalDialog.tsx`)
* Passed the new `handleEscapeKeyDown` to `DialogPrimitive.Content` and ensured the original `onEscapeKeyDown` handler is still called if appropriate. (`packages/client/src/components/OriginalDialog.tsx`)

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

### Before

https://github.com/user-attachments/assets/1d90bb2e-cd4a-44ef-a028-815c53081499

### After

https://github.com/user-attachments/assets/8b5933f8-c747-41ac-ad64-85ddf701f1fd

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes