### PR TITLE
♿ a11y: Hide Collapsed Thinking Content From Screen Readers

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
@@ -111,6 +111,7 @@ const Reasoning = memo(({ reasoning, isLast }: ReasoningProps) => {
         <div
           id={contentId}
           role="region"
+          aria-label={label}
           aria-hidden={!isExpanded}
           className={cn(
             'grid transition-all duration-300 ease-out',

--- a/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo, useState, useCallback, useRef } from 'react';
+import { memo, useMemo, useState, useCallback, useRef, useId } from 'react';
 import { useAtom } from 'jotai';
 import type { MouseEvent, FocusEvent } from 'react';
 import { ContentTypes } from 'librechat-data-provider';
@@ -36,6 +36,7 @@ type ReasoningProps = {
  * For legacy text-based messages, see Thinking.tsx component.
  */
 const Reasoning = memo(({ reasoning, isLast }: ReasoningProps) => {
+  const contentId = useId();
   const localize = useLocalize();
   const [showThinking] = useAtom(showThinkingAtom);
   const [isExpanded, setIsExpanded] = useState(showThinking);
@@ -104,9 +105,13 @@ const Reasoning = memo(({ reasoning, isLast }: ReasoningProps) => {
             onClick={handleClick}
             label={label}
             content={reasoningText}
+            contentId={contentId}
           />
         </div>
         <div
+          id={contentId}
+          role="region"
+          aria-hidden={!isExpanded}
           className={cn(
             'grid transition-all duration-300 ease-out',
             nextType !== ContentTypes.THINK && isExpanded && 'mb-4',

--- a/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Reasoning.tsx
@@ -110,9 +110,9 @@ const Reasoning = memo(({ reasoning, isLast }: ReasoningProps) => {
         </div>
         <div
           id={contentId}
-          role="region"
+          role="group"
           aria-label={label}
-          aria-hidden={!isExpanded}
+          aria-hidden={!isExpanded || undefined}
           className={cn(
             'grid transition-all duration-300 ease-out',
             nextType !== ContentTypes.THINK && isExpanded && 'mb-4',
@@ -128,6 +128,7 @@ const Reasoning = memo(({ reasoning, isLast }: ReasoningProps) => {
               isExpanded={isExpanded}
               onClick={handleClick}
               content={reasoningText}
+              contentId={contentId}
             />
           </div>
         </div>

--- a/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, memo, useCallback, useRef, type MouseEvent } from 'react';
+import { useState, useMemo, memo, useCallback, useRef, useId, type MouseEvent } from 'react';
 import { useAtomValue } from 'jotai';
 import { Clipboard, CheckMark, TooltipAnchor } from '@librechat/client';
 import { Lightbulb, ChevronDown, ChevronUp } from 'lucide-react';
@@ -35,12 +35,14 @@ export const ThinkingButton = memo(
     onClick,
     label,
     content,
+    contentId,
     showCopyButton = true,
   }: {
     isExpanded: boolean;
     onClick: (e: MouseEvent<HTMLButtonElement>) => void;
     label: string;
     content?: string;
+    contentId?: string;
     showCopyButton?: boolean;
   }) => {
     const localize = useLocalize();
@@ -66,6 +68,7 @@ export const ThinkingButton = memo(
           type="button"
           onClick={onClick}
           aria-expanded={isExpanded}
+          aria-controls={contentId}
           className={cn(
             'group/button flex flex-1 items-center justify-start rounded-lg leading-[18px]',
             fontSize,
@@ -240,6 +243,7 @@ const Thinking: React.ElementType = memo(({ children }: { children: React.ReactN
   const [isExpanded, setIsExpanded] = useState(showThinking);
   const [isBarVisible, setIsBarVisible] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const contentId = useId();
 
   const handleClick = useCallback((e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
@@ -295,9 +299,13 @@ const Thinking: React.ElementType = memo(({ children }: { children: React.ReactN
           onClick={handleClick}
           label={label}
           content={textContent}
+          contentId={contentId}
         />
       </div>
       <div
+        id={contentId}
+        role="region"
+        aria-hidden={!isExpanded}
         className={cn('grid transition-all duration-300 ease-out', isExpanded && 'mb-8')}
         style={{
           gridTemplateRows: isExpanded ? '1fr' : '0fr',

--- a/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
@@ -305,6 +305,7 @@ const Thinking: React.ElementType = memo(({ children }: { children: React.ReactN
       <div
         id={contentId}
         role="region"
+        aria-label={label}
         aria-hidden={!isExpanded}
         className={cn('grid transition-all duration-300 ease-out', isExpanded && 'mb-8')}
         style={{
@@ -330,4 +331,4 @@ ThinkingContent.displayName = 'ThinkingContent';
 FloatingThinkingBar.displayName = 'FloatingThinkingBar';
 Thinking.displayName = 'Thinking';
 
-export default memo(Thinking);
+export default Thinking;

--- a/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Thinking.tsx
@@ -42,7 +42,7 @@ export const ThinkingButton = memo(
     onClick: (e: MouseEvent<HTMLButtonElement>) => void;
     label: string;
     content?: string;
-    contentId?: string;
+    contentId: string;
     showCopyButton?: boolean;
   }) => {
     const localize = useLocalize();
@@ -135,11 +135,13 @@ export const FloatingThinkingBar = memo(
     isExpanded,
     onClick,
     content,
+    contentId,
   }: {
     isVisible: boolean;
     isExpanded: boolean;
     onClick: (e: MouseEvent<HTMLButtonElement>) => void;
     content?: string;
+    contentId: string;
   }) => {
     const localize = useLocalize();
     const [isCopied, setIsCopied] = useState(false);
@@ -179,6 +181,8 @@ export const FloatingThinkingBar = memo(
               tabIndex={isVisible ? 0 : -1}
               onClick={onClick}
               aria-label={collapseTooltip}
+              aria-expanded={isExpanded}
+              aria-controls={contentId}
               className={cn(
                 'flex items-center justify-center rounded-lg bg-surface-secondary p-1.5 text-text-secondary-alt shadow-sm',
                 'hover:bg-surface-hover hover:text-text-primary',
@@ -304,9 +308,9 @@ const Thinking: React.ElementType = memo(({ children }: { children: React.ReactN
       </div>
       <div
         id={contentId}
-        role="region"
+        role="group"
         aria-label={label}
-        aria-hidden={!isExpanded}
+        aria-hidden={!isExpanded || undefined}
         className={cn('grid transition-all duration-300 ease-out', isExpanded && 'mb-8')}
         style={{
           gridTemplateRows: isExpanded ? '1fr' : '0fr',
@@ -319,6 +323,7 @@ const Thinking: React.ElementType = memo(({ children }: { children: React.ReactN
             isExpanded={isExpanded}
             onClick={handleClick}
             content={textContent}
+            contentId={contentId}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

Closes #8097

I fixed the thinking/reasoning toggle so that collapsed content is fully hidden from screen readers, not just visually collapsed. The CSS grid animation (`gridTemplateRows: 0fr` + `overflow-hidden`) kept content in the DOM and readable by assistive technology, cluttering the reading flow.

- Add `aria-hidden={!isExpanded || undefined}` to the collapsible content region in both the legacy `Thinking` component and the modern `Reasoning` component, so screen readers skip collapsed thoughts entirely.
- Add `role="group"` and a unique `id` (via `useId`) to each collapsible content div, giving it a semantic grouping for assistive technology without polluting landmark navigation.
- Add `aria-label` to each content group so screen readers can announce the region's purpose.
- Add required `contentId` prop to `ThinkingButton` and wire it to `aria-controls` on the toggle button, establishing an explicit relationship between the button and the region it expands/collapses.
- Add `contentId`, `aria-expanded`, and `aria-controls` to `FloatingThinkingBar`'s collapse button, ensuring both toggle entry points are fully accessible.
- Remove redundant double `memo()` wrapping on the `Thinking` default export, since the component is already defined with `memo()`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verify with a screen reader (VoiceOver/NVDA) that collapsed thinking blocks are not announced when navigating through a conversation.
- Expand a thinking block and confirm the screen reader announces the content region.
- Confirm the toggle button announces "expanded"/"collapsed" state via `aria-expanded`.
- Tab to the `FloatingThinkingBar` collapse button inside an expanded block and verify it also announces expanded state and its controlled region.
- Test with multiple consecutive thinking blocks in a single conversation to verify each has a distinct `id` and no `aria-controls` collisions.
- Confirm no visual regressions in the expand/collapse animation for both `Thinking` (legacy) and `Reasoning` (modern) components.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes