### PR TITLE
🤿 fix: Unexpected Tooltip Closures

### DIFF
--- a/packages/client/src/components/Tooltip.css
+++ b/packages/client/src/components/Tooltip.css
@@ -1,6 +1,7 @@
 .tooltip {
   z-index: 50;
   cursor: pointer;
+  pointer-events: auto;
   border-radius: 0.275rem;
   background-color: var(--surface-primary);
   padding-top: 0.25rem;


### PR DESCRIPTION
## Summary

This pull request makes a minor update to the tooltip styling to improve its interactivity and address [axe-auditor issue 749](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/e1105b3e-9718-11f0-b595-0b9c9a70c7d0?activeTab=issues-list&page=11&sortField=ordinal&sortDir=asc&pageSize=10&xhr=true&_=1764856686563). Now AnchorTooltips will no longer interact with lower z-index components causing the tooltip to unexpectedly close while the mouse is still within the bounds of the tooltip.

* Added `pointer-events: auto;` to the `.tooltip` CSS class in `Tooltip.css`, allowing tooltips to properly respond to mouse events.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before

https://github.com/user-attachments/assets/f54496c0-7389-4cc3-bf8f-c2341c12e91a

### After

https://github.com/user-attachments/assets/aae4e16f-8625-4367-8321-f9ca45c63e13

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes