### PR TITLE
📦 chore: `@librechat/agents` to v3.1.43

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.42",
+    "@librechat/agents": "^3.1.43",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.42",
+        "@librechat/agents": "^3.1.43",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11208,9 +11208,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.42",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.42.tgz",
-      "integrity": "sha512-zD+b+EpKdvYRO0STkOTiY4UwKK1522aD0BwmUPto7YWk4YmAXBB3uvyGN9ulP3Zr+1vqvypq2ZPfTLTrpqampw==",
+      "version": "3.1.43",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.43.tgz",
+      "integrity": "sha512-KtcBA7b/63RfYAQwVVt3TNAcZHAfmHe8wLNnSjF9NTEXI1EETBHCqh9yuGicjwdIMXVQhi64qmLPDqEFoFr7ww==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -42205,7 +42205,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.42",
+        "@librechat/agents": "^3.1.43",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -87,7 +87,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.42",
+    "@librechat/agents": "^3.1.43",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@smithy/node-http-handler": "^4.4.5",


### PR DESCRIPTION

## Changes in `@librechat/agents` v3.1.43 (from v3.1.42)

Version 3.1.43 includes **3 bug fixes** committed between v3.1.42 (Feb 14) and v3.1.43 (Feb 16):

---

### 1. **Fix: Bedrock Reasoning Chain Handling** 
**Commit:** [`df7f663`](https://github.com/danny-avila/agents/commit/df7f6630d0ed6557e683eff40d4f1168c6f1f9c1)  
**Files:** `src/messages/format.ts`, `src/messages/ensureThinkingBlock.test.ts`  
**Stats:** +313 lines, -10 lines

Fixed three issues with `ensureThinkingBlockInMessages` for Bedrock reasoning models:

- **Issue 1**: Only checked `content[0].type` for thinking/reasoning blocks, but Bedrock emits a whitespace text chunk before the thinking block, pushing `reasoning_content` to index 1+. Now scans all content blocks.

- **Issue 2**: Bedrock reasoning models produce reasoning on the first AI response, then follow-up tool calls with empty content (`content: ""`) and no reasoning block. These follow-ups were incorrectly converted to `HumanMessages`. Added `chainHasThinkingBlock()` to walk backwards and skip conversion when an earlier AI message in the same chain has reasoning.

- **Issue 3**: Bedrock stores reasoning in `additional_kwargs.reasoning_content` which was not checked. Now detected in both the current message and the chain walk-back.

Also adds role-based fallback detection for AI/Tool messages in case cache-control cloning produced plain objects that lost the prototype.

---

### 2. **Fix: Preserve LangChain Message Instance Types During Cache-Control Cloning**
**Commit:** [`dc9272c`](https://github.com/danny-avila/agents/commit/dc9272cde7a6ec907f2b99a9a950f65515b3ab56)  
**Files:** `src/messages/cache.ts`, `src/messages/cache.test.ts`  
**Stats:** +124 lines, -4 lines

Fixed `cloneMessage()` which used object spread that stripped LangChain class prototypes, causing downstream `instanceof` checks (e.g., in `ensureThinkingBlockInMessages`) to fail silently. Now constructs proper `AIMessage`/`HumanMessage`/`SystemMessage`/`ToolMessage` instances with `tool_calls` and `tool_call_id` preserved.

---

### 3. **Fix: Count Tool Definition Tokens in Instruction Token Budget**
**Commit:** [`b2d2698`](https://github.com/danny-avila/agents/commit/b2d269812d7e9b3539a4855744f476b93e8dcccf)  
**File:** `src/agents/AgentContext.ts`  
**Stats:** +28 lines, -1 line

Fixed `calculateInstructionTokens()` which only counted tokens from bound `StructuredTool` instances (`this.tools`) but ignored tool definitions (`this.toolDefinitions`) used by MCP/event-driven tools. This caused instruction token budget to be undercounted when tool definitions were present alongside graph tools and native tools.

Added a loop over `this.toolDefinitions` with deduplication via a `countedToolNames` set to avoid double-counting tools that appear in both collections.

---

### Summary

All three fixes address edge cases in agent message handling and token counting:
- Better Bedrock reasoning chain detection
- Proper LangChain message type preservation during cloning
- Accurate token counting for MCP/event-driven tool definitions