### PR TITLE
feat: add region configuration for Mistral OCR on Vertex AI

### DIFF
--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -882,6 +882,7 @@ export const ocrSchema = z.object({
   mistralModel: z.string().optional(),
   apiKey: z.string().optional().default('${OCR_API_KEY}'),
   baseURL: z.string().optional().default('${OCR_BASEURL}'),
+  region: z.string().optional().default('${MISTRAL_VERTEX_REGION}'),
   strategy: z.nativeEnum(OCRStrategy).default(OCRStrategy.MISTRAL_OCR),
 });
 

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -882,7 +882,7 @@ export const ocrSchema = z.object({
   mistralModel: z.string().optional(),
   apiKey: z.string().optional().default('${OCR_API_KEY}'),
   baseURL: z.string().optional().default('${OCR_BASEURL}'),
-  region: z.string().optional().default('${MISTRAL_VERTEX_REGION}'),
+  region: z.string().optional(),
   strategy: z.nativeEnum(OCRStrategy).default(OCRStrategy.MISTRAL_OCR),
 });
 


### PR DESCRIPTION
Add separate region configuration for Mistral OCR to resolve conflicts with Gemini 3 models that require the global endpoint.

Changes:
- Add `region` field to OCR schema in data-provider
- Add `MISTRAL_VERTEX_REGION` environment variable support
- Add `getRegionConfig()` helper function
- Update `performGoogleVertexOCR()` to accept region parameter
- Add region resolution logic with priority: config > MISTRAL_VERTEX_REGION > GOOGLE_LOC
- Maintains full backward compatibility

This follows the pattern established by Anthropic Vertex AI configuration.

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [ ] My code adheres to this project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [ ] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
