### PR TITLE
🚦 fix: 404 JSON Responses for Unmatched API Routes

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -124,7 +124,9 @@ class BaseClient {
    * @returns {number}
    */
   getTokenCountForResponse(responseMessage) {
-    logger.debug('[BaseClient] `recordTokenUsage` not implemented.', responseMessage);
+    logger.debug('[BaseClient] `recordTokenUsage` not implemented.', {
+      messageId: responseMessage?.messageId,
+    });
   }
 
   /**
@@ -661,10 +663,13 @@ class BaseClient {
     );
 
     if (tokenCountMap) {
-      logger.debug('[BaseClient] tokenCountMap', tokenCountMap);
       if (tokenCountMap[userMessage.messageId]) {
         userMessage.tokenCount = tokenCountMap[userMessage.messageId];
-        logger.debug('[BaseClient] userMessage', userMessage);
+        logger.debug('[BaseClient] userMessage', {
+          messageId: userMessage.messageId,
+          tokenCount: userMessage.tokenCount,
+          conversationId: userMessage.conversationId,
+        });
       }
 
       this.handleTokenCountMap(tokenCountMap);

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -798,6 +798,13 @@ class BaseClient {
           model: responseMessage.model,
         });
       }
+
+      logger.debug('[BaseClient] Response token usage', {
+        messageId: responseMessage.messageId,
+        model: responseMessage.model,
+        promptTokens,
+        completionTokens,
+      });
     }
 
     if (userMessagePromise) {

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -14,6 +14,7 @@ const { logger } = require('@librechat/data-schemas');
 const mongoSanitize = require('express-mongo-sanitize');
 const {
   isEnabled,
+  apiNotFound,
   ErrorController,
   performStartupChecks,
   handleJsonParseError,
@@ -297,6 +298,7 @@ if (cluster.isMaster) {
     /** Routes */
     app.use('/oauth', routes.oauth);
     app.use('/api/auth', routes.auth);
+    app.use('/api/admin', routes.adminAuth);
     app.use('/api/actions', routes.actions);
     app.use('/api/keys', routes.keys);
     app.use('/api/api-keys', routes.apiKeys);
@@ -310,7 +312,6 @@ if (cluster.isMaster) {
     app.use('/api/endpoints', routes.endpoints);
     app.use('/api/balance', routes.balance);
     app.use('/api/models', routes.models);
-    app.use('/api/plugins', routes.plugins);
     app.use('/api/config', routes.config);
     app.use('/api/assistants', routes.assistants);
     app.use('/api/files', await routes.files.initialize());
@@ -325,9 +326,7 @@ if (cluster.isMaster) {
     app.use('/api/mcp', routes.mcp);
 
     /** 404 for unmatched API routes */
-    app.use('/api', (req, res) => {
-      res.status(404).json({ message: 'Endpoint not found' });
-    });
+    app.use('/api', apiNotFound);
 
     /** SPA fallback - serve index.html for all unmatched routes */
     app.use((req, res) => {
@@ -345,7 +344,7 @@ if (cluster.isMaster) {
       res.send(updatedIndexHtml);
     });
 
-    /** Error handler (must be last — Express identifies error middleware by its 4-arg signature) */
+    /** Error handler (must be last - Express identifies error middleware by its 4-arg signature) */
     app.use(ErrorController);
 
     /** Start listening on shared port (cluster will distribute connections) */

--- a/api/server/experimental.js
+++ b/api/server/experimental.js
@@ -324,8 +324,10 @@ if (cluster.isMaster) {
     app.use('/api/tags', routes.tags);
     app.use('/api/mcp', routes.mcp);
 
-    /** Error handler */
-    app.use(ErrorController);
+    /** 404 for unmatched API routes */
+    app.use('/api', (req, res) => {
+      res.status(404).json({ message: 'Endpoint not found' });
+    });
 
     /** SPA fallback - serve index.html for all unmatched routes */
     app.use((req, res) => {
@@ -342,6 +344,9 @@ if (cluster.isMaster) {
       res.type('html');
       res.send(updatedIndexHtml);
     });
+
+    /** Error handler (must be last — Express identifies error middleware by its 4-arg signature) */
+    app.use(ErrorController);
 
     /** Start listening on shared port (cluster will distribute connections) */
     app.listen(port, host, async (err) => {

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -12,6 +12,7 @@ const { logger } = require('@librechat/data-schemas');
 const mongoSanitize = require('express-mongo-sanitize');
 const {
   isEnabled,
+  apiNotFound,
   ErrorController,
   memoryDiagnostics,
   performStartupChecks,
@@ -164,9 +165,7 @@ const startServer = async () => {
   app.use('/api/mcp', routes.mcp);
 
   /** 404 for unmatched API routes */
-  app.use('/api', (req, res) => {
-    res.status(404).json({ message: 'Endpoint not found' });
-  });
+  app.use('/api', apiNotFound);
 
   /** SPA fallback - serve index.html for all unmatched routes */
   app.use((req, res) => {
@@ -184,7 +183,7 @@ const startServer = async () => {
     res.send(updatedIndexHtml);
   });
 
-  /** Error handler (must be last — Express identifies error middleware by its 4-arg signature) */
+  /** Error handler (must be last - Express identifies error middleware by its 4-arg signature) */
   app.use(ErrorController);
 
   app.listen(port, host, async (err) => {

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -163,8 +163,12 @@ const startServer = async () => {
   app.use('/api/tags', routes.tags);
   app.use('/api/mcp', routes.mcp);
 
-  app.use(ErrorController);
+  /** 404 for unmatched API routes */
+  app.use('/api', (req, res) => {
+    res.status(404).json({ message: 'Endpoint not found' });
+  });
 
+  /** SPA fallback - serve index.html for all unmatched routes */
   app.use((req, res) => {
     res.set({
       'Cache-Control': process.env.INDEX_CACHE_CONTROL || 'no-cache, no-store, must-revalidate',
@@ -179,6 +183,9 @@ const startServer = async () => {
     res.type('html');
     res.send(updatedIndexHtml);
   });
+
+  /** Error handler (must be last — Express identifies error middleware by its 4-arg signature) */
+  app.use(ErrorController);
 
   app.listen(port, host, async (err) => {
     if (err) {

--- a/api/server/index.spec.js
+++ b/api/server/index.spec.js
@@ -100,6 +100,24 @@ describe('Server Configuration', () => {
     expect(response.headers['expires']).toBe('0');
   });
 
+  it('should return 404 JSON for undefined API routes', async () => {
+    const response = await request(app).get('/api/nonexistent');
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ message: 'Endpoint not found' });
+  });
+
+  it('should return 404 JSON for nested undefined API routes', async () => {
+    const response = await request(app).get('/api/nonexistent/nested/path');
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ message: 'Endpoint not found' });
+  });
+
+  it('should serve SPA HTML for non-API unmatched routes', async () => {
+    const response = await request(app).get('/this/does/not/exist');
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toMatch(/html/);
+  });
+
   it('should return 500 for unknown errors via ErrorController', async () => {
     // Testing the error handling here on top of unit tests to ensure the middleware is correctly integrated
 

--- a/api/server/index.spec.js
+++ b/api/server/index.spec.js
@@ -112,6 +112,22 @@ describe('Server Configuration', () => {
     expect(response.body).toEqual({ message: 'Endpoint not found' });
   });
 
+  it('should return 404 JSON for non-GET methods on undefined API routes', async () => {
+    const post = await request(app).post('/api/nonexistent');
+    expect(post.status).toBe(404);
+    expect(post.body).toEqual({ message: 'Endpoint not found' });
+
+    const del = await request(app).delete('/api/nonexistent');
+    expect(del.status).toBe(404);
+    expect(del.body).toEqual({ message: 'Endpoint not found' });
+  });
+
+  it('should return 404 JSON for the /api root path', async () => {
+    const response = await request(app).get('/api');
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ message: 'Endpoint not found' });
+  });
+
   it('should serve SPA HTML for non-API unmatched routes', async () => {
     const response = await request(app).get('/this/does/not/exist');
     expect(response.status).toBe(200);

--- a/api/server/services/Endpoints/agents/addedConvo.js
+++ b/api/server/services/Endpoints/agents/addedConvo.js
@@ -55,15 +55,15 @@ const processAddedConvo = async ({
   userMCPAuthMap,
 }) => {
   const addedConvo = endpointOption.addedConvo;
-  logger.debug('[processAddedConvo] Called with addedConvo:', {
-    hasAddedConvo: addedConvo != null,
-    addedConvoEndpoint: addedConvo?.endpoint,
-    addedConvoModel: addedConvo?.model,
-    addedConvoAgentId: addedConvo?.agent_id,
-  });
   if (addedConvo == null) {
     return { userMCPAuthMap };
   }
+
+  logger.debug('[processAddedConvo] Processing added conversation', {
+    model: addedConvo.model,
+    agentId: addedConvo.agent_id,
+    endpoint: addedConvo.endpoint,
+  });
 
   try {
     const addedAgent = await loadAddedAgent({ req, conversation: addedConvo, primaryAgent });

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -204,13 +204,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
   );
 
   logger.debug(
-    `[initializeClient] Tool definitions for primary agent: ${primaryConfig.toolDefinitions?.length ?? 0}`,
-  );
-
-  /** Store primary agent's tool context for ON_TOOL_EXECUTE callback */
-  logger.debug(`[initializeClient] Storing tool context for agentId: ${primaryConfig.id}`);
-  logger.debug(
-    `[initializeClient] toolRegistry size: ${primaryConfig.toolRegistry?.size ?? 'undefined'}`,
+    `[initializeClient] Storing tool context for ${primaryConfig.id}: ${primaryConfig.toolDefinitions?.length ?? 0} tools, registry size: ${primaryConfig.toolRegistry?.size ?? '0'}`,
   );
   agentToolContexts.set(primaryConfig.id, {
     agent: primaryAgent,

--- a/packages/api/src/agents/memory.ts
+++ b/packages/api/src/agents/memory.ts
@@ -475,13 +475,21 @@ ${memory ?? 'No existing memories'}`;
     };
     const content = await run.processStream(inputs, config);
     if (content) {
-      logger.debug('Memory Agent processed memory successfully', content);
+      logger.debug('[MemoryAgent] Processed successfully', {
+        userId,
+        conversationId,
+        messageId,
+        provider: llmConfig?.provider,
+      });
     } else {
-      logger.warn('Memory Agent processed memory but returned no content');
+      logger.debug('[MemoryAgent] Returned no content', { userId, conversationId, messageId });
     }
     return await Promise.all(artifactPromises);
   } catch (error) {
-    logger.error('Memory Agent failed to process memory', error);
+    logger.error(
+      `[MemoryAgent] Failed to process memory | userId: ${userId} | conversationId: ${conversationId} | messageId: ${messageId}`,
+      { error },
+    );
   }
 }
 

--- a/packages/api/src/middleware/error.ts
+++ b/packages/api/src/middleware/error.ts
@@ -40,15 +40,6 @@ function isCustomError(err: unknown): err is CustomError {
   return err !== null && typeof err === 'object' && 'statusCode' in err && 'body' in err;
 }
 
-export function apiNotFound(req: Request, res: Response): void {
-  const safePath = req.path
-    .replace(/[\r\n]/g, '_')
-    .replaceAll('\0', '_')
-    .slice(0, 200);
-  logger.warn(`[API 404] ${req.method} ${safePath}`);
-  res.status(404).json({ message: 'Endpoint not found' });
-}
-
 export const ErrorController = (
   err: Error | CustomError,
   req: Request,

--- a/packages/api/src/middleware/error.ts
+++ b/packages/api/src/middleware/error.ts
@@ -41,7 +41,11 @@ function isCustomError(err: unknown): err is CustomError {
 }
 
 export function apiNotFound(req: Request, res: Response): void {
-  logger.warn(`[API 404] ${req.method} ${req.originalUrl}`);
+  const safePath = req.path
+    .replace(/[\r\n]/g, '_')
+    .replaceAll('\0', '_')
+    .slice(0, 200);
+  logger.warn(`[API 404] ${req.method} ${safePath}`);
   res.status(404).json({ message: 'Endpoint not found' });
 }
 

--- a/packages/api/src/middleware/error.ts
+++ b/packages/api/src/middleware/error.ts
@@ -40,6 +40,11 @@ function isCustomError(err: unknown): err is CustomError {
   return err !== null && typeof err === 'object' && 'statusCode' in err && 'body' in err;
 }
 
+export function apiNotFound(req: Request, res: Response): void {
+  logger.warn(`[API 404] ${req.method} ${req.originalUrl}`);
+  res.status(404).json({ message: 'Endpoint not found' });
+}
+
 export const ErrorController = (
   err: Error | CustomError,
   req: Request,

--- a/packages/api/src/middleware/index.ts
+++ b/packages/api/src/middleware/index.ts
@@ -1,6 +1,7 @@
 export * from './access';
 export * from './admin';
 export * from './error';
+export * from './notFound';
 export * from './balance';
 export * from './json';
 export * from './concurrency';

--- a/packages/api/src/middleware/notFound.ts
+++ b/packages/api/src/middleware/notFound.ts
@@ -1,6 +1,7 @@
 import { logger } from '@librechat/data-schemas';
 import type { Request, Response } from 'express';
 
+/** Safe to reuse with .replace() at module scope - does not retain lastIndex state */
 // eslint-disable-next-line no-control-regex
 const unsafeChars = /[\r\n\u0000]/g;
 

--- a/packages/api/src/middleware/notFound.ts
+++ b/packages/api/src/middleware/notFound.ts
@@ -1,0 +1,11 @@
+import { logger } from '@librechat/data-schemas';
+import type { Request, Response } from 'express';
+
+// eslint-disable-next-line no-control-regex
+const unsafeChars = /[\r\n\u0000]/g;
+
+export function apiNotFound(req: Request, res: Response): void {
+  const safePath = req.path.replace(unsafeChars, '_').slice(0, 200);
+  logger.debug(`[API 404] ${req.method} ${safePath}`);
+  res.status(404).json({ message: 'Endpoint not found' });
+}


### PR DESCRIPTION


## Summary

Fixed a bug where unmatched `/api/*` routes fell through to the SPA fallback and returned `200 HTML` instead of an appropriate JSON error response, and repositioned `ErrorController` to be last in the middleware stack per Express conventions.

- Fixed the SPA fallback from handling unmatched API routes by inserting a dedicated catch-all middleware at `app.use('/api', ...)` that returns `{ message: 'Endpoint not found' }` with HTTP 404.
- Added an explanatory comment to the SPA fallback handler clarifying its scope is limited to non-API routes.
- Moved `ErrorController` registration to after the SPA fallback, aligning with Express's requirement that 4-argument error-handling middleware be positioned last in the stack.
- Applied identical middleware ordering changes to `experimental.js` to keep the clustered server configuration consistent.
- Added three integration tests to `index.spec.js` covering 404 JSON responses for simple and nested undefined API paths, and HTML responses for unmatched non-API routes.

### Other Changes

Also improved/consolidated logging for some minor items that were either not useful, duplicated, or too verbose

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran the integration test suite in `api/server/index.spec.js`, which covers the new behavior directly. To reproduce manually:

1. Start the server locally.
2. Send `GET /api/nonexistent` — confirm `404` with body `{ "message": "Endpoint not found" }` and `Content-Type: application/json`.
3. Send `GET /api/nonexistent/nested/path` — confirm the same 404 JSON response.
4. Send `GET /this/does/not/exist` — confirm `200` with `Content-Type: text/html` (SPA fallback).
5. Trigger a route that throws (e.g., force a MongoDB failure on `POST /api/auth/login`) — confirm `500` is still returned, verifying `ErrorController` remains reachable in its new position.

### **Test Configuration**:
- Node.js with MongoMemoryServer (in-memory MongoDB)
- `PORT=0` for automatic port assignment during tests

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes