### PR TITLE
feat: auto-enable artifacts toggle when capability is configured

### DIFF
--- a/client/src/Providers/BadgeRowContext.tsx
+++ b/client/src/Providers/BadgeRowContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useRef } from 'react';
 import { useSetRecoilState } from 'recoil';
-import { Tools, Constants, LocalStorageKeys, AgentCapabilities } from 'librechat-data-provider';
+import { Tools, Constants, LocalStorageKeys, AgentCapabilities, ArtifactModes } from 'librechat-data-provider';
 import type { TAgentsEndpoint } from 'librechat-data-provider';
 import {
   useMCPServerManager,
@@ -114,7 +114,8 @@ export default function BadgeRowProvider({
         [Tools.execute_code]: initialValues[Tools.execute_code] ?? false,
         [Tools.web_search]: initialValues[Tools.web_search] ?? false,
         [Tools.file_search]: initialValues[Tools.file_search] ?? false,
-        [AgentCapabilities.artifacts]: initialValues[AgentCapabilities.artifacts] ?? false,
+        [AgentCapabilities.artifacts]: initialValues[AgentCapabilities.artifacts] ??
+          (agentsConfig?.capabilities?.includes(AgentCapabilities.artifacts) ? ArtifactModes.DEFAULT : false),
       };
 
       setEphemeralAgent((prev) => ({
@@ -138,7 +139,7 @@ export default function BadgeRowProvider({
         }
       });
     }
-  }, [key, isSubmitting, setEphemeralAgent]);
+  }, [key, isSubmitting, setEphemeralAgent, agentsConfig]);
 
   /** CodeInterpreter hooks */
   const codeApiKeyForm = useCodeApiKeyForm({});

--- a/client/src/Providers/__tests__/BadgeRowContext.test.tsx
+++ b/client/src/Providers/__tests__/BadgeRowContext.test.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AgentCapabilities, ArtifactModes, Tools } from 'librechat-data-provider';
+
+const mockSetEphemeralAgent = jest.fn();
+const mockGetTimestampedValue = jest.fn();
+const mockSetTimestamp = jest.fn();
+
+jest.mock('recoil', () => {
+  const actual = jest.requireActual('recoil');
+  return {
+    ...actual,
+    useSetRecoilState: () => mockSetEphemeralAgent,
+  };
+});
+
+jest.mock('~/utils/timestamps', () => ({
+  getTimestampedValue: (...args) => mockGetTimestampedValue(...args),
+  setTimestamp: (...args) => mockSetTimestamp(...args),
+}));
+
+const mockAgentsConfig = {
+  agentsConfig: null,
+};
+
+jest.mock('~/hooks', () => ({
+  useGetAgentsConfig: () => mockAgentsConfig,
+  useToolToggle: () => ({
+    toggleState: false,
+    handleToggle: jest.fn(),
+    isAuthenticated: true,
+    isAuthLoading: false,
+    isPinned: false,
+    handlePinToggle: jest.fn(),
+  }),
+  useCodeApiKeyForm: () => ({
+    isDialogOpen: false,
+    setIsDialogOpen: jest.fn(),
+    apiKey: '',
+    setApiKey: jest.fn(),
+  }),
+  useSearchApiKeyForm: () => ({
+    isDialogOpen: false,
+    setIsDialogOpen: jest.fn(),
+    apiKey: '',
+    setApiKey: jest.fn(),
+  }),
+  useMCPServerManager: () => ({
+    availableTools: [],
+    selectedTools: [],
+    handleToggleTool: jest.fn(),
+  }),
+}));
+
+jest.mock('~/store', () => ({
+  ephemeralAgentByConvoId: () => null,
+}));
+
+import BadgeRowProvider from '../BadgeRowContext';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+function Wrapper({ children }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>{children}</RecoilRoot>
+    </QueryClientProvider>
+  );
+}
+
+function renderProvider(conversationId?: string | null) {
+  return render(
+    <BadgeRowProvider conversationId={conversationId}>
+      <div data-testid="child">child</div>
+    </BadgeRowProvider>,
+    { wrapper: Wrapper },
+  );
+}
+
+describe('BadgeRowProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetTimestampedValue.mockReturnValue(null);
+    mockAgentsConfig.agentsConfig = null;
+  });
+
+  it('renders children', () => {
+    const { getByTestId } = renderProvider();
+    expect(getByTestId('child')).toBeInTheDocument();
+  });
+
+  describe('artifacts default initialization', () => {
+    it('defaults artifacts to false when no localStorage value and no artifacts capability', () => {
+      mockAgentsConfig.agentsConfig = { capabilities: [] };
+      mockGetTimestampedValue.mockReturnValue(null);
+
+      renderProvider('test-convo-1');
+
+      expect(mockSetEphemeralAgent).toHaveBeenCalled();
+      const updater = mockSetEphemeralAgent.mock.calls[0][0];
+      const result = typeof updater === 'function' ? updater(null) : updater;
+
+      expect(result[AgentCapabilities.artifacts]).toBe(false);
+    });
+
+    it('defaults artifacts to ArtifactModes.DEFAULT when artifacts capability is present', () => {
+      mockAgentsConfig.agentsConfig = {
+        capabilities: [AgentCapabilities.artifacts],
+      };
+      mockGetTimestampedValue.mockReturnValue(null);
+
+      renderProvider('test-convo-2');
+
+      expect(mockSetEphemeralAgent).toHaveBeenCalled();
+      const updater = mockSetEphemeralAgent.mock.calls[0][0];
+      const result = typeof updater === 'function' ? updater(null) : updater;
+
+      expect(result[AgentCapabilities.artifacts]).toBe(ArtifactModes.DEFAULT);
+    });
+
+    it('respects localStorage false value even when artifacts capability is present', () => {
+      mockAgentsConfig.agentsConfig = {
+        capabilities: [AgentCapabilities.artifacts],
+      };
+      mockGetTimestampedValue.mockImplementation((key: string) => {
+        if (key.includes('ARTIFACTS')) {
+          return JSON.stringify(false);
+        }
+        return null;
+      });
+
+      renderProvider('test-convo-3');
+
+      expect(mockSetEphemeralAgent).toHaveBeenCalled();
+      const updater = mockSetEphemeralAgent.mock.calls[0][0];
+      const result = typeof updater === 'function' ? updater(null) : updater;
+
+      expect(result[AgentCapabilities.artifacts]).toBe(false);
+    });
+
+    it('respects localStorage saved "default" value', () => {
+      mockAgentsConfig.agentsConfig = { capabilities: [] };
+      mockGetTimestampedValue.mockImplementation((key: string) => {
+        if (key.includes('ARTIFACTS')) {
+          return JSON.stringify(ArtifactModes.DEFAULT);
+        }
+        return null;
+      });
+
+      renderProvider('test-convo-4');
+
+      expect(mockSetEphemeralAgent).toHaveBeenCalled();
+      const updater = mockSetEphemeralAgent.mock.calls[0][0];
+      const result = typeof updater === 'function' ? updater(null) : updater;
+
+      expect(result[AgentCapabilities.artifacts]).toBe(ArtifactModes.DEFAULT);
+    });
+
+    it('defaults artifacts to false when agentsConfig is null', () => {
+      mockAgentsConfig.agentsConfig = null;
+      mockGetTimestampedValue.mockReturnValue(null);
+
+      renderProvider('test-convo-5');
+
+      expect(mockSetEphemeralAgent).toHaveBeenCalled();
+      const updater = mockSetEphemeralAgent.mock.calls[0][0];
+      const result = typeof updater === 'function' ? updater(null) : updater;
+
+      expect(result[AgentCapabilities.artifacts]).toBe(false);
+    });
+  });
+
+  describe('other tool defaults', () => {
+    it('defaults all tools to false when no localStorage values', () => {
+      mockAgentsConfig.agentsConfig = { capabilities: [] };
+      mockGetTimestampedValue.mockReturnValue(null);
+
+      renderProvider('test-convo-6');
+
+      expect(mockSetEphemeralAgent).toHaveBeenCalled();
+      const updater = mockSetEphemeralAgent.mock.calls[0][0];
+      const result = typeof updater === 'function' ? updater(null) : updater;
+
+      expect(result[Tools.execute_code]).toBe(false);
+      expect(result[Tools.web_search]).toBe(false);
+      expect(result[Tools.file_search]).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- When `artifacts` is included in the agents endpoint `capabilities` array (in `librechat.yaml`), the artifacts toggle now defaults to `ArtifactModes.DEFAULT` for new conversations instead of `false`
- This means agents with artifact-producing prompts will render artifacts without requiring users to manually enable the toggle each time they start a new conversation
- Existing behavior is fully preserved: localStorage saved values take precedence, no capability = no change, null config = safe fallback

## Problem

When an admin configures `artifacts` in the agents endpoint capabilities:

```yaml
endpoints:
  agents:
    capabilities:
      - "artifacts"
```

The artifacts toggle in the chat input still defaults to `false` for every new conversation. Users must manually click the artifacts badge each time. This defeats the purpose of the capability configuration — agents with artifact-producing prompts can't render artifacts until the user manually toggles it on.

## Changes

**Single file modified:** `client/src/Providers/BadgeRowContext.tsx`

1. Import `ArtifactModes` from `librechat-data-provider`
2. Change artifacts default from `false` to capability-aware: check `agentsConfig.capabilities` for `artifacts` and default to `ArtifactModes.DEFAULT` when present
3. Add `agentsConfig` to useEffect dependency array

**New test file:** `client/src/Providers/__tests__/BadgeRowContext.test.tsx`

7 test cases covering all branches of the initialization logic.

## Backward Compatibility

| Scenario | Before | After |
|----------|--------|-------|
| No localStorage, no artifacts capability | `false` | `false` (unchanged) |
| No localStorage, artifacts capability present | `false` | `ArtifactModes.DEFAULT` ✨ |
| localStorage has saved `false` | `false` | `false` (unchanged) |
| localStorage has saved `"default"` | `"default"` | `"default"` (unchanged) |
| agentsConfig is null | `false` | `false` (unchanged) |

## Test plan

- [x] All 7 unit tests pass (`npx jest src/Providers/__tests__/BadgeRowContext.test.tsx`)
- [ ] New conversation with artifacts capability → badge auto-enabled
- [ ] New conversation without artifacts capability → badge off (no change)
- [ ] Toggle artifacts off manually → persists via localStorage on refresh
- [ ] Non-agent endpoints unaffected