### PR TITLE
fix: Fetch serverInstructions for OAuth MCP servers after connection

### DIFF
--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -1,5 +1,6 @@
 import pick from 'lodash/pick';
 import { logger } from '@librechat/data-schemas';
+import { isEnabled } from '~/utils';
 import { CallToolResultSchema, ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { TokenMethods, IUser } from '@librechat/data-schemas';
@@ -118,6 +119,15 @@ export class MCPManager extends UserConnectionManager {
     const configs = await MCPServersRegistry.getInstance().getAllServerConfigs();
     for (const [serverName, config] of Object.entries(configs)) {
       if (config.serverInstructions != null) {
+        // Skip if serverInstructions is true/boolean or "true" string - this means
+        // instructions should be fetched from server but weren't (e.g., OAuth server
+        // that couldn't be connected to at startup)
+        if (isEnabled(config.serverInstructions) && typeof config.serverInstructions !== 'string') {
+          continue;
+        }
+        if (typeof config.serverInstructions === 'string' && config.serverInstructions.toLowerCase().trim() === 'true') {
+          continue;
+        }
         instructions[serverName] = config.serverInstructions as string;
       }
     }

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -6,6 +6,7 @@ import { MCPConnection } from './connection';
 import type * as t from './types';
 import { ConnectionsRepository } from '~/mcp/ConnectionsRepository';
 import { mcpConfig } from './mcpConfig';
+import { isEnabled } from '~/utils';
 
 /**
  * Abstract base class for managing user-specific MCP connections with lifecycle management.
@@ -143,6 +144,25 @@ export abstract class UserConnectionManager {
       this.userConnections.get(userId)?.set(serverName, connection);
 
       logger.info(`[MCP][User: ${userId}][${serverName}] Connection successfully established`);
+
+      // For OAuth servers, fetch and update serverInstructions if enabled but not yet fetched
+      if (config.requiresOAuth && isEnabled(config.serverInstructions)) {
+        try {
+          const instructions = connection.client.getInstructions();
+          if (instructions && typeof instructions === 'string') {
+            await MCPServersRegistry.getInstance().updateServerInstructions(serverName, instructions);
+            logger.debug(
+              `[MCP][User: ${userId}][${serverName}] Fetched and updated server instructions`,
+            );
+          }
+        } catch (instructionsError) {
+          logger.warn(
+            `[MCP][User: ${userId}][${serverName}] Failed to fetch server instructions:`,
+            instructionsError,
+          );
+        }
+      }
+
       // Update timestamp on creation
       this.updateUserLastActivity(userId);
       return connection;

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -182,6 +182,25 @@ export class MCPServersRegistry {
     return parsedConfig;
   }
 
+  /**
+   * Updates the serverInstructions field for a server config.
+   * Used to set instructions fetched from OAuth servers after successful connection.
+   * @param serverName - The name of the server
+   * @param instructions - The instructions string fetched from the server
+   */
+  public async updateServerInstructions(serverName: string, instructions: string): Promise<void> {
+    // Update in cache repository (YAML-defined servers)
+    const configFromCache = await this.cacheConfigsRepo.get(serverName);
+    if (configFromCache) {
+      configFromCache.serverInstructions = instructions;
+      await this.cacheConfigsRepo.update(serverName, configFromCache);
+      // Clear read-through caches to ensure fresh data on next read
+      await this.readThroughCache.clear();
+      await this.readThroughCacheAll.clear();
+      logger.debug(`[MCPServersRegistry] Updated serverInstructions for "${serverName}"`);
+    }
+  }
+
   // TODO: This is currently used to determine if a server requires OAuth. However, this info can
   // can be determined through config.requiresOAuth. Refactor usages and remove this method.
   public async getOAuthServers(userId?: string): Promise<Set<string>> {


### PR DESCRIPTION
## Summary

When an MCP server requires OAuth, the server inspection at startup skips fetching `serverInstructions` since no user is authenticated yet. This caused `serverInstructions: true` to be shown as the literal string `"true"` in the LLM context instead of the actual instructions.

This fix:
- Skips including boolean `true` or string `"true"` values in the formatted instructions (prevents showing literal "true")
- Fetches actual instructions from the server after a successful OAuth connection is established
- Adds `updateServerInstructions` method to `MCPServersRegistry` to update the cached config with fetched instructions

Fixes: https://github.com/danny-avila/LibreChat/discussions/9700

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Testing

- Configure an MCP server with OAuth that has `serverInstructions: true`
- Verify the literal "true" is no longer shown in the LLM context before OAuth
- Complete OAuth authentication flow
- Verify actual server instructions are fetched and shown in subsequent requests

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.