### PR TITLE
🌊 fix: Prevent Truncations When Redis Resumable Streams Are Enabled

### DIFF
--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -745,7 +745,6 @@ class GenerationJobManagerClass {
     const subscription = this.eventTransport.subscribe(streamId, {
       onChunk: (event) => {
         const e = event as t.ServerSentEvent;
-        // Filter out internal events
         if (!(e as Record<string, unknown>)._internal) {
           onChunk(e);
         }
@@ -754,14 +753,15 @@ class GenerationJobManagerClass {
       onError,
     });
 
-    // Check if this is the first subscriber
+    if (subscription.ready) {
+      await subscription.ready;
+    }
+
     const isFirst = this.eventTransport.isFirstSubscriber(streamId);
 
-    // First subscriber: replay buffered events and mark as connected
     if (!runtime.hasSubscriber) {
       runtime.hasSubscriber = true;
 
-      // Replay any events that were emitted before subscriber connected
       if (runtime.earlyEventBuffer.length > 0) {
         logger.debug(
           `[GenerationJobManager] Replaying ${runtime.earlyEventBuffer.length} buffered events for ${streamId}`,
@@ -823,12 +823,11 @@ class GenerationJobManagerClass {
       }
     }
 
-    // Buffer early events if no subscriber yet (replay when first subscriber connects)
     if (!runtime.hasSubscriber) {
       runtime.earlyEventBuffer.push(event);
+      return;
     }
 
-    // Await the transport emit - critical for Redis mode to maintain event order
     await this.eventTransport.emitChunk(streamId, event);
   }
 

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -772,7 +772,7 @@ class GenerationJobManagerClass {
         runtime.earlyEventBuffer = [];
       }
 
-      this.eventTransport.resetSequence?.(streamId);
+      this.eventTransport.syncReorderBuffer?.(streamId);
     }
 
     if (isFirst) {

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -771,6 +771,8 @@ class GenerationJobManagerClass {
         }
         runtime.earlyEventBuffer = [];
       }
+
+      this.eventTransport.resetSequence?.(streamId);
     }
 
     if (isFirst) {
@@ -825,7 +827,9 @@ class GenerationJobManagerClass {
 
     if (!runtime.hasSubscriber) {
       runtime.earlyEventBuffer.push(event);
-      return;
+      if (!this._isRedis) {
+        return;
+      }
     }
 
     await this.eventTransport.emitChunk(streamId, event);

--- a/packages/api/src/stream/__tests__/collectedUsage.spec.ts
+++ b/packages/api/src/stream/__tests__/collectedUsage.spec.ts
@@ -146,7 +146,7 @@ describe('CollectedUsage - GenerationJobManager', () => {
       cleanupOnComplete: false,
     });
 
-    await GenerationJobManager.initialize();
+    GenerationJobManager.initialize();
 
     const streamId = `manager-test-${Date.now()}`;
     await GenerationJobManager.createJob(streamId, 'user-1');
@@ -179,7 +179,7 @@ describe('CollectedUsage - GenerationJobManager', () => {
       cleanupOnComplete: false,
     });
 
-    await GenerationJobManager.initialize();
+    GenerationJobManager.initialize();
 
     const streamId = `no-usage-test-${Date.now()}`;
     await GenerationJobManager.createJob(streamId, 'user-1');
@@ -202,7 +202,7 @@ describe('CollectedUsage - GenerationJobManager', () => {
       isRedis: false,
     });
 
-    await GenerationJobManager.initialize();
+    GenerationJobManager.initialize();
 
     const collectedUsage: UsageMetadata[] = [
       { input_tokens: 100, output_tokens: 50, model: 'gpt-4' },
@@ -235,7 +235,7 @@ describe('AbortJob - Text and CollectedUsage', () => {
       cleanupOnComplete: false,
     });
 
-    await GenerationJobManager.initialize();
+    GenerationJobManager.initialize();
 
     const streamId = `text-extract-${Date.now()}`;
     await GenerationJobManager.createJob(streamId, 'user-1');
@@ -267,7 +267,7 @@ describe('AbortJob - Text and CollectedUsage', () => {
       cleanupOnComplete: false,
     });
 
-    await GenerationJobManager.initialize();
+    GenerationJobManager.initialize();
 
     const streamId = `empty-text-${Date.now()}`;
     await GenerationJobManager.createJob(streamId, 'user-1');
@@ -291,7 +291,7 @@ describe('AbortJob - Text and CollectedUsage', () => {
       cleanupOnComplete: false,
     });
 
-    await GenerationJobManager.initialize();
+    GenerationJobManager.initialize();
 
     const streamId = `full-abort-${Date.now()}`;
     await GenerationJobManager.createJob(streamId, 'user-1');
@@ -328,7 +328,7 @@ describe('AbortJob - Text and CollectedUsage', () => {
       isRedis: false,
     });
 
-    await GenerationJobManager.initialize();
+    GenerationJobManager.initialize();
 
     const abortResult = await GenerationJobManager.abortJob('non-existent-job');
 
@@ -365,7 +365,7 @@ describe('Real-world Scenarios', () => {
       cleanupOnComplete: false,
     });
 
-    await GenerationJobManager.initialize();
+    GenerationJobManager.initialize();
 
     const streamId = `parallel-abort-${Date.now()}`;
     await GenerationJobManager.createJob(streamId, 'user-1');
@@ -419,7 +419,7 @@ describe('Real-world Scenarios', () => {
       cleanupOnComplete: false,
     });
 
-    await GenerationJobManager.initialize();
+    GenerationJobManager.initialize();
 
     const streamId = `cache-abort-${Date.now()}`;
     await GenerationJobManager.createJob(streamId, 'user-1');
@@ -459,7 +459,7 @@ describe('Real-world Scenarios', () => {
       cleanupOnComplete: false,
     });
 
-    await GenerationJobManager.initialize();
+    GenerationJobManager.initialize();
 
     const streamId = `sequential-abort-${Date.now()}`;
     await GenerationJobManager.createJob(streamId, 'user-1');

--- a/packages/api/src/stream/implementations/InMemoryEventTransport.ts
+++ b/packages/api/src/stream/implementations/InMemoryEventTransport.ts
@@ -32,7 +32,7 @@ export class InMemoryEventTransport implements IEventTransport {
       onDone?: (event: unknown) => void;
       onError?: (error: string) => void;
     },
-  ): { unsubscribe: () => void } {
+  ): { unsubscribe: () => void; ready?: Promise<void> } {
     const state = this.getOrCreateStream(streamId);
 
     const chunkHandler = (event: unknown) => handlers.onChunk(event);

--- a/packages/api/src/stream/implementations/RedisEventTransport.ts
+++ b/packages/api/src/stream/implementations/RedisEventTransport.ts
@@ -612,7 +612,12 @@ export class RedisEventTransport implements IEventTransport {
     this.streams.clear();
     this.sequenceCounters.clear();
 
-    // Note: Don't close Redis connections - they may be shared
+    try {
+      this.subscriber.disconnect();
+    } catch {
+      /* ignore */
+    }
+
     logger.info('[RedisEventTransport] Destroyed');
   }
 }

--- a/packages/api/src/stream/implementations/RedisEventTransport.ts
+++ b/packages/api/src/stream/implementations/RedisEventTransport.ts
@@ -127,6 +127,10 @@ export class RedisEventTransport implements IEventTransport {
     this.sequenceCounters.delete(streamId);
     const state = this.streams.get(streamId);
     if (state) {
+      if (state.reorderBuffer.flushTimeout) {
+        clearTimeout(state.reorderBuffer.flushTimeout);
+        state.reorderBuffer.flushTimeout = null;
+      }
       state.reorderBuffer.nextSeq = 0;
       state.reorderBuffer.pending.clear();
     }
@@ -137,6 +141,10 @@ export class RedisEventTransport implements IEventTransport {
     const currentSeq = this.sequenceCounters.get(streamId) ?? 0;
     const state = this.streams.get(streamId);
     if (state) {
+      if (state.reorderBuffer.flushTimeout) {
+        clearTimeout(state.reorderBuffer.flushTimeout);
+        state.reorderBuffer.flushTimeout = null;
+      }
       state.reorderBuffer.nextSeq = currentSeq;
       state.reorderBuffer.pending.clear();
     }

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -286,7 +286,7 @@ export interface IJobStore {
  * Implementations can use EventEmitter, Redis Pub/Sub, etc.
  */
 export interface IEventTransport {
-  /** Subscribe to events for a stream */
+  /** Subscribe to events for a stream. `ready` resolves once the transport can receive messages. */
   subscribe(
     streamId: string,
     handlers: {
@@ -294,7 +294,7 @@ export interface IEventTransport {
       onDone?: (event: unknown) => void;
       onError?: (error: string) => void;
     },
-  ): { unsubscribe: () => void };
+  ): { unsubscribe: () => void; ready?: Promise<void> };
 
   /** Publish a chunk event - returns Promise in Redis mode for ordered delivery */
   emitChunk(streamId: string, event: unknown): void | Promise<void>;

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -329,6 +329,9 @@ export interface IEventTransport {
   /** Listen for all subscribers leaving */
   onAllSubscribersLeft(streamId: string, callback: () => void): void;
 
+  /** Reset publish sequence counter for a stream (Redis: prevents gaps after buffer replay) */
+  resetSequence?(streamId: string): void;
+
   /** Cleanup transport resources for a specific stream */
   cleanup(streamId: string): void;
 

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -329,8 +329,11 @@ export interface IEventTransport {
   /** Listen for all subscribers leaving */
   onAllSubscribersLeft(streamId: string, callback: () => void): void;
 
-  /** Reset publish sequence counter for a stream (Redis: prevents gaps after buffer replay) */
+  /** Reset publish sequence counter for a stream (used during full stream cleanup) */
   resetSequence?(streamId: string): void;
+
+  /** Advance subscriber reorder buffer to match publisher sequence (cross-replica safe: doesn't reset publisher counter) */
+  syncReorderBuffer?(streamId: string): void;
 
   /** Cleanup transport resources for a specific stream */
   cleanup(streamId: string): void;


### PR DESCRIPTION


## Summary

I fixed a critical race condition in Redis resumable streams that caused early events to be silently dropped, resulting in truncated or missing response text in the UI. The race occurred because the Redis SUBSCRIBE command was fire-and-forget, but GenerationJobManager immediately set `hasSubscriber=true`, disabling the earlyEventBuffer before Redis was actually listening.

- Added optional `ready` promise to `IEventTransport.subscribe()` that resolves once the transport can actually receive messages
- Implemented `ready` promise in `RedisEventTransport` that returns the Redis SUBSCRIBE acknowledgment instead of firing it as fire-and-forget
- Modified `GenerationJobManager.subscribe()` to await the `ready` promise before setting `hasSubscriber=true`, keeping the earlyEventBuffer active during the subscription window
- Added early return in `emitChunk()` after buffering when no subscriber is connected for in-memory transport, preventing wasteful Redis PUBLISHes while still publishing for cross-replica scenarios
- Introduced `syncReorderBuffer()` method to advance the local reorder buffer to match the publisher's current sequence position without resetting the global publisher counter, preventing cross-replica data loss
- Implemented `channelSubscriptions` Map to track in-flight subscribe promises per channel, ensuring all concurrent subscribers receive the same ready promise
- Added cleanup of pending flush timeouts in `resetSequence()` and `syncReorderBuffer()` to prevent timer leaks
- Removed channel from `channelSubscriptions` on subscribe failure to allow retry attempts
- Implemented graceful error handling that logs failures and allows degraded operation rather than crashing on Redis connection issues
- Added 14 comprehensive integration tests covering race conditions, cross-replica event publishing, concurrent subscriber readiness, sequence reset safety, and error recovery scenarios

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

I validated the fix with comprehensive integration tests covering both in-memory and Redis modes:

**Race Condition Tests:**
- Verified events emitted before subscribe are buffered and replayed for both in-memory and Redis transports
- Confirmed no events are lost when emitting before and after subscribe
- Validated RedisEventTransport returns a ready promise while InMemoryEventTransport does not

**Cross-Replica Tests:**
- Confirmed events are published to Redis even when no local subscriber exists (Replica A generates without local subscribers, Replica B receives via Redis pub/sub)
- Validated buffered events are delivered locally AND live events are published cross-replica
- Verified publisher sequence remains monotonic for all replicas when local subscriber joins

**Concurrent Subscriber Tests:**
- Validated all concurrent subscribers receive the same ready promise and all promises resolve

**Sequence Reset Safety Tests:**
- Confirmed pre-subscribe events are buffered and post-subscribe events start from correct sequence without gaps
- Verified sequence is not reset when a second subscriber joins mid-stream, maintaining event integrity for all subscribers

**Error Recovery Tests:**
- Validated resubscription succeeds after Redis subscribe failure, confirming channel cleanup allows retries

### **Test Configuration**:

- Redis mode: `USE_REDIS=true` with local Redis instance at `redis://127.0.0.1:6379`
- In-memory mode: `USE_REDIS=false`
- All tests use unique stream IDs with timestamps to prevent collisions
- Cross-replica tests use separate `GenerationJobManagerClass` instances to simulate multiple replicas

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules