### PR TITLE
feat: display model name in conversation messages (#3203)

### DIFF
--- a/client/src/components/Chat/Messages/MessageParts.tsx
+++ b/client/src/components/Chat/Messages/MessageParts.tsx
@@ -40,6 +40,7 @@ export default function Message(props: TMessageProps) {
 
   const fontSize = useAtomValue(fontSizeAtom);
   const maximizeChatSpace = useRecoilValue(store.maximizeChatSpace);
+  const ModelNameDisplay = useRecoilValue<boolean>(store.ModelNameDisplay);
   const { children, messageId = null, isCreatedByUser } = message ?? {};
 
   const name = useMemo(() => {
@@ -76,6 +77,17 @@ export default function Message(props: TMessageProps) {
   );
 
   const { hasParallelContent } = useContentMetadata(message);
+
+  const displayModel = useMemo(() => {
+    if (!ModelNameDisplay || isCreatedByUser) {
+      return '';
+    }
+    const resolvedModel = agent?.model ?? assistant?.model ?? message?.model ?? '';
+    if (!resolvedModel || resolvedModel === name) {
+      return '';
+    }
+    return resolvedModel;
+  }, [ModelNameDisplay, isCreatedByUser, message?.model, agent, assistant, name]);
 
   if (!message) {
     return null;
@@ -126,6 +138,11 @@ export default function Message(props: TMessageProps) {
               {!hasParallelContent && (
                 <h2 className={cn('select-none font-semibold text-text-primary', fontSize)}>
                   {name}
+                  {displayModel && (
+                    <span className="ml-2 text-xs font-normal text-text-secondary">
+                      {displayModel}
+                    </span>
+                  )}
                 </h2>
               )}
               <div className="flex flex-col gap-1">

--- a/client/src/components/Chat/Messages/SearchMessage.tsx
+++ b/client/src/components/Chat/Messages/SearchMessage.tsx
@@ -22,11 +22,18 @@ const MessageAvatar = ({ iconData }: { iconData: TMessageIcon }) => (
   </div>
 );
 
-const MessageBody = ({ message, messageLabel, fontSize }) => (
+const MessageBody = ({ message, messageLabel, fontSize, displayModel }) => (
   <div
     className={cn('relative flex w-11/12 flex-col', message.isCreatedByUser ? '' : 'agent-turn')}
   >
-    <div className={cn('select-none font-semibold', fontSize)}>{messageLabel}</div>
+    <div className={cn('select-none font-semibold', fontSize)}>
+      {messageLabel}
+      {displayModel && (
+        <span className="ml-2 text-xs font-normal text-text-secondary">
+          {displayModel}
+        </span>
+      )}
+    </div>
     <SearchContent message={message} />
     <SubRow classes="text-xs">
       <MinimalHoverButtons message={message} />
@@ -38,6 +45,7 @@ const MessageBody = ({ message, messageLabel, fontSize }) => (
 export default function SearchMessage({ message }: Pick<TMessageProps, 'message'>) {
   const fontSize = useAtomValue(fontSizeAtom);
   const UsernameDisplay = useRecoilValue<boolean>(store.UsernameDisplay);
+  const ModelNameDisplay = useRecoilValue<boolean>(store.ModelNameDisplay);
   const { user } = useAuthContext();
   const localize = useLocalize();
 
@@ -71,12 +79,28 @@ export default function SearchMessage({ message }: Pick<TMessageProps, 'message'
     return null;
   }
 
+  const displayModel = useMemo(() => {
+    if (!ModelNameDisplay || message?.isCreatedByUser) {
+      return '';
+    }
+    const model = message?.model ?? '';
+    if (!model || model === messageLabel) {
+      return '';
+    }
+    return model;
+  }, [ModelNameDisplay, message?.isCreatedByUser, message?.model, messageLabel]);
+
   return (
     <div className="text-token-text-primary w-full bg-transparent">
       <div className="m-auto p-4 py-2 md:gap-6">
         <div className="final-completion group mx-auto flex flex-1 gap-3 md:max-w-3xl md:px-5 lg:max-w-[40rem] lg:px-1 xl:max-w-[48rem] xl:px-5">
           <MessageAvatar iconData={iconData} />
-          <MessageBody message={message} messageLabel={messageLabel} fontSize={fontSize} />
+          <MessageBody
+            message={message}
+            messageLabel={messageLabel}
+            fontSize={fontSize}
+            displayModel={displayModel}
+          />
         </div>
       </div>
     </div>

--- a/client/src/components/Chat/Messages/ui/MessageRender.tsx
+++ b/client/src/components/Chat/Messages/ui/MessageRender.tsx
@@ -55,6 +55,7 @@ const MessageRender = memo(
     });
     const fontSize = useAtomValue(fontSizeAtom);
     const maximizeChatSpace = useRecoilValue(store.maximizeChatSpace);
+    const ModelNameDisplay = useRecoilValue<boolean>(store.ModelNameDisplay);
 
     const handleRegenerateMessage = useCallback(() => regenerateMessage(), [regenerateMessage]);
     const hasNoChildren = !(msg?.children?.length ?? 0);
@@ -86,6 +87,17 @@ const MessageRender = memo(
     );
 
     const { hasParallelContent } = useContentMetadata(msg);
+
+    const displayModel = useMemo(() => {
+      if (!ModelNameDisplay || msg?.isCreatedByUser) {
+        return '';
+      }
+      const resolvedModel = agent?.model ?? assistant?.model ?? msg?.model ?? '';
+      if (!resolvedModel || resolvedModel === messageLabel) {
+        return '';
+      }
+      return resolvedModel;
+    }, [ModelNameDisplay, msg?.isCreatedByUser, msg?.model, agent, assistant, messageLabel]);
 
     if (!msg) {
       return null;
@@ -137,7 +149,14 @@ const MessageRender = memo(
           )}
         >
           {!hasParallelContent && (
-            <h2 className={cn('select-none font-semibold', fontSize)}>{messageLabel}</h2>
+            <h2 className={cn('select-none font-semibold', fontSize)}>
+              {messageLabel}
+              {displayModel && (
+                <span className="ml-2 text-xs font-normal text-text-secondary">
+                  {displayModel}
+                </span>
+              )}
+            </h2>
           )}
 
           <div className="flex flex-col gap-1">

--- a/client/src/components/Messages/ContentRender.tsx
+++ b/client/src/components/Messages/ContentRender.tsx
@@ -58,6 +58,7 @@ const ContentRender = memo(
     });
     const fontSize = useAtomValue(fontSizeAtom);
     const maximizeChatSpace = useRecoilValue(store.maximizeChatSpace);
+    const ModelNameDisplay = useRecoilValue<boolean>(store.ModelNameDisplay);
 
     const handleRegenerateMessage = useCallback(() => regenerateMessage(), [regenerateMessage]);
     const isLast = useMemo(
@@ -90,6 +91,17 @@ const ContentRender = memo(
     );
 
     const { hasParallelContent } = useContentMetadata(msg);
+
+    const displayModel = useMemo(() => {
+      if (!ModelNameDisplay || msg?.isCreatedByUser) {
+        return '';
+      }
+      const resolvedModel = agent?.model ?? assistant?.model ?? msg?.model ?? '';
+      if (!resolvedModel || resolvedModel === messageLabel) {
+        return '';
+      }
+      return resolvedModel;
+    }, [ModelNameDisplay, msg?.isCreatedByUser, msg?.model, agent, assistant, messageLabel]);
 
     if (!msg) {
       return null;
@@ -141,7 +153,14 @@ const ContentRender = memo(
           )}
         >
           {!hasParallelContent && (
-            <h2 className={cn('select-none font-semibold', fontSize)}>{messageLabel}</h2>
+            <h2 className={cn('select-none font-semibold', fontSize)}>
+              {messageLabel}
+              {displayModel && (
+                <span className="ml-2 text-xs font-normal text-text-secondary">
+                  {displayModel}
+                </span>
+              )}
+            </h2>
           )}
 
           <div className="flex flex-col gap-1">

--- a/client/src/components/Nav/SettingsTabs/Account/Account.tsx
+++ b/client/src/components/Nav/SettingsTabs/Account/Account.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import DisplayUsernameMessages from './DisplayUsernameMessages';
+import DisplayModelName from './DisplayModelName';
 import DeleteAccount from './DeleteAccount';
 import Avatar from './Avatar';
 import EnableTwoFactorItem from './TwoFactorAuthentication';
@@ -13,6 +14,9 @@ function Account() {
     <div className="flex flex-col gap-3 p-1 text-sm text-text-primary">
       <div className="pb-3">
         <DisplayUsernameMessages />
+      </div>
+      <div className="pb-3">
+        <DisplayModelName />
       </div>
       <div className="pb-3">
         <Avatar />

--- a/client/src/components/Nav/SettingsTabs/Account/DisplayModelName.tsx
+++ b/client/src/components/Nav/SettingsTabs/Account/DisplayModelName.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useRecoilState } from 'recoil';
+import { Switch, Label, InfoHoverCard, ESide } from '@librechat/client';
+import { useLocalize } from '~/hooks';
+import store from '~/store';
+
+export default function DisplayModelName() {
+  const localize = useLocalize();
+  const [ModelNameDisplay, setModelNameDisplay] = useRecoilState(store.ModelNameDisplay);
+
+  const handleCheckedChange = (checked: boolean) => {
+    setModelNameDisplay(checked);
+  };
+
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center space-x-2">
+        <Label id="model-name-display-label">{localize('com_nav_model_name_display')}</Label>
+        <InfoHoverCard side={ESide.Bottom} text={localize('com_nav_info_model_name_display')} />
+      </div>
+      <Switch
+        id="ModelNameDisplay"
+        checked={ModelNameDisplay}
+        onCheckedChange={handleCheckedChange}
+        className="ml-4"
+        data-testid="ModelNameDisplay"
+        aria-labelledby="model-name-display-label"
+      />
+    </div>
+  );
+}

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -598,6 +598,8 @@
   "com_nav_user": "USER",
   "com_nav_user_msg_markdown": "Render user messages as markdown",
   "com_nav_user_name_display": "Display username in messages",
+  "com_nav_model_name_display": "Display model name in messages",
+  "com_nav_info_model_name_display": "When enabled, the model name will be shown to the right of the sender label for AI messages, helping you identify which model generated each response.",
   "com_nav_voice_select": "Voice",
   "com_show_examples": "Show Examples",
   "com_sidepanel_agent_builder": "Agent Builder",

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -70,6 +70,7 @@ const localStorageAtoms = {
 
   // Account settings
   UsernameDisplay: atomWithLocalStorage('UsernameDisplay', true),
+  ModelNameDisplay: atomWithLocalStorage('ModelNameDisplay', false),
 };
 
 export default { ...staticAtoms, ...localStorageAtoms };


### PR DESCRIPTION
## Summary

Resolves #3203

Adds an optional toggle in **Settings → Account** to display the verbatim model name (e.g. `gpt-4o-mini-2024-07-18`, `gemini-2.5-flash-lite`) to the right of the sender label in AI messages. This helps users identify which specific model generated each response, especially useful in multi-model conversations or when using providers like OpenRouter where the sender label (e.g. "GPT-4o") doesn't distinguish between model variants.

The setting is **off by default** and persisted in localStorage. For agents/assistants, the actual underlying model is resolved from agent/assistant data rather than displaying the agent_id/assistant_id.

**Files changed (8):**
- translation.json — 2 new translation keys
- settings.ts — `ModelNameDisplay` atom
- DisplayModelName.tsx — New toggle component
- Account.tsx — Import & render toggle
- MessageRender.tsx — Show model name
- MessageParts.tsx — Show model name
- ContentRender.tsx — Show model name (main rendering path)
- SearchMessage.tsx — Show model name in search

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

1. Build and start LibreChat
2. Go to **Settings → Account**
3. Enable **"Display model name in messages"**
4. Send messages using different models/endpoints
5. Verify the model name appears to the right of the sender label for AI messages
6. Verify user messages are unaffected
7. Verify the setting persists after page reload
8. Test with agents (should show the agent's underlying model, not agent_id)
9. Toggle off and verify model names disappear

### **Test Configuration**:
- LibreChat v0.8.2, Docker deployment
- Tested with: OpenAI-compatible endpoint (`gpt-4o-mini-2024-07-18`), Google (`gemini-2.5-flash-lite`)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes