### PR TITLE
⛰️ fix: Higher Z-Index Popovers

### DIFF
--- a/packages/client/src/components/Dropdown.css
+++ b/packages/client/src/components/Dropdown.css
@@ -23,6 +23,7 @@
   translate: 0 -0.5rem;
   margin-top: 4px;
   margin-right: -2px;
+  z-index: 100;
 }
 
 .popover-animate {


### PR DESCRIPTION
## Summary

This pull request makes a minor update to the dropdown component's CSS to improve its display layering. Previously, the z-index of the popover was below 50, so the dropdown would appear beneath the mobile sidenav component and be totally obscured / inaccessible.

* Added `z-index: 100;` to the dropdown menu in `Dropdown.css` to ensure it appears above other elements.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Filter dropdown in Prompts page now visible within mobile sidenav
<img width="1728" height="957" alt="Screenshot 2025-12-08 at 9 23 34 PM" src="https://github.com/user-attachments/assets/d1678e6c-e522-4c8c-9aff-a69b7999de92" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes