### PR TITLE
🚀 feat: Add "floating buttons" support

### DIFF
--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -97,6 +97,7 @@ router.get('/', async function (req, res) {
       interface: appConfig?.interfaceConfig,
       turnstile: appConfig?.turnstileConfig,
       modelSpecs: appConfig?.modelSpecs,
+      floatingButtons: appConfig?.floatingButtons,
       balance: balanceConfig,
       sharedLinksEnabled,
       publicSharedLinksEnabled,

--- a/client/src/components/Chat/Header.tsx
+++ b/client/src/components/Chat/Header.tsx
@@ -13,6 +13,7 @@ import { TemporaryChat } from './TemporaryChat';
 import AddMultiConvo from './AddMultiConvo';
 import { useHasAccess } from '~/hooks';
 import { cn } from '~/utils';
+import { FloatingButtons } from '../FloatingButtons';
 
 const defaultInterface = getConfigDefaults().interface;
 
@@ -39,7 +40,7 @@ export default function Header() {
 
   return (
     <div className="via-presentation/70 md:from-presentation/80 md:via-presentation/50 2xl:from-presentation/0 absolute top-0 z-10 flex h-14 w-full items-center justify-between bg-gradient-to-b from-presentation to-transparent p-2 font-semibold text-text-primary 2xl:via-transparent">
-      <div className="hide-scrollbar flex w-full items-center justify-between gap-2 overflow-x-auto">
+      <div className="flex w-full items-center justify-between gap-2">
         <div className="mx-1 flex items-center">
           <AnimatePresence initial={false}>
             {!navVisible && (
@@ -82,6 +83,7 @@ export default function Header() {
 
         {!isSmallScreen && (
           <div className="flex items-center gap-2">
+            <FloatingButtons />
             <ExportAndShareMenu
               isSharedButtonEnabled={startupConfig?.sharedLinksEnabled ?? false}
             />

--- a/client/src/components/FloatingButtons/FloatingButtons.css
+++ b/client/src/components/FloatingButtons/FloatingButtons.css
@@ -1,5 +1,5 @@
 .floating-buttons {
-  @apply fixed top-2 right-14 text-text-primary flex gap-2;
+  @apply text-text-primary flex gap-2;
 }
 
 .floating-buttons_button {

--- a/client/src/components/FloatingButtons/FloatingButtons.css
+++ b/client/src/components/FloatingButtons/FloatingButtons.css
@@ -1,0 +1,35 @@
+.floating-buttons {
+  @apply fixed top-2 right-14 text-text-primary flex gap-2;
+}
+
+.floating-buttons_button {
+  @apply relative flex flex-col cursor-pointer size-10 flex-shrink-0 items-center justify-center rounded-xl border border-border-light bg-presentation text-text-primary transition-all ease-in-out hover:bg-surface-tertiary opacity-50 disabled:pointer-events-none disabled:opacity-50 radix-state-open:bg-surface-tertiary;
+}
+.floating-buttons_button:is(:hover, :focus) {
+  @apply bg-surface-hover opacity-100;
+}
+
+.floating-buttons_button:before {
+  @apply absolute top-[110%] rounded-full bg-surface-hover px-2 py-1 text-xs opacity-0 pointer-events-none whitespace-nowrap text-text-primary;
+  content: attr(data-label);
+}
+.floating-buttons_button:is(:hover, :focus):before {
+  @apply opacity-100;
+}
+
+.floating-buttons_icon {
+  @apply flex size-14 w-full items-center justify-center gap-2;
+}
+
+.floating-buttons_icon svg {
+  @apply size-6;
+}
+
+.floating-buttons_label {
+  font-size: 0.2em;
+  display: none;
+}
+
+.floating-buttons_icon path {
+  fill: currentColor;
+}

--- a/client/src/components/FloatingButtons/FloatingButtons.tsx
+++ b/client/src/components/FloatingButtons/FloatingButtons.tsx
@@ -1,0 +1,31 @@
+
+import { useGetBannerQuery, useGetStartupConfig } from '~/data-provider';
+import './FloatingButtons.css';
+
+export const FloatingButtons = ({}: {}) => {
+  const { data: startupConfig } = useGetStartupConfig();
+
+    if (!startupConfig?.floatingButtons?.length) {
+      return null;
+    }
+
+  return <nav className="floating-buttons">
+    {startupConfig.floatingButtons.map((button, index) => (
+      <a
+        key={index}
+        href={button.url}
+        target={button.newTab ? '_blank' : '_self'  }
+        rel="noopener noreferrer"
+        data-label={button.label}
+        className="floating-buttons_button"
+      >
+        {button.icon && (
+            <i className="floating-buttons_icon" dangerouslySetInnerHTML={{ __html: button.icon }} />
+        )}
+        {/* {button.label && (
+            <span className="floating-buttons_label">{button.label}</span>
+        )} */}
+      </a>
+    ))}
+  </nav>;
+};

--- a/client/src/components/FloatingButtons/FloatingButtons.tsx
+++ b/client/src/components/FloatingButtons/FloatingButtons.tsx
@@ -1,8 +1,8 @@
 
-import { useGetBannerQuery, useGetStartupConfig } from '~/data-provider';
+import { useGetStartupConfig } from '~/data-provider';
 import './FloatingButtons.css';
 
-export const FloatingButtons = ({}: {}) => {
+export const FloatingButtons = () => {
   const { data: startupConfig } = useGetStartupConfig();
 
     if (!startupConfig?.floatingButtons?.length) {
@@ -22,9 +22,6 @@ export const FloatingButtons = ({}: {}) => {
         {button.icon && (
             <i className="floating-buttons_icon" dangerouslySetInnerHTML={{ __html: button.icon }} />
         )}
-        {/* {button.label && (
-            <span className="floating-buttons_label">{button.label}</span>
-        )} */}
       </a>
     ))}
   </nav>;

--- a/client/src/components/FloatingButtons/FloatingButtons.tsx
+++ b/client/src/components/FloatingButtons/FloatingButtons.tsx
@@ -1,28 +1,32 @@
-
 import { useGetStartupConfig } from '~/data-provider';
 import './FloatingButtons.css';
 
 export const FloatingButtons = () => {
   const { data: startupConfig } = useGetStartupConfig();
 
-    if (!startupConfig?.floatingButtons?.length) {
-      return null;
-    }
+  if (!startupConfig?.floatingButtons?.length) {
+    return null;
+  }
 
-  return <nav className="floating-buttons">
-    {startupConfig.floatingButtons.map((button, index) => (
-      <a
-        key={index}
-        href={button.url}
-        target={button.newTab ? '_blank' : '_self'  }
-        rel="noopener noreferrer"
-        data-label={button.label}
-        className="floating-buttons_button"
-      >
-        {button.icon && (
-            <i className="floating-buttons_icon" dangerouslySetInnerHTML={{ __html: button.icon }} />
-        )}
-      </a>
-    ))}
-  </nav>;
+  return (
+    <nav className="floating-buttons">
+      {startupConfig.floatingButtons.map((button, index) => (
+        <a
+          key={index}
+          href={button.url}
+          target={button.newTab ? '_blank' : '_self'}
+          rel="noopener noreferrer"
+          data-label={button.label}
+          className="floating-buttons_button"
+        >
+          {button.icon != null && (
+            <i
+              className="floating-buttons_icon"
+              dangerouslySetInnerHTML={{ __html: button.icon }}
+            />
+          )}
+        </a>
+      ))}
+    </nav>
+  );
 };

--- a/client/src/components/FloatingButtons/index.ts
+++ b/client/src/components/FloatingButtons/index.ts
@@ -1,0 +1,1 @@
+export { FloatingButtons } from './FloatingButtons';

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -21,7 +21,6 @@ import { Nav, MobileNav, NAV_WIDTH } from '~/components/Nav';
 import { TermsAndConditionsModal } from '~/components/ui';
 import { useHealthCheck } from '~/data-provider';
 import { Banner } from '~/components/Banners';
-import { FloatingButtons } from '~/components/FloatingButtons';
 
 export default function Root() {
   const [showTerms, setShowTerms] = useState(false);
@@ -95,7 +94,6 @@ export default function Root() {
                   </div>
                 </div>
               </div>
-              <FloatingButtons />
             </PromptGroupsProvider>
           </AgentsMapContext.Provider>
           {config?.interface?.termsOfService?.modalAcceptance === true && (

--- a/client/src/routes/Root.tsx
+++ b/client/src/routes/Root.tsx
@@ -21,6 +21,7 @@ import { Nav, MobileNav, NAV_WIDTH } from '~/components/Nav';
 import { TermsAndConditionsModal } from '~/components/ui';
 import { useHealthCheck } from '~/data-provider';
 import { Banner } from '~/components/Banners';
+import { FloatingButtons } from '~/components/FloatingButtons';
 
 export default function Root() {
   const [showTerms, setShowTerms] = useState(false);
@@ -94,11 +95,12 @@ export default function Root() {
                   </div>
                 </div>
               </div>
+              <FloatingButtons />
             </PromptGroupsProvider>
           </AgentsMapContext.Provider>
           {config?.interface?.termsOfService?.modalAcceptance === true && (
             <TermsAndConditionsModal
-              open={showTerms}
+              open={showTerms}    
               onOpenChange={setShowTerms}
               onAccept={handleAcceptTerms}
               onDecline={handleDeclineTerms}

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -609,3 +609,16 @@ endpoints:
 #     # instructions: "You are a memory management assistant. Store and manage user information accurately."
 #     # model_parameters:
 #     #   temperature: 0.1
+
+# Floating button configuration for quick access to features like feedback, support, or documentation
+floatingButtons:
+    # Can be of type: "link"
+  - type: "link"
+    # A label to display on hover
+    label: "By some credits"
+    # an icon that has to have only 1 "path" to work property
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M296 88C296 74.7 306.7 64 320 64C333.3 64 344 74.7 344 88L344 128L400 128C417.7 128 432 142.3 432 160C432 177.7 417.7 192 400 192L285.1 192C260.2 192 240 212.2 240 237.1C240 259.6 256.5 278.6 278.7 281.8L370.3 294.9C424.1 302.6 464 348.6 464 402.9C464 463.2 415.1 512 354.9 512L344 512L344 552C344 565.3 333.3 576 320 576C306.7 576 296 565.3 296 552L296 512L224 512C206.3 512 192 497.7 192 480C192 462.3 206.3 448 224 448L354.9 448C379.8 448 400 427.8 400 402.9C400 380.4 383.5 361.4 361.3 358.2L269.7 345.1C215.9 337.5 176 291.4 176 237.1C176 176.9 224.9 128 285.1 128L296 128L296 88z" fill="black"/></svg>'
+    # An url where to redirect when the button is clicked
+    url: "https://librechat.ai/by-som-credits"
+    # Open the link in a new tab
+    newTab: true

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -723,6 +723,7 @@ export const interfaceSchema = z
 export type TInterfaceConfig = z.infer<typeof interfaceSchema>;
 export type TBalanceConfig = z.infer<typeof balanceSchema>;
 export type TTransactionsConfig = z.infer<typeof transactionsSchema>;
+export type TFloatingButtonsConfig = z.infer<typeof floatingButtonsSchema>;
 
 export const turnstileOptionsSchema = z
   .object({
@@ -777,6 +778,7 @@ export type TStartupConfig = {
   helpAndFaqURL: string;
   customFooter?: string;
   modelSpecs?: TSpecsConfig;
+  floatingButtons?: TFloatingButtonsConfig;
   modelDescriptions?: Record<string, Record<string, string>>;
   sharedLinksEnabled: boolean;
   publicSharedLinksEnabled: boolean;
@@ -920,6 +922,14 @@ export const balanceSchema = z.object({
   refillAmount: z.number().optional().default(10000),
 });
 
+export const floatingButtonsSchema = z.array(z.object({
+  type: z.enum(['link']).optional().default('link'),
+  label: z.string(),
+  url: z.string(),
+  icon: z.string(),
+  newTab: z.boolean().optional().default(true),
+}))
+
 export const transactionsSchema = z.object({
   enabled: z.boolean().optional().default(true),
 });
@@ -982,6 +992,7 @@ export const configSchema = z.object({
     })
     .default({ socialLogins: defaultSocialLogins }),
   balance: balanceSchema.optional(),
+  floatingButtons: floatingButtonsSchema.optional(),
   transactions: transactionsSchema.optional(),
   speech: z
     .object({

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -922,13 +922,15 @@ export const balanceSchema = z.object({
   refillAmount: z.number().optional().default(10000),
 });
 
-export const floatingButtonsSchema = z.array(z.object({
-  type: z.enum(['link']).optional().default('link'),
-  label: z.string(),
-  url: z.string(),
-  icon: z.string(),
-  newTab: z.boolean().optional().default(true),
-}))
+export const floatingButtonsSchema = z.array(
+  z.object({
+    type: z.enum(['link']).optional().default('link'),
+    label: z.string(),
+    url: z.string(),
+    icon: z.string().optional(),
+    newTab: z.boolean().optional().default(true),
+  }),
+);
 
 export const transactionsSchema = z.object({
   enabled: z.boolean().optional().default(true),

--- a/packages/data-schemas/src/app/service.ts
+++ b/packages/data-schemas/src/app/service.ts
@@ -110,6 +110,7 @@ export const AppService = async (params?: {
     fileConfig: config?.fileConfig as AppConfig['fileConfig'],
     secureImageLinks: config?.secureImageLinks,
     modelSpecs: processModelSpecs(config?.endpoints, config.modelSpecs, interfaceConfig),
+    floatingButtons: config?.floatingButtons,
     endpoints: loadedEndpoints,
   };
 

--- a/packages/data-schemas/src/types/app.ts
+++ b/packages/data-schemas/src/types/app.ts
@@ -92,6 +92,8 @@ export interface AppConfig {
   secureImageLinks?: TCustomConfig['secureImageLinks'];
   /** Processed model specifications */
   modelSpecs?: TCustomConfig['modelSpecs'];
+  /** Floating buttons configuration */
+  floatingButtons?: TCustomConfig['floatingButtons'];
   /** Available tools */
   availableTools?: Record<string, FunctionTool>;
   endpoints?: {


### PR DESCRIPTION
# 🚀 feat: Add "floating buttons" support

## Add some custom buttons on top right

This feature allows you to add some buttons on the top right corner of the UI with custom links, icons, etc...

### Here's an example of `librechat.yaml` configuration

```yml
# Floating button configuration for quick access to features like feedback, support, or documentation
floatingButtons:
  - type: "link"
    label: "By some credits"
    icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M296 88C296 74.7 306.7 64 320 64C333.3 64 344 74.7 344 88L344 128L400 128C417.7 128 432 142.3 432 160C432 177.7 417.7 192 400 192L285.1 192C260.2 192 240 212.2 240 237.1C240 259.6 256.5 278.6 278.7 281.8L370.3 294.9C424.1 302.6 464 348.6 464 402.9C464 463.2 415.1 512 354.9 512L344 512L344 552C344 565.3 333.3 576 320 576C306.7 576 296 565.3 296 552L296 512L224 512C206.3 512 192 497.7 192 480C192 462.3 206.3 448 224 448L354.9 448C379.8 448 400 427.8 400 402.9C400 380.4 383.5 361.4 361.3 358.2L269.7 345.1C215.9 337.5 176 291.4 176 237.1C176 176.9 224.9 128 285.1 128L296 128L296 88z" fill="black"/></svg>'
    url: "https://librechat.ai/support"  # URL to open when clicked
    newTab: true  # Open link in a new tab
```

### Here's how it will display:

![](https://iili.io/q2Qms9V.png)

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Translation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.