### PR TITLE
📊 feat: Add zoom hint for Mermaid

### DIFF
--- a/client/src/components/Messages/Content/Mermaid.tsx
+++ b/client/src/components/Messages/Content/Mermaid.tsx
@@ -58,6 +58,8 @@ const Mermaid: React.FC<MermaidProps> = memo(({ children, id, theme }) => {
   }, []);
 
   const [zoom, setZoom] = useState(1);
+  const [showZoomHint, setShowZoomHint] = useState(false);
+  const zoomHintTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   // Dialog zoom and pan state (separate from inline view)
   const [dialogZoom, setDialogZoom] = useState(1);
   const [dialogPan, setDialogPan] = useState({ x: 0, y: 0 });
@@ -363,12 +365,25 @@ const Mermaid: React.FC<MermaidProps> = memo(({ children, id, theme }) => {
         e.preventDefault();
         const delta = e.deltaY > 0 ? -ZOOM_STEP : ZOOM_STEP;
         setZoom((prev) => Math.min(Math.max(prev + delta, MIN_ZOOM), MAX_ZOOM));
+      } else {
+        setShowZoomHint(true);
+        if (zoomHintTimeoutRef.current) {
+          clearTimeout(zoomHintTimeoutRef.current);
+        }
+        zoomHintTimeoutRef.current = setTimeout(() => {
+          setShowZoomHint(false);
+        }, 1500);
       }
     };
 
     // use native event listener with passive: false to prevent scroll
     container.addEventListener('wheel', handleWheelNative, { passive: false });
-    return () => container.removeEventListener('wheel', handleWheelNative);
+    return () => {
+      container.removeEventListener('wheel', handleWheelNative);
+      if (zoomHintTimeoutRef.current) {
+        clearTimeout(zoomHintTimeoutRef.current);
+      }
+    };
   }, [blobUrl]); // blobUrl dep (unused in callback) ensures listener re-attaches when container mounts
 
   const handleMouseDown = useCallback(
@@ -428,6 +443,9 @@ const Mermaid: React.FC<MermaidProps> = memo(({ children, id, theme }) => {
     setDialogPan({ x: 0, y: 0 });
     setIsDialogOpen(true);
   }, []);
+
+  const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.userAgent);
+  const modifierKey = isMac ? '⌘' : 'Ctrl';
 
   const zoomControls = (
     <div
@@ -821,6 +839,22 @@ const Mermaid: React.FC<MermaidProps> = memo(({ children, id, theme }) => {
             />
           </div>
           {zoomControls}
+          <div
+            className={cn(
+              'absolute right-2 top-12 z-10 rounded-full border border-border-light bg-surface-secondary px-3 py-1.5 text-xs text-text-secondary shadow-sm transition-all duration-300',
+              showControls && showZoomHint
+                ? 'translate-y-0 opacity-100'
+                : 'pointer-events-none -translate-y-2 opacity-0',
+            )}
+          >
+            <span className="flex items-center gap-1.5">
+              <kbd className="rounded border border-border-medium bg-surface-hover px-1.5 py-0.5 font-sans text-[10px]">
+                {modifierKey}
+              </kbd>
+              <span>+</span>
+              <span>{localize('com_ui_scroll_to_zoom')}</span>
+            </span>
+          </div>
         </div>
       </div>
     </>

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1234,6 +1234,7 @@
   "com_ui_reset_adjustments": "Reset adjustments",
   "com_ui_reset_var": "Reset {{0}}",
   "com_ui_reset_zoom": "Reset Zoom",
+  "com_ui_scroll_to_zoom": "Scroll to zoom",
   "com_ui_resource": "resource",
   "com_ui_response": "Response",
   "com_ui_result": "Result",


### PR DESCRIPTION
# Pull Request Template

## Summary

Most users likely won't notice that the inline Mermaid diagrams are zoomable using the mouse wheel. This PR adds a zoom hint to improve discoverability of the Ctrl/Cmd + Scroll zoom feature.

When users scroll on a Mermaid diagram without holding the modifier key, a hint briefly appears showing "⌘ + Scroll to zoom" (or "Ctrl + Scroll to zoom" on Windows/Linux).

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Tested manually:
1. Hover over a Mermaid diagram and scroll without Ctrl/Cmd → hint appears
2. Scroll with Ctrl/Cmd held → diagram zooms, no hint

https://github.com/user-attachments/assets/0c6559af-a07a-4d0a-8fb0-e31aa35754c2

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
