### PR TITLE
🔧 fix: Proper Shared Links Modal Title

### DIFF
--- a/client/src/components/Nav/SettingsTabs/Data/SharedLinks.tsx
+++ b/client/src/components/Nav/SettingsTabs/Data/SharedLinks.tsx
@@ -302,7 +302,7 @@ export default function SharedLinks() {
         </OGDialogTrigger>
 
         <OGDialogContent
-          title={localize('com_nav_my_files')}
+          title={localize('com_nav_shared_links')}
           className="w-11/12 max-w-5xl bg-background text-text-primary shadow-2xl"
         >
           <OGDialogHeader>


### PR DESCRIPTION
## Summary

This pull request updates the dialog title in the shared links settings tab to properly reflect its purpose.

* UI text update:
  * Changed the dialog title from `com_nav_my_files` to `com_nav_shared_links` in the `SharedLinks` component (`SharedLinks.tsx`).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified proper screenreader announcement of modal title

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes