### PR TITLE
🍪 refactor: Move OpenID Tokens from Cookies to Server-Side Sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -525,6 +525,8 @@ OPENID_ON_BEHALF_FLOW_FOR_USERINFO_REQUIRED=
 OPENID_ON_BEHALF_FLOW_USERINFO_SCOPE="user.read" # example for Scope Needed for Microsoft Graph API
 # Set to true to use the OpenID Connect end session endpoint for logout
 OPENID_USE_END_SESSION_ENDPOINT=
+# URL to redirect to after OpenID logout (defaults to ${DOMAIN_CLIENT}/login)
+OPENID_POST_LOGOUT_REDIRECT_URI=
 
 #========================#
 # SharePoint Integration #

--- a/api/cache/banViolation.js
+++ b/api/cache/banViolation.js
@@ -47,7 +47,15 @@ const banViolation = async (req, res, errorMessage) => {
   }
 
   await deleteAllUserSessions({ userId: user_id });
+
+  /** Clear OpenID session tokens if present */
+  if (req.session?.openidTokens) {
+    delete req.session.openidTokens;
+  }
+
   res.clearCookie('refreshToken');
+  res.clearCookie('openid_access_token');
+  res.clearCookie('token_provider');
 
   const banLogs = getLogStores(ViolationTypes.BAN);
   const duration = errorMessage.duration || banLogs.opts.ttl;

--- a/api/cache/banViolation.js
+++ b/api/cache/banViolation.js
@@ -55,6 +55,7 @@ const banViolation = async (req, res, errorMessage) => {
 
   res.clearCookie('refreshToken');
   res.clearCookie('openid_access_token');
+  res.clearCookie('openid_user_id');
   res.clearCookie('token_provider');
 
   const banLogs = getLogStores(ViolationTypes.BAN);

--- a/api/server/controllers/auth/LogoutController.js
+++ b/api/server/controllers/auth/LogoutController.js
@@ -39,7 +39,12 @@ const logoutController = async (req, res) => {
           ? openIdConfig.serverMetadata().end_session_endpoint
           : null;
         if (endSessionEndpoint) {
-          response.redirect = endSessionEndpoint;
+          const endSessionUrl = new URL(endSessionEndpoint);
+          /** Redirect back to app's login page after IdP logout */
+          const postLogoutRedirectUri =
+            process.env.OPENID_POST_LOGOUT_REDIRECT_URI || `${process.env.DOMAIN_CLIENT}/login`;
+          endSessionUrl.searchParams.set('post_logout_redirect_uri', postLogoutRedirectUri);
+          response.redirect = endSessionUrl.toString();
         } else {
           logger.warn(
             '[logoutController] end_session_endpoint not found in OpenID issuer metadata. Please verify that the issuer is correct.',

--- a/api/server/controllers/auth/LogoutController.js
+++ b/api/server/controllers/auth/LogoutController.js
@@ -6,7 +6,7 @@ const { getOpenIdConfig } = require('~/strategies');
 
 const logoutController = async (req, res) => {
   const parsedCookies = req.headers.cookie ? cookies.parse(req.headers.cookie) : {};
-  const isOpenIdUser = req.user?.openidId != null;
+  const isOpenIdUser = req.user?.openidId != null && req.user?.provider === 'openid';
 
   /** For OpenID users, read refresh token from session; for others, use cookie */
   let refreshToken;
@@ -25,7 +25,7 @@ const logoutController = async (req, res) => {
     res.clearCookie('token_provider');
     const response = { message };
     if (
-      req.user.openidId != null &&
+      isOpenIdUser &&
       isEnabled(process.env.OPENID_USE_END_SESSION_ENDPOINT) &&
       process.env.OPENID_ISSUER
     ) {

--- a/api/server/controllers/auth/LogoutController.js
+++ b/api/server/controllers/auth/LogoutController.js
@@ -22,6 +22,7 @@ const logoutController = async (req, res) => {
 
     res.clearCookie('refreshToken');
     res.clearCookie('openid_access_token');
+    res.clearCookie('openid_user_id');
     res.clearCookie('token_provider');
     const response = { message };
     if (

--- a/api/server/routes/oauth.js
+++ b/api/server/routes/oauth.js
@@ -42,7 +42,7 @@ const oauthHandler = async (req, res, next) => {
       isEnabled(process.env.OPENID_REUSE_TOKENS) === true
     ) {
       await syncUserEntraGroupMemberships(req.user, req.user.tokenset.access_token);
-      setOpenIDAuthTokens(req.user.tokenset, res, req.user._id.toString());
+      setOpenIDAuthTokens(req.user.tokenset, req, res, req.user._id.toString());
     } else {
       await setAuthTokens(req.user._id, res);
     }

--- a/api/strategies/openIdJwtStrategy.js
+++ b/api/strategies/openIdJwtStrategy.js
@@ -81,10 +81,18 @@ const openIdJwtLogin = (openIdConfig) => {
             await updateUser(user.id, updateData);
           }
 
-          const cookieHeader = req.headers.cookie;
-          const parsedCookies = cookieHeader ? cookies.parse(cookieHeader) : {};
-          const accessToken = parsedCookies.openid_access_token;
-          const refreshToken = parsedCookies.refreshToken;
+          /** Read tokens from session (server-side) to avoid large cookie issues */
+          const sessionTokens = req.session?.openidTokens;
+          let accessToken = sessionTokens?.accessToken;
+          let refreshToken = sessionTokens?.refreshToken;
+
+          /** Fallback to cookies for backward compatibility */
+          if (!accessToken || !refreshToken) {
+            const cookieHeader = req.headers.cookie;
+            const parsedCookies = cookieHeader ? cookies.parse(cookieHeader) : {};
+            accessToken = accessToken || parsedCookies.openid_access_token;
+            refreshToken = refreshToken || parsedCookies.refreshToken;
+          }
 
           user.federatedTokens = {
             access_token: accessToken || rawToken,


### PR DESCRIPTION
## Summary

I refactored OpenID token storage to use server-side sessions instead of cookies to address HTTP/2 header size limits, particularly for users with many group memberships.

- Store OpenID access and refresh tokens in `req.session.openidTokens` instead of cookies to avoid exceeding header size limits
- Add backward compatibility fallback to cookies when session is unavailable
- Update `refreshController` to read OpenID refresh tokens from session first, then cookies
- Update `LogoutController` to clear session tokens and all OpenID-related cookies (`openid_access_token`, `openid_user_id`, `token_provider`)
- Update `banViolation` to clear OpenID session tokens and cookies when banning users
- Update `openIdJwtStrategy` to read tokens from session with cookie fallback
- Update `validateImageRequest` to only require `refreshToken` for non-OpenID users
- Add `OPENID_POST_LOGOUT_REDIRECT_URI` environment variable for configurable post-logout redirect
- Append `post_logout_redirect_uri` parameter to OpenID end session endpoint URL

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested OpenID authentication flow with session-based token storage, verifying login, token refresh, image access, and logout functionality.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings