### PR TITLE
♻️ fix: use DOMAIN_CLIENT for MCP OAuth Redirects

### DIFF
--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -2,6 +2,7 @@ const express = require('express');
 const request = require('supertest');
 const mongoose = require('mongoose');
 const { MongoMemoryServer } = require('mongodb-memory-server');
+const { getBasePath } = require('@librechat/api');
 
 const mockRegistryInstance = {
   getServerConfig: jest.fn(),
@@ -281,27 +282,30 @@ describe('MCP Routes', () => {
         error: 'access_denied',
         state: 'test-flow-id',
       });
+      const basePath = getBasePath();
 
       expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/oauth/error?error=access_denied');
+      expect(response.headers.location).toBe(`${basePath}/oauth/error?error=access_denied`);
     });
 
     it('should redirect to error page when code is missing', async () => {
       const response = await request(app).get('/api/mcp/test-server/oauth/callback').query({
         state: 'test-flow-id',
       });
+      const basePath = getBasePath();
 
       expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/oauth/error?error=missing_code');
+      expect(response.headers.location).toBe(`${basePath}/oauth/error?error=missing_code`);
     });
 
     it('should redirect to error page when state is missing', async () => {
       const response = await request(app).get('/api/mcp/test-server/oauth/callback').query({
         code: 'test-auth-code',
       });
+      const basePath = getBasePath();
 
       expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/oauth/error?error=missing_state');
+      expect(response.headers.location).toBe(`${basePath}/oauth/error?error=missing_state`);
     });
 
     it('should redirect to error page when flow state is not found', async () => {
@@ -311,9 +315,10 @@ describe('MCP Routes', () => {
         code: 'test-auth-code',
         state: 'invalid-flow-id',
       });
+      const basePath = getBasePath();
 
       expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/oauth/error?error=invalid_state');
+      expect(response.headers.location).toBe(`${basePath}/oauth/error?error=invalid_state`);
     });
 
     it('should handle OAuth callback successfully', async () => {
@@ -368,9 +373,10 @@ describe('MCP Routes', () => {
         code: 'test-auth-code',
         state: 'test-flow-id',
       });
+      const basePath = getBasePath();
 
       expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/oauth/success?serverName=test-server');
+      expect(response.headers.location).toBe(`${basePath}/oauth/success?serverName=test-server`);
       expect(MCPOAuthHandler.completeOAuthFlow).toHaveBeenCalledWith(
         'test-flow-id',
         'test-auth-code',
@@ -404,9 +410,10 @@ describe('MCP Routes', () => {
         code: 'test-auth-code',
         state: 'test-flow-id',
       });
+      const basePath = getBasePath();
 
       expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/oauth/error?error=callback_failed');
+      expect(response.headers.location).toBe(`${basePath}/oauth/error?error=callback_failed`);
     });
 
     it('should handle system-level OAuth completion', async () => {
@@ -439,9 +446,10 @@ describe('MCP Routes', () => {
         code: 'test-auth-code',
         state: 'test-flow-id',
       });
+      const basePath = getBasePath();
 
       expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/oauth/success?serverName=test-server');
+      expect(response.headers.location).toBe(`${basePath}/oauth/success?serverName=test-server`);
       expect(mockFlowManager.deleteFlow).toHaveBeenCalledWith('test-flow-id', 'mcp_get_tokens');
     });
 
@@ -484,9 +492,10 @@ describe('MCP Routes', () => {
         code: 'test-auth-code',
         state: 'test-flow-id',
       });
+      const basePath = getBasePath();
 
       expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/oauth/success?serverName=test-server');
+      expect(response.headers.location).toBe(`${basePath}/oauth/success?serverName=test-server`);
       expect(MCPTokenStorage.storeTokens).toHaveBeenCalled();
       expect(mockFlowManager.deleteFlow).toHaveBeenCalledWith('test-flow-id', 'mcp_get_tokens');
     });
@@ -525,9 +534,10 @@ describe('MCP Routes', () => {
         code: 'test-auth-code',
         state: 'test-flow-id',
       });
+      const basePath = getBasePath();
 
       expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/oauth/error?error=callback_failed');
+      expect(response.headers.location).toBe(`${basePath}/oauth/error?error=callback_failed`);
       expect(mockMcpManager.getUserConnection).not.toHaveBeenCalled();
     });
 
@@ -583,9 +593,10 @@ describe('MCP Routes', () => {
         code: 'test-auth-code',
         state: 'test-flow-id',
       });
+      const basePath = getBasePath();
 
       expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/oauth/success?serverName=test-server');
+      expect(response.headers.location).toBe(`${basePath}/oauth/success?serverName=test-server`);
 
       // Verify storeTokens was called with ORIGINAL flow state credentials
       expect(MCPTokenStorage.storeTokens).toHaveBeenCalledWith(
@@ -624,9 +635,10 @@ describe('MCP Routes', () => {
         code: 'test-auth-code',
         state: 'test-flow-id',
       });
+      const basePath = getBasePath();
 
       expect(response.status).toBe(302);
-      expect(response.headers.location).toBe('/oauth/success?serverName=test-server');
+      expect(response.headers.location).toBe(`${basePath}/oauth/success?serverName=test-server`);
 
       // Verify completeOAuthFlow was NOT called (prevented duplicate)
       expect(MCPOAuthHandler.completeOAuthFlow).not.toHaveBeenCalled();
@@ -1395,8 +1407,10 @@ describe('MCP Routes', () => {
         .get('/api/mcp/test-server/oauth/callback?code=test-code&state=test-flow-id')
         .expect(302);
 
+      const basePath = getBasePath();
+
       expect(mockFlowManager.completeFlow).not.toHaveBeenCalled();
-      expect(response.headers.location).toContain('/oauth/success');
+      expect(response.headers.location).toContain(`${basePath}/oauth/success`);
     });
 
     it('should handle null cached tools in OAuth callback (triggers || {} fallback)', async () => {
@@ -1443,7 +1457,9 @@ describe('MCP Routes', () => {
         .get('/api/mcp/test-server/oauth/callback?code=test-code&state=test-flow-id')
         .expect(302);
 
-      expect(response.headers.location).toContain('/oauth/success');
+      const basePath = getBasePath();
+
+      expect(response.headers.location).toContain(`${basePath}/oauth/success`);
     });
   });
 


### PR DESCRIPTION
## Summary

MCP OAuth success/error redirects do not account for `DOMAIN_CLIENT` subpath configuration, causing redirects to fail when LibreChat is deployed on a subpath (e.g., `https://example.com/chat`).

Current behavior: After OAuth callback, user is redirected to: `https://example.com/oauth/success`
Expected redirect: `https://example.com/chat/oauth/success`

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing

**Setup**
1. Deploy LibreChat on a subpath:  `DOMAIN_CLIENT=https://example.com/chat`
1. Enable MCP server and configure with OAuth: Keycloak

**Test OAuth Success Flow:**
1. Open LibreChat at `https://example.com/chat`
1. Click MCP OAuth authentication button
1. Complete OAuth flow in Keycloak
1. Verify redirect to: `https://example.com/chat/oauth/success?serverName=...` 
1. Verify success page displays correctly
1. Verify MCP server is authenticated and tools are available

**Test OAuth Error Flow:**
1. Trigger OAuth error
1. Verify redirect to: `https://example.com/chat/oauth/error?error=...` 
1. Verify error page displays correctly

### **Test Configuration**:

## Checklist

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes do not introduce new warnings
- [ ] Local unit tests pass with my changes
