### PR TITLE
🪪 fix: Pass Scope in OpenID Refresh Token Grant for Azure Custom API

### DIFF
--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -80,7 +80,11 @@ const refreshController = async (req, res) => {
     try {
       const openIdConfig = getOpenIdConfig();
       const refreshParams = process.env.OPENID_SCOPE ? { scope: process.env.OPENID_SCOPE } : {};
-      const tokenset = await openIdClient.refreshTokenGrant(openIdConfig, refreshToken, refreshParams);
+      const tokenset = await openIdClient.refreshTokenGrant(
+        openIdConfig,
+        refreshToken,
+        refreshParams,
+      );
       const claims = tokenset.claims();
       const { user, error, migration } = await findOpenIDUser({
         findUser,

--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -79,7 +79,8 @@ const refreshController = async (req, res) => {
 
     try {
       const openIdConfig = getOpenIdConfig();
-      const tokenset = await openIdClient.refreshTokenGrant(openIdConfig, refreshToken);
+      const refreshParams = process.env.OPENID_SCOPE ? { scope: process.env.OPENID_SCOPE } : {};
+      const tokenset = await openIdClient.refreshTokenGrant(openIdConfig, refreshToken, refreshParams);
       const claims = tokenset.claims();
       const { user, error, migration } = await findOpenIDUser({
         findUser,


### PR DESCRIPTION
  ## Summary                                                                                                                                                                  
  - Fix refresh token exchange failure (AADSTS90009) when using Azure Entra ID with custom API scopes
  - Pass `OPENID_SCOPE` as scope parameter to `openid-client` v6 `refreshTokenGrant()`
  - Maintains backward compatibility: no scope sent if `OPENID_SCOPE` is unset

  ## Problem
  When `OPENID_REUSE_TOKENS=true` with a custom `OPENID_SCOPE` like `api://app-id/access_user`, the initial login succeeds but the subsequent refresh token exchange fails
  with:
  > AADSTS90009: Application is requesting a token for itself. This scenario is supported only if resource is specified using the GUID based App Identifier.

  Azure AD v2.0 requires the `scope` parameter in refresh requests when the original token was issued for a custom API audience.

  ## Solution
  ```js
  // Before
  const tokenset = await openIdClient.refreshTokenGrant(openIdConfig, refreshToken);

  // After
  const refreshParams = process.env.OPENID_SCOPE ? { scope: process.env.OPENID_SCOPE } : {};
  const tokenset = await openIdClient.refreshTokenGrant(openIdConfig, refreshToken, refreshParams);

  Test plan

  - Azure Entra ID + OPENID_REUSE_TOKENS=true + custom API scope: login + refresh works
  - Azure Entra ID + OPENID_REUSE_TOKENS=true + standard scopes: no regression
  - Non-Azure OIDC providers: no regression (scope parameter ignored if not needed)
  - OPENID_REUSE_TOKENS=false: not affected (different code path)