### PR TITLE
🪟 fix: Tab Isolation for Agent Favorites + MCP Selections

### DIFF
--- a/client/src/hooks/MCP/useMCPSelect.ts
+++ b/client/src/hooks/MCP/useMCPSelect.ts
@@ -28,7 +28,7 @@ export function useMCPSelect({
     const mcps = ephemeralAgent?.mcp ?? [];
     if (mcps.length === 1 && mcps[0] === Constants.mcp_clear) {
       setMCPValuesRaw([]);
-    } else if (mcps.length > 0) {
+    } else if (mcps.length > 0 && configuredServers.size > 0) {
       // Strip out servers that are not available in the startup config
       const activeMcps = mcps.filter((mcp) => configuredServers.has(mcp));
       setMCPValuesRaw(activeMcps);

--- a/client/src/store/favorites.ts
+++ b/client/src/store/favorites.ts
@@ -1,4 +1,4 @@
-import { createStorageAtom } from './jotai-utils';
+import { createTabIsolatedAtom } from './jotai-utils';
 
 export type Favorite = {
   agentId?: string;
@@ -16,4 +16,4 @@ export type FavoritesState = Favorite[];
 /**
  * This atom stores the user's favorite models/agents
  */
-export const favoritesAtom = createStorageAtom<FavoritesState>('favorites', []);
+export const favoritesAtom = createTabIsolatedAtom<FavoritesState>('favorites', []);

--- a/client/src/store/mcp.ts
+++ b/client/src/store/mcp.ts
@@ -1,6 +1,14 @@
 import { atom } from 'jotai';
 import { atomFamily, atomWithStorage } from 'jotai/utils';
 import { Constants, LocalStorageKeys } from 'librechat-data-provider';
+import { createTabIsolatedStorage } from './jotai-utils';
+
+/**
+ * Tab-isolated storage for MCP values — prevents cross-tab sync so that
+ * each tab's MCP server selections are independent (especially for new chats
+ * which all share the same `LAST_MCP_new` localStorage key).
+ */
+const mcpTabIsolatedStorage = createTabIsolatedStorage<string[]>();
 
 /**
  * Creates a storage atom for MCP values per conversation
@@ -10,7 +18,7 @@ export const mcpValuesAtomFamily = atomFamily((conversationId: string | null) =>
   const key = conversationId ?? Constants.NEW_CONVO;
   const storageKey = `${LocalStorageKeys.LAST_MCP_}${key}`;
 
-  return atomWithStorage<string[]>(storageKey, [], undefined, { getOnInit: true });
+  return atomWithStorage<string[]>(storageKey, [], mcpTabIsolatedStorage, { getOnInit: true });
 });
 
 /**


### PR DESCRIPTION
Closes #11578

## Summary

I implemented tab isolation for agent favorites and MCP server selections to prevent cross-tab synchronization issues, particularly addressing race conditions where multiple tabs with new conversations would conflict over shared localStorage keys.

- Created `createTabIsolatedStorage<T>()` utility function that provides a SyncStorage adapter reading/writing to localStorage while intentionally omitting the `subscribe` method to prevent browser storage event synchronization
- Created `createTabIsolatedAtom<T>()` helper function that wraps `atomWithStorage` with tab-isolated storage, maintaining localStorage persistence without cross-tab sync
- Updated `favoritesAtom` to use `createTabIsolatedAtom` instead of `createStorageAtom`, ensuring each tab maintains independent favorites toggle state
- Updated `mcpValuesAtomFamily` to use tab-isolated storage, preventing race conditions where multiple new conversation tabs would overwrite each other's MCP server selections via the shared `LAST_MCP_new` key
- Added guard condition in `useMCPSelect` effect to skip MCP value synchronization when `configuredServers` is empty, preventing premature clearing of valid persisted values before servers finish loading

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Open multiple browser tabs and verify that favorites toggles and MCP server selections remain independent per tab:

1. Open Tab A and select specific MCP servers for a new conversation
2. Open Tab B and select different MCP servers for a new conversation
3. Verify Tab A's selections remain unchanged (not overwritten by Tab B)
4. Toggle agent favorites in Tab A
5. Switch to Tab B and verify favorites state is independent
6. Refresh both tabs and verify their respective states persist correctly from localStorage

### **Test Configuration**:
- Browser: Any modern browser supporting localStorage
- Multiple MCP servers configured
- Agent favorites enabled

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes