### PR TITLE
📦 chore: Update @librechat/agents to v3.1.32

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -45,7 +45,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.31",
+    "@librechat/agents": "^3.1.32",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.31",
+        "@librechat/agents": "^3.1.32",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -10753,9 +10753,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.31",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.31.tgz",
-      "integrity": "sha512-MRRp1B+giJkd5PNdbYFcTJ99bEL2mEzGiM/gY1iQNjEHoRUr4Nu3MIXBH75PRh3xgciDngcX08kqYipn9t4sJQ==",
+      "version": "3.1.32",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.32.tgz",
+      "integrity": "sha512-6VrozsSAM3N/uos7mfyKH2wjTuvoPLiFxV01i3Rpodyu5f0V76Ej0+wVFbcD65KUDTKn0Lpw+rBRpDAy7hXn8g==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.980.0",
@@ -42329,7 +42329,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.31",
+        "@librechat/agents": "^3.1.32",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.25.3",
         "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -87,7 +87,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.31",
+    "@librechat/agents": "^3.1.32",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "@smithy/node-http-handler": "^4.4.5",


### PR DESCRIPTION
- Bumped the version of @librechat/agents to 3.1.32 across multiple package.json and package-lock.json files to ensure compatibility and access to the latest features.
- This update enhances the functionality and stability of the application by integrating the latest improvements from the @librechat/agents package.
