### PR TITLE
feat: auto-inject X-LibreChat-Username header on every MCP tool call

### DIFF
--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -17,7 +17,7 @@ import { MCPConnectionFactory } from './MCPConnectionFactory';
 import { preProcessGraphTokens } from '~/utils/graph';
 import { formatToolContent } from './parsers';
 import { MCPConnection } from './connection';
-import { processMCPEnv } from '~/utils/env';
+import { processMCPEnv, encodeHeaderValue } from '~/utils/env';
 
 /**
  * Centralized manager for MCP server connections and tool execution.
@@ -307,9 +307,17 @@ Please follow these instructions when using tools from the respective MCP server
         customUserVars: customUserVars,
         body: requestBody,
       });
-      if ('headers' in currentOptions) {
-        connection.setRequestHeaders(currentOptions.headers || {});
+      const headers: Record<string, string> = {
+        ...('headers' in currentOptions ? currentOptions.headers : {}),
+      };
+      const username = user?.username || user?.name;
+      const hasUserHeader = Object.keys(headers).some(
+        (k) => k.toLowerCase() === 'x-librechat-username',
+      );
+      if (username && !hasUserHeader) {
+        headers['x-librechat-username'] = encodeHeaderValue(username);
       }
+      connection.setRequestHeaders(headers);
 
       const result = await connection.client.request(
         {


### PR DESCRIPTION
## Summary

MCP servers often need to perform audit logging, access control, or request tracing based on the identity of the LibreChat user who initiated the tool call. Currently, there is no built-in mechanism to pass the LibreChat user identity to MCP servers — each server must be manually configured with a `X-LibreChat-Username: "{{LIBRECHAT_USER_USERNAME}}"` header in `librechat.yaml` or via the UI, which is error-prone and easy to overlook.

This PR automatically injects an `X-LibreChat-Username` header into every MCP tool call request, so that MCP servers can reliably identify and track the originating LibreChat user without any additional configuration.

## Changes

- Automatically inject `X-LibreChat-Username` header in `MCPManager.callTool()` using `user.username` (falls back to `user.name`)
- Non-ASCII usernames are safely encoded using the existing `encodeHeaderValue()` utility (`b64:` prefix)
- Server-specific headers take precedence — if a server already defines `x-librechat-username`, the default is not overwritten

## Use Case

- **Audit logging**: MCP servers can log which LibreChat user triggered each tool call (e.g., for Splunk/SIEM integration)
- **Access control**: MCP servers can enforce per-user permissions based on the header
- **Request tracing**: Correlate MCP requests back to specific LibreChat users for debugging and compliance