### PR TITLE
🧭 fix: Robust 404 Conversation Not Found Redirect

### DIFF
--- a/client/src/data-provider/queries.ts
+++ b/client/src/data-provider/queries.ts
@@ -32,7 +32,7 @@ import type {
 } from 'librechat-data-provider';
 import type { ConversationCursorData } from '~/utils/convos';
 import { findConversationInInfinite } from '~/utils';
-import { AxiosError } from 'axios';
+import axios from 'axios';
 
 export const useGetPresetsQuery = (
   config?: UseQueryOptions<TPreset[]>,
@@ -74,7 +74,7 @@ export const useGetConvoIdQuery = (
       refetchOnMount: false,
       retry: (failureCount, error) => {
         // Early exit on 404
-        if (error instanceof AxiosError && error.response?.status == 404) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
           return false;
         }
 

--- a/client/src/data-provider/queries.ts
+++ b/client/src/data-provider/queries.ts
@@ -31,8 +31,7 @@ import type {
   SharedLinksResponse,
 } from 'librechat-data-provider';
 import type { ConversationCursorData } from '~/utils/convos';
-import { findConversationInInfinite } from '~/utils';
-import axios from 'axios';
+import { findConversationInInfinite, isNotFoundError } from '~/utils';
 
 export const useGetPresetsQuery = (
   config?: UseQueryOptions<TPreset[]>,
@@ -73,12 +72,9 @@ export const useGetConvoIdQuery = (
       refetchOnReconnect: false,
       refetchOnMount: false,
       retry: (failureCount, error) => {
-        // Early exit on 404
-        if (axios.isAxiosError(error) && error.response?.status === 404) {
+        if (isNotFoundError(error)) {
           return false;
         }
-
-        // Default to 3 retries
         return failureCount < 3;
       },
       ...config,

--- a/client/src/data-provider/queries.ts
+++ b/client/src/data-provider/queries.ts
@@ -32,6 +32,7 @@ import type {
 } from 'librechat-data-provider';
 import type { ConversationCursorData } from '~/utils/convos';
 import { findConversationInInfinite } from '~/utils';
+import { AxiosError } from 'axios';
 
 export const useGetPresetsQuery = (
   config?: UseQueryOptions<TPreset[]>,
@@ -71,6 +72,15 @@ export const useGetConvoIdQuery = (
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
       refetchOnMount: false,
+      retry: (failureCount, error) => {
+        // Early exit on 404
+        if (error instanceof AxiosError && error.response?.status == 404) {
+          return false;
+        }
+
+        // Default to 3 retries
+        return failureCount < 3;
+      },
       ...config,
     },
   );

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -842,6 +842,7 @@
   "com_ui_controls": "Controls",
   "com_ui_conversation": "conversation",
   "com_ui_conversation_label": "{{title}} conversation",
+  "com_ui_conversation_not_found": "Conversation not found",
   "com_ui_conversations": "conversations",
   "com_ui_convo_archived": "Conversation archived",
   "com_ui_convo_delete_error": "Failed to delete conversation",

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -13,6 +13,7 @@ import ChatView from '~/components/Chat/ChatView';
 import useAuthRedirect from './useAuthRedirect';
 import temporaryStore from '~/store/temporary';
 import store from '~/store';
+import { AxiosError } from 'axios';
 
 export default function ChatRoute() {
   const { data: startupConfig } = useGetStartupConfig();
@@ -117,6 +118,14 @@ export default function ChatRoute() {
         modelsData: modelsQuery.data,
         keepLatestMessage: true,
       });
+      hasSetConversation.current = true;
+    } else if (
+      initialConvoQuery.isError &&
+      initialConvoQuery.error instanceof AxiosError &&
+      initialConvoQuery.error.response?.status === 404
+    ) {
+      // If we get a 404, the conversation doesn't exist - reroute to a new conversation
+      newConversation();
       hasSetConversation.current = true;
     }
     /* Creates infinite render if all dependencies included due to newConversation invocations exceeding call stack before hasSetConversation.current becomes truthy */

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -114,6 +114,11 @@ export default function ChatRoute() {
         message: localize('com_ui_conversation_not_found'),
         severity: NotificationSeverity.WARNING,
       });
+      logger.log(
+        'conversation',
+        'ChatRoute initialConvoQuery isNotFoundError',
+        initialConvoQuery.error,
+      );
       newConversation({
         modelsData: modelsQuery.data,
         ...(spec ? { preset: getModelSpecPreset(spec) } : {}),

--- a/client/src/routes/ChatRoute.tsx
+++ b/client/src/routes/ChatRoute.tsx
@@ -101,12 +101,23 @@ export default function ChatRoute() {
         keepLatestMessage: true,
       });
       hasSetConversation.current = true;
-    } else if (initialConvoQuery.isError && isNotFoundError(initialConvoQuery.error)) {
+    } else if (
+      conversationId &&
+      endpointsQuery.data &&
+      modelsQuery.data &&
+      initialConvoQuery.isError &&
+      isNotFoundError(initialConvoQuery.error)
+    ) {
+      const result = getDefaultModelSpec(startupConfig);
+      const spec = result?.default ?? result?.last;
       showToast({
         message: localize('com_ui_conversation_not_found'),
         severity: NotificationSeverity.WARNING,
       });
-      newConversation();
+      newConversation({
+        modelsData: modelsQuery.data,
+        ...(spec ? { preset: getModelSpecPreset(spec) } : {}),
+      });
       hasSetConversation.current = true;
     } else if (
       conversationId === Constants.NEW_CONVO &&

--- a/client/src/utils/errors.ts
+++ b/client/src/utils/errors.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+/**
+ * Returns the HTTP response status code from an error, regardless of the
+ * HTTP client used.  Handles Axios errors first, then falls back to checking
+ * for a plain `status` property so callers never need to import axios.
+ */
+export const getResponseStatus = (error: unknown): number | undefined => {
+  if (axios.isAxiosError(error)) {
+    return error.response?.status;
+  }
+  if (error != null && typeof error === 'object' && 'status' in error) {
+    return (error as { status: number }).status;
+  }
+  return undefined;
+};
+
+export const isNotFoundError = (error: unknown): boolean => getResponseStatus(error) === 404;

--- a/client/src/utils/errors.ts
+++ b/client/src/utils/errors.ts
@@ -10,7 +10,10 @@ export const getResponseStatus = (error: unknown): number | undefined => {
     return error.response?.status;
   }
   if (error != null && typeof error === 'object' && 'status' in error) {
-    return (error as { status: number }).status;
+    const { status } = error as { status: unknown };
+    if (typeof status === 'number') {
+      return status;
+    }
   }
   return undefined;
 };

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -3,6 +3,7 @@ import type { UIActionResult } from '@mcp-ui/client';
 import { TAskFunction } from '~/common';
 import logger from './logger';
 
+export * from './errors';
 export * from './map';
 export * from './json';
 export * from './files';


### PR DESCRIPTION


## Summary

I added robust handling for when a user navigates to a conversation URL that no longer exists, replacing silent retry loops with an immediate redirect and a user-facing toast notification.

- Created `client/src/utils/errors.ts` exporting `getResponseStatus`, which extracts an HTTP status code from either an Axios error or a plain object with a `status` property, and `isNotFoundError`, which returns `true` when that status is `404`; re-exported both through `client/src/utils/index.ts`.
- Added a `retry` function to `useGetConvoIdQuery` that immediately short-circuits with `false` on 404 errors, eliminating the exponential-backoff retry delay that previously stalled error-state surfacing.
- Added an error branch to the `ChatRoute` initialization effect that fires when `initialConvoQuery.isError` is true and `isNotFoundError` confirms a 404, displays a `WARNING` severity toast with the new `com_ui_conversation_not_found` locale key, and calls `newConversation()` to redirect to a fresh conversation.
- Added `initialConvoQuery.isError` to the effect's dependency array so the effect correctly re-runs when the query transitions into an error state.
- Added the `"com_ui_conversation_not_found": "Conversation not found"` key to the English locale file.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

To test, navigate directly to a conversation URL with a deleted or otherwise non-existent conversation ID (e.g., `/c/some-invalid-id`). Confirm:

1. A "Conversation not found" warning toast is displayed.
2. The app redirects immediately to a new conversation (`/c/new`).
3. Only a single network request is made for the invalid ID — no retries occur before the redirect.
4. Navigating to a valid, existing conversation still loads correctly.
5. Simulate a non-404 network failure (e.g., 500 or offline) on the conversation fetch and confirm the query still retries up to 3 times before entering the error state.

### Test Configuration

- Any authenticated session with access to at least one existing conversation.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings