### PR TITLE
fix: complete OIDC logout implementation

### DIFF
--- a/api/server/controllers/auth/LogoutController.js
+++ b/api/server/controllers/auth/LogoutController.js
@@ -8,13 +8,16 @@ const logoutController = async (req, res) => {
   const parsedCookies = req.headers.cookie ? cookies.parse(req.headers.cookie) : {};
   const isOpenIdUser = req.user?.openidId != null && req.user?.provider === 'openid';
 
-  /** For OpenID users, read refresh token from session; for others, use cookie */
+  /** For OpenID users, read tokens from session; for others, use cookie */
   let refreshToken;
+  let idToken;
   if (isOpenIdUser && req.session?.openidTokens) {
     refreshToken = req.session.openidTokens.refreshToken;
+    idToken = req.session.openidTokens.idToken;
     delete req.session.openidTokens;
   }
   refreshToken = refreshToken || parsedCookies.refreshToken;
+  idToken = idToken || parsedCookies.openid_id_token;
 
   try {
     const logout = await logoutUser(req, refreshToken);
@@ -46,6 +49,14 @@ const logoutController = async (req, res) => {
           const postLogoutRedirectUri =
             process.env.OPENID_POST_LOGOUT_REDIRECT_URI || `${process.env.DOMAIN_CLIENT}/login`;
           endSessionUrl.searchParams.set('post_logout_redirect_uri', postLogoutRedirectUri);
+
+          /** Add id_token_hint (preferred) or client_id for OIDC spec compliance */
+          if (idToken) {
+            endSessionUrl.searchParams.set('id_token_hint', idToken);
+          } else {
+            endSessionUrl.searchParams.set('client_id', process.env.OPENID_CLIENT_ID);
+          }
+
           response.redirect = endSessionUrl.toString();
         } else {
           logger.warn(

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -106,11 +106,15 @@ const AuthContextProvider = ({
   });
   const logoutUser = useLogoutUserMutation({
     onSuccess: (data) => {
+      if (data.redirect) {
+        window.location.replace(data.redirect);
+        return;
+      }
       setUserContext({
         token: undefined,
         isAuthenticated: false,
         user: undefined,
-        redirect: data.redirect ?? '/login',
+        redirect: '/login',
       });
     },
     onError: (error) => {


### PR DESCRIPTION
## Summary

This PR completes the OIDC logout feature added in #5626 and builds on the session-based token storage from #11236. The original implementation added backend support for `end_session_endpoint` redirects, but was missing required OIDC parameters and the frontend was never updated to handle external URLs.

**Related issues:** #5506, #8951, #9635

### Background

PR #5626 added backend support for OIDC logout by returning a redirect URL to the IdP's `end_session_endpoint`. However:
1. The logout URL only included `post_logout_redirect_uri`, missing the required `id_token_hint` or `client_id`
2. The frontend passes this URL through `isSafeRedirect()`, which rejects all absolute URLs—the redirect is silently dropped

### Problems Fixed

1. **Backend: Missing OIDC spec parameters** - The [RP-Initiated Logout spec](https://openid.net/specs/openid-connect-rpinitiated-1_0.html) requires `id_token_hint` or `client_id` when `post_logout_redirect_uri` is used. Without these, Keycloak 18+ rejects the request.

2. **Frontend: External redirect silently dropped** - The logout redirect URL fails `isSafeRedirect()` and is silently dropped. The user appears logged out but the IdP session persists.

### Solution

**Backend:** Add `id_token_hint` (preferred, using session storage from #11236) or `client_id` (fallback) to the logout URL.

**Frontend:** Use `window.location.replace()` for logout redirects, bypassing `isSafeRedirect()` which was designed for user-input validation, not trusted backend responses.

Fixes #5506

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested with Keycloak 26.5.3 in a deployed environment.

### Test Configuration

- Keycloak 26.5.3
- `OPENID_USE_END_SESSION_ENDPOINT=true`
- `OPENID_REUSE_TOKENS=true`
- `OPENID_AUTO_REDIRECT=true` (to verify no auto re-login after logout)

### Manual Test Results

- [x] Logout URL contains `id_token_hint`
- [x] Logout URL contains `client_id` fallback (when `OPENID_REUSE_TOKENS=false`)
- [x] Browser navigates to IdP logout URL
- [x] IdP session terminated (no auto re-login)
- [x] Non-OIDC logout still works

### Automated Tests

- Frontend: 89/89 suites passed
- Backend: 87/87 suites passed (3 failed + 2 skipped are pre-existing on main, unrelated to this PR)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes