### PR TITLE
feat: Add Vercel endpoint icon

### DIFF
--- a/client/public/assets/vercel.svg
+++ b/client/public/assets/vercel.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 1155 1000" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    path { fill: #000; }
+    @media (prefers-color-scheme: dark) { path { fill: #fff; } }
+  </style>
+  <path d="M577.344 0L1154.69 1000H0L577.344 0Z"/>
+</svg>

--- a/client/src/hooks/Endpoint/UnknownIcon.tsx
+++ b/client/src/hooks/Endpoint/UnknownIcon.tsx
@@ -24,6 +24,7 @@ const knownEndpointAssets = {
   [KnownEndpoints.shuttleai]: 'assets/shuttleai.png',
   [KnownEndpoints['together.ai']]: 'assets/together.png',
   [KnownEndpoints.unify]: 'assets/unify.webp',
+  [KnownEndpoints.vercel]: 'assets/vercel.svg',
 };
 
 const knownEndpointClasses = {


### PR DESCRIPTION
## Summary
- Add SVG icon for Vercel endpoint with light/dark mode support via `prefers-color-scheme`

## Test plan
- [x] Icon displays for Vercel endpoint
- [x] Light mode: black triangle
- [x] Dark mode: white triangle