### PR TITLE
fix: add title to MCP server descriptions to overcome cutoff

### DIFF
--- a/client/src/components/MCP/MCPServerMenuItem.tsx
+++ b/client/src/components/MCP/MCPServerMenuItem.tsx
@@ -85,7 +85,9 @@ export default function MCPServerMenuItem({
           <span className="truncate text-sm font-medium text-text-primary">{displayName}</span>
         </div>
         {server.config?.description && (
-          <p className="truncate text-xs text-text-secondary">{server.config.description}</p>
+          <p className="truncate text-xs text-text-secondary" title={server.config.description}>
+            {server.config.description}
+          </p>
         )}
       </div>
 

--- a/client/src/components/SidePanel/MCPBuilder/MCPServerCard.tsx
+++ b/client/src/components/SidePanel/MCPBuilder/MCPServerCard.tsx
@@ -124,7 +124,11 @@ export default function MCPServerCard({
         {/* Server Info */}
         <div className="min-w-0 flex-1">
           <span className="truncate text-sm font-medium text-text-primary">{displayName}</span>
-          {description && <p className="truncate text-xs text-text-secondary">{description}</p>}
+          {description && (
+            <p className="truncate text-xs text-text-secondary" title={description}>
+              {description}
+            </p>
+          )}
         </div>
 
         {/* Actions */}


### PR DESCRIPTION
## Summary

MCP server descriptions longer than a few words become cut off in the UI. 

<img width="366" height="189" alt="image" src="https://github.com/user-attachments/assets/8d3bf019-1633-4ac8-be7d-f134885f8527" />

This PR adds the descriptions as `title` attributes so that they appear in full on hover.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
