### PR TITLE
feat: add individual message deletion (#2673)

### DIFF
--- a/client/src/components/Chat/Messages/HoverButtons.tsx
+++ b/client/src/components/Chat/Messages/HoverButtons.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, memo } from 'react';
 import { useRecoilState } from 'recoil';
+import { Trash2 } from 'lucide-react';
 import type { TConversation, TMessage, TFeedback } from 'librechat-data-provider';
 import { EditIcon, Clipboard, CheckMark, ContinueIcon, RegenerateIcon } from '@librechat/client';
 import { useGenerationsByLatest, useLocalize } from '~/hooks';
@@ -22,6 +23,7 @@ type THoverButtons = {
   isLast: boolean;
   index: number;
   handleFeedback?: ({ feedback }: { feedback: TFeedback | undefined }) => void;
+  onDelete?: () => void;
 };
 
 type HoverButtonProps = {
@@ -122,6 +124,7 @@ const HoverButtons = ({
   latestMessage,
   isLast,
   handleFeedback,
+  onDelete,
 }: THoverButtons) => {
   const localize = useLocalize();
   const [isCopied, setIsCopied] = useState(false);
@@ -246,6 +249,16 @@ const HoverButtons = ({
       {/* Feedback Buttons */}
       {!isCreatedByUser && handleFeedback != null && (
         <Feedback handleFeedback={handleFeedback} feedback={message.feedback} isLast={isLast} />
+      )}
+
+      {/* Delete Button */}
+      {onDelete != null && (
+        <HoverButton
+          onClick={onDelete}
+          title={localize('com_ui_delete')}
+          icon={<Trash2 className="h-[18px] w-[18px]" />}
+          isLast={isLast}
+        />
       )}
 
       {/* Regenerate Button */}

--- a/client/src/components/Chat/Messages/MessageParts.tsx
+++ b/client/src/components/Chat/Messages/MessageParts.tsx
@@ -33,6 +33,7 @@ export default function Message(props: TMessageProps) {
     conversation,
     isSubmitting,
     latestMessage,
+    handleDelete,
     handleContinue,
     copyToClipboard,
     regenerateMessage,
@@ -167,6 +168,7 @@ export default function Message(props: TMessageProps) {
                       handleContinue={handleContinue}
                       latestMessage={latestMessage}
                       isLast={isLast}
+                      onDelete={handleDelete}
                     />
                   </SubRow>
                 )}

--- a/client/src/components/Chat/Messages/ui/MessageRender.tsx
+++ b/client/src/components/Chat/Messages/ui/MessageRender.tsx
@@ -44,6 +44,7 @@ const MessageRender = memo(
       conversation,
       messageLabel,
       latestMessage,
+      handleDelete,
       handleFeedback,
       handleContinue,
       copyToClipboard,
@@ -189,6 +190,7 @@ const MessageRender = memo(
                   latestMessage={latestMessage}
                   handleFeedback={handleFeedback}
                   isLast={isLast}
+                  onDelete={handleDelete}
                 />
               </SubRow>
             )}

--- a/client/src/components/Messages/ContentRender.tsx
+++ b/client/src/components/Messages/ContentRender.tsx
@@ -46,6 +46,7 @@ const ContentRender = memo(
       conversation,
       messageLabel,
       latestMessage,
+      handleDelete,
       handleContinue,
       handleFeedback,
       copyToClipboard,
@@ -184,6 +185,7 @@ const ContentRender = memo(
                   latestMessage={latestMessage}
                   handleFeedback={handleFeedback}
                   isLast={isLast}
+                  onDelete={handleDelete}
                 />
               </SubRow>
             )}

--- a/client/src/hooks/Messages/useMessageActions.tsx
+++ b/client/src/hooks/Messages/useMessageActions.tsx
@@ -12,6 +12,7 @@ import {
 } from 'librechat-data-provider';
 import type { TMessageProps } from '~/common';
 import { useChatContext, useAssistantsMapContext, useAgentsMapContext } from '~/Providers';
+import { useDeleteMessageMutation } from '~/data-provider/Messages/mutations';
 import useCopyToClipboard from './useCopyToClipboard';
 import { useAuthContext } from '~/hooks/AuthContext';
 import { useGetAddedConvo } from '~/hooks/Chat';
@@ -100,6 +101,16 @@ export default function useMessageActions(props: TMessageActions) {
 
   const copyToClipboard = useCopyToClipboard({ text, content, searchResults });
 
+  const deleteMutation = useDeleteMessageMutation(conversation?.conversationId ?? null);
+
+  const handleDelete = useCallback(() => {
+    const conversationId = conversation?.conversationId;
+    if (!messageId || !conversationId) {
+      return;
+    }
+    deleteMutation.mutate({ conversationId, messageId: messageId as string });
+  }, [conversation?.conversationId, messageId, deleteMutation]);
+
   const messageLabel = useMemo(() => {
     if (message?.isCreatedByUser === true) {
       return UsernameDisplay ? (user?.name ?? '') || user?.username : localize('com_user_message');
@@ -155,6 +166,7 @@ export default function useMessageActions(props: TMessageActions) {
     conversation,
     messageLabel,
     latestMessage,
+    handleDelete,
     handleFeedback,
     handleContinue,
     copyToClipboard,

--- a/client/src/hooks/Messages/useMessageHelpers.tsx
+++ b/client/src/hooks/Messages/useMessageHelpers.tsx
@@ -3,6 +3,7 @@ import throttle from 'lodash/throttle';
 import { Constants, isAssistantsEndpoint, isAgentsEndpoint } from 'librechat-data-provider';
 import type { TMessageProps } from '~/common';
 import { useMessagesViewContext, useAssistantsMapContext, useAgentsMapContext } from '~/Providers';
+import { useDeleteMessageMutation } from '~/data-provider/Messages/mutations';
 import { getTextKey, TEXT_KEY_DIVIDER, logger } from '~/utils';
 import useCopyToClipboard from './useCopyToClipboard';
 import { useGetAddedConvo } from '~/hooks/Chat';
@@ -130,6 +131,16 @@ export default function useMessageHelpers(props: TMessageProps) {
 
   const copyToClipboard = useCopyToClipboard({ text, content });
 
+  const deleteMutation = useDeleteMessageMutation(conversation?.conversationId ?? null);
+
+  const handleDelete = useCallback(() => {
+    const conversationId = conversation?.conversationId;
+    if (!messageId || !conversationId) {
+      return;
+    }
+    deleteMutation.mutate({ conversationId, messageId: messageId as string });
+  }, [conversation?.conversationId, messageId, deleteMutation]);
+
   return {
     ask,
     edit,
@@ -141,6 +152,7 @@ export default function useMessageHelpers(props: TMessageProps) {
     conversation,
     isSubmitting,
     handleScroll,
+    handleDelete,
     latestMessage,
     handleContinue,
     copyToClipboard,

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -776,6 +776,14 @@ export const branchMessage = async (
   return request.post(endpoints.messagesBranch(), payload);
 };
 
+export function deleteMessage(payload: {
+  conversationId: string;
+  messageId: string;
+}): Promise<{ deletedMessageIds: string[] }> {
+  const { conversationId, messageId } = payload;
+  return request.delete(endpoints.messages({ conversationId, messageId }));
+}
+
 export function getMessagesByConvoId(conversationId: string): Promise<s.TMessage[]> {
   if (
     conversationId === config.Constants.NEW_CONVO ||


### PR DESCRIPTION
## Summary

Resolves #2673

Adds the ability to delete individual messages from a conversation. A trash icon button appears in the message hover actions bar. Deleting a message cascade-deletes all its descendant messages (children, grandchildren, etc.) to keep the conversation tree consistent.

**Files changed (9):**
- **Backend:** messages.js — Enhanced the existing `DELETE /:conversationId/:messageId` route to traverse the message tree via `parentMessageId` and cascade-delete all descendants; now returns `{ deletedMessageIds }` for precise client cache updates
- **Data Provider:** data-service.ts — Added `deleteMessage()` function
- **Client Mutation:** mutations.ts — Added `useDeleteMessageMutation` hook with optimistic cache filtering and rollback on error
- **Client Hooks:** useMessageActions.tsx, useMessageHelpers.tsx — Added `handleDelete` callback wiring the mutation
- **Client UI:** HoverButtons.tsx — Added `onDelete` prop and Trash2 icon button between Feedback and Regenerate
- **Client Wiring:** MessageRender.tsx, ContentRender.tsx, MessageParts.tsx — Pass `onDelete` to `HoverButtons`

No new dependencies were added.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

1. Start the app and open any conversation with messages
2. Hover over any message (user or assistant) — a trash icon (🗑) should appear in the hover action buttons row
3. Click the trash icon — the message and all its replies below it should be removed immediately from the UI
4. Refresh the page — deleted messages remain gone (persisted in DB)
5. Test on a branched conversation — delete a mid-tree message and verify descendants are removed while sibling branches remain intact
6. Test error case — if the API fails, the messages should reappear (optimistic rollback)

### **Test Configuration**:

- LibreChat running via `docker compose up`
- Tested with OpenAI and Agents endpoints
- Node.js 20.x

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes