### PR TITLE
📑 refactor: File Search Citations Dual-Format Unicode Handling

### DIFF
--- a/api/app/clients/tools/util/fileSearch.js
+++ b/api/app/clients/tools/util/fileSearch.js
@@ -169,11 +169,12 @@ const createFileSearchTool = async ({ userId, files, entity_id, fileCitations = 
           ? `
 
 **CITE FILE SEARCH RESULTS:**
-Use anchor markers immediately after statements derived from file content. Reference the filename in your text:
+Use the EXACT anchor markers shown below (copy them verbatim) immediately after statements derived from file content. Reference the filename in your text:
 - File citation: "The document.pdf states that... \\ue202turn0file0"  
 - Page reference: "According to report.docx... \\ue202turn0file1"
 - Multi-file: "Multiple sources confirm... \\ue200\\ue202turn0file0\\ue202turn0file1\\ue201"
 
+**CRITICAL:** Output these escape sequences EXACTLY as shown (e.g., \\ue202turn0file0). Do NOT substitute with other characters like † or similar symbols.
 **ALWAYS mention the filename in your text before the citation marker. NEVER use markdown links or footnotes.**`
           : ''
       }`,

--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -320,19 +320,19 @@ Current Date & Time: ${replaceSpecialVars({ text: '{{iso_datetime}}' })}
 
 **Execute immediately without preface.** After search, provide a brief summary addressing the query directly, then structure your response with clear Markdown formatting (## headers, lists, tables). Cite sources properly, tailor tone to query type, and provide comprehensive details.
 
-**CITATION FORMAT - INVISIBLE UNICODE ANCHORS ONLY:**
-Use these Unicode characters: \\ue202 (before each anchor), \\ue200 (group start), \\ue201 (group end), \\ue203 (highlight start), \\ue204 (highlight end)
+**CITATION FORMAT - UNICODE ESCAPE SEQUENCES ONLY:**
+Use these EXACT escape sequences (copy verbatim): \\ue202 (before each anchor), \\ue200 (group start), \\ue201 (group end), \\ue203 (highlight start), \\ue204 (highlight end)
 
-Anchor pattern: turn{N}{type}{index} where N=turn number, type=search|news|image|ref, index=0,1,2...
+Anchor pattern: \\ue202turn{N}{type}{index} where N=turn number, type=search|news|image|ref, index=0,1,2...
 
-**Examples:**
+**Examples (copy these exactly):**
 - Single: "Statement.\\ue202turn0search0"
 - Multiple: "Statement.\\ue202turn0search0\\ue202turn0news1"
 - Group: "Statement. \\ue200\\ue202turn0search0\\ue202turn0news1\\ue201"
 - Highlight: "\\ue203Cited text.\\ue204\\ue202turn0search0"
 - Image: "See photo\\ue202turn0image0."
 
-**CRITICAL:** Place anchors AFTER punctuation. Cite every non-obvious fact/quote. NEVER use markdown links, [1], footnotes, or HTML tags.`.trim();
+**CRITICAL:** Output escape sequences EXACTLY as shown. Do NOT substitute with † or other symbols. Place anchors AFTER punctuation. Cite every non-obvious fact/quote. NEVER use markdown links, [1], footnotes, or HTML tags.`.trim();
         return createSearchTool({
           ...result.authResult,
           onSearchResults,

--- a/client/src/components/Web/plugin.ts
+++ b/client/src/components/Web/plugin.ts
@@ -8,8 +8,14 @@ import { SPAN_REGEX, STANDALONE_PATTERN, CLEANUP_REGEX, COMPOSITE_REGEX } from '
  */
 function isStandaloneMarker(text: string, position: number): boolean {
   const beforeText = text.substring(0, position);
-  const lastUe200 = beforeText.lastIndexOf('\\ue200');
-  const lastUe201 = beforeText.lastIndexOf('\\ue201');
+  // Check for both literal text and actual Unicode character
+  const lastUe200Literal = beforeText.lastIndexOf('\\ue200');
+  const lastUe200Char = beforeText.lastIndexOf('\ue200');
+  const lastUe200 = Math.max(lastUe200Literal, lastUe200Char);
+
+  const lastUe201Literal = beforeText.lastIndexOf('\\ue201');
+  const lastUe201Char = beforeText.lastIndexOf('\ue201');
+  const lastUe201 = Math.max(lastUe201Literal, lastUe201Char);
 
   return lastUe200 === -1 || (lastUe201 !== -1 && lastUe201 > lastUe200);
 }

--- a/client/src/components/Web/plugin.ts
+++ b/client/src/components/Web/plugin.ts
@@ -4,19 +4,29 @@ import type { Citation, CitationNode } from './types';
 import { SPAN_REGEX, STANDALONE_PATTERN, CLEANUP_REGEX, COMPOSITE_REGEX } from '~/utils/citations';
 
 /**
- * Checks if a standalone marker is truly standalone (not inside a composite block)
+ * Checks if a standalone marker is truly standalone (not inside a composite block).
+ * A marker is inside a composite if there's an opening \ue200 without a closing \ue201 after it.
+ *
+ * Handles both literal text format ("\ue200") and actual Unicode (U+E200) by checking
+ * for both and using the rightmost occurrence. This correctly handles:
+ * - Pure literal format: "\ue200...\ue201"
+ * - Pure Unicode format: "..."
+ * - Mixed formats: "\ue200..." (different formats for open/close)
  */
 function isStandaloneMarker(text: string, position: number): boolean {
   const beforeText = text.substring(0, position);
-  // Check for both literal text and actual Unicode character
+
+  // Find rightmost composite block start (either format)
   const lastUe200Literal = beforeText.lastIndexOf('\\ue200');
   const lastUe200Char = beforeText.lastIndexOf('\ue200');
   const lastUe200 = Math.max(lastUe200Literal, lastUe200Char);
 
+  // Find rightmost composite block end (either format)
   const lastUe201Literal = beforeText.lastIndexOf('\\ue201');
   const lastUe201Char = beforeText.lastIndexOf('\ue201');
   const lastUe201 = Math.max(lastUe201Literal, lastUe201Char);
 
+  // Standalone if: no opening marker OR closing marker appears after opening
   return lastUe200 === -1 || (lastUe201 !== -1 && lastUe201 > lastUe200);
 }
 

--- a/client/src/hooks/Messages/useCopyToClipboard.ts
+++ b/client/src/hooks/Messages/useCopyToClipboard.ts
@@ -129,7 +129,7 @@ function processCitations(text: string, searchResults: { [key: string]: SearchRe
 
   // Step 1: Process highlighted text first (simplify by just making it bold in markdown)
   formattedText = formattedText.replace(SPAN_REGEX, (match) => {
-    const text = match.replace(/\\ue203|\\ue204/g, '');
+    const text = match.replace(/\\ue203|\\ue204|\ue203|\ue204/g, '');
     return `**${text}**`;
   });
 

--- a/client/src/utils/__tests__/citations.test.ts
+++ b/client/src/utils/__tests__/citations.test.ts
@@ -1,0 +1,194 @@
+import {
+  SPAN_REGEX,
+  COMPOSITE_REGEX,
+  STANDALONE_PATTERN,
+  CLEANUP_REGEX,
+  INVALID_CITATION_REGEX,
+} from '../citations';
+
+describe('Citation Regex Patterns', () => {
+  beforeEach(() => {
+    // Reset regex lastIndex for global patterns
+    SPAN_REGEX.lastIndex = 0;
+    COMPOSITE_REGEX.lastIndex = 0;
+    STANDALONE_PATTERN.lastIndex = 0;
+    CLEANUP_REGEX.lastIndex = 0;
+    INVALID_CITATION_REGEX.lastIndex = 0;
+  });
+
+  describe('STANDALONE_PATTERN', () => {
+    describe('literal text format (\\ue202)', () => {
+      it('should match literal text search citation', () => {
+        const text = 'Some fact \\ue202turn0search0 here';
+        STANDALONE_PATTERN.lastIndex = 0;
+        const match = STANDALONE_PATTERN.exec(text);
+        expect(match).not.toBeNull();
+        expect(match?.[1]).toBe('0'); // turn number
+        expect(match?.[2]).toBe('search'); // type
+        expect(match?.[3]).toBe('0'); // index
+      });
+
+      it('should match literal text file citation', () => {
+        const text = 'Document says \\ue202turn0file0 (doc.pdf)';
+        STANDALONE_PATTERN.lastIndex = 0;
+        const match = STANDALONE_PATTERN.exec(text);
+        expect(match).not.toBeNull();
+        expect(match?.[1]).toBe('0');
+        expect(match?.[2]).toBe('file');
+        expect(match?.[3]).toBe('0');
+      });
+
+      it('should match literal text news citation', () => {
+        const text = 'Breaking news \\ue202turn0news1';
+        STANDALONE_PATTERN.lastIndex = 0;
+        const match = STANDALONE_PATTERN.exec(text);
+        expect(match).not.toBeNull();
+        expect(match?.[1]).toBe('0');
+        expect(match?.[2]).toBe('news');
+        expect(match?.[3]).toBe('1');
+      });
+
+      it('should match multiple literal text citations', () => {
+        const text = 'Fact one \\ue202turn0search0 and fact two \\ue202turn0file1';
+        const matches = [];
+        let match;
+        STANDALONE_PATTERN.lastIndex = 0;
+        while ((match = STANDALONE_PATTERN.exec(text)) !== null) {
+          matches.push(match);
+        }
+        expect(matches).toHaveLength(2);
+        expect(matches[0][2]).toBe('search');
+        expect(matches[1][2]).toBe('file');
+      });
+
+      it('should match all supported types in literal text format', () => {
+        const types = ['search', 'image', 'news', 'video', 'ref', 'file'];
+        for (const type of types) {
+          const text = `Test \\ue202turn0${type}0`;
+          STANDALONE_PATTERN.lastIndex = 0;
+          const match = STANDALONE_PATTERN.exec(text);
+          expect(match).not.toBeNull();
+          expect(match?.[2]).toBe(type);
+        }
+      });
+    });
+
+    describe('actual Unicode character format (U+E202)', () => {
+      it('should match actual Unicode search citation', () => {
+        const text = 'Some fact \ue202turn0search0 here';
+        STANDALONE_PATTERN.lastIndex = 0;
+        const match = STANDALONE_PATTERN.exec(text);
+        expect(match).not.toBeNull();
+        expect(match?.[1]).toBe('0');
+        expect(match?.[2]).toBe('search');
+        expect(match?.[3]).toBe('0');
+      });
+
+      it('should match actual Unicode file citation', () => {
+        const text = 'Document says \ue202turn0file0 (doc.pdf)';
+        STANDALONE_PATTERN.lastIndex = 0;
+        const match = STANDALONE_PATTERN.exec(text);
+        expect(match).not.toBeNull();
+        expect(match?.[1]).toBe('0');
+        expect(match?.[2]).toBe('file');
+        expect(match?.[3]).toBe('0');
+      });
+
+      it('should match all supported types in actual Unicode format', () => {
+        const types = ['search', 'image', 'news', 'video', 'ref', 'file'];
+        for (const type of types) {
+          const text = `Test \ue202turn0${type}0`;
+          STANDALONE_PATTERN.lastIndex = 0;
+          const match = STANDALONE_PATTERN.exec(text);
+          expect(match).not.toBeNull();
+          expect(match?.[2]).toBe(type);
+        }
+      });
+    });
+
+    describe('mixed format handling', () => {
+      it('should match both formats in the same text', () => {
+        const text = 'Literal \\ue202turn0search0 and Unicode \ue202turn0file1';
+        const matches = [];
+        let match;
+        STANDALONE_PATTERN.lastIndex = 0;
+        while ((match = STANDALONE_PATTERN.exec(text)) !== null) {
+          matches.push(match);
+        }
+        expect(matches).toHaveLength(2);
+        expect(matches[0][2]).toBe('search');
+        expect(matches[1][2]).toBe('file');
+      });
+    });
+  });
+
+  describe('SPAN_REGEX', () => {
+    it('should match literal text span markers', () => {
+      const text = 'Before \\ue203highlighted text\\ue204 after';
+      SPAN_REGEX.lastIndex = 0;
+      const match = SPAN_REGEX.exec(text);
+      expect(match).not.toBeNull();
+      expect(match?.[0]).toContain('highlighted text');
+    });
+
+    it('should match actual Unicode span markers', () => {
+      const text = 'Before \ue203highlighted text\ue204 after';
+      SPAN_REGEX.lastIndex = 0;
+      const match = SPAN_REGEX.exec(text);
+      expect(match).not.toBeNull();
+      expect(match?.[0]).toContain('highlighted text');
+    });
+  });
+
+  describe('COMPOSITE_REGEX', () => {
+    it('should match literal text composite markers', () => {
+      const text = 'Statement \\ue200\\ue202turn0search0\\ue202turn0news0\\ue201';
+      COMPOSITE_REGEX.lastIndex = 0;
+      const match = COMPOSITE_REGEX.exec(text);
+      expect(match).not.toBeNull();
+    });
+
+    it('should match actual Unicode composite markers', () => {
+      const text = 'Statement \ue200\ue202turn0search0\ue202turn0news0\ue201';
+      COMPOSITE_REGEX.lastIndex = 0;
+      const match = COMPOSITE_REGEX.exec(text);
+      expect(match).not.toBeNull();
+    });
+  });
+
+  describe('CLEANUP_REGEX', () => {
+    it('should clean up literal text markers', () => {
+      const text = '\\ue200\\ue201\\ue202\\ue203\\ue204\\ue206';
+      const cleaned = text.replace(CLEANUP_REGEX, '');
+      expect(cleaned).toBe('');
+    });
+
+    it('should clean up actual Unicode markers', () => {
+      const text = '\ue200\ue201\ue202\ue203\ue204\ue206';
+      const cleaned = text.replace(CLEANUP_REGEX, '');
+      expect(cleaned).toBe('');
+    });
+
+    it('should preserve normal text while cleaning markers', () => {
+      const text = 'Hello \\ue202turn0search0 world';
+      const cleaned = text.replace(CLEANUP_REGEX, '');
+      expect(cleaned).toBe('Hello turn0search0 world');
+    });
+  });
+
+  describe('INVALID_CITATION_REGEX', () => {
+    it('should match invalid literal text citations with leading whitespace', () => {
+      const text = 'Text  \\ue202turn0search5';
+      INVALID_CITATION_REGEX.lastIndex = 0;
+      const match = INVALID_CITATION_REGEX.exec(text);
+      expect(match).not.toBeNull();
+    });
+
+    it('should match invalid actual Unicode citations with leading whitespace', () => {
+      const text = 'Text  \ue202turn0search5';
+      INVALID_CITATION_REGEX.lastIndex = 0;
+      const match = INVALID_CITATION_REGEX.exec(text);
+      expect(match).not.toBeNull();
+    });
+  });
+});

--- a/client/src/utils/citations.ts
+++ b/client/src/utils/citations.ts
@@ -1,5 +1,9 @@
-export const SPAN_REGEX = /(\\ue203.*?\\ue204)/g;
-export const COMPOSITE_REGEX = /(\\ue200.*?\\ue201)/g;
-export const STANDALONE_PATTERN = /\\ue202turn(\d+)(search|image|news|video|ref|file)(\d+)/g;
-export const CLEANUP_REGEX = /\\ue200|\\ue201|\\ue202|\\ue203|\\ue204|\\ue206/g;
-export const INVALID_CITATION_REGEX = /\s*\\ue202turn\d+(search|news|image|video|ref|file)\d+/g;
+/** Matches both literal text \ue203...\ue204 and actual Unicode characters */
+export const SPAN_REGEX = /((?:\\ue203|\ue203).*?(?:\\ue204|\ue204))/g;
+export const COMPOSITE_REGEX = /((?:\\ue200|\ue200).*?(?:\\ue201|\ue201))/g;
+export const STANDALONE_PATTERN =
+  /(?:\\ue202|\ue202)turn(\d+)(search|image|news|video|ref|file)(\d+)/g;
+export const CLEANUP_REGEX =
+  /\\ue200|\\ue201|\\ue202|\\ue203|\\ue204|\\ue206|\ue200|\ue201|\ue202|\ue203|\ue204|\ue206/g;
+export const INVALID_CITATION_REGEX =
+  /\s*(?:\\ue202|\ue202)turn\d+(search|news|image|video|ref|file)\d+/g;

--- a/client/src/utils/citations.ts
+++ b/client/src/utils/citations.ts
@@ -1,9 +1,46 @@
-/** Matches both literal text \ue203...\ue204 and actual Unicode characters */
+/**
+ * Citation Regex Patterns
+ *
+ * These patterns handle two formats that LLMs may output:
+ * 1. Literal escape sequences: "\ue202turn0search0" (backslash + "ue202" = 6 chars)
+ * 2. Actual Unicode characters: "turn0search0" (U+E202 = 1 char, private use area)
+ *
+ * The system instructs LLMs to output literal escape sequences, but some models
+ * may convert them to actual Unicode characters during text generation. These
+ * dual-format patterns ensure robust citation handling regardless of output format.
+ *
+ * Citation Format:
+ * - \ue202 / U+E202: Standalone citation marker (before each anchor)
+ * - \ue200 / U+E200: Composite group start
+ * - \ue201 / U+E201: Composite group end
+ * - \ue203 / U+E203: Highlight span start
+ * - \ue204 / U+E204: Highlight span end
+ *
+ * Anchor Pattern: turn{N}{type}{index}
+ * - N: Turn number (0-based)
+ * - type: search|image|news|video|ref|file
+ * - index: Result index within that type (0-based)
+ *
+ * Examples:
+ * - Standalone: "Statement.\ue202turn0search0"
+ * - Composite: "\ue200\ue202turn0search0\ue202turn0news1\ue201"
+ * - Highlighted: "\ue203Cited text.\ue204\ue202turn0search0"
+ */
+
+/** Matches highlighted text spans in both literal and Unicode formats */
 export const SPAN_REGEX = /((?:\\ue203|\ue203).*?(?:\\ue204|\ue204))/g;
+
+/** Matches composite citation blocks (multiple citations grouped together) */
 export const COMPOSITE_REGEX = /((?:\\ue200|\ue200).*?(?:\\ue201|\ue201))/g;
+
+/** Matches standalone citation anchors with turn, type, and index capture groups */
 export const STANDALONE_PATTERN =
   /(?:\\ue202|\ue202)turn(\d+)(search|image|news|video|ref|file)(\d+)/g;
+
+/** Removes all citation marker characters from text for clean display */
 export const CLEANUP_REGEX =
   /\\ue200|\\ue201|\\ue202|\\ue203|\\ue204|\\ue206|\ue200|\ue201|\ue202|\ue203|\ue204|\ue206/g;
+
+/** Matches invalid/orphaned citations (with leading whitespace) for removal */
 export const INVALID_CITATION_REGEX =
   /\s*(?:\\ue202|\ue202)turn\d+(search|news|image|video|ref|file)\d+/g;


### PR DESCRIPTION

## Summary

I refactored the file search citation system to handle both literal text escape sequences (``) and actual Unicode characters (U+E202), addressing cases where LLMs substitute one format for the other.

- Update all citation regex patterns in `citations.ts` to match both literal text and actual Unicode character formats using alternation groups.
- Add `searchQuery` parameter to `createQueryBody` and extract search logic into a dedicated `executeSearch` function for improved modularity.
- Distinguish between "all requests failed" (returns null) and "empty results" (returns empty array) in file search error handling with distinct user messages.
- Enhance `isStandaloneMarker` in `plugin.ts` to detect both literal and Unicode marker formats when determining marker positions.
- Update `useCopyToClipboard.ts` regex to strip both literal and Unicode span markers when copying text.
- Revise LLM prompts in `fileSearch.js` and `handleTools.js` to emphasize copying escape sequences exactly and warn against symbol substitution.
- Add comprehensive unit tests covering literal text format, actual Unicode format, and mixed format scenarios for all citation regex patterns.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

Tested citation parsing with both literal escape sequences and actual Unicode characters in LLM responses. Verified regex patterns correctly match standalone, composite, span, and invalid citation formats in both representations. Confirmed file search returns appropriate error messages for failed requests vs empty results.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules