### PR TITLE
 🔧 fix: Show MCP Builder panel for users with CREATE permission even when no servers exist

### DIFF
--- a/client/src/hooks/Nav/useSideNavLinks.ts
+++ b/client/src/hooks/Nav/useSideNavLinks.ts
@@ -64,6 +64,10 @@ export default function useSideNavLinks({
     permissionType: PermissionTypes.MCP_SERVERS,
     permission: Permissions.USE,
   });
+  const hasAccessToCreateMCP = useHasAccess({
+    permissionType: PermissionTypes.MCP_SERVERS,
+    permission: Permissions.CREATE,
+  });
   const { availableMCPServers } = useMCPServerManager();
 
   const Links = useMemo(() => {
@@ -155,7 +159,10 @@ export default function useSideNavLinks({
       });
     }
 
-    if (hasAccessToUseMCPSettings && availableMCPServers && availableMCPServers.length > 0) {
+    if (
+      (hasAccessToUseMCPSettings && availableMCPServers && availableMCPServers.length > 0) ||
+      hasAccessToCreateMCP
+    ) {
       links.push({
         title: 'com_nav_setting_mcp',
         label: '',
@@ -188,6 +195,7 @@ export default function useSideNavLinks({
     hasAccessToBookmarks,
     availableMCPServers,
     hasAccessToUseMCPSettings,
+    hasAccessToCreateMCP,
     hidePanel,
   ]);
 


### PR DESCRIPTION
## Summary
- Fixed a bug where the MCP Builder panel would disappear when a user had no MCP servers, even if they had CREATE permission
- Added a CREATE permission check so users can access the panel to create their first MCP server

## Problem
The MCP Builder panel visibility was conditioned on `availableMCPServers.length > 0`, which prevented users with CREATE permission from seeing the panel when they had no servers yet. This made it impossible for them to create their first server.

  ## Solution
Updated the visibility condition in `useSideNavLinks.ts` to show the panel when:
- User has USE permission AND has servers available, OR
- User has CREATE permission (regardless of server count)

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

- [ ] Verify user with CREATE permission but no servers can see the MCP Builder panel
- [ ] Verify user with only USE permission and no servers does not see the panel
- [ ] Verify user with USE permission and existing servers can still see and use the panel
- [ ] Verify the "Add MCP" button appears correctly for users with CREATE permission

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

