### PR TITLE
Fix: Detect OAuth for stdio MCP servers

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,45 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,46 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository }}
+        tags: |
+          type=ref,event=branch
+          type=sha,prefix={{branch}}-
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+

--- a/COMMIT_AND_PUSH.md
+++ b/COMMIT_AND_PUSH.md
@@ -1,0 +1,62 @@
+# Commit and Push OAuth Fix
+
+## Steps to Commit and Push
+
+1. **Check the changes:**
+   ```bash
+   git status
+   git diff packages/api/src/mcp/registry/MCPServerInspector.ts
+   ```
+
+2. **Add the modified file:**
+   ```bash
+   git add packages/api/src/mcp/registry/MCPServerInspector.ts
+   ```
+
+3. **Commit the changes:**
+   ```bash
+   git commit -m "Fix: Detect OAuth for stdio MCP servers
+
+   - Check oauth configuration in librechat.yaml for all server types
+   - Allows stdio servers to have OAuth configured even without a URL
+   - Fixes issue where google-workspace shows OAuth Required: false
+   - Resolves: OAuth flow not triggering for command-based MCP servers"
+   ```
+
+4. **Push to your fork:**
+   ```bash
+   git push origin main
+   ```
+
+5. **Create a Pull Request (optional but recommended):**
+   - Go to https://github.com/danny-avila/LibreChat
+   - Click "Pull requests" → "New pull request"
+   - Select "compare across forks"
+   - Choose your fork: `softuvo-shanky/LibreChat-Clone`
+   - Create the PR with a description of the fix
+
+## Verify the Commit
+
+```bash
+git log --oneline -1
+git show HEAD
+```
+
+## Next Steps After Pushing
+
+1. **Build Docker image from your fork:**
+   ```bash
+   cd LibreChat-Clone
+   docker build -t librechat-custom:latest .
+   ```
+
+2. **Or use GitHub Actions** (if configured in your fork):
+   - The fork will automatically build Docker images
+   - Use those images in your docker-compose.yml
+
+3. **Update docker-compose.yml:**
+   ```yaml
+   api:
+     image: librechat-custom:latest  # Or your GitHub registry image
+   ```
+

--- a/packages/api/src/mcp/registry/MCPServerInspector.ts
+++ b/packages/api/src/mcp/registry/MCPServerInspector.ts
@@ -74,6 +74,17 @@ export class MCPServerInspector {
 
   private async detectOAuth(): Promise<void> {
     if (this.config.requiresOAuth != null) return;
+    
+    // Check for OAuth configuration in librechat.yaml for ALL server types
+    // This allows stdio servers to have OAuth configured even without a URL
+    if (this.config.oauth && 
+        this.config.oauth.client_id && 
+        this.config.oauth.client_secret && 
+        this.config.oauth.redirect_uri) {
+      this.config.requiresOAuth = true;
+      return;
+    }
+    
     if (this.config.url == null || this.config.startup === false) {
       this.config.requiresOAuth = false;
       return;


### PR DESCRIPTION
- Check oauth configuration in librechat.yaml for all server types
- Allows stdio servers to have OAuth configured even without a URL
- Fixes issue where google-workspace shows OAuth Required: false
- Resolves: OAuth flow not triggering for command-based MCP servers

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
