### PR TITLE
🔧 fix: Update Z-index values for Navigation and Mask layers

### DIFF
--- a/client/src/components/Conversations/ConvoOptions/ConvoOptions.tsx
+++ b/client/src/components/Conversations/ConvoOptions/ConvoOptions.tsx
@@ -294,6 +294,7 @@ function ConvoOptions({
         portal={true}
         menuId={menuId}
         focusLoop={true}
+        className="z-[125]"
         unmountOnHide={true}
         isOpen={isPopoverActive}
         setIsOpen={setIsPopoverActive}
@@ -321,7 +322,6 @@ function ConvoOptions({
           </Ariakit.MenuButton>
         }
         items={dropdownItems}
-        className="z-30"
       />
       {showShareDialog && (
         <ShareButton

--- a/client/src/components/Nav/AccountSettings.tsx
+++ b/client/src/components/Nav/AccountSettings.tsx
@@ -40,7 +40,7 @@ function AccountSettings() {
         </div>
       </Select.Select>
       <Select.SelectPopover
-        className="popover-ui w-[305px] rounded-lg md:w-[244px]"
+        className="popover-ui z-[125] w-[305px] rounded-lg md:w-[244px]"
         style={{
           transformOrigin: 'bottom',
           translate: '0 -4px',

--- a/client/src/components/Nav/Bookmarks/BookmarkNav.tsx
+++ b/client/src/components/Nav/Bookmarks/BookmarkNav.tsx
@@ -89,6 +89,7 @@ const BookmarkNav: FC<BookmarkNavProps> = ({ tags, setTags }: BookmarkNavProps) 
       unmountOnHide={true}
       setIsOpen={setIsMenuOpen}
       keyPrefix="bookmark-nav-"
+      className="z-[125]"
       trigger={
         <TooltipAnchor
           description={label}

--- a/client/src/components/Nav/Favorites/FavoriteItem.tsx
+++ b/client/src/components/Nav/Favorites/FavoriteItem.tsx
@@ -136,6 +136,7 @@ export default function FavoriteItem({
           mountByState={true}
           isOpen={isPopoverActive}
           setIsOpen={setIsPopoverActive}
+          className="z-[125]"
           trigger={
             <Menu.MenuButton
               className={cn(

--- a/client/src/components/Nav/Nav.tsx
+++ b/client/src/components/Nav/Nav.tsx
@@ -262,7 +262,7 @@ const Nav = memo(
           <div
             data-testid="nav"
             className={cn(
-              'nav fixed left-0 top-0 z-[70] h-full bg-surface-primary-alt',
+              'nav fixed left-0 top-0 z-[110] h-full bg-surface-primary-alt',
               navVisible && 'active',
             )}
             style={{

--- a/client/src/mobile.css
+++ b/client/src/mobile.css
@@ -36,7 +36,7 @@
   }
   .nav-mask {
     position: fixed;
-    z-index: 63;
+    z-index: 105;
     left: 0;
     right: 0;
     top: 0;

--- a/client/src/mobile.css
+++ b/client/src/mobile.css
@@ -9,7 +9,7 @@
 
 .nav {
   position: fixed;
-  z-index: 64;
+  z-index: 110;
   top: 0;
 
   /* max-width: 260px; */


### PR DESCRIPTION
- Increased z-index of the .nav-mask class from 63 to 105 for improved layering.
- Updated z-index of the nav component from 70 to 110 to ensure it appears above other elements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns layering to prevent popovers and the mobile sidebar from being obscured.
> 
> - Increase mobile sidebar `nav` to `z-[110]` and `nav-mask` to `z-[105]` in `Nav.tsx` and `mobile.css`
> - Set popovers to `z-[125]` for `ConvoOptions` `DropdownPopup`, `AccountSettings` `SelectPopover`, `BookmarkNav` `DropdownPopup`, and `FavoriteItem` `DropdownPopup`
> - Removes lower z-index on older menu instance to ensure consistent overlay behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d856bb6fb35207a35f7aa14ebaa7a9d4047969f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->