### PR TITLE
🌙 fix: Agent Builder MCP Tool Removal Button Text Contrast

### DIFF
--- a/client/src/components/Tools/MCPToolItem.tsx
+++ b/client/src/components/Tools/MCPToolItem.tsx
@@ -38,8 +38,7 @@ function MCPToolItem({
       return {
         text: localize('com_nav_tool_remove'),
         icon: <XCircle className="flex h-4 w-4 items-center stroke-2" aria-hidden="true" />,
-        className:
-          'btn relative bg-gray-300 hover:bg-gray-400 dark:bg-gray-50 dark:hover:bg-gray-200',
+        className: 'btn btn-neutral border-token-border-light relative',
         disabled: false,
       };
     }


### PR DESCRIPTION
## Summary

This pull request makes a small UI update to the `MCPToolItem` component, specifically changing the styling of the remove button to use a more neutral appearance and consistent border styling.

- Updated the `className` for the remove button in `MCPToolItem` to use `btn-neutral` and `border-token-border-light` classes for improved visual consistency.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before
<img width="1382" height="956" alt="Screenshot 2026-01-05 at 11 26 31 PM" src="https://github.com/user-attachments/assets/c993ac86-80e4-45c2-9634-63eb46f3d117" />

### After
<img width="1382" height="956" alt="Screenshot 2026-01-05 at 11 30 40 PM" src="https://github.com/user-attachments/assets/60d452c6-6be4-45b2-9a02-722a04ce2e05" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes