### PR TITLE
📋 chore: Document Uncaught Exception Config and Fix Empty Text Export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,10 @@ TRUST_PROXY=1
 # password policies.
 # MIN_PASSWORD_LENGTH=8
 
+# When enabled, the app will continue running after encountering uncaught exceptions
+# instead of exiting the process. Not recommended for production unless necessary.
+# CONTINUE_ON_UNCAUGHT_EXCEPTION=false
+
 #===============#
 # JSON Logging  #
 #===============#

--- a/client/src/hooks/Conversations/useExportConversation.ts
+++ b/client/src/hooks/Conversations/useExportConversation.ts
@@ -106,6 +106,9 @@ export default function useExportConversation({
       // TEXT
       const textPart = content[ContentTypes.TEXT];
       const text = typeof textPart === 'string' ? textPart : (textPart?.value ?? '');
+      if (text.trim().length === 0) {
+        return [];
+      }
       return [sender, text];
     }
 


### PR DESCRIPTION


## Summary

I addressed two minor issues: documenting an existing but undocumented environment variable and fixing a bug where empty text content parts would appear in conversation exports.

- Add `CONTINUE_ON_UNCAUGHT_EXCEPTION` to `.env.example` with a description of its behavior and a production warning, matching the existing usage in the server's `uncaughtException` handler.
- Guard against exporting empty or whitespace-only text content in `useExportConversation`, returning an empty array so the downstream `.filter((text) => text.length > 0)` correctly excludes blank entries from text, markdown, and CSV exports.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

- Verified `CONTINUE_ON_UNCAUGHT_EXCEPTION` is already consumed in `api/server/index.js` and the `.env.example` entry accurately reflects its behavior.
- For the export fix, trigger a conversation export (text, markdown, or CSV) on a conversation containing messages with empty text content parts (e.g., tool-call-only assistant messages). Confirm that blank `>> sender:\n` entries no longer appear in the exported output.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings