### PR TITLE
feat: add conversation_id and entity_id to Code Execution Tool

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -274,9 +274,16 @@ const loadTools = async ({
         if (toolContext) {
           toolContextMap[tool] = toolContext;
         }
+        // Get conversation_id for session isolation
+        let conversationId = options.req?.body?.conversationId;
+        if (!conversationId || conversationId === 'new') {
+          conversationId = options.req?._resumableStreamId || null;
+        }
         const CodeExecutionTool = createCodeExecutionTool({
           user_id: user,
           files,
+          conversation_id: conversationId,
+          entity_id: agent?.id || null,
           ...authValues,
         });
         CodeExecutionTool.apiKey = codeApiKey;


### PR DESCRIPTION
Pass conversation_id and entity_id parameters to createCodeExecutionTool for better session isolation in code execution contexts.

- Extract conversationId from request body or fallback to _resumableStreamId
- Pass entity_id from agent for proper context tracking
