### PR TITLE
🔍 fix: Correct Conversations ARIA Role and Increase Placeholder Contrast

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -194,7 +194,7 @@ const ChatForm = memo(({ index = 0 }: { index?: number }) => {
   const baseClasses = useMemo(
     () =>
       cn(
-        'md:py-3.5 m-0 w-full resize-none py-[13px] placeholder-black/50 bg-transparent dark:placeholder-white/50 [&:has(textarea:focus)]:shadow-[0_2px_6px_rgba(0,0,0,.05)]',
+        'md:py-3.5 m-0 w-full resize-none py-[13px] placeholder-black/60 bg-transparent dark:placeholder-white/60 [&:has(textarea:focus)]:shadow-[0_2px_6px_rgba(0,0,0,.05)]',
         isCollapsed ? 'max-h-[52px]' : 'max-h-[45vh] md:max-h-[55vh]',
         isMoreThanThreeRows ? 'pl-5' : 'px-5',
       ),

--- a/client/src/components/Conversations/Conversations.tsx
+++ b/client/src/components/Conversations/Conversations.tsx
@@ -384,6 +384,7 @@ const Conversations: FC<ConversationsProps> = ({
                 onRowsRendered={handleRowsRendered}
                 tabIndex={-1}
                 style={{ outline: 'none', scrollbarGutter: 'stable' }}
+                containerRole="rowgroup"
               />
             )}
           </AutoSizer>


### PR DESCRIPTION
## Summary

- Set Conversations list role as "rowgroup", which better describes what is actually going on than "row".

- Increased contrast on placeholder text in ChatForm.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I went through the ChatForm and the Conversations using a screen reader.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
