### PR TITLE
feat: display message timestamps in conversations

### DIFF
--- a/client/src/components/Chat/Messages/HoverButtons.tsx
+++ b/client/src/components/Chat/Messages/HoverButtons.tsx
@@ -4,6 +4,7 @@ import type { TConversation, TMessage, TFeedback } from 'librechat-data-provider
 import { EditIcon, Clipboard, CheckMark, ContinueIcon, RegenerateIcon } from '@librechat/client';
 import { useGenerationsByLatest, useLocalize } from '~/hooks';
 import { Fork } from '~/components/Conversations';
+import MessageTimestamp from './MessageTimestamp';
 import MessageAudio from './MessageAudio';
 import Feedback from './Feedback';
 import { cn } from '~/utils';
@@ -185,7 +186,7 @@ const HoverButtons = ({
   const handleCopy = () => copyToClipboard(setIsCopied);
 
   return (
-    <div className="group visible flex justify-center gap-0.5 self-end focus-within:outline-none lg:justify-start">
+    <div className="group visible flex w-full justify-center gap-0.5 self-end focus-within:outline-none lg:justify-start">
       {/* Text to Speech */}
       {TextToSpeech && (
         <MessageAudio
@@ -269,6 +270,9 @@ const HoverButtons = ({
           className="active"
         />
       )}
+
+      {/* Message Timestamp */}
+      <MessageTimestamp createdAt={message.createdAt} />
     </div>
   );
 };

--- a/client/src/components/Chat/Messages/MessageTimestamp.tsx
+++ b/client/src/components/Chat/Messages/MessageTimestamp.tsx
@@ -1,0 +1,33 @@
+import { memo } from 'react';
+import { useRecoilValue } from 'recoil';
+import store from '~/store';
+
+type MessageTimestampProps = {
+  createdAt?: string | Date;
+};
+
+const MessageTimestamp = memo(({ createdAt }: MessageTimestampProps) => {
+  const lang = useRecoilValue(store.lang);
+
+  if (!createdAt) {
+    return null;
+  }
+
+  const date = new Date(createdAt);
+
+  const formattedDate = date.toLocaleString(lang, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return (
+    <span className="ml-auto flex items-center text-xs text-text-secondary">{formattedDate}</span>
+  );
+});
+
+MessageTimestamp.displayName = 'MessageTimestamp';
+
+export default MessageTimestamp;


### PR DESCRIPTION
# feat: display message timestamps in conversations

## Summary

Adds a localized timestamp display for each message in conversations, showing when the message was created.

**Changes:**
- **New component**: `MessageTimestamp.tsx` - displays localized date/time for each message
- **Modified**: `HoverButtons.tsx` - integrates the timestamp at the end of the action buttons row

**Features:**
- Displays: day, month (short), year, hour (2-digit), minute (2-digit)
- Automatically localized using the app's language setting via `toLocaleString()`
- Positioned at the right end of the action buttons row
- Appears/disappears with the hover buttons (same behavior as existing action buttons)

**Example output by locale:**
| Locale | Format |
|--------|--------|
| English (en) | `5 Jan 2026, 14:32` |
| French (fr) | `5 janv. 2026, 14:32` |
| German (de) | `5. Jan. 2026, 14:32` |

**Technical notes:**
- Uses existing `createdAt` field already available in the message object
- No database changes required (timestamps already stored via Mongoose `{ timestamps: true }`)
- No new localization strings needed (uses native `toLocaleString()`)
- No new dependencies

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

1. Start the LibreChat application
2. Open any conversation with messages
3. Hover over a message to reveal the action buttons
4. Verify the timestamp appears at the right end of the action buttons row
5. Change the app language in settings and verify the timestamp format updates accordingly

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes