### PR TITLE
✂️ fix: Unicode-Safe Title Truncation and Shared View Layout Polish

### DIFF
--- a/client/src/components/Share/MessagesView.tsx
+++ b/client/src/components/Share/MessagesView.tsx
@@ -13,7 +13,7 @@ export default function MessagesView({
   const localize = useLocalize();
   const [currentEditId, setCurrentEditId] = useState<number | string | null>(-1);
   return (
-    <div className="min-h-0 flex-1 overflow-hidden pb-[50px]">
+    <div className="min-h-0 flex-1 overflow-hidden">
       <div className="dark:gpt-dark-gray relative h-full">
         <div
           style={{
@@ -22,7 +22,7 @@ export default function MessagesView({
             width: '100%',
           }}
         >
-          <div className="flex flex-col pb-9 text-sm dark:bg-transparent">
+          <div className="flex flex-col pb-16 text-sm dark:bg-transparent">
             {(_messagesTree && _messagesTree.length == 0) || _messagesTree === null ? (
               <div className="flex w-full items-center justify-center gap-1 bg-gray-50 p-3 text-sm text-gray-500 dark:border-gray-800/50 dark:bg-gray-800 dark:text-gray-300">
                 {localize('com_ui_nothing_found')}

--- a/client/src/components/Share/MessagesView.tsx
+++ b/client/src/components/Share/MessagesView.tsx
@@ -23,7 +23,7 @@ export default function MessagesView({
           }}
         >
           <div className="flex flex-col pb-16 text-sm dark:bg-transparent">
-            {(_messagesTree && _messagesTree.length == 0) || _messagesTree === null ? (
+            {(_messagesTree && _messagesTree.length === 0) || _messagesTree === null ? (
               <div className="flex w-full items-center justify-center gap-1 bg-gray-50 p-3 text-sm text-gray-500 dark:border-gray-800/50 dark:bg-gray-800 dark:text-gray-300">
                 {localize('com_ui_nothing_found')}
               </div>

--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -123,14 +123,14 @@ function SharedView() {
   }
 
   const footer = (
-    <div className="w-full border-t-0 pl-0 pt-2 md:w-[calc(100%-.5rem)] md:border-t-0 md:border-transparent md:pl-0 md:pt-0 md:dark:border-transparent">
-      <Footer className="relative mx-auto mt-4 flex max-w-[55rem] flex-wrap items-center justify-center gap-2 px-3 pb-4 pt-2 text-center text-xs text-text-secondary" />
+    <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 bg-gradient-to-t from-surface-secondary from-40% to-transparent">
+      <Footer className="pointer-events-auto relative mx-auto flex max-w-[55rem] flex-wrap items-center justify-center gap-2 px-3 pb-4 pt-6 text-center text-xs text-text-secondary" />
     </div>
   );
 
   const mainContent = (
     <div className="transition-width relative flex h-full w-full flex-1 flex-col items-stretch overflow-hidden pt-0 dark:bg-surface-secondary">
-      <div className="flex h-full min-h-0 flex-col text-text-primary" role="presentation">
+      <div className="relative flex h-full min-h-0 flex-col text-text-primary" role="presentation">
         {content}
         {footer}
       </div>
@@ -189,11 +189,13 @@ function ShareHeader({
   }, []);
 
   return (
-    <section className="mx-auto w-full px-3 pb-4 pt-6 md:px-5">
-      <div className="bg-surface-primary/80 relative mx-auto flex w-full max-w-[60rem] flex-col gap-4 rounded-3xl border border-border-light px-6 py-5 shadow-xl backdrop-blur">
+    <section className="mx-auto w-full px-2 pb-3 pt-4 md:px-5 md:pb-4 md:pt-6">
+      <div className="bg-surface-primary/80 relative mx-auto flex w-full max-w-[60rem] flex-col gap-3 rounded-2xl border border-border-light px-4 py-4 shadow-xl backdrop-blur md:gap-4 md:rounded-3xl md:px-6 md:py-5">
         <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
-          <div className="space-y-2">
-            <h1 className="line-clamp-2 text-4xl font-semibold text-text-primary">{title}</h1>
+          <div className="min-w-0 space-y-1.5 md:space-y-2">
+            <h1 className="line-clamp-2 break-words text-2xl font-semibold text-text-primary md:text-4xl">
+              {title}
+            </h1>
             {formattedDate && (
               <div className="flex items-center gap-2 text-sm text-text-secondary">
                 <CalendarDays className="size-4" aria-hidden="true" />

--- a/client/src/components/Share/ShareView.tsx
+++ b/client/src/components/Share/ShareView.tsx
@@ -193,7 +193,7 @@ function ShareHeader({
       <div className="bg-surface-primary/80 relative mx-auto flex w-full max-w-[60rem] flex-col gap-4 rounded-3xl border border-border-light px-6 py-5 shadow-xl backdrop-blur">
         <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
           <div className="space-y-2">
-            <h1 className="text-4xl font-semibold text-text-primary">{title}</h1>
+            <h1 className="line-clamp-2 text-4xl font-semibold text-text-primary">{title}</h1>
             {formattedDate && (
               <div className="flex items-center gap-2 text-sm text-text-secondary">
                 <CalendarDays className="size-4" aria-hidden="true" />

--- a/packages/api/src/utils/sanitizeTitle.spec.ts
+++ b/packages/api/src/utils/sanitizeTitle.spec.ts
@@ -174,6 +174,23 @@ describe('sanitizeTitle', () => {
     });
   });
 
+  describe('Max Length Truncation', () => {
+    it('should pass through a title exactly at max length unchanged', () => {
+      const input = 'A'.repeat(200);
+      expect(sanitizeTitle(input)).toBe(input);
+    });
+
+    it('should truncate a title over max length with ellipsis', () => {
+      const input = 'A'.repeat(250);
+      expect(sanitizeTitle(input)).toBe('A'.repeat(200) + '...');
+    });
+
+    it('should truncate after think-block removal', () => {
+      const input = '<think>reasoning</think> ' + 'B'.repeat(250);
+      expect(sanitizeTitle(input)).toBe('B'.repeat(200) + '...');
+    });
+  });
+
   describe('Idempotency', () => {
     it('should be idempotent', () => {
       const input = '<think>reasoning</think> My Title';

--- a/packages/api/src/utils/sanitizeTitle.spec.ts
+++ b/packages/api/src/utils/sanitizeTitle.spec.ts
@@ -1,4 +1,4 @@
-import { sanitizeTitle } from './sanitizeTitle';
+import { sanitizeTitle, MAX_TITLE_LENGTH, DEFAULT_TITLE_FALLBACK } from './sanitizeTitle';
 
 describe('sanitizeTitle', () => {
   describe('Happy Path', () => {
@@ -123,21 +123,21 @@ describe('sanitizeTitle', () => {
 
   describe('Empty and Fallback Cases', () => {
     it('should return fallback for empty string', () => {
-      expect(sanitizeTitle('')).toBe('Untitled Conversation');
+      expect(sanitizeTitle('')).toBe(DEFAULT_TITLE_FALLBACK);
     });
 
     it('should return fallback when only whitespace remains', () => {
       const input = '<think>thinking</think>     \n\t\r\n    ';
-      expect(sanitizeTitle(input)).toBe('Untitled Conversation');
+      expect(sanitizeTitle(input)).toBe(DEFAULT_TITLE_FALLBACK);
     });
 
     it('should return fallback when only think blocks exist', () => {
       const input = '<think>just thinking</think><think>more thinking</think>';
-      expect(sanitizeTitle(input)).toBe('Untitled Conversation');
+      expect(sanitizeTitle(input)).toBe(DEFAULT_TITLE_FALLBACK);
     });
 
     it('should return fallback for non-string whitespace', () => {
-      expect(sanitizeTitle('   ')).toBe('Untitled Conversation');
+      expect(sanitizeTitle('   ')).toBe(DEFAULT_TITLE_FALLBACK);
     });
   });
 
@@ -175,19 +175,49 @@ describe('sanitizeTitle', () => {
   });
 
   describe('Max Length Truncation', () => {
+    const ellipsis = '...';
+    const maxContent = MAX_TITLE_LENGTH - ellipsis.length;
+
     it('should pass through a title exactly at max length unchanged', () => {
-      const input = 'A'.repeat(200);
+      const input = 'A'.repeat(MAX_TITLE_LENGTH);
       expect(sanitizeTitle(input)).toBe(input);
     });
 
     it('should truncate a title over max length with ellipsis', () => {
-      const input = 'A'.repeat(250);
-      expect(sanitizeTitle(input)).toBe('A'.repeat(200) + '...');
+      const input = 'A'.repeat(MAX_TITLE_LENGTH + 50);
+      const result = sanitizeTitle(input);
+      expect(result).toBe('A'.repeat(maxContent) + ellipsis);
+      expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
     });
 
     it('should truncate after think-block removal', () => {
-      const input = '<think>reasoning</think> ' + 'B'.repeat(250);
-      expect(sanitizeTitle(input)).toBe('B'.repeat(200) + '...');
+      const input = '<think>reasoning</think> ' + 'B'.repeat(MAX_TITLE_LENGTH + 50);
+      const result = sanitizeTitle(input);
+      expect(result).toBe('B'.repeat(maxContent) + ellipsis);
+      expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    });
+
+    it('should trimEnd before appending ellipsis when slice ends with whitespace', () => {
+      const input = 'A'.repeat(maxContent - 1) + ' B' + 'C'.repeat(MAX_TITLE_LENGTH);
+      const result = sanitizeTitle(input);
+      expect(result).toBe('A'.repeat(maxContent - 1) + ellipsis);
+      expect(result).not.toMatch(/ \.\.\./);
+    });
+
+    it('should not produce lone surrogates when truncating emoji titles', () => {
+      const input = 'A'.repeat(MAX_TITLE_LENGTH - 2) + '\u{1F389}rest';
+      const result = sanitizeTitle(input);
+      expect(result.isWellFormed()).toBe(true);
+      expect([...result].length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    });
+
+    it('should handle a title composed entirely of emoji', () => {
+      const emoji = '\u{1F680}';
+      const input = emoji.repeat(MAX_TITLE_LENGTH + 10);
+      const result = sanitizeTitle(input);
+      expect(result.isWellFormed()).toBe(true);
+      expect(result.endsWith(ellipsis)).toBe(true);
+      expect([...result].length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
     });
   });
 
@@ -205,7 +235,7 @@ describe('sanitizeTitle', () => {
       const once = sanitizeTitle(input);
       const twice = sanitizeTitle(once);
       expect(once).toBe(twice);
-      expect(once).toBe('Untitled Conversation');
+      expect(once).toBe(DEFAULT_TITLE_FALLBACK);
     });
   });
 

--- a/packages/api/src/utils/sanitizeTitle.ts
+++ b/packages/api/src/utils/sanitizeTitle.ts
@@ -25,6 +25,16 @@ export function sanitizeTitle(rawTitle: string): string {
   // Step 4: Trim leading and trailing whitespace
   const trimmed = normalized.trim();
 
-  // Step 5: Return trimmed result or fallback if empty
-  return trimmed.length > 0 ? trimmed : DEFAULT_FALLBACK;
+  // Step 5: Return fallback if empty
+  if (trimmed.length === 0) {
+    return DEFAULT_FALLBACK;
+  }
+
+  // Step 6: Truncate to max length
+  const MAX_TITLE_LENGTH = 200;
+  if (trimmed.length > MAX_TITLE_LENGTH) {
+    return trimmed.slice(0, MAX_TITLE_LENGTH).trimEnd() + '...';
+  }
+
+  return trimmed;
 }

--- a/packages/api/src/utils/sanitizeTitle.ts
+++ b/packages/api/src/utils/sanitizeTitle.ts
@@ -1,39 +1,34 @@
+/** Max character length for sanitized titles (the output will never exceed this). */
+export const MAX_TITLE_LENGTH = 200;
+export const DEFAULT_TITLE_FALLBACK = 'Untitled Conversation';
+
 /**
- * Sanitizes LLM-generated chat titles by removing <think>...</think> reasoning blocks.
+ * Sanitizes LLM-generated chat titles by removing {@link https://en.wikipedia.org/wiki/Chain-of-thought_prompting <think>}
+ * reasoning blocks, normalizing whitespace, and truncating to {@link MAX_TITLE_LENGTH} characters.
  *
- * This function strips out all reasoning blocks (with optional attributes and newlines)
- * and returns a clean title. If the result is empty, a fallback is returned.
+ * Titles exceeding the limit are truncated at a code-point-safe boundary and suffixed with `...`.
  *
  * @param rawTitle - The raw LLM-generated title string, potentially containing <think> blocks.
- * @returns A sanitized title string, never empty (fallback used if needed).
+ * @returns A sanitized, potentially truncated title string, never empty (fallback used if needed).
  */
 export function sanitizeTitle(rawTitle: string): string {
-  const DEFAULT_FALLBACK = 'Untitled Conversation';
-
-  // Step 1: Input Validation
   if (!rawTitle || typeof rawTitle !== 'string') {
-    return DEFAULT_FALLBACK;
+    return DEFAULT_TITLE_FALLBACK;
   }
 
-  // Step 2: Build and apply the regex to remove all <think>...</think> blocks
   const thinkBlockRegex = /<think\b[^>]*>[\s\S]*?<\/think>/gi;
   const cleaned = rawTitle.replace(thinkBlockRegex, '');
-
-  // Step 3: Normalize whitespace (collapse multiple spaces/newlines to single space)
   const normalized = cleaned.replace(/\s+/g, ' ');
-
-  // Step 4: Trim leading and trailing whitespace
   const trimmed = normalized.trim();
 
-  // Step 5: Return fallback if empty
   if (trimmed.length === 0) {
-    return DEFAULT_FALLBACK;
+    return DEFAULT_TITLE_FALLBACK;
   }
 
-  // Step 6: Truncate to max length
-  const MAX_TITLE_LENGTH = 200;
-  if (trimmed.length > MAX_TITLE_LENGTH) {
-    return trimmed.slice(0, MAX_TITLE_LENGTH).trimEnd() + '...';
+  const codePoints = [...trimmed];
+  if (codePoints.length > MAX_TITLE_LENGTH) {
+    const truncateAt = MAX_TITLE_LENGTH - 3;
+    return codePoints.slice(0, truncateAt).join('').trimEnd() + '...';
   }
 
   return trimmed;


### PR DESCRIPTION


## Summary

Fixed title overflow edge cases in the shared conversation view by hardening `sanitizeTitle` with a strict, code-point-safe length cap and reworking the `ShareView` header and footer layout to gracefully handle long titles on all viewports.

- Replaced the naive `String.prototype.slice` truncation in `sanitizeTitle` with a Unicode code-point-safe spread (`[...trimmed].slice(...)`) to prevent lone surrogates when truncating at an emoji boundary, which would otherwise produce corrupted characters in MongoDB.
- Fixed the truncation math to slice at `MAX_TITLE_LENGTH - 3` before appending `'...'`, ensuring the output never exceeds the stated 200-character cap.
- Extracted `MAX_TITLE_LENGTH` and `DEFAULT_TITLE_FALLBACK` as exported module-level constants, replacing hardcoded values in both the implementation and the test suite.
- Updated the JSDoc on `sanitizeTitle` to document the truncation behavior and link to `MAX_TITLE_LENGTH`.
- Removed all step-numbered inline comments from `sanitizeTitle`, letting the code speak for itself.
- Updated `ShareHeader` title `h1` with `line-clamp-2 break-words` and responsive font sizing (`text-2xl` → `md:text-4xl`), added `min-w-0` to the flex container to prevent overflow escaping the flex layout.
- Tightened `ShareHeader` section and card spacing for mobile viewports.
- Repositioned the shared view footer as an `absolute` gradient overlay (`bg-gradient-to-t`) with `pointer-events-none`/`pointer-events-auto` layering so it no longer participates in flow layout.
- Adjusted `MessagesView` bottom padding from `pb-9` to `pb-16` to clear the gradient footer overlay, and removed the now-redundant outer `pb-[50px]`.
- Fixed a pre-existing loose equality `==` to strict `===` in the empty-tree check in `MessagesView`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Covered by the `sanitizeTitle` unit test suite (`packages/api/src/utils/sanitizeTitle.spec.ts`). All 40 tests pass.

New test cases added:

- Passes through a title exactly at `MAX_TITLE_LENGTH` unchanged.
- Truncates a title over the limit and verifies the result is `≤ MAX_TITLE_LENGTH` characters.
- Truncates correctly after `<think>` block removal.
- Calls `trimEnd()` before appending `'...'` when the slice boundary falls on whitespace (asserts no `" ..."`).
- Asserts `String.prototype.isWellFormed() === true` when truncating a title whose code-point boundary falls inside an emoji surrogate pair.
- Asserts well-formedness and correct length cap on a title composed entirely of emoji.

### Test Configuration

```bash
cd packages/api && npx jest sanitizeTitle
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes