### PR TITLE
ᯤ fix: Better Contrast on Filter Icons in DataTables

### DIFF
--- a/client/src/components/Chat/Input/Files/Table/SortFilterHeader.tsx
+++ b/client/src/components/Chat/Input/Files/Table/SortFilterHeader.tsx
@@ -33,12 +33,12 @@ export function SortFilterHeader<TData, TValue>({
       {
         label: localize('com_ui_ascending'),
         onClick: () => column.toggleSorting(false),
-        icon: <ArrowUpIcon className="icon-sm opacity-60" />,
+        icon: <ArrowUpIcon className="icon-sm text-text-secondary" />,
       },
       {
         label: localize('com_ui_descending'),
         onClick: () => column.toggleSorting(true),
-        icon: <ArrowDownIcon className="icon-sm opacity-60" />,
+        icon: <ArrowDownIcon className="icon-sm text-text-secondary" />,
       },
     ];
 
@@ -56,7 +56,7 @@ export function SortFilterHeader<TData, TValue>({
             items.push({
               label: filterValue,
               onClick: () => column.setFilterValue(value),
-              icon: <ListFilter className="icon-sm opacity-60" aria-hidden="true" />,
+              icon: <ListFilter className="icon-sm text-text-secondary" aria-hidden="true" />,
               show: true,
               className: isActive ? 'border-l-2 border-l-border-xheavy' : '',
             });
@@ -68,7 +68,7 @@ export function SortFilterHeader<TData, TValue>({
       items.push({
         label: localize('com_ui_show_all'),
         onClick: () => column.setFilterValue(undefined),
-        icon: <FilterX className="icon-sm opacity-60" />,
+        icon: <FilterX className="icon-sm text-text-secondary" />,
         show: true,
       });
     }
@@ -113,7 +113,7 @@ export function SortFilterHeader<TData, TValue>({
                 {column.getIsFiltered() ? (
                   <ListFilter className="icon-sm" aria-hidden="true" />
                 ) : (
-                  <ListFilter className="icon-sm opacity-60" aria-hidden="true" />
+                  <ListFilter className="icon-sm text-text-secondary" aria-hidden="true" />
                 )}
                 {(() => {
                   const sortState = column.getIsSorted();

--- a/client/src/components/Chat/Input/Files/Table/SortFilterHeader.tsx
+++ b/client/src/components/Chat/Input/Files/Table/SortFilterHeader.tsx
@@ -33,12 +33,12 @@ export function SortFilterHeader<TData, TValue>({
       {
         label: localize('com_ui_ascending'),
         onClick: () => column.toggleSorting(false),
-        icon: <ArrowUpIcon className="h-3.5 w-3.5 text-muted-foreground/70" />,
+        icon: <ArrowUpIcon className="icon-sm opacity-60" />,
       },
       {
         label: localize('com_ui_descending'),
         onClick: () => column.toggleSorting(true),
-        icon: <ArrowDownIcon className="h-3.5 w-3.5 text-muted-foreground/70" />,
+        icon: <ArrowDownIcon className="icon-sm opacity-60" />,
       },
     ];
 
@@ -56,9 +56,7 @@ export function SortFilterHeader<TData, TValue>({
             items.push({
               label: filterValue,
               onClick: () => column.setFilterValue(value),
-              icon: (
-                <ListFilter className="h-3.5 w-3.5 text-muted-foreground/70" aria-hidden="true" />
-              ),
+              icon: <ListFilter className="icon-sm opacity-60" aria-hidden="true" />,
               show: true,
               className: isActive ? 'border-l-2 border-l-border-xheavy' : '',
             });
@@ -70,7 +68,7 @@ export function SortFilterHeader<TData, TValue>({
       items.push({
         label: localize('com_ui_show_all'),
         onClick: () => column.setFilterValue(undefined),
-        icon: <FilterX className="h-3.5 w-3.5 text-muted-foreground/70" />,
+        icon: <FilterX className="icon-sm opacity-60" />,
         show: true,
       });
     }
@@ -113,9 +111,9 @@ export function SortFilterHeader<TData, TValue>({
               >
                 <span>{title}</span>
                 {column.getIsFiltered() ? (
-                  <ListFilter className="icon-sm text-muted-foreground/70" aria-hidden="true" />
+                  <ListFilter className="icon-sm" aria-hidden="true" />
                 ) : (
-                  <ListFilter className="icon-sm opacity-30" aria-hidden="true" />
+                  <ListFilter className="icon-sm opacity-60" aria-hidden="true" />
                 )}
                 {(() => {
                   const sortState = column.getIsSorted();


### PR DESCRIPTION
## Summary

This pull request updates the icon styling in the `SortFilterHeader` component to raise the contrast ratio between the filter funnel icon and its background past the 3:1 contrast threshold minimum required for WCAG compliance.

**UI consistency improvements:**

* Updated all icon components (`ArrowUpIcon`, `ArrowDownIcon`, `ListFilter`, `FilterX`) in `SortFilterHeader.tsx` to use the `icon-sm` and `text-text-secondary` classes for consistent sizing and contrast, replacing previous custom class combinations. [[1]](diffhunk://#diff-8ff6d33795798a61b52750896e2c9e29577e53a727cd0c26ae1d1cfbfe72e632L36-R41) [[2]](diffhunk://#diff-8ff6d33795798a61b52750896e2c9e29577e53a727cd0c26ae1d1cfbfe72e632L59-R59) [[3]](diffhunk://#diff-8ff6d33795798a61b52750896e2c9e29577e53a727cd0c26ae1d1cfbfe72e632L73-R71) [[4]](diffhunk://#diff-8ff6d33795798a61b52750896e2c9e29577e53a727cd0c26ae1d1cfbfe72e632L116-R116)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Confirmed threshold minimums hit for icon in light and dark mode using Color Contrast Analyzer

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes