### PR TITLE
🔧 fix: Incorrect count query in meilisearch sync

### DIFF
--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -61,6 +61,17 @@ describe('Meilisearch Mongoose plugin', () => {
     expect(mockAddDocuments).toHaveBeenCalled();
   });
 
+  test('saving conversation indexes with expiredAt=null w/ meilisearch', async () => {
+    await createConversationModel(mongoose).create({
+      conversationId: new mongoose.Types.ObjectId(),
+      user: new mongoose.Types.ObjectId(),
+      title: 'Test Conversation',
+      endpoint: EModelEndpoint.openAI,
+      expiredAt: null,
+    });
+    expect(mockAddDocuments).toHaveBeenCalled();
+  });
+
   test('saving TTL conversation does NOT index w/ meilisearch', async () => {
     await createConversationModel(mongoose).create({
       conversationId: new mongoose.Types.ObjectId(),
@@ -78,6 +89,17 @@ describe('Meilisearch Mongoose plugin', () => {
       conversationId: new mongoose.Types.ObjectId(),
       user: new mongoose.Types.ObjectId(),
       isCreatedByUser: true,
+    });
+    expect(mockAddDocuments).toHaveBeenCalled();
+  });
+
+  test('saving messages with expiredAt=null indexes w/ meilisearch', async () => {
+    await createMessageModel(mongoose).create({
+      messageId: new mongoose.Types.ObjectId(),
+      conversationId: new mongoose.Types.ObjectId(),
+      user: new mongoose.Types.ObjectId(),
+      isCreatedByUser: true,
+      expiredAt: null,
     });
     expect(mockAddDocuments).toHaveBeenCalled();
   });

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -183,9 +183,8 @@ const createMeiliMongooseModel = ({
         );
 
         // Build query with resume capability
-        const query: FilterQuery<unknown> = {
-          expiredAt: { $exists: false }, // Do not sync TTL documents
-        };
+        // Do not sync TTL documents
+        const query: FilterQuery<unknown> = { expiredAt: null };
         if (options?.resumeFromId) {
           query._id = { $gt: options.resumeFromId };
         }


### PR DESCRIPTION
## Summary

The `exists` condition may not fetch documents where the `expiredAt` property is `null`, which can cause documents to become out of sync.
The new condition covers both cases: when the value is not set at all and when it is explicitly `null`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Updated previously added automated unit-tests.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
