### PR TITLE
🏃 feat: Keep Modals Open on Escape in Dropdown Menus

### DIFF
--- a/packages/client/src/components/OriginalDialog.tsx
+++ b/packages/client/src/components/OriginalDialog.tsx
@@ -84,39 +84,18 @@ const DialogContent = React.forwardRef<
     const handleEscapeKeyDown = React.useCallback(
       (event: KeyboardEvent) => {
         const tooltips = document.querySelectorAll('.tooltip');
-
-        for (const tooltip of Array.from(tooltips)) {
-          const computedStyle = window.getComputedStyle(tooltip);
-          const opacity = parseFloat(computedStyle.opacity);
-
-          if (
-            tooltip.parentElement &&
-            computedStyle.display !== 'none' &&
-            computedStyle.visibility !== 'hidden' &&
-            opacity > 0
-          ) {
-            event.preventDefault();
-            return;
-          }
-        }
-
-        // Check if a dropdown menu is open
         const dropdownMenus = document.querySelectorAll('[role="menu"]');
-        for (const dropdown of Array.from(dropdownMenus)) {
-          const computedStyle = window.getComputedStyle(dropdown);
-          const opacity = parseFloat(computedStyle.opacity);
 
-          if (
-            computedStyle.display !== 'none' &&
-            computedStyle.visibility !== 'hidden' &&
-            opacity > 0
-          ) {
-            event.preventDefault();
-            return;
-          }
+        if (tooltips.length > 0) {
+          event.preventDefault();
+          return;
         }
 
-        // Call the original handler if it exists
+        if (dropdownMenus.length > 0) {
+          event.preventDefault();
+          return;
+        }
+
         propsOnEscapeKeyDown?.(event);
       },
       [propsOnEscapeKeyDown],

--- a/packages/client/src/components/OriginalDialog.tsx
+++ b/packages/client/src/components/OriginalDialog.tsx
@@ -78,22 +78,37 @@ const DialogContent = React.forwardRef<
     },
     ref,
   ) => {
+    const contentRef = React.useRef<HTMLDivElement>(null);
+
+    React.useImperativeHandle(ref, () => contentRef.current as HTMLDivElement, []);
+
     /* Handle Escape key to prevent closing dialog if a tooltip or dropdown is open 
     (this is a workaround in order to achieve WCAG compliance which requires
     that our tooltips be dismissable with Escape key) */
     const handleEscapeKeyDown = React.useCallback(
       (event: KeyboardEvent) => {
-        const tooltips = document.querySelectorAll('.tooltip');
-        const dropdownMenus = document.querySelectorAll('[role="menu"]');
-
-        if (tooltips.length > 0) {
-          event.preventDefault();
+        if (!contentRef.current) {
+          propsOnEscapeKeyDown?.(event);
           return;
         }
 
-        if (dropdownMenus.length > 0) {
-          event.preventDefault();
-          return;
+        const tooltips = contentRef.current.querySelectorAll('.tooltip');
+        const dropdownMenus = contentRef.current.querySelectorAll('[role="menu"]');
+
+        for (const tooltip of tooltips) {
+          const style = window.getComputedStyle(tooltip);
+          if (style.display !== 'none') {
+            event.preventDefault();
+            return;
+          }
+        }
+
+        for (const dropdownMenu of dropdownMenus) {
+          const style = window.getComputedStyle(dropdownMenu);
+          if (style.display !== 'none') {
+            event.preventDefault();
+            return;
+          }
         }
 
         propsOnEscapeKeyDown?.(event);
@@ -105,7 +120,7 @@ const DialogContent = React.forwardRef<
       <DialogPortal>
         <DialogOverlay className={overlayClassName} />
         <DialogPrimitive.Content
-          ref={ref}
+          ref={contentRef}
           onEscapeKeyDown={handleEscapeKeyDown}
           className={cn(
             'max-w-11/12 fixed left-[50%] top-[50%] z-50 grid max-h-[90vh] w-full translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-2xl bg-background p-6 text-text-primary shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',

--- a/packages/client/src/components/OriginalDialog.tsx
+++ b/packages/client/src/components/OriginalDialog.tsx
@@ -78,7 +78,7 @@ const DialogContent = React.forwardRef<
     },
     ref,
   ) => {
-    /* Handle Escape key to prevent closing dialog if a tooltip is open 
+    /* Handle Escape key to prevent closing dialog if a tooltip or dropdown is open 
     (this is a workaround in order to achieve WCAG compliance which requires
     that our tooltips be dismissable with Escape key) */
     const handleEscapeKeyDown = React.useCallback(
@@ -91,6 +91,22 @@ const DialogContent = React.forwardRef<
 
           if (
             tooltip.parentElement &&
+            computedStyle.display !== 'none' &&
+            computedStyle.visibility !== 'hidden' &&
+            opacity > 0
+          ) {
+            event.preventDefault();
+            return;
+          }
+        }
+
+        // Check if a dropdown menu is open
+        const dropdownMenus = document.querySelectorAll('[role="menu"]');
+        for (const dropdown of Array.from(dropdownMenus)) {
+          const computedStyle = window.getComputedStyle(dropdown);
+          const opacity = parseFloat(computedStyle.opacity);
+
+          if (
             computedStyle.display !== 'none' &&
             computedStyle.visibility !== 'hidden' &&
             opacity > 0


### PR DESCRIPTION
## Summary

This pull request updates the escape key handling logic in the `DialogContent` component to improve accessibility. Now, the dialog will not close when the escape key is pressed if either a tooltip or a dropdown menu is open, ensuring better compliance with WCAG requirements.

**Accessibility improvements:**

* Updated the escape key handler in `OriginalDialog.tsx` to prevent the dialog from closing if a tooltip or a dropdown menu (elements with `[role="menu"]`) is open, enhancing WCAG compliance.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Confirmed filter dropdowns are now closable with Escape key press without closing outer modal.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes