### PR TITLE
⏱️ feat(mcp): Make User Connection Idle Timeout Configurable

### DIFF
--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -5,6 +5,7 @@ import { mcpServersRegistry as serversRegistry } from '~/mcp/registry/MCPServers
 import { MCPConnection } from './connection';
 import type * as t from './types';
 import { ConnectionsRepository } from '~/mcp/ConnectionsRepository';
+import { mcpConfig } from './mcpConfig';
 
 /**
  * Abstract base class for managing user-specific MCP connections with lifecycle management.
@@ -20,7 +21,6 @@ export abstract class UserConnectionManager {
   protected userConnections: Map<string, Map<string, MCPConnection>> = new Map();
   /** Last activity timestamp for users (not per server) */
   protected userLastActivity: Map<string, number> = new Map();
-  protected readonly USER_CONNECTION_IDLE_TIMEOUT = 15 * 60 * 1000; // 15 minutes (TODO: make configurable)
 
   /** Updates the last activity timestamp for a user */
   protected updateUserLastActivity(userId: string): void {
@@ -67,7 +67,7 @@ export abstract class UserConnectionManager {
 
     // Check if user is idle
     const lastActivity = this.userLastActivity.get(userId);
-    if (lastActivity && now - lastActivity > this.USER_CONNECTION_IDLE_TIMEOUT) {
+    if (lastActivity && now - lastActivity > mcpConfig.USER_CONNECTION_IDLE_TIMEOUT) {
       logger.info(`[MCP][User: ${userId}] User idle for too long. Disconnecting all connections.`);
       // Disconnect all user connections
       try {
@@ -217,7 +217,7 @@ export abstract class UserConnectionManager {
       if (currentUserId && currentUserId === userId) {
         continue;
       }
-      if (now - lastActivity > this.USER_CONNECTION_IDLE_TIMEOUT) {
+      if (now - lastActivity > mcpConfig.USER_CONNECTION_IDLE_TIMEOUT) {
         logger.info(
           `[MCP][User: ${userId}] User idle for too long. Disconnecting all connections...`,
         );

--- a/packages/api/src/mcp/mcpConfig.ts
+++ b/packages/api/src/mcp/mcpConfig.ts
@@ -8,4 +8,6 @@ export const mcpConfig = {
   OAUTH_ON_AUTH_ERROR: isEnabled(process.env.MCP_OAUTH_ON_AUTH_ERROR ?? true),
   OAUTH_DETECTION_TIMEOUT: math(process.env.MCP_OAUTH_DETECTION_TIMEOUT ?? 5000),
   CONNECTION_CHECK_TTL: math(process.env.MCP_CONNECTION_CHECK_TTL ?? 60000),
+  /** Idle timeout (ms) after which user connections are disconnected. Default: 15 minutes */
+  USER_CONNECTION_IDLE_TIMEOUT: math(process.env.MCP_USER_CONNECTION_IDLE_TIMEOUT ?? 15 * 60 * 1000),
 };


### PR DESCRIPTION
## Summary

Makes the MCP user connection idle timeout configurable via environment variable, completing the TODO item in UserConnectionManager.ts.

## Changes
- Added USER_CONNECTION_IDLE_TIMEOUT to mcpConfig.ts with environment variable 
- MCP_USER_CONNECTION_IDLE_TIMEOUT
- Updated UserConnectionManager.ts to use the centralized config value
- Default remains 15 minutes (900000ms) for backward compatibility

## Change Type

- [x] New feature (non-breaking change which adds functionality)


## Testing
1.  Start the application without the environment variable set - verify default 15-minute timeout behavior
2. Set MCP_USER_CONNECTION_IDLE_TIMEOUT to a lower value (e.g., 60000 for 1 minute) and verify connections are disconnected after the configured idle period

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
