### PR TITLE
chore(client): data-testid for message containers

### DIFF
--- a/client/src/components/Chat/Messages/MessageParts.tsx
+++ b/client/src/components/Chat/Messages/MessageParts.tsx
@@ -109,6 +109,7 @@ export default function Message(props: TMessageProps) {
                 'relative flex w-11/12 flex-col',
                 isCreatedByUser ? 'user-turn' : 'agent-turn',
               )}
+              data-testid={isCreatedByUser ? 'user-message' : 'assistant-message'}
             >
               <h2 className={cn('select-none font-semibold text-text-primary', fontSize)}>
                 {name}

--- a/client/src/components/Chat/Messages/SearchMessage.tsx
+++ b/client/src/components/Chat/Messages/SearchMessage.tsx
@@ -25,6 +25,7 @@ const MessageAvatar = ({ iconData }: { iconData: TMessageIcon }) => (
 const MessageBody = ({ message, messageLabel, fontSize }) => (
   <div
     className={cn('relative flex w-11/12 flex-col', message.isCreatedByUser ? '' : 'agent-turn')}
+    data-testid={message.isCreatedByUser ? 'user-message' : 'assistant-message'}
   >
     <div className={cn('select-none font-semibold', fontSize)}>{messageLabel}</div>
     <SearchContent message={message} />

--- a/client/src/components/Chat/Messages/ui/MessageRender.tsx
+++ b/client/src/components/Chat/Messages/ui/MessageRender.tsx
@@ -164,6 +164,7 @@ const MessageRender = memo(
             'relative flex w-11/12 flex-col',
             msg.isCreatedByUser ? 'user-turn' : 'agent-turn',
           )}
+          data-testid={msg.isCreatedByUser ? 'user-message' : 'assistant-message'}
         >
           <h2 className={cn('select-none font-semibold', fontSize)}>{messageLabel}</h2>
 

--- a/client/src/components/Messages/ContentRender.tsx
+++ b/client/src/components/Messages/ContentRender.tsx
@@ -164,6 +164,7 @@ const ContentRender = memo(
             'relative flex w-11/12 flex-col',
             msg.isCreatedByUser ? 'user-turn' : 'agent-turn',
           )}
+          data-testid={msg.isCreatedByUser ? 'user-message' : 'assistant-message'}
         >
           <h2 className={cn('select-none font-semibold', fontSize)}>{messageLabel}</h2>
 

--- a/client/src/components/Share/Message.tsx
+++ b/client/src/components/Share/Message.tsx
@@ -66,6 +66,7 @@ export default function Message(props: TMessageProps) {
             </div>
             <div
               className={cn('relative flex w-11/12 flex-col', isCreatedByUser ? '' : 'agent-turn')}
+              data-testid={isCreatedByUser ? 'user-message' : 'assistant-message'}
             >
               <div className={cn('select-none font-semibold', fontSize)}>{messageLabel}</div>
               <div className="flex-col gap-1 md:gap-3">


### PR DESCRIPTION
## Summary

Add `data-testid="assistant-message"` and `data-testid="user-message"` attributes to message containers for stable E2E testing in downstream repositories.

Using CSS selectors like `.agent-turn` is fragile as they can break if class names are refactored. Test IDs provide an explicit contract for testing that won't break when styling changes.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

1. Start the application locally
2. Open a conversation and send a message
3. Open browser DevTools and inspect a user message element
4. Confirm it has `data-testid="user-message"`
5. Inspect an assistant response element
6. Confirm it has `data-testid="assistant-message"`

### **Test Configuration**:

N/A

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
