### PR TITLE
🛠️ fix: improved retry logic during meili sync & improved batching 

### DIFF
--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -55,12 +55,6 @@ export interface SchemaWithMeiliMethods extends Model<DocumentWithMeiliIndex> {
   processSyncBatch(
     index: Index<MeiliIndexable>,
     documents: Array<Record<string, unknown>>,
-    updateOps: Array<{
-      updateOne: {
-        filter: Record<string, unknown>;
-        update: { $set: { _meiliIndex: boolean } };
-      };
-    }>,
   ): Promise<void>;
   cleanupMeiliIndex(
     index: Index<MeiliIndexable>,
@@ -156,8 +150,8 @@ const createMeiliMongooseModel = ({
      * Get the current sync progress
      */
     static async getSyncProgress(this: SchemaWithMeiliMethods): Promise<SyncProgress> {
-      const totalDocuments = await this.countDocuments();
-      const indexedDocuments = await this.countDocuments({ _meiliIndex: true });
+      const totalDocuments = await this.countDocuments({ expiredAt: null });
+      const indexedDocuments = await this.countDocuments({ expiredAt: null, _meiliIndex: true });
 
       return {
         totalProcessed: indexedDocuments,
@@ -168,105 +162,77 @@ const createMeiliMongooseModel = ({
 
     /**
      * Synchronizes the data between the MongoDB collection and the MeiliSearch index.
-     * Now uses streaming and batching to reduce memory usage.
      */
-    static async syncWithMeili(
-      this: SchemaWithMeiliMethods,
-      options?: { resumeFromId?: string },
-    ): Promise<void> {
+    static async syncWithMeili(this: SchemaWithMeiliMethods): Promise<void> {
+      const startTime = Date.now();
+      const { batchSize, delayMs } = syncConfig;
+
+      const collectionName = primaryKey === 'messageId' ? 'messages' : 'conversations';
+      logger.info(
+        `[syncWithMeili] Starting sync for ${collectionName} with batch size ${batchSize}`,
+      );
+
+      // Get approximate total count for raw estimation, the sync should not overcome this number
+      const approxTotalCount = await this.estimatedDocumentCount();
+      logger.info(
+        `[syncWithMeili] Approximate total number of all ${collectionName}: ${approxTotalCount}`,
+      );
+
       try {
-        const startTime = Date.now();
-        const { batchSize, delayMs } = syncConfig;
-
-        logger.info(
-          `[syncWithMeili] Starting sync for ${primaryKey === 'messageId' ? 'messages' : 'conversations'} with batch size ${batchSize}`,
-        );
-
-        // Build query with resume capability
-        // Do not sync TTL documents
-        const query: FilterQuery<unknown> = { expiredAt: null };
-        if (options?.resumeFromId) {
-          query._id = { $gt: options.resumeFromId };
-        }
-
-        // Get approximate total count for progress tracking
-        const approxTotalCount = await this.estimatedDocumentCount();
-        logger.info(`[syncWithMeili] Approximate total number of documents to sync: ${approxTotalCount}`);
-        
-        let processedCount = 0;
-
         // First, handle documents that need to be removed from Meili
+        logger.info(`[syncWithMeili] Starting cleanup of Meili index ${index.uid} before sync`);
         await this.cleanupMeiliIndex(index, primaryKey, batchSize, delayMs);
-
-        // Process MongoDB documents in batches using cursor
-        const cursor = this.find(query)
-          .select(attributesToIndex.join(' ') + ' _meiliIndex')
-          .sort({ _id: 1 })
-          .batchSize(batchSize)
-          .cursor();
-
-        const format = (doc: Record<string, unknown>) =>
-          _.omitBy(_.pick(doc, attributesToIndex), (v, k) => k.startsWith('$'));
-
-        let documentBatch: Array<Record<string, unknown>> = [];
-        let updateOps: Array<{
-          updateOne: {
-            filter: Record<string, unknown>;
-            update: { $set: { _meiliIndex: boolean } };
-          };
-        }> = [];
-
-        // Process documents in streaming fashion
-        for await (const doc of cursor) {
-          const typedDoc = doc.toObject() as unknown as Record<string, unknown>;
-          const formatted = format(typedDoc);
-
-          // Check if document needs indexing
-          if (!typedDoc._meiliIndex) {
-            documentBatch.push(formatted);
-            updateOps.push({
-              updateOne: {
-                filter: { _id: typedDoc._id },
-                update: { $set: { _meiliIndex: true } },
-              },
-            });
-          }
-
-          processedCount++;
-
-          // Process batch when it reaches the configured size
-          if (documentBatch.length >= batchSize) {
-            await this.processSyncBatch(index, documentBatch, updateOps);
-            documentBatch = [];
-            updateOps = [];
-
-            // Log progress
-            // Calculate percentage based on approximate total count sometimes might lead to more than 100%
-            // the difference is very small and acceptable for progress tracking
-            const percent = Math.round((processedCount / approxTotalCount) * 100);
-            const progress = Math.min(percent, 100);
-            logger.info(`[syncWithMeili] Progress: ${progress}% (count: ${processedCount})`);
-
-            // Add delay to prevent overwhelming resources
-            if (delayMs > 0) {
-              await new Promise((resolve) => setTimeout(resolve, delayMs));
-            }
-          }
-        }
-
-        // Process remaining documents
-        if (documentBatch.length > 0) {
-          await this.processSyncBatch(index, documentBatch, updateOps);
-        }
-
-        const duration = Date.now() - startTime;
-        logger.info(
-          `[syncWithMeili] Completed sync for ${primaryKey === 'messageId' ? 'messages' : 'conversations'} in ${duration}ms`,
-        );
+        logger.info(`[syncWithMeili] Completed cleanup of Meili index: ${index.uid}`);
       } catch (error) {
-        logger.error('[syncWithMeili] Error during sync:', error);
+        logger.error('[syncWithMeili] Error during cleanup Meili before sync:', error);
         throw error;
       }
+
+      let processedCount = 0;
+      let hasMore = true;
+
+      while (hasMore) {
+        
+        const query: FilterQuery<unknown> = {
+          expiredAt: null,
+          _meiliIndex: false,
+        };
+
+        try {
+          const documents = await this.find(query)
+            .select(attributesToIndex.join(' ') + ' _meiliIndex')
+            .limit(batchSize)
+            .lean();
+
+          // Check if there are more documents to process
+          if (documents.length === 0) {
+            logger.info('[syncWithMeili] No more documents to process');
+            break;
+          }
+
+          // Process the batch
+          await this.processSyncBatch(index, documents);
+          processedCount += documents.length;
+          logger.info(`[syncWithMeili] Processed: ${processedCount}`);
+
+          if (documents.length < batchSize) {
+            hasMore = false;
+          }
+
+          // Add delay to prevent overwhelming resources
+          if (hasMore && delayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
+        } catch (error) {
+          logger.error('[syncWithMeili] Error processing documents batch:', error);
+          throw error;
+        }
+      }
+
+      const duration = Date.now() - startTime;
+      logger.info(
+        `[syncWithMeili] Completed sync for ${collectionName}. Processed ${processedCount} documents in ${duration}ms`,
+      );
     }
 
     /**
@@ -276,25 +242,23 @@ const createMeiliMongooseModel = ({
       this: SchemaWithMeiliMethods,
       index: Index<MeiliIndexable>,
       documents: Array<Record<string, unknown>>,
-      updateOps: Array<{
-        updateOne: {
-          filter: Record<string, unknown>;
-          update: { $set: { _meiliIndex: boolean } };
-        };
-      }>,
     ): Promise<void> {
       if (documents.length === 0) {
         return;
       }
 
+      // Format documents for MeiliSearch
+      const formattedDocs = documents.map((doc) =>
+        _.omitBy(_.pick(doc, attributesToIndex), (_v, k) => k.startsWith('$')),
+      );
+
       try {
         // Add documents to MeiliSearch
-        await index.addDocuments(documents);
+        await index.addDocumentsInBatches(formattedDocs);
 
         // Update MongoDB to mark documents as indexed
-        if (updateOps.length > 0) {
-          await this.collection.bulkWrite(updateOps);
-        }
+        const docsIds = documents.map((doc) => doc._id);
+        await this.updateMany({ _id: { $in: docsIds } }, { $set: { _meiliIndex: true } });
       } catch (error) {
         logger.error('[processSyncBatch] Error processing batch:', error);
         // Don't throw - allow sync to continue with other documents
@@ -336,7 +300,7 @@ const createMeiliMongooseModel = ({
           // Delete documents that don't exist in MongoDB
           const toDelete = meiliIds.filter((id) => !existingIds.has(id));
           if (toDelete.length > 0) {
-            await Promise.all(toDelete.map((id) => index.deleteDocument(id as string)));
+            await index.deleteDocuments(toDelete.map(String));
             logger.debug(`[cleanupMeiliIndex] Deleted ${toDelete.length} orphaned documents`);
           }
 


### PR DESCRIPTION
## Summary

This PR improves the MeiliSearch sync flow focusing on resilience, correctness, and performance.

#### Changes
- **More resilient retry logic:** Reworked retry handling to match patterns used elsewhere in the codebase. The sync no longer relies on a long-lived MongoDB cursor (which can be disposed due to network issues or server-side cursor cleanup). Instead, it repeatedly pulls documents that still need processing using the existing queue filter.
- **Faster batch updates:** Replaced `bulkWrite` with `updateMany` where the code applies the same filter and the same update to multiple documents. This reduces client-side overhead and improves update performance.
- **Faster pre-sync cleanup deletes:** Optimized the deletion of documents during MeiliSearch cleanup before the sync starts.
- **Fix: missing “should sync” decision condition:** Added the missing condition for counting total documents prior to starting Meili sync, ensuring the “sync needed” decision is correct.
- **Code simplification + better logs:** Reduced complexity in the sync implementation and improved logging for easier debugging and visibility.

#### Motivation
The previous implementation could fail or stall when MongoDB cursors were invalidated (e.g., transient network failures or server-side cursor disposal). It also used a heavier write path for uniform updates. These changes make the sync more reliable and more performant.


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Extended existing unit-tests

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
