### PR TITLE
🛡️ feat: Bedrock Guardrail Config Environment Variable Resolution

### DIFF
--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -204,18 +204,112 @@ describe('initializeBedrock', () => {
       expect(result.llmConfig.guardrailConfig?.trace).toBe('enabled_full');
     });
 
-    it('should resolve environment variables in guardrailIdentifier', async () => {
-      const guardrailId = 'gr-abc123xyz';
-      process.env.GUARDRAIL_ID = guardrailId;
+    it.each([
+      {
+        description: 'guardrailIdentifier only',
+        envVars: { GUARDRAIL_ID: 'gr-abc123xyz' },
+        input: {
+          guardrailIdentifier: '${GUARDRAIL_ID}',
+          guardrailVersion: '1',
+        },
+        expected: {
+          guardrailIdentifier: 'gr-abc123xyz',
+          guardrailVersion: '1',
+        },
+      },
+      {
+        description: 'guardrailVersion only',
+        envVars: { GUARDRAIL_VERSION: 'DRAFT' },
+        input: {
+          guardrailIdentifier: 'static-guardrail-id',
+          guardrailVersion: '${GUARDRAIL_VERSION}',
+        },
+        expected: {
+          guardrailIdentifier: 'static-guardrail-id',
+          guardrailVersion: 'DRAFT',
+        },
+      },
+      {
+        description: 'both guardrailIdentifier and guardrailVersion',
+        envVars: { PROD_GUARDRAIL_ID: 'gr-production-123', PROD_GUARDRAIL_VERSION: '5' },
+        input: {
+          guardrailIdentifier: '${PROD_GUARDRAIL_ID}',
+          guardrailVersion: '${PROD_GUARDRAIL_VERSION}',
+          trace: 'enabled' as const,
+        },
+        expected: {
+          guardrailIdentifier: 'gr-production-123',
+          guardrailVersion: '5',
+          trace: 'enabled',
+        },
+      },
+      {
+        description: 'direct values when no env variable syntax is used',
+        envVars: {},
+        input: {
+          guardrailIdentifier: 'direct-guardrail-id',
+          guardrailVersion: '3',
+        },
+        expected: {
+          guardrailIdentifier: 'direct-guardrail-id',
+          guardrailVersion: '3',
+        },
+      },
+      {
+        description: 'fallback to original string when env variable is not set',
+        envVars: {},
+        deleteEnvVars: ['NONEXISTENT_GUARDRAIL_ID'],
+        input: {
+          guardrailIdentifier: '${NONEXISTENT_GUARDRAIL_ID}',
+          guardrailVersion: '1',
+        },
+        expected: {
+          guardrailIdentifier: '${NONEXISTENT_GUARDRAIL_ID}',
+          guardrailVersion: '1',
+        },
+      },
+      {
+        description: 'env variable with whitespace around it',
+        envVars: { TRIMMED_GUARDRAIL_ID: 'gr-trimmed-123' },
+        input: {
+          guardrailIdentifier: '  ${TRIMMED_GUARDRAIL_ID}  ',
+          guardrailVersion: '2',
+        },
+        expected: {
+          guardrailIdentifier: 'gr-trimmed-123',
+          guardrailVersion: '2',
+        },
+      },
+      {
+        description: 'preserve trace field when resolving env variables',
+        envVars: { GUARDRAIL_WITH_TRACE: 'gr-with-trace' },
+        input: {
+          guardrailIdentifier: '${GUARDRAIL_WITH_TRACE}',
+          guardrailVersion: '1',
+          trace: 'enabled_full' as const,
+        },
+        expected: {
+          guardrailIdentifier: 'gr-with-trace',
+          guardrailVersion: '1',
+          trace: 'enabled_full',
+        },
+      },
+    ])('should resolve environment variables: $description', async ({ envVars, deleteEnvVars, input, expected }) => {
+      // Set up environment variables
+      Object.entries(envVars).forEach(([key, value]) => {
+        process.env[key] = value;
+      });
+
+      // Delete specified environment variables
+      deleteEnvVars?.forEach((key) => {
+        delete process.env[key];
+      });
 
       const params = createMockParams({
         config: {
           endpoints: {
             [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: '${GUARDRAIL_ID}',
-                guardrailVersion: '1',
-              },
+              guardrailConfig: input,
             },
           },
         },
@@ -223,150 +317,7 @@ describe('initializeBedrock', () => {
 
       const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
 
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(guardrailId);
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('1');
-    });
-
-    it('should resolve environment variables in guardrailVersion', async () => {
-      const guardrailVersion = 'DRAFT';
-      process.env.GUARDRAIL_VERSION = guardrailVersion;
-
-      const params = createMockParams({
-        config: {
-          endpoints: {
-            [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: 'static-guardrail-id',
-                guardrailVersion: '${GUARDRAIL_VERSION}',
-              },
-            },
-          },
-        },
-      });
-
-      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
-
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe('static-guardrail-id');
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe(guardrailVersion);
-    });
-
-    it('should resolve environment variables in both guardrailIdentifier and guardrailVersion', async () => {
-      const guardrailId = 'gr-production-123';
-      const guardrailVersion = '5';
-      process.env.PROD_GUARDRAIL_ID = guardrailId;
-      process.env.PROD_GUARDRAIL_VERSION = guardrailVersion;
-
-      const params = createMockParams({
-        config: {
-          endpoints: {
-            [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: '${PROD_GUARDRAIL_ID}',
-                guardrailVersion: '${PROD_GUARDRAIL_VERSION}',
-                trace: 'enabled' as const,
-              },
-            },
-          },
-        },
-      });
-
-      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
-
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(guardrailId);
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe(guardrailVersion);
-      expect(result.llmConfig.guardrailConfig?.trace).toBe('enabled');
-    });
-
-    it('should use direct values when no env variable syntax is used', async () => {
-      const params = createMockParams({
-        config: {
-          endpoints: {
-            [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: 'direct-guardrail-id',
-                guardrailVersion: '3',
-              },
-            },
-          },
-        },
-      });
-
-      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
-
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe('direct-guardrail-id');
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('3');
-    });
-
-    it('should fall back to original string when env variable is not set', async () => {
-      delete process.env.NONEXISTENT_GUARDRAIL_ID;
-
-      const params = createMockParams({
-        config: {
-          endpoints: {
-            [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: '${NONEXISTENT_GUARDRAIL_ID}',
-                guardrailVersion: '1',
-              },
-            },
-          },
-        },
-      });
-
-      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
-
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(
-        '${NONEXISTENT_GUARDRAIL_ID}',
-      );
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('1');
-    });
-
-    it('should handle env variable with whitespace around it', async () => {
-      const guardrailId = 'gr-trimmed-123';
-      process.env.TRIMMED_GUARDRAIL_ID = guardrailId;
-
-      const params = createMockParams({
-        config: {
-          endpoints: {
-            [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: '  ${TRIMMED_GUARDRAIL_ID}  ',
-                guardrailVersion: '2',
-              },
-            },
-          },
-        },
-      });
-
-      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
-
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(guardrailId);
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('2');
-    });
-
-    it('should preserve trace field when resolving env variables', async () => {
-      const guardrailId = 'gr-with-trace';
-      process.env.GUARDRAIL_WITH_TRACE = guardrailId;
-
-      const params = createMockParams({
-        config: {
-          endpoints: {
-            [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: '${GUARDRAIL_WITH_TRACE}',
-                guardrailVersion: '1',
-                trace: 'enabled_full' as const,
-              },
-            },
-          },
-        },
-      });
-
-      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
-
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(guardrailId);
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('1');
-      expect(result.llmConfig.guardrailConfig?.trace).toBe('enabled_full');
+      expect(result.llmConfig.guardrailConfig).toEqual(expected);
     });
   });
 

