### PR TITLE
📬 fix: Email Verification Handling in Create-User Command

### DIFF
--- a/config/create-user.js
+++ b/config/create-user.js
@@ -14,7 +14,7 @@ const connect = require('./connect');
   console.purple('--------------------------');
 
   if (process.argv.length < 5) {
-    console.orange('Usage: npm run create-user <email> <name> <username> [--email-verified=false]');
+    console.orange('Usage: npm run create-user -- <email> <name> <username> [--email-verified=false]');
     console.orange('Note: if you do not pass in the arguments, you will be prompted for them.');
     console.orange(
       'If you really need to pass in the password, you can do so as the 4th argument (not recommended for security).',
@@ -90,6 +90,9 @@ or the user will need to attempt logging in to have a verification link sent to 
 
     if (emailVerifiedInput.toLowerCase() === 'n') {
       emailVerified = false;
+    }
+    if (emailVerifiedInput.toLowerCase() === 'y') {
+      emailVerified = true;
     }
   }
 

--- a/config/create-user.js
+++ b/config/create-user.js
@@ -88,11 +88,12 @@ If \`n\`, and email service is configured, the user will be sent a verification 
 If \`n\`, and email service is not configured, you must have the \`ALLOW_UNVERIFIED_EMAIL_LOGIN\` .env variable set to true,
 or the user will need to attempt logging in to have a verification link sent to them.`);
 
-    if (emailVerifiedInput.toLowerCase() === 'n') {
+    const normalizedEmailVerifiedInput = emailVerifiedInput.trim().toLowerCase()
+
+    emailVerified = true
+
+    if (normalizedEmailVerifiedInput === 'n') {
       emailVerified = false;
-    }
-    if (emailVerifiedInput.toLowerCase() === 'y') {
-      emailVerified = true;
     }
   }
 


### PR DESCRIPTION
## Summary

set `emailVerified` to true when the input is 'y'.  As mentioned in the `create-user.js`

> If \`y\`, the user's email will be considered verified.

## Testing

Run the below command without the  `--email-verified=false` arg

```shell
npm run create-user
```

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)