### PR TITLE
🛡️ fix: Secure MCP/Actions OAuth Flows, Resolve Race Condition & Tool Cache Cleanup

### DIFF
--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -36,6 +36,7 @@ const {
 const { updateUserPluginAuth, deleteUserPluginAuth } = require('~/server/services/PluginService');
 const { verifyEmail, resendVerificationEmail } = require('~/server/services/AuthService');
 const { getMCPManager, getFlowStateManager, getMCPServersRegistry } = require('~/config');
+const { invalidateCachedTools } = require('~/server/services/Config/getCachedTools');
 const { needsRefresh, getNewS3URL } = require('~/server/services/Files/S3/crud');
 const { processDeleteRequest } = require('~/server/services/Files/process');
 const { getAppConfig } = require('~/server/services/Config');
@@ -215,6 +216,7 @@ const updateUserPluginsController = async (req, res) => {
               `[updateUserPluginsController] Attempting disconnect of MCP server "${serverName}" for user ${user.id} after plugin auth update.`,
             );
             await mcpManager.disconnectUserConnection(user.id, serverName);
+            await invalidateCachedTools({ userId: user.id, serverName });
           }
         } catch (disconnectError) {
           logger.error(

--- a/api/server/middleware/requireJwtAuth.js
+++ b/api/server/middleware/requireJwtAuth.js
@@ -7,16 +7,13 @@ const { isEnabled } = require('@librechat/api');
  * Switches between JWT and OpenID authentication based on cookies and environment settings
  */
 const requireJwtAuth = (req, res, next) => {
-  // Check if token provider is specified in cookies
   const cookieHeader = req.headers.cookie;
   const tokenProvider = cookieHeader ? cookies.parse(cookieHeader).token_provider : null;
 
-  // Use OpenID authentication if token provider is OpenID and OPENID_REUSE_TOKENS is enabled
   if (tokenProvider === 'openid' && isEnabled(process.env.OPENID_REUSE_TOKENS)) {
     return passport.authenticate('openidJwt', { session: false })(req, res, next);
   }
 
-  // Default to standard JWT authentication
   return passport.authenticate('jwt', { session: false })(req, res, next);
 };
 

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -3,8 +3,8 @@ const express = require('express');
 const request = require('supertest');
 const mongoose = require('mongoose');
 const cookieParser = require('cookie-parser');
-const { MongoMemoryServer } = require('mongodb-memory-server');
 const { getBasePath } = require('@librechat/api');
+const { MongoMemoryServer } = require('mongodb-memory-server');
 
 function generateTestCsrfToken(flowId) {
   return crypto

--- a/api/server/routes/actions.js
+++ b/api/server/routes/actions.js
@@ -1,14 +1,47 @@
 const express = require('express');
 const jwt = require('jsonwebtoken');
-const { getAccessToken, getBasePath } = require('@librechat/api');
 const { logger } = require('@librechat/data-schemas');
 const { CacheKeys } = require('librechat-data-provider');
+const {
+  getBasePath,
+  getAccessToken,
+  setOAuthSession,
+  validateOAuthCsrf,
+  OAUTH_CSRF_COOKIE,
+  setOAuthCsrfCookie,
+  validateOAuthSession,
+  OAUTH_SESSION_COOKIE,
+} = require('@librechat/api');
 const { findToken, updateToken, createToken } = require('~/models');
+const { requireJwtAuth } = require('~/server/middleware');
 const { getFlowStateManager } = require('~/config');
 const { getLogStores } = require('~/cache');
 
 const router = express.Router();
 const JWT_SECRET = process.env.JWT_SECRET;
+const OAUTH_CSRF_COOKIE_PATH = '/api/actions';
+
+/**
+ * Sets a CSRF cookie binding the action OAuth flow to the current browser session.
+ * Must be called before the user opens the IdP authorization URL.
+ *
+ * @route POST /actions/:action_id/oauth/bind
+ */
+router.post('/:action_id/oauth/bind', requireJwtAuth, setOAuthSession, async (req, res) => {
+  try {
+    const { action_id } = req.params;
+    const user = req.user;
+    if (!user?.id) {
+      return res.status(401).json({ error: 'User not authenticated' });
+    }
+    const flowId = `${user.id}:${action_id}`;
+    setOAuthCsrfCookie(res, flowId, OAUTH_CSRF_COOKIE_PATH);
+    res.json({ success: true });
+  } catch (error) {
+    logger.error('[Action OAuth] Failed to set CSRF binding cookie', error);
+    res.status(500).json({ error: 'Failed to bind OAuth flow' });
+  }
+});
 
 /**
  * Handles the OAuth callback and exchanges the authorization code for tokens.
@@ -45,7 +78,22 @@ router.get('/:action_id/oauth/callback', async (req, res) => {
       await flowManager.failFlow(identifier, 'oauth', 'Invalid user ID in state parameter');
       return res.redirect(`${basePath}/oauth/error?error=invalid_state`);
     }
+
     identifier = `${decodedState.user}:${action_id}`;
+
+    if (
+      !validateOAuthCsrf(req, res, identifier, OAUTH_CSRF_COOKIE_PATH) &&
+      !validateOAuthSession(req, decodedState.user)
+    ) {
+      logger.error('[Action OAuth] CSRF validation failed: no valid CSRF or session cookie', {
+        identifier,
+        hasCsrfCookie: !!req.cookies?.[OAUTH_CSRF_COOKIE],
+        hasSessionCookie: !!req.cookies?.[OAUTH_SESSION_COOKIE],
+      });
+      await flowManager.failFlow(identifier, 'oauth', 'CSRF validation failed');
+      return res.redirect(`${basePath}/oauth/error?error=csrf_validation_failed`);
+    }
+
     const flowState = await flowManager.getFlowState(identifier, 'oauth');
     if (!flowState) {
       throw new Error('OAuth flow not found');
@@ -71,7 +119,6 @@ router.get('/:action_id/oauth/callback', async (req, res) => {
     );
     await flowManager.completeFlow(identifier, 'oauth', tokenData);
 
-    /** Redirect to React success page */
     const serverName = flowState.metadata?.action_name || `Action ${action_id}`;
     const redirectUrl = `${basePath}/oauth/success?serverName=${encodeURIComponent(serverName)}`;
     res.redirect(redirectUrl);

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -8,18 +8,32 @@ const {
   Permissions,
 } = require('librechat-data-provider');
 const {
+  getBasePath,
   createSafeUser,
   MCPOAuthHandler,
   MCPTokenStorage,
-  getBasePath,
+  setOAuthSession,
   getUserMCPAuthMap,
+  validateOAuthCsrf,
+  OAUTH_CSRF_COOKIE,
+  setOAuthCsrfCookie,
   generateCheckAccess,
+  validateOAuthSession,
+  OAUTH_SESSION_COOKIE,
 } = require('@librechat/api');
 const {
-  getMCPManager,
-  getFlowStateManager,
+  createMCPServerController,
+  updateMCPServerController,
+  deleteMCPServerController,
+  getMCPServersList,
+  getMCPServerById,
+  getMCPTools,
+} = require('~/server/controllers/mcp');
+const {
   getOAuthReconnectionManager,
   getMCPServersRegistry,
+  getFlowStateManager,
+  getMCPManager,
 } = require('~/config');
 const { getMCPSetupData, getServerConnectionStatus } = require('~/server/services/MCP');
 const { requireJwtAuth, canAccessMCPServerResource } = require('~/server/middleware');
@@ -27,19 +41,13 @@ const { findToken, updateToken, createToken, deleteTokens } = require('~/models'
 const { getUserPluginAuthValue } = require('~/server/services/PluginService');
 const { updateMCPServerTools } = require('~/server/services/Config/mcp');
 const { reinitMCPServer } = require('~/server/services/Tools/mcp');
-const { getMCPTools } = require('~/server/controllers/mcp');
 const { findPluginAuthsByKeys } = require('~/models');
 const { getRoleByName } = require('~/models/Role');
 const { getLogStores } = require('~/cache');
-const {
-  createMCPServerController,
-  getMCPServerById,
-  getMCPServersList,
-  updateMCPServerController,
-  deleteMCPServerController,
-} = require('~/server/controllers/mcp');
 
 const router = Router();
+
+const OAUTH_CSRF_COOKIE_PATH = '/api/mcp';
 
 /**
  * Get all MCP tools available to the user
@@ -53,7 +61,7 @@ router.get('/tools', requireJwtAuth, async (req, res) => {
  * Initiate OAuth flow
  * This endpoint is called when the user clicks the auth link in the UI
  */
-router.get('/:serverName/oauth/initiate', requireJwtAuth, async (req, res) => {
+router.get('/:serverName/oauth/initiate', requireJwtAuth, setOAuthSession, async (req, res) => {
   try {
     const { serverName } = req.params;
     const { userId, flowId } = req.query;
@@ -93,7 +101,7 @@ router.get('/:serverName/oauth/initiate', requireJwtAuth, async (req, res) => {
 
     logger.debug('[MCP OAuth] OAuth flow initiated', { oauthFlowId, authorizationUrl });
 
-    // Redirect user to the authorization URL
+    setOAuthCsrfCookie(res, oauthFlowId, OAUTH_CSRF_COOKIE_PATH);
     res.redirect(authorizationUrl);
   } catch (error) {
     logger.error('[MCP OAuth] Failed to initiate OAuth', error);
@@ -137,6 +145,19 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
 
     const flowId = state;
     logger.debug('[MCP OAuth] Using flow ID from state', { flowId });
+
+    const [flowUserId] = flowId.split(':');
+    if (
+      !validateOAuthCsrf(req, res, flowId, OAUTH_CSRF_COOKIE_PATH) &&
+      !validateOAuthSession(req, flowUserId)
+    ) {
+      logger.error('[MCP OAuth] CSRF validation failed: no valid CSRF or session cookie', {
+        flowId,
+        hasCsrfCookie: !!req.cookies?.[OAUTH_CSRF_COOKIE],
+        hasSessionCookie: !!req.cookies?.[OAUTH_SESSION_COOKIE],
+      });
+      return res.redirect(`${basePath}/oauth/error?error=csrf_validation_failed`);
+    }
 
     const flowsCache = getLogStores(CacheKeys.FLOWS);
     const flowManager = getFlowStateManager(flowsCache);
@@ -303,12 +324,46 @@ router.get('/oauth/tokens/:flowId', requireJwtAuth, async (req, res) => {
 });
 
 /**
+ * Set CSRF binding cookie for OAuth flows initiated outside of HTTP request/response
+ * (e.g. during chat via SSE). The frontend should call this before opening the OAuth URL
+ * so the callback can verify the browser matches the flow initiator.
+ */
+router.post('/:serverName/oauth/bind', requireJwtAuth, setOAuthSession, async (req, res) => {
+  try {
+    const { serverName } = req.params;
+    const user = req.user;
+
+    if (!user?.id) {
+      return res.status(401).json({ error: 'User not authenticated' });
+    }
+
+    const flowId = MCPOAuthHandler.generateFlowId(user.id, serverName);
+    setOAuthCsrfCookie(res, flowId, OAUTH_CSRF_COOKIE_PATH);
+
+    res.json({ success: true });
+  } catch (error) {
+    logger.error('[MCP OAuth] Failed to set CSRF binding cookie', error);
+    res.status(500).json({ error: 'Failed to bind OAuth flow' });
+  }
+});
+
+/**
  * Check OAuth flow status
  * This endpoint can be used to poll the status of an OAuth flow
  */
-router.get('/oauth/status/:flowId', async (req, res) => {
+router.get('/oauth/status/:flowId', requireJwtAuth, async (req, res) => {
   try {
     const { flowId } = req.params;
+    const user = req.user;
+
+    if (!user?.id) {
+      return res.status(401).json({ error: 'User not authenticated' });
+    }
+
+    if (!flowId.startsWith(`${user.id}:`) && !flowId.startsWith('system:')) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
     const flowsCache = getLogStores(CacheKeys.FLOWS);
     const flowManager = getFlowStateManager(flowsCache);
 
@@ -375,7 +430,7 @@ router.post('/oauth/cancel/:serverName', requireJwtAuth, async (req, res) => {
  * Reinitialize MCP server
  * This endpoint allows reinitializing a specific MCP server
  */
-router.post('/:serverName/reinitialize', requireJwtAuth, async (req, res) => {
+router.post('/:serverName/reinitialize', requireJwtAuth, setOAuthSession, async (req, res) => {
   try {
     const { serverName } = req.params;
     const user = createSafeUser(req.user);
@@ -420,6 +475,11 @@ router.post('/:serverName/reinitialize', requireJwtAuth, async (req, res) => {
     }
 
     const { success, message, oauthRequired, oauthUrl } = result;
+
+    if (oauthRequired) {
+      const flowId = MCPOAuthHandler.generateFlowId(user.id, serverName);
+      setOAuthCsrfCookie(res, flowId, OAUTH_CSRF_COOKIE_PATH);
+    }
 
     res.json({
       success,

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -146,7 +146,13 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
     const flowId = state;
     logger.debug('[MCP OAuth] Using flow ID from state', { flowId });
 
-    const [flowUserId] = flowId.split(':');
+    const flowParts = flowId.split(':');
+    if (flowParts.length < 2 || !flowParts[0] || !flowParts[1]) {
+      logger.error('[MCP OAuth] Invalid flow ID format in state', { flowId });
+      return res.redirect(`${basePath}/oauth/error?error=invalid_state`);
+    }
+
+    const [flowUserId] = flowParts;
     if (
       !validateOAuthCsrf(req, res, flowId, OAUTH_CSRF_COOKIE_PATH) &&
       !validateOAuthSession(req, flowUserId)

--- a/api/server/routes/oauth.js
+++ b/api/server/routes/oauth.js
@@ -29,7 +29,7 @@ const oauthHandler = createOAuthHandler();
 
 router.get('/error', (req, res) => {
   /** A single error message is pushed by passport when authentication fails. */
-  const errorMessage = req.session?.messages?.pop() || 'Unknown error';
+  const errorMessage = req.session?.messages?.pop() || 'Unknown OAuth error';
   logger.error('Error in OAuth authentication:', {
     message: errorMessage,
   });

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -1339,6 +1339,7 @@ async function loadActionToolsForExecution({
     });
   }
 
+  const domainSeparatorRegex = new RegExp(actionDomainSeparator, 'g');
   for (const toolName of actionToolNames) {
     let currentDomain = '';
     for (const domain of domainMap.keys()) {
@@ -1355,7 +1356,6 @@ async function loadActionToolsForExecution({
 
     const { action, encrypted, zodSchemas, requestBuilders, functionSignatures } =
       processedActionSets.get(currentDomain);
-    const domainSeparatorRegex = new RegExp(actionDomainSeparator, 'g');
     const normalizedDomain = currentDomain.replace(domainSeparatorRegex, '_');
     const functionName = toolName.replace(`${actionDelimiter}${normalizedDomain}`, '');
     const functionSig = functionSignatures.find((sig) => sig.name === functionName);

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -298,38 +298,45 @@ export class MCPConnectionFactory {
     const oauthHandler = async (data: { serverUrl?: string }) => {
       logger.info(`${this.logPrefix} oauthRequired event received`);
 
-      // If we just want to initiate OAuth and return, handle it differently
       if (this.returnOnOAuth) {
         try {
           const config = this.serverConfig;
-          const { authorizationUrl, flowId, flowMetadata } =
-            await MCPOAuthHandler.initiateOAuthFlow(
-              this.serverName,
-              data.serverUrl || '',
-              this.userId!,
-              config?.oauth_headers ?? {},
-              config?.oauth,
+          const flowId = MCPOAuthHandler.generateFlowId(this.userId!, this.serverName);
+          const existingFlow = await this.flowManager!.getFlowState(flowId, 'mcp_oauth');
+
+          if (existingFlow?.status === 'PENDING') {
+            logger.debug(
+              `${this.logPrefix} PENDING OAuth flow already exists, skipping new initiation`,
             );
+            connection.emit('oauthFailed', new Error('OAuth flow initiated - return early'));
+            return;
+          }
 
-          // Delete any existing flow state to ensure we start fresh
-          // This prevents stale codeVerifier issues when re-authenticating
-          await this.flowManager!.deleteFlow(flowId, 'mcp_oauth');
+          const {
+            authorizationUrl,
+            flowId: newFlowId,
+            flowMetadata,
+          } = await MCPOAuthHandler.initiateOAuthFlow(
+            this.serverName,
+            data.serverUrl || '',
+            this.userId!,
+            config?.oauth_headers ?? {},
+            config?.oauth,
+          );
 
-          // Create the flow state so the OAuth callback can find it
-          // We spawn this in the background without waiting for it
-          // Pass signal so the flow can be aborted if the request is cancelled
-          this.flowManager!.createFlow(flowId, 'mcp_oauth', flowMetadata, this.signal).catch(() => {
-            // The OAuth callback will resolve this flow, so we expect it to timeout here
-            // or it will be aborted if the request is cancelled - both are fine
-          });
+          if (existingFlow) {
+            await this.flowManager!.deleteFlow(newFlowId, 'mcp_oauth');
+          }
+
+          this.flowManager!.createFlow(newFlowId, 'mcp_oauth', flowMetadata, this.signal).catch(
+            () => {},
+          );
 
           if (this.oauthStart) {
             logger.info(`${this.logPrefix} OAuth flow started, issuing authorization URL`);
             await this.oauthStart(authorizationUrl);
           }
 
-          // Emit oauthFailed to signal that connection should not proceed
-          // but OAuth was successfully initiated
           connection.emit('oauthFailed', new Error('OAuth flow initiated - return early'));
           return;
         } catch (error) {
@@ -391,11 +398,9 @@ export class MCPConnectionFactory {
     logger.error(`${this.logPrefix} Failed to establish connection.`);
   }
 
-  // Handles connection attempts with retry logic and OAuth error handling
   private async connectTo(connection: MCPConnection): Promise<void> {
     const maxAttempts = 3;
     let attempts = 0;
-    let oauthHandled = false;
 
     while (attempts < maxAttempts) {
       try {
@@ -408,22 +413,6 @@ export class MCPConnectionFactory {
         attempts++;
 
         if (this.useOAuth && this.isOAuthError(error)) {
-          // For returnOnOAuth mode, let the event handler (handleOAuthEvents) deal with OAuth
-          // We just need to stop retrying and let the error propagate
-          if (this.returnOnOAuth) {
-            logger.info(
-              `${this.logPrefix} OAuth required (return on OAuth mode), stopping retries`,
-            );
-            throw error;
-          }
-
-          // Normal flow - wait for OAuth to complete
-          if (this.oauthStart && !oauthHandled) {
-            oauthHandled = true;
-            logger.info(`${this.logPrefix} Handling OAuth`);
-            await this.handleOAuthRequired();
-          }
-          // Don't retry on OAuth errors - just throw
           logger.info(`${this.logPrefix} OAuth required, stopping connection attempts`);
           throw error;
         }
@@ -499,26 +488,15 @@ export class MCPConnectionFactory {
       /** Check if there's already an ongoing OAuth flow for this flowId */
       const existingFlow = await this.flowManager.getFlowState(flowId, 'mcp_oauth');
 
-      // If any flow exists (PENDING, COMPLETED, FAILED), cancel it and start fresh
-      // This ensures the user always gets a new OAuth URL instead of waiting for stale flows
       if (existingFlow) {
         logger.debug(
-          `${this.logPrefix} Found existing OAuth flow (status: ${existingFlow.status}), cancelling to start fresh`,
+          `${this.logPrefix} Found existing OAuth flow (status: ${existingFlow.status}), cleaning up to start fresh`,
         );
         try {
-          if (existingFlow.status === 'PENDING') {
-            await this.flowManager.failFlow(
-              flowId,
-              'mcp_oauth',
-              new Error('Cancelled for new OAuth request'),
-            );
-          } else {
-            await this.flowManager.deleteFlow(flowId, 'mcp_oauth');
-          }
+          await this.flowManager.deleteFlow(flowId, 'mcp_oauth');
         } catch (error) {
-          logger.warn(`${this.logPrefix} Failed to cancel existing OAuth flow`, error);
+          logger.warn(`${this.logPrefix} Failed to clean up existing OAuth flow`, error);
         }
-        // Continue to start a new flow below
       }
 
       logger.debug(`${this.logPrefix} Initiating new OAuth flow for ${this.serverName}...`);

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -270,7 +270,54 @@ describe('MCPConnectionFactory', () => {
       );
     });
 
-    it('should delete existing flow before creating new OAuth flow to prevent stale codeVerifier', async () => {
+    it('should skip new OAuth flow initiation when a PENDING flow already exists (returnOnOAuth)', async () => {
+      const basicOptions = {
+        serverName: 'test-server',
+        serverConfig: mockServerConfig,
+        user: mockUser,
+      };
+
+      const oauthOptions: t.OAuthConnectionOptions = {
+        user: mockUser,
+        useOAuth: true,
+        returnOnOAuth: true,
+        oauthStart: jest.fn(),
+        flowManager: mockFlowManager,
+      };
+
+      mockFlowManager.getFlowState.mockResolvedValue({
+        status: 'PENDING',
+        type: 'mcp_oauth',
+        metadata: { codeVerifier: 'existing-verifier' },
+        createdAt: Date.now(),
+      });
+      mockConnectionInstance.isConnected.mockResolvedValue(false);
+
+      let oauthRequiredHandler: (data: Record<string, unknown>) => Promise<void>;
+      mockConnectionInstance.on.mockImplementation((event, handler) => {
+        if (event === 'oauthRequired') {
+          oauthRequiredHandler = handler as (data: Record<string, unknown>) => Promise<void>;
+        }
+        return mockConnectionInstance;
+      });
+
+      try {
+        await MCPConnectionFactory.create(basicOptions, oauthOptions);
+      } catch {
+        // Expected to fail
+      }
+
+      await oauthRequiredHandler!({ serverUrl: 'https://api.example.com' });
+
+      expect(mockMCPOAuthHandler.initiateOAuthFlow).not.toHaveBeenCalled();
+      expect(mockFlowManager.deleteFlow).not.toHaveBeenCalled();
+      expect(mockConnectionInstance.emit).toHaveBeenCalledWith(
+        'oauthFailed',
+        expect.objectContaining({ message: 'OAuth flow initiated - return early' }),
+      );
+    });
+
+    it('should delete stale flow and create new OAuth flow when existing flow is COMPLETED', async () => {
       const basicOptions = {
         serverName: 'test-server',
         serverConfig: mockServerConfig,
@@ -303,6 +350,12 @@ describe('MCPConnectionFactory', () => {
         },
       };
 
+      mockFlowManager.getFlowState.mockResolvedValue({
+        status: 'COMPLETED',
+        type: 'mcp_oauth',
+        metadata: { codeVerifier: 'old-verifier' },
+        createdAt: Date.now() - 60000,
+      });
       mockMCPOAuthHandler.initiateOAuthFlow.mockResolvedValue(mockFlowData);
       mockFlowManager.deleteFlow.mockResolvedValue(true);
       mockFlowManager.createFlow.mockRejectedValue(new Error('Timeout expected'));
@@ -319,21 +372,17 @@ describe('MCPConnectionFactory', () => {
       try {
         await MCPConnectionFactory.create(basicOptions, oauthOptions);
       } catch {
-        // Expected to fail due to connection not established
+        // Expected to fail
       }
 
       await oauthRequiredHandler!({ serverUrl: 'https://api.example.com' });
 
-      // Verify deleteFlow was called with correct parameters
       expect(mockFlowManager.deleteFlow).toHaveBeenCalledWith('user123:test-server', 'mcp_oauth');
 
-      // Verify deleteFlow was called before createFlow
       const deleteCallOrder = mockFlowManager.deleteFlow.mock.invocationCallOrder[0];
       const createCallOrder = mockFlowManager.createFlow.mock.invocationCallOrder[0];
       expect(deleteCallOrder).toBeLessThan(createCallOrder);
 
-      // Verify createFlow was called with fresh metadata
-      // 4th arg is the abort signal (undefined in this test since no signal was provided)
       expect(mockFlowManager.createFlow).toHaveBeenCalledWith(
         'user123:test-server',
         'mcp_oauth',

--- a/packages/api/src/oauth/csrf.ts
+++ b/packages/api/src/oauth/csrf.ts
@@ -1,0 +1,89 @@
+import crypto from 'crypto';
+import type { Request, Response } from 'express';
+
+export const OAUTH_CSRF_COOKIE = 'oauth_csrf';
+export const OAUTH_CSRF_MAX_AGE = 10 * 60 * 1000;
+
+export const OAUTH_SESSION_COOKIE = 'oauth_session';
+export const OAUTH_SESSION_MAX_AGE = 24 * 60 * 60 * 1000;
+export const OAUTH_SESSION_COOKIE_PATH = '/api';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+/** Generates an HMAC-based token for OAuth CSRF protection */
+export function generateOAuthCsrfToken(flowId: string, secret?: string): string {
+  return crypto
+    .createHmac('sha256', secret || process.env.JWT_SECRET || '')
+    .update(flowId)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+/** Sets a SameSite=Lax CSRF cookie bound to a specific OAuth flow */
+export function setOAuthCsrfCookie(res: Response, flowId: string, cookiePath: string): void {
+  res.cookie(OAUTH_CSRF_COOKIE, generateOAuthCsrfToken(flowId), {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax',
+    maxAge: OAUTH_CSRF_MAX_AGE,
+    path: cookiePath,
+  });
+}
+
+/**
+ * Validates the per-flow CSRF cookie against the expected HMAC.
+ * Uses timing-safe comparison and always clears the cookie to prevent replay.
+ */
+export function validateOAuthCsrf(
+  req: Request,
+  res: Response,
+  flowId: string,
+  cookiePath: string,
+): boolean {
+  const cookie = (req.cookies as Record<string, string> | undefined)?.[OAUTH_CSRF_COOKIE];
+  res.clearCookie(OAUTH_CSRF_COOKIE, { path: cookiePath });
+  if (!cookie) {
+    return false;
+  }
+  const expected = generateOAuthCsrfToken(flowId);
+  if (cookie.length !== expected.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(Buffer.from(cookie), Buffer.from(expected));
+}
+
+/**
+ * Express middleware that sets the OAuth session cookie after JWT authentication.
+ * Chain after requireJwtAuth on routes that precede an OAuth redirect (e.g., reinitialize, bind).
+ */
+export function setOAuthSession(req: Request, res: Response, next: () => void): void {
+  const user = (req as Request & { user?: { id?: string } }).user;
+  if (user?.id && !(req.cookies as Record<string, string> | undefined)?.[OAUTH_SESSION_COOKIE]) {
+    setOAuthSessionCookie(res, user.id);
+  }
+  next();
+}
+
+/** Sets a SameSite=Lax session cookie that binds the browser to the authenticated userId */
+export function setOAuthSessionCookie(res: Response, userId: string): void {
+  res.cookie(OAUTH_SESSION_COOKIE, generateOAuthCsrfToken(userId), {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax',
+    maxAge: OAUTH_SESSION_MAX_AGE,
+    path: OAUTH_SESSION_COOKIE_PATH,
+  });
+}
+
+/** Validates the session cookie against the expected userId using timing-safe comparison */
+export function validateOAuthSession(req: Request, userId: string): boolean {
+  const cookie = (req.cookies as Record<string, string> | undefined)?.[OAUTH_SESSION_COOKIE];
+  if (!cookie) {
+    return false;
+  }
+  const expected = generateOAuthCsrfToken(userId);
+  if (cookie.length !== expected.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(Buffer.from(cookie), Buffer.from(expected));
+}

--- a/packages/api/src/oauth/index.ts
+++ b/packages/api/src/oauth/index.ts
@@ -1,1 +1,2 @@
+export * from './csrf';
 export * from './tokens';

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -181,6 +181,11 @@ export const cancelMCPOAuth = (serverName: string) => {
   return `${BASE_URL}/api/mcp/oauth/cancel/${serverName}`;
 };
 
+export const mcpOAuthBind = (serverName: string) => `${BASE_URL}/api/mcp/${serverName}/oauth/bind`;
+
+export const actionOAuthBind = (actionId: string) =>
+  `${BASE_URL}/api/actions/${actionId}/oauth/bind`;
+
 export const config = () => `${BASE_URL}/api/config`;
 
 export const prompts = () => `${BASE_URL}/api/prompts`;

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -178,6 +178,14 @@ export const reinitializeMCPServer = (serverName: string) => {
   return request.post(endpoints.mcpReinitialize(serverName));
 };
 
+export const bindMCPOAuth = (serverName: string): Promise<{ success: boolean }> => {
+  return request.post(endpoints.mcpOAuthBind(serverName));
+};
+
+export const bindActionOAuth = (actionId: string): Promise<{ success: boolean }> => {
+  return request.post(endpoints.actionOAuthBind(actionId));
+};
+
 export const getMCPConnectionStatus = (): Promise<q.MCPConnectionStatusResponse> => {
   return request.get(endpoints.mcpConnectionStatus());
 };


### PR DESCRIPTION


### Summary

This PR addresses a critical security vulnerability in the MCP and Actions OAuth callback endpoints, fixes a PKCE `code_verifier` race condition caused by concurrent OAuth flow initiations, ensures proper tool cache invalidation on token revocation, and fixes a TDZ runtime error in action tool execution.

### Security Vulnerability (CVE-level)

The MCP OAuth callback (`GET /:serverName/oauth/callback`) and Actions OAuth callback (`GET /:action_id/oauth/callback`) accepted redirects from identity providers and stored OAuth tokens based solely on the `state` parameter -- without verifying that the browser completing the redirect belonged to the user who initiated the flow. An attacker could start an OAuth flow, send the authorization URL to a victim, and when the victim completed the IdP consent, the victim's OAuth tokens would be stored on the attacker's LibreChat account. This enabled account takeover of any MCP-linked service (e.g. Atlassian, Outlook).

### Changes

#### 1. CSRF/Session Cookie Protection (`packages/api/src/oauth/csrf.ts`) -- New Module

Introduced a centralized TypeScript module in `@librechat/api` that provides two layers of browser-binding verification for OAuth callbacks:

- **Per-flow CSRF cookie (`oauth_csrf`)**: An `HttpOnly`, `SameSite=Lax` cookie set when an OAuth flow is initiated (via `initiate`, `bind`, or `reinitialize` endpoints). The cookie value is an HMAC-SHA256 of the `flowId` keyed by `JWT_SECRET`. On callback, it's validated with `crypto.timingSafeEqual` and immediately cleared to prevent replay.

- **Session cookie (`oauth_session`)**: An `HttpOnly`, `SameSite=Lax` cookie containing an HMAC of the authenticated user's ID. Set by a dedicated `setOAuthSession` middleware that chains after `requireJwtAuth` on only the OAuth-initiating routes -- not globally. On callback, if the per-flow CSRF cookie is missing (e.g., SSE/tool-call-initiated flows where the browser didn't directly call `bind`), the session cookie serves as a fallback by verifying the browser belongs to the user identified in the flow state.

- **Both callbacks** (`mcp.js` and `actions.js`) now reject the request with a redirect to `/oauth/error?error=csrf_validation_failed` if neither cookie validates.

#### 2. Scoped `setOAuthSession` Middleware vs Global `requireJwtAuth`

Rather than injecting session cookie logic into the global `requireJwtAuth` middleware (which would touch every authenticated route in the app), the session cookie is set by a standalone `setOAuthSession` Express middleware applied only to the routes that precede OAuth redirects:

- `GET /:serverName/oauth/initiate` (UI-driven MCP OAuth)
- `POST /:serverName/oauth/bind` (SSE/tool-call MCP OAuth binding)
- `POST /:serverName/reinitialize` (reconnection that may trigger OAuth)
- `POST /:action_id/oauth/bind` (Actions OAuth binding)

`requireJwtAuth` remains a clean, single-responsibility JWT auth middleware with no OAuth coupling.

#### 3. Client-Side CSRF Binding (`ToolCall.tsx`, `data-provider`)

When the user clicks "Sign in" from a tool call OAuth prompt, the client now calls the appropriate `bind` endpoint (MCP or Actions) before opening the IdP URL. This sets the per-flow CSRF cookie in the user's browser. Added:

- `dataService.bindMCPOAuth(serverName)` and `dataService.bindActionOAuth(actionId)` in `data-provider`
- `POST /api/mcp/:serverName/oauth/bind` and `POST /api/actions/:action_id/oauth/bind` route handlers
- `actionId` extraction from the OAuth redirect URI in `ToolCall.tsx` for Actions-based tool calls

#### 4. PKCE Race Condition Fix (`MCPConnectionFactory.ts`)

Multiple concurrent connection attempts (tool definition discovery via `returnOnOAuth` mode + reconnection via `reconnectServer`) could each call `initiateOAuthFlow`, generating separate `codeVerifier` values. Each call overwrote the previous flow state, but only the first authorization URL was sent to the user. When the user completed the flow, the `codeVerifier` in flow state no longer matched the `code_challenge` in the authorization request, causing `code_verifier invalid` errors.

Fixed by:

- **`handleOAuthEvents` (`returnOnOAuth` branch)**: Now checks for an existing PENDING flow before initiating. If one exists, it skips initiation entirely and emits `oauthFailed` to return early. This prevents discovery-mode factories from overwriting a legitimate pending flow.
- **`handleOAuthRequired`**: Always deletes any existing flow (PENDING or otherwise) and starts fresh. This ensures the factory that actually sends the SSE event with the authorization URL is the one that owns the flow and the `codeVerifier`.
- **`connectTo`**: Removed the redundant `handleOAuthRequired()` call from the catch block that was a second source of duplicate flow initiations. OAuth errors are now handled solely by the event listener.

#### 5. Tool Cache Invalidation on Token Revocation (`UserController.js`)

When a user uninstalls an MCP plugin (revoking OAuth tokens), the per-user/per-server tool cache (`tools:mcp:<userId>:<serverName>`) was not invalidated. Cached tool definitions could persist for up to 12 hours after revocation. Added `invalidateCachedTools({ userId, serverName })` immediately after `disconnectUserConnection` in the uninstall flow.

#### 6. `domainSeparatorRegex` TDZ Fix (`ToolService.js`)

A `const domainSeparatorRegex` declaration inside a `for` loop body created a Temporal Dead Zone that shadowed its usage in an earlier inner loop within the same block. Hoisted the declaration above the outer loop to fix `Cannot access 'domainSeparatorRegex' before initialization` crashes during action tool execution.

### Change Type

- Bug fix (non-breaking)
- Security fix

### Testing

- All 74 MCP route tests pass (updated cookie names and added CSRF/session validation test cases)
- `MCPConnectionFactory` unit tests updated to cover: skipping initiation when PENDING flow exists (`returnOnOAuth`), cleaning up stale COMPLETED flows before new initiation
- Manual testing: MCP OAuth via UI initiation, MCP OAuth via tool-call SSE trigger, Actions OAuth callback, token revocation + tool cache cleanup
- Verified the PoC attack scenario (sending auth URL to another user/browser) is rejected with `csrf_validation_failed`

### Files Changed (14 files, +502 / -129)

| File | Change |
|---|---|
| `packages/api/src/oauth/csrf.ts` | New module: CSRF token generation, cookie management, session middleware, validation |
| `packages/api/src/oauth/index.ts` | Barrel export for `csrf.ts` |
| `packages/api/src/mcp/MCPConnectionFactory.ts` | PKCE race condition fix, removed duplicate OAuth handling |
| `packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts` | Tests for new flow deduplication logic |
| `api/server/routes/mcp.js` | CSRF/session validation on callback, `setOAuthSession` on initiating routes, `bind` endpoint |
| `api/server/routes/actions.js` | CSRF/session validation on callback, `setOAuthSession` on `bind` endpoint |
| `api/server/routes/oauth.js` | Updated error message wording |
| `api/server/routes/__tests__/mcp.spec.js` | Updated cookie names and test assertions |
| `api/server/middleware/requireJwtAuth.js` | Reverted to clean JWT-only middleware (no OAuth coupling) |
| `api/server/controllers/UserController.js` | Tool cache invalidation on MCP plugin uninstall |
| `api/server/services/ToolService.js` | Fixed `domainSeparatorRegex` TDZ |
| `client/src/components/Chat/Messages/Content/ToolCall.tsx` | Client-side CSRF binding before OAuth redirect |
| `packages/data-provider/src/api-endpoints.ts` | New `bindMCPOAuth` and `bindActionOAuth` endpoints |
| `packages/data-provider/src/data-service.ts` | New `bindMCPOAuth` and `bindActionOAuth` service functions |