### PR TITLE
🎯 feat: High Contrast Focus Outlines for Settings Popup Menu Items

### DIFF
--- a/client/src/components/Nav/AccountSettings.tsx
+++ b/client/src/components/Nav/AccountSettings.tsx
@@ -40,7 +40,7 @@ function AccountSettings() {
         </div>
       </Select.Select>
       <Select.SelectPopover
-        className="popover-ui z-[125] w-[305px] rounded-lg md:w-[244px]"
+        className="account-settings-popover popover-ui z-[125] w-[305px] rounded-lg md:w-[244px]"
         style={{
           transformOrigin: 'bottom',
           translate: '0 -4px',

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -2666,6 +2666,9 @@ html {
 .select-item[data-active-item] {
   background-color: var(--surface-hover);
   color: var(--text-primary);
+}
+
+.account-settings-popover .select-item[data-active-item] {
   box-shadow: 0 0 0 2px hsl(var(--ring));
 }
 

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -2666,6 +2666,7 @@ html {
 .select-item[data-active-item] {
   background-color: var(--surface-hover);
   color: var(--text-primary);
+  box-shadow: 0 0 0 2px hsl(var(--ring));
 }
 
 .popover-ui[data-enter] {


### PR DESCRIPTION
## Summary

This pull request improves the focus indicators for the active item in the Account Settings popover by introducing a new CSS class and updating the relevant component. The most important changes are:

**UI/UX improvements:**

* Added a new CSS rule for `.account-settings-popover .select-item[data-active-item]` to display a ring-style box-shadow around the active item in the Account Settings popover, enhancing accessibility and clarity.

**Component updates:**

* Updated the `AccountSettings` component to add the `account-settings-popover` class to the popover, enabling the new styling for active items.
Closes [Axe Auditor Issue #571](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/a88a4f1e-8cd6-11f0-9273-238d0cc06ec1?activeTab=dt-issue&page=0&pageSize=100&sortField=ordinal&sortDir=asc&row=0&filter%5Bseverity%5D=3&filter%5Bstatus%5D=open)
## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

### Before

https://github.com/user-attachments/assets/8180004e-31c1-4876-8b33-77aa4df2325f

### After

https://github.com/user-attachments/assets/e4b43c17-bbcf-4a76-8a96-ae837f40a273

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes