### PR TITLE
🎯 fix: Actions Allowed Domains Handling

### DIFF
--- a/client/src/components/SidePanel/Agents/ActionsInput.tsx
+++ b/client/src/components/SidePanel/Agents/ActionsInput.tsx
@@ -121,12 +121,12 @@ export default function ActionsInput({
     const action_id = action?.action_id;
     metadata.raw_spec = inputValue;
     const parsedUrl = new URL(data[0].domain);
-    const domain = parsedUrl.hostname;
-    if (!domain) {
+    if (!parsedUrl.hostname) {
       // alert user?
       return;
     }
-    metadata.domain = domain;
+    // Send protocol + hostname for proper SSRF validation (e.g., "http://192.168.1.1")
+    metadata.domain = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
 
     const { type, saved_auth_fields } = authFormData;
 
@@ -208,23 +208,21 @@ export default function ActionsInput({
             htmlFor="schemaInput"
             className="text-token-text-primary whitespace-nowrap font-medium"
           >
-            Schema
+            {localize('com_ui_schema')}
           </label>
+          {/* TODO: Implement examples functionality
           <div className="flex items-center gap-2">
-            {/* <button className="btn btn-neutral border-token-border-light relative h-8 min-w-[100px] rounded-lg font-medium">
-              <div className="flex w-full items-center justify-center text-xs">Import from URL</div>
-            </button> */}
             <select
               onChange={(e) => logger.log('actions', 'selecting example action', e.target.value)}
               className="border-token-border-medium h-8 min-w-[100px] rounded-lg border bg-transparent px-2 py-0 text-sm"
             >
               <option value="label">{localize('com_ui_examples')}</option>
-              {/* TODO: make these appear and function correctly */}
               <option value="0">Weather (JSON)</option>
               <option value="1">Pet Store (YAML)</option>
               <option value="2">Blank Template</option>
             </select>
           </div>
+          */}
         </div>
         <div className="border-token-border-medium bg-token-surface-primary hover:border-token-border-hover mb-4 w-full overflow-hidden rounded-lg border ring-0">
           <div className="relative">

--- a/client/src/components/SidePanel/Builder/ActionsInput.tsx
+++ b/client/src/components/SidePanel/Builder/ActionsInput.tsx
@@ -131,12 +131,12 @@ export default function ActionsInput({
     const action_id = action?.action_id;
     metadata.raw_spec = inputValue;
     const parsedUrl = new URL(data[0].domain);
-    const domain = parsedUrl.hostname;
-    if (!domain) {
+    if (!parsedUrl.hostname) {
       // alert user?
       return;
     }
-    metadata.domain = domain;
+    // Send protocol + hostname for proper SSRF validation (e.g., "http://192.168.1.1")
+    metadata.domain = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
 
     const { type, saved_auth_fields } = authFormData;
 
@@ -221,22 +221,20 @@ export default function ActionsInput({
           >
             {localize('com_ui_schema')}
           </label>
+          {/* TODO: Implement examples functionality
           <div className="flex items-center gap-2">
-            {/* <button className="btn btn-neutral border-token-border-light relative h-8 min-w-[100px] rounded-lg font-medium">
-              <div className="flex w-full items-center justify-center text-xs">Import from URL</div>
-            </button> */}
             <select
               id="example-schema"
               onChange={(e) => console.log(e.target.value)}
               className="border-token-border-medium h-8 min-w-[100px] rounded-lg border bg-transparent px-2 py-0 text-sm"
             >
               <option value="label">{localize('com_ui_examples')}</option>
-              {/* TODO: make these appear and function correctly */}
               <option value="0">Weather (JSON)</option>
               <option value="1">Pet Store (YAML)</option>
               <option value="2">Blank Template</option>
             </select>
           </div>
+          */}
         </div>
         <div className="border-token-border-medium bg-token-surface-primary hover:border-token-border-hover mb-4 w-full overflow-hidden rounded-lg border ring-0">
           <div className="relative">

--- a/packages/data-provider/src/actions.ts
+++ b/packages/data-provider/src/actions.ts
@@ -698,9 +698,9 @@ export function validateActionDomain(
     if (clientHasProtocol) {
       normalizedClientDomain = extractDomainFromUrl(clientProvidedDomain);
     } else {
-      // IP addresses inherit protocol from spec, domains default to https
+      // No protocol specified by client
       if (isIPAddress) {
-        // IPv6 addresses need brackets in URLs
+        // IPs inherit protocol from spec (for legitimate internal services)
         const ipVersion = isIP(normalizedClientHostname);
         const hostname =
           ipVersion === 6 && !clientHostname.startsWith('[')
@@ -708,6 +708,7 @@ export function validateActionDomain(
             : clientHostname;
         normalizedClientDomain = `${specUrl.protocol}//${hostname}`;
       } else {
+        // Domain names default to HTTPS for security (forces explicit protocol)
         normalizedClientDomain = `https://${clientHostname}`;
       }
     }

--- a/packages/data-schemas/src/app/service.ts
+++ b/packages/data-schemas/src/app/service.ts
@@ -62,6 +62,7 @@ export const AppService = async (params?: {
 
   const mcpServersConfig = config.mcpServers || null;
   const mcpSettings = config.mcpSettings || null;
+  const actions = config.actions;
   const registration = config.registration ?? configDefaults.registration;
   const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
   const turnstileConfig = loadTurnstileConfig(config, configDefaults);
@@ -74,6 +75,7 @@ export const AppService = async (params?: {
     memory,
     speech,
     balance,
+    actions,
     transactions,
     mcpConfig: mcpServersConfig,
     mcpSettings,
@@ -103,9 +105,9 @@ export const AppService = async (params?: {
 
   const loadedEndpoints = loadEndpoints(config, agentsDefaults);
 
-  const appConfig = {
+  const appConfig: AppConfig = {
     ...defaultConfig,
-    fileConfig: config?.fileConfig,
+    fileConfig: config?.fileConfig as AppConfig['fileConfig'],
     secureImageLinks: config?.secureImageLinks,
     modelSpecs: processModelSpecs(config?.endpoints, config.modelSpecs, interfaceConfig),
     endpoints: loadedEndpoints,


### PR DESCRIPTION
## Summary

I fixed how action domains are sent from the frontend to enable proper SSRF validation. The frontend now includes the protocol with the hostname instead of sending just the hostname alone.

- Modify domain metadata to include protocol + hostname (e.g., `http://192.168.1.1`) for accurate SSRF validation in both Agents and Builder ActionsInput components
- Replace hardcoded "Schema" label with localized `com_ui_schema` key
- Comment out non-functional example schema selector UI until implementation is complete
- Add clarifying comments in `validateActionDomain` explaining protocol inheritance logic for IPs vs domain names
- Expose `actions` config in AppService and add proper TypeScript typing for `appConfig`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested by configuring an OpenAPI action with an IP-based internal service URL and verifying the domain validation correctly processes the protocol during SSRF checks.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings