### PR TITLE
fix(mcp): do not ignore SSE 404 when Streamable HTTP session exists

### DIFF
--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -311,20 +311,22 @@ Please follow these instructions when using tools from the respective MCP server
         connection.setRequestHeaders(currentOptions.headers || {});
       }
 
-      const result = await connection.client.request(
-        {
-          method: 'tools/call',
-          params: {
-            name: toolName,
-            arguments: toolArguments,
+      const result = await connection.callWithReconnectOnSessionGone(() =>
+        connection.client.request(
+          {
+            method: 'tools/call',
+            params: {
+              name: toolName,
+              arguments: toolArguments,
+            },
           },
-        },
-        CallToolResultSchema,
-        {
-          timeout: connection.timeout,
-          resetTimeoutOnProgress: true,
-          ...options,
-        },
+          CallToolResultSchema,
+          {
+            timeout: connection.timeout,
+            resetTimeoutOnProgress: true,
+            ...options,
+          },
+        ),
       );
       if (userId) {
         this.updateUserLastActivity(userId);

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -71,6 +71,8 @@ const FIVE_MINUTES = 5 * 60 * 1000;
 const DEFAULT_TIMEOUT = 60000;
 /** SSE connections through proxies may need longer initial handshake time */
 const SSE_CONNECT_TIMEOUT = 120000;
+/** Streamable HTTP: GET SSE stream is long-lived; same fetch is used for GET and POST. Use a very long bodyTimeout so the GET stream is not aborted after initTimeout (e.g. 120s). */
+const STREAMABLE_HTTP_SSE_BODY_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24h
 
 /**
  * Headers for SSE connections.
@@ -488,7 +490,7 @@ export class MCPConnection extends EventEmitter {
             },
             fetch: this.createFetchFunction(
               this.getRequestHeaders.bind(this),
-              this.timeout,
+              STREAMABLE_HTTP_SSE_BODY_TIMEOUT_MS,
             ) as unknown as FetchLike,
           });
 

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -71,8 +71,6 @@ const FIVE_MINUTES = 5 * 60 * 1000;
 const DEFAULT_TIMEOUT = 60000;
 /** SSE connections through proxies may need longer initial handshake time */
 const SSE_CONNECT_TIMEOUT = 120000;
-/** Streamable HTTP: GET SSE stream is long-lived; same fetch is used for GET and POST. Use a very long bodyTimeout so the GET stream is not aborted after initTimeout (e.g. 120s). */
-const STREAMABLE_HTTP_SSE_BODY_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24h
 
 /**
  * Headers for SSE connections.
@@ -490,7 +488,7 @@ export class MCPConnection extends EventEmitter {
             },
             fetch: this.createFetchFunction(
               this.getRequestHeaders.bind(this),
-              STREAMABLE_HTTP_SSE_BODY_TIMEOUT_MS,
+              this.timeout,
             ) as unknown as FetchLike,
           });
 


### PR DESCRIPTION
## Summary

Fixes [#11868](https://github.com/danny-avila/LibreChat/issues/11868).

The MCP Streamable HTTP client was ignoring **all** SSE 404 responses (treating them as “SSE not supported” for backwards compatibility). For stateful MCP servers, when the server restarts or terminates a session, it correctly returns **404 Not Found** for requests carrying that session ID (per [MCP spec 2025-11-25 § Session Management](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management)). Because we ignored that 404, reconnection was never triggered; the client kept using the dead session ID, POSTs failed with “Session not found”, and we ended up with “Stopping reconnection attempts” and a broken MCP until API restart.

**Change:** Only ignore SSE 404 when **no session has been established yet** (backwards-compat probe for servers that don’t offer SSE). When the transport already has a `sessionId` and GET /mcp returns 404, treat it as “session gone” and **do not** ignore the error, so the existing reconnection logic runs and sends a fresh `InitializeRequest` without session ID, as required by the spec.

**File:** `packages/api/src/mcp/connection.ts` — `setupTransportErrorHandlers`: add a check for `transport.sessionId` before returning early on SSE 404; if a session exists, log a warning and fall through so the error is emitted and reconnection proceeds.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

1. Configure a stateful MCP server (Streamable HTTP with sessions), e.g. one that stores sessions in memory.
2. Use the app until the MCP connection is established and a session exists.
3. Restart the MCP server (or kill the session) so it returns 404 for that session ID.
4. Trigger MCP usage again (e.g. send a message that uses an MCP tool).
5. **Before fix:** Logs show “Failed to open SSE stream: Not Found” (ignored), then “Session not found” on POST, “Stopping reconnection attempts”; MCP stays broken.
6. **After fix:** SSE 404 with active session is not ignored; reconnection runs, new `InitializeRequest` is sent, and the MCP connection recovers without restarting the API.

No new unit tests added; the change is a conditional in the existing error handler. Manual testing as above confirms recovery after server restart.

### **Test Configuration**:

- MCP server: Streamable HTTP, stateful (session-based), e.g. `http://mcp-server:3015/mcp` type `streamable-http`.
- Reproduce by restarting the MCP server while a chat using that MCP is active.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
