### PR TITLE
feat: add Brainiall LLM Gateway as custom endpoint example

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -445,6 +445,29 @@ endpoints:
       modelDisplayLabel: 'Portkey'
       iconURL: https://images.crunchbase.com/image/upload/c_pad,f_auto,q_auto:eco,dpr_1/rjqy7ghvjoiu4cd1xjbf
 
+    # Brainiall Example
+    - name: 'Brainiall'
+      apiKey: '${BRAINIALL_API_KEY}'
+      baseURL: 'https://apim-ai-apis.azure-api.net/v1'
+      models:
+        default:
+          - 'claude-opus-4-6'
+          - 'claude-sonnet-4-6'
+          - 'claude-haiku-4-5'
+          - 'deepseek-r1'
+          - 'deepseek-v3'
+          - 'llama-3.3-70b'
+          - 'llama-4-scout'
+          - 'qwen3-80b'
+          - 'mistral-large-3'
+          - 'minimax-m2'
+          - 'nova-pro'
+          - 'nova-micro'
+        fetch: true
+      titleConvo: true
+      titleModel: 'claude-haiku-4-5'
+      modelDisplayLabel: 'Brainiall'
+
   # AWS Bedrock Example
   # Note: Bedrock endpoint is configured via environment variables
   # bedrock:


### PR DESCRIPTION
## Summary

- Add Brainiall as a custom endpoint example in `librechat.example.yaml`, following the same format as existing examples (Groq, Mistral, OpenRouter, Helicone, Portkey)
- Brainiall is an OpenAI-compatible LLM Gateway providing 113+ models from 17 providers (Claude, DeepSeek, Llama, Mistral, Qwen, Nova, MiniMax, and more) through a single API endpoint backed by AWS Bedrock
- Website: https://brainiall.com

The example includes 12 default models spanning multiple providers, `fetch: true` for auto-discovery of additional models, and `claude-haiku-4-5` as the title model for cost-efficient title generation.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

1. Copy `librechat.example.yaml` to `librechat.yaml`
2. Set `BRAINIALL_API_KEY` environment variable
3. Start LibreChat and verify the Brainiall endpoint appears with the listed models
4. Confirm `fetch: true` retrieves the full model catalog from the API

### **Test Configuration**:
- Validated YAML syntax with `python3 -c "import yaml; yaml.safe_load(open('librechat.example.yaml'))"`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings