### PR TITLE
⚖️ feat: Aria-Sort Attributes for Shared Links and Archived Chats DataTables

### DIFF
--- a/packages/client/src/components/DataTable.tsx
+++ b/packages/client/src/components/DataTable.tsx
@@ -438,26 +438,37 @@ export default function DataTable<TData, TValue>({
           <TableHeader className="sticky top-0 z-50 bg-surface-secondary">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id} className="border-b border-border-light">
-                {headerGroup.headers.map((header) => (
-                  <TableHead
-                    key={header.id}
-                    className="whitespace-nowrap bg-surface-secondary px-2 py-2 text-left text-sm font-medium text-text-secondary sm:px-4"
-                    style={getColumnStyle(
-                      header.column.columnDef as TableColumn<TData, TValue>,
-                      isSmallScreen,
-                    )}
-                    onClick={
-                      header.column.getCanSort()
-                        ? header.column.getToggleSortingHandler()
-                        : undefined
-                    }
-                    scope="col"
-                  >
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(header.column.columnDef.header, header.getContext())}
-                  </TableHead>
-                ))}
+                {headerGroup.headers.map((header) => {
+                  const sortState = header.column.getIsSorted();
+                  let ariaSort: 'ascending' | 'descending' | undefined;
+                  if (sortState === 'asc') {
+                    ariaSort = 'ascending';
+                  } else if (sortState === 'desc') {
+                    ariaSort = 'descending';
+                  }
+
+                  return (
+                    <TableHead
+                      key={header.id}
+                      className="whitespace-nowrap bg-surface-secondary px-2 py-2 text-left text-sm font-medium text-text-secondary sm:px-4"
+                      style={getColumnStyle(
+                        header.column.columnDef as TableColumn<TData, TValue>,
+                        isSmallScreen,
+                      )}
+                      onClick={
+                        header.column.getCanSort()
+                          ? header.column.getToggleSortingHandler()
+                          : undefined
+                      }
+                      scope="col"
+                      aria-sort={ariaSort}
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableHead>
+                  );
+                })}
               </TableRow>
             ))}
           </TableHeader>


### PR DESCRIPTION
## Summary

This pull request improves accessibility in the `DataTable` component by adding proper ARIA attributes to table header cells that indicate the current sort order. This was already implemented in My Files, but Archived Chats and Shared Links use a separate `DataTable` component so this pull request provides parity between the components for this accessibility feature.

Accessibility improvements:

* In `DataTable.tsx`, added logic to set the `aria-sort` attribute on each `TableHead` cell based on the column's sort state, using `'ascending'` or `'descending'` as appropriate. This helps screen readers convey the sort order to users. [[1]](diffhunk://#diff-df2e7931a8ac8a0d4920dcb8ca704e915214281cfb435247d6a2130056be3cf8L441-R450) [[2]](diffhunk://#diff-df2e7931a8ac8a0d4920dcb8ca704e915214281cfb435247d6a2130056be3cf8R464-R471)

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Tests pending (Can't verify sorts are being read out properly with VoiceOver)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes