### PR TITLE
📌 fix: Populate userMessage.files Before First DB Save

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -670,11 +670,7 @@ class BaseClient {
       this.handleTokenCountMap(tokenCountMap);
     }
 
-    if (
-      !isEdited &&
-      this.options.req?.body?.files &&
-      Array.isArray(this.options.attachments)
-    ) {
+    if (!isEdited && this.options.req?.body?.files && Array.isArray(this.options.attachments)) {
       const requestFileIds = new Set(this.options.req.body.files.map((f) => f.file_id));
       userMessage.files = [];
       for (const attachment of this.options.attachments) {

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -8,6 +8,7 @@ const {
   encodeAndFormatAudios,
   encodeAndFormatVideos,
   encodeAndFormatDocuments,
+  sanitizeFileForTransmit,
 } = require('@librechat/api');
 const {
   Constants,
@@ -667,6 +668,24 @@ class BaseClient {
       }
 
       this.handleTokenCountMap(tokenCountMap);
+    }
+
+    if (
+      !isEdited &&
+      this.options.req?.body?.files &&
+      Array.isArray(this.options.attachments)
+    ) {
+      const requestFileIds = new Set(this.options.req.body.files.map((f) => f.file_id));
+      userMessage.files = [];
+      for (const attachment of this.options.attachments) {
+        if (requestFileIds.has(attachment.file_id)) {
+          userMessage.files.push(sanitizeFileForTransmit(attachment));
+        }
+      }
+      if (userMessage.files.length === 0) {
+        delete userMessage.files;
+      }
+      delete userMessage.image_urls;
     }
 
     if (!isEdited && !this.skipSaveUserMessage) {

--- a/api/strategies/openIdJwtStrategy.js
+++ b/api/strategies/openIdJwtStrategy.js
@@ -4,8 +4,8 @@ const { logger } = require('@librechat/data-schemas');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const { SystemRoles } = require('librechat-data-provider');
 const { isEnabled, findOpenIDUser, math } = require('@librechat/api');
-const { getOpenIdEmail } = require('./openidStrategy');
 const { Strategy: JwtStrategy, ExtractJwt } = require('passport-jwt');
+const { getOpenIdEmail } = require('./openidStrategy');
 const { updateUser, findUser } = require('~/models');
 
 /**


### PR DESCRIPTION
## Summary

Currently, `userMessage.files` is only populated **after** the AI response completes. This means any external system or script querying `messages.files` from MongoDB cannot see file metadata until the full response cycle finishes.

This PR moves the `files` assignment to happen **before** the first `saveMessageToDatabase()` call in `BaseClient.sendMessage()`. At this point, `this.options.attachments` is already a resolved array (after `buildMessages()`), so it's safe to use.

The existing post-response file assignment in `request.js` remains untouched — it harmlessly overwrites with the same data.

**Changes:**
- Import `sanitizeFileForTransmit` from `@librechat/api`
- After `buildMessages()` resolves but before the first DB save, populate `userMessage.files` from the resolved attachments filtered by `req.body.files`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Upload a file to a conversation
2. Before the AI response completes, query MongoDB:
```js
db.messages.find({
  conversationId: "<id>",
  files: { $exists: true, $ne: [] }
})
```
3. **Before this fix:** empty result until AI response finishes
4. **After this fix:** `messages.files` is populated as soon as the user message is saved (before AI generation starts)

### **Test Configuration**:
- LibreChat with MongoDB
- Any endpoint (agents, assistants, OpenAI, etc.)
- File upload via chat UI

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
