### PR TITLE
⏱️ fix: Separate MCP GET SSE Stream Timeout from POST and Suppress SDK-Internal Recovery Errors

### DIFF
--- a/packages/api/src/mcp/__tests__/MCPConnectionAgentLifecycle.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionAgentLifecycle.test.ts
@@ -316,10 +316,11 @@ describe('MCPConnection Agent lifecycle – streamable-http', () => {
 
     const optionsSym = Object.getOwnPropertySymbols(agents[0]).find(
       (s) => s.toString() === 'Symbol(options)',
-    ) as symbol;
+    );
+    expect(optionsSym).toBeDefined();
 
     const bodyTimeouts = agents.map(
-      (a) => (a as unknown as Record<symbol, { bodyTimeout: number }>)[optionsSym].bodyTimeout,
+      (a) => (a as unknown as Record<symbol, { bodyTimeout: number }>)[optionsSym!].bodyTimeout,
     );
 
     const hasShortTimeout = bodyTimeouts.some((t) => t <= 120_000);
@@ -342,10 +343,11 @@ describe('MCPConnection Agent lifecycle – streamable-http', () => {
     const agents = (conn as unknown as { agents: Agent[] }).agents;
     const optionsSym = Object.getOwnPropertySymbols(agents[0]).find(
       (s) => s.toString() === 'Symbol(options)',
-    ) as symbol;
+    );
+    expect(optionsSym).toBeDefined();
 
     const bodyTimeouts = agents.map(
-      (a) => (a as unknown as Record<symbol, { bodyTimeout: number }>)[optionsSym].bodyTimeout,
+      (a) => (a as unknown as Record<symbol, { bodyTimeout: number }>)[optionsSym!].bodyTimeout,
     );
 
     expect(bodyTimeouts).toContain(customTimeout);

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -71,6 +71,8 @@ const FIVE_MINUTES = 5 * 60 * 1000;
 const DEFAULT_TIMEOUT = 60000;
 /** SSE connections through proxies may need longer initial handshake time */
 const SSE_CONNECT_TIMEOUT = 120000;
+/** Default body timeout for Streamable HTTP GET SSE streams that idle between server pushes */
+const DEFAULT_SSE_READ_TIMEOUT = 5 * 60 * 1000;
 
 /**
  * Headers for SSE connections.
@@ -254,6 +256,7 @@ export class MCPConnection extends EventEmitter {
   private readonly useSSRFProtection: boolean;
   iconPath?: string;
   timeout?: number;
+  sseReadTimeout?: number;
   url?: string;
 
   /**
@@ -285,6 +288,7 @@ export class MCPConnection extends EventEmitter {
     this.useSSRFProtection = params.useSSRFProtection === true;
     this.iconPath = params.serverConfig.iconPath;
     this.timeout = params.serverConfig.timeout;
+    this.sseReadTimeout = params.serverConfig.sseReadTimeout;
     this.lastPingTime = Date.now();
     this.createdAt = Date.now(); // Record creation timestamp for staleness detection
     if (params.oauthTokens) {
@@ -313,30 +317,45 @@ export class MCPConnection extends EventEmitter {
    * Factory function to create fetch functions without capturing the entire `this` context.
    * This helps prevent memory leaks by only passing necessary dependencies.
    *
-   * @param getHeaders Function to retrieve request headers
-   * @param timeout Timeout value for the agent (in milliseconds)
-   * @returns A fetch function that merges headers appropriately
+   * When `sseBodyTimeout` is provided, a second Agent is created with a much longer
+   * body timeout for GET requests (the Streamable HTTP SSE stream). POST requests
+   * continue using the normal timeout so they fail fast on real errors.
    */
   private createFetchFunction(
     getHeaders: () => Record<string, string> | null | undefined,
     timeout?: number,
+    sseBodyTimeout?: number,
   ): (input: UndiciRequestInfo, init?: UndiciRequestInit) => Promise<UndiciResponse> {
     const ssrfConnect = this.useSSRFProtection ? createSSRFSafeUndiciConnect() : undefined;
+    const connectOpts = ssrfConnect != null ? { connect: ssrfConnect } : {};
     const effectiveTimeout = timeout || DEFAULT_TIMEOUT;
-    const agent = new Agent({
+    const postAgent = new Agent({
       bodyTimeout: effectiveTimeout,
       headersTimeout: effectiveTimeout,
-      ...(ssrfConnect != null ? { connect: ssrfConnect } : {}),
+      ...connectOpts,
     });
-    this.agents.push(agent);
+    this.agents.push(postAgent);
+
+    let getAgent: Agent | undefined;
+    if (sseBodyTimeout != null) {
+      getAgent = new Agent({
+        bodyTimeout: sseBodyTimeout,
+        headersTimeout: effectiveTimeout,
+        ...connectOpts,
+      });
+      this.agents.push(getAgent);
+    }
 
     return function customFetch(
       input: UndiciRequestInfo,
       init?: UndiciRequestInit,
     ): Promise<UndiciResponse> {
+      const isGet = init?.method === 'GET';
+      const dispatcher = isGet && getAgent ? getAgent : postAgent;
+
       const requestHeaders = getHeaders();
       if (!requestHeaders) {
-        return undiciFetch(input, { ...init, dispatcher: agent });
+        return undiciFetch(input, { ...init, dispatcher });
       }
 
       let initHeaders: Record<string, string> = {};
@@ -356,7 +375,7 @@ export class MCPConnection extends EventEmitter {
           ...initHeaders,
           ...requestHeaders,
         },
-        dispatcher: agent,
+        dispatcher,
       });
     };
   }
@@ -507,6 +526,7 @@ export class MCPConnection extends EventEmitter {
             fetch: this.createFetchFunction(
               this.getRequestHeaders.bind(this),
               this.timeout,
+              this.sseReadTimeout || DEFAULT_SSE_READ_TIMEOUT,
             ) as unknown as FetchLike,
           });
 
@@ -829,7 +849,26 @@ export class MCPConnection extends EventEmitter {
 
   private setupTransportErrorHandlers(transport: Transport): void {
     transport.onerror = (error) => {
-      // Extract meaningful error information (handles "SSE error: undefined" cases)
+      const rawMessage =
+        error && typeof error === 'object' ? ((error as { message?: string }).message ?? '') : '';
+
+      /**
+       * The MCP SDK's StreamableHTTPClientTransport fires onerror for SSE GET stream
+       * disconnects but also handles reconnection internally via _scheduleReconnection.
+       * Escalating these to a full transport rebuild creates a redundant reconnection
+       * loop. Log at debug level and let the SDK recover the GET stream on its own.
+       *
+       * "Maximum reconnection attempts … exceeded" means the SDK gave up — that one
+       * must fall through so our higher-level reconnection takes over.
+       */
+      if (
+        rawMessage.startsWith('SSE stream disconnected') ||
+        rawMessage.startsWith('Failed to reconnect SSE stream')
+      ) {
+        logger.debug(`${this.getLogPrefix()} SDK SSE stream recovery in progress: ${rawMessage}`);
+        return;
+      }
+
       const {
         message: errorMessage,
         code: errorCode,

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -19,7 +19,7 @@ const BaseOptionsSchema = z.object({
   startup: z.boolean().optional(),
   iconPath: z.string().optional(),
   timeout: z.number().optional(),
-  /** Timeout (ms) for the long-lived SSE GET stream body before undici aborts it. Default: 300 000 (5 min). */
+  /** Timeout (ms) for the long-lived SSE GET stream body before undici aborts it. Default: 300_000 (5 min). */
   sseReadTimeout: z.number().positive().optional(),
   initTimeout: z.number().optional(),
   /** Controls visibility in chat dropdown menu (MCPSelect) */

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -20,7 +20,7 @@ const BaseOptionsSchema = z.object({
   iconPath: z.string().optional(),
   timeout: z.number().optional(),
   /** Timeout (ms) for the long-lived SSE GET stream body before undici aborts it. Default: 300 000 (5 min). */
-  sseReadTimeout: z.number().optional(),
+  sseReadTimeout: z.number().positive().optional(),
   initTimeout: z.number().optional(),
   /** Controls visibility in chat dropdown menu (MCPSelect) */
   chatMenu: z.boolean().optional(),

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -19,6 +19,8 @@ const BaseOptionsSchema = z.object({
   startup: z.boolean().optional(),
   iconPath: z.string().optional(),
   timeout: z.number().optional(),
+  /** Timeout (ms) for the long-lived SSE GET stream body before undici aborts it. Default: 300 000 (5 min). */
+  sseReadTimeout: z.number().optional(),
   initTimeout: z.number().optional(),
   /** Controls visibility in chat dropdown menu (MCPSelect) */
   chatMenu: z.boolean().optional(),
@@ -212,6 +214,7 @@ const omitServerManagedFields = <T extends z.ZodObject<z.ZodRawShape>>(schema: T
   schema.omit({
     startup: true,
     timeout: true,
+    sseReadTimeout: true,
     initTimeout: true,
     chatMenu: true,
     serverInstructions: true,


### PR DESCRIPTION

## Summary

I fixed the reconnect-loop log flood (Discussion #11230, PR #11874) where idle Streamable HTTP SSE GET streams were aborting after `bodyTimeout` and escalating through `setupTransportErrorHandlers` into full transport rebuilds — even though the MCP SDK handles GET stream reconnection internally. I also added a configurable per-server `sseReadTimeout` option, matching the pattern established by the [Python MCP SDK's `MCP_DEFAULT_SSE_READ_TIMEOUT`](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/shared/_httpx_utils.py).

- Split `createFetchFunction` into two Agents: `postAgent` with the normal request timeout and `getAgent` with a longer body timeout for the idle SSE GET stream, routing by HTTP method inside the fetch closure.
- Default `sseReadTimeout` to 5 minutes (300s), matching the Python MCP SDK convention, instead of a blanket 24h timeout that would hold resources open for idle users in a multi-user deployment.
- Add `sseReadTimeout` as an optional field in `BaseOptionsSchema` (data-provider), allowing admins to tune the GET SSE body timeout per server in `librechat.yaml`.
- Suppress `"SSE stream disconnected"` and `"Failed to reconnect SSE stream"` errors in `setupTransportErrorHandlers` — these are SDK-internal recovery events where `StreamableHTTPClientTransport._scheduleReconnection` handles the GET stream autonomously. Log at debug level instead of escalating to `emit('connectionChange', 'error')`.
- Preserve escalation for `"Maximum reconnection attempts exceeded"` (SDK gave up) and all non-SSE-stream errors (POST failures, 404s, etc.), ensuring real transport failures still trigger full reconnection.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
[x] My code adheres to this project's style guidelines
[x] I have performed a self-review of my own code
[x] My changes do not introduce new warnings
[x] I have written tests demonstrating that my changes are effective or that my feature works
[x] Local unit tests pass with my changes
[x] Any changes dependent on mine have been merged and published in downstream modules.