### PR TITLE
🛰️  feat: Add Bedrock Parameter Settings for MoonshotAI and Z.AI Models

### DIFF
--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -197,6 +197,8 @@ const moonshotModels = {
   'moonshot.kimi-k2.5': 262144,
   'moonshot.kimi-k2-thinking': 262144,
   'moonshot.kimi-k2-0711': 131072,
+  'moonshotai.kimi': 262144,
+  'moonshotai.kimi-k2.5': 262144,
 };
 
 const metaModels = {

--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -952,6 +952,8 @@ export const paramSettings: Record<string, SettingsConfiguration | undefined> = 
   [`${EModelEndpoint.bedrock}-${BedrockProviders.Amazon}`]: bedrockGeneral,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.DeepSeek}`]: bedrockGeneral,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.Moonshot}`]: bedrockMoonshot,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.MoonshotAI}`]: bedrockMoonshot,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.ZAI}`]: bedrockGeneral,
   [EModelEndpoint.google]: googleConfig,
 };
 
@@ -1000,6 +1002,11 @@ export const presetSettings: Record<
     col1: bedrockMoonshotCol1,
     col2: bedrockMoonshotCol2,
   },
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.MoonshotAI}`]: {
+    col1: bedrockMoonshotCol1,
+    col2: bedrockMoonshotCol2,
+  },
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.ZAI}`]: bedrockGeneralColumns,
   [EModelEndpoint.google]: {
     col1: googleCol1,
     col2: googleCol2,

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -101,7 +101,9 @@ export enum BedrockProviders {
   Meta = 'meta',
   MistralAI = 'mistral',
   Moonshot = 'moonshot',
+  MoonshotAI = 'moonshotai',
   StabilityAI = 'stability',
+  ZAI = 'zai',
 }
 
 export const getModelKey = (endpoint: EModelEndpoint | string, model: string) => {


### PR DESCRIPTION
### Summary                                                                                                                                

  I added missing Bedrock provider mappings for newly launched moonshotai.* (Kimi K2.5) and zai.* (GLM 4.7) model prefixes, which caused
  agent model parameter settings to render blank.

  - Add MoonshotAI and ZAI entries to the BedrockProviders enum in schemas.ts to match the model ID prefixes used by these new Bedrock
  models
  - Map bedrock-moonshotai to the existing bedrockMoonshot parameter settings in both paramSettings and presetSettings, preserving the
  original moonshot mapping for older models
  - Map bedrock-zai to bedrockGeneral (same parameters as Meta/Llama) in both paramSettings and presetSettings
  - Add moonshotai.kimi and moonshotai.kimi-k2.5 token context length entries to the Bedrock moonshot models config

  Change Type

  - Bug fix (non-breaking change which fixes an issue)

  Testing

  1. Configure Amazon Bedrock as a provider
  2. Create or edit an agent, select Amazon Bedrock
  3. Select a moonshotai.* model (e.g., Kimi K2.5) -- verify model parameter settings (temperature, top_p, max_tokens, etc.) now appear
  4. Select a zai.* model (e.g., GLM 4.7) -- verify model parameter settings appear with the general Bedrock config
  5. Select an older moonshot.* model (e.g., kimi-k2-thinking) -- verify settings still appear as before (no regression)
  6. Verify existing Bedrock providers (Anthropic, Meta, Mistral, etc.) are unaffected

  Checklist

  - My code adheres to this project's style guidelines
  - I have performed a self-review of my own code
  - My changes do not introduce new warnings
  - Local unit tests pass with my changes