### PR TITLE
📦 chore: `@librechat/agents` to v3.1.44

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.43",
+    "@librechat/agents": "^3.1.44",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.43",
+        "@librechat/agents": "^3.1.44",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11208,9 +11208,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.43",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.43.tgz",
-      "integrity": "sha512-KtcBA7b/63RfYAQwVVt3TNAcZHAfmHe8wLNnSjF9NTEXI1EETBHCqh9yuGicjwdIMXVQhi64qmLPDqEFoFr7ww==",
+      "version": "3.1.44",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.44.tgz",
+      "integrity": "sha512-S5hNYTCQqqPfabsdS2nSdGHtcZ4ZvwFnMN11BvJZUEgZ8VHMS9/a+plTSTLqSCoYmUeFI5hIK3pahk5H9vOPug==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -42205,7 +42205,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.43",
+        "@librechat/agents": "^3.1.44",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -87,7 +87,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.43",
+    "@librechat/agents": "^3.1.44",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@smithy/node-http-handler": "^4.4.5",


### PR DESCRIPTION

## Version Change
**Package:** `@librechat/agents`  
**3.1.43 → 3.1.44**

## Single Commit Change

**Commit:** `c85ab574b075` (Feb 16, 2026)  
**Message:** "refactor: annotate deferred tools with parameters in listing"  
**Stats:** 2 files, +82/-5 lines

## What Changed

### Core Feature
Added parameter annotation to deferred tool listings. Tools with parameters now display with `(…)` suffix to signal the LLM should discover the schema via `tool_search` before calling.

**Example:**
```
Before: myserver: get_data, set_config, list_items
After:  myserver: get_data(…), set_config(…), list_items
```

### Implementation
1. **New helper function:** `hasParams()` - checks if a tool has defined parameters
2. **Updated listing:** Tools with parameters get `(…)` annotation via `\u2026` character
3. **Updated hints:** Description now reads "search to load; … = has params, search first"

### Test Coverage
Added 4 new tests validating annotation behavior:
- Tools without parameters (no annotation)
- Tools with parameters (gets `…` annotation)
- Mixed scenarios (some with/without params)
- MCP tools with parameters

## Purpose
Provides visual cues to LLMs about which tools require schema discovery before use, preventing premature tool calls with missing parameters and improving agent reliability.