### PR TITLE
🧠 style: Expanded Thinking footer, Banner links, and Copy Thoughts accessibility

### DIFF
--- a/client/src/components/Banners/Banner.tsx
+++ b/client/src/components/Banners/Banner.tsx
@@ -38,10 +38,13 @@ export const Banner = ({ onHeightChange }: { onHeightChange?: (height: number) =
   return (
     <div
       ref={bannerRef}
-      className="sticky top-0 z-20 flex items-center bg-surface-secondary px-2 py-1 text-text-primary dark:bg-gradient-to-r md:relative"
+      className="sticky top-0 z-20 flex items-center bg-presentation px-2 py-1 text-text-primary dark:bg-gradient-to-r md:relative"
     >
       <div
-        className={cn('text-md w-full truncate text-center', !banner.persistable && 'px-4')}
+        className={cn(
+          'text-md w-full truncate text-center [&_a]:text-blue-700 [&_a]:underline dark:[&_a]:text-blue-400',
+          !banner.persistable && 'px-4',
+        )}
         dangerouslySetInnerHTML={{ __html: banner.message }}
       ></div>
       {!banner.persistable && (

--- a/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
@@ -88,7 +88,7 @@ const Reasoning = memo(({ reasoning, isLast }: ReasoningProps) => {
         >
           <div className="overflow-hidden">
             <ThinkingContent>{reasoningText}</ThinkingContent>
-            <ThinkingFooter onClick={handleClick} content={reasoningText} />
+            <ThinkingFooter onClick={handleClick} />
           </div>
         </div>
       </div>

--- a/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo, useState, useCallback } from 'react';
 import { useAtom } from 'jotai';
 import type { MouseEvent } from 'react';
 import { ContentTypes } from 'librechat-data-provider';
-import { ThinkingContent, ThinkingButton } from './Thinking';
+import { ThinkingContent, ThinkingButton, ThinkingFooter } from './Thinking';
 import { showThinkingAtom } from '~/store/showThinking';
 import { useMessageContext } from '~/Providers';
 import { useLocalize } from '~/hooks';
@@ -69,7 +69,7 @@ const Reasoning = memo(({ reasoning, isLast }: ReasoningProps) => {
   return (
     <div className="group/reasoning">
       <div className="group/thinking-container">
-        <div className="sticky top-0 z-10 mb-2 bg-presentation pb-2 pt-2">
+        <div className="mb-2 pb-2 pt-2">
           <ThinkingButton
             isExpanded={isExpanded}
             onClick={handleClick}
@@ -88,6 +88,7 @@ const Reasoning = memo(({ reasoning, isLast }: ReasoningProps) => {
         >
           <div className="overflow-hidden">
             <ThinkingContent>{reasoningText}</ThinkingContent>
+            <ThinkingFooter onClick={handleClick} content={reasoningText} />
           </div>
         </div>
       </div>

--- a/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, memo, useCallback } from 'react';
 import { useAtomValue } from 'jotai';
-import { Lightbulb, ChevronDown } from 'lucide-react';
+import { Lightbulb, ChevronDown, ChevronUp } from 'lucide-react';
 import { Clipboard, CheckMark } from '@librechat/client';
 import type { MouseEvent, FC } from 'react';
 import { showThinkingAtom } from '~/store/showThinking';
@@ -90,13 +90,13 @@ export const ThinkingButton = memo(
           <button
             type="button"
             onClick={handleCopy}
-            title={
+            aria-label={
               isCopied
                 ? localize('com_ui_copied_to_clipboard')
                 : localize('com_ui_copy_thoughts_to_clipboard')
             }
             className={cn(
-              'rounded-lg p-1.5 text-text-secondary-alt transition-colors duration-200',
+              'rounded-lg p-1.5 text-text-secondary-alt',
               isExpanded
                 ? 'opacity-0 group-focus-within/thinking-container:opacity-100 group-hover/thinking-container:opacity-100'
                 : 'opacity-0',
@@ -104,9 +104,59 @@ export const ThinkingButton = memo(
               'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black dark:focus-visible:ring-white',
             )}
           >
-            {isCopied ? <CheckMark className="h-[18px] w-[18px]" /> : <Clipboard size="19" />}
+            {isCopied ? (
+              <CheckMark className="h-[18px] w-[18px]" aria-hidden="true" />
+            ) : (
+              <Clipboard size="19" aria-hidden="true" />
+            )}
           </button>
         )}
+      </div>
+    );
+  },
+);
+
+/**
+ * ThinkingFooter - Footer with collapse and copy buttons shown at the bottom of expanded content
+ * Allows users to collapse without scrolling back to the top
+ */
+export const ThinkingFooter = memo(
+  ({
+    onClick,
+    content,
+  }: {
+    onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+    content?: string;
+  }) => {
+    const localize = useLocalize();
+    const [isCopied, setIsCopied] = useState(false);
+
+    const handleCopy = useCallback(
+      (e: MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+        if (content) {
+          navigator.clipboard.writeText(content);
+          setIsCopied(true);
+          setTimeout(() => setIsCopied(false), 2000);
+        }
+      },
+      [content],
+    );
+
+    return (
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label={localize('com_ui_collapse')}
+          className={cn(
+            'rounded-lg p-1.5 text-text-secondary-alt',
+            'hover:bg-surface-hover hover:text-text-primary',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black dark:focus-visible:ring-white',
+          )}
+        >
+          <ChevronUp className="h-[18px] w-[18px]" aria-hidden="true" />
+        </button>
       </div>
     );
   },
@@ -153,7 +203,7 @@ const Thinking: React.ElementType = memo(({ children }: { children: React.ReactN
 
   return (
     <div className="group/thinking-container">
-      <div className="sticky top-0 z-10 mb-4 bg-presentation pb-2 pt-2">
+      <div className="mb-4 pb-2 pt-2">
         <ThinkingButton
           isExpanded={isExpanded}
           onClick={handleClick}
@@ -169,6 +219,7 @@ const Thinking: React.ElementType = memo(({ children }: { children: React.ReactN
       >
         <div className="overflow-hidden">
           <ThinkingContent>{children}</ThinkingContent>
+          <ThinkingFooter onClick={handleClick} content={textContent} />
         </div>
       </div>
     </div>
@@ -177,6 +228,7 @@ const Thinking: React.ElementType = memo(({ children }: { children: React.ReactN
 
 ThinkingButton.displayName = 'ThinkingButton';
 ThinkingContent.displayName = 'ThinkingContent';
+ThinkingFooter.displayName = 'ThinkingFooter';
 Thinking.displayName = 'Thinking';
 
 export default memo(Thinking);

--- a/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
@@ -122,7 +122,7 @@ export const ThinkingButton = memo(
 );
 
 /**
- * ThinkingFooter - Footer with collapse and copy buttons shown at the bottom of expanded content
+ * ThinkingFooter - Footer with collapse button shown at the bottom of expanded content
  * Allows users to collapse without scrolling back to the top
  */
 export const ThinkingFooter = memo(

--- a/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
@@ -104,6 +104,11 @@ export const ThinkingButton = memo(
               'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black dark:focus-visible:ring-white',
             )}
           >
+            <span className="sr-only">
+              {isCopied
+                ? localize('com_ui_copied_to_clipboard')
+                : localize('com_ui_copy_thoughts_to_clipboard')}
+            </span>
             {isCopied ? (
               <CheckMark className="h-[18px] w-[18px]" aria-hidden="true" />
             ) : (
@@ -121,40 +126,22 @@ export const ThinkingButton = memo(
  * Allows users to collapse without scrolling back to the top
  */
 export const ThinkingFooter = memo(
-  ({
-    onClick,
-    content,
-  }: {
-    onClick: (e: MouseEvent<HTMLButtonElement>) => void;
-    content?: string;
-  }) => {
+  ({ onClick }: { onClick: (e: MouseEvent<HTMLButtonElement>) => void }) => {
     const localize = useLocalize();
-    const [isCopied, setIsCopied] = useState(false);
-
-    const handleCopy = useCallback(
-      (e: MouseEvent<HTMLButtonElement>) => {
-        e.stopPropagation();
-        if (content) {
-          navigator.clipboard.writeText(content);
-          setIsCopied(true);
-          setTimeout(() => setIsCopied(false), 2000);
-        }
-      },
-      [content],
-    );
 
     return (
       <div className="mt-3 flex items-center justify-end gap-2">
         <button
           type="button"
           onClick={onClick}
-          aria-label={localize('com_ui_collapse')}
+          aria-label={localize('com_ui_collapse_thoughts')}
           className={cn(
             'rounded-lg p-1.5 text-text-secondary-alt',
             'hover:bg-surface-hover hover:text-text-primary',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black dark:focus-visible:ring-white',
           )}
         >
+          <span className="sr-only">{localize('com_ui_collapse_thoughts')}</span>
           <ChevronUp className="h-[18px] w-[18px]" aria-hidden="true" />
         </button>
       </div>
@@ -219,7 +206,7 @@ const Thinking: React.ElementType = memo(({ children }: { children: React.ReactN
       >
         <div className="overflow-hidden">
           <ThinkingContent>{children}</ThinkingContent>
-          <ThinkingFooter onClick={handleClick} content={textContent} />
+          <ThinkingFooter onClick={handleClick} />
         </div>
       </div>
     </div>

--- a/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, memo, useCallback } from 'react';
 import { useAtomValue } from 'jotai';
-import { Lightbulb, ChevronDown, ChevronUp } from 'lucide-react';
 import { Clipboard, CheckMark } from '@librechat/client';
+import { Lightbulb, ChevronDown, ChevronUp } from 'lucide-react';
 import type { MouseEvent, FC } from 'react';
 import { showThinkingAtom } from '~/store/showThinking';
 import { fontSizeAtom } from '~/store/fontSize';

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -798,6 +798,7 @@
   "com_ui_close_window": "Close Window",
   "com_ui_code": "Code",
   "com_ui_collapse": "Collapse",
+  "com_ui_collapse_thoughts": "Collapse Thoughts",
   "com_ui_collapse_chat": "Collapse Chat",
   "com_ui_command_placeholder": "Optional: Enter a command for the prompt or name will be used",
   "com_ui_command_usage_placeholder": "Select a Prompt by command or name",


### PR DESCRIPTION
## Summary

- Added a footer with a collapse button at the bottom of the expanded thinking content
- Automatically applies hyperlink styling in banner messages
- Fixed screen reader accessibility issues with the “Copy Thoughts” button

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] a11y

## Testing

- [x] Expand a long thinking/reasoning block and verify collapse button appears at the bottom
- [x] Test keyboard navigation and screen reader accessibility on the new button
- [x] Add a banner with an HTML link and verify it displays with proper hyperlink styling

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.