### PR TITLE
🪵 refactor: `onmessage` Handler and Restructure MCP Debug Logging

### DIFF
--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -691,7 +691,7 @@ export class MCPConnection extends EventEmitter {
         }
 
         this.transport = await runOutsideTracing(() => this.constructTransport(this.options));
-        this.setupTransportDebugHandlers();
+        this.patchTransportSend();
 
         const connectTimeout = this.options.initTimeout ?? 120000;
         await runOutsideTracing(() =>
@@ -816,7 +816,7 @@ export class MCPConnection extends EventEmitter {
     return this.connectPromise;
   }
 
-  private setupTransportDebugHandlers(): void {
+  private patchTransportSend(): void {
     if (!this.transport) {
       return;
     }

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -830,7 +830,10 @@ export class MCPConnection extends EventEmitter {
     }
 
     this.transport.onmessage = (msg) => {
-      logger.debug(`${this.getLogPrefix()} Transport received: ${JSON.stringify(msg)}`);
+      const { method, id } = msg as { method?: string; id?: number };
+      logger.debug(
+        `${this.getLogPrefix()} Transport received: method=${method ?? 'response'} id=${id}`,
+      );
     };
 
     const originalSend = this.transport.send.bind(this.transport);
@@ -841,7 +844,10 @@ export class MCPConnection extends EventEmitter {
         }
         this.lastPingTime = Date.now();
       }
-      logger.debug(`${this.getLogPrefix()} Transport sending: ${JSON.stringify(msg)}`);
+      const { method, id } = msg as { method?: string; id?: number };
+      logger.debug(
+        `${this.getLogPrefix()} Transport sending: method=${method ?? 'response'} id=${id}`,
+      );
       return originalSend(msg);
     };
   }


### PR DESCRIPTION

## Summary

Refactored MCP transport debug logging to fix a dead `onmessage` handler and replace full `JSON.stringify` payloads with structured `method`/`id` fields on debug log lines.

- Renamed `setupTransportDebugHandlers` to `patchTransportSend` to accurately reflect that it only patches the `send` path.
- Extracted a new `setupTransportOnMessageHandler()` method that runs after `client.connect()`, wrapping the SDK-assigned handler rather than setting one before it — the prior approach left a handler that was unconditionally overwritten by `Protocol.connect()` and never executed.
- Replaced `JSON.stringify(msg)` in both the send and receive debug log lines with structured `method`/`id` extraction using `'in'`-narrowing, avoiding 100KB+ payload serialization on tool responses and file content messages.
- Fixed the `id` type assertion from `id?: number` to `string | number | null`, matching the MCP SDK's `RequestId` definition and the JSON-RPC 2.0 spec.
- Added `id ?? 'none'` fallback so notifications (which carry no `id`) render cleanly instead of `id=undefined`.
- Removed dead `onmessage` assignments from the SSE and streamable-http transport construction paths in `constructTransport` — both were immediately overwritten and never fired.
- Removed the now-unused `JSONRPCMessage` import.

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Testing

Enable debug-level logging and connect to any MCP server (stdio, SSE, or streamable-http). Verify:

1. `Transport sending:` lines appear for outgoing requests and responses with correct `method` and `id` values.
2. `Transport received:` lines now actually appear — they were silently suppressed before this change.
3. Notifications (e.g., `notifications/resources/list_changed`) log `id=none` rather than `id=undefined`.
4. Full MCP tool call round-trip completes without regression.

### **Test Configuration**:

Set `LOG_LEVEL=debug` (or equivalent for the logger in use) and trigger any MCP tool call from the agent panel.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings