### PR TITLE
✨feat: ldap url failover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -584,6 +584,7 @@ ENTRA_ID_INCLUDE_OWNERS_AS_MEMBERS=false
 OPENID_GRAPH_SCOPES=User.Read,People.Read,GroupMember.Read.All
 
 # LDAP
+# LDAP_URL can be a comma-separated list
 LDAP_URL=
 LDAP_BIND_DN=
 LDAP_BIND_CREDENTIALS=

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -22,6 +22,7 @@ const {
 const { connectDb, indexSync } = require('~/db');
 const initializeOAuthReconnectManager = require('./services/initializeOAuthReconnectManager');
 const createValidateImageRequest = require('./middleware/validateImageRequest');
+const registerLdapStrategies = require('./utils/registerLdapStrategies');
 const { jwtLogin, ldapLogin, passportLogin } = require('~/strategies');
 const { updateInterfacePermissions } = require('~/models/interface');
 const { checkMigrations } = require('./services/start/migration');
@@ -286,9 +287,7 @@ if (cluster.isMaster) {
     passport.use(passportLogin());
 
     /** LDAP Auth */
-    if (process.env.LDAP_URL && process.env.LDAP_USER_SEARCH_BASE) {
-      passport.use(ldapLogin);
-    }
+    registerLdapStrategies(passport, ldapLogin);
 
     if (isEnabled(ALLOW_SOCIAL_LOGIN)) {
       await configureSocialLogins(app);

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -22,6 +22,7 @@ const {
 const { connectDb, indexSync } = require('~/db');
 const initializeOAuthReconnectManager = require('./services/initializeOAuthReconnectManager');
 const createValidateImageRequest = require('./middleware/validateImageRequest');
+const registerLdapStrategies = require('./utils/registerLdapStrategies');
 const { jwtLogin, ldapLogin, passportLogin } = require('~/strategies');
 const { updateInterfacePermissions } = require('~/models/interface');
 const { checkMigrations } = require('./services/start/migration');
@@ -123,9 +124,7 @@ const startServer = async () => {
   passport.use(passportLogin());
 
   /* LDAP Auth */
-  if (process.env.LDAP_URL && process.env.LDAP_USER_SEARCH_BASE) {
-    passport.use(ldapLogin);
-  }
+  registerLdapStrategies(passport, ldapLogin);
 
   if (isEnabled(ALLOW_SOCIAL_LOGIN)) {
     await configureSocialLogins(app);

--- a/api/server/middleware/requireLdapAuth.js
+++ b/api/server/middleware/requireLdapAuth.js
@@ -1,22 +1,73 @@
 const passport = require('passport');
+const { ldapLogin } = require('~/strategies');
+
+const CONNECTION_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'EHOSTUNREACH',
+  'ENOTFOUND',
+  'ECONNRESET',
+]);
+
+const isConnectionError = (err) => {
+  if (err?.name === 'ConnectionError' || err?.name === 'TimeoutError') {
+    return true;
+  }
+  if (err?.code && CONNECTION_ERROR_CODES.has(err.code)) {
+    return true;
+  }
+  if (Array.isArray(err?.errors)) {
+    return err.errors.some(
+      (error) =>
+        CONNECTION_ERROR_CODES.has(error?.code) ||
+        error?.name === 'ConnectionError' ||
+        error?.name === 'TimeoutError',
+    );
+  }
+  return false;
+};
+
+const getLdapStrategyNames = () => {
+  const urls = ldapLogin?.getLdapUrls?.() ?? [];
+  if (urls.length > 1) {
+    return urls.map((_, index) => (index === 0 ? 'ldapauth' : `ldapauth-${index}`));
+  }
+  return ['ldapauth'];
+};
 
 const requireLdapAuth = (req, res, next) => {
-  passport.authenticate('ldapauth', (err, user, info) => {
-    if (err) {
-      console.log({
-        title: '(requireLdapAuth) Error at passport.authenticate',
-        parameters: [{ name: 'error', value: err }],
-      });
-      return next(err);
+  const strategyNames = getLdapStrategyNames();
+  let handled = false;
+  const authenticate = (index = 0) => {
+    if (handled) {
+      return;
     }
-    if (!user) {
-      console.log({
-        title: '(requireLdapAuth) Error: No user',
-      });
-      return res.status(404).send(info);
-    }
-    req.user = user;
-    next();
-  })(req, res, next);
+    passport.authenticate(strategyNames[index], (err, user, info) => {
+      if (handled) {
+        return;
+      }
+      if (err && isConnectionError(err) && index < strategyNames.length - 1) {
+        return authenticate(index + 1);
+      }
+      handled = true;
+      if (err) {
+        console.log({
+          title: '(requireLdapAuth) Error at passport.authenticate',
+          parameters: [{ name: 'error', value: err }],
+        });
+        return next(err);
+      }
+      if (!user) {
+        console.log({
+          title: '(requireLdapAuth) Error: No user',
+        });
+        return res.status(404).send(info);
+      }
+      req.user = user;
+      next();
+    })(req, res, next);
+  };
+  authenticate();
 };
+
 module.exports = requireLdapAuth;

--- a/api/server/middleware/requireLdapAuth.spec.js
+++ b/api/server/middleware/requireLdapAuth.spec.js
@@ -1,0 +1,106 @@
+const passport = require('passport');
+
+const requireLdapAuth = require('./requireLdapAuth');
+
+jest.mock('passport', () => ({
+  authenticate: jest.fn(),
+}));
+
+jest.mock('~/strategies', () => ({
+  ldapLogin: {
+    getLdapUrls: () => ['ldap://ldap1.example', 'ldap://ldap2.example'],
+  },
+}));
+
+const createReqResNext = () => {
+  const req = {};
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn(),
+  };
+  const next = jest.fn();
+  return { req, res, next };
+};
+
+describe('requireLdapAuth', () => {
+  afterEach(() => {
+    passport.authenticate.mockReset();
+  });
+
+  test('fails over on connection error and succeeds on next strategy', async () => {
+    passport.authenticate
+      .mockImplementationOnce((_strategy, callback) => {
+        return (_req, _res, _next) => {
+          setImmediate(() => callback({ code: 'ECONNREFUSED' }));
+        };
+      })
+      .mockImplementationOnce((_strategy, callback) => {
+        return (_req, _res, _next) => {
+          setImmediate(() => callback(null, { id: 'user-1' }));
+        };
+      });
+
+    const { req, res, next } = createReqResNext();
+
+    await new Promise((resolve) => {
+      const nextWithAssert = (...args) => {
+        next(...args);
+        resolve();
+      };
+      requireLdapAuth(req, res, nextWithAssert);
+    });
+
+    expect(passport.authenticate).toHaveBeenCalledTimes(2);
+    expect(req.user).toEqual({ id: 'user-1' });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('does not fail over on non-connection error', async () => {
+    const error = new Error('nope');
+    passport.authenticate.mockImplementationOnce((_strategy, callback) => {
+      return (_req, _res, _next) => {
+        setImmediate(() => callback(error));
+      };
+    });
+
+    const { req, res, next } = createReqResNext();
+
+    await new Promise((resolve) => {
+      const nextWithAssert = (...args) => {
+        next(...args);
+        resolve();
+      };
+      requireLdapAuth(req, res, nextWithAssert);
+    });
+
+    expect(passport.authenticate).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(error);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test('propagates error when all strategies fail with connection errors', async () => {
+    const error = { code: 'ECONNREFUSED' };
+    passport.authenticate.mockImplementation((_strategy, callback) => {
+      return (_req, _res, _next) => {
+        setImmediate(() => callback(error));
+      };
+    });
+
+    const { req, res, next } = createReqResNext();
+    const { ldapLogin } = require('~/strategies');
+    const expectedAttempts = ldapLogin.getLdapUrls().length;
+
+    await new Promise((resolve) => {
+      const nextWithAssert = (...args) => {
+        next(...args);
+        resolve();
+      };
+      requireLdapAuth(req, res, nextWithAssert);
+    });
+
+    expect(passport.authenticate).toHaveBeenCalledTimes(expectedAttempts);
+    expect(next).toHaveBeenCalledWith(error);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/api/server/utils/registerLdapStrategies.js
+++ b/api/server/utils/registerLdapStrategies.js
@@ -1,0 +1,18 @@
+const registerLdapStrategies = (passportInstance, ldapLoginStrategy) => {
+  if (!process.env.LDAP_URL || !process.env.LDAP_USER_SEARCH_BASE || !ldapLoginStrategy) {
+    return;
+  }
+
+  const ldapUrls = ldapLoginStrategy.getLdapUrls?.() ?? [];
+  if (ldapUrls.length > 1) {
+    ldapUrls.forEach((url, index) => {
+      const strategyName = index === 0 ? 'ldapauth' : `ldapauth-${index}`;
+      passportInstance.use(strategyName, ldapLoginStrategy.create(url));
+    });
+    return;
+  }
+
+  passportInstance.use(ldapLoginStrategy);
+};
+
+module.exports = registerLdapStrategies;


### PR DESCRIPTION
## Summary

- Enable multiple `LDAP_URL` entries (comma-separated) and register multiple LDAP strategies for failover on connection errors. 
- Add unit tests to verify LDAP URL list handling and failover middleware behavior
- Update `.env.example` to show the multi-URL format. 
- Docs updated in librechat.ai.

Closes #7967.

## Change Type

Please delete any irrelevant options.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- Updated unit tests:
  ```sh
  npx jest strategies/ldapStrategy.spec.js
  npx jest server/middleware/requireLdapAuth.spec.js
  ```
- API unit tests:
  ```sh
  npm run test:api
  ```
- Manual LDAP check with [slapd-server-mock](https://github.com/docker-ThoTeam/slapd-server-mock) (two instances):
  ```sh
  docker pull thoteam/slapd-server-mock --platform linux/amd64
  docker run --rm -d -p 389:389 -p 636:636 --name ldapmock1 --platform linux/amd64 thoteam/slapd-server-mock
  docker run --rm -d -p 3891:389 -p 6361:636 --name ldapmock2 --platform linux/amd64 thoteam/slapd-server-mock
  ```
  - Login succeeds with both servers running.
  - Failover check: stop either container (`docker stop ldapmock1` or `docker stop ldapmock2`) and verify login still succeeds against the remaining server.

### **Test Configuration**:

- `.env` example used:
  ```sh
  LDAP_URL=ldap://localhost:389,ldap://localhost:3891
  LDAP_BIND_DN=cn=admin,dc=ldapmock,dc=local
  LDAP_BIND_CREDENTIALS=adminpass
  LDAP_USER_SEARCH_BASE=dc=ldapmock,dc=local
  ```

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted.
