### PR TITLE
🪪 fix: Handle Delimited String Role Claims in OpenID Strategy

### DIFF
--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -524,13 +524,14 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
     }
 
     const adminRoles = get(adminRoleObject, adminRoleParameterPath);
+    let adminRoleValues = [];
+    if (Array.isArray(adminRoles)) {
+      adminRoleValues = adminRoles;
+    } else if (typeof adminRoles === 'string') {
+      adminRoleValues = adminRoles.split(/[\s,]+/).filter(Boolean);
+    }
 
-    if (
-      adminRoles &&
-      (adminRoles === true ||
-        adminRoles === adminRole ||
-        (Array.isArray(adminRoles) && adminRoles.includes(adminRole)))
-    ) {
+    if (adminRoles && (adminRoles === true || adminRoleValues.includes(adminRole))) {
       user.role = SystemRoles.ADMIN;
       logger.info(`[openidStrategy] User ${username} is an admin based on role: ${adminRole}`);
     } else if (user.role === SystemRoles.ADMIN) {

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -451,7 +451,7 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
       throw new Error(`You must have ${rolesList} role to log in.`);
     }
 
-    const roleValues = Array.isArray(roles) ? roles : [roles];
+    const roleValues = Array.isArray(roles) ? roles : roles.split(/[\s,]+/).filter(Boolean);
 
     if (!requiredRoles.some((role) => roleValues.includes(role))) {
       const rolesList =

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -385,45 +385,57 @@ describe('setupOpenId', () => {
   });
 
   it('should allow login when roles claim is a space-separated string containing the required role', async () => {
+    // Arrange – IdP returns roles as a space-delimited string
     jwtDecode.mockReturnValue({
       roles: 'role1 role2 requiredRole',
     });
 
+    // Act
     const { user } = await validate(tokenset);
 
+    // Assert – login succeeds when required role is present after splitting
     expect(user).toBeTruthy();
     expect(createUser).toHaveBeenCalled();
   });
 
   it('should allow login when roles claim is a comma-separated string containing the required role', async () => {
+    // Arrange – IdP returns roles as a comma-delimited string
     jwtDecode.mockReturnValue({
       roles: 'role1,role2,requiredRole',
     });
 
+    // Act
     const { user } = await validate(tokenset);
 
+    // Assert – login succeeds when required role is present after splitting
     expect(user).toBeTruthy();
     expect(createUser).toHaveBeenCalled();
   });
 
   it('should allow login when roles claim is a mixed comma-and-space-separated string containing the required role', async () => {
+    // Arrange – IdP returns roles with comma-and-space delimiters
     jwtDecode.mockReturnValue({
       roles: 'role1, role2, requiredRole',
     });
 
+    // Act
     const { user } = await validate(tokenset);
 
+    // Assert – login succeeds when required role is present after splitting
     expect(user).toBeTruthy();
     expect(createUser).toHaveBeenCalled();
   });
 
   it('should reject login when roles claim is a space-separated string that does not contain the required role', async () => {
+    // Arrange – IdP returns a delimited string but required role is absent
     jwtDecode.mockReturnValue({
       roles: 'role1 role2 otherRole',
     });
 
+    // Act
     const { user, details } = await validate(tokenset);
 
+    // Assert – login is rejected with the correct error message
     expect(user).toBe(false);
     expect(details.message).toBe('You must have "requiredRole" role to log in.');
   });
@@ -1223,6 +1235,46 @@ describe('setupOpenId', () => {
 
       const { user } = await validate(tokenset);
 
+      expect(user.role).toBeUndefined();
+    });
+
+    it('should grant admin when admin role claim is a space-separated string containing the admin role', async () => {
+      // Arrange – IdP returns admin roles as a space-delimited string
+      process.env.OPENID_ADMIN_ROLE = 'site-admin';
+      process.env.OPENID_ADMIN_ROLE_PARAMETER_PATH = 'app_roles';
+
+      jwtDecode.mockReturnValue({
+        roles: ['requiredRole'],
+        app_roles: 'user site-admin moderator',
+      });
+
+      await setupOpenId();
+      verifyCallback = require('openid-client/passport').__getVerifyCallbackByName('openid');
+
+      // Act
+      const { user } = await validate(tokenset);
+
+      // Assert – admin role is granted after splitting the delimited string
+      expect(user.role).toBe('ADMIN');
+    });
+
+    it('should not grant admin when admin role claim is a space-separated string that does not contain the admin role', async () => {
+      // Arrange – delimited string present but admin role is absent
+      process.env.OPENID_ADMIN_ROLE = 'site-admin';
+      process.env.OPENID_ADMIN_ROLE_PARAMETER_PATH = 'app_roles';
+
+      jwtDecode.mockReturnValue({
+        roles: ['requiredRole'],
+        app_roles: 'user moderator',
+      });
+
+      await setupOpenId();
+      verifyCallback = require('openid-client/passport').__getVerifyCallbackByName('openid');
+
+      // Act
+      const { user } = await validate(tokenset);
+
+      // Assert – admin role is not granted
       expect(user.role).toBeUndefined();
     });
 

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -384,6 +384,50 @@ describe('setupOpenId', () => {
     expect(details.message).toBe('You must have "read" role to log in.');
   });
 
+  it('should allow login when roles claim is a space-separated string containing the required role', async () => {
+    jwtDecode.mockReturnValue({
+      roles: 'role1 role2 requiredRole',
+    });
+
+    const { user } = await validate(tokenset);
+
+    expect(user).toBeTruthy();
+    expect(createUser).toHaveBeenCalled();
+  });
+
+  it('should allow login when roles claim is a comma-separated string containing the required role', async () => {
+    jwtDecode.mockReturnValue({
+      roles: 'role1,role2,requiredRole',
+    });
+
+    const { user } = await validate(tokenset);
+
+    expect(user).toBeTruthy();
+    expect(createUser).toHaveBeenCalled();
+  });
+
+  it('should allow login when roles claim is a mixed comma-and-space-separated string containing the required role', async () => {
+    jwtDecode.mockReturnValue({
+      roles: 'role1, role2, requiredRole',
+    });
+
+    const { user } = await validate(tokenset);
+
+    expect(user).toBeTruthy();
+    expect(createUser).toHaveBeenCalled();
+  });
+
+  it('should reject login when roles claim is a space-separated string that does not contain the required role', async () => {
+    jwtDecode.mockReturnValue({
+      roles: 'role1 role2 otherRole',
+    });
+
+    const { user, details } = await validate(tokenset);
+
+    expect(user).toBe(false);
+    expect(details.message).toBe('You must have "requiredRole" role to log in.');
+  });
+
   it('should allow login when single required role is present (backward compatibility)', async () => {
     // Arrange – ensure single role configuration (as set in beforeEach)
     // OPENID_REQUIRED_ROLE = 'requiredRole'


### PR DESCRIPTION


## Summary

Fixed two related bugs in `processOpenIDAuth` where string-typed role claims returned by an IdP were not split before comparison, causing access control checks to silently fail for valid users.

- Fixed required role check to split a string `roles` claim on whitespace and commas via `/[\s,]+/` before membership comparison, replacing the previous behavior that wrapped the entire string as a single array element.
- Applied the same splitting logic to the admin role check — builds `adminRoleValues` from the claim by splitting string types or passing arrays through directly, then uses `.includes(adminRole)` in place of the prior exact string equality check.
- Preserved the `adminRoles === true` boolean shortcut for admin role grants.
- Added four regression tests for the required role string path covering space-separated, comma-separated, mixed delimiter, and non-matching cases.
- Added two regression tests for the admin role string path covering a positive grant and a negative (role absent) case.
- Updated the four required-role string tests to follow the `// Arrange / // Act / // Assert` comment pattern consistent with the rest of the test file.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Unit tests were added directly in `api/strategies/openidStrategy.spec.js` and cover all new code paths. To reproduce locally:

```bash
cd api
npx jest strategies/openidStrategy.spec.js
```

### **Test Configuration**:

The relevant environment variables exercised by the new tests:

```env
OPENID_REQUIRED_ROLE=requiredRole
OPENID_REQUIRED_ROLE_PARAMETER_PATH=roles
OPENID_REQUIRED_ROLE_TOKEN_KIND=id
OPENID_ADMIN_ROLE=site-admin
OPENID_ADMIN_ROLE_PARAMETER_PATH=app_roles
OPENID_ADMIN_ROLE_TOKEN_KIND=id
```

For manual verification against a live IdP, configure the above variables and confirm that an IdP returning `roles` as `"role1 role2 requiredRole"` (space-separated) or `"role1,role2,requiredRole"` (comma-separated) grants login, while a string that omits the required role does not.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes