### PR TITLE
🛡️ fix: Preserve CREATE/SHARE/SHARE_PUBLIC Permissions with Boolean Config

### DIFF
--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -568,6 +568,7 @@ async function loadToolDefinitionsWrapper({ req, res, agent, streamId = null, to
 
     const definitions = [];
     const allowedDomains = appConfig?.actions?.allowedDomains;
+    const domainSeparatorRegex = new RegExp(actionDomainSeparator, 'g');
 
     for (const action of actionSets) {
       const domain = await domainParser(action.metadata.domain, true);
@@ -590,7 +591,6 @@ async function loadToolDefinitionsWrapper({ req, res, agent, streamId = null, to
 
       const { functionSignatures } = openapiToFunction(validationResult.spec, true);
 
-      const domainSeparatorRegex = new RegExp(actionDomainSeparator, 'g');
       for (const sig of functionSignatures) {
         const toolName = `${sig.name}${actionDelimiter}${normalizedDomain}`;
         if (!actionToolNames.some((name) => name.replace(domainSeparatorRegex, '_') === toolName)) {

--- a/packages/api/src/app/permissions.spec.ts
+++ b/packages/api/src/app/permissions.spec.ts
@@ -962,8 +962,7 @@ describe('updateInterfacePermissions - permissions', () => {
     const expectedPermissionsForUser = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        // SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
+        // CREATE/SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
       }, // Explicitly configured
       // All other permissions that don't exist in the database
       [PermissionTypes.MEMORIES]: {
@@ -1002,8 +1001,7 @@ describe('updateInterfacePermissions - permissions', () => {
     const expectedPermissionsForAdmin = {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
-        [Permissions.CREATE]: true,
-        // SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
+        // CREATE/SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
       }, // Explicitly configured
       // All other permissions that don't exist in the database
       [PermissionTypes.MEMORIES]: {
@@ -1458,10 +1456,9 @@ describe('updateInterfacePermissions - permissions', () => {
     );
 
     // Explicitly configured permissions should be updated
-    // SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
+    // CREATE/SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
     expect(userCall[1][PermissionTypes.PROMPTS]).toEqual({
       [Permissions.USE]: true,
-      [Permissions.CREATE]: true,
     });
     expect(userCall[1][PermissionTypes.BOOKMARKS]).toEqual({ [Permissions.USE]: true });
     expect(userCall[1][PermissionTypes.MARKETPLACE]).toEqual({ [Permissions.USE]: true });
@@ -1782,10 +1779,9 @@ describe('updateInterfacePermissions - permissions', () => {
     );
     // Memory permissions should be updated even though they already exist
     expect(userCall[1][PermissionTypes.MEMORIES]).toEqual(expectedMemoryPermissions);
-    // Prompts should be updated (explicitly configured) - SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
+    // Prompts should be updated (explicitly configured) - CREATE/SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
     expect(userCall[1][PermissionTypes.PROMPTS]).toEqual({
       [Permissions.USE]: true,
-      [Permissions.CREATE]: true,
     });
     // Bookmarks should be updated (explicitly configured)
     expect(userCall[1][PermissionTypes.BOOKMARKS]).toEqual({ [Permissions.USE]: true });
@@ -1796,10 +1792,9 @@ describe('updateInterfacePermissions - permissions', () => {
     );
     // Memory permissions should be updated even though they already exist
     expect(adminCall[1][PermissionTypes.MEMORIES]).toEqual(expectedMemoryPermissions);
-    // SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
+    // CREATE/SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
     expect(adminCall[1][PermissionTypes.PROMPTS]).toEqual({
       [Permissions.USE]: true,
-      [Permissions.CREATE]: true,
     });
     expect(adminCall[1][PermissionTypes.BOOKMARKS]).toEqual({ [Permissions.USE]: true });
 
@@ -1865,21 +1860,21 @@ describe('updateInterfacePermissions - permissions', () => {
     );
 
     // CRITICAL: When using boolean config and permissions already exist,
-    // SHARE and SHARE_PUBLIC should NOT be in the update payload.
+    // only USE should be updated. CREATE, SHARE, and SHARE_PUBLIC should NOT be in the update payload.
     // This means they will be preserved in the database (not reset to defaults).
     expect(userCall[1][PermissionTypes.AGENTS]).toEqual({
       [Permissions.USE]: true,
-      [Permissions.CREATE]: true,
-      // SHARE and SHARE_PUBLIC intentionally omitted - preserves existing DB values
+      // CREATE, SHARE, and SHARE_PUBLIC intentionally omitted - preserves existing DB values
     });
+    expect(userCall[1][PermissionTypes.AGENTS]).not.toHaveProperty(Permissions.CREATE);
     expect(userCall[1][PermissionTypes.AGENTS]).not.toHaveProperty(Permissions.SHARE);
     expect(userCall[1][PermissionTypes.AGENTS]).not.toHaveProperty(Permissions.SHARE_PUBLIC);
 
     expect(userCall[1][PermissionTypes.PROMPTS]).toEqual({
       [Permissions.USE]: true,
-      [Permissions.CREATE]: true,
-      // SHARE and SHARE_PUBLIC intentionally omitted - preserves existing DB values
+      // CREATE, SHARE, and SHARE_PUBLIC intentionally omitted - preserves existing DB values
     });
+    expect(userCall[1][PermissionTypes.PROMPTS]).not.toHaveProperty(Permissions.CREATE);
     expect(userCall[1][PermissionTypes.PROMPTS]).not.toHaveProperty(Permissions.SHARE);
     expect(userCall[1][PermissionTypes.PROMPTS]).not.toHaveProperty(Permissions.SHARE_PUBLIC);
   });

--- a/packages/api/src/app/permissions.spec.ts
+++ b/packages/api/src/app/permissions.spec.ts
@@ -963,8 +963,7 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
         [Permissions.CREATE]: true,
-        [Permissions.SHARE]: false,
-        [Permissions.SHARE_PUBLIC]: false,
+        // SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
       }, // Explicitly configured
       // All other permissions that don't exist in the database
       [PermissionTypes.MEMORIES]: {
@@ -1004,8 +1003,7 @@ describe('updateInterfacePermissions - permissions', () => {
       [PermissionTypes.PROMPTS]: {
         [Permissions.USE]: true,
         [Permissions.CREATE]: true,
-        [Permissions.SHARE]: true,
-        [Permissions.SHARE_PUBLIC]: true,
+        // SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
       }, // Explicitly configured
       // All other permissions that don't exist in the database
       [PermissionTypes.MEMORIES]: {
@@ -1460,11 +1458,10 @@ describe('updateInterfacePermissions - permissions', () => {
     );
 
     // Explicitly configured permissions should be updated
+    // SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
     expect(userCall[1][PermissionTypes.PROMPTS]).toEqual({
       [Permissions.USE]: true,
       [Permissions.CREATE]: true,
-      [Permissions.SHARE]: false,
-      [Permissions.SHARE_PUBLIC]: false,
     });
     expect(userCall[1][PermissionTypes.BOOKMARKS]).toEqual({ [Permissions.USE]: true });
     expect(userCall[1][PermissionTypes.MARKETPLACE]).toEqual({ [Permissions.USE]: true });
@@ -1785,12 +1782,10 @@ describe('updateInterfacePermissions - permissions', () => {
     );
     // Memory permissions should be updated even though they already exist
     expect(userCall[1][PermissionTypes.MEMORIES]).toEqual(expectedMemoryPermissions);
-    // Prompts should be updated (explicitly configured)
+    // Prompts should be updated (explicitly configured) - SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
     expect(userCall[1][PermissionTypes.PROMPTS]).toEqual({
       [Permissions.USE]: true,
       [Permissions.CREATE]: true,
-      [Permissions.SHARE]: false,
-      [Permissions.SHARE_PUBLIC]: false,
     });
     // Bookmarks should be updated (explicitly configured)
     expect(userCall[1][PermissionTypes.BOOKMARKS]).toEqual({ [Permissions.USE]: true });
@@ -1801,11 +1796,10 @@ describe('updateInterfacePermissions - permissions', () => {
     );
     // Memory permissions should be updated even though they already exist
     expect(adminCall[1][PermissionTypes.MEMORIES]).toEqual(expectedMemoryPermissions);
+    // SHARE/SHARE_PUBLIC not included since prompts: true is boolean and PROMPTS already exists
     expect(adminCall[1][PermissionTypes.PROMPTS]).toEqual({
       [Permissions.USE]: true,
       [Permissions.CREATE]: true,
-      [Permissions.SHARE]: true,
-      [Permissions.SHARE_PUBLIC]: true,
     });
     expect(adminCall[1][PermissionTypes.BOOKMARKS]).toEqual({ [Permissions.USE]: true });
 

--- a/packages/api/src/app/permissions.ts
+++ b/packages/api/src/app/permissions.ts
@@ -146,21 +146,28 @@ export async function updateInterfacePermissions({
     };
 
     // Helper to extract value from boolean or object config
-    const getConfigUse = (
-      config: boolean | { use?: boolean; share?: boolean; public?: boolean } | undefined,
-    ) => (typeof config === 'boolean' ? config : config?.use);
-    const getConfigShare = (
-      config: boolean | { use?: boolean; share?: boolean; public?: boolean } | undefined,
-    ) => (typeof config === 'boolean' ? undefined : config?.share);
-    const getConfigPublic = (
-      config: boolean | { use?: boolean; share?: boolean; public?: boolean } | undefined,
-    ) => (typeof config === 'boolean' ? undefined : config?.public);
+    type PermissionConfig =
+      | boolean
+      | { use?: boolean; create?: boolean; share?: boolean; public?: boolean }
+      | undefined;
+    const getConfigUse = (config: PermissionConfig) =>
+      typeof config === 'boolean' ? config : config?.use;
+    const getConfigCreate = (config: PermissionConfig) =>
+      typeof config === 'boolean' ? undefined : config?.create;
+    const getConfigShare = (config: PermissionConfig) =>
+      typeof config === 'boolean' ? undefined : config?.share;
+    const getConfigPublic = (config: PermissionConfig) =>
+      typeof config === 'boolean' ? undefined : config?.public;
 
-    // Get default use values (for backward compat when config is boolean)
+    // Get default values (for backward compat when config is boolean)
     const promptsDefaultUse =
       typeof defaults.prompts === 'boolean' ? defaults.prompts : defaults.prompts?.use;
     const agentsDefaultUse =
       typeof defaults.agents === 'boolean' ? defaults.agents : defaults.agents?.use;
+    const promptsDefaultCreate =
+      typeof defaults.prompts === 'object' ? defaults.prompts?.create : undefined;
+    const agentsDefaultCreate =
+      typeof defaults.agents === 'object' ? defaults.agents?.create : undefined;
     const promptsDefaultShare =
       typeof defaults.prompts === 'object' ? defaults.prompts?.share : undefined;
     const agentsDefaultShare =
@@ -178,9 +185,9 @@ export async function updateInterfacePermissions({
           promptsDefaultUse,
         ),
         [Permissions.CREATE]: getPermissionValue(
-          undefined,
+          getConfigCreate(loadedInterface.prompts),
           defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.CREATE],
-          true,
+          promptsDefaultCreate ?? true,
         ),
         ...(typeof interfaceConfig?.prompts === 'object' ||
         !existingPermissions?.[PermissionTypes.PROMPTS]
@@ -248,9 +255,9 @@ export async function updateInterfacePermissions({
           agentsDefaultUse,
         ),
         [Permissions.CREATE]: getPermissionValue(
-          undefined,
+          getConfigCreate(loadedInterface.agents),
           defaultPerms[PermissionTypes.AGENTS]?.[Permissions.CREATE],
-          true,
+          agentsDefaultCreate ?? true,
         ),
         ...(typeof interfaceConfig?.agents === 'object' ||
         !existingPermissions?.[PermissionTypes.AGENTS]

--- a/packages/api/src/app/permissions.ts
+++ b/packages/api/src/app/permissions.ts
@@ -184,11 +184,16 @@ export async function updateInterfacePermissions({
           defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.USE],
           promptsDefaultUse,
         ),
-        [Permissions.CREATE]: getPermissionValue(
-          getConfigCreate(loadedInterface.prompts),
-          defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.CREATE],
-          promptsDefaultCreate ?? true,
-        ),
+        ...((typeof interfaceConfig?.prompts === 'object' && 'create' in interfaceConfig.prompts) ||
+        !existingPermissions?.[PermissionTypes.PROMPTS]
+          ? {
+              [Permissions.CREATE]: getPermissionValue(
+                getConfigCreate(loadedInterface.prompts),
+                defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.CREATE],
+                promptsDefaultCreate ?? true,
+              ),
+            }
+          : {}),
         ...((typeof interfaceConfig?.prompts === 'object' &&
           ('share' in interfaceConfig.prompts || 'public' in interfaceConfig.prompts)) ||
         !existingPermissions?.[PermissionTypes.PROMPTS]
@@ -255,11 +260,16 @@ export async function updateInterfacePermissions({
           defaultPerms[PermissionTypes.AGENTS]?.[Permissions.USE],
           agentsDefaultUse,
         ),
-        [Permissions.CREATE]: getPermissionValue(
-          getConfigCreate(loadedInterface.agents),
-          defaultPerms[PermissionTypes.AGENTS]?.[Permissions.CREATE],
-          agentsDefaultCreate ?? true,
-        ),
+        ...((typeof interfaceConfig?.agents === 'object' && 'create' in interfaceConfig.agents) ||
+        !existingPermissions?.[PermissionTypes.AGENTS]
+          ? {
+              [Permissions.CREATE]: getPermissionValue(
+                getConfigCreate(loadedInterface.agents),
+                defaultPerms[PermissionTypes.AGENTS]?.[Permissions.CREATE],
+                agentsDefaultCreate ?? true,
+              ),
+            }
+          : {}),
         ...((typeof interfaceConfig?.agents === 'object' &&
           ('share' in interfaceConfig.agents || 'public' in interfaceConfig.agents)) ||
         !existingPermissions?.[PermissionTypes.AGENTS]

--- a/packages/api/src/app/permissions.ts
+++ b/packages/api/src/app/permissions.ts
@@ -182,16 +182,21 @@ export async function updateInterfacePermissions({
           defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.CREATE],
           true,
         ),
-        [Permissions.SHARE]: getPermissionValue(
-          getConfigShare(loadedInterface.prompts),
-          defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.SHARE],
-          promptsDefaultShare,
-        ),
-        [Permissions.SHARE_PUBLIC]: getPermissionValue(
-          getConfigPublic(loadedInterface.prompts),
-          defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.SHARE_PUBLIC],
-          promptsDefaultPublic,
-        ),
+        ...(typeof interfaceConfig?.prompts === 'object' ||
+        !existingPermissions?.[PermissionTypes.PROMPTS]
+          ? {
+              [Permissions.SHARE]: getPermissionValue(
+                getConfigShare(loadedInterface.prompts),
+                defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.SHARE],
+                promptsDefaultShare,
+              ),
+              [Permissions.SHARE_PUBLIC]: getPermissionValue(
+                getConfigPublic(loadedInterface.prompts),
+                defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.SHARE_PUBLIC],
+                promptsDefaultPublic,
+              ),
+            }
+          : {}),
       },
       [PermissionTypes.BOOKMARKS]: {
         [Permissions.USE]: getPermissionValue(
@@ -247,16 +252,21 @@ export async function updateInterfacePermissions({
           defaultPerms[PermissionTypes.AGENTS]?.[Permissions.CREATE],
           true,
         ),
-        [Permissions.SHARE]: getPermissionValue(
-          getConfigShare(loadedInterface.agents),
-          defaultPerms[PermissionTypes.AGENTS]?.[Permissions.SHARE],
-          agentsDefaultShare,
-        ),
-        [Permissions.SHARE_PUBLIC]: getPermissionValue(
-          getConfigPublic(loadedInterface.agents),
-          defaultPerms[PermissionTypes.AGENTS]?.[Permissions.SHARE_PUBLIC],
-          agentsDefaultPublic,
-        ),
+        ...(typeof interfaceConfig?.agents === 'object' ||
+        !existingPermissions?.[PermissionTypes.AGENTS]
+          ? {
+              [Permissions.SHARE]: getPermissionValue(
+                getConfigShare(loadedInterface.agents),
+                defaultPerms[PermissionTypes.AGENTS]?.[Permissions.SHARE],
+                agentsDefaultShare,
+              ),
+              [Permissions.SHARE_PUBLIC]: getPermissionValue(
+                getConfigPublic(loadedInterface.agents),
+                defaultPerms[PermissionTypes.AGENTS]?.[Permissions.SHARE_PUBLIC],
+                agentsDefaultPublic,
+              ),
+            }
+          : {}),
       },
       [PermissionTypes.TEMPORARY_CHAT]: {
         [Permissions.USE]: getPermissionValue(
@@ -328,16 +338,22 @@ export async function updateInterfacePermissions({
           defaultPerms[PermissionTypes.MCP_SERVERS]?.[Permissions.CREATE],
           defaults.mcpServers?.create,
         ),
-        [Permissions.SHARE]: getPermissionValue(
-          loadedInterface.mcpServers?.share,
-          defaultPerms[PermissionTypes.MCP_SERVERS]?.[Permissions.SHARE],
-          defaults.mcpServers?.share,
-        ),
-        [Permissions.SHARE_PUBLIC]: getPermissionValue(
-          loadedInterface.mcpServers?.public,
-          defaultPerms[PermissionTypes.MCP_SERVERS]?.[Permissions.SHARE_PUBLIC],
-          defaults.mcpServers?.public,
-        ),
+        ...((typeof interfaceConfig?.mcpServers === 'object' &&
+          ('share' in interfaceConfig.mcpServers || 'public' in interfaceConfig.mcpServers)) ||
+        !existingPermissions?.[PermissionTypes.MCP_SERVERS]
+          ? {
+              [Permissions.SHARE]: getPermissionValue(
+                loadedInterface.mcpServers?.share,
+                defaultPerms[PermissionTypes.MCP_SERVERS]?.[Permissions.SHARE],
+                defaults.mcpServers?.share,
+              ),
+              [Permissions.SHARE_PUBLIC]: getPermissionValue(
+                loadedInterface.mcpServers?.public,
+                defaultPerms[PermissionTypes.MCP_SERVERS]?.[Permissions.SHARE_PUBLIC],
+                defaults.mcpServers?.public,
+              ),
+            }
+          : {}),
       },
       [PermissionTypes.REMOTE_AGENTS]: {
         [Permissions.USE]: getPermissionValue(
@@ -350,16 +366,22 @@ export async function updateInterfacePermissions({
           defaultPerms[PermissionTypes.REMOTE_AGENTS]?.[Permissions.CREATE],
           defaults.remoteAgents?.create,
         ),
-        [Permissions.SHARE]: getPermissionValue(
-          loadedInterface.remoteAgents?.share,
-          defaultPerms[PermissionTypes.REMOTE_AGENTS]?.[Permissions.SHARE],
-          defaults.remoteAgents?.share,
-        ),
-        [Permissions.SHARE_PUBLIC]: getPermissionValue(
-          loadedInterface.remoteAgents?.public,
-          defaultPerms[PermissionTypes.REMOTE_AGENTS]?.[Permissions.SHARE_PUBLIC],
-          defaults.remoteAgents?.public,
-        ),
+        ...((typeof interfaceConfig?.remoteAgents === 'object' &&
+          ('share' in interfaceConfig.remoteAgents || 'public' in interfaceConfig.remoteAgents)) ||
+        !existingPermissions?.[PermissionTypes.REMOTE_AGENTS]
+          ? {
+              [Permissions.SHARE]: getPermissionValue(
+                loadedInterface.remoteAgents?.share,
+                defaultPerms[PermissionTypes.REMOTE_AGENTS]?.[Permissions.SHARE],
+                defaults.remoteAgents?.share,
+              ),
+              [Permissions.SHARE_PUBLIC]: getPermissionValue(
+                loadedInterface.remoteAgents?.public,
+                defaultPerms[PermissionTypes.REMOTE_AGENTS]?.[Permissions.SHARE_PUBLIC],
+                defaults.remoteAgents?.public,
+              ),
+            }
+          : {}),
       },
     };
 

--- a/packages/api/src/app/permissions.ts
+++ b/packages/api/src/app/permissions.ts
@@ -189,7 +189,8 @@ export async function updateInterfacePermissions({
           defaultPerms[PermissionTypes.PROMPTS]?.[Permissions.CREATE],
           promptsDefaultCreate ?? true,
         ),
-        ...(typeof interfaceConfig?.prompts === 'object' ||
+        ...((typeof interfaceConfig?.prompts === 'object' &&
+          ('share' in interfaceConfig.prompts || 'public' in interfaceConfig.prompts)) ||
         !existingPermissions?.[PermissionTypes.PROMPTS]
           ? {
               [Permissions.SHARE]: getPermissionValue(
@@ -259,7 +260,8 @@ export async function updateInterfacePermissions({
           defaultPerms[PermissionTypes.AGENTS]?.[Permissions.CREATE],
           agentsDefaultCreate ?? true,
         ),
-        ...(typeof interfaceConfig?.agents === 'object' ||
+        ...((typeof interfaceConfig?.agents === 'object' &&
+          ('share' in interfaceConfig.agents || 'public' in interfaceConfig.agents)) ||
         !existingPermissions?.[PermissionTypes.AGENTS]
           ? {
               [Permissions.SHARE]: getPermissionValue(

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -628,6 +628,7 @@ export const interfaceSchema = z
         z.boolean(),
         z.object({
           use: z.boolean().optional(),
+          create: z.boolean().optional(),
           share: z.boolean().optional(),
           public: z.boolean().optional(),
         }),
@@ -638,6 +639,7 @@ export const interfaceSchema = z
         z.boolean(),
         z.object({
           use: z.boolean().optional(),
+          create: z.boolean().optional(),
           share: z.boolean().optional(),
           public: z.boolean().optional(),
         }),
@@ -681,11 +683,13 @@ export const interfaceSchema = z
     memories: true,
     prompts: {
       use: true,
+      create: true,
       share: false,
       public: false,
     },
     agents: {
       use: true,
+      create: true,
       share: false,
       public: false,
     },


### PR DESCRIPTION
## Summary

I fixed a critical bug where CREATE, SHARE, and SHARE_PUBLIC permissions were being reset to defaults when using boolean configuration (e.g., `agents: true` or `prompts: true`), overwriting admin panel customizations on application restart.

- Implemented conditional logic to preserve existing CREATE, SHARE, and SHARE_PUBLIC permissions when not explicitly configured in `librechat.yaml`
- Aligned permission handling across all types (prompts, agents, mcpServers, remoteAgents) to ensure consistent granular control
- Added `create` field support to permission configuration schemas, allowing explicit control over CREATE permissions alongside USE
- Refactored helper functions to extract `create`, `share`, and `public` values from both boolean and object configurations
- Ensured boolean configs function as feature toggles (USE only), while object configs provide granular permission control
- Added three comprehensive regression tests validating boolean config preservation, explicit object config updates, and partial object config preservation
- Updated existing test assertions to reflect the new permission handling logic with detailed comments explaining behavior
- Fixed performance issue in ToolService.js by moving `domainSeparatorRegex` creation outside the loop to avoid redundant regex instantiation

The changes ensure that when `agents: true` is configured, only the USE permission is updated, treating it as a feature toggle. CREATE, SHARE, and SHARE_PUBLIC remain untouched in the database, preserving admin panel customizations. When `agents: { create: false, share: true }` is explicitly configured, only the specified permissions are updated, providing granular control over each permission type.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

I verified the fix by writing and running three new regression tests that cover all permission configuration scenarios:

1. **Boolean config with existing permissions**: Validates that `prompts: true` and `agents: true` preserve existing CREATE/SHARE/SHARE_PUBLIC database values, only updating USE
2. **Explicit object config**: Validates that `agents: { use: true, share: true, public: true }` updates SHARE and SHARE_PUBLIC as expected
3. **Partial object config**: Validates that `agents: { use: true, create: false }` updates USE and CREATE while preserving existing SHARE/SHARE_PUBLIC values

All tests pass, confirming that admin panel permission changes are no longer overwritten on restart and that boolean configs function as intended feature toggles.

### **Test Configuration**:
- Tested with mock database containing existing CREATE/SHARE/SHARE_PUBLIC permissions set to `true`
- Tested with boolean config: `interface.agents: true` (only USE updated)
- Tested with full object config: `interface.agents: { use: true, share: true, public: true }` (all specified permissions updated)
- Tested with partial object config: `interface.agents: { use: true, create: false }` (only USE and CREATE updated, SHARE/SHARE_PUBLIC preserved)
- Verified behavior on first-time setup (no existing permissions) defaults to schema values

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes


Relevant updated docs: https://github.com/LibreChat-AI/librechat.ai/pull/497