### PR TITLE
🧹 fix: MCP Panel Regressions after UI refactor

### DIFF
--- a/client/src/components/SidePanel/MCPBuilder/MCPCardActions.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPCardActions.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pencil, PlugZap, SlidersHorizontal, RefreshCw, X } from 'lucide-react';
+import { Pencil, PlugZap, SlidersHorizontal, RefreshCw, X, Trash2 } from 'lucide-react';
 import { Spinner, TooltipAnchor } from '@librechat/client';
 import type { MCPServerStatus } from 'librechat-data-provider';
 import { useLocalize } from '~/hooks';
@@ -17,6 +17,7 @@ interface MCPCardActionsProps {
   onConfigClick: (e: React.MouseEvent) => void;
   onInitialize: () => void;
   onCancel: (e: React.MouseEvent) => void;
+  onRevoke?: () => void;
 }
 
 /**
@@ -26,6 +27,7 @@ interface MCPCardActionsProps {
  * - Pencil: Edit server definition (Settings panel only)
  * - PlugZap: Connect/Authenticate (for disconnected/error servers)
  * - SlidersHorizontal: Configure custom variables (for connected servers with vars)
+ * - Trash2: Revoke OAuth access (for connected OAuth servers)
  * - RefreshCw: Reconnect/Refresh (for connected servers)
  * - Spinner: Loading state (with X on hover for cancel)
  */
@@ -41,6 +43,7 @@ export default function MCPCardActions({
   onConfigClick,
   onInitialize,
   onCancel,
+  onRevoke,
 }: MCPCardActionsProps) {
   const localize = useLocalize();
 
@@ -146,6 +149,20 @@ export default function MCPCardActions({
           onClick={onConfigClick}
         >
           <SlidersHorizontal className="size-3.5" aria-hidden="true" />
+        </TooltipAnchor>
+      )}
+
+      {/* Revoke button - for OAuth servers (available regardless of connection state) */}
+      {serverStatus?.requiresOAuth && onRevoke && (
+        <TooltipAnchor
+          description={localize('com_ui_revoke')}
+          side="top"
+          className={cn(buttonBaseClass, 'text-red-500 hover:text-red-600')}
+          aria-label={localize('com_ui_revoke')}
+          role="button"
+          onClick={onRevoke}
+        >
+          <Trash2 className="size-3.5" aria-hidden="true" />
         </TooltipAnchor>
       )}
 

--- a/client/src/components/SidePanel/MCPBuilder/MCPCardActions.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPCardActions.tsx
@@ -152,20 +152,6 @@ export default function MCPCardActions({
         </TooltipAnchor>
       )}
 
-      {/* Revoke button - for OAuth servers (available regardless of connection state) */}
-      {serverStatus?.requiresOAuth && onRevoke && (
-        <TooltipAnchor
-          description={localize('com_ui_revoke')}
-          side="top"
-          className={cn(buttonBaseClass, 'text-red-500 hover:text-red-600')}
-          aria-label={localize('com_ui_revoke')}
-          role="button"
-          onClick={onRevoke}
-        >
-          <Trash2 className="size-3.5" aria-hidden="true" />
-        </TooltipAnchor>
-      )}
-
       {/* Refresh button - for connected servers (allows reconnection) */}
       {isConnected && (
         <TooltipAnchor
@@ -177,6 +163,20 @@ export default function MCPCardActions({
           onClick={() => onInitialize()}
         >
           <RefreshCw className="size-3.5" aria-hidden="true" />
+        </TooltipAnchor>
+      )}
+
+      {/* Revoke button - for OAuth servers (available regardless of connection state) */}
+      {serverStatus?.requiresOAuth && onRevoke && (
+        <TooltipAnchor
+          description={localize('com_ui_revoke')}
+          side="top"
+          className={cn(buttonBaseClass, 'text-red-500 hover:text-red-600')}
+          aria-label={localize('com_ui_revoke')}
+          role="button"
+          onClick={onRevoke}
+        >
+          <Trash2 className="size-3.5" aria-hidden="true" />
         </TooltipAnchor>
       )}
     </div>

--- a/client/src/components/SidePanel/MCPBuilder/MCPServerCard.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPServerCard.tsx
@@ -30,7 +30,7 @@ export default function MCPServerCard({
 }: MCPServerCardProps) {
   const localize = useLocalize();
   const triggerRef = useRef<HTMLDivElement>(null);
-  const { initializeServer } = useMCPServerManager();
+  const { initializeServer, revokeOAuthForServer } = useMCPServerManager();
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const statusIconProps = getServerStatusIconProps(server.serverName);
@@ -50,7 +50,18 @@ export default function MCPServerCard({
   const canEdit = canCreateEditMCPs && canEditThisServer;
 
   const handleInitialize = () => {
+    /** If server has custom user vars and is not already connected, show config dialog first
+     *  This ensures users can enter credentials before initialization attempts
+     */
+    if (hasCustomUserVars && serverStatus?.connectionState !== 'connected') {
+      onConfigClick({ stopPropagation: () => {}, preventDefault: () => {} } as React.MouseEvent);
+      return;
+    }
     initializeServer(server.serverName);
+  };
+
+  const handleRevoke = () => {
+    revokeOAuthForServer(server.serverName);
   };
 
   const handleEditClick = (e: React.MouseEvent) => {
@@ -130,6 +141,7 @@ export default function MCPServerCard({
             onConfigClick={onConfigClick}
             onInitialize={handleInitialize}
             onCancel={onCancel}
+            onRevoke={handleRevoke}
           />
         </div>
       </div>

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -94,8 +94,12 @@ export function useMCPServerManager({ conversationId }: { conversationId?: strin
   const cancelOAuthMutation = useCancelMCPOAuthMutation();
 
   const updateUserPluginsMutation = useUpdateUserPluginsMutation({
-    onSuccess: async () => {
-      showToast({ message: localize('com_nav_mcp_vars_updated'), status: 'success' });
+    onSuccess: async (_data, variables) => {
+      const message =
+        variables.action === 'uninstall'
+          ? localize('com_nav_mcp_access_revoked')
+          : localize('com_nav_mcp_vars_updated');
+      showToast({ message, status: 'success' });
 
       await Promise.all([
         queryClient.invalidateQueries([QueryKeys.mcpServers]),

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -95,11 +95,19 @@ export function useMCPServerManager({ conversationId }: { conversationId?: strin
 
   const updateUserPluginsMutation = useUpdateUserPluginsMutation({
     onSuccess: async (_data, variables) => {
-      const message =
-        variables.action === 'uninstall'
-          ? localize('com_nav_mcp_access_revoked')
-          : localize('com_nav_mcp_vars_updated');
+      const isRevoke = variables.action === 'uninstall';
+      const message = isRevoke
+        ? localize('com_nav_mcp_access_revoked')
+        : localize('com_nav_mcp_vars_updated');
       showToast({ message, status: 'success' });
+
+      /** Deselect server from mcpValues when revoking access */
+      if (isRevoke && variables.pluginKey?.startsWith(Constants.mcp_prefix)) {
+        const serverName = variables.pluginKey.replace(Constants.mcp_prefix, '');
+        const currentValues = mcpValuesRef.current ?? [];
+        const filteredValues = currentValues.filter((name) => name !== serverName);
+        setMCPValues(filteredValues);
+      }
 
       await Promise.all([
         queryClient.invalidateQueries([QueryKeys.mcpServers]),
@@ -495,13 +503,10 @@ export function useMCPServerManager({ conversationId }: { conversationId?: strin
           auth: {},
         };
         updateUserPluginsMutation.mutate(payload);
-
-        const currentValues = mcpValues ?? [];
-        const filteredValues = currentValues.filter((name) => name !== targetName);
-        setMCPValues(filteredValues);
+        /** Deselection is now handled centrally in updateUserPluginsMutation.onSuccess */
       }
     },
-    [selectedToolForConfig, updateUserPluginsMutation, mcpValues, setMCPValues],
+    [selectedToolForConfig, updateUserPluginsMutation],
   );
 
   /** Standalone revoke function for OAuth servers - doesn't require selectedToolForConfig */

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -546,6 +546,7 @@
   "com_nav_mcp_status_unknown": "Unknown",
   "com_nav_mcp_vars_update_error": "Error updating MCP custom user variables",
   "com_nav_mcp_vars_updated": "MCP custom user variables updated successfully.",
+  "com_nav_mcp_access_revoked": "MCP server access revoked successfully.",
   "com_nav_modular_chat": "Enable switching Endpoints mid-conversation",
   "com_nav_my_files": "My Files",
   "com_nav_not_supported": "Not Supported",


### PR DESCRIPTION
## Summary

I fixed MCP panel regressions by adding a revoke button for OAuth servers and improving the initialization flow for servers with custom user variables.

- Add revoke button (Trash2 icon) to MCPCardActions for OAuth servers, styled with red color scheme for destructive action
- Show config dialog first when initializing servers with custom user variables that aren't connected yet, ensuring users can enter credentials before initialization attempts
- Implement centralized server deselection in `updateUserPluginsMutation.onSuccess` to properly remove revoked servers from active selection
- Display dynamic toast messages based on action type (revoke vs update)
- Remove redundant deselection logic from `handleConfigRevoke` since it's now handled centrally
- Add `com_nav_mcp_access_revoked` localization string

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested OAuth server flows by:
1. Connecting an OAuth MCP server and verifying revoke button appears
2. Revoking access and confirming server is deselected from active selection
3. Verifying appropriate toast message displays on revoke
4. Testing servers with custom user variables show config dialog before initialization when disconnected

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes