### PR TITLE
🪜 fix: Layering Conflicts and UX Polish

### DIFF
--- a/client/src/components/Chat/Input/Artifacts.tsx
+++ b/client/src/components/Chat/Input/Artifacts.tsx
@@ -107,7 +107,7 @@ function Artifacts() {
           <Ariakit.Menu
             gutter={4}
             className={cn(
-              'animate-popover-top-left z-50 flex min-w-[250px] flex-col rounded-xl',
+              'animate-popover-top-left z-40 flex min-w-[250px] flex-col rounded-xl',
               'border border-border-light bg-surface-secondary shadow-lg',
             )}
             portal={true}

--- a/client/src/components/Chat/Input/ArtifactsSubMenu.tsx
+++ b/client/src/components/Chat/Input/ArtifactsSubMenu.tsx
@@ -90,7 +90,7 @@ const ArtifactsSubMenu = React.forwardRef<HTMLDivElement, ArtifactsSubMenuProps>
               portal={true}
               unmountOnHide={true}
               className={cn(
-                'animate-popover-left z-50 ml-3 mt-6 flex min-w-[250px] flex-col rounded-xl',
+                'animate-popover-left z-40 ml-3 mt-6 flex min-w-[250px] flex-col rounded-xl',
                 'border border-border-light bg-surface-secondary shadow-lg',
               )}
             >

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -94,13 +94,13 @@ const AttachFileMenu = ({
     }
     inputRef.current.value = '';
     if (fileType === 'image') {
-      inputRef.current.accept = 'image/*';
+      inputRef.current.accept = 'image/*,.heif,.heic';
     } else if (fileType === 'document') {
       inputRef.current.accept = '.pdf,application/pdf';
     } else if (fileType === 'image_document') {
-      inputRef.current.accept = 'image/*,.pdf,application/pdf';
+      inputRef.current.accept = 'image/*,.heif,.heic,.pdf,application/pdf';
     } else if (fileType === 'image_document_video_audio') {
-      inputRef.current.accept = 'image/*,.pdf,application/pdf,video/*,audio/*';
+      inputRef.current.accept = 'image/*,.heif,.heic,.pdf,application/pdf,video/*,audio/*';
     } else {
       inputRef.current.accept = '';
     }

--- a/client/src/components/Chat/Input/MCPSubMenu.tsx
+++ b/client/src/components/Chat/Input/MCPSubMenu.tsx
@@ -87,7 +87,7 @@ const MCPSubMenu = React.forwardRef<HTMLDivElement, MCPSubMenuProps>(
             unmountOnHide={true}
             aria-label={localize('com_ui_mcp_servers')}
             className={cn(
-              'animate-popover-left z-50 ml-3 flex min-w-[260px] max-w-[320px] flex-col rounded-xl',
+              'animate-popover-left z-40 ml-3 flex min-w-[260px] max-w-[320px] flex-col rounded-xl',
               'border border-border-light bg-presentation p-1.5 shadow-lg',
             )}
           >

--- a/client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx
@@ -64,7 +64,8 @@ export const CustomMenu = React.forwardRef<HTMLDivElement, CustomMenuProps>(func
         unmountOnHide
         gutter={parent ? -4 : 4}
         className={cn(
-          `${parent ? 'animate-popover-left ml-3' : 'animate-popover'} outline-none! z-40 flex max-h-[min(450px,var(--popover-available-height))] w-full`,
+          parent ? 'animate-popover-left ml-3' : 'animate-popover',
+          'outline-none! z-40 flex max-h-[min(450px,var(--popover-available-height))] w-full',
           'w-[var(--menu-width,auto)] min-w-[300px] flex-col overflow-auto rounded-xl border border-border-light',
           'bg-presentation px-3 py-2 text-sm text-text-primary shadow-lg',
           'max-w-[calc(100vw-4rem)] sm:max-h-[calc(65vh)] sm:max-w-[400px]',

--- a/client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx
@@ -64,7 +64,7 @@ export const CustomMenu = React.forwardRef<HTMLDivElement, CustomMenuProps>(func
         unmountOnHide
         gutter={parent ? -4 : 4}
         className={cn(
-          `${parent ? 'animate-popover-left ml-3' : 'animate-popover'} outline-none! z-50 flex max-h-[min(450px,var(--popover-available-height))] w-full`,
+          `${parent ? 'animate-popover-left ml-3' : 'animate-popover'} outline-none! z-40 flex max-h-[min(450px,var(--popover-available-height))] w-full`,
           'w-[var(--menu-width,auto)] min-w-[300px] flex-col overflow-auto rounded-xl border border-border-light',
           'bg-presentation px-3 py-2 text-sm text-text-primary shadow-lg',
           'max-w-[calc(100vw-4rem)] sm:max-h-[calc(65vh)] sm:max-w-[400px]',

--- a/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
@@ -121,6 +121,7 @@ const Reasoning = memo(({ reasoning, isLast }: ReasoningProps) => {
               isVisible={isBarVisible && isExpanded}
               isExpanded={isExpanded}
               onClick={handleClick}
+              content={reasoningText}
             />
           </div>
         </div>

--- a/client/src/components/Chat/Messages/Content/SiblingHeader.tsx
+++ b/client/src/components/Chat/Messages/Content/SiblingHeader.tsx
@@ -118,23 +118,22 @@ export default function SiblingHeader({
         </div>
         <span className="truncate text-sm font-medium text-text-primary">{displayName}</span>
       </div>
-      {messageId && agentId && !isSubmitting && (
-        <button
-          type="button"
-          onClick={handleBranch}
-          disabled={isSubmitting || branchMessage.isLoading}
-          className={cn(
-            'flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md',
-            'text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary',
-            'focus:outline-none focus:ring-2 focus:ring-border-medium focus:ring-offset-1',
-            'disabled:cursor-not-allowed disabled:opacity-50',
-          )}
-          aria-label={localize('com_ui_branch_message')}
-          title={localize('com_ui_branch_message')}
-        >
-          <GitBranchPlus className="h-4 w-4" aria-hidden="true" />
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={handleBranch}
+        disabled={!messageId || !agentId || isSubmitting || branchMessage.isLoading}
+        className={cn(
+          'flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md',
+          'text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary',
+          'focus:outline-none focus:ring-2 focus:ring-border-medium focus:ring-offset-1',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          (!messageId || !agentId || isSubmitting) && 'invisible',
+        )}
+        aria-label={localize('com_ui_branch_message')}
+        title={localize('com_ui_branch_message')}
+      >
+        <GitBranchPlus className="h-4 w-4" aria-hidden="true" />
+      </button>
     </div>
   );
 }

--- a/client/src/components/Conversations/Convo.tsx
+++ b/client/src/components/Conversations/Convo.tsx
@@ -142,6 +142,7 @@ export default function Conversation({
     conversationId,
     isPopoverActive,
     setIsPopoverActive,
+    isShiftHeld: isActiveConvo ? isShiftHeld : false,
   };
 
   return (
@@ -236,7 +237,7 @@ export default function Conversation({
           isPopoverActive || isActiveConvo
             ? 'pointer-events-auto scale-x-100 opacity-100'
             : 'pointer-events-none max-w-0 scale-x-0 opacity-0 group-focus-within:pointer-events-auto group-focus-within:max-w-[60px] group-focus-within:scale-x-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:max-w-[60px] group-hover:scale-x-100 group-hover:opacity-100',
-          (isPopoverActive || isActiveConvo) && (isShiftHeld ? 'max-w-[60px]' : 'max-w-[28px]'),
+          !isPopoverActive && isActiveConvo && isShiftHeld ? 'max-w-[60px]' : 'max-w-[28px]',
         )}
         // Removing aria-hidden to fix accessibility issue: ARIA hidden element must not be focusable or contain focusable elements
         // but not sure what its original purpose was, so leaving the property commented out until it can be cleared safe to delete.

--- a/client/src/components/Conversations/ConvoOptions/ConvoOptions.tsx
+++ b/client/src/components/Conversations/ConvoOptions/ConvoOptions.tsx
@@ -13,7 +13,7 @@ import {
   useGetStartupConfig,
   useArchiveConvoMutation,
 } from '~/data-provider';
-import { useLocalize, useNavigateToConvo, useNewConvo, useShiftKey } from '~/hooks';
+import { useLocalize, useNavigateToConvo, useNewConvo } from '~/hooks';
 import { NotificationSeverity } from '~/common';
 import { useChatContext } from '~/Providers';
 import DeleteButton from './DeleteButton';
@@ -28,6 +28,7 @@ function ConvoOptions({
   isPopoverActive,
   setIsPopoverActive,
   isActiveConvo,
+  isShiftHeld = false,
 }: {
   conversationId: string | null;
   title: string | null;
@@ -36,10 +37,10 @@ function ConvoOptions({
   isPopoverActive: boolean;
   setIsPopoverActive: React.Dispatch<React.SetStateAction<boolean>>;
   isActiveConvo: boolean;
+  isShiftHeld?: boolean;
 }) {
   const localize = useLocalize();
   const queryClient = useQueryClient();
-  const isShiftHeld = useShiftKey();
   const { index } = useChatContext();
   const { data: startupConfig } = useGetStartupConfig();
   const { navigateToConvo } = useNavigateToConvo(index);
@@ -253,7 +254,7 @@ function ConvoOptions({
       : 'opacity-0 focus:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100 data-[open]:opacity-100',
   );
 
-  if (isShiftHeld) {
+  if (isShiftHeld && isActiveConvo && !isPopoverActive && !showShareDialog && !showDeleteDialog) {
     return (
       <div className="flex items-center gap-0.5">
         <button
@@ -350,6 +351,7 @@ export default memo(ConvoOptions, (prevProps, nextProps) => {
     prevProps.conversationId === nextProps.conversationId &&
     prevProps.title === nextProps.title &&
     prevProps.isPopoverActive === nextProps.isPopoverActive &&
-    prevProps.isActiveConvo === nextProps.isActiveConvo
+    prevProps.isActiveConvo === nextProps.isActiveConvo &&
+    prevProps.isShiftHeld === nextProps.isShiftHeld
   );
 });

--- a/client/src/components/Messages/Content/CodeBlock.tsx
+++ b/client/src/components/Messages/Content/CodeBlock.tsx
@@ -112,7 +112,7 @@ const FloatingCodeBar: React.FC<FloatingCodeBarProps> = React.memo(
         ) : (
           <>
             {allowExecution === true && (
-              <RunCode lang={lang} codeRef={codeRef} blockIndex={blockIndex} />
+              <RunCode lang={lang} codeRef={codeRef} blockIndex={blockIndex} iconOnly />
             )}
             <TooltipAnchor
               description={isCopied ? localize('com_ui_copied') : localize('com_ui_copy_code')}

--- a/client/src/components/Messages/Content/RunCode.tsx
+++ b/client/src/components/Messages/Content/RunCode.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useCallback, useEffect } from 'react';
 import debounce from 'lodash/debounce';
 import { TerminalSquareIcon } from 'lucide-react';
 import { Tools, AuthType } from 'librechat-data-provider';
-import { Spinner, useToastContext } from '@librechat/client';
+import { Spinner, TooltipAnchor, useToastContext } from '@librechat/client';
 import type { CodeBarProps } from '~/common';
 import { useVerifyAgentToolAuth, useToolCallMutation } from '~/data-provider';
 import ApiKeyDialog from '~/components/SidePanel/Agents/Code/ApiKeyDialog';
@@ -10,107 +10,125 @@ import { useLocalize, useCodeApiKeyForm } from '~/hooks';
 import { useMessageContext } from '~/Providers';
 import { cn, normalizeLanguage } from '~/utils';
 
-const RunCode: React.FC<CodeBarProps> = React.memo(({ lang, codeRef, blockIndex }) => {
-  const localize = useLocalize();
-  const { showToast } = useToastContext();
-  const execute = useToolCallMutation(Tools.execute_code, {
-    onError: () => {
-      showToast({ message: localize('com_ui_run_code_error'), status: 'error' });
-    },
-  });
+const RunCode: React.FC<CodeBarProps & { iconOnly?: boolean }> = React.memo(
+  ({ lang, codeRef, blockIndex, iconOnly = false }) => {
+    const localize = useLocalize();
+    const { showToast } = useToastContext();
+    const execute = useToolCallMutation(Tools.execute_code, {
+      onError: () => {
+        showToast({ message: localize('com_ui_run_code_error'), status: 'error' });
+      },
+    });
 
-  const { messageId, conversationId, partIndex } = useMessageContext();
-  const normalizedLang = useMemo(() => normalizeLanguage(lang), [lang]);
-  const { data } = useVerifyAgentToolAuth(
-    { toolId: Tools.execute_code },
-    {
-      retry: 1,
-    },
-  );
-  const authType = useMemo(() => data?.message ?? false, [data?.message]);
-  const isAuthenticated = useMemo(() => data?.authenticated ?? false, [data?.authenticated]);
-  const { methods, onSubmit, isDialogOpen, setIsDialogOpen, handleRevokeApiKey } =
-    useCodeApiKeyForm({});
+    const { messageId, conversationId, partIndex } = useMessageContext();
+    const normalizedLang = useMemo(() => normalizeLanguage(lang), [lang]);
+    const { data } = useVerifyAgentToolAuth(
+      { toolId: Tools.execute_code },
+      {
+        retry: 1,
+      },
+    );
+    const authType = useMemo(() => data?.message ?? false, [data?.message]);
+    const isAuthenticated = useMemo(() => data?.authenticated ?? false, [data?.authenticated]);
+    const { methods, onSubmit, isDialogOpen, setIsDialogOpen, handleRevokeApiKey } =
+      useCodeApiKeyForm({});
 
-  const handleExecute = useCallback(async () => {
-    if (!isAuthenticated) {
-      setIsDialogOpen(true);
-      return;
-    }
-    const codeString: string = codeRef.current?.textContent ?? '';
-    if (
-      typeof codeString !== 'string' ||
-      codeString.length === 0 ||
-      typeof normalizedLang !== 'string' ||
-      normalizedLang.length === 0
-    ) {
-      return;
-    }
+    const handleExecute = useCallback(async () => {
+      if (!isAuthenticated) {
+        setIsDialogOpen(true);
+        return;
+      }
+      const codeString: string = codeRef.current?.textContent ?? '';
+      if (
+        typeof codeString !== 'string' ||
+        codeString.length === 0 ||
+        typeof normalizedLang !== 'string' ||
+        normalizedLang.length === 0
+      ) {
+        return;
+      }
 
-    execute.mutate({
+      execute.mutate({
+        partIndex,
+        messageId,
+        blockIndex,
+        conversationId: conversationId ?? '',
+        lang: normalizedLang,
+        code: codeString,
+      });
+    }, [
+      codeRef,
+      execute,
       partIndex,
       messageId,
       blockIndex,
-      conversationId: conversationId ?? '',
-      lang: normalizedLang,
-      code: codeString,
-    });
-  }, [
-    codeRef,
-    execute,
-    partIndex,
-    messageId,
-    blockIndex,
-    conversationId,
-    normalizedLang,
-    setIsDialogOpen,
-    isAuthenticated,
-  ]);
+      conversationId,
+      normalizedLang,
+      setIsDialogOpen,
+      isAuthenticated,
+    ]);
 
-  const debouncedExecute = useMemo(
-    () => debounce(handleExecute, 1000, { leading: true }),
-    [handleExecute],
-  );
+    const debouncedExecute = useMemo(
+      () => debounce(handleExecute, 1000, { leading: true }),
+      [handleExecute],
+    );
 
-  useEffect(() => {
-    return () => {
-      debouncedExecute.cancel();
-    };
-  }, [debouncedExecute]);
+    useEffect(() => {
+      return () => {
+        debouncedExecute.cancel();
+      };
+    }, [debouncedExecute]);
 
-  if (typeof normalizedLang !== 'string' || normalizedLang.length === 0) {
-    return null;
-  }
+    if (typeof normalizedLang !== 'string' || normalizedLang.length === 0) {
+      return null;
+    }
 
-  return (
-    <>
-      <button
-        type="button"
-        className={cn(
-          'ml-auto flex gap-2 rounded-sm px-2 py-1 hover:bg-gray-700 focus:bg-gray-700 focus:outline focus:outline-white',
-        )}
-        onClick={debouncedExecute}
-        disabled={execute.isLoading}
-      >
+    const buttonContent = (
+      <>
         {execute.isLoading ? (
           <Spinner className="animate-spin" size={18} />
         ) : (
           <TerminalSquareIcon size={18} aria-hidden="true" />
         )}
-        {localize('com_ui_run_code')}
+        {!iconOnly && localize('com_ui_run_code')}
+      </>
+    );
+
+    const button = (
+      <button
+        type="button"
+        className={cn(
+          'flex items-center justify-center rounded-sm hover:bg-gray-700 focus:bg-gray-700 focus:outline focus:outline-white',
+          iconOnly ? 'p-1.5' : 'ml-auto gap-2 px-2 py-1',
+        )}
+        onClick={debouncedExecute}
+        disabled={execute.isLoading}
+        aria-label={localize('com_ui_run_code')}
+      >
+        {buttonContent}
       </button>
-      <ApiKeyDialog
-        onSubmit={onSubmit}
-        isOpen={isDialogOpen}
-        register={methods.register}
-        onRevoke={handleRevokeApiKey}
-        onOpenChange={setIsDialogOpen}
-        handleSubmit={methods.handleSubmit}
-        isToolAuthenticated={isAuthenticated}
-        isUserProvided={authType === AuthType.USER_PROVIDED}
-      />
-    </>
-  );
-});
+    );
+
+    return (
+      <>
+        {iconOnly ? (
+          <TooltipAnchor description={localize('com_ui_run_code')} render={button} />
+        ) : (
+          button
+        )}
+        <ApiKeyDialog
+          onSubmit={onSubmit}
+          isOpen={isDialogOpen}
+          register={methods.register}
+          onRevoke={handleRevokeApiKey}
+          onOpenChange={setIsDialogOpen}
+          handleSubmit={methods.handleSubmit}
+          isToolAuthenticated={isAuthenticated}
+          isUserProvided={authType === AuthType.USER_PROVIDED}
+        />
+      </>
+    );
+  },
+);
 
 export default RunCode;

--- a/client/src/components/Nav/ExportConversation/ExportModal.tsx
+++ b/client/src/components/Nav/ExportConversation/ExportModal.tsx
@@ -1,13 +1,13 @@
 import filenamify from 'filenamify';
 import { useEffect, useState, useMemo, useCallback } from 'react';
 import {
-  OGDialogTemplate,
-  OGDialog,
-  Button,
   Input,
   Label,
+  Button,
+  OGDialog,
   Checkbox,
   Dropdown,
+  OGDialogTemplate,
 } from '@librechat/client';
 import type { TConversation } from 'librechat-data-provider';
 import { useLocalize, useExportConversation } from '~/hooks';

--- a/client/src/components/Prompts/Groups/FilterPrompts.tsx
+++ b/client/src/components/Prompts/Groups/FilterPrompts.tsx
@@ -9,7 +9,13 @@ import { usePromptGroupsContext } from '~/Providers';
 import { cn } from '~/utils';
 import store from '~/store';
 
-export default function FilterPrompts({ className = '' }: { className?: string }) {
+export default function FilterPrompts({
+  className = '',
+  dropdownClassName = '',
+}: {
+  className?: string;
+  dropdownClassName?: string;
+}) {
   const localize = useLocalize();
   const { name, setName, hasAccess, promptGroups } = usePromptGroupsContext();
   const { categories } = useCategories({ className: 'h-4 w-4', hasAccess });
@@ -94,7 +100,7 @@ export default function FilterPrompts({ className = '' }: { className?: string }
         value={categoryFilter || SystemCategories.ALL}
         onChange={onSelect}
         options={filterOptions}
-        className="rounded-lg bg-transparent"
+        className={cn('rounded-lg bg-transparent', dropdownClassName)}
         icon={<ListFilter className="h-4 w-4" />}
         label="Filter: "
         ariaLabel={localize('com_ui_filter_prompts')}

--- a/client/src/components/Prompts/PromptsView.tsx
+++ b/client/src/components/Prompts/PromptsView.tsx
@@ -93,7 +93,7 @@ export default function PromptsView() {
                 onClose={isSmallerScreen && isDetailView ? togglePanel : undefined}
               >
                 <div className="mt-1 flex flex-row items-center justify-between px-2 md:px-2">
-                  <FilterPrompts />
+                  <FilterPrompts dropdownClassName="z-[100]" />
                 </div>
               </GroupSidePanel>
             </div>

--- a/client/src/hooks/Files/useDragHelpers.ts
+++ b/client/src/hooks/Files/useDragHelpers.ts
@@ -8,6 +8,7 @@ import {
   Tools,
   QueryKeys,
   Constants,
+  inferMimeType,
   EToolResources,
   EModelEndpoint,
   mergeFileConfig,
@@ -118,7 +119,9 @@ export default function useDragHelpers() {
       }
 
       /** Determine if dragged files are all images (enables the base image option) */
-      const allImages = item.files.every((f) => f.type?.startsWith('image/'));
+      const allImages = item.files.every((f) =>
+        inferMimeType(f.name, f.type)?.startsWith('image/'),
+      );
 
       const shouldShowModal =
         allImages ||

--- a/client/src/routes/Layouts/DashBreadcrumb.tsx
+++ b/client/src/routes/Layouts/DashBreadcrumb.tsx
@@ -1,27 +1,20 @@
 import { useMemo, useCallback } from 'react';
 import { useSetRecoilState } from 'recoil';
+import { Sidebar } from '@librechat/client';
 import { useLocation } from 'react-router-dom';
 import { SystemRoles } from 'librechat-data-provider';
 import { ArrowLeft, MessageSquareQuote } from 'lucide-react';
-import { Sidebar } from '@librechat/client';
 import {
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbLink,
   BreadcrumbList,
   BreadcrumbSeparator,
-  // BreadcrumbEllipsis,
-  // DropdownMenu,
-  // DropdownMenuItem,
-  // DropdownMenuContent,
-  // DropdownMenuTrigger,
 } from '@librechat/client';
 import { useLocalize, useCustomLink, useAuthContext } from '~/hooks';
 import AdvancedSwitch from '~/components/Prompts/AdvancedSwitch';
-// import { RightPanel } from '../../components/Prompts/RightPanel';
 import AdminSettings from '~/components/Prompts/AdminSettings';
 import { useDashboardContext } from '~/Providers';
-// import { PromptsEditorMode } from '~/common';
 import store from '~/store';
 
 const promptsPathPattern = /prompts\/(?!new(?:\/|$)).*$/;

--- a/packages/client/src/components/Combobox.tsx
+++ b/packages/client/src/components/Combobox.tsx
@@ -104,7 +104,7 @@ export default function ComboboxComponent({
             aria-label={ariaLabel + 's'}
             position="popper"
             className={cn(
-              'bg-popover text-popover-foreground relative z-50 max-h-[52vh] min-w-[8rem] overflow-hidden rounded-md border border-gray-200 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-gray-600',
+              'bg-popover text-popover-foreground relative z-40 max-h-[52vh] min-w-[8rem] overflow-hidden rounded-md border border-gray-200 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-gray-600',
               'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
               'bg-white dark:bg-gray-700',
             )}

--- a/packages/client/src/components/ControlCombobox.tsx
+++ b/packages/client/src/components/ControlCombobox.tsx
@@ -134,7 +134,7 @@ function ControlCombobox({
         gutter={4}
         portal
         className={cn(
-          'animate-popover z-50 overflow-hidden rounded-xl border border-border-light bg-surface-secondary shadow-lg',
+          'animate-popover z-40 overflow-hidden rounded-xl border border-border-light bg-surface-secondary shadow-lg',
         )}
         style={{ width: isCollapsed ? '300px' : (buttonWidth ?? '300px') }}
       >

--- a/packages/client/src/components/Dropdown.css
+++ b/packages/client/src/components/Dropdown.css
@@ -23,7 +23,7 @@
   translate: 0 -0.5rem;
   margin-top: 4px;
   margin-right: -2px;
-  z-index: 100;
+  z-index: 40;
 }
 
 .popover-animate {

--- a/packages/client/src/components/Dropdown.css
+++ b/packages/client/src/components/Dropdown.css
@@ -23,7 +23,6 @@
   translate: 0 -0.5rem;
   margin-top: 4px;
   margin-right: -2px;
-  z-index: 40;
 }
 
 .popover-animate {

--- a/packages/client/src/components/Dropdown.tsx
+++ b/packages/client/src/components/Dropdown.tsx
@@ -102,7 +102,7 @@ const Dropdown: React.FC<DropdownProps> = ({
         portal={portal}
         store={selectProps}
         className={cn(
-          'popover-ui',
+          'popover-ui z-40',
           sizeClasses,
           className,
           'max-h-[80vh] overflow-y-auto',

--- a/packages/client/src/components/DropdownMenu.tsx
+++ b/packages/client/src/components/DropdownMenu.tsx
@@ -30,7 +30,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          'text-popover-foreground max-h-(--radix-dropdown-menu-content-available-height) origin-(--radix-dropdown-menu-content-transform-origin) z-50 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border border-border-light bg-surface-secondary p-1 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          'text-popover-foreground max-h-(--radix-dropdown-menu-content-available-height) origin-(--radix-dropdown-menu-content-transform-origin) z-40 min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border border-border-light bg-surface-secondary p-1 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           className,
         )}
         {...props}
@@ -198,7 +198,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        'text-popover-foreground origin-(--radix-dropdown-menu-content-transform-origin) z-50 min-w-[8rem] overflow-hidden rounded-md border border-border-medium bg-surface-secondary p-1 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'text-popover-foreground origin-(--radix-dropdown-menu-content-transform-origin) z-40 min-w-[8rem] overflow-hidden rounded-md border border-border-medium bg-surface-secondary p-1 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className,
       )}
       {...props}

--- a/packages/client/src/components/DropdownPopup.tsx
+++ b/packages/client/src/components/DropdownPopup.tsx
@@ -85,7 +85,7 @@ const Menu: React.FC<MenuProps> = ({
       finalFocus={finalFocus}
       unmountOnHide={unmountOnHide}
       preserveTabOrder={preserveTabOrder}
-      className={cn('popover-ui z-50', className)}
+      className={cn('popover-ui z-40', className)}
       {...props}
     >
       {items

--- a/packages/client/src/components/MultiSelect.tsx
+++ b/packages/client/src/components/MultiSelect.tsx
@@ -137,7 +137,7 @@ export default function MultiSelect<T extends string>({
           unmountOnHide
           finalFocus={selectRef}
           className={cn(
-            'animate-popover z-50 flex max-h-[300px]',
+            'animate-popover z-40 flex max-h-[300px]',
             'flex-col overflow-auto overscroll-contain rounded-xl',
             'bg-surface-secondary px-1.5 py-1 text-text-primary shadow-lg',
             'border border-border-light',

--- a/packages/client/src/components/OriginalDialog.tsx
+++ b/packages/client/src/components/OriginalDialog.tsx
@@ -103,10 +103,18 @@ const DialogContent = React.forwardRef<
       (event: KeyboardEvent) => {
         const activeElement = document.activeElement;
 
-        // Check if a dropdown menu has focus (focus is within it)
-        const dropdownMenus = document.querySelectorAll('[role="menu"]');
-        for (const dropdownMenu of dropdownMenus) {
-          if (dropdownMenu.contains(activeElement)) {
+        // Check if active element is a trigger with an open popover (aria-expanded="true")
+        if (activeElement?.getAttribute('aria-expanded') === 'true') {
+          event.preventDefault();
+          return;
+        }
+
+        // Check if a dropdown menu, listbox, or combobox has focus (focus is within it)
+        const popoverElements = document.querySelectorAll(
+          '[role="menu"], [role="listbox"], [role="combobox"]',
+        );
+        for (const popover of popoverElements) {
+          if (popover.contains(activeElement)) {
             event.preventDefault();
             return;
           }

--- a/packages/client/src/components/OriginalDialog.tsx
+++ b/packages/client/src/components/OriginalDialog.tsx
@@ -96,33 +96,26 @@ const DialogContent = React.forwardRef<
     const depth = React.useContext(DialogDepthContext);
     const contentZIndex = 100 + (depth - 1) * 60;
 
-    /* Handle Escape key to prevent closing dialog if a tooltip or dropdown is open
+    /* Handle Escape key to prevent closing dialog if a tooltip or dropdown has focus
     (this is a workaround in order to achieve WCAG compliance which requires
     that our tooltips be dismissable with Escape key) */
     const handleEscapeKeyDown = React.useCallback(
       (event: KeyboardEvent) => {
-        const tooltips = document.querySelectorAll('.tooltip');
-        const dropdownMenus = document.querySelectorAll('[role="menu"]');
+        const activeElement = document.activeElement;
 
-        for (const tooltip of tooltips) {
-          const computedStyle = window.getComputedStyle(tooltip);
-          if (
-            computedStyle.display !== 'none' &&
-            computedStyle.visibility !== 'hidden' &&
-            parseFloat(computedStyle.opacity) > 0
-          ) {
+        // Check if a dropdown menu has focus (focus is within it)
+        const dropdownMenus = document.querySelectorAll('[role="menu"]');
+        for (const dropdownMenu of dropdownMenus) {
+          if (dropdownMenu.contains(activeElement)) {
             event.preventDefault();
             return;
           }
         }
 
-        for (const dropdownMenu of dropdownMenus) {
-          const computedStyle = window.getComputedStyle(dropdownMenu);
-          if (
-            computedStyle.display !== 'none' &&
-            computedStyle.visibility !== 'hidden' &&
-            parseFloat(computedStyle.opacity) > 0
-          ) {
+        // Check if a tooltip has focus (focus is within it)
+        const tooltips = document.querySelectorAll('.tooltip');
+        for (const tooltip of tooltips) {
+          if (tooltip.contains(activeElement)) {
             event.preventDefault();
             return;
           }

--- a/packages/client/src/components/Select.tsx
+++ b/packages/client/src/components/Select.tsx
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'bg-popover text-popover-foreground relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-gray-200 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-gray-600',
+        'bg-popover text-popover-foreground relative z-40 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-gray-200 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-gray-600',
         position === 'popper'
           ? 'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1'
           : '',


### PR DESCRIPTION
## Summary

I fixed multiple styling issues, z-index conflicts, and UX improvements across the application.

- Standardized z-index values from z-50 to z-40 across dropdown/popover components (Artifacts menus, MCP submenus, Custom menus, and all client package components) to resolve layering conflicts
- Removed hardcoded `z-index: 100` from Dropdown.css and set FilterPrompts to z-[100] for proper layering in PromptsView
- Added HEIF/HEIC image format support to file upload inputs
- Added copy-to-clipboard functionality to Thinking and Reasoning blocks with visual feedback
- Refactored RunCode component with `iconOnly` prop and TooltipAnchor for floating code bar integration
- Fixed shift-key behavior in ConvoOptions by passing `isShiftHeld` as a prop only when `isActiveConvo`, preventing incorrect shift behavior and unnecessary re-renders
- Changed branch button in SiblingHeader to always render with `invisible` class when disabled, preventing layout shifts
- Rewrote escape key handler in OriginalDialog to use semantic focus tracking (aria-expanded, role attributes) instead of computed styles
- Improved MIME type detection in useDragHelpers using `inferMimeType` for more reliable file type identification

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Verify the following interactions work correctly:
- Dropdown/popover components display at proper z-index levels without conflicts
- HEIF/HEIC images can be uploaded through the attach file menu
- Copy button appears and functions correctly in Thinking/Reasoning blocks
- Shift-click behavior on conversation options only activates for the active conversation
- Branch buttons maintain consistent spacing when disabled
- Escape key properly closes dialogs without closing parent dialogs when focus is within nested menus/comboboxes
- Drag-and-drop file uploads correctly identify image types

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes