### PR TITLE
feat: make logo configurable via LOGO_URL env var

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -61,6 +61,7 @@ router.get('/', async function (req, res) {
     /** @type {TStartupConfig} */
     const payload = {
       appTitle: process.env.APP_TITLE || 'LibreChat',
+      logoUrl: process.env.LOGO_URL,
       socialLogins: appConfig?.registration?.socialLogins ?? defaultSocialLogins,
       discordLoginEnabled: !!process.env.DISCORD_CLIENT_ID && !!process.env.DISCORD_CLIENT_SECRET,
       facebookLoginEnabled:

--- a/client/src/components/Auth/AuthLayout.tsx
+++ b/client/src/components/Auth/AuthLayout.tsx
@@ -62,7 +62,7 @@ function AuthLayout({
       <BlinkAnimation active={isFetching}>
         <div className="mt-6 h-10 w-full bg-cover">
           <img
-            src="assets/logo.svg"
+            src={startupConfig?.logoUrl ?? 'assets/logo.svg'}
             className="h-full w-full object-contain"
             alt={localize('com_ui_logo', { 0: startupConfig?.appTitle ?? 'LibreChat' })}
           />

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -692,6 +692,7 @@ export type TTurnstileConfig = z.infer<typeof turnstileSchema>;
 
 export type TStartupConfig = {
   appTitle: string;
+  logoUrl?: string;
   socialLogins?: string[];
   interface?: TInterfaceConfig;
   turnstile?: TTurnstileConfig;


### PR DESCRIPTION
## Summary

This PR adds the ability to configure a custom logo via the `LOGO_URL` environment variable. When set, the specified logo (either a path or full URL) will be displayed on the authentication pages instead of the default LibreChat logo. This allows organizations to white-label the application with their own branding.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Testing

1. Set the `LOGO_URL` environment variable to a custom logo path or URL (e.g., `LOGO_URL=https://example.com/my-logo.svg`)
2. Start the application
3. Navigate to the login page
4. Verify the custom logo is displayed instead of the default LibreChat logo
5. Remove or unset the `LOGO_URL` environment variable
6. Restart and verify the default logo is displayed (fallback works)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes