### PR TITLE
👨‍✈️ chore: Minor MCP-UI Logic Cleanup

### DIFF
--- a/client/src/components/MCPUIResource/MCPUIResource.tsx
+++ b/client/src/components/MCPUIResource/MCPUIResource.tsx
@@ -56,7 +56,7 @@ export function MCPUIResource(props: MCPUIResourceProps) {
     console.error('Error rendering UI resource:', error);
     return (
       <span className="inline-flex items-center rounded bg-red-50 px-2 py-1 text-xs font-medium text-red-600">
-        {localize('com_ui_ui_resource_error', { 0: uiResource.name })}
+        {localize('com_ui_ui_resource_error', { 0: uiResource.name || resourceId })}
       </span>
     );
   }

--- a/client/src/components/Share/ShareMessagesProvider.tsx
+++ b/client/src/components/Share/ShareMessagesProvider.tsx
@@ -19,7 +19,7 @@ interface ShareMessagesProviderProps {
 export function ShareMessagesProvider({ messages, children }: ShareMessagesProviderProps) {
   const contextValue = useMemo<MessagesViewContextValue>(
     () => ({
-      conversation: { conversationId: 'shared-conversation' },
+      conversation: null,
       conversationId: undefined,
       // These are required by the context but not used in share view
       ask: () => Promise.resolve(),

--- a/client/src/store/misc.ts
+++ b/client/src/store/misc.ts
@@ -30,7 +30,7 @@ const conversationAttachmentsSelector = selectorFamily<
 
       // Filter to only include attachments for this conversation
       Object.entries(attachmentsMap).forEach(([messageId, attachments]) => {
-        if (!attachments) {
+        if (!attachments || attachments.length === 0) {
           return;
         }
 

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -1,4 +1,7 @@
 import React from 'react';
+import type { UIActionResult } from '@mcp-ui/client';
+import { TAskFunction } from '~/common';
+import logger from './logger';
 
 export * from './map';
 export * from './json';
@@ -125,7 +128,7 @@ export const normalizeLayout = (layout: number[]) => {
   return normalizedLayout;
 };
 
-export const handleUIAction = async (result: any, ask: any) => {
+export const handleUIAction = async (result: UIActionResult, ask: TAskFunction) => {
   const supportedTypes = ['intent', 'tool', 'prompt'];
 
   const { type, payload } = result;
@@ -171,12 +174,7 @@ Execute the intention of the prompt that is mentioned in the message using the t
     `;
   }
 
-  console.log('About to submit message:', messageText);
-
-  try {
-    await ask({ text: messageText });
-    console.log('Message submitted successfully');
-  } catch (error) {
-    console.error('Error submitting message:', error);
-  }
+  logger.debug('MCP-UI', 'About to submit message:', messageText);
+  ask({ text: messageText });
+  logger.debug('MCP-UI', 'Message submitted successfully');
 };

--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -141,8 +141,10 @@ export function formatToolContent(
       const resourceText: string[] = [];
 
       if (isUiResource) {
-        const resourceTextValue = 'text' in item.resource ? item.resource.text : undefined;
-        const contentToHash = resourceTextValue || item.resource.uri || '';
+        const contentToHash =
+          'text' in item.resource && item.resource.text && typeof item.resource.text === 'string'
+            ? item.resource.text
+            : item.resource.uri;
         const resourceId = generateResourceId(contentToHash);
         const uiResource: UIResource = {
           ...item.resource,


### PR DESCRIPTION
## Summary

This pull request addresses the Copilot comments made in #9669 and fixed in #10898's branch (62395f8dc13d15a5adfcb94f86e3afc7883ad749).

**UI and Error Handling Improvements:**
- Updated error rendering in `MCPUIResource` to fall back to `resourceId` if `uiResource.name` is unavailable, preventing blank error messages.

**Type Safety and Utility Refactoring:**
- Improved the `handleUIAction` utility by explicitly typing its parameters with `UIActionResult` and `TAskFunction`, and replaced `console` statements with the `logger` utility for better logging consistency. [[1]](diffhunk://#diff-e9de05f628dd0cc0a655b22a3f0d4d068142b9a172b701a7762089d3fc37a663R2-R4) [[2]](diffhunk://#diff-e9de05f628dd0cc0a655b22a3f0d4d068142b9a172b701a7762089d3fc37a663L128-R131) [[3]](diffhunk://#diff-e9de05f628dd0cc0a655b22a3f0d4d068142b9a172b701a7762089d3fc37a663L174-R179)

**Attachment and Message Handling:**
- Fixed the attachment selector to filter out entries with empty attachment arrays, ensuring only relevant attachments are processed.
- Adjusted the `ShareMessagesProvider` to set `conversation` to `null` in the shared view context, clarifying that no actual conversation object is present.

**Resource ID Generation:**
- Refined the logic for generating resource IDs for UI resources, ensuring that only valid string content is used for hashing, which prevents potential errors with non-string values.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Ensured MCP-UI elements (single and carousel) rendered and were interactable in main chat and shared view.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes