### PR TITLE
🧰 fix: Convert `const` to `enum` in MCP Schemas for Gemini Compatibility

### DIFF
--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -488,7 +488,7 @@ const setOpenIDAuthTokens = (tokenset, req, res, userId, existingRefreshToken) =
         res.cookie('openid_id_token', tokenset.id_token, {
           expires: expirationDate,
           httpOnly: true,
-          secure: isProduction,
+          secure: shouldUseSecureCookie(),
           sameSite: 'strict',
         });
       }

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -11,8 +11,9 @@ const {
   MCPOAuthHandler,
   isMCPDomainAllowed,
   normalizeServerName,
-  resolveJsonSchemaRefs,
+  normalizeJsonSchema,
   GenerationJobManager,
+  resolveJsonSchemaRefs,
 } = require('@librechat/api');
 const {
   Time,
@@ -443,7 +444,7 @@ function createToolInstance({
   const { description, parameters } = toolDefinition;
   const isGoogle = _provider === Providers.VERTEXAI || _provider === Providers.GOOGLE;
 
-  let schema = parameters ? resolveJsonSchemaRefs(parameters) : null;
+  let schema = parameters ? normalizeJsonSchema(resolveJsonSchemaRefs(parameters)) : null;
 
   if (!schema || (isGoogle && isEmptyObjectSchema(schema))) {
     schema = {

--- a/packages/api/src/tools/definitions.ts
+++ b/packages/api/src/tools/definitions.ts
@@ -8,9 +8,10 @@
 import { Constants, actionDelimiter } from 'librechat-data-provider';
 import type { AgentToolOptions } from 'librechat-data-provider';
 import type { LCToolRegistry, JsonSchemaType, LCTool, GenericTool } from '@librechat/agents';
-import { buildToolClassification, type ToolDefinition } from './classification';
+import type { ToolDefinition } from './classification';
+import { buildToolClassification } from './classification';
+import { resolveJsonSchemaRefs, normalizeJsonSchema } from '~/mcp/zod';
 import { getToolDefinition } from './registry/definitions';
-import { resolveJsonSchemaRefs } from '~/mcp/zod';
 
 export interface MCPServerTool {
   function?: {
@@ -138,7 +139,7 @@ export async function loadToolDefinitions(
             name: actualToolName,
             description: toolDef.function.description,
             parameters: toolDef.function.parameters
-              ? resolveJsonSchemaRefs(toolDef.function.parameters)
+              ? normalizeJsonSchema(resolveJsonSchemaRefs(toolDef.function.parameters))
               : undefined,
             serverName,
           });
@@ -153,7 +154,7 @@ export async function loadToolDefinitions(
         name: toolName,
         description: toolDef.function.description,
         parameters: toolDef.function.parameters
-          ? resolveJsonSchemaRefs(toolDef.function.parameters)
+          ? normalizeJsonSchema(resolveJsonSchemaRefs(toolDef.function.parameters))
           : undefined,
         serverName,
       });

--- a/packages/api/src/tools/definitions.ts
+++ b/packages/api/src/tools/definitions.ts
@@ -9,8 +9,8 @@ import { Constants, actionDelimiter } from 'librechat-data-provider';
 import type { AgentToolOptions } from 'librechat-data-provider';
 import type { LCToolRegistry, JsonSchemaType, LCTool, GenericTool } from '@librechat/agents';
 import type { ToolDefinition } from './classification';
-import { buildToolClassification } from './classification';
 import { resolveJsonSchemaRefs, normalizeJsonSchema } from '~/mcp/zod';
+import { buildToolClassification } from './classification';
 import { getToolDefinition } from './registry/definitions';
 
 export interface MCPServerTool {


### PR DESCRIPTION


  Gemini/Vertex AI rejects the JSON Schema `const` keyword in function declarations
  with a 400 error. Previously, the Zod conversion layer accidentally stripped `const`,
  but after migrating to pass raw JSON schemas directly to providers, the unsupported
  keyword now reaches Gemini verbatim.

  Add `normalizeJsonSchema` to recursively convert `const: X` → `enum: [X]`, which is
  semantically equivalent per the JSON Schema spec and supported by all providers.
