### PR TITLE
🎨 fix: Use presentation background for header buttons

### DIFF
--- a/client/src/components/Chat/Menus/HeaderNewChat.tsx
+++ b/client/src/components/Chat/Menus/HeaderNewChat.tsx
@@ -29,7 +29,7 @@ export default function HeaderNewChat() {
           variant="outline"
           data-testid="wide-header-new-chat-button"
           aria-label={localize('com_ui_new_chat')}
-          className="rounded-xl duration-0 hover:bg-surface-active-alt max-md:hidden"
+          className="rounded-xl bg-presentation duration-0 hover:bg-surface-active-alt max-md:hidden"
           onClick={clickHandler}
         >
           <NewChatIcon />

--- a/client/src/components/Chat/Menus/OpenSidebar.tsx
+++ b/client/src/components/Chat/Menus/OpenSidebar.tsx
@@ -44,7 +44,10 @@ export default function OpenSidebar({
           aria-label={localize('com_nav_open_sidebar')}
           aria-expanded={false}
           aria-controls="chat-history-nav"
-          className={cn('rounded-xl duration-0 hover:bg-surface-active-alt', className)}
+          className={cn(
+            'rounded-xl bg-presentation duration-0 hover:bg-surface-active-alt',
+            className,
+          )}
           onClick={handleClick}
         >
           <Sidebar aria-hidden="true" />


### PR DESCRIPTION
# Pull Request Template

## Summary

The background of the header buttons cannot be transparent anymore due to #11122. This PR fixes the backgrounds of the remaining buttons.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Checked manually in dark and light theme.

Before:
<img width="296" height="146" alt="image" src="https://github.com/user-attachments/assets/199b75f1-fa54-402e-840c-4beffcb9c580" />

After:
<img width="297" height="145" alt="image" src="https://github.com/user-attachments/assets/4a2b9484-7218-4ef8-a902-ba356b886e7f" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] Local unit tests pass with my changes
