### PR TITLE
🥂 feat: High Contrast Toasts

### DIFF
--- a/packages/client/src/components/Toast.tsx
+++ b/packages/client/src/components/Toast.tsx
@@ -5,10 +5,16 @@ import { useToast } from '~/hooks';
 export function Toast() {
   const { toast, onOpenChange } = useToast();
   const severityClassName = {
+    /* Going up by 100 units in terms of darkness (eg bg-green-500 to bg-green-600) for
+     * bg colors produces colors that are too visually dissimilar to LibreChat's standard color palette.
+     * These colors were derived by adjusting the values in the HSV color space using CCA
+     * until the 4.5:1 contrast ratio threshold was met against white text while maintaining
+     * a relatively recognizable color scheme for toasts without compromising accessibility.
+     * */
     [NotificationSeverity.INFO]: 'border-gray-500 bg-gray-500',
-    [NotificationSeverity.SUCCESS]: 'border-green-500 bg-green-500',
-    [NotificationSeverity.WARNING]: 'border-orange-600 bg-orange-600',
-    [NotificationSeverity.ERROR]: 'border-red-500 bg-red-500',
+    [NotificationSeverity.SUCCESS]: 'border-[#02855E] bg-[#02855E]',
+    [NotificationSeverity.WARNING]: 'border-[#C75209] bg-[#C75209]',
+    [NotificationSeverity.ERROR]: 'border-[#E02F1F] bg-[#E02F1F]',
   };
 
   return (


### PR DESCRIPTION
## Summary

This pull request updates the toast notification color palette to improve accessibility and visual consistency with LibreChat's standard colors. The changes ensure that toast background colors meet the 4.5:1 contrast ratio threshold for readability while maintaining a recognizable color scheme.

**Accessibility and color update:**

* Updated the `severityClassName` mapping in `Toast.tsx` to use custom hex color codes for success, warning, and error toasts, replacing the previous Tailwind color classes. The new colors were chosen for better accessibility and consistency, with comments explaining the rationale and method used.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

### New Success Color
<div align="center">
  <img width="404" height="54" alt="Screenshot 2025-12-18 at 12 24 42 PM" src="https://github.com/user-attachments/assets/a795ccc6-eb6a-4809-b45e-06f15a7417ac" style="border-radius: 20px;" />
</div>

### New Warning Color
<div align="center">
  <img width="404" height="54" alt="Screenshot 2025-12-18 at 12 25 40 PM" src="https://github.com/user-attachments/assets/3c9bf20b-4a70-4ad3-8d90-682fe4d58c10" style="border-radius: 20px;" />
</div>

### New Error Color
<div align="center">
  <img width="404" height="54" alt="Screenshot 2025-12-18 at 12 28 56 PM" src="https://github.com/user-attachments/assets/06e82b76-5dac-4c2d-acc8-6eaf1585db12" style="border-radius: 20px;" />
</div>

### Same Info Color (already hit threshold minimums)
<div align="center">
  <img width="404" height="54" alt="Screenshot 2025-12-18 at 12 29 36 PM" src="https://github.com/user-attachments/assets/8ceb5e42-613a-47a1-9c88-e3584f5e52c6" style="border-radius: 20px;" />
</div>
## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes