### PR TITLE
🏁 fix: Resolve Content Aggregation Race Condition in Agent Event Handlers

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.39",
+    "@librechat/agents": "^3.1.40",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -209,6 +209,7 @@ function getDefaultHandlers({
        * @param {GraphRunnableConfig['configurable']} [metadata] The runnable metadata.
        */
       handle: async (event, data, metadata) => {
+        aggregateContent({ event, data });
         if (data?.stepDetails.type === StepTypes.TOOL_CALLS) {
           await emitEvent(res, streamId, { event, data });
         } else if (checkIfLastAgent(metadata?.last_agent_id, metadata?.langgraph_node)) {
@@ -227,7 +228,6 @@ function getDefaultHandlers({
             },
           });
         }
-        aggregateContent({ event, data });
       },
     },
     [GraphEvents.ON_RUN_STEP_DELTA]: {
@@ -238,6 +238,7 @@ function getDefaultHandlers({
        * @param {GraphRunnableConfig['configurable']} [metadata] The runnable metadata.
        */
       handle: async (event, data, metadata) => {
+        aggregateContent({ event, data });
         if (data?.delta.type === StepTypes.TOOL_CALLS) {
           await emitEvent(res, streamId, { event, data });
         } else if (checkIfLastAgent(metadata?.last_agent_id, metadata?.langgraph_node)) {
@@ -245,7 +246,6 @@ function getDefaultHandlers({
         } else if (!metadata?.hide_sequential_outputs) {
           await emitEvent(res, streamId, { event, data });
         }
-        aggregateContent({ event, data });
       },
     },
     [GraphEvents.ON_RUN_STEP_COMPLETED]: {
@@ -256,6 +256,7 @@ function getDefaultHandlers({
        * @param {GraphRunnableConfig['configurable']} [metadata] The runnable metadata.
        */
       handle: async (event, data, metadata) => {
+        aggregateContent({ event, data });
         if (data?.result != null) {
           await emitEvent(res, streamId, { event, data });
         } else if (checkIfLastAgent(metadata?.last_agent_id, metadata?.langgraph_node)) {
@@ -263,7 +264,6 @@ function getDefaultHandlers({
         } else if (!metadata?.hide_sequential_outputs) {
           await emitEvent(res, streamId, { event, data });
         }
-        aggregateContent({ event, data });
       },
     },
     [GraphEvents.ON_MESSAGE_DELTA]: {
@@ -274,12 +274,12 @@ function getDefaultHandlers({
        * @param {GraphRunnableConfig['configurable']} [metadata] The runnable metadata.
        */
       handle: async (event, data, metadata) => {
+        aggregateContent({ event, data });
         if (checkIfLastAgent(metadata?.last_agent_id, metadata?.langgraph_node)) {
           await emitEvent(res, streamId, { event, data });
         } else if (!metadata?.hide_sequential_outputs) {
           await emitEvent(res, streamId, { event, data });
         }
-        aggregateContent({ event, data });
       },
     },
     [GraphEvents.ON_REASONING_DELTA]: {
@@ -290,12 +290,12 @@ function getDefaultHandlers({
        * @param {GraphRunnableConfig['configurable']} [metadata] The runnable metadata.
        */
       handle: async (event, data, metadata) => {
+        aggregateContent({ event, data });
         if (checkIfLastAgent(metadata?.last_agent_id, metadata?.langgraph_node)) {
           await emitEvent(res, streamId, { event, data });
         } else if (!metadata?.hide_sequential_outputs) {
           await emitEvent(res, streamId, { event, data });
         }
-        aggregateContent({ event, data });
       },
     },
   };

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -969,7 +969,7 @@ class AgentClient extends BaseClient {
           },
           user: createSafeUser(this.options.req.user),
         },
-        recursionLimit: agentsEConfig?.recursionLimit ?? 25,
+        recursionLimit: agentsEConfig?.recursionLimit ?? 50,
         signal: abortController.signal,
         streamMode: 'values',
         version: 'v2',

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.39",
+        "@librechat/agents": "^3.1.40",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11207,9 +11207,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.39",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.39.tgz",
-      "integrity": "sha512-HsMOkAKap6O0w4rpr/YdZIrRXBo8tEIM9iO8Z/6txeQUHyRsrdBFo7Kdu+t0leUOq+3NysnD8BRQpcfXKfMF3Q==",
+      "version": "3.1.40",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.40.tgz",
+      "integrity": "sha512-L7caKWIQ7z/lMgASc7MscnH7oqVG0pYTuU4nn6GEr8QIG+oH2ow+q1+xXDJADHS84Zysj93i/tIeuEZrBYrabA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -42102,7 +42102,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.39",
+        "@librechat/agents": "^3.1.40",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -87,7 +87,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.39",
+    "@librechat/agents": "^3.1.40",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@smithy/node-http-handler": "^4.4.5",


### PR DESCRIPTION
## Summary

Follow-up PR to fully resolve issue identified in https://github.com/danny-avila/LibreChat/issues/11702

I fixed a critical race condition in agent event handlers where content aggregation could be skipped if conditional branches exited early or execution was interrupted. I also increased the default recursion limit and upgraded the agents package to incorporate upstream fixes for event handling and multi-agent handoffs.

- Moved `aggregateContent({ event, data })` calls to the beginning of five event handler functions (`ON_RUN_STEP_START`, `ON_RUN_STEP_DELTA`, `ON_RUN_STEP_COMPLETED`, `ON_MESSAGE_DELTA`, `ON_REASONING_DELTA`) in `callbacks.js`, ensuring content is always aggregated before any conditional logic that might skip execution paths
- Increased default recursion limit from 25 to 50 in `client.js` to support more complex agent workflows
- Bumped `@librechat/agents` dependency from version 3.1.39 to 3.1.40, which includes:
  - Custom event handler with `awaitHandlers` support ensuring content aggregation completes before streams return
  - Enhanced token management with `baseIndexTokenCountMap` for improved token accounting during resets
  - Multi-agent config forwarding fix that resolves MCP header placeholder issues in handoff scenarios

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Any changes dependent on mine have been merged and published in downstream modules