### PR TITLE
🔦 fix: Tool resource files not visible in event-driven mode

### DIFF
--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -1,3 +1,5 @@
+const { logger } = require('@librechat/data-schemas');
+const { tool: toolFn, DynamicStructuredTool } = require('@langchain/core/tools');
 const {
   sleep,
   EnvVar,
@@ -7,8 +9,6 @@ const {
   Constants: AgentConstants,
   createProgrammaticToolCallingTool,
 } = require('@librechat/agents');
-const { logger } = require('@librechat/data-schemas');
-const { tool: toolFn, DynamicStructuredTool } = require('@langchain/core/tools');
 const {
   sendEvent,
   getToolkitKey,

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -42,6 +42,7 @@ export type InitializedAgent = Agent & {
   maxContextTokens: number;
   useLegacyContent: boolean;
   resendFiles: boolean;
+  tool_resources?: AgentToolResources;
   userMCPAuthMap?: Record<string, Record<string, string>>;
   /** Tool map for ToolNode to use when executing tools (required for PTC) */
   toolMap?: ToolMap;
@@ -405,6 +406,7 @@ export async function initializeAgent(
     tools: (tools ?? []) as GenericTool[] & string[],
     attachments: finalAttachments,
     resendFiles,
+    tool_resources,
     userMCPAuthMap,
     toolRegistry,
     toolDefinitions,

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -403,16 +403,16 @@ export async function initializeAgent(
 
   const initializedAgent: InitializedAgent = {
     ...agent,
-    tools: (tools ?? []) as GenericTool[] & string[],
-    attachments: finalAttachments,
     resendFiles,
+    toolRegistry,
     tool_resources,
     userMCPAuthMap,
-    toolRegistry,
     toolDefinitions,
     hasDeferredTools,
+    attachments: finalAttachments,
     toolContextMap: toolContextMap ?? {},
     useLegacyContent: !!options.useLegacyContent,
+    tools: (tools ?? []) as GenericTool[] & string[],
     maxContextTokens: Math.round((agentMaxContextNum - maxOutputTokensNum) * 0.9),
   };
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #11588 where files uploaded for code execution are no longer visible to agents.

Closes #11609

**Root Cause:** The event-driven lazy tool loading refactor made `primeResources` non-mutating, but callers weren't updated to use the returned values:
1. `initializeAgent` wasn't updated to return the primed `tool_resources`
2. `loadToolDefinitionsWrapper` doesn't prime files or generate `toolContextMap`
3. `loadToolsForExecution` discards `toolContextMap` from `loadTools`

**Changes:**
- Add `tool_resources` to `InitializedAgent` type and return object
- Prime execute_code files in `loadToolDefinitionsWrapper` for event-driven mode
- Pass `tool_resources` to `loadToolDefinitionsWrapper`
- Capture and return `toolContextMap` from `loadToolsForExecution`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Start backend: `npm run backend:dev`
2. Create agent with `execute_code` tool enabled
3. Upload a file to agent's code files section
4. Send message: "List files in /mnt/data/"
5. Verify agent correctly lists the uploaded file

The system message should now include:
```
- Note: The following files are available in the "execute_code" tool environment:
    - /mnt/data/<filename>
```

### Test Configuration:
- Node.js 20.x
- MongoDB local instance

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes