### PR TITLE
👆 fix: Web Search and Code Interpreter Toggle Cursor Hover Behavior

### DIFF
--- a/client/src/components/SidePanel/Agents/Code/Action.tsx
+++ b/client/src/components/SidePanel/Agents/Code/Action.tsx
@@ -14,6 +14,7 @@ import type { AgentForm } from '~/common';
 import { useLocalize, useCodeApiKeyForm } from '~/hooks';
 import ApiKeyDialog from './ApiKeyDialog';
 import { ESide } from '~/common';
+import { cn } from '~/utils';
 
 export default function Action({ authType = '', isToolAuthenticated = false }) {
   const localize = useLocalize();
@@ -73,7 +74,10 @@ export default function Action({ authType = '', isToolAuthenticated = false }) {
           <label
             id="execute-code-label"
             htmlFor="execute-code-checkbox"
-            className="form-check-label text-token-text-primary cursor-pointer"
+            className={cn(
+              'form-check-label text-token-text-primary',
+              (runCodeIsEnabled || isToolAuthenticated) && 'cursor-pointer',
+            )}
           >
             {localize('com_ui_run_code')}
           </label>

--- a/client/src/components/SidePanel/Agents/Search/Action.tsx
+++ b/client/src/components/SidePanel/Agents/Search/Action.tsx
@@ -14,6 +14,7 @@ import type { AgentForm } from '~/common';
 import { useLocalize, useSearchApiKeyForm } from '~/hooks';
 import ApiKeyDialog from './ApiKeyDialog';
 import { ESide } from '~/common';
+import { cn } from '~/utils';
 
 export default function Action({
   authTypes = [],
@@ -81,7 +82,10 @@ export default function Action({
           <label
             id="web-search-label"
             htmlFor="web-search-checkbox"
-            className="form-check-label text-token-text-primary cursor-pointer"
+            className={cn(
+              'form-check-label text-token-text-primary',
+              (webSearchIsEnabled || isToolAuthenticated) && 'cursor-pointer',
+            )}
           >
             {localize('com_ui_web_search')}
           </label>


### PR DESCRIPTION
## Summary

This pull request updates the `Action` components for both the Code and Search agent side panels to improve how label classes are applied; the cursor no longer makes the hovered text coupled to the checkbox appear clickable when the checkbox is disabled.

Styling improvements:

* Updated the label in `Code/Action.tsx` to use the `cn` utility, making the `cursor-pointer` class conditional on whether code execution is enabled or the tool is authenticated. [[1]](diffhunk://#diff-10f9b09c6a5601dec15cd76cac580dbd4da17b4a25e60f9797224a1a971d612eR17) [[2]](diffhunk://#diff-10f9b09c6a5601dec15cd76cac580dbd4da17b4a25e60f9797224a1a971d612eL76-R80)
* Updated the label in `Search/Action.tsx` to use the `cn` utility, making the `cursor-pointer` class conditional on whether web search is enabled or the tool is authenticated. [[1]](diffhunk://#diff-8f22b77563952b125f9326e8560cdd57d8128460976b864b2f62800f84b90178R17) [[2]](diffhunk://#diff-8f22b77563952b125f9326e8560cdd57d8128460976b864b2f62800f84b90178L84-R88)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before
https://github.com/user-attachments/assets/54c0eeec-ff7c-457e-9611-3215cc860048

### After
https://github.com/user-attachments/assets/516146a7-3fa6-4041-8f27-7669a4f860f1

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes