### PR TITLE
fix(mcp): Improve OAuth discovery and error detection for MCP servers

### DIFF
--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -78,7 +78,8 @@ async function reinitMCPServer({
       const isOAuthError =
         err.message?.includes('OAuth') ||
         err.message?.includes('authentication') ||
-        err.message?.includes('401');
+        err.message?.includes('401') ||
+        err.message?.includes('Unauthorized');
 
       const isOAuthFlowInitiated = err.message === 'OAuth flow initiated - return early';
 

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -288,9 +288,13 @@ export class MCPConnectionFactory {
       return false;
     }
 
-    // Check for SSE error with 401 status
+    // Check for SSE/HTTP error messages indicating auth failure
     if ('message' in error && typeof error.message === 'string') {
-      return error.message.includes('401') || error.message.includes('Non-200 status code (401)');
+      return (
+        error.message.includes('401') ||
+        error.message.includes('Non-200 status code (401)') ||
+        error.message.includes('Unauthorized')
+      );
     }
 
     // Check for error code

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -741,9 +741,13 @@ export class MCPConnection extends EventEmitter {
       return false;
     }
 
-    // Check for SSE error with 401 status
+    // Check for SSE/HTTP error messages indicating auth failure
     if ('message' in error && typeof error.message === 'string') {
-      return error.message.includes('401') || error.message.includes('Non-200 status code (401)');
+      return (
+        error.message.includes('401') ||
+        error.message.includes('Non-200 status code (401)') ||
+        error.message.includes('Unauthorized')
+      );
     }
 
     // Check for error code


### PR DESCRIPTION
## Summary

This PR fixes two OAuth-related issues affecting MCP server connections:

### 1. OAuth Metadata Discovery Fallback for Servers Like Atlassian

**Problem:** When connecting to MCP servers with path-based URLs (e.g., `https://mcp.atlassian.com/v1/sse`), OAuth metadata discovery was failing because the MCP SDK's discovery function appends the path to `.well-known` URLs, resulting in requests to non-existent endpoints like `/.well-known/oauth-authorization-server/v1/sse`.

Atlassian (and potentially other servers) serve OAuth metadata at the root origin (`https://mcp.atlassian.com/.well-known/oauth-authorization-server`) rather than at path-based URLs.

**Solution:** Added fallback logic in `handler.ts` to try the origin URL when path-based discovery fails. If the server URL has a path and discovery returns no metadata, we now also try discovering from just the origin.

### 2. "Unauthorized" Error Detection for OAuth Flow Triggering

**Problem:** When connecting to MCP servers that return HTTP errors with the message "Unauthorized" (without the status code "401" in the message), the OAuth flow was not being triggered. For example, Google MCP returns `"Error POSTing to endpoint: Unauthorized"` which wasn't being detected as an OAuth error.

**Solution:** Added `'Unauthorized'` to the error message checks in the `isOAuthError` functions across three files to properly detect these errors and trigger the OAuth authentication flow.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

### Files Modified

| File | Change |
|------|--------|
| `packages/api/src/mcp/oauth/handler.ts` | Added origin URL fallback when path-based OAuth discovery fails |
| `packages/api/src/mcp/connection.ts` | Added `'Unauthorized'` to `isOAuthError` check |
| `packages/api/src/mcp/MCPConnectionFactory.ts` | Added `'Unauthorized'` to `isOAuthError` check |
| `api/server/services/Tools/mcp.js` | Added `'Unauthorized'` to OAuth error detection |

### Test Files Modified

| File | Change |
|------|--------|
| `packages/api/src/mcp/__tests__/handler.test.ts` | Added 3 tests for origin URL fallback behavior |
| `packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts` | Added 3 tests for "Unauthorized" error detection |

## Testing

All existing and new tests pass:

```
handler.test.ts: 33 tests passed
MCPConnectionFactory.test.ts: 11 tests passed
```

### New Test Cases

**Origin URL Fallback Tests:**
- `should try origin URL when path-based discovery fails (like Atlassian)`
- `should not try origin fallback when URL has no path`
- `should use fallback metadata when both path-based and origin discovery fail`

**Unauthorized Detection Tests:**
- `should identify OAuth errors with "Unauthorized" message (like Google MCP)`
- `should identify OAuth errors with "Non-200 status code (401)" message`
- `should not identify non-OAuth errors as OAuth errors`

### Test Configuration

```bash
npm run test:ci --workspace=@librechat/api -- --testPathPatterns="handler.test.ts" --no-coverage
npm run test:ci --workspace=@librechat/api -- --testPathPatterns="MCPConnectionFactory.test.ts" --no-coverage
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
