### PR TITLE
🤔 fix: Programmatic Expansion State for Thinking Button

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
@@ -65,6 +65,7 @@ export const ThinkingButton = memo(
         <button
           type="button"
           onClick={onClick}
+          aria-expanded={isExpanded}
           className={cn(
             'group/button flex flex-1 items-center justify-start rounded-lg leading-[18px]',
             fontSize,


### PR DESCRIPTION
## Summary

This pull request introduces a small accessibility improvement to the `ThinkingButton` component. The change adds the `aria-expanded` attribute to the button, which helps screen readers understand whether the associated content is expanded or collapsed.

Accessibility enhancement:

* [`client/src/components/Chat/Messages/Content/Parts/Thinking.tsx`](diffhunk://#diff-8f691369278c965baaf9228bd59e21c367df75a524b0a6340eda72390d153e08R68): Added the `aria-expanded` attribute to the button element in `ThinkingButton` to improve accessibility for users relying on assistive technologies.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

### Before
<img width="1221" height="953" alt="Screenshot 2025-12-11 at 6 38 51 AM" src="https://github.com/user-attachments/assets/c4c13021-0106-479d-9a0c-a34c23aaa91a" />

<img width="1221" height="955" alt="Screenshot 2025-12-11 at 6 38 41 AM" src="https://github.com/user-attachments/assets/97274565-3c3a-46e5-86ce-4f9ec53b1389" />

### After
<img width="1225" height="956" alt="Screenshot 2025-12-11 at 6 36 57 AM" src="https://github.com/user-attachments/assets/198da76a-0a46-4f99-9598-e79bcf2af116" />

<img width="1225" height="953" alt="Screenshot 2025-12-11 at 6 37 05 AM" src="https://github.com/user-attachments/assets/220c7994-7860-44f8-983f-f2d405f5f545" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes