### PR TITLE
👥 fix: Duplicate Indicators for Model Specs

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
@@ -140,6 +140,7 @@ function EndpointMenuContent({
             endpoint.models || [],
             selectedModel,
             selectedEndpoint,
+            selectedSpec,
             filteredModels,
             endpointIndex,
           )
@@ -149,6 +150,7 @@ function EndpointMenuContent({
             endpoint.models,
             selectedModel,
             selectedEndpoint,
+            selectedSpec,
             undefined,
             endpointIndex,
           )}
@@ -166,7 +168,7 @@ export function EndpointItem({ endpoint, endpointIndex }: EndpointItemProps) {
     setEndpointSearchValue,
     endpointRequiresUserKey,
   } = useModelSelectorContext();
-  const { endpoint: selectedEndpoint } = selectedValues;
+  const { endpoint: selectedEndpoint, modelSpec: selectedSpec } = selectedValues;
 
   const searchValue = endpointSearchValues[endpoint.value] || '';
   const isUserProvided = useMemo(
@@ -188,7 +190,7 @@ export function EndpointItem({ endpoint, endpointIndex }: EndpointItemProps) {
     </div>
   );
 
-  const isEndpointSelected = selectedEndpoint === endpoint.value;
+  const isEndpointSelected = !selectedSpec && selectedEndpoint === endpoint.value;
 
   if (endpoint.hasModels) {
     const placeholder =

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
@@ -96,7 +96,8 @@ function EndpointMenuContent({
   const localize = useLocalize();
   const { agentsMap, assistantsMap, modelSpecs, selectedValues, endpointSearchValues } =
     useModelSelectorContext();
-  const { model: selectedModel, modelSpec: selectedSpec } = selectedValues;
+  const { endpoint: selectedEndpoint, model: selectedModel, modelSpec: selectedSpec } =
+    selectedValues;
   const searchValue = endpointSearchValues[endpoint.value] || '';
 
   const endpointSpecs = useMemo(() => {
@@ -138,11 +139,19 @@ function EndpointMenuContent({
             endpoint,
             endpoint.models || [],
             selectedModel,
+            selectedEndpoint,
             filteredModels,
             endpointIndex,
           )
         : endpoint.models &&
-          renderEndpointModels(endpoint, endpoint.models, selectedModel, undefined, endpointIndex)}
+          renderEndpointModels(
+            endpoint,
+            endpoint.models,
+            selectedModel,
+            selectedEndpoint,
+            undefined,
+            endpointIndex,
+          )}
     </>
   );
 }

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
@@ -96,8 +96,11 @@ function EndpointMenuContent({
   const localize = useLocalize();
   const { agentsMap, assistantsMap, modelSpecs, selectedValues, endpointSearchValues } =
     useModelSelectorContext();
-  const { endpoint: selectedEndpoint, model: selectedModel, modelSpec: selectedSpec } =
-    selectedValues;
+  const {
+    endpoint: selectedEndpoint,
+    model: selectedModel,
+    modelSpec: selectedSpec,
+  } = selectedValues;
   const searchValue = endpointSearchValues[endpoint.value] || '';
 
   const endpointSpecs = useMemo(() => {

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointItem.tsx
@@ -96,11 +96,7 @@ function EndpointMenuContent({
   const localize = useLocalize();
   const { agentsMap, assistantsMap, modelSpecs, selectedValues, endpointSearchValues } =
     useModelSelectorContext();
-  const {
-    endpoint: selectedEndpoint,
-    model: selectedModel,
-    modelSpec: selectedSpec,
-  } = selectedValues;
+  const { modelSpec: selectedSpec } = selectedValues;
   const searchValue = endpointSearchValues[endpoint.value] || '';
 
   const endpointSpecs = useMemo(() => {
@@ -138,25 +134,9 @@ function EndpointMenuContent({
         <ModelSpecItem key={spec.name} spec={spec} isSelected={selectedSpec === spec.name} />
       ))}
       {filteredModels
-        ? renderEndpointModels(
-            endpoint,
-            endpoint.models || [],
-            selectedModel,
-            selectedEndpoint,
-            selectedSpec,
-            filteredModels,
-            endpointIndex,
-          )
+        ? renderEndpointModels(endpoint, endpoint.models || [], filteredModels, endpointIndex)
         : endpoint.models &&
-          renderEndpointModels(
-            endpoint,
-            endpoint.models,
-            selectedModel,
-            selectedEndpoint,
-            selectedSpec,
-            undefined,
-            endpointIndex,
-          )}
+          renderEndpointModels(endpoint, endpoint.models, undefined, endpointIndex)}
     </>
   );
 }

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
@@ -11,12 +11,18 @@ import { cn } from '~/utils';
 interface EndpointModelItemProps {
   modelId: string | null;
   endpoint: Endpoint;
-  isSelected: boolean;
 }
 
-export function EndpointModelItem({ modelId, endpoint, isSelected }: EndpointModelItemProps) {
+export function EndpointModelItem({ modelId, endpoint }: EndpointModelItemProps) {
   const localize = useLocalize();
-  const { handleSelectModel } = useModelSelectorContext();
+  const { handleSelectModel, selectedValues } = useModelSelectorContext();
+  const {
+    endpoint: selectedEndpoint,
+    model: selectedModel,
+    modelSpec: selectedSpec,
+  } = selectedValues;
+  const isSelected =
+    !selectedSpec && selectedEndpoint === endpoint.value && selectedModel === modelId;
   const { isFavoriteModel, toggleFavoriteModel, isFavoriteAgent, toggleFavoriteAgent } =
     useFavorites();
 
@@ -147,9 +153,6 @@ export function EndpointModelItem({ modelId, endpoint, isSelected }: EndpointMod
 export function renderEndpointModels(
   endpoint: Endpoint | null,
   models: Array<{ name: string; isGlobal?: boolean }>,
-  selectedModel: string | null,
-  selectedEndpoint: string | null,
-  selectedSpec: string | null,
   filteredModels?: string[],
   endpointIndex?: number,
 ) {
@@ -163,9 +166,6 @@ export function renderEndpointModels(
           key={`${endpoint.value}${indexSuffix}-${modelId}-${modelIndex}`}
           modelId={modelId}
           endpoint={endpoint}
-          isSelected={
-            !selectedSpec && selectedEndpoint === endpoint.value && selectedModel === modelId
-          }
         />
       ),
   );

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
@@ -149,6 +149,7 @@ export function renderEndpointModels(
   models: Array<{ name: string; isGlobal?: boolean }>,
   selectedModel: string | null,
   selectedEndpoint: string | null,
+  selectedSpec: string | null,
   filteredModels?: string[],
   endpointIndex?: number,
 ) {
@@ -162,7 +163,9 @@ export function renderEndpointModels(
           key={`${endpoint.value}${indexSuffix}-${modelId}-${modelIndex}`}
           modelId={modelId}
           endpoint={endpoint}
-          isSelected={selectedEndpoint === endpoint.value && selectedModel === modelId}
+          isSelected={
+            !selectedSpec && selectedEndpoint === endpoint.value && selectedModel === modelId
+          }
         />
       ),
   );

--- a/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/EndpointModelItem.tsx
@@ -148,6 +148,7 @@ export function renderEndpointModels(
   endpoint: Endpoint | null,
   models: Array<{ name: string; isGlobal?: boolean }>,
   selectedModel: string | null,
+  selectedEndpoint: string | null,
   filteredModels?: string[],
   endpointIndex?: number,
 ) {
@@ -161,7 +162,7 @@ export function renderEndpointModels(
           key={`${endpoint.value}${indexSuffix}-${modelId}-${modelIndex}`}
           modelId={modelId}
           endpoint={endpoint}
-          isSelected={selectedModel === modelId}
+          isSelected={selectedEndpoint === endpoint.value && selectedModel === modelId}
         />
       ),
   );

--- a/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/SearchResults.tsx
@@ -160,7 +160,9 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
                   }
 
                   const isModelSelected =
-                    selectedEndpoint === endpoint.value && selectedModel === modelId;
+                    !selectedSpec &&
+                    selectedEndpoint === endpoint.value &&
+                    selectedModel === modelId;
                   return (
                     <MenuItem
                       key={`${endpoint.value}-${modelId}-search-${i}`}
@@ -199,7 +201,7 @@ export function SearchResults({ results, localize, searchValue }: SearchResultsP
             );
           } else {
             // Endpoints with no models
-            const isEndpointSelected = selectedEndpoint === endpoint.value;
+            const isEndpointSelected = !selectedSpec && selectedEndpoint === endpoint.value;
             return (
               <MenuItem
                 key={`endpoint-${endpoint.value}-search-item`}

--- a/client/src/components/Chat/Menus/Endpoints/components/__tests__/EndpointModelItem.test.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/__tests__/EndpointModelItem.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import type { Endpoint, SelectedValues } from '~/common';
+import { EndpointModelItem } from '../EndpointModelItem';
+
+const mockHandleSelectModel = jest.fn();
+let mockSelectedValues: SelectedValues;
+
+jest.mock('~/components/Chat/Menus/Endpoints/ModelSelectorContext', () => ({
+  useModelSelectorContext: () => ({
+    handleSelectModel: mockHandleSelectModel,
+    selectedValues: mockSelectedValues,
+  }),
+}));
+
+jest.mock('~/components/Chat/Menus/Endpoints/CustomMenu', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return {
+    CustomMenuItem: React.forwardRef(function MockMenuItem(
+      { children, ...rest }: { children?: React.ReactNode },
+      ref: React.Ref<HTMLDivElement>,
+    ) {
+      return React.createElement('div', { ref, role: 'menuitem', ...rest }, children);
+    }),
+  };
+});
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+  useFavorites: () => ({
+    isFavoriteModel: () => false,
+    toggleFavoriteModel: jest.fn(),
+    isFavoriteAgent: () => false,
+    toggleFavoriteAgent: jest.fn(),
+  }),
+}));
+
+const baseEndpoint: Endpoint = {
+  value: 'anthropic',
+  label: 'Anthropic',
+  hasModels: true,
+  models: [{ name: 'claude-opus-4-6' }],
+  icon: null,
+};
+
+describe('EndpointModelItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders checkmark when model and endpoint match with no active spec', () => {
+    mockSelectedValues = { endpoint: 'anthropic', model: 'claude-opus-4-6', modelSpec: null };
+    render(<EndpointModelItem modelId="claude-opus-4-6" endpoint={baseEndpoint} />);
+
+    const menuItem = screen.getByRole('menuitem');
+    expect(menuItem).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('does NOT render checkmark when a model spec is active even if endpoint and model match', () => {
+    mockSelectedValues = {
+      endpoint: 'anthropic',
+      model: 'claude-opus-4-6',
+      modelSpec: 'my-anthropic-spec',
+    };
+    render(<EndpointModelItem modelId="claude-opus-4-6" endpoint={baseEndpoint} />);
+
+    const menuItem = screen.getByRole('menuitem');
+    expect(menuItem).not.toHaveAttribute('aria-selected');
+  });
+
+  it('does NOT render checkmark when model matches but endpoint differs', () => {
+    mockSelectedValues = { endpoint: 'openai', model: 'claude-opus-4-6', modelSpec: null };
+    render(<EndpointModelItem modelId="claude-opus-4-6" endpoint={baseEndpoint} />);
+
+    const menuItem = screen.getByRole('menuitem');
+    expect(menuItem).not.toHaveAttribute('aria-selected');
+  });
+
+  it('does NOT render checkmark when endpoint matches but model differs', () => {
+    mockSelectedValues = { endpoint: 'anthropic', model: 'claude-sonnet-4-5', modelSpec: null };
+    render(<EndpointModelItem modelId="claude-opus-4-6" endpoint={baseEndpoint} />);
+
+    const menuItem = screen.getByRole('menuitem');
+    expect(menuItem).not.toHaveAttribute('aria-selected');
+  });
+});

--- a/client/src/components/Chat/Menus/Endpoints/components/__tests__/EndpointModelItem.test.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/__tests__/EndpointModelItem.test.tsx
@@ -48,7 +48,7 @@ describe('EndpointModelItem', () => {
   });
 
   it('renders checkmark when model and endpoint match with no active spec', () => {
-    mockSelectedValues = { endpoint: 'anthropic', model: 'claude-opus-4-6', modelSpec: null };
+    mockSelectedValues = { endpoint: 'anthropic', model: 'claude-opus-4-6', modelSpec: '' };
     render(<EndpointModelItem modelId="claude-opus-4-6" endpoint={baseEndpoint} />);
 
     const menuItem = screen.getByRole('menuitem');
@@ -68,7 +68,7 @@ describe('EndpointModelItem', () => {
   });
 
   it('does NOT render checkmark when model matches but endpoint differs', () => {
-    mockSelectedValues = { endpoint: 'openai', model: 'claude-opus-4-6', modelSpec: null };
+    mockSelectedValues = { endpoint: 'openai', model: 'claude-opus-4-6', modelSpec: '' };
     render(<EndpointModelItem modelId="claude-opus-4-6" endpoint={baseEndpoint} />);
 
     const menuItem = screen.getByRole('menuitem');
@@ -76,7 +76,7 @@ describe('EndpointModelItem', () => {
   });
 
   it('does NOT render checkmark when endpoint matches but model differs', () => {
-    mockSelectedValues = { endpoint: 'anthropic', model: 'claude-sonnet-4-5', modelSpec: null };
+    mockSelectedValues = { endpoint: 'anthropic', model: 'claude-sonnet-4-5', modelSpec: '' };
     render(<EndpointModelItem modelId="claude-opus-4-6" endpoint={baseEndpoint} />);
 
     const menuItem = screen.getByRole('menuitem');

--- a/client/src/components/Chat/Menus/Endpoints/components/__tests__/SearchResults.test.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/components/__tests__/SearchResults.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import type { Endpoint, SelectedValues } from '~/common';
+import { SearchResults } from '../SearchResults';
+
+const mockHandleSelectSpec = jest.fn();
+const mockHandleSelectModel = jest.fn();
+const mockHandleSelectEndpoint = jest.fn();
+let mockSelectedValues: SelectedValues;
+
+jest.mock('~/components/Chat/Menus/Endpoints/ModelSelectorContext', () => ({
+  useModelSelectorContext: () => ({
+    selectedValues: mockSelectedValues,
+    handleSelectSpec: mockHandleSelectSpec,
+    handleSelectModel: mockHandleSelectModel,
+    handleSelectEndpoint: mockHandleSelectEndpoint,
+    endpointsConfig: {},
+  }),
+}));
+
+jest.mock('~/components/Chat/Menus/Endpoints/CustomMenu', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return {
+    CustomMenuItem: React.forwardRef(function MockMenuItem(
+      { children, ...rest }: { children?: React.ReactNode },
+      ref: React.Ref<HTMLDivElement>,
+    ) {
+      return React.createElement('div', { ref, role: 'menuitem', ...rest }, children);
+    }),
+  };
+});
+
+jest.mock('../SpecIcon', () => {
+  const React = jest.requireActual<typeof import('react')>('react');
+  return {
+    __esModule: true,
+    default: () => React.createElement('span', null, 'icon'),
+  };
+});
+
+const localize = (key: string) => key;
+
+const anthropicEndpoint: Endpoint = {
+  value: 'anthropic',
+  label: 'Anthropic',
+  hasModels: true,
+  models: [{ name: 'claude-opus-4-6' }, { name: 'claude-sonnet-4-5' }],
+  icon: null,
+};
+
+const noModelsEndpoint: Endpoint = {
+  value: 'custom',
+  label: 'Custom',
+  hasModels: false,
+  icon: null,
+};
+
+describe('SearchResults', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('marks model as selected when endpoint and model match with no active spec', () => {
+    mockSelectedValues = { endpoint: 'anthropic', model: 'claude-opus-4-6', modelSpec: '' };
+    render(
+      <SearchResults results={[anthropicEndpoint]} localize={localize} searchValue="claude" />,
+    );
+
+    const items = screen.getAllByRole('menuitem');
+    const selectedItem = items.find((el) => el.getAttribute('aria-selected') === 'true');
+    expect(selectedItem).toBeDefined();
+    expect(selectedItem).toHaveTextContent('claude-opus-4-6');
+  });
+
+  it('does not mark model as selected when a spec is active', () => {
+    mockSelectedValues = {
+      endpoint: 'anthropic',
+      model: 'claude-opus-4-6',
+      modelSpec: 'my-spec',
+    };
+    render(
+      <SearchResults results={[anthropicEndpoint]} localize={localize} searchValue="claude" />,
+    );
+
+    const items = screen.getAllByRole('menuitem');
+    for (const item of items) {
+      expect(item).not.toHaveAttribute('aria-selected');
+    }
+  });
+
+  it('does not mark endpoint as selected when a spec is active', () => {
+    mockSelectedValues = {
+      endpoint: 'custom',
+      model: '',
+      modelSpec: 'my-spec',
+    };
+    render(<SearchResults results={[noModelsEndpoint]} localize={localize} searchValue="custom" />);
+
+    const item = screen.getByRole('menuitem');
+    expect(item).not.toHaveAttribute('aria-selected');
+  });
+
+  it('marks endpoint as selected when no spec is active and endpoint matches', () => {
+    mockSelectedValues = { endpoint: 'custom', model: '', modelSpec: '' };
+    render(<SearchResults results={[noModelsEndpoint]} localize={localize} searchValue="custom" />);
+
+    const item = screen.getByRole('menuitem');
+    expect(item).toHaveAttribute('aria-selected', 'true');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two bugs in the model selector checkmark logic:

- **Model spec duplicate checkmarks**: When a model spec (e.g., "Test Anthropic Spec" wrapping `claude-opus-4-6`) was selected, its backing endpoint and model also showed checkmarks because `selectedValues.endpoint` was set to the spec's underlying endpoint. Now, endpoint and model-level checkmarks are suppressed whenever `selectedSpec` is active.
- **Cross-endpoint model name collision**: If two endpoints exposed the same model ID, selecting one would incorrectly mark the other as selected because the check only compared model names without verifying the endpoint. The `isSelected` logic now requires both endpoint and model to match.

### Approach

- Moved the `isSelected` computation from `renderEndpointModels` into `EndpointModelItem`, where it reads `selectedValues` from context. This eliminates 3 positional `string | null` parameters from `renderEndpointModels` and makes the selection logic co-located with the component that renders the checkmark.
- Applied the same `!selectedSpec` guard to `SearchResults.tsx` for both model-level and endpoint-level checks.
- Added unit tests for `EndpointModelItem` covering: spec active (no checkmark), correct selection (checkmark), wrong endpoint (no checkmark), wrong model (no checkmark).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before
<img width="1725" height="960" alt="Screenshot 2026-02-25 at 11 55 24 AM" src="https://github.com/user-attachments/assets/7833f242-1e4f-4278-8f12-2650d3b456cb" />

### After
<img width="1725" height="960" alt="Screenshot 2026-02-25 at 11 54 47 AM" src="https://github.com/user-attachments/assets/b28b4ff6-423d-49a4-b378-dc74b7e83a49" />

### **Test Configuration**:

```yaml
modelSpecs:
  list:
    - name: 'test-anthropic-spec'
      label: 'Test Anthropic Spec'
      description: 'Wraps claude-opus-4-6 to verify duplicate checkmark fix'
      preset:
        endpoint: 'anthropic'
        model: 'claude-opus-4-6'
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] New unit tests added for `EndpointModelItem` selection logic