### PR TITLE
📊 refactor: Use Estimated Document Count for Meilisearch Sync

### DIFF
--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -189,8 +189,10 @@ const createMeiliMongooseModel = ({
           query._id = { $gt: options.resumeFromId };
         }
 
-        // Get total count for progress tracking
-        const totalCount = await this.countDocuments(query);
+        // Get approximate total count for progress tracking
+        const approxTotalCount = await this.estimatedDocumentCount();
+        logger.info(`[syncWithMeili] Approximate total number of documents to sync: ${approxTotalCount}`);
+        
         let processedCount = 0;
 
         // First, handle documents that need to be removed from Meili
@@ -239,8 +241,8 @@ const createMeiliMongooseModel = ({
             updateOps = [];
 
             // Log progress
-            const progress = Math.round((processedCount / totalCount) * 100);
-            logger.info(`[syncWithMeili] Progress: ${progress}% (${processedCount}/${totalCount})`);
+            const progress = Math.round((processedCount / approxTotalCount) * 100);
+            logger.info(`[syncWithMeili] Progress: ${progress}% (count: ${processedCount})`);
 
             // Add delay to prevent overwhelming resources
             if (delayMs > 0) {

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -241,7 +241,10 @@ const createMeiliMongooseModel = ({
             updateOps = [];
 
             // Log progress
-            const progress = Math.round((processedCount / approxTotalCount) * 100);
+            // Calculate percentage based on approximate total count sometimes might lead to more than 100%
+            // the difference is very small and acceptable for progress tracking
+            const percent = Math.round((processedCount / approxTotalCount) * 100);
+            const progress = Math.min(percent, 100);
             logger.info(`[syncWithMeili] Progress: ${progress}% (count: ${processedCount})`);
 
             // Add delay to prevent overwhelming resources


### PR DESCRIPTION
## Summary

This PR improves the performance of the MongoDB → Meilisearch sync process, which is especially important for lower-tier deployments with large message volumes.

Today we call countDocuments() to determine the total number of documents for progress reporting. On large collections, countDocuments() can be slow because it may require scanning a significant portion of the collection (even when an index exists).

This PR switches to [estimatedDocumentCount()](https://www.mongodb.com/docs/manual/reference/method/db.collection.estimatedDocumentCount), which uses collection metadata and avoids a full scan. The trade-off is that the returned value may be slightly inaccurate.

In our case, the document count is only used to display sync progress and is not used for any critical calculations, so an approximate value is acceptable. This change significantly reduces the time spent computing the total count and helps avoid long delays before the sync can begin.

The number of temporary conversations and messages can also be neglected in the total count as insignificant

On a collection with ~300,000 documents, countDocuments() can take minutes on weaker/lower-tier instances, while estimatedDocumentCount() typically returns in under a second.

I also slightly rephrased the output text to emphasize that the document count is an estimate rather than an exact value.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Added new cases in existing unit-tests

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
