### PR TITLE
🪂 fix: Handle MongoDB Connection Errors to Prevent Process Crashes

### DIFF
--- a/api/db/connect.js
+++ b/api/db/connect.js
@@ -40,6 +40,10 @@ if (!cached) {
   cached = global.mongoose = { conn: null, promise: null };
 }
 
+mongoose.connection.on('error', (err) => {
+  logger.error('[connectDb] MongoDB connection error:', err.message);
+});
+
 async function connectDb() {
   if (cached.conn && cached.conn?._readyState === 1) {
     return cached.conn;
@@ -65,12 +69,6 @@ async function connectDb() {
     logger.info('Mongo Connection options');
     logger.info(JSON.stringify(opts, null, 2));
     mongoose.set('strictQuery', true);
-    if (!cached.errorListenerRegistered) {
-      mongoose.connection.on('error', (err) => {
-        logger.error('[connectDb] MongoDB connection error:', err.message);
-      });
-      cached.errorListenerRegistered = true;
-    }
     cached.promise = mongoose.connect(MONGO_URI, opts).then((mongoose) => {
       return mongoose;
     });

--- a/api/db/connect.js
+++ b/api/db/connect.js
@@ -41,7 +41,7 @@ if (!cached) {
 }
 
 mongoose.connection.on('error', (err) => {
-  logger.error('[connectDb] MongoDB connection error:', err.message);
+  logger.error('[connectDb] MongoDB connection error:', err);
 });
 
 async function connectDb() {

--- a/api/db/connect.js
+++ b/api/db/connect.js
@@ -65,6 +65,12 @@ async function connectDb() {
     logger.info('Mongo Connection options');
     logger.info(JSON.stringify(opts, null, 2));
     mongoose.set('strictQuery', true);
+    if (!cached.errorListenerRegistered) {
+      mongoose.connection.on('error', (err) => {
+        logger.error('[connectDb] MongoDB connection error:', err.message);
+      });
+      cached.errorListenerRegistered = true;
+    }
     cached.promise = mongoose.connect(MONGO_URI, opts).then((mongoose) => {
       return mongoose;
     });

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -251,6 +251,21 @@ process.on('uncaughtException', (err) => {
     return;
   }
 
+  if (
+    err.message &&
+    (err.message.includes('timed out') ||
+      err.message.includes('MongoNetworkError') ||
+      err.message.includes('MongoServerSelectionError') ||
+      err.message.includes('ECONNREFUSED') ||
+      err.message.includes('ECONNRESET'))
+  ) {
+    logger.error(
+      'A MongoDB connection error occurred. The app will continue running.',
+      { message: err.message },
+    );
+    return;
+  }
+
   process.exit(1);
 });
 

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -251,15 +251,16 @@ process.on('uncaughtException', (err) => {
     return;
   }
 
-  if (isEnabled(process.env.CRASH_ON_UNCAUGHT_EXCEPTION)) {
-    process.exit(1);
+  if (isEnabled(process.env.CONTINUE_ON_UNCAUGHT_EXCEPTION)) {
+    logger.error('Unhandled error encountered. The app will continue running.', {
+      name: err?.name,
+      message: err?.message,
+      stack: err?.stack,
+    });
+    return;
   }
 
-  logger.error('Unhandled error encountered. The app will continue running.', {
-    name: err?.name,
-    message: err?.message,
-    stack: err?.stack,
-  });
+  process.exit(1);
 });
 
 /** Export app for easier testing purposes */

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -259,10 +259,9 @@ process.on('uncaughtException', (err) => {
       err.message.includes('ECONNREFUSED') ||
       err.message.includes('ECONNRESET'))
   ) {
-    logger.error(
-      'A MongoDB connection error occurred. The app will continue running.',
-      { message: err.message },
-    );
+    logger.error('A MongoDB connection error occurred. The app will continue running.', {
+      message: err.message,
+    });
     return;
   }
 

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -251,19 +251,11 @@ process.on('uncaughtException', (err) => {
     return;
   }
 
-  if (
-    err.name === 'MongoNetworkError' ||
-    err.name === 'MongoServerSelectionError' ||
-    err.name === 'MongoNetworkTimeoutError' ||
-    (err.message && /connection \d+ to .+:\d+ timed out/.test(err.message))
-  ) {
-    logger.error('A MongoDB connection error occurred. The app will continue running.', {
-      message: err.message,
-    });
-    return;
-  }
-
-  process.exit(1);
+  logger.error('Unhandled error encountered. The app will continue running.', {
+    name: err.name,
+    message: err.message,
+    stack: err.stack,
+  });
 });
 
 /** Export app for easier testing purposes */

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -252,12 +252,10 @@ process.on('uncaughtException', (err) => {
   }
 
   if (
-    err.message &&
-    (err.message.includes('timed out') ||
-      err.message.includes('MongoNetworkError') ||
-      err.message.includes('MongoServerSelectionError') ||
-      err.message.includes('ECONNREFUSED') ||
-      err.message.includes('ECONNRESET'))
+    err.name === 'MongoNetworkError' ||
+    err.name === 'MongoServerSelectionError' ||
+    err.name === 'MongoNetworkTimeoutError' ||
+    (err.message && /connection \d+ to .+:\d+ timed out/.test(err.message))
   ) {
     logger.error('A MongoDB connection error occurred. The app will continue running.', {
       message: err.message,

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -251,10 +251,14 @@ process.on('uncaughtException', (err) => {
     return;
   }
 
+  if (isEnabled(process.env.CRASH_ON_UNCAUGHT_EXCEPTION)) {
+    process.exit(1);
+  }
+
   logger.error('Unhandled error encountered. The app will continue running.', {
-    name: err.name,
-    message: err.message,
-    stack: err.stack,
+    name: err?.name,
+    message: err?.message,
+    stack: err?.stack,
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `mongoose.connection.on('error')` listener in `api/db/connect.js` to handle connection-level errors from MongoDB driver's SDAM background monitoring. Without this, these errors become uncaught exceptions per Node.js EventEmitter behavior and crash the process.
- Add MongoDB error patterns (`timed out`, `MongoNetworkError`, `MongoServerSelectionError`, `ECONNREFUSED`, `ECONNRESET`) to the `uncaughtException` handler in `api/server/index.js` as defense-in-depth, following the same pattern already used for GoogleGenerativeAI, Meilisearch, and OpenAI errors.

## Context

Under high load, MongoDB connection timeouts cause the Node.js process to crash via `process.exit(1)`. We observed 5 crashes in ~43 minutes in production, each triggered by:

```
There was an uncaught error: connection <N> to <host>:27017 timed out
```

Each restart triggers a full Meilisearch index sync, adding more MongoDB load and creating a cascading restart loop.

Root cause: the MongoDB driver's SDAM monitoring emits `error` events on the Mongoose connection when it detects connection issues. With no listener registered, Node.js treats these as uncaught exceptions ([docs](https://nodejs.org/api/events.html#error-events)). The `uncaughtException` handler has no pattern for MongoDB errors, so they fall through to `process.exit(1)`.

Fixes #11808

## Change Details

**`api/db/connect.js`**
- Register `mongoose.connection.on('error')` listener before `mongoose.connect()` call
- Use a `cached.errorListenerRegistered` flag to prevent duplicate listeners on reconnection

**`api/server/index.js`**
- Add MongoDB error pattern check before `process.exit(1)`, matching the existing pattern for other services

## Testing

- Verified that emitting `mongoose.connection.emit('error', new Error('connection 1 to localhost:27017 timed out'))` is now caught and logged instead of crashing
- Normal startup and operation unchanged