### PR TITLE
🔖 fix: Announce Bookmark Selection State

### DIFF
--- a/client/src/common/menus.ts
+++ b/client/src/common/menus.ts
@@ -15,6 +15,8 @@ export interface MenuItemProps {
   separate?: boolean;
   hideOnClick?: boolean;
   dialog?: React.ReactElement;
+  ariaLabel?: string;
+  ariaChecked?: boolean;
   ref?: React.Ref<any>;
   className?: string;
   render?:

--- a/client/src/components/Chat/Menus/BookmarkMenu.tsx
+++ b/client/src/components/Chat/Menus/BookmarkMenu.tsx
@@ -99,6 +99,16 @@ const BookmarkMenu: FC = () => {
 
   const newBookmarkRef = useRef<HTMLButtonElement>(null);
 
+  const tagsCount = tags?.length ?? 0;
+  const hasBookmarks = tagsCount > 0;
+
+  const buttonAriaLabel = useMemo(() => {
+    if (tagsCount > 0) {
+      return localize('com_ui_bookmarks_count_selected', { count: tagsCount });
+    }
+    return localize('com_ui_bookmarks_add');
+  }, [tagsCount, localize]);
+
   const dropdownItems: t.MenuItemProps[] = useMemo(() => {
     const items: t.MenuItemProps[] = [
       {
@@ -141,16 +151,6 @@ const BookmarkMenu: FC = () => {
   if (isTemporary) {
     return null;
   }
-
-  const tagsCount = tags?.length ?? 0;
-  const hasBookmarks = tagsCount > 0;
-
-  const buttonAriaLabel = useMemo(() => {
-    if (hasBookmarks) {
-      return localize('com_ui_bookmarks_count_selected', { count: tagsCount });
-    }
-    return localize('com_ui_bookmarks_add');
-  }, [hasBookmarks, tagsCount, localize]);
 
   const renderButtonContent = () => {
     if (mutation.isLoading) {

--- a/client/src/components/Chat/Menus/BookmarkMenu.tsx
+++ b/client/src/components/Chat/Menus/BookmarkMenu.tsx
@@ -114,19 +114,19 @@ const BookmarkMenu: FC = () => {
 
     if (data) {
       for (const tag of data) {
-        const isSelected = tags?.includes(tag.tag);
+        const isSelected = tags?.includes(tag.tag) === true;
         items.push({
           id: tag.tag,
           label: tag.tag,
           hideOnClick: false,
-          icon:
-            isSelected === true ? (
-              <BookmarkFilledIcon className="size-4" />
-            ) : (
-              <BookmarkIcon className="size-4" />
-            ),
+          icon: isSelected ? (
+            <BookmarkFilledIcon className="size-4" />
+          ) : (
+            <BookmarkIcon className="size-4" />
+          ),
           onClick: () => handleSubmit(tag.tag),
           disabled: mutation.isLoading,
+          ariaChecked: isSelected,
         });
       }
     }
@@ -142,14 +142,24 @@ const BookmarkMenu: FC = () => {
     return null;
   }
 
+  const tagsCount = tags?.length ?? 0;
+  const hasBookmarks = tagsCount > 0;
+
+  const buttonAriaLabel = useMemo(() => {
+    if (hasBookmarks) {
+      return localize('com_ui_bookmarks_count_selected', { count: tagsCount });
+    }
+    return localize('com_ui_bookmarks_add');
+  }, [hasBookmarks, tagsCount, localize]);
+
   const renderButtonContent = () => {
     if (mutation.isLoading) {
       return <Spinner aria-label="Spinner" />;
     }
-    if ((tags?.length ?? 0) > 0) {
-      return <BookmarkFilledIcon className="icon-lg" aria-label="Filled Bookmark" />;
+    if (hasBookmarks) {
+      return <BookmarkFilledIcon className="icon-lg" aria-hidden="true" />;
     }
-    return <BookmarkIcon className="icon-lg" aria-label="Bookmark" />;
+    return <BookmarkIcon className="icon-lg" aria-hidden="true" />;
   };
 
   return (
@@ -168,7 +178,8 @@ const BookmarkMenu: FC = () => {
             render={
               <Ariakit.MenuButton
                 id="bookmark-menu-button"
-                aria-label={localize('com_ui_bookmarks_add')}
+                aria-label={buttonAriaLabel}
+                aria-pressed={hasBookmarks}
                 className={cn(
                   'mt-text-sm flex size-10 flex-shrink-0 items-center justify-center gap-2 rounded-xl border border-border-light bg-presentation text-sm transition-colors duration-200 hover:bg-surface-hover',
                   isMenuOpen ? 'bg-surface-hover' : '',

--- a/client/src/components/Nav/Bookmarks/BookmarkNav.tsx
+++ b/client/src/components/Nav/Bookmarks/BookmarkNav.tsx
@@ -25,6 +25,13 @@ const BookmarkNav: FC<BookmarkNavProps> = ({ tags, setTags }: BookmarkNavProps) 
     [tags, localize],
   );
 
+  const buttonAriaLabel = useMemo(() => {
+    if (tags.length === 0) {
+      return localize('com_ui_bookmarks');
+    }
+    return localize('com_ui_bookmarks_count_selected', { count: tags.length });
+  }, [tags.length, localize]);
+
   const bookmarks = useMemo(() => data?.filter((tag) => tag.count > 0) ?? [], [data]);
 
   const handleTagClick = useCallback(
@@ -73,6 +80,7 @@ const BookmarkNav: FC<BookmarkNavProps> = ({ tags, setTags }: BookmarkNavProps) 
             <BookmarkIcon className="size-4" />
           ),
           onClick: () => handleTagClick(bookmark.tag),
+          ariaChecked: isSelected,
         });
       }
     }
@@ -96,7 +104,8 @@ const BookmarkNav: FC<BookmarkNavProps> = ({ tags, setTags }: BookmarkNavProps) 
           render={
             <Ariakit.MenuButton
               id="bookmark-nav-menu-button"
-              aria-label={localize('com_ui_bookmarks')}
+              aria-label={buttonAriaLabel}
+              aria-pressed={tags.length > 0}
               className={cn(
                 'flex items-center justify-center',
                 'size-10 border-none text-text-primary hover:bg-accent hover:text-accent-foreground',

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -771,6 +771,7 @@
   "com_ui_bookmarks_title": "Title",
   "com_ui_bookmarks_update_error": "There was an error updating the bookmark",
   "com_ui_bookmarks_update_success": "Bookmark updated successfully",
+  "com_ui_bookmarks_count_selected": "Bookmarks, {{count}} selected",
   "com_ui_branch_created": "Branch created successfully",
   "com_ui_branch_error": "Failed to create branch",
   "com_ui_branch_message": "Create branch from this response",

--- a/packages/client/src/common/menus.ts
+++ b/packages/client/src/common/menus.ts
@@ -27,6 +27,8 @@ export interface MenuItemProps {
     | 'grid'
     | undefined;
   ariaControls?: string;
+  ariaLabel?: string;
+  ariaChecked?: boolean;
   ref?: React.Ref<any>;
   className?: string;
   render?:

--- a/packages/client/src/components/DropdownPopup.tsx
+++ b/packages/client/src/components/DropdownPopup.tsx
@@ -150,7 +150,7 @@ const Menu: React.FC<MenuProps> = ({
               aria-controls={item.ariaControls}
               aria-label={item.ariaLabel}
               aria-checked={item.ariaChecked}
-              role={item.ariaChecked !== undefined ? 'menuitemcheckbox' : undefined}
+              {...(item.ariaChecked !== undefined ? { role: 'menuitemcheckbox' } : {})}
               onClick={(event) => {
                 event.preventDefault();
                 if (item.onClick) {

--- a/packages/client/src/components/DropdownPopup.tsx
+++ b/packages/client/src/components/DropdownPopup.tsx
@@ -148,6 +148,9 @@ const Menu: React.FC<MenuProps> = ({
               hideOnClick={item.hideOnClick}
               aria-haspopup={item.ariaHasPopup}
               aria-controls={item.ariaControls}
+              aria-label={item.ariaLabel}
+              aria-checked={item.ariaChecked}
+              role={item.ariaChecked !== undefined ? 'menuitemcheckbox' : undefined}
               onClick={(event) => {
                 event.preventDefault();
                 if (item.onClick) {


### PR DESCRIPTION
## Summary

This pull request improves the accessibility of bookmark-related menus by adding ARIA attributes and enhancing screen reader support. The main changes include introducing `aria-label` and `aria-checked` properties to menu items, updating button ARIA attributes for dynamic feedback, and localizing ARIA labels to reflect the current selection state.

**Accessibility Improvements:**

* Added `ariaLabel` and `ariaChecked` properties to the `MenuItemProps` interface in both `client/src/common/menus.ts` and `packages/client/src/common/menus.ts`, enabling menu items to provide better context for screen readers. [[1]](diffhunk://#diff-2822ec84e3c041305d6299268e4c186ce6fee3ee29acf9f4822b9656835e9bbbR18-R19) [[2]](diffhunk://#diff-4e518f0add005e9dc1466a0abf56c8b54c3493b564eb15d032d7fa2c00dba83cR30-R31)
* Updated the `Menu` component (`DropdownPopup.tsx`) to use these new ARIA properties and set `role="menuitemcheckbox"` when `ariaChecked` is present, improving accessibility for menu items that represent selectable states.

**Bookmark Menu Enhancements:**

* In `BookmarkMenu.tsx` and `BookmarkNav.tsx`, added logic to compute and localize ARIA labels for menu buttons, reflecting the number of selected bookmarks, and set `aria-pressed` to indicate active states. [[1]](diffhunk://#diff-e2b11e787015337e442598eaaa0820802ca5a778a39b3d47d3b8cab3dad1371cR145-R162) [[2]](diffhunk://#diff-e2b11e787015337e442598eaaa0820802ca5a778a39b3d47d3b8cab3dad1371cL171-R182) [[3]](diffhunk://#diff-280e7aadecaa0d00917e720be1864035b1cf7839430ca719d958310be1d2057fR28-R34) [[4]](diffhunk://#diff-280e7aadecaa0d00917e720be1864035b1cf7839430ca719d958310be1d2057fL99-R108)
* Each bookmark menu item now includes the `ariaChecked` property to communicate selection state to assistive technologies. [[1]](diffhunk://#diff-e2b11e787015337e442598eaaa0820802ca5a778a39b3d47d3b8cab3dad1371cL117-R129) [[2]](diffhunk://#diff-280e7aadecaa0d00917e720be1864035b1cf7839430ca719d958310be1d2057fR83)

**Localization:**

* Added a new localized string `com_ui_bookmarks_count_selected` to provide meaningful ARIA labels that include the count of selected bookmarks.

Closes [Axe Auditor Issue #570](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/b396b11e-8cd5-11f0-9538-f7d7c247859d?activeTab=dt-issue&page=0&pageSize=100&sortField=ordinal&sortDir=asc&row=0&filter%5Bseverity%5D=3&filter%5Bstatus%5D=open)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

https://github.com/user-attachments/assets/884da16b-f495-4af3-99c5-298c31207a65

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes