### PR TITLE
feat: Add Avian as a known endpoint provider

### DIFF
--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -252,6 +252,11 @@ const tokenValues = Object.assign(
     'moonshot-v1-128k': { prompt: 2.0, completion: 5.0 },
     'moonshot-v1-128k-vision': { prompt: 2.0, completion: 5.0 },
     'moonshot-v1-128k-vision-preview': { prompt: 2.0, completion: 5.0 },
+    // Avian models (https://avian.io)
+    'deepseek/deepseek-v3.2': { prompt: 0.26, completion: 0.38 },
+    'moonshotai/kimi-k2.5': { prompt: 0.45, completion: 2.2 },
+    'z-ai/glm-5': { prompt: 0.3, completion: 2.55 },
+    'minimax/minimax-m2.5': { prompt: 0.3, completion: 1.1 },
     // GPT-OSS models (specific sizes)
     'gpt-oss:20b': { prompt: 0.05, completion: 0.2 },
     'gpt-oss-20b': { prompt: 0.05, completion: 0.2 },

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -336,6 +336,21 @@ endpoints:
   #     #     deploymentName: claude-3-5-haiku@20241022  # Override for this model
 
   custom:
+    # Avian Example
+    - name: 'avian'
+      apiKey: '${AVIAN_API_KEY}'
+      baseURL: 'https://api.avian.io/v1'
+      models:
+        default:
+          - 'deepseek/deepseek-v3.2'
+          - 'moonshotai/kimi-k2.5'
+          - 'z-ai/glm-5'
+          - 'minimax/minimax-m2.5'
+        fetch: false
+      titleConvo: true
+      titleModel: 'deepseek/deepseek-v3.2'
+      modelDisplayLabel: 'avian'
+
     # Groq Example
     - name: 'groq'
       apiKey: '${GROQ_API_KEY}'

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -355,6 +355,11 @@ const aggregateModels = {
   ...bedrockModels,
   ...xAIModels,
   ...qwenModels,
+  // Avian models (https://avian.io)
+  'deepseek/deepseek-v3.2': 164000,
+  'moonshotai/kimi-k2.5': 131000,
+  'z-ai/glm-5': 131000,
+  'minimax/minimax-m2.5': 1000000,
   // GPT-OSS
   'gpt-oss': 131000,
   'gpt-oss:20b': 131000,
@@ -423,11 +428,19 @@ const deepseekMaxOutputs = {
   'deepseek.r1': 64000,
 };
 
+/** Outputs for Avian models (https://avian.io) */
+const avianMaxOutputs = {
+  'deepseek/deepseek-v3.2': 65000,
+  'moonshotai/kimi-k2.5': 8000,
+  'z-ai/glm-5': 16000,
+  'minimax/minimax-m2.5': 1000000,
+};
+
 export const maxOutputTokensMap = {
   [EModelEndpoint.anthropic]: anthropicMaxOutputs,
   [EModelEndpoint.azureOpenAI]: modelMaxOutputs,
-  [EModelEndpoint.openAI]: { ...modelMaxOutputs, ...deepseekMaxOutputs },
-  [EModelEndpoint.custom]: { ...modelMaxOutputs, ...deepseekMaxOutputs },
+  [EModelEndpoint.openAI]: { ...modelMaxOutputs, ...deepseekMaxOutputs, ...avianMaxOutputs },
+  [EModelEndpoint.custom]: { ...modelMaxOutputs, ...deepseekMaxOutputs, ...avianMaxOutputs },
 };
 
 /**

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1046,6 +1046,7 @@ export type TProviderSchema =
 export enum KnownEndpoints {
   anyscale = 'anyscale',
   apipie = 'apipie',
+  avian = 'avian',
   cohere = 'cohere',
   fireworks = 'fireworks',
   deepseek = 'deepseek',
@@ -1098,6 +1099,7 @@ export const alternateName = {
   [KnownEndpoints.xai]: 'xAI',
   [KnownEndpoints.vercel]: 'Vercel',
   [KnownEndpoints.helicone]: 'Helicone',
+  [KnownEndpoints.avian]: 'Avian',
 };
 
 const sharedOpenAIModels = [


### PR DESCRIPTION
## Summary

Add [Avian](https://avian.io) as a recognized custom endpoint provider. Avian is an OpenAI-compatible LLM API gateway offering access to frontier models at competitive pricing.

**Models available:**
- `deepseek/deepseek-v3.2` — 164K context, $0.26/$0.38 per M tokens
- `moonshotai/kimi-k2.5` — 131K context, $0.45/$2.20 per M tokens
- `z-ai/glm-5` — 131K context, $0.30/$2.55 per M tokens
- `minimax/minimax-m2.5` — 1M context, $0.30/$1.10 per M tokens

**Supports:** chat completions, streaming, function calling/tools, tool_choice, response_format

## Changes

- **`packages/data-provider/src/config.ts`** — Add `avian` to `KnownEndpoints` enum and `alternateName` display map
- **`api/models/tx.js`** — Add token pricing for all Avian models
- **`packages/api/src/utils/tokens.ts`** — Add context window sizes and max output token limits
- **`librechat.example.yaml`** — Add example custom endpoint configuration

## Configuration

Users can add Avian by setting `AVIAN_API_KEY` in their environment and adding the following to `librechat.yaml`:

```yaml
endpoints:
  custom:
    - name: 'avian'
      apiKey: '${AVIAN_API_KEY}'
      baseURL: 'https://api.avian.io/v1'
      models:
        default:
          - 'deepseek/deepseek-v3.2'
          - 'moonshotai/kimi-k2.5'
          - 'z-ai/glm-5'
          - 'minimax/minimax-m2.5'
        fetch: false
      titleConvo: true
      titleModel: 'deepseek/deepseek-v3.2'
      modelDisplayLabel: 'avian'
```

## Test plan

- [ ] Verify `KnownEndpoints.avian` resolves correctly and displays as "Avian" in the UI
- [ ] Verify token pricing matches for all four models via `getMultiplier()`
- [ ] Verify context window limits are applied correctly for each model
- [ ] Verify max output token limits are applied correctly for each model
- [ ] Verify example YAML configuration works end-to-end with a valid API key