### PR TITLE
Support expiring files uploaded during temporary conversations

### DIFF
--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -39,8 +39,8 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   try {
     const appConfig = req.config;
-    const files = await getFiles({ user: req.user.id });
-    if (appConfig.fileStrategy === FileSources.s3) {
+    const files = await getFiles({ user: req.user.id, expiresAt: { $exists: false } });
+    if (appConfig?.fileStrategy === FileSources.s3) {
       try {
         const cache = getLogStores(CacheKeys.S3_EXPIRY_INTERVAL);
         const alreadyChecked = await cache.get(req.user.id);
@@ -376,6 +376,7 @@ router.post('/', async (req, res) => {
 
     metadata.temp_file_id = metadata.file_id;
     metadata.file_id = req.file_id;
+    metadata.temporary = metadata.temporary === 'true';
 
     if (isAssistantsEndpoint(metadata.endpoint)) {
       return await processFileUpload({ req, res, metadata });

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -169,6 +169,39 @@ describe('File Routes - Delete with Agent Access', () => {
     });
   });
 
+  describe('GET /files', () => {
+    it('should return files', async () => {
+      await createFile({
+        user: otherUserId,
+        file_id: new mongoose.Types.ObjectId(),
+        filename: 'user-file.txt',
+        filepath: '/uploads/user-file.txt',
+        bytes: 200,
+        type: 'text/plain',
+      });
+
+      const response = await request(app).get('/files');
+
+      expect(response.body.length).toBe(1);
+    });
+
+    it('should not return temporary files', async () => {
+      await createFile({
+        user: otherUserId,
+        file_id: new mongoose.Types.ObjectId(),
+        filename: 'user-file.txt',
+        filepath: '/uploads/user-file.txt',
+        bytes: 200,
+        type: 'text/plain',
+        expiresAt: new Date(),
+      });
+
+      const response = await request(app).get('/files');
+
+      expect(response.body.length).toBe(0);
+    });
+  });
+
   describe('DELETE /files', () => {
     it('should allow deleting files owned by the user', async () => {
       // Create a file owned by the current user

--- a/api/server/routes/files/images.js
+++ b/api/server/routes/files/images.js
@@ -20,6 +20,7 @@ router.post('/', async (req, res) => {
 
     metadata.temp_file_id = metadata.file_id;
     metadata.file_id = req.file_id;
+    metadata.temporary = metadata.temporary === 'true';
 
     if (!isAssistantsEndpoint(metadata.endpoint) && metadata.tool_resource != null) {
       return await processAgentFileUpload({ req, res, metadata });

--- a/api/server/services/Files/Azure/azure.spec.js
+++ b/api/server/services/Files/Azure/azure.spec.js
@@ -1,0 +1,171 @@
+const { v4 } = require('uuid');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { saveBufferToAzure, uploadFileToAzure } = require('~/server/services/Files/Azure/crud');
+const { getAzureContainerClient } = require('@librechat/api');
+const { uploadImageToAzure } = require('~/server/services/Files/Azure/images');
+
+jest.mock('@librechat/api', () => {
+  return {
+    ...jest.requireActual('@librechat/api'),
+    getAzureContainerClient: jest.fn(),
+  };
+});
+
+describe('Azure CDN', () => {
+  const mockGetAzureContainerClient = getAzureContainerClient;
+  const mockGetBlockBlobClient = jest.fn();
+
+  const fileName = 'test-file.png';
+  let tempDir;
+  let testFilePath;
+
+  beforeEach(async () => {
+    // Setup Azure mocks
+    jest.resetAllMocks();
+    mockGetBlockBlobClient.mockReturnValue({
+      uploadData: jest.fn(),
+      uploadStream: jest.fn(),
+      url: 'test-url',
+    });
+    mockGetAzureContainerClient.mockReturnValue({
+      createIfNotExists: async () => {},
+      getBlockBlobClient: mockGetBlockBlobClient,
+    });
+
+    // Create a test image file (we do this each time because sometimes file uploads
+    // delete the source file after upload)
+    const base64Data =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==';
+    const buffer = Buffer.from(base64Data, 'base64');
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jest-test-'));
+    testFilePath = path.join(tempDir, fileName);
+    await fs.promises.writeFile(testFilePath, buffer);
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test('uploadFileToAzure() default path', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = { user: { id: v4() } };
+    const file_id = v4();
+    const basePath = 'my_path';
+
+    await uploadFileToAzure({
+      req,
+      file,
+      file_id,
+      basePath,
+    });
+
+    const expectedPath = `${basePath}/${req.user.id}/${file_id}__${file.originalname}`;
+    expect(mockGetBlockBlobClient).toHaveBeenCalledWith(expectedPath);
+  });
+
+  test('uploadFileToAzure() path w/ `temporary` parameter', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = { user: { id: v4() } };
+    const file_id = v4();
+    const basePath = 'my_path';
+
+    await uploadFileToAzure({
+      req,
+      file,
+      file_id,
+      basePath,
+      temporary: true,
+    });
+
+    const expectedPath = `tmp/${basePath}/${req.user.id}/${file_id}__${file.originalname}`;
+    expect(mockGetBlockBlobClient).toHaveBeenCalledWith(expectedPath);
+  });
+
+  test('saveBufferToAzure() default path', async () => {
+    const userId = v4();
+    const buffer = 'test';
+    const basePath = 'my_path';
+
+    await saveBufferToAzure({
+      userId,
+      buffer,
+      fileName,
+      basePath,
+    });
+
+    const expectedPath = `${basePath}/${userId}/${fileName}`;
+    expect(mockGetBlockBlobClient).toHaveBeenCalledWith(expectedPath);
+  });
+
+  test('saveBufferToAzure() path w/ `temporary` parameter', async () => {
+    const userId = v4();
+    const buffer = 'test';
+    const basePath = 'my_path';
+    await saveBufferToAzure({
+      userId,
+      buffer,
+      fileName,
+      basePath,
+      temporary: true,
+    });
+    const expectedPath = `tmp/${basePath}/${userId}/${fileName}`;
+    expect(mockGetBlockBlobClient).toHaveBeenCalledWith(expectedPath);
+  });
+
+  test('uploadImageToAzure() default path', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = {
+      user: { id: v4() },
+      config: { imageOutputType: 'png' },
+    };
+    const file_id = v4();
+    const basePath = 'my_path';
+
+    await uploadImageToAzure({
+      req,
+      file,
+      file_id,
+      endpoint: 'custom',
+      basePath,
+    });
+
+    const expectedPath = `${basePath}/${req.user.id}/${file_id}__${file.originalname}`;
+    expect(mockGetBlockBlobClient).toHaveBeenCalledWith(expectedPath);
+  });
+
+  test('uploadImageToAzure() path w/ `temporary` parameter', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = {
+      user: { id: v4() },
+      config: { imageOutputType: 'png' },
+    };
+    const file_id = v4();
+    const basePath = 'my_path';
+
+    await uploadImageToAzure({
+      req,
+      file,
+      file_id,
+      endpoint: 'custom',
+      basePath,
+      temporary: true,
+    });
+
+    const expectedPath = `tmp/${basePath}/${req.user.id}/${file_id}__${file.originalname}`;
+    expect(mockGetBlockBlobClient).toHaveBeenCalledWith(expectedPath);
+  });
+});

--- a/api/server/services/Files/Azure/crud.js
+++ b/api/server/services/Files/Azure/crud.js
@@ -20,6 +20,7 @@ const { AZURE_STORAGE_PUBLIC_ACCESS = 'true', AZURE_CONTAINER_NAME = 'files' } =
  * @param {string} params.fileName - The name of the file.
  * @param {string} [params.basePath='images'] - The base folder within the container.
  * @param {string} [params.containerName] - The Azure Blob container name.
+ * @param {boolean} [params.temporary] - If true, this file should be marked as temporary.
  * @returns {Promise<string>} The URL of the uploaded blob.
  */
 async function saveBufferToAzure({
@@ -28,13 +29,14 @@ async function saveBufferToAzure({
   fileName,
   basePath = defaultBasePath,
   containerName,
+  temporary,
 }) {
   try {
     const containerClient = await getAzureContainerClient(containerName);
     const access = AZURE_STORAGE_PUBLIC_ACCESS?.toLowerCase() === 'true' ? 'blob' : undefined;
     // Create the container if it doesn't exist. This is done per operation.
     await containerClient.createIfNotExists({ access });
-    const blobPath = `${basePath}/${userId}/${fileName}`;
+    const blobPath = getBlobPath(basePath, userId, fileName, temporary);
     const blockBlobClient = containerClient.getBlockBlobClient(blobPath);
     await blockBlobClient.uploadData(buffer);
     return blockBlobClient.url;
@@ -85,7 +87,7 @@ async function saveURLToAzure({
 async function getAzureURL({ fileName, basePath = defaultBasePath, userId, containerName }) {
   try {
     const containerClient = await getAzureContainerClient(containerName);
-    const blobPath = userId ? `${basePath}/${userId}/${fileName}` : `${basePath}/${fileName}`;
+    const blobPath = getBlobPath(basePath, userId, fileName);
     const blockBlobClient = containerClient.getBlockBlobClient(blobPath);
     return blockBlobClient.url;
   } catch (error) {
@@ -132,6 +134,7 @@ async function deleteFileFromAzure(req, file) {
  * @param {string} params.fileName - The name of the file in Azure.
  * @param {string} [params.basePath='images'] - The base folder within the container.
  * @param {string} [params.containerName] - The Azure Blob container name.
+ * @param {boolean} [params.temporary] - If true, this file should be marked as temporary.
  * @returns {Promise<string>} The URL of the uploaded blob.
  */
 async function streamFileToAzure({
@@ -140,6 +143,7 @@ async function streamFileToAzure({
   fileName,
   basePath = defaultBasePath,
   containerName,
+  temporary,
 }) {
   try {
     const containerClient = await getAzureContainerClient(containerName);
@@ -148,7 +152,7 @@ async function streamFileToAzure({
     // Create the container if it doesn't exist
     await containerClient.createIfNotExists({ access });
 
-    const blobPath = `${basePath}/${userId}/${fileName}`;
+    const blobPath = getBlobPath(basePath, userId, fileName, temporary);
     const blockBlobClient = containerClient.getBlockBlobClient(blobPath);
 
     // Get file size for proper content length
@@ -193,6 +197,7 @@ async function streamFileToAzure({
  * @param {string} params.file_id - The file id.
  * @param {string} [params.basePath='images'] - The base folder within the container.
  * @param {string} [params.containerName] - The Azure Blob container name.
+ * @param {boolean} [params.temporary] - If true, this file should be marked as temporary.
  * @returns {Promise<{ filepath: string, bytes: number }>} An object containing the blob URL and its byte size.
  */
 async function uploadFileToAzure({
@@ -201,6 +206,7 @@ async function uploadFileToAzure({
   file_id,
   basePath = defaultBasePath,
   containerName,
+  temporary,
 }) {
   try {
     const inputFilePath = file.path;
@@ -215,6 +221,7 @@ async function uploadFileToAzure({
       fileName,
       basePath,
       containerName,
+      temporary,
     });
 
     return { filepath: fileURL, bytes };
@@ -243,6 +250,12 @@ async function getAzureFileStream(_req, fileURL) {
     logger.error('[getAzureFileStream] Error getting blob stream:', error);
     throw error;
   }
+}
+
+function getBlobPath(basePath, userId, fileName, temporary) {
+  const tempPath = temporary ? 'tmp/' : '';
+  const userIdPath = userId ? `${userId}/` : '';
+  return `${tempPath}${basePath}/${userIdPath}${fileName}`;
 }
 
 module.exports = {

--- a/api/server/services/Files/Azure/images.js
+++ b/api/server/services/Files/Azure/images.js
@@ -15,6 +15,7 @@ const { saveBufferToAzure } = require('./crud');
  * @param {Express.Multer.File} params.file - The file object.
  * @param {string} params.file_id - The file id.
  * @param {EModelEndpoint} params.endpoint - The endpoint parameters.
+ * @param {boolean} [params.temporary] - If true, this file should be marked as temporary.
  * @param {string} [params.resolution='high'] - The image resolution.
  * @param {string} [params.basePath='images'] - The base folder within the container.
  * @param {string} [params.containerName] - The Azure Blob container name.
@@ -25,6 +26,7 @@ async function uploadImageToAzure({
   file,
   file_id,
   endpoint,
+  temporary,
   resolution = 'high',
   basePath = 'images',
   containerName,
@@ -59,6 +61,7 @@ async function uploadImageToAzure({
       buffer: webPBuffer,
       fileName,
       basePath,
+      temporary,
       containerName,
     });
     await fs.promises.unlink(inputFilePath);

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -226,7 +226,7 @@ const processCodeOutput = async ({
       createdAt: isUpdate ? claimed.createdAt : formattedDate,
     };
 
-    await createFile(file, true);
+    await createFile(file);
     return Object.assign(file, { messageId, toolCallId });
   } catch (error) {
     logAxiosError({

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -403,7 +403,6 @@ describe('Code Process', () => {
             file_id: 'mock-uuid-1234',
             context: FileContext.execute_code,
           }),
-          true, // upsert flag
         );
       });
     });

--- a/api/server/services/Files/Firebase/crud.js
+++ b/api/server/services/Files/Firebase/crud.js
@@ -56,7 +56,7 @@ async function saveURLToFirebase({ userId, URL, fileName, basePath = 'images' })
     return null;
   }
 
-  const storageRef = ref(storage, `${basePath}/${userId.toString()}/${fileName}`);
+  const storageRef = ref(storage, getPath(basePath, userId, fileName));
   const response = await fetch(URL);
   const buffer = await response.buffer();
 
@@ -80,19 +80,20 @@ async function saveURLToFirebase({ userId, URL, fileName, basePath = 'images' })
  *                                   include the file extension.
  * @param {string} [params.basePath='images'] - Optional. The base basePath in Firebase Storage where the file is
  *                                          stored. Defaults to 'images' if not specified.
+ * @param {boolean} [params.temporary] - If true, the file is temporary.
  *
  * @returns {Promise<string|null>}
  *          A promise that resolves to the download URL of the file if successful, or null if there is an
  *          error in initialization or fetching the URL.
  */
-async function getFirebaseURL({ fileName, basePath = 'images' }) {
+async function getFirebaseURL({ fileName, basePath = 'images', temporary }) {
   const storage = getFirebaseStorage();
   if (!storage) {
     logger.error('Firebase is not initialized. Cannot get image URL from Firebase Storage.');
     return null;
   }
 
-  const storageRef = ref(storage, `${basePath}/${fileName}`);
+  const storageRef = ref(storage, `${temporary ? 'tmp/' : ''}${basePath}/${fileName}`);
 
   try {
     return await getDownloadURL(storageRef);
@@ -112,20 +113,21 @@ async function getFirebaseURL({ fileName, basePath = 'images' }) {
  * @param {string} params.buffer - The buffer to be uploaded.
  * @param {string} [params.basePath='images'] - Optional. The base basePath in Firebase Storage where the file will
  *                                          be stored. Defaults to 'images' if not specified.
+ * @param {boolean} [params.temporary] - If true, this file should be marked as temporary.
  *
  * @returns {Promise<string>} - A promise that resolves to the download URL of the uploaded file.
  */
-async function saveBufferToFirebase({ userId, buffer, fileName, basePath = 'images' }) {
+async function saveBufferToFirebase({ userId, buffer, fileName, basePath = 'images', temporary }) {
   const storage = getFirebaseStorage();
   if (!storage) {
     throw new Error('Firebase is not initialized');
   }
 
-  const storageRef = ref(storage, `${basePath}/${userId}/${fileName}`);
+  const storageRef = ref(storage, getPath(basePath, userId, fileName, temporary));
   await uploadBytes(storageRef, buffer);
 
   // Assuming you have a function to get the download URL
-  return await getFirebaseURL({ fileName, basePath: `${basePath}/${userId}` });
+  return await getFirebaseURL({ fileName, basePath: `${basePath}/${userId}`, temporary });
 }
 
 /**
@@ -193,20 +195,26 @@ const deleteFirebaseFile = async (req, file) => {
  * @param {Express.Multer.File} params.file - The file object, which is part of the request. The file object should
  *                                     have a `path` property that points to the location of the uploaded file.
  * @param {string} params.file_id - The file ID.
+ * @param {boolean} [params.temporary] - If true, this file should be marked as temporary.
  *
  * @returns {Promise<{ filepath: string, bytes: number }>}
  *          A promise that resolves to an object containing:
  *            - filepath: The download URL of the uploaded file.
  *            - bytes: The size of the uploaded file in bytes.
  */
-async function uploadFileToFirebase({ req, file, file_id }) {
+async function uploadFileToFirebase({ req, file, file_id, temporary }) {
   const inputFilePath = file.path;
   const inputBuffer = await fs.promises.readFile(inputFilePath);
   const bytes = Buffer.byteLength(inputBuffer);
   const userId = req.user.id;
   const fileName = `${file_id}__${path.basename(inputFilePath)}`;
   try {
-    const downloadURL = await saveBufferToFirebase({ userId, buffer: inputBuffer, fileName });
+    const downloadURL = await saveBufferToFirebase({
+      userId,
+      buffer: inputBuffer,
+      fileName,
+      temporary,
+    });
     return { filepath: downloadURL, bytes };
   } catch (err) {
     logger.error('[uploadFileToFirebase] Error saving file buffer to Firebase:', err);
@@ -249,6 +257,10 @@ async function getFirebaseFileStream(_req, filepath) {
     logger.error('Error getting Firebase file stream:', error);
     throw error;
   }
+}
+
+function getPath(basePath, userId, fileName, temporary) {
+  return `${temporary ? 'tmp/' : ''}${basePath}/${userId}/${fileName}`;
 }
 
 module.exports = {

--- a/api/server/services/Files/Firebase/firebase.spec.js
+++ b/api/server/services/Files/Firebase/firebase.spec.js
@@ -1,0 +1,193 @@
+const { v4 } = require('uuid');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const {
+  saveBufferToFirebase,
+  uploadFileToFirebase,
+} = require('~/server/services/Files/Firebase/crud');
+const { ref } = require('firebase/storage');
+const { uploadImageToFirebase } = require('~/server/services/Files/Firebase/images');
+
+jest.mock('firebase/app', () => ({
+  initializeApp: jest.fn().mockReturnValue({}),
+}));
+jest.mock('firebase/storage', () => ({
+  getStorage: jest.fn().mockReturnValue('mockStorage'),
+  uploadBytes: jest.fn(),
+  ref: jest.fn(),
+  getDownloadURL: jest.fn(),
+}));
+
+describe('Firebase CDN', () => {
+  let originalEnv;
+
+  let mockRef = ref;
+
+  const fileName = 'test-file.png';
+  let tempDir;
+  let testFilePath;
+
+  beforeAll(() => {
+    // Firebase init requires defining some env vars (that will go unused since we mock FB)
+    originalEnv = process.env;
+    process.env = {
+      ...originalEnv,
+      FIREBASE_API_KEY: 'test_api_key',
+      FIREBASE_AUTH_DOMAIN: 'test_auth_domain',
+      FIREBASE_PROJECT_ID: 'test_project_id',
+      FIREBASE_STORAGE_BUCKET: 'test_storage_bucket',
+      FIREBASE_MESSAGING_SENDER_ID: 'test_messaging_sender_id',
+      FIREBASE_APP_ID: 'test_app_id',
+    };
+  });
+
+  beforeEach(async () => {
+    // Setup Firebase mocks
+    mockRef.mockClear();
+
+    // Create a test image file (we do this each time because sometimes file uploads
+    // delete the source file after upload)
+    const base64Data =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==';
+    const buffer = Buffer.from(base64Data, 'base64');
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jest-test-'));
+    testFilePath = path.join(tempDir, fileName);
+    await fs.promises.writeFile(testFilePath, buffer);
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test('uploadFileToFirebase() default path', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = { user: { id: v4() } };
+    const file_id = v4();
+
+    await uploadFileToFirebase({
+      req,
+      file,
+      file_id,
+    });
+
+    const expectedPath = `images/${req.user.id}/${file_id}__${file.originalname}`;
+    expect(mockRef).toHaveBeenCalledTimes(2);
+    expect(mockRef).toHaveBeenNthCalledWith(1, 'mockStorage', expectedPath);
+    expect(mockRef).toHaveBeenNthCalledWith(2, 'mockStorage', expectedPath);
+  });
+
+  test('uploadFileToFirebase() path w/ `temporary` parameter', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = { user: { id: v4() } };
+    const file_id = v4();
+
+    await uploadFileToFirebase({
+      req,
+      file,
+      file_id,
+      temporary: true,
+    });
+
+    const expectedPath = `tmp/images/${req.user.id}/${file_id}__${file.originalname}`;
+    expect(mockRef).toHaveBeenCalledTimes(2);
+    expect(mockRef).toHaveBeenNthCalledWith(1, 'mockStorage', expectedPath);
+    expect(mockRef).toHaveBeenNthCalledWith(2, 'mockStorage', expectedPath);
+  });
+
+  test('saveBufferToFirebase() default path', async () => {
+    const userId = v4();
+    const buffer = 'test';
+    const basePath = 'my_path';
+
+    await saveBufferToFirebase({
+      userId,
+      buffer,
+      fileName,
+      basePath,
+    });
+
+    const expectedPath = `${basePath}/${userId}/${fileName}`;
+    expect(mockRef).toHaveBeenCalledTimes(2);
+    expect(mockRef).toHaveBeenNthCalledWith(1, 'mockStorage', expectedPath);
+    expect(mockRef).toHaveBeenNthCalledWith(2, 'mockStorage', expectedPath);
+  });
+
+  test('saveBufferToFirebase() path w/ `temporary` parameter', async () => {
+    const userId = v4();
+    const buffer = 'test';
+    const basePath = 'my_path';
+
+    await saveBufferToFirebase({
+      userId,
+      buffer,
+      fileName,
+      basePath,
+      temporary: true,
+    });
+
+    const expectedPath = `tmp/${basePath}/${userId}/${fileName}`;
+    expect(mockRef).toHaveBeenCalledTimes(2);
+    expect(mockRef).toHaveBeenNthCalledWith(1, 'mockStorage', expectedPath);
+    expect(mockRef).toHaveBeenNthCalledWith(2, 'mockStorage', expectedPath);
+  });
+
+  test('uploadImageToFirebase() default path', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = {
+      user: { id: v4() },
+      config: { imageOutputType: 'png' },
+    };
+    const file_id = v4();
+
+    await uploadImageToFirebase({
+      req,
+      file,
+      file_id,
+      endpoint: 'custom',
+    });
+
+    const expectedPath = `images/${req.user.id}/${file_id}__${file.originalname}`;
+    expect(mockRef).toHaveBeenCalledTimes(2);
+    expect(mockRef).toHaveBeenNthCalledWith(1, 'mockStorage', expectedPath);
+    expect(mockRef).toHaveBeenNthCalledWith(2, 'mockStorage', expectedPath);
+  });
+
+  test('uploadImageToFirebase() path w/ `temporary` parameter', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = {
+      user: { id: v4() },
+      config: { imageOutputType: 'png' },
+    };
+    const file_id = v4();
+
+    await uploadImageToFirebase({
+      req,
+      file,
+      file_id,
+      endpoint: 'custom',
+      temporary: true,
+    });
+
+    const expectedPath = `tmp/images/${req.user.id}/${file_id}__${file.originalname}`;
+    expect(mockRef).toHaveBeenCalledTimes(2);
+    expect(mockRef).toHaveBeenNthCalledWith(1, 'mockStorage', expectedPath);
+    expect(mockRef).toHaveBeenNthCalledWith(2, 'mockStorage', expectedPath);
+  });
+});

--- a/api/server/services/Files/Firebase/images.js
+++ b/api/server/services/Files/Firebase/images.js
@@ -15,6 +15,7 @@ const { saveBufferToFirebase } = require('./crud');
  * @param {Express.Multer.File} params.file - The file object, which is part of the request. The file object should
  *                                     have a `path` property that points to the location of the uploaded file.
  * @param {EModelEndpoint} params.endpoint - The params object.
+ * @param {boolean} [params.temporary] - If true, this file should be marked as temporary.
  * @param {string} [params.resolution='high'] - Optional. The desired resolution for the image resizing. Default is 'high'.
  *
  * @returns {Promise<{ filepath: string, bytes: number, width: number, height: number}>}
@@ -24,7 +25,14 @@ const { saveBufferToFirebase } = require('./crud');
  *            - width: The width of the converted image.
  *            - height: The height of the converted image.
  */
-async function uploadImageToFirebase({ req, file, file_id, endpoint, resolution = 'high' }) {
+async function uploadImageToFirebase({
+  req,
+  file,
+  file_id,
+  endpoint,
+  temporary,
+  resolution = 'high',
+}) {
   const appConfig = req.config;
   const inputFilePath = file.path;
   const inputBuffer = await fs.promises.readFile(inputFilePath);
@@ -51,7 +59,12 @@ async function uploadImageToFirebase({ req, file, file_id, endpoint, resolution 
     }
   }
 
-  const downloadURL = await saveBufferToFirebase({ userId, buffer: webPBuffer, fileName });
+  const downloadURL = await saveBufferToFirebase({
+    userId,
+    buffer: webPBuffer,
+    fileName,
+    temporary,
+  });
 
   await fs.promises.unlink(inputFilePath);
 

--- a/api/server/services/Files/Local/crud.js
+++ b/api/server/services/Files/Local/crud.js
@@ -61,9 +61,10 @@ const saveLocalImage = async (req, file, filename) => {
  * @param {string} params.fileName - The name of the file to be saved.
  * @param {string} [params.basePath='images'] - Optional. The base path where the file will be stored.
  *                                          Defaults to 'images' if not specified.
+ * @param {boolean} [params.temporary] - If true, this file should be marked as temporary.
  * @returns {Promise<string>} - A promise that resolves to the path of the saved file.
  */
-async function saveLocalBuffer({ userId, buffer, fileName, basePath = 'images' }) {
+async function saveLocalBuffer({ userId, buffer, fileName, basePath = 'images', temporary }) {
   try {
     const { publicPath, uploads } = paths;
 
@@ -71,8 +72,13 @@ async function saveLocalBuffer({ userId, buffer, fileName, basePath = 'images' }
      * For 'images': save to publicPath/images/userId (images are served statically)
      * For 'uploads': save to uploads/userId (files downloaded via API)
      * */
-    const directoryPath =
-      basePath === 'images' ? path.join(publicPath, basePath, userId) : path.join(uploads, userId);
+    let fileDir;
+    if (basePath === 'images') {
+      fileDir = temporary ? path.join(basePath, 'tmp', userId) : path.join(basePath, userId);
+    } else {
+      fileDir = temporary ? path.join('tmp', userId) : userId;
+    }
+    const directoryPath = path.join(basePath === 'images' ? publicPath : uploads, fileDir);
 
     if (!fs.existsSync(directoryPath)) {
       fs.mkdirSync(directoryPath, { recursive: true });
@@ -80,9 +86,7 @@ async function saveLocalBuffer({ userId, buffer, fileName, basePath = 'images' }
 
     fs.writeFileSync(path.join(directoryPath, fileName), buffer);
 
-    const filePath = path.posix.join('/', basePath, userId, fileName);
-
-    return filePath;
+    return path.posix.join('/', fileDir, fileName);
   } catch (error) {
     logger.error('[saveLocalBuffer] Error while saving the buffer:', error);
     throw error;
@@ -257,20 +261,23 @@ const deleteLocalFile = async (req, file) => {
  * @param {Express.Multer.File} params.file - The file object, which is part of the request. The file object should
  *                                     have a `path` property that points to the location of the uploaded file.
  * @param {string} params.file_id - The file ID.
+ * @param {boolean} [params.temporary] - If true, this file should be marked as temporary.
  *
  * @returns {Promise<{ filepath: string, bytes: number }>}
  *          A promise that resolves to an object containing:
  *            - filepath: The path where the file is saved.
  *            - bytes: The size of the file in bytes.
  */
-async function uploadLocalFile({ req, file, file_id }) {
+async function uploadLocalFile({ req, file, file_id, temporary }) {
   const appConfig = req.config;
   const inputFilePath = file.path;
   const inputBuffer = await fs.promises.readFile(inputFilePath);
   const bytes = Buffer.byteLength(inputBuffer);
 
   const { uploads } = appConfig.paths;
-  const userPath = path.join(uploads, req.user.id);
+  let userPath = temporary
+    ? path.join(uploads, 'tmp', req.user.id)
+    : path.join(uploads, req.user.id);
 
   if (!fs.existsSync(userPath)) {
     fs.mkdirSync(userPath, { recursive: true });

--- a/api/server/services/Files/Local/local.spec.js
+++ b/api/server/services/Files/Local/local.spec.js
@@ -1,0 +1,226 @@
+const { v4 } = require('uuid');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { saveLocalBuffer, uploadLocalFile } = require('~/server/services/Files/Local/crud');
+const paths = require('~/config/paths');
+const { uploadLocalImage } = require('~/server/services/Files/Local/images');
+
+describe('Local files', () => {
+  const fileName = 'librechat-test-file.png';
+  let tempDir;
+  let testFilePath;
+  const userId = 'librechat-test';
+  const basePath = 'test-base-path';
+
+  beforeEach(async () => {
+    // Create a test image file (we do this each time because sometimes file uploads
+    // delete the source file after upload)
+    const base64Data =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==';
+    const buffer = Buffer.from(base64Data, 'base64');
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jest-test-'));
+    testFilePath = path.join(tempDir, fileName);
+    await fs.promises.writeFile(testFilePath, buffer);
+  });
+
+  afterEach(async () => {
+    // Clear out any directories possibly created by these tests
+    const opts = { recursive: true, force: true };
+    await Promise.all([
+      fs.promises.rm(tempDir, opts),
+      fs.promises.rm(path.posix.join(paths.imageOutput, userId), opts),
+      fs.promises.rm(path.posix.join(paths.imageOutput, 'tmp'), opts),
+      fs.promises.rm(path.posix.join(paths.uploads, basePath), opts),
+      fs.promises.rm(path.posix.join(paths.uploads, 'tmp'), opts),
+    ]);
+  });
+
+  test('uploadLocalFile() default path', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = {
+      config: {
+        paths: {
+          uploads: path.posix.join(paths.uploads, basePath),
+        },
+      },
+      user: { id: userId },
+    };
+    const file_id = v4();
+
+    const { filepath } = await uploadLocalFile({
+      req,
+      file,
+      file_id,
+    });
+    expect(filepath).toEqual(path.posix.join('/', 'uploads', userId, `${file_id}__${fileName}`));
+
+    const expectedPath = path.posix.join(
+      paths.uploads,
+      basePath,
+      userId,
+      `${file_id}__${fileName}`,
+    );
+    expect(fs.existsSync(expectedPath)).toEqual(true);
+  });
+
+  test('uploadLocalFile() path w/ `temporary` parameter', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = {
+      config: {
+        paths: {
+          uploads: path.posix.join(paths.uploads, basePath),
+        },
+      },
+      user: { id: userId },
+    };
+    const file_id = v4();
+
+    const { filepath } = await uploadLocalFile({
+      req,
+      file,
+      file_id,
+      temporary: true,
+    });
+    expect(filepath).toEqual(path.posix.join('/', 'uploads', userId, `${file_id}__${fileName}`));
+
+    const expectedPath = path.posix.join(
+      paths.uploads,
+      basePath,
+      'tmp',
+      userId,
+      `${file_id}__${fileName}`,
+    );
+    expect(fs.existsSync(expectedPath)).toEqual(true);
+  });
+
+  test('saveLocalBuffer() default path', async () => {
+    const buffer = 'test';
+
+    const filePath = await saveLocalBuffer({
+      userId,
+      buffer,
+      fileName,
+    });
+    expect(filePath).toEqual(path.posix.join('/', 'images', userId, fileName));
+
+    const expectedPath = path.posix.join(paths.publicPath, 'images', userId, fileName);
+    expect(fs.existsSync(expectedPath)).toEqual(true);
+  });
+
+  test('saveLocalBuffer() path w/ `temporary` parameter', async () => {
+    const buffer = 'test';
+
+    const filePath = await saveLocalBuffer({
+      userId,
+      buffer,
+      fileName,
+      temporary: true,
+    });
+    expect(filePath).toEqual(path.posix.join('/', 'images', 'tmp', userId, fileName));
+
+    const expectedPath = path.posix.join(paths.publicPath, 'images', 'tmp', userId, fileName);
+    expect(fs.existsSync(expectedPath)).toEqual(true);
+  });
+
+  test('saveLocalBuffer() path w/ `basePath` parameter', async () => {
+    const buffer = 'test';
+
+    const filePath = await saveLocalBuffer({
+      userId,
+      buffer,
+      fileName,
+      basePath,
+    });
+    expect(filePath).toEqual(path.posix.join('/', userId, fileName));
+
+    const expectedPath = path.posix.join(paths.uploads, userId, fileName);
+    expect(fs.existsSync(expectedPath)).toEqual(true);
+  });
+
+  test('saveLocalBuffer() path w/ `basePath` & `temporary` parameters', async () => {
+    const buffer = 'test';
+
+    const filePath = await saveLocalBuffer({
+      userId,
+      buffer,
+      fileName,
+      basePath,
+      temporary: true,
+    });
+    expect(filePath).toEqual(path.posix.join('/', 'tmp', userId, fileName));
+
+    const expectedPath = path.posix.join(paths.uploads, 'tmp', userId, fileName);
+    expect(fs.existsSync(expectedPath)).toEqual(true);
+  });
+
+  test('uploadLocalImage() default path', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = {
+      config: {
+        paths: {
+          imageOutput: paths.imageOutput,
+        },
+        imageOutputType: 'png',
+      },
+      user: { id: userId },
+    };
+    const file_id = v4();
+
+    const { filepath } = await uploadLocalImage({
+      req,
+      file,
+      file_id,
+      endpoint: 'custom',
+    });
+    expect(filepath).toEqual(path.posix.join('/', 'images', userId, `${file_id}__${fileName}`));
+
+    const expectedPath = path.posix.join(paths.imageOutput, userId, `${file_id}__${fileName}`);
+    expect(fs.existsSync(expectedPath)).toEqual(true);
+  });
+
+  test('uploadLocalImage() w/ `temporary` parameter', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = {
+      config: {
+        paths: {
+          imageOutput: paths.imageOutput,
+        },
+        imageOutputType: 'png',
+      },
+      user: { id: userId },
+    };
+    const file_id = v4();
+
+    const { filepath } = await uploadLocalImage({
+      req,
+      file,
+      file_id,
+      endpoint: 'custom',
+      temporary: true,
+    });
+    expect(filepath).toEqual(
+      path.posix.join('/', 'images', 'tmp', userId, `${file_id}__${fileName}`),
+    );
+
+    const expectedPath = path.posix.join(
+      paths.imageOutput,
+      'tmp',
+      userId,
+      `${file_id}__${fileName}`,
+    );
+    expect(fs.existsSync(expectedPath)).toEqual(true);
+  });
+});

--- a/api/server/services/Files/S3/crud.js
+++ b/api/server/services/Files/S3/crud.js
@@ -47,7 +47,9 @@ if (process.env.S3_REFRESH_EXPIRY_MS !== null && process.env.S3_REFRESH_EXPIRY_M
 /**
  * Constructs the S3 key based on the base path, user ID, and file name.
  */
-const getS3Key = (basePath, userId, fileName) => `${basePath}/${userId}/${fileName}`;
+const getS3Key = (basePath, userId, fileName, temporary) => {
+  return `${temporary ? 'tmp/' : ''}${basePath}/${userId}/${fileName}`;
+};
 
 /**
  * Uploads a buffer to S3 and returns a signed URL.
@@ -57,16 +59,17 @@ const getS3Key = (basePath, userId, fileName) => `${basePath}/${userId}/${fileNa
  * @param {Buffer} params.buffer - The buffer containing file data.
  * @param {string} params.fileName - The file name to use in S3.
  * @param {string} [params.basePath='images'] - The base path in the bucket.
+ * @param {boolean} [params.temporary] - If true, this file should be marked as temporary.
  * @returns {Promise<string>} Signed URL of the uploaded file.
  */
-async function saveBufferToS3({ userId, buffer, fileName, basePath = defaultBasePath }) {
-  const key = getS3Key(basePath, userId, fileName);
+async function saveBufferToS3({ userId, buffer, fileName, basePath = defaultBasePath, temporary }) {
+  const key = getS3Key(basePath, userId, fileName, temporary);
   const params = { Bucket: bucketName, Key: key, Body: buffer };
 
   try {
     const s3 = initializeS3();
     await s3.send(new PutObjectCommand(params));
-    return await getS3URL({ userId, fileName, basePath });
+    return await getS3URL({ userId, fileName, basePath, temporary });
   } catch (error) {
     logger.error('[saveBufferToS3] Error uploading buffer to S3:', error.message);
     throw error;
@@ -83,6 +86,7 @@ async function saveBufferToS3({ userId, buffer, fileName, basePath = defaultBase
  * @param {string} [params.basePath='images'] - The base path in the bucket.
  * @param {string} [params.customFilename] - Custom filename for Content-Disposition header (overrides extracted filename).
  * @param {string} [params.contentType] - Custom content type for the response.
+ * @param {boolean} [params.temporary] - If true, the file is temporary.
  * @returns {Promise<string>} A URL to access the S3 object
  */
 async function getS3URL({
@@ -91,8 +95,9 @@ async function getS3URL({
   basePath = defaultBasePath,
   customFilename = null,
   contentType = null,
+  temporary = false,
 }) {
-  const key = getS3Key(basePath, userId, fileName);
+  const key = getS3Key(basePath, userId, fileName, temporary);
   const params = { Bucket: bucketName, Key: key };
 
   // Add response headers if specified
@@ -202,14 +207,15 @@ async function deleteFileFromS3(req, file) {
  * @param {Express.Multer.File} params.file - The file object from Multer.
  * @param {string} params.file_id - Unique file identifier.
  * @param {string} [params.basePath='images'] - The base path in the bucket.
+ * @param {boolean} [params.temporary] - If true, this file should be marked as temporary.
  * @returns {Promise<{ filepath: string, bytes: number }>}
  */
-async function uploadFileToS3({ req, file, file_id, basePath = defaultBasePath }) {
+async function uploadFileToS3({ req, file, file_id, basePath = defaultBasePath, temporary }) {
   try {
     const inputFilePath = file.path;
     const userId = req.user.id;
     const fileName = `${file_id}__${file.originalname}`;
-    const key = getS3Key(basePath, userId, fileName);
+    const key = getS3Key(basePath, userId, fileName, temporary);
 
     const stats = await fs.promises.stat(inputFilePath);
     const bytes = stats.size;
@@ -223,7 +229,7 @@ async function uploadFileToS3({ req, file, file_id, basePath = defaultBasePath }
     };
 
     await s3.send(new PutObjectCommand(uploadParams));
-    const fileURL = await getS3URL({ userId, fileName, basePath });
+    const fileURL = await getS3URL({ userId, fileName, basePath, temporary });
     return { filepath: fileURL, bytes };
   } catch (error) {
     logger.error('[uploadFileToS3] Error streaming file to S3:', error);

--- a/api/server/services/Files/S3/images.js
+++ b/api/server/services/Files/S3/images.js
@@ -16,6 +16,7 @@ const defaultBasePath = 'images';
  * @param {Express.Multer.File} params.file - File object from Multer.
  * @param {string} params.file_id - Unique file identifier.
  * @param {any} params.endpoint - Endpoint identifier used in image processing.
+ * @param {boolean} [params.temporary] - If true, this file should be marked as temporary.
  * @param {string} [params.resolution='high'] - Desired image resolution.
  * @param {string} [params.basePath='images'] - Base path in the bucket.
  * @returns {Promise<{ filepath: string, bytes: number, width: number, height: number }>}
@@ -25,6 +26,7 @@ async function uploadImageToS3({
   file,
   file_id,
   endpoint,
+  temporary,
   resolution = 'high',
   basePath = defaultBasePath,
 }) {
@@ -59,6 +61,7 @@ async function uploadImageToS3({
       buffer: processedBuffer,
       fileName,
       basePath,
+      temporary,
     });
     await fs.promises.unlink(inputFilePath);
     const bytes = Buffer.byteLength(processedBuffer);

--- a/api/server/services/Files/S3/s3.spec.js
+++ b/api/server/services/Files/S3/s3.spec.js
@@ -1,0 +1,209 @@
+const { uploadFileToS3, saveBufferToS3 } = require('~/server/services/Files/S3/crud');
+const { v4 } = require('uuid');
+const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { uploadImageToS3 } = require('~/server/services/Files/S3/images');
+
+jest.mock('@aws-sdk/client-s3');
+jest.mock('@aws-sdk/s3-request-presigner');
+
+describe('S3 CDN', () => {
+  let previousAwsRegion;
+  const mockSend = jest.fn();
+  const fileName = 'test-file.png';
+  let tempDir;
+  let testFilePath;
+
+  beforeAll(() => {
+    // S3 init requires defining a region
+    previousAwsRegion = process.env.AWS_REGION;
+    process.env.AWS_REGION = 'fake-region';
+  });
+
+  beforeEach(async () => {
+    // Setup S3 mocks
+    mockSend.mockClear();
+    S3Client.mockImplementation(() => ({ send: mockSend }));
+    PutObjectCommand.mockImplementation((input) => ({ input }));
+
+    // Create a test image file (we do this each time because sometimes file uploads
+    // delete the source file after upload)
+    const base64Data =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==';
+    const buffer = Buffer.from(base64Data, 'base64');
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jest-test-'));
+    testFilePath = path.join(tempDir, fileName);
+    await fs.promises.writeFile(testFilePath, buffer);
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    process.env.AWS_REGION = previousAwsRegion;
+  });
+
+  test('uploadFileToS3() default key', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = { user: { id: v4() } };
+    const file_id = v4();
+    const basePath = 'my_path';
+
+    await uploadFileToS3({
+      req,
+      file,
+      file_id,
+      basePath,
+    });
+
+    const expectedKey = `${basePath}/${req.user.id}/${file_id}__${file.originalname}`;
+    expect(mockSend).toHaveBeenCalledWith(
+      new PutObjectCommand(
+        expect.objectContaining({
+          Key: expectedKey,
+        }),
+      ),
+    );
+  });
+
+  test('uploadFileToS3() key w/ `temporary` parameter', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = { user: { id: v4() } };
+    const file_id = v4();
+    const basePath = 'my_path';
+
+    await uploadFileToS3({
+      req,
+      file,
+      file_id,
+      basePath,
+      temporary: true,
+    });
+
+    const expectedKey = `tmp/${basePath}/${req.user.id}/${file_id}__${file.originalname}`;
+    expect(mockSend).toHaveBeenCalledWith(
+      new PutObjectCommand(
+        expect.objectContaining({
+          Key: expectedKey,
+        }),
+      ),
+    );
+  });
+
+  test('saveBufferToS3() default key', async () => {
+    const userId = v4();
+    const buffer = 'test';
+    const basePath = 'my_path';
+
+    await saveBufferToS3({
+      userId,
+      buffer,
+      fileName,
+      basePath,
+    });
+
+    const expectedKey = `${basePath}/${userId}/${fileName}`;
+    expect(mockSend).toHaveBeenCalledWith(
+      new PutObjectCommand(
+        expect.objectContaining({
+          Key: expectedKey,
+        }),
+      ),
+    );
+  });
+
+  test('saveBufferToS3() key w/ `temporary` parameter', async () => {
+    const userId = v4();
+    const buffer = 'test';
+    const basePath = 'my_path';
+
+    await saveBufferToS3({
+      userId,
+      buffer,
+      fileName,
+      basePath,
+      temporary: true,
+    });
+
+    const expectedKey = `tmp/${basePath}/${userId}/${fileName}`;
+    expect(mockSend).toHaveBeenCalledWith(
+      new PutObjectCommand(
+        expect.objectContaining({
+          Key: expectedKey,
+        }),
+      ),
+    );
+  });
+
+  test('uploadImageToS3() default key', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = {
+      user: { id: v4() },
+      config: { imageOutputType: 'png' },
+    };
+    const file_id = v4();
+    const basePath = 'my_path';
+
+    await uploadImageToS3({
+      req,
+      file,
+      file_id,
+      endpoint: 'custom',
+      basePath,
+    });
+
+    const expectedKey = `${basePath}/${req.user.id}/${file_id}__${file.originalname}`;
+    expect(mockSend).toHaveBeenCalledWith(
+      new PutObjectCommand(
+        expect.objectContaining({
+          Key: expectedKey,
+        }),
+      ),
+    );
+  });
+
+  test('uploadImageToS3() key w/ `temporary` parameter', async () => {
+    const file = {
+      path: testFilePath,
+      originalname: fileName,
+    };
+    const req = {
+      user: { id: v4() },
+      config: {
+        imageOutputType: 'png',
+      },
+    };
+    const file_id = v4();
+    const basePath = 'my_path';
+
+    await uploadImageToS3({
+      req,
+      file,
+      file_id,
+      endpoint: 'custom',
+      basePath,
+      temporary: true,
+    });
+
+    const expectedKey = `tmp/${basePath}/${req.user.id}/${file_id}__${file.originalname}`;
+    expect(mockSend).toHaveBeenCalledWith(
+      new PutObjectCommand(
+        expect.objectContaining({
+          Key: expectedKey,
+        }),
+      ),
+    );
+  });
+});

--- a/api/server/services/Files/process-temp-files.spec.js
+++ b/api/server/services/Files/process-temp-files.spec.js
@@ -1,0 +1,120 @@
+const { processImageFile, processFileUpload } = require('~/server/services/Files/process');
+const { getStrategyFunctions } = require('~/server/services/Files/strategies');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const { File } = require('~/db/models');
+
+jest.mock('~/server/services/Files/strategies', () => {
+  return { getStrategyFunctions: jest.fn() };
+});
+
+describe('File Process', () => {
+  let mongoServer;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+    await mongoose.connect(mongoUri);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  test('processImageFile() handles temporary files', async () => {
+    const now = new Date();
+
+    const mockHandleImageUpload = jest.fn().mockReturnValue({
+      filepath: 'ignore',
+      bytes: 1,
+      width: 1,
+      height: 1,
+    });
+    getStrategyFunctions.mockImplementation(() => {
+      return { handleImageUpload: mockHandleImageUpload };
+    });
+
+    // Fake an image file upload request
+    const file = { originalname: 'test.txt' };
+    const file_id = new mongoose.Types.ObjectId();
+    const endpoint = 'the_endpoint';
+    const temporary = true;
+    const req = {
+      file,
+      config: {},
+      user: { id: new mongoose.Types.ObjectId() },
+    };
+    const res = { status: jest.fn().mockReturnValue({ json: jest.fn() }) };
+    const metadata = {
+      file_id,
+      temp_file_id: new mongoose.Types.ObjectId(),
+      endpoint,
+      temporary,
+    };
+
+    await processImageFile({ req, res, metadata });
+
+    // Verify that handleImageUpload() called w/ temporary metadata
+    expect(mockHandleImageUpload).toHaveBeenCalledWith({
+      req,
+      file,
+      file_id,
+      endpoint,
+      temporary,
+    });
+
+    // Verify that MongoDB File has expiresAt set (and is after now)
+    const dbFile = await File.findOne({ file_id });
+    expect(dbFile.expiresAt).not.toBeNull();
+    expect(dbFile.expiresAt - now).toBeGreaterThan(0);
+  });
+
+  test('processFileUpload() handles temporary files', async () => {
+    const now = new Date();
+
+    const mockHandleFileUpload = jest.fn().mockReturnValue({
+      filepath: 'ignore',
+      bytes: 1,
+    });
+    getStrategyFunctions.mockImplementation(() => {
+      return { handleFileUpload: mockHandleFileUpload };
+    });
+
+    // Fake a file upload request
+    const file = { originalname: 'test.txt' };
+    const file_id = new mongoose.Types.ObjectId();
+    const temporary = true;
+    const req = {
+      file,
+      config: {},
+      user: { id: new mongoose.Types.ObjectId() },
+    };
+    const res = { status: jest.fn().mockReturnValue({ json: jest.fn() }) };
+    const metadata = {
+      file_id,
+      temp_file_id: new mongoose.Types.ObjectId(),
+      temporary,
+    };
+
+    await processFileUpload({ req, res, metadata });
+
+    // Verify that handleFileUpload() called w/ temporary metadata
+    expect(mockHandleFileUpload).toHaveBeenCalledWith({
+      req,
+      file,
+      file_id,
+      openai: undefined,
+      temporary,
+    });
+
+    // Verify that MongoDB File has expiresAt set (and is after now)
+    const dbFile = await File.findOne({ file_id });
+    expect(dbFile.expiresAt).not.toBeNull();
+    expect(dbFile.expiresAt - now).toBeGreaterThan(0);
+  });
+});

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -251,21 +251,18 @@ const processFileURL = async ({ fileStrategy, userId, URL, fileName, basePath, c
       dimensions = {},
     } = (await saveURL({ userId, URL, fileName, basePath })) || {};
     const filepath = await getFileURL({ fileName: `${userId}/${fileName}`, basePath });
-    return await createFile(
-      {
-        user: userId,
-        file_id: v4(),
-        bytes,
-        filepath,
-        filename: fileName,
-        source: fileStrategy,
-        type,
-        context,
-        width: dimensions.width,
-        height: dimensions.height,
-      },
-      true,
-    );
+    return await createFile({
+      user: userId,
+      file_id: v4(),
+      bytes,
+      filepath,
+      filename: fileName,
+      source: fileStrategy,
+      type,
+      context,
+      width: dimensions.width,
+      height: dimensions.height,
+    });
   } catch (error) {
     logger.error(`Error while processing the image with ${fileStrategy}:`, error);
     throw new Error(`Failed to process the image with ${fileStrategy}. ${error.message}`);
@@ -297,22 +294,19 @@ const processImageFile = async ({ req, res, metadata, returnFile = false }) => {
     endpoint,
   });
 
-  const result = await createFile(
-    {
-      user: req.user.id,
-      file_id,
-      temp_file_id,
-      bytes,
-      filepath,
-      filename: file.originalname,
-      context: FileContext.message_attachment,
-      source,
-      type: `image/${appConfig.imageOutputType}`,
-      width,
-      height,
-    },
-    true,
-  );
+  const result = await createFile({
+    user: req.user.id,
+    file_id,
+    temp_file_id,
+    bytes,
+    filepath,
+    filename: file.originalname,
+    context: FileContext.message_attachment,
+    source,
+    type: `image/${appConfig.imageOutputType}`,
+    width,
+    height,
+  });
 
   if (returnFile) {
     return result;
@@ -349,21 +343,18 @@ const uploadImageBuffer = async ({ req, context, metadata = {}, resize = true })
   }
   const fileName = `${file_id}-${filename}`;
   const filepath = await saveBuffer({ userId: req.user.id, fileName, buffer });
-  return await createFile(
-    {
-      user: req.user.id,
-      file_id,
-      bytes,
-      filepath,
-      filename,
-      context,
-      source,
-      type,
-      width,
-      height,
-    },
-    true,
-  );
+  return await createFile({
+    user: req.user.id,
+    file_id,
+    bytes,
+    filepath,
+    filename,
+    context,
+    source,
+    type,
+    width,
+    height,
+  });
 };
 
 /**
@@ -435,24 +426,21 @@ const processFileUpload = async ({ req, res, metadata }) => {
     filepath = result.filepath;
   }
 
-  const result = await createFile(
-    {
-      user: req.user.id,
-      file_id: id ?? file_id,
-      temp_file_id,
-      bytes,
-      filepath,
-      filename: filename ?? sanitizeFilename(file.originalname),
-      context: isAssistantUpload ? FileContext.assistants : FileContext.message_attachment,
-      model: isAssistantUpload ? req.body.model : undefined,
-      type: file.mimetype,
-      embedded,
-      source,
-      height,
-      width,
-    },
-    true,
-  );
+  const result = await createFile({
+    user: req.user.id,
+    file_id: id ?? file_id,
+    temp_file_id,
+    bytes,
+    filepath,
+    filename: filename ?? sanitizeFilename(file.originalname),
+    context: isAssistantUpload ? FileContext.assistants : FileContext.message_attachment,
+    model: isAssistantUpload ? req.body.model : undefined,
+    type: file.mimetype,
+    embedded,
+    source,
+    height,
+    width,
+  });
   res.status(200).json({ message: 'File uploaded and processed successfully', ...result });
 };
 
@@ -552,7 +540,7 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
           tool_resource,
         });
       }
-      const result = await createFile(fileInfo, true);
+      const result = await createFile(fileInfo);
       return res
         .status(200)
         .json({ message: 'Agent file uploaded and processed successfully', ...result });
@@ -720,7 +708,7 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
     width,
   });
 
-  const result = await createFile(fileInfo, true);
+  const result = await createFile(fileInfo);
 
   res.status(200).json({ message: 'Agent file uploaded and processed successfully', ...result });
 };
@@ -766,7 +754,7 @@ const processOpenAIFile = async ({
   };
 
   if (saveFile) {
-    await createFile(file, true);
+    await createFile(file);
   } else if (updateUsage) {
     try {
       await updateFileUsage({ file_id });
@@ -807,7 +795,7 @@ const processOpenAIImageOutput = async ({ req, buffer, file_id, filename, fileEx
     file_id,
     filename,
   };
-  createFile(file, true);
+  createFile(file);
   return file;
 };
 
@@ -951,21 +939,18 @@ async function saveBase64Image(
     fileName: filename,
     buffer: image.buffer,
   });
-  return await createFile(
-    {
-      type,
-      source,
-      context,
-      file_id,
-      filepath,
-      filename,
-      user: req.user.id,
-      bytes: image.bytes,
-      width: image.width,
-      height: image.height,
-    },
-    true,
-  );
+  return await createFile({
+    type,
+    source,
+    context,
+    file_id,
+    filepath,
+    filename,
+    user: req.user.id,
+    bytes: image.bytes,
+    width: image.width,
+    height: image.height,
+  });
 }
 
 /**

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -20,7 +20,12 @@ const {
 } = require('librechat-data-provider');
 const { EnvVar } = require('@librechat/agents');
 const { logger } = require('@librechat/data-schemas');
-const { sanitizeFilename, parseText, processAudioFile } = require('@librechat/api');
+const {
+  sanitizeFilename,
+  parseText,
+  processAudioFile,
+  createTempChatExpirationDate,
+} = require('@librechat/api');
 const {
   convertImage,
   resizeAndConvert,
@@ -285,13 +290,14 @@ const processImageFile = async ({ req, res, metadata, returnFile = false }) => {
   const appConfig = req.config;
   const source = getFileStrategy(appConfig, { isImage: true });
   const { handleImageUpload } = getStrategyFunctions(source);
-  const { file_id, temp_file_id, endpoint } = metadata;
+  const { file_id, temp_file_id, endpoint, temporary } = metadata;
 
   const { filepath, bytes, width, height } = await handleImageUpload({
     req,
     file,
     file_id,
     endpoint,
+    temporary,
   });
 
   const result = await createFile({
@@ -306,6 +312,7 @@ const processImageFile = async ({ req, res, metadata, returnFile = false }) => {
     type: `image/${appConfig.imageOutputType}`,
     width,
     height,
+    expiresAt: getExpiresAt(appConfig, temporary),
   });
 
   if (returnFile) {
@@ -376,7 +383,7 @@ const processFileUpload = async ({ req, res, metadata }) => {
   // Use the configured file strategy for regular file uploads (not vectordb)
   const source = isAssistantUpload ? assistantSource : appConfig.fileStrategy;
   const { handleFileUpload } = getStrategyFunctions(source);
-  const { file_id, temp_file_id = null } = metadata;
+  const { file_id, temp_file_id = null, temporary } = metadata;
 
   /** @type {OpenAI | undefined} */
   let openai;
@@ -399,6 +406,7 @@ const processFileUpload = async ({ req, res, metadata }) => {
     file,
     file_id,
     openai,
+    temporary,
   });
 
   if (isAssistantUpload && !metadata.message_file && !metadata.tool_resource) {
@@ -440,6 +448,7 @@ const processFileUpload = async ({ req, res, metadata }) => {
     source,
     height,
     width,
+    expiresAt: getExpiresAt(appConfig, temporary),
   });
   res.status(200).json({ message: 'File uploaded and processed successfully', ...result });
 };
@@ -1029,6 +1038,10 @@ function filterFile({ req, image, isAvatar }) {
   if (!height) {
     throw new Error('No height provided');
   }
+}
+
+function getExpiresAt(appConfig, temporary) {
+  return temporary ? createTempChatExpirationDate(appConfig?.interfaceConfig) : undefined;
 }
 
 module.exports = {

--- a/client/src/components/Chat/Input/Files/AttachFile.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFile.tsx
@@ -2,13 +2,18 @@ import React, { useRef } from 'react';
 import { FileUpload, TooltipAnchor, AttachmentIcon } from '@librechat/client';
 import { useLocalize, useFileHandling } from '~/hooks';
 import { cn } from '~/utils';
+import { useRecoilValue } from 'recoil';
+import store from '~/store';
 
 const AttachFile = ({ disabled }: { disabled?: boolean | null }) => {
   const localize = useLocalize();
   const inputRef = useRef<HTMLInputElement>(null);
+  const isTemporary = useRecoilValue(store.isTemporary);
   const isUploadDisabled = disabled ?? false;
 
-  const { handleFileChange } = useFileHandling();
+  const { handleFileChange } = useFileHandling({
+    additionalMetadata: { temporary: isTemporary.toString() },
+  });
 
   return (
     <FileUpload ref={inputRef} handleFileChange={handleFileChange}>

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useMemo } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import * as Ariakit from '@ariakit/react';
 import {
   FileSearch,
@@ -34,7 +34,7 @@ import {
 import useSharePointFileHandling from '~/hooks/Files/useSharePointFileHandling';
 import { SharePointPickerDialog } from '~/components/SharePoint';
 import { useGetStartupConfig } from '~/data-provider';
-import { ephemeralAgentByConvoId } from '~/store';
+import store, { ephemeralAgentByConvoId } from '~/store';
 import { MenuItemProps } from '~/common';
 import { cn } from '~/utils';
 
@@ -72,7 +72,10 @@ const AttachFileMenu = ({
     ephemeralAgentByConvoId(conversationId),
   );
   const [toolResource, setToolResource] = useState<EToolResources | undefined>();
-  const { handleFileChange } = useFileHandling();
+  const isTemporary = useRecoilValue(store.isTemporary);
+  const { handleFileChange } = useFileHandling({
+    additionalMetadata: { temporary: isTemporary.toString() },
+  });
   const { handleSharePointFiles, isProcessing, downloadProgress } = useSharePointFileHandling({
     toolResource,
   });

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFile.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFile.spec.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { RecoilRoot } from 'recoil';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AttachFile from '~/components/Chat/Input/Files/AttachFile';
+import store from '~/store';
+
+// Mock all the hooks
+jest.mock('~/hooks', () => ({
+  useFileHandling: jest.fn(),
+  useLocalize: jest.fn(),
+}));
+
+const mockUseFileHandling = jest.requireMock('~/hooks').useFileHandling;
+const mockUseLocalize = jest.requireMock('~/hooks').useLocalize;
+
+describe('AttachFile', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  const mockHandleFileChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default mock implementations
+    mockUseLocalize.mockReturnValue((key: string) => {
+      const translations: Record<string, string> = {
+        com_sidepanel_attach_files: 'Attach Files',
+      };
+      return translations[key] || key;
+    });
+
+    mockUseFileHandling.mockReturnValue({
+      handleFileChange: mockHandleFileChange,
+    });
+  });
+
+  const renderAttachFile = (props: any = {}, initialRecoilState?: (MutableSnapshot) => void) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <RecoilRoot initializeState={initialRecoilState}>
+          <AttachFile {...props} />
+        </RecoilRoot>
+      </QueryClientProvider>,
+    );
+  };
+
+  describe('Additional metadata', () => {
+    it('should pass additional metadata w/ temporary status to file handler', () => {
+      renderAttachFile({}, ({ set }) => set(store.isTemporary, true));
+
+      expect(mockUseFileHandling).toHaveBeenCalledWith({
+        additionalMetadata: { temporary: 'true' },
+      });
+    });
+  });
+});

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
@@ -4,6 +4,7 @@ import { RecoilRoot } from 'recoil';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { EModelEndpoint, Providers } from 'librechat-data-provider';
 import AttachFileMenu from '../AttachFileMenu';
+import store from '~/store';
 
 jest.mock('~/hooks', () => ({
   useAgentToolPermissions: jest.fn(),
@@ -106,10 +107,13 @@ function setupMocks(overrides: { provider?: string } = {}) {
   });
 }
 
-function renderMenu(props: Record<string, unknown> = {}) {
+function renderMenu(
+  props: Record<string, unknown> = {},
+  initialRecoilState?: (MutableSnapshot) => void,
+) {
   return render(
     <QueryClientProvider client={queryClient}>
-      <RecoilRoot>
+      <RecoilRoot initializeState={initialRecoilState}>
         <AttachFileMenu conversationId="test-convo" {...props} />
       </RecoilRoot>
     </QueryClientProvider>,
@@ -350,6 +354,16 @@ describe('AttachFileMenu', () => {
       setupMocks();
       renderMenu({ agentId: '', endpointType: EModelEndpoint.openAI });
       expect(screen.getByRole('button', { name: /attach file options/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Additional metadata', () => {
+    it('should pass additional metadata w/ temporary status to file handler', () => {
+      renderMenu({}, ({ set }) => set(store.isTemporary, true));
+
+      expect(mockUseFileHandling).toHaveBeenCalledWith({
+        additionalMetadata: { temporary: 'true' },
+      });
     });
   });
 });

--- a/client/src/hooks/Files/__tests__/useDragHelpers.spec.tsx
+++ b/client/src/hooks/Files/__tests__/useDragHelpers.spec.tsx
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/react';
+import useDragHelpers from '~/hooks/Files/useDragHelpers';
+import { RecoilRoot } from 'recoil';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import store from '~/store';
+
+jest.mock('~/hooks/Files/useFileHandling', () => {
+  return jest.fn(() => ({
+    handleFiles: jest.fn(),
+  }));
+});
+
+const mockUseFileHandling = jest.requireMock('~/hooks/Files/useFileHandling');
+
+function DragHelpersTest() {
+  useDragHelpers();
+  return null;
+}
+
+describe('useDragHelpers()', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderDragHelper = (props: any = {}, initialRecoilState?: (MutableSnapshot) => void) => {
+    return render(
+      <DndProvider backend={HTML5Backend}>
+        <QueryClientProvider client={queryClient}>
+          <RecoilRoot initializeState={initialRecoilState}>
+            <DragHelpersTest {...props} />
+          </RecoilRoot>
+        </QueryClientProvider>
+      </DndProvider>,
+    );
+  };
+
+  test('should pass additional metadata w/ temporary status to file handler', () => {
+    renderDragHelper({}, ({ set }) => set(store.isTemporary, true));
+
+    expect(mockUseFileHandling).toHaveBeenCalledWith({
+      additionalMetadata: { temporary: 'true' },
+    });
+  });
+});

--- a/client/src/hooks/Files/useDragHelpers.ts
+++ b/client/src/hooks/Files/useDragHelpers.ts
@@ -35,13 +35,16 @@ export default function useDragHelpers() {
   const setEphemeralAgent = useSetRecoilState(
     ephemeralAgentByConvoId(conversation?.conversationId ?? Constants.NEW_CONVO),
   );
+  const isTemporary = useRecoilValue(store.isTemporary);
 
   const isAssistants = useMemo(
     () => isAssistantsEndpoint(conversation?.endpoint),
     [conversation?.endpoint],
   );
 
-  const { handleFiles } = useFileHandling();
+  const { handleFiles } = useFileHandling({
+    additionalMetadata: { temporary: isTemporary.toString() },
+  });
 
   const handleOptionSelect = useCallback(
     (toolResource: EToolResources | undefined) => {

--- a/packages/data-schemas/src/methods/file.spec.ts
+++ b/packages/data-schemas/src/methods/file.spec.ts
@@ -45,7 +45,7 @@ describe('File Methods', () => {
   });
 
   describe('createFile', () => {
-    it('should create a new file with TTL', async () => {
+    it('should create a new file', async () => {
       const fileId = uuidv4();
       const userId = new mongoose.Types.ObjectId();
 
@@ -56,33 +56,13 @@ describe('File Methods', () => {
         filepath: '/uploads/test.txt',
         type: 'text/plain',
         bytes: 100,
+        expiresAt: new Date(Date.now() + 3600 * 1000),
       });
 
       expect(file).not.toBeNull();
       expect(file?.file_id).toBe(fileId);
       expect(file?.filename).toBe('test.txt');
       expect(file?.expiresAt).toBeDefined();
-    });
-
-    it('should create a file without TTL when disableTTL is true', async () => {
-      const fileId = uuidv4();
-      const userId = new mongoose.Types.ObjectId();
-
-      const file = await fileMethods.createFile(
-        {
-          file_id: fileId,
-          user: userId,
-          filename: 'permanent.txt',
-          filepath: '/uploads/permanent.txt',
-          type: 'text/plain',
-          bytes: 200,
-        },
-        true,
-      );
-
-      expect(file).not.toBeNull();
-      expect(file?.file_id).toBe(fileId);
-      expect(file?.expiresAt).toBeUndefined();
     });
   });
 

--- a/packages/data-schemas/src/methods/file.ts
+++ b/packages/data-schemas/src/methods/file.ts
@@ -201,26 +201,13 @@ export function createFileMethods(mongoose: typeof import('mongoose')) {
   }
 
   /**
-   * Creates a new file with a TTL of 1 hour.
+   * Creates a new file.
    * @param data - The file data to be created, must contain file_id
-   * @param disableTTL - Whether to disable the TTL
    * @returns A promise that resolves to the created file document
    */
-  async function createFile(
-    data: Partial<IMongoFile>,
-    disableTTL?: boolean,
-  ): Promise<IMongoFile | null> {
+  async function createFile(data: Partial<IMongoFile>): Promise<IMongoFile | null> {
     const File = mongoose.models.File as Model<IMongoFile>;
-    const fileData: Partial<IMongoFile> = {
-      ...data,
-      expiresAt: new Date(Date.now() + 3600 * 1000),
-    };
-
-    if (disableTTL) {
-      delete fileData.expiresAt;
-    }
-
-    return File.findOneAndUpdate({ file_id: data.file_id }, fileData, {
+    return File.findOneAndUpdate({ file_id: data.file_id }, data, {
       new: true,
       upsert: true,
     }).lean();

--- a/packages/data-schemas/src/schema/file.ts
+++ b/packages/data-schemas/src/schema/file.ts
@@ -76,7 +76,6 @@ const file: Schema<IMongoFile> = new Schema(
     },
     expiresAt: {
       type: Date,
-      expires: 3600, // 1 hour in seconds
     },
   },
   {
@@ -84,6 +83,7 @@ const file: Schema<IMongoFile> = new Schema(
   },
 );
 
+file.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 file.index({ createdAt: 1, updatedAt: 1 });
 file.index(
   { filename: 1, conversationId: 1, context: 1 },


### PR DESCRIPTION
## Summary

Temporary chats do not expire any files uploaded during the conversation. Temporary chats *do* delete the conversations/messages, but the files remain accessible indefinitely, which runs counter to the concept of "temporary."

This change adds temporary file support in two ways:

1. Temporary file metadata in MongoDB now has an accurate `expiresAt` column. The metadata is cleared when the expiration date is hit.
2. Temporary files uploaded to CDNs now prefix their path with `tmp/`, which allows one to configure lifecycle rules that can automatically clear those files after a certain number of days.

This PR addresses issue https://github.com/danny-avila/LibreChat/issues/10829.

There is additional documentation about configuring CDNs for temporary files in https://github.com/LibreChat-AI/librechat.ai/pull/484.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

I added extensive automated tests for each aspect of the feature:

1. Verifying that files uploaded during temporary chats send along a `temporary` boolean in the metadata (in the HTTP request).
2. Verifying that file upload API routes read the new `temporary` parameter and pass it along to the CDN strategy.
3. Verifying that each CDN strategy uses the new `temporary` boolean to determine file path.
4. Verifying that temporary files are not shown in the UI except in the temporary chat itself.

I also manually tested the flow for every CDN (Firebase, S3, Azure, local). I did so by:

1. Configuring the CDN to support temporary files (see [new documentation](https://github.com/LibreChat-AI/librechat.ai/pull/484) for how).
2. Uploading a file in a normal chat.
5. Uploading another file in a temporary chat.
6. Waiting until the CDN expiration passes.
7. Verify that the normal file remains but the temporary file was removed automatically.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted ([here](https://github.com/LibreChat-AI/librechat.ai/pull/484)).