### PR TITLE
fix: downgrade expected /files/images + ENOENT logs

### DIFF
--- a/api/server/services/Files/Local/crud.js
+++ b/api/server/services/Files/Local/crud.js
@@ -185,6 +185,11 @@ const unlinkFile = async (filepath) => {
   try {
     await fs.promises.unlink(filepath);
   } catch (error) {
+    // Deleting a file that no longer exists is expected in some flows (races/cleanup).
+    if (error?.code === 'ENOENT') {
+      logger.debug('[unlinkFile] File already deleted');
+      return;
+    }
     logger.error('Error deleting file:', error);
   }
 };


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

This PR reduces noisy error logs for expected image-related flows:

- Treat image uploads for file_search tool resources as an expected validation failure (log at debug instead of error).
- Downgrade expected ENOENT (“file not found”) during image cleanup/delete/open (common race/cleanup case) from error → debug.
- Keep unexpected failures logged as errors.

## Change Type

Please delete any irrelevant options.

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code