### PR TITLE
🧩 fix: Redirect Stability and Build Chunking

### DIFF
--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -11,8 +11,8 @@ import { debounce } from 'lodash';
 import { useRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import { setTokenHeader, SystemRoles } from 'librechat-data-provider';
-import type { ReactNode } from 'react';
 import type * as t from 'librechat-data-provider';
+import type { ReactNode } from 'react';
 import {
   useGetRole,
   useGetUserQuery,

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -167,7 +167,8 @@ const AuthContextProvider = ({
         navigate(buildLoginRedirectUrl());
       },
     });
-  }, [authConfig?.test, refreshToken, setUserContext, navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deps are stable at mount; adding refreshToken causes infinite re-fire
+  }, []);
 
   useEffect(() => {
     if (userQuery.data) {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -8,15 +8,18 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vitejs.dev/config/
-const backendPort = process.env.BACKEND_PORT && Number(process.env.BACKEND_PORT) || 3080;
-const backendURL = process.env.HOST ? `http://${process.env.HOST}:${backendPort}` : `http://localhost:${backendPort}`;
+const backendPort = (process.env.BACKEND_PORT && Number(process.env.BACKEND_PORT)) || 3080;
+const backendURL = process.env.HOST
+  ? `http://${process.env.HOST}:${backendPort}`
+  : `http://localhost:${backendPort}`;
 
 export default defineConfig(({ command }) => ({
   base: '',
   server: {
-    allowedHosts: process.env.VITE_ALLOWED_HOSTS && process.env.VITE_ALLOWED_HOSTS.split(',') || [],
+    allowedHosts:
+      (process.env.VITE_ALLOWED_HOSTS && process.env.VITE_ALLOWED_HOSTS.split(',')) || [],
     host: process.env.HOST || 'localhost',
-    port: process.env.PORT && Number(process.env.PORT) || 3090,
+    port: (process.env.PORT && Number(process.env.PORT)) || 3090,
     strictPort: false,
     proxy: {
       '/api': {
@@ -143,7 +146,12 @@ export default defineConfig(({ command }) => ({
             if (normalizedId.includes('@dicebear')) {
               return 'avatars';
             }
-            if (normalizedId.includes('react-dnd') || normalizedId.includes('react-flip-toolkit')) {
+            if (
+              normalizedId.includes('react-dnd') ||
+              normalizedId.includes('dnd-core') ||
+              normalizedId.includes('react-flip-toolkit') ||
+              normalizedId.includes('flip-toolkit')
+            ) {
               return 'react-interactions';
             }
             if (normalizedId.includes('react-hook-form')) {
@@ -219,7 +227,10 @@ export default defineConfig(({ command }) => ({
             if (normalizedId.includes('framer-motion')) {
               return 'framer-motion';
             }
-            if (normalizedId.includes('node_modules/highlight.js')) {
+            if (
+              normalizedId.includes('node_modules/highlight.js') ||
+              normalizedId.includes('node_modules/lowlight')
+            ) {
               return 'markdown_highlight';
             }
             if (normalizedId.includes('katex') || normalizedId.includes('node_modules/katex')) {


### PR DESCRIPTION
Follows up on https://github.com/danny-avila/LibreChat/pull/10275 and https://github.com/danny-avila/LibreChat/pull/11964
## Summary

I fixed an infinite re-render loop in the authentication context and improved the Vite build configuration for better chunk splitting and readability.

- Fix an infinite re-render loop in `AuthContext` caused by `refreshToken` (from `useRefreshTokenMutation`) producing a new object reference every render, which cascaded through the `silentRefresh` `useCallback` deps into the downstream `useEffect`, re-triggering the refresh indefinitely. Replaced the dependency array with `[]` since all captured values (`navigate`, `setUserContext`, `authConfig?.test`) are referentially stable at mount time.
- Add transitive dependency grouping in the Vite `manualChunks` config: `dnd-core` now co-locates with `react-dnd`, `flip-toolkit` with `react-flip-toolkit`, and `lowlight` with `highlight.js`, preventing cache invalidation of the generic `vendor` chunk when these libraries update.
- Wrap `&&`/`||` expressions in `vite.config.ts` with explicit parentheses to clarify operator precedence intent for `backendPort`, `allowedHosts`, and `port` assignments (no behavioral change).
- Reorder type imports in `AuthContext.tsx` to place third-party type imports before React type imports.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verify the app loads without an infinite refresh loop by watching the Network tab for repeated `/api/auth/refresh` calls; there should be exactly one on initial mount when unauthenticated.
- Confirm silent refresh still works: clear the access token (e.g., via DevTools), wait for the token to expire, and verify the app silently re-authenticates without redirecting to `/login`.
- Run a production build (`npm run build` in `client/`) and inspect the output chunks: `react-interactions` should contain `dnd-core` and `flip-toolkit`; `markdown_highlight` should contain both `highlight.js` and `lowlight`. Neither should appear in the `vendor` chunk.
- Confirm the dev server starts correctly with custom `BACKEND_PORT`, `HOST`, `PORT`, and `VITE_ALLOWED_HOSTS` env vars to validate the parenthesized expressions resolve identically.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings