### PR TITLE
🛡️ fix: Implement TOCTOU-Safe SSRF Protection for Actions and MCP

### DIFF
--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -338,6 +338,7 @@ async function processRequiredActions(client, requiredActions) {
       }
 
       // We've already decrypted the metadata, so we can pass it directly
+      const _allowedDomains = appConfig?.actions?.allowedDomains;
       tool = await createActionTool({
         userId: client.req.user.id,
         res: client.res,
@@ -345,6 +346,7 @@ async function processRequiredActions(client, requiredActions) {
         requestBuilder,
         // Note: intentionally not passing zodSchema, name, and description for assistants API
         encrypted, // Pass the encrypted values for OAuth flow
+        useSSRFProtection: !Array.isArray(_allowedDomains) || _allowedDomains.length === 0,
       });
       if (!tool) {
         logger.warn(
@@ -1064,6 +1066,7 @@ async function loadAgentTools({
     const zodSchema = zodSchemas[functionName];
 
     if (requestBuilder) {
+      const _allowedDomains = appConfig?.actions?.allowedDomains;
       const tool = await createActionTool({
         userId: req.user.id,
         res,
@@ -1074,6 +1077,7 @@ async function loadAgentTools({
         name: toolName,
         description: functionSig.description,
         streamId,
+        useSSRFProtection: !Array.isArray(_allowedDomains) || _allowedDomains.length === 0,
       });
 
       if (!tool) {
@@ -1372,6 +1376,7 @@ async function loadActionToolsForExecution({
       requestBuilder,
       name: toolName,
       description: functionSig?.description ?? '',
+      useSSRFProtection: !Array.isArray(allowedDomains) || allowedDomains.length === 0,
     });
 
     if (!tool) {

--- a/packages/api/src/auth/agent.spec.ts
+++ b/packages/api/src/auth/agent.spec.ts
@@ -1,0 +1,113 @@
+jest.mock('node:dns', () => {
+  const actual = jest.requireActual('node:dns');
+  return {
+    ...actual,
+    lookup: jest.fn(),
+  };
+});
+
+import dns from 'node:dns';
+import { createSSRFSafeAgents, createSSRFSafeUndiciConnect } from './agent';
+
+type LookupCallback = (err: NodeJS.ErrnoException | null, address: string, family: number) => void;
+
+const mockedDnsLookup = dns.lookup as jest.MockedFunction<typeof dns.lookup>;
+
+function mockDnsResult(address: string, family: number): void {
+  mockedDnsLookup.mockImplementation(((
+    _hostname: string,
+    _options: unknown,
+    callback: LookupCallback,
+  ) => {
+    callback(null, address, family);
+  }) as never);
+}
+
+function mockDnsError(err: NodeJS.ErrnoException): void {
+  mockedDnsLookup.mockImplementation(((
+    _hostname: string,
+    _options: unknown,
+    callback: LookupCallback,
+  ) => {
+    callback(err, '', 0);
+  }) as never);
+}
+
+describe('createSSRFSafeAgents', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return httpAgent and httpsAgent', () => {
+    const agents = createSSRFSafeAgents();
+    expect(agents.httpAgent).toBeDefined();
+    expect(agents.httpsAgent).toBeDefined();
+  });
+
+  it('should patch httpAgent createConnection to inject SSRF lookup', () => {
+    const agents = createSSRFSafeAgents();
+    const internal = agents.httpAgent as unknown as {
+      createConnection: (opts: Record<string, unknown>) => unknown;
+    };
+    expect(internal.createConnection).toBeInstanceOf(Function);
+  });
+});
+
+describe('createSSRFSafeUndiciConnect', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return an object with a lookup function', () => {
+    const connect = createSSRFSafeUndiciConnect();
+    expect(connect).toHaveProperty('lookup');
+    expect(connect.lookup).toBeInstanceOf(Function);
+  });
+
+  it('lookup should block private IPs', async () => {
+    mockDnsResult('10.0.0.1', 4);
+    const connect = createSSRFSafeUndiciConnect();
+
+    const result = await new Promise<{ err: NodeJS.ErrnoException | null }>((resolve) => {
+      connect.lookup('evil.example.com', {}, (err) => {
+        resolve({ err });
+      });
+    });
+
+    expect(result.err).toBeTruthy();
+    expect(result.err!.code).toBe('ESSRF');
+  });
+
+  it('lookup should allow public IPs', async () => {
+    mockDnsResult('93.184.216.34', 4);
+    const connect = createSSRFSafeUndiciConnect();
+
+    const result = await new Promise<{ err: NodeJS.ErrnoException | null; address: string }>(
+      (resolve) => {
+        connect.lookup('example.com', {}, (err, address) => {
+          resolve({ err, address: address as string });
+        });
+      },
+    );
+
+    expect(result.err).toBeNull();
+    expect(result.address).toBe('93.184.216.34');
+  });
+
+  it('lookup should forward DNS errors', async () => {
+    const dnsError = Object.assign(new Error('ENOTFOUND'), {
+      code: 'ENOTFOUND',
+    }) as NodeJS.ErrnoException;
+    mockDnsError(dnsError);
+    const connect = createSSRFSafeUndiciConnect();
+
+    const result = await new Promise<{ err: NodeJS.ErrnoException | null }>((resolve) => {
+      connect.lookup('nonexistent.example.com', {}, (err) => {
+        resolve({ err });
+      });
+    });
+
+    expect(result.err).toBeTruthy();
+    expect(result.err!.code).toBe('ENOTFOUND');
+  });
+});

--- a/packages/api/src/auth/agent.ts
+++ b/packages/api/src/auth/agent.ts
@@ -1,0 +1,53 @@
+import dns from 'node:dns';
+import http from 'node:http';
+import https from 'node:https';
+import type { LookupFunction } from 'node:net';
+import { isPrivateIP } from './domain';
+
+/** DNS lookup wrapper that blocks resolution to private/reserved IP addresses */
+const ssrfSafeLookup: LookupFunction = (hostname, options, callback) => {
+  dns.lookup(hostname, options, (err, address, family) => {
+    if (err) {
+      callback(err, '', 0);
+      return;
+    }
+    if (typeof address === 'string' && isPrivateIP(address)) {
+      const ssrfError = Object.assign(
+        new Error(`SSRF protection: ${hostname} resolved to blocked address ${address}`),
+        { code: 'ESSRF' },
+      ) as NodeJS.ErrnoException;
+      callback(ssrfError, address, family as number);
+      return;
+    }
+    callback(null, address as string, family as number);
+  });
+};
+
+/** Internal agent shape exposing createConnection (exists at runtime but not in TS types) */
+type AgentInternal = {
+  createConnection: (options: Record<string, unknown>, oncreate?: unknown) => unknown;
+};
+
+/** Patches an agent instance to inject SSRF-safe DNS lookup at connect time */
+function withSSRFProtection<T extends http.Agent>(agent: T): T {
+  const internal = agent as unknown as AgentInternal;
+  const origCreate = internal.createConnection.bind(agent);
+  internal.createConnection = (options: Record<string, unknown>, oncreate?: unknown) => {
+    options.lookup = ssrfSafeLookup;
+    return origCreate(options, oncreate);
+  };
+  return agent;
+}
+
+/**
+ * Creates HTTP and HTTPS agents that block TCP connections to private/reserved IP addresses.
+ * Provides TOCTOU-safe SSRF protection by validating the resolved IP at connect time,
+ * preventing DNS rebinding attacks where a hostname resolves to a public IP during
+ * pre-validation but to a private IP when the actual connection is made.
+ */
+export function createSSRFSafeAgents(): { httpAgent: http.Agent; httpsAgent: https.Agent } {
+  return {
+    httpAgent: withSSRFProtection(new http.Agent()),
+    httpsAgent: withSSRFProtection(new https.Agent()),
+  };
+}

--- a/packages/api/src/auth/agent.ts
+++ b/packages/api/src/auth/agent.ts
@@ -51,3 +51,11 @@ export function createSSRFSafeAgents(): { httpAgent: http.Agent; httpsAgent: htt
     httpsAgent: withSSRFProtection(new https.Agent()),
   };
 }
+
+/**
+ * Returns undici-compatible `connect` options with SSRF-safe DNS lookup.
+ * Pass the result as the `connect` property when constructing an undici `Agent`.
+ */
+export function createSSRFSafeUndiciConnect(): { lookup: LookupFunction } {
+  return { lookup: ssrfSafeLookup };
+}

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -1,3 +1,4 @@
 export * from './domain';
 export * from './openid';
 export * from './exchange';
+export * from './agent';

--- a/packages/api/src/mcp/ConnectionsRepository.ts
+++ b/packages/api/src/mcp/ConnectionsRepository.ts
@@ -73,6 +73,7 @@ export class ConnectionsRepository {
       {
         serverName,
         serverConfig,
+        useSSRFProtection: MCPServersRegistry.getInstance().shouldEnableSSRFProtection(),
       },
       this.oauthOpts,
     );

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -29,6 +29,7 @@ export class MCPConnectionFactory {
   protected readonly serverConfig: t.MCPOptions;
   protected readonly logPrefix: string;
   protected readonly useOAuth: boolean;
+  protected readonly useSSRFProtection: boolean;
 
   // OAuth-related properties (only set when useOAuth is true)
   protected readonly userId?: string;
@@ -72,6 +73,7 @@ export class MCPConnectionFactory {
       serverConfig: this.serverConfig,
       userId: this.userId,
       oauthTokens,
+      useSSRFProtection: this.useSSRFProtection,
     });
 
     const oauthHandler = async () => {
@@ -146,6 +148,7 @@ export class MCPConnectionFactory {
       serverConfig: this.serverConfig,
       userId: this.userId,
       oauthTokens: null,
+      useSSRFProtection: this.useSSRFProtection,
     });
 
     unauthConnection.on('oauthRequired', () => {
@@ -189,6 +192,7 @@ export class MCPConnectionFactory {
     });
     this.serverName = basic.serverName;
     this.useOAuth = !!oauth?.useOAuth;
+    this.useSSRFProtection = basic.useSSRFProtection === true;
     this.connectionTimeout = oauth?.connectionTimeout;
     this.logPrefix = oauth?.user
       ? `[MCP][${basic.serverName}][${oauth.user.id}]`
@@ -213,6 +217,7 @@ export class MCPConnectionFactory {
       serverConfig: this.serverConfig,
       userId: this.userId,
       oauthTokens,
+      useSSRFProtection: this.useSSRFProtection,
     });
 
     let cleanupOAuthHandlers: (() => void) | null = null;

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -102,7 +102,8 @@ export class MCPManager extends UserConnectionManager {
       serverConfig.requiresOAuth || (serverConfig as t.ParsedServerConfig).oauthMetadata,
     );
 
-    const basic: t.BasicConnectionOptions = { serverName, serverConfig };
+    const useSSRFProtection = MCPServersRegistry.getInstance().shouldEnableSSRFProtection();
+    const basic: t.BasicConnectionOptions = { serverName, serverConfig, useSSRFProtection };
 
     if (!useOAuth) {
       const result = await MCPConnectionFactory.discoverTools(basic);

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -117,6 +117,7 @@ export abstract class UserConnectionManager {
         {
           serverName: serverName,
           serverConfig: config,
+          useSSRFProtection: MCPServersRegistry.getInstance().shouldEnableSSRFProtection(),
         },
         {
           useOAuth: true,

--- a/packages/api/src/mcp/__tests__/ConnectionsRepository.test.ts
+++ b/packages/api/src/mcp/__tests__/ConnectionsRepository.test.ts
@@ -24,6 +24,7 @@ jest.mock('../connection');
 const mockRegistryInstance = {
   getServerConfig: jest.fn(),
   getAllServerConfigs: jest.fn(),
+  shouldEnableSSRFProtection: jest.fn().mockReturnValue(false),
 };
 
 jest.mock('../registry/MCPServersRegistry', () => ({
@@ -108,6 +109,7 @@ describe('ConnectionsRepository', () => {
         {
           serverName: 'server1',
           serverConfig: mockServerConfigs.server1,
+          useSSRFProtection: false,
         },
         undefined,
       );
@@ -129,6 +131,7 @@ describe('ConnectionsRepository', () => {
         {
           serverName: 'server1',
           serverConfig: mockServerConfigs.server1,
+          useSSRFProtection: false,
         },
         undefined,
       );
@@ -167,6 +170,7 @@ describe('ConnectionsRepository', () => {
         {
           serverName: 'server1',
           serverConfig: configWithCachedAt,
+          useSSRFProtection: false,
         },
         undefined,
       );

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -84,6 +84,7 @@ describe('MCPConnectionFactory', () => {
         serverConfig: mockServerConfig,
         userId: undefined,
         oauthTokens: null,
+        useSSRFProtection: false,
       });
       expect(mockConnectionInstance.connect).toHaveBeenCalled();
     });
@@ -125,6 +126,7 @@ describe('MCPConnectionFactory', () => {
         serverConfig: mockServerConfig,
         userId: 'user123',
         oauthTokens: mockTokens,
+        useSSRFProtection: false,
       });
     });
   });
@@ -184,6 +186,7 @@ describe('MCPConnectionFactory', () => {
         serverConfig: mockServerConfig,
         userId: 'user123',
         oauthTokens: null,
+        useSSRFProtection: false,
       });
       expect(mockLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining('No existing tokens found or error loading tokens'),

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -33,6 +33,7 @@ const mockRegistryInstance = {
   getServerConfig: jest.fn(),
   getAllServerConfigs: jest.fn(),
   getOAuthServers: jest.fn(),
+  shouldEnableSSRFProtection: jest.fn().mockReturnValue(false),
 };
 
 jest.mock('~/mcp/registry/MCPServersRegistry', () => ({

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -20,6 +20,7 @@ import type {
 import type { MCPOAuthTokens } from './oauth/types';
 import { withTimeout } from '~/utils/promise';
 import type * as t from './types';
+import { createSSRFSafeUndiciConnect } from '~/auth';
 import { sanitizeUrlForLogging } from './utils';
 import { mcpConfig } from './mcpConfig';
 
@@ -213,6 +214,7 @@ interface MCPConnectionParams {
   serverConfig: t.MCPOptions;
   userId?: string;
   oauthTokens?: MCPOAuthTokens | null;
+  useSSRFProtection?: boolean;
 }
 
 export class MCPConnection extends EventEmitter {
@@ -233,6 +235,7 @@ export class MCPConnection extends EventEmitter {
   private oauthTokens?: MCPOAuthTokens | null;
   private requestHeaders?: Record<string, string> | null;
   private oauthRequired = false;
+  private readonly useSSRFProtection: boolean;
   iconPath?: string;
   timeout?: number;
   url?: string;
@@ -263,6 +266,7 @@ export class MCPConnection extends EventEmitter {
     this.options = params.serverConfig;
     this.serverName = params.serverName;
     this.userId = params.userId;
+    this.useSSRFProtection = params.useSSRFProtection === true;
     this.iconPath = params.serverConfig.iconPath;
     this.timeout = params.serverConfig.timeout;
     this.lastPingTime = Date.now();
@@ -301,6 +305,7 @@ export class MCPConnection extends EventEmitter {
     getHeaders: () => Record<string, string> | null | undefined,
     timeout?: number,
   ): (input: UndiciRequestInfo, init?: UndiciRequestInit) => Promise<UndiciResponse> {
+    const ssrfConnect = this.useSSRFProtection ? createSSRFSafeUndiciConnect() : undefined;
     return function customFetch(
       input: UndiciRequestInfo,
       init?: UndiciRequestInit,
@@ -310,6 +315,7 @@ export class MCPConnection extends EventEmitter {
       const agent = new Agent({
         bodyTimeout: effectiveTimeout,
         headersTimeout: effectiveTimeout,
+        ...(ssrfConnect != null ? { connect: ssrfConnect } : {}),
       });
       if (!requestHeaders) {
         return undiciFetch(input, { ...init, dispatcher: agent });
@@ -402,6 +408,7 @@ export class MCPConnection extends EventEmitter {
            * The connect timeout is extended because proxies may delay initial response.
            */
           const sseTimeout = this.timeout || SSE_CONNECT_TIMEOUT;
+          const ssrfConnect = this.useSSRFProtection ? createSSRFSafeUndiciConnect() : undefined;
           const transport = new SSEClientTransport(url, {
             requestInit: {
               /** User/OAuth headers override SSE defaults */
@@ -420,6 +427,7 @@ export class MCPConnection extends EventEmitter {
                   /** Extended keep-alive for long-lived SSE connections */
                   keepAliveTimeout: sseTimeout,
                   keepAliveMaxTimeout: sseTimeout * 2,
+                  ...(ssrfConnect != null ? { connect: ssrfConnect } : {}),
                 });
                 return undiciFetch(url, {
                   ...init,

--- a/packages/api/src/mcp/registry/MCPServerInspector.ts
+++ b/packages/api/src/mcp/registry/MCPServerInspector.ts
@@ -18,6 +18,7 @@ export class MCPServerInspector {
     private readonly serverName: string,
     private readonly config: t.ParsedServerConfig,
     private connection: MCPConnection | undefined,
+    private readonly useSSRFProtection: boolean = false,
   ) {}
 
   /**
@@ -42,8 +43,9 @@ export class MCPServerInspector {
       throw new MCPDomainNotAllowedError(domain ?? 'unknown');
     }
 
+    const useSSRFProtection = !Array.isArray(allowedDomains) || allowedDomains.length === 0;
     const start = Date.now();
-    const inspector = new MCPServerInspector(serverName, rawConfig, connection);
+    const inspector = new MCPServerInspector(serverName, rawConfig, connection, useSSRFProtection);
     await inspector.inspectServer();
     inspector.config.initDuration = Date.now() - start;
     return inspector.config;
@@ -59,6 +61,7 @@ export class MCPServerInspector {
         this.connection = await MCPConnectionFactory.create({
           serverName: this.serverName,
           serverConfig: this.config,
+          useSSRFProtection: this.useSSRFProtection,
         });
       }
 

--- a/packages/api/src/mcp/registry/MCPServersRegistry.ts
+++ b/packages/api/src/mcp/registry/MCPServersRegistry.ts
@@ -77,6 +77,15 @@ export class MCPServersRegistry {
     return MCPServersRegistry.instance;
   }
 
+  public getAllowedDomains(): string[] | null | undefined {
+    return this.allowedDomains;
+  }
+
+  /** Returns true when no explicit allowedDomains allowlist is configured, enabling SSRF TOCTOU protection */
+  public shouldEnableSSRFProtection(): boolean {
+    return !Array.isArray(this.allowedDomains) || this.allowedDomains.length === 0;
+  }
+
   public async getServerConfig(
     serverName: string,
     userId?: string,

--- a/packages/api/src/mcp/registry/__tests__/MCPServerInspector.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServerInspector.test.ts
@@ -276,6 +276,7 @@ describe('MCPServerInspector', () => {
       expect(MCPConnectionFactory.create).toHaveBeenCalledWith({
         serverName: 'test_server',
         serverConfig: expect.objectContaining({ type: 'stdio', command: 'node' }),
+        useSSRFProtection: true,
       });
 
       // Verify temporary connection was disconnected

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -166,6 +166,7 @@ export type AddServerResult = {
 export interface BasicConnectionOptions {
   serverName: string;
   serverConfig: MCPOptions;
+  useSSRFProtection?: boolean;
 }
 
 export interface OAuthConnectionOptions {


### PR DESCRIPTION


## Summary

I implemented comprehensive SSRF protection for Actions and MCP connections to prevent DNS rebinding attacks and DNS-based bypasses, including TOCTOU-safe agent validation for HTTP transports and DNS pre-validation for WebSocket connections.

- Created `createSSRFSafeAgents()` and `createSSRFSafeUndiciConnect()` functions that inject custom DNS lookup at TCP connect time, preventing DNS rebinding attacks where hostnames resolve to public IPs during validation but private IPs during connection
- Implemented `isPrivateIP()` function to detect IPv4, IPv6, and IPv4-mapped IPv6 addresses in private/reserved/link-local ranges (127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, ::1, fc00::/7, fe80::/10)
- Added `resolveHostnameSSRF()` async function to detect DNS-based SSRF bypasses like nip.io wildcard DNS and attacker-controlled nameservers
- Modified `RequestExecutor.execute()` to accept optional `httpAgent` and `httpsAgent` parameters and pass them to axios.create() for TOCTOU-safe SSRF protection
- Updated `createActionTool()` in ActionService and ToolService to conditionally enable SSRF protection when no `allowedDomains` allowlist is configured
- Enhanced `MCPConnection.constructTransport()` to async and added DNS pre-validation for WebSocket connections, blocking connections to private/reserved IPs before transport creation
- Integrated SSRF-safe undici agents into SSE and Streamable HTTP transports via `createFetchFunction()` using `createSSRFSafeUndiciConnect()`
- Added `useSSRFProtection` parameter to `MCPConnectionParams`, `BasicConnectionOptions`, and throughout MCP connection factory classes
- Implemented `MCPServersRegistry.shouldEnableSSRFProtection()` to centralize SSRF protection enablement logic based on allowlist configuration
- Refactored `isSSRFTarget()` to use the new `isPrivateIP()` function for cleaner IP validation logic
- Enhanced `isDomainAllowedCore()` to call `resolveHostnameSSRF()` for hostname validation when no allowlist is configured
- Wrote comprehensive unit tests in `agent.spec.ts` covering SSRF-safe agent creation, DNS lookup blocking/allowing, and error forwarding
- Expanded `domain.spec.ts` with 159 additional test cases for `isPrivateIP()`, `resolveHostnameSSRF()`, and DNS resolution SSRF protection scenarios
- Added test coverage in `actions.spec.ts` verifying httpAgent/httpsAgent passthrough to axios.create() for GET and POST requests
- Updated all MCP test files to mock `shouldEnableSSRFProtection()` and include `useSSRFProtection` parameter in assertions

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

I tested the SSRF protection implementation with comprehensive unit tests and manual verification of DNS resolution behavior.

### **Test Configuration**:

**Unit Tests:**
- Verified SSRF-safe agents block private IPs (10.0.0.1) while allowing public IPs (93.184.216.34)
- Tested DNS error forwarding (ENOTFOUND) passes through correctly
- Validated `isPrivateIP()` correctly identifies all private IPv4 ranges (127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16), IPv6 loopback/link-local (::1, fc00::/7, fe80::/10), and IPv4-mapped IPv6 addresses (::ffff:169.254.169.254)
- Confirmed `resolveHostnameSSRF()` detects nip.io-style DNS bypasses (169.254.169.254.nip.io), dual-stack addresses with mixed public/private IPs, and fails open on DNS errors
- Tested cloud metadata IP blocking (169.254.169.254) and Docker network blocking (172.16.0.1)
- Verified SSRF protection skips when `allowedDomains` is explicitly configured
- Confirmed httpAgent/httpsAgent passthrough to axios.create() for Actions
- Validated WebSocket DNS pre-validation throws errors for private IPs when SSRF protection is enabled

**Manual Testing:**
- Enabled SSRF protection by removing `allowedDomains` configuration
- Attempted to create actions pointing to localhost, 127.0.0.1, 10.0.0.1, 169.254.169.254, and verified blocking
- Tested MCP connections to WebSocket servers with private IPs and confirmed connection rejection
- Verified SSE and HTTP transports connect successfully to public endpoints with SSRF agents active

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules