### PR TITLE
💬 feat: Allow multiple welcome message configuration

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -27,7 +27,18 @@ cache: true
 
 # Custom interface configuration
 interface:
-  customWelcome: 'Welcome to LibreChat! Enjoy your experience.'
+  customWelcome:
+    messages:
+      en:
+        - 'Welcome, {{user.name}}!'
+        - 'How can I help you today?'
+      es:
+        - 'Bienvenido, {{user.name}}!'
+        - 'En qué puedo ayudarte hoy?'
+      de:
+        - 'Willkommen, {{user.name}}!'
+        - 'Wie kann ich Ihnen heute helfen?'
+    includeTimeGreetings: true  # Include "Good morning, {{username}}", "Good afternoon, {{username}}", etc.
   # Enable/disable file search as a chatarea selection (default: true)
   # Note: This setting does not disable the Agents File Search Capability.
   # To disable the Agents Capability, see the Agents Endpoint configuration instead.

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -520,6 +520,15 @@ export type TTermsOfService = z.infer<typeof termsOfServiceSchema>;
 const localizedStringSchema = z.union([z.string(), z.record(z.string())]);
 export type LocalizedString = z.infer<typeof localizedStringSchema>;
 
+const customWelcomeConfigSchema = z.object({
+  messages: z.record(z.array(z.string())).optional(),
+  includeTimeGreetings: z.boolean().optional().default(false),
+});
+export type TCustomWelcomeConfig = z.infer<typeof customWelcomeConfigSchema>;
+
+// customWelcome can be a string (legacy) or a full config object with language-keyed messages
+const customWelcomeSchema = z.union([z.string(), customWelcomeConfigSchema]);
+
 const mcpServersSchema = z
   .object({
     placeholder: z.string().optional(),
@@ -546,7 +555,7 @@ export const interfaceSchema = z
       })
       .optional(),
     termsOfService: termsOfServiceSchema.optional(),
-    customWelcome: z.string().optional(),
+    customWelcome: customWelcomeSchema.optional(),
     mcpServers: mcpServersSchema.optional(),
     endpointsMenu: z.boolean().optional(),
     modelSelect: z.boolean().optional(),


### PR DESCRIPTION
# Pull Request Template

## Summary

This PR adds support for multiple localized welcome messages on the landing page instead of a single string while maintaining backward compatibility with the existing single-string format.

**New config format:**
```
interface:
  customWelcome:
    messages:
      en:
        - 'Welcome to LibreChat!'
        - 'Hello, {{user.name}}!'
      de:
        - 'Willkommen bei LibreChat!'
        - 'Hallo, {{user.name}}!'
    includeTimeGreetings: true
```

One message of the users language is randomly selected and displayed.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- Configure multiple welcome messages using the new format
- Start LibreChat and verify a random message displays on the landing page
- Change language in settings and verify messages switch to the configured language
- Test `{{user.name}}` template replacement
- Test `includeTimeGreetings: true` to verify time-based greetings also appear randomly
- Test legacy format config (single string) still works

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] A pull request for updating the documentation has been submitted.
