### PR TITLE
🔀 feat: update OpenRouter with new Reasoning config

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.52",
+    "@librechat/agents": "^3.1.53",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.52",
+        "@librechat/agents": "^3.1.53",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11836,9 +11836,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.52",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.52.tgz",
-      "integrity": "sha512-Bg35zp+vEDZ0AEJQPZ+ukWb/UqBrsLcr3YQWRQpuvpftEgfQz0fHM5Wrxn6l5P7PvaD1ViolxoG44nggjCt7Hw==",
+      "version": "3.1.53",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.53.tgz",
+      "integrity": "sha512-jK9JHIhQYgr+Ha2FhknEYQmS6Ft3/TGdYIlL6L6EtIq20SIA59r1DvQx/x9sd3wHoHkk6AZumMgqAUTTCaWBIA==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -43797,7 +43797,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.52",
+        "@librechat/agents": "^3.1.53",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -90,7 +90,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.52",
+    "@librechat/agents": "^3.1.53",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/src/endpoints/openai/config.spec.ts
+++ b/packages/api/src/endpoints/openai/config.spec.ts
@@ -861,7 +861,7 @@ describe('getOpenAIConfig', () => {
       expect(result.provider).toBe('openrouter');
     });
 
-    it('should handle OpenRouter with reasoning params', () => {
+    it('should handle OpenRouter with reasoning params (no summary)', () => {
       const modelOptions = {
         reasoning_effort: ReasoningEffort.high,
         reasoning_summary: ReasoningSummary.detailed,
@@ -872,10 +872,11 @@ describe('getOpenAIConfig', () => {
         modelOptions,
       });
 
+      // OpenRouter reasoning object should only include effort, not summary
       expect(result.llmConfig.reasoning).toEqual({
         effort: ReasoningEffort.high,
-        summary: ReasoningSummary.detailed,
       });
+      expect(result.llmConfig.include_reasoning).toBeUndefined();
       expect(result.provider).toBe('openrouter');
     });
 
@@ -1205,8 +1206,9 @@ describe('getOpenAIConfig', () => {
         model: 'gpt-4-turbo',
         temperature: 0.8,
         streaming: false,
-        include_reasoning: true, // OpenRouter specific
+        reasoning: { effort: ReasoningEffort.high }, // OpenRouter reasoning object
       });
+      expect(result.llmConfig.include_reasoning).toBeUndefined();
       // Should NOT have useResponsesApi for OpenRouter
       expect(result.llmConfig.useResponsesApi).toBeUndefined();
       expect(result.llmConfig.maxTokens).toBe(2000);
@@ -1480,13 +1482,12 @@ describe('getOpenAIConfig', () => {
           user: 'openrouter-user',
           temperature: 0.7,
           maxTokens: 4000,
-          include_reasoning: true, // OpenRouter specific
           reasoning: {
             effort: ReasoningEffort.high,
-            summary: ReasoningSummary.detailed,
           },
           apiKey: apiKey,
         });
+        expect(result.llmConfig.include_reasoning).toBeUndefined();
         expect(result.llmConfig.modelKwargs).toMatchObject({
           top_k: 50,
           repetition_penalty: 1.1,

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -225,15 +225,15 @@ export function getOpenAILLMConfig({
 
   if (useOpenRouter) {
     if (hasReasoningParams({ reasoning_effort })) {
-      /** OpenRouter uses a unified `reasoning` object instead of `reasoning_effort` */
-      llmConfig.reasoning = removeNullishValues(
-        {
-          effort: reasoning_effort,
-        },
-        true,
-      ) as OpenRouterReasoning;
+      /**
+       * OpenRouter uses a `reasoning` object — `summary` is not supported.
+       * ChatOpenRouter treats `reasoning` and `include_reasoning` as mutually exclusive:
+       * `include_reasoning` is legacy compat that maps to `{ enabled: true }` only when
+       * no `reasoning` object is present, so we intentionally omit it here.
+       */
+      llmConfig.reasoning = { effort: reasoning_effort } as OpenRouterReasoning;
     } else {
-      /** Fallback: enable reasoning by default for OpenRouter (replaces legacy include_reasoning) */
+      /** No explicit effort; fall back to legacy `include_reasoning` for reasoning token inclusion */
       llmConfig.include_reasoning = true;
     }
   } else if (


### PR DESCRIPTION


## Summary

Fixed a bug in `getOpenAILLMConfig` where OpenRouter requests with `reasoning_effort` set could simultaneously produce both `include_reasoning: true` and a `reasoning` object containing `summary`, neither of which is correct for OpenRouter's API.

- Rewired the OpenRouter branch to produce `reasoning: { effort }` when `reasoning_effort` is present, replacing the unconditional `include_reasoning: true` assignment that previously always fired.
- Explicitly excludes `reasoning_summary` from the OpenRouter `reasoning` object, as OpenRouter's API does not support a `summary` field.
- Retains `include_reasoning: true` as a fallback when no `reasoning_effort` is provided, preserving legacy behavior for models that surface reasoning tokens without an explicit effort level.
- Added an inline comment documenting the mutual exclusivity of `reasoning` and `include_reasoning` in ChatOpenRouter, citing that `include_reasoning` maps to `{ enabled: true }` only when no `reasoning` object is present.
- Removed a redundant `removeNullishValues` call wrapping `{ effort: reasoning_effort }`, which was a guaranteed no-op after the `hasReasoningParams` guard.
- Converted a `for` loop across effort-level variants in `llm.spec.ts` to `it.each` for per-value failure diagnostics and added the missing `not.toHaveProperty('include_reasoning')` assertion to each iteration.
- Added a test covering the `ReasoningEffort.unset` (`''`) edge case, verifying that the empty string is stripped before the guard and correctly falls through to the `include_reasoning` fallback.
- Added a test for the `web_search + reasoning_effort` combination on OpenRouter, confirming both `reasoning: { effort }` and `plugins: [{ id: 'web' }]` are produced simultaneously without `include_reasoning`.
- Removed a logically redundant `.summary` undefined assertion from the summary-exclusion test, as `toHaveProperty` with a value argument already performs deep equality.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Unit tests cover all modified and new code paths directly in `llm.spec.ts` and transitively in `config.spec.ts`.

### **Test Configuration**:

Run the unit tests for the `@librechat/api` package:

```bash
cd packages/api
npm run test:ci
```

Key test suites to verify:

- `describe('OpenRouter Configuration')` in `llm.spec.ts` — covers the new `reasoning` object path, the `include_reasoning` fallback, the `unset` edge case, all three OpenRouter-specific effort levels via `it.each`, and the `web_search + reasoning_effort` combination.
- `describe('OpenRouter Configuration')` in `config.spec.ts` — integration-level coverage verifying the full `getOpenAIConfig` call chain produces the correct output for OpenRouter with and without `reasoning_effort`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes