### PR TITLE
🪨 fix: Bedrock Provider Support for Memory Agent

### DIFF
--- a/packages/api/src/agents/memory.ts
+++ b/packages/api/src/agents/memory.ts
@@ -396,10 +396,26 @@ ${memory ?? 'No existing memories'}`;
 
     if (isBedrock) {
       const combinedInstructions = [instructions, memoryStatus].filter(Boolean).join('\n\n');
-      const originalContent =
-        messages.length > 0 && typeof messages[0].content === 'string' ? messages[0].content : '';
-      const bedrockUserMessage = new HumanMessage(`${combinedInstructions}\n\n${originalContent}`);
-      processedMessages = [bedrockUserMessage];
+
+      if (messages.length > 0) {
+        const firstMessage = messages[0];
+        const originalContent =
+          typeof firstMessage.content === 'string' ? firstMessage.content : '';
+
+        if (typeof firstMessage.content !== 'string') {
+          logger.warn(
+            'Bedrock memory processing: First message has non-string content, using empty string',
+          );
+        }
+
+        const bedrockUserMessage = new HumanMessage(
+          `${combinedInstructions}\n\n${originalContent}`,
+        );
+        processedMessages = [bedrockUserMessage, ...messages.slice(1)];
+      } else {
+        processedMessages = [new HumanMessage(combinedInstructions)];
+      }
+
       graphInstructions = undefined;
       graphAdditionalInstructions = undefined;
     }

--- a/packages/api/src/agents/memory.ts
+++ b/packages/api/src/agents/memory.ts
@@ -369,6 +369,19 @@ ${memory ?? 'No existing memories'}`;
       }
     }
 
+    // Handle Bedrock with thinking enabled - temperature must be 1
+    const bedrockConfig = finalLLMConfig as {
+      additionalModelRequestFields?: { thinking?: unknown };
+      temperature?: number;
+    };
+    if (
+      llmConfig?.provider === Providers.BEDROCK &&
+      bedrockConfig.additionalModelRequestFields?.thinking != null &&
+      bedrockConfig.temperature != null
+    ) {
+      (finalLLMConfig as unknown as Record<string, unknown>).temperature = 1;
+    }
+
     const llmConfigWithHeaders = finalLLMConfig as OpenAIClientOptions;
     if (llmConfigWithHeaders?.configuration?.defaultHeaders != null) {
       llmConfigWithHeaders.configuration.defaultHeaders = resolveHeaders({


### PR DESCRIPTION
## Summary

I added support for AWS Bedrock provider in memory processing by adapting how instructions are passed to the model. Bedrock's Converse API requires conversations to start with a user message rather than a system message, so I moved instructions from system prompts into the first user message content for Bedrock providers.

- Detect Bedrock provider and prepend combined instructions to the first user message content instead of using system prompts
- Preserve all subsequent messages when processing for Bedrock
- Add logging when non-string message content is encountered
- Handle Bedrock's extended thinking mode by forcing temperature to 1 when thinking is enabled
- Handle empty messages array case by creating a new message with just instructions
- Add comprehensive tests for both Bedrock and non-Bedrock provider instruction handling
- Refactor imports to consolidate utility functions from `~/utils`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Tested memory processing with Bedrock provider configuration using Claude models. Verified that:
- Instructions are correctly prepended to user messages for Bedrock
- Non-Bedrock providers continue to use system prompts as before
- Extended thinking mode works with forced temperature setting

### Test Configuration

```yaml
memory:
  agent:
    provider: "bedrock"
    model: "us.anthropic.claude-3-5-haiku-20241022-v1:0"
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes