### PR TITLE
feat: add User-Agent header for Anthropic calls

### DIFF
--- a/packages/api/src/endpoints/anthropic/llm.ts
+++ b/packages/api/src/endpoints/anthropic/llm.ts
@@ -1,7 +1,12 @@
 import { Dispatcher, ProxyAgent } from 'undici';
 import { logger } from '@librechat/data-schemas';
 import { AnthropicClientOptions } from '@librechat/agents';
-import { anthropicSettings, removeNullishValues, AuthKeys } from 'librechat-data-provider';
+import {
+  anthropicSettings,
+  removeNullishValues,
+  AuthKeys,
+  Constants,
+} from 'librechat-data-provider';
 import type {
   AnthropicLLMConfigResult,
   AnthropicConfigOptions,
@@ -189,8 +194,11 @@ function getLLMConfig(
   }
 
   const headers = getClaudeHeaders(requestOptions.model ?? '', supportsCacheControl);
-  if (headers && requestOptions.clientOptions) {
-    requestOptions.clientOptions.defaultHeaders = headers;
+  if (requestOptions.clientOptions) {
+    requestOptions.clientOptions.defaultHeaders = {
+      'User-Agent': `LibreChat/${Constants.VERSION}`,
+      ...(headers || {}),
+    };
   }
 
   if (options.proxy && requestOptions.clientOptions) {
@@ -274,6 +282,7 @@ function getLLMConfig(
       }
 
       requestOptions.clientOptions.defaultHeaders = {
+        'User-Agent': `LibreChat/${Constants.VERSION}`,
         ...requestOptions.clientOptions.defaultHeaders,
         'anthropic-beta': 'web-search-2025-03-05',
       };

--- a/packages/api/src/endpoints/openai/config.anthropic.spec.ts
+++ b/packages/api/src/endpoints/openai/config.anthropic.spec.ts
@@ -45,6 +45,7 @@ describe('getOpenAIConfig - Anthropic Compatibility', () => {
         configOptions: {
           baseURL: 'http://host.docker.internal:4000/v1',
           defaultHeaders: {
+            'User-Agent': expect.stringContaining('LibreChat/'),
             'anthropic-beta': 'context-1m-2025-08-07',
           },
         },
@@ -94,6 +95,7 @@ describe('getOpenAIConfig - Anthropic Compatibility', () => {
         configOptions: {
           baseURL: 'http://localhost:4000/v1',
           defaultHeaders: {
+            'User-Agent': expect.stringContaining('LibreChat/'),
             'anthropic-beta': 'token-efficient-tools-2025-02-19,output-128k-2025-02-19',
           },
         },
@@ -142,6 +144,7 @@ describe('getOpenAIConfig - Anthropic Compatibility', () => {
         configOptions: {
           baseURL: 'http://localhost:4000/v1',
           defaultHeaders: {
+            'User-Agent': expect.stringContaining('LibreChat/'),
             'anthropic-beta': 'token-efficient-tools-2025-02-19,output-128k-2025-02-19',
           },
         },
@@ -184,6 +187,7 @@ describe('getOpenAIConfig - Anthropic Compatibility', () => {
         configOptions: {
           baseURL: 'https://api.anthropic.proxy.com/v1',
           defaultHeaders: {
+            'User-Agent': expect.stringContaining('LibreChat/'),
             'anthropic-beta': 'max-tokens-3-5-sonnet-2024-07-15',
           },
         },
@@ -228,6 +232,7 @@ describe('getOpenAIConfig - Anthropic Compatibility', () => {
         configOptions: {
           baseURL: 'http://custom.proxy/v1',
           defaultHeaders: {
+            'User-Agent': expect.stringContaining('LibreChat/'),
             'Custom-Header': 'custom-value',
             Authorization: 'Bearer custom-token',
           },
@@ -270,6 +275,9 @@ describe('getOpenAIConfig - Anthropic Compatibility', () => {
         },
         configOptions: {
           baseURL: 'http://litellm:4000/v1',
+          defaultHeaders: {
+            'User-Agent': expect.stringContaining('LibreChat/'),
+          },
         },
         tools: [],
       });
@@ -314,6 +322,9 @@ describe('getOpenAIConfig - Anthropic Compatibility', () => {
         },
         configOptions: {
           baseURL: 'http://proxy.litellm/v1',
+          defaultHeaders: {
+            'User-Agent': expect.stringContaining('LibreChat/'),
+          },
         },
         tools: [],
       });
@@ -353,6 +364,9 @@ describe('getOpenAIConfig - Anthropic Compatibility', () => {
         },
         configOptions: {
           baseURL: 'http://litellm/v1',
+          defaultHeaders: {
+            'User-Agent': expect.stringContaining('LibreChat/'),
+          },
         },
         tools: [],
       });
@@ -392,6 +406,9 @@ describe('getOpenAIConfig - Anthropic Compatibility', () => {
         },
         configOptions: {
           baseURL: 'http://litellm/v1',
+          defaultHeaders: {
+            'User-Agent': expect.stringContaining('LibreChat/'),
+          },
         },
         tools: [
           {
@@ -439,6 +456,9 @@ describe('getOpenAIConfig - Anthropic Compatibility', () => {
         },
         configOptions: {
           baseURL: 'http://litellm/v1',
+          defaultHeaders: {
+            'User-Agent': expect.stringContaining('LibreChat/'),
+          },
         },
         tools: [],
       });
@@ -487,6 +507,9 @@ describe('getOpenAIConfig - Anthropic Compatibility', () => {
         },
         configOptions: {
           baseURL: 'http://litellm/v1',
+          defaultHeaders: {
+            'User-Agent': expect.stringContaining('LibreChat/'),
+          },
         },
         tools: [],
       });
@@ -538,6 +561,7 @@ describe('getOpenAIConfig - Anthropic Compatibility', () => {
         configOptions: {
           baseURL: 'http://litellm/v1',
           defaultHeaders: {
+            'User-Agent': expect.stringContaining('LibreChat/'),
             'anthropic-beta': 'max-tokens-3-5-sonnet-2024-07-15',
           },
         },


### PR DESCRIPTION
## Summary

A small change to add a user-agent to identify librechat for Anthropic.

## Change Type

- [X] New feature (non-breaking change which adds functionality)

## Testing

Modifies existing tests to validate that the user-agent header is filled out.

## Checklist

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [X] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
