### PR TITLE
🛂 fix: Detect OAuth Errors From HTTP 400 Responses

### DIFF
--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -545,6 +545,10 @@ export class MCPConnectionFactory {
       if (message.includes('authentication required') || message.includes('unauthorized')) {
         return true;
       }
+      // Check for missing authorization values (e.g., Amazon Ads MCP returns HTTP 400 with this)
+      if (message.includes('no authorization')) {
+        return true;
+      }
     }
 
     return false;

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -541,6 +541,10 @@ export class MCPConnectionFactory {
       if (message.includes('invalid_token')) {
         return true;
       }
+      // Check for invalid_grant (OAuth servers return this for expired/revoked grants)
+      if (message.includes('invalid_grant')) {
+        return true;
+      }
       // Check for authentication required
       if (message.includes('authentication required') || message.includes('unauthorized')) {
         return true;

--- a/packages/api/src/mcp/__tests__/MCPConnection.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnection.test.ts
@@ -82,6 +82,10 @@ describe('MCPConnection Error Detection', () => {
       if (message.includes('authentication required') || message.includes('unauthorized')) {
         return true;
       }
+      // Check for missing authorization values (e.g., Amazon Ads MCP returns HTTP 400 with this)
+      if (message.includes('no authorization')) {
+        return true;
+      }
     }
 
     return false;
@@ -170,6 +174,24 @@ describe('MCPConnection Error Detection', () => {
           'Streamable HTTP error: Error POSTing to endpoint: {"error":"invalid_grant","error_description":"The provided authorization grant is invalid, expired, or revoked"}',
       };
       expect(isOAuthError(error)).toBe(true);
+    });
+
+    it('should detect OAuth error for "no authorization" in message (HTTP 400)', () => {
+      const error = {
+        message:
+          'Either no authorization values are specified or it could not be derived from the request',
+      };
+      expect(isOAuthError(error)).toBe(true);
+    });
+
+    it('should detect OAuth error for "No authorization" with different casing', () => {
+      const error = { message: 'No Authorization header provided' };
+      expect(isOAuthError(error)).toBe(true);
+    });
+
+    it('should not detect OAuth error for unrelated 400 errors', () => {
+      const error = { code: 400, message: 'Bad request: missing required field' };
+      expect(isOAuthError(error)).toBe(false);
     });
   });
 

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -816,6 +816,39 @@ describe('MCPConnectionFactory', () => {
         expect.stringContaining('OAuth required, stopping connection attempts'),
       );
     });
+
+    it('should identify "no authorization" errors as OAuth errors (HTTP 400)', async () => {
+      const basicOptions = {
+        serverName: 'test-server',
+        serverConfig: mockServerConfig,
+      };
+
+      const oauthOptions = {
+        useOAuth: true as const,
+        user: mockUser,
+        flowManager: mockFlowManager,
+        tokenMethods: {
+          findToken: jest.fn(),
+          createToken: jest.fn(),
+          updateToken: jest.fn(),
+          deleteTokens: jest.fn(),
+        },
+      };
+
+      const noAuthError = new Error(
+        'Either no authorization values are specified or it could not be derived from the request',
+      );
+
+      mockConnectionInstance.connect.mockRejectedValue(noAuthError);
+      mockConnectionInstance.isConnected.mockResolvedValue(false);
+
+      await expect(MCPConnectionFactory.create(basicOptions, oauthOptions)).rejects.toThrow(
+        'no authorization',
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('OAuth required, stopping connection attempts'),
+      );
+    });
   });
 
   describe('discoverTools static method', () => {

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -849,6 +849,39 @@ describe('MCPConnectionFactory', () => {
         expect.stringContaining('OAuth required, stopping connection attempts'),
       );
     });
+
+    it('should identify invalid_grant errors as OAuth errors', async () => {
+      const basicOptions = {
+        serverName: 'test-server',
+        serverConfig: mockServerConfig,
+      };
+
+      const oauthOptions = {
+        useOAuth: true as const,
+        user: mockUser,
+        flowManager: mockFlowManager,
+        tokenMethods: {
+          findToken: jest.fn(),
+          createToken: jest.fn(),
+          updateToken: jest.fn(),
+          deleteTokens: jest.fn(),
+        },
+      };
+
+      const invalidGrantError = new Error(
+        'Streamable HTTP error: Error POSTing to endpoint: {"error":"invalid_grant"}',
+      );
+
+      mockConnectionInstance.connect.mockRejectedValue(invalidGrantError);
+      mockConnectionInstance.isConnected.mockResolvedValue(false);
+
+      await expect(MCPConnectionFactory.create(basicOptions, oauthOptions)).rejects.toThrow(
+        'invalid_grant',
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('OAuth required, stopping connection attempts'),
+      );
+    });
   });
 
   describe('discoverTools static method', () => {

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -2326,6 +2326,10 @@ export class MCPConnection extends EventEmitter {
       if (message.includes('authentication required') || message.includes('unauthorized')) {
         return true;
       }
+      // Check for missing authorization values (e.g., Amazon Ads MCP returns HTTP 400 with this)
+      if (message.includes('no authorization')) {
+        return true;
+      }
     }
 
     return false;


### PR DESCRIPTION
…P 400

## Summary

- Add `"no authorization"` pattern to `isOAuthError()` in both `MCPConnection` and `MCPConnectionFactory`
- This enables the MCP OAuth flow for servers that return HTTP 400 (instead of 401/403) when authentication is missing, such as for amazon ads. 
- This is more of an issue with the amazon ads oauth implementation, so i'm not sure if its appropriate to submit this PR here. But as it is an small fix that circumvents the issue, i would like to implement this.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The issue is triggered when trying to connect to an oauth mcp server that returns a status code of 400 instead of 401 or 403/no WW-Authenticate headers, specifically the recent [Amazon Ads MCP Server](https://advertising.amazon.com/API/docs/en-us/mcp/get-started). 

I used

### **Test Configuration**:

This is the configuration i used for the amazon ads mcp server:
```yaml
  mcpServers:
    amazon-ads:
      type: streamable-http
      url: https://advertising-ai-eu.amazon.com/mcp # see docs for other regions
      requiresOAuth: true
      headers:
        Amazon-Ads-ClientId: "${AMAZON_ADS_CLIENT_ID}"
        Accept: "application/json, text/event-stream"
      oauth:
        authorization_url: "https://eu.account.amazon.com/ap/oa"
        token_url: "https://api.amazon.com/auth/o2/token"
        client_id: "${AMAZON_ADS_CLIENT_ID}"
        client_secret: "${AMAZON_ADS_CLIENT_SECRET}"
        scope: "advertising::campaign_management"
        token_exchange_method: "default_post"
        redirect_uri: "http://localhost:3080/api/mcp/amazon-ads/oauth/callback"
```
Except for the model configuration, everything else was kept the same as in the .env.example file. I'm using the provided docker-compose.yaml

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
