### PR TITLE
🪢 docs: add Langfuse to `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,16 @@ NODE_MAX_OLD_SPACE_SIZE=6144
 
 # CONFIG_PATH="/alternative/path/to/librechat.yaml"
 
+#==================#
+# Langfuse Tracing #
+#==================#
+
+# Get Langfuse API keys for your project from the project settings page: https://cloud.langfuse.com
+
+# LANGFUSE_PUBLIC_KEY=
+# LANGFUSE_SECRET_KEY=
+# LANGFUSE_BASE_URL=
+
 #===================================================#
 #                     Endpoints                     #
 #===================================================#


### PR DESCRIPTION
Adding Langfuse environment variables to the env.example file to enable Langfuse tracing. 