### PR TITLE
fix: route to new conversation when conversation not found

### DIFF
--- a/client/src/data-provider/queries.ts
+++ b/client/src/data-provider/queries.ts
@@ -32,7 +32,7 @@ import type {
 } from 'librechat-data-provider';
 import type { ConversationCursorData } from '~/utils/convos';
 import { findConversationInInfinite } from '~/utils';
-import { AxiosError } from 'axios';
+import axios from 'axios';
 
 export const useGetPresetsQuery = (
   config?: UseQueryOptions<TPreset[]>,
@@ -74,7 +74,7 @@ export const useGetConvoIdQuery = (
       refetchOnMount: false,
       retry: (failureCount, error) => {
         // Early exit on 404
-        if (error instanceof AxiosError && error.response?.status == 404) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
           return false;
         }
 

--- a/client/src/data-provider/queries.ts
+++ b/client/src/data-provider/queries.ts
@@ -32,6 +32,7 @@ import type {
 } from 'librechat-data-provider';
 import type { ConversationCursorData } from '~/utils/convos';
 import { findConversationInInfinite } from '~/utils';
+import { AxiosError } from 'axios';
 
 export const useGetPresetsQuery = (
   config?: UseQueryOptions<TPreset[]>,
@@ -71,6 +72,15 @@ export const useGetConvoIdQuery = (
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       refetchOnMount: false,
+      retry: (failureCount, error) => {
+        // Early exit on 404
+        if (error instanceof AxiosError && error.response?.status == 404) {
+          return false;
+        }
+
+        // Default to 3 retries
+        return failureCount < 3;
+      },
       ...config,
     },
   );

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -13,6 +13,7 @@ import ChatView from '~/components/Chat/ChatView';
 import useAuthRedirect from './useAuthRedirect';
 import temporaryStore from '~/store/temporary';
 import store from '~/store';
+import { AxiosError } from 'axios';
 
 export default function ChatRoute() {
   const { data: startupConfig } = useGetStartupConfig();
@@ -117,6 +118,14 @@ export default function ChatRoute() {
         modelsData: modelsQuery.data,
         keepLatestMessage: true,
       });
+      hasSetConversation.current = true;
+    } else if (
+      initialConvoQuery.isError &&
+      initialConvoQuery.error instanceof AxiosError &&
+      initialConvoQuery.error.response?.status === 404
+    ) {
+      // If we get a 404, the conversation doesn't exist - reroute to a new conversation
+      newConversation();
       hasSetConversation.current = true;
     }
     /* Creates infinite render if all dependencies included due to newConversation invocations exceeding call stack before hasSetConversation.current becomes truthy */


### PR DESCRIPTION
## Summary

Temporary conversations naturally expire at some point, after which they return 404 from the API. However, a user might still try to navigate to a temporary conversation later (or simply have the tab open still), which results in a blank screen (which is confusing).

Now, we quickly detect if the conversation can't be found (via 404) and reroute them to a new conversation if that's the case.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tried navigating to a conversation by modifying the URL in the browser to an invalid UUID, then verified that the app redirected me back to a new conversation.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
