### PR TITLE
🌉 fix: Add Proxy Support to Gemini Image Gen Tool

### DIFF
--- a/api/app/clients/tools/structured/GeminiImageGen.js
+++ b/api/app/clients/tools/structured/GeminiImageGen.js
@@ -33,7 +33,6 @@ if (process.env.PROXY) {
 
   globalThis.fetch = function (url, options = {}) {
     const urlString = url.toString();
-    // Only add proxy dispatcher for Google API calls
     if (urlString.includes('googleapis.com')) {
       options = { ...options, dispatcher: proxyAgent };
     }

--- a/api/app/clients/tools/structured/GeminiImageGen.js
+++ b/api/app/clients/tools/structured/GeminiImageGen.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const sharp = require('sharp');
 const { v4 } = require('uuid');
+const { ProxyAgent } = require('undici');
 const { GoogleGenAI } = require('@google/genai');
 const { tool } = require('@langchain/core/tools');
 const { logger } = require('@librechat/data-schemas');
@@ -20,6 +21,25 @@ const {
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { spendTokens } = require('~/models/spendTokens');
 const { getFiles } = require('~/models/File');
+
+/**
+ * Configure proxy support for Google APIs
+ * This wraps globalThis.fetch to add a proxy dispatcher only for googleapis.com URLs
+ * This is necessary because @google/genai SDK doesn't support custom fetch or httpOptions.dispatcher
+ */
+if (process.env.PROXY) {
+  const originalFetch = globalThis.fetch;
+  const proxyAgent = new ProxyAgent(process.env.PROXY);
+
+  globalThis.fetch = function (url, options = {}) {
+    const urlString = url.toString();
+    // Only add proxy dispatcher for Google API calls
+    if (urlString.includes('googleapis.com')) {
+      options = { ...options, dispatcher: proxyAgent };
+    }
+    return originalFetch.call(this, url, options);
+  };
+}
 
 /**
  * Get the default service key file path (consistent with main Google endpoint)

--- a/api/app/clients/tools/structured/specs/GeminiImageGen-proxy.spec.js
+++ b/api/app/clients/tools/structured/specs/GeminiImageGen-proxy.spec.js
@@ -1,0 +1,125 @@
+const { ProxyAgent } = require('undici');
+
+/**
+ * These tests verify the proxy wrapper behavior for GeminiImageGen.
+ * Instead of loading the full module (which has many dependencies),
+ * we directly test the wrapper logic that would be applied.
+ */
+describe('GeminiImageGen Proxy Configuration', () => {
+  let originalEnv;
+  let originalFetch;
+
+  beforeAll(() => {
+    originalEnv = { ...process.env };
+    originalFetch = globalThis.fetch;
+  });
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    globalThis.fetch = originalFetch;
+  });
+
+  /**
+   * Simulates the proxy wrapper that GeminiImageGen applies at module load.
+   * This is the same logic from GeminiImageGen.js lines 30-42.
+   */
+  function applyProxyWrapper() {
+    if (process.env.PROXY) {
+      const _originalFetch = globalThis.fetch;
+      const proxyAgent = new ProxyAgent(process.env.PROXY);
+
+      globalThis.fetch = function (url, options = {}) {
+        const urlString = url.toString();
+        if (urlString.includes('googleapis.com')) {
+          options = { ...options, dispatcher: proxyAgent };
+        }
+        return _originalFetch.call(this, url, options);
+      };
+    }
+  }
+
+  it('should wrap globalThis.fetch when PROXY env is set', () => {
+    process.env.PROXY = 'http://proxy.example.com:8080';
+
+    const fetchBeforeWrap = globalThis.fetch;
+
+    applyProxyWrapper();
+
+    expect(globalThis.fetch).not.toBe(fetchBeforeWrap);
+  });
+
+  it('should not wrap globalThis.fetch when PROXY env is not set', () => {
+    delete process.env.PROXY;
+
+    const fetchBeforeWrap = globalThis.fetch;
+
+    applyProxyWrapper();
+
+    expect(globalThis.fetch).toBe(fetchBeforeWrap);
+  });
+
+  it('should add dispatcher to googleapis.com URLs', async () => {
+    process.env.PROXY = 'http://proxy.example.com:8080';
+
+    let capturedOptions = null;
+    const mockFetch = jest.fn((url, options) => {
+      capturedOptions = options;
+      return Promise.resolve({ ok: true });
+    });
+    globalThis.fetch = mockFetch;
+
+    applyProxyWrapper();
+
+    await globalThis.fetch('https://generativelanguage.googleapis.com/v1/models', {});
+
+    expect(capturedOptions).toBeDefined();
+    expect(capturedOptions.dispatcher).toBeInstanceOf(ProxyAgent);
+  });
+
+  it('should not add dispatcher to non-googleapis.com URLs', async () => {
+    process.env.PROXY = 'http://proxy.example.com:8080';
+
+    let capturedOptions = null;
+    const mockFetch = jest.fn((url, options) => {
+      capturedOptions = options;
+      return Promise.resolve({ ok: true });
+    });
+    globalThis.fetch = mockFetch;
+
+    applyProxyWrapper();
+
+    await globalThis.fetch('https://api.openai.com/v1/images', {});
+
+    expect(capturedOptions).toBeDefined();
+    expect(capturedOptions.dispatcher).toBeUndefined();
+  });
+
+  it('should preserve existing options when adding dispatcher', async () => {
+    process.env.PROXY = 'http://proxy.example.com:8080';
+
+    let capturedOptions = null;
+    const mockFetch = jest.fn((url, options) => {
+      capturedOptions = options;
+      return Promise.resolve({ ok: true });
+    });
+    globalThis.fetch = mockFetch;
+
+    applyProxyWrapper();
+
+    const customHeaders = { 'X-Custom-Header': 'test' };
+    await globalThis.fetch('https://aiplatform.googleapis.com/v1/models', {
+      headers: customHeaders,
+      method: 'POST',
+    });
+
+    expect(capturedOptions).toBeDefined();
+    expect(capturedOptions.dispatcher).toBeInstanceOf(ProxyAgent);
+    expect(capturedOptions.headers).toEqual(customHeaders);
+    expect(capturedOptions.method).toBe('POST');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #11301

The GeminiImageGen tool fails with `TypeError: fetch failed` when running in a Docker environment that requires HTTP proxy access to reach external APIs. This PR adds proxy support to the GeminiImageGen tool.

**Root Cause:** The `@google/genai` SDK doesn't support custom fetch options or `httpOptions.dispatcher`, so it uses native `fetch()` which doesn't respect `HTTP_PROXY`/`HTTPS_PROXY` environment variables.

**Solution:** Override `globalThis.fetch` with a wrapper that adds a proxy dispatcher only for `googleapis.com` URLs when `PROXY` env var is set. This approach:
- Only affects Google API calls (googleapis.com URLs)
- Has no concurrent request risk (each call gets its own options object)
- Doesn't affect other tools that already handle proxy (DALLE3, OpenAI, etc.)
- Doesn't affect normal Gemini LLM chat (uses different SDK with separate proxy handling)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Deploy LibreChat in an environment requiring HTTP proxy
2. Set `PROXY=http://<proxy>:<port>` environment variable
3. Configure GeminiImageGen with Vertex AI credentials
4. Create an agent with GeminiImageGen tool enabled
5. Request image generation - should now work through proxy

### **Test Configuration**:
- LibreChat with `PROXY` environment variable set
- GeminiImageGen tool enabled on an agent
- Squid proxy or similar HTTP proxy

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes