### PR TITLE
🌙 fix: Accessible Contrast for Theme Switcher Icons

### DIFF
--- a/packages/client/src/components/ThemeSelector.tsx
+++ b/packages/client/src/components/ThemeSelector.tsx
@@ -16,7 +16,7 @@ const Theme = ({ theme, onChange }: { theme: string; onChange: (value: string) =
 
   const themeIcons: Record<ThemeType, JSX.Element> = {
     system: <Monitor aria-hidden="true" />,
-    dark: <Moon color="white" aria-hidden="true" />,
+    dark: <Moon aria-hidden="true" />,
     light: <Sun aria-hidden="true" />,
   };
 
@@ -35,7 +35,7 @@ const Theme = ({ theme, onChange }: { theme: string; onChange: (value: string) =
 
   return (
     <button
-      className="flex items-center gap-2 rounded-lg p-2 transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 dark:focus-visible:ring-0"
+      className="flex items-center gap-2 rounded-lg p-2 text-gray-800 transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 dark:text-white dark:focus-visible:ring-0"
       aria-label={localize('com_ui_toggle_theme')}
       aria-keyshortcuts="Ctrl+Shift+T"
       onClick={(e) => {

--- a/packages/client/src/components/ThemeSelector.tsx
+++ b/packages/client/src/components/ThemeSelector.tsx
@@ -35,7 +35,7 @@ const Theme = ({ theme, onChange }: { theme: string; onChange: (value: string) =
 
   return (
     <button
-      className="flex items-center gap-2 rounded-lg p-2 text-gray-800 transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 dark:text-white dark:focus-visible:ring-0"
+      className="flex items-center gap-2 rounded-lg p-2 text-text-primary transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 dark:focus-visible:ring-0"
       aria-label={localize('com_ui_toggle_theme')}
       aria-keyshortcuts="Ctrl+Shift+T"
       onClick={(e) => {


### PR DESCRIPTION
## Summary

This pull request makes minor UI adjustments to the `ThemeSelector` component to improve visual consistency across themes.

* UI consistency improvements:
  * Removed the explicit white color from the `Moon` icon so that it inherits color from the theme, ensuring better appearance in both light and dark modes. (`packages/client/src/components/ThemeSelector.tsx`)
  * Added `text-gray-800` for light mode and `dark:text-white` for dark mode to the button, ensuring the text color adapts appropriately to the selected theme. (`packages/client/src/components/ThemeSelector.tsx`)

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before
<img width="851" height="565" alt="Screenshot 2026-02-14 at 8 26 40 AM" src="https://github.com/user-attachments/assets/196d4a22-62b5-4049-bb5d-1e0d3a1323dc" />

### After

<img width="1728" height="1117" alt="Screenshot 2026-02-14 at 8 33 16 AM" src="https://github.com/user-attachments/assets/5822604b-0f52-4260-b936-78d760b4d2b1" />

<img width="1728" height="1117" alt="Screenshot 2026-02-14 at 8 30 57 AM" src="https://github.com/user-attachments/assets/507c280d-ac26-41ac-b61b-341aea47ae9c" />

<img width="1728" height="1117" alt="Screenshot 2026-02-14 at 8 30 40 AM" src="https://github.com/user-attachments/assets/b3d5443d-aef9-4ea8-8a29-7e545a852fb1" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes