### PR TITLE
🏢 fix: Handle Group Overage for Azure Entra Authentication

### DIFF
--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -1,5 +1,6 @@
 const fetch = require('node-fetch');
 const jwtDecode = require('jsonwebtoken/decode');
+const undici = require('undici');
 const { ErrorTypes } = require('librechat-data-provider');
 const { findUser, createUser, updateUser } = require('~/models');
 const { setupOpenId } = require('./openidStrategy');
@@ -7,6 +8,10 @@ const { setupOpenId } = require('./openidStrategy');
 // --- Mocks ---
 jest.mock('node-fetch');
 jest.mock('jsonwebtoken/decode');
+jest.mock('undici', () => ({
+  fetch: jest.fn(),
+  ProxyAgent: jest.fn(),
+}));
 jest.mock('~/server/services/Files/strategies', () => ({
   getStrategyFunctions: jest.fn(() => ({
     saveBuffer: jest.fn().mockResolvedValue('/fake/path/to/avatar.png'),
@@ -360,6 +365,25 @@ describe('setupOpenId', () => {
     expect(details.message).toBe('You must have "requiredRole" role to log in.');
   });
 
+  it('should not treat substring matches in string roles as satisfying required role', async () => {
+    // Arrange – override required role to "read" then re-setup
+    process.env.OPENID_REQUIRED_ROLE = 'read';
+    await setupOpenId();
+    verifyCallback = require('openid-client/passport').__getVerifyCallbackByName('openid');
+
+    // Token contains "bread" which *contains* "read" as a substring
+    jwtDecode.mockReturnValue({
+      roles: 'bread',
+    });
+
+    // Act
+    const { user, details } = await validate(tokenset);
+
+    // Assert – verify that substring match does not grant access
+    expect(user).toBe(false);
+    expect(details.message).toBe('You must have "read" role to log in.');
+  });
+
   it('should allow login when single required role is present (backward compatibility)', async () => {
     // Arrange – ensure single role configuration (as set in beforeEach)
     // OPENID_REQUIRED_ROLE = 'requiredRole'
@@ -376,6 +400,292 @@ describe('setupOpenId', () => {
     expect(user.email).toBe(tokenset.claims().email);
     expect(user.username).toBe(tokenset.claims().preferred_username);
     expect(createUser).toHaveBeenCalled();
+  });
+
+  describe('group overage and groups handling', () => {
+    it.each([
+      ['groups array contains required group', ['group-required', 'other-group'], true, undefined],
+      [
+        'groups array missing required group',
+        ['other-group'],
+        false,
+        'You must have "group-required" role to log in.',
+      ],
+      ['groups string equals required group', 'group-required', true, undefined],
+      [
+        'groups string is other group',
+        'other-group',
+        false,
+        'You must have "group-required" role to log in.',
+      ],
+    ])(
+      'uses groups claim directly when %s (no overage)',
+      async (_label, groupsClaim, expectedAllowed, expectedMessage) => {
+        process.env.OPENID_REQUIRED_ROLE = 'group-required';
+        process.env.OPENID_REQUIRED_ROLE_PARAMETER_PATH = 'groups';
+        process.env.OPENID_REQUIRED_ROLE_TOKEN_KIND = 'id';
+
+        jwtDecode.mockReturnValue({
+          groups: groupsClaim,
+          permissions: ['admin'],
+        });
+
+        await setupOpenId();
+        verifyCallback = require('openid-client/passport').__getVerifyCallbackByName('openid');
+
+        const { user, details } = await validate(tokenset);
+
+        expect(undici.fetch).not.toHaveBeenCalled();
+        expect(Boolean(user)).toBe(expectedAllowed);
+        expect(details?.message).toBe(expectedMessage);
+      },
+    );
+
+    it.each([
+      ['token kind is not id', { kind: 'access', path: 'groups', decoded: { hasgroups: true } }],
+      ['parameter path is not groups', { kind: 'id', path: 'roles', decoded: { hasgroups: true } }],
+      ['decoded token is falsy', { kind: 'id', path: 'groups', decoded: null }],
+      [
+        'no overage indicators in decoded token',
+        {
+          kind: 'id',
+          path: 'groups',
+          decoded: {
+            permissions: ['admin'],
+          },
+        },
+      ],
+      [
+        'only _claim_names present (no _claim_sources)',
+        {
+          kind: 'id',
+          path: 'groups',
+          decoded: {
+            _claim_names: { groups: 'src1' },
+            permissions: ['admin'],
+          },
+        },
+      ],
+      [
+        'only _claim_sources present (no _claim_names)',
+        {
+          kind: 'id',
+          path: 'groups',
+          decoded: {
+            _claim_sources: { src1: { endpoint: 'https://graph.windows.net/ignored' } },
+            permissions: ['admin'],
+          },
+        },
+      ],
+    ])('does not attempt overage resolution when %s', async (_label, cfg) => {
+      process.env.OPENID_REQUIRED_ROLE = 'group-required';
+      process.env.OPENID_REQUIRED_ROLE_PARAMETER_PATH = cfg.path;
+      process.env.OPENID_REQUIRED_ROLE_TOKEN_KIND = cfg.kind;
+
+      jwtDecode.mockReturnValue(cfg.decoded);
+
+      await setupOpenId();
+      verifyCallback = require('openid-client/passport').__getVerifyCallbackByName('openid');
+
+      const { user, details } = await validate(tokenset);
+
+      expect(undici.fetch).not.toHaveBeenCalled();
+      expect(user).toBe(false);
+      expect(details.message).toBe('You must have "group-required" role to log in.');
+      const { logger } = require('@librechat/data-schemas');
+      const expectedTokenKind = cfg.kind === 'access' ? 'access token' : 'id token';
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining(`Key '${cfg.path}' not found in ${expectedTokenKind}!`),
+      );
+    });
+  });
+
+  describe('resolving groups via Microsoft Graph', () => {
+    it('denies login and does not call Graph when access token is missing', async () => {
+      process.env.OPENID_REQUIRED_ROLE = 'group-required';
+      process.env.OPENID_REQUIRED_ROLE_PARAMETER_PATH = 'groups';
+      process.env.OPENID_REQUIRED_ROLE_TOKEN_KIND = 'id';
+
+      const { logger } = require('@librechat/data-schemas');
+
+      jwtDecode.mockReturnValue({
+        hasgroups: true,
+        permissions: ['admin'],
+      });
+
+      await setupOpenId();
+      verifyCallback = require('openid-client/passport').__getVerifyCallbackByName('openid');
+
+      const tokensetWithoutAccess = {
+        ...tokenset,
+        access_token: undefined,
+      };
+
+      const { user, details } = await validate(tokensetWithoutAccess);
+
+      expect(user).toBe(false);
+      expect(details.message).toBe('You must have "group-required" role to log in.');
+
+      expect(undici.fetch).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Access token missing; cannot resolve group overage'),
+      );
+    });
+
+    it.each([
+      [
+        'Graph returns HTTP error',
+        async () => ({
+          ok: false,
+          status: 403,
+          statusText: 'Forbidden',
+          json: async () => ({}),
+        }),
+        [
+          '[openidStrategy] Failed to resolve groups via Microsoft Graph getMemberObjects: HTTP 403 Forbidden',
+        ],
+      ],
+      [
+        'Graph network error',
+        async () => {
+          throw new Error('network error');
+        },
+        [
+          '[openidStrategy] Error resolving groups via Microsoft Graph getMemberObjects:',
+          expect.any(Error),
+        ],
+      ],
+      [
+        'Graph returns unexpected shape (no value)',
+        async () => ({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({}),
+        }),
+        [
+          '[openidStrategy] Unexpected response format when resolving groups via Microsoft Graph getMemberObjects',
+        ],
+      ],
+      [
+        'Graph returns invalid value type',
+        async () => ({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({ value: 'not-an-array' }),
+        }),
+        [
+          '[openidStrategy] Unexpected response format when resolving groups via Microsoft Graph getMemberObjects',
+        ],
+      ],
+    ])(
+      'denies login when overage resolution fails because %s',
+      async (_label, setupFetch, expectedErrorArgs) => {
+        process.env.OPENID_REQUIRED_ROLE = 'group-required';
+        process.env.OPENID_REQUIRED_ROLE_PARAMETER_PATH = 'groups';
+        process.env.OPENID_REQUIRED_ROLE_TOKEN_KIND = 'id';
+
+        const { logger } = require('@librechat/data-schemas');
+
+        jwtDecode.mockReturnValue({
+          hasgroups: true,
+          permissions: ['admin'],
+        });
+
+        await setupOpenId();
+        verifyCallback = require('openid-client/passport').__getVerifyCallbackByName('openid');
+
+        undici.fetch.mockImplementation(setupFetch);
+
+        const { user, details } = await validate(tokenset);
+
+        expect(undici.fetch).toHaveBeenCalled();
+        expect(user).toBe(false);
+        expect(details.message).toBe('You must have "group-required" role to log in.');
+
+        expect(logger.error).toHaveBeenCalledWith(...expectedErrorArgs);
+      },
+    );
+
+    it.each([
+      [
+        'hasgroups overage and Graph contains required group',
+        {
+          hasgroups: true,
+        },
+        ['group-required', 'some-other-group'],
+        true,
+      ],
+      [
+        '_claim_* overage and Graph contains required group',
+        {
+          _claim_names: { groups: 'src1' },
+          _claim_sources: { src1: { endpoint: 'https://graph.windows.net/ignored' } },
+        },
+        ['group-required', 'some-other-group'],
+        true,
+      ],
+      [
+        'hasgroups overage and Graph does NOT contain required group',
+        {
+          hasgroups: true,
+        },
+        ['some-other-group'],
+        false,
+      ],
+      [
+        '_claim_* overage and Graph does NOT contain required group',
+        {
+          _claim_names: { groups: 'src1' },
+          _claim_sources: { src1: { endpoint: 'https://graph.windows.net/ignored' } },
+        },
+        ['some-other-group'],
+        false,
+      ],
+    ])(
+      'resolves groups via Microsoft Graph when %s',
+      async (_label, decodedTokenValue, graphGroups, expectedAllowed) => {
+        process.env.OPENID_REQUIRED_ROLE = 'group-required';
+        process.env.OPENID_REQUIRED_ROLE_PARAMETER_PATH = 'groups';
+        process.env.OPENID_REQUIRED_ROLE_TOKEN_KIND = 'id';
+
+        const { logger } = require('@librechat/data-schemas');
+
+        jwtDecode.mockReturnValue(decodedTokenValue);
+
+        await setupOpenId();
+        verifyCallback = require('openid-client/passport').__getVerifyCallbackByName('openid');
+
+        undici.fetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({
+            value: graphGroups,
+          }),
+        });
+
+        const { user } = await validate(tokenset);
+
+        expect(undici.fetch).toHaveBeenCalledWith(
+          'https://graph.microsoft.com/v1.0/me/getMemberObjects',
+          expect.objectContaining({
+            method: 'POST',
+            headers: expect.objectContaining({
+              Authorization: `Bearer ${tokenset.access_token}`,
+            }),
+          }),
+        );
+        expect(Boolean(user)).toBe(expectedAllowed);
+
+        expect(logger.debug).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `Successfully resolved ${graphGroups.length} groups via Microsoft Graph getMemberObjects`,
+          ),
+        );
+      },
+    );
   });
 
   it('should attempt to download and save the avatar if picture is provided', async () => {


### PR DESCRIPTION
# Pull Request Template

## Summary

When using OpenID based authentication, LibreChat allows you to gate sign-in by setting environment variables `OPENID_REQUIRED_ROLE`, `OPENID_REQUIRED_ROLE_KIND` and `OPEN_ID_REQUIRED_ROLE_PARAMETER`. More specifically, when using Azure Entra for authentication, you can gate sign-in by setting :
```yaml
OPENID_REQUIRED_ROLE = <SOME_GROUP>
OPENID_RQUIRED_ROLE_TOKEN_KIND = id 
OPENID_REQUIRED_ROLE_PARAMETER_PATH = groups
```
This works fine most of the time. 

However, if a user is part of more than 200 groups, then something very weird happens. At this point the id token of the user will no longer contain a `groups` claim, due to what is known as [group overage](https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference#groups-overage-claim). In this case Microsoft expects the handler of the token to manually call an appropriate Graph API endpoint to retrieve all the groups for the given user.  

The edge case described above is not currently handled by LibreChat, meaning it is impossible to sign in to a gated instance of LibreChat when using Azure Entra and a user is a member of more than 200 groups.  The following PR fixes this bug by updating `openidStrategy.js` so that the edge case is handled. 


## Change Type

Please delete any irrelevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

So far manual testing with an internal user who is affected by this problem as well as testing with users who are not affected by the problem.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [X] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
- [X] Any changes dependent on mine have been merged and published in downstream modules.
- [X] A pull request for updating the documentation has been submitted.
