### PR TITLE
📦 chore: `@librechat/agents` to v3.1.42

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.41",
+    "@librechat/agents": "^3.1.42",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.41",
+        "@librechat/agents": "^3.1.42",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11208,9 +11208,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.41",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.41.tgz",
-      "integrity": "sha512-djdJOGv8GxiI3vRyJZ5MoN8Gy3ZzfSTPOuWtqXLO0MzUkyQB32FqiM3YmtAjBbHLu0CSoOgkE8VVubQsOZauWQ==",
+      "version": "3.1.42",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.42.tgz",
+      "integrity": "sha512-zD+b+EpKdvYRO0STkOTiY4UwKK1522aD0BwmUPto7YWk4YmAXBB3uvyGN9ulP3Zr+1vqvypq2ZPfTLTrpqampw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -42205,7 +42205,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.41",
+        "@librechat/agents": "^3.1.42",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -87,7 +87,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.41",
+    "@librechat/agents": "^3.1.42",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@smithy/node-http-handler": "^4.4.5",


### PR DESCRIPTION

## Key Changes

### 1. **Fix: Handoff Instructions System Prompt** (#58, #59)
**Problem:** Multi-agent handoffs were causing "400 Unexpected role 'user' after role 'tool'" errors when a router agent ran a non-handoff tool before handing off to another agent.

**Solution:**
- Moved handoff instructions from being appended as a `HumanMessage` to being injected into the **system prompt** (via `AgentContext.setHandoffContext`)
- This prevents invalid message role sequences (tool → user) that many chat APIs reject
- Handoff instructions are now added under a "## Task Instructions" section in the system prompt
- Role ordering is never affected regardless of what the last filtered message is



### 2. **Fix: Event-Driven Tools Merging** (#57)
- Updated `getEventDrivenToolsForBinding` method to properly **merge schema-only tools with native tools**
- Ensures both `graphTools` and regular `tools` are included in final output for event-driven mode
- Improves flexibility and completeness of tool definitions


## Impact

These changes primarily improve **multi-agent handoff reliability** by fixing a critical bug where message role ordering could break agent-to-agent transfers, and enhance **tool handling in event-driven mode**.