### PR TITLE
🗂️  refactor: Artifacts via Model Specs & Scope Badge Persistence by Spec Context

### DIFF
--- a/client/src/Providers/BadgeRowContext.tsx
+++ b/client/src/Providers/BadgeRowContext.tsx
@@ -82,14 +82,16 @@ export default function BadgeRowProvider({
   const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(key));
 
   /** Initialize ephemeralAgent from localStorage on mount and when conversation/spec changes.
-   *  Skipped when a spec is active — spec state comes entirely from applyModelSpecEphemeralAgent. */
+   *  Skipped when a spec is active — applyModelSpecEphemeralAgent handles both new conversations
+   *  (pure spec values) and existing conversations (spec values + localStorage overrides). */
   useEffect(() => {
     if (isSubmitting) {
       return;
     }
     if (specName) {
-      // Spec active: all state comes from applyModelSpecEphemeralAgent, no localStorage reads.
-      // Reset init flag so switching back to non-spec triggers a fresh re-init.
+      // Spec active: applyModelSpecEphemeralAgent handles all state (spec base + localStorage
+      // overrides for existing conversations). Reset init flag so switching back to non-spec
+      // triggers a fresh re-init.
       hasInitializedRef.current = false;
       return;
     }

--- a/client/src/Providers/BadgeRowContext.tsx
+++ b/client/src/Providers/BadgeRowContext.tsx
@@ -107,36 +107,16 @@ export default function BadgeRowProvider({
       }
 
       /**
-       * Always set values for all tools (use defaults if not in `localStorage`)
-       * If `ephemeralAgent` is `null`, create a new object with just our tool values
+       * Only apply values from localStorage that were actually stored.
+       * If localStorage has no value for a tool, don't override ephemeralAgent —
+       * it may already have been set by a model spec.
        */
-      const finalValues = {
-        [Tools.execute_code]: initialValues[Tools.execute_code] ?? false,
-        [Tools.web_search]: initialValues[Tools.web_search] ?? false,
-        [Tools.file_search]: initialValues[Tools.file_search] ?? false,
-        [AgentCapabilities.artifacts]: initialValues[AgentCapabilities.artifacts] ?? false,
-      };
-
-      setEphemeralAgent((prev) => ({
-        ...(prev || {}),
-        ...finalValues,
-      }));
-
-      Object.entries(finalValues).forEach(([toolKey, value]) => {
-        if (value !== false) {
-          let storageKey = artifactsToggleKey;
-          if (toolKey === Tools.execute_code) {
-            storageKey = codeToggleKey;
-          } else if (toolKey === Tools.web_search) {
-            storageKey = webSearchToggleKey;
-          } else if (toolKey === Tools.file_search) {
-            storageKey = fileSearchToggleKey;
-          }
-          // Store the value and set timestamp for existing values
-          localStorage.setItem(storageKey, JSON.stringify(value));
-          setTimestamp(storageKey);
-        }
-      });
+      if (Object.keys(initialValues).length > 0) {
+        setEphemeralAgent((prev) => ({
+          ...(prev || {}),
+          ...initialValues,
+        }));
+      }
     }
   }, [key, isSubmitting, setEphemeralAgent]);
 

--- a/client/src/components/Chat/Input/BadgeRow.tsx
+++ b/client/src/components/Chat/Input/BadgeRow.tsx
@@ -28,6 +28,7 @@ interface BadgeRowProps {
   onChange: (badges: Pick<BadgeItem, 'id'>[]) => void;
   onToggle?: (badgeId: string, currentActive: boolean) => void;
   conversationId?: string | null;
+  specName?: string | null;
   isSubmitting?: boolean;
   isInChat: boolean;
 }
@@ -142,6 +143,7 @@ const dragReducer = (state: DragState, action: DragAction): DragState => {
 function BadgeRow({
   showEphemeralBadges,
   conversationId,
+  specName,
   isSubmitting,
   onChange,
   onToggle,
@@ -320,7 +322,11 @@ function BadgeRow({
   }, [dragState.draggedBadge, handleMouseMove, handleMouseUp]);
 
   return (
-    <BadgeRowProvider conversationId={conversationId} isSubmitting={isSubmitting}>
+    <BadgeRowProvider
+      conversationId={conversationId}
+      specName={specName}
+      isSubmitting={isSubmitting}
+    >
       <div ref={containerRef} className="relative flex flex-wrap items-center gap-2">
         {showEphemeralBadges === true && <ToolsDropdown />}
         {tempBadges.map((badge, index) => (

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -325,6 +325,7 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
                 }
                 isSubmitting={isSubmitting}
                 conversationId={conversationId}
+                specName={conversation?.spec}
                 onChange={setBadges}
                 isInChat={
                   Array.isArray(conversation?.messages) && conversation.messages.length >= 1

--- a/client/src/components/Chat/Input/MCPSelect.tsx
+++ b/client/src/components/Chat/Input/MCPSelect.tsx
@@ -11,7 +11,7 @@ import { useHasAccess } from '~/hooks';
 import { cn } from '~/utils';
 
 function MCPSelectContent() {
-  const { conversationId, mcpServerManager } = useBadgeRowContext();
+  const { conversationId, storageContextKey, mcpServerManager } = useBadgeRowContext();
   const {
     localize,
     isPinned,
@@ -128,7 +128,11 @@ function MCPSelectContent() {
         </Ariakit.Menu>
       </Ariakit.MenuProvider>
       {configDialogProps && (
-        <MCPConfigDialog {...configDialogProps} conversationId={conversationId} />
+        <MCPConfigDialog
+          {...configDialogProps}
+          conversationId={conversationId}
+          storageContextKey={storageContextKey}
+        />
       )}
     </>
   );

--- a/client/src/components/Chat/Input/MCPSubMenu.tsx
+++ b/client/src/components/Chat/Input/MCPSubMenu.tsx
@@ -15,7 +15,7 @@ interface MCPSubMenuProps {
 const MCPSubMenu = React.forwardRef<HTMLDivElement, MCPSubMenuProps>(
   ({ placeholder, ...props }, ref) => {
     const localize = useLocalize();
-    const { mcpServerManager } = useBadgeRowContext();
+    const { storageContextKey, mcpServerManager } = useBadgeRowContext();
     const {
       isPinned,
       mcpValues,
@@ -106,7 +106,9 @@ const MCPSubMenu = React.forwardRef<HTMLDivElement, MCPSubMenuProps>(
             </div>
           </Ariakit.Menu>
         </Ariakit.MenuProvider>
-        {configDialogProps && <MCPConfigDialog {...configDialogProps} />}
+        {configDialogProps && (
+          <MCPConfigDialog {...configDialogProps} storageContextKey={storageContextKey} />
+        )}
       </div>
     );
   },

--- a/client/src/components/MCP/MCPConfigDialog.tsx
+++ b/client/src/components/MCP/MCPConfigDialog.tsx
@@ -24,6 +24,7 @@ interface MCPConfigDialogProps {
   serverName: string;
   serverStatus?: MCPServerStatus;
   conversationId?: string | null;
+  storageContextKey?: string;
 }
 
 export default function MCPConfigDialog({
@@ -36,6 +37,7 @@ export default function MCPConfigDialog({
   serverName,
   serverStatus,
   conversationId,
+  storageContextKey,
 }: MCPConfigDialogProps) {
   const localize = useLocalize();
 
@@ -167,6 +169,7 @@ export default function MCPConfigDialog({
         <ServerInitializationSection
           serverName={serverName}
           conversationId={conversationId}
+          storageContextKey={storageContextKey}
           requiresOAuth={serverStatus?.requiresOAuth || false}
           hasCustomUserVars={fieldsSchema && Object.keys(fieldsSchema).length > 0}
         />

--- a/client/src/components/MCP/ServerInitializationSection.tsx
+++ b/client/src/components/MCP/ServerInitializationSection.tsx
@@ -9,12 +9,14 @@ interface ServerInitializationSectionProps {
   requiresOAuth: boolean;
   hasCustomUserVars?: boolean;
   conversationId?: string | null;
+  storageContextKey?: string;
 }
 
 export default function ServerInitializationSection({
   serverName,
   requiresOAuth,
   conversationId,
+  storageContextKey,
   sidePanel = false,
   hasCustomUserVars = false,
 }: ServerInitializationSectionProps) {
@@ -28,7 +30,7 @@ export default function ServerInitializationSection({
     initializeServer,
     availableMCPServers,
     revokeOAuthForServer,
-  } = useMCPServerManager({ conversationId });
+  } = useMCPServerManager({ conversationId, storageContextKey });
 
   const { connectionStatus } = useMCPConnectionStatus({
     enabled: !!availableMCPServers && availableMCPServers.length > 0,

--- a/client/src/hooks/Agents/useApplyModelSpecAgents.ts
+++ b/client/src/hooks/Agents/useApplyModelSpecAgents.ts
@@ -80,6 +80,9 @@ export function useApplyAgentTemplate() {
         web_search: ephemeralAgent?.web_search ?? modelSpec.webSearch ?? false,
         file_search: ephemeralAgent?.file_search ?? modelSpec.fileSearch ?? false,
         execute_code: ephemeralAgent?.execute_code ?? modelSpec.executeCode ?? false,
+        artifacts:
+          ephemeralAgent?.artifacts ??
+          (modelSpec.artifacts === true ? 'default' : modelSpec.artifacts || ''),
       };
 
       mergedAgent.mcp = [...new Set(mergedAgent.mcp)];

--- a/client/src/hooks/Agents/useApplyModelSpecAgents.ts
+++ b/client/src/hooks/Agents/useApplyModelSpecAgents.ts
@@ -26,8 +26,8 @@ export function useApplyModelSpecEffects() {
     }) => {
       if (specName == null || !specName) {
         if (startupConfig?.modelSpecs?.list?.length) {
-          /** Specs are configured but none selected — reset ephemeral agent so
-           *  BadgeRowContext can fill in from localStorage (non-spec defaults). */
+          /** Specs are configured but none selected — reset ephemeral agent to null
+           *  so BadgeRowContext fills all values (tool toggles + MCP) from localStorage. */
           updateEphemeralAgent((convoId ?? Constants.NEW_CONVO) || Constants.NEW_CONVO, null);
         }
         return;

--- a/client/src/hooks/Agents/useApplyModelSpecAgents.ts
+++ b/client/src/hooks/Agents/useApplyModelSpecAgents.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { Constants } from 'librechat-data-provider';
 import type { TStartupConfig, TSubmission } from 'librechat-data-provider';
 import { useUpdateEphemeralAgent, useApplyNewAgentTemplate } from '~/store/agents';
 import { getModelSpec, applyModelSpecEphemeralAgent } from '~/utils';
@@ -6,6 +7,10 @@ import { getModelSpec, applyModelSpecEphemeralAgent } from '~/utils';
 /**
  * Hook that applies a model spec from a preset to an ephemeral agent.
  * This is used when initializing a new conversation with a preset that has a spec.
+ *
+ * When a spec is provided, its tool settings are applied to the ephemeral agent.
+ * When no spec is provided but specs are configured, the ephemeral agent is reset
+ * to null so BadgeRowContext can apply localStorage defaults (non-spec experience).
  */
 export function useApplyModelSpecEffects() {
   const updateEphemeralAgent = useUpdateEphemeralAgent();
@@ -20,6 +25,11 @@ export function useApplyModelSpecEffects() {
       startupConfig?: TStartupConfig;
     }) => {
       if (specName == null || !specName) {
+        if (startupConfig?.modelSpecs?.list?.length) {
+          /** Specs are configured but none selected — reset ephemeral agent so
+           *  BadgeRowContext can fill in from localStorage (non-spec defaults). */
+          updateEphemeralAgent((convoId ?? Constants.NEW_CONVO) || Constants.NEW_CONVO, null);
+        }
         return;
       }
 

--- a/client/src/hooks/MCP/__tests__/useMCPSelect.test.tsx
+++ b/client/src/hooks/MCP/__tests__/useMCPSelect.test.tsx
@@ -415,7 +415,7 @@ describe('useMCPSelect', () => {
       });
     });
 
-    it('should handle empty ephemeralAgent.mcp array correctly', async () => {
+    it('should clear mcpValues when ephemeralAgent.mcp is set to empty array', async () => {
       // Create a shared wrapper
       const { Wrapper, servers } = createWrapper(['initial-value']);
 
@@ -437,16 +437,18 @@ describe('useMCPSelect', () => {
         expect(result.current.mcpHook.mcpValues).toEqual(['initial-value']);
       });
 
-      // Try to set empty array externally
+      // Set empty array externally (e.g., spec with no MCP servers)
       act(() => {
         result.current.setEphemeralAgent({
           mcp: [],
         });
       });
 
-      // Values should remain unchanged since empty mcp array doesn't trigger update
-      // (due to the condition: ephemeralAgent?.mcp && ephemeralAgent.mcp.length > 0)
-      expect(result.current.mcpHook.mcpValues).toEqual(['initial-value']);
+      // Jotai atom should be cleared — an explicit empty mcp array means
+      // the spec (or reset) has no MCP servers, so the visual selection must clear
+      await waitFor(() => {
+        expect(result.current.mcpHook.mcpValues).toEqual([]);
+      });
     });
 
     it('should handle ephemeralAgent being reset to null', async () => {
@@ -586,6 +588,233 @@ describe('useMCPSelect', () => {
 
       // Should unmount without errors
       expect(() => unmount()).not.toThrow();
+    });
+  });
+
+  describe('Environment-Keyed Storage (storageContextKey)', () => {
+    it('should use storageContextKey as atom key for new conversations', async () => {
+      const { Wrapper, servers } = createWrapper(['server1', 'server2']);
+      const storageContextKey = '__defaults__';
+
+      // Hook A: new conversation with storageContextKey
+      const { result: resultA } = renderHook(
+        () => useMCPSelect({ conversationId: null, storageContextKey, servers }),
+        { wrapper: Wrapper },
+      );
+
+      act(() => {
+        resultA.current.setMCPValues(['server1']);
+      });
+
+      await waitFor(() => {
+        expect(resultA.current.mcpValues).toEqual(['server1']);
+      });
+
+      // Hook B: new conversation WITHOUT storageContextKey (different environment)
+      const { result: resultB } = renderHook(
+        () => useMCPSelect({ conversationId: null, servers }),
+        { wrapper: Wrapper },
+      );
+
+      // Should NOT see server1 since it's a different atom (NEW_CONVO vs __defaults__)
+      expect(resultB.current.mcpValues).toEqual([]);
+    });
+
+    it('should use conversationId as atom key for existing conversations even with storageContextKey', async () => {
+      const conversationId = 'existing-convo-123';
+      const { Wrapper, servers } = createWrapper(['server1', 'server2']);
+      const storageContextKey = '__defaults__';
+
+      const { result } = renderHook(
+        () => useMCPSelect({ conversationId, storageContextKey, servers }),
+        { wrapper: Wrapper },
+      );
+
+      act(() => {
+        result.current.setMCPValues(['server1', 'server2']);
+      });
+
+      await waitFor(() => {
+        expect(result.current.mcpValues).toEqual(['server1', 'server2']);
+      });
+
+      // Verify timestamp was written to the conversation key, not the environment key
+      const convoKey = `${LocalStorageKeys.LAST_MCP_}${conversationId}`;
+      expect(setTimestamp).toHaveBeenCalledWith(convoKey);
+    });
+
+    it('should dual-write to environment key when storageContextKey is provided', async () => {
+      const { Wrapper, servers } = createWrapper(['server1', 'server2']);
+      const storageContextKey = '__defaults__';
+
+      const { result } = renderHook(
+        () => useMCPSelect({ conversationId: null, storageContextKey, servers }),
+        { wrapper: Wrapper },
+      );
+
+      act(() => {
+        result.current.setMCPValues(['server1', 'server2']);
+      });
+
+      await waitFor(() => {
+        // Verify dual-write to environment key
+        const envKey = `${LocalStorageKeys.LAST_MCP_}${storageContextKey}`;
+        expect(localStorage.getItem(envKey)).toEqual(JSON.stringify(['server1', 'server2']));
+        expect(setTimestamp).toHaveBeenCalledWith(envKey);
+      });
+    });
+
+    it('should NOT dual-write when storageContextKey is undefined', async () => {
+      const conversationId = 'convo-no-specs';
+      const { Wrapper, servers } = createWrapper(['server1']);
+
+      const { result } = renderHook(() => useMCPSelect({ conversationId, servers }), {
+        wrapper: Wrapper,
+      });
+
+      act(() => {
+        result.current.setMCPValues(['server1']);
+      });
+
+      await waitFor(() => {
+        expect(result.current.mcpValues).toEqual(['server1']);
+      });
+
+      // Only the conversation-keyed timestamp should be set, no environment key
+      const envKey = `${LocalStorageKeys.LAST_MCP_}__defaults__`;
+      expect(localStorage.getItem(envKey)).toBeNull();
+    });
+
+    it('should isolate per-conversation state from environment defaults', async () => {
+      const { Wrapper, servers } = createWrapper(['server1', 'server2', 'server3']);
+      const storageContextKey = '__defaults__';
+
+      // Set environment defaults via new conversation
+      const { result: newConvoResult } = renderHook(
+        () => useMCPSelect({ conversationId: null, storageContextKey, servers }),
+        { wrapper: Wrapper },
+      );
+
+      act(() => {
+        newConvoResult.current.setMCPValues(['server1', 'server2']);
+      });
+
+      await waitFor(() => {
+        expect(newConvoResult.current.mcpValues).toEqual(['server1', 'server2']);
+      });
+
+      // Existing conversation should have its own isolated state
+      const { result: existingResult } = renderHook(
+        () => useMCPSelect({ conversationId: 'existing-convo', storageContextKey, servers }),
+        { wrapper: Wrapper },
+      );
+
+      // Should start empty (its own atom), not inherit from defaults
+      expect(existingResult.current.mcpValues).toEqual([]);
+
+      // Set different value for existing conversation
+      act(() => {
+        existingResult.current.setMCPValues(['server3']);
+      });
+
+      await waitFor(() => {
+        expect(existingResult.current.mcpValues).toEqual(['server3']);
+      });
+
+      // New conversation defaults should be unchanged
+      expect(newConvoResult.current.mcpValues).toEqual(['server1', 'server2']);
+    });
+  });
+
+  describe('Spec/Non-Spec Context Switching', () => {
+    it('should clear MCP when ephemeral agent switches to empty mcp (spec with no MCP)', async () => {
+      const { Wrapper, servers } = createWrapper(['server1', 'server2']);
+      const storageContextKey = '__defaults__';
+
+      const TestComponent = ({ ctxKey }: { ctxKey?: string }) => {
+        const mcpHook = useMCPSelect({ conversationId: null, storageContextKey: ctxKey, servers });
+        const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(Constants.NEW_CONVO));
+        return { mcpHook, setEphemeralAgent };
+      };
+
+      // Start in non-spec context with some servers selected
+      const { result } = renderHook(() => TestComponent({ ctxKey: storageContextKey }), {
+        wrapper: Wrapper,
+      });
+
+      act(() => {
+        result.current.mcpHook.setMCPValues(['server1', 'server2']);
+      });
+
+      await waitFor(() => {
+        expect(result.current.mcpHook.mcpValues).toEqual(['server1', 'server2']);
+      });
+
+      // Simulate switching to a spec with no MCP — ephemeral agent gets mcp: []
+      act(() => {
+        result.current.setEphemeralAgent({ mcp: [] });
+      });
+
+      // MCP values should clear since the spec explicitly has no MCP servers
+      await waitFor(() => {
+        expect(result.current.mcpHook.mcpValues).toEqual([]);
+      });
+    });
+
+    it('should handle ephemeral agent with spec MCP servers syncing to Jotai atom', async () => {
+      const { Wrapper, servers } = createWrapper(['spec-server1', 'spec-server2']);
+
+      const TestComponent = () => {
+        const mcpHook = useMCPSelect({ conversationId: null, servers });
+        const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(Constants.NEW_CONVO));
+        return { mcpHook, setEphemeralAgent };
+      };
+
+      const { result } = renderHook(() => TestComponent(), { wrapper: Wrapper });
+
+      // Simulate spec application setting ephemeral agent MCP
+      act(() => {
+        result.current.setEphemeralAgent({
+          mcp: ['spec-server1', 'spec-server2'],
+          execute_code: true,
+        });
+      });
+
+      await waitFor(() => {
+        expect(result.current.mcpHook.mcpValues).toEqual(['spec-server1', 'spec-server2']);
+      });
+    });
+
+    it('should handle null ephemeral agent reset (non-spec with specs configured)', async () => {
+      const { Wrapper, servers } = createWrapper(['server1', 'server2']);
+
+      const TestComponent = () => {
+        const mcpHook = useMCPSelect({ servers });
+        const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(Constants.NEW_CONVO));
+        return { mcpHook, setEphemeralAgent };
+      };
+
+      const { result } = renderHook(() => TestComponent(), { wrapper: Wrapper });
+
+      // Set values from a spec
+      act(() => {
+        result.current.setEphemeralAgent({ mcp: ['server1', 'server2'] });
+      });
+
+      await waitFor(() => {
+        expect(result.current.mcpHook.mcpValues).toEqual(['server1', 'server2']);
+      });
+
+      // Reset ephemeral agent to null (switching to non-spec)
+      act(() => {
+        result.current.setEphemeralAgent(null);
+      });
+
+      // mcpValues should remain unchanged — null ephemeral agent doesn't trigger sync
+      // (BadgeRowContext will fill from localStorage defaults separately)
+      await waitFor(() => {
+        expect(result.current.mcpHook.mcpValues).toEqual(['server1', 'server2']);
+      });
     });
   });
 

--- a/client/src/hooks/MCP/__tests__/useMCPSelect.test.tsx
+++ b/client/src/hooks/MCP/__tests__/useMCPSelect.test.tsx
@@ -449,7 +449,7 @@ describe('useMCPSelect', () => {
       expect(result.current.mcpHook.mcpValues).toEqual(['initial-value']);
     });
 
-    it('should handle ephemeralAgent with clear mcp value', async () => {
+    it('should handle ephemeralAgent being reset to null', async () => {
       // Create a shared wrapper
       const { Wrapper, servers } = createWrapper(['server1', 'server2']);
 
@@ -471,16 +471,15 @@ describe('useMCPSelect', () => {
         expect(result.current.mcpHook.mcpValues).toEqual(['server1', 'server2']);
       });
 
-      // Set ephemeralAgent with clear value
+      // Reset ephemeralAgent to null (simulating non-spec reset)
       act(() => {
-        result.current.setEphemeralAgent({
-          mcp: [Constants.mcp_clear as string],
-        });
+        result.current.setEphemeralAgent(null);
       });
 
-      // mcpValues should be cleared
+      // mcpValues should remain unchanged since null ephemeral agent
+      // doesn't trigger the sync effect (mcps.length === 0)
       await waitFor(() => {
-        expect(result.current.mcpHook.mcpValues).toEqual([]);
+        expect(result.current.mcpHook.mcpValues).toEqual(['server1', 'server2']);
       });
     });
 

--- a/client/src/hooks/MCP/useMCPSelect.ts
+++ b/client/src/hooks/MCP/useMCPSelect.ts
@@ -36,15 +36,6 @@ export function useMCPSelect({
   }, [ephemeralAgent?.mcp, setMCPValuesRaw, configuredServers]);
 
   useEffect(() => {
-    setEphemeralAgent((prev) => {
-      if (!isEqual(prev?.mcp, mcpValues)) {
-        return { ...(prev ?? {}), mcp: mcpValues };
-      }
-      return prev;
-    });
-  }, [mcpValues, setEphemeralAgent]);
-
-  useEffect(() => {
     const mcpStorageKey = `${LocalStorageKeys.LAST_MCP_}${key}`;
     if (mcpValues.length > 0) {
       setTimestamp(mcpStorageKey);
@@ -58,8 +49,14 @@ export function useMCPSelect({
         return;
       }
       setMCPValuesRaw(value);
+      setEphemeralAgent((prev) => {
+        if (!isEqual(prev?.mcp, value)) {
+          return { ...(prev ?? {}), mcp: value };
+        }
+        return prev;
+      });
     },
-    [setMCPValuesRaw],
+    [setMCPValuesRaw, setEphemeralAgent],
   );
 
   return {

--- a/client/src/hooks/MCP/useMCPSelect.ts
+++ b/client/src/hooks/MCP/useMCPSelect.ts
@@ -9,9 +9,11 @@ import { MCPServerDefinition } from './useMCPServerManager';
 
 export function useMCPSelect({
   conversationId,
+  storageContextKey,
   servers,
 }: {
   conversationId?: string | null;
+  storageContextKey?: string;
   servers: MCPServerDefinition[];
 }) {
   const key = conversationId ?? Constants.NEW_CONVO;
@@ -19,30 +21,41 @@ export function useMCPSelect({
     return new Set(servers?.map((s) => s.serverName));
   }, [servers]);
 
+  /**
+   * For new conversations, key the MCP atom by environment (spec or defaults)
+   * so switching between spec ↔ non-spec gives each its own atom.
+   * For existing conversations, key by conversation ID for per-conversation isolation.
+   */
+  const isNewConvo = key === Constants.NEW_CONVO;
+  const mcpAtomKey = isNewConvo && storageContextKey ? storageContextKey : key;
+
   const [isPinned, setIsPinned] = useAtom(mcpPinnedAtom);
-  const [mcpValues, setMCPValuesRaw] = useAtom(mcpValuesAtomFamily(key));
+  const [mcpValues, setMCPValuesRaw] = useAtom(mcpValuesAtomFamily(mcpAtomKey));
   const [ephemeralAgent, setEphemeralAgent] = useRecoilState(ephemeralAgentByConvoId(key));
 
-  // Sync Jotai state with ephemeral agent state
+  // Sync ephemeral agent MCP → Jotai atom (strip unconfigured servers)
   useEffect(() => {
-    const mcps = ephemeralAgent?.mcp ?? [];
-    if (mcps.length === 1 && mcps[0] === Constants.mcp_clear) {
-      setMCPValuesRaw([]);
-    } else if (mcps.length > 0 && configuredServers.size > 0) {
-      // Strip out servers that are not available in the startup config
+    const mcps = ephemeralAgent?.mcp;
+    if (Array.isArray(mcps) && mcps.length > 0 && configuredServers.size > 0) {
       const activeMcps = mcps.filter((mcp) => configuredServers.has(mcp));
-      setMCPValuesRaw(activeMcps);
+      if (!isEqual(activeMcps, mcpValues)) {
+        setMCPValuesRaw(activeMcps);
+      }
+    } else if (Array.isArray(mcps) && mcps.length === 0 && mcpValues.length > 0) {
+      // Ephemeral agent explicitly has empty MCP (e.g., spec with no MCP servers) — clear atom
+      setMCPValuesRaw([]);
     }
-  }, [ephemeralAgent?.mcp, setMCPValuesRaw, configuredServers]);
+  }, [ephemeralAgent?.mcp, setMCPValuesRaw, configuredServers, mcpValues]);
 
+  // Write timestamp when MCP values change
   useEffect(() => {
-    const mcpStorageKey = `${LocalStorageKeys.LAST_MCP_}${key}`;
+    const mcpStorageKey = `${LocalStorageKeys.LAST_MCP_}${mcpAtomKey}`;
     if (mcpValues.length > 0) {
       setTimestamp(mcpStorageKey);
     }
-  }, [mcpValues, key]);
+  }, [mcpValues, mcpAtomKey]);
 
-  /** Stable memoized setter */
+  /** Stable memoized setter with dual-write to environment key */
   const setMCPValues = useCallback(
     (value: string[]) => {
       if (!Array.isArray(value)) {
@@ -55,8 +68,14 @@ export function useMCPSelect({
         }
         return prev;
       });
+      // Dual-write to environment key for new conversation defaults
+      if (storageContextKey) {
+        const envKey = `${LocalStorageKeys.LAST_MCP_}${storageContextKey}`;
+        localStorage.setItem(envKey, JSON.stringify(value));
+        setTimestamp(envKey);
+      }
     },
-    [setMCPValuesRaw, setEphemeralAgent],
+    [setMCPValuesRaw, setEphemeralAgent, storageContextKey],
   );
 
   return {

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -28,7 +28,10 @@ export interface MCPServerDefinition {
 // The init states (isInitializing, isCancellable, etc.) are stored in the global Jotai atom
 type PollIntervals = Record<string, NodeJS.Timeout | null>;
 
-export function useMCPServerManager({ conversationId }: { conversationId?: string | null } = {}) {
+export function useMCPServerManager({
+  conversationId,
+  storageContextKey,
+}: { conversationId?: string | null; storageContextKey?: string } = {}) {
   const localize = useLocalize();
   const queryClient = useQueryClient();
   const { showToast } = useToastContext();
@@ -73,6 +76,7 @@ export function useMCPServerManager({ conversationId }: { conversationId?: strin
 
   const { mcpValues, setMCPValues, isPinned, setIsPinned } = useMCPSelect({
     conversationId,
+    storageContextKey,
     servers: selectableServers,
   });
   const mcpValuesRef = useRef(mcpValues);

--- a/client/src/hooks/Plugins/__tests__/useToolToggle.test.tsx
+++ b/client/src/hooks/Plugins/__tests__/useToolToggle.test.tsx
@@ -1,0 +1,328 @@
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { LocalStorageKeys, Tools } from 'librechat-data-provider';
+import { RecoilRoot, useRecoilValue, useSetRecoilState } from 'recoil';
+import { ephemeralAgentByConvoId } from '~/store';
+import { useToolToggle } from '../useToolToggle';
+
+/**
+ * Tests for useToolToggle — the hook responsible for toggling tool badges
+ * (code execution, web search, file search, artifacts) and persisting state.
+ *
+ * Desired behaviors:
+ * - User toggles persist to per-conversation localStorage
+ * - In non-spec mode with specs configured (storageContextKey = '__defaults__'),
+ *   toggles ALSO persist to the defaults key so future new conversations inherit them
+ * - In spec mode (storageContextKey = undefined), toggles only persist per-conversation
+ * - The hook reflects the current ephemeral agent state
+ */
+
+// Mock data-provider auth query
+jest.mock('~/data-provider', () => ({
+  useVerifyAgentToolAuth: jest.fn().mockReturnValue({
+    data: { authenticated: true },
+  }),
+}));
+
+// Mock timestamps (track calls without actual localStorage timestamp logic)
+jest.mock('~/utils/timestamps', () => ({
+  setTimestamp: jest.fn(),
+}));
+
+// Mock useLocalStorageAlt (isPinned state — not relevant to our behavior tests)
+jest.mock('~/hooks/useLocalStorageAlt', () => jest.fn(() => [false, jest.fn()]));
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <RecoilRoot>{children}</RecoilRoot>
+);
+
+describe('useToolToggle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  // ─── Dual-Write Behavior ───────────────────────────────────────────
+
+  describe('non-spec mode: dual-write to defaults key', () => {
+    const storageContextKey = '__defaults__';
+
+    it('should write to both conversation key and defaults key when user toggles a tool', () => {
+      const conversationId = 'convo-123';
+      const { result } = renderHook(
+        () =>
+          useToolToggle({
+            conversationId,
+            storageContextKey,
+            toolKey: Tools.execute_code,
+            localStorageKey: LocalStorageKeys.LAST_CODE_TOGGLE_,
+            isAuthenticated: true,
+          }),
+        { wrapper: Wrapper },
+      );
+
+      act(() => {
+        result.current.handleChange({ value: true });
+      });
+
+      // Conversation key: per-conversation persistence
+      const convoKey = `${LocalStorageKeys.LAST_CODE_TOGGLE_}${conversationId}`;
+      // Defaults key: persists for future new conversations
+      const defaultsKey = `${LocalStorageKeys.LAST_CODE_TOGGLE_}${storageContextKey}`;
+
+      // Sync effect writes to conversation key
+      expect(localStorage.getItem(convoKey)).toBe(JSON.stringify(true));
+      // handleChange dual-writes to defaults key
+      expect(localStorage.getItem(defaultsKey)).toBe(JSON.stringify(true));
+    });
+
+    it('should persist false values to defaults key when user disables a tool', () => {
+      const { result } = renderHook(
+        () =>
+          useToolToggle({
+            conversationId: 'convo-456',
+            storageContextKey,
+            toolKey: Tools.web_search,
+            localStorageKey: LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_,
+            isAuthenticated: true,
+          }),
+        { wrapper: Wrapper },
+      );
+
+      // Enable then disable
+      act(() => {
+        result.current.handleChange({ value: true });
+      });
+      act(() => {
+        result.current.handleChange({ value: false });
+      });
+
+      const defaultsKey = `${LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_}${storageContextKey}`;
+      expect(localStorage.getItem(defaultsKey)).toBe(JSON.stringify(false));
+    });
+  });
+
+  describe('spec mode: no dual-write', () => {
+    it('should only write to conversation key, not to any defaults key', () => {
+      const conversationId = 'spec-convo-789';
+      const { result } = renderHook(
+        () =>
+          useToolToggle({
+            conversationId,
+            storageContextKey: undefined, // spec mode
+            toolKey: Tools.execute_code,
+            localStorageKey: LocalStorageKeys.LAST_CODE_TOGGLE_,
+            isAuthenticated: true,
+          }),
+        { wrapper: Wrapper },
+      );
+
+      act(() => {
+        result.current.handleChange({ value: true });
+      });
+
+      // Conversation key should have the value
+      const convoKey = `${LocalStorageKeys.LAST_CODE_TOGGLE_}${conversationId}`;
+      expect(localStorage.getItem(convoKey)).toBe(JSON.stringify(true));
+
+      // Defaults key should NOT have a value
+      const defaultsKey = `${LocalStorageKeys.LAST_CODE_TOGGLE_}__defaults__`;
+      expect(localStorage.getItem(defaultsKey)).toBeNull();
+    });
+  });
+
+  // ─── Per-Conversation Isolation ────────────────────────────────────
+
+  describe('per-conversation isolation', () => {
+    it('should maintain separate toggle state per conversation', () => {
+      const TestComponent = ({ conversationId }: { conversationId: string }) => {
+        const toggle = useToolToggle({
+          conversationId,
+          toolKey: Tools.execute_code,
+          localStorageKey: LocalStorageKeys.LAST_CODE_TOGGLE_,
+          isAuthenticated: true,
+        });
+        const ephemeralAgent = useRecoilValue(ephemeralAgentByConvoId(conversationId));
+        return { toggle, ephemeralAgent };
+      };
+
+      // Conversation A: enable code
+      const { result: resultA } = renderHook(() => TestComponent({ conversationId: 'convo-A' }), {
+        wrapper: Wrapper,
+      });
+
+      act(() => {
+        resultA.current.toggle.handleChange({ value: true });
+      });
+
+      // Conversation B: disable code
+      const { result: resultB } = renderHook(() => TestComponent({ conversationId: 'convo-B' }), {
+        wrapper: Wrapper,
+      });
+
+      act(() => {
+        resultB.current.toggle.handleChange({ value: false });
+      });
+
+      // Each conversation has its own value in localStorage
+      expect(localStorage.getItem(`${LocalStorageKeys.LAST_CODE_TOGGLE_}convo-A`)).toBe('true');
+      expect(localStorage.getItem(`${LocalStorageKeys.LAST_CODE_TOGGLE_}convo-B`)).toBe('false');
+    });
+  });
+
+  // ─── Ephemeral Agent Sync ──────────────────────────────────────────
+
+  describe('ephemeral agent reflects toggle state', () => {
+    it('should update ephemeral agent when user toggles a tool', async () => {
+      const conversationId = 'convo-sync-test';
+      const TestComponent = () => {
+        const toggle = useToolToggle({
+          conversationId,
+          toolKey: Tools.execute_code,
+          localStorageKey: LocalStorageKeys.LAST_CODE_TOGGLE_,
+          isAuthenticated: true,
+        });
+        const ephemeralAgent = useRecoilValue(ephemeralAgentByConvoId(conversationId));
+        return { toggle, ephemeralAgent };
+      };
+
+      const { result } = renderHook(() => TestComponent(), { wrapper: Wrapper });
+
+      act(() => {
+        result.current.toggle.handleChange({ value: true });
+      });
+
+      await waitFor(() => {
+        expect(result.current.ephemeralAgent?.execute_code).toBe(true);
+      });
+
+      act(() => {
+        result.current.toggle.handleChange({ value: false });
+      });
+
+      await waitFor(() => {
+        expect(result.current.ephemeralAgent?.execute_code).toBe(false);
+      });
+    });
+
+    it('should reflect external ephemeral agent changes in toolValue', async () => {
+      const conversationId = 'convo-external';
+      const TestComponent = () => {
+        const toggle = useToolToggle({
+          conversationId,
+          toolKey: Tools.web_search,
+          localStorageKey: LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_,
+          isAuthenticated: true,
+        });
+        const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(conversationId));
+        return { toggle, setEphemeralAgent };
+      };
+
+      const { result } = renderHook(() => TestComponent(), { wrapper: Wrapper });
+
+      // External update (e.g., from applyModelSpecEphemeralAgent)
+      act(() => {
+        result.current.setEphemeralAgent({ web_search: true, execute_code: false });
+      });
+
+      await waitFor(() => {
+        expect(result.current.toggle.toolValue).toBe(true);
+        expect(result.current.toggle.isToolEnabled).toBe(true);
+      });
+    });
+
+    it('should sync externally-set ephemeral agent values to localStorage', async () => {
+      const conversationId = 'convo-sync-ls';
+      const TestComponent = () => {
+        const toggle = useToolToggle({
+          conversationId,
+          toolKey: Tools.file_search,
+          localStorageKey: LocalStorageKeys.LAST_FILE_SEARCH_TOGGLE_,
+          isAuthenticated: true,
+        });
+        const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(conversationId));
+        return { toggle, setEphemeralAgent };
+      };
+
+      const { result } = renderHook(() => TestComponent(), { wrapper: Wrapper });
+
+      // Simulate applyModelSpecEphemeralAgent setting a value
+      act(() => {
+        result.current.setEphemeralAgent({ file_search: true });
+      });
+
+      // The sync effect should write to conversation-keyed localStorage
+      await waitFor(() => {
+        const storageKey = `${LocalStorageKeys.LAST_FILE_SEARCH_TOGGLE_}${conversationId}`;
+        expect(localStorage.getItem(storageKey)).toBe(JSON.stringify(true));
+      });
+    });
+  });
+
+  // ─── isToolEnabled computation ─────────────────────────────────────
+
+  describe('isToolEnabled computation', () => {
+    it('should return false when tool is not set', () => {
+      const { result } = renderHook(
+        () =>
+          useToolToggle({
+            conversationId: 'convo-1',
+            toolKey: Tools.execute_code,
+            localStorageKey: LocalStorageKeys.LAST_CODE_TOGGLE_,
+            isAuthenticated: true,
+          }),
+        { wrapper: Wrapper },
+      );
+
+      expect(result.current.isToolEnabled).toBe(false);
+    });
+
+    it('should treat non-empty string as enabled (artifacts)', async () => {
+      const conversationId = 'convo-artifacts';
+      const TestComponent = () => {
+        const toggle = useToolToggle({
+          conversationId,
+          toolKey: 'artifacts',
+          localStorageKey: LocalStorageKeys.LAST_ARTIFACTS_TOGGLE_,
+          isAuthenticated: true,
+        });
+        const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(conversationId));
+        return { toggle, setEphemeralAgent };
+      };
+
+      const { result } = renderHook(() => TestComponent(), { wrapper: Wrapper });
+
+      act(() => {
+        result.current.setEphemeralAgent({ artifacts: 'default' });
+      });
+
+      await waitFor(() => {
+        expect(result.current.toggle.isToolEnabled).toBe(true);
+      });
+    });
+
+    it('should treat empty string as disabled (artifacts off)', async () => {
+      const conversationId = 'convo-no-artifacts';
+      const TestComponent = () => {
+        const toggle = useToolToggle({
+          conversationId,
+          toolKey: 'artifacts',
+          localStorageKey: LocalStorageKeys.LAST_ARTIFACTS_TOGGLE_,
+          isAuthenticated: true,
+        });
+        const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(conversationId));
+        return { toggle, setEphemeralAgent };
+      };
+
+      const { result } = renderHook(() => TestComponent(), { wrapper: Wrapper });
+
+      act(() => {
+        result.current.setEphemeralAgent({ artifacts: '' });
+      });
+
+      await waitFor(() => {
+        expect(result.current.toggle.isToolEnabled).toBe(false);
+      });
+    });
+  });
+});

--- a/client/src/hooks/Plugins/useToolToggle.ts
+++ b/client/src/hooks/Plugins/useToolToggle.ts
@@ -13,6 +13,7 @@ type ToolValue = boolean | string;
 
 interface UseToolToggleOptions {
   conversationId?: string | null;
+  storageContextKey?: string;
   toolKey: string;
   localStorageKey: LocalStorageKeys;
   isAuthenticated?: boolean;
@@ -26,6 +27,7 @@ interface UseToolToggleOptions {
 
 export function useToolToggle({
   conversationId,
+  storageContextKey,
   toolKey: _toolKey,
   localStorageKey,
   isAuthenticated: externalIsAuthenticated,
@@ -93,8 +95,22 @@ export function useToolToggle({
         ...(prev || {}),
         [toolKey]: value,
       }));
+
+      // Dual-write to environment key for new conversation defaults
+      if (storageContextKey) {
+        const envKey = `${localStorageKey}${storageContextKey}`;
+        localStorage.setItem(envKey, JSON.stringify(value));
+        setTimestamp(envKey);
+      }
     },
-    [setIsDialogOpen, isAuthenticated, setEphemeralAgent, toolKey],
+    [
+      setIsDialogOpen,
+      isAuthenticated,
+      setEphemeralAgent,
+      toolKey,
+      storageContextKey,
+      localStorageKey,
+    ],
   );
 
   const debouncedChange = useMemo(

--- a/client/src/utils/__tests__/applyModelSpecEphemeralAgent.test.ts
+++ b/client/src/utils/__tests__/applyModelSpecEphemeralAgent.test.ts
@@ -1,0 +1,274 @@
+import { Constants, LocalStorageKeys } from 'librechat-data-provider';
+import type { TModelSpec, TEphemeralAgent } from 'librechat-data-provider';
+import { applyModelSpecEphemeralAgent } from '../endpoints';
+import { setTimestamp } from '../timestamps';
+
+/**
+ * Tests for applyModelSpecEphemeralAgent — the function responsible for
+ * constructing the ephemeral agent state when navigating to a spec conversation.
+ *
+ * Desired behaviors:
+ * - New conversations always get the admin's exact spec configuration
+ * - Existing conversations merge per-conversation localStorage overrides on top of spec
+ * - Cleared localStorage for existing conversations falls back to fresh spec config
+ */
+
+const createModelSpec = (overrides: Partial<TModelSpec> = {}): TModelSpec =>
+  ({
+    name: 'test-spec',
+    label: 'Test Spec',
+    preset: { endpoint: 'agents' },
+    mcpServers: ['spec-server1'],
+    webSearch: true,
+    executeCode: true,
+    fileSearch: false,
+    artifacts: true,
+    ...overrides,
+  }) as TModelSpec;
+
+/** Write a value + fresh timestamp to localStorage (simulates a user toggle) */
+function writeToolToggle(storagePrefix: string, convoId: string, value: unknown): void {
+  const key = `${storagePrefix}${convoId}`;
+  localStorage.setItem(key, JSON.stringify(value));
+  setTimestamp(key);
+}
+
+describe('applyModelSpecEphemeralAgent', () => {
+  let updateEphemeralAgent: jest.Mock<void, [string, TEphemeralAgent | null]>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    updateEphemeralAgent = jest.fn();
+  });
+
+  // ─── New Conversations ─────────────────────────────────────────────
+
+  describe('new conversations always get fresh admin spec config', () => {
+    it('should apply exactly the admin-configured tools and MCP servers', () => {
+      const modelSpec = createModelSpec({
+        mcpServers: ['clickhouse', 'github'],
+        executeCode: true,
+        webSearch: false,
+        fileSearch: true,
+        artifacts: true,
+      });
+
+      applyModelSpecEphemeralAgent({
+        convoId: null,
+        modelSpec,
+        updateEphemeralAgent,
+      });
+
+      expect(updateEphemeralAgent).toHaveBeenCalledWith(Constants.NEW_CONVO, {
+        mcp: ['clickhouse', 'github'],
+        execute_code: true,
+        web_search: false,
+        file_search: true,
+        artifacts: 'default',
+      });
+    });
+
+    it('should not read from localStorage even if stale values exist', () => {
+      // Simulate stale localStorage from a previous session
+      writeToolToggle(LocalStorageKeys.LAST_CODE_TOGGLE_, Constants.NEW_CONVO, false);
+      writeToolToggle(LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_, Constants.NEW_CONVO, true);
+      localStorage.setItem(
+        `${LocalStorageKeys.LAST_MCP_}${Constants.NEW_CONVO}`,
+        JSON.stringify(['stale-server']),
+      );
+
+      const modelSpec = createModelSpec({ executeCode: true, webSearch: false, mcpServers: [] });
+
+      applyModelSpecEphemeralAgent({
+        convoId: null,
+        modelSpec,
+        updateEphemeralAgent,
+      });
+
+      const agent = updateEphemeralAgent.mock.calls[0][1] as TEphemeralAgent;
+      // Should be spec values, NOT localStorage values
+      expect(agent.execute_code).toBe(true);
+      expect(agent.web_search).toBe(false);
+      expect(agent.mcp).toEqual([]);
+    });
+
+    it('should handle spec with no MCP servers', () => {
+      const modelSpec = createModelSpec({ mcpServers: undefined });
+
+      applyModelSpecEphemeralAgent({ convoId: null, modelSpec, updateEphemeralAgent });
+
+      const agent = updateEphemeralAgent.mock.calls[0][1] as TEphemeralAgent;
+      expect(agent.mcp).toEqual([]);
+    });
+
+    it('should map artifacts: true to "default" string', () => {
+      const modelSpec = createModelSpec({ artifacts: true });
+
+      applyModelSpecEphemeralAgent({ convoId: null, modelSpec, updateEphemeralAgent });
+
+      const agent = updateEphemeralAgent.mock.calls[0][1] as TEphemeralAgent;
+      expect(agent.artifacts).toBe('default');
+    });
+
+    it('should pass through artifacts string value directly', () => {
+      const modelSpec = createModelSpec({ artifacts: 'custom-renderer' as any });
+
+      applyModelSpecEphemeralAgent({ convoId: null, modelSpec, updateEphemeralAgent });
+
+      const agent = updateEphemeralAgent.mock.calls[0][1] as TEphemeralAgent;
+      expect(agent.artifacts).toBe('custom-renderer');
+    });
+  });
+
+  // ─── Existing Conversations: Per-Conversation Persistence ──────────
+
+  describe('existing conversations merge user overrides from localStorage', () => {
+    const convoId = 'convo-abc-123';
+
+    it('should preserve user tool modifications across navigation', () => {
+      // User previously toggled off code execution and enabled file search
+      writeToolToggle(LocalStorageKeys.LAST_CODE_TOGGLE_, convoId, false);
+      writeToolToggle(LocalStorageKeys.LAST_FILE_SEARCH_TOGGLE_, convoId, true);
+
+      const modelSpec = createModelSpec({
+        executeCode: true,
+        fileSearch: false,
+        webSearch: true,
+      });
+
+      applyModelSpecEphemeralAgent({ convoId, modelSpec, updateEphemeralAgent });
+
+      const agent = updateEphemeralAgent.mock.calls[0][1] as TEphemeralAgent;
+      expect(agent.execute_code).toBe(false); // user override
+      expect(agent.file_search).toBe(true); // user override
+      expect(agent.web_search).toBe(true); // not overridden, spec value
+    });
+
+    it('should preserve user-added MCP servers across navigation', () => {
+      // Spec has clickhouse, user also added github during the conversation
+      localStorage.setItem(
+        `${LocalStorageKeys.LAST_MCP_}${convoId}`,
+        JSON.stringify(['clickhouse', 'github']),
+      );
+
+      const modelSpec = createModelSpec({ mcpServers: ['clickhouse'] });
+
+      applyModelSpecEphemeralAgent({ convoId, modelSpec, updateEphemeralAgent });
+
+      const agent = updateEphemeralAgent.mock.calls[0][1] as TEphemeralAgent;
+      expect(agent.mcp).toEqual(['clickhouse', 'github']);
+    });
+
+    it('should preserve user-removed MCP servers (empty array) across navigation', () => {
+      // User removed all MCP servers during the conversation
+      localStorage.setItem(`${LocalStorageKeys.LAST_MCP_}${convoId}`, JSON.stringify([]));
+
+      const modelSpec = createModelSpec({ mcpServers: ['clickhouse', 'github'] });
+
+      applyModelSpecEphemeralAgent({ convoId, modelSpec, updateEphemeralAgent });
+
+      const agent = updateEphemeralAgent.mock.calls[0][1] as TEphemeralAgent;
+      expect(agent.mcp).toEqual([]);
+    });
+
+    it('should only override keys that exist in localStorage, leaving the rest as spec defaults', () => {
+      // User only changed artifacts, nothing else
+      writeToolToggle(LocalStorageKeys.LAST_ARTIFACTS_TOGGLE_, convoId, '');
+
+      const modelSpec = createModelSpec({
+        executeCode: true,
+        webSearch: true,
+        fileSearch: false,
+        artifacts: true,
+        mcpServers: ['server1'],
+      });
+
+      applyModelSpecEphemeralAgent({ convoId, modelSpec, updateEphemeralAgent });
+
+      const agent = updateEphemeralAgent.mock.calls[0][1] as TEphemeralAgent;
+      expect(agent.execute_code).toBe(true); // spec default (not in localStorage)
+      expect(agent.web_search).toBe(true); // spec default
+      expect(agent.file_search).toBe(false); // spec default
+      expect(agent.artifacts).toBe(''); // user override
+      expect(agent.mcp).toEqual(['server1']); // spec default (not in localStorage)
+    });
+  });
+
+  // ─── Existing Conversations: Cleared localStorage ──────────────────
+
+  describe('existing conversations with cleared localStorage get fresh spec config', () => {
+    const convoId = 'convo-cleared-456';
+
+    it('should fall back to pure spec values when localStorage is empty', () => {
+      // localStorage.clear() was already called in beforeEach
+
+      const modelSpec = createModelSpec({
+        executeCode: true,
+        webSearch: false,
+        fileSearch: true,
+        artifacts: true,
+        mcpServers: ['server1', 'server2'],
+      });
+
+      applyModelSpecEphemeralAgent({ convoId, modelSpec, updateEphemeralAgent });
+
+      expect(updateEphemeralAgent).toHaveBeenCalledWith(convoId, {
+        mcp: ['server1', 'server2'],
+        execute_code: true,
+        web_search: false,
+        file_search: true,
+        artifacts: 'default',
+      });
+    });
+
+    it('should fall back to spec values when timestamps have expired (>2 days)', () => {
+      // Write values with expired timestamps (3 days old)
+      const expiredTimestamp = (Date.now() - 3 * 24 * 60 * 60 * 1000).toString();
+      const codeKey = `${LocalStorageKeys.LAST_CODE_TOGGLE_}${convoId}`;
+      localStorage.setItem(codeKey, JSON.stringify(false));
+      localStorage.setItem(`${codeKey}_TIMESTAMP`, expiredTimestamp);
+
+      const modelSpec = createModelSpec({ executeCode: true });
+
+      applyModelSpecEphemeralAgent({ convoId, modelSpec, updateEphemeralAgent });
+
+      const agent = updateEphemeralAgent.mock.calls[0][1] as TEphemeralAgent;
+      // Expired override should be ignored — spec value wins
+      expect(agent.execute_code).toBe(true);
+    });
+  });
+
+  // ─── Guard Clauses ─────────────────────────────────────────────────
+
+  describe('guard clauses', () => {
+    it('should not call updateEphemeralAgent when modelSpec is undefined', () => {
+      applyModelSpecEphemeralAgent({
+        convoId: 'convo-1',
+        modelSpec: undefined,
+        updateEphemeralAgent,
+      });
+
+      expect(updateEphemeralAgent).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when updateEphemeralAgent is undefined', () => {
+      expect(() =>
+        applyModelSpecEphemeralAgent({
+          convoId: 'convo-1',
+          modelSpec: createModelSpec(),
+          updateEphemeralAgent: undefined,
+        }),
+      ).not.toThrow();
+    });
+
+    it('should use NEW_CONVO key when convoId is empty string', () => {
+      applyModelSpecEphemeralAgent({
+        convoId: '',
+        modelSpec: createModelSpec(),
+        updateEphemeralAgent,
+      });
+
+      expect(updateEphemeralAgent).toHaveBeenCalledWith(Constants.NEW_CONVO, expect.any(Object));
+    });
+  });
+});

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -11,7 +11,6 @@ import {
 } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { LocalizeFunction, IconsRecord } from '~/common';
-import { setTimestamp } from './timestamps';
 
 /**
  * Clears model for non-ephemeral agent conversations.
@@ -221,32 +220,13 @@ export function applyModelSpecEphemeralAgent({
     return;
   }
   const key = (convoId ?? Constants.NEW_CONVO) || Constants.NEW_CONVO;
-  const artifacts = modelSpec.artifacts === true ? 'default' : modelSpec.artifacts || '';
-  const web_search = modelSpec.webSearch ?? false;
-  const file_search = modelSpec.fileSearch ?? false;
-  const execute_code = modelSpec.executeCode ?? false;
-
   updateEphemeralAgent(key, {
     mcp: modelSpec.mcpServers ?? [Constants.mcp_clear as string],
-    web_search,
-    file_search,
-    execute_code,
-    artifacts,
+    web_search: modelSpec.webSearch ?? false,
+    file_search: modelSpec.fileSearch ?? false,
+    execute_code: modelSpec.executeCode ?? false,
+    artifacts: modelSpec.artifacts === true ? 'default' : modelSpec.artifacts || '',
   });
-
-  /** Write tool values to localStorage so BadgeRowContext reads them on initialization */
-  const toolEntries: [LocalStorageKeys, t.TEphemeralAgent[keyof t.TEphemeralAgent]][] = [
-    [LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_, web_search],
-    [LocalStorageKeys.LAST_FILE_SEARCH_TOGGLE_, file_search],
-    [LocalStorageKeys.LAST_CODE_TOGGLE_, execute_code],
-    [LocalStorageKeys.LAST_ARTIFACTS_TOGGLE_, artifacts],
-  ];
-
-  for (const [prefix, value] of toolEntries) {
-    const storageKey = `${prefix}${key}`;
-    localStorage.setItem(storageKey, JSON.stringify(value));
-    setTimestamp(storageKey);
-  }
 }
 
 /**

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -221,7 +221,7 @@ export function applyModelSpecEphemeralAgent({
   }
   const key = (convoId ?? Constants.NEW_CONVO) || Constants.NEW_CONVO;
   updateEphemeralAgent(key, {
-    mcp: modelSpec.mcpServers ?? [Constants.mcp_clear as string],
+    mcp: modelSpec.mcpServers ?? [],
     web_search: modelSpec.webSearch ?? false,
     file_search: modelSpec.fileSearch ?? false,
     execute_code: modelSpec.executeCode ?? false,

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -11,6 +11,7 @@ import {
 } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { LocalizeFunction, IconsRecord } from '~/common';
+import { getTimestampedValue } from './timestamps';
 
 /**
  * Clears model for non-ephemeral agent conversations.
@@ -220,13 +221,50 @@ export function applyModelSpecEphemeralAgent({
     return;
   }
   const key = (convoId ?? Constants.NEW_CONVO) || Constants.NEW_CONVO;
-  updateEphemeralAgent(key, {
+  const agent: t.TEphemeralAgent = {
     mcp: modelSpec.mcpServers ?? [],
     web_search: modelSpec.webSearch ?? false,
     file_search: modelSpec.fileSearch ?? false,
     execute_code: modelSpec.executeCode ?? false,
     artifacts: modelSpec.artifacts === true ? 'default' : modelSpec.artifacts || '',
-  });
+  };
+
+  // For existing conversations, layer per-conversation localStorage overrides
+  // on top of spec defaults so user modifications persist across navigation.
+  // If localStorage is empty (e.g., cleared), spec values stand alone.
+  if (key !== Constants.NEW_CONVO) {
+    const toolStorageMap: Array<[keyof t.TEphemeralAgent, string]> = [
+      ['execute_code', LocalStorageKeys.LAST_CODE_TOGGLE_],
+      ['web_search', LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_],
+      ['file_search', LocalStorageKeys.LAST_FILE_SEARCH_TOGGLE_],
+      ['artifacts', LocalStorageKeys.LAST_ARTIFACTS_TOGGLE_],
+    ];
+
+    for (const [toolKey, storagePrefix] of toolStorageMap) {
+      const raw = getTimestampedValue(`${storagePrefix}${key}`);
+      if (raw !== null) {
+        try {
+          agent[toolKey] = JSON.parse(raw) as never;
+        } catch {
+          // ignore parse errors
+        }
+      }
+    }
+
+    const mcpRaw = localStorage.getItem(`${LocalStorageKeys.LAST_MCP_}${key}`);
+    if (mcpRaw !== null) {
+      try {
+        const parsed = JSON.parse(mcpRaw);
+        if (Array.isArray(parsed)) {
+          agent.mcp = parsed;
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }
+
+  updateEphemeralAgent(key, agent);
 }
 
 /**

--- a/client/src/utils/endpoints.ts
+++ b/client/src/utils/endpoints.ts
@@ -11,6 +11,7 @@ import {
 } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { LocalizeFunction, IconsRecord } from '~/common';
+import { setTimestamp } from './timestamps';
 
 /**
  * Clears model for non-ephemeral agent conversations.
@@ -219,12 +220,33 @@ export function applyModelSpecEphemeralAgent({
   if (!modelSpec || !updateEphemeralAgent) {
     return;
   }
-  updateEphemeralAgent((convoId ?? Constants.NEW_CONVO) || Constants.NEW_CONVO, {
+  const key = (convoId ?? Constants.NEW_CONVO) || Constants.NEW_CONVO;
+  const artifacts = modelSpec.artifacts === true ? 'default' : modelSpec.artifacts || '';
+  const web_search = modelSpec.webSearch ?? false;
+  const file_search = modelSpec.fileSearch ?? false;
+  const execute_code = modelSpec.executeCode ?? false;
+
+  updateEphemeralAgent(key, {
     mcp: modelSpec.mcpServers ?? [Constants.mcp_clear as string],
-    web_search: modelSpec.webSearch ?? false,
-    file_search: modelSpec.fileSearch ?? false,
-    execute_code: modelSpec.executeCode ?? false,
+    web_search,
+    file_search,
+    execute_code,
+    artifacts,
   });
+
+  /** Write tool values to localStorage so BadgeRowContext reads them on initialization */
+  const toolEntries: [LocalStorageKeys, t.TEphemeralAgent[keyof t.TEphemeralAgent]][] = [
+    [LocalStorageKeys.LAST_WEB_SEARCH_TOGGLE_, web_search],
+    [LocalStorageKeys.LAST_FILE_SEARCH_TOGGLE_, file_search],
+    [LocalStorageKeys.LAST_CODE_TOGGLE_, execute_code],
+    [LocalStorageKeys.LAST_ARTIFACTS_TOGGLE_, artifacts],
+  ];
+
+  for (const [prefix, value] of toolEntries) {
+    const storageKey = `${prefix}${key}`;
+    localStorage.setItem(storageKey, JSON.stringify(value));
+    setTimestamp(storageKey);
+  }
 }
 
 /**

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1758,6 +1758,8 @@ export enum Constants {
   mcp_all = 'sys__all__sys',
   /** Unique value to indicate clearing MCP servers from UI state. For frontend use only. */
   mcp_clear = 'sys__clear__sys',
+  /** Key suffix for non-spec user default tool storage */
+  spec_defaults_key = '__defaults__',
   /**
    * Unique value to indicate the MCP tool was added to an agent.
    * This helps inform the UI if the mcp server was previously added.

--- a/packages/data-provider/src/models.ts
+++ b/packages/data-provider/src/models.ts
@@ -35,6 +35,7 @@ export type TModelSpec = {
   webSearch?: boolean;
   fileSearch?: boolean;
   executeCode?: boolean;
+  artifacts?: string | boolean;
   mcpServers?: string[];
 };
 
@@ -54,6 +55,7 @@ export const tModelSpecSchema = z.object({
   webSearch: z.boolean().optional(),
   fileSearch: z.boolean().optional(),
   executeCode: z.boolean().optional(),
+  artifacts: z.union([z.string(), z.boolean()]).optional(),
   mcpServers: z.array(z.string()).optional(),
 });
 

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -99,6 +99,7 @@ export type TEphemeralAgent = {
   web_search?: boolean;
   file_search?: boolean;
   execute_code?: boolean;
+  artifacts?: string;
 };
 
 export type TPayload = Partial<TMessage> &


### PR DESCRIPTION
## Summary

- Isolate model spec and non-spec tool/MCP state so switching between them never cross-pollinates. Each environment maintains its own persisted defaults for new conversations.
- Persist per-conversation tool/MCP modifications for existing spec conversations. User overrides survive navigation, while new spec conversations always start fresh from admin config.
- Add artifacts support to model specifications. Admins can enable artifacts in spec config, mapped to ephemeral agent state.

## Problem

When model specs are configured, tool badge state (code execution, web search, file search, artifacts) and MCP server selections shared the same `localStorage` keys regardless of whether a spec was active. This caused:

1. **Spec to non-spec leakage:** Switching from a spec with tools enabled to a non-spec model left those tools on.
2. **Non-spec to spec leakage:** MCP servers selected in non-spec mode appeared when switching to a spec.
3. **No per-conversation persistence for specs:** User modifications during a spec conversation were lost on navigation.

## Design

Two-layer persistence model:

| Context | New conversation | Existing conversation |
| --- | --- | --- |
| Spec active | Pure admin config (no `localStorage`) | Admin config base + per-conversation `localStorage` overrides |
| Non-spec (specs configured) | Read from `__defaults__` `localStorage` key | Read from conversation-keyed `localStorage` |
| No specs configured | Original behavior (conversation-keyed) | Original behavior |

**Key mechanisms:**

- **`storageContextKey`** (`__defaults__` or `undefined`) threads through `BadgeRowProvider` → `useToolToggle` / `useMCPSelect` to control which environment writes go to.
- **Dual-write:** User toggles in non-spec mode write to both the conversation key (per-conversation) AND the `__defaults__` key (future new conversation defaults).
- **Environment-keyed MCP atoms:** For new conversations, the Jotai atom is keyed by `storageContextKey` so spec and non-spec each get their own atom; existing conversations always use conversation-keyed atoms.
- **`applyModelSpecEphemeralAgent` merges `localStorage`:** For existing conversations, reads per-conversation `localStorage` overrides and layers them on top of spec defaults. If `localStorage` is cleared, spec values stand alone (fresh admin config).
- **Null ephemeral agent reset:** Switching to non-spec (with specs configured) resets the ephemeral agent to `null`, letting `BadgeRowContext` hydrate from `__defaults__` `localStorage`.

## Changes

### Data layer

- `packages/data-provider/src/config.ts`: Add `spec_defaults_key` constant.
- `packages/data-provider/src/models.ts`: Add `artifacts` field to `TModelSpec` schema.
- `packages/data-provider/src/types.ts`: Add `artifacts` to `TEphemeralAgent` type.

### Core logic

- `client/src/utils/endpoints.ts`: `applyModelSpecEphemeralAgent` now merges per-conversation `localStorage` overrides for existing conversations; add artifacts mapping (`true` → `'default'`).
- `client/src/Providers/BadgeRowContext.tsx`: Compute `storageContextKey` and `storageSuffix`; init effect skips for all spec conversations (handled by `applyModelSpecEphemeralAgent`); read MCP overrides from `localStorage`; thread `storageContextKey` to all hooks.
- `client/src/hooks/Plugins/useToolToggle.ts`: Accept `storageContextKey`; dual-write to environment key in `handleChange`.
- `client/src/hooks/MCP/useMCPSelect.ts`: Environment-keyed Jotai atom for new conversations; dual-write in `setMCPValues`; clear atom when ephemeral agent has explicit empty MCP.
- `client/src/hooks/Agents/useApplyModelSpecAgents.ts`: Reset ephemeral agent to `null` (not `mcp_clear`) for non-spec; add artifacts merging in `useApplyAgentTemplate`.

### Plumbing

- `ChatForm.tsx` → `BadgeRow.tsx` → `BadgeRowProvider`: Thread `specName={conversation?.spec}`.
- `useMCPServerManager.ts` → `useMCPSelect`: Forward `storageContextKey`.
- MCP component chain (`MCPSelect`, `MCPSubMenu`, `MCPConfigDialog`, `ServerInitializationSection`): Thread `storageContextKey`.

## Tests (58 total)

- **`applyModelSpecEphemeralAgent.test.ts`** (14 tests): New conversation fresh config, existing conversation `localStorage` merge, cleared `localStorage` fallback, artifacts mapping, guard clauses.
- **`useToolToggle.test.tsx`** (10 tests): Dual-write behavior, spec-mode no-dual-write, per-conversation isolation, ephemeral agent sync, `isToolEnabled` computation.
- **`useMCPSelect.test.tsx`** (34 tests): Environment-keyed atoms, dual-write, empty MCP clearing, spec/non-spec switching, per-conversation isolation.

## Test plan

- **Spec auto-enable:** Configure a spec with `executeCode: true`, `mcpServers: ["clickhouse"]`. New chat → badges and MCP should show selected.
- **Spec override persistence:** Toggle off `executeCode` within a spec conversation, submit a message. Navigate away and back → `executeCode` should still be off.
- **Fresh spec on new chat:** In the same spec, start a new chat → `executeCode` should be on (fresh admin config).
- **Cleared `localStorage`:** Clear `localStorage`, navigate to the existing spec conversation → should show fresh admin config.
- **Non-spec defaults:** In non-spec mode, enable `webSearch`. New chat (non-spec) → `webSearch` should persist.
- **No cross-pollination:** Select MCP servers in non-spec, switch to a spec → non-spec MCP should not appear.
- **No specs configured:** Remove all model specs. Tool toggles should work exactly as before.