### PR TITLE
📏 fix: Dropdown Menu Z-Index Adjustments

### DIFF
--- a/packages/client/src/components/OriginalDialog.tsx
+++ b/packages/client/src/components/OriginalDialog.tsx
@@ -55,7 +55,7 @@ export const DialogOverlay = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, style, ...props }, ref) => {
   const depth = React.useContext(DialogDepthContext);
-  const overlayZIndex = 50 + (depth - 1) * 60;
+  const overlayZIndex = 130 + (depth - 1) * 60;
 
   return (
     <DialogPrimitive.Overlay
@@ -94,7 +94,7 @@ const DialogContent = React.forwardRef<
     ref,
   ) => {
     const depth = React.useContext(DialogDepthContext);
-    const contentZIndex = 100 + (depth - 1) * 60;
+    const contentZIndex = 140 + (depth - 1) * 60;
 
     /* Handle Escape key to prevent closing dialog if a tooltip or dropdown has focus
     (this is a workaround in order to achieve WCAG compliance which requires


### PR DESCRIPTION
## Summary

This pull request adjusts the z-index values for dialog overlays and dialog content in the `OriginalDialog.tsx` component to improve stacking order and ensure dialogs appear above other UI elements.

**Dialog z-index adjustments:**

* Increased the base z-index for `DialogOverlay` from 50 to 130 to ensure overlays are rendered above more elements.
* Increased the base z-index for `DialogContent` from 100 to 140 to maintain proper stacking above overlays and other content.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Went through modals spawned via Conversation Options dropdown menu items for Share Chat and Delete Chat modals, checked dropdown menus within My Files modal spawned from filter and sort buttons to check for regressions.

### Before
<img width="1728" height="961" alt="Screenshot 2026-01-20 at 1 54 39 PM" src="https://github.com/user-attachments/assets/b34a9958-86cb-40f3-9f28-997e8ecf8dbc" />

### After
<img width="1728" height="961" alt="Screenshot 2026-01-20 at 1 54 31 PM" src="https://github.com/user-attachments/assets/12eaa301-d885-447d-96d8-908c8d74f85a" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes