### PR TITLE
🔗 fix: Share Links Respect Custom Base Path

### DIFF
--- a/client/src/components/Conversations/ConvoOptions/ShareButton.tsx
+++ b/client/src/components/Conversations/ConvoOptions/ShareButton.tsx
@@ -9,7 +9,6 @@ import SharedLinkButton from './SharedLinkButton';
 import { buildShareLinkUrl, cn } from '~/utils';
 import store from '~/store';
 
-
 export default function ShareButton({
   conversationId,
   open,

--- a/client/src/components/Conversations/ConvoOptions/ShareButton.tsx
+++ b/client/src/components/Conversations/ConvoOptions/ShareButton.tsx
@@ -6,8 +6,8 @@ import { useGetSharedLinkQuery } from 'librechat-data-provider/react-query';
 import { OGDialogTemplate, Button, Spinner, OGDialog } from '@librechat/client';
 import { useLocalize, useCopyToClipboard } from '~/hooks';
 import SharedLinkButton from './SharedLinkButton';
-import { cn } from '~/utils';
 import store from '~/store';
+import { buildShareLinkUrl, cn } from '~/utils';
 
 export default function ShareButton({
   conversationId,
@@ -40,8 +40,7 @@ export default function ShareButton({
 
   useEffect(() => {
     if (share?.shareId !== undefined) {
-      const link = `${window.location.protocol}//${window.location.host}/share/${share.shareId}`;
-      setSharedLink(link);
+      setSharedLink(buildShareLinkUrl(share.shareId));
     }
   }, [share]);
 

--- a/client/src/components/Conversations/ConvoOptions/ShareButton.tsx
+++ b/client/src/components/Conversations/ConvoOptions/ShareButton.tsx
@@ -6,8 +6,9 @@ import { useGetSharedLinkQuery } from 'librechat-data-provider/react-query';
 import { OGDialogTemplate, Button, Spinner, OGDialog } from '@librechat/client';
 import { useLocalize, useCopyToClipboard } from '~/hooks';
 import SharedLinkButton from './SharedLinkButton';
-import store from '~/store';
 import { buildShareLinkUrl, cn } from '~/utils';
+import store from '~/store';
+
 
 export default function ShareButton({
   conversationId,

--- a/client/src/components/Conversations/ConvoOptions/SharedLinkButton.tsx
+++ b/client/src/components/Conversations/ConvoOptions/SharedLinkButton.tsx
@@ -20,8 +20,8 @@ import {
   useDeleteSharedLinkMutation,
 } from '~/data-provider';
 import { NotificationSeverity } from '~/common';
-import { useLocalize } from '~/hooks';
 import { buildShareLinkUrl } from '~/utils';
+import { useLocalize } from '~/hooks';
 
 export default function SharedLinkButton({
   share,

--- a/client/src/components/Conversations/ConvoOptions/SharedLinkButton.tsx
+++ b/client/src/components/Conversations/ConvoOptions/SharedLinkButton.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useRef } from 'react';
 import { Trans } from 'react-i18next';
 import { QrCode, RotateCw, Trash2 } from 'lucide-react';
 import {
@@ -21,6 +21,7 @@ import {
 } from '~/data-provider';
 import { NotificationSeverity } from '~/common';
 import { useLocalize } from '~/hooks';
+import { buildShareLinkUrl } from '~/utils';
 
 export default function SharedLinkButton({
   share,
@@ -85,9 +86,7 @@ export default function SharedLinkButton({
     },
   });
 
-  const generateShareLink = useCallback((shareId: string) => {
-    return `${window.location.protocol}//${window.location.host}/share/${shareId}`;
-  }, []);
+  const generateShareLink = (shareId: string) => buildShareLinkUrl(shareId);
 
   const updateSharedLink = async () => {
     if (!shareId) {

--- a/client/src/utils/__tests__/share.test.ts
+++ b/client/src/utils/__tests__/share.test.ts
@@ -1,0 +1,22 @@
+jest.mock('librechat-data-provider', () => ({
+  apiBaseUrl: jest.fn(),
+}));
+
+import { apiBaseUrl } from 'librechat-data-provider';
+import { buildShareLinkUrl } from '../share';
+
+describe('buildShareLinkUrl', () => {
+  it('includes the base path for subdirectory deployments', () => {
+    (apiBaseUrl as jest.Mock).mockReturnValue('/librechat');
+    expect(buildShareLinkUrl('reW8SsFGQEH1b1uzSHe4I')).toBe(
+      'http://localhost:3080/librechat/share/reW8SsFGQEH1b1uzSHe4I',
+    );
+  });
+
+  it('works when base path is root', () => {
+    (apiBaseUrl as jest.Mock).mockReturnValue('');
+    expect(buildShareLinkUrl('reW8SsFGQEH1b1uzSHe4I')).toBe(
+      'http://localhost:3080/share/reW8SsFGQEH1b1uzSHe4I',
+    );
+  });
+});

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -23,6 +23,7 @@ export * from './roles';
 export * from './localStorage';
 export * from './promptGroups';
 export * from './email';
+export * from './share';
 export * from './timestamps';
 export { default as cn } from './cn';
 export { default as logger } from './logger';

--- a/client/src/utils/share.ts
+++ b/client/src/utils/share.ts
@@ -1,0 +1,6 @@
+import { apiBaseUrl } from 'librechat-data-provider';
+
+export const buildShareLinkUrl = (shareId: string): string => {
+  const baseURL = apiBaseUrl();
+  return new URL(`${baseURL}/share/${shareId}`, window.location.origin).toString();
+};


### PR DESCRIPTION
Fixes #11072.

## Summary

This pull request refactors how shareable conversation links are generated in the application, centralizing the URL construction logic to now respect subdirectory deployments (custom <base href>) through the addition of a small helper functoin`buildShareLinkUrl`. It also adds tests to verify this behavior.

**Refactoring share link URL logic:**

* Introduced a new utility function `buildShareLinkUrl` in `client/src/utils/share.ts` to generate shareable conversation links, using the `apiBaseUrl` for correct subdirectory support.
* Updated `ShareButton.tsx` and `SharedLinkButton.tsx` components to use the new `buildShareLinkUrl` function instead of constructing URLs inline, ensuring consistent link generation. [[1]](diffhunk://#diff-0af71fc281116431de293eae9c4e1ebae9e57d30f4dcce611f1b46e04bf6411bL9-R9) [[2]](diffhunk://#diff-0af71fc281116431de293eae9c4e1ebae9e57d30f4dcce611f1b46e04bf6411bL43-R43) [[3]](diffhunk://#diff-d3339308fd893a5fb1f609ba82b5cc7914f7eb0fb3e8a810ed9fd204a1bdc2bfR23) [[4]](diffhunk://#diff-d3339308fd893a5fb1f609ba82b5cc7914f7eb0fb3e8a810ed9fd204a1bdc2bfL88-R89)

**Code cleanup:**

* Removed the unnecessary `useCallback` import from `SharedLinkButton.tsx` as the share link generation no longer requires memoization.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

* Added unit tests in `client/src/utils/__tests__/share.test.ts` to verify that `buildShareLinkUrl` correctly handles both root and subdirectory deployments.

* Manually verified proper link generation with custom base url through nginx (localhost/librechat)

<img width="1001" height="1048" alt="Screenshot 2025-12-23 at 8 58 54 AM" src="https://github.com/user-attachments/assets/df99f2b6-8810-4c10-b5b9-ff6ff4426a63" />

<img width="1724" height="1042" alt="Screenshot 2025-12-23 at 9 01 56 AM" src="https://github.com/user-attachments/assets/9148b576-091f-4392-b39e-6092f19bf89e" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
