### PR TITLE
🧽 chore: Remove deprecated Claude models from Default List

### DIFF
--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1125,16 +1125,6 @@ const sharedAnthropicModels = [
   'claude-3-5-sonnet-20241022',
   'claude-3-5-sonnet-20240620',
   'claude-3-5-sonnet-latest',
-  'claude-3-opus-20240229',
-  'claude-3-sonnet-20240229',
-  'claude-3-haiku-20240307',
-  'claude-2.1',
-  'claude-2',
-  'claude-1.2',
-  'claude-1',
-  'claude-1-100k',
-  'claude-instant-1',
-  'claude-instant-1-100k',
 ];
 
 export const bedrockModels = [
@@ -1144,12 +1134,6 @@ export const bedrockModels = [
   'anthropic.claude-3-5-sonnet-20241022-v2:0',
   'anthropic.claude-3-5-sonnet-20240620-v1:0',
   'anthropic.claude-3-5-haiku-20241022-v1:0',
-  'anthropic.claude-3-haiku-20240307-v1:0',
-  'anthropic.claude-3-opus-20240229-v1:0',
-  'anthropic.claude-3-sonnet-20240229-v1:0',
-  'anthropic.claude-v2',
-  'anthropic.claude-v2:1',
-  'anthropic.claude-instant-v1',
   // 'cohere.command-text-v14', // no conversation history
   // 'cohere.command-light-text-v14', // no conversation history
   'cohere.command-r-v1:0',


### PR DESCRIPTION
## Summary

This PR removes deprecated Claude models from the model configuration lists to keep the model selection clean and aligned with Anthropic's current offerings.

**Related Issue:** #11638

**Motivation:**
Several Claude models have been deprecated by Anthropic in favor of newer, more capable versions:
- Claude 1.x and 2.x models are legacy and have been superseded by Claude 3.5+ models
- Early 2024 Claude 3.x models (from February/March 2024) have been replaced by newer versions
- Claude Instant models have been replaced by Claude 3.5 Haiku

Keeping deprecated models in the configuration can confuse users and may lead to API errors if they try to use unavailable models.

**Changes:**
- Removed 9 deprecated models from `sharedAnthropicModels` array:
  - `claude-1`, `claude-1.2`, `claude-1-100k`
  - `claude-instant-1`, `claude-instant-1-100k`
  - `claude-2`, `claude-2.1`
  - `claude-3-opus-20240229`, `claude-3-sonnet-20240229`, `claude-3-haiku-20240307`

- Removed 6 deprecated models from `bedrockModels` array:
  - `anthropic.claude-3-haiku-20240307-v1:0`
  - `anthropic.claude-3-opus-20240229-v1:0`
  - `anthropic.claude-3-sonnet-20240229-v1:0`
  - `anthropic.claude-instant-v1`
  - `anthropic.claude-v2`, `anthropic.claude-v2:1`

**Dependencies:** None

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

**Note:** This is a breaking change for users who have presets or conversations using the deprecated models. They will need to update their model selection to use newer versions.

## Testing

### Test Process

1. **Code Review:**
   - Verified deprecated models removed from both arrays
   - Confirmed no syntax errors introduced
   - Checked that remaining models are valid

2. **Build Verification:**
   - Ran `npm run build:data-provider` - ✅ Build successful
   - No TypeScript compilation errors related to changes

3. **Linting:**
   - Ran `npm run lint` - ✅ No new linting errors introduced
   - Pre-existing TypeScript configuration warnings remain (unrelated to this change)

4. **Functional Testing:**
   - Verified deprecated models no longer appear in model selection UI
   - Confirmed current models (Claude 3.5+, Claude 4.x) still available
   - Tested that model selection dropdowns work correctly

### Test Configuration

**Environment:**
- Node.js 20.x
- All dependencies installed via `npm ci`

**Test Commands Run:**
npm run build:data-provider
npm run lint**Manual Testing:**
- Model selection UI in chat interface
- Model selection in agent configuration
- Settings panels for Anthropic endpoint

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code (N/A - simple array removal)
- [x] I have made pertinent documentation changes (N/A - no documentation changes needed)
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works (N/A - configuration change, existing tests cover model functionality)
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules (N/A - no downstream dependencies)
- [x] A pull request for updating the documentation has been submitted (N/A - no documentation updates needed)

## Additional Notes

- Test files may still reference deprecated models for legacy behavior testing - this is acceptable
- Pattern-based references in pricing (`api/models/tx.js`) and token limits (`packages/api/src/utils/tokens.ts`) use pattern matching and don't need changes
- Users with existing presets using deprecated models will need to update their model selection manually

Fixes #11638