### PR TITLE
  ♻️  refactor: On-demand MCP connections: remove proactive reconnection, default to available

### DIFF
--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -18,7 +18,6 @@ const {
   findUser,
 } = require('~/models');
 const { getGraphApiToken } = require('~/server/services/GraphTokenService');
-const { getOAuthReconnectionManager } = require('~/config');
 const { getOpenIdConfig } = require('~/strategies');
 
 const registrationController = async (req, res) => {
@@ -165,17 +164,6 @@ const refreshController = async (req, res) => {
 
     if (session && session.expiration > new Date()) {
       const token = await setAuthTokens(userId, res, session);
-
-      // trigger OAuth MCP server reconnection asynchronously (best effort)
-      try {
-        void getOAuthReconnectionManager()
-          .reconnectServers(userId)
-          .catch((err) => {
-            logger.error('[refreshController] Error reconnecting OAuth MCP servers:', err);
-          });
-      } catch (err) {
-        logger.warn(`[refreshController] Cannot attempt OAuth MCP servers reconnection:`, err);
-      }
 
       res.status(200).send({ token, user });
     } else if (req?.query?.retry) {

--- a/client/src/components/SidePanel/Agents/MCPTools.tsx
+++ b/client/src/components/SidePanel/Agents/MCPTools.tsx
@@ -46,7 +46,7 @@ export default function MCPTools({
               return null;
             }
 
-            if (serverInfo.isConnected) {
+            if (serverInfo?.tools?.length && serverInfo.tools.length > 0) {
               return (
                 <MCPTool key={`${serverInfo.serverName}-${agentId}`} serverInfo={serverInfo} />
               );

--- a/client/src/components/Tools/MCPToolSelectDialog.tsx
+++ b/client/src/components/Tools/MCPToolSelectDialog.tsx
@@ -96,17 +96,17 @@ function MCPToolSelectDialog({
         await new Promise((resolve) => setTimeout(resolve, 500));
       }
 
-      // Then initialize server if needed
+      // Initialize server if not connected (connects on-demand)
       const serverInfo = mcpServersMap.get(serverName);
       if (!serverInfo?.isConnected) {
         const result = await initializeServer(serverName);
-        if (result?.success && result.oauthRequired && result.oauthUrl) {
+        if (result?.oauthRequired && result.oauthUrl) {
           setIsInitializing(null);
-          return;
+          return; // OAuth flow must complete first
         }
       }
 
-      // Finally, add tools to form
+      // Add tools to form (uses cached tools from DB, refreshed by initializeServer if needed)
       await addToolsToForm(serverName);
       setIsInitializing(null);
     } catch (error) {

--- a/client/src/components/Tools/MCPToolSelectDialog.tsx
+++ b/client/src/components/Tools/MCPToolSelectDialog.tsx
@@ -96,9 +96,9 @@ function MCPToolSelectDialog({
         await new Promise((resolve) => setTimeout(resolve, 500));
       }
 
-      // Initialize server if not connected (connects on-demand)
+      // Only initialize if no cached tools exist; skip if tools are already available from DB
       const serverInfo = mcpServersMap.get(serverName);
-      if (!serverInfo?.isConnected) {
+      if (!serverInfo?.tools?.length) {
         const result = await initializeServer(serverName);
         if (result?.oauthRequired && result.oauthUrl) {
           setIsInitializing(null);
@@ -106,7 +106,7 @@ function MCPToolSelectDialog({
         }
       }
 
-      // Add tools to form (uses cached tools from DB, refreshed by initializeServer if needed)
+      // Add tools to form (refetches from backend's persisted cache)
       await addToolsToForm(serverName);
       setIsInitializing(null);
     } catch (error) {

--- a/client/src/data-provider/MCP/queries.ts
+++ b/client/src/data-provider/MCP/queries.ts
@@ -12,10 +12,10 @@ export const useMCPServersQuery = <TData = t.MCPServersListResponse>(
     [QueryKeys.mcpServers],
     () => dataService.getMCPServers(),
     {
-      staleTime: 1000 * 60 * 5, // 5 minutes - data stays fresh longer
-      refetchOnWindowFocus: false,
+      staleTime: 30 * 1000, // 30 seconds — short enough to pick up servers that finish initializing after first load
+      refetchOnWindowFocus: true,
       refetchOnReconnect: false,
-      refetchOnMount: false,
+      refetchOnMount: true,
       retry: false,
       ...config,
     },

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -447,13 +447,9 @@ export function useMCPServerManager({
         setMCPValues(filteredValues);
       } else {
         setMCPValues([...currentValues, serverName]);
-        const serverStatus = connectionStatus?.[serverName];
-        if (serverStatus?.connectionState !== 'connected') {
-          initializeServer(serverName);
-        }
       }
     },
-    [mcpValues, setMCPValues, initializeServer, isInitializing, connectionStatus],
+    [mcpValues, setMCPValues, isInitializing],
   );
 
   const handleConfigSave = useCallback(

--- a/client/src/hooks/MCP/useMCPServerManager.ts
+++ b/client/src/hooks/MCP/useMCPServerManager.ts
@@ -433,33 +433,6 @@ export function useMCPServerManager({
     [startupConfig?.interface?.mcpServers?.placeholder, localize],
   );
 
-  const batchToggleServers = useCallback(
-    (serverNames: string[]) => {
-      const connectedServers: string[] = [];
-      const disconnectedServers: string[] = [];
-
-      serverNames.forEach((serverName) => {
-        if (isInitializing(serverName)) {
-          return;
-        }
-
-        const serverStatus = connectionStatus?.[serverName];
-        if (serverStatus?.connectionState === 'connected') {
-          connectedServers.push(serverName);
-        } else {
-          disconnectedServers.push(serverName);
-        }
-      });
-
-      setMCPValues(connectedServers);
-
-      disconnectedServers.forEach((serverName) => {
-        initializeServer(serverName);
-      });
-    },
-    [connectionStatus, setMCPValues, initializeServer, isInitializing],
-  );
-
   const toggleServerSelection = useCallback(
     (serverName: string) => {
       if (isInitializing(serverName)) {
@@ -473,15 +446,14 @@ export function useMCPServerManager({
         const filteredValues = currentValues.filter((name) => name !== serverName);
         setMCPValues(filteredValues);
       } else {
+        setMCPValues([...currentValues, serverName]);
         const serverStatus = connectionStatus?.[serverName];
-        if (serverStatus?.connectionState === 'connected') {
-          setMCPValues([...currentValues, serverName]);
-        } else {
+        if (serverStatus?.connectionState !== 'connected') {
           initializeServer(serverName);
         }
       }
     },
-    [mcpValues, setMCPValues, connectionStatus, initializeServer, isInitializing],
+    [mcpValues, setMCPValues, initializeServer, isInitializing, connectionStatus],
   );
 
   const handleConfigSave = useCallback(
@@ -677,7 +649,6 @@ export function useMCPServerManager({
     isPinned,
     setIsPinned,
     placeholderText,
-    batchToggleServers,
     toggleServerSelection,
     localize,
 

--- a/packages/api/src/mcp/ConnectionsRepository.ts
+++ b/packages/api/src/mcp/ConnectionsRepository.ts
@@ -4,6 +4,8 @@ import { MCPConnection } from './connection';
 import { MCPServersRegistry } from '~/mcp/registry/MCPServersRegistry';
 import type * as t from './types';
 
+const CONNECT_CONCURRENCY = 3;
+
 /**
  * Manages MCP connections with lazy loading and reconnection.
  * Maintains a pool of connections and handles connection lifecycle management.
@@ -84,9 +86,17 @@ export class ConnectionsRepository {
 
   /** Gets or creates connections for multiple servers concurrently */
   async getMany(serverNames: string[]): Promise<Map<string, MCPConnection>> {
-    const connectionPromises = serverNames.map(async (name) => [name, await this.get(name)]);
-    const connections = await Promise.all(connectionPromises);
-    return new Map((connections as [string, MCPConnection][]).filter((v) => !!v[1]));
+    const results: [string, MCPConnection | null][] = [];
+    for (let i = 0; i < serverNames.length; i += CONNECT_CONCURRENCY) {
+      const batch = serverNames.slice(i, i + CONNECT_CONCURRENCY);
+      const batchResults = await Promise.all(
+        batch.map(
+          async (name): Promise<[string, MCPConnection | null]> => [name, await this.get(name)],
+        ),
+      );
+      results.push(...batchResults);
+    }
+    return new Map(results.filter((v): v is [string, MCPConnection] => v[1] != null));
   }
 
   /** Returns all currently loaded connections without creating new ones */

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -559,7 +559,11 @@ export class MCPConnection extends EventEmitter {
     }
 
     this.isReconnecting = true;
-    const backoffDelay = (attempt: number) => Math.min(1000 * Math.pow(2, attempt), 30000);
+    const backoffDelay = (attempt: number) => {
+      const base = Math.min(1000 * Math.pow(2, attempt), 30000);
+      const jitter = Math.floor(Math.random() * 1000); // up to 1s of random jitter
+      return base + jitter;
+    };
 
     try {
       while (


### PR DESCRIPTION
Closes #11648 as UI is no longer "blocking" if an MCP server is not connected.