### PR TITLE
↕️ feat: Improve Sorting Accessibility in Archived Chats and Shared Links Modals  

### DIFF
--- a/client/src/components/Nav/SettingsTabs/Data/SharedLinks.tsx
+++ b/client/src/components/Nav/SettingsTabs/Data/SharedLinks.tsx
@@ -12,6 +12,7 @@ import {
   ExternalLink,
 } from 'lucide-react';
 import type { SharedLinkItem, SharedLinksListParams } from 'librechat-data-provider';
+import type { TranslationKeys } from '~/hooks';
 import {
   OGDialog,
   useToastContext,
@@ -120,7 +121,7 @@ export default function SharedLinks() {
 
       if (validRows.length === 0) {
         showToast({
-          message: localize('com_ui_no_valid_items'),
+          message: localize('com_ui_no_valid_items' as TranslationKeys),
           severity: NotificationSeverity.WARNING,
         });
         return;
@@ -134,15 +135,15 @@ export default function SharedLinks() {
         showToast({
           message: localize(
             validRows.length === 1
-              ? 'com_ui_shared_link_delete_success'
-              : 'com_ui_shared_link_bulk_delete_success',
+              ? ('com_ui_shared_link_delete_success' as TranslationKeys)
+              : ('com_ui_shared_link_bulk_delete_success' as TranslationKeys),
           ),
           severity: NotificationSeverity.SUCCESS,
         });
       } catch (error) {
         console.error('Failed to delete shared links:', error);
         showToast({
-          message: localize('com_ui_bulk_delete_error'),
+          message: localize('com_ui_bulk_delete_error' as TranslationKeys),
           severity: NotificationSeverity.ERROR,
         });
       }
@@ -225,10 +226,8 @@ export default function SharedLinks() {
             <Button
               variant="ghost"
               className="px-2 py-0 text-xs hover:bg-surface-hover sm:px-2 sm:py-2 sm:text-sm"
-              onClick={() =>
-                handleSort('createdAt', isSorted && sortDirection === 'asc' ? 'desc' : 'asc')
-              }
-              aria-label={localize('com_ui_creation_date_sort')}
+              aria-label={localize('com_ui_creation_date_sort' as TranslationKeys)}
+              aria-current={sortState ? 'true' : 'false'}
             >
               {localize('com_ui_date')}
               {isSorted && sortDirection === 'asc' && (

--- a/client/src/components/Nav/SettingsTabs/Data/SharedLinks.tsx
+++ b/client/src/components/Nav/SettingsTabs/Data/SharedLinks.tsx
@@ -63,14 +63,6 @@ export default function SharedLinks() {
       refetchOnMount: false,
     });
 
-  const handleSort = useCallback((sortField: string, sortOrder: 'asc' | 'desc') => {
-    setQueryParams((prev) => ({
-      ...prev,
-      sortBy: sortField as 'title' | 'createdAt',
-      sortDirection: sortOrder,
-    }));
-  }, []);
-
   const handleFilterChange = useCallback((value: string) => {
     const encodedValue = encodeURIComponent(value.trim());
     setQueryParams((prev) => ({
@@ -169,26 +161,28 @@ export default function SharedLinks() {
     () => [
       {
         accessorKey: 'title',
-        header: () => {
-          const isSorted = queryParams.sortBy === 'title';
-          const sortDirection = queryParams.sortDirection;
+        header: ({ column }) => {
+          const sortState = column.getIsSorted();
+          let SortIcon = ArrowUpDown;
+          let ariaSort: 'ascending' | 'descending' | 'none' = 'none';
+          if (sortState === 'desc') {
+            SortIcon = ArrowDown;
+            ariaSort = 'descending';
+          } else if (sortState === 'asc') {
+            SortIcon = ArrowUp;
+            ariaSort = 'ascending';
+          }
           return (
             <Button
               variant="ghost"
+              onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
               className="px-2 py-0 text-xs hover:bg-surface-hover sm:px-2 sm:py-2 sm:text-sm"
-              onClick={() =>
-                handleSort('title', isSorted && sortDirection === 'asc' ? 'desc' : 'asc')
-              }
+              aria-sort={ariaSort}
               aria-label={localize('com_ui_name_sort')}
+              aria-current={sortState ? 'true' : 'false'}
             >
               {localize('com_ui_name')}
-              {isSorted && sortDirection === 'asc' && (
-                <ArrowUp className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />
-              )}
-              {isSorted && sortDirection === 'desc' && (
-                <ArrowDown className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />
-              )}
-              {!isSorted && <ArrowUpDown className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />}
+              <SortIcon className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />
             </Button>
           );
         },
@@ -219,24 +213,28 @@ export default function SharedLinks() {
       },
       {
         accessorKey: 'createdAt',
-        header: () => {
-          const isSorted = queryParams.sortBy === 'createdAt';
-          const sortDirection = queryParams.sortDirection;
+        header: ({ column }) => {
+          const sortState = column.getIsSorted();
+          let SortIcon = ArrowUpDown;
+          let ariaSort: 'ascending' | 'descending' | 'none' = 'none';
+          if (sortState === 'desc') {
+            SortIcon = ArrowDown;
+            ariaSort = 'descending';
+          } else if (sortState === 'asc') {
+            SortIcon = ArrowUp;
+            ariaSort = 'ascending';
+          }
           return (
             <Button
               variant="ghost"
+              onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
               className="px-2 py-0 text-xs hover:bg-surface-hover sm:px-2 sm:py-2 sm:text-sm"
+              aria-sort={ariaSort}
               aria-label={localize('com_ui_creation_date_sort' as TranslationKeys)}
               aria-current={sortState ? 'true' : 'false'}
             >
               {localize('com_ui_date')}
-              {isSorted && sortDirection === 'asc' && (
-                <ArrowUp className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />
-              )}
-              {isSorted && sortDirection === 'desc' && (
-                <ArrowDown className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />
-              )}
-              {!isSorted && <ArrowUpDown className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />}
+              <SortIcon className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />
             </Button>
           );
         },
@@ -299,7 +297,7 @@ export default function SharedLinks() {
         ),
       },
     ],
-    [isSmallScreen, localize, queryParams, handleSort],
+    [isSmallScreen, localize],
   );
 
   return (

--- a/client/src/components/Nav/SettingsTabs/General/ArchivedChatsTable.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/ArchivedChatsTable.tsx
@@ -56,14 +56,6 @@ export default function ArchivedChatsTable({
       refetchOnMount: false,
     });
 
-  const handleSort = useCallback((sortField: string, sortOrder: 'asc' | 'desc') => {
-    setQueryParams((prev) => ({
-      ...prev,
-      sortBy: sortField as 'title' | 'createdAt',
-      sortDirection: sortOrder,
-    }));
-  }, []);
-
   const handleFilterChange = useCallback((value: string) => {
     const encodedValue = encodeURIComponent(value.trim());
     setQueryParams((prev) => ({
@@ -133,25 +125,28 @@ export default function ArchivedChatsTable({
     () => [
       {
         accessorKey: 'title',
-        header: () => {
-          const isSorted = queryParams.sortBy === 'title';
-          const sortDirection = queryParams.sortDirection;
+        header: ({ column }) => {
+          const sortState = column.getIsSorted();
+          let SortIcon = ArrowUpDown;
+          let ariaSort: 'ascending' | 'descending' | 'none' = 'none';
+          if (sortState === 'desc') {
+            SortIcon = ArrowDown;
+            ariaSort = 'descending';
+          } else if (sortState === 'asc') {
+            SortIcon = ArrowUp;
+            ariaSort = 'ascending';
+          }
           return (
             <Button
               variant="ghost"
+              onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
               className="px-2 py-0 text-xs hover:bg-surface-hover sm:px-2 sm:py-2 sm:text-sm"
-              onClick={() =>
-                handleSort('title', isSorted && sortDirection === 'asc' ? 'desc' : 'asc')
-              }
+              aria-sort={ariaSort}
+              aria-label={localize('com_nav_archive_name_sort')}
+              aria-current={sortState ? 'true' : 'false'}
             >
               {localize('com_nav_archive_name')}
-              {isSorted && sortDirection === 'asc' && (
-                <ArrowUp className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />
-              )}
-              {isSorted && sortDirection === 'desc' && (
-                <ArrowDown className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />
-              )}
-              {!isSorted && <ArrowUpDown className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />}
+              <SortIcon className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />
             </Button>
           );
         },
@@ -180,26 +175,28 @@ export default function ArchivedChatsTable({
       },
       {
         accessorKey: 'createdAt',
-        header: () => {
-          const isSorted = queryParams.sortBy === 'createdAt';
-          const sortDirection = queryParams.sortDirection;
+        header: ({ column }) => {
+          const sortState = column.getIsSorted();
+          let SortIcon = ArrowUpDown;
+          let ariaSort: 'ascending' | 'descending' | 'none' = 'none';
+          if (sortState === 'desc') {
+            SortIcon = ArrowDown;
+            ariaSort = 'descending';
+          } else if (sortState === 'asc') {
+            SortIcon = ArrowUp;
+            ariaSort = 'ascending';
+          }
           return (
             <Button
               variant="ghost"
+              onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
               className="px-2 py-0 text-xs hover:bg-surface-hover sm:px-2 sm:py-2 sm:text-sm"
-              onClick={() =>
-                handleSort('createdAt', isSorted && sortDirection === 'asc' ? 'desc' : 'asc')
-              }
+              aria-sort={ariaSort}
               aria-label={localize('com_nav_archive_created_at_sort')}
+              aria-current={sortState ? 'true' : 'false'}
             >
               {localize('com_nav_archive_created_at')}
-              {isSorted && sortDirection === 'asc' && (
-                <ArrowUp className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />
-              )}
-              {isSorted && sortDirection === 'desc' && (
-                <ArrowDown className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />
-              )}
-              {!isSorted && <ArrowUpDown className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />}
+              <SortIcon className="ml-2 h-3 w-4 sm:h-4 sm:w-4" />
             </Button>
           );
         },
@@ -270,7 +267,7 @@ export default function ArchivedChatsTable({
         },
       },
     ],
-    [handleSort, isSmallScreen, localize, queryParams, unarchiveMutation],
+    [isSmallScreen, localize, unarchiveMutation],
   );
 
   return (

--- a/client/src/components/Nav/SettingsTabs/General/ArchivedChatsTable.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/ArchivedChatsTable.tsx
@@ -17,6 +17,7 @@ import {
   OGDialogContent,
 } from '@librechat/client';
 import type { ConversationListParams, TConversation } from 'librechat-data-provider';
+import type { TranslationKeys } from '~/hooks';
 import {
   useConversationsInfiniteQuery,
   useDeleteConversationMutation,
@@ -142,7 +143,7 @@ export default function ArchivedChatsTable({
               onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
               className="px-2 py-0 text-xs hover:bg-surface-hover sm:px-2 sm:py-2 sm:text-sm"
               aria-sort={ariaSort}
-              aria-label={localize('com_nav_archive_name_sort')}
+              aria-label={localize('com_nav_archive_name_sort' as TranslationKeys)}
               aria-current={sortState ? 'true' : 'false'}
             >
               {localize('com_nav_archive_name')}
@@ -192,7 +193,7 @@ export default function ArchivedChatsTable({
               onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
               className="px-2 py-0 text-xs hover:bg-surface-hover sm:px-2 sm:py-2 sm:text-sm"
               aria-sort={ariaSort}
-              aria-label={localize('com_nav_archive_created_at_sort')}
+              aria-label={localize('com_nav_archive_created_at_sort' as TranslationKeys)}
               aria-current={sortState ? 'true' : 'false'}
             >
               {localize('com_nav_archive_created_at')}


### PR DESCRIPTION
## Summary

This pull request refactors the sorting logic and improves accessibility for the data tables in both the `SharedLinks` and `ArchivedChatsTable` components. The main changes involve removing custom sorting handlers and leveraging the table library's built-in sorting features, updating header rendering for better accessibility, and ensuring proper typing for translation keys. After this change, focus should now remain on the sort button on key press rather than being sent to the modal, which improves accessibility for keyboard users.

**Table Sorting and Accessibility Improvements:**

* Replaced custom `handleSort` callback and manual sorting state management with the table library's built-in `column.toggleSorting()` method in both `SharedLinks.tsx` and `ArchivedChatsTable.tsx`. This simplifies the code and aligns sorting behavior with the table library's API. [[1]](diffhunk://#diff-43d7bd3c9192302385a4bb914ea48fb433ff73817013db6e25ad2a486f7f4db9L65-L72) [[2]](diffhunk://#diff-3b2da294b28349bd23748a1f878d255bd07fc71d61c505e3afafd53992ba70f4L59-L66)
* Updated table column headers to use the `column.getIsSorted()` state, dynamically set sort icons, and include accessibility attributes like `aria-sort` and `aria-current` for improved screen reader support. [[1]](diffhunk://#diff-43d7bd3c9192302385a4bb914ea48fb433ff73817013db6e25ad2a486f7f4db9L171-R185) [[2]](diffhunk://#diff-43d7bd3c9192302385a4bb914ea48fb433ff73817013db6e25ad2a486f7f4db9L221-R237) [[3]](diffhunk://#diff-3b2da294b28349bd23748a1f878d255bd07fc71d61c505e3afafd53992ba70f4L136-R150) [[4]](diffhunk://#diff-3b2da294b28349bd23748a1f878d255bd07fc71d61c505e3afafd53992ba70f4L183-R200)
* Cleaned up dependencies in the `useMemo` hooks for columns, removing now-unnecessary dependencies on custom sort handlers and query parameters. [[1]](diffhunk://#diff-43d7bd3c9192302385a4bb914ea48fb433ff73817013db6e25ad2a486f7f4db9L303-R300) [[2]](diffhunk://#diff-3b2da294b28349bd23748a1f878d255bd07fc71d61c505e3afafd53992ba70f4L273-R271)

**Type Safety and Localization:**

* Added explicit typing for translation keys by importing and using `TranslationKeys`, and updated calls to `localize()` to use these types for better type safety. [[1]](diffhunk://#diff-43d7bd3c9192302385a4bb914ea48fb433ff73817013db6e25ad2a486f7f4db9R15) [[2]](diffhunk://#diff-43d7bd3c9192302385a4bb914ea48fb433ff73817013db6e25ad2a486f7f4db9L123-R116) [[3]](diffhunk://#diff-43d7bd3c9192302385a4bb914ea48fb433ff73817013db6e25ad2a486f7f4db9L137-R138) [[4]](diffhunk://#diff-3b2da294b28349bd23748a1f878d255bd07fc71d61c505e3afafd53992ba70f4R20)

These changes result in cleaner code, better maintainability, and improved accessibility for sorting table columns.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Confirmed focus no longer boots to parent modal when actuating sort buttons in DataTable in ArchivedChats and Shared Links

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes