### PR TITLE
🔧 fix: Remove initialData field from useGetModelsQuery hook

### DIFF
--- a/packages/data-provider/src/react-query/react-query-service.ts
+++ b/packages/data-provider/src/react-query/react-query-service.ts
@@ -184,7 +184,6 @@ export const useGetModelsQuery = (
   config?: UseQueryOptions<t.TModelsConfig>,
 ): QueryObserverResult<t.TModelsConfig> => {
   return useQuery<t.TModelsConfig>([QueryKeys.models], () => dataService.getModels(), {
-    initialData: initialModelsConfig,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     refetchOnMount: false,


### PR DESCRIPTION
## Summary

This pull request makes a minor adjustment to the `useGetModelsQuery` hook in `react-query-service.ts` by removing the use of the `initialData` field. This change ensures that the hook no longer relies on potentially unfiltered initial data. As raised in #11252, the Agent Builder Model Selection List would sometimes show a list of models which would not respect model lists restrictions set in the env through variables like `ANTHROPIC_MODELS`, because the initialModelsConfig fed to initialData in the query hook would contain full lists, such as in `sharedAnthropicModels` from `config.ts`. 

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Was no longer able to reproduce unexpected model list behavior during light testing after change was implemented

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes