### PR TITLE
Resizable Nav on desktop

### DIFF
--- a/client/src/components/Nav/Nav.tsx
+++ b/client/src/components/Nav/Nav.tsx
@@ -10,7 +10,6 @@ import {
   startTransition,
 } from 'react';
 import { useRecoilValue } from 'recoil';
-import { motion } from 'framer-motion';
 import { Skeleton, useMediaQuery } from '@librechat/client';
 import { PermissionTypes, Permissions } from 'librechat-data-provider';
 import type { InfiniteQueryObserverResult } from '@tanstack/react-query';
@@ -278,24 +277,17 @@ const Nav = memo(
       );
     }
 
-    // Desktop: Inline sidebar with width transition
+    // Desktop: Rendered inside ResizablePanel in Root.tsx
     return (
       <div
-        className="flex-shrink-0 overflow-hidden"
-        style={{ width: navVisible ? sidebarWidth : 0, transition: 'width 0.2s ease-out' }}
+        data-testid="nav"
+        className={cn(
+          'nav h-full bg-surface-primary-alt',
+          navVisible && 'active',
+          !navVisible && 'hidden',
+        )}
       >
-        <motion.div
-          data-testid="nav"
-          className={cn('nav h-full bg-surface-primary-alt', navVisible && 'active')}
-          style={{ width: sidebarWidth }}
-          initial={false}
-          animate={{
-            x: navVisible ? 0 : -sidebarWidth,
-          }}
-          transition={{ duration: 0.2, ease: 'easeOut' }}
-        >
-          {sidebarContent}
-        </motion.div>
+        {sidebarContent}
       </div>
     );
   },

--- a/client/src/components/Nav/Nav.tsx
+++ b/client/src/components/Nav/Nav.tsx
@@ -277,7 +277,6 @@ const Nav = memo(
       );
     }
 
-    // Desktop: Rendered inside ResizablePanel in Root.tsx
     return (
       <div
         data-testid="nav"

--- a/client/src/components/Nav/ResizableNav.tsx
+++ b/client/src/components/Nav/ResizableNav.tsx
@@ -1,0 +1,107 @@
+import { useRef, useCallback, useEffect } from 'react';
+import type { ImperativePanelHandle } from 'react-resizable-panels';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandleAlt } from '@librechat/client';
+import type { ContextType } from '~/common';
+import { Nav, MobileNav, NAV_WIDTH } from '~/components/Nav';
+
+interface ResizableNavProps {
+  navVisible: boolean;
+  setNavVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  isSmallScreen: boolean;
+  children: (context: ContextType) => React.ReactNode;
+}
+
+export default function ResizableNav({
+  navVisible,
+  setNavVisible,
+  isSmallScreen,
+  children,
+}: ResizableNavProps) {
+  const navPanelRef = useRef<ImperativePanelHandle>(null);
+
+  // Sync panel state with navVisible prop on mount and when switching to desktop
+  useEffect(() => {
+    if (!isSmallScreen && navPanelRef.current) {
+      const isCollapsed = navPanelRef.current.isCollapsed();
+
+      // Only update if there's a mismatch between prop and panel state
+      if (navVisible && isCollapsed) {
+        navPanelRef.current.expand();
+      } else if (!navVisible && !isCollapsed) {
+        navPanelRef.current.collapse();
+      }
+    }
+  }, [navVisible, isSmallScreen]);
+
+  // Custom setNavVisible that also controls the resizable panel
+  const handleSetNavVisible = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) => {
+      setNavVisible((prev) => {
+        const newValue = typeof value === 'function' ? value(prev) : value;
+
+        // Control the resizable panel on desktop
+        if (!isSmallScreen && navPanelRef.current) {
+          if (newValue) {
+            navPanelRef.current.expand();
+          } else {
+            navPanelRef.current.collapse();
+          }
+        }
+
+        localStorage.setItem('navVisible', JSON.stringify(newValue));
+        return newValue;
+      });
+    },
+    [isSmallScreen, setNavVisible],
+  );
+
+  const context: ContextType = { navVisible, setNavVisible: handleSetNavVisible };
+
+  // Mobile: Original overlay behavior
+  if (isSmallScreen) {
+    return (
+      <>
+        <Nav navVisible={navVisible} setNavVisible={handleSetNavVisible} />
+        <div
+          className="relative flex h-full max-w-full flex-1 flex-col overflow-hidden"
+          style={{
+            transform: navVisible ? `translateX(${NAV_WIDTH.MOBILE}px)` : 'translateX(0)',
+            transition: 'transform 0.2s ease-out',
+          }}
+        >
+          <MobileNav navVisible={navVisible} setNavVisible={handleSetNavVisible} />
+          {children(context)}
+        </div>
+      </>
+    );
+  }
+
+  // Desktop: Resizable panel layout
+  return (
+    <ResizablePanelGroup direction="horizontal" className="h-full w-full" autoSaveId="nav-layout">
+      <ResizablePanel
+        ref={navPanelRef}
+        defaultSize={navVisible ? 15 : 0}
+        minSize={15}
+        maxSize={35}
+        collapsible={true}
+        collapsedSize={0}
+        onCollapse={() => {
+          setNavVisible(false);
+        }}
+        onExpand={() => {
+          setNavVisible(true);
+        }}
+      >
+        <Nav navVisible={navVisible} setNavVisible={handleSetNavVisible} />
+      </ResizablePanel>
+      <ResizableHandleAlt withHandle className="w-px" />
+      <ResizablePanel defaultSize={85} minSize={65}>
+        <div className="relative flex h-full max-w-full flex-1 flex-col overflow-hidden">
+          <MobileNav navVisible={navVisible} setNavVisible={handleSetNavVisible} />
+          {children(context)}
+        </div>
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  );
+}

--- a/client/src/components/Nav/ResizableNav.tsx
+++ b/client/src/components/Nav/ResizableNav.tsx
@@ -2,7 +2,8 @@ import { useRef, useCallback, useEffect } from 'react';
 import type { ImperativePanelHandle } from 'react-resizable-panels';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandleAlt } from '@librechat/client';
 import type { ContextType } from '~/common';
-import { Nav, MobileNav, NAV_WIDTH } from '~/components/Nav';
+import Nav, { NAV_WIDTH } from './Nav';
+import MobileNav from './MobileNav';
 
 interface ResizableNavProps {
   navVisible: boolean;
@@ -48,7 +49,9 @@ export default function ResizableNav({
           }
         }
 
-        localStorage.setItem('navVisible', JSON.stringify(newValue));
+        if (typeof value === 'boolean') {
+          localStorage.setItem('navVisible', JSON.stringify(newValue));
+        }
         return newValue;
       });
     },
@@ -87,10 +90,10 @@ export default function ResizableNav({
         collapsible={true}
         collapsedSize={0}
         onCollapse={() => {
-          setNavVisible(false);
+          handleSetNavVisible(false);
         }}
         onExpand={() => {
-          setNavVisible(true);
+          handleSetNavVisible(true);
         }}
       >
         <Nav navVisible={navVisible} setNavVisible={handleSetNavVisible} />

--- a/client/src/components/Nav/index.ts
+++ b/client/src/components/Nav/index.ts
@@ -4,5 +4,6 @@ export { default as MobileNav } from './MobileNav';
 export { default as Nav, NAV_WIDTH } from './Nav';
 export { default as NavLink } from './NavLink';
 export { default as NewChat } from './NewChat';
+export { default as ResizableNav } from './ResizableNav';
 export { default as SearchBar } from './SearchBar';
 export { default as Settings } from './Settings';

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { useMediaQuery } from '@librechat/client';
-import type { ContextType } from '~/common';
 import {
   useSearchEnabled,
   useAssistantsMap,
@@ -17,7 +16,7 @@ import {
   FileMapContext,
 } from '~/Providers';
 import { useUserTermsQuery, useGetStartupConfig } from '~/data-provider';
-import { Nav, MobileNav, NAV_WIDTH } from '~/components/Nav';
+import { ResizableNav } from '~/components/Nav';
 import { TermsAndConditionsModal } from '~/components/ui';
 import { useHealthCheck } from '~/data-provider';
 import { Banner } from '~/components/Banners';
@@ -75,23 +74,13 @@ export default function Root() {
               <Banner onHeightChange={setBannerHeight} />
               <div className="flex" style={{ height: `calc(100dvh - ${bannerHeight}px)` }}>
                 <div className="relative z-0 flex h-full w-full overflow-hidden">
-                  <Nav navVisible={navVisible} setNavVisible={setNavVisible} />
-                  <div
-                    className="relative flex h-full max-w-full flex-1 flex-col overflow-hidden"
-                    style={
-                      isSmallScreen
-                        ? {
-                            transform: navVisible
-                              ? `translateX(${NAV_WIDTH.MOBILE}px)`
-                              : 'translateX(0)',
-                            transition: 'transform 0.2s ease-out',
-                          }
-                        : undefined
-                    }
+                  <ResizableNav
+                    navVisible={navVisible}
+                    setNavVisible={setNavVisible}
+                    isSmallScreen={isSmallScreen}
                   >
-                    <MobileNav navVisible={navVisible} setNavVisible={setNavVisible} />
-                    <Outlet context={{ navVisible, setNavVisible } satisfies ContextType} />
-                  </div>
+                    {(context) => <Outlet context={context} />}
+                  </ResizableNav>
                 </div>
               </div>
             </PromptGroupsProvider>


### PR DESCRIPTION
# Resizable Nav on desktop

## 📋 Summary

This PR adds a resizable navigation panel, allowing users to adjust the width of the sidebar on desktop while maintaining the existing overlay behavior on mobile devices.

## 🎯 Problem

Currently, the navigation sidebar has a fixed width on desktop, which may not be optimal for all screen sizes and user preferences. Users cannot adjust the sidebar width to better fit their workspace or viewing preferences, leading to suboptimal screen space utilization.

## ✨ Solution

Implemented a new ResizableNav component that wraps the existing Nav component with react-resizable-panels functionality:

- **Desktop Experience**: Users can now drag the navigation panel edge to resize it (15%-35% of screen width), with state persistence across sessions
- **Mobile Experience**: Preserved the existing overlay behavior with smooth transitions
- **Bidirectional Sync**: Collapse button and resizable panel state stay synchronized
- **State Persistence**: Navigation width and visibility preferences saved to localStorage

## 📸 Visual Changes

On desktop:
- A draggable handle appears between the navigation panel and main content area
- Users can smoothly resize the sidebar by dragging the handle
- Sidebar can be collapsed/expanded with the toggle button or by resizing to minimum width
- The selected width persists across page reloads

On mobile:
- No changes to the existing overlay behavior
- Navigation slides in/out as before

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
