### PR TITLE
🍪 refactor: Secure Cookie Setting for Localhost OAuth Sessions

### DIFF
--- a/api/server/socialLogins.js
+++ b/api/server/socialLogins.js
@@ -23,7 +23,27 @@ const { getLogStores } = require('~/cache');
 function shouldUseSecureCookie() {
   const isProduction = process.env.NODE_ENV === 'production';
   const domainServer = process.env.DOMAIN_SERVER || '';
-  const isLocalhost = domainServer.includes('localhost') || domainServer.includes('127.0.0.1');
+
+  let hostname = '';
+  if (domainServer) {
+    try {
+      const normalized = /^https?:\/\//i.test(domainServer)
+        ? domainServer
+        : `http://${domainServer}`;
+      const url = new URL(normalized);
+      hostname = (url.hostname || '').toLowerCase();
+    } catch {
+      // Fallback: treat DOMAIN_SERVER directly as a hostname-like string
+      hostname = domainServer.toLowerCase();
+    }
+  }
+
+  const isLocalhost =
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    hostname.endsWith('.localhost');
+
   return isProduction && !isLocalhost;
 }
 


### PR DESCRIPTION
## Summary

Fixes OpenID/SAML authentication failing on localhost when running in production mode (NODE_ENV=production).                                                      

PR #11407 introduced secure: isProduction for session cookies, which correctly enforces secure cookies in production. However, this breaks local development when running in production mode over HTTP (e.g., http://localhost:3080), because browsers refuse to send Secure cookies over non-HTTPS connections.

The session cookie is never sent back after the OAuth redirect, causing the session to be lost and authentication to fail with an unhelpful "Unknown error" message.

This PR adds a shouldUseSecureCookie() helper that only enables secure cookies when:
1. NODE_ENV=production AND
2. DOMAIN_SERVER does not contain localhost or 127.0.0.1

## Change Type

- Bug fix (non-breaking change which fixes an issue)

## Testing

1. Set DOMAIN_SERVER=http://localhost:3080 in .env
2. Run npm run backend (production mode)
3. Attempt to authenticate via OpenID (e.g., Entra ID)
4. Before fix: Authentication fails with "Unknown error", client shows "Token is not present"
5. After fix: Authentication succeeds

## Test Configuration:

- NODE_ENV=production
- DOMAIN_SERVER=http://localhost:3080
- OpenID provider: Microsoft Entra ID

## Checklist

- My code adheres to this project's style guidelines
- I have performed a self-review of my own code
- I have commented in any complex areas of my code
- My changes do not introduce new warnings