### PR TITLE
feat(openid): add support for LDAP Distinguished Names in groups claim

### DIFF
--- a/packages/api/src/auth/openid.ts
+++ b/packages/api/src/auth/openid.ts
@@ -1,6 +1,60 @@
 import { logger } from '@librechat/data-schemas';
 import { ErrorTypes } from 'librechat-data-provider';
 import type { IUser, UserMethods } from '@librechat/data-schemas';
+import { safeStringify } from '../utils/openid';
+
+/**
+ * Extracts the CN (Common Name) from an LDAP DN (Distinguished Name).
+ * If the input is not a DN format string, returns the original value.
+ *
+ * Note: This function assumes that any string starting with "CN=" (case-insensitive)
+ * is an LDAP DN. While unlikely in practice, a simple role name legitimately starting
+ * with "CN=" would be treated as a DN and have its CN extracted.
+ *
+ * @example
+ * extractCNFromDN("CN=MY-GROUP,OU=groups,O=company,C=FR") // returns "MY-GROUP"
+ * extractCNFromDN("simple-role") // returns "simple-role"
+ * extractCNFromDN("CN=Group\\, Inc,OU=groups") // returns "Group, Inc" (handles escaped commas)
+ *
+ * @param dn - The LDAP Distinguished Name or simple role name
+ * @returns The extracted CN or the original string if not a DN, empty string for non-string inputs
+ */
+export function extractCNFromDN(dn: unknown): string {
+  if (typeof dn !== 'string') {
+    return '';
+  }
+  // Match CN= at the start (case-insensitive), capturing until the first unescaped comma
+  // Handles escaped characters like \, in DN values (e.g., "CN=Group\, Inc,OU=groups")
+  const match = dn.match(/^cn=((?:\\.|[^,])+)/i);
+  if (match) {
+    // Unescape any escaped characters (e.g., \, becomes ,)
+    return match[1].replace(/\\(.)/g, '$1');
+  }
+  return dn;
+}
+
+/**
+ * Normalizes roles by extracting CN from LDAP DNs.
+ * This allows comparing simple role names like "MY-GROUP" with
+ * LDAP DN values like "CN=MY-GROUP,OU=groups,O=company,C=FR".
+ *
+ * @param roles - The roles to normalize
+ * @returns Array of normalized role names
+ */
+export function normalizeRoles(roles: unknown): string[] {
+  if (typeof roles === 'string') {
+    return [extractCNFromDN(roles)];
+  }
+  if (Array.isArray(roles)) {
+    return roles.map(extractCNFromDN).filter(Boolean);
+  }
+  logger.warn(
+    `[openidStrategy] Unexpected roles format, expected string or array, got "${typeof roles}": ${safeStringify(
+      roles,
+    )}`,
+  );
+  return [];
+}
 
 /**
  * Finds or migrates a user for OpenID authentication


### PR DESCRIPTION
## Summary                                                                                                                                    
                                                                                                                                                
  This PR adds support for LDAP Distinguished Names (DN) format in the `groups` claim when using `OPENID_REQUIRED_ROLE`.                        
                                                                                                                                                
  ### Problem                                                                                                                                   
                                                                                                                                                
  When using OIDC with identity providers (like ForgeRock AM) that return LDAP groups in DN format, the `OPENID_REQUIRED_ROLE` check fails      
  because LibreChat expects simple group names.                                                                                                 
                                                                                                                                                
  **Example:** The `groups` claim contains:                                                                                                     
  ```json                                                                                                                                       
  "groups": [                                                                                                                                   
    "CN=MY-APP-USERS,OU=group,O=company,C=FR"                                                                                                   
  ]                                                                                                                                             
  ```                                                                                                                                           
                                                                                                                                                
  With configuration `OPENID_REQUIRED_ROLE=MY-APP-USERS`, the check fails because the array contains the full DN, not the simple name.          
                                                                                                                                                
  ### Solution                                                                                                                                  
                                                                                                                                                
  This PR adds two helper functions:                                                                                                            
  - `extractCNFromDN()` - Extracts the CN (Common Name) from an LDAP DN string                                                                  
  - `normalizeRoles()` - Normalizes an array of roles by extracting CN from any DN format entries                                               
                                                                                                                                                
  The role comparison now uses normalized roles, allowing simple role names to match DN format groups.                                          
                                                                                                                                                
  ### Changes                                                                                                                                   
                                                                                                                                                
  - Added `extractCNFromDN()` function with JSDoc documentation                                                                                 
  - Added `normalizeRoles()` function with JSDoc documentation                                                                                  
  - Modified role checking logic to normalize roles before comparison                                                                           
  - **Fully backward compatible** - simple group names continue to work as before                                                               
                                                                                                                                                
  ### Testing                                                                                                                                   
                                                                                                                                                
  Tested with ForgeRock AM identity provider returning LDAP groups in DN format:                                                                
  - ✅ Simple role names now match DN format groups                                                                                             
  - ✅ Simple role names still work with simple group values                                                                                    
  - ✅ No breaking changes to existing configurations                                                                                           
                                                                                                                                                
  Fixes #11443                                                                                                                                  
                                                                                                                                                
  ## Change Type                                                                                                                                
                                                                                                                                                
  - [ ] Bug fix (non-breaking change which fixes an issue)                                                                                      
  - [x] New feature (non-breaking change which adds functionality)                                                                              
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)                                        
  - [ ] Documentation update                                                                                                                    
                                                                                                                                                
  ## Testing                                                                                                                                    
                                                                                                                                                
  - [x] Tested locally with ForgeRock AM identity provider                                                                                      
  - [x] Verified backward compatibility with simple group names 