### PR TITLE
🧬 fix: Backfill Missing SHARE Permissions and Migrate Legacy SHARED_GLOBAL Fields

### DIFF
--- a/api/models/Role.spec.js
+++ b/api/models/Role.spec.js
@@ -233,51 +233,96 @@ describe('updateAccessPermissions', () => {
     expect(updatedRole.permissions[PermissionTypes.MULTI_CONVO]).toEqual({ USE: true });
   });
 
-  it('should migrate SHARED_GLOBAL=true to SHARE=true when SHARE is absent', async () => {
-    // Simulates a pre-#11283 DB document where SHARED_GLOBAL existed instead of SHARE
+  it('should inherit SHARED_GLOBAL value into SHARE when SHARE is absent from both DB and update', async () => {
+    // Simulates the startup backfill path: caller sends SHARE_PUBLIC but not SHARE;
+    // migration should inherit SHARED_GLOBAL to preserve the deployment's sharing intent.
     await Role.collection.insertOne({
       name: SystemRoles.USER,
       permissions: {
-        [PermissionTypes.PROMPTS]: {
-          USE: true,
-          CREATE: true,
-          SHARED_GLOBAL: true, // legacy field
-        },
-        [PermissionTypes.AGENTS]: {
-          USE: true,
-          CREATE: true,
-          SHARED_GLOBAL: false, // legacy field — user had sharing disabled
-        },
+        [PermissionTypes.PROMPTS]: { USE: true, CREATE: true, SHARED_GLOBAL: true },
+        [PermissionTypes.AGENTS]: { USE: true, CREATE: true, SHARED_GLOBAL: false },
       },
     });
 
     await updateAccessPermissions(SystemRoles.USER, {
-      [PermissionTypes.PROMPTS]: { SHARE: false, SHARE_PUBLIC: false },
-      [PermissionTypes.AGENTS]: { SHARE: false, SHARE_PUBLIC: false },
+      // No explicit SHARE — migration should inherit from SHARED_GLOBAL
+      [PermissionTypes.PROMPTS]: { SHARE_PUBLIC: false },
+      [PermissionTypes.AGENTS]: { SHARE_PUBLIC: false },
     });
 
     const updatedRole = await getRoleByName(SystemRoles.USER);
 
-    // SHARED_GLOBAL=true should be migrated to SHARE=true (preserving intent)
+    // SHARED_GLOBAL=true → SHARE=true (inherited)
     expect(updatedRole.permissions[PermissionTypes.PROMPTS].SHARE).toBe(true);
-    // SHARED_GLOBAL=false should be migrated to SHARE=false (preserving intent)
+    // SHARED_GLOBAL=false → SHARE=false (inherited)
     expect(updatedRole.permissions[PermissionTypes.AGENTS].SHARE).toBe(false);
-
-    // SHARED_GLOBAL should be removed from the DB
+    // SHARED_GLOBAL cleaned up
     expect(updatedRole.permissions[PermissionTypes.PROMPTS].SHARED_GLOBAL).toBeUndefined();
     expect(updatedRole.permissions[PermissionTypes.AGENTS].SHARED_GLOBAL).toBeUndefined();
   });
 
-  it('should remove SHARED_GLOBAL even when the permType is not in the update payload', async () => {
-    // SHARED_GLOBAL cleanup should run even if no update was triggered for that permType
+  it('should respect explicit SHARE in update payload and not override it with SHARED_GLOBAL', async () => {
+    // Caller explicitly passes SHARE: false even though SHARED_GLOBAL=true in DB.
+    // The explicit intent must win; migration must not silently overwrite it.
+    await Role.collection.insertOne({
+      name: SystemRoles.USER,
+      permissions: {
+        [PermissionTypes.PROMPTS]: { USE: true, SHARED_GLOBAL: true },
+      },
+    });
+
+    await updateAccessPermissions(SystemRoles.USER, {
+      [PermissionTypes.PROMPTS]: { SHARE: false }, // explicit false — should be preserved
+    });
+
+    const updatedRole = await getRoleByName(SystemRoles.USER);
+
+    expect(updatedRole.permissions[PermissionTypes.PROMPTS].SHARE).toBe(false);
+    expect(updatedRole.permissions[PermissionTypes.PROMPTS].SHARED_GLOBAL).toBeUndefined();
+  });
+
+  it('should migrate SHARED_GLOBAL to SHARE even when the permType is not in the update payload', async () => {
+    // Bug #2 regression: cleanup block removes SHARED_GLOBAL but migration block only
+    // runs when the permType is in the update payload. Without the fix, SHARE would be
+    // lost when any other permType (e.g. MULTI_CONVO) is the only thing being updated.
     await Role.collection.insertOne({
       name: SystemRoles.USER,
       permissions: {
         [PermissionTypes.PROMPTS]: {
           USE: true,
-          CREATE: true,
-          SHARE: true, // SHARE already exists — no migration needed
-          SHARED_GLOBAL: true, // orphaned legacy field still in DB
+          SHARED_GLOBAL: true, // legacy — NO SHARE present
+        },
+        [PermissionTypes.MULTI_CONVO]: { USE: false },
+      },
+    });
+
+    // Only update MULTI_CONVO — PROMPTS is intentionally absent from the payload
+    await updateAccessPermissions(SystemRoles.USER, {
+      [PermissionTypes.MULTI_CONVO]: { USE: true },
+    });
+
+    const updatedRole = await getRoleByName(SystemRoles.USER);
+
+    // SHARE should have been inherited from SHARED_GLOBAL, not silently dropped
+    expect(updatedRole.permissions[PermissionTypes.PROMPTS].SHARE).toBe(true);
+    // SHARED_GLOBAL should be removed
+    expect(updatedRole.permissions[PermissionTypes.PROMPTS].SHARED_GLOBAL).toBeUndefined();
+    // Original USE should be untouched
+    expect(updatedRole.permissions[PermissionTypes.PROMPTS].USE).toBe(true);
+    // The actual update should have applied
+    expect(updatedRole.permissions[PermissionTypes.MULTI_CONVO].USE).toBe(true);
+  });
+
+  it('should remove orphaned SHARED_GLOBAL when SHARE already exists and permType is not in update', async () => {
+    // Safe cleanup case: SHARE already set, SHARED_GLOBAL is just orphaned noise.
+    // SHARE must not be changed; SHARED_GLOBAL must be removed.
+    await Role.collection.insertOne({
+      name: SystemRoles.USER,
+      permissions: {
+        [PermissionTypes.PROMPTS]: {
+          USE: true,
+          SHARE: true, // already migrated
+          SHARED_GLOBAL: true, // orphaned
         },
         [PermissionTypes.MULTI_CONVO]: { USE: false },
       },
@@ -289,11 +334,8 @@ describe('updateAccessPermissions', () => {
 
     const updatedRole = await getRoleByName(SystemRoles.USER);
 
-    // SHARED_GLOBAL should be cleaned up even though PROMPTS was not in the update
     expect(updatedRole.permissions[PermissionTypes.PROMPTS].SHARED_GLOBAL).toBeUndefined();
-    // Existing SHARE should be untouched
     expect(updatedRole.permissions[PermissionTypes.PROMPTS].SHARE).toBe(true);
-    // The actual update should still have applied
     expect(updatedRole.permissions[PermissionTypes.MULTI_CONVO].USE).toBe(true);
   });
 


### PR DESCRIPTION


## Summary

Addresses the DB migration gap left by PR #11283, which renamed `SHARED_GLOBAL` → `SHARE`/`SHARE_PUBLIC` in the permissions schema without a corresponding migration, leaving existing deployments with stale or incomplete role documents.

- Adds a backfill loop in `updateInterfacePermissions` that injects missing `SHARE`/`SHARE_PUBLIC` fields into permission types that already exist in the DB but predate the schema change, without overwriting any field that is already set.
- Restricts backfill to fields literally absent from the DB document, and guards against clobbering values already queued by `addPermissionIfNeeded` (e.g. via explicit config).
- Adds migration logic in `updateAccessPermissions` to inherit `SHARED_GLOBAL` into `SHARE` when `SHARE` is absent from both the DB document and the update payload, preserving the deployment's sharing intent.
- Guards the migration block against overwriting an explicit `SHARE` value provided by the caller, ensuring caller intent is always respected.
- Fixes a data-loss bug in the cleanup block where `SHARED_GLOBAL` was deleted without first writing `SHARE` when the affected permission type was absent from the update payload — now handles `SHARED_GLOBAL` → `SHARE` inheritance symmetrically in both the migration and cleanup paths.
- Extends the `permissions.spec.ts` test fixtures to reflect post-#11283 DB documents and relaxes over-specified `toEqual` matchers to `objectContaining` where appropriate.
- Replaces the ambiguous migration test in `Role.spec.js` with four focused tests covering: inheritance when `SHARE` is absent from the payload, explicit caller intent winning over `SHARED_GLOBAL`, migration when the permission type is entirely absent from the update payload, and safe orphaned-field cleanup when `SHARE` already exists.
- Adds a `permissions.spec.ts` integration test simulating a legacy pre-#11283 DB document to verify `SHARE`/`SHARE_PUBLIC` are correctly backfilled, including the partial-backfill case for `MCP_SERVERS`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Unit tests were added and updated to cover all affected code paths. To reproduce:

```bash
# Role.js migration/cleanup logic
cd api && npx jest models/Role.spec.js --verbose

# permissions.ts backfill logic
cd packages/api && npx jest src/app/permissions.spec.ts --verbose
```

### **Test Configuration**:
- Tests run against an in-memory MongoDB instance via `mongodb-memory-server`
- No external services or environment variables required

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes