### PR TITLE
🌅 fix: Agent Avatar S3 URL Refresh Pagination and Persistence

### DIFF
--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -92,14 +92,11 @@ const refreshListAvatars = async (agents, userId) => {
         return;
       }
 
-      logger.debug('[/Agents] Refreshing S3 avatar for agent: %s', agent._id);
-
       try {
+        logger.debug('[/Agents] Refreshing S3 avatar for agent: %s', agent._id);
         const newPath = await refreshS3Url(agent.avatar);
         if (newPath && newPath !== agent.avatar.filepath) {
-          logger.debug('[/Agents] New S3 avatar path args: %s', newPath.split('?')[1] ?? newPath);
           agent.avatar = { ...agent.avatar, filepath: newPath };
-
           try {
             await updateAgent(
               { id: agent.id },
@@ -580,7 +577,6 @@ const getListAgentsHandler = async (req, res) => {
     const cache = getLogStores(CacheKeys.S3_EXPIRY_INTERVAL);
     const refreshKey = `${userId}:agents_avatar_refresh`;
     const alreadyChecked = await cache.get(refreshKey);
-    logger.debug('[/Agents] Already checked: %s', alreadyChecked);
     if (alreadyChecked) {
       logger.debug('[/Agents] S3 avatar refresh already checked, skipping');
     } else {

--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -116,7 +116,7 @@ const refreshListAvatars = async (agents, userId) => {
           }
         }
       } catch (err) {
-        logger.debug('[/Agents] Avatar refresh error for list item: %o', err);
+        logger.error('[/Agents] Avatar S3 avatar refresh error: %o', err);
       }
     }),
   );
@@ -590,7 +590,7 @@ const getListAgentsHandler = async (req, res) => {
         await refreshListAvatars(fullList?.data ?? [], userId);
         await cache.set(refreshKey, true, Time.THIRTY_MINUTES);
       } catch (err) {
-        logger.debug('[/Agents] Error refreshing avatars for full list: %o', err);
+        logger.error('[/Agents] Error refreshing avatars for full list: %o', err);
       }
     }
 

--- a/api/server/controllers/agents/v1.spec.js
+++ b/api/server/controllers/agents/v1.spec.js
@@ -1,8 +1,9 @@
 const mongoose = require('mongoose');
-const { v4: uuidv4 } = require('uuid');
 const { nanoid } = require('nanoid');
-const { MongoMemoryServer } = require('mongodb-memory-server');
+const { v4: uuidv4 } = require('uuid');
 const { agentSchema } = require('@librechat/data-schemas');
+const { FileSources } = require('librechat-data-provider');
+const { MongoMemoryServer } = require('mongodb-memory-server');
 
 // Only mock the dependencies that are not database-related
 jest.mock('~/server/services/Config', () => ({
@@ -54,6 +55,15 @@ jest.mock('~/models', () => ({
   getCategoriesWithCounts: jest.fn(),
 }));
 
+// Mock cache for S3 avatar refresh tests
+const mockCache = {
+  get: jest.fn(),
+  set: jest.fn(),
+};
+jest.mock('~/cache', () => ({
+  getLogStores: jest.fn(() => mockCache),
+}));
+
 const {
   createAgent: createAgentHandler,
   updateAgent: updateAgentHandler,
@@ -64,6 +74,8 @@ const {
   findAccessibleResources,
   findPubliclyAccessibleResources,
 } = require('~/server/services/PermissionService');
+
+const { refreshS3Url } = require('~/server/services/Files/S3/crud');
 
 /**
  * @type {import('mongoose').Model<import('@librechat/data-schemas').IAgent>}
@@ -1205,6 +1217,351 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
       expect(response.data[0].id).toBe(productivityPromoted.id);
       expect(response.data[0].category).toBe('productivity');
       expect(response.data[0].is_promoted).toBe(true);
+    });
+  });
+
+  describe('S3 Avatar Refresh', () => {
+    let userA, userB;
+    let agentWithS3Avatar, agentWithLocalAvatar, agentOwnedByOther;
+
+    beforeEach(async () => {
+      await Agent.deleteMany({});
+      jest.clearAllMocks();
+
+      // Reset cache mock
+      mockCache.get.mockResolvedValue(false);
+      mockCache.set.mockResolvedValue(undefined);
+
+      userA = new mongoose.Types.ObjectId();
+      userB = new mongoose.Types.ObjectId();
+
+      // Create agent with S3 avatar owned by userA
+      agentWithS3Avatar = await Agent.create({
+        id: `agent_${nanoid(12)}`,
+        name: 'Agent with S3 Avatar',
+        description: 'Has S3 avatar',
+        provider: 'openai',
+        model: 'gpt-4',
+        author: userA,
+        avatar: {
+          source: FileSources.s3,
+          filepath: 'old-s3-path.jpg',
+        },
+        versions: [
+          {
+            name: 'Agent with S3 Avatar',
+            description: 'Has S3 avatar',
+            provider: 'openai',
+            model: 'gpt-4',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+      });
+
+      // Create agent with local avatar owned by userA
+      agentWithLocalAvatar = await Agent.create({
+        id: `agent_${nanoid(12)}`,
+        name: 'Agent with Local Avatar',
+        description: 'Has local avatar',
+        provider: 'openai',
+        model: 'gpt-4',
+        author: userA,
+        avatar: {
+          source: 'local',
+          filepath: 'local-path.jpg',
+        },
+        versions: [
+          {
+            name: 'Agent with Local Avatar',
+            description: 'Has local avatar',
+            provider: 'openai',
+            model: 'gpt-4',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+      });
+
+      // Create agent with S3 avatar owned by userB
+      agentOwnedByOther = await Agent.create({
+        id: `agent_${nanoid(12)}`,
+        name: 'Agent Owned By Other',
+        description: 'Owned by userB',
+        provider: 'openai',
+        model: 'gpt-4',
+        author: userB,
+        avatar: {
+          source: FileSources.s3,
+          filepath: 'other-s3-path.jpg',
+        },
+        versions: [
+          {
+            name: 'Agent Owned By Other',
+            description: 'Owned by userB',
+            provider: 'openai',
+            model: 'gpt-4',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+      });
+    });
+
+    test('should skip avatar refresh if cache hit', async () => {
+      mockCache.get.mockResolvedValue(true);
+      findAccessibleResources.mockResolvedValue([agentWithS3Avatar._id]);
+      findPubliclyAccessibleResources.mockResolvedValue([]);
+
+      const mockReq = {
+        user: { id: userA.toString(), role: 'USER' },
+        query: {},
+      };
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      };
+
+      await getListAgentsHandler(mockReq, mockRes);
+
+      // Should not call refreshS3Url when cache hit
+      expect(refreshS3Url).not.toHaveBeenCalled();
+    });
+
+    test('should refresh and persist S3 avatars on cache miss', async () => {
+      mockCache.get.mockResolvedValue(false);
+      findAccessibleResources.mockResolvedValue([agentWithS3Avatar._id]);
+      findPubliclyAccessibleResources.mockResolvedValue([]);
+      refreshS3Url.mockResolvedValue('new-s3-path.jpg');
+
+      const mockReq = {
+        user: { id: userA.toString(), role: 'USER' },
+        query: {},
+      };
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      };
+
+      await getListAgentsHandler(mockReq, mockRes);
+
+      // Verify S3 URL was refreshed
+      expect(refreshS3Url).toHaveBeenCalled();
+
+      // Verify cache was set
+      expect(mockCache.set).toHaveBeenCalled();
+
+      // Verify response was returned
+      expect(mockRes.json).toHaveBeenCalled();
+    });
+
+    test('should only refresh avatars for user-owned agents', async () => {
+      mockCache.get.mockResolvedValue(false);
+      // User A has access to both their own agent and userB's agent
+      findAccessibleResources.mockResolvedValue([agentWithS3Avatar._id, agentOwnedByOther._id]);
+      findPubliclyAccessibleResources.mockResolvedValue([]);
+      refreshS3Url.mockResolvedValue('new-path.jpg');
+
+      const mockReq = {
+        user: { id: userA.toString(), role: 'USER' },
+        query: {},
+      };
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      };
+
+      await getListAgentsHandler(mockReq, mockRes);
+
+      // Should only be called once - for userA's own agent
+      expect(refreshS3Url).toHaveBeenCalledTimes(1);
+    });
+
+    test('should skip non-S3 avatars', async () => {
+      mockCache.get.mockResolvedValue(false);
+      findAccessibleResources.mockResolvedValue([agentWithLocalAvatar._id, agentWithS3Avatar._id]);
+      findPubliclyAccessibleResources.mockResolvedValue([]);
+      refreshS3Url.mockResolvedValue('new-path.jpg');
+
+      const mockReq = {
+        user: { id: userA.toString(), role: 'USER' },
+        query: {},
+      };
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      };
+
+      await getListAgentsHandler(mockReq, mockRes);
+
+      // Should only be called for S3 avatar agent
+      expect(refreshS3Url).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not update if S3 URL unchanged', async () => {
+      mockCache.get.mockResolvedValue(false);
+      findAccessibleResources.mockResolvedValue([agentWithS3Avatar._id]);
+      findPubliclyAccessibleResources.mockResolvedValue([]);
+      // Return the same path - no update needed
+      refreshS3Url.mockResolvedValue('old-s3-path.jpg');
+
+      const mockReq = {
+        user: { id: userA.toString(), role: 'USER' },
+        query: {},
+      };
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      };
+
+      await getListAgentsHandler(mockReq, mockRes);
+
+      // Verify refreshS3Url was called
+      expect(refreshS3Url).toHaveBeenCalled();
+
+      // Response should still be returned
+      expect(mockRes.json).toHaveBeenCalled();
+    });
+
+    test('should handle S3 refresh errors gracefully', async () => {
+      mockCache.get.mockResolvedValue(false);
+      findAccessibleResources.mockResolvedValue([agentWithS3Avatar._id]);
+      findPubliclyAccessibleResources.mockResolvedValue([]);
+      refreshS3Url.mockRejectedValue(new Error('S3 error'));
+
+      const mockReq = {
+        user: { id: userA.toString(), role: 'USER' },
+        query: {},
+      };
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      };
+
+      // Should not throw - handles error gracefully
+      await expect(getListAgentsHandler(mockReq, mockRes)).resolves.not.toThrow();
+
+      // Response should still be returned
+      expect(mockRes.json).toHaveBeenCalled();
+    });
+
+    test('should process agents in batches', async () => {
+      mockCache.get.mockResolvedValue(false);
+
+      // Create 25 agents (should be processed in batches of 20)
+      const manyAgents = [];
+      for (let i = 0; i < 25; i++) {
+        const agent = await Agent.create({
+          id: `agent_${nanoid(12)}`,
+          name: `Agent ${i}`,
+          description: `Agent ${i} description`,
+          provider: 'openai',
+          model: 'gpt-4',
+          author: userA,
+          avatar: {
+            source: FileSources.s3,
+            filepath: `path${i}.jpg`,
+          },
+          versions: [
+            {
+              name: `Agent ${i}`,
+              description: `Agent ${i} description`,
+              provider: 'openai',
+              model: 'gpt-4',
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          ],
+        });
+        manyAgents.push(agent);
+      }
+
+      const allAgentIds = manyAgents.map((a) => a._id);
+      findAccessibleResources.mockResolvedValue(allAgentIds);
+      findPubliclyAccessibleResources.mockResolvedValue([]);
+      refreshS3Url.mockImplementation((avatar) =>
+        Promise.resolve(avatar.filepath.replace('.jpg', '-new.jpg')),
+      );
+
+      const mockReq = {
+        user: { id: userA.toString(), role: 'USER' },
+        query: {},
+      };
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      };
+
+      await getListAgentsHandler(mockReq, mockRes);
+
+      // All 25 should be processed
+      expect(refreshS3Url).toHaveBeenCalledTimes(25);
+    });
+
+    test('should skip agents without id or author', async () => {
+      mockCache.get.mockResolvedValue(false);
+
+      // Create agent without proper id field (edge case)
+      const agentWithoutId = await Agent.create({
+        id: `agent_${nanoid(12)}`,
+        name: 'Agent without ID field',
+        description: 'Testing',
+        provider: 'openai',
+        model: 'gpt-4',
+        author: userA,
+        avatar: {
+          source: FileSources.s3,
+          filepath: 'test-path.jpg',
+        },
+        versions: [
+          {
+            name: 'Agent without ID field',
+            description: 'Testing',
+            provider: 'openai',
+            model: 'gpt-4',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+      });
+
+      findAccessibleResources.mockResolvedValue([agentWithoutId._id, agentWithS3Avatar._id]);
+      findPubliclyAccessibleResources.mockResolvedValue([]);
+      refreshS3Url.mockResolvedValue('new-path.jpg');
+
+      const mockReq = {
+        user: { id: userA.toString(), role: 'USER' },
+        query: {},
+      };
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      };
+
+      await getListAgentsHandler(mockReq, mockRes);
+
+      // Should still complete without errors
+      expect(mockRes.json).toHaveBeenCalled();
+    });
+
+    test('should use MAX_AVATAR_REFRESH_AGENTS limit for full list query', async () => {
+      mockCache.get.mockResolvedValue(false);
+      findAccessibleResources.mockResolvedValue([]);
+      findPubliclyAccessibleResources.mockResolvedValue([]);
+
+      const mockReq = {
+        user: { id: userA.toString(), role: 'USER' },
+        query: {},
+      };
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      };
+
+      await getListAgentsHandler(mockReq, mockRes);
+
+      // Verify that the handler completed successfully
+      expect(mockRes.json).toHaveBeenCalled();
     });
   });
 });

--- a/api/server/controllers/agents/v1.spec.js
+++ b/api/server/controllers/agents/v1.spec.js
@@ -1355,7 +1355,7 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
       expect(mockRes.json).toHaveBeenCalled();
     });
 
-    test('should only refresh avatars for user-owned agents', async () => {
+    test('should refresh avatars for all accessible agents (VIEW permission)', async () => {
       mockCache.get.mockResolvedValue(false);
       // User A has access to both their own agent and userB's agent
       findAccessibleResources.mockResolvedValue([agentWithS3Avatar._id, agentOwnedByOther._id]);
@@ -1373,8 +1373,8 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
 
       await getListAgentsHandler(mockReq, mockRes);
 
-      // Should only be called once - for userA's own agent
-      expect(refreshS3Url).toHaveBeenCalledTimes(1);
+      // Should be called for both agents - any user with VIEW access can refresh
+      expect(refreshS3Url).toHaveBeenCalledTimes(2);
     });
 
     test('should skip non-S3 avatars', async () => {

--- a/api/server/services/start/tools.js
+++ b/api/server/services/start/tools.js
@@ -5,7 +5,7 @@ const { Calculator } = require('@librechat/agents');
 const { logger } = require('@librechat/data-schemas');
 const { zodToJsonSchema } = require('zod-to-json-schema');
 const { Tools, ImageVisionTool } = require('librechat-data-provider');
-const { getToolkitKey, oaiToolkit, ytToolkit, geminiToolkit } = require('@librechat/api');
+const { getToolkitKey, oaiToolkit, geminiToolkit } = require('@librechat/api');
 const { toolkits } = require('~/app/clients/tools/manifest');
 
 /**
@@ -83,7 +83,6 @@ function loadAndFormatTools({ directory, adminFilter = [], adminIncluded = [] })
   const basicToolInstances = [
     new Calculator(),
     ...Object.values(oaiToolkit),
-    ...Object.values(ytToolkit),
     ...Object.values(geminiToolkit),
   ];
   for (const toolInstance of basicToolInstances) {

--- a/packages/api/src/agents/avatars.spec.ts
+++ b/packages/api/src/agents/avatars.spec.ts
@@ -1,0 +1,238 @@
+import { FileSources } from 'librechat-data-provider';
+import type { Agent, AgentAvatar, AgentModelParameters } from 'librechat-data-provider';
+import type { RefreshS3UrlFn, UpdateAgentFn } from './avatars';
+import {
+  MAX_AVATAR_REFRESH_AGENTS,
+  AVATAR_REFRESH_BATCH_SIZE,
+  refreshListAvatars,
+} from './avatars';
+
+describe('refreshListAvatars', () => {
+  let mockRefreshS3Url: jest.MockedFunction<RefreshS3UrlFn>;
+  let mockUpdateAgent: jest.MockedFunction<UpdateAgentFn>;
+  const userId = 'user123';
+
+  beforeEach(() => {
+    mockRefreshS3Url = jest.fn();
+    mockUpdateAgent = jest.fn();
+  });
+
+  const createAgent = (overrides: Partial<Agent> = {}): Agent => ({
+    _id: 'obj1',
+    id: 'agent1',
+    name: 'Test Agent',
+    author: userId,
+    description: 'Test',
+    created_at: Date.now(),
+    avatar: {
+      source: FileSources.s3,
+      filepath: 'old-path.jpg',
+    },
+    instructions: null,
+    provider: 'openai',
+    model: 'gpt-4',
+    model_parameters: {} as AgentModelParameters,
+    ...overrides,
+  });
+
+  it('should return empty stats for empty agents array', async () => {
+    const stats = await refreshListAvatars({
+      agents: [],
+      userId,
+      refreshS3Url: mockRefreshS3Url,
+      updateAgent: mockUpdateAgent,
+    });
+
+    expect(stats.updated).toBe(0);
+    expect(mockRefreshS3Url).not.toHaveBeenCalled();
+    expect(mockUpdateAgent).not.toHaveBeenCalled();
+  });
+
+  it('should skip non-S3 avatars', async () => {
+    const agent = createAgent({
+      avatar: { source: 'local', filepath: 'local-path.jpg' } as AgentAvatar,
+    });
+
+    const stats = await refreshListAvatars({
+      agents: [agent],
+      userId,
+      refreshS3Url: mockRefreshS3Url,
+      updateAgent: mockUpdateAgent,
+    });
+
+    expect(stats.not_s3).toBe(1);
+    expect(stats.updated).toBe(0);
+    expect(mockRefreshS3Url).not.toHaveBeenCalled();
+  });
+
+  it('should skip agents without id', async () => {
+    const agent = createAgent({ id: '' });
+
+    const stats = await refreshListAvatars({
+      agents: [agent],
+      userId,
+      refreshS3Url: mockRefreshS3Url,
+      updateAgent: mockUpdateAgent,
+    });
+
+    expect(stats.no_id).toBe(1);
+    expect(mockRefreshS3Url).not.toHaveBeenCalled();
+  });
+
+  it('should skip agents without author', async () => {
+    const agent = createAgent({ author: undefined });
+
+    const stats = await refreshListAvatars({
+      agents: [agent],
+      userId,
+      refreshS3Url: mockRefreshS3Url,
+      updateAgent: mockUpdateAgent,
+    });
+
+    expect(stats.no_author).toBe(1);
+    expect(mockRefreshS3Url).not.toHaveBeenCalled();
+  });
+
+  it('should skip agents not owned by user', async () => {
+    const agent = createAgent({ author: 'otherUser' });
+
+    const stats = await refreshListAvatars({
+      agents: [agent],
+      userId,
+      refreshS3Url: mockRefreshS3Url,
+      updateAgent: mockUpdateAgent,
+    });
+
+    expect(stats.not_owner).toBe(1);
+    expect(mockRefreshS3Url).not.toHaveBeenCalled();
+  });
+
+  it('should refresh and persist S3 avatars', async () => {
+    const agent = createAgent();
+    mockRefreshS3Url.mockResolvedValue('new-path.jpg');
+    mockUpdateAgent.mockResolvedValue({});
+
+    const stats = await refreshListAvatars({
+      agents: [agent],
+      userId,
+      refreshS3Url: mockRefreshS3Url,
+      updateAgent: mockUpdateAgent,
+    });
+
+    expect(stats.updated).toBe(1);
+    expect(mockRefreshS3Url).toHaveBeenCalledWith(agent.avatar);
+    expect(mockUpdateAgent).toHaveBeenCalledWith(
+      { id: 'agent1' },
+      { avatar: { filepath: 'new-path.jpg', source: FileSources.s3 } },
+      { updatingUserId: userId, skipVersioning: true },
+    );
+  });
+
+  it('should not update if S3 URL unchanged', async () => {
+    const agent = createAgent();
+    mockRefreshS3Url.mockResolvedValue('old-path.jpg');
+
+    const stats = await refreshListAvatars({
+      agents: [agent],
+      userId,
+      refreshS3Url: mockRefreshS3Url,
+      updateAgent: mockUpdateAgent,
+    });
+
+    expect(stats.no_change).toBe(1);
+    expect(stats.updated).toBe(0);
+    expect(mockUpdateAgent).not.toHaveBeenCalled();
+  });
+
+  it('should handle S3 refresh errors gracefully', async () => {
+    const agent = createAgent();
+    mockRefreshS3Url.mockRejectedValue(new Error('S3 error'));
+
+    const stats = await refreshListAvatars({
+      agents: [agent],
+      userId,
+      refreshS3Url: mockRefreshS3Url,
+      updateAgent: mockUpdateAgent,
+    });
+
+    expect(stats.s3_error).toBe(1);
+    expect(stats.updated).toBe(0);
+  });
+
+  it('should handle database persist errors gracefully', async () => {
+    const agent = createAgent();
+    mockRefreshS3Url.mockResolvedValue('new-path.jpg');
+    mockUpdateAgent.mockRejectedValue(new Error('DB error'));
+
+    const stats = await refreshListAvatars({
+      agents: [agent],
+      userId,
+      refreshS3Url: mockRefreshS3Url,
+      updateAgent: mockUpdateAgent,
+    });
+
+    expect(stats.persist_error).toBe(1);
+    expect(stats.updated).toBe(0);
+  });
+
+  it('should process agents in batches', async () => {
+    const agents = Array.from({ length: 25 }, (_, i) =>
+      createAgent({
+        _id: `obj${i}`,
+        id: `agent${i}`,
+        avatar: { source: FileSources.s3, filepath: `path${i}.jpg` },
+      }),
+    );
+
+    mockRefreshS3Url.mockImplementation((avatar) =>
+      Promise.resolve(avatar.filepath.replace('.jpg', '-new.jpg')),
+    );
+    mockUpdateAgent.mockResolvedValue({});
+
+    const stats = await refreshListAvatars({
+      agents,
+      userId,
+      refreshS3Url: mockRefreshS3Url,
+      updateAgent: mockUpdateAgent,
+    });
+
+    expect(stats.updated).toBe(25);
+    expect(mockRefreshS3Url).toHaveBeenCalledTimes(25);
+    expect(mockUpdateAgent).toHaveBeenCalledTimes(25);
+  });
+
+  it('should track mixed statistics correctly', async () => {
+    const agents = [
+      createAgent({ id: 'agent1' }),
+      createAgent({ id: 'agent2', author: 'otherUser' }),
+      createAgent({
+        id: 'agent3',
+        avatar: { source: 'local', filepath: 'local.jpg' } as AgentAvatar,
+      }),
+    ];
+
+    mockRefreshS3Url.mockResolvedValue('new-path.jpg');
+    mockUpdateAgent.mockResolvedValue({});
+
+    const stats = await refreshListAvatars({
+      agents,
+      userId,
+      refreshS3Url: mockRefreshS3Url,
+      updateAgent: mockUpdateAgent,
+    });
+
+    expect(stats.updated).toBe(1);
+    expect(stats.not_owner).toBe(1);
+    expect(stats.not_s3).toBe(1);
+  });
+});
+
+describe('Constants', () => {
+  it('should export MAX_AVATAR_REFRESH_AGENTS as 1000', () => {
+    expect(MAX_AVATAR_REFRESH_AGENTS).toBe(1000);
+  });
+
+  it('should export AVATAR_REFRESH_BATCH_SIZE as 20', () => {
+    expect(AVATAR_REFRESH_BATCH_SIZE).toBe(20);
+  });
+});

--- a/packages/api/src/agents/avatars.ts
+++ b/packages/api/src/agents/avatars.ts
@@ -1,0 +1,136 @@
+import { logger } from '@librechat/data-schemas';
+import { FileSources } from 'librechat-data-provider';
+import type { Agent, AgentAvatar } from 'librechat-data-provider';
+
+const MAX_AVATAR_REFRESH_AGENTS = 1000;
+const AVATAR_REFRESH_BATCH_SIZE = 20;
+
+export { MAX_AVATAR_REFRESH_AGENTS, AVATAR_REFRESH_BATCH_SIZE };
+
+export type RefreshS3UrlFn = (avatar: AgentAvatar) => Promise<string | undefined>;
+
+export type UpdateAgentFn = (
+  searchParams: { id: string },
+  updateData: { avatar: AgentAvatar },
+  options: { updatingUserId: string; skipVersioning: boolean },
+) => Promise<unknown>;
+
+export type RefreshListAvatarsParams = {
+  agents: Agent[];
+  userId: string;
+  refreshS3Url: RefreshS3UrlFn;
+  updateAgent: UpdateAgentFn;
+};
+
+export type RefreshStats = {
+  updated: number;
+  not_s3: number;
+  no_id: number;
+  no_author: number;
+  not_owner: number;
+  no_change: number;
+  s3_error: number;
+  persist_error: number;
+};
+
+/**
+ * Opportunistically refreshes S3-backed avatars for agent list responses.
+ * Processes agents in batches to prevent database connection pool exhaustion.
+ * Only list responses are refreshed because they're the highest-traffic surface and
+ * the avatar URLs have a short-lived TTL. The refresh is cached per-user for 30 minutes
+ * so we refresh once per interval at most.
+ */
+export const refreshListAvatars = async ({
+  agents,
+  userId,
+  refreshS3Url,
+  updateAgent,
+}: RefreshListAvatarsParams): Promise<RefreshStats> => {
+  const stats: RefreshStats = {
+    updated: 0,
+    not_s3: 0,
+    no_id: 0,
+    no_author: 0,
+    not_owner: 0,
+    no_change: 0,
+    s3_error: 0,
+    persist_error: 0,
+  };
+
+  if (!agents?.length) {
+    return stats;
+  }
+
+  logger.debug('[refreshListAvatars] Refreshing S3 avatars for agents: %d', agents.length);
+
+  for (let i = 0; i < agents.length; i += AVATAR_REFRESH_BATCH_SIZE) {
+    const batch = agents.slice(i, i + AVATAR_REFRESH_BATCH_SIZE);
+
+    await Promise.all(
+      batch.map(async (agent) => {
+        if (agent?.avatar?.source !== FileSources.s3 || !agent?.avatar?.filepath) {
+          stats.not_s3++;
+          return;
+        }
+
+        if (!agent?.id) {
+          logger.debug(
+            '[refreshListAvatars] Skipping S3 avatar refresh for agent: %s, ID is not set',
+            agent._id,
+          );
+          stats.no_id++;
+          return;
+        }
+
+        if (!agent?.author) {
+          logger.debug(
+            '[refreshListAvatars] Skipping S3 avatar refresh for agent: %s, author is not set',
+            agent._id,
+          );
+          stats.no_author++;
+          return;
+        }
+
+        if (agent.author.toString() !== userId) {
+          stats.not_owner++;
+          return;
+        }
+
+        try {
+          logger.debug('[refreshListAvatars] Refreshing S3 avatar for agent: %s', agent._id);
+          const newPath = await refreshS3Url(agent.avatar);
+
+          if (newPath && newPath !== agent.avatar.filepath) {
+            try {
+              await updateAgent(
+                { id: agent.id },
+                {
+                  avatar: {
+                    filepath: newPath,
+                    source: agent.avatar.source,
+                  },
+                },
+                {
+                  updatingUserId: userId,
+                  skipVersioning: true,
+                },
+              );
+              stats.updated++;
+            } catch (persistErr) {
+              logger.error('[refreshListAvatars] Avatar refresh persist error: %o', persistErr);
+              stats.persist_error++;
+            }
+          } else {
+            stats.no_change++;
+          }
+        } catch (err) {
+          logger.error('[refreshListAvatars] S3 avatar refresh error: %o', err);
+          stats.s3_error++;
+        }
+      }),
+    );
+  }
+
+  logger.info('[refreshListAvatars] Avatar refresh summary: %o', stats);
+  return stats;
+};

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -1,3 +1,4 @@
+export * from './avatars';
 export * from './chain';
 export * from './edges';
 export * from './initialize';


### PR DESCRIPTION
## Summary

The changes in #10527 have resulted in the agent avatar refresh not being run on any agents beyond the first page of results for any agent market place category.

The client is setting the `limit` query argument to a value of 6 [for this call](https://github.com/danny-avila/LibreChat/blob/2a50c372efa7d999eed355c3e7657742513a8e37/api/server/controllers/agents/v1.js#L548-L553), which results in only 6 agents being sent to the [refreshListAvatars function](https://github.com/danny-avila/LibreChat/blob/2a50c372efa7d999eed355c3e7657742513a8e37/api/server/controllers/agents/v1.js#L576).

A more important issue though is that, even though some of the 6 might get refreshed, they are not persisted to MongoDB. This means we only get new avatar URLs that work, for one API call every 30 minutes per user, and only for a max of whatever `limit` is set to.

To address both of these issues, the PR refactors the refresh caching and update to run on all of a user's agents, once every 30 minutes. This doesn't fix the issue of refreshing avatars for users that haven't logged in for a while. That would be a change from the current implementation and has been left for discussion and another PR.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Tested locally using the docker compose, that includes a minio service for the s3 backend, that only the user that created ther agent is the one that refreshes the avatar presigned URL. And then deployed to our production environment that has a fair number of agents and users.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
