### PR TITLE
feat: Custom Role Support

### DIFF
--- a/api/server/routes/roles.js
+++ b/api/server/routes/roles.js
@@ -111,10 +111,10 @@ router.get('/:roleName', async (req, res) => {
   // TODO: TEMP, use a better parsing for roleName
   const roleName = _r.toUpperCase();
 
-  if (
-    (req.user.role !== SystemRoles.ADMIN && roleName === SystemRoles.ADMIN) ||
-    (req.user.role !== SystemRoles.ADMIN && !roleDefaults[roleName])
-  ) {
+  const isAdmin = req.user.role === SystemRoles.ADMIN;
+  const isOwnRole = req.user.role === roleName;
+  const isUserRole = roleName === SystemRoles.USER;
+  if (!isAdmin && !isOwnRole && !isUserRole) {
     return res.status(403).send({ message: 'Unauthorized' });
   }
 

--- a/packages/data-provider/src/roles.ts
+++ b/packages/data-provider/src/roles.ts
@@ -203,3 +203,28 @@ export const roleDefaults = defaultRolesSchema.parse({
     },
   },
 });
+
+/** Valid custom role name format: uppercase letters, digits, underscores; 1-50 chars */
+export const CUSTOM_ROLE_NAME_REGEX = /^[A-Z][A-Z0-9_]{0,49}$/;
+
+/** Returns true if the role name is a system-defined role (ADMIN or USER) */
+export function isSystemRole(roleName: string): boolean {
+  return roleName === SystemRoles.ADMIN || roleName === SystemRoles.USER;
+}
+
+/** Clones USER-level permissions with a custom role name */
+export function getCustomRoleDefaults(roleName: string): TRole {
+  const userPerms = roleDefaults[SystemRoles.USER].permissions;
+  return {
+    name: roleName,
+    permissions: JSON.parse(JSON.stringify(userPerms)),
+  };
+}
+
+/** Returns system defaults for ADMIN/USER, or USER-level defaults for any custom role */
+export function getRoleDefaultPermissions(roleName: string): TRole {
+  if (isSystemRole(roleName)) {
+    return roleDefaults[roleName as SystemRoles];
+  }
+  return getCustomRoleDefaults(roleName);
+}


### PR DESCRIPTION
## Summary

- Add `isSystemRole()`, `getCustomRoleDefaults()`, `getRoleDefaultPermissions()` utility functions and `CUSTOM_ROLE_NAME_REGEX` to `packages/data-provider/src/roles.ts` for dynamic role defaults
- Fix `getRoleByName` in `api/models/Role.js` to auto-create roles with valid custom name format (`/^[A-Z][A-Z0-9_]{0,49}$/`) using USER-level permission defaults
- Fix `GET /api/roles/:roleName` access control in `api/server/routes/roles.js` so non-admin users can fetch their own role or the USER role

## Test plan

- [x] Docker build succeeds
- [x] GET /api/roles/user returns USER role (as ADMIN)
- [x] GET /api/roles/admin returns ADMIN role (as ADMIN)
- [x] GET /api/roles/agent_user auto-creates AGENT_USER with USER-level permissions (as ADMIN)
- [x] Non-admin with AGENT_USER role can fetch USER role (200)
- [x] Non-admin with AGENT_USER role can fetch own AGENT_USER role (200)
- [x] Non-admin with AGENT_USER role cannot fetch ADMIN role (403)
- [x] Non-admin with AGENT_USER role cannot fetch other custom roles (403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)