### PR TITLE
↕️ fix: Add `aria-expanded` Attribute to ConvoOptions

### DIFF
--- a/client/src/components/Conversations/ConvoOptions/ConvoOptions.tsx
+++ b/client/src/components/Conversations/ConvoOptions/ConvoOptions.tsx
@@ -302,7 +302,7 @@ function ConvoOptions({
           <Ariakit.MenuButton
             id={`conversation-menu-${conversationId}`}
             aria-label={localize('com_nav_convo_menu_options')}
-            aria-readonly={undefined}
+            aria-expanded={isPopoverActive}
             className={cn(
               'inline-flex h-7 w-7 items-center justify-center gap-2 rounded-md border-none p-0 text-sm font-medium ring-ring-primary transition-all duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50',
               isActiveConvo === true || isPopoverActive


### PR DESCRIPTION
## Summary

This pull request makes a small accessibility improvement to the `ConvoOptions` component. The `Ariakit.MenuButton` now correctly uses the `aria-expanded` attribute to reflect whether the menu popover is active, improving screen reader support and accessibility.

Closes [Axe Auditor Issue #576](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/4d67e91e-8cec-11f0-b3de-539b28766a4c?activeTab=dt-issue&page=0&pageSize=100&sortField=ordinal&sortDir=asc&row=0&filter%5Bseverity%5D=3&filter%5Bstatus%5D=open)
## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<img width="1728" height="1117" alt="Screenshot 2026-01-01 at 9 19 02 PM" src="https://github.com/user-attachments/assets/aa74958f-f24a-4218-a30c-f3d9fd93d9a8" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes