### PR TITLE
🔓 docs: Comment Out MCP Permissions in `librechat.example.yaml`

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -102,17 +102,14 @@ interface:
   marketplace:
     use: false
   fileCitations: true
-  mcpServers:
-    # MCP Servers configuration
+  # MCP Servers configuration example
+  # mcpServers:
     # Controls user permissions for MCP (Model Context Protocol) server management
     # - use: Allow users to use configured MCP servers
     # - create: Allow users to create and manage new MCP servers
     # - share: Allow users to share MCP servers with other users
     # - public: Allow users to share MCP servers publicly (with everyone)
-    use: false
-    share: false
-    create: false
-    public: false
+     
     # Creation / edit MCP server config Dialog config example
     # trustCheckbox:
     #   label:


### PR DESCRIPTION
## Summary

This pull request makes a small change to the `librechat.example.yaml` configuration file by commenting out the `mcpServers` configuration section and providing it as an example instead of active configuration. This improves clarity for users editing the file.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes