### PR TITLE
💎 fix: Gemini Image Gen Tool Vertex AI Auth and File Storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -243,10 +243,6 @@ GOOGLE_KEY=user_provided
 # Option A: Use dedicated Gemini API key for image generation
 # GEMINI_API_KEY=your-gemini-api-key
 
-# Option B: Use Vertex AI (no API key needed, uses service account)
-# Set this to enable Vertex AI and allow tool without requiring API keys
-# GEMINI_VERTEX_ENABLED=true
-
 # Vertex AI model for image generation (defaults to gemini-2.5-flash-image)
 # GEMINI_IMAGE_MODEL=gemini-2.5-flash-image
 

--- a/api/app/clients/tools/manifest.json
+++ b/api/app/clients/tools/manifest.json
@@ -162,8 +162,8 @@
     "authConfig": [
       {
         "authField": "GEMINI_API_KEY||GOOGLE_KEY",
-        "label": "Gemini API Key",
-        "description": "Your Google Gemini API Key from <a href='https://aistudio.google.com/app/apikey' target='_blank'>Google AI Studio</a>. Leave blank if using Vertex AI with service account."
+        "label": "Gemini API Key (optional)",
+        "description": "Your Google Gemini API Key from <a href='https://aistudio.google.com/app/apikey' target='_blank'>Google AI Studio</a>. Leave blank to use Vertex AI with a service account (GOOGLE_SERVICE_KEY_FILE or api/data/auth.json)."
       }
     ]
   }

--- a/api/app/clients/tools/manifest.json
+++ b/api/app/clients/tools/manifest.json
@@ -161,9 +161,10 @@
     "icon": "assets/gemini_image_gen.svg",
     "authConfig": [
       {
-        "authField": "GEMINI_API_KEY||GOOGLE_KEY",
+        "authField": "GEMINI_API_KEY||GOOGLE_KEY||GOOGLE_SERVICE_KEY_FILE",
         "label": "Gemini API Key (optional)",
-        "description": "Your Google Gemini API Key from <a href='https://aistudio.google.com/app/apikey' target='_blank'>Google AI Studio</a>. Leave blank to use Vertex AI with a service account (GOOGLE_SERVICE_KEY_FILE or api/data/auth.json)."
+        "description": "Your Google Gemini API Key from <a href='https://aistudio.google.com/app/apikey' target='_blank'>Google AI Studio</a>. Leave blank to use Vertex AI with a service account (GOOGLE_SERVICE_KEY_FILE or api/data/auth.json).",
+        "optional": true
       }
     ]
   }

--- a/api/app/clients/tools/manifest.json
+++ b/api/app/clients/tools/manifest.json
@@ -161,8 +161,8 @@
     "icon": "assets/gemini_image_gen.svg",
     "authConfig": [
       {
-        "authField": "GEMINI_API_KEY||GOOGLE_KEY||GEMINI_VERTEX_ENABLED",
-        "label": "Gemini API Key (Optional if Vertex AI is configured)",
+        "authField": "GEMINI_API_KEY||GOOGLE_KEY",
+        "label": "Gemini API Key",
         "description": "Your Google Gemini API Key from <a href='https://aistudio.google.com/app/apikey' target='_blank'>Google AI Studio</a>. Leave blank if using Vertex AI with service account."
       }
     ]

--- a/api/app/clients/tools/structured/GeminiImageGen.js
+++ b/api/app/clients/tools/structured/GeminiImageGen.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const path = require('path');
 const sharp = require('sharp');
 const { v4 } = require('uuid');
@@ -118,17 +117,11 @@ async function initializeGeminiClient(options = {}) {
     );
   }
 
-  try {
-    await fs.promises.access(credentialsPath);
-    process.env.GOOGLE_APPLICATION_CREDENTIALS = credentialsPath;
-  } catch {
-    // File doesn't exist, skip setting env var
-  }
-
   return new GoogleGenAI({
     vertexai: true,
     project: serviceKey.project_id,
     location: process.env.GOOGLE_LOC || process.env.GOOGLE_CLOUD_LOCATION || 'global',
+    googleAuthOptions: { credentials: serviceKey },
   });
 }
 

--- a/api/app/clients/tools/structured/GeminiImageGen.js
+++ b/api/app/clients/tools/structured/GeminiImageGen.js
@@ -322,20 +322,7 @@ function createGeminiImageTool(fields = {}) {
     throw new Error('This tool is only available for agents.');
   }
 
-  // Skip validation during tool creation - validation happens at runtime in initializeGeminiClient
-  // This allows the tool to be added to agents when using Vertex AI without requiring API keys
-  // The actual credentials check happens when the tool is invoked
-
-  const {
-    req,
-    imageFiles = [],
-    userId,
-    fileStrategy,
-    GEMINI_API_KEY,
-    GOOGLE_KEY,
-    // GEMINI_VERTEX_ENABLED is used for auth validation only (not used in code)
-    // When set as env var, it signals Vertex AI is configured and bypasses API key requirement
-  } = fields;
+  const { req, imageFiles = [], userId, fileStrategy, GEMINI_API_KEY, GOOGLE_KEY } = fields;
 
   const imageOutputType = fields.imageOutputType || EImageOutputType.PNG;
 

--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -207,7 +207,7 @@ const loadTools = async ({
     },
     gemini_image_gen: async (toolContextMap) => {
       const authFields = getAuthFields('gemini_image_gen');
-      const authValues = await loadAuthValues({ userId: user, authFields });
+      const authValues = await loadAuthValues({ userId: user, authFields, throwError: false });
       const imageFiles = options.tool_resources?.[EToolResources.image_edit]?.files ?? [];
       const toolContext = buildImageToolContext({
         imageFiles,
@@ -222,7 +222,6 @@ const loadTools = async ({
         isAgent: !!agent,
         req: options.req,
         imageFiles,
-        processFileURL: options.processFileURL,
         userId: user,
         fileStrategy,
       });

--- a/client/src/components/Plugins/Store/PluginAuthForm.tsx
+++ b/client/src/components/Plugins/Store/PluginAuthForm.tsx
@@ -20,6 +20,7 @@ function PluginAuthForm({ plugin, onSubmit, isEntityTool }: TPluginAuthFormProps
 
   const localize = useLocalize();
   const authConfig = plugin?.authConfig ?? [];
+  const allFieldsOptional = authConfig.length > 0 && authConfig.every((c) => c.optional === true);
 
   return (
     <div className="flex w-full flex-col items-center gap-2">
@@ -38,6 +39,7 @@ function PluginAuthForm({ plugin, onSubmit, isEntityTool }: TPluginAuthFormProps
         >
           {authConfig.map((config: TPluginAuthConfig, i: number) => {
             const authField = config.authField.split('||')[0];
+            const isOptional = config.optional === true;
             return (
               <div key={`${authField}-${i}`} className="flex w-full flex-col gap-1">
                 <label
@@ -55,19 +57,24 @@ function PluginAuthForm({ plugin, onSubmit, isEntityTool }: TPluginAuthFormProps
                       aria-invalid={!!errors[authField]}
                       aria-describedby={`${authField}-error`}
                       aria-label={config.label}
-                      aria-required="true"
+                      aria-required={!isOptional}
                       /* autoFocus is generally disabled due to the fact that it can disorient users,
                        * but in this case, the required field must be navigated to anyways, and the component's functionality
                        * emulates that of a new modal opening, where users would expect focus to be shifted to the new content */
                       // eslint-disable-next-line jsx-a11y/no-autofocus
                       autoFocus={i === 0}
-                      {...register(authField, {
-                        required: `${config.label} is required.`,
-                        minLength: {
-                          value: 1,
-                          message: `${config.label} must be at least 1 character long`,
-                        },
-                      })}
+                      {...register(
+                        authField,
+                        isOptional
+                          ? {}
+                          : {
+                              required: `${config.label} is required.`,
+                              minLength: {
+                                value: 1,
+                                message: `${config.label} must be at least 1 character long`,
+                              },
+                            },
+                      )}
                       className="flex h-10 max-h-10 w-full resize-none rounded-md border border-gray-200 bg-transparent px-3 py-2 text-sm text-gray-700 shadow-[0_0_10px_rgba(0,0,0,0.05)] outline-none placeholder:text-gray-400 focus:border-gray-400 focus:bg-gray-50 focus:outline-none focus:ring-0 focus:ring-gray-400 focus:ring-opacity-0 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-500 dark:bg-gray-700 dark:text-gray-50 dark:shadow-[0_0_15px_rgba(0,0,0,0.10)] dark:focus:border-gray-400 focus:dark:bg-gray-600 dark:focus:outline-none dark:focus:ring-0 dark:focus:ring-gray-400 dark:focus:ring-offset-0"
                     />
                   </HoverCardTrigger>
@@ -82,7 +89,7 @@ function PluginAuthForm({ plugin, onSubmit, isEntityTool }: TPluginAuthFormProps
             );
           })}
           <button
-            disabled={!isDirty || !isValid || isSubmitting}
+            disabled={allFieldsOptional ? isSubmitting : !isDirty || !isValid || isSubmitting}
             type="button"
             className="btn btn-primary relative"
             onClick={() => {

--- a/packages/api/src/tools/format.spec.ts
+++ b/packages/api/src/tools/format.spec.ts
@@ -189,6 +189,77 @@ describe('format.ts helper functions', () => {
       const result = checkPluginAuth(plugin);
       expect(result).toBe(true);
     });
+
+    it('should return true when auth field is marked as optional with no env vars', () => {
+      const plugin: TPlugin = {
+        name: 'Test',
+        pluginKey: 'test',
+        description: 'Test plugin',
+        authConfig: [
+          { authField: 'MISSING_KEY', label: 'API Key', description: 'API Key', optional: true },
+        ],
+      };
+
+      const result = checkPluginAuth(plugin);
+      expect(result).toBe(true);
+    });
+
+    it('should return true when all auth fields are optional', () => {
+      const plugin: TPlugin = {
+        name: 'Test',
+        pluginKey: 'test',
+        description: 'Test plugin',
+        authConfig: [
+          { authField: 'MISSING_KEY_A', label: 'Key A', description: 'Key A', optional: true },
+          { authField: 'MISSING_KEY_B', label: 'Key B', description: 'Key B', optional: true },
+        ],
+      };
+
+      const result = checkPluginAuth(plugin);
+      expect(result).toBe(true);
+    });
+
+    it('should return false when required field is missing even if optional field exists', () => {
+      const plugin: TPlugin = {
+        name: 'Test',
+        pluginKey: 'test',
+        description: 'Test plugin',
+        authConfig: [
+          { authField: 'MISSING_KEY', label: 'Required Key', description: 'Required' },
+          {
+            authField: 'OPTIONAL_KEY',
+            label: 'Optional Key',
+            description: 'Optional',
+            optional: true,
+          },
+        ],
+      };
+
+      const result = checkPluginAuth(plugin);
+      expect(result).toBe(false);
+    });
+
+    it('should return true when optional field has no env var but required field is satisfied', () => {
+      process.env.REQUIRED_KEY = 'valid-key';
+
+      const plugin: TPlugin = {
+        name: 'Test',
+        pluginKey: 'test',
+        description: 'Test plugin',
+        authConfig: [
+          { authField: 'REQUIRED_KEY', label: 'Required Key', description: 'Required' },
+          {
+            authField: 'OPTIONAL_KEY',
+            label: 'Optional Key',
+            description: 'Optional',
+            optional: true,
+          },
+        ],
+      };
+
+      const result = checkPluginAuth(plugin);
+      expect(result).toBe(true);
+    });
   });
 
   describe('getToolkitKey', () => {

--- a/packages/api/src/tools/format.ts
+++ b/packages/api/src/tools/format.ts
@@ -31,6 +31,10 @@ export const checkPluginAuth = (plugin?: TPlugin): boolean => {
   }
 
   return plugin.authConfig.every((authFieldObj) => {
+    if (authFieldObj.optional === true) {
+      return true;
+    }
+
     const authFieldOptions = authFieldObj.authField.split('||');
     let isFieldAuthenticated = false;
 

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -544,6 +544,7 @@ export const tPluginAuthConfigSchema = z.object({
   authField: z.string(),
   label: z.string(),
   description: z.string(),
+  optional: z.boolean().optional(),
 });
 
 export type TPluginAuthConfig = z.infer<typeof tPluginAuthConfigSchema>;


### PR DESCRIPTION
Closes #11909
Closes #11915 

## Summary

Fixes two bugs affecting the Gemini image generation tool: Vertex AI service account users being blocked from adding the tool to agents, and image generation crashing when S3 `fileStrategy` is configured.

- Replaced the previous `GEMINI_VERTEX_ENABLED` flag requirement with implicit Vertex AI fallback — if no `GEMINI_API_KEY` or `GOOGLE_KEY` is found, the tool now automatically falls back to a service account at the configured path, removing the need for an explicit opt-in env var.
- Passed `googleAuthOptions: { credentials: serviceKey }` directly to the `GoogleGenAI` constructor for Vertex AI, eliminating the previous `process.env.GOOGLE_APPLICATION_CREDENTIALS` mutation which was a global side effect.
- Added `throwError: false` to `loadAuthValues` in the `gemini_image_gen` tool loader so that missing API key credentials no longer throw before the tool's own auth fallback logic can execute.
- Removed `GEMINI_VERTEX_ENABLED` from `manifest.json` `authField` and from `.env.example`, simplifying the auth config to `GEMINI_API_KEY||GOOGLE_KEY` only.
- Removed the local filesystem and cloud storage dispatch logic (`saveImageLocally`, `saveToCloudStorage`) entirely, returning data URLs directly — consistent with the agent-only image tool pattern used elsewhere and eliminating the root cause of the S3 `data:` URI protocol crash.
- Removed `processFileURL` from the tool initialization call in `handleTools.js` as it is no longer consumed.
- Added abort signal forwarding via `config.abortSignal = runnableConfig.signal` to support cancellable image generation requests.
- Simplified `replaceUnwantedChars` to match the implementation in `OpenAIImageTools.js`, replacing the overly aggressive character-stripping regex with newline normalization and quote removal.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

To reproduce and verify both fixes, the following configurations should be tested:

### **Test Configuration**:

**Fix for #11909 — Vertex AI service account auth:**
1. Configure LibreChat with no `GEMINI_API_KEY` or `GOOGLE_KEY` set, and a valid service account JSON at `api/data/auth.json` (or `GOOGLE_SERVICE_KEY_FILE`).
2. Navigate to Agent Settings → Add Tool → Gemini Image Tools.
3. Confirm the tool can be saved without entering an API key and that image generation succeeds.

**Fix for #11915 — S3 file strategy crash:**
1. Configure LibreChat with `fileStrategy: "s3"` and valid S3 credentials.
2. Add the Gemini Image Gen tool to an agent and prompt it to generate an image.
3. Confirm no `Only HTTP(S) protocols are supported` error is thrown and the image is returned successfully as a data URL in the conversation.

**Regression — API key auth:**
1. Configure `GEMINI_API_KEY` or `GOOGLE_KEY` and confirm image generation continues to work as expected.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings