### PR TITLE
🎙️ fix: Prefer OGG and WAV for External STT Recording

### DIFF
--- a/client/src/hooks/Input/useSpeechToTextExternal.ts
+++ b/client/src/hooks/Input/useSpeechToTextExternal.ts
@@ -48,12 +48,12 @@ const useSpeechToTextExternal = (
 
   function getBestSupportedMimeType() {
     const types = [
-      'audio/webm',
-      'audio/webm;codecs=opus',
-      'audio/mp4',
       'audio/ogg;codecs=opus',
       'audio/ogg',
       'audio/wav',
+      'audio/webm',
+      'audio/webm;codecs=opus',
+      'audio/mp4',
     ];
 
     for (const type of types) {


### PR DESCRIPTION
# Pull Request Template

## Summary

External STT recording previously preferred WebM and MP4, which some OpenAI-compatible Audio Transcriptions APIs reject with an invalid file format response. The updated priority selects `audio/ogg;codecs=opus`, `audio/ogg`, or `audio/wav` first when the browser supports them, while retaining WebM and MP4 fallbacks.

Firefox recording and transcription were verified against Scaleway STT with the `whisper-large-v3` model. The implementation is continued in #14864, which targets `dev` and adds direct regression coverage because this source branch does not allow maintainer edits.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified recording uses OGG in Firefox.
- Verified transcription succeeds with Scaleway's OpenAI-compatible Audio Transcriptions API and the `whisper-large-v3` model.
- Confirmed the browser capability check retains WebM and MP4 fallbacks when OGG or WAV is unavailable.

### **Test Configuration**:

- Firefox
- Scaleway STT
- `whisper-large-v3`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
