### PR TITLE
🔒 fix: Better SSRF protection for Actions

### DIFF
--- a/packages/api/src/auth/domain.ts
+++ b/packages/api/src/auth/domain.ts
@@ -23,11 +23,134 @@ export function isEmailDomainAllowed(email: string, allowedDomains?: string[] | 
 }
 
 /**
- * Normalizes a domain string. If the domain is invalid, returns null.
- * Normalized === lowercase, trimmed, and protocol added if missing.
- * @param domain
+ * SSRF Protection: Checks if a hostname/IP is a potentially dangerous internal target.
+ * Blocks private IPs, localhost, cloud metadata IPs, and common internal hostnames.
+ * @param hostname - The hostname or IP to check
+ * @returns true if the target is blocked (SSRF risk), false if safe
  */
-function normalizeDomain(domain: string): string | null {
+export function isSSRFTarget(hostname: string): boolean {
+  const normalizedHost = hostname.toLowerCase().trim();
+
+  // Block localhost variations
+  if (
+    normalizedHost === 'localhost' ||
+    normalizedHost === 'localhost.localdomain' ||
+    normalizedHost.endsWith('.localhost')
+  ) {
+    return true;
+  }
+
+  // Check if it's an IP address and block private/internal ranges
+  const ipv4Match = normalizedHost.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4Match) {
+    const [, a, b, c] = ipv4Match.map(Number);
+
+    // 127.0.0.0/8 - Loopback
+    if (a === 127) {
+      return true;
+    }
+
+    // 10.0.0.0/8 - Private
+    if (a === 10) {
+      return true;
+    }
+
+    // 172.16.0.0/12 - Private (172.16.x.x - 172.31.x.x)
+    if (a === 172 && b >= 16 && b <= 31) {
+      return true;
+    }
+
+    // 192.168.0.0/16 - Private
+    if (a === 192 && b === 168) {
+      return true;
+    }
+
+    // 169.254.0.0/16 - Link-local (includes cloud metadata 169.254.169.254)
+    if (a === 169 && b === 254) {
+      return true;
+    }
+
+    // 0.0.0.0 - Special
+    if (a === 0 && b === 0 && c === 0) {
+      return true;
+    }
+  }
+
+  // IPv6 loopback and private ranges
+  const ipv6Normalized = normalizedHost.replace(/^\[|\]$/g, ''); // Remove brackets if present
+  if (
+    ipv6Normalized === '::1' ||
+    ipv6Normalized === '::' ||
+    ipv6Normalized.startsWith('fc') || // fc00::/7 - Unique local
+    ipv6Normalized.startsWith('fd') || // fd00::/8 - Unique local
+    ipv6Normalized.startsWith('fe80') // fe80::/10 - Link-local
+  ) {
+    return true;
+  }
+
+  // Block common internal Docker/Kubernetes service names
+  const internalHostnames = [
+    'rag_api',
+    'rag-api',
+    'api',
+    'redis',
+    'mongodb',
+    'mongo',
+    'postgres',
+    'postgresql',
+    'mysql',
+    'database',
+    'db',
+    'elasticsearch',
+    'kibana',
+    'grafana',
+    'prometheus',
+    'rabbitmq',
+    'kafka',
+    'zookeeper',
+    'consul',
+    'vault',
+    'etcd',
+    'minio',
+    'internal',
+    'backend',
+    'metadata', // Common metadata service name
+  ];
+
+  if (internalHostnames.includes(normalizedHost)) {
+    return true;
+  }
+
+  // Block .internal and .local TLDs (common in internal networks)
+  if (normalizedHost.endsWith('.internal') || normalizedHost.endsWith('.local')) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Parsed domain specification including protocol and port constraints.
+ */
+interface ParsedDomainSpec {
+  hostname: string;
+  protocol?: 'http:' | 'https:' | null; // null means any protocol
+  port?: string | null; // null means any port
+  explicitPort: boolean; // true if port was explicitly specified in original string
+  isWildcard: boolean;
+}
+
+/**
+ * Parses a domain specification into its components.
+ * Supports formats:
+ *   - `example.com` (any protocol, any port)
+ *   - `https://example.com` (https only, any port)
+ *   - `https://example.com:443` (https only, port 443)
+ *   - `*.example.com` (wildcard subdomain)
+ * @param domain - Domain specification string
+ * @returns ParsedDomainSpec or null if invalid
+ */
+function parseDomainSpec(domain: string): ParsedDomainSpec | null {
   try {
     let normalizedDomain = domain.toLowerCase().trim();
 
@@ -36,27 +159,71 @@ function normalizeDomain(domain: string): string | null {
       return null;
     }
 
-    // If it's not already a URL, make it one
-    if (!normalizedDomain.startsWith('http://') && !normalizedDomain.startsWith('https://')) {
+    // Check for wildcard prefix before parsing
+    const isWildcard = normalizedDomain.startsWith('*.');
+
+    // Check if it has a protocol
+    const hasProtocol =
+      normalizedDomain.startsWith('http://') || normalizedDomain.startsWith('https://');
+
+    // Check if port was explicitly specified (e.g., :443, :8080)
+    // Need to check before URL parsing because URL normalizes default ports
+    const portMatch = normalizedDomain.match(/:(\d+)(\/|$|\?)/);
+    const explicitPort = portMatch !== null;
+    const explicitPortValue = portMatch ? portMatch[1] : null;
+
+    // If no protocol, add one temporarily for URL parsing
+    if (!hasProtocol) {
       normalizedDomain = `https://${normalizedDomain}`;
     }
 
     const url = new URL(normalizedDomain);
+
     // Additional validation that hostname isn't just protocol
     if (!url.hostname || url.hostname === 'http:' || url.hostname === 'https:') {
       return null;
     }
 
-    return url.hostname.replace(/^www\./i, '');
+    const hostname = url.hostname.replace(/^www\./i, '');
+
+    return {
+      hostname,
+      protocol: hasProtocol ? (url.protocol as 'http:' | 'https:') : null,
+      // Use the explicitly specified port, or null if no port was specified
+      port: explicitPort ? explicitPortValue : null,
+      explicitPort,
+      isWildcard,
+    };
   } catch {
     return null;
   }
 }
 
 /**
- * Checks if the given domain is allowed. If no restrictions are set, allows all domains.
- * @param domain
- * @param allowedDomains
+ * Checks if hostname matches an allowed pattern (supports wildcards).
+ */
+function hostnameMatches(inputHostname: string, allowedSpec: ParsedDomainSpec): boolean {
+  if (allowedSpec.isWildcard) {
+    // Extract base domain from wildcard (e.g., "*.example.com" -> "example.com")
+    const baseDomain = allowedSpec.hostname.replace(/^\*\./, '');
+    return inputHostname === baseDomain || inputHostname.endsWith(`.${baseDomain}`);
+  }
+  return inputHostname === allowedSpec.hostname;
+}
+
+/**
+ * Checks if the given domain is allowed.
+ * SECURITY: When no allowedDomains is configured, blocks SSRF-prone targets
+ * (private IPs, localhost, metadata services) to prevent attacks.
+ * When allowedDomains IS configured, admins can explicitly allow internal targets if needed.
+ *
+ * Supports protocol and port restrictions in allowedDomains:
+ *   - `example.com` - allows any protocol/port
+ *   - `https://example.com` - allows only HTTPS on default port
+ *   - `https://example.com:8443` - allows only HTTPS on port 8443
+ *
+ * @param domain - The domain to check (can include protocol/port)
+ * @param allowedDomains - List of allowed domain patterns
  */
 export async function isActionDomainAllowed(
   domain?: string | null,
@@ -66,32 +233,50 @@ export async function isActionDomainAllowed(
     return false;
   }
 
-  if (!Array.isArray(allowedDomains) || !allowedDomains.length) {
-    return true;
-  }
-
-  const normalizedInputDomain = normalizeDomain(domain);
-  if (!normalizedInputDomain) {
+  const inputSpec = parseDomainSpec(domain);
+  if (!inputSpec) {
     return false;
   }
 
+  /** If no domain restrictions configured, block SSRF targets but allow all else */
+  if (!Array.isArray(allowedDomains) || !allowedDomains.length) {
+    /** SECURITY: Block SSRF-prone targets when no allowlist is configured */
+    if (isSSRFTarget(inputSpec.hostname)) {
+      return false;
+    }
+    return true;
+  }
+
+  /** When allowedDomains is configured, check against the list with protocol/port matching */
   for (const allowedDomain of allowedDomains) {
-    const normalizedAllowedDomain = normalizeDomain(allowedDomain);
-    if (!normalizedAllowedDomain) {
+    const allowedSpec = parseDomainSpec(allowedDomain);
+    if (!allowedSpec) {
       continue;
     }
 
-    if (normalizedAllowedDomain.startsWith('*.')) {
-      const baseDomain = normalizedAllowedDomain.slice(2);
-      if (
-        normalizedInputDomain === baseDomain ||
-        normalizedInputDomain.endsWith(`.${baseDomain}`)
-      ) {
-        return true;
-      }
-    } else if (normalizedInputDomain === normalizedAllowedDomain) {
-      return true;
+    // Check hostname match (with wildcard support)
+    if (!hostnameMatches(inputSpec.hostname, allowedSpec)) {
+      continue;
     }
+
+    // If allowedSpec has protocol restriction, input must match
+    if (allowedSpec.protocol !== null) {
+      // Input must have protocol specified to match a protocol-restricted rule
+      if (inputSpec.protocol === null || inputSpec.protocol !== allowedSpec.protocol) {
+        continue;
+      }
+    }
+
+    // If allowedSpec has explicit port restriction, input must have matching explicit port
+    if (allowedSpec.explicitPort) {
+      // Input must also have an explicit port that matches
+      if (!inputSpec.explicitPort || inputSpec.port !== allowedSpec.port) {
+        continue;
+      }
+    }
+
+    // All specified constraints matched
+    return true;
   }
 
   return false;


### PR DESCRIPTION
Addresses Server-Side Request Forgery vulnerability that allowed authenticated attackers to interact with arbitrary internal/external HTTP services via the Actions feature, including the internal RAG API, localhost services, and cloud metadata endpoints.

## Security Changes

### 1. SSRF Target Blocklist (when allowedDomains is empty)
- Block localhost and loopback addresses (127.0.0.0/8, ::1)
- Block private IP ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
- Block link-local/cloud metadata IPs (169.254.0.0/16)
- Block common internal Docker/Kubernetes service names (rag_api, redis, mongo, etc.)
- Block .internal and .local TLDs

Admins can still explicitly allow internal targets by adding them to `actions.allowedDomains` in librechat.yaml.

### 2. Protocol and Port Restrictions
Enhanced `allowedDomains` to support protocol and port constraints:
- `example.com` - any protocol, any port (existing behavior)
- `https://example.com` - HTTPS only, any port
- `https://api.example.com:8443` - HTTPS only, port 8443 only

This allows admins to restrict actions to specific protocols/ports, preventing attackers from accessing unintended services on allowed domains.

### 3. Redirect-based SSRF Prevention
Disabled automatic redirect following in action HTTP requests (`maxRedirects: 0`). This prevents attackers from bypassing domain restrictions by:
1. Pointing action to allowed external domain
2. External domain redirects to internal service (e.g., 127.0.0.1)
3. Server follows redirect and accesses internal service

## Files Changed
- packages/api/src/auth/domain.ts: Added isSSRFTarget(), parseDomainSpec(), updated isActionDomainAllowed() with protocol/port matching
- packages/api/src/auth/domain.spec.ts: Added tests for SSRF protection, protocol restrictions, and port restrictions
- packages/data-provider/src/actions.ts: Added maxRedirects: 0 to axios config

## Configuration Example
# librechat.yaml
actions:
  allowedDomains:
    - "https://api.example.com"        # HTTPS only
    - "https://api.example.com:8443"   # HTTPS + specific port
    - "http://localhost:3000"          # Admin override for local devRef: SBA-ADV-20251205-02
CVSSv3: 9.1 (Critical) - CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:L

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