--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -211,18 +211,112 @@ describe('initializeBedrock', () => {
       expect(result.llmConfig.guardrailConfig?.trace).toBe('enabled_full');
     });
 
-    it('should resolve environment variables in guardrailIdentifier', async () => {
-      const guardrailId = 'gr-abc123xyz';
-      process.env.GUARDRAIL_ID = guardrailId;
+    it.each([
+      {
+        description: 'guardrailIdentifier only',
+        envVars: { GUARDRAIL_ID: 'gr-abc123xyz' },
+        input: {
+          guardrailIdentifier: '${GUARDRAIL_ID}',
+          guardrailVersion: '1',
+        },
+        expected: {
+          guardrailIdentifier: 'gr-abc123xyz',
+          guardrailVersion: '1',
+        },
+      },
+      {
+        description: 'guardrailVersion only',
+        envVars: { GUARDRAIL_VERSION: 'DRAFT' },
+        input: {
+          guardrailIdentifier: 'static-guardrail-id',
+          guardrailVersion: '${GUARDRAIL_VERSION}',
+        },
+        expected: {
+          guardrailIdentifier: 'static-guardrail-id',
+          guardrailVersion: 'DRAFT',
+        },
+      },
+      {
+        description: 'both guardrailIdentifier and guardrailVersion',
+        envVars: { PROD_GUARDRAIL_ID: 'gr-production-123', PROD_GUARDRAIL_VERSION: '5' },
+        input: {
+          guardrailIdentifier: '${PROD_GUARDRAIL_ID}',
+          guardrailVersion: '${PROD_GUARDRAIL_VERSION}',
+          trace: 'enabled' as const,
+        },
+        expected: {
+          guardrailIdentifier: 'gr-production-123',
+          guardrailVersion: '5',
+          trace: 'enabled',
+        },
+      },
+      {
+        description: 'direct values when no env variable syntax is used',
+        envVars: {},
+        input: {
+          guardrailIdentifier: 'direct-guardrail-id',
+          guardrailVersion: '3',
+        },
+        expected: {
+          guardrailIdentifier: 'direct-guardrail-id',
+          guardrailVersion: '3',
+        },
+      },
+      {
+        description: 'fallback to original string when env variable is not set',
+        envVars: {},
+        deleteEnvVars: ['NONEXISTENT_GUARDRAIL_ID'],
+        input: {
+          guardrailIdentifier: '${NONEXISTENT_GUARDRAIL_ID}',
+          guardrailVersion: '1',
+        },
+        expected: {
+          guardrailIdentifier: '${NONEXISTENT_GUARDRAIL_ID}',
+          guardrailVersion: '1',
+        },
+      },
+      {
+        description: 'env variable with whitespace around it',
+        envVars: { TRIMMED_GUARDRAIL_ID: 'gr-trimmed-123' },
+        input: {
+          guardrailIdentifier: '  ${TRIMMED_GUARDRAIL_ID}  ',
+          guardrailVersion: '2',
+        },
+        expected: {
+          guardrailIdentifier: 'gr-trimmed-123',
+          guardrailVersion: '2',
+        },
+      },
+      {
+        description: 'preserve trace field when resolving env variables',
+        envVars: { GUARDRAIL_WITH_TRACE: 'gr-with-trace' },
+        input: {
+          guardrailIdentifier: '${GUARDRAIL_WITH_TRACE}',
+          guardrailVersion: '1',
+          trace: 'enabled_full' as const,
+        },
+        expected: {
+          guardrailIdentifier: 'gr-with-trace',
+          guardrailVersion: '1',
+          trace: 'enabled_full',
+        },
+      },
+    ])('should resolve environment variables: $description', async ({ envVars, deleteEnvVars, input, expected }) => {
+      // Set up environment variables
+      Object.entries(envVars).forEach(([key, value]) => {
+        process.env[key] = value;
+      });
+
+      // Delete specified environment variables
+      deleteEnvVars?.forEach((key) => {
+        delete process.env[key];
+      });
 
       const params = createMockParams({
         config: {
           endpoints: {
             [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: '${GUARDRAIL_ID}',
-                guardrailVersion: '1',
-              },
+              guardrailConfig: input,
             },
           },
         },
@@ -230,150 +324,7 @@ describe('initializeBedrock', () => {
 
       const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
 
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(guardrailId);
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('1');
-    });
-
-    it('should resolve environment variables in guardrailVersion', async () => {
-      const guardrailVersion = 'DRAFT';
-      process.env.GUARDRAIL_VERSION = guardrailVersion;
-
-      const params = createMockParams({
-        config: {
-          endpoints: {
-            [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: 'static-guardrail-id',
-                guardrailVersion: '${GUARDRAIL_VERSION}',
-              },
-            },
-          },
-        },
-      });
-
-      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
-
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe('static-guardrail-id');
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe(guardrailVersion);
-    });
-
-    it('should resolve environment variables in both guardrailIdentifier and guardrailVersion', async () => {
-      const guardrailId = 'gr-production-123';
-      const guardrailVersion = '5';
-      process.env.PROD_GUARDRAIL_ID = guardrailId;
-      process.env.PROD_GUARDRAIL_VERSION = guardrailVersion;
-
-      const params = createMockParams({
-        config: {
-          endpoints: {
-            [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: '${PROD_GUARDRAIL_ID}',
-                guardrailVersion: '${PROD_GUARDRAIL_VERSION}',
-                trace: 'enabled' as const,
-              },
-            },
-          },
-        },
-      });
-
-      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
-
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(guardrailId);
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe(guardrailVersion);
-      expect(result.llmConfig.guardrailConfig?.trace).toBe('enabled');
-    });
-
-    it('should use direct values when no env variable syntax is used', async () => {
-      const params = createMockParams({
-        config: {
-          endpoints: {
-            [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: 'direct-guardrail-id',
-                guardrailVersion: '3',
-              },
-            },
-          },
-        },
-      });
-
-      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
-
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe('direct-guardrail-id');
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('3');
-    });
-
-    it('should fall back to original string when env variable is not set', async () => {
-      delete process.env.NONEXISTENT_GUARDRAIL_ID;
-
-      const params = createMockParams({
-        config: {
-          endpoints: {
-            [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: '${NONEXISTENT_GUARDRAIL_ID}',
-                guardrailVersion: '1',
-              },
-            },
-          },
-        },
-      });
-
-      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
-
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(
-        '${NONEXISTENT_GUARDRAIL_ID}',
-      );
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('1');
-    });
-
-    it('should handle env variable with whitespace around it', async () => {
-      const guardrailId = 'gr-trimmed-123';
-      process.env.TRIMMED_GUARDRAIL_ID = guardrailId;
-
-      const params = createMockParams({
-        config: {
-          endpoints: {
-            [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: '  ${TRIMMED_GUARDRAIL_ID}  ',
-                guardrailVersion: '2',
-              },
-            },
-          },
-        },
-      });
-
-      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
-
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(guardrailId);
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('2');
-    });
-
-    it('should preserve trace field when resolving env variables', async () => {
-      const guardrailId = 'gr-with-trace';
-      process.env.GUARDRAIL_WITH_TRACE = guardrailId;
-
-      const params = createMockParams({
-        config: {
-          endpoints: {
-            [EModelEndpoint.bedrock]: {
-              guardrailConfig: {
-                guardrailIdentifier: '${GUARDRAIL_WITH_TRACE}',
-                guardrailVersion: '1',
-                trace: 'enabled_full' as const,
-              },
-            },
-          },
-        },
-      });
-
-      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
-
-      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(guardrailId);
-      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('1');
-      expect(result.llmConfig.guardrailConfig?.trace).toBe('enabled_full');
+      expect(result.llmConfig.guardrailConfig).toEqual(expected);
     });
   });
 

--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -210,6 +210,171 @@ describe('initializeBedrock', () => {
       expect(result.llmConfig.guardrailConfig).toEqual(guardrailConfig);
       expect(result.llmConfig.guardrailConfig?.trace).toBe('enabled_full');
     });
+
+    it('should resolve environment variables in guardrailIdentifier', async () => {
+      const guardrailId = 'gr-abc123xyz';
+      process.env.GUARDRAIL_ID = guardrailId;
+
+      const params = createMockParams({
+        config: {
+          endpoints: {
+            [EModelEndpoint.bedrock]: {
+              guardrailConfig: {
+                guardrailIdentifier: '${GUARDRAIL_ID}',
+                guardrailVersion: '1',
+              },
+            },
+          },
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(guardrailId);
+      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('1');
+    });
+
+    it('should resolve environment variables in guardrailVersion', async () => {
+      const guardrailVersion = 'DRAFT';
+      process.env.GUARDRAIL_VERSION = guardrailVersion;
+
+      const params = createMockParams({
+        config: {
+          endpoints: {
+            [EModelEndpoint.bedrock]: {
+              guardrailConfig: {
+                guardrailIdentifier: 'static-guardrail-id',
+                guardrailVersion: '${GUARDRAIL_VERSION}',
+              },
+            },
+          },
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe('static-guardrail-id');
+      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe(guardrailVersion);
+    });
+
+    it('should resolve environment variables in both guardrailIdentifier and guardrailVersion', async () => {
+      const guardrailId = 'gr-production-123';
+      const guardrailVersion = '5';
+      process.env.PROD_GUARDRAIL_ID = guardrailId;
+      process.env.PROD_GUARDRAIL_VERSION = guardrailVersion;
+
+      const params = createMockParams({
+        config: {
+          endpoints: {
+            [EModelEndpoint.bedrock]: {
+              guardrailConfig: {
+                guardrailIdentifier: '${PROD_GUARDRAIL_ID}',
+                guardrailVersion: '${PROD_GUARDRAIL_VERSION}',
+                trace: 'enabled' as const,
+              },
+            },
+          },
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(guardrailId);
+      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe(guardrailVersion);
+      expect(result.llmConfig.guardrailConfig?.trace).toBe('enabled');
+    });
+
+    it('should use direct values when no env variable syntax is used', async () => {
+      const params = createMockParams({
+        config: {
+          endpoints: {
+            [EModelEndpoint.bedrock]: {
+              guardrailConfig: {
+                guardrailIdentifier: 'direct-guardrail-id',
+                guardrailVersion: '3',
+              },
+            },
+          },
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe('direct-guardrail-id');
+      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('3');
+    });
+
+    it('should fall back to original string when env variable is not set', async () => {
+      delete process.env.NONEXISTENT_GUARDRAIL_ID;
+
+      const params = createMockParams({
+        config: {
+          endpoints: {
+            [EModelEndpoint.bedrock]: {
+              guardrailConfig: {
+                guardrailIdentifier: '${NONEXISTENT_GUARDRAIL_ID}',
+                guardrailVersion: '1',
+              },
+            },
+          },
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(
+        '${NONEXISTENT_GUARDRAIL_ID}',
+      );
+      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('1');
+    });
+
+    it('should handle env variable with whitespace around it', async () => {
+      const guardrailId = 'gr-trimmed-123';
+      process.env.TRIMMED_GUARDRAIL_ID = guardrailId;
+
+      const params = createMockParams({
+        config: {
+          endpoints: {
+            [EModelEndpoint.bedrock]: {
+              guardrailConfig: {
+                guardrailIdentifier: '  ${TRIMMED_GUARDRAIL_ID}  ',
+                guardrailVersion: '2',
+              },
+            },
+          },
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(guardrailId);
+      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('2');
+    });
+
+    it('should preserve trace field when resolving env variables', async () => {
+      const guardrailId = 'gr-with-trace';
+      process.env.GUARDRAIL_WITH_TRACE = guardrailId;
+
+      const params = createMockParams({
+        config: {
+          endpoints: {
+            [EModelEndpoint.bedrock]: {
+              guardrailConfig: {
+                guardrailIdentifier: '${GUARDRAIL_WITH_TRACE}',
+                guardrailVersion: '1',
+                trace: 'enabled_full' as const,
+              },
+            },
+          },
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.guardrailConfig?.guardrailIdentifier).toBe(guardrailId);
+      expect(result.llmConfig.guardrailConfig?.guardrailVersion).toBe('1');
+      expect(result.llmConfig.guardrailConfig?.trace).toBe('enabled_full');
+    });
   });
 
   describe('Proxy Configuration', () => {

--- a/packages/api/src/endpoints/bedrock/initialize.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.ts
@@ -120,7 +120,11 @@ export async function initializeBedrock({
   };
 
   if (bedrockConfig?.guardrailConfig) {
-    llmConfig.guardrailConfig = bedrockConfig.guardrailConfig;
+    llmConfig.guardrailConfig = {
+      guardrailIdentifier: extractEnvVariable(bedrockConfig.guardrailConfig.guardrailIdentifier),
+      guardrailVersion: extractEnvVariable(bedrockConfig.guardrailConfig.guardrailVersion),
+      trace: bedrockConfig.guardrailConfig.trace,
+    };
   }
 
   const model = model_parameters?.model as string | undefined;

--- a/packages/api/src/endpoints/bedrock/initialize.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.ts
@@ -121,9 +121,9 @@ export async function initializeBedrock({
 
   if (bedrockConfig?.guardrailConfig) {
     llmConfig.guardrailConfig = {
+      ...bedrockConfig.guardrailConfig,
       guardrailIdentifier: extractEnvVariable(bedrockConfig.guardrailConfig.guardrailIdentifier),
       guardrailVersion: extractEnvVariable(bedrockConfig.guardrailConfig.guardrailVersion),
-      trace: bedrockConfig.guardrailConfig.trace,
     };
   }
 


### PR DESCRIPTION
## Summary

Supports loading Bedrock guardrailConfig items from environment variables, using the existing extractEnvVariable() method.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

I've added tests in the Bedrock initialize.spec.ts to ensure env var expansion is working as expected.

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
