### PR TITLE
📦 chore: Update `@librechat/agents` to v3.1.45

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.44",
+    "@librechat/agents": "^3.1.45",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.44",
+        "@librechat/agents": "^3.1.45",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11208,9 +11208,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.44",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.44.tgz",
-      "integrity": "sha512-S5hNYTCQqqPfabsdS2nSdGHtcZ4ZvwFnMN11BvJZUEgZ8VHMS9/a+plTSTLqSCoYmUeFI5hIK3pahk5H9vOPug==",
+      "version": "3.1.45",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.45.tgz",
+      "integrity": "sha512-izapt5PScVF52xhDH5N5uzCbjK1BMaGsUiKFNVeO20AjDWul+ipDm5zWmXnfX4veD8YHqY5rPnRU0oAecljZIg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -42205,7 +42205,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.44",
+        "@librechat/agents": "^3.1.45",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -87,7 +87,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.44",
+    "@librechat/agents": "^3.1.45",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@smithy/node-http-handler": "^4.4.5",


### PR DESCRIPTION
## `@librechat/agents` v3.1.44 → v3.1.45 Changelog

**One commit** between version bumps:

### `fc137a1` — fix: optimize `ensureThinkingBlockInMessages` for early exit on `HumanMessage`

| | |
|---|---|
| **Files** | `src/messages/format.ts` (+15 lines), `src/messages/ensureThinkingBlock.test.ts` (+62 lines) |
| **Author** | Danny Avila |

#### What changed
The `ensureThinkingBlockInMessages` function now short-circuits and returns early when it encounters a `HumanMessage` during its backwards walk through the message array. Previously, the function would continue scanning every message in the array regardless of message type. Fifteen lines of logic were added to `format.ts` to implement the early exit, and 62 lines of new test cases validate the behavior.

#### Why it matters
This function was substantially reworked in v3.1.43 to handle Bedrock reasoning chains (scanning all content blocks for thinking/reasoning, walking backwards with `chainHasThinkingBlock()`, detecting `additional_kwargs.reasoning_content`, etc.). That rework made the function do more work per call. A `HumanMessage` is a natural boundary: reasoning chains from an AI model never span across a user turn, so any backwards walk can safely stop there. Without this optimization, every invocation paid the cost of scanning the full history, which grows linearly with conversation length.

#### Before/After behavior

| | Before (v3.1.44) | After (v3.1.45) |
|---|---|---|
| **Backwards walk** | Scans from the current message all the way to the start of the array, checking every AI/Tool message for reasoning blocks | Stops as soon as it hits a `HumanMessage`, skipping all older messages |
| **Correctness** | Identical. A user turn always breaks a reasoning chain, so messages before it can never be part of the current chain | Identical |
| **Performance** | O(n) over total message count on every call | O(k) where k is the number of messages since the last user turn (typically a small, bounded number) |
| **Functional output** | No change. The same messages get converted (or not) in exactly the same way | No change |

**TL;DR:** A targeted performance fix. Long conversations with many turns were doing unnecessary work in the thinking-block enforcement path. The early exit on `HumanMessage` bounds the cost to the current turn's messages only, with no behavioral change.