### PR TITLE
🔎 fix: Include Legacy Documents With Undefined `_meiliIndex` in Search Sync

### DIFF
--- a/api/db/utils.js
+++ b/api/db/utils.js
@@ -26,7 +26,7 @@ async function batchResetMeiliFlags(collection) {
   try {
     while (hasMore) {
       const docs = await collection
-        .find({ expiredAt: null, _meiliIndex: true }, { projection: { _id: 1 } })
+        .find({ expiredAt: null, _meiliIndex: { $ne: false } }, { projection: { _id: 1 } })
         .limit(BATCH_SIZE)
         .toArray();
 

--- a/api/db/utils.spec.js
+++ b/api/db/utils.spec.js
@@ -286,7 +286,7 @@ describe('batchResetMeiliFlags', () => {
       const flaggedDocs = await testCollection
         .find({ expiredAt: null, _meiliIndex: false })
         .toArray();
-      expect(flaggedDocs).toHaveLength(5); // 2 were updated, 1 was already false
+      expect(flaggedDocs).toHaveLength(5); // 4 were updated, 1 was already false
     });
   });
 

--- a/api/db/utils.spec.js
+++ b/api/db/utils.spec.js
@@ -265,8 +265,8 @@ describe('batchResetMeiliFlags', () => {
 
       const result = await batchResetMeiliFlags(testCollection);
 
-      // Only one document has _meiliIndex: true
-      expect(result).toBe(1);
+      // both documents should be updated
+      expect(result).toBe(2);
     });
 
     it('should handle mixed document states correctly', async () => {
@@ -275,16 +275,18 @@ describe('batchResetMeiliFlags', () => {
         { _id: new mongoose.Types.ObjectId(), expiredAt: null, _meiliIndex: false },
         { _id: new mongoose.Types.ObjectId(), expiredAt: new Date(), _meiliIndex: true },
         { _id: new mongoose.Types.ObjectId(), expiredAt: null, _meiliIndex: true },
+        { _id: new mongoose.Types.ObjectId(), expiredAt: null, _meiliIndex: null },
+        { _id: new mongoose.Types.ObjectId(), expiredAt: null },
       ]);
 
       const result = await batchResetMeiliFlags(testCollection);
 
-      expect(result).toBe(2);
+      expect(result).toBe(4);
 
       const flaggedDocs = await testCollection
         .find({ expiredAt: null, _meiliIndex: false })
         .toArray();
-      expect(flaggedDocs).toHaveLength(3); // 2 were updated, 1 was already false
+      expect(flaggedDocs).toHaveLength(5); // 2 were updated, 1 was already false
     });
   });
 

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -196,7 +196,7 @@ const createMeiliMongooseModel = ({
       while (hasMore) {
         const query: FilterQuery<unknown> = {
           expiredAt: null,
-          _meiliIndex: false,
+          _meiliIndex: { $ne: true },
         };
 
         try {

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -162,8 +162,8 @@ const createMeiliMongooseModel = ({
 
     /**
      * Synchronizes data between the MongoDB collection and the MeiliSearch index by
-     * incrementally indexing only documents where `expiredAt` is `null` and `_meiliIndex` is `false`
-     * (i.e., non-expired documents that have not yet been indexed).
+     * incrementally indexing only documents where `expiredAt` is `null` and `_meiliIndex` is not `true`
+     * (i.e., non-expired documents that have not yet been indexed, including those with missing or null `_meiliIndex`).
      * */
     static async syncWithMeili(this: SchemaWithMeiliMethods): Promise<void> {
       const startTime = Date.now();


### PR DESCRIPTION
## Summary

Legacy documents in MongoDB might be missing the `_meiliIndex` property. The current sync process skips these documents, causing them to be excluded from search results.

This PR updates the query to include these documents (via `$ne: false`) in both the sync process and the `reset-meili-sync` command.

Confirmed that the updated query utilizes the index properly via `.explain("executionStats")`:

```javascript
// Query: db.messages.find({_meiliIndex: { $ne: false }})

// Key stats from output:
{
  "stage": "FETCH",
  "nReturned": 1044645,
  "inputStage": {
      "stage": "IXSCAN",
      "indexName": "_meiliIndex_1_expiredAt_1"
  }
}
```
## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Extended unit-tests to test cases where _meiliSearch property is not present.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
