### PR TITLE
🐋 fix: NODE_MAX_OLD_SPACE_SIZE arg not being applied in `Dockerfile.multi` file's `client build` stage

### DIFF
--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -63,6 +63,7 @@ COPY client ./
 COPY --from=data-provider-build /app/packages/data-provider/dist /app/packages/data-provider/dist
 COPY --from=client-package-build /app/packages/client/dist /app/packages/client/dist
 COPY --from=client-package-build /app/packages/client/src /app/packages/client/src
+ARG NODE_MAX_OLD_SPACE_SIZE
 ENV NODE_OPTIONS="--max-old-space-size=${NODE_MAX_OLD_SPACE_SIZE}"
 RUN npm run build
 


### PR DESCRIPTION
## Summary

Fixes `NODE_MAX_OLD_SPACE_SIZE` not being applied to the client build step in `Dockerfile.multi` file. 

The build argument defined at the top in the global scope was not automatically inherited by the `client-build` stage, causing the client build to run with default Node.js memory limits instead of the configured 6144 MB and caused `JavaScript heap out of memory` error when building client.

According to Docker documentation, build arguments declared in the global scope must be explicitly declared within each stage to be inherited.

[https://docs.docker.com/build/building/variables/#scoping](https://docs.docker.com/build/building/variables/#scoping)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing

Build the Docker image using Dockerfile.multi and verify that the `NODE_OPTIONS` environment variable is correctly set in the client-build stage.

```bash
docker build -f Dockerfile.multi .
```

After the fix, the build should use the specified `NODE_MAX_OLD_SPACE_SIZE` (default 6144 MB) during the client build step. Without the fix, the variable expands to an empty string, resulting in default Node.js memory settings.

## Checklist

- [x] My changes do not introduce new warnings
