### PR TITLE
🔧 feat: `deleteRagFile` utility for Consistent RAG API document deletion

### DIFF
--- a/api/server/services/Files/Azure/crud.js
+++ b/api/server/services/Files/Azure/crud.js
@@ -4,7 +4,7 @@ const mime = require('mime');
 const axios = require('axios');
 const fetch = require('node-fetch');
 const { logger } = require('@librechat/data-schemas');
-const { getAzureContainerClient } = require('@librechat/api');
+const { getAzureContainerClient, deleteRagFile } = require('@librechat/api');
 
 const defaultBasePath = 'images';
 const { AZURE_STORAGE_PUBLIC_ACCESS = 'true', AZURE_CONTAINER_NAME = 'files' } = process.env;
@@ -102,6 +102,9 @@ async function getAzureURL({ fileName, basePath = defaultBasePath, userId, conta
  * @param {MongoFile} params.file - The file object.
  */
 async function deleteFileFromAzure(req, file) {
+  // Delete from RAG API if the file has embeddings
+  await deleteRagFile({ userId: req.user.id, file });
+
   try {
     const containerClient = await getAzureContainerClient(AZURE_CONTAINER_NAME);
     const blobPath = file.filepath.split(`${AZURE_CONTAINER_NAME}/`)[1];

--- a/api/server/services/Files/Azure/crud.js
+++ b/api/server/services/Files/Azure/crud.js
@@ -102,7 +102,6 @@ async function getAzureURL({ fileName, basePath = defaultBasePath, userId, conta
  * @param {MongoFile} params.file - The file object.
  */
 async function deleteFileFromAzure(req, file) {
-  // Delete from RAG API if the file has embeddings
   await deleteRagFile({ userId: req.user.id, file });
 
   try {

--- a/api/server/services/Files/Firebase/crud.js
+++ b/api/server/services/Files/Firebase/crud.js
@@ -167,7 +167,6 @@ function extractFirebaseFilePath(urlString) {
  *          Throws an error if there is an issue with deletion.
  */
 const deleteFirebaseFile = async (req, file) => {
-  // Delete from RAG API if the file has embeddings
   await deleteRagFile({ userId: req.user.id, file });
 
   const fileName = extractFirebaseFilePath(file.filepath);

--- a/api/server/services/Files/Firebase/crud.js
+++ b/api/server/services/Files/Firebase/crud.js
@@ -3,7 +3,7 @@ const path = require('path');
 const axios = require('axios');
 const fetch = require('node-fetch');
 const { logger } = require('@librechat/data-schemas');
-const { getFirebaseStorage } = require('@librechat/api');
+const { getFirebaseStorage, deleteRagFile } = require('@librechat/api');
 const { ref, uploadBytes, getDownloadURL, deleteObject } = require('firebase/storage');
 const { getBufferMetadata } = require('~/server/utils');
 
@@ -167,27 +167,8 @@ function extractFirebaseFilePath(urlString) {
  *          Throws an error if there is an issue with deletion.
  */
 const deleteFirebaseFile = async (req, file) => {
-  if (file.embedded && process.env.RAG_API_URL) {
-    const jwtToken = req.headers.authorization.split(' ')[1];
-    try {
-      await axios.delete(`${process.env.RAG_API_URL}/documents`, {
-        headers: {
-          Authorization: `Bearer ${jwtToken}`,
-          'Content-Type': 'application/json',
-          accept: 'application/json',
-        },
-        data: [file.file_id],
-      });
-    } catch (error) {
-      if (error.response?.status === 404) {
-        logger.warn(
-          `[deleteFirebaseFile] Document ${file.file_id} not found in RAG API, may have been deleted already`,
-        );
-      } else {
-        logger.error('[deleteFirebaseFile] Error deleting document from RAG API:', error);
-      }
-    }
-  }
+  // Delete from RAG API if the file has embeddings
+  await deleteRagFile({ userId: req.user.id, file });
 
   const fileName = extractFirebaseFilePath(file.filepath);
   if (!fileName.includes(req.user.id)) {

--- a/api/server/services/Files/Local/crud.js
+++ b/api/server/services/Files/Local/crud.js
@@ -3,7 +3,7 @@ const path = require('path');
 const axios = require('axios');
 const { logger } = require('@librechat/data-schemas');
 const { EModelEndpoint } = require('librechat-data-provider');
-const { generateShortLivedToken } = require('@librechat/api');
+const { deleteRagFile } = require('@librechat/api');
 const { resizeImageBuffer } = require('~/server/services/Files/images/resize');
 const { getBufferMetadata } = require('~/server/utils');
 const paths = require('~/config/paths');
@@ -208,27 +208,8 @@ const deleteLocalFile = async (req, file) => {
   /** Filepath stripped of query parameters (e.g., ?manual=true) */
   const cleanFilepath = file.filepath.split('?')[0];
 
-  if (file.embedded && process.env.RAG_API_URL) {
-    const jwtToken = generateShortLivedToken(req.user.id);
-    try {
-      await axios.delete(`${process.env.RAG_API_URL}/documents`, {
-        headers: {
-          Authorization: `Bearer ${jwtToken}`,
-          'Content-Type': 'application/json',
-          accept: 'application/json',
-        },
-        data: [file.file_id],
-      });
-    } catch (error) {
-      if (error.response?.status === 404) {
-        logger.warn(
-          `[deleteLocalFile] Document ${file.file_id} not found in RAG API, may have been deleted already`,
-        );
-      } else {
-        logger.error('[deleteLocalFile] Error deleting document from RAG API:', error);
-      }
-    }
-  }
+  // Delete from RAG API if the file has embeddings
+  await deleteRagFile({ userId: req.user.id, file });
 
   if (cleanFilepath.startsWith(`/uploads/${req.user.id}`)) {
     const userUploadDir = path.join(uploads, req.user.id);

--- a/api/server/services/Files/Local/crud.js
+++ b/api/server/services/Files/Local/crud.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 const axios = require('axios');
+const { deleteRagFile } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const { EModelEndpoint } = require('librechat-data-provider');
-const { deleteRagFile } = require('@librechat/api');
 const { resizeImageBuffer } = require('~/server/services/Files/images/resize');
 const { getBufferMetadata } = require('~/server/utils');
 const paths = require('~/config/paths');

--- a/api/server/services/Files/Local/crud.js
+++ b/api/server/services/Files/Local/crud.js
@@ -208,7 +208,6 @@ const deleteLocalFile = async (req, file) => {
   /** Filepath stripped of query parameters (e.g., ?manual=true) */
   const cleanFilepath = file.filepath.split('?')[0];
 
-  // Delete from RAG API if the file has embeddings
   await deleteRagFile({ userId: req.user.id, file });
 
   if (cleanFilepath.startsWith(`/uploads/${req.user.id}`)) {

--- a/api/server/services/Files/S3/crud.js
+++ b/api/server/services/Files/S3/crud.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const fetch = require('node-fetch');
-const { initializeS3 } = require('@librechat/api');
+const { initializeS3, deleteRagFile } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const { FileSources } = require('librechat-data-provider');
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
@@ -142,6 +142,9 @@ async function saveURLToS3({ userId, URL, fileName, basePath = defaultBasePath }
  * @returns {Promise<void>}
  */
 async function deleteFileFromS3(req, file) {
+  // Delete from RAG API if the file has embeddings
+  await deleteRagFile({ userId: req.user.id, file });
+
   const key = extractKeyFromS3Url(file.filepath);
   const params = { Bucket: bucketName, Key: key };
   if (!key.includes(req.user.id)) {

--- a/api/server/services/Files/S3/crud.js
+++ b/api/server/services/Files/S3/crud.js
@@ -1,9 +1,9 @@
 const fs = require('fs');
 const fetch = require('node-fetch');
-const { initializeS3, deleteRagFile } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const { FileSources } = require('librechat-data-provider');
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
+const { initializeS3, deleteRagFile } = require('@librechat/api');
 const {
   PutObjectCommand,
   GetObjectCommand,
@@ -142,7 +142,6 @@ async function saveURLToS3({ userId, URL, fileName, basePath = defaultBasePath }
  * @returns {Promise<void>}
  */
 async function deleteFileFromS3(req, file) {
-  // Delete from RAG API if the file has embeddings
   await deleteRagFile({ userId: req.user.id, file });
 
   const key = extractKeyFromS3Url(file.filepath);

--- a/packages/api/src/files/index.ts
+++ b/packages/api/src/files/index.ts
@@ -5,5 +5,6 @@ export * from './filter';
 export * from './mistral/crud';
 export * from './ocr';
 export * from './parse';
+export * from './rag';
 export * from './validation';
 export * from './text';

--- a/packages/api/src/files/rag.spec.ts
+++ b/packages/api/src/files/rag.spec.ts
@@ -1,0 +1,150 @@
+jest.mock('@librechat/data-schemas', () => ({
+	logger: {
+		debug: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+	},
+}));
+
+jest.mock('~/crypto/jwt', () => ({
+	generateShortLivedToken: jest.fn().mockReturnValue('mock-jwt-token'),
+}));
+
+jest.mock('axios', () => ({
+	delete: jest.fn(),
+	interceptors: {
+		request: { use: jest.fn(), eject: jest.fn() },
+		response: { use: jest.fn(), eject: jest.fn() },
+	},
+}));
+
+import axios from 'axios';
+import { deleteRagFile } from './rag';
+import { logger } from '@librechat/data-schemas';
+import { generateShortLivedToken } from '~/crypto/jwt';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedLogger = logger as jest.Mocked<typeof logger>;
+const mockedGenerateShortLivedToken = generateShortLivedToken as jest.MockedFunction<
+	typeof generateShortLivedToken
+>;
+
+describe('deleteRagFile', () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		process.env = { ...originalEnv };
+		process.env.RAG_API_URL = 'http://localhost:8000';
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	describe('when file is embedded and RAG_API_URL is configured', () => {
+		it('should delete the document from RAG API successfully', async () => {
+			const file = { file_id: 'file-123', embedded: true };
+			mockedAxios.delete.mockResolvedValueOnce({ status: 200 });
+
+			const result = await deleteRagFile({ userId: 'user123', file });
+
+			expect(result).toBe(true);
+			expect(mockedGenerateShortLivedToken).toHaveBeenCalledWith('user123');
+			expect(mockedAxios.delete).toHaveBeenCalledWith('http://localhost:8000/documents', {
+				headers: {
+					Authorization: 'Bearer mock-jwt-token',
+					'Content-Type': 'application/json',
+					accept: 'application/json',
+				},
+				data: ['file-123'],
+			});
+			expect(mockedLogger.debug).toHaveBeenCalledWith(
+				'[deleteRagFile] Successfully deleted document file-123 from RAG API',
+			);
+		});
+
+		it('should return true and log warning when document is not found (404)', async () => {
+			const file = { file_id: 'file-not-found', embedded: true };
+			const error = new Error('Not Found') as Error & { response?: { status?: number } };
+			error.response = { status: 404 };
+			mockedAxios.delete.mockRejectedValueOnce(error);
+
+			const result = await deleteRagFile({ userId: 'user123', file });
+
+			expect(result).toBe(true);
+			expect(mockedLogger.warn).toHaveBeenCalledWith(
+				'[deleteRagFile] Document file-not-found not found in RAG API, may have been deleted already',
+			);
+		});
+
+		it('should return false and log error on other errors', async () => {
+			const file = { file_id: 'file-error', embedded: true };
+			const error = new Error('Server Error') as Error & { response?: { status?: number } };
+			error.response = { status: 500 };
+			mockedAxios.delete.mockRejectedValueOnce(error);
+
+			const result = await deleteRagFile({ userId: 'user123', file });
+
+			expect(result).toBe(false);
+			expect(mockedLogger.error).toHaveBeenCalledWith(
+				'[deleteRagFile] Error deleting document from RAG API:',
+				'Server Error',
+			);
+		});
+	});
+
+	describe('when file is not embedded', () => {
+		it('should skip RAG deletion and return true', async () => {
+			const file = { file_id: 'file-123', embedded: false };
+
+			const result = await deleteRagFile({ userId: 'user123', file });
+
+			expect(result).toBe(true);
+			expect(mockedAxios.delete).not.toHaveBeenCalled();
+			expect(mockedGenerateShortLivedToken).not.toHaveBeenCalled();
+		});
+
+		it('should skip RAG deletion when embedded is undefined', async () => {
+			const file = { file_id: 'file-123' };
+
+			const result = await deleteRagFile({ userId: 'user123', file });
+
+			expect(result).toBe(true);
+			expect(mockedAxios.delete).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('when RAG_API_URL is not configured', () => {
+		it('should skip RAG deletion and return true', async () => {
+			delete process.env.RAG_API_URL;
+			const file = { file_id: 'file-123', embedded: true };
+
+			const result = await deleteRagFile({ userId: 'user123', file });
+
+			expect(result).toBe(true);
+			expect(mockedAxios.delete).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('userId handling', () => {
+		it('should return false when no userId is provided', async () => {
+			const file = { file_id: 'file-123', embedded: true };
+
+			const result = await deleteRagFile({ userId: '', file });
+
+			expect(result).toBe(false);
+			expect(mockedLogger.error).toHaveBeenCalledWith('[deleteRagFile] No user ID provided');
+			expect(mockedAxios.delete).not.toHaveBeenCalled();
+		});
+
+		it('should return false when userId is undefined', async () => {
+			const file = { file_id: 'file-123', embedded: true };
+
+			const result = await deleteRagFile({ userId: undefined as unknown as string, file });
+
+			expect(result).toBe(false);
+			expect(mockedLogger.error).toHaveBeenCalledWith('[deleteRagFile] No user ID provided');
+		});
+	});
+});

--- a/packages/api/src/files/rag.ts
+++ b/packages/api/src/files/rag.ts
@@ -1,0 +1,62 @@
+import axios from 'axios';
+import { logger } from '@librechat/data-schemas';
+import { generateShortLivedToken } from '~/crypto/jwt';
+
+interface DeleteRagFileParams {
+	/** The user ID. Required for authentication. If not provided, the function returns false and logs an error. */
+	userId: string;
+	/** The file object. Must have `embedded` and `file_id` properties. */
+	file: {
+		file_id: string;
+		embedded?: boolean;
+	};
+}
+
+/**
+ * Deletes embedded document(s) from the RAG API.
+ * This is a shared utility function used by all file storage strategies
+ * (S3, Azure, Firebase, Local) to delete RAG embeddings when a file is deleted.
+ *
+ * @param params - The parameters object.
+ * @param params.userId - The user ID for authentication.
+ * @param params.file - The file object. Must have `embedded` and `file_id` properties.
+ * @returns Returns true if deletion was successful or skipped, false if there was an error.
+ */
+export async function deleteRagFile({ userId, file }: DeleteRagFileParams): Promise<boolean> {
+	// Skip if the file is not embedded or RAG API URL is not configured
+	if (!file.embedded || !process.env.RAG_API_URL) {
+		return true;
+	}
+
+	if (!userId) {
+		logger.error('[deleteRagFile] No user ID provided');
+		return false;
+	}
+
+	// Generate a short-lived token for authentication
+	const jwtToken = generateShortLivedToken(userId);
+
+	try {
+		await axios.delete(`${process.env.RAG_API_URL}/documents`, {
+			headers: {
+				Authorization: `Bearer ${jwtToken}`,
+				'Content-Type': 'application/json',
+				accept: 'application/json',
+			},
+			data: [file.file_id],
+		});
+		logger.debug(`[deleteRagFile] Successfully deleted document ${file.file_id} from RAG API`);
+		return true;
+	} catch (error) {
+		const axiosError = error as { response?: { status?: number }; message?: string };
+		if (axiosError.response?.status === 404) {
+			logger.warn(
+				`[deleteRagFile] Document ${file.file_id} not found in RAG API, may have been deleted already`,
+			);
+			return true;
+		} else {
+			logger.error('[deleteRagFile] Error deleting document from RAG API:', axiosError.message);
+			return false;
+		}
+	}
+}

--- a/packages/api/src/files/rag.ts
+++ b/packages/api/src/files/rag.ts
@@ -23,7 +23,6 @@ interface DeleteRagFileParams {
  * @returns Returns true if deletion was successful or skipped, false if there was an error.
  */
 export async function deleteRagFile({ userId, file }: DeleteRagFileParams): Promise<boolean> {
-	// Skip if the file is not embedded or RAG API URL is not configured
 	if (!file.embedded || !process.env.RAG_API_URL) {
 		return true;
 	}
@@ -33,7 +32,6 @@ export async function deleteRagFile({ userId, file }: DeleteRagFileParams): Prom
 		return false;
 	}
 
-	// Generate a short-lived token for authentication
 	const jwtToken = generateShortLivedToken(userId);
 
 	try {


### PR DESCRIPTION
# Pull Request Template

## Summary

This pull request refactors and centralizes the logic for deleting embedded files from the RAG API across all file storage backends (S3, Azure, Firebase, Local). It introduces a new shared utility function, `deleteRagFile`, to handle RAG document deletions, replacing duplicated code in each backend. Comprehensive unit tests for this utility are also added.

**Centralization and Refactoring of RAG Deletion Logic:**

* Introduced a new utility function `deleteRagFile` in `packages/api/src/files/rag.ts` to handle deletion of embedded documents from the RAG API, consolidating logic previously duplicated in each storage backend.
* Updated all file storage backend CRUD modules (`Azure`, `Firebase`, `Local`, `S3`) to use the new `deleteRagFile` utility instead of inline RAG deletion logic, simplifying code and ensuring consistent behavior. [[1]](diffhunk://#diff-50720c98138063e48ffb616796f4e09e6edc255943cbc1bc516faeb7590b36e8L7-R7) [[2]](diffhunk://#diff-50720c98138063e48ffb616796f4e09e6edc255943cbc1bc516faeb7590b36e8R105-R107) [[3]](diffhunk://#diff-e0d20f7d56d5674ef4605919416999b1e2dc3d07c2d6d2e5dd57e1152bb6ae98L6-R6) [[4]](diffhunk://#diff-e0d20f7d56d5674ef4605919416999b1e2dc3d07c2d6d2e5dd57e1152bb6ae98L170-R171) [[5]](diffhunk://#diff-8be70ea7d6cc188896e06c7b427cbd92afd1de3e3a9ce4494fb9935d93eac2cfL6-R6) [[6]](diffhunk://#diff-8be70ea7d6cc188896e06c7b427cbd92afd1de3e3a9ce4494fb9935d93eac2cfL211-R212) [[7]](diffhunk://#diff-18be5d015a50a00ae5dbedd67d60517c1a0a7b252633f408c71361855f7a8016L3-R3) [[8]](diffhunk://#diff-18be5d015a50a00ae5dbedd67d60517c1a0a7b252633f408c71361855f7a8016R145-R147)

**Testing and Exports:**

* Added comprehensive unit tests for `deleteRagFile` in `packages/api/src/files/rag.spec.ts`, covering successful deletion, error handling, and edge cases.
* Exported the new `rag` utility module in the files index for broader availability.

## Change Type

Please delete any irrelevant options.

- [X] New feature (non-breaking change which adds functionality)

## Testing

Uploaded a PDF in chat, saw it upload to S3 and the embeddings in PG Vector DB. Then I deleted it in two ways:

1) Without starting the chat (essentially upload and immediately delete) - saw it get removed from S3 and embeddings DB
2) In the "Manage Files" modal - saw it get removed from S3 and embeddings DB

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [X] My changes do not introduce new warnings
- [X] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
