### PR TITLE
feat: expand file picker accept types to match OpenAI supported formats

### DIFF
--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -36,6 +36,44 @@ import { ephemeralAgentByConvoId } from '~/store';
 import { MenuItemProps } from '~/common';
 import { cn } from '~/utils';
 
+/**
+ * File types supported by OpenAI File Search API
+ * https://platform.openai.com/docs/assistants/tools/file-search/supported-files
+ */
+const OPENAI_SUPPORTED_EXTENSIONS = [
+  // Images
+  'image/*',
+  // Documents
+  '.pdf',
+  'application/pdf',
+  // Microsoft Office (modern)
+  '.docx',
+  '.pptx',
+  '.xlsx',
+  // Microsoft Office (legacy)
+  '.doc',
+  '.ppt',
+  '.xls',
+  // Text and code files
+  '.txt',
+  '.md',
+  '.json',
+  '.html',
+  '.css',
+  '.js',
+  '.ts',
+  '.py',
+  '.c',
+  '.cpp',
+  '.cs',
+  '.go',
+  '.java',
+  '.php',
+  '.rb',
+  '.sh',
+  '.tex',
+].join(',');
+
 interface AttachFileMenuProps {
   agentId?: string | null;
   endpoint?: string | null;
@@ -95,9 +133,10 @@ const AttachFileMenu = ({
     } else if (fileType === 'document') {
       inputRef.current.accept = '.pdf,application/pdf';
     } else if (fileType === 'multimodal') {
-      inputRef.current.accept = 'image/*,.pdf,application/pdf';
+      // Use expanded list of OpenAI-supported file types
+      inputRef.current.accept = OPENAI_SUPPORTED_EXTENSIONS;
     } else if (fileType === 'google_multimodal') {
-      inputRef.current.accept = 'image/*,.pdf,application/pdf,video/*,audio/*';
+      inputRef.current.accept = OPENAI_SUPPORTED_EXTENSIONS + ',video/*,audio/*';
     } else {
       inputRef.current.accept = '';
     }


### PR DESCRIPTION
## Summary
The "Upload to Provider" button was restricting file selection to only images and PDFs in the browser's file picker, even though OpenAI File Search API supports many more formats including `.pptx`, `.docx`, `.xlsx`, `.txt`, `.md`, `.json`, and various code files.

This PR expands the HTML file input `accept` attribute to include all file formats officially supported by OpenAI's File Search API.

## Problem
When users click "Upload to Provider" and try to select a PowerPoint file (`.pptx`), Word document (`.docx`), or Excel spreadsheet (`.xlsx`), these files appear greyed out in the file picker dialog. This is confusing because:

1. The backend `fileConfig` may have these MIME types configured as allowed
2. OpenAI's File Search API explicitly supports these file types
3. Users expect to be able to upload common Office documents

The root cause is that the `accept` attribute on the file input was hardcoded to `'image/*,.pdf,application/pdf'`, which doesn't include Office documents or code files.

## Solution
Created a constant `OPENAI_SUPPORTED_EXTENSIONS` that lists all file types supported by [OpenAI's File Search API](https://platform.openai.com/docs/assistants/tools/file-search/supported-files):

### Now Supported File Types
| Category | Extensions |
|----------|------------|
| **Images** | `image/*` |
| **Documents** | `.pdf` |
| **Microsoft Office (modern)** | `.docx`, `.pptx`, `.xlsx` |
| **Microsoft Office (legacy)** | `.doc`, `.ppt`, `.xls` |
| **Text/Markup** | `.txt`, `.md`, `.json`, `.html`, `.css`, `.tex` |
| **Code** | `.js`, `.ts`, `.py`, `.c`, `.cpp`, `.cs`, `.go`, `.java`, `.php`, `.rb`, `.sh` |

## Changes
- Added `OPENAI_SUPPORTED_EXTENSIONS` constant with documented file types
- Updated `multimodal` file type to use expanded extensions list
- Updated `google_multimodal` to use expanded list + video/audio

## Testing
- [ ] File picker now shows `.pptx`, `.docx`, `.xlsx` files as selectable
- [ ] Existing image and PDF upload functionality unchanged
- [ ] Code files can now be selected from the file picker

## Related Issues
This addresses user feedback about not being able to upload PowerPoint presentations and other Office documents via the "Upload to Provider" option.