### PR TITLE
✅️ feat: Accessible Model Selection Icons and Announcements

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { VisuallyHidden } from '@ariakit/react';
 import { Spinner, TooltipAnchor } from '@librechat/client';
 import { CheckCircle2, MousePointerClick, SettingsIcon } from 'lucide-react';
 import { EModelEndpoint, isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
@@ -126,6 +127,8 @@ export function EndpointItem({ endpoint, endpointIndex }: EndpointItemProps) {
     </div>
   );
 
+  const isEndpointSelected = selectedEndpoint === endpoint.value;
+
   if (endpoint.hasModels) {
     const filteredModels = searchValue
       ? filterModels(
@@ -153,9 +156,20 @@ export function EndpointItem({ endpoint, endpointIndex }: EndpointItemProps) {
         label={
           <div className="group flex w-full min-w-0 items-center justify-between gap-1.5 py-1 text-sm">
             {renderIconLabel()}
-            {isUserProvided && (
-              <SettingsButton endpoint={endpoint} handleOpenKeyDialog={handleOpenKeyDialog} />
-            )}
+            <div className="flex shrink-0 items-center gap-1">
+              {isUserProvided && (
+                <SettingsButton endpoint={endpoint} handleOpenKeyDialog={handleOpenKeyDialog} />
+              )}
+              {isEndpointSelected && (
+                <>
+                  <CheckCircle2
+                    className="size-4 shrink-0 text-text-primary"
+                    aria-hidden="true"
+                  />
+                  <VisuallyHidden>{localize('com_a11y_selected')}</VisuallyHidden>
+                </>
+              )}
+            </div>
           </div>
         }
       >
@@ -200,6 +214,7 @@ export function EndpointItem({ endpoint, endpointIndex }: EndpointItemProps) {
         id={`endpoint-${endpoint.value}-menu`}
         key={`endpoint-${endpoint.value}-item`}
         onClick={() => handleSelectEndpoint(endpoint)}
+        aria-selected={isEndpointSelected || undefined}
         className="group flex w-full cursor-pointer items-center justify-between gap-1.5 py-2 text-sm"
       >
         {renderIconLabel()}
@@ -218,8 +233,11 @@ export function EndpointItem({ endpoint, endpointIndex }: EndpointItemProps) {
               }
             />
           )}
-          {selectedEndpoint === endpoint.value && !isAssistantsNotLoaded && (
-            <CheckCircle2 className="size-4 shrink-0 text-text-primary" aria-hidden="true" />
+          {isEndpointSelected && !isAssistantsNotLoaded && (
+            <>
+              <CheckCircle2 className="size-4 shrink-0 text-text-primary" aria-hidden="true" />
+              <VisuallyHidden>{localize('com_a11y_selected')}</VisuallyHidden>
+            </>
           )}
         </div>
       </MenuItem>

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
@@ -162,10 +162,7 @@ export function EndpointItem({ endpoint, endpointIndex }: EndpointItemProps) {
               )}
               {isEndpointSelected && (
                 <>
-                  <CheckCircle2
-                    className="size-4 shrink-0 text-text-primary"
-                    aria-hidden="true"
-                  />
+                  <CheckCircle2 className="size-4 shrink-0 text-text-primary" aria-hidden="true" />
                   <VisuallyHidden>{localize('com_a11y_selected')}</VisuallyHidden>
                 </>
               )}

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { EarthIcon, Pin, PinOff } from 'lucide-react';
+import { VisuallyHidden } from '@ariakit/react';
+import { CheckCircle2, EarthIcon, Pin, PinOff } from 'lucide-react';
 import { isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
 import { useModelSelectorContext } from '../ModelSelectorContext';
 import { CustomMenuItem as MenuItem } from '../CustomMenu';
@@ -110,6 +111,7 @@ export function EndpointModelItem({ modelId, endpoint, isSelected }: EndpointMod
     <MenuItem
       ref={itemRef}
       onClick={() => handleSelectModel(endpoint, modelId ?? '')}
+      aria-selected={isSelected || undefined}
       className="group flex w-full cursor-pointer items-center justify-between rounded-lg px-2 text-sm"
     >
       <div className="flex w-full min-w-0 items-center gap-2 px-1 py-1">
@@ -133,23 +135,10 @@ export function EndpointModelItem({ modelId, endpoint, isSelected }: EndpointMod
         )}
       </button>
       {isSelected && (
-        <div className="flex-shrink-0 self-center">
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            className="block"
-          >
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM16.0755 7.93219C16.5272 8.25003 16.6356 8.87383 16.3178 9.32549L11.5678 16.0755C11.3931 16.3237 11.1152 16.4792 10.8123 16.4981C10.5093 16.517 10.2142 16.3973 10.0101 16.1727L7.51006 13.4227C7.13855 13.014 7.16867 12.3816 7.57733 12.0101C7.98598 11.6386 8.61843 11.6687 8.98994 12.0773L10.6504 13.9039L14.6822 8.17451C15 7.72284 15.6238 7.61436 16.0755 7.93219Z"
-              fill="currentColor"
-            />
-          </svg>
-        </div>
+        <>
+          <CheckCircle2 className="size-4 shrink-0 text-text-primary" aria-hidden="true" />
+          <VisuallyHidden>{localize('com_a11y_selected')}</VisuallyHidden>
+        </>
       )}
     </MenuItem>
   );

--- a/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import { CheckCircle2 } from 'lucide-react';
+import { VisuallyHidden } from '@ariakit/react';
 import type { TModelSpec } from 'librechat-data-provider';
 import { CustomMenuItem as MenuItem } from '../CustomMenu';
 import { useModelSelectorContext } from '../ModelSelectorContext';
+import { useLocalize } from '~/hooks';
 import SpecIcon from './SpecIcon';
 import { cn } from '~/utils';
 
@@ -11,12 +14,14 @@ interface ModelSpecItemProps {
 }
 
 export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
+  const localize = useLocalize();
   const { handleSelectSpec, endpointsConfig } = useModelSelectorContext();
   const { showIconInMenu = true } = spec;
   return (
     <MenuItem
       key={spec.name}
       onClick={() => handleSelectSpec(spec)}
+      aria-selected={isSelected || undefined}
       className={cn(
         'flex w-full cursor-pointer items-center justify-between rounded-lg px-2 text-sm',
       )}
@@ -40,23 +45,10 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
         </div>
       </div>
       {isSelected && (
-        <div className="flex-shrink-0 self-center">
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            className="block"
-          >
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM16.0755 7.93219C16.5272 8.25003 16.6356 8.87383 16.3178 9.32549L11.5678 16.0755C11.3931 16.3237 11.1152 16.4792 10.8123 16.4981C10.5093 16.517 10.2142 16.3973 10.0101 16.1727L7.51006 13.4227C7.13855 13.014 7.16867 12.3816 7.57733 12.0101C7.98598 11.6386 8.61843 11.6687 8.98994 12.0773L10.6504 13.9039L14.6822 8.17451C15 7.72284 15.6238 7.61436 16.0755 7.93219Z"
-              fill="currentColor"
-            />
-          </svg>
-        </div>
+        <>
+          <CheckCircle2 className="size-4 shrink-0 self-center text-text-primary" aria-hidden="true" />
+          <VisuallyHidden>{localize('com_a11y_selected')}</VisuallyHidden>
+        </>
       )}
     </MenuItem>
   );

--- a/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/ModelSpecItem.tsx
@@ -46,7 +46,10 @@ export function ModelSpecItem({ spec, isSelected }: ModelSpecItemProps) {
       </div>
       {isSelected && (
         <>
-          <CheckCircle2 className="size-4 shrink-0 self-center text-text-primary" aria-hidden="true" />
+          <CheckCircle2
+            className="size-4 shrink-0 self-center text-text-primary"
+            aria-hidden="true"
+          />
           <VisuallyHidden>{localize('com_a11y_selected')}</VisuallyHidden>
         </>
       )}

--- a/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
-import { EarthIcon } from 'lucide-react';
+import { VisuallyHidden } from '@ariakit/react';
+import { CheckCircle2, EarthIcon } from 'lucide-react';
 import { isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
 import type { TModelSpec } from 'librechat-data-provider';
 import type { Endpoint } from '~/common';
@@ -60,6 +61,7 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
             <MenuItem
               key={spec.name}
               onClick={() => handleSelectSpec(spec)}
+              aria-selected={selectedSpec === spec.name || undefined}
               className={cn(
                 'flex w-full cursor-pointer justify-between rounded-lg px-2 text-sm',
                 spec.description ? 'items-start' : 'items-center',
@@ -84,23 +86,13 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
                 </div>
               </div>
               {selectedSpec === spec.name && (
-                <div className={cn('flex-shrink-0', spec.description ? 'pt-1' : '')}>
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="block"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      clipRule="evenodd"
-                      d="M2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM16.0755 7.93219C16.5272 8.25003 16.6356 8.87383 16.3178 9.32549L11.5678 16.0755C11.3931 16.3237 11.1152 16.4792 10.8123 16.4981C10.5093 16.517 10.2142 16.3973 10.0101 16.1727L7.51006 13.4227C7.13855 13.014 7.16867 12.3816 7.57733 12.0101C7.98598 11.6386 8.61843 11.6687 8.98994 12.0773L10.6504 13.9039L14.6822 8.17451C15 7.72284 15.6238 7.61436 16.0755 7.93219Z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </div>
+                <>
+                  <CheckCircle2
+                    className={cn('size-4 shrink-0 text-text-primary', spec.description ? 'mt-1' : '')}
+                    aria-hidden="true"
+                  />
+                  <VisuallyHidden>{localize('com_a11y_selected')}</VisuallyHidden>
+                </>
               )}
             </MenuItem>
           );
@@ -164,10 +156,13 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
                     modelName = endpoint.assistantNames[modelId];
                   }
 
+                  const isModelSelected =
+                    selectedEndpoint === endpoint.value && selectedModel === modelId;
                   return (
                     <MenuItem
                       key={`${endpoint.value}-${modelId}-search-${i}`}
                       onClick={() => handleSelectModel(endpoint, modelId)}
+                      aria-selected={isModelSelected || undefined}
                       className="flex w-full cursor-pointer items-center justify-start rounded-lg px-3 py-2 pl-6 text-sm"
                     >
                       <div className="flex items-center gap-2">
@@ -185,22 +180,11 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
                       {isGlobal && (
                         <EarthIcon className="ml-auto size-4 text-green-400" aria-hidden="true" />
                       )}
-                      {selectedEndpoint === endpoint.value && selectedModel === modelId && (
-                        <svg
-                          width="16"
-                          height="16"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="block"
-                        >
-                          <path
-                            fillRule="evenodd"
-                            clipRule="evenodd"
-                            d="M2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM16.0755 7.93219C16.5272 8.25003 16.6356 8.87383 16.3178 9.32549L11.5678 16.0755C11.3931 16.3237 11.1152 16.4792 10.8123 16.4981C10.5093 16.517 10.2142 16.3973 10.0101 16.1727L7.51006 13.4227C7.13855 13.014 7.16867 12.3816 7.57733 12.0101C7.98598 11.6386 8.61843 11.6687 8.98994 12.0773L10.6504 13.9039L14.6822 8.17451C15 7.72284 15.6238 7.61436 16.0755 7.93219Z"
-                            fill="currentColor"
-                          />
-                        </svg>
+                      {isModelSelected && (
+                        <>
+                          <CheckCircle2 className="size-4 shrink-0 text-text-primary" aria-hidden="true" />
+                          <VisuallyHidden>{localize('com_a11y_selected')}</VisuallyHidden>
+                        </>
                       )}
                     </MenuItem>
                   );
@@ -209,10 +193,12 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
             );
           } else {
             // Endpoints with no models
+            const isEndpointSelected = selectedEndpoint === endpoint.value;
             return (
               <MenuItem
                 key={`endpoint-${endpoint.value}-search-item`}
                 onClick={() => handleSelectEndpoint(endpoint)}
+                aria-selected={isEndpointSelected || undefined}
                 className="flex w-full cursor-pointer items-center justify-between rounded-xl px-3 py-2 text-sm"
               >
                 <div className="flex items-center gap-2">
@@ -226,22 +212,11 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
                   )}
                   <span>{endpoint.label}</span>
                 </div>
-                {selectedEndpoint === endpoint.value && (
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="block"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      clipRule="evenodd"
-                      d="M2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12ZM16.0755 7.93219C16.5272 8.25003 16.6356 8.87383 16.3178 9.32549L11.5678 16.0755C11.3931 16.3237 11.1152 16.4792 10.8123 16.4981C10.5093 16.517 10.2142 16.3973 10.0101 16.1727L7.51006 13.4227C7.13855 13.014 7.16867 12.3816 7.57733 12.0101C7.98598 11.6386 8.61843 11.6687 8.98994 12.0773L10.6504 13.9039L14.6822 8.17451C15 7.72284 15.6238 7.61436 16.0755 7.93219Z"
-                      fill="currentColor"
-                    />
-                  </svg>
+                {isEndpointSelected && (
+                  <>
+                    <CheckCircle2 className="size-4 shrink-0 text-text-primary" aria-hidden="true" />
+                    <VisuallyHidden>{localize('com_a11y_selected')}</VisuallyHidden>
+                  </>
                 )}
               </MenuItem>
             );

--- a/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
@@ -88,7 +88,10 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
               {selectedSpec === spec.name && (
                 <>
                   <CheckCircle2
-                    className={cn('size-4 shrink-0 text-text-primary', spec.description ? 'mt-1' : '')}
+                    className={cn(
+                      'size-4 shrink-0 text-text-primary',
+                      spec.description ? 'mt-1' : '',
+                    )}
                     aria-hidden="true"
                   />
                   <VisuallyHidden>{localize('com_a11y_selected')}</VisuallyHidden>
@@ -182,7 +185,10 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
                       )}
                       {isModelSelected && (
                         <>
-                          <CheckCircle2 className="size-4 shrink-0 text-text-primary" aria-hidden="true" />
+                          <CheckCircle2
+                            className="size-4 shrink-0 text-text-primary"
+                            aria-hidden="true"
+                          />
                           <VisuallyHidden>{localize('com_a11y_selected')}</VisuallyHidden>
                         </>
                       )}
@@ -214,7 +220,10 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
                 </div>
                 {isEndpointSelected && (
                   <>
-                    <CheckCircle2 className="size-4 shrink-0 text-text-primary" aria-hidden="true" />
+                    <CheckCircle2
+                      className="size-4 shrink-0 text-text-primary"
+                      aria-hidden="true"
+                    />
                     <VisuallyHidden>{localize('com_a11y_selected')}</VisuallyHidden>
                   </>
                 )}

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -3,6 +3,7 @@
   "chat_direction_right_to_left": "Right to Left",
   "com_a11y_ai_composing": "The AI is still composing.",
   "com_a11y_end": "The AI has finished their reply.",
+  "com_a11y_selected": "selected",
   "com_a11y_start": "The AI has started their reply.",
   "com_agents_agent_card_label": "{{name}} agent. {{description}}",
   "com_agents_all": "All Agents",


### PR DESCRIPTION
## Summary

This pull request improves accessibility and visual consistency in the endpoint and model selection menus by replacing custom SVG checkmarks with the standardized `CheckCircle2` icon, adding screen reader-only labels, and ensuring proper ARIA attributes are set. These updates help users with assistive technologies better understand which items are selected and streamline the codebase. Additionally, selected provider / endpoints will now be visually indicated with a checkmark so that users can quickly identify which model is currently selected.

**Accessibility Improvements:**

* Added the `VisuallyHidden` component with a localized "selected" label (`com_a11y_selected`) next to each checkmark icon, making the selection state accessible to screen readers across all relevant menu items. [[1]](diffhunk://#diff-f8a4b897ba4266a7218c4c2f4ce89ca887c539b323cea8c3ce152a17a2343f4bR159-R172) [[2]](diffhunk://#diff-f8931152ff3b053b1efd2641fd7b46a0d4eab81acdb3212558548eace800786cL136-R141) [[3]](diffhunk://#diff-aec699fce278787bf47bc644a33c1159ce8aaebc6adf7ef479cbe3a0033d158eL43-R51) [[4]](diffhunk://#diff-e10f5a92a54738fbf7cdc7ace53d0367d2f5a9ab473c7dfea7497e634ccd2cf9L87-R95) [[5]](diffhunk://#diff-e10f5a92a54738fbf7cdc7ace53d0367d2f5a9ab473c7dfea7497e634ccd2cf9L188-R187) [[6]](diffhunk://#diff-e10f5a92a54738fbf7cdc7ace53d0367d2f5a9ab473c7dfea7497e634ccd2cf9L229-R219) [[7]](diffhunk://#diff-c0fa59f8385909de9f593c765770ac70cec3d86cbfc11c3e2e4749ecc5c0f476R6)
* Set the `aria-selected` attribute on menu items to reflect their selection state, enhancing keyboard and screen reader navigation. [[1]](diffhunk://#diff-f8a4b897ba4266a7218c4c2f4ce89ca887c539b323cea8c3ce152a17a2343f4bR217) [[2]](diffhunk://#diff-f8931152ff3b053b1efd2641fd7b46a0d4eab81acdb3212558548eace800786cR114) [[3]](diffhunk://#diff-aec699fce278787bf47bc644a33c1159ce8aaebc6adf7ef479cbe3a0033d158eR17-R24) [[4]](diffhunk://#diff-e10f5a92a54738fbf7cdc7ace53d0367d2f5a9ab473c7dfea7497e634ccd2cf9R64) [[5]](diffhunk://#diff-e10f5a92a54738fbf7cdc7ace53d0367d2f5a9ab473c7dfea7497e634ccd2cf9R159-R165) [[6]](diffhunk://#diff-e10f5a92a54738fbf7cdc7ace53d0367d2f5a9ab473c7dfea7497e634ccd2cf9R196-R201)

**Visual and Code Consistency:**

* Replaced all custom inline SVG checkmarks with the `CheckCircle2` icon from `lucide-react` for a unified and modern appearance. [[1]](diffhunk://#diff-f8931152ff3b053b1efd2641fd7b46a0d4eab81acdb3212558548eace800786cL2-R3) [[2]](diffhunk://#diff-aec699fce278787bf47bc644a33c1159ce8aaebc6adf7ef479cbe3a0033d158eR2-R7) [[3]](diffhunk://#diff-e10f5a92a54738fbf7cdc7ace53d0367d2f5a9ab473c7dfea7497e634ccd2cf9L2-R3) [[4]](diffhunk://#diff-e10f5a92a54738fbf7cdc7ace53d0367d2f5a9ab473c7dfea7497e634ccd2cf9L87-R95) [[5]](diffhunk://#diff-e10f5a92a54738fbf7cdc7ace53d0367d2f5a9ab473c7dfea7497e634ccd2cf9L188-R187) [[6]](diffhunk://#diff-e10f5a92a54738fbf7cdc7ace53d0367d2f5a9ab473c7dfea7497e634ccd2cf9L229-R219)
* Refactored logic to use consistent selection state variables (like `isEndpointSelected` and `isModelSelected`) across components for clarity and maintainability. [[1]](diffhunk://#diff-f8a4b897ba4266a7218c4c2f4ce89ca887c539b323cea8c3ce152a17a2343f4bR130-R131) [[2]](diffhunk://#diff-e10f5a92a54738fbf7cdc7ace53d0367d2f5a9ab473c7dfea7497e634ccd2cf9R159-R165) [[3]](diffhunk://#diff-e10f5a92a54738fbf7cdc7ace53d0367d2f5a9ab473c7dfea7497e634ccd2cf9R196-R201)

**Localization:**

* Added the `"com_a11y_selected"` key to the English translation file for use in accessibility labels.

Closes [Axe Auditor Issue #605](https://harvard-axeauditor.dequecloud.com/test-run/b0f753f6-8a18-11f0-86d0-b7eb120aea63/issue/198c0398-8d99-11f0-912c-87d739e01df9?activeTab=dt-issue&page=0&pageSize=100&sortField=ordinal&sortDir=asc&row=0&filter%5Bseverity%5D=3&filter%5Bstatus%5D=open)

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

https://github.com/user-attachments/assets/78c2c1f2-b5f3-430f-a5cd-3e17583c2d20

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes