### PR TITLE
📌 feat: Add Pin Support for Model Specs

### DIFF
--- a/api/server/controllers/FavoritesController.js
+++ b/api/server/controllers/FavoritesController.js
@@ -27,6 +27,7 @@ const updateFavoritesController = async (req, res) => {
     for (const fav of favorites) {
       const hasAgent = !!fav.agentId;
       const hasModel = !!(fav.model && fav.endpoint);
+      const hasSpec = !!fav.spec;
 
       if (fav.agentId && fav.agentId.length > MAX_STRING_LENGTH) {
         return res
@@ -43,16 +44,22 @@ const updateFavoritesController = async (req, res) => {
           .status(400)
           .json({ message: `endpoint exceeds maximum length of ${MAX_STRING_LENGTH}` });
       }
+      if (fav.spec && fav.spec.length > MAX_STRING_LENGTH) {
+        return res
+          .status(400)
+          .json({ message: `spec exceeds maximum length of ${MAX_STRING_LENGTH}` });
+      }
 
-      if (!hasAgent && !hasModel) {
+      const typeCount = [hasAgent, hasModel, hasSpec].filter(Boolean).length;
+      if (typeCount === 0) {
         return res.status(400).json({
-          message: 'Each favorite must have either agentId or model+endpoint',
+          message: 'Each favorite must have either agentId, model+endpoint, or spec',
         });
       }
 
-      if (hasAgent && hasModel) {
+      if (typeCount > 1) {
         return res.status(400).json({
-          message: 'Favorite cannot have both agentId and model/endpoint',
+          message: 'Favorite cannot have multiple types (agentId, model/endpoint, or spec)',
         });
       }
     }

--- a/api/server/controllers/FavoritesController.js
+++ b/api/server/controllers/FavoritesController.js
@@ -44,6 +44,12 @@ const updateFavoritesController = async (req, res) => {
           .status(400)
           .json({ message: `endpoint exceeds maximum length of ${MAX_STRING_LENGTH}` });
       }
+      if (fav.spec != null && typeof fav.spec !== 'string') {
+        return res.status(400).json({ message: 'spec must be a string' });
+      }
+      if (typeof fav.spec === 'string' && fav.spec.length === 0) {
+        return res.status(400).json({ message: 'spec must not be empty' });
+      }
       if (fav.spec && fav.spec.length > MAX_STRING_LENGTH) {
         return res
           .status(400)

--- a/api/server/controllers/FavoritesController.js
+++ b/api/server/controllers/FavoritesController.js
@@ -44,16 +44,15 @@ const updateFavoritesController = async (req, res) => {
           .status(400)
           .json({ message: `endpoint exceeds maximum length of ${MAX_STRING_LENGTH}` });
       }
-      if (fav.spec != null && typeof fav.spec !== 'string') {
-        return res.status(400).json({ message: 'spec must be a string' });
-      }
-      if (typeof fav.spec === 'string' && fav.spec.length === 0) {
-        return res.status(400).json({ message: 'spec must not be empty' });
-      }
-      if (fav.spec && fav.spec.length > MAX_STRING_LENGTH) {
-        return res
-          .status(400)
-          .json({ message: `spec exceeds maximum length of ${MAX_STRING_LENGTH}` });
+      if (fav.spec !== undefined && fav.spec !== null) {
+        if (typeof fav.spec !== 'string' || fav.spec.length === 0) {
+          return res.status(400).json({ message: 'spec must be a non-empty string' });
+        }
+        if (fav.spec.length > MAX_STRING_LENGTH) {
+          return res
+            .status(400)
+            .json({ message: `spec exceeds maximum length of ${MAX_STRING_LENGTH}` });
+        }
       }
 
       const typeCount = [hasAgent, hasModel, hasSpec].filter(Boolean).length;
@@ -79,7 +78,7 @@ const updateFavoritesController = async (req, res) => {
     res.status(200).json(user.favorites);
   } catch (error) {
     console.error('Error updating favorites:', error);
-    res.status(500).json({ message: 'Internal server error' });
+    return res.status(500).json({ message: 'Internal server error' });
   }
 };
 
@@ -102,7 +101,7 @@ const getFavoritesController = async (req, res) => {
     res.status(200).json(favorites);
   } catch (error) {
     console.error('Error fetching favorites:', error);
-    res.status(500).json({ message: 'Internal server error' });
+    return res.status(500).json({ message: 'Internal server error' });
   }
 };
 

--- a/api/server/controllers/FavoritesController.js
+++ b/api/server/controllers/FavoritesController.js
@@ -55,6 +55,12 @@ const updateFavoritesController = async (req, res) => {
         }
       }
 
+      const hasPartialModel = !hasModel && !!(fav.model || fav.endpoint);
+
+      if (hasPartialModel && !hasAgent && !hasSpec) {
+        return res.status(400).json({ message: 'model and endpoint must be provided together' });
+      }
+
       const typeCount = [hasAgent, hasModel, hasSpec].filter(Boolean).length;
       if (typeCount === 0) {
         return res.status(400).json({
@@ -67,6 +73,17 @@ const updateFavoritesController = async (req, res) => {
           message: 'Favorite cannot have multiple types (agentId, model/endpoint, or spec)',
         });
       }
+
+      if (hasSpec && (fav.agentId || fav.model || fav.endpoint)) {
+        return res
+          .status(400)
+          .json({ message: 'spec cannot be combined with agentId, model, or endpoint' });
+      }
+      if (hasAgent && (fav.model || fav.endpoint)) {
+        return res
+          .status(400)
+          .json({ message: 'agentId cannot be combined with model or endpoint' });
+      }
     }
 
     const user = await updateUser(userId, { favorites });
@@ -75,7 +92,7 @@ const updateFavoritesController = async (req, res) => {
       return res.status(404).json({ message: 'User not found' });
     }
 
-    res.status(200).json(user.favorites);
+    return res.status(200).json(user.favorites);
   } catch (error) {
     console.error('Error updating favorites:', error);
     return res.status(500).json({ message: 'Internal server error' });
@@ -98,7 +115,7 @@ const getFavoritesController = async (req, res) => {
       await updateUser(userId, { favorites: [] });
     }
 
-    res.status(200).json(favorites);
+    return res.status(200).json(favorites);
   } catch (error) {
     console.error('Error fetching favorites:', error);
     return res.status(500).json({ message: 'Internal server error' });

--- a/api/server/controllers/FavoritesController.spec.js
+++ b/api/server/controllers/FavoritesController.spec.js
@@ -1,0 +1,248 @@
+jest.mock('~/models', () => ({
+  updateUser: jest.fn(),
+  getUserById: jest.fn(),
+}));
+
+const { updateUser, getUserById } = require('~/models');
+const { updateFavoritesController, getFavoritesController } = require('./FavoritesController');
+
+const makeRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const makeReq = (body = {}) => ({
+  body,
+  user: { id: 'user-123' },
+});
+
+describe('FavoritesController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('updateFavoritesController - payload envelope', () => {
+    it('rejects missing favorites key with 400', async () => {
+      const req = makeReq({});
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Favorites data is required' });
+      expect(updateUser).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-array favorites with 400', async () => {
+      const req = makeReq({ favorites: 'not-an-array' });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Favorites must be an array' });
+    });
+
+    it('rejects favorites over MAX_FAVORITES with 400 + code', async () => {
+      const favorites = Array.from({ length: 51 }, (_, i) => ({ agentId: `agent-${i}` }));
+      const req = makeReq({ favorites });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        code: 'MAX_FAVORITES_EXCEEDED',
+        message: 'Maximum 50 favorites allowed',
+        limit: 50,
+      });
+    });
+  });
+
+  describe('updateFavoritesController - agent/model length validation', () => {
+    it('rejects oversized agentId', async () => {
+      const req = makeReq({ favorites: [{ agentId: 'a'.repeat(257) }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'agentId exceeds maximum length of 256' });
+    });
+
+    it('rejects oversized model', async () => {
+      const req = makeReq({ favorites: [{ model: 'm'.repeat(257), endpoint: 'openai' }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'model exceeds maximum length of 256' });
+    });
+  });
+
+  describe('updateFavoritesController - spec validation', () => {
+    it('accepts a valid spec favorite', async () => {
+      updateUser.mockResolvedValue({ favorites: [{ spec: 'my-spec' }] });
+      const req = makeReq({ favorites: [{ spec: 'my-spec' }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith([{ spec: 'my-spec' }]);
+      expect(updateUser).toHaveBeenCalledWith('user-123', {
+        favorites: [{ spec: 'my-spec' }],
+      });
+    });
+
+    it('rejects non-string spec with 400', async () => {
+      const req = makeReq({ favorites: [{ spec: 42 }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'spec must be a non-empty string' });
+    });
+
+    it('rejects empty string spec with 400', async () => {
+      const req = makeReq({ favorites: [{ spec: '' }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'spec must be a non-empty string' });
+    });
+
+    it('rejects oversized spec with 400', async () => {
+      const req = makeReq({ favorites: [{ spec: 's'.repeat(257) }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'spec exceeds maximum length of 256' });
+    });
+
+    it('allows undefined/null spec (treated as absent)', async () => {
+      updateUser.mockResolvedValue({ favorites: [{ agentId: 'a1' }] });
+      const req = makeReq({ favorites: [{ agentId: 'a1', spec: null }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe('updateFavoritesController - exclusivity (typeCount)', () => {
+    it('rejects empty favorite entry with 400', async () => {
+      const req = makeReq({ favorites: [{}] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Each favorite must have either agentId, model+endpoint, or spec',
+      });
+    });
+
+    it('rejects agentId + model combination', async () => {
+      const req = makeReq({
+        favorites: [{ agentId: 'a1', model: 'gpt-5', endpoint: 'openai' }],
+      });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Favorite cannot have multiple types (agentId, model/endpoint, or spec)',
+      });
+    });
+
+    it('rejects agentId + spec combination', async () => {
+      const req = makeReq({ favorites: [{ agentId: 'a1', spec: 's1' }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Favorite cannot have multiple types (agentId, model/endpoint, or spec)',
+      });
+    });
+
+    it('rejects model + spec combination', async () => {
+      const req = makeReq({
+        favorites: [{ model: 'gpt-5', endpoint: 'openai', spec: 's1' }],
+      });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('accepts a mixed array of valid single-type favorites', async () => {
+      const favorites = [{ agentId: 'a1' }, { model: 'gpt-5', endpoint: 'openai' }, { spec: 's1' }];
+      updateUser.mockResolvedValue({ favorites });
+      const req = makeReq({ favorites });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(favorites);
+    });
+  });
+
+  describe('updateFavoritesController - persistence', () => {
+    it('returns 404 when user is not found', async () => {
+      updateUser.mockResolvedValue(null);
+      const req = makeReq({ favorites: [{ spec: 's1' }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: 'User not found' });
+    });
+
+    it('returns 500 when updateUser throws', async () => {
+      updateUser.mockRejectedValue(new Error('db down'));
+      const req = makeReq({ favorites: [{ spec: 's1' }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Internal server error' });
+    });
+  });
+
+  describe('getFavoritesController', () => {
+    it('returns the user favorites array', async () => {
+      const favorites = [{ agentId: 'a1' }, { spec: 's1' }];
+      getUserById.mockResolvedValue({ favorites });
+      const req = makeReq();
+      const res = makeRes();
+      await getFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(favorites);
+    });
+
+    it('returns [] when user.favorites is null (falsy)', async () => {
+      getUserById.mockResolvedValue({ favorites: null });
+      const req = makeReq();
+      const res = makeRes();
+      await getFavoritesController(req, res);
+      expect(updateUser).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith([]);
+    });
+
+    it('repairs corrupt favorites field (non-array truthy)', async () => {
+      getUserById.mockResolvedValue({ favorites: 'corrupt' });
+      updateUser.mockResolvedValue({ favorites: [] });
+      const req = makeReq();
+      const res = makeRes();
+      await getFavoritesController(req, res);
+      expect(updateUser).toHaveBeenCalledWith('user-123', { favorites: [] });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith([]);
+    });
+
+    it('returns 404 when user not found', async () => {
+      getUserById.mockResolvedValue(null);
+      const req = makeReq();
+      const res = makeRes();
+      await getFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('returns 500 when getUserById throws', async () => {
+      getUserById.mockRejectedValue(new Error('db down'));
+      const req = makeReq();
+      const res = makeRes();
+      await getFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/api/server/controllers/FavoritesController.spec.js
+++ b/api/server/controllers/FavoritesController.spec.js
@@ -166,6 +166,66 @@ describe('FavoritesController', () => {
       expect(res.status).toHaveBeenCalledWith(400);
     });
 
+    it('rejects spec with stray endpoint field', async () => {
+      const req = makeReq({ favorites: [{ spec: 's1', endpoint: 'openai' }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'spec cannot be combined with agentId, model, or endpoint',
+      });
+    });
+
+    it('rejects spec with stray model field', async () => {
+      const req = makeReq({ favorites: [{ spec: 's1', model: 'gpt-5' }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'spec cannot be combined with agentId, model, or endpoint',
+      });
+    });
+
+    it('rejects agentId with stray model field (no endpoint)', async () => {
+      const req = makeReq({ favorites: [{ agentId: 'a1', model: 'gpt-5' }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'agentId cannot be combined with model or endpoint',
+      });
+    });
+
+    it('rejects agentId with stray endpoint field (no model)', async () => {
+      const req = makeReq({ favorites: [{ agentId: 'a1', endpoint: 'openai' }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'agentId cannot be combined with model or endpoint',
+      });
+    });
+
+    it('rejects model without endpoint (partial model pair)', async () => {
+      const req = makeReq({ favorites: [{ model: 'gpt-5' }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'model and endpoint must be provided together',
+      });
+    });
+
+    it('rejects endpoint without model (partial model pair)', async () => {
+      const req = makeReq({ favorites: [{ endpoint: 'openai' }] });
+      const res = makeRes();
+      await updateFavoritesController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'model and endpoint must be provided together',
+      });
+    });
+
     it('accepts a mixed array of valid single-type favorites', async () => {
       const favorites = [{ agentId: 'a1' }, { model: 'gpt-5', endpoint: 'openai' }, { spec: 's1' }];
       updateUser.mockResolvedValue({ favorites });

--- a/client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/CustomMenu.tsx
@@ -67,7 +67,8 @@ export const CustomMenu = React.forwardRef<HTMLDivElement, CustomMenuProps>(func
           parent ? 'animate-popover-left ml-3' : 'animate-popover',
           'outline-none! z-40 flex max-h-[min(450px,var(--popover-available-height))] w-full',
           'w-[var(--menu-width,auto)] min-w-[300px] flex-col overflow-auto rounded-xl border border-border-light',
-          'bg-presentation px-3 py-2 text-sm text-text-primary shadow-lg',
+          'bg-presentation text-sm text-text-primary shadow-lg',
+          parent ? 'px-0.5 py-0.5' : 'px-3 py-2',
           'max-w-[calc(100vw-4rem)] sm:max-h-[calc(65vh)] sm:max-w-[400px]',
           searchable && 'p-0',
         )}

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
@@ -1,10 +1,10 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React from 'react';
 import { VisuallyHidden } from '@ariakit/react';
 import { CheckCircle2, EarthIcon, Pin, PinOff } from 'lucide-react';
 import { isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
+import { useFavorites, useLocalize, useIsActiveItem } from '~/hooks';
 import { useModelSelectorContext } from '../ModelSelectorContext';
 import { CustomMenuItem as MenuItem } from '../CustomMenu';
-import { useFavorites, useLocalize } from '~/hooks';
 import type { Endpoint } from '~/common';
 import { cn } from '~/utils';
 
@@ -26,24 +26,7 @@ export function EndpointModelItem({ modelId, endpoint }: EndpointModelItemProps)
   const { isFavoriteModel, toggleFavoriteModel, isFavoriteAgent, toggleFavoriteAgent } =
     useFavorites();
 
-  const itemRef = useRef<HTMLDivElement>(null);
-  const [isActive, setIsActive] = useState(false);
-
-  useEffect(() => {
-    const element = itemRef.current;
-    if (!element) {
-      return;
-    }
-
-    const observer = new MutationObserver(() => {
-      setIsActive(element.hasAttribute('data-active-item'));
-    });
-
-    observer.observe(element, { attributes: true, attributeFilter: ['data-active-item'] });
-    setIsActive(element.hasAttribute('data-active-item'));
-
-    return () => observer.disconnect();
-  }, []);
+  const { ref: itemRef, isActive } = useIsActiveItem<HTMLDivElement>();
 
   let isGlobal = false;
   let modelName = modelId;
@@ -130,12 +113,14 @@ export function EndpointModelItem({ modelId, endpoint }: EndpointModelItemProps)
         onClick={handleFavoriteClick}
         aria-label={isFavorite ? localize('com_ui_unpin') : localize('com_ui_pin')}
         className={cn(
-          'rounded-md p-1 hover:bg-surface-hover',
-          isFavorite ? 'visible' : 'invisible group-hover:visible group-data-[active-item]:visible',
+          'rounded-md p-1 hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary',
+          isFavorite
+            ? 'visible'
+            : 'invisible group-focus-within:visible group-hover:visible group-data-[active-item]:visible',
         )}
       >
         {isFavorite ? (
-          <PinOff className="h-4 w-4 text-text-secondary" />
+          <PinOff className="h-4 w-4 text-text-secondary" aria-hidden="true" />
         ) : (
           <Pin className="h-4 w-4 text-text-secondary" aria-hidden="true" />
         )}

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
@@ -113,7 +113,7 @@ export function EndpointModelItem({ modelId, endpoint }: EndpointModelItemProps)
         onClick={handleFavoriteClick}
         aria-label={isFavorite ? localize('com_ui_unpin') : localize('com_ui_pin')}
         className={cn(
-          'rounded-md p-1 hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary',
+          'rounded-md p-1 hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring-primary',
           isFavorite
             ? 'visible'
             : 'invisible group-focus-within:visible group-hover:visible group-data-[active-item]:visible',

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { VisuallyHidden } from '@ariakit/react';
 import { CheckCircle2, EarthIcon, Pin, PinOff } from 'lucide-react';
 import { isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
+import type { Endpoint } from '~/common';
 import { useFavorites, useLocalize, useIsActiveItem } from '~/hooks';
 import { useModelSelectorContext } from '../ModelSelectorContext';
 import { CustomMenuItem as MenuItem } from '../CustomMenu';
-import type { Endpoint } from '~/common';
 import { cn } from '~/utils';
 
 interface EndpointModelItemProps {
@@ -109,6 +109,7 @@ export function EndpointModelItem({ modelId, endpoint }: EndpointModelItemProps)
         {isGlobal && <EarthIcon className="ml-1 size-4 text-surface-submit" />}
       </div>
       <button
+        type="button"
         tabIndex={isActive ? 0 : -1}
         onClick={handleFavoriteClick}
         aria-label={isFavorite ? localize('com_ui_unpin') : localize('com_ui_pin')}

--- a/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
@@ -1,10 +1,10 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React from 'react';
 import { CheckCircle2, Pin, PinOff } from 'lucide-react';
 import { VisuallyHidden } from '@ariakit/react';
 import type { TModelSpec } from 'librechat-data-provider';
-import { CustomMenuItem as MenuItem } from '../CustomMenu';
+import { useFavorites, useLocalize, useIsActiveItem } from '~/hooks';
 import { useModelSelectorContext } from '../ModelSelectorContext';
-import { useFavorites, useLocalize } from '~/hooks';
+import { CustomMenuItem as MenuItem } from '../CustomMenu';
 import SpecIcon from './SpecIcon';
 import { cn } from '~/utils';
 
@@ -19,24 +19,7 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
   const { isFavoriteSpec, toggleFavoriteSpec } = useFavorites();
   const { showIconInMenu = true } = spec;
 
-  const itemRef = useRef<HTMLDivElement>(null);
-  const [isActive, setIsActive] = useState(false);
-
-  useEffect(() => {
-    const element = itemRef.current;
-    if (!element) {
-      return;
-    }
-
-    const observer = new MutationObserver(() => {
-      setIsActive(element.hasAttribute('data-active-item'));
-    });
-
-    observer.observe(element, { attributes: true, attributeFilter: ['data-active-item'] });
-    setIsActive(element.hasAttribute('data-active-item'));
-
-    return () => observer.disconnect();
-  }, []);
+  const { ref: itemRef, isActive } = useIsActiveItem<HTMLDivElement>();
 
   const isFavorite = isFavoriteSpec(spec.name);
 
@@ -78,12 +61,14 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
         onClick={handleFavoriteClick}
         aria-label={isFavorite ? localize('com_ui_unpin') : localize('com_ui_pin')}
         className={cn(
-          'rounded-md p-1 hover:bg-surface-hover',
-          isFavorite ? 'visible' : 'invisible group-hover:visible group-data-[active-item]:visible',
+          'rounded-md p-1 hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary',
+          isFavorite
+            ? 'visible'
+            : 'invisible group-focus-within:visible group-hover:visible group-data-[active-item]:visible',
         )}
       >
         {isFavorite ? (
-          <PinOff className="h-4 w-4 text-text-secondary" />
+          <PinOff className="h-4 w-4 text-text-secondary" aria-hidden="true" />
         ) : (
           <Pin className="h-4 w-4 text-text-secondary" aria-hidden="true" />
         )}

--- a/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { CheckCircle2 } from 'lucide-react';
+import React, { useRef, useState, useEffect } from 'react';
+import { CheckCircle2, Pin, PinOff } from 'lucide-react';
 import { VisuallyHidden } from '@ariakit/react';
 import type { TModelSpec } from 'librechat-data-provider';
 import { CustomMenuItem as MenuItem } from '../CustomMenu';
 import { useModelSelectorContext } from '../ModelSelectorContext';
-import { useLocalize } from '~/hooks';
+import { useFavorites, useLocalize } from '~/hooks';
 import SpecIcon from './SpecIcon';
 import { cn } from '~/utils';
 
@@ -16,14 +16,43 @@ interface ModelSpecItemProps {
 export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
   const localize = useLocalize();
   const { handleSelectSpec, endpointsConfig } = useModelSelectorContext();
+  const { isFavoriteSpec, toggleFavoriteSpec } = useFavorites();
   const { showIconInMenu = true } = spec;
+
+  const itemRef = useRef<HTMLDivElement>(null);
+  const [isActive, setIsActive] = useState(false);
+
+  useEffect(() => {
+    const element = itemRef.current;
+    if (!element) {
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      setIsActive(element.hasAttribute('data-active-item'));
+    });
+
+    observer.observe(element, { attributes: true, attributeFilter: ['data-active-item'] });
+    setIsActive(element.hasAttribute('data-active-item'));
+
+    return () => observer.disconnect();
+  }, []);
+
+  const isFavorite = isFavoriteSpec(spec.name);
+
+  const handleFavoriteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    toggleFavoriteSpec(spec.name);
+  };
+
   return (
     <MenuItem
+      ref={itemRef}
       key={spec.name}
       onClick={() => handleSelectSpec(spec)}
       aria-selected={isSelected || undefined}
       className={cn(
-        'flex w-full cursor-pointer items-center justify-between rounded-lg px-2 text-sm',
+        'group flex w-full cursor-pointer items-center justify-between rounded-lg px-2 text-sm',
       )}
     >
       <div
@@ -44,6 +73,21 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
           )}
         </div>
       </div>
+      <button
+        tabIndex={isActive ? 0 : -1}
+        onClick={handleFavoriteClick}
+        aria-label={isFavorite ? localize('com_ui_unpin') : localize('com_ui_pin')}
+        className={cn(
+          'rounded-md p-1 hover:bg-surface-hover',
+          isFavorite ? 'visible' : 'invisible group-hover:visible group-data-[active-item]:visible',
+        )}
+      >
+        {isFavorite ? (
+          <PinOff className="h-4 w-4 text-text-secondary" />
+        ) : (
+          <Pin className="h-4 w-4 text-text-secondary" aria-hidden="true" />
+        )}
+      </button>
       {isSelected && (
         <>
           <CheckCircle2

--- a/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
@@ -34,9 +34,7 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
       key={spec.name}
       onClick={() => handleSelectSpec(spec)}
       aria-selected={isSelected || undefined}
-      className={cn(
-        'group flex w-full cursor-pointer items-center justify-between rounded-lg px-2 text-sm',
-      )}
+      className="group flex w-full cursor-pointer items-center justify-between rounded-lg px-2 text-sm"
     >
       <div
         className={cn(
@@ -61,7 +59,7 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
         onClick={handleFavoriteClick}
         aria-label={isFavorite ? localize('com_ui_unpin') : localize('com_ui_pin')}
         className={cn(
-          'rounded-md p-1 hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-primary',
+          'rounded-md p-1 hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring-primary',
           isFavorite
             ? 'visible'
             : 'invisible group-focus-within:visible group-hover:visible group-data-[active-item]:visible',

--- a/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { CheckCircle2, Pin, PinOff } from 'lucide-react';
 import { VisuallyHidden } from '@ariakit/react';
+import { CheckCircle2, Pin, PinOff } from 'lucide-react';
 import type { TModelSpec } from 'librechat-data-provider';
 import { useFavorites, useLocalize, useIsActiveItem } from '~/hooks';
 import { useModelSelectorContext } from '../ModelSelectorContext';
@@ -31,7 +31,6 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
   return (
     <MenuItem
       ref={itemRef}
-      key={spec.name}
       onClick={() => handleSelectSpec(spec)}
       aria-selected={isSelected || undefined}
       className="group flex w-full cursor-pointer items-center justify-between rounded-lg px-2 text-sm"
@@ -55,6 +54,7 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
         </div>
       </div>
       <button
+        type="button"
         tabIndex={isActive ? 0 : -1}
         onClick={handleFavoriteClick}
         aria-label={isFavorite ? localize('com_ui_unpin') : localize('com_ui_pin')}

--- a/client/src/components/Chat/Menus/Endpoints/components/__tests__/EndpointModelItem.test.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/__tests__/EndpointModelItem.test.tsx
@@ -32,6 +32,7 @@ jest.mock('~/hooks', () => ({
     isFavoriteAgent: () => false,
     toggleFavoriteAgent: jest.fn(),
   }),
+  useIsActiveItem: () => ({ ref: { current: null }, isActive: false }),
 }));
 
 const baseEndpoint: Endpoint = {

--- a/client/src/components/Chat/Menus/Endpoints/components/__tests__/ModelSpecItem.test.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/__tests__/ModelSpecItem.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { TModelSpec } from 'librechat-data-provider';
+import { ModelSpecItem } from '../ModelSpecItem';
+
+const mockHandleSelectSpec = jest.fn();
+const mockToggleFavoriteSpec = jest.fn();
+let mockIsFavoriteSpec = false;
+let mockIsActive = false;
+
+jest.mock('~/components/Chat/Menus/Endpoints/ModelSelectorContext', () => ({
+  useModelSelectorContext: () => ({
+    handleSelectSpec: mockHandleSelectSpec,
+    endpointsConfig: {},
+  }),
+}));
+
+jest.mock('~/components/Chat/Menus/Endpoints/CustomMenu', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return {
+    CustomMenuItem: React.forwardRef(function MockMenuItem(
+      { children, ...rest }: { children?: React.ReactNode },
+      ref: React.Ref<HTMLDivElement>,
+    ) {
+      return React.createElement('div', { ref, role: 'menuitem', ...rest }, children);
+    }),
+  };
+});
+
+jest.mock('../SpecIcon', () => ({
+  __esModule: true,
+  default: () => <span data-testid="spec-icon" />,
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+  useFavorites: () => ({
+    isFavoriteSpec: () => mockIsFavoriteSpec,
+    toggleFavoriteSpec: mockToggleFavoriteSpec,
+  }),
+  useIsActiveItem: () => ({ ref: { current: null }, isActive: mockIsActive }),
+}));
+
+const baseSpec: TModelSpec = {
+  name: 'my-spec',
+  label: 'My Spec',
+  preset: {
+    endpoint: 'openai',
+    model: 'gpt-5',
+  },
+};
+
+describe('ModelSpecItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsFavoriteSpec = false;
+    mockIsActive = false;
+  });
+
+  it('renders the spec label and icon', () => {
+    render(<ModelSpecItem spec={baseSpec} isSelected={false} />);
+    expect(screen.getByText('My Spec')).toBeInTheDocument();
+    expect(screen.getByTestId('spec-icon')).toBeInTheDocument();
+  });
+
+  it('renders description when provided', () => {
+    render(
+      <ModelSpecItem spec={{ ...baseSpec, description: 'Fast and cheap' }} isSelected={false} />,
+    );
+    expect(screen.getByText('Fast and cheap')).toBeInTheDocument();
+  });
+
+  it('renders aria-selected=true when isSelected', () => {
+    render(<ModelSpecItem spec={baseSpec} isSelected={true} />);
+    expect(screen.getByRole('menuitem')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('does NOT set aria-selected when not selected', () => {
+    render(<ModelSpecItem spec={baseSpec} isSelected={false} />);
+    expect(screen.getByRole('menuitem')).not.toHaveAttribute('aria-selected');
+  });
+
+  it('calls handleSelectSpec on row click', () => {
+    render(<ModelSpecItem spec={baseSpec} isSelected={false} />);
+    fireEvent.click(screen.getByRole('menuitem'));
+    expect(mockHandleSelectSpec).toHaveBeenCalledWith(baseSpec);
+  });
+
+  describe('pin button', () => {
+    it('renders Pin icon with "com_ui_pin" label when not favorited', () => {
+      mockIsFavoriteSpec = false;
+      render(<ModelSpecItem spec={baseSpec} isSelected={false} />);
+      expect(screen.getByRole('button', { name: 'com_ui_pin' })).toBeInTheDocument();
+    });
+
+    it('renders PinOff icon with "com_ui_unpin" label when favorited', () => {
+      mockIsFavoriteSpec = true;
+      render(<ModelSpecItem spec={baseSpec} isSelected={false} />);
+      expect(screen.getByRole('button', { name: 'com_ui_unpin' })).toBeInTheDocument();
+    });
+
+    it('calls toggleFavoriteSpec with spec.name on click', () => {
+      render(<ModelSpecItem spec={baseSpec} isSelected={false} />);
+      fireEvent.click(screen.getByRole('button', { name: 'com_ui_pin' }));
+      expect(mockToggleFavoriteSpec).toHaveBeenCalledWith('my-spec');
+    });
+
+    it('stops propagation so handleSelectSpec is not fired', () => {
+      render(<ModelSpecItem spec={baseSpec} isSelected={false} />);
+      fireEvent.click(screen.getByRole('button', { name: 'com_ui_pin' }));
+      expect(mockHandleSelectSpec).not.toHaveBeenCalled();
+    });
+
+    it('has tabIndex=-1 when item is not active', () => {
+      mockIsActive = false;
+      render(<ModelSpecItem spec={baseSpec} isSelected={false} />);
+      expect(screen.getByRole('button', { name: 'com_ui_pin' })).toHaveAttribute('tabindex', '-1');
+    });
+
+    it('has tabIndex=0 when item is active', () => {
+      mockIsActive = true;
+      render(<ModelSpecItem spec={baseSpec} isSelected={false} />);
+      expect(screen.getByRole('button', { name: 'com_ui_pin' })).toHaveAttribute('tabindex', '0');
+    });
+  });
+});

--- a/client/src/components/Nav/Favorites/FavoriteItem.tsx
+++ b/client/src/components/Nav/Favorites/FavoriteItem.tsx
@@ -105,27 +105,18 @@ export default function FavoriteItem(props: FavoriteItemProps) {
     );
   };
 
-  const getName = (): string => {
-    if (props.type === 'agent') {
-      return props.item.name ?? '';
-    }
-    if (props.type === 'spec') {
-      return props.item.label;
-    }
-    return props.item.model;
-  };
-
-  const name = getName();
-  const getTypeLabel = (): string => {
-    if (props.type === 'agent') {
-      return localize('com_ui_agent');
-    }
-    if (props.type === 'spec') {
-      return localize('com_ui_model_spec');
-    }
-    return localize('com_ui_model');
-  };
-  const typeLabel = getTypeLabel();
+  const name =
+    props.type === 'agent'
+      ? (props.item.name ?? '')
+      : props.type === 'spec'
+        ? props.item.label
+        : props.item.model;
+  const typeLabel =
+    props.type === 'agent'
+      ? localize('com_ui_agent')
+      : props.type === 'spec'
+        ? localize('com_ui_model_spec')
+        : localize('com_ui_model');
   const ariaLabel = `${name} (${typeLabel})`;
 
   const menuId = React.useId();

--- a/client/src/components/Nav/Favorites/FavoriteItem.tsx
+++ b/client/src/components/Nav/Favorites/FavoriteItem.tsx
@@ -105,18 +105,18 @@ export default function FavoriteItem(props: FavoriteItemProps) {
     );
   };
 
-  const name =
-    props.type === 'agent'
-      ? (props.item.name ?? '')
-      : props.type === 'spec'
-        ? props.item.label
-        : props.item.model;
-  const typeLabel =
-    props.type === 'agent'
-      ? localize('com_ui_agent')
-      : props.type === 'spec'
-        ? localize('com_ui_model_spec')
-        : localize('com_ui_model');
+  let name: string;
+  let typeLabel: string;
+  if (props.type === 'agent') {
+    name = props.item.name ?? '';
+    typeLabel = localize('com_ui_agent');
+  } else if (props.type === 'spec') {
+    name = props.item.label;
+    typeLabel = localize('com_ui_model_spec');
+  } else {
+    name = props.item.model;
+    typeLabel = localize('com_ui_model');
+  }
   const ariaLabel = `${name} (${typeLabel})`;
 
   const menuId = React.useId();

--- a/client/src/components/Nav/Favorites/FavoriteItem.tsx
+++ b/client/src/components/Nav/Favorites/FavoriteItem.tsx
@@ -3,9 +3,8 @@ import * as Menu from '@ariakit/react/menu';
 import { Ellipsis, PinOff } from 'lucide-react';
 import { DropdownPopup } from '@librechat/client';
 import { EModelEndpoint } from 'librechat-data-provider';
-import type { TModelSpec, TEndpointsConfig } from 'librechat-data-provider';
+import type { Agent, TModelSpec, TEndpointsConfig } from 'librechat-data-provider';
 import type { FavoriteModel } from '~/store/favorites';
-import type t from 'librechat-data-provider';
 import SpecIcon from '~/components/Chat/Menus/Endpoints/components/SpecIcon';
 import MinimalIcon from '~/components/Endpoints/MinimalIcon';
 import { useFavorites, useLocalize } from '~/hooks';
@@ -24,7 +23,7 @@ type FavoriteItemBaseProps = {
 
 type AgentFavoriteProps = FavoriteItemBaseProps & {
   type: 'agent';
-  item: t.Agent;
+  item: Agent;
   onSelectEndpoint?: (endpoint?: EModelEndpoint | string | null, kwargs?: Kwargs) => void;
 };
 
@@ -44,7 +43,7 @@ type SpecFavoriteProps = FavoriteItemBaseProps & {
 type FavoriteItemProps = AgentFavoriteProps | ModelFavoriteProps | SpecFavoriteProps;
 
 export default function FavoriteItem(props: FavoriteItemProps) {
-  const { type, onRemoveFocus } = props;
+  const { onRemoveFocus } = props;
   const localize = useLocalize();
   const { removeFavoriteAgent, removeFavoriteModel, removeFavoriteSpec } = useFavorites();
   const [isPopoverActive, setIsPopoverActive] = useState(false);
@@ -117,11 +116,11 @@ export default function FavoriteItem(props: FavoriteItemProps) {
   };
 
   const name = getName();
-  const getTypeLabel = () => {
-    if (type === 'agent') {
+  const getTypeLabel = (): string => {
+    if (props.type === 'agent') {
       return localize('com_ui_agent');
     }
-    if (type === 'spec') {
+    if (props.type === 'spec') {
       return localize('com_ui_model_spec');
     }
     return localize('com_ui_model');

--- a/client/src/components/Nav/Favorites/FavoritesList.tsx
+++ b/client/src/components/Nav/Favorites/FavoritesList.tsx
@@ -1,12 +1,13 @@
 import React, { useRef, useCallback, useMemo, useEffect } from 'react';
 import { LayoutGrid } from 'lucide-react';
+import { useRecoilValue } from 'recoil';
 import { useDrag, useDrop } from 'react-dnd';
 import { Skeleton } from '@librechat/client';
 import { useNavigate } from 'react-router-dom';
 import { useQueries } from '@tanstack/react-query';
-import { useRecoilValue } from 'recoil';
 import { QueryKeys, dataService } from 'librechat-data-provider';
-import type t from 'librechat-data-provider';
+import type { Agent, TEndpointsConfig, TModelSpec } from 'librechat-data-provider';
+import type { AgentQueryResult } from '~/common';
 import {
   useGetConversation,
   useFavorites,
@@ -16,7 +17,6 @@ import {
 } from '~/hooks';
 import { useGetEndpointsQuery, useGetStartupConfig } from '~/data-provider';
 import { useAssistantsMapContext, useAgentsMapContext } from '~/Providers';
-import type { AgentQueryResult } from '~/common';
 import useSelectMention from '~/hooks/Input/useSelectMention';
 import FavoriteItem from './FavoriteItem';
 import store from '~/store';
@@ -133,7 +133,7 @@ export default function FavoritesList({
   const { newConversation } = useNewConvo();
   const assistantsMap = useAssistantsMapContext();
   const agentsMap = useAgentsMapContext();
-  const { data: endpointsConfig = {} as t.TEndpointsConfig } = useGetEndpointsQuery();
+  const { data: endpointsConfig = {} as TEndpointsConfig } = useGetEndpointsQuery();
   const { data: startupConfig } = useGetStartupConfig();
 
   const modelSpecs = useMemo(
@@ -142,7 +142,7 @@ export default function FavoritesList({
   );
 
   const specsMap = useMemo(() => {
-    const map: Record<string, t.TModelSpec> = {};
+    const map: Record<string, TModelSpec> = {};
     for (const spec of modelSpecs) {
       map[spec.name] = spec;
     }
@@ -271,7 +271,7 @@ export default function FavoritesList({
     if (agentsMap === undefined) {
       return undefined;
     }
-    const combined: Record<string, t.Agent> = {};
+    const combined: Record<string, Agent> = {};
     for (const [key, value] of Object.entries(agentsMap)) {
       if (value) {
         combined[key] = value;

--- a/client/src/components/Nav/Favorites/FavoritesList.tsx
+++ b/client/src/components/Nav/Favorites/FavoritesList.tsx
@@ -7,16 +7,16 @@ import { useQueries } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 import { QueryKeys, dataService } from 'librechat-data-provider';
 import type t from 'librechat-data-provider';
-import type { AgentQueryResult } from '~/common';
 import {
   useGetConversation,
-  useShowMarketplace,
   useFavorites,
   useLocalize,
+  useShowMarketplace,
   useNewConvo,
 } from '~/hooks';
-import { useAssistantsMapContext, useAgentsMapContext } from '~/Providers';
 import { useGetEndpointsQuery, useGetStartupConfig } from '~/data-provider';
+import { useAssistantsMapContext, useAgentsMapContext } from '~/Providers';
+import type { AgentQueryResult } from '~/common';
 import useSelectMention from '~/hooks/Input/useSelectMention';
 import FavoriteItem from './FavoriteItem';
 import store from '~/store';

--- a/client/src/components/Nav/Favorites/FavoritesList.tsx
+++ b/client/src/components/Nav/Favorites/FavoritesList.tsx
@@ -268,12 +268,15 @@ export default function FavoritesList({
   }, [staleAgentIdsKey, safeFavorites, reorderFavorites]);
 
   const staleSpecNamesKey = useMemo(() => {
+    if (startupConfig === undefined) {
+      return '';
+    }
     return safeFavorites
       .filter((f) => f.spec && !specsMap[f.spec])
       .map((f) => f.spec as string)
       .sort()
       .join(',');
-  }, [safeFavorites, specsMap]);
+  }, [safeFavorites, specsMap, startupConfig]);
 
   const specCleanupAttemptedRef = useRef('');
 

--- a/client/src/components/Nav/Favorites/FavoritesList.tsx
+++ b/client/src/components/Nav/Favorites/FavoritesList.tsx
@@ -267,6 +267,28 @@ export default function FavoritesList({
     }
   }, [staleAgentIdsKey, safeFavorites, reorderFavorites]);
 
+  const staleSpecNamesKey = useMemo(() => {
+    return safeFavorites
+      .filter((f) => f.spec && !specsMap[f.spec])
+      .map((f) => f.spec as string)
+      .sort()
+      .join(',');
+  }, [safeFavorites, specsMap]);
+
+  const specCleanupAttemptedRef = useRef('');
+
+  useEffect(() => {
+    if (!staleSpecNamesKey || specCleanupAttemptedRef.current === staleSpecNamesKey) {
+      return;
+    }
+    const staleSet = new Set(staleSpecNamesKey.split(','));
+    const cleaned = safeFavorites.filter((f) => !f.spec || !staleSet.has(f.spec));
+    if (cleaned.length < safeFavorites.length) {
+      specCleanupAttemptedRef.current = staleSpecNamesKey;
+      reorderFavorites(cleaned, true);
+    }
+  }, [staleSpecNamesKey, safeFavorites, reorderFavorites]);
+
   const combinedAgentsMap = useMemo(() => {
     if (agentsMap === undefined) {
       return undefined;

--- a/client/src/components/Nav/Favorites/FavoritesList.tsx
+++ b/client/src/components/Nav/Favorites/FavoritesList.tsx
@@ -16,8 +16,8 @@ import {
   useNewConvo,
 } from '~/hooks';
 import { useAssistantsMapContext, useAgentsMapContext } from '~/Providers';
+import { useGetEndpointsQuery, useGetStartupConfig } from '~/data-provider';
 import useSelectMention from '~/hooks/Input/useSelectMention';
-import { useGetEndpointsQuery } from '~/data-provider';
 import FavoriteItem from './FavoriteItem';
 import store from '~/store';
 
@@ -134,9 +134,23 @@ export default function FavoritesList({
   const assistantsMap = useAssistantsMapContext();
   const agentsMap = useAgentsMapContext();
   const { data: endpointsConfig = {} as t.TEndpointsConfig } = useGetEndpointsQuery();
+  const { data: startupConfig } = useGetStartupConfig();
 
-  const { onSelectEndpoint: _onSelectEndpoint } = useSelectMention({
-    modelSpecs: [],
+  const modelSpecs = useMemo(
+    () => startupConfig?.modelSpecs?.list ?? [],
+    [startupConfig?.modelSpecs?.list],
+  );
+
+  const specsMap = useMemo(() => {
+    const map: Record<string, t.TModelSpec> = {};
+    for (const spec of modelSpecs) {
+      map[spec.name] = spec;
+    }
+    return map;
+  }, [modelSpecs]);
+
+  const { onSelectEndpoint: _onSelectEndpoint, onSelectSpec: _onSelectSpec } = useSelectMention({
+    modelSpecs,
     assistantsMap,
     endpointsConfig,
     getConversation,
@@ -152,6 +166,16 @@ export default function FavoritesList({
       }
     },
     [_onSelectEndpoint, isSmallScreen, toggleNav],
+  );
+
+  const onSelectSpec = useCallback(
+    (...args: Parameters<NonNullable<typeof _onSelectSpec>>) => {
+      _onSelectSpec?.(...args);
+      if (isSmallScreen && toggleNav) {
+        toggleNav();
+      }
+    },
+    [_onSelectSpec, isSmallScreen, toggleNav],
   );
 
   const marketplaceRef = useRef<HTMLDivElement>(null);
@@ -366,6 +390,28 @@ export default function FavoritesList({
                       type="agent"
                       onSelectEndpoint={onSelectEndpoint}
                       onRemoveFocus={handleRemoveFocus}
+                    />
+                  </DraggableFavoriteItem>
+                );
+              } else if (fav.spec) {
+                const spec = specsMap[fav.spec];
+                if (!spec) {
+                  return null;
+                }
+                return (
+                  <DraggableFavoriteItem
+                    key={`spec-${fav.spec}`}
+                    id={`spec-${fav.spec}`}
+                    index={index}
+                    moveItem={moveItem}
+                    onDrop={handleDrop}
+                  >
+                    <FavoriteItem
+                      item={spec}
+                      type="spec"
+                      onSelectSpec={onSelectSpec}
+                      onRemoveFocus={handleRemoveFocus}
+                      endpointsConfig={endpointsConfig}
                     />
                   </DraggableFavoriteItem>
                 );

--- a/client/src/components/Nav/Favorites/tests/FavoriteItem.spec.tsx
+++ b/client/src/components/Nav/Favorites/tests/FavoriteItem.spec.tsx
@@ -1,0 +1,150 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { Agent, TModelSpec } from 'librechat-data-provider';
+import type { FavoriteModel } from '~/store/favorites';
+import FavoriteItem from '../FavoriteItem';
+
+const mockRemoveFavoriteAgent = jest.fn();
+const mockRemoveFavoriteModel = jest.fn();
+const mockRemoveFavoriteSpec = jest.fn();
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+  useFavorites: () => ({
+    removeFavoriteAgent: mockRemoveFavoriteAgent,
+    removeFavoriteModel: mockRemoveFavoriteModel,
+    removeFavoriteSpec: mockRemoveFavoriteSpec,
+  }),
+}));
+
+jest.mock('~/components/Chat/Menus/Endpoints/components/SpecIcon', () => ({
+  __esModule: true,
+  default: () => <span data-testid="spec-icon" />,
+}));
+
+jest.mock('~/components/Endpoints/MinimalIcon', () => ({
+  __esModule: true,
+  default: () => <span data-testid="minimal-icon" />,
+}));
+
+jest.mock('~/utils', () => ({
+  ...jest.requireActual('~/utils'),
+  renderAgentAvatar: () => <span data-testid="agent-avatar" />,
+}));
+
+jest.mock('@librechat/client', () => ({
+  ...jest.requireActual('@librechat/client'),
+  DropdownPopup: () => <div data-testid="dropdown-popup" />,
+}));
+
+jest.mock('@ariakit/react/menu', () => ({
+  MenuButton: ({ children }: { children?: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+const baseAgent: Agent = {
+  id: 'agent-123',
+  name: 'Research Agent',
+  avatar: null,
+  provider: 'openai',
+  model: 'gpt-5',
+  instructions: '',
+  description: '',
+  tools: [],
+  created_at: 0,
+  updated_at: 0,
+  author: 'u1',
+} as unknown as Agent;
+
+const baseModel: FavoriteModel = { model: 'gpt-5', endpoint: 'openai' };
+
+const baseSpec: TModelSpec = {
+  name: 'my-spec',
+  label: 'My Model Spec',
+  preset: { endpoint: 'openai', model: 'gpt-5' },
+};
+
+describe('FavoriteItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('type="agent"', () => {
+    it('renders the agent name and avatar', () => {
+      const onSelectEndpoint = jest.fn();
+      render(<FavoriteItem type="agent" item={baseAgent} onSelectEndpoint={onSelectEndpoint} />);
+      expect(screen.getByText('Research Agent')).toBeInTheDocument();
+      expect(screen.getByTestId('agent-avatar')).toBeInTheDocument();
+    });
+
+    it('has aria-label formatted as "<name> (com_ui_agent)"', () => {
+      render(<FavoriteItem type="agent" item={baseAgent} />);
+      expect(
+        screen.getByRole('button', { name: 'Research Agent (com_ui_agent)' }),
+      ).toBeInTheDocument();
+    });
+
+    it('calls onSelectEndpoint with agents endpoint + agent_id on click', () => {
+      const onSelectEndpoint = jest.fn();
+      render(<FavoriteItem type="agent" item={baseAgent} onSelectEndpoint={onSelectEndpoint} />);
+      fireEvent.click(screen.getByTestId('favorite-item'));
+      expect(onSelectEndpoint).toHaveBeenCalledWith('agents', { agent_id: 'agent-123' });
+    });
+  });
+
+  describe('type="model"', () => {
+    it('renders model name and minimal icon', () => {
+      render(<FavoriteItem type="model" item={baseModel} />);
+      expect(screen.getByText('gpt-5')).toBeInTheDocument();
+      expect(screen.getByTestId('minimal-icon')).toBeInTheDocument();
+    });
+
+    it('has aria-label formatted as "<model> (com_ui_model)"', () => {
+      render(<FavoriteItem type="model" item={baseModel} />);
+      expect(screen.getByRole('button', { name: 'gpt-5 (com_ui_model)' })).toBeInTheDocument();
+    });
+
+    it('calls onSelectEndpoint with endpoint + model on click', () => {
+      const onSelectEndpoint = jest.fn();
+      render(<FavoriteItem type="model" item={baseModel} onSelectEndpoint={onSelectEndpoint} />);
+      fireEvent.click(screen.getByTestId('favorite-item'));
+      expect(onSelectEndpoint).toHaveBeenCalledWith('openai', { model: 'gpt-5' });
+    });
+  });
+
+  describe('type="spec"', () => {
+    it('renders the spec label and SpecIcon', () => {
+      render(<FavoriteItem type="spec" item={baseSpec} />);
+      expect(screen.getByText('My Model Spec')).toBeInTheDocument();
+      expect(screen.getByTestId('spec-icon')).toBeInTheDocument();
+    });
+
+    it('has aria-label formatted as "<label> (com_ui_model_spec)"', () => {
+      render(<FavoriteItem type="spec" item={baseSpec} />);
+      expect(
+        screen.getByRole('button', { name: 'My Model Spec (com_ui_model_spec)' }),
+      ).toBeInTheDocument();
+    });
+
+    it('calls onSelectSpec with the full spec on click', () => {
+      const onSelectSpec = jest.fn();
+      render(<FavoriteItem type="spec" item={baseSpec} onSelectSpec={onSelectSpec} />);
+      fireEvent.click(screen.getByTestId('favorite-item'));
+      expect(onSelectSpec).toHaveBeenCalledWith(baseSpec);
+    });
+
+    it('activates on Enter key', () => {
+      const onSelectSpec = jest.fn();
+      render(<FavoriteItem type="spec" item={baseSpec} onSelectSpec={onSelectSpec} />);
+      fireEvent.keyDown(screen.getByTestId('favorite-item'), { key: 'Enter' });
+      expect(onSelectSpec).toHaveBeenCalledWith(baseSpec);
+    });
+
+    it('activates on Space key', () => {
+      const onSelectSpec = jest.fn();
+      render(<FavoriteItem type="spec" item={baseSpec} onSelectSpec={onSelectSpec} />);
+      fireEvent.keyDown(screen.getByTestId('favorite-item'), { key: ' ' });
+      expect(onSelectSpec).toHaveBeenCalledWith(baseSpec);
+    });
+  });
+});

--- a/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
+++ b/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
@@ -65,8 +65,10 @@ jest.mock('~/Providers', () => ({
   useAgentsMapContext: () => ({}),
 }));
 
+const mockOnSelectSpec = jest.fn();
 jest.mock('~/hooks/Input/useSelectMention', () => () => ({
   onSelectEndpoint: jest.fn(),
+  onSelectSpec: mockOnSelectSpec,
 }));
 
 const mockUseGetStartupConfig = jest.fn(() => ({

--- a/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
+++ b/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
@@ -33,6 +33,7 @@ type FavoriteItem = {
   agentId?: string;
   model?: string;
   endpoint?: string;
+  spec?: string;
 };
 
 // Mock dataService
@@ -68,17 +69,30 @@ jest.mock('~/hooks/Input/useSelectMention', () => () => ({
   onSelectEndpoint: jest.fn(),
 }));
 
+const mockUseGetStartupConfig = jest.fn(() => ({
+  data: { modelSpecs: { list: [] as unknown[] } },
+}));
+
 jest.mock('~/data-provider', () => ({
   useGetEndpointsQuery: () => ({ data: {} }),
+  useGetStartupConfig: () => mockUseGetStartupConfig(),
 }));
 
 jest.mock('../FavoriteItem', () => ({
   __esModule: true,
-  default: ({ item, type }: { item: any; type: string }) => (
-    <div data-testid="favorite-item" data-type={type}>
-      {type === 'agent' ? item.name : item.model}
-    </div>
-  ),
+  default: ({ item, type }: { item: any; type: string }) => {
+    let label = item.model;
+    if (type === 'agent') {
+      label = item.name;
+    } else if (type === 'spec') {
+      label = item.label;
+    }
+    return (
+      <div data-testid="favorite-item" data-type={type}>
+        {label}
+      </div>
+    );
+  },
 }));
 
 const createTestQueryClient = () =>
@@ -107,6 +121,14 @@ describe('FavoritesList', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFavorites.length = 0;
+    mockUseFavorites.mockImplementation(() => ({
+      favorites: mockFavorites,
+      reorderFavorites: jest.fn(),
+      isLoading: false,
+    }));
+    mockUseGetStartupConfig.mockImplementation(() => ({
+      data: { modelSpecs: { list: [] } },
+    }));
   });
 
   describe('rendering', () => {
@@ -268,6 +290,72 @@ describe('FavoritesList', () => {
       await new Promise((r) => setTimeout(r, 50));
 
       expect(mockReorderFavorites).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('model spec rendering', () => {
+    it('renders a spec favorite when startupConfig has a matching spec', async () => {
+      mockUseGetStartupConfig.mockImplementation(() => ({
+        data: {
+          modelSpecs: {
+            list: [
+              {
+                name: 'fast-spec',
+                label: 'Fast Spec',
+                preset: { endpoint: 'openai', model: 'gpt-5' },
+              },
+            ],
+          },
+        },
+      }));
+      mockFavorites.push({ spec: 'fast-spec' });
+
+      const { findAllByTestId } = renderWithProviders(<FavoritesList />);
+      const items = await findAllByTestId('favorite-item');
+
+      expect(items).toHaveLength(1);
+      expect(items[0]).toHaveAttribute('data-type', 'spec');
+      expect(items[0]).toHaveTextContent('Fast Spec');
+    });
+
+    it('skips a spec favorite when the spec is no longer in startupConfig', () => {
+      mockUseGetStartupConfig.mockImplementation(() => ({
+        data: { modelSpecs: { list: [] } },
+      }));
+      mockFavorites.push({ spec: 'stale-spec' });
+
+      const { queryAllByTestId } = renderWithProviders(<FavoritesList />);
+      expect(queryAllByTestId('favorite-item')).toHaveLength(0);
+    });
+
+    it('renders a mix of agents, models, and specs', async () => {
+      const validAgent: t.Agent = {
+        id: 'a1',
+        name: 'Agent One',
+        author: 'me',
+      } as t.Agent;
+      mockUseGetStartupConfig.mockImplementation(() => ({
+        data: {
+          modelSpecs: {
+            list: [
+              {
+                name: 's1',
+                label: 'Spec One',
+                preset: { endpoint: 'openai', model: 'gpt-5' },
+              },
+            ],
+          },
+        },
+      }));
+      mockFavorites.push({ agentId: 'a1' }, { model: 'gpt-5', endpoint: 'openai' }, { spec: 's1' });
+      (dataService.getAgentById as jest.Mock).mockResolvedValue(validAgent);
+
+      const { findAllByTestId } = renderWithProviders(<FavoritesList />);
+      const items = await findAllByTestId('favorite-item');
+
+      expect(items).toHaveLength(3);
+      const types = items.map((el) => el.getAttribute('data-type'));
+      expect(types).toEqual(['agent', 'model', 'spec']);
     });
   });
 });

--- a/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
+++ b/client/src/components/Nav/Favorites/tests/FavoritesList.spec.tsx
@@ -7,7 +7,7 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { BrowserRouter } from 'react-router-dom';
 import { dataService } from 'librechat-data-provider';
-import type t from 'librechat-data-provider';
+import type { Agent } from 'librechat-data-provider';
 
 // Mock store before importing FavoritesList
 jest.mock('~/store', () => {
@@ -156,11 +156,11 @@ describe('FavoritesList', () => {
 
   describe('missing agent handling', () => {
     it('should exclude missing agents (404) from rendered favorites and render valid agents', async () => {
-      const validAgent: t.Agent = {
+      const validAgent: Agent = {
         id: 'valid-agent',
         name: 'Valid Agent',
         author: 'test-author',
-      } as t.Agent;
+      } as Agent;
 
       // Set up favorites with both valid and missing agent
       mockFavorites.push({ agentId: 'valid-agent' }, { agentId: 'deleted-agent' });
@@ -214,11 +214,11 @@ describe('FavoritesList', () => {
     });
 
     it('should treat 403 the same as 404 — agent not rendered', async () => {
-      const validAgent: t.Agent = {
+      const validAgent: Agent = {
         id: 'valid-agent',
         name: 'Valid Agent',
         author: 'test-author',
-      } as t.Agent;
+      } as Agent;
 
       mockFavorites.push({ agentId: 'valid-agent' }, { agentId: 'revoked-agent' });
 
@@ -330,12 +330,45 @@ describe('FavoritesList', () => {
       expect(queryAllByTestId('favorite-item')).toHaveLength(0);
     });
 
+    it('calls reorderFavorites to auto-remove stale spec favorites', async () => {
+      const mockReorderFavorites = jest.fn().mockResolvedValue(undefined);
+      mockUseFavorites.mockReturnValue({
+        favorites: [{ spec: 'stale-spec' }],
+        reorderFavorites: mockReorderFavorites,
+        isLoading: false,
+      });
+      mockUseGetStartupConfig.mockReturnValue({
+        data: { modelSpecs: { list: [] } },
+      });
+
+      renderWithProviders(<FavoritesList />);
+
+      await waitFor(() => {
+        expect(mockReorderFavorites).toHaveBeenCalledWith([], true);
+      });
+    });
+
+    it('does not clean up specs when startupConfig is still loading', async () => {
+      const mockReorderFavorites = jest.fn().mockResolvedValue(undefined);
+      mockUseFavorites.mockReturnValue({
+        favorites: [{ spec: 'valid-spec' }],
+        reorderFavorites: mockReorderFavorites,
+        isLoading: false,
+      });
+      mockUseGetStartupConfig.mockReturnValue({ data: undefined });
+
+      renderWithProviders(<FavoritesList />);
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mockReorderFavorites).not.toHaveBeenCalled();
+    });
+
     it('renders a mix of agents, models, and specs', async () => {
-      const validAgent: t.Agent = {
+      const validAgent: Agent = {
         id: 'a1',
         name: 'Agent One',
         author: 'me',
-      } as t.Agent;
+      } as Agent;
       mockUseGetStartupConfig.mockImplementation(() => ({
         data: {
           modelSpecs: {

--- a/client/src/hooks/__tests__/useFavorites.spec.tsx
+++ b/client/src/hooks/__tests__/useFavorites.spec.tsx
@@ -101,7 +101,7 @@ describe('useFavorites — spec methods', () => {
       expect(mockMutateAsync).toHaveBeenCalledWith([{ spec: 'keep' }]);
     });
 
-    it('is a no-op when spec is not present', async () => {
+    it('still persists when the target spec is absent', async () => {
       const { result } = renderUseFavorites([{ spec: 'keep' }]);
       await act(async () => {
         result.current.removeFavoriteSpec('missing');

--- a/client/src/hooks/__tests__/useFavorites.spec.tsx
+++ b/client/src/hooks/__tests__/useFavorites.spec.tsx
@@ -1,0 +1,186 @@
+/**
+ * @jest-environment @happy-dom/jest-environment
+ */
+import React from 'react';
+import { Provider as JotaiProvider, createStore } from 'jotai';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { favoritesAtom } from '~/store';
+import useFavorites from '../useFavorites';
+import type { Favorite } from '~/store/favorites';
+
+const mockMutateAsync = jest.fn();
+const mockShowToast = jest.fn();
+const mockRefetch = jest.fn();
+
+jest.mock('@librechat/client', () => ({
+  ...jest.requireActual('@librechat/client'),
+  useToastContext: () => ({ showToast: mockShowToast }),
+}));
+
+jest.mock('~/data-provider', () => ({
+  useGetFavoritesQuery: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: mockRefetch,
+  }),
+  useUpdateFavoritesMutation: () => ({
+    mutateAsync: mockMutateAsync,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+}));
+
+const renderUseFavorites = (initialFavorites: Favorite[] = []) => {
+  const store = createStore();
+  store.set(favoritesAtom, initialFavorites);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <JotaiProvider store={store}>{children}</JotaiProvider>
+    </QueryClientProvider>
+  );
+  return { ...renderHook(() => useFavorites(), { wrapper }), store };
+};
+
+describe('useFavorites — spec methods', () => {
+  beforeEach(() => {
+    mockMutateAsync.mockReset();
+    mockShowToast.mockReset();
+    mockRefetch.mockReset();
+    mockMutateAsync.mockResolvedValue(undefined);
+  });
+
+  describe('addFavoriteSpec', () => {
+    it('adds a new spec favorite and persists', async () => {
+      const { result } = renderUseFavorites([]);
+      await act(async () => {
+        result.current.addFavoriteSpec('gpt-5-spec');
+      });
+      expect(mockMutateAsync).toHaveBeenCalledWith([{ spec: 'gpt-5-spec' }]);
+      expect(result.current.favorites).toEqual([{ spec: 'gpt-5-spec' }]);
+    });
+
+    it('is a no-op when spec is already favorited', async () => {
+      const { result } = renderUseFavorites([{ spec: 'gpt-5-spec' }]);
+      await act(async () => {
+        result.current.addFavoriteSpec('gpt-5-spec');
+      });
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it('preserves existing agent/model favorites when adding a spec', async () => {
+      const existing: Favorite[] = [{ agentId: 'a1' }, { model: 'gpt-5', endpoint: 'openai' }];
+      const { result } = renderUseFavorites(existing);
+      await act(async () => {
+        result.current.addFavoriteSpec('my-spec');
+      });
+      expect(mockMutateAsync).toHaveBeenCalledWith([
+        { agentId: 'a1' },
+        { model: 'gpt-5', endpoint: 'openai' },
+        { spec: 'my-spec' },
+      ]);
+    });
+  });
+
+  describe('removeFavoriteSpec', () => {
+    it('removes an existing spec favorite', async () => {
+      const { result } = renderUseFavorites([{ spec: 'keep' }, { spec: 'drop' }]);
+      await act(async () => {
+        result.current.removeFavoriteSpec('drop');
+      });
+      expect(mockMutateAsync).toHaveBeenCalledWith([{ spec: 'keep' }]);
+    });
+
+    it('is a no-op when spec is not present', async () => {
+      const { result } = renderUseFavorites([{ spec: 'keep' }]);
+      await act(async () => {
+        result.current.removeFavoriteSpec('missing');
+      });
+      expect(mockMutateAsync).toHaveBeenCalledWith([{ spec: 'keep' }]);
+      expect(result.current.favorites).toEqual([{ spec: 'keep' }]);
+    });
+  });
+
+  describe('isFavoriteSpec', () => {
+    it('returns false for undefined / null / empty string', () => {
+      const { result } = renderUseFavorites([{ spec: 'x' }]);
+      expect(result.current.isFavoriteSpec(undefined)).toBe(false);
+      expect(result.current.isFavoriteSpec(null)).toBe(false);
+      expect(result.current.isFavoriteSpec('')).toBe(false);
+    });
+
+    it('returns true when spec is present', () => {
+      const { result } = renderUseFavorites([{ spec: 'x' }]);
+      expect(result.current.isFavoriteSpec('x')).toBe(true);
+    });
+
+    it('returns false when spec is not present', () => {
+      const { result } = renderUseFavorites([{ spec: 'x' }]);
+      expect(result.current.isFavoriteSpec('y')).toBe(false);
+    });
+  });
+
+  describe('toggleFavoriteSpec', () => {
+    it('adds when absent', async () => {
+      const { result } = renderUseFavorites([]);
+      await act(async () => {
+        result.current.toggleFavoriteSpec('new');
+      });
+      expect(mockMutateAsync).toHaveBeenCalledWith([{ spec: 'new' }]);
+    });
+
+    it('removes when present', async () => {
+      const { result } = renderUseFavorites([{ spec: 'new' }]);
+      await act(async () => {
+        result.current.toggleFavoriteSpec('new');
+      });
+      expect(mockMutateAsync).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('cleanFavorites (via saveFavorites)', () => {
+    it('filters out entries with no canonical shape', async () => {
+      const { result } = renderUseFavorites([]);
+      await act(async () => {
+        result.current.reorderFavorites(
+          [
+            { agentId: 'a1' },
+            {} as Favorite, // stripped
+            { spec: 's1' },
+            { model: 'm', endpoint: 'e' },
+          ],
+          true,
+        );
+      });
+      expect(mockMutateAsync).toHaveBeenCalledWith([
+        { agentId: 'a1' },
+        { spec: 's1' },
+        { model: 'm', endpoint: 'e' },
+      ]);
+    });
+
+    it('collapses mixed-shape entry to the first-matching canonical variant', async () => {
+      const { result } = renderUseFavorites([]);
+      await act(async () => {
+        result.current.reorderFavorites(
+          [
+            // agentId takes priority in cleanFavorites
+            { agentId: 'a1', spec: 'ignored' } as Favorite,
+          ],
+          true,
+        );
+      });
+      expect(mockMutateAsync).toHaveBeenCalledWith([{ agentId: 'a1' }]);
+    });
+  });
+});

--- a/client/src/hooks/__tests__/useIsActiveItem.spec.tsx
+++ b/client/src/hooks/__tests__/useIsActiveItem.spec.tsx
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment @happy-dom/jest-environment
+ */
+import React from 'react';
+import { act, render } from '@testing-library/react';
+
+import useIsActiveItem from '../useIsActiveItem';
+
+function Probe() {
+  const { ref, isActive } = useIsActiveItem<HTMLDivElement>();
+  return <div ref={ref} data-testid="probe" data-active={isActive ? 'true' : 'false'} />;
+}
+
+const getProbe = (container: HTMLElement) =>
+  container.querySelector('[data-testid="probe"]') as HTMLDivElement;
+
+describe('useIsActiveItem', () => {
+  it('starts with isActive=false when data-active-item is absent', () => {
+    const { container } = render(<Probe />);
+    expect(getProbe(container).getAttribute('data-active')).toBe('false');
+  });
+
+  it('initializes isActive=true when data-active-item is already set pre-mount', () => {
+    // Render wrapper that sets the attribute BEFORE Probe mounts.
+    function Wrapper() {
+      const [mounted, setMounted] = React.useState(false);
+      return (
+        <div>
+          {mounted && <Probe />}
+          <button
+            data-testid="mount-trigger"
+            onClick={() => {
+              setMounted(true);
+            }}
+          />
+        </div>
+      );
+    }
+    // Simplest: assert default is false (initial mount has no attribute); the pre-mount
+    // hydration case is effectively the same code path covered by the update test below.
+    const { container } = render(<Wrapper />);
+    // Not strictly asserting here — initial-attribute path is exercised below via mutation.
+    expect(container).toBeTruthy();
+  });
+
+  it('flips isActive to true when data-active-item is added after mount', async () => {
+    const { container } = render(<Probe />);
+    const probe = getProbe(container);
+
+    await act(async () => {
+      probe.setAttribute('data-active-item', '');
+      // Allow the MutationObserver microtask to run
+      await Promise.resolve();
+    });
+
+    expect(probe.getAttribute('data-active')).toBe('true');
+  });
+
+  it('flips isActive back to false when data-active-item is removed', async () => {
+    const { container } = render(<Probe />);
+    const probe = getProbe(container);
+
+    await act(async () => {
+      probe.setAttribute('data-active-item', '');
+      await Promise.resolve();
+    });
+    expect(probe.getAttribute('data-active')).toBe('true');
+
+    await act(async () => {
+      probe.removeAttribute('data-active-item');
+      await Promise.resolve();
+    });
+    expect(probe.getAttribute('data-active')).toBe('false');
+  });
+
+  it('ignores unrelated attribute mutations', async () => {
+    const { container } = render(<Probe />);
+    const probe = getProbe(container);
+
+    await act(async () => {
+      probe.setAttribute('data-something-else', 'x');
+      await Promise.resolve();
+    });
+
+    expect(probe.getAttribute('data-active')).toBe('false');
+  });
+
+  it('disconnects the MutationObserver on unmount', async () => {
+    const disconnectSpy = jest.fn();
+    const realObserver = globalThis.MutationObserver;
+    class SpyObserver extends realObserver {
+      disconnect(): void {
+        disconnectSpy();
+        super.disconnect();
+      }
+    }
+    globalThis.MutationObserver = SpyObserver;
+
+    const { unmount } = render(<Probe />);
+    unmount();
+
+    expect(disconnectSpy).toHaveBeenCalled();
+
+    globalThis.MutationObserver = realObserver;
+  });
+});

--- a/client/src/hooks/__tests__/useIsActiveItem.spec.tsx
+++ b/client/src/hooks/__tests__/useIsActiveItem.spec.tsx
@@ -20,29 +20,6 @@ describe('useIsActiveItem', () => {
     expect(getProbe(container).getAttribute('data-active')).toBe('false');
   });
 
-  it('initializes isActive=true when data-active-item is already set pre-mount', () => {
-    // Render wrapper that sets the attribute BEFORE Probe mounts.
-    function Wrapper() {
-      const [mounted, setMounted] = React.useState(false);
-      return (
-        <div>
-          {mounted && <Probe />}
-          <button
-            data-testid="mount-trigger"
-            onClick={() => {
-              setMounted(true);
-            }}
-          />
-        </div>
-      );
-    }
-    // Simplest: assert default is false (initial mount has no attribute); the pre-mount
-    // hydration case is effectively the same code path covered by the update test below.
-    const { container } = render(<Wrapper />);
-    // Not strictly asserting here — initial-attribute path is exercised below via mutation.
-    expect(container).toBeTruthy();
-  });
-
   it('flips isActive to true when data-active-item is added after mount', async () => {
     const { container } = render(<Probe />);
     const probe = getProbe(container);

--- a/client/src/hooks/index.ts
+++ b/client/src/hooks/index.ts
@@ -30,6 +30,7 @@ export { default as useFocusTrap } from './useFocusTrap';
 export { default as useFavorites } from './useFavorites';
 export { default as useChatBadges } from './useChatBadges';
 export { default as useScrollToRef } from './useScrollToRef';
+export { default as useIsActiveItem } from './useIsActiveItem';
 export { default as useLocalStorage } from './useLocalStorage';
 export { default as useDocumentTitle } from './useDocumentTitle';
 export { default as useSpeechToText } from './Input/useSpeechToText';

--- a/client/src/hooks/useFavorites.ts
+++ b/client/src/hooks/useFavorites.ts
@@ -23,7 +23,7 @@ const MAX_FAVORITES = 50;
  */
 
 /**
- * Cleans favorites array to only include canonical shapes (agentId or model+endpoint).
+ * Cleans favorites array to only include canonical shapes (agentId, model+endpoint, or spec).
  */
 const cleanFavorites = (favorites: Favorite[]): Favorite[] => {
   if (!Array.isArray(favorites)) {
@@ -35,6 +35,9 @@ const cleanFavorites = (favorites: Favorite[]): Favorite[] => {
     }
     if (f.model && f.endpoint) {
       return { model: f.model, endpoint: f.endpoint };
+    }
+    if (f.spec) {
+      return { spec: f.spec };
     }
     return f;
   });
@@ -137,6 +140,34 @@ export default function useFavorites() {
     return favorites.some((f) => f.model === model && f.endpoint === endpoint);
   };
 
+  const addFavoriteSpec = (spec: string) => {
+    if (favorites.some((f) => f.spec === spec)) {
+      return;
+    }
+    const newFavorites = [...favorites, { spec }];
+    saveFavorites(newFavorites);
+  };
+
+  const removeFavoriteSpec = (spec: string) => {
+    const newFavorites = favorites.filter((f) => f.spec !== spec);
+    saveFavorites(newFavorites);
+  };
+
+  const isFavoriteSpec = (spec: string | undefined | null) => {
+    if (!spec) {
+      return false;
+    }
+    return favorites.some((f) => f.spec === spec);
+  };
+
+  const toggleFavoriteSpec = (spec: string) => {
+    if (isFavoriteSpec(spec)) {
+      removeFavoriteSpec(spec);
+    } else {
+      addFavoriteSpec(spec);
+    }
+  };
+
   const toggleFavoriteAgent = (agentId: string) => {
     if (isFavoriteAgent(agentId)) {
       removeFavoriteAgent(agentId);
@@ -187,10 +218,14 @@ export default function useFavorites() {
     removeFavoriteAgent,
     addFavoriteModel,
     removeFavoriteModel,
+    addFavoriteSpec,
+    removeFavoriteSpec,
     isFavoriteAgent,
     isFavoriteModel,
+    isFavoriteSpec,
     toggleFavoriteAgent,
     toggleFavoriteModel,
+    toggleFavoriteSpec,
     reorderFavorites,
     /** Whether the favorites query is currently loading */
     isLoading: getFavoritesQuery.isLoading,

--- a/client/src/hooks/useFavorites.ts
+++ b/client/src/hooks/useFavorites.ts
@@ -11,12 +11,13 @@ import { logger } from '~/utils';
 const MAX_FAVORITES = 50;
 
 /**
- * Hook for managing user favorites (pinned agents and models).
+ * Hook for managing user favorites (pinned agents, models, and model specs).
  *
  * Favorites are synchronized with the server via `/api/user/settings/favorites`.
  * Each favorite is either:
  * - An agent: `{ agentId: string }`
  * - A model: `{ model: string, endpoint: string }`
+ * - A model spec: `{ spec: string }`
  *
  * @returns Object containing favorites state and helper methods for
  * adding, removing, toggling, reordering, and checking favorites.
@@ -29,18 +30,20 @@ const cleanFavorites = (favorites: Favorite[]): Favorite[] => {
   if (!Array.isArray(favorites)) {
     return [];
   }
-  return favorites.map((f) => {
-    if (f.agentId) {
-      return { agentId: f.agentId };
-    }
-    if (f.model && f.endpoint) {
-      return { model: f.model, endpoint: f.endpoint };
-    }
-    if (f.spec) {
-      return { spec: f.spec };
-    }
-    return f;
-  });
+  return favorites
+    .map((f) => {
+      if (f.agentId) {
+        return { agentId: f.agentId };
+      }
+      if (f.model && f.endpoint) {
+        return { model: f.model, endpoint: f.endpoint };
+      }
+      if (f.spec) {
+        return { spec: f.spec };
+      }
+      return null;
+    })
+    .filter((f): f is NonNullable<typeof f> => f !== null);
 };
 
 export default function useFavorites() {

--- a/client/src/hooks/useIsActiveItem.ts
+++ b/client/src/hooks/useIsActiveItem.ts
@@ -1,0 +1,24 @@
+import { useRef, useState, useEffect } from 'react';
+
+export default function useIsActiveItem<T extends HTMLElement = HTMLElement>() {
+  const ref = useRef<T>(null);
+  const [isActive, setIsActive] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      setIsActive(element.hasAttribute('data-active-item'));
+    });
+
+    observer.observe(element, { attributes: true, attributeFilter: ['data-active-item'] });
+    setIsActive(element.hasAttribute('data-active-item'));
+
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, isActive };
+}

--- a/client/src/hooks/useIsActiveItem.ts
+++ b/client/src/hooks/useIsActiveItem.ts
@@ -1,6 +1,15 @@
 import { useRef, useState, useEffect } from 'react';
+import type { RefObject } from 'react';
 
-export default function useIsActiveItem<T extends HTMLElement = HTMLElement>() {
+/**
+ * Mirrors Ariakit's composite `data-active-item` attribute into a React state value.
+ * The ref must be attached to an element that mounts synchronously on first render;
+ * late-mounting refs will not be observed.
+ */
+export default function useIsActiveItem<T extends HTMLElement = HTMLElement>(): {
+  ref: RefObject<T>;
+  isActive: boolean;
+} {
   const ref = useRef<T>(null);
   const [isActive, setIsActive] = useState(false);
 

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1196,6 +1196,7 @@
   "com_ui_model_parameters": "Model Parameters",
   "com_ui_model_parameters_reset": "Model Parameters have been reset.",
   "com_ui_model_selected": "{{0}} selected",
+  "com_ui_model_spec": "Model Spec",
   "com_ui_more_info": "More info",
   "com_ui_my_prompts": "My Prompts",
   "com_ui_name": "Name",

--- a/client/src/store/favorites.ts
+++ b/client/src/store/favorites.ts
@@ -4,6 +4,7 @@ export type Favorite = {
   agentId?: string;
   model?: string;
   endpoint?: string;
+  spec?: string;
 };
 
 export type FavoriteModel = {

--- a/client/src/store/favorites.ts
+++ b/client/src/store/favorites.ts
@@ -1,11 +1,7 @@
+import type { TUserFavorite } from 'librechat-data-provider';
 import { createTabIsolatedAtom } from './jotai-utils';
 
-export type Favorite = {
-  agentId?: string;
-  model?: string;
-  endpoint?: string;
-  spec?: string;
-};
+export type Favorite = TUserFavorite;
 
 export type FavoriteModel = {
   model: string;

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -29,6 +29,7 @@ export type FavoriteItem = {
   agentId?: string;
   model?: string;
   endpoint?: string;
+  spec?: string;
 };
 
 export function getFavorites(): Promise<FavoriteItem[]> {

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -25,18 +25,11 @@ export function deleteUser(payload?: t.TDeleteUserRequest): Promise<unknown> {
   return request.deleteWithOptions(endpoints.deleteUser(), { data: payload });
 }
 
-export type FavoriteItem = {
-  agentId?: string;
-  model?: string;
-  endpoint?: string;
-  spec?: string;
-};
-
-export function getFavorites(): Promise<FavoriteItem[]> {
+export function getFavorites(): Promise<q.TUserFavorite[]> {
   return request.get(`${endpoints.apiBaseUrl()}/api/user/settings/favorites`);
 }
 
-export function updateFavorites(favorites: FavoriteItem[]): Promise<FavoriteItem[]> {
+export function updateFavorites(favorites: q.TUserFavorite[]): Promise<q.TUserFavorite[]> {
   return request.post(`${endpoints.apiBaseUrl()}/api/user/settings/favorites`, { favorites });
 }
 

--- a/packages/data-provider/src/types/queries.ts
+++ b/packages/data-provider/src/types/queries.ts
@@ -202,6 +202,18 @@ export interface MCPAuthValuesResponse {
   authValueFlags: Record<string, boolean>;
 }
 
+/**
+ * User Favorites — pinned agents, models, and model specs.
+ * Exactly one variant should be set per entry; exclusivity is enforced
+ * server-side in FavoritesController. Shape is loose for state-update ergonomics.
+ */
+export type TUserFavorite = {
+  agentId?: string;
+  model?: string;
+  endpoint?: string;
+  spec?: string;
+};
+
 /* SharePoint Graph API Token */
 export type GraphTokenParams = {
   scopes: string;

--- a/packages/data-schemas/src/schema/user.ts
+++ b/packages/data-schemas/src/schema/user.ts
@@ -137,10 +137,10 @@ const userSchema = new Schema<IUser>(
       type: [
         {
           _id: false,
-          agentId: String, // for agent
-          model: String, // for model
-          endpoint: String, // for model
-          spec: String, // for model spec
+          agentId: { type: String, maxlength: 256 },
+          model: { type: String, maxlength: 256 },
+          endpoint: { type: String, maxlength: 256 },
+          spec: { type: String, maxlength: 256 },
         },
       ],
       default: [],

--- a/packages/data-schemas/src/schema/user.ts
+++ b/packages/data-schemas/src/schema/user.ts
@@ -140,6 +140,7 @@ const userSchema = new Schema<IUser>(
           agentId: String, // for agent
           model: String, // for model
           endpoint: String, // for model
+          spec: String, // for model spec
         },
       ],
       default: [],

--- a/packages/data-schemas/src/types/user.ts
+++ b/packages/data-schemas/src/types/user.ts
@@ -1,4 +1,5 @@
 import type { Document, Types } from 'mongoose';
+import type { TUserFavorite } from 'librechat-data-provider';
 import { CursorPaginationParams } from '~/common';
 
 export interface IUser extends Document {
@@ -41,12 +42,7 @@ export interface IUser extends Document {
   personalization?: {
     memories?: boolean;
   };
-  favorites?: Array<{
-    agentId?: string;
-    model?: string;
-    endpoint?: string;
-    spec?: string;
-  }>;
+  favorites?: TUserFavorite[];
   createdAt?: Date;
   updatedAt?: Date;
   /** Field for external source identification (for consistency with TPrincipal schema) */

--- a/packages/data-schemas/src/types/user.ts
+++ b/packages/data-schemas/src/types/user.ts
@@ -45,6 +45,7 @@ export interface IUser extends Document {
     agentId?: string;
     model?: string;
     endpoint?: string;
+    spec?: string;
   }>;
   createdAt?: Date;
   updatedAt?: Date;


### PR DESCRIPTION
## Summary
- Adds the ability to pin/favorite model specs, similar to existing support for models and agents
- Reduces padding on submenu dropdowns for a more compact look

### Changes
**Frontend**:
- Added `spec` field to `Favorite` type
- Added `addFavoriteSpec`, `removeFavoriteSpec`, `isFavoriteSpec`, `toggleFavoriteSpec` methods to `useFavorites` hook
- Added pin button to `ModelSpecItem` component (shows on hover)
- Updated `FavoriteItem` and `FavoritesList` to render pinned specs
- Reduced submenu padding from `px-3 py-2` to `px-0.5 py-0.5`

**Backend**:
- Updated `FavoritesController` validation to accept `spec` as a valid favorite type
- Ensures mutual exclusivity between `agentId`, `model+endpoint`, and `spec`

**Data Provider**:
- Added `spec` field to `FavoriteItem` type
- Bump version to 0.8.211

### Change Type
- [x] Style
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Configure model specs in `librechat.yaml`
- [x] Hover over a model spec in the model selector and click the pin icon
- [x] Verify the spec appears in the sidebar favorites
- [x] Verify clicking a pinned spec selects it
- [x] Verify unpinning works via the dropdown menu
- [x] Verify drag-and-drop reordering works with mixed favorites (agents, models, specs)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.