### PR TITLE
🔊 fix: Conversation Search Result Announcement

### DIFF
--- a/client/src/routes/Search.tsx
+++ b/client/src/routes/Search.tsx
@@ -79,12 +79,15 @@ export default function Search() {
   }
 
   const resultsCount = messages?.length ?? 0;
-  const resultsAnnouncement =
-    resultsCount === 0
-      ? localize('com_ui_nothing_found')
-      : resultsCount === 1
-        ? localize('com_ui_result_found', { count: resultsCount })
-        : localize('com_ui_results_found', { count: resultsCount });
+  const resultsAnnouncement = (() => {
+    if (resultsCount === 0) {
+      return localize('com_ui_nothing_found');
+    }
+    if (resultsCount === 1) {
+      return localize('com_ui_result_found', { count: resultsCount });
+    }
+    return localize('com_ui_results_found', { count: resultsCount });
+  })();
 
   return (
     <MinimalMessagesWrapper ref={containerRef} className="relative flex h-full pt-4">

--- a/client/src/routes/Search.tsx
+++ b/client/src/routes/Search.tsx
@@ -64,6 +64,17 @@ export default function Search() {
     }
   }, [isError, searchQuery, showToast]);
 
+  const resultsCount = messages?.length ?? 0;
+  const resultsAnnouncement = useMemo(() => {
+    if (resultsCount === 0) {
+      return localize('com_ui_nothing_found');
+    }
+    if (resultsCount === 1) {
+      return localize('com_ui_result_found', { count: resultsCount });
+    }
+    return localize('com_ui_results_found', { count: resultsCount });
+  }, [resultsCount, localize]);
+
   const isSearchLoading = search.isTyping || isLoading || isFetchingNextPage;
 
   if (isSearchLoading) {
@@ -77,17 +88,6 @@ export default function Search() {
   if (!searchQuery) {
     return null;
   }
-
-  const resultsCount = messages?.length ?? 0;
-  const resultsAnnouncement = (() => {
-    if (resultsCount === 0) {
-      return localize('com_ui_nothing_found');
-    }
-    if (resultsCount === 1) {
-      return localize('com_ui_result_found', { count: resultsCount });
-    }
-    return localize('com_ui_results_found', { count: resultsCount });
-  })();
 
   return (
     <MinimalMessagesWrapper ref={containerRef} className="relative flex h-full pt-4">

--- a/client/src/routes/Search.tsx
+++ b/client/src/routes/Search.tsx
@@ -88,7 +88,7 @@ export default function Search() {
 
   return (
     <MinimalMessagesWrapper ref={containerRef} className="relative flex h-full pt-4">
-      <div className="sr-only" role="alert" aria-live="polite" aria-atomic="true">
+      <div className="sr-only" role="alert" aria-atomic="true">
         {resultsAnnouncement}
       </div>
       {(messages && messages.length === 0) || messages == null ? (

--- a/client/src/routes/Search.tsx
+++ b/client/src/routes/Search.tsx
@@ -78,8 +78,19 @@ export default function Search() {
     return null;
   }
 
+  const resultsCount = messages?.length ?? 0;
+  const resultsAnnouncement =
+    resultsCount === 0
+      ? localize('com_ui_nothing_found')
+      : resultsCount === 1
+        ? localize('com_ui_result_found', { count: resultsCount })
+        : localize('com_ui_results_found', { count: resultsCount });
+
   return (
     <MinimalMessagesWrapper ref={containerRef} className="relative flex h-full pt-4">
+      <div className="sr-only" role="alert" aria-live="polite" aria-atomic="true">
+        {resultsAnnouncement}
+      </div>
       {(messages && messages.length === 0) || messages == null ? (
         <div className="absolute inset-0 flex items-center justify-center">
           <div className="rounded-lg bg-white p-6 text-lg text-gray-500 dark:border-gray-800/50 dark:bg-gray-800 dark:text-gray-300">


### PR DESCRIPTION
## Summary

This pull request adds an accessibility improvement to the search results page by announcing the number of results found to screen readers. This ensures users relying on assistive technologies receive immediate feedback about their search.

Accessibility enhancements:

* Added a visually hidden (`sr-only`) alert element with `aria-live="polite"` and `aria-atomic="true"` to announce the number of search results found, supporting both zero, singular, and plural cases. (`client/src/routes/Search.tsx`)

Closes [Axe Auditor Issue #569](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/d525c6a4-8cd4-11f0-9d7a-13adc3db6809?activeTab=dt-issue&page=0&pageSize=100&sortField=ordinal&sortDir=asc&row=0&filter%5Bseverity%5D=3&filter%5Bstatus%5D=open)
## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

https://github.com/user-attachments/assets/b036550b-f45c-4cf5-956a-550a98be17b0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes