### PR TITLE
🔧 fix: Error handling in Firebase and Local file deletion

### DIFF
--- a/api/server/services/Files/Firebase/crud.js
+++ b/api/server/services/Files/Firebase/crud.js
@@ -169,14 +169,24 @@ function extractFirebaseFilePath(urlString) {
 const deleteFirebaseFile = async (req, file) => {
   if (file.embedded && process.env.RAG_API_URL) {
     const jwtToken = req.headers.authorization.split(' ')[1];
-    axios.delete(`${process.env.RAG_API_URL}/documents`, {
-      headers: {
-        Authorization: `Bearer ${jwtToken}`,
-        'Content-Type': 'application/json',
-        accept: 'application/json',
-      },
-      data: [file.file_id],
-    });
+    try {
+      await axios.delete(`${process.env.RAG_API_URL}/documents`, {
+        headers: {
+          Authorization: `Bearer ${jwtToken}`,
+          'Content-Type': 'application/json',
+          accept: 'application/json',
+        },
+        data: [file.file_id],
+      });
+    } catch (error) {
+      if (error.response?.status === 404) {
+        logger.warn(
+          `[deleteFirebaseFile] Document ${file.file_id} not found in RAG API, may have been deleted already`,
+        );
+      } else {
+        logger.error('[deleteFirebaseFile] Error deleting document from RAG API:', error);
+      }
+    }
   }
 
   const fileName = extractFirebaseFilePath(file.filepath);


### PR DESCRIPTION

- Added try-catch blocks to handle errors during document deletion from the RAG API.
- Implemented logging for 404 errors indicating that the document may have already been deleted.
- Improved error logging for other deletion errors in both Firebase and Local file services.