### PR TITLE
🎯 refactor: Centralize Agent Model Handling Across Conversation Lifecycle

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -966,6 +966,11 @@ class BaseClient {
 
     const unsetFields = {};
     const exceptions = new Set(['spec', 'iconURL']);
+    const hasNonEphemeralAgent =
+      endpointOptions?.agent_id && endpointOptions.agent_id !== Constants.EPHEMERAL_AGENT_ID;
+    if (hasNonEphemeralAgent) {
+      exceptions.add('model');
+    }
     if (existingConvo != null) {
       this.fetchedConvo = true;
       for (const key in existingConvo) {

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -967,7 +967,9 @@ class BaseClient {
     const unsetFields = {};
     const exceptions = new Set(['spec', 'iconURL']);
     const hasNonEphemeralAgent =
-      endpointOptions?.agent_id && endpointOptions.agent_id !== Constants.EPHEMERAL_AGENT_ID;
+      isAgentsEndpoint(this.options.endpoint) &&
+      endpointOptions?.agent_id &&
+      endpointOptions.agent_id !== Constants.EPHEMERAL_AGENT_ID;
     if (hasNonEphemeralAgent) {
       exceptions.add('model');
     }

--- a/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
@@ -104,10 +104,18 @@ export function ModelSelectorProvider({ children, startupConfig }: ModelSelector
   });
 
   // State
-  const [selectedValues, setSelectedValues] = useState<SelectedValues>({
-    endpoint: endpoint || '',
-    model: model || '',
-    modelSpec: spec || '',
+  const [selectedValues, setSelectedValues] = useState<SelectedValues>(() => {
+    let initialModel = model || '';
+    if (isAgentsEndpoint(endpoint) && agent_id) {
+      initialModel = agent_id;
+    } else if (isAssistantsEndpoint(endpoint) && assistant_id) {
+      initialModel = assistant_id;
+    }
+    return {
+      endpoint: endpoint || '',
+      model: initialModel,
+      modelSpec: spec || '',
+    };
   });
   useSelectorEffects({
     agentsMap,

--- a/client/src/hooks/Conversations/useNavigateToConvo.tsx
+++ b/client/src/hooks/Conversations/useNavigateToConvo.tsx
@@ -9,7 +9,13 @@ import type {
   TModelsConfig,
   TConversation,
 } from 'librechat-data-provider';
-import { getDefaultEndpoint, clearMessagesCache, buildDefaultConvo, logger } from '~/utils';
+import {
+  clearModelForNonEphemeralAgent,
+  getDefaultEndpoint,
+  clearMessagesCache,
+  buildDefaultConvo,
+  logger,
+} from '~/utils';
 import { useApplyModelSpecEffects } from '~/hooks/Agents';
 import store from '~/store';
 
@@ -49,7 +55,10 @@ const useNavigateToConvo = (index = 0) => {
         dataService.getConversationById(conversationId),
       );
       logger.log('conversation', 'Fetched fresh conversation data', data);
-      setConversation(data);
+
+      const convoData = { ...data };
+      clearModelForNonEphemeralAgent(convoData);
+      setConversation(convoData);
       navigate(`/c/${conversationId ?? Constants.NEW_CONVO}`, { state: { focusChat: true } });
     } catch (error) {
       console.error('Error fetching conversation data on navigation', error);

--- a/client/src/hooks/Input/useQueryParams.spec.ts
+++ b/client/src/hooks/Input/useQueryParams.spec.ts
@@ -76,6 +76,7 @@ jest.mock('~/utils', () => ({
   })),
   getModelSpecIconURL: jest.fn(() => 'icon-url'),
   removeUnavailableTools: jest.fn((preset) => preset),
+  clearModelForNonEphemeralAgent: jest.fn(),
   logger: { log: jest.fn() },
   getInitialTheme: jest.fn(() => 'light'),
   applyFontSize: jest.fn(),

--- a/client/src/hooks/Input/useQueryParams.spec.ts
+++ b/client/src/hooks/Input/useQueryParams.spec.ts
@@ -65,39 +65,33 @@ jest.mock('~/hooks/Agents/useAgentDefaultPermissionLevel', () => ({
   default: jest.fn(() => ({})),
 }));
 
-jest.mock('~/utils', () => ({
-  getConvoSwitchLogic: jest.fn(() => ({
-    template: {},
-    shouldSwitch: false,
-    isNewModular: false,
-    newEndpointType: null,
-    isCurrentModular: false,
-    isExistingConversation: false,
-  })),
-  getModelSpecIconURL: jest.fn(() => 'icon-url'),
-  removeUnavailableTools: jest.fn((preset) => preset),
-  clearModelForNonEphemeralAgent: jest.fn(),
-  logger: { log: jest.fn() },
-  getInitialTheme: jest.fn(() => 'light'),
-  applyFontSize: jest.fn(),
-}));
+jest.mock('~/utils', () => {
+  const actualUtils = jest.requireActual('~/utils');
+  return {
+    ...actualUtils,
+    // Only mock logger to suppress test output
+    logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    // Mock theme utilities that interact with DOM
+    getInitialTheme: jest.fn(() => 'light'),
+    applyFontSize: jest.fn(),
+  };
+});
 
-// Mock the tQueryParamsSchema
-jest.mock('librechat-data-provider', () => ({
-  ...jest.requireActual('librechat-data-provider'),
-  tQueryParamsSchema: {
-    shape: {
-      model: { parse: jest.fn((value) => value) },
-      endpoint: { parse: jest.fn((value) => value) },
-      temperature: { parse: jest.fn((value) => value) },
-      // Add other schema shapes as needed
+// Use actual librechat-data-provider with minimal overrides
+jest.mock('librechat-data-provider', () => {
+  const actual = jest.requireActual('librechat-data-provider');
+  return {
+    ...actual,
+    // Override schema to avoid complex validation in tests
+    tQueryParamsSchema: {
+      shape: {
+        model: { parse: jest.fn((value) => value) },
+        endpoint: { parse: jest.fn((value) => value) },
+        temperature: { parse: jest.fn((value) => value) },
+      },
     },
-  },
-  isAgentsEndpoint: jest.fn(() => false),
-  isAssistantsEndpoint: jest.fn(() => false),
-  QueryKeys: { startupConfig: 'startupConfig', endpoints: 'endpoints' },
-  EModelEndpoint: { custom: 'custom', assistants: 'assistants', agents: 'agents' },
-}));
+  };
+});
 
 // Mock data-provider hooks
 jest.mock('~/data-provider', () => ({

--- a/client/src/hooks/Input/useQueryParams.ts
+++ b/client/src/hooks/Input/useQueryParams.ts
@@ -11,13 +11,19 @@ import {
   PermissionBits,
 } from 'librechat-data-provider';
 import type {
-  TPreset,
+  AgentListResponse,
   TEndpointsConfig,
   TStartupConfig,
-  AgentListResponse,
+  TPreset,
 } from 'librechat-data-provider';
 import type { ZodAny } from 'zod';
-import { getConvoSwitchLogic, getModelSpecIconURL, removeUnavailableTools, logger } from '~/utils';
+import {
+  clearModelForNonEphemeralAgent,
+  removeUnavailableTools,
+  getModelSpecIconURL,
+  getConvoSwitchLogic,
+  logger,
+} from '~/utils';
 import { useAuthContext, useAgentsMap, useDefaultConvo, useSubmitMessage } from '~/hooks';
 import { useChatContext, useChatFormContext } from '~/Providers';
 import { useGetAgentByIdQuery } from '~/data-provider';
@@ -193,6 +199,12 @@ export default function useQueryParams({
         resetParams = { spec: null, iconURL: null, modelLabel: null };
         newPreset = { ...newPreset, ...resetParams };
       }
+
+      // Sync agent_id from newPreset to template, then clear model if non-ephemeral agent
+      if (newPreset.agent_id) {
+        template.agent_id = newPreset.agent_id;
+      }
+      clearModelForNonEphemeralAgent(template);
 
       const isModular = isCurrentModular && isNewModular && shouldSwitch;
       if (isExistingConversation && isModular) {

--- a/client/src/hooks/Input/useSelectMention.ts
+++ b/client/src/hooks/Input/useSelectMention.ts
@@ -9,7 +9,13 @@ import type {
   TEndpointsConfig,
 } from 'librechat-data-provider';
 import type { MentionOption, ConvoGenerator } from '~/common';
-import { getConvoSwitchLogic, getModelSpecIconURL, removeUnavailableTools, logger } from '~/utils';
+import {
+  clearModelForNonEphemeralAgent,
+  removeUnavailableTools,
+  getModelSpecIconURL,
+  getConvoSwitchLogic,
+  logger,
+} from '~/utils';
 import { useDefaultConvo } from '~/hooks';
 import store from '~/store';
 
@@ -154,6 +160,7 @@ export default function useSelectMention({
       if (agent_id) {
         template.agent_id = agent_id;
       }
+      clearModelForNonEphemeralAgent(template);
 
       template.spec = null;
       template.iconURL = null;

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -16,7 +16,7 @@ import store from '~/store';
 
 export default function ChatRoute() {
   const { data: startupConfig } = useGetStartupConfig();
-  const { isAuthenticated, user } = useAuthRedirect();
+  const { isAuthenticated, user, roles } = useAuthRedirect();
 
   const defaultTemporaryChat = useRecoilValue(temporaryStore.defaultTemporaryChat);
   const setIsTemporary = useRecoilCallback(
@@ -61,8 +61,11 @@ export default function ChatRoute() {
    *  Adjusting this may have unintended consequences on the conversation state.
    */
   useEffect(() => {
+    // Wait for roles to load so hasAgentAccess has a definitive value in useNewConvo
+    const rolesLoaded = roles?.USER != null;
     const shouldSetConvo =
-      (startupConfig && !hasSetConversation.current && !modelsQuery.data?.initial) ?? false;
+      (startupConfig && rolesLoaded && !hasSetConversation.current && !modelsQuery.data?.initial) ??
+      false;
     /* Early exit if startupConfig is not loaded and conversation is already set and only initial models have loaded */
     if (!shouldSetConvo) {
       return;
@@ -119,6 +122,7 @@ export default function ChatRoute() {
     /* Creates infinite render if all dependencies included due to newConversation invocations exceeding call stack before hasSetConversation.current becomes truthy */
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    roles,
     startupConfig,
     initialConvoQuery.data,
     endpointsQuery.data,

--- a/client/src/routes/useAuthRedirect.ts
+++ b/client/src/routes/useAuthRedirect.ts
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuthContext } from '~/hooks';
 
 export default function useAuthRedirect() {
-  const { user, isAuthenticated } = useAuthContext();
+  const { user, roles, isAuthenticated } = useAuthContext();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -20,6 +20,7 @@ export default function useAuthRedirect() {
 
   return {
     user,
+    roles,
     isAuthenticated,
   };
 }

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -11,7 +11,7 @@ import {
   useSetRecoilState,
   useRecoilCallback,
 } from 'recoil';
-import { LocalStorageKeys } from 'librechat-data-provider';
+import { LocalStorageKeys, Constants } from 'librechat-data-provider';
 import type { TMessage, TPreset, TConversation, TSubmission } from 'librechat-data-provider';
 import type { TOptionSettings, ExtendedFile } from '~/common';
 import {

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { createSearchParams } from 'react-router-dom';
 import {
   atom,
   selector,
@@ -10,12 +11,16 @@ import {
   useSetRecoilState,
   useRecoilCallback,
 } from 'recoil';
-import { LocalStorageKeys, Constants } from 'librechat-data-provider';
+import { LocalStorageKeys } from 'librechat-data-provider';
 import type { TMessage, TPreset, TConversation, TSubmission } from 'librechat-data-provider';
 import type { TOptionSettings, ExtendedFile } from '~/common';
+import {
+  clearModelForNonEphemeralAgent,
+  createChatSearchParams,
+  storeEndpointSettings,
+  logger,
+} from '~/utils';
 import { useSetConvoContext } from '~/Providers/SetConvoContext';
-import { storeEndpointSettings, logger, createChatSearchParams } from '~/utils';
-import { createSearchParams } from 'react-router-dom';
 
 const latestMessageKeysAtom = atom<(string | number)[]>({
   key: 'latestMessageKeys',
@@ -101,9 +106,12 @@ const conversationByIndex = atomFamily<TConversation | null, string | number>({
         }
 
         storeEndpointSettings(newValue);
+
+        const convoToStore = { ...newValue };
+        clearModelForNonEphemeralAgent(convoToStore);
         localStorage.setItem(
           `${LocalStorageKeys.LAST_CONVO_SETUP}_${index}`,
-          JSON.stringify(newValue),
+          JSON.stringify(convoToStore),
         );
 
         const disableParams = newValue.disableParams === true;

--- a/client/src/utils/buildDefaultConvo.ts
+++ b/client/src/utils/buildDefaultConvo.ts
@@ -1,10 +1,12 @@
 import {
+  Constants,
   parseConvo,
   EModelEndpoint,
   isAssistantsEndpoint,
   isAgentsEndpoint,
 } from 'librechat-data-provider';
 import type { TConversation, EndpointSchemaKey } from 'librechat-data-provider';
+import { clearModelForNonEphemeralAgent } from './endpoints';
 import { getLocalStorageItems } from './localStorage';
 
 const buildDefaultConvo = ({
@@ -66,9 +68,16 @@ const buildDefaultConvo = ({
   // Ensures agent_id is always defined
   const agentId = convo?.agent_id ?? '';
   const defaultAgentId = lastConversationSetup?.agent_id ?? '';
-  if (isAgentsEndpoint(endpoint) && !defaultAgentId && agentId) {
+  if (
+    isAgentsEndpoint(endpoint) &&
+    agentId &&
+    (!defaultAgentId || defaultAgentId === Constants.EPHEMERAL_AGENT_ID)
+  ) {
     defaultConvo.agent_id = agentId;
   }
+
+  // Clear model for non-ephemeral agents - agents use their configured model internally
+  clearModelForNonEphemeralAgent(defaultConvo);
 
   defaultConvo.tools = lastConversationSetup?.tools ?? lastSelectedTools ?? defaultConvo.tools;
 

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -11,6 +11,27 @@ import {
 import type * as t from 'librechat-data-provider';
 import type { LocalizeFunction, IconsRecord } from '~/common';
 
+/**
+ * Clears model for non-ephemeral agent conversations.
+ * Agents use their configured model internally, so the conversation model should be undefined.
+ * Mutates the template in place.
+ */
+export function clearModelForNonEphemeralAgent<
+  T extends {
+    endpoint?: EModelEndpoint | string | null;
+    agent_id?: string | null;
+    model?: string | null;
+  },
+>(template: T): void {
+  if (
+    isAgentsEndpoint(template.endpoint) &&
+    template.agent_id &&
+    template.agent_id !== Constants.EPHEMERAL_AGENT_ID
+  ) {
+    template.model = undefined as T['model'];
+  }
+}
+
 export const getEntityName = ({
   name = '',
   localize,
@@ -124,6 +145,18 @@ export function getConvoSwitchLogic(params: ConversationInitParams): InitiatedTe
     endpoint: newEndpoint,
     conversationId: 'new',
   };
+
+  // Reset agent_id if switching to a non-agents endpoint but template has a non-ephemeral agent_id
+  if (
+    !isAgentsEndpoint(newEndpoint) &&
+    template.agent_id &&
+    template.agent_id !== Constants.EPHEMERAL_AGENT_ID
+  ) {
+    template.agent_id = Constants.EPHEMERAL_AGENT_ID;
+  }
+
+  // Clear model for non-ephemeral agents - agents use their configured model internally
+  clearModelForNonEphemeralAgent(template);
 
   const isAssistantSwitch =
     isAssistantsEndpoint(newEndpoint) &&


### PR DESCRIPTION
## Summary

This pull request centralizes agent model handling across the conversation lifecycle to ensure non-ephemeral agents use their configured model internally rather than storing model information in the conversation object.

**Key changes:**
- Introduced `clearModelForNonEphemeralAgent` utility function to systematically clear the model field for non-ephemeral agent conversations
- Added roles loading check in ChatRoute to ensure agent access permissions are properly initialized before conversation setup
- Updated conversation storage and navigation logic to apply model clearing consistently

### Reviewed changes

Copilot reviewed 12 out of 12 changed files in this pull request and generated 1 comment.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| client/src/utils/endpoints.ts | Added `clearModelForNonEphemeralAgent` utility function and integrated it into `getConvoSwitchLogic` to handle agent_id resets when switching endpoints |
| client/src/utils/buildDefaultConvo.ts | Applied model clearing when building default conversations for non-ephemeral agents |
| client/src/store/families.ts | Integrated model clearing before storing conversation to localStorage; removed Constants from imports causing a critical bug |
| client/src/routes/useAuthRedirect.ts | Exposed roles in the hook's return value for downstream consumption |
| client/src/routes/ChatRoute.tsx | Added roles loading check to ensure agent access permissions are loaded before setting initial conversation |
| client/src/hooks/useNewConvo.ts | Enhanced agent access logic to handle existing agent conversations by checking both conversation and localStorage |
| client/src/hooks/Input/useSelectMention.ts | Applied model clearing after setting agent_id when selecting agent mentions |
| client/src/hooks/Input/useQueryParams.ts | Synced agent_id from preset to template and applied model clearing when processing query parameters |
| client/src/hooks/Input/useQueryParams.spec.ts | Refactored test mocks to use actual implementations with minimal overrides for better test reliability |
| client/src/hooks/Conversations/useNavigateToConvo.tsx | Applied model clearing after fetching fresh conversation data during navigation |
| client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx | Improved initial state calculation to use agent_id or assistant_id when available for agents/assistants endpoints |
| api/app/clients/BaseClient.js | Added 'model' field to exceptions set for non-ephemeral agents to prevent unsetting during conversation saves |
</details>