### PR TITLE
🏞️ fix: Gemini Image Filenames and Add Tool Cache Safety

### DIFF
--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -408,7 +408,7 @@ function createToolEndCallback({ req, res, artifactPromises, streamId = null }) 
         const { url } = part.image_url;
         artifactPromises.push(
           (async () => {
-            const filename = `${output.name}_${output.tool_call_id}_img_${nanoid()}`;
+            const filename = `${output.name}_img_${nanoid()}`;
             const file_id = output.artifact.file_ids?.[i];
             const file = await saveBase64Image(url, {
               req,

--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -119,7 +119,7 @@ const createAgentHandler = async (req, res) => {
     agentData.author = userId;
     agentData.tools = [];
 
-    const availableTools = await getCachedTools();
+    const availableTools = (await getCachedTools()) ?? {};
     for (const tool of tools) {
       if (availableTools[tool]) {
         agentData.tools.push(tool);

--- a/api/server/controllers/assistants/v1.js
+++ b/api/server/controllers/assistants/v1.js
@@ -31,7 +31,7 @@ const createAssistant = async (req, res) => {
     delete assistantData.conversation_starters;
     delete assistantData.append_current_datetime;
 
-    const toolDefinitions = await getCachedTools();
+    const toolDefinitions = (await getCachedTools()) ?? {};
 
     assistantData.tools = tools
       .map((tool) => {
@@ -136,7 +136,7 @@ const patchAssistant = async (req, res) => {
       ...updateData
     } = req.body;
 
-    const toolDefinitions = await getCachedTools();
+    const toolDefinitions = (await getCachedTools()) ?? {};
 
     updateData.tools = (updateData.tools ?? [])
       .map((tool) => {

--- a/api/server/controllers/assistants/v2.js
+++ b/api/server/controllers/assistants/v2.js
@@ -28,7 +28,7 @@ const createAssistant = async (req, res) => {
     delete assistantData.conversation_starters;
     delete assistantData.append_current_datetime;
 
-    const toolDefinitions = await getCachedTools();
+    const toolDefinitions = (await getCachedTools()) ?? {};
 
     assistantData.tools = tools
       .map((tool) => {
@@ -125,7 +125,7 @@ const updateAssistant = async ({ req, openai, assistant_id, updateData }) => {
 
   let hasFileSearch = false;
   for (const tool of updateData.tools ?? []) {
-    const toolDefinitions = await getCachedTools();
+    const toolDefinitions = (await getCachedTools()) ?? {};
     let actualTool = typeof tool === 'string' ? toolDefinitions[tool] : tool;
 
     if (!actualTool && manifestToolMap[tool] && manifestToolMap[tool].toolkit === true) {

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -79,7 +79,7 @@ async function processRequiredActions(client, requiredActions) {
     requiredActions,
   );
   const appConfig = client.req.config;
-  const toolDefinitions = await getCachedTools();
+  const toolDefinitions = (await getCachedTools()) ?? {};
   const seenToolkits = new Set();
   const tools = requiredActions
     .map((action) => {


### PR DESCRIPTION
## Summary

This PR fixes two Gemini tool-related bugs affecting image generation and tool caching.

- Simplified filename generation for Gemini image artifacts by removing `tool_call_id` from filenames, which was causing ENOENT errors due to excessively long names containing invalid characters like `/` that were interpreted as subdirectories.
- Added null coalescing operators (`?? {}`) to `getCachedTools()` calls across agents and assistants controllers to prevent "Cannot read properties of undefined" crashes when the tool cache returns `undefined`.
- Applied the null safety fix consistently in `v1.js`, `v2.js`, and `ToolService.js` to ensure robust tool definition handling.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verify Gemini image generation works without filesystem errors and that agent/assistant creation doesn't crash when tool cache is unavailable.

- Test Gemini image generation tool to confirm images save successfully with the simplified filename format (`${output.name}_img_${nanoid()}.png`)
- Confirm tool call associations are still tracked via the `toolCallId` metadata field
- Test agent/assistant creation flows to ensure no crashes occur from undefined tool definitions

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes