### PR TITLE
🧭 fix: Correct Subpath Routing for SSE and Favorites Endpoints

### DIFF
--- a/client/src/data-provider/SSE/mutations.ts
+++ b/client/src/data-provider/SSE/mutations.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { request } from 'librechat-data-provider';
+import { apiBaseUrl, request } from 'librechat-data-provider';
 
 export interface AbortStreamParams {
   /** The stream ID to abort (if known) */
@@ -23,7 +23,10 @@ export interface AbortStreamResponse {
  */
 export const abortStream = async (params: AbortStreamParams): Promise<AbortStreamResponse> => {
   console.log('[abortStream] Calling abort endpoint with params:', params);
-  const result = (await request.post('/api/agents/chat/abort', params)) as AbortStreamResponse;
+  const result = (await request.post(
+    `${apiBaseUrl()}/api/agents/chat/abort`,
+    params,
+  )) as AbortStreamResponse;
   console.log('[abortStream] Abort response:', result);
   return result;
 };

--- a/client/src/data-provider/SSE/queries.ts
+++ b/client/src/data-provider/SSE/queries.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { QueryKeys, request, dataService } from 'librechat-data-provider';
+import { apiBaseUrl, QueryKeys, request, dataService } from 'librechat-data-provider';
 import { useQuery, useQueries, useQueryClient } from '@tanstack/react-query';
 import type { Agents, TConversation } from 'librechat-data-provider';
 import { updateConvoInAllQueries } from '~/utils';
@@ -16,7 +16,9 @@ export interface StreamStatusResponse {
 export const streamStatusQueryKey = (conversationId: string) => ['streamStatus', conversationId];
 
 export const fetchStreamStatus = async (conversationId: string): Promise<StreamStatusResponse> => {
-  return request.get<StreamStatusResponse>(`/api/agents/chat/status/${conversationId}`);
+  return request.get<StreamStatusResponse>(
+    `${apiBaseUrl()}/api/agents/chat/status/${conversationId}`,
+  );
 };
 
 export function useStreamStatus(conversationId: string | undefined, enabled = true) {

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -4,6 +4,7 @@ import { SSE } from 'sse.js';
 import { useSetRecoilState } from 'recoil';
 import { useQueryClient } from '@tanstack/react-query';
 import {
+  apiBaseUrl,
   request,
   Constants,
   QueryKeys,
@@ -144,7 +145,7 @@ export default function useResumableSSE(
       let { userMessage } = currentSubmission;
       let textIndex: number | null = null;
 
-      const baseUrl = `/api/agents/chat/stream/${encodeURIComponent(currentStreamId)}`;
+      const baseUrl = `${apiBaseUrl()}/api/agents/chat/stream/${encodeURIComponent(currentStreamId)}`;
       const url = isResume ? `${baseUrl}?resume=true` : baseUrl;
       console.log('[ResumableSSE] Subscribing to stream:', url, { isResume });
 

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -32,11 +32,11 @@ export type FavoriteItem = {
 };
 
 export function getFavorites(): Promise<FavoriteItem[]> {
-  return request.get('/api/user/settings/favorites');
+  return request.get(`${endpoints.apiBaseUrl()}/api/user/settings/favorites`);
 }
 
 export function updateFavorites(favorites: FavoriteItem[]): Promise<FavoriteItem[]> {
-  return request.post('/api/user/settings/favorites', { favorites });
+  return request.post(`${endpoints.apiBaseUrl()}/api/user/settings/favorites`, { favorites });
 }
 
 export function getSharedMessages(shareId: string): Promise<t.TSharedMessagesResponse> {


### PR DESCRIPTION
## Summary

When hosted on subpath some client requests ignore base url, including streaming response feature. In order to see response from a model page reload is required.

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Deploy LibreChat on a subpath: DOMAIN_CLIENT=https://example.com/chat
1. Verify streaming response is working
1. Verify favorite feature works

### **Test Configuration**:

## Checklist

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] My changes do not introduce new warnings
- [ ] Local unit tests pass with my changes
