### PR TITLE
📌 feat: memorize agent/model selection and use from last choice

### DIFF
--- a/client/src/hooks/useNewConvo.ts
+++ b/client/src/hooks/useNewConvo.ts
@@ -297,8 +297,42 @@ const useNewConvo = (index = 0) => {
 
       let preset = _preset;
       const result = getDefaultModelSpec(startupConfig);
-      const defaultModelSpec = result?.default ?? result?.last;
-      if (
+
+      // Prefer last used spec over default spec for better user experience
+      const defaultModelSpec = result?.last ?? result?.default;
+
+      // Check for last used agent_id that might be outside of modelSpecs
+      const lastAgentId = localStorage.getItem(`${LocalStorageKeys.AGENT_ID_PREFIX}${index}`);
+
+      // Get the last conversation setup to determine what was most recently selected
+      // This is the most reliable way to know if a custom agent was selected after a modelSpec
+      const lastConvoSetup = JSON.parse(
+        localStorage.getItem(`${LocalStorageKeys.LAST_CONVO_SETUP}_${index}`) ?? '{}',
+      );
+      const lastConvoAgentId = lastConvoSetup?.agent_id;
+      const lastConvoSpec = lastConvoSetup?.spec;
+
+      // Use lastAgentId if:
+      // 1. No preset passed AND no template AND lastAgentId exists
+      // 2. AND the last conversation had this agent_id without a spec (custom agent selection)
+      //    OR there's no defaultModelSpec at all
+      // This ensures:
+      // - Custom agent selection (no spec) is remembered
+      // - ModelSpec selections (has spec) take priority when they were the last action
+      const shouldUseLastAgent =
+        !_preset &&
+        lastAgentId &&
+        Object.keys(_template).length === 0 &&
+        ((!lastConvoSpec && lastConvoAgentId === lastAgentId) || !defaultModelSpec);
+
+      if (shouldUseLastAgent) {
+        // Create a preset for the last used agent outside of modelSpecs
+        preset = {
+          endpoint: EModelEndpoint.agents,
+          agent_id: lastAgentId,
+        };
+        logger.log('conversation', 'Using last used agent_id outside modelSpecs', lastAgentId);
+      } else if (
         !preset &&
         startupConfig &&
         (startupConfig.modelSpecs?.prioritize === true ||
@@ -352,6 +386,7 @@ const useNewConvo = (index = 0) => {
       );
     },
     [
+      index,
       files,
       setFiles,
       saveDrafts,

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -7,7 +7,7 @@ import { useGetModelsQuery } from 'librechat-data-provider/react-query';
 import type { TPreset } from 'librechat-data-provider';
 import { useGetConvoIdQuery, useGetStartupConfig, useGetEndpointsQuery } from '~/data-provider';
 import { useNewConvo, useAppStartup, useAssistantListMap, useIdChangeEffect } from '~/hooks';
-import { getDefaultModelSpec, getModelSpecPreset, logger } from '~/utils';
+import { logger } from '~/utils';
 import { ToolCallsMapProvider } from '~/Providers';
 import ChatView from '~/components/Chat/ChatView';
 import useAuthRedirect from './useAuthRedirect';
@@ -72,13 +72,12 @@ export default function ChatRoute() {
     }
 
     if (conversationId === Constants.NEW_CONVO && endpointsQuery.data && modelsQuery.data) {
-      const result = getDefaultModelSpec(startupConfig);
-      const spec = result?.default ?? result?.last;
+      // Let useNewConvo handle the full logic for determining the preset
+      // (including last used agent_id that might be outside of modelSpecs)
       logger.log('conversation', 'ChatRoute, new convo effect', conversation);
       newConversation({
         modelsData: modelsQuery.data,
         template: conversation ? conversation : undefined,
-        ...(spec ? { preset: getModelSpecPreset(spec) } : {}),
       });
 
       hasSetConversation.current = true;
@@ -97,13 +96,12 @@ export default function ChatRoute() {
       assistantListMap[EModelEndpoint.assistants] &&
       assistantListMap[EModelEndpoint.azureAssistants]
     ) {
-      const result = getDefaultModelSpec(startupConfig);
-      const spec = result?.default ?? result?.last;
+      // Let useNewConvo handle the full logic for determining the preset
+      // (including last used agent_id that might be outside of modelSpecs)
       logger.log('conversation', 'ChatRoute new convo, assistants effect', conversation);
       newConversation({
         modelsData: modelsQuery.data,
         template: conversation ? conversation : undefined,
-        ...(spec ? { preset: getModelSpecPreset(spec) } : {}),
       });
       hasSetConversation.current = true;
     } else if (

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -229,8 +229,8 @@ export function applyModelSpecEphemeralAgent({
 
 /**
  * Gets default model spec from config and user preferences.
- * Priority: admin default → last selected → first spec (when prioritize=true or modelSelect disabled).
- * Otherwise: admin default or last conversation spec.
+ * Returns both admin default and last selected spec when available.
+ * Priority for usage: last selected → admin default → first spec (when prioritize=true or modelSelect disabled).
  */
 export function getDefaultModelSpec(startupConfig?: t.TStartupConfig):
   | {
@@ -244,20 +244,30 @@ export function getDefaultModelSpec(startupConfig?: t.TStartupConfig):
     return;
   }
   const defaultSpec = list?.find((spec) => spec.default);
+
+  // Try to get last selected spec from localStorage
+  const lastSelectedSpecName = localStorage.getItem(LocalStorageKeys.LAST_SPEC);
+  let lastSelectedSpec = lastSelectedSpecName
+    ? list?.find((spec) => spec.name === lastSelectedSpecName)
+    : undefined;
+
+  // Fallback: try to get spec from last conversation setup
+  if (!lastSelectedSpec) {
+    const lastConversationSetup = JSON.parse(
+      localStorage.getItem(LocalStorageKeys.LAST_CONVO_SETUP + '_0') ?? '{}',
+    );
+    if (lastConversationSetup.spec) {
+      lastSelectedSpec = list?.find((spec) => spec.name === lastConversationSetup.spec);
+    }
+  }
+
   if (prioritize === true || !interfaceConfig?.modelSelect) {
-    const lastSelectedSpecName = localStorage.getItem(LocalStorageKeys.LAST_SPEC);
-    const lastSelectedSpec = list?.find((spec) => spec.name === lastSelectedSpecName);
-    return { default: defaultSpec || lastSelectedSpec || list?.[0] };
-  } else if (defaultSpec) {
-    return { default: defaultSpec };
+    // When prioritize is true or modelSelect is disabled, return the effective spec as default
+    return { default: lastSelectedSpec || defaultSpec || list?.[0], last: lastSelectedSpec };
   }
-  const lastConversationSetup = JSON.parse(
-    localStorage.getItem(LocalStorageKeys.LAST_CONVO_SETUP + '_0') ?? '{}',
-  );
-  if (!lastConversationSetup.spec) {
-    return;
-  }
-  return { last: list?.find((spec) => spec.name === lastConversationSetup.spec) };
+
+  // Return both default and last, allowing consumer to choose priority
+  return { default: defaultSpec, last: lastSelectedSpec };
 }
 
 export function getModelSpecPreset(modelSpec?: t.TModelSpec) {


### PR DESCRIPTION
## Summary

In https://github.com/danny-avila/LibreChat/pull/10634, users can pin their favorite models on the sidebar. However, when users start a new conversation, the interface jumps back to a default configured model/agent (if any). For example,

```
modelSpecs:
  enforce: false
  prioritize: false
  list:
    - name: "my-agent"
      label: "My Agent"
      description: "Default Assistant."
      showIconInMenu: true
      showIconInHeader: true
      default: true
      preset:
        endpoint: "agents"
        agent_id: "agent_abcd"
        modelLabel: "My Agent"
```

This setting gives new users a default setup for all kinds of activities, but as soon as they start exploring other models and building their own customized agents, we observe that users prefer to stick to their last choice, and the pinned model does not fully unlock this capability.

In this PR, we enhanced the model choice behavior when starting a new conversation, allowing new conversations to use the last chosen model/agent (persisted in storage).

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)

## Testing

Manually tested. Procedure:

- Select a model/agent
- Start a new conversation

The new conversation starts with the previously selected model/agent.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.