### PR TITLE
🪆 refactor: Internalize Producer Event Handling into Agent Graph Context

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.45",
+    "@librechat/agents": "^3.1.50",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -1,22 +1,13 @@
 const { nanoid } = require('nanoid');
-const { Constants } = require('@librechat/agents');
 const { logger } = require('@librechat/data-schemas');
+const { Constants, EnvVar, GraphEvents, ToolEndHandler } = require('@librechat/agents');
+const { Tools, StepTypes, FileContext, ErrorTypes } = require('librechat-data-provider');
 const {
   sendEvent,
   GenerationJobManager,
   writeAttachmentEvent,
   createToolExecuteHandler,
 } = require('@librechat/api');
-const { Tools, StepTypes, FileContext, ErrorTypes } = require('librechat-data-provider');
-const {
-  EnvVar,
-  Providers,
-  GraphEvents,
-  getMessageId,
-  ToolEndHandler,
-  handleToolCalls,
-  ChatModelStreamHandler,
-} = require('@librechat/agents');
 const { processFileCitations } = require('~/server/services/Files/Citations');
 const { processCodeOutput } = require('~/server/services/Files/Code/process');
 const { loadAuthValues } = require('~/server/services/Tools/credentials');
@@ -57,8 +48,6 @@ class ModelEndHandler {
     let errorMessage;
     try {
       const agentContext = graph.getAgentContext(metadata);
-      const isGoogle = agentContext.provider === Providers.GOOGLE;
-      const streamingDisabled = !!agentContext.clientOptions?.disableStreaming;
       if (data?.output?.additional_kwargs?.stop_reason === 'refusal') {
         const info = { ...data.output.additional_kwargs };
         errorMessage = JSON.stringify({
@@ -73,21 +62,6 @@ class ModelEndHandler {
         });
       }
 
-      const toolCalls = data?.output?.tool_calls;
-      let hasUnprocessedToolCalls = false;
-      if (Array.isArray(toolCalls) && toolCalls.length > 0 && graph?.toolCallStepIds?.has) {
-        try {
-          hasUnprocessedToolCalls = toolCalls.some(
-            (tc) => tc?.id && !graph.toolCallStepIds.has(tc.id),
-          );
-        } catch {
-          hasUnprocessedToolCalls = false;
-        }
-      }
-      if (isGoogle || streamingDisabled || hasUnprocessedToolCalls) {
-        await handleToolCalls(toolCalls, metadata, graph);
-      }
-
       const usage = data?.output?.usage_metadata;
       if (!usage) {
         return this.finalize(errorMessage);
@@ -98,38 +72,6 @@ class ModelEndHandler {
       }
 
       this.collectedUsage.push(usage);
-      if (!streamingDisabled) {
-        return this.finalize(errorMessage);
-      }
-      if (!data.output.content) {
-        return this.finalize(errorMessage);
-      }
-      const stepKey = graph.getStepKey(metadata);
-      const message_id = getMessageId(stepKey, graph) ?? '';
-      if (message_id) {
-        await graph.dispatchRunStep(stepKey, {
-          type: StepTypes.MESSAGE_CREATION,
-          message_creation: {
-            message_id,
-          },
-        });
-      }
-      const stepId = graph.getStepIdByKey(stepKey);
-      const content = data.output.content;
-      if (typeof content === 'string') {
-        await graph.dispatchMessageDelta(stepId, {
-          content: [
-            {
-              type: 'text',
-              text: content,
-            },
-          ],
-        });
-      } else if (content.every((c) => c.type?.startsWith('text'))) {
-        await graph.dispatchMessageDelta(stepId, {
-          content,
-        });
-      }
     } catch (error) {
       logger.error('Error handling model end event:', error);
       return this.finalize(errorMessage);
@@ -200,7 +142,6 @@ function getDefaultHandlers({
   const handlers = {
     [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage),
     [GraphEvents.TOOL_END]: new ToolEndHandler(toolEndCallback, logger),
-    [GraphEvents.CHAT_MODEL_STREAM]: new ChatModelStreamHandler(),
     [GraphEvents.ON_RUN_STEP]: {
       /**
        * Handle ON_RUN_STEP event.

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.45",
+        "@librechat/agents": "^3.1.50",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11208,9 +11208,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.45",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.45.tgz",
-      "integrity": "sha512-izapt5PScVF52xhDH5N5uzCbjK1BMaGsUiKFNVeO20AjDWul+ipDm5zWmXnfX4veD8YHqY5rPnRU0oAecljZIg==",
+      "version": "3.1.50",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.50.tgz",
+      "integrity": "sha512-+gdfUJ7X3PJ20/c+8lETY68D6QpxFlCIlGUQBF4A8VKv+Po9J/TO5rWE+OmzmPByYpye7GrcxVCBLfRTvZKraw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -42205,7 +42205,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.45",
+        "@librechat/agents": "^3.1.50",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -87,7 +87,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.45",
+    "@librechat/agents": "^3.1.50",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@smithy/node-http-handler": "^4.4.5",


### PR DESCRIPTION

## `@librechat/agents` v3.1.45 → v3.1.50: Changelog Summary

**4 substantive commits** between the two version bumps:

---

### 1. Internalize `CHAT_MODEL_STREAM` event handling into the Graph
[`b9de5116`](https://github.com/danny-avila/agents/commit/b9de5116) — `Graph.ts`, `run.ts`, `ToolNode.ts`, `handlers.ts` (+184/−19)

**What changed:** The `CHAT_MODEL_STREAM` event, previously emitted externally for consumers (like LibreChat's `callbacks.js`) to handle, is now processed internally within the `Graph` class. The graph itself handles streaming chunks, tool call chunk detection, and message delta dispatching. The `ChatModelStreamHandler` class is no longer needed or exported as an external handler.

**Why it matters:** This cleanly separates producer vs. consumer concerns. The graph is the producer of streaming content and tool calls; it should own the logic for processing those stream chunks into structured events (run steps, message deltas, tool call steps). External consumers no longer need to wire up their own `ChatModelStreamHandler`.

**Before:** LibreChat had to register a `ChatModelStreamHandler` in its handler map and that handler was responsible for interpreting raw stream chunks, accumulating tool call fragments, and dispatching structured events.
**After:** The graph does all of this internally. Consumers just listen for the higher-level structured events (`ON_RUN_STEP`, message deltas, etc.).

---

### 2. Move tool completion handling from Graph into ToolNode; eliminate race conditions
[`cac0c9ed`](https://github.com/danny-avila/agents/commit/cac0c9ed) — `events.ts`, `Graph.ts`, `ToolNode.ts` (+140/−149)

**What changed:** ~134 lines of tool-call handling logic were removed from `Graph.ts` and ~121 lines were added to `ToolNode.ts`. The `ToolNode` now owns the full lifecycle of tool completion: detecting unprocessed tool calls, dispatching `TOOL_CALLS` run steps, and handling the Google/streaming-disabled fallback paths. The events enum was also cleaned up (11 additions, 14 deletions).

**Why it matters:** Previously, tool completion was split across Graph (which ran in `ModelEndHandler`) and ToolNode, creating timing-sensitive race conditions where the model-end event and tool execution could conflict. By co-locating all tool completion logic in `ToolNode`, the ordering is deterministic: tool calls are processed by the same component that executes them.

**Before:** LibreChat's `ModelEndHandler` in `callbacks.js` contained special-case code to detect unprocessed tool calls, check for Google provider or disabled streaming, and manually call `handleToolCalls()` plus dispatch message deltas. This was fragile and race-prone.
**After:** All of that is gone from both the agents library's Graph and from LibreChat's callback handler. `ToolNode` handles it atomically. The LibreChat PR removes ~60 lines of this now-unnecessary logic from `callbacks.js`.

---

### 3. Clear `toolCallTurns` before each run
[`6b6967e6`](https://github.com/danny-avila/agents/commit/6b6967e6) — `ToolNode.ts` (+1)

**What changed:** A single line added to clear `toolCallTurns` at the start of each ToolNode run.

**Why it matters:** Without this reset, stale tool call turn data from a previous iteration could persist into the next run, causing incorrect tracking of which tool calls belong to which turn. This is especially relevant for multi-turn agent loops where the model calls tools repeatedly.

**Before:** `toolCallTurns` could carry over leftover entries from a prior iteration, potentially double-counting or misattributing tool calls.
**After:** Each run starts with a clean slate, ensuring accurate per-turn tracking.

---

### 4. Remove `ChatModelStreamHandler` from all test files
[`eaf228bb`](https://github.com/danny-avila/agents/commit/eaf228bb) — 10 test files (+11/−22)

**What changed:** Every test spec (Anthropic, Azure, OpenAI, OpenRouter, DeepSeek, Moonshot, reasoning, tool-error, cache, custom-event-await) was updated to remove `ChatModelStreamHandler` from the handler maps they register.

**Why it matters:** Follows directly from commit #1. Since `CHAT_MODEL_STREAM` is now internal to the graph, test setups that manually registered the handler would be registering a handler for an event that no longer fires externally. Removing it keeps tests accurate and prevents confusion about what consumers are responsible for.

---

### Net effect on LibreChat (PR #11816)

The LibreChat side is a clean consumer-side cleanup (−68 lines, +9 lines):

| Removed from `callbacks.js` | Why |
|---|---|
| `ChatModelStreamHandler` import and handler registration | Now internal to Graph (commit #1) |
| `Providers`, `getMessageId`, `handleToolCalls` imports | No longer needed externally |
| Google/`streamingDisabled` special-case tool call handling | Moved into ToolNode (commit #2) |
| Manual `dispatchRunStep` + `dispatchMessageDelta` for non-streaming | ToolNode + Graph handle this internally now |

The only additions are updated imports pulling `GraphEvents`, `ToolEndHandler`, etc. from a cleaner, consolidated import path.

**TL;DR:** These changes move streaming chunk processing and tool call lifecycle management from external consumers (LibreChat) into the agents library itself, eliminating race conditions and ~60 lines of fragile special-case code in the process.