### PR TITLE
feat: Add Custom Role Support

### DIFF
--- a/api/models/Role.js
+++ b/api/models/Role.js
@@ -1,9 +1,10 @@
 const {
   CacheKeys,
   SystemRoles,
-  roleDefaults,
   permissionsSchema,
   removeNullishValues,
+  CUSTOM_ROLE_NAME_REGEX,
+  getRoleDefaultPermissions,
 } = require('librechat-data-provider');
 const { logger } = require('@librechat/data-schemas');
 const getLogStores = require('~/cache/getLogStores');
@@ -11,8 +12,8 @@ const { Role } = require('~/db/models');
 
 /**
  * Retrieve a role by name and convert the found role document to a plain object.
- * If the role with the given name doesn't exist and the name is a system defined role,
- * create it and return the lean version.
+ * If the role doesn't exist and the name is valid (system role or valid custom format),
+ * auto-create it with appropriate defaults and return the lean version.
  *
  * @param {string} roleName - The name of the role to find or create.
  * @param {string|string[]} [fieldsToSelect] - The fields to include or exclude in the returned document.
@@ -31,8 +32,8 @@ const getRoleByName = async function (roleName, fieldsToSelect = null) {
     }
     let role = await query.lean().exec();
 
-    if (!role && SystemRoles[roleName]) {
-      role = await new Role(roleDefaults[roleName]).save();
+    if (!role && (SystemRoles[roleName] || CUSTOM_ROLE_NAME_REGEX.test(roleName))) {
+      role = await new Role(getRoleDefaultPermissions(roleName)).save();
       await cache.set(roleName, role);
       return role.toObject();
     }

--- a/api/models/Role.spec.js
+++ b/api/models/Role.spec.js
@@ -96,10 +96,10 @@ describe('updateAccessPermissions', () => {
   });
 
   it('should handle non-existent roles', async () => {
-    await updateAccessPermissions('NON_EXISTENT_ROLE', {
+    await updateAccessPermissions('invalid_role_name', {
       [PermissionTypes.PROMPTS]: { CREATE: true },
     });
-    const role = await Role.findOne({ name: 'NON_EXISTENT_ROLE' });
+    const role = await Role.findOne({ name: 'invalid_role_name' });
     expect(role).toBeNull();
   });
 

--- a/api/server/routes/roles.js
+++ b/api/server/routes/roles.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const {
   SystemRoles,
-  roleDefaults,
   PermissionTypes,
   agentPermissionsSchema,
   promptPermissionsSchema,
@@ -111,10 +110,10 @@ router.get('/:roleName', async (req, res) => {
   // TODO: TEMP, use a better parsing for roleName
   const roleName = _r.toUpperCase();
 
-  if (
-    (req.user.role !== SystemRoles.ADMIN && roleName === SystemRoles.ADMIN) ||
-    (req.user.role !== SystemRoles.ADMIN && !roleDefaults[roleName])
-  ) {
+  const isAdmin = req.user.role === SystemRoles.ADMIN;
+  const isOwnRole = req.user.role === roleName;
+  const isUserRole = roleName === SystemRoles.USER;
+  if (!isAdmin && !isOwnRole && !isUserRole) {
     return res.status(403).send({ message: 'Unauthorized' });
   }
 

--- a/packages/data-provider/src/roles.ts
+++ b/packages/data-provider/src/roles.ts
@@ -203,3 +203,28 @@ export const roleDefaults = defaultRolesSchema.parse({
     },
   },
 });
+
+/** Valid custom role name format: uppercase letters, digits, underscores; 1-50 chars */
+export const CUSTOM_ROLE_NAME_REGEX = /^[A-Z][A-Z0-9_]{0,49}$/;
+
+/** Returns true if the role name is a system-defined role (ADMIN or USER) */
+export function isSystemRole(roleName: string): boolean {
+  return roleName === SystemRoles.ADMIN || roleName === SystemRoles.USER;
+}
+
+/** Clones USER-level permissions with a custom role name */
+export function getCustomRoleDefaults(roleName: string): TRole {
+  const userPerms = roleDefaults[SystemRoles.USER].permissions;
+  return {
+    name: roleName,
+    permissions: JSON.parse(JSON.stringify(userPerms)),
+  };
+}
+
+/** Returns system defaults for ADMIN/USER, or USER-level defaults for any custom role */
+export function getRoleDefaultPermissions(roleName: string): TRole {
+  if (isSystemRole(roleName)) {
+    return roleDefaults[roleName as SystemRoles];
+  }
+  return getCustomRoleDefaults(roleName);
+}


### PR DESCRIPTION
## Summary

- Add `isSystemRole()`, `getCustomRoleDefaults()`, `getRoleDefaultPermissions()` utility functions and `CUSTOM_ROLE_NAME_REGEX` to `packages/data-provider/src/roles.ts` for dynamic role defaults
- Fix `getRoleByName` in `api/models/Role.js` to auto-create roles with valid custom name format (`/^[A-Z][A-Z0-9_]{0,49}$/`) using USER-level permission defaults
- Fix `GET /api/roles/:roleName` access control in `api/server/routes/roles.js` so non-admin users can fetch their own role or the USER role
- Update `Role.spec.js` test for custom role auto-creation behavior

## Test plan

- [x] `npm run build` succeeds
- [x] Lint passes on all changed files (`npx eslint` — 0 errors, 0 warnings)
- [x] `npm run test:api` — all role tests pass (37/37), no regressions from changes
- [x] `npm run test:client` — 87/88 suites pass (1 pre-existing perf timing flake)
- [x] Docker build and manual API testing:
  - GET /api/roles/user returns USER role (as ADMIN)
  - GET /api/roles/admin returns ADMIN role (as ADMIN)
  - GET /api/roles/agent_user auto-creates AGENT_USER with USER-level permissions
  - Non-admin with AGENT_USER role can fetch USER role (200)
  - Non-admin with AGENT_USER role can fetch own AGENT_USER role (200)
  - Non-admin with AGENT_USER role cannot fetch ADMIN role (403)
  - Non-admin with AGENT_USER role cannot fetch other custom roles (403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)