### PR TITLE
⏭️ fix: Skip Title Generation for Temporary Chats

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1122,7 +1122,9 @@ class AgentClient extends BaseClient {
     const { req, agent } = this.options;
 
     if (req?.body?.isTemporary) {
-      logger.debug(`[api/server/controllers/agents/client.js #titleConvo] Skipping title generation for temporary conversation`);
+      logger.debug(
+        `[api/server/controllers/agents/client.js #titleConvo] Skipping title generation for temporary conversation`,
+      );
       return;
     }
 

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1120,6 +1120,12 @@ class AgentClient extends BaseClient {
     }
     const { handleLLMEnd, collected: collectedMetadata } = createMetadataAggregator();
     const { req, agent } = this.options;
+
+    if (req?.body?.isTemporary) {
+      logger.debug(`[api/server/controllers/agents/client.js #titleConvo] Skipping title generation for temporary conversation`);
+      return;
+    }
+
     const appConfig = req.config;
     let endpoint = agent.endpoint;
 

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -336,6 +336,25 @@ describe('AgentClient - titleConvo', () => {
       expect(client.recordCollectedUsage).not.toHaveBeenCalled();
     });
 
+    it('should skip title generation for temporary chats', async () => {
+      // Set isTemporary to true
+      mockReq.body.isTemporary = true;
+
+      const text = 'Test temporary chat';
+      const abortController = new AbortController();
+
+      const result = await client.titleConvo({ text, abortController });
+
+      // Should return undefined without generating title
+      expect(result).toBeUndefined();
+
+      // generateTitle should NOT have been called
+      expect(mockRun.generateTitle).not.toHaveBeenCalled();
+
+      // recordCollectedUsage should NOT have been called
+      expect(client.recordCollectedUsage).not.toHaveBeenCalled();
+    });
+
     it('should skip title generation when titleConvo is false in all config', async () => {
       // Set titleConvo to false in "all" config
       mockReq.config = {

--- a/api/server/services/Endpoints/agents/title.js
+++ b/api/server/services/Endpoints/agents/title.js
@@ -17,6 +17,11 @@ const addTitle = async (req, { text, response, client }) => {
     return;
   }
 
+  // Skip title generation for temporary conversations
+  if (req?.body?.isTemporary) {
+    return;
+  }
+
   const titleCache = getLogStores(CacheKeys.GEN_TITLE);
   const key = `${req.user.id}-${response.conversationId}`;
   /** @type {NodeJS.Timeout} */

--- a/api/server/services/Endpoints/assistants/title.js
+++ b/api/server/services/Endpoints/assistants/title.js
@@ -50,6 +50,11 @@ const addTitle = async (req, { text, responseText, conversationId }) => {
     return;
   }
 
+  // Skip title generation for temporary conversations
+  if (req?.body?.isTemporary) {
+    return;
+  }
+
   const titleCache = getLogStores(CacheKeys.GEN_TITLE);
   const key = `${req.user.id}-${conversationId}`;
 


### PR DESCRIPTION
## Summary

I noticed that temporary chats still send an LLM request to generate a conversation title even though this title is never displayed anywhere. This request therefore incurs unnecessary costs (costs about as much as the initial user input+assistant response in input tokens). This small change skips the title generation for temporary chats to avoid any unnecessary costs.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

I tested this by connecting LibreChat to my organization's LLM gateway which has some logging enabled. Through these logs I could see the extra title generation requests. After this change, temporary chats no longer have an additional title generation prompt (but non-temporary chats still do).

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
