### PR TITLE
😶‍🌫 feat: Better Blur on Collapsed Chat Input

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -258,7 +258,17 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
             <FileFormChat conversation={conversation} />
             {endpoint && (
               <div className={cn('flex', isRTL ? 'flex-row-reverse' : 'flex-row')}>
-                <div className="relative flex-1">
+                <div
+                  className="relative flex-1"
+                  style={
+                    isCollapsed
+                      ? {
+                          WebkitMaskImage: 'linear-gradient(to bottom, black 60%, transparent 90%)',
+                          maskImage: 'linear-gradient(to bottom, black 60%, transparent 90%)',
+                        }
+                      : undefined
+                  }
+                >
                   <TextareaAutosize
                     {...registerProps}
                     ref={(e) => {
@@ -290,16 +300,6 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
                       'scrollbar-hover transition-[max-height] duration-200 disabled:cursor-not-allowed',
                     )}
                   />
-                  {isCollapsed && (
-                    <div
-                      className="pointer-events-none absolute bottom-0 left-0 right-0 h-10 transition-all duration-200"
-                      style={{
-                        backdropFilter: 'blur(2px)',
-                        WebkitMaskImage: 'linear-gradient(to top, black 15%, transparent 75%)',
-                        maskImage: 'linear-gradient(to top, black 15%, transparent 75%)',
-                      }}
-                    />
-                  )}
                 </div>
                 <div className="flex flex-col items-start justify-start pr-2.5 pt-1.5">
                   <CollapseChat


### PR DESCRIPTION
## Summary

This pull request updates the chat input area to improve the visual experience when the chat is collapsed. The main change is the replacement of the previous overlay blur effect with a gradient mask applied directly to the input container, resulting in a cleaner and more efficient implementation.

**UI improvements for collapsed chat:**

* Applied a `WebkitMaskImage` and `maskImage` gradient directly to the input container when the chat is collapsed, providing a fade-out effect at the bottom instead of using an absolutely positioned blur overlay.
* Removed the overlay `<div>` that previously handled the gaussian blur and fade effect at the bottom of the chat input when collapsed.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

### Before
<img width="1025" height="202" alt="Screenshot 2026-01-21 at 9 53 23 AM" src="https://github.com/user-attachments/assets/62f77420-6cf9-4722-8df1-86a2500050c0" />

<img width="1025" height="202" alt="Screenshot 2026-01-21 at 9 53 16 AM" src="https://github.com/user-attachments/assets/87dd4bb4-04eb-4204-b867-80d8a5d6cdcb" />

<img width="1025" height="202" alt="Screenshot 2026-01-21 at 9 53 06 AM" src="https://github.com/user-attachments/assets/bfc6de17-17a8-4113-9a7d-8d8fe7c3a913" />

<img width="1025" height="202" alt="Screenshot 2026-01-21 at 9 53 00 AM" src="https://github.com/user-attachments/assets/9ec57285-884f-45a6-9789-d0420893082f" />

### After
<img width="1025" height="202" alt="Screenshot 2026-01-21 at 9 52 35 AM" src="https://github.com/user-attachments/assets/82029fca-29f1-436d-9387-ea71dcd8b962" />

<img width="1025" height="202" alt="Screenshot 2026-01-21 at 9 52 28 AM" src="https://github.com/user-attachments/assets/d4efb793-8977-4bbe-b86d-df715f0d2286" />

<img width="1025" height="202" alt="Screenshot 2026-01-21 at 9 52 15 AM" src="https://github.com/user-attachments/assets/dbe712a5-6866-45d7-be4d-5beac6ea5bf1" />

<img width="1025" height="202" alt="Screenshot 2026-01-21 at 9 52 07 AM" src="https://github.com/user-attachments/assets/53d71bc7-9fa6-42fc-a69f-9499c82df43a" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes