### PR TITLE
🪪 feat: Add OPENID_EMAIL_CLAIM for Configurable OpenID User Identifier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -513,6 +513,9 @@ OPENID_ADMIN_ROLE_TOKEN_KIND=
 OPENID_USERNAME_CLAIM=
 # Set to determine which user info property returned from OpenID Provider to store as the User's name
 OPENID_NAME_CLAIM=
+# Set to determine which user info claim to use as the email/identifier for user matching (e.g., "upn" for Entra ID)
+# When not set, defaults to: email -> preferred_username -> upn
+OPENID_EMAIL_CLAIM=
 # Optional audience parameter for OpenID authorization requests
 OPENID_AUDIENCE=
 

--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -18,7 +18,7 @@ const {
   findUser,
 } = require('~/models');
 const { getGraphApiToken } = require('~/server/services/GraphTokenService');
-const { getOpenIdConfig } = require('~/strategies');
+const { getOpenIdConfig, getOpenIdEmail } = require('~/strategies');
 
 const registrationController = async (req, res) => {
   try {
@@ -87,7 +87,7 @@ const refreshController = async (req, res) => {
       const claims = tokenset.claims();
       const { user, error, migration } = await findOpenIDUser({
         findUser,
-        email: claims.email,
+        email: getOpenIdEmail(claims),
         openidId: claims.sub,
         idOnTheSource: claims.oid,
         strategyName: 'refreshController',

--- a/api/server/controllers/AuthController.spec.js
+++ b/api/server/controllers/AuthController.spec.js
@@ -11,7 +11,8 @@ jest.mock('~/server/services/AuthService', () => ({
   setAuthTokens: jest.fn(),
   registerUser: jest.fn(),
 }));
-jest.mock('~/strategies', () => ({ getOpenIdConfig: jest.fn() }));
+jest.mock('~/strategies', () => ({ getOpenIdConfig: jest.fn(), getOpenIdEmail: jest.fn() }));
+jest.mock('openid-client', () => ({ refreshTokenGrant: jest.fn() }));
 jest.mock('~/models', () => ({
   deleteAllUserSessions: jest.fn(),
   getUserById: jest.fn(),
@@ -24,9 +25,13 @@ jest.mock('@librechat/api', () => ({
   findOpenIDUser: jest.fn(),
 }));
 
-const { isEnabled } = require('@librechat/api');
+const openIdClient = require('openid-client');
+const { isEnabled, findOpenIDUser } = require('@librechat/api');
+const { graphTokenController, refreshController } = require('./AuthController');
 const { getGraphApiToken } = require('~/server/services/GraphTokenService');
-const { graphTokenController } = require('./AuthController');
+const { setOpenIDAuthTokens } = require('~/server/services/AuthService');
+const { getOpenIdConfig, getOpenIdEmail } = require('~/strategies');
+const { updateUser } = require('~/models');
 
 describe('graphTokenController', () => {
   let req, res;
@@ -140,5 +145,145 @@ describe('graphTokenController', () => {
     expect(res.json).toHaveBeenCalledWith({
       message: 'Failed to obtain Microsoft Graph token',
     });
+  });
+});
+
+describe('refreshController – OpenID path', () => {
+  const mockTokenset = {
+    claims: jest.fn(),
+    access_token: 'new-access',
+    id_token: 'new-id',
+    refresh_token: 'new-refresh',
+  };
+
+  const baseClaims = {
+    sub: 'oidc-sub-123',
+    oid: 'oid-456',
+    email: 'user@example.com',
+    exp: 9999999999,
+  };
+
+  let req, res;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    isEnabled.mockReturnValue(true);
+    getOpenIdConfig.mockReturnValue({ some: 'config' });
+    openIdClient.refreshTokenGrant.mockResolvedValue(mockTokenset);
+    mockTokenset.claims.mockReturnValue(baseClaims);
+    getOpenIdEmail.mockReturnValue(baseClaims.email);
+    setOpenIDAuthTokens.mockReturnValue('new-app-token');
+    updateUser.mockResolvedValue({});
+
+    req = {
+      headers: { cookie: 'token_provider=openid; refreshToken=stored-refresh' },
+      session: {},
+    };
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+      redirect: jest.fn(),
+    };
+  });
+
+  it('should call getOpenIdEmail with token claims and use result for findOpenIDUser', async () => {
+    const user = {
+      _id: 'user-db-id',
+      email: baseClaims.email,
+      openidId: baseClaims.sub,
+    };
+    findOpenIDUser.mockResolvedValue({ user, error: null, migration: false });
+
+    await refreshController(req, res);
+
+    expect(getOpenIdEmail).toHaveBeenCalledWith(baseClaims);
+    expect(findOpenIDUser).toHaveBeenCalledWith(
+      expect.objectContaining({ email: baseClaims.email }),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should use OPENID_EMAIL_CLAIM-resolved value when claim is present in token', async () => {
+    const claimsWithUpn = { ...baseClaims, upn: 'user@corp.example.com' };
+    mockTokenset.claims.mockReturnValue(claimsWithUpn);
+    getOpenIdEmail.mockReturnValue('user@corp.example.com');
+
+    const user = {
+      _id: 'user-db-id',
+      email: 'user@corp.example.com',
+      openidId: baseClaims.sub,
+    };
+    findOpenIDUser.mockResolvedValue({ user, error: null, migration: false });
+
+    await refreshController(req, res);
+
+    expect(getOpenIdEmail).toHaveBeenCalledWith(claimsWithUpn);
+    expect(findOpenIDUser).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'user@corp.example.com' }),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should fall back to claims.email when configured claim is absent from token claims', async () => {
+    getOpenIdEmail.mockReturnValue(baseClaims.email);
+
+    const user = {
+      _id: 'user-db-id',
+      email: baseClaims.email,
+      openidId: baseClaims.sub,
+    };
+    findOpenIDUser.mockResolvedValue({ user, error: null, migration: false });
+
+    await refreshController(req, res);
+
+    expect(findOpenIDUser).toHaveBeenCalledWith(
+      expect.objectContaining({ email: baseClaims.email }),
+    );
+  });
+
+  it('should return 401 and redirect to /login when findOpenIDUser returns no user', async () => {
+    findOpenIDUser.mockResolvedValue({ user: null, error: null, migration: false });
+
+    await refreshController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.redirect).toHaveBeenCalledWith('/login');
+  });
+
+  it('should return 401 and redirect when findOpenIDUser returns an error', async () => {
+    findOpenIDUser.mockResolvedValue({ user: null, error: 'AUTH_FAILED', migration: false });
+
+    await refreshController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.redirect).toHaveBeenCalledWith('/login');
+  });
+
+  it('should skip OpenID path when token_provider is not openid', async () => {
+    req.headers.cookie = 'token_provider=local; refreshToken=some-token';
+
+    await refreshController(req, res);
+
+    expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('should skip OpenID path when OPENID_REUSE_TOKENS is disabled', async () => {
+    isEnabled.mockReturnValue(false);
+
+    await refreshController(req, res);
+
+    expect(openIdClient.refreshTokenGrant).not.toHaveBeenCalled();
+  });
+
+  it('should return 200 with token not provided when refresh token is absent', async () => {
+    req.headers.cookie = 'token_provider=openid';
+    req.session = {};
+
+    await refreshController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith('Refresh token not provided');
   });
 });

--- a/api/strategies/index.js
+++ b/api/strategies/index.js
@@ -1,4 +1,4 @@
-const { setupOpenId, getOpenIdConfig } = require('./openidStrategy');
+const { setupOpenId, getOpenIdConfig, getOpenIdEmail } = require('./openidStrategy');
 const openIdJwtLogin = require('./openIdJwtStrategy');
 const facebookLogin = require('./facebookStrategy');
 const discordLogin = require('./discordStrategy');
@@ -20,6 +20,7 @@ module.exports = {
   facebookLogin,
   setupOpenId,
   getOpenIdConfig,
+  getOpenIdEmail,
   ldapLogin,
   setupSaml,
   openIdJwtLogin,

--- a/api/strategies/openIdJwtStrategy.js
+++ b/api/strategies/openIdJwtStrategy.js
@@ -4,6 +4,7 @@ const { logger } = require('@librechat/data-schemas');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const { SystemRoles } = require('librechat-data-provider');
 const { isEnabled, findOpenIDUser, math } = require('@librechat/api');
+const { getOpenIdEmail } = require('./openidStrategy');
 const { Strategy: JwtStrategy, ExtractJwt } = require('passport-jwt');
 const { updateUser, findUser } = require('~/models');
 
@@ -53,7 +54,7 @@ const openIdJwtLogin = (openIdConfig) => {
 
         const { user, error, migration } = await findOpenIDUser({
           findUser,
-          email: payload?.email,
+          email: payload ? getOpenIdEmail(payload) : undefined,
           openidId: payload?.sub,
           idOnTheSource: payload?.oid,
           strategyName: 'openIdJwtLogin',

--- a/api/strategies/openIdJwtStrategy.spec.js
+++ b/api/strategies/openIdJwtStrategy.spec.js
@@ -29,9 +29,20 @@ jest.mock('~/models', () => ({
   findUser: jest.fn(),
   updateUser: jest.fn(),
 }));
+jest.mock('~/server/services/Files/strategies', () => ({
+  getStrategyFunctions: jest.fn(() => ({
+    saveBuffer: jest.fn().mockResolvedValue('/fake/path/to/avatar.png'),
+  })),
+}));
+jest.mock('~/server/services/Config', () => ({
+  getCustomConfig: jest.fn(),
+}));
+jest.mock('~/cache/getLogStores', () =>
+  jest.fn().mockReturnValue({ get: jest.fn(), set: jest.fn() }),
+);
 
 const { findOpenIDUser } = require('@librechat/api');
-const { updateUser } = require('~/models');
+const { findUser, updateUser } = require('~/models');
 const openIdJwtLogin = require('./openIdJwtStrategy');
 
 // Helper: build a mock openIdConfig
@@ -179,5 +190,90 @@ describe('openIdJwtStrategy – token source handling', () => {
     expect(user.federatedTokens.access_token).toBe('the-access-token');
     expect(user.federatedTokens.id_token).toBe('the-id-token');
     expect(user.federatedTokens.access_token).not.toBe(user.federatedTokens.id_token);
+  });
+});
+
+describe('openIdJwtStrategy – OPENID_EMAIL_CLAIM', () => {
+  const payload = {
+    sub: 'oidc-123',
+    email: 'test@example.com',
+    preferred_username: 'testuser',
+    upn: 'test@corp.example.com',
+    exp: 9999999999,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.OPENID_EMAIL_CLAIM;
+
+    // Use real findOpenIDUser so it delegates to the findUser mock
+    const realFindOpenIDUser = jest.requireActual('@librechat/api').findOpenIDUser;
+    findOpenIDUser.mockImplementation(realFindOpenIDUser);
+
+    findUser.mockResolvedValue(null);
+    updateUser.mockResolvedValue({});
+
+    openIdJwtLogin(mockOpenIdConfig);
+  });
+
+  afterEach(() => {
+    delete process.env.OPENID_EMAIL_CLAIM;
+  });
+
+  it('should use the default email when OPENID_EMAIL_CLAIM is not set', async () => {
+    const existingUser = {
+      _id: 'user-id-1',
+      provider: 'openid',
+      openidId: payload.sub,
+      email: payload.email,
+      role: SystemRoles.USER,
+    };
+    findUser.mockImplementation(async (query) => {
+      if (query.$or && query.$or.some((c) => c.openidId === payload.sub)) {
+        return existingUser;
+      }
+      return null;
+    });
+
+    const req = { headers: { authorization: 'Bearer tok' }, session: {} };
+    await invokeVerify(req, payload);
+
+    expect(findUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        $or: expect.arrayContaining([{ openidId: payload.sub }]),
+      }),
+    );
+  });
+
+  it('should use OPENID_EMAIL_CLAIM when set for email lookup', async () => {
+    process.env.OPENID_EMAIL_CLAIM = 'upn';
+    findUser.mockResolvedValue(null);
+
+    const req = { headers: { authorization: 'Bearer tok' }, session: {} };
+    const { user } = await invokeVerify(req, payload);
+
+    expect(findUser).toHaveBeenCalledWith({ email: 'test@corp.example.com' });
+    expect(user).toBe(false);
+  });
+
+  it('should fall back to default chain when OPENID_EMAIL_CLAIM points to missing claim', async () => {
+    process.env.OPENID_EMAIL_CLAIM = 'nonexistent_claim';
+    findUser.mockResolvedValue(null);
+
+    const req = { headers: { authorization: 'Bearer tok' }, session: {} };
+    const { user } = await invokeVerify(req, payload);
+
+    expect(findUser).toHaveBeenCalledWith({ email: payload.email });
+    expect(user).toBe(false);
+  });
+
+  it('should trim whitespace from OPENID_EMAIL_CLAIM', async () => {
+    process.env.OPENID_EMAIL_CLAIM = '  upn  ';
+    findUser.mockResolvedValue(null);
+
+    const req = { headers: { authorization: 'Bearer tok' }, session: {} };
+    await invokeVerify(req, payload);
+
+    expect(findUser).toHaveBeenCalledWith({ email: 'test@corp.example.com' });
   });
 });

--- a/api/strategies/openIdJwtStrategy.spec.js
+++ b/api/strategies/openIdJwtStrategy.spec.js
@@ -339,5 +339,9 @@ describe('openIdJwtStrategy – OPENID_EMAIL_CLAIM', () => {
     expect(findUser).toHaveBeenCalledTimes(2);
     expect(findUser.mock.calls[1][0]).toEqual({ email: 'legacy@corp.com' });
     expect(user).toBeTruthy();
+    expect(updateUser).toHaveBeenCalledWith(
+      'legacy-db-id',
+      expect.objectContaining({ provider: 'openid', openidId: payloadNoEmail.sub }),
+    );
   });
 });

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -268,25 +268,31 @@ function getFullName(userinfo) {
 }
 
 /**
- * Extracts the email/identifier from OpenID userinfo based on environment configuration.
- * When OPENID_EMAIL_CLAIM is set, uses that specific claim from userinfo.
- * Otherwise, falls back to: email -> preferred_username -> upn.
+ * Resolves the user identifier from OpenID claims.
+ * Configurable via OPENID_EMAIL_CLAIM; defaults to: email -> preferred_username -> upn.
  *
  * @param {Object} userinfo - The user information object from OpenID Connect
- * @returns {string|undefined} The email/identifier value
+ * @returns {string|undefined} The resolved identifier string
  */
 function getOpenIdEmail(userinfo) {
   const claimKey = process.env.OPENID_EMAIL_CLAIM?.trim();
   if (claimKey) {
     const value = userinfo[claimKey];
-    if (value) {
+    if (typeof value === 'string' && value) {
       return value;
     }
-    logger.warn(
-      `[openidStrategy] OPENID_EMAIL_CLAIM is set to "${claimKey}" but the claim is not present in userinfo. Falling back to default email chain.`,
-    );
+    if (value !== undefined && value !== null) {
+      logger.warn(
+        `[openidStrategy] OPENID_EMAIL_CLAIM="${claimKey}" resolved to a non-string value (type: ${typeof value}). Falling back to: email -> preferred_username -> upn.`,
+      );
+    } else {
+      logger.warn(
+        `[openidStrategy] OPENID_EMAIL_CLAIM="${claimKey}" not present in userinfo. Falling back to: email -> preferred_username -> upn.`,
+      );
+    }
   }
-  return userinfo.email || userinfo.preferred_username || userinfo.upn;
+  const fallback = userinfo.email || userinfo.preferred_username || userinfo.upn;
+  return typeof fallback === 'string' ? fallback : undefined;
 }
 
 /**
@@ -401,11 +407,10 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
   }
 
   const appConfig = await getAppConfig();
-  /** Azure AD sometimes doesn't return email, use preferred_username as fallback */
   const email = getOpenIdEmail(userinfo);
   if (!isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {
     logger.error(
-      `[OpenID Strategy] Authentication blocked - email domain not allowed [Email: ${userinfo.email}]`,
+      `[OpenID Strategy] Authentication blocked - email domain not allowed [Identifier: ${email}]`,
     );
     throw new Error('Email domain not allowed');
   }

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -1,6 +1,6 @@
+const undici = require('undici');
 const fetch = require('node-fetch');
 const jwtDecode = require('jsonwebtoken/decode');
-const undici = require('undici');
 const { ErrorTypes } = require('librechat-data-provider');
 const { findUser, createUser, updateUser } = require('~/models');
 const { setupOpenId } = require('./openidStrategy');
@@ -1477,7 +1477,7 @@ describe('setupOpenId', () => {
 
       expect(user.email).toBe('test@example.com');
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('OPENID_EMAIL_CLAIM is set to "nonexistent_claim"'),
+        expect.stringContaining('OPENID_EMAIL_CLAIM="nonexistent_claim" not present in userinfo'),
       );
     });
   });

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -152,6 +152,7 @@ describe('setupOpenId', () => {
     process.env.OPENID_ADMIN_ROLE_TOKEN_KIND = 'id';
     delete process.env.OPENID_USERNAME_CLAIM;
     delete process.env.OPENID_NAME_CLAIM;
+    delete process.env.OPENID_EMAIL_CLAIM;
     delete process.env.PROXY;
     delete process.env.OPENID_USE_PKCE;
 
@@ -1400,6 +1401,84 @@ describe('setupOpenId', () => {
         expect.stringContaining("Key 'roleCount' not found in id token!"),
       );
       expect(user).toBe(false);
+    });
+  });
+
+  describe('OPENID_EMAIL_CLAIM', () => {
+    it('should use the default email when OPENID_EMAIL_CLAIM is not set', async () => {
+      const { user } = await validate(tokenset);
+      expect(user.email).toBe('test@example.com');
+    });
+
+    it('should use the configured claim when OPENID_EMAIL_CLAIM is set', async () => {
+      process.env.OPENID_EMAIL_CLAIM = 'upn';
+      const userinfo = { ...tokenset.claims(), upn: 'user@corp.example.com' };
+
+      const { user } = await validate({ ...tokenset, claims: () => userinfo });
+
+      expect(user.email).toBe('user@corp.example.com');
+      expect(createUser).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'user@corp.example.com' }),
+        expect.anything(),
+        true,
+        true,
+      );
+    });
+
+    it('should fall back to preferred_username when email is missing and OPENID_EMAIL_CLAIM is not set', async () => {
+      const userinfo = { ...tokenset.claims() };
+      delete userinfo.email;
+
+      const { user } = await validate({ ...tokenset, claims: () => userinfo });
+
+      expect(user.email).toBe('testusername');
+    });
+
+    it('should fall back to upn when email and preferred_username are missing and OPENID_EMAIL_CLAIM is not set', async () => {
+      const userinfo = { ...tokenset.claims(), upn: 'user@corp.example.com' };
+      delete userinfo.email;
+      delete userinfo.preferred_username;
+
+      const { user } = await validate({ ...tokenset, claims: () => userinfo });
+
+      expect(user.email).toBe('user@corp.example.com');
+    });
+
+    it('should ignore empty string OPENID_EMAIL_CLAIM and use default fallback', async () => {
+      process.env.OPENID_EMAIL_CLAIM = '';
+
+      const { user } = await validate(tokenset);
+
+      expect(user.email).toBe('test@example.com');
+    });
+
+    it('should trim whitespace from OPENID_EMAIL_CLAIM and resolve correctly', async () => {
+      process.env.OPENID_EMAIL_CLAIM = '  upn  ';
+      const userinfo = { ...tokenset.claims(), upn: 'user@corp.example.com' };
+
+      const { user } = await validate({ ...tokenset, claims: () => userinfo });
+
+      expect(user.email).toBe('user@corp.example.com');
+    });
+
+    it('should ignore whitespace-only OPENID_EMAIL_CLAIM and use default fallback', async () => {
+      process.env.OPENID_EMAIL_CLAIM = '   ';
+
+      const { user } = await validate(tokenset);
+
+      expect(user.email).toBe('test@example.com');
+    });
+
+    it('should fall back to default chain with warning when configured claim is missing from userinfo', async () => {
+      const { logger } = require('@librechat/data-schemas');
+      process.env.OPENID_EMAIL_CLAIM = 'nonexistent_claim';
+
+      const { user } = await validate(tokenset);
+
+      expect(user.email).toBe('test@example.com');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('OPENID_EMAIL_CLAIM is set to "nonexistent_claim"'),
+      );
     });
   });
 });


### PR DESCRIPTION
# Pull Request Template

## Summary

With our Microsoft Entra ID, the email claim is always present but not necessarily unique across the organization. The upn (User Principal Name) is our unique identifier. The existing fallback chain (email -> preferred_username -> upn) only kicks in when email is missing. Which never happens with Entra ID.

Proposal: This PR adds OPENID_EMAIL_CLAIM (similar to the existing SAML_EMAIL_CLAIM) so administrators can configure which claim to use for user matching.

```
OPENID_EMAIL_CLAIM=upn
```

Also fixes an inconsistency: the preferred_username/upn fallback was only applied in the main login flow, not in JWT auth or token refresh. All three paths would use the same getOpenIdEmail() helper.

## Change Type

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## Testing

Included a test spec.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] My changes do not introduce new warnings
- [X] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
- [NOT YET] A pull request for updating the documentation has been submitted.

Can you include this PR? I would also create a documentation PR update.
Thank you!