### PR TITLE
🧩 fix: Missing Memory Agent Assignment for Matching IDs

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -616,6 +616,8 @@ class AgentClient extends BaseClient {
           agent_id: memoryConfig.agent.id,
           endpoint: EModelEndpoint.agents,
         });
+      } else if (memoryConfig.agent?.id != null) {
+        prelimAgent = this.options.agent;
       } else if (
         memoryConfig.agent?.id == null &&
         memoryConfig.agent?.model != null &&
@@ -628,6 +630,10 @@ class AgentClient extends BaseClient {
         '[api/server/controllers/agents/client.js #useMemory] Error loading agent for memory',
         error,
       );
+    }
+
+    if (!prelimAgent) {
+      return;
     }
 
     const agent = await initializeAgent(

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -12,6 +12,17 @@ jest.mock('@librechat/agents', () => ({
 
 jest.mock('@librechat/api', () => ({
   ...jest.requireActual('@librechat/api'),
+  checkAccess: jest.fn(),
+  initializeAgent: jest.fn(),
+  createMemoryProcessor: jest.fn(),
+}));
+
+jest.mock('~/models/Agent', () => ({
+  loadAgent: jest.fn(),
+}));
+
+jest.mock('~/models/Role', () => ({
+  getRoleByName: jest.fn(),
 }));
 
 // Mock getMCPManager
@@ -2068,6 +2079,181 @@ describe('AgentClient - titleConvo', () => {
       ).resolves.not.toThrow();
 
       expect(client.options.agent.instructions).toContain(memoryContent);
+    });
+  });
+
+  describe('useMemory method - prelimAgent assignment', () => {
+    let client;
+    let mockReq;
+    let mockRes;
+    let mockAgent;
+    let mockOptions;
+    let mockCheckAccess;
+    let mockLoadAgent;
+    let mockInitializeAgent;
+    let mockCreateMemoryProcessor;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      mockAgent = {
+        id: 'agent-123',
+        endpoint: EModelEndpoint.openAI,
+        provider: EModelEndpoint.openAI,
+        instructions: 'Test instructions',
+        model: 'gpt-4',
+        model_parameters: {
+          model: 'gpt-4',
+        },
+      };
+
+      mockReq = {
+        user: {
+          id: 'user-123',
+          personalization: {
+            memories: true,
+          },
+        },
+        config: {
+          memory: {
+            agent: {
+              id: 'agent-123',
+            },
+          },
+          endpoints: {
+            [EModelEndpoint.agents]: {
+              allowedProviders: ['openAI'],
+            },
+          },
+        },
+      };
+
+      mockRes = {};
+
+      mockOptions = {
+        req: mockReq,
+        res: mockRes,
+        agent: mockAgent,
+      };
+
+      mockCheckAccess = require('@librechat/api').checkAccess;
+      mockLoadAgent = require('~/models/Agent').loadAgent;
+      mockInitializeAgent = require('@librechat/api').initializeAgent;
+      mockCreateMemoryProcessor = require('@librechat/api').createMemoryProcessor;
+    });
+
+    it('should use current agent when memory config agent.id matches current agent id', async () => {
+      mockCheckAccess.mockResolvedValue(true);
+      mockInitializeAgent.mockResolvedValue({
+        ...mockAgent,
+        provider: EModelEndpoint.openAI,
+      });
+      mockCreateMemoryProcessor.mockResolvedValue([undefined, jest.fn()]);
+
+      client = new AgentClient(mockOptions);
+      client.conversationId = 'convo-123';
+      client.responseMessageId = 'response-123';
+
+      await client.useMemory();
+
+      expect(mockLoadAgent).not.toHaveBeenCalled();
+      expect(mockInitializeAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: mockAgent,
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('should load different agent when memory config agent.id differs from current agent id', async () => {
+      const differentAgentId = 'different-agent-456';
+      const differentAgent = {
+        id: differentAgentId,
+        provider: EModelEndpoint.openAI,
+        model: 'gpt-4',
+        instructions: 'Different agent instructions',
+      };
+
+      mockReq.config.memory.agent.id = differentAgentId;
+
+      mockCheckAccess.mockResolvedValue(true);
+      mockLoadAgent.mockResolvedValue(differentAgent);
+      mockInitializeAgent.mockResolvedValue({
+        ...differentAgent,
+        provider: EModelEndpoint.openAI,
+      });
+      mockCreateMemoryProcessor.mockResolvedValue([undefined, jest.fn()]);
+
+      client = new AgentClient(mockOptions);
+      client.conversationId = 'convo-123';
+      client.responseMessageId = 'response-123';
+
+      await client.useMemory();
+
+      expect(mockLoadAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent_id: differentAgentId,
+        }),
+      );
+      expect(mockInitializeAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: differentAgent,
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('should return early when prelimAgent is undefined (no valid memory agent config)', async () => {
+      mockReq.config.memory = {
+        agent: {},
+      };
+
+      mockCheckAccess.mockResolvedValue(true);
+
+      client = new AgentClient(mockOptions);
+      client.conversationId = 'convo-123';
+      client.responseMessageId = 'response-123';
+
+      const result = await client.useMemory();
+
+      expect(result).toBeUndefined();
+      expect(mockInitializeAgent).not.toHaveBeenCalled();
+      expect(mockCreateMemoryProcessor).not.toHaveBeenCalled();
+    });
+
+    it('should create ephemeral agent when no id but model and provider are specified', async () => {
+      mockReq.config.memory = {
+        agent: {
+          model: 'gpt-4',
+          provider: EModelEndpoint.openAI,
+        },
+      };
+
+      mockCheckAccess.mockResolvedValue(true);
+      mockInitializeAgent.mockResolvedValue({
+        id: Constants.EPHEMERAL_AGENT_ID,
+        model: 'gpt-4',
+        provider: EModelEndpoint.openAI,
+      });
+      mockCreateMemoryProcessor.mockResolvedValue([undefined, jest.fn()]);
+
+      client = new AgentClient(mockOptions);
+      client.conversationId = 'convo-123';
+      client.responseMessageId = 'response-123';
+
+      await client.useMemory();
+
+      expect(mockLoadAgent).not.toHaveBeenCalled();
+      expect(mockInitializeAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: expect.objectContaining({
+            id: Constants.EPHEMERAL_AGENT_ID,
+            model: 'gpt-4',
+            provider: EModelEndpoint.openAI,
+          }),
+        }),
+        expect.any(Object),
+      );
     });
   });
 });

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -2122,7 +2122,7 @@ describe('AgentClient - titleConvo', () => {
           },
           endpoints: {
             [EModelEndpoint.agents]: {
-              allowedProviders: ['openAI'],
+              allowedProviders: [EModelEndpoint.openAI],
             },
           },
         },

--- a/packages/api/src/agents/memory.spec.ts
+++ b/packages/api/src/agents/memory.spec.ts
@@ -37,21 +37,18 @@ jest.mock('~/utils', () => ({
 
 const { createSafeUser } = jest.requireMock('~/utils');
 
-jest.mock('@librechat/agents', () => ({
-  Run: {
-    create: jest.fn(() => ({
-      processStream: jest.fn(() => Promise.resolve('success')),
-    })),
-  },
-  Providers: {
-    OPENAI: Providers.OPENAI,
-    BEDROCK: Providers.BEDROCK,
-    ANTHROPIC: Providers.ANTHROPIC,
-  },
-  GraphEvents: {
-    TOOL_END: 'tool_end',
-  },
-}));
+jest.mock('@librechat/agents', () => {
+  const actual = jest.requireActual('@librechat/agents');
+  return {
+    Run: {
+      create: jest.fn(() => ({
+        processStream: jest.fn(() => Promise.resolve('success')),
+      })),
+    },
+    Providers: actual.Providers,
+    GraphEvents: actual.GraphEvents,
+  };
+});
 
 function createTestUser(overrides: Partial<IUser> = {}): IUser {
   return {

--- a/packages/api/src/agents/memory.spec.ts
+++ b/packages/api/src/agents/memory.spec.ts
@@ -45,8 +45,8 @@ jest.mock('@librechat/agents', () => ({
   },
   Providers: {
     OPENAI: Providers.OPENAI,
-    BEDROCK: 'bedrock',
-    ANTHROPIC: 'anthropic',
+    BEDROCK: Providers.BEDROCK,
+    ANTHROPIC: Providers.ANTHROPIC,
   },
   GraphEvents: {
     TOOL_END: 'tool_end',
@@ -325,7 +325,7 @@ describe('Memory Agent Header Resolution', () => {
 
   it('should include instructions in user message for Bedrock provider', async () => {
     const llmConfig = {
-      provider: 'bedrock',
+      provider: Providers.BEDROCK,
       model: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
     };
 
@@ -386,7 +386,7 @@ describe('Memory Agent Header Resolution', () => {
 
   it('should set temperature to 1 for Bedrock with thinking enabled', async () => {
     const llmConfig = {
-      provider: 'bedrock',
+      provider: Providers.BEDROCK,
       model: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
       temperature: 0.7,
       additionalModelRequestFields: {
@@ -420,7 +420,7 @@ describe('Memory Agent Header Resolution', () => {
 
   it('should not modify temperature for Bedrock without thinking enabled', async () => {
     const llmConfig = {
-      provider: 'bedrock',
+      provider: Providers.BEDROCK,
       model: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
       temperature: 0.7,
     };
@@ -448,7 +448,7 @@ describe('Memory Agent Header Resolution', () => {
 
   it('should remove temperature for Anthropic with thinking enabled', async () => {
     const llmConfig = {
-      provider: 'anthropic',
+      provider: Providers.ANTHROPIC,
       model: 'claude-sonnet-4-20250514',
       temperature: 0.7,
       thinking: {
@@ -484,7 +484,7 @@ describe('Memory Agent Header Resolution', () => {
 
   it('should not modify temperature for Anthropic without thinking enabled', async () => {
     const llmConfig = {
-      provider: 'anthropic',
+      provider: Providers.ANTHROPIC,
       model: 'claude-sonnet-4-20250514',
       temperature: 0.7,
     };
@@ -512,7 +512,7 @@ describe('Memory Agent Header Resolution', () => {
 
   it('should not modify temperature for Anthropic with thinking type not enabled', async () => {
     const llmConfig = {
-      provider: 'anthropic',
+      provider: Providers.ANTHROPIC,
       model: 'claude-sonnet-4-20250514',
       temperature: 0.7,
       thinking: {

--- a/packages/api/src/agents/memory.spec.ts
+++ b/packages/api/src/agents/memory.spec.ts
@@ -1,5 +1,5 @@
 import { Types } from 'mongoose';
-import { Run } from '@librechat/agents';
+import { Run, Providers } from '@librechat/agents';
 import type { IUser } from '@librechat/data-schemas';
 import type { Response } from 'express';
 import { processMemory } from './memory';
@@ -44,8 +44,9 @@ jest.mock('@librechat/agents', () => ({
     })),
   },
   Providers: {
-    OPENAI: 'openai',
+    OPENAI: Providers.OPENAI,
     BEDROCK: 'bedrock',
+    ANTHROPIC: 'anthropic',
   },
   GraphEvents: {
     TOOL_END: 'tool_end',
@@ -255,7 +256,7 @@ describe('Memory Agent Header Resolution', () => {
 
   it('should not throw when llmConfig has no configuration', async () => {
     const llmConfig = {
-      provider: 'openai',
+      provider: Providers.OPENAI,
       model: 'gpt-4o-mini',
     };
 
@@ -288,7 +289,7 @@ describe('Memory Agent Header Resolution', () => {
     } as unknown as Partial<IUser>);
 
     const llmConfig = {
-      provider: 'openai',
+      provider: Providers.OPENAI,
       model: 'gpt-4o-mini',
       configuration: {
         defaultHeaders: {
@@ -356,7 +357,7 @@ describe('Memory Agent Header Resolution', () => {
 
   it('should pass instructions to graphConfig for non-Bedrock providers', async () => {
     const llmConfig = {
-      provider: 'openai',
+      provider: Providers.OPENAI,
       model: 'gpt-4o-mini',
     };
 
@@ -381,5 +382,162 @@ describe('Memory Agent Header Resolution', () => {
     // For non-Bedrock providers, instructions should be passed to graphConfig
     expect(runConfig.graphConfig.instructions).toBe('test instructions');
     expect(runConfig.graphConfig.additional_instructions).toBeDefined();
+  });
+
+  it('should set temperature to 1 for Bedrock with thinking enabled', async () => {
+    const llmConfig = {
+      provider: 'bedrock',
+      model: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
+      temperature: 0.7,
+      additionalModelRequestFields: {
+        thinking: {
+          type: 'enabled',
+          budget_tokens: 5000,
+        },
+      },
+    };
+
+    await processMemory({
+      res: mockRes,
+      userId: 'user-123',
+      setMemory: mockMemoryMethods.setMemory,
+      deleteMemory: mockMemoryMethods.deleteMemory,
+      messages: [],
+      memory: 'existing memory',
+      messageId: 'msg-123',
+      conversationId: 'conv-123',
+      validKeys: ['preferences'],
+      instructions: 'test instructions',
+      llmConfig,
+      user: testUser,
+    });
+
+    expect(Run.create as jest.Mock).toHaveBeenCalled();
+    const runConfig = (Run.create as jest.Mock).mock.calls[0][0];
+
+    expect(runConfig.graphConfig.llmConfig.temperature).toBe(1);
+  });
+
+  it('should not modify temperature for Bedrock without thinking enabled', async () => {
+    const llmConfig = {
+      provider: 'bedrock',
+      model: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+      temperature: 0.7,
+    };
+
+    await processMemory({
+      res: mockRes,
+      userId: 'user-123',
+      setMemory: mockMemoryMethods.setMemory,
+      deleteMemory: mockMemoryMethods.deleteMemory,
+      messages: [],
+      memory: 'existing memory',
+      messageId: 'msg-123',
+      conversationId: 'conv-123',
+      validKeys: ['preferences'],
+      instructions: 'test instructions',
+      llmConfig,
+      user: testUser,
+    });
+
+    expect(Run.create as jest.Mock).toHaveBeenCalled();
+    const runConfig = (Run.create as jest.Mock).mock.calls[0][0];
+
+    expect(runConfig.graphConfig.llmConfig.temperature).toBe(0.7);
+  });
+
+  it('should remove temperature for Anthropic with thinking enabled', async () => {
+    const llmConfig = {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-20250514',
+      temperature: 0.7,
+      thinking: {
+        type: 'enabled',
+        budget_tokens: 5000,
+      },
+    };
+
+    await processMemory({
+      res: mockRes,
+      userId: 'user-123',
+      setMemory: mockMemoryMethods.setMemory,
+      deleteMemory: mockMemoryMethods.deleteMemory,
+      messages: [],
+      memory: 'existing memory',
+      messageId: 'msg-123',
+      conversationId: 'conv-123',
+      validKeys: ['preferences'],
+      instructions: 'test instructions',
+      llmConfig,
+      user: testUser,
+    });
+
+    expect(Run.create as jest.Mock).toHaveBeenCalled();
+    const runConfig = (Run.create as jest.Mock).mock.calls[0][0];
+
+    expect(runConfig.graphConfig.llmConfig.temperature).toBeUndefined();
+    expect(runConfig.graphConfig.llmConfig.thinking).toEqual({
+      type: 'enabled',
+      budget_tokens: 5000,
+    });
+  });
+
+  it('should not modify temperature for Anthropic without thinking enabled', async () => {
+    const llmConfig = {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-20250514',
+      temperature: 0.7,
+    };
+
+    await processMemory({
+      res: mockRes,
+      userId: 'user-123',
+      setMemory: mockMemoryMethods.setMemory,
+      deleteMemory: mockMemoryMethods.deleteMemory,
+      messages: [],
+      memory: 'existing memory',
+      messageId: 'msg-123',
+      conversationId: 'conv-123',
+      validKeys: ['preferences'],
+      instructions: 'test instructions',
+      llmConfig,
+      user: testUser,
+    });
+
+    expect(Run.create as jest.Mock).toHaveBeenCalled();
+    const runConfig = (Run.create as jest.Mock).mock.calls[0][0];
+
+    expect(runConfig.graphConfig.llmConfig.temperature).toBe(0.7);
+  });
+
+  it('should not modify temperature for Anthropic with thinking type not enabled', async () => {
+    const llmConfig = {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-20250514',
+      temperature: 0.7,
+      thinking: {
+        type: 'disabled',
+      },
+    };
+
+    await processMemory({
+      res: mockRes,
+      userId: 'user-123',
+      setMemory: mockMemoryMethods.setMemory,
+      deleteMemory: mockMemoryMethods.deleteMemory,
+      messages: [],
+      memory: 'existing memory',
+      messageId: 'msg-123',
+      conversationId: 'conv-123',
+      validKeys: ['preferences'],
+      instructions: 'test instructions',
+      llmConfig,
+      user: testUser,
+    });
+
+    expect(Run.create as jest.Mock).toHaveBeenCalled();
+    const runConfig = (Run.create as jest.Mock).mock.calls[0][0];
+
+    expect(runConfig.graphConfig.llmConfig.temperature).toBe(0.7);
   });
 });

--- a/packages/api/src/agents/memory.ts
+++ b/packages/api/src/agents/memory.ts
@@ -369,7 +369,6 @@ ${memory ?? 'No existing memories'}`;
       }
     }
 
-    // Handle Bedrock with thinking enabled - temperature must be 1
     const bedrockConfig = finalLLMConfig as {
       additionalModelRequestFields?: { thinking?: unknown };
       temperature?: number;
@@ -380,6 +379,18 @@ ${memory ?? 'No existing memories'}`;
       bedrockConfig.temperature != null
     ) {
       (finalLLMConfig as unknown as Record<string, unknown>).temperature = 1;
+    }
+
+    const anthropicConfig = finalLLMConfig as {
+      thinking?: { type?: string };
+      temperature?: number;
+    };
+    if (
+      llmConfig?.provider === Providers.ANTHROPIC &&
+      anthropicConfig.thinking?.type === 'enabled' &&
+      anthropicConfig.temperature != null
+    ) {
+      delete (finalLLMConfig as Record<string, unknown>).temperature;
     }
 
     const llmConfigWithHeaders = finalLLMConfig as OpenAIClientOptions;


### PR DESCRIPTION
## Summary

This PR fixes a bug in the memory agent initialization logic where `prelimAgent` was never assigned when the memory config agent ID matched the current agent's ID, and adds temperature handling for Anthropic's thinking mode.

- Add missing condition in `useMemory()` to assign `this.options.agent` as `prelimAgent` when the memory config agent ID matches the current agent ID
- Add early return guard when `prelimAgent` is undefined to prevent downstream errors
- Remove temperature from Anthropic LLM config when thinking mode is enabled, as the API does not support custom temperature values in this mode
- Add comprehensive test coverage for all `prelimAgent` assignment scenarios in the `useMemory` method
- Refactor memory spec mocks to use actual `Providers` enum instead of hardcoded strings
- Add tests verifying temperature handling for both Bedrock and Anthropic providers with and without thinking mode

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified the fix by testing memory agent initialization with:
- Memory config agent ID matching current agent ID (previously broken)
- Memory config agent ID different from current agent ID
- Memory config with no agent ID but model/provider specified
- Empty memory agent config

Tested Anthropic thinking mode to confirm temperature is properly removed when thinking is enabled.

### Test Configuration

- Node.js with Jest
- Unit tests for `AgentClient.useMemory()` method
- Unit tests for `processMemory()` temperature handling

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules