### PR TITLE
💾 feat: Custom Endpoint Support for Memory LLM Config 

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -676,7 +676,7 @@ class AgentClient extends BaseClient {
         getFormattedMemories: db.getFormattedMemories,
       },
       res: this.options.res,
-      user: this.options.req.user,
+      user: createSafeUser(this.options.req.user),
     });
 
     this.processMemory = processMemory;

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -676,6 +676,7 @@ class AgentClient extends BaseClient {
         getFormattedMemories: db.getFormattedMemories,
       },
       res: this.options.res,
+      user: this.options.req.user,
     });
 
     this.processMemory = processMemory;

--- a/packages/api/src/agents/memory.spec.ts
+++ b/packages/api/src/agents/memory.spec.ts
@@ -1,0 +1,254 @@
+import { Types } from 'mongoose';
+import type { Response } from 'express';
+import type { IUser } from '@librechat/data-schemas';
+import { Run } from '@librechat/agents';
+import { processMemory } from './memory';
+
+jest.mock('~/stream/GenerationJobManager');
+jest.mock('~/utils', () => ({
+  Tokenizer: {
+    getTokenCount: jest.fn(() => 10),
+  },
+}));
+
+jest.mock('@librechat/agents', () => ({
+  Run: {
+    create: jest.fn(() => ({
+      processStream: jest.fn(() => Promise.resolve('success')),
+    })),
+  },
+  Providers: {
+    OPENAI: 'openai',
+  },
+  GraphEvents: {
+    TOOL_END: 'tool_end',
+  },
+}));
+
+function createTestUser(overrides: Partial<IUser> = {}): IUser {
+  return {
+    _id: new Types.ObjectId(),
+    id: new Types.ObjectId().toString(),
+    username: 'testuser',
+    email: 'test@example.com',
+    name: 'Test User',
+    avatar: 'https://example.com/avatar.png',
+    provider: 'email',
+    role: 'user',
+    createdAt: new Date('2021-01-01'),
+    updatedAt: new Date('2021-01-01'),
+    emailVerified: true,
+    ...overrides,
+  } as IUser;
+}
+
+describe('Memory Agent Header Resolution', () => {
+  let testUser: IUser;
+  let mockRes: Response;
+  let mockMemoryMethods: {
+    setMemory: jest.Mock;
+    deleteMemory: jest.Mock;
+    getFormattedMemories: jest.Mock;
+  };
+
+  beforeEach(() => {
+    process.env.CUSTOM_API_KEY = 'sk-custom-test-key';
+    process.env.TEST_CUSTOM_API_KEY = 'sk-custom-test-key';
+
+    testUser = createTestUser({
+      id: 'user-123',
+      email: 'test@example.com',
+    });
+
+    mockRes = {
+      write: jest.fn(),
+      end: jest.fn(),
+      headersSent: false,
+    } as unknown as Response;
+
+    mockMemoryMethods = {
+      setMemory: jest.fn(),
+      deleteMemory: jest.fn(),
+      getFormattedMemories: jest.fn(() =>
+        Promise.resolve({
+          withKeys: 'formatted memories',
+          withoutKeys: 'memories without keys',
+          totalTokens: 100,
+        }),
+      ),
+    };
+
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.CUSTOM_API_KEY;
+    delete process.env.TEST_CUSTOM_API_KEY;
+  });
+
+  it('should resolve environment variables in custom endpoint headers', async () => {
+    const llmConfig = {
+      provider: 'custom',
+      model: 'gpt-4o-mini',
+      configuration: {
+        defaultHeaders: {
+          'x-custom-api-key': '${CUSTOM_API_KEY}',
+          'api-key': '${TEST_CUSTOM_API_KEY}',
+        },
+      },
+    };
+
+    await processMemory({
+      res: mockRes,
+      userId: 'user-123',
+      setMemory: mockMemoryMethods.setMemory,
+      deleteMemory: mockMemoryMethods.deleteMemory,
+      messages: [],
+      memory: 'test memory',
+      messageId: 'msg-123',
+      conversationId: 'conv-123',
+      validKeys: ['preferences'],
+      instructions: 'test instructions',
+      llmConfig,
+      user: testUser,
+    });
+
+    expect(Run.create as jest.Mock).toHaveBeenCalled();
+    const runConfig = (Run.create as jest.Mock).mock.calls[0][0];
+    expect(runConfig.graphConfig.llmConfig.configuration.defaultHeaders).toEqual({
+      'x-custom-api-key': 'sk-custom-test-key',
+      'api-key': 'sk-custom-test-key',
+    });
+  });
+
+  it('should resolve user placeholders in custom endpoint headers', async () => {
+    const llmConfig = {
+      provider: 'custom',
+      model: 'gpt-4o-mini',
+      configuration: {
+        defaultHeaders: {
+          'X-User-Identifier': '{{LIBRECHAT_USER_EMAIL}}',
+          'X-User-ID': '{{LIBRECHAT_USER_ID}}',
+        },
+      },
+    };
+
+    await processMemory({
+      res: mockRes,
+      userId: 'user-123',
+      setMemory: mockMemoryMethods.setMemory,
+      deleteMemory: mockMemoryMethods.deleteMemory,
+      messages: [],
+      memory: 'test memory',
+      messageId: 'msg-123',
+      conversationId: 'conv-123',
+      validKeys: ['preferences'],
+      instructions: 'test instructions',
+      llmConfig,
+      user: testUser,
+    });
+
+    expect(Run.create as jest.Mock).toHaveBeenCalled();
+    const runConfig = (Run.create as jest.Mock).mock.calls[0][0];
+    expect(runConfig.graphConfig.llmConfig.configuration.defaultHeaders).toEqual({
+      'X-User-Identifier': 'test@example.com',
+      'X-User-ID': 'user-123',
+    });
+  });
+
+  it('should handle mixed environment variables and user placeholders', async () => {
+    const llmConfig = {
+      provider: 'custom',
+      model: 'gpt-4o-mini',
+      configuration: {
+        defaultHeaders: {
+          'x-custom-api-key': '${CUSTOM_API_KEY}',
+          'X-User-Identifier': '{{LIBRECHAT_USER_EMAIL}}',
+          'X-Application-Identifier': 'LibreChat - Test',
+        },
+      },
+    };
+
+    await processMemory({
+      res: mockRes,
+      userId: 'user-123',
+      setMemory: mockMemoryMethods.setMemory,
+      deleteMemory: mockMemoryMethods.deleteMemory,
+      messages: [],
+      memory: 'test memory',
+      messageId: 'msg-123',
+      conversationId: 'conv-123',
+      validKeys: ['preferences'],
+      instructions: 'test instructions',
+      llmConfig,
+      user: testUser,
+    });
+
+    expect(Run.create as jest.Mock).toHaveBeenCalled();
+    const runConfig = (Run.create as jest.Mock).mock.calls[0][0];
+    expect(runConfig.graphConfig.llmConfig.configuration.defaultHeaders).toEqual({
+      'x-custom-api-key': 'sk-custom-test-key',
+      'X-User-Identifier': 'test@example.com',
+      'X-Application-Identifier': 'LibreChat - Test',
+    });
+  });
+
+  it('should resolve env vars when user is undefined', async () => {
+    const llmConfig = {
+      provider: 'custom',
+      model: 'gpt-4o-mini',
+      configuration: {
+        defaultHeaders: {
+          'x-custom-api-key': '${CUSTOM_API_KEY}',
+        },
+      },
+    };
+
+    await processMemory({
+      res: mockRes,
+      userId: 'user-123',
+      setMemory: mockMemoryMethods.setMemory,
+      deleteMemory: mockMemoryMethods.deleteMemory,
+      messages: [],
+      memory: 'test memory',
+      messageId: 'msg-123',
+      conversationId: 'conv-123',
+      validKeys: ['preferences'],
+      instructions: 'test instructions',
+      llmConfig,
+      user: undefined,
+    });
+
+    expect(Run.create as jest.Mock).toHaveBeenCalled();
+    const runConfig = (Run.create as jest.Mock).mock.calls[0][0];
+    expect(runConfig.graphConfig.llmConfig.configuration.defaultHeaders).toEqual({
+      'x-custom-api-key': 'sk-custom-test-key',
+    });
+  });
+
+  it('should not throw when llmConfig has no configuration', async () => {
+    const llmConfig = {
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+    };
+
+    await processMemory({
+      res: mockRes,
+      userId: 'user-123',
+      setMemory: mockMemoryMethods.setMemory,
+      deleteMemory: mockMemoryMethods.deleteMemory,
+      messages: [],
+      memory: 'test memory',
+      messageId: 'msg-123',
+      conversationId: 'conv-123',
+      validKeys: ['preferences'],
+      instructions: 'test instructions',
+      llmConfig,
+      user: testUser,
+    });
+
+    expect(Run.create as jest.Mock).toHaveBeenCalled();
+    const runConfig = (Run.create as jest.Mock).mock.calls[0][0];
+    expect(runConfig.graphConfig.llmConfig.configuration).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #11012 

## Summary

This pull request introduces the ability to designate custom endpoints for usage with the Memory feature. This was previously not possible due to an architectural difference in the way agent runs are handled across normal chat completions and memory chat completions, such that `resolveHeaders` was not invoked, and as such, API keys passed through custom headers would not be expanded / replaced with their environment variables, as mentioned in #11012. Now that `resolveHeaders` has been implemented in `memory.ts`, the custom headers will be properly populated for custom endpoints and the memory feature will work as intended.

**User context propagation and header resolution:**

* The `user` object is now passed from the API request (`req.user`) into the agent client and down through the memory processing functions, including `processMemory` and `createMemoryProcessor` (`api/server/controllers/agents/client.js`, `packages/api/src/agents/memory.ts`). [[1]](diffhunk://#diff-8c99b1ddca0d7fa6758088ffec41bed3ff6ce185163505281c9e3de03450e8aaR679) [[2]](diffhunk://#diff-9e323913c7896d2ce82c27a66371c08510dc41bb273e54625687f08fac1b9b83R289) [[3]](diffhunk://#diff-9e323913c7896d2ce82c27a66371c08510dc41bb273e54625687f08fac1b9b83R305) [[4]](diffhunk://#diff-9e323913c7896d2ce82c27a66371c08510dc41bb273e54625687f08fac1b9b83R435) [[5]](diffhunk://#diff-9e323913c7896d2ce82c27a66371c08510dc41bb273e54625687f08fac1b9b83R444) [[6]](diffhunk://#diff-9e323913c7896d2ce82c27a66371c08510dc41bb273e54625687f08fac1b9b83R472)
* When preparing LLM configuration, the code now resolves and injects custom headers using the `resolveHeaders` and `createSafeUser` utilities (`packages/api/src/agents/memory.ts`). [[1]](diffhunk://#diff-9e323913c7896d2ce82c27a66371c08510dc41bb273e54625687f08fac1b9b83L17-R21) [[2]](diffhunk://#diff-9e323913c7896d2ce82c27a66371c08510dc41bb273e54625687f08fac1b9b83R372-R379)

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

* Added a new test suite in `memory.spec.ts` to verify that environment variables and user placeholders in custom endpoint headers are correctly resolved, including cases with mixed placeholders, missing users, and missing configuration. [[1]](diffhunk://#diff-497e15550396f817869686c3e2a60952d493464ae23434b3447cc140edf68a3cR1-R254)

### Before (Memory not updated)

<img width="1469" height="964" alt="Screenshot 2026-01-05 at 12 09 08 PM" src="https://github.com/user-attachments/assets/784adc63-567c-44ca-9e3b-92fd0ab81e08" />

```
2026-01-05 10:35:40 error: Failed to fetch models from Portkey API The server responded with status 401: Request failed with status code 401
2026-01-05 10:35:44 error: Memory Agent failed to process memory 401 status code (no body)

Troubleshooting URL: https://js.langchain.com/docs/troubleshooting/errors/MODEL_AUTHENTICATION/
```

### After
<img width="1469" height="964" alt="Screenshot 2026-01-05 at 11 18 58 AM" src="https://github.com/user-attachments/assets/9c36513a-d9c1-4594-8590-ab2deaee8f8b" />


#### Headers now properly being expanded and received at gateway (see dustin-test-expansion)


```json
"headers": {
    "accept": "application/json",
    "accept-encoding": "gzip, br",
    "accept-language": "*",
    "api-key": "du********ion", # dustin-test-expansion
    "cf-connecting-ip": "76.14.4.27",
    "cf-ipcountry": "US",
    "cf-ray": "9b9523c9fa46faa2",
    "cf-visitor": "{\"scheme\":\"https\"}",
    "connection": "Keep-Alive",
    "content-length": "2620",
    "content-type": "application/json",
    "host": "[api.portkey.ai](http://api.portkey.ai/)",
    "sec-fetch-mode": "cors",
    "user-agent": "CustomOpenAIClient/JS 5.8.2",
    "x-application-identifier": "LibreChat - Test",
    "x-forwarded-proto": "https",
    "x-real-ip": "76.14.4.27",
    "x-stainless-arch": "arm64",
    "x-stainless-lang": "js",
    "x-stainless-os": "MacOS",
    "x-stainless-package-version": "5.8.2",
    "x-stainless-retry-count": "0",
    "x-stainless-runtime": "node",
    "x-stainless-runtime-version": "v20.19.0",
    "x-user-identifier": "[me@me.com](mailto:me@me.com)"
  }
```

### **Test Configuration**:
```yaml
endpoints:
    custom:
        - name: 'Test Custom Endpoint Memory Expansion'
           apiKey: 'dummy'
           baseURL: 'https://api.portkey.ai/v1'
           headers:
             x-portkey-api-key: '${PORTKEY_API_KEY}'
             x-portkey-virtual-key: '${PORTKEY_OPENAI_VIRTUAL_KEY}'
             X-User-Identifier: '{{LIBRECHAT_USER_EMAIL}}'
             X-Application-Identifier: 'LibreChat - Test'
             api-key: '${TEST_CUSTOM_API_KEY}' # This should be expanded to dustin-test-expansion
           models:
             default:
               - 'gpt-4o-mini'
               - 'gpt-4o'
             fetch: false
  
memory:
  disabled: false
  tokenLimit: 3000
  personalize: true
  messageWindowSize: 10
  agent:
    provider: 'Test Custom Endpoint Memory Expansion'
    model: 'gpt-4o-mini'
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes