### PR TITLE
🛜 feat: Enable Network Requests in Offline Mode

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,6 +18,16 @@ const App = () => {
   const { setError } = useApiErrorBoundary();
 
   const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        // Always attempt network requests, even when navigator.onLine is false
+        // This is needed because localhost is reachable without WiFi
+        networkMode: 'always',
+      },
+      mutations: {
+        networkMode: 'always',
+      },
+    },
     queryCache: new QueryCache({
       onError: (error) => {
         if (error?.response?.status === 401) {


### PR DESCRIPTION
## Summary

I enabled network requests to proceed even when `navigator.onLine` reports `false` by configuring `networkMode: 'always'` for both queries and mutations in the React Query `QueryClient`.

- Add `defaultOptions` configuration to `QueryClient` with `networkMode: 'always'` for queries
- Add `networkMode: 'always'` for mutations to ensure consistent behavior
- Include inline comments explaining the rationale for localhost reachability without WiFi

This fixes an issue where the application would refuse to make network requests when WiFi was disconnected, even though localhost or local network servers remain reachable.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested by disabling WiFi while running the application locally and confirming that queries and mutations still execute successfully against localhost.

### **Test Configuration**:
- Local development environment
- WiFi disabled with localhost server running

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes