### PR TITLE
🧈 fix: Smoother Control Panel Tab Expansion Animations

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -476,7 +476,7 @@ export default function AgentPanel() {
     <FormProvider {...methods}>
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="scrollbar-gutter-stable h-auto w-full flex-shrink-0 overflow-x-visible"
+        className="scrollbar-gutter-stable h-auto w-full flex-shrink-0 overflow-y-hidden overflow-x-visible"
         aria-label="Agent configuration form"
       >
         <div className="mx-1 mt-2 flex w-full flex-wrap gap-2">

--- a/client/src/components/SidePanel/Nav.tsx
+++ b/client/src/components/SidePanel/Nav.tsx
@@ -90,7 +90,7 @@ function NavContent({ links, isCollapsed, resize }: Omit<NavProps, 'defaultActiv
                           </AccordionPrimitive.Trigger>
                         </AccordionPrimitive.Header>
 
-                        <AccordionContent className="w-full text-text-primary">
+                        <AccordionContent className="bg-token-sidebar-surface-primary w-full text-text-primary">
                           {link.Component && <link.Component />}
                         </AccordionContent>
                       </AccordionItem>

--- a/packages/client/src/components/Accordion.tsx
+++ b/packages/client/src/components/Accordion.tsx
@@ -39,7 +39,7 @@ const AccordionContent = React.forwardRef<
 >(({ className = '', children, ...props }, ref) => (
   <AccordionPrimitive.Content
     ref={ref}
-    className="overflow-x-visible text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    className="overflow-y-hidden overflow-x-visible text-sm transition-opacity data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down data-[state=closed]:opacity-0 data-[state=open]:opacity-100"
     {...props}
   >
     <div className={cn('pb-4 pt-0', className)}>{children}</div>


### PR DESCRIPTION
## Summary

This pull request introduces UI improvements to the side panel components, focusing on better control of overflow behavior and visual consistency for accordion elements during expansion / collapse. The changes improve the visual transition animation for expanded sections of the control panel so that they no longer vertically overlap into adjacent elements as they expand and collapse.

**UI/UX Improvements:**

* Updated the `AccordionContent` component to use opacity transitions and hide vertical overflow, resulting in smoother open/close animations and preventing content from overflowing vertically.
* Added a background color (`bg-token-sidebar-surface-primary`) to the `AccordionContent` in the sidebar navigation to ensure visual consistency with the sidebar's surface as the opacity transitions during the fade animation.
* Hid y-overflow on the `AgentPanel` so that the Agent Builder accordion would animate open more smoothly.

Closes #11058 

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before

https://github.com/user-attachments/assets/75b96ffa-7248-452b-9dc0-6a051561f776

### After

https://github.com/user-attachments/assets/300bf6fa-9131-441d-a9bb-1ad4e855c3f9

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes