### PR TITLE
🔐 fix: MCP OAuth Tool Discovery and Event Emission

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -45,7 +45,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.27",
+    "@librechat/agents": "^3.1.29",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -1,7 +1,6 @@
 const {
   sleep,
   EnvVar,
-  Constants,
   StepTypes,
   GraphEvents,
   createToolSearch,
@@ -22,6 +21,7 @@ const {
 const {
   Time,
   Tools,
+  Constants,
   CacheKeys,
   ErrorTypes,
   ContentTypes,
@@ -498,7 +498,7 @@ async function loadToolDefinitionsWrapper({ req, res, agent, streamId = null }) 
       };
 
       const runStepData = {
-        runId: 'USE_PRELIM_RESPONSE_MESSAGE_ID',
+        runId: Constants.USE_PRELIM_RESPONSE_MESSAGE_ID,
         id: stepId,
         type: StepTypes.TOOL_CALLS,
         index: 0,
@@ -619,7 +619,7 @@ async function loadToolDefinitionsWrapper({ req, res, agent, streamId = null }) 
     },
   );
 
-  if (pendingOAuthServers.size > 0 && res) {
+  if (pendingOAuthServers.size > 0 && (res || streamId)) {
     const serverNames = Array.from(pendingOAuthServers);
     logger.info(
       `[Tool Definitions] OAuth required for ${serverNames.length} server(s): ${serverNames.join(', ')}. Emitting events and waiting.`,

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -524,7 +524,7 @@ async function loadToolDefinitionsWrapper({ req, res, agent, streamId = null }) 
       if (streamId) {
         GenerationJobManager.emitChunk(streamId, runStepEvent);
         GenerationJobManager.emitChunk(streamId, runStepDeltaEvent);
-      } else if (res && !res.headersSent) {
+      } else if (res && !res.writableEnded) {
         sendEvent(res, runStepEvent);
         sendEvent(res, runStepDeltaEvent);
       } else {

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -6,6 +6,9 @@ const { updateMCPServerTools } = require('~/server/services/Config');
 const { getLogStores } = require('~/cache');
 
 /**
+ * Reinitializes an MCP server connection and discovers available tools.
+ * When OAuth is required, uses discovery mode to list tools without full authentication
+ * (per MCP spec, tool listing should be possible without auth).
  * @param {Object} params
  * @param {IUser} params.user - The user from the request object.
  * @param {string} params.serverName - The name of the MCP server
@@ -36,10 +39,12 @@ async function reinitMCPServer({
   let tools = null;
   let oauthRequired = false;
   let oauthUrl = null;
+
   try {
     const customUserVars = userMCPAuthMap?.[`${Constants.mcp_prefix}${serverName}`];
     const flowManager = _flowManager ?? getFlowStateManager(getLogStores(CacheKeys.FLOWS));
     const mcpManager = getMCPManager();
+    const tokenMethods = { findToken, updateToken, createToken, deleteTokens };
 
     const oauthStart =
       _oauthStart ??
@@ -57,15 +62,10 @@ async function reinitMCPServer({
         oauthStart,
         serverName,
         flowManager,
+        tokenMethods,
         returnOnOAuth,
         customUserVars,
         connectionTimeout,
-        tokenMethods: {
-          findToken,
-          updateToken,
-          createToken,
-          deleteTokens,
-        },
       });
 
       logger.info(`[MCP Reinitialize] Successfully established connection for ${serverName}`);
@@ -84,9 +84,37 @@ async function reinitMCPServer({
 
       if (isOAuthError || oauthRequired || isOAuthFlowInitiated) {
         logger.info(
-          `[MCP Reinitialize] OAuth required for ${serverName} (isOAuthError: ${isOAuthError}, oauthRequired: ${oauthRequired}, isOAuthFlowInitiated: ${isOAuthFlowInitiated})`,
+          `[MCP Reinitialize] OAuth required for ${serverName}, attempting tool discovery without auth`,
         );
         oauthRequired = true;
+
+        try {
+          const discoveryResult = await mcpManager.discoverServerTools({
+            user,
+            signal,
+            serverName,
+            flowManager,
+            tokenMethods,
+            oauthStart,
+            customUserVars,
+            connectionTimeout,
+          });
+
+          if (discoveryResult.tools && discoveryResult.tools.length > 0) {
+            tools = discoveryResult.tools;
+            logger.info(
+              `[MCP Reinitialize] Discovered ${tools.length} tools for ${serverName} without full auth`,
+            );
+          }
+
+          if (discoveryResult.oauthUrl) {
+            oauthUrl = discoveryResult.oauthUrl;
+          }
+        } catch (discoveryErr) {
+          logger.debug(
+            `[MCP Reinitialize] Tool discovery failed for ${serverName}: ${discoveryErr.message}`,
+          );
+        }
       } else {
         logger.error(
           `[MCP Reinitialize] Error initializing MCP server ${serverName} for user:`,
@@ -97,6 +125,9 @@ async function reinitMCPServer({
 
     if (connection && !oauthRequired) {
       tools = await connection.fetchTools();
+    }
+
+    if (tools && tools.length > 0) {
       availableTools = await updateMCPServerTools({
         userId: user.id,
         serverName,
@@ -109,6 +140,9 @@ async function reinitMCPServer({
     );
 
     const getResponseMessage = () => {
+      if (oauthRequired && tools && tools.length > 0) {
+        return `MCP server '${serverName}' tools discovered, OAuth required for execution`;
+      }
       if (oauthRequired) {
         return `MCP server '${serverName}' ready for OAuth authentication`;
       }
@@ -120,19 +154,25 @@ async function reinitMCPServer({
 
     const result = {
       availableTools,
-      success: Boolean((connection && !oauthRequired) || (oauthRequired && oauthUrl)),
+      success: Boolean(
+        (connection && !oauthRequired) ||
+          (oauthRequired && oauthUrl) ||
+          (tools && tools.length > 0),
+      ),
       message: getResponseMessage(),
       oauthRequired,
       serverName,
       oauthUrl,
       tools,
     };
+
     logger.debug(`[MCP Reinitialize] Response for ${serverName}:`, {
       success: result.success,
       oauthRequired: result.oauthRequired,
       oauthUrl: result.oauthUrl ? 'present' : null,
       toolsCount: tools?.length ?? 0,
     });
+
     return result;
   } catch (error) {
     logger.error(

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -106,10 +106,6 @@ async function reinitMCPServer({
               `[MCP Reinitialize] Discovered ${tools.length} tools for ${serverName} without full auth`,
             );
           }
-
-          if (discoveryResult.oauthUrl && !oauthUrl) {
-            oauthUrl = discoveryResult.oauthUrl;
-          }
         } catch (discoveryErr) {
           logger.debug(
             `[MCP Reinitialize] Tool discovery failed for ${serverName}: ${discoveryErr?.message ?? String(discoveryErr)}`,

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -1,8 +1,8 @@
 const { logger } = require('@librechat/data-schemas');
 const { CacheKeys, Constants } = require('librechat-data-provider');
 const { findToken, createToken, updateToken, deleteTokens } = require('~/models');
-const { getMCPManager, getFlowStateManager } = require('~/config');
 const { updateMCPServerTools } = require('~/server/services/Config');
+const { getMCPManager, getFlowStateManager } = require('~/config');
 const { getLogStores } = require('~/cache');
 
 /**
@@ -17,7 +17,7 @@ const { getLogStores } = require('~/cache');
  * @param {boolean} [params.forceNew]
  * @param {number} [params.connectionTimeout]
  * @param {FlowStateManager<any>} [params.flowManager]
- * @param {(authURL: string) => Promise<boolean>} [params.oauthStart]
+ * @param {(authURL: string) => Promise<void>} [params.oauthStart]
  * @param {Record<string, Record<string, string>>} [params.userMCPAuthMap]
  */
 async function reinitMCPServer({

--- a/api/server/services/Tools/mcp.js
+++ b/api/server/services/Tools/mcp.js
@@ -107,12 +107,12 @@ async function reinitMCPServer({
             );
           }
 
-          if (discoveryResult.oauthUrl) {
+          if (discoveryResult.oauthUrl && !oauthUrl) {
             oauthUrl = discoveryResult.oauthUrl;
           }
         } catch (discoveryErr) {
           logger.debug(
-            `[MCP Reinitialize] Tool discovery failed for ${serverName}: ${discoveryErr.message}`,
+            `[MCP Reinitialize] Tool discovery failed for ${serverName}: ${discoveryErr?.message ?? String(discoveryErr)}`,
           );
         }
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.27",
+        "@librechat/agents": "^3.1.29",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11709,9 +11709,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.27",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.27.tgz",
-      "integrity": "sha512-cThf2+OoyjBGf1PoG3H9Au3zm+zFICHF53qHYc6B3/j9mss9NgmGXd30ILRXiXPgsMCfOHqJoqUWidQHFJLiiA==",
+      "version": "3.1.29",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.29.tgz",
+      "integrity": "sha512-jY2+UVjnJvkUmvcsz7wic4CKJuJVUgOlVv3ICInpd3SZFhsKlUwSNKQl1PbzrZPNFuIyUt9CgGWYw1I022zhaA==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.970.0",
@@ -30903,12 +30903,6 @@
         "tslib": "^1.14.1"
       }
     },
-    "node_modules/keyv-file/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
     "node_modules/keyv/node_modules/@keyv/serialize": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
@@ -43020,7 +43014,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.27",
+        "@librechat/agents": "^3.1.29",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -87,7 +87,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.27",
+    "@librechat/agents": "^3.1.29",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -1,5 +1,6 @@
 import { logger } from '@librechat/data-schemas';
 import type { OAuthClientInformation } from '@modelcontextprotocol/sdk/shared/auth.js';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { TokenMethods } from '@librechat/data-schemas';
 import type { MCPOAuthTokens, OAuthMetadata } from '~/mcp/oauth';
 import type { FlowStateManager } from '~/flow/manager';
@@ -10,6 +11,13 @@ import { sanitizeUrlForLogging } from './utils';
 import { withTimeout } from '~/utils/promise';
 import { MCPConnection } from './connection';
 import { processMCPEnv } from '~/utils';
+
+export interface ToolDiscoveryResult {
+  tools: Tool[] | null;
+  connection: MCPConnection | null;
+  oauthRequired: boolean;
+  oauthUrl: string | null;
+}
 
 /**
  * Factory for creating MCP connections with optional OAuth authentication.
@@ -41,6 +49,150 @@ export class MCPConnectionFactory {
     return factory.createConnection();
   }
 
+  /**
+   * Discovers tools from an MCP server, even when OAuth is required.
+   * Per MCP spec, tool listing should be possible without authentication.
+   * Returns tools if discoverable, plus OAuth status for tool execution.
+   */
+  static async discoverTools(
+    basic: t.BasicConnectionOptions,
+    oauth?: Omit<t.OAuthConnectionOptions, 'returnOnOAuth'>,
+  ): Promise<ToolDiscoveryResult> {
+    const factory = new this(basic, oauth ? { ...oauth, returnOnOAuth: true } : undefined);
+    return factory.discoverToolsInternal();
+  }
+
+  protected async discoverToolsInternal(): Promise<ToolDiscoveryResult> {
+    let oauthUrl: string | null = null;
+    let oauthRequired = false;
+
+    const oauthTokens = this.useOAuth ? await this.getOAuthTokens() : null;
+    const connection = new MCPConnection({
+      serverName: this.serverName,
+      serverConfig: this.serverConfig,
+      userId: this.userId,
+      oauthTokens,
+    });
+
+    const captureOAuthUrl = async (authURL: string) => {
+      oauthUrl = authURL;
+      oauthRequired = true;
+      if (this.oauthStart) {
+        await this.oauthStart(authURL);
+      }
+    };
+
+    const oauthHandler = async (data: { serverUrl?: string }) => {
+      logger.info(
+        `${this.logPrefix} [Discovery] OAuth required, capturing auth URL for tool listing`,
+      );
+      oauthRequired = true;
+
+      try {
+        const config = this.serverConfig;
+        const { authorizationUrl } = await MCPOAuthHandler.initiateOAuthFlow(
+          this.serverName,
+          data.serverUrl || '',
+          this.userId!,
+          config?.oauth_headers ?? {},
+          config?.oauth,
+        );
+
+        await captureOAuthUrl(authorizationUrl);
+        connection.emit('oauthFailed', new Error('OAuth flow initiated - discovery mode'));
+      } catch (error) {
+        logger.error(`${this.logPrefix} [Discovery] Failed to initiate OAuth flow`, error);
+        connection.emit('oauthFailed', new Error('OAuth initiation failed'));
+      }
+    };
+
+    if (this.useOAuth) {
+      connection.on('oauthRequired', oauthHandler);
+    }
+
+    try {
+      const connectTimeout = this.connectionTimeout ?? this.serverConfig.initTimeout ?? 30000;
+      await withTimeout(
+        connection.connect(),
+        connectTimeout,
+        `Connection timeout after ${connectTimeout}ms`,
+      );
+
+      if (await connection.isConnected()) {
+        const tools = await connection.fetchTools();
+        if (this.useOAuth) {
+          connection.removeListener('oauthRequired', oauthHandler);
+        }
+        return { tools, connection, oauthRequired: false, oauthUrl: null };
+      }
+    } catch {
+      logger.debug(
+        `${this.logPrefix} [Discovery] Connection failed, attempting unauthenticated tool listing`,
+      );
+    }
+
+    try {
+      const tools = await this.attemptUnauthenticatedToolListing();
+      if (this.useOAuth) {
+        connection.removeListener('oauthRequired', oauthHandler);
+      }
+      if (tools && tools.length > 0) {
+        logger.info(
+          `${this.logPrefix} [Discovery] Successfully discovered ${tools.length} tools without auth`,
+        );
+        return { tools, connection: null, oauthRequired, oauthUrl };
+      }
+    } catch (listError) {
+      logger.debug(`${this.logPrefix} [Discovery] Unauthenticated tool listing failed:`, listError);
+    }
+
+    if (this.useOAuth) {
+      connection.removeListener('oauthRequired', oauthHandler);
+    }
+
+    return { tools: null, connection: null, oauthRequired, oauthUrl };
+  }
+
+  protected async attemptUnauthenticatedToolListing(): Promise<Tool[] | null> {
+    const unauthConnection = new MCPConnection({
+      serverName: this.serverName,
+      serverConfig: this.serverConfig,
+      userId: this.userId,
+      oauthTokens: null,
+    });
+
+    unauthConnection.on('oauthRequired', () => {
+      logger.debug(
+        `${this.logPrefix} [Discovery] Unauthenticated connection requires OAuth, failing fast`,
+      );
+      unauthConnection.emit(
+        'oauthFailed',
+        new Error('OAuth not supported in unauthenticated discovery'),
+      );
+    });
+
+    try {
+      const connectTimeout = this.connectionTimeout ?? this.serverConfig.initTimeout ?? 15000;
+      await withTimeout(unauthConnection.connect(), connectTimeout, `Unauth connection timeout`);
+
+      if (await unauthConnection.isConnected()) {
+        const tools = await unauthConnection.fetchTools();
+        await unauthConnection.disconnect();
+        return tools;
+      }
+    } catch {
+      logger.debug(`${this.logPrefix} [Discovery] Unauthenticated connection attempt failed`);
+    }
+
+    try {
+      await unauthConnection.disconnect();
+    } catch {
+      // Ignore cleanup errors
+    }
+
+    return null;
+  }
+
   protected constructor(basic: t.BasicConnectionOptions, oauth?: t.OAuthConnectionOptions) {
     this.serverConfig = processMCPEnv({
       options: basic.serverConfig,
@@ -56,7 +208,7 @@ export class MCPConnectionFactory {
       : `[MCP][${basic.serverName}]`;
 
     if (oauth?.useOAuth) {
-      this.userId = oauth.user.id;
+      this.userId = oauth.user?.id;
       this.flowManager = oauth.flowManager;
       this.tokenMethods = oauth.tokenMethods;
       this.signal = oauth.signal;

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -140,6 +140,11 @@ export class MCPConnectionFactory {
         logger.info(
           `${this.logPrefix} [Discovery] Successfully discovered ${tools.length} tools without auth`,
         );
+        try {
+          await connection.disconnect();
+        } catch {
+          // Ignore cleanup errors
+        }
         return { tools, connection: null, oauthRequired, oauthUrl };
       }
     } catch (listError) {
@@ -148,6 +153,12 @@ export class MCPConnectionFactory {
 
     if (this.useOAuth) {
       connection.removeListener('oauthRequired', oauthHandler);
+    }
+
+    try {
+      await connection.disconnect();
+    } catch {
+      // Ignore cleanup errors
     }
 
     return { tools: null, connection: null, oauthRequired, oauthUrl };

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -63,7 +63,7 @@ export class MCPConnectionFactory {
   }
 
   protected async discoverToolsInternal(): Promise<ToolDiscoveryResult> {
-    let oauthUrl: string | null = null;
+    const oauthUrl: string | null = null;
     let oauthRequired = false;
 
     const oauthTokens = this.useOAuth ? await this.getOAuthTokens() : null;
@@ -74,36 +74,12 @@ export class MCPConnectionFactory {
       oauthTokens,
     });
 
-    const captureOAuthUrl = async (authURL: string) => {
-      oauthUrl = authURL;
-      oauthRequired = true;
-      if (this.oauthStart) {
-        await this.oauthStart(authURL);
-      }
-    };
-
-    const oauthHandler = async (data: { serverUrl?: string }) => {
+    const oauthHandler = async () => {
       logger.info(
-        `${this.logPrefix} [Discovery] OAuth required, capturing auth URL for tool listing`,
+        `${this.logPrefix} [Discovery] OAuth required; skipping URL generation in discovery mode`,
       );
       oauthRequired = true;
-
-      try {
-        const config = this.serverConfig;
-        const { authorizationUrl } = await MCPOAuthHandler.initiateOAuthFlow(
-          this.serverName,
-          data.serverUrl || '',
-          this.userId!,
-          config?.oauth_headers ?? {},
-          config?.oauth,
-        );
-
-        await captureOAuthUrl(authorizationUrl);
-        connection.emit('oauthFailed', new Error('OAuth flow initiated - discovery mode'));
-      } catch (error) {
-        logger.error(`${this.logPrefix} [Discovery] Failed to initiate OAuth flow`, error);
-        connection.emit('oauthFailed', new Error('OAuth initiation failed'));
-      }
+      connection.emit('oauthFailed', new Error('OAuth required during tool discovery'));
     };
 
     if (this.useOAuth) {

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -8,11 +8,12 @@ import type { FlowStateManager } from '~/flow/manager';
 import type { MCPOAuthTokens } from './oauth';
 import type { RequestBody } from '~/types';
 import type * as t from './types';
+import { MCPServersInitializer } from './registry/MCPServersInitializer';
+import { MCPServerInspector } from './registry/MCPServerInspector';
+import { MCPServersRegistry } from './registry/MCPServersRegistry';
 import { UserConnectionManager } from './UserConnectionManager';
 import { ConnectionsRepository } from './ConnectionsRepository';
-import { MCPServerInspector } from './registry/MCPServerInspector';
-import { MCPServersInitializer } from './registry/MCPServersInitializer';
-import { MCPServersRegistry } from './registry/MCPServersRegistry';
+import { MCPConnectionFactory } from './MCPConnectionFactory';
 import { preProcessGraphTokens } from '~/utils/graph';
 import { formatToolContent } from './parsers';
 import { MCPConnection } from './connection';
@@ -66,6 +67,70 @@ export class MCPManager extends UserConnectionManager {
         `No connection found for server ${args.serverName}`,
       );
     }
+  }
+
+  /**
+   * Discovers tools from an MCP server, even when OAuth is required.
+   * Per MCP spec, tool listing should be possible without authentication.
+   * Use this for agent initialization to get tool schemas before OAuth flow.
+   */
+  public async discoverServerTools(args: t.ToolDiscoveryOptions): Promise<t.ToolDiscoveryResult> {
+    const { serverName, user } = args;
+    const logPrefix = user?.id ? `[MCP][User: ${user.id}][${serverName}]` : `[MCP][${serverName}]`;
+
+    try {
+      const existingAppConnection = await this.appConnections?.get(serverName);
+      if (existingAppConnection && (await existingAppConnection.isConnected())) {
+        const tools = await existingAppConnection.fetchTools();
+        return { tools, oauthRequired: false, oauthUrl: null };
+      }
+    } catch {
+      logger.debug(`${logPrefix} [Discovery] App connection not available, trying discovery mode`);
+    }
+
+    const serverConfig = (await MCPServersRegistry.getInstance().getServerConfig(
+      serverName,
+      user?.id,
+    )) as t.MCPOptions | null;
+
+    if (!serverConfig) {
+      logger.warn(`${logPrefix} [Discovery] Server config not found`);
+      return { tools: null, oauthRequired: false, oauthUrl: null };
+    }
+
+    const useOAuth = Boolean(
+      serverConfig.requiresOAuth || (serverConfig as t.ParsedServerConfig).oauthMetadata,
+    );
+
+    const basic: t.BasicConnectionOptions = { serverName, serverConfig };
+
+    if (!useOAuth) {
+      const result = await MCPConnectionFactory.discoverTools(basic);
+      return {
+        tools: result.tools,
+        oauthRequired: result.oauthRequired,
+        oauthUrl: result.oauthUrl,
+      };
+    }
+
+    if (!user || !args.flowManager) {
+      logger.warn(`${logPrefix} [Discovery] OAuth server requires user and flowManager`);
+      return { tools: null, oauthRequired: true, oauthUrl: null };
+    }
+
+    const result = await MCPConnectionFactory.discoverTools(basic, {
+      user,
+      useOAuth: true,
+      flowManager: args.flowManager,
+      tokenMethods: args.tokenMethods,
+      signal: args.signal,
+      oauthStart: args.oauthStart,
+      customUserVars: args.customUserVars,
+      requestBody: args.requestBody,
+      connectionTimeout: args.connectionTimeout,
+    });
+
+    return { tools: result.tools, oauthRequired: result.oauthRequired, oauthUrl: result.oauthUrl };
   }
 
   /** Returns all available tool functions from app-level connections */

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -49,7 +49,7 @@ export abstract class UserConnectionManager {
     serverName: string;
     forceNew?: boolean;
   } & Omit<t.OAuthConnectionOptions, 'useOAuth'>): Promise<MCPConnection> {
-    const userId = user.id;
+    const userId = user?.id;
     if (!userId) {
       throw new McpError(ErrorCode.InvalidRequest, `[MCP] User object missing id property`);
     }

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -1,6 +1,5 @@
 import { logger } from '@librechat/data-schemas';
-import type { TokenMethods } from '@librechat/data-schemas';
-import type { TUser } from 'librechat-data-provider';
+import type { TokenMethods, IUser } from '@librechat/data-schemas';
 import type { FlowStateManager } from '~/flow/manager';
 import type { MCPOAuthTokens } from '~/mcp/oauth';
 import type * as t from '~/mcp/types';
@@ -27,7 +26,7 @@ const mockMCPConnection = MCPConnection as jest.MockedClass<typeof MCPConnection
 const mockMCPOAuthHandler = MCPOAuthHandler as jest.Mocked<typeof MCPOAuthHandler>;
 
 describe('MCPConnectionFactory', () => {
-  let mockUser: TUser;
+  let mockUser: IUser | undefined;
   let mockServerConfig: t.MCPOptions;
   let mockFlowManager: jest.Mocked<FlowStateManager<MCPOAuthTokens | null>>;
   let mockConnectionInstance: jest.Mocked<MCPConnection>;
@@ -37,7 +36,7 @@ describe('MCPConnectionFactory', () => {
     mockUser = {
       id: 'user123',
       email: 'test@example.com',
-    } as TUser;
+    } as IUser;
 
     mockServerConfig = {
       command: 'node',
@@ -275,7 +274,7 @@ describe('MCPConnectionFactory', () => {
         user: mockUser,
       };
 
-      const oauthOptions = {
+      const oauthOptions: t.OAuthConnectionOptions = {
         user: mockUser,
         useOAuth: true,
         returnOnOAuth: true,
@@ -422,6 +421,128 @@ describe('MCPConnectionFactory', () => {
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.stringContaining('OAuth required, stopping connection attempts'),
       );
+    });
+  });
+
+  describe('discoverTools static method', () => {
+    const mockTools = [
+      { name: 'tool1', description: 'First tool', inputSchema: { type: 'object' } },
+      { name: 'tool2', description: 'Second tool', inputSchema: { type: 'object' } },
+    ];
+
+    it('should discover tools from a successfully connected server', async () => {
+      const basicOptions = {
+        serverName: 'test-server',
+        serverConfig: mockServerConfig,
+      };
+
+      mockConnectionInstance.connect.mockResolvedValue(undefined);
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+      mockConnectionInstance.fetchTools = jest.fn().mockResolvedValue(mockTools);
+
+      const result = await MCPConnectionFactory.discoverTools(basicOptions);
+
+      expect(result.tools).toEqual(mockTools);
+      expect(result.oauthRequired).toBe(false);
+      expect(result.oauthUrl).toBeNull();
+      expect(result.connection).toBe(mockConnectionInstance);
+    });
+
+    it('should capture OAuth URL via oauthStart callback when OAuth is required', async () => {
+      const basicOptions = {
+        serverName: 'test-server',
+        serverConfig: {
+          ...mockServerConfig,
+          url: 'https://api.example.com',
+          type: 'sse' as const,
+        } as t.SSEOptions,
+      };
+
+      const mockOAuthStart = jest.fn();
+
+      const oauthOptions = {
+        useOAuth: true as const,
+        user: mockUser as unknown as IUser,
+        flowManager: mockFlowManager,
+        oauthStart: mockOAuthStart,
+        tokenMethods: {
+          findToken: jest.fn(),
+          createToken: jest.fn(),
+          updateToken: jest.fn(),
+          deleteTokens: jest.fn(),
+        },
+      };
+
+      const mockFlowData = {
+        authorizationUrl: 'https://auth.example.com/authorize',
+        flowId: 'flow123',
+        flowMetadata: {
+          serverName: 'test-server',
+          userId: 'user123',
+          serverUrl: 'https://api.example.com',
+          state: 'random-state',
+          clientInfo: { client_id: 'client123' },
+        },
+      };
+
+      mockMCPOAuthHandler.initiateOAuthFlow.mockResolvedValue(mockFlowData);
+      mockFlowManager.createFlow.mockRejectedValue(new Error('Timeout expected'));
+      mockFlowManager.deleteFlow.mockResolvedValue(true);
+
+      mockConnectionInstance.connect.mockRejectedValue(new Error('Connection failed'));
+      mockConnectionInstance.isConnected.mockResolvedValue(false);
+      mockConnectionInstance.disconnect = jest.fn().mockResolvedValue(undefined);
+
+      let oauthHandler: ((data: { serverUrl?: string }) => Promise<void>) | undefined;
+      mockConnectionInstance.on.mockImplementation((event, handler) => {
+        if (event === 'oauthRequired') {
+          oauthHandler = handler as (data: { serverUrl?: string }) => Promise<void>;
+          setTimeout(() => {
+            oauthHandler?.({ serverUrl: 'https://api.example.com' });
+          }, 10);
+        }
+        return mockConnectionInstance;
+      });
+
+      const result = await MCPConnectionFactory.discoverTools(basicOptions, oauthOptions);
+
+      expect(result.connection).toBeNull();
+      expect(result.tools).toBeNull();
+    });
+
+    it('should return null tools when discovery fails completely', async () => {
+      const basicOptions = {
+        serverName: 'test-server',
+        serverConfig: mockServerConfig,
+      };
+
+      mockConnectionInstance.connect.mockRejectedValue(new Error('Connection failed'));
+      mockConnectionInstance.isConnected.mockResolvedValue(false);
+      mockConnectionInstance.disconnect = jest.fn().mockResolvedValue(undefined);
+
+      const result = await MCPConnectionFactory.discoverTools(basicOptions);
+
+      expect(result.tools).toBeNull();
+      expect(result.connection).toBeNull();
+      expect(result.oauthRequired).toBe(false);
+    });
+
+    it('should handle disconnect errors gracefully during cleanup', async () => {
+      const basicOptions = {
+        serverName: 'test-server',
+        serverConfig: mockServerConfig,
+      };
+
+      mockConnectionInstance.connect.mockRejectedValue(new Error('Connection failed'));
+      mockConnectionInstance.isConnected.mockResolvedValue(false);
+      mockConnectionInstance.disconnect = jest
+        .fn()
+        .mockRejectedValue(new Error('Disconnect failed'));
+
+      const result = await MCPConnectionFactory.discoverTools(basicOptions);
+
+      expect(result.tools).toBeNull();
+      expect(mockLogger.debug).toHaveBeenCalled();
     });
   });
 });

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -169,7 +169,7 @@ export interface BasicConnectionOptions {
 }
 
 export interface OAuthConnectionOptions {
-  user: IUser;
+  user?: IUser;
   useOAuth: true;
   requestBody?: RequestBody;
   customUserVars?: Record<string, string>;
@@ -180,4 +180,22 @@ export interface OAuthConnectionOptions {
   oauthEnd?: () => Promise<void>;
   returnOnOAuth?: boolean;
   connectionTimeout?: number;
+}
+
+export interface ToolDiscoveryOptions {
+  serverName: string;
+  user?: IUser;
+  flowManager?: FlowStateManager<o.MCPOAuthTokens | null>;
+  tokenMethods?: TokenMethods;
+  signal?: AbortSignal;
+  oauthStart?: (authURL: string) => Promise<void>;
+  customUserVars?: Record<string, string>;
+  requestBody?: RequestBody;
+  connectionTimeout?: number;
+}
+
+export interface ToolDiscoveryResult {
+  tools: Tool[] | null;
+  oauthRequired: boolean;
+  oauthUrl: string | null;
 }

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -238,6 +238,7 @@ class GenerationJobManagerClass {
       const currentRuntime = this.runtimeState.get(streamId);
       if (currentRuntime) {
         currentRuntime.syncSent = false;
+        currentRuntime.hasSubscriber = false;
         // Persist syncSent=false to Redis for cross-replica consistency
         this.jobStore.updateJob(streamId, { syncSent: false }).catch((err) => {
           logger.error(`[GenerationJobManager] Failed to persist syncSent=false:`, err);
@@ -435,6 +436,7 @@ class GenerationJobManagerClass {
       const currentRuntime = this.runtimeState.get(streamId);
       if (currentRuntime) {
         currentRuntime.syncSent = false;
+        currentRuntime.hasSubscriber = false;
         // Persist syncSent=false to Redis
         this.jobStore.updateJob(streamId, { syncSent: false }).catch((err) => {
           logger.error(`[GenerationJobManager] Failed to persist syncSent=false:`, err);
@@ -767,7 +769,6 @@ class GenerationJobManagerClass {
         for (const bufferedEvent of runtime.earlyEventBuffer) {
           onChunk(bufferedEvent);
         }
-        // Clear buffer after replay
         runtime.earlyEventBuffer = [];
       }
     }
@@ -822,7 +823,6 @@ class GenerationJobManagerClass {
     // Buffer early events if no subscriber yet (replay when first subscriber connects)
     if (!runtime.hasSubscriber) {
       runtime.earlyEventBuffer.push(event);
-      // Also emit to transport in case subscriber connects mid-flight
     }
 
     this.eventTransport.emitChunk(streamId, event);


### PR DESCRIPTION


## Summary

I fixed an issue where MCP servers requiring OAuth authentication could not have their tools discovered, violating the MCP protocol specification which states that tool listing should be possible without authentication. Previously, when OAuth was required, `getConnection()` would throw an error leaving `connection` as `null`, meaning tools were never discovered, users were never prompted to authenticate, and the LLM never saw these tools in its schema.

This implements **Phase 2 (Partial Connection Support)** from the MCP OAuth Tool Discovery plan, along with fixing a critical bug where OAuth events were not being emitted to the UI in event-driven mode.

- Added `discoverServerTools` method to `MCPManager.ts` that attempts tool discovery even when OAuth is required, capturing the OAuth URL for later use.
- Added `ToolDiscoveryOptions` and `ToolDiscoveryResult` interfaces to MCP types for structured tool discovery with OAuth handling.
- Updated `reinitMCPServer` in `api/server/services/Tools/mcp.js` to use the new `discoverServerTools` method and propagate OAuth authentication URLs.
- Fixed `createOAuthEmitter` in `ToolService.js` to emit both `ON_RUN_STEP` and `ON_RUN_STEP_DELTA` events sequentially, matching the expected UI pattern for creating run steps with OAuth prompts.
- Fixed a race condition in `GenerationJobManager.ts` where the `hasSubscriber` flag was not reset to `false` in `onAllSubscribersLeft` handlers, preventing proper event buffering when SSE clients reconnected.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Test with an MCP server configured to require OAuth authentication:

1. Configure an MCP server that requires OAuth (e.g., a server with OAuth 2.0 authorization)
2. Create or select an agent that uses tools from this MCP server
3. Send a message to the agent
4. Verify the OAuth login prompt appears in the UI (previously it would hang indefinitely)
5. Complete the OAuth flow and verify tools load successfully
6. Verify subsequent messages work without requiring re-authentication

Additionally test mixed scenarios:
- Create an agent with both OAuth and non-OAuth MCP tools
- Verify non-OAuth tools work immediately
- Verify OAuth tools properly prompt for authentication

### **Test Configuration**:
- MCP server with OAuth 2.0 authentication configured
- Agent configured to use tools from the OAuth-protected MCP server

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes