### PR TITLE
🔒 fix: Access Check for User-Specific Job Metadata in Streaming Endpoint

### DIFF
--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -47,6 +47,10 @@ router.get('/chat/stream/:streamId', async (req, res) => {
     });
   }
 
+  if (job.metadata?.userId && job.metadata.userId !== req.user.id) {
+    return res.status(403).json({ error: 'Unauthorized' });
+  }
+
   res.setHeader('Content-Encoding', 'identity');
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache, no-transform');


### PR DESCRIPTION
* Implemented a check to ensure that only the user associated with a job can access its chat stream, returning a 403 Unauthorized response for mismatched user IDs.
* This enhancement improves security by preventing unauthorized access to user-specific job data.