### PR TITLE
🔎 fix: Focus Credential Inputs in Agent Tools 

### DIFF
--- a/client/src/components/MCP/CustomUserVarsSection.tsx
+++ b/client/src/components/MCP/CustomUserVarsSection.tsx
@@ -86,6 +86,10 @@ function AuthField({ name, config, hasValue, control, errors, autoFocus }: AuthF
           <Input
             id={name}
             type="text"
+            /* autoFocus is generally disabled due to the fact that it can disorient users,
+             * but in this case, the required field would logically be immediately navigated to anyways, and the component's
+             * functionality emulates that of a new modal opening, where users would expect focus to be shifted to the new content */
+            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus={autoFocus}
             {...field}
             placeholder={
@@ -163,6 +167,7 @@ export default function CustomUserVarsSection({
               hasValue={hasValue}
               control={control}
               errors={errors}
+              // eslint-disable-next-line jsx-a11y/no-autofocus -- See AuthField autoFocus comment for more details
               autoFocus={index === 0}
             />
           );

--- a/client/src/components/MCP/CustomUserVarsSection.tsx
+++ b/client/src/components/MCP/CustomUserVarsSection.tsx
@@ -23,9 +23,10 @@ interface AuthFieldProps {
   hasValue: boolean;
   control: any;
   errors: any;
+  autoFocus?: boolean;
 }
 
-function AuthField({ name, config, hasValue, control, errors }: AuthFieldProps) {
+function AuthField({ name, config, hasValue, control, errors, autoFocus }: AuthFieldProps) {
   const localize = useLocalize();
   const statusText = hasValue ? localize('com_ui_set') : localize('com_ui_unset');
 
@@ -85,6 +86,7 @@ function AuthField({ name, config, hasValue, control, errors }: AuthFieldProps) 
           <Input
             id={name}
             type="text"
+            autoFocus={autoFocus}
             {...field}
             placeholder={
               hasValue
@@ -150,7 +152,7 @@ export default function CustomUserVarsSection({
   return (
     <div className="flex-1 space-y-4">
       <form onSubmit={handleSubmit(onFormSubmit)} className="space-y-4">
-        {Object.entries(fields).map(([key, config]) => {
+        {Object.entries(fields).map(([key, config], index) => {
           const hasValue = authValuesData?.authValueFlags?.[key] || false;
 
           return (
@@ -161,6 +163,7 @@ export default function CustomUserVarsSection({
               hasValue={hasValue}
               control={control}
               errors={errors}
+              autoFocus={index === 0}
             />
           );
         })}

--- a/client/src/components/Plugins/Store/PluginAuthForm.tsx
+++ b/client/src/components/Plugins/Store/PluginAuthForm.tsx
@@ -57,6 +57,10 @@ function PluginAuthForm({ plugin, onSubmit, isEntityTool }: TPluginAuthFormProps
                       aria-describedby={`${authField}-error`}
                       aria-label={config.label}
                       aria-required="true"
+                      /* autoFocus is generally disabled due to the fact that it can disorient users,
+                       * but in this case, the required field must be navigated to anyways, and the component's functionality
+                       * emulates that of a new modal opening, where users would expect focus to be shifted to the new content */
+                      // eslint-disable-next-line jsx-a11y/no-autofocus
                       autoFocus={i === 0}
                       {...register(authField, {
                         required: `${config.label} is required.`,

--- a/client/src/components/Plugins/Store/PluginAuthForm.tsx
+++ b/client/src/components/Plugins/Store/PluginAuthForm.tsx
@@ -23,6 +23,7 @@ function PluginAuthForm({ plugin, onSubmit, isEntityTool }: TPluginAuthFormProps
 
   return (
     <div className="flex w-full flex-col items-center gap-2">
+
       <div className="grid w-full gap-6 sm:grid-cols-2">
         <form
           className="col-span-1 flex w-full flex-col items-start justify-start gap-2"
@@ -56,6 +57,7 @@ function PluginAuthForm({ plugin, onSubmit, isEntityTool }: TPluginAuthFormProps
                       aria-describedby={`${authField}-error`}
                       aria-label={config.label}
                       aria-required="true"
+                      autoFocus={i === 0}
                       {...register(authField, {
                         required: `${config.label} is required.`,
                         minLength: {
@@ -70,7 +72,7 @@ function PluginAuthForm({ plugin, onSubmit, isEntityTool }: TPluginAuthFormProps
                 </HoverCard>
                 {errors[authField] && (
                   <span role="alert" className="mt-1 text-sm text-red-400">
-                    {errors?.[authField]?.message ?? ''}
+                    {String(errors?.[authField]?.message ?? '')}
                   </span>
                 )}
               </div>

--- a/client/src/components/Plugins/Store/PluginAuthForm.tsx
+++ b/client/src/components/Plugins/Store/PluginAuthForm.tsx
@@ -23,7 +23,6 @@ function PluginAuthForm({ plugin, onSubmit, isEntityTool }: TPluginAuthFormProps
 
   return (
     <div className="flex w-full flex-col items-center gap-2">
-
       <div className="grid w-full gap-6 sm:grid-cols-2">
         <form
           className="col-span-1 flex w-full flex-col items-start justify-start gap-2"


### PR DESCRIPTION
Closes #5505 

## Summary

This pull request improves the accessibility of authentication and user variable forms within the Agent Builder Panel's 'Add Tools' and 'Add MCP Server Tools' Dialogs by ensuring the first input field is automatically focused when attempting to add a tool. This ensures that screen readers are explicitly informed of a change in content. Previously, there was no indication that further input was required for the tool addition to complete if a user was relying on a screen reader unless they navigated back through the page to discover the new inputs.

> Note: The autoFocus ESLint rule has been disabled here, though if a future rework of this component were to take place, these additional fields might benefit from being presented within the context of another modal to align with user expectations and how other components in the app handle custom user vars and API Key inputs, rather than being added to the existing modal and requiring the autoFocus linter override.

##### Example: A modal like this with 'Confirm' button rather than 'Reinitialize'
<img width="660" height="365" alt="Screenshot 2026-01-18 at 10 46 22 AM" src="https://github.com/user-attachments/assets/abf65218-a101-4b1e-a986-61084c423d27" />

**Enhanced Form Usability:**

* Added `autoFocus` support to the `AuthField` component and its props in `CustomUserVarsSection.tsx`, and set `autoFocus` on the first input field in both custom user variables and plugin authentication forms to streamline user input. [[1]](diffhunk://#diff-2e21b7c04e320fc4abe0b69cea733b8172f429857bdac28445106166ab9b07d1R26-R29) [[2]](diffhunk://#diff-2e21b7c04e320fc4abe0b69cea733b8172f429857bdac28445106166ab9b07d1R89) [[3]](diffhunk://#diff-2e21b7c04e320fc4abe0b69cea733b8172f429857bdac28445106166ab9b07d1L153-R155) [[4]](diffhunk://#diff-2e21b7c04e320fc4abe0b69cea733b8172f429857bdac28445106166ab9b07d1R166) [[5]](diffhunk://#diff-51e7396faca10cb464e39ca565f0c914ccf3d2b4343a6e3d53498b0a82ea4ae4R60)

**ESLint Error Cleanup:**

* Updated error message rendering in `PluginAuthForm.tsx` to explicitly convert messages to strings, preventing potential issues with non-string error values.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before
#### No indication of presence of required inputs
https://github.com/user-attachments/assets/74720725-df6f-4ecb-b7ba-7952b3f08728

### After
#### Focus automatically transferred to new input field
https://github.com/user-attachments/assets/946e1636-2248-45a9-9b03-07f592082af3

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes