### PR TITLE
🔒 fix: Prevent Race Condition in RedisJobStore

### DIFF
--- a/packages/api/src/stream/implementations/RedisJobStore.ts
+++ b/packages/api/src/stream/implementations/RedisJobStore.ts
@@ -156,13 +156,13 @@ export class RedisJobStore implements IJobStore {
     // For cluster mode, we can't pipeline keys on different slots
     // The job key uses hash tag {streamId}, runningJobs and userJobs are on different slots
     if (this.isCluster) {
-      await this.redis.hmset(key, this.serializeJob(job));
+      await this.redis.hset(key, this.serializeJob(job));
       await this.redis.expire(key, this.ttl.running);
       await this.redis.sadd(KEYS.runningJobs, streamId);
       await this.redis.sadd(userJobsKey, streamId);
     } else {
       const pipeline = this.redis.pipeline();
-      pipeline.hmset(key, this.serializeJob(job));
+      pipeline.hset(key, this.serializeJob(job));
       pipeline.expire(key, this.ttl.running);
       pipeline.sadd(KEYS.runningJobs, streamId);
       pipeline.sadd(userJobsKey, streamId);
@@ -191,7 +191,7 @@ export class RedisJobStore implements IJobStore {
 
     const fields = Object.entries(serialized).flat();
     const updated = await this.redis.eval(
-      'if redis.call("EXISTS", KEYS[1]) == 1 then redis.call("HMSET", KEYS[1], unpack(ARGV)) return 1 else return 0 end',
+      'if redis.call("EXISTS", KEYS[1]) == 1 then redis.call("HSET", KEYS[1], unpack(ARGV)) return 1 else return 0 end',
       1,
       key,
       ...fields,


### PR DESCRIPTION
Closes #11762 

## Summary

I fixed a critical race condition in RedisJobStore where `updateJob` could recreate a job hash after `deleteJob` had removed it, and modernized the codebase to use the current Redis hash commands.

- Refactored `updateJob` method to use an atomic Lua script that only updates jobs if they exist in Redis, eliminating the race condition between existence checks and updates
- Replaced all deprecated `hmset` commands with `hset` (deprecated since Redis 4.0.0) in both direct calls and Lua scripts for compatibility with modern Redis versions and cloud providers
- Added comprehensive integration tests that verify `updateJob` behavior after `deleteJob`, ensuring no orphan job hashes are created
- Introduced concurrent operation tests using `Promise.all` to validate atomic behavior under race conditions
- Refactored violationCache integration tests by extracting `waitForRedisClients` helper function to streamline Redis client readiness checks and improve maintainability

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes