### PR TITLE
🔧 fix: Model List Query Data in Agent Builder Panel

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -217,7 +217,7 @@ export default function AgentPanel() {
 
   const { onSelect: onSelectAgent } = useSelectAgent();
 
-  const modelsQuery = useGetModelsQuery();
+  const modelsQuery = useGetModelsQuery({ refetchOnMount: 'always' });
   const basicAgentQuery = useGetAgentByIdQuery(current_agent_id);
 
   const { hasPermission, isLoading: permissionsLoading } = useResourcePermissions(

--- a/packages/data-provider/src/react-query/react-query-service.ts
+++ b/packages/data-provider/src/react-query/react-query-service.ts
@@ -184,7 +184,6 @@ export const useGetModelsQuery = (
   config?: UseQueryOptions<t.TModelsConfig>,
 ): QueryObserverResult<t.TModelsConfig> => {
   return useQuery<t.TModelsConfig>([QueryKeys.models], () => dataService.getModels(), {
-    initialData: initialModelsConfig,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     refetchOnMount: false,

--- a/packages/data-provider/src/react-query/react-query-service.ts
+++ b/packages/data-provider/src/react-query/react-query-service.ts
@@ -184,6 +184,7 @@ export const useGetModelsQuery = (
   config?: UseQueryOptions<t.TModelsConfig>,
 ): QueryObserverResult<t.TModelsConfig> => {
   return useQuery<t.TModelsConfig>([QueryKeys.models], () => dataService.getModels(), {
+    initialData: initialModelsConfig,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
     refetchOnMount: false,


### PR DESCRIPTION
Rework of #11253 

## Summary

This pull request makes a small update to the `AgentPanel` component to ensure that the list of models is always refreshed when the component is mounted.

* The `useGetModelsQuery` hook is now called with `{ refetchOnMount: 'always' }`, similarly to how it is called in `client/src/routes/ChatRoute.tsx`, to guarantee that model data is re-fetched every time the panel mounts, ensuring up-to-date information is displayed.

As raised in #11252, the Agent Builder Model Selection List would previously show a list of models which would not respect model lists restrictions set in the env through variables like `ANTHROPIC_MODELS`, because the initialModelsConfig fed to initialData in the query hook would contain full lists, such as in `sharedAnthropicModels` from `config.ts`, and be cached and served to the users when the cache was cleared with something like a hard refresh or when switching to the Agent Marketplace. 

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Was no longer able to reproduce unexpected model list behavior during light testing after change was implemented

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes