### PR TITLE
🔧 refactor: Display name logic in Parallel Responses

### DIFF
--- a/api/models/Agent.js
+++ b/api/models/Agent.js
@@ -8,7 +8,6 @@ const {
   ResourceType,
   actionDelimiter,
   isAgentsEndpoint,
-  getResponseSender,
   isEphemeralAgentId,
   encodeEphemeralAgentId,
 } = require('librechat-data-provider');
@@ -150,7 +149,7 @@ const loadEphemeralAgent = async ({ req, spec, endpoint, model_parameters: _m })
 
   const instructions = req.body.promptPrefix;
 
-  // Compute display name using getResponseSender (same logic used for addedConvo agents)
+  // Get endpoint config for modelDisplayLabel fallback
   const appConfig = req.config;
   let endpointConfig = appConfig?.endpoints?.[endpoint];
   if (!isAgentsEndpoint(endpoint) && !endpointConfig) {
@@ -161,10 +160,10 @@ const loadEphemeralAgent = async ({ req, spec, endpoint, model_parameters: _m })
     }
   }
 
-  const sender = getResponseSender({
-    modelLabel: model_parameters?.modelLabel,
-    modelDisplayLabel: endpointConfig?.modelDisplayLabel,
-  });
+  // For ephemeral agents, use modelLabel if provided, then model spec's label,
+  // then modelDisplayLabel from endpoint config, otherwise empty string to show model name
+  const sender =
+    model_parameters?.modelLabel ?? modelSpec?.label ?? endpointConfig?.modelDisplayLabel ?? '';
 
   // Encode ephemeral agent ID with endpoint, model, and computed sender for display
   const ephemeralId = encodeEphemeralAgentId({ endpoint, model, sender });

--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -18,6 +18,7 @@ import type {
   TMessage,
   TSubmission,
   TConversation,
+  TStartupConfig,
   TEndpointOption,
   TEndpointsConfig,
   EndpointSchemaKey,
@@ -169,6 +170,7 @@ export default function useChatFunctions({
     }
 
     const endpointsConfig = queryClient.getQueryData<TEndpointsConfig>([QueryKeys.endpoints]);
+    const startupConfig = queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]);
     const endpointType = getEndpointField(endpointsConfig, endpoint, 'type');
     const iconURL = conversation?.iconURL;
 
@@ -291,6 +293,7 @@ export default function useChatFunctions({
           conversation,
           addedConvo,
           endpointsConfig,
+          startupConfig?.modelSpecs?.list,
         );
       } else {
         initialResponse.content = [];


### PR DESCRIPTION
- Removed the use of `getResponseSender` for computing display names in both `Agent.js` and `loadAddedAgent.js`.
- Implemented fallback logic to derive display names from `modelLabel`, `modelSpec.label`, and `endpointConfig.modelDisplayLabel`.
- Enhanced comments for clarity on the new display name resolution process.
- Updated `useChatFunctions` and `createDualMessageContent` to accommodate changes in sender logic, ensuring consistent handling of ephemeral agents across the application.
