### PR TITLE
✈️ refactor: Single-Flight Deduplication for MCP Server Configs and Optimize Redis Batch Fetching

### DIFF
--- a/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
@@ -254,7 +254,7 @@ describe('MCPServersRegistry Redis Integration Tests', () => {
 
       const results = await Promise.all(promises);
 
-      expect(cacheRepoGetAllSpy.mock.calls.length).toBeLessThanOrEqual(2);
+      expect(cacheRepoGetAllSpy.mock.calls.length).toBe(1);
 
       for (const result of results) {
         expect(Object.keys(result).length).toBe(3);
@@ -277,7 +277,7 @@ describe('MCPServersRegistry Redis Integration Tests', () => {
         registry.getAllServerConfigs('user1'),
       ]);
 
-      expect(cacheRepoGetAllSpy.mock.calls.length).toBeLessThanOrEqual(3);
+      expect(cacheRepoGetAllSpy.mock.calls.length).toBe(2);
 
       expect(Object.keys(result1)).toContain('shared_server');
       expect(Object.keys(result2)).toContain('shared_server');

--- a/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersRegistry.cache_integration.spec.ts
@@ -236,4 +236,106 @@ describe('MCPServersRegistry Redis Integration Tests', () => {
       expect(Object.keys(configsAfter)).toHaveLength(0);
     });
   });
+
+  describe('single-flight deduplication', () => {
+    it('should deduplicate concurrent getAllServerConfigs calls', async () => {
+      await registry.addServer('server1', testRawConfig, 'CACHE');
+      await registry.addServer('server2', testRawConfig, 'CACHE');
+      await registry.addServer('server3', testRawConfig, 'CACHE');
+
+      await registry['readThroughCacheAll'].clear();
+
+      const cacheRepoGetAllSpy = jest.spyOn(registry['cacheConfigsRepo'], 'getAll');
+
+      const concurrentCalls = 10;
+      const promises = Array.from({ length: concurrentCalls }, () =>
+        registry.getAllServerConfigs(),
+      );
+
+      const results = await Promise.all(promises);
+
+      expect(cacheRepoGetAllSpy.mock.calls.length).toBeLessThanOrEqual(2);
+
+      for (const result of results) {
+        expect(Object.keys(result).length).toBe(3);
+        expect(result).toHaveProperty('server1');
+        expect(result).toHaveProperty('server2');
+        expect(result).toHaveProperty('server3');
+      }
+    });
+
+    it('should handle different userIds independently', async () => {
+      await registry.addServer('shared_server', testRawConfig, 'CACHE');
+
+      await registry['readThroughCacheAll'].clear();
+
+      const cacheRepoGetAllSpy = jest.spyOn(registry['cacheConfigsRepo'], 'getAll');
+
+      const [result1, result2, result3] = await Promise.all([
+        registry.getAllServerConfigs('user1'),
+        registry.getAllServerConfigs('user2'),
+        registry.getAllServerConfigs('user1'),
+      ]);
+
+      expect(cacheRepoGetAllSpy.mock.calls.length).toBeLessThanOrEqual(3);
+
+      expect(Object.keys(result1)).toContain('shared_server');
+      expect(Object.keys(result2)).toContain('shared_server');
+      expect(Object.keys(result3)).toContain('shared_server');
+    });
+
+    it('should complete concurrent requests without timeout', async () => {
+      for (let i = 0; i < 10; i++) {
+        await registry.addServer(`stress_server_${i}`, testRawConfig, 'CACHE');
+      }
+
+      await registry['readThroughCacheAll'].clear();
+
+      const concurrentCalls = 50;
+      const startTime = Date.now();
+
+      const promises = Array.from({ length: concurrentCalls }, () =>
+        registry.getAllServerConfigs(),
+      );
+
+      const results = await Promise.all(promises);
+      const elapsed = Date.now() - startTime;
+
+      expect(elapsed).toBeLessThan(10000);
+
+      for (const result of results) {
+        expect(Object.keys(result).length).toBe(10);
+      }
+    });
+
+    it('should return consistent results across all concurrent callers', async () => {
+      await registry.addServer('consistency_server_a', testRawConfig, 'CACHE');
+      await registry.addServer(
+        'consistency_server_b',
+        {
+          ...testRawConfig,
+          command: 'python',
+        },
+        'CACHE',
+      );
+
+      await registry['readThroughCacheAll'].clear();
+
+      const results = await Promise.all([
+        registry.getAllServerConfigs(),
+        registry.getAllServerConfigs(),
+        registry.getAllServerConfigs(),
+        registry.getAllServerConfigs(),
+        registry.getAllServerConfigs(),
+      ]);
+
+      const firstResult = results[0];
+      for (const result of results) {
+        expect(Object.keys(result).sort()).toEqual(Object.keys(firstResult).sort());
+        for (const key of Object.keys(firstResult)) {
+          expect(result[key]).toMatchObject(firstResult[key]);
+        }
+      }
+    });
+  });
 });

--- a/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedis.ts
+++ b/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedis.ts
@@ -80,10 +80,8 @@ export class ServerConfigsCacheRedis
       return {};
     }
 
-    const keyNames = keys.map((key) => {
-      const lastColonIndex = key.lastIndexOf(':');
-      return key.substring(lastColonIndex + 1);
-    });
+    /** Extract keyName from full Redis key format: "prefix::namespace:keyName" */
+    const keyNames = keys.map((key) => key.substring(key.lastIndexOf(':') + 1));
 
     const entries: Array<[string, ParsedServerConfig]> = [];
 

--- a/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedis.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedis.cache_integration.spec.ts
@@ -270,9 +270,9 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
     });
   });
 
-  describe('getAll MGET optimization', () => {
-    it('should handle many configs efficiently with MGET batching', async () => {
-      const testCache = new ServerConfigsCacheRedis('mget-test', false);
+  describe('getAll parallel fetching', () => {
+    it('should handle many configs efficiently with parallel fetching', async () => {
+      const testCache = new ServerConfigsCacheRedis('parallel-test', false);
       const configCount = 20;
 
       for (let i = 0; i < configCount; i++) {
@@ -388,9 +388,6 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
       }
 
       expect(elapsed).toBeLessThan(maxAllowedMs);
-      console.log(
-        `[PERF] ${concurrentRequests} concurrent getAll() with ${configCount} configs: ${elapsed}ms`,
-      );
     });
   });
 });

--- a/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedis.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedis.cache_integration.spec.ts
@@ -7,25 +7,25 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
 
   let cache: InstanceType<typeof import('../ServerConfigsCacheRedis').ServerConfigsCacheRedis>;
 
-  // Test data
-  const mockConfig1: ParsedServerConfig = {
+  const mockConfig1 = {
+    type: 'stdio',
     command: 'node',
     args: ['server1.js'],
     env: { TEST: 'value1' },
-  };
+  } as ParsedServerConfig;
 
-  const mockConfig2: ParsedServerConfig = {
+  const mockConfig2 = {
+    type: 'stdio',
     command: 'python',
     args: ['server2.py'],
     env: { TEST: 'value2' },
-  };
+  } as ParsedServerConfig;
 
-  const mockConfig3: ParsedServerConfig = {
-    command: 'node',
-    args: ['server3.js'],
+  const mockConfig3 = {
+    type: 'sse',
     url: 'http://localhost:3000',
     requiresOAuth: true,
-  };
+  } as ParsedServerConfig;
 
   beforeAll(async () => {
     // Set up environment variables for Redis (only if not already set)
@@ -52,9 +52,8 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
   });
 
   beforeEach(() => {
-    // Create a fresh instance for each test with leaderOnly=true
     jest.resetModules();
-    cache = new ServerConfigsCacheRedis('test-user', 'Shared', false);
+    cache = new ServerConfigsCacheRedis('test-user', false);
   });
 
   afterEach(async () => {
@@ -114,8 +113,8 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
     });
 
     it('should isolate caches by owner namespace', async () => {
-      const userCache = new ServerConfigsCacheRedis('user1', 'Private', false);
-      const globalCache = new ServerConfigsCacheRedis('global', 'Shared', false);
+      const userCache = new ServerConfigsCacheRedis('user1-private', false);
+      const globalCache = new ServerConfigsCacheRedis('global-shared', false);
 
       await userCache.add('server1', mockConfig1);
       await globalCache.add('server1', mockConfig2);
@@ -161,8 +160,8 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
     });
 
     it('should only return configs for the specific owner', async () => {
-      const userCache = new ServerConfigsCacheRedis('user1', 'Private', false);
-      const globalCache = new ServerConfigsCacheRedis('global', 'Private', false);
+      const userCache = new ServerConfigsCacheRedis('user1-owner', false);
+      const globalCache = new ServerConfigsCacheRedis('global-owner', false);
 
       await userCache.add('server1', mockConfig1);
       await userCache.add('server2', mockConfig2);
@@ -206,8 +205,8 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
     });
 
     it('should only update in the specific owner namespace', async () => {
-      const userCache = new ServerConfigsCacheRedis('user1', 'Private', false);
-      const globalCache = new ServerConfigsCacheRedis('global', 'Shared', false);
+      const userCache = new ServerConfigsCacheRedis('user1-update', false);
+      const globalCache = new ServerConfigsCacheRedis('global-update', false);
 
       await userCache.add('server1', mockConfig1);
       await globalCache.add('server1', mockConfig2);
@@ -258,8 +257,8 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
     });
 
     it('should only remove from the specific owner namespace', async () => {
-      const userCache = new ServerConfigsCacheRedis('user1', 'Private', false);
-      const globalCache = new ServerConfigsCacheRedis('global', 'Shared', false);
+      const userCache = new ServerConfigsCacheRedis('user1-remove', false);
+      const globalCache = new ServerConfigsCacheRedis('global-remove', false);
 
       await userCache.add('server1', mockConfig1);
       await globalCache.add('server1', mockConfig2);
@@ -268,6 +267,130 @@ describe('ServerConfigsCacheRedis Integration Tests', () => {
 
       expect(await userCache.get('server1')).toBeUndefined();
       expect(await globalCache.get('server1')).toMatchObject(mockConfig2);
+    });
+  });
+
+  describe('getAll MGET optimization', () => {
+    it('should handle many configs efficiently with MGET batching', async () => {
+      const testCache = new ServerConfigsCacheRedis('mget-test', false);
+      const configCount = 20;
+
+      for (let i = 0; i < configCount; i++) {
+        await testCache.add(`server-${i}`, {
+          type: 'stdio',
+          command: `cmd-${i}`,
+          args: [`arg-${i}`],
+        } as ParsedServerConfig);
+      }
+
+      const startTime = Date.now();
+      const result = await testCache.getAll();
+      const elapsed = Date.now() - startTime;
+
+      expect(Object.keys(result).length).toBe(configCount);
+      for (let i = 0; i < configCount; i++) {
+        expect(result[`server-${i}`]).toBeDefined();
+        const config = result[`server-${i}`] as { command?: string };
+        expect(config.command).toBe(`cmd-${i}`);
+      }
+
+      expect(elapsed).toBeLessThan(5000);
+    });
+
+    it('should handle concurrent getAll calls without timeout', async () => {
+      const testCache = new ServerConfigsCacheRedis('concurrent-test', false);
+
+      for (let i = 0; i < 10; i++) {
+        await testCache.add(`server-${i}`, {
+          type: 'stdio',
+          command: `cmd-${i}`,
+          args: [`arg-${i}`],
+        } as ParsedServerConfig);
+      }
+
+      const concurrentCalls = 50;
+      const startTime = Date.now();
+      const promises = Array.from({ length: concurrentCalls }, () => testCache.getAll());
+
+      const results = await Promise.all(promises);
+      const elapsed = Date.now() - startTime;
+
+      for (const result of results) {
+        expect(Object.keys(result).length).toBe(10);
+      }
+
+      expect(elapsed).toBeLessThan(10000);
+    });
+
+    it('should return consistent results across concurrent calls', async () => {
+      const testCache = new ServerConfigsCacheRedis('consistency-test', false);
+
+      await testCache.add('server-a', mockConfig1);
+      await testCache.add('server-b', mockConfig2);
+      await testCache.add('server-c', mockConfig3);
+
+      const results = await Promise.all([
+        testCache.getAll(),
+        testCache.getAll(),
+        testCache.getAll(),
+        testCache.getAll(),
+        testCache.getAll(),
+      ]);
+
+      const firstResult = results[0];
+      for (const result of results) {
+        expect(Object.keys(result).sort()).toEqual(Object.keys(firstResult).sort());
+        expect(result['server-a']).toMatchObject(mockConfig1);
+        expect(result['server-b']).toMatchObject(mockConfig2);
+        expect(result['server-c']).toMatchObject(mockConfig3);
+      }
+    });
+
+    /**
+     * Performance regression test for N+1 Redis fix.
+     *
+     * Before fix: getAll() used sequential GET calls inside an async loop:
+     *   for await (key of scan) { await cache.get(key); }  // N sequential calls
+     *
+     * With 30 configs and 100 concurrent requests, this would cause:
+     *   - 100 × 30 = 3000 sequential Redis roundtrips
+     *   - Under load, requests would queue and timeout at 60s
+     *
+     * After fix: getAll() uses Promise.all for parallel fetching:
+     *   Promise.all(keys.map(k => cache.get(k)));  // N parallel calls
+     *
+     * This test validates the fix by ensuring 100 concurrent requests
+     * complete in under 5 seconds - impossible with the old N+1 pattern.
+     */
+    it('should complete 100 concurrent requests in under 5s (regression test for N+1 fix)', async () => {
+      const testCache = new ServerConfigsCacheRedis('perf-regression-test', false);
+      const configCount = 30;
+
+      for (let i = 0; i < configCount; i++) {
+        await testCache.add(`server-${i}`, {
+          type: 'stdio',
+          command: `cmd-${i}`,
+          args: [`arg-${i}`],
+        } as ParsedServerConfig);
+      }
+
+      const concurrentRequests = 100;
+      const maxAllowedMs = 5000;
+
+      const startTime = Date.now();
+      const promises = Array.from({ length: concurrentRequests }, () => testCache.getAll());
+      const results = await Promise.all(promises);
+      const elapsed = Date.now() - startTime;
+
+      expect(results.length).toBe(concurrentRequests);
+      for (const result of results) {
+        expect(Object.keys(result).length).toBe(configCount);
+      }
+
+      expect(elapsed).toBeLessThan(maxAllowedMs);
+      console.log(
+        `[PERF] ${concurrentRequests} concurrent getAll() with ${configCount} configs: ${elapsed}ms`,
+      );
     });
   });
 });


### PR DESCRIPTION

## Summary

I implemented single-flight deduplication for concurrent `getAllServerConfigs` calls and optimized Redis batch fetching to prevent N+1 query patterns and improve scalability under high concurrency.

- Added a `pendingGetAllPromises` Map to track in-flight requests and deduplicate concurrent calls for the same userId/cacheKey, preventing duplicate database queries and race conditions
- Extracted `fetchAllServerConfigs` as a private method to encapsulate the actual fetching logic while the public method handles deduplication
- Implemented batched parallel fetching in `ServerConfigsCacheRedis.getAll()` with a batch size of 100 to prevent unbounded concurrent Redis connections
- Refactored from sequential async iteration (`for await...await get()`) to batched `Promise.all` execution, eliminating the N+1 query bottleneck that caused 60-second timeouts under load
- Added comprehensive integration tests validating single-flight deduplication with exact spy assertions (10 concurrent calls → 1 fetch)
- Added tests for per-user isolation ensuring different userIds maintain separate flight groups
- Added stress tests with 50-100 concurrent requests to validate performance improvements and prevent regressions
- Added data consistency tests ensuring all concurrent callers receive identical results
- Updated test suite naming from "MGET optimization" to "getAll parallel fetching" for accuracy
- Added debug logging to track fetch performance and key counts in production

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

I tested the changes using comprehensive integration tests against a live Redis instance:

1. **Deduplication Validation**: Verified 10 concurrent calls result in exactly 1 database fetch using Jest spies
2. **Multi-User Isolation**: Confirmed 3 concurrent calls (2 for user1, 1 for user2) result in exactly 2 fetches
3. **Stress Testing**: Validated 100 concurrent requests with 30 configs complete in under 5 seconds (previously timed out at 60s)
4. **Data Consistency**: Ensured all concurrent callers receive identical results by comparing object keys and values
5. **Batch Performance**: Tested with 20+ configs to verify batching logic prevents connection exhaustion

### **Test Configuration**:
- Redis instance running locally or via Docker
- Jest with integration test suite
- Spy mocking on `cacheConfigsRepo.getAll()`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes