### PR TITLE
feat: Add LLM API (llmapi.ai) as known endpoint

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -411,6 +411,21 @@ endpoints:
       dropParams: ['stop']
       modelDisplayLabel: 'OpenRouter'
 
+    # LLM API Example
+    # llmapi.ai is an OpenAI-compatible gateway providing access to 120+ models
+    # across OpenAI, Anthropic, Google, xAI, Alibaba, Moonshot, and more.
+    - name: 'llmapi'
+      # For `apiKey` and `baseURL`, you can use environment variables that you define.
+      # recommended environment variables:
+      apiKey: '${LLMAPI_KEY}'
+      baseURL: 'https://api.llmapi.ai/v1'
+      models:
+        default: ['gpt-4o', 'claude-sonnet-4-20250514', 'gemini-2.5-flash']
+        fetch: true
+      titleConvo: true
+      titleModel: 'gpt-4o'
+      modelDisplayLabel: 'LLM API'
+
     # Helicone Example
     - name: 'Helicone'
       # For `apiKey` and `baseURL`, you can use environment variables that you define.

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1052,6 +1052,7 @@ export enum KnownEndpoints {
   groq = 'groq',
   helicone = 'helicone',
   huggingface = 'huggingface',
+  llmapi = 'llmapi',
   mistral = 'mistral',
   mlx = 'mlx',
   ollama = 'ollama',
@@ -1097,6 +1098,7 @@ export const alternateName = {
   [KnownEndpoints.xai]: 'xAI',
   [KnownEndpoints.vercel]: 'Vercel',
   [KnownEndpoints.helicone]: 'Helicone',
+  [KnownEndpoints.llmapi]: 'LLM API',
 };
 
 const sharedOpenAIModels = [


### PR DESCRIPTION
## Summary
- Adds [LLM API](https://llmapi.ai) (llmapi.ai) as a `KnownEndpoints` entry for recognized display name
- Adds example YAML configuration in `librechat.example.yaml`
- LLM API is a unified API gateway providing access to 120+ models across OpenAI, Anthropic, Google, xAI, Alibaba, Moonshot, and more

## Changes
- Added `llmapi` to `KnownEndpoints` enum in `packages/data-provider/src/config.ts`
- Added `alternateName` mapping for proper "LLM API" display
- Added example configuration block in `librechat.example.yaml`

## Test plan
- [ ] Configure `llmapi` endpoint in `librechat.yaml` with an API key
- [ ] Verify the endpoint appears as "LLM API" in the UI
- [ ] Verify model fetching works via `fetch: true`
- [ ] Send a chat message and verify response streaming works

🤖 Generated with [Claude Code](https://claude.com/claude-code)