### PR TITLE
🎮 feat: Bedrock Parameters for OpenAI GPT-OSS models

### DIFF
--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -310,6 +310,11 @@ const amazonModels = {
   'nova-premier': 995000, // -5000 from max
 };
 
+const openAIBedrockModels = {
+  'openai.gpt-oss-20b': 128000,
+  'openai.gpt-oss-120b': 128000,
+};
+
 const bedrockModels = {
   ...anthropicModels,
   ...mistralModels,
@@ -319,6 +324,7 @@ const bedrockModels = {
   ...metaModels,
   ...ai21Models,
   ...amazonModels,
+  ...openAIBedrockModels,
 };
 
 const xAIModels = {

--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -953,6 +953,7 @@ export const paramSettings: Record<string, SettingsConfiguration | undefined> = 
   [`${EModelEndpoint.bedrock}-${BedrockProviders.DeepSeek}`]: bedrockGeneral,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.Moonshot}`]: bedrockMoonshot,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.MoonshotAI}`]: bedrockMoonshot,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.OpenAI}`]: bedrockGeneral,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.ZAI}`]: bedrockGeneral,
   [EModelEndpoint.google]: googleConfig,
 };
@@ -1006,6 +1007,7 @@ export const presetSettings: Record<
     col1: bedrockMoonshotCol1,
     col2: bedrockMoonshotCol2,
   },
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.OpenAI}`]: bedrockGeneralColumns,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.ZAI}`]: bedrockGeneralColumns,
   [EModelEndpoint.google]: {
     col1: googleCol1,

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -102,6 +102,7 @@ export enum BedrockProviders {
   MistralAI = 'mistral',
   Moonshot = 'moonshot',
   MoonshotAI = 'moonshotai',
+  OpenAI = 'openai',
   StabilityAI = 'stability',
   ZAI = 'zai',
 }


### PR DESCRIPTION
Add OpenAI as a Bedrock provider so that selecting openai.gpt-oss-* models in the Bedrock agent UI renders the general parameter settings (temperature, top_p, max_tokens) instead of a blank panel. 

Also add token context lengths (128K) for gpt-oss-20b and gpt-oss-120b.