### PR TITLE
🧠 feat: Add `reasoning_effort` configuration for Bedrock models

### DIFF
--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -236,6 +236,7 @@
   "com_endpoint_assistant": "Assistant",
   "com_endpoint_assistant_model": "Assistant Model",
   "com_endpoint_assistant_placeholder": "Please select an Assistant from the right-hand Side Panel",
+  "com_endpoint_bedrock_reasoning_config": "Controls the reasoning level for supported Bedrock models (e.g. Kimi K2.5, GLM). Higher levels produce more thorough reasoning at the cost of increased latency and tokens.",
   "com_endpoint_config_click_here": "Click Here",
   "com_endpoint_config_google_api_info": "To get your Generative Language API key (for Gemini),",
   "com_endpoint_config_google_api_key": "Google API Key",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -236,7 +236,7 @@
   "com_endpoint_assistant": "Assistant",
   "com_endpoint_assistant_model": "Assistant Model",
   "com_endpoint_assistant_placeholder": "Please select an Assistant from the right-hand Side Panel",
-  "com_endpoint_bedrock_reasoning_config": "Controls the reasoning level for supported Bedrock models (e.g. Kimi K2.5, GLM). Higher levels produce more thorough reasoning at the cost of increased latency and tokens.",
+  "com_endpoint_bedrock_reasoning_effort": "Controls the reasoning level for supported Bedrock models (e.g. Kimi K2.5, GLM). Higher levels produce more thorough reasoning at the cost of increased latency and tokens.",
   "com_endpoint_config_click_here": "Click Here",
   "com_endpoint_config_google_api_info": "To get your Generative Language API key (for Gemini),",
   "com_endpoint_config_google_api_key": "Google API Key",

--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -722,4 +722,66 @@ describe('initializeBedrock', () => {
       expect(amrf.effort).toBeUndefined();
     });
   });
+
+  describe('Bedrock reasoning_effort for Moonshot/ZAI models', () => {
+    it('should map reasoning_effort to reasoning_config for Moonshot Kimi K2.5', async () => {
+      const params = createMockParams({
+        model_parameters: {
+          model: 'moonshotai.kimi-k2.5',
+          reasoning_effort: 'high',
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+      const amrf = result.llmConfig.additionalModelRequestFields as Record<string, unknown>;
+
+      expect(amrf.reasoning_config).toBe('high');
+      expect(amrf.reasoning_effort).toBeUndefined();
+      expect(amrf.thinking).toBeUndefined();
+      expect(amrf.anthropic_beta).toBeUndefined();
+    });
+
+    it('should map reasoning_effort to reasoning_config for ZAI GLM', async () => {
+      const params = createMockParams({
+        model_parameters: {
+          model: 'zai.glm-4.7',
+          reasoning_effort: 'medium',
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+      const amrf = result.llmConfig.additionalModelRequestFields as Record<string, unknown>;
+
+      expect(amrf.reasoning_config).toBe('medium');
+      expect(amrf.reasoning_effort).toBeUndefined();
+    });
+
+    it('should not include reasoning_config when reasoning_effort is unset', async () => {
+      const params = createMockParams({
+        model_parameters: {
+          model: 'moonshotai.kimi-k2.5',
+          reasoning_effort: '',
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+
+      expect(result.llmConfig.additionalModelRequestFields).toBeUndefined();
+    });
+
+    it('should not map reasoning_effort to reasoning_config for Anthropic models', async () => {
+      const params = createMockParams({
+        model_parameters: {
+          model: 'anthropic.claude-opus-4-6-v1',
+          reasoning_effort: 'high',
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+      const amrf = result.llmConfig.additionalModelRequestFields as Record<string, unknown>;
+
+      expect(amrf.reasoning_config).toBeUndefined();
+      expect(amrf.thinking).toEqual({ type: 'adaptive' });
+    });
+  });
 });

--- a/packages/data-provider/specs/bedrock.spec.ts
+++ b/packages/data-provider/specs/bedrock.spec.ts
@@ -700,6 +700,30 @@ describe('bedrockInputParser', () => {
       const amrf = result.additionalModelRequestFields as Record<string, unknown>;
       expect(amrf.reasoning_config).toBeUndefined();
     });
+
+    test('should strip stale reasoning_config when switching from Moonshot to Meta model', () => {
+      const staleData = {
+        model: 'meta.llama-3-1-70b',
+        additionalModelRequestFields: {
+          reasoning_config: 'high',
+        },
+      };
+      const result = bedrockInputParser.parse(staleData) as Record<string, unknown>;
+      const amrf = result.additionalModelRequestFields as Record<string, unknown> | undefined;
+      expect(amrf?.reasoning_config).toBeUndefined();
+    });
+
+    test('should strip stale reasoning_config when switching from ZAI to DeepSeek model', () => {
+      const staleData = {
+        model: 'deepseek.deepseek-r1',
+        additionalModelRequestFields: {
+          reasoning_config: 'medium',
+        },
+      };
+      const result = bedrockInputParser.parse(staleData) as Record<string, unknown>;
+      const amrf = result.additionalModelRequestFields as Record<string, unknown> | undefined;
+      expect(amrf?.reasoning_config).toBeUndefined();
+    });
   });
 
   describe('Bedrock reasoning_effort → reasoning_config for Moonshot/ZAI models', () => {
@@ -759,6 +783,33 @@ describe('bedrockInputParser', () => {
         model: 'moonshotai.kimi-k2.5',
       };
       const result = bedrockInputParser.parse(input) as Record<string, unknown>;
+      const amrf = result.additionalModelRequestFields as Record<string, unknown> | undefined;
+      expect(amrf?.reasoning_config).toBeUndefined();
+    });
+
+    test('should not forward reasoning_effort "none" to reasoning_config', () => {
+      const result = bedrockInputParser.parse({
+        model: 'moonshotai.kimi-k2.5',
+        reasoning_effort: 'none',
+      }) as Record<string, unknown>;
+      const amrf = result.additionalModelRequestFields as Record<string, unknown> | undefined;
+      expect(amrf?.reasoning_config).toBeUndefined();
+    });
+
+    test('should not forward reasoning_effort "minimal" to reasoning_config', () => {
+      const result = bedrockInputParser.parse({
+        model: 'moonshotai.kimi-k2.5',
+        reasoning_effort: 'minimal',
+      }) as Record<string, unknown>;
+      const amrf = result.additionalModelRequestFields as Record<string, unknown> | undefined;
+      expect(amrf?.reasoning_config).toBeUndefined();
+    });
+
+    test('should not forward reasoning_effort "xhigh" to reasoning_config', () => {
+      const result = bedrockInputParser.parse({
+        model: 'zai.glm-4.7',
+        reasoning_effort: 'xhigh',
+      }) as Record<string, unknown>;
       const amrf = result.additionalModelRequestFields as Record<string, unknown> | undefined;
       expect(amrf?.reasoning_config).toBeUndefined();
     });

--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -534,7 +534,7 @@ const bedrock: Record<string, SettingDefinition> = {
     key: 'reasoning_effort',
     label: 'com_endpoint_reasoning_effort',
     labelCode: true,
-    description: 'com_endpoint_bedrock_reasoning_config',
+    description: 'com_endpoint_bedrock_reasoning_effort',
     descriptionCode: true,
     type: 'enum',
     default: ReasoningEffort.unset,

--- a/packages/data-provider/src/parameterSettings.ts
+++ b/packages/data-provider/src/parameterSettings.ts
@@ -530,6 +530,30 @@ const bedrock: Record<string, SettingDefinition> = {
     showDefault: false,
     columnSpan: 2,
   },
+  reasoning_effort: {
+    key: 'reasoning_effort',
+    label: 'com_endpoint_reasoning_effort',
+    labelCode: true,
+    description: 'com_endpoint_bedrock_reasoning_config',
+    descriptionCode: true,
+    type: 'enum',
+    default: ReasoningEffort.unset,
+    component: 'slider',
+    options: [
+      ReasoningEffort.unset,
+      ReasoningEffort.low,
+      ReasoningEffort.medium,
+      ReasoningEffort.high,
+    ],
+    enumMappings: {
+      [ReasoningEffort.unset]: 'com_ui_off',
+      [ReasoningEffort.low]: 'com_ui_low',
+      [ReasoningEffort.medium]: 'com_ui_medium',
+      [ReasoningEffort.high]: 'com_ui_high',
+    },
+    optionType: 'model',
+    columnSpan: 4,
+  },
 };
 
 const mistral: Record<string, SettingDefinition> = {
@@ -905,6 +929,34 @@ const bedrockGeneralCol2: SettingsConfiguration = [
   librechat.fileTokenLimit,
 ];
 
+const bedrockZAI: SettingsConfiguration = [
+  librechat.modelLabel,
+  librechat.promptPrefix,
+  librechat.maxContextTokens,
+  meta.temperature,
+  meta.topP,
+  librechat.resendFiles,
+  bedrock.region,
+  bedrock.reasoning_effort,
+  librechat.fileTokenLimit,
+];
+
+const bedrockZAICol1: SettingsConfiguration = [
+  baseDefinitions.model as SettingDefinition,
+  librechat.modelLabel,
+  librechat.promptPrefix,
+];
+
+const bedrockZAICol2: SettingsConfiguration = [
+  librechat.maxContextTokens,
+  meta.temperature,
+  meta.topP,
+  librechat.resendFiles,
+  bedrock.region,
+  bedrock.reasoning_effort,
+  librechat.fileTokenLimit,
+];
+
 const bedrockMoonshot: SettingsConfiguration = [
   librechat.modelLabel,
   bedrock.system,
@@ -917,6 +969,7 @@ const bedrockMoonshot: SettingsConfiguration = [
   baseDefinitions.stop,
   librechat.resendFiles,
   bedrock.region,
+  bedrock.reasoning_effort,
   librechat.fileTokenLimit,
 ];
 
@@ -936,6 +989,7 @@ const bedrockMoonshotCol2: SettingsConfiguration = [
   bedrock.topP,
   librechat.resendFiles,
   bedrock.region,
+  bedrock.reasoning_effort,
   librechat.fileTokenLimit,
 ];
 
@@ -954,7 +1008,7 @@ export const paramSettings: Record<string, SettingsConfiguration | undefined> = 
   [`${EModelEndpoint.bedrock}-${BedrockProviders.Moonshot}`]: bedrockMoonshot,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.MoonshotAI}`]: bedrockMoonshot,
   [`${EModelEndpoint.bedrock}-${BedrockProviders.OpenAI}`]: bedrockGeneral,
-  [`${EModelEndpoint.bedrock}-${BedrockProviders.ZAI}`]: bedrockGeneral,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.ZAI}`]: bedrockZAI,
   [EModelEndpoint.google]: googleConfig,
 };
 
@@ -1008,7 +1062,10 @@ export const presetSettings: Record<
     col2: bedrockMoonshotCol2,
   },
   [`${EModelEndpoint.bedrock}-${BedrockProviders.OpenAI}`]: bedrockGeneralColumns,
-  [`${EModelEndpoint.bedrock}-${BedrockProviders.ZAI}`]: bedrockGeneralColumns,
+  [`${EModelEndpoint.bedrock}-${BedrockProviders.ZAI}`]: {
+    col1: bedrockZAICol1,
+    col2: bedrockZAICol2,
+  },
   [EModelEndpoint.google]: {
     col1: googleCol1,
     col2: googleCol2,

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -185,6 +185,12 @@ export enum AnthropicEffort {
   max = 'max',
 }
 
+export enum BedrockReasoningConfig {
+  low = 'low',
+  medium = 'medium',
+  high = 'high',
+}
+
 export enum ReasoningSummary {
   none = '',
   auto = 'auto',


### PR DESCRIPTION
- Introduced a new `reasoning_effort` setting in the Bedrock configuration, allowing users to specify the reasoning level for supported models.
- Updated the input parser to map `reasoning_effort` to `reasoning_config` for Moonshot and ZAI models, ensuring proper handling of reasoning levels.
- Enhanced tests to validate the mapping of `reasoning_effort` to `reasoning_config` and to ensure correct behavior for various model types, including Anthropic models.
- Updated translation files to include descriptions for the new configuration option.
