### PR TITLE
🙋‍♂️ feat: Accessible Default User Icon Colors

### DIFF
--- a/packages/client/src/hooks/useAvatar.ts
+++ b/packages/client/src/hooks/useAvatar.ts
@@ -25,6 +25,24 @@ const useAvatar = (user: TUser | undefined) => {
       seed,
       fontFamily: ['Verdana'],
       fontSize: 36,
+      backgroundType: ['solid'],
+      backgroundColor: [
+        'd81b60',
+        '8e24aa',
+        '5e35b1',
+        '3949ab',
+        'DB3733',
+        '1B79CC',
+        '027CB8',
+        '008291',
+        '008577',
+        '58802F',
+        '8A761D',
+        '9C6D00',
+        'B06200',
+        'D1451A',
+      ],
+      textColor: ['ffffff'],
     });
 
     let avatarDataUri = '';


### PR DESCRIPTION
## Summary

This pull request updates the avatar generation logic in the `useAvatar` hook to improve the appearance and consistency of user avatars. The main change is the addition of a curated set of background colors which are just the default color hex values downshifted by their HSV value until they hit 4.5:1 contrast threshold against white foreground text, ensuring avatars have visually distinctive and consistent backgrounds while still having the text be readable by vision-impaired users.

Avatar appearance improvements:

* Introduced a specific array of `backgroundColor` values to provide a range of visually appealing and consistent avatar backgrounds.
* Explicitly set the `textColor` option to always use white (`'ffffff'`) for better readability against the new background colors.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

N/A

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes