### PR TITLE
💸 fix: Model Identifier Edge Case in Agent Transactions

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -797,7 +797,8 @@ class BaseClient {
           promptTokens,
           completionTokens,
           balance: balanceConfig,
-          model: responseMessage.model,
+          /** Note: When using agents, responseMessage.model is the agent ID, not the model */
+          model: this.model,
           messageId: this.responseMessageId,
         });
       }

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -306,6 +306,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
       }
     } catch (err) {
       logger.error(`[initializeClient] Error processing agent ${agentId}:`, err);
+      skippedAgentIds.add(agentId);
     }
   }
 

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -316,7 +316,12 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
       if (checkAgentInit(agentId)) {
         continue;
       }
-      await processAgent(agentId);
+      try {
+        await processAgent(agentId);
+      } catch (err) {
+        logger.error(`[initializeClient] Error processing chain agent ${agentId}:`, err);
+        skippedAgentIds.add(agentId);
+      }
     }
     const chain = await createSequentialChainEdges([primaryConfig.id].concat(agent_ids), '{convo}');
     collectEdges(chain);


### PR DESCRIPTION


## Summary

Fixes two silent bugs in agent handling — one causing the agent ID to be recorded as the model name for token spend tracking, and another leaving failed handoff agents unfiltered from the agent graph's edge set.

- Replaced `responseMessage.model` with `this.model` in the `recordTokenUsage` call inside `BaseClient.sendMessage`, as `responseMessage.model` resolves via `getResponseModel()` to the agent's ID (e.g. `agent_abc123`) rather than the actual underlying model name (e.g. `gpt-4o`) when using agent endpoints, causing token transactions to be recorded with an invalid model key.
- Added an inline comment clarifying the reasoning behind the model field assignment to guard against future regressions at the same call site.
- Added `skippedAgentIds.add(agentId)` to the catch block of the BFS handoff agent traversal loop in `initializeClient`, ensuring agents that throw during initialization (e.g. failing model validation) are tracked and subsequently filtered from the graph's edge set by `filterOrphanedEdges`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

These changes affect the silent, non-throwing code paths in agent transaction pricing and graph initialization. No visible runtime error surfaces when either bug is present, making manual confirmation important.

**Recommended test steps:**

1. Configure an agent backed by a real model (e.g. `gpt-4o`) and send a message that produces output.
2. Confirm via the transactions/balance logs that the recorded model is `gpt-4o` (or the configured model name), not the agent's ID string.
3. Configure a multi-agent setup where one handoff agent references a model that is not allowed by `allowedProviders`, triggering a validation failure during `initializeClient`.
4. Confirm the primary agent's conversation completes successfully rather than failing entirely, and that the invalid agent's edges are absent from the graph.

### **Test Configuration**:
- Agent endpoint with a non-ephemeral agent ID
- `balance.enabled: true` to activate the `recordTokenUsage` path
- A secondary handoff agent configured with a disallowed model to exercise the `skippedAgentIds` path

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings