### PR TITLE
🆔 fix: Atomic File Dedupe, Bedrock Tokens Fix, and Allowed MIME Types

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.37",
+    "@librechat/agents": "^3.1.38",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -18,9 +18,9 @@ const {
   getEndpointFileConfig,
 } = require('librechat-data-provider');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
+const { createFile, getFiles, updateFile, claimCodeFile } = require('~/models');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
-const { createFile, getFiles, updateFile } = require('~/models');
 const { determineFileType } = require('~/server/utils');
 
 /**
@@ -54,50 +54,6 @@ const createDownloadFallback = ({
     toolCallId,
     messageId,
   };
-};
-
-/**
- * Find an existing code-generated file by filename in the conversation.
- * Used to update existing files instead of creating duplicates.
- *
- * ## Deduplication Strategy
- *
- * Files are deduplicated by `(conversationId, filename)` - NOT including `messageId`.
- * This is an intentional design decision to handle iterative code development patterns:
- *
- * **Rationale:**
- * - When users iteratively refine code (e.g., "regenerate that chart with red bars"),
- *   the same logical file (e.g., "chart.png") is produced multiple times
- * - Without deduplication, each iteration would create a new file, leading to storage bloat
- * - The latest version is what matters for re-upload to the code environment
- *
- * **Implications:**
- * - Different messages producing files with the same name will update the same file record
- * - The `messageId` field tracks which message last updated the file
- * - The `usage` counter tracks how many times the file has been generated
- *
- * **Future Considerations:**
- * - If file versioning is needed, consider adding a `versions` array or separate version collection
- * - The current approach prioritizes storage efficiency over history preservation
- *
- * @param {string} filename - The filename to search for.
- * @param {string} conversationId - The conversation ID.
- * @returns {Promise<MongoFile | null>} The existing file or null.
- */
-const findExistingCodeFile = async (filename, conversationId) => {
-  if (!filename || !conversationId) {
-    return null;
-  }
-  const files = await getFiles(
-    {
-      filename,
-      conversationId,
-      context: FileContext.execute_code,
-    },
-    { createdAt: -1 },
-    { text: 0 },
-  );
-  return files?.[0] ?? null;
 };
 
 /**
@@ -170,12 +126,18 @@ const processCodeOutput = async ({
     const fileIdentifier = `${session_id}/${id}`;
 
     /**
-     * Check for existing file with same filename in this conversation.
-     * If found, we'll update it instead of creating a duplicate.
+     * Atomically claim a file_id for this (filename, conversationId, context) tuple.
+     * Uses $setOnInsert so concurrent calls for the same filename converge on
+     * a single record instead of creating duplicates (TOCTOU race fix).
      */
-    const existingFile = await findExistingCodeFile(name, conversationId);
-    const file_id = existingFile?.file_id ?? v4();
-    const isUpdate = !!existingFile;
+    const claimed = await claimCodeFile({
+      filename: name,
+      conversationId,
+      file_id: v4(),
+      user: req.user.id,
+    });
+    const file_id = claimed.file_id;
+    const isUpdate = claimed.usage != null && claimed.usage > 0;
 
     if (isUpdate) {
       logger.debug(
@@ -184,27 +146,28 @@ const processCodeOutput = async ({
     }
 
     if (isImage) {
-      const _file = await convertImage(req, buffer, 'high', `${file_id}${fileExt}`);
+      const usage = isUpdate ? (claimed.usage ?? 0) + 1 : 1;
+      const versionSuffix = usage > 1 ? `_v${usage}` : '';
+      const _file = await convertImage(req, buffer, 'high', `${file_id}${versionSuffix}${fileExt}`);
       const file = {
         ..._file,
         file_id,
         messageId,
-        usage: isUpdate ? (existingFile.usage ?? 0) + 1 : 1,
+        usage,
         filename: name,
         conversationId,
         user: req.user.id,
         type: `image/${appConfig.imageOutputType}`,
-        createdAt: isUpdate ? existingFile.createdAt : formattedDate,
+        createdAt: isUpdate ? claimed.createdAt : formattedDate,
         updatedAt: formattedDate,
         source: appConfig.fileStrategy,
         context: FileContext.execute_code,
         metadata: { fileIdentifier },
       };
-      createFile(file, true);
+      await createFile(file, true);
       return Object.assign(file, { messageId, toolCallId });
     }
 
-    // For non-image files, save to configured storage strategy
     const { saveBuffer } = getStrategyFunctions(appConfig.fileStrategy);
     if (!saveBuffer) {
       logger.warn(
@@ -221,7 +184,6 @@ const processCodeOutput = async ({
       });
     }
 
-    // Determine MIME type from buffer or extension
     const detectedType = await determineFileType(buffer, true);
     const mimeType = detectedType?.mime || inferMimeType(name, '') || 'application/octet-stream';
 
@@ -258,11 +220,11 @@ const processCodeOutput = async ({
       metadata: { fileIdentifier },
       source: appConfig.fileStrategy,
       context: FileContext.execute_code,
-      usage: isUpdate ? (existingFile.usage ?? 0) + 1 : 1,
-      createdAt: isUpdate ? existingFile.createdAt : formattedDate,
+      usage: isUpdate ? (claimed.usage ?? 0) + 1 : 1,
+      createdAt: isUpdate ? claimed.createdAt : formattedDate,
     };
 
-    createFile(file, true);
+    await createFile(file, true);
     return Object.assign(file, { messageId, toolCallId });
   } catch (error) {
     logAxiosError({

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -147,10 +147,11 @@ const processCodeOutput = async ({
 
     if (isImage) {
       const usage = isUpdate ? (claimed.usage ?? 0) + 1 : 1;
-      const versionSuffix = usage > 1 ? `_v${usage}` : '';
-      const _file = await convertImage(req, buffer, 'high', `${file_id}${versionSuffix}${fileExt}`);
+      const _file = await convertImage(req, buffer, 'high', `${file_id}${fileExt}`);
+      const filepath = usage > 1 ? `${_file.filepath}?v=${Date.now()}` : _file.filepath;
       const file = {
         ..._file,
+        filepath,
         file_id,
         messageId,
         usage,

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -130,14 +130,15 @@ const processCodeOutput = async ({
      * Uses $setOnInsert so concurrent calls for the same filename converge on
      * a single record instead of creating duplicates (TOCTOU race fix).
      */
+    const newFileId = v4();
     const claimed = await claimCodeFile({
       filename: name,
       conversationId,
-      file_id: v4(),
+      file_id: newFileId,
       user: req.user.id,
     });
     const file_id = claimed.file_id;
-    const isUpdate = claimed.usage != null && claimed.usage > 0;
+    const isUpdate = file_id !== newFileId;
 
     if (isUpdate) {
       logger.debug(

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -202,7 +202,7 @@ describe('Code Process', () => {
         expect(result.filename).toBe('chart.png');
       });
 
-      it('should update existing image file with versioned filename', async () => {
+      it('should update existing image file with cache-busted filepath', async () => {
         const imageParams = { ...baseParams, name: 'chart.png' };
         mockClaimCodeFile.mockResolvedValue({
           file_id: 'existing-img-id',
@@ -212,7 +212,7 @@ describe('Code Process', () => {
 
         const imageBuffer = Buffer.alloc(500);
         axios.mockResolvedValue({ data: imageBuffer });
-        convertImage.mockResolvedValue({ filepath: '/uploads/img_v2.webp' });
+        convertImage.mockResolvedValue({ filepath: '/images/user-123/existing-img-id.webp' });
 
         const result = await processCodeOutput(imageParams);
 
@@ -220,10 +220,11 @@ describe('Code Process', () => {
           mockReq,
           imageBuffer,
           'high',
-          'existing-img-id_v2.png',
+          'existing-img-id.png',
         );
         expect(result.file_id).toBe('existing-img-id');
         expect(result.usage).toBe(2);
+        expect(result.filepath).toMatch(/^\/images\/user-123\/existing-img-id\.webp\?v=\d+$/);
         expect(logger.debug).toHaveBeenCalledWith(
           expect.stringContaining('Updating existing file'),
         );

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -61,10 +61,12 @@ jest.mock('@librechat/api', () => ({
 }));
 
 // Mock models
+const mockClaimCodeFile = jest.fn();
 jest.mock('~/models', () => ({
-  createFile: jest.fn(),
+  createFile: jest.fn().mockResolvedValue({}),
   getFiles: jest.fn(),
   updateFile: jest.fn(),
+  claimCodeFile: (...args) => mockClaimCodeFile(...args),
 }));
 
 // Mock permissions (must be before process.js import)
@@ -119,7 +121,11 @@ describe('Code Process', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Default mock implementations
+    // Default mock: atomic claim returns a new file record (no existing file)
+    mockClaimCodeFile.mockResolvedValue({
+      file_id: 'mock-uuid-1234',
+      user: 'user-123',
+    });
     getFiles.mockResolvedValue(null);
     createFile.mockResolvedValue({});
     getStrategyFunctions.mockReturnValue({
@@ -128,66 +134,45 @@ describe('Code Process', () => {
     determineFileType.mockResolvedValue({ mime: 'text/plain' });
   });
 
-  describe('findExistingCodeFile (via processCodeOutput)', () => {
-    it('should find existing file by filename and conversationId', async () => {
-      const existingFile = {
+  describe('atomic file claim (via processCodeOutput)', () => {
+    it('should reuse file_id from existing record via atomic claim', async () => {
+      mockClaimCodeFile.mockResolvedValue({
         file_id: 'existing-file-id',
         filename: 'test-file.txt',
         usage: 2,
         createdAt: '2024-01-01T00:00:00.000Z',
-      };
-      getFiles.mockResolvedValue([existingFile]);
+      });
 
       const smallBuffer = Buffer.alloc(100);
       axios.mockResolvedValue({ data: smallBuffer });
 
       const result = await processCodeOutput(baseParams);
 
-      // Verify getFiles was called with correct deduplication query
-      expect(getFiles).toHaveBeenCalledWith(
-        {
-          filename: 'test-file.txt',
-          conversationId: 'conv-123',
-          context: FileContext.execute_code,
-        },
-        { createdAt: -1 },
-        { text: 0 },
-      );
+      expect(mockClaimCodeFile).toHaveBeenCalledWith({
+        filename: 'test-file.txt',
+        conversationId: 'conv-123',
+        file_id: 'mock-uuid-1234',
+        user: 'user-123',
+      });
 
-      // Verify the existing file_id was reused
       expect(result.file_id).toBe('existing-file-id');
-      // Verify usage was incremented
       expect(result.usage).toBe(3);
-      // Verify original createdAt was preserved
       expect(result.createdAt).toBe('2024-01-01T00:00:00.000Z');
     });
 
     it('should create new file when no existing file found', async () => {
-      getFiles.mockResolvedValue(null);
+      mockClaimCodeFile.mockResolvedValue({
+        file_id: 'mock-uuid-1234',
+        user: 'user-123',
+      });
 
       const smallBuffer = Buffer.alloc(100);
       axios.mockResolvedValue({ data: smallBuffer });
 
       const result = await processCodeOutput(baseParams);
 
-      // Should use the mocked uuid
       expect(result.file_id).toBe('mock-uuid-1234');
-      // Should have usage of 1 for new file
       expect(result.usage).toBe(1);
-    });
-
-    it('should return null for invalid inputs (empty filename)', async () => {
-      const smallBuffer = Buffer.alloc(100);
-      axios.mockResolvedValue({ data: smallBuffer });
-
-      // The function handles this internally - with empty name
-      // findExistingCodeFile returns null early for empty filename (guard clause)
-      const result = await processCodeOutput({ ...baseParams, name: '' });
-
-      // getFiles should NOT be called due to early return in findExistingCodeFile
-      expect(getFiles).not.toHaveBeenCalled();
-      // A new file_id should be generated since no existing file was found
-      expect(result.file_id).toBe('mock-uuid-1234');
     });
   });
 
@@ -203,7 +188,6 @@ describe('Code Process', () => {
           bytes: 400,
         };
         convertImage.mockResolvedValue(convertedFile);
-        getFiles.mockResolvedValue(null);
 
         const result = await processCodeOutput(imageParams);
 
@@ -218,21 +202,26 @@ describe('Code Process', () => {
         expect(result.filename).toBe('chart.png');
       });
 
-      it('should update existing image file and increment usage', async () => {
+      it('should update existing image file with versioned filename', async () => {
         const imageParams = { ...baseParams, name: 'chart.png' };
-        const existingFile = {
+        mockClaimCodeFile.mockResolvedValue({
           file_id: 'existing-img-id',
           usage: 1,
           createdAt: '2024-01-01T00:00:00.000Z',
-        };
-        getFiles.mockResolvedValue([existingFile]);
+        });
 
         const imageBuffer = Buffer.alloc(500);
         axios.mockResolvedValue({ data: imageBuffer });
-        convertImage.mockResolvedValue({ filepath: '/uploads/img.webp' });
+        convertImage.mockResolvedValue({ filepath: '/uploads/img_v2.webp' });
 
         const result = await processCodeOutput(imageParams);
 
+        expect(convertImage).toHaveBeenCalledWith(
+          mockReq,
+          imageBuffer,
+          'high',
+          'existing-img-id_v2.png',
+        );
         expect(result.file_id).toBe('existing-img-id');
         expect(result.usage).toBe(2);
         expect(logger.debug).toHaveBeenCalledWith(
@@ -335,7 +324,6 @@ describe('Code Process', () => {
 
     describe('usage counter increment', () => {
       it('should set usage to 1 for new files', async () => {
-        getFiles.mockResolvedValue(null);
         const smallBuffer = Buffer.alloc(100);
         axios.mockResolvedValue({ data: smallBuffer });
 
@@ -345,8 +333,11 @@ describe('Code Process', () => {
       });
 
       it('should increment usage for existing files', async () => {
-        const existingFile = { file_id: 'existing-id', usage: 5, createdAt: '2024-01-01' };
-        getFiles.mockResolvedValue([existingFile]);
+        mockClaimCodeFile.mockResolvedValue({
+          file_id: 'existing-id',
+          usage: 5,
+          createdAt: '2024-01-01',
+        });
         const smallBuffer = Buffer.alloc(100);
         axios.mockResolvedValue({ data: smallBuffer });
 
@@ -356,14 +347,15 @@ describe('Code Process', () => {
       });
 
       it('should handle existing file with undefined usage', async () => {
-        const existingFile = { file_id: 'existing-id', createdAt: '2024-01-01' };
-        getFiles.mockResolvedValue([existingFile]);
+        mockClaimCodeFile.mockResolvedValue({
+          file_id: 'existing-id',
+          createdAt: '2024-01-01',
+        });
         const smallBuffer = Buffer.alloc(100);
         axios.mockResolvedValue({ data: smallBuffer });
 
         const result = await processCodeOutput(baseParams);
 
-        // (undefined ?? 0) + 1 = 1
         expect(result.usage).toBe(1);
       });
     });

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -111,7 +111,7 @@ export default function useStepHandler({
     const updatedContent = [...(message.content || [])] as Array<
       Partial<TMessageContentParts> | undefined
     >;
-    if (!updatedContent[index]) {
+    if (!updatedContent[index] && contentType !== ContentTypes.TOOL_CALL) {
       updatedContent[index] = { type: contentPart.type as AllContentTypes };
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.37",
+        "@librechat/agents": "^3.1.38",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11207,9 +11207,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.37",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.37.tgz",
-      "integrity": "sha512-179dSddx8uQcJFLu5LMhZQckIQHoV3kmkJj+py6uewGNlf9gsmG6M8JYi6i65Y4X73u05KRKUtO9U+n3Z85dOw==",
+      "version": "3.1.38",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.38.tgz",
+      "integrity": "sha512-s8WkS2bXkTWsPGKsQKlUFWUVijMAIQvpv4LZLbNj/rZui0R+82vY/CVnkK3jeUueNMo6GS7GG9Fj01FZmhXslw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -42102,7 +42102,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.37",
+        "@librechat/agents": "^3.1.38",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -87,7 +87,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.37",
+    "@librechat/agents": "^3.1.38",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -615,7 +615,7 @@ describe('initializeBedrock', () => {
   });
 
   describe('Opus 4.6 Adaptive Thinking', () => {
-    it('should configure adaptive thinking with default maxTokens for Opus 4.6', async () => {
+    it('should configure adaptive thinking with no default maxTokens for Opus 4.6', async () => {
       const params = createMockParams({
         model_parameters: {
           model: 'anthropic.claude-opus-4-6-v1',
@@ -626,7 +626,7 @@ describe('initializeBedrock', () => {
       const amrf = result.llmConfig.additionalModelRequestFields as Record<string, unknown>;
 
       expect(amrf.thinking).toEqual({ type: 'adaptive' });
-      expect(result.llmConfig.maxTokens).toBe(16000);
+      expect(result.llmConfig.maxTokens).toBeUndefined();
       expect(amrf.anthropic_beta).toEqual(
         expect.arrayContaining(['output-128k-2025-02-19', 'context-1m-2025-08-07']),
       );

--- a/packages/data-provider/specs/bedrock.spec.ts
+++ b/packages/data-provider/specs/bedrock.spec.ts
@@ -455,14 +455,14 @@ describe('bedrockInputParser', () => {
   });
 
   describe('bedrockOutputParser with configureThinking', () => {
-    test('should preserve adaptive thinking config and set default maxTokens', () => {
+    test('should preserve adaptive thinking config without setting default maxTokens', () => {
       const parsed = bedrockInputParser.parse({
         model: 'anthropic.claude-opus-4-6-v1',
       }) as Record<string, unknown>;
       const output = bedrockOutputParser(parsed as Record<string, unknown>);
       const amrf = output.additionalModelRequestFields as Record<string, unknown>;
       expect(amrf.thinking).toEqual({ type: 'adaptive' });
-      expect(output.maxTokens).toBe(16000);
+      expect(output.maxTokens).toBeUndefined();
       expect(output.maxOutputTokens).toBeUndefined();
     });
 
@@ -473,6 +473,16 @@ describe('bedrockInputParser', () => {
       }) as Record<string, unknown>;
       const output = bedrockOutputParser(parsed as Record<string, unknown>);
       expect(output.maxTokens).toBe(32000);
+    });
+
+    test('should use maxOutputTokens as maxTokens for adaptive model when maxTokens is not set', () => {
+      const parsed = bedrockInputParser.parse({
+        model: 'anthropic.claude-opus-4-6-v1',
+        maxOutputTokens: 24000,
+      }) as Record<string, unknown>;
+      const output = bedrockOutputParser(parsed as Record<string, unknown>);
+      expect(output.maxTokens).toBe(24000);
+      expect(output.maxOutputTokens).toBeUndefined();
     });
 
     test('should convert thinking=true to enabled config for non-adaptive models', () => {
@@ -496,14 +506,14 @@ describe('bedrockInputParser', () => {
       expect(amrf.output_config).toEqual({ effort: 'low' });
     });
 
-    test('should use adaptive default maxTokens (16000) over maxOutputTokens for adaptive models', () => {
+    test('should not set maxTokens for adaptive models when neither maxTokens nor maxOutputTokens are provided', () => {
       const parsed = bedrockInputParser.parse({
         model: 'anthropic.claude-opus-4-6-v1',
       }) as Record<string, unknown>;
       parsed.maxOutputTokens = undefined;
       (parsed as Record<string, unknown>).maxTokens = undefined;
       const output = bedrockOutputParser(parsed as Record<string, unknown>);
-      expect(output.maxTokens).toBe(16000);
+      expect(output.maxTokens).toBeUndefined();
     });
 
     test('should use enabled default maxTokens (8192) for non-adaptive thinking models', () => {

--- a/packages/data-provider/src/bedrock.ts
+++ b/packages/data-provider/src/bedrock.ts
@@ -2,7 +2,6 @@ import { z } from 'zod';
 import * as s from './schemas';
 
 const DEFAULT_ENABLED_MAX_TOKENS = 8192;
-const DEFAULT_ADAPTIVE_MAX_TOKENS = 16000;
 const DEFAULT_THINKING_BUDGET = 2000;
 
 type ThinkingConfig = { type: 'enabled'; budget_tokens: number } | { type: 'adaptive' };
@@ -340,8 +339,9 @@ function configureThinking(data: AnthropicInput): AnthropicInput {
     thinking != null &&
     (thinking as { type: string }).type === 'adaptive'
   ) {
-    updatedData.maxTokens =
-      updatedData.maxTokens ?? updatedData.maxOutputTokens ?? DEFAULT_ADAPTIVE_MAX_TOKENS;
+    if (updatedData.maxTokens == null && updatedData.maxOutputTokens != null) {
+      updatedData.maxTokens = updatedData.maxOutputTokens;
+    }
     delete updatedData.maxOutputTokens;
     delete updatedData.additionalModelRequestFields!.thinkingBudget;
   }

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -60,6 +60,7 @@ export const fullMimeTypesList = [
   'application/vnd.coffeescript',
   'application/xml',
   'application/zip',
+  'application/x-parquet',
   'image/svg',
   'image/svg+xml',
   // Video formats
@@ -114,6 +115,7 @@ export const codeInterpreterMimeTypesList = [
   'application/typescript',
   'application/xml',
   'application/zip',
+  'application/x-parquet',
   ...excelFileTypes,
 ];
 
@@ -144,7 +146,7 @@ export const textMimeTypes =
   /^(text\/(x-c|x-csharp|tab-separated-values|x-c\+\+|x-h|x-java|html|markdown|x-php|x-python|x-script\.python|x-ruby|x-tex|plain|css|vtt|javascript|csv|xml))$/;
 
 export const applicationMimeTypes =
-  /^(application\/(epub\+zip|csv|json|pdf|x-tar|x-sh|typescript|sql|yaml|vnd\.coffeescript|vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation|spreadsheetml\.sheet)|xml|zip))$/;
+  /^(application\/(epub\+zip|csv|json|pdf|x-tar|x-sh|typescript|sql|yaml|x-parquet|vnd\.apache\.parquet|vnd\.coffeescript|vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation|spreadsheetml\.sheet)|xml|zip))$/;
 
 export const imageMimeTypes = /^image\/(jpeg|gif|png|webp|heic|heif)$/;
 
@@ -202,6 +204,7 @@ export const codeTypeMapping: { [key: string]: string } = {
   log: 'text/plain', // .log - Log file
   csv: 'text/csv', // .csv - Comma-separated values
   tsv: 'text/tab-separated-values', // .tsv - Tab-separated values
+  parquet: 'application/x-parquet', // .parquet - Apache Parquet columnar storage
   json: 'application/json', // .json - JSON file
   xml: 'application/xml', // .xml - XML file
   html: 'text/html', // .html - HTML file

--- a/packages/data-schemas/src/methods/file.ts
+++ b/packages/data-schemas/src/methods/file.ts
@@ -183,7 +183,7 @@ export function createFileMethods(mongoose: typeof import('mongoose')) {
     user: string;
   }): Promise<IMongoFile> {
     const File = mongoose.models.File as Model<IMongoFile>;
-    return File.findOneAndUpdate(
+    const result = await File.findOneAndUpdate(
       {
         filename: data.filename,
         conversationId: data.conversationId,
@@ -191,7 +191,13 @@ export function createFileMethods(mongoose: typeof import('mongoose')) {
       },
       { $setOnInsert: { file_id: data.file_id, user: data.user } },
       { upsert: true, new: true },
-    ).lean() as unknown as IMongoFile;
+    ).lean();
+    if (!result) {
+      throw new Error(
+        `[claimCodeFile] Failed to claim file "${data.filename}" for conversation ${data.conversationId}`,
+      );
+    }
+    return result as IMongoFile;
   }
 
   /**

--- a/packages/data-schemas/src/schema/file.ts
+++ b/packages/data-schemas/src/schema/file.ts
@@ -1,5 +1,5 @@
 import mongoose, { Schema } from 'mongoose';
-import { FileSources } from 'librechat-data-provider';
+import { FileContext, FileSources } from 'librechat-data-provider';
 import type { IMongoFile } from '~/types';
 
 const file: Schema<IMongoFile> = new Schema(
@@ -85,5 +85,9 @@ const file: Schema<IMongoFile> = new Schema(
 );
 
 file.index({ createdAt: 1, updatedAt: 1 });
+file.index(
+  { filename: 1, conversationId: 1, context: 1 },
+  { unique: true, partialFilterExpression: { context: FileContext.execute_code } },
+);
 
 export default file;


### PR DESCRIPTION


## Summary

I implemented atomic file claiming to eliminate race conditions in code execution file deduplication, added Parquet MIME type support, and refined Bedrock adaptive thinking token handling.

- Introduced `claimCodeFile` method using MongoDB's `$setOnInsert` with `upsert` to atomically claim file_id for `(filename, conversationId, context)` tuples, preventing TOCTOU race conditions when concurrent code outputs generate identically named files
- Added unique partial index on `(filename, conversationId, context)` filtered to `execute_code` context, enforcing deduplication at the database level
- Refactored `isUpdate` detection to compare generated `file_id` against returned `file_id` from atomic claim instead of relying on `usage` field semantics, providing deterministic update detection
- Implemented cache-busting for updated code execution images by appending `?v=${Date.now()}` query parameter on subsequent generations (usage > 1)
- Added null guard in `claimCodeFile` with descriptive error message for failed database operations
- Added Parquet columnar storage format support with `application/x-parquet` MIME type and `.parquet` extension mapping to code interpreter and full MIME type lists
- Updated `applicationMimeTypes` regex to recognize `x-parquet` and `vnd.apache.parquet` variants
- Removed default `maxTokens` (16000) for Bedrock adaptive thinking models, only mapping `maxOutputTokens` to `maxTokens` when explicitly provided
- Fixed client-side `useStepHandler` to skip placeholder content part initialization for `TOOL_CALL` content type, preventing unnecessary empty objects
- Refactored tests to mock `claimCodeFile` with atomic claim behavior instead of `getFiles` queries
- Added test coverage for cache-busted image paths and file_id comparison logic
- Awaited `createFile` calls that were previously fire-and-forget
- Bumped `@librechat/agents` dependency from 3.1.37 to 3.1.38

**Note:** Deployments with existing duplicate `execute_code` files will require deduplication migration before the unique index can be created.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Tested code execution file generation with concurrent outputs producing identically named files (e.g., multiple chart.png generations) to verify atomic claiming prevents duplicates. Validated cache-busting behavior by regenerating image files and confirming query parameter prevents stale browser cache. Tested Parquet file uploads to code interpreter. Verified Bedrock adaptive thinking models respect explicit token limits without applying defaults.

### **Test Configuration**:
- MongoDB with execute_code file documents (both new and with existing usage counters)
- Concurrent code execution sessions generating overlapping filenames
- Bedrock Claude Opus 4 with adaptive thinking enabled
- Code interpreter with Parquet data files

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes