### PR TITLE
feat: Add Gemini 3 models and remove deprecated legacy models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -178,10 +178,10 @@ GOOGLE_KEY=user_provided
 # GOOGLE_AUTH_HEADER=true
 
 # Gemini API (AI Studio)
-# GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash,gemini-2.0-flash-lite
+# GOOGLE_MODELS=gemini-3-flash-preview,gemini-3-pro-preview,gemini-3-pro-image-preview,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash,gemini-2.0-flash-lite
 
 # Vertex AI
-# GOOGLE_MODELS=gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001
+# GOOGLE_MODELS=gemini-3-flash-preview,gemini-3-pro-preview,gemini-3-pro-image-preview,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001
 
 # GOOGLE_TITLE_MODEL=gemini-2.0-flash-lite-001
 

--- a/add-kimi-bedrock.md
+++ b/add-kimi-bedrock.md
@@ -1,0 +1,197 @@
+# Add AWS Bedrock Kimi K2 Thinking (Moonshot) Support
+
+This document describes the code changes required to add **Moonshot Kimi K2 Thinking** (`moonshot.kimi-k2-thinking`) model support to LibreChat's Bedrock endpoint.
+
+## Model Information
+
+- **Provider**: Moonshot AI
+- **Model ID**: `moonshot.kimi-k2-thinking`
+- **Context Window**: 256K tokens
+- **Recommended Max Output Tokens**: 16,384+ (for full reasoning + output)
+- **Recommended Temperature**: 1.0
+- **AWS Regions**: `ap-northeast-1`, `ap-south-1`, and more
+
+## Files to Modify
+
+### 1. `packages/data-provider/src/schemas.ts`
+
+**Location**: Around line 98-100, inside the `BedrockProviders` enum.
+
+**Change**: Add `Moonshot = 'moonshot'` to the enum.
+
+**Before**:
+```typescript
+export enum BedrockProviders {
+  AI21 = 'ai21',
+  Amazon = 'amazon',
+  Anthropic = 'anthropic',
+  Cohere = 'cohere',
+  Meta = 'meta',
+  MistralAI = 'mistral',
+  StabilityAI = 'stability',
+  DeepSeek = 'deepseek',
+}
+```
+
+**After**:
+```typescript
+export enum BedrockProviders {
+  AI21 = 'ai21',
+  Amazon = 'amazon',
+  Anthropic = 'anthropic',
+  Cohere = 'cohere',
+  Meta = 'meta',
+  MistralAI = 'mistral',
+  Moonshot = 'moonshot',
+  StabilityAI = 'stability',
+  DeepSeek = 'deepseek',
+}
+```
+
+---
+
+### 2. `packages/data-provider/src/parameterSettings.ts`
+
+**Change 1**: Add Moonshot configuration arrays after `bedrockGeneralCol2` (around line 880).
+
+**Insert this code block after the `bedrockGeneralCol2` definition**:
+
+```typescript
+const bedrockMoonshot: SettingsConfiguration = [
+  librechat.modelLabel,
+  bedrock.system,
+  librechat.maxContextTokens,
+  createDefinition(bedrock.maxTokens, {
+    default: 16384,
+  }),
+  bedrock.temperature,
+  bedrock.topP,
+  baseDefinitions.stop,
+  librechat.resendFiles,
+  bedrock.region,
+  librechat.fileTokenLimit,
+];
+
+const bedrockMoonshotCol1: SettingsConfiguration = [
+  baseDefinitions.model as SettingDefinition,
+  librechat.modelLabel,
+  bedrock.system,
+  baseDefinitions.stop,
+];
+
+const bedrockMoonshotCol2: SettingsConfiguration = [
+  librechat.maxContextTokens,
+  createDefinition(bedrock.maxTokens, {
+    default: 16384,
+  }),
+  bedrock.temperature,
+  bedrock.topP,
+  librechat.resendFiles,
+  bedrock.region,
+  librechat.fileTokenLimit,
+];
+```
+
+---
+
+**Change 2**: Register in `paramSettings` object.
+
+**Location**: Inside `export const paramSettings = { ... }`, after the `DeepSeek` entry.
+
+**Add this line**:
+```typescript
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.Moonshot}`]: bedrockMoonshot,
+```
+
+**Context** (showing surrounding lines):
+```typescript
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.AI21}`]: bedrockGeneral,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.Amazon}`]: bedrockGeneral,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.DeepSeek}`]: bedrockGeneral,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.Moonshot}`]: bedrockMoonshot,  // <-- ADD THIS
+  [EModelEndpoint.google]: googleConfig,
+```
+
+---
+
+**Change 3**: Register in `presetSettings` object.
+
+**Location**: Inside `export const presetSettings = { ... }`, after the `DeepSeek` entry.
+
+**Add this block**:
+```typescript
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.Moonshot}`]: {
+    col1: bedrockMoonshotCol1,
+    col2: bedrockMoonshotCol2,
+  },
+```
+
+**Context** (showing surrounding lines):
+```typescript
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.AI21}`]: bedrockGeneralColumns,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.Amazon}`]: bedrockGeneralColumns,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.DeepSeek}`]: bedrockGeneralColumns,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.Moonshot}`]: {  // <-- ADD THIS BLOCK
+    col1: bedrockMoonshotCol1,
+    col2: bedrockMoonshotCol2,
+  },
+  [EModelEndpoint.google]: {
+    col1: googleCol1,
+    col2: googleCol2,
+  },
+```
+
+---
+
+### 3. `packages/data-provider/src/bedrock.ts`
+
+**Location**: Around line 137-140, inside the `bedrockInputParser` transform function.
+
+**Change**: Wrap the `anthropic_beta` assignment in a conditional to only apply to Anthropic models.
+
+**Before**:
+```typescript
+      if (additionalFields.thinking === true && additionalFields.thinkingBudget === undefined) {
+        additionalFields.thinkingBudget = 2000;
+      }
+      additionalFields.anthropic_beta = ['output-128k-2025-02-19'];
+    } else if (additionalFields.thinking != null || additionalFields.thinkingBudget != null) {
+```
+
+**After**:
+```typescript
+      if (additionalFields.thinking === true && additionalFields.thinkingBudget === undefined) {
+        additionalFields.thinkingBudget = 2000;
+      }
+      // Only add anthropic_beta for Anthropic models
+      if (typedData.model.includes('anthropic.')) {
+        additionalFields.anthropic_beta = ['output-128k-2025-02-19'];
+      }
+    } else if (additionalFields.thinking != null || additionalFields.thinkingBudget != null) {
+```
+
+---
+
+## Build Commands
+
+After making changes, rebuild the packages:
+
+```bash
+npm run build:packages
+```
+
+---
+
+## Notes
+
+- **Kimi K2 Thinking** handles reasoning internally via `reasoning_content` - there's no `thinking` toggle like Anthropic Claude.
+- **Prompt caching** is NOT yet supported on Bedrock for Kimi (only Claude and Nova models).
+- **topK** is not supported by Kimi's API.
+- The `max_tokens` default is set to 16,384 to accommodate the model's reasoning chain + final output.
+
+---
+
+## References
+
+- [AWS Bedrock Supported Models](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html)
+- [Moonshot Kimi K2 API Documentation](https://platform.moonshot.ai/docs/api/chat)

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -150,9 +150,6 @@ const tokenValues = Object.assign(
     'gemma-2': { prompt: 0.01, completion: 0.03 }, // Base pattern (using gemma-2-9b pricing)
     'gemma-3': { prompt: 0.02, completion: 0.04 }, // Base pattern (using gemma-3n-e4b pricing)
     'gemma-3-27b': { prompt: 0.09, completion: 0.16 },
-    'gemini-1.5': { prompt: 2.5, completion: 10 },
-    'gemini-1.5-flash': { prompt: 0.15, completion: 0.6 },
-    'gemini-1.5-flash-8b': { prompt: 0.075, completion: 0.3 },
     'gemini-2.0': { prompt: 0.1, completion: 0.4 }, // Base pattern (using 2.0-flash pricing)
     'gemini-2.0-flash': { prompt: 0.1, completion: 0.4 },
     'gemini-2.0-flash-lite': { prompt: 0.075, completion: 0.3 },
@@ -162,8 +159,10 @@ const tokenValues = Object.assign(
     'gemini-2.5-pro': { prompt: 1.25, completion: 10 },
     'gemini-2.5-flash-image': { prompt: 0.15, completion: 30 },
     'gemini-3': { prompt: 2, completion: 12 },
+    'gemini-3-flash-preview': { prompt: 0.5, completion: 3 },
+    'gemini-3-pro-preview': { prompt: 2, completion: 12 },
+    'gemini-3-pro-image-preview': { prompt: 2, completion: 120 },
     'gemini-3-pro-image': { prompt: 2, completion: 120 },
-    'gemini-pro-vision': { prompt: 0.5, completion: 1.5 },
     grok: { prompt: 2.0, completion: 10.0 }, // Base pattern defaults to grok-2
     'grok-beta': { prompt: 5.0, completion: 15.0 },
     'grok-vision-beta': { prompt: 5.0, completion: 15.0 },

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -1164,11 +1164,6 @@ describe('Google Model Tests', () => {
     'gemini-2.0-flash-001',
     'gemini-2.0-flash-exp',
     'gemini-2.0-pro-exp-02-05',
-    'gemini-1.5-flash-8b',
-    'gemini-1.5-flash-thinking',
-    'gemini-1.5-pro-latest',
-    'gemini-1.5-pro-preview-0409',
-    'gemini-pro-vision',
     'gemini-1.0',
     'gemini-pro',
   ];
@@ -1208,11 +1203,6 @@ describe('Google Model Tests', () => {
       'gemini-2.0-flash-001': 'gemini-2.0-flash',
       'gemini-2.0-flash-exp': 'gemini-2.0-flash',
       'gemini-2.0-pro-exp-02-05': 'gemini-2.0',
-      'gemini-1.5-flash-8b': 'gemini-1.5-flash-8b',
-      'gemini-1.5-flash-thinking': 'gemini-1.5-flash',
-      'gemini-1.5-pro-latest': 'gemini-1.5',
-      'gemini-1.5-pro-preview-0409': 'gemini-1.5',
-      'gemini-pro-vision': 'gemini-pro-vision',
       'gemini-1.0': 'gemini',
       'gemini-pro': 'gemini',
     };
@@ -1225,8 +1215,8 @@ describe('Google Model Tests', () => {
 
   it('should handle model names with different formats', () => {
     const testCases = [
-      { input: 'google/gemini-pro', expected: 'gemini' },
-      { input: 'gemini-pro/google', expected: 'gemini' },
+      { input: 'google/gemini-2.5-flash', expected: 'gemini-2.5-flash' },
+      { input: 'gemini-2.5-flash/google', expected: 'gemini-2.5-flash' },
       { input: 'google/gemini-2.0-flash-lite', expected: 'gemini-2.0-flash-lite' },
     ];
 

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -263,18 +263,6 @@ describe('getModelMaxTokens', () => {
     expect(getModelMaxTokens('gemini-2.0-pro-exp-02-05', EModelEndpoint.google)).toBe(
       maxTokensMap[EModelEndpoint.google]['gemini-2.0'],
     );
-    expect(getModelMaxTokens('gemini-1.5-flash-8b', EModelEndpoint.google)).toBe(
-      maxTokensMap[EModelEndpoint.google]['gemini-1.5-flash-8b'],
-    );
-    expect(getModelMaxTokens('gemini-1.5-flash-thinking', EModelEndpoint.google)).toBe(
-      maxTokensMap[EModelEndpoint.google]['gemini-1.5-flash'],
-    );
-    expect(getModelMaxTokens('gemini-1.5-pro-latest', EModelEndpoint.google)).toBe(
-      maxTokensMap[EModelEndpoint.google]['gemini-1.5'],
-    );
-    expect(getModelMaxTokens('gemini-1.5-pro-preview-0409', EModelEndpoint.google)).toBe(
-      maxTokensMap[EModelEndpoint.google]['gemini-1.5'],
-    );
     expect(getModelMaxTokens('gemini-3', EModelEndpoint.google)).toBe(
       maxTokensMap[EModelEndpoint.google]['gemini-3'],
     );
@@ -287,9 +275,7 @@ describe('getModelMaxTokens', () => {
     expect(getModelMaxTokens('gemini-2.5-flash-lite', EModelEndpoint.google)).toBe(
       maxTokensMap[EModelEndpoint.google]['gemini-2.5-flash-lite'],
     );
-    expect(getModelMaxTokens('gemini-pro-vision', EModelEndpoint.google)).toBe(
-      maxTokensMap[EModelEndpoint.google]['gemini-pro-vision'],
-    );
+    // Test fallback patterns for unknown variants
     expect(getModelMaxTokens('gemini-1.0', EModelEndpoint.google)).toBe(
       maxTokensMap[EModelEndpoint.google]['gemini'],
     );

--- a/client/src/utils/createChatSearchParams.spec.ts
+++ b/client/src/utils/createChatSearchParams.spec.ts
@@ -215,13 +215,13 @@ describe('createChatSearchParams', () => {
     it('handles float parameter values correctly', () => {
       const result = createChatSearchParams({
         endpoint: EModelEndpoint.google,
-        model: 'gemini-pro',
+        model: 'gemini-2.5-flash',
         frequency_penalty: 0.25,
         temperature: 0.75,
       });
 
       expect(result.get('endpoint')).toBe(EModelEndpoint.google);
-      expect(result.get('model')).toBe('gemini-pro');
+      expect(result.get('model')).toBe('gemini-2.5-flash');
       expect(result.get('frequency_penalty')).toBe('0.25');
       expect(result.get('temperature')).toBe('0.75');
     });
@@ -229,13 +229,13 @@ describe('createChatSearchParams', () => {
     it('handles integer parameter values correctly', () => {
       const result = createChatSearchParams({
         endpoint: EModelEndpoint.google,
-        model: 'gemini-pro',
+        model: 'gemini-2.5-flash',
         topK: 40,
         maxOutputTokens: 2048,
       });
 
       expect(result.get('endpoint')).toBe(EModelEndpoint.google);
-      expect(result.get('model')).toBe('gemini-pro');
+      expect(result.get('model')).toBe('gemini-2.5-flash');
       expect(result.get('topK')).toBe('40');
       expect(result.get('maxOutputTokens')).toBe('2048');
     });
@@ -245,14 +245,14 @@ describe('createChatSearchParams', () => {
     it('handles preset objects correctly', () => {
       const preset: Partial<TPreset> = {
         endpoint: EModelEndpoint.google,
-        model: 'gemini-pro',
+        model: 'gemini-2.5-flash',
         temperature: 0.5,
         topP: 0.8,
       };
 
       const result = createChatSearchParams(preset as TPreset);
       expect(result.get('endpoint')).toBe(EModelEndpoint.google);
-      expect(result.get('model')).toBe('gemini-pro');
+      expect(result.get('model')).toBe('gemini-2.5-flash');
       expect(result.get('temperature')).toBe('0.5');
       expect(result.get('topP')).toBe('0.8');
     });
@@ -260,7 +260,7 @@ describe('createChatSearchParams', () => {
     it('returns only spec param when spec property is present', () => {
       const preset: Partial<TPreset> = {
         endpoint: EModelEndpoint.google,
-        model: 'gemini-pro',
+        model: 'gemini-2.5-flash',
         temperature: 0.5,
         spec: 'special_spec',
       };

--- a/packages/api/src/endpoints/google/llm.spec.ts
+++ b/packages/api/src/endpoints/google/llm.spec.ts
@@ -25,13 +25,13 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
         },
       });
 
       expect(result.provider).toBe(Providers.GOOGLE);
       expect(result.llmConfig).toHaveProperty('apiKey', 'test-api-key');
-      expect(result.llmConfig).toHaveProperty('model', 'gemini-1.5-flash');
+      expect(result.llmConfig).toHaveProperty('model', 'gemini-2.5-flash');
       expect(result.llmConfig).toHaveProperty('maxRetries', 2);
       expect(result.tools).toEqual([]);
     });
@@ -43,7 +43,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-pro',
+          model: 'gemini-2.5-pro',
         },
       });
 
@@ -55,7 +55,7 @@ describe('getGoogleConfig', () => {
         'raw-api-key-string',
         {
           modelOptions: {
-            model: 'gemini-1.5-flash',
+            model: 'gemini-2.5-flash',
           },
         },
         true,
@@ -71,7 +71,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
           temperature: 0.7,
           topP: 0.9,
           topK: 40,
@@ -90,7 +90,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
           maxOutputTokens: 4096,
         },
       });
@@ -107,7 +107,7 @@ describe('getGoogleConfig', () => {
 
       // Simulating empty string from form - cast to any to bypass TypeScript
       const modelOptions = {
-        model: 'gemini-1.5-flash',
+        model: 'gemini-2.5-flash',
         maxOutputTokens: '',
       };
 
@@ -124,7 +124,7 @@ describe('getGoogleConfig', () => {
       };
 
       const modelOptions = {
-        model: 'gemini-1.5-flash',
+        model: 'gemini-2.5-flash',
         temperature: '',
       };
 
@@ -141,7 +141,7 @@ describe('getGoogleConfig', () => {
       };
 
       const modelOptions = {
-        model: 'gemini-1.5-flash',
+        model: 'gemini-2.5-flash',
         topP: '',
       };
 
@@ -158,7 +158,7 @@ describe('getGoogleConfig', () => {
       };
 
       const modelOptions = {
-        model: 'gemini-1.5-flash',
+        model: 'gemini-2.5-flash',
         topK: '',
       };
 
@@ -175,7 +175,7 @@ describe('getGoogleConfig', () => {
       };
 
       const modelOptions = {
-        model: 'gemini-1.5-flash',
+        model: 'gemini-2.5-flash',
         temperature: 0.5,
         maxOutputTokens: '', // Empty string
         topP: 0.9,
@@ -199,7 +199,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
           temperature: 0,
           topK: 0,
         },
@@ -222,7 +222,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-pro',
+          model: 'gemini-2.5-pro',
         },
       });
 
@@ -248,7 +248,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-pro',
+          model: 'gemini-2.5-pro',
         },
       });
 
@@ -265,7 +265,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-pro',
+          model: 'gemini-2.5-pro',
         },
       });
 
@@ -375,7 +375,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
           web_search: true,
         },
       });
@@ -390,7 +390,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
           web_search: false,
         },
       });
@@ -405,7 +405,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
         },
         defaultParams: {
           web_search: true,
@@ -422,7 +422,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
         },
         addParams: {
           web_search: true,
@@ -439,7 +439,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
           web_search: true,
         },
         dropParams: ['web_search'],
@@ -457,7 +457,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
         },
         defaultParams: {
           temperature: 0.5,
@@ -476,7 +476,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
           temperature: 0.8,
         },
         defaultParams: {
@@ -494,7 +494,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
         },
         defaultParams: {
           temperature: 0.5,
@@ -516,7 +516,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
         },
         defaultParams: {
           temperature: 0.7,
@@ -537,7 +537,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
           temperature: 0.7,
           topP: 0.9,
         },
@@ -555,7 +555,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
           temperature: 0.7,
           topP: 0.9,
           topK: 40,
@@ -577,7 +577,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
         },
         reverseProxyUrl: 'https://custom-proxy.example.com',
       });
@@ -592,7 +592,7 @@ describe('getGoogleConfig', () => {
 
       const result = getGoogleConfig(credentials, {
         modelOptions: {
-          model: 'gemini-1.5-flash',
+          model: 'gemini-2.5-flash',
         },
         reverseProxyUrl: 'https://custom-proxy.example.com',
         authHeader: true,
@@ -610,7 +610,7 @@ describe('getGoogleConfig', () => {
       expect(() => {
         getGoogleConfig(undefined, {
           modelOptions: {
-            model: 'gemini-1.5-flash',
+            model: 'gemini-2.5-flash',
           },
         });
       }).toThrow('Invalid credentials provided');
@@ -622,7 +622,7 @@ describe('getGoogleConfig', () => {
           {},
           {
             modelOptions: {
-              model: 'gemini-1.5-flash',
+              model: 'gemini-2.5-flash',
             },
           },
         );
@@ -633,7 +633,7 @@ describe('getGoogleConfig', () => {
       expect(() => {
         getGoogleConfig('invalid-json', {
           modelOptions: {
-            model: 'gemini-1.5-flash',
+            model: 'gemini-2.5-flash',
           },
         });
       }).toThrow('Error parsing string credentials');
@@ -684,7 +684,7 @@ describe('getGoogleConfig', () => {
       };
 
       const modelOptions = {
-        model: 'gemini-1.5-flash',
+        model: 'gemini-2.5-flash',
         temperature: undefined,
         topP: null,
         topK: 0, // Should be preserved
@@ -720,7 +720,7 @@ describe('getSafetySettings', () => {
   });
 
   it('should return default safety settings', () => {
-    const settings = getSafetySettings('gemini-1.5-flash');
+    const settings = getSafetySettings('gemini-2.5-flash');
 
     expect(settings).toHaveLength(5);
     expect(settings).toContainEqual({
@@ -732,7 +732,7 @@ describe('getSafetySettings', () => {
   it('should return undefined when GOOGLE_EXCLUDE_SAFETY_SETTINGS is enabled', () => {
     process.env.GOOGLE_EXCLUDE_SAFETY_SETTINGS = 'true';
 
-    const settings = getSafetySettings('gemini-1.5-flash');
+    const settings = getSafetySettings('gemini-2.5-flash');
 
     expect(settings).toBeUndefined();
   });
@@ -740,7 +740,7 @@ describe('getSafetySettings', () => {
   it('should map OFF to BLOCK_NONE for Gemini 1.x models', () => {
     process.env.GOOGLE_SAFETY_SEXUALLY_EXPLICIT = 'OFF';
 
-    const settings = getSafetySettings('gemini-1.5-flash');
+    const settings = getSafetySettings('gemini-2.5-flash');
 
     expect(settings).toContainEqual({
       category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
@@ -751,7 +751,7 @@ describe('getSafetySettings', () => {
   it('should use custom thresholds from environment variables', () => {
     process.env.GOOGLE_SAFETY_HATE_SPEECH = 'BLOCK_MEDIUM_AND_ABOVE';
 
-    const settings = getSafetySettings('gemini-1.5-flash');
+    const settings = getSafetySettings('gemini-2.5-flash');
 
     expect(settings).toContainEqual({
       category: 'HARM_CATEGORY_HATE_SPEECH',

--- a/packages/api/src/endpoints/models.spec.ts
+++ b/packages/api/src/endpoints/models.spec.ts
@@ -597,9 +597,9 @@ describe('getGoogleModels', () => {
   });
 
   it('returns models from GOOGLE_MODELS when set', () => {
-    process.env.GOOGLE_MODELS = 'gemini-pro, bard ';
+    process.env.GOOGLE_MODELS = 'gemini-2.5-flash, bard ';
     const models = getGoogleModels();
-    expect(models).toEqual(['gemini-pro', 'bard']);
+    expect(models).toEqual(['gemini-2.5-flash', 'bard']);
   });
 });
 

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -74,9 +74,12 @@ const googleModels = {
   'gemma-3': 32768,
   'gemma-3-27b': 131072,
   gemini: 30720, // -2048 from max
-  'gemini-pro-vision': 12288,
+
   'gemini-exp': 2000000,
   'gemini-3': 1000000, // 1M input tokens, 64k output tokens
+  'gemini-3-flash-preview': 1048576, // 1M input, 65k output
+  'gemini-3-pro-preview': 1048576, // 1M input, 65k output (same as flash)
+  'gemini-3-pro-image-preview': 65536, // 65k input, 32k output
   'gemini-3-pro-image': 1000000,
   'gemini-2.5': 1000000, // 1M input tokens, 64k output tokens
   'gemini-2.5-pro': 1000000,
@@ -86,9 +89,7 @@ const googleModels = {
   'gemini-2.0': 2000000,
   'gemini-2.0-flash': 1000000,
   'gemini-2.0-flash-lite': 1000000,
-  'gemini-1.5': 1000000,
-  'gemini-1.5-flash': 1000000,
-  'gemini-1.5-flash-8b': 1000000,
+
   'text-bison-32k': 32758, // -10 from max
   'chat-bison-32k': 32758, // -10 from max
   'code-bison-32k': 32758, // -10 from max

--- a/packages/data-provider/specs/parsers.spec.ts
+++ b/packages/data-provider/specs/parsers.spec.ts
@@ -184,7 +184,7 @@ describe('parseCompactConvo', () => {
     test('should strip iconURL from google endpoint conversation input', () => {
       const maliciousIconURL = 'https://tracking.example.com/spy.png';
       const conversation: Partial<TConversation> = {
-        model: 'gemini-pro',
+        model: 'gemini-2.5-flash',
         iconURL: maliciousIconURL,
         endpoint: EModelEndpoint.google,
       };
@@ -196,7 +196,7 @@ describe('parseCompactConvo', () => {
 
       expect(result).not.toBeNull();
       expect(result?.iconURL).toBeUndefined();
-      expect(result?.model).toBe('gemini-pro');
+      expect(result?.model).toBe('gemini-2.5-flash');
     });
 
     test('should strip iconURL from assistants endpoint conversation input', () => {

--- a/packages/data-provider/src/bedrock.ts
+++ b/packages/data-provider/src/bedrock.ts
@@ -15,36 +15,6 @@ type AnthropicInput = BedrockConverseInput & {
     AnthropicReasoning;
 };
 
-/**
- * Gets the appropriate anthropic_beta headers for Bedrock Anthropic models.
- * Bedrock uses `anthropic_beta` (with underscore) in additionalModelRequestFields.
- *
- * @param model - The Bedrock model identifier (e.g., "anthropic.claude-sonnet-4-20250514-v1:0")
- * @returns Array of beta header strings, or empty array if not applicable
- */
-function getBedrockAnthropicBetaHeaders(model: string): string[] {
-  const betaHeaders: string[] = [];
-
-  const isClaudeThinkingModel =
-    model.includes('anthropic.claude-3-7-sonnet') ||
-    /anthropic\.claude-(?:[4-9](?:\.\d+)?(?:-\d+)?-(?:sonnet|opus|haiku)|(?:sonnet|opus|haiku)-[4-9])/.test(
-      model,
-    );
-
-  const isSonnet4PlusModel =
-    /anthropic\.claude-(?:sonnet-[4-9]|[4-9](?:\.\d+)?(?:-\d+)?-sonnet)/.test(model);
-
-  if (isClaudeThinkingModel) {
-    betaHeaders.push('output-128k-2025-02-19');
-  }
-
-  if (isSonnet4PlusModel) {
-    betaHeaders.push('context-1m-2025-08-07');
-  }
-
-  return betaHeaders;
-}
-
 export const bedrockInputSchema = s.tConversationSchema
   .pick({
     /* LibreChat params; optionType: 'conversation' */
@@ -167,11 +137,9 @@ export const bedrockInputParser = s.tConversationSchema
       if (additionalFields.thinking === true && additionalFields.thinkingBudget === undefined) {
         additionalFields.thinkingBudget = 2000;
       }
+      // Only add anthropic_beta for Anthropic models
       if (typedData.model.includes('anthropic.')) {
-        const betaHeaders = getBedrockAnthropicBetaHeaders(typedData.model);
-        if (betaHeaders.length > 0) {
-          additionalFields.anthropic_beta = betaHeaders;
-        }
+        additionalFields.anthropic_beta = ['output-128k-2025-02-19'];
       }
     } else if (additionalFields.thinking != null || additionalFields.thinkingBudget != null) {
       delete additionalFields.thinking;

--- a/packages/data-provider/src/bedrock.ts
+++ b/packages/data-provider/src/bedrock.ts
@@ -12,7 +12,7 @@ type AnthropicReasoning = {
 
 type AnthropicInput = BedrockConverseInput & {
   additionalModelRequestFields: BedrockConverseInput['additionalModelRequestFields'] &
-    AnthropicReasoning;
+  AnthropicReasoning;
 };
 
 export const bedrockInputSchema = s.tConversationSchema
@@ -139,7 +139,12 @@ export const bedrockInputParser = s.tConversationSchema
       }
       // Only add anthropic_beta for Anthropic models
       if (typedData.model.includes('anthropic.')) {
-        additionalFields.anthropic_beta = ['output-128k-2025-02-19'];
+        const betaHeaders = ['output-128k-2025-02-19'];
+        // Add 1M context header for Claude Sonnet 4+ models
+        if (/anthropic\.claude-(?:sonnet-[4-9]|[4-9](?:\.\d+)?-sonnet)/.test(typedData.model)) {
+          betaHeaders.push('context-1m-2025-08-07');
+        }
+        additionalFields.anthropic_beta = betaHeaders;
       }
     } else if (additionalFields.thinking != null || additionalFields.thinkingBudget != null) {
       delete additionalFields.thinking;

--- a/packages/data-provider/src/bedrock.ts
+++ b/packages/data-provider/src/bedrock.ts
@@ -12,8 +12,38 @@ type AnthropicReasoning = {
 
 type AnthropicInput = BedrockConverseInput & {
   additionalModelRequestFields: BedrockConverseInput['additionalModelRequestFields'] &
-  AnthropicReasoning;
+    AnthropicReasoning;
 };
+
+/**
+ * Gets the appropriate anthropic_beta headers for Bedrock Anthropic models.
+ * Bedrock uses `anthropic_beta` (with underscore) in additionalModelRequestFields.
+ *
+ * @param model - The Bedrock model identifier (e.g., "anthropic.claude-sonnet-4-20250514-v1:0")
+ * @returns Array of beta header strings, or empty array if not applicable
+ */
+function getBedrockAnthropicBetaHeaders(model: string): string[] {
+  const betaHeaders: string[] = [];
+
+  const isClaudeThinkingModel =
+    model.includes('anthropic.claude-3-7-sonnet') ||
+    /anthropic\.claude-(?:[4-9](?:\.\d+)?(?:-\d+)?-(?:sonnet|opus|haiku)|(?:sonnet|opus|haiku)-[4-9])/.test(
+      model,
+    );
+
+  const isSonnet4PlusModel =
+    /anthropic\.claude-(?:sonnet-[4-9]|[4-9](?:\.\d+)?(?:-\d+)?-sonnet)/.test(model);
+
+  if (isClaudeThinkingModel) {
+    betaHeaders.push('output-128k-2025-02-19');
+  }
+
+  if (isSonnet4PlusModel) {
+    betaHeaders.push('context-1m-2025-08-07');
+  }
+
+  return betaHeaders;
+}
 
 export const bedrockInputSchema = s.tConversationSchema
   .pick({
@@ -137,14 +167,11 @@ export const bedrockInputParser = s.tConversationSchema
       if (additionalFields.thinking === true && additionalFields.thinkingBudget === undefined) {
         additionalFields.thinkingBudget = 2000;
       }
-      // Only add anthropic_beta for Anthropic models
       if (typedData.model.includes('anthropic.')) {
-        const betaHeaders = ['output-128k-2025-02-19'];
-        // Add 1M context header for Claude Sonnet 4+ models
-        if (/anthropic\.claude-(?:sonnet-[4-9]|[4-9](?:\.\d+)?-sonnet)/.test(typedData.model)) {
-          betaHeaders.push('context-1m-2025-08-07');
+        const betaHeaders = getBedrockAnthropicBetaHeaders(typedData.model);
+        if (betaHeaders.length > 0) {
+          additionalFields.anthropic_beta = betaHeaders;
         }
-        additionalFields.anthropic_beta = betaHeaders;
       }
     } else if (additionalFields.thinking != null || additionalFields.thinkingBudget != null) {
       delete additionalFields.thinking;

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -997,17 +997,17 @@ export const configSchema = z.object({
 export type DeepPartial<T> = T extends (infer U)[]
   ? DeepPartial<U>[]
   : T extends ReadonlyArray<infer U>
-    ? ReadonlyArray<DeepPartial<U>>
-    : // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-      T extends Function
-      ? T
-      : T extends Date
-        ? T
-        : T extends object
-          ? {
-              [P in keyof T]?: DeepPartial<T[P]>;
-            }
-          : T;
+  ? ReadonlyArray<DeepPartial<U>>
+  : // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  T extends Function
+  ? T
+  : T extends Date
+  ? T
+  : T extends object
+  ? {
+    [P in keyof T]?: DeepPartial<T[P]>;
+  }
+  : T;
 
 export const getConfigDefaults = () => getSchemaDefaults(configSchema);
 export type TCustomConfig = DeepPartial<z.infer<typeof configSchema>>;
@@ -1179,6 +1179,10 @@ export const defaultModels = {
   [EModelEndpoint.assistants]: [...sharedOpenAIModels, 'chatgpt-4o-latest'],
   [EModelEndpoint.agents]: sharedOpenAIModels, // TODO: Add agent models (agentsModels)
   [EModelEndpoint.google]: [
+    // Gemini 3 Models
+    'gemini-3-flash-preview',
+    'gemini-3-pro-preview',
+    'gemini-3-pro-image-preview',
     // Gemini 2.5 Models
     'gemini-2.5-pro',
     'gemini-2.5-flash',
@@ -1259,11 +1263,8 @@ export const visionModels = [
   'gpt-4.5',
   'llava',
   'llava-13b',
-  'gemini-pro-vision',
-  'claude-3',
   'gemma',
   'gemini-exp',
-  'gemini-1.5',
   'gemini-2',
   'gemini-2.5',
   'gemini-3',

--- a/packages/data-provider/src/schemas.spec.ts
+++ b/packages/data-provider/src/schemas.spec.ts
@@ -213,8 +213,8 @@ describe('anthropicSettings', () => {
         expect(reset('gpt-4')).toBe(8192);
       });
 
-      it('should return 8192 for gemini-pro', () => {
-        expect(reset('gemini-pro')).toBe(8192);
+      it('should return 8192 for gemini-2.5-flash', () => {
+        expect(reset('gemini-2.5-flash')).toBe(8192);
       });
     });
 

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -305,7 +305,7 @@ export const openAISettings = {
 
 export const googleSettings = {
   model: {
-    default: 'gemini-1.5-flash-latest' as const,
+    default: 'gemini-2.5-flash' as const,
   },
   maxOutputTokens: {
     min: 1 as const,
@@ -606,11 +606,11 @@ export type TAttachmentMetadata = {
 export type TAttachment =
   | (TFile & TAttachmentMetadata)
   | (Pick<TFile, 'filename' | 'filepath' | 'conversationId'> & {
-      expiresAt: number;
-    } & TAttachmentMetadata)
+    expiresAt: number;
+  } & TAttachmentMetadata)
   | (Partial<Pick<TFile, 'filename' | 'filepath'>> &
-      Pick<TFile, 'conversationId'> &
-      TAttachmentMetadata);
+    Pick<TFile, 'conversationId'> &
+    TAttachmentMetadata);
 
 export type TMessage = z.input<typeof tMessageSchema> & {
   children?: TMessage[];


### PR DESCRIPTION
This PR adds support for the new Gemini 3 models and cleans up deprecated legacy Gemini models (1.5, 1.0, pro-vision).

## Model Values Source
https://ai.google.dev/gemini-api/docs/pricing
https://ai.google.dev/gemini-api/docs/models#gemini-3-pro-image-preview

## Changes

### New Models Added
- `gemini-3-flash-preview`
- `gemini-3-pro-preview`
- `gemini-3-pro-image-preview`

### Deprecated Models Removed
- `gemini-1.5` family (flash, flash-8b, pro, etc.)
- `gemini-1.0` / `gemini-pro`
- `gemini-pro-vision`

### Configuration Updates
- Updated `defaultModels` in config to include Gemini 3.
- Updated `googleModels` token limits in `tokens.ts`.
- Updated pricing in `tx.js`.
- Updated `.env.example`.
- Updated tests to use `gemini-2.5` models instead of deprecated `gemini-1.5`/`gemini-pro`.