### PR TITLE
fix: strip null/undefined values from MCP tool arguments before call

### DIFF
--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -311,12 +311,21 @@ Please follow these instructions when using tools from the respective MCP server
         connection.setRequestHeaders(currentOptions.headers || {});
       }
 
+      // Strip null/undefined values from tool arguments before sending to MCP server.
+      // Some models (e.g. certain OpenAI, Gemini variants) emit null for optional params
+      // like { country: null }, which fails Zod validation on servers like Brave Search.
+      const sanitizedArguments = toolArguments
+        ? Object.fromEntries(
+          Object.entries(toolArguments).filter(([, v]) => v != null),
+        )
+        : toolArguments;
+
       const result = await connection.client.request(
         {
           method: 'tools/call',
           params: {
             name: toolName,
-            arguments: toolArguments,
+            arguments: sanitizedArguments,
           },
         },
         CallToolResultSchema,


### PR DESCRIPTION
## Summary

Some models (e.g. certain OpenAI, Gemini variants) emit `null` for optional parameters in MCP tool calls — for example `{ query: "lakers scores", country: null, language: null }` when calling Brave Search. The MCP server's Zod schema validation rejects these `null` values, causing the entire tool call to fail with a validation error.

This adds a lightweight sanitization step in `MCPManager.callTool()` that filters out `null`/`undefined` values from `toolArguments` before sending them to the MCP server. This prevents Zod validation failures while preserving all valid parameter values.

**Root cause:** The MCP tool's `inputSchema` declares optional parameters (e.g. `country?: string`), but some models interpret "optional" as "send null" rather than "omit the key." The MCP SDK passes these through verbatim, and the downstream server's Zod schema rightfully rejects `null` for a `string` type.

**Fix location:** `packages/api/src/mcp/MCPManager.ts` in `callTool()` — this is the single chokepoint where all MCP tool calls pass through, so the fix covers all MCP servers, not just Brave Search.

**Affected MCP servers (confirmed):** Brave Search, but any server with optional string parameters in its tool schema could be affected.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Translation update

## Testing

1. Configured Brave Search MCP server with `@anthropic-ai/mcp-server-brave-search`
2. Sent queries using models that emit null optional params (confirmed with MiniMax M2.5, also observed with certain OpenAI and Gemini variants)
3. **Before fix:** Tool call fails with Zod validation error (`expected string, received null`)
4. **After fix:** Null params stripped, tool call succeeds, search results returned normally
5. Verified that valid parameters (non-null) are preserved and passed through correctly

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules