### PR TITLE
🫳 fix: Restore Background on Drag and Drop Overlay

### DIFF
--- a/client/src/components/Chat/Input/Files/DragDropOverlay.tsx
+++ b/client/src/components/Chat/Input/Files/DragDropOverlay.tsx
@@ -36,7 +36,7 @@ const DragDropOverlay = memo(({ isActive }: DragDropOverlayProps) => {
         }}
       >
         {/** Content area with subtle background */}
-        <div className="bg-surface-primary/95 flex flex-col items-center rounded-lg p-8 shadow-xl">
+        <div className="flex flex-col items-center rounded-lg bg-surface-primary p-8 shadow-xl">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 132 108"


### PR DESCRIPTION
## Summary

The drag & drop background was practically translucent, which made it hard to see the rest of the overlay (especially on light mode).

Now, we no longer make the background translucent, so you can see the overlay clearly.

------

Here's screenshots of BEFORE the fix:

<img width="1005" height="683" alt="Screenshot 2026-03-02 at 11 17 56 AM" src="https://github.com/user-attachments/assets/116adacd-16ec-43d1-be93-bd3bdcf2a4b1" />

<img width="1005" height="683" alt="Screenshot 2026-03-02 at 11 17 44 AM" src="https://github.com/user-attachments/assets/c2df6393-1c8e-4227-8efd-d9786a771258" />

And screenshots from AFTER the fix:

<img width="1005" height="683" alt="Screenshot 2026-03-02 at 11 18 36 AM" src="https://github.com/user-attachments/assets/1c87b011-00bc-4608-90ea-879743a6425a" />

<img width="1005" height="683" alt="Screenshot 2026-03-02 at 11 18 22 AM" src="https://github.com/user-attachments/assets/ca8ff57f-38f1-4e2d-87fd-a1cea5106824" />

------

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I used drag & drop to drop a file in both light & dark mode. In both cases, I made sure that elements below the overlay were no longer visible when the overlay is happening.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes