### PR TITLE
📅 refactor: Replace Numeric Weekday Index with Named Day in Date Template Variables

### DIFF
--- a/packages/data-provider/specs/parsers.spec.ts
+++ b/packages/data-provider/specs/parsers.spec.ts
@@ -13,8 +13,11 @@ jest.mock('dayjs', () => {
       if (format === 'YYYY-MM-DD') {
         return '2024-04-29';
       }
-      if (format === 'YYYY-MM-DD HH:mm:ss') {
-        return '2024-04-29 12:34:56';
+      if (format === 'YYYY-MM-DD HH:mm:ss Z') {
+        return '2024-04-29 12:34:56 -04:00';
+      }
+      if (format === 'dddd') {
+        return 'Monday';
       }
       return format; // fallback
     },
@@ -53,7 +56,7 @@ describe('replaceSpecialVars', () => {
 
   test('should replace {{current_datetime}} with the current datetime', () => {
     const result = replaceSpecialVars({ text: 'Now is {{current_datetime}}' });
-    expect(result).toBe('Now is 2024-04-29 12:34:56 (1)');
+    expect(result).toBe('Now is 2024-04-29 12:34:56 -04:00 (weekday=Monday)');
   });
 
   test('should replace {{iso_datetime}} with the ISO datetime', () => {
@@ -90,7 +93,7 @@ describe('replaceSpecialVars', () => {
       user: mockUser,
     });
     expect(result).toBe(
-      'Hello Test User! Today is 2024-04-29 (1) and the time is 2024-04-29 12:34:56 (1). ISO: 2024-04-29T16:34:56.000Z',
+      'Hello Test User! Today is 2024-04-29 (1) and the time is 2024-04-29 12:34:56 -04:00 (weekday=Monday). ISO: 2024-04-29T16:34:56.000Z',
     );
   });
 
@@ -121,7 +124,7 @@ describe('replaceSpecialVars', () => {
 
     // Verify the expected replacements
     expect(result).toContain('2024-04-29 (1)'); // current_date
-    expect(result).toContain('2024-04-29 12:34:56 (1)'); // current_datetime
+    expect(result).toContain('2024-04-29 12:34:56 -04:00 (weekday=Monday)'); // current_datetime
     expect(result).toContain('2024-04-29T16:34:56.000Z'); // iso_datetime
     expect(result).toContain('Test User'); // current_user
   });

--- a/packages/data-provider/specs/parsers.spec.ts
+++ b/packages/data-provider/specs/parsers.spec.ts
@@ -22,7 +22,6 @@ jest.mock('dayjs', () => {
         `Unhandled dayjs().format() call in mock: "${format}". Update the mock in parsers.spec.ts`,
       );
     },
-    day: () => 1,
     toISOString: () => '2024-04-29T16:34:56.000Z',
   });
 

--- a/packages/data-provider/specs/parsers.spec.ts
+++ b/packages/data-provider/specs/parsers.spec.ts
@@ -7,7 +7,6 @@ import type { TUser, TConversation } from '../src/types';
 
 // Mock dayjs module with consistent date/time values regardless of environment
 jest.mock('dayjs', () => {
-  // Create a mock implementation that returns fixed values
   const mockDayjs = () => ({
     format: (format: string) => {
       if (format === 'YYYY-MM-DD') {
@@ -19,13 +18,14 @@ jest.mock('dayjs', () => {
       if (format === 'dddd') {
         return 'Monday';
       }
-      return format; // fallback
+      throw new Error(
+        `Unhandled dayjs().format() call in mock: "${format}". Update the mock in parsers.spec.ts`,
+      );
     },
-    day: () => 1, // 1 = Monday
+    day: () => 1,
     toISOString: () => '2024-04-29T16:34:56.000Z',
   });
 
-  // Add any static methods needed
   mockDayjs.extend = jest.fn();
 
   return mockDayjs;
@@ -50,13 +50,12 @@ describe('replaceSpecialVars', () => {
 
   test('should replace {{current_date}} with the current date', () => {
     const result = replaceSpecialVars({ text: 'Today is {{current_date}}' });
-    // dayjs().day() returns 1 for Monday (April 29, 2024 is a Monday)
-    expect(result).toBe('Today is 2024-04-29 (1)');
+    expect(result).toBe('Today is 2024-04-29 (Monday)');
   });
 
   test('should replace {{current_datetime}} with the current datetime', () => {
     const result = replaceSpecialVars({ text: 'Now is {{current_datetime}}' });
-    expect(result).toBe('Now is 2024-04-29 12:34:56 -04:00 (weekday=Monday)');
+    expect(result).toBe('Now is 2024-04-29 12:34:56 -04:00 (Monday)');
   });
 
   test('should replace {{iso_datetime}} with the ISO datetime', () => {
@@ -93,7 +92,7 @@ describe('replaceSpecialVars', () => {
       user: mockUser,
     });
     expect(result).toBe(
-      'Hello Test User! Today is 2024-04-29 (1) and the time is 2024-04-29 12:34:56 -04:00 (weekday=Monday). ISO: 2024-04-29T16:34:56.000Z',
+      'Hello Test User! Today is 2024-04-29 (Monday) and the time is 2024-04-29 12:34:56 -04:00 (Monday). ISO: 2024-04-29T16:34:56.000Z',
     );
   });
 
@@ -102,7 +101,7 @@ describe('replaceSpecialVars', () => {
       text: 'Date: {{CURRENT_DATE}}, User: {{Current_User}}',
       user: mockUser,
     });
-    expect(result).toBe('Date: 2024-04-29 (1), User: Test User');
+    expect(result).toBe('Date: 2024-04-29 (Monday), User: Test User');
   });
 
   test('should confirm all specialVariables from config.ts get parsed', () => {
@@ -123,8 +122,8 @@ describe('replaceSpecialVars', () => {
     });
 
     // Verify the expected replacements
-    expect(result).toContain('2024-04-29 (1)'); // current_date
-    expect(result).toContain('2024-04-29 12:34:56 -04:00 (weekday=Monday)'); // current_datetime
+    expect(result).toContain('2024-04-29 (Monday)'); // current_date
+    expect(result).toContain('2024-04-29 12:34:56 -04:00 (Monday)'); // current_datetime
     expect(result).toContain('2024-04-29T16:34:56.000Z'); // iso_datetime
     expect(result).toContain('Test User'); // current_user
   });

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -408,14 +408,15 @@ export function replaceSpecialVars({ text, user }: { text: string; user?: t.TUse
     return result;
   }
 
-  // e.g., "2024-04-29 (1)" (1=Monday)
+  // e.g., "2024-04-29 (1)" where dayjs().day() uses 0=Sunday..6=Saturday
   const currentDate = dayjs().format('YYYY-MM-DD');
   const dayNumber = dayjs().day();
   const combinedDate = `${currentDate} (${dayNumber})`;
   result = result.replace(/{{current_date}}/gi, combinedDate);
 
-  const currentDatetime = dayjs().format('YYYY-MM-DD HH:mm:ss');
-  result = result.replace(/{{current_datetime}}/gi, `${currentDatetime} (${dayNumber})`);
+  const weekdayName = dayjs().format('dddd');
+  const currentDatetime = dayjs().format('YYYY-MM-DD HH:mm:ss Z');
+  result = result.replace(/{{current_datetime}}/gi, `${currentDatetime} (weekday=${weekdayName})`);
 
   const isoDatetime = dayjs().toISOString();
   result = result.replace(/{{iso_datetime}}/gi, isoDatetime);

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -408,17 +408,16 @@ export function replaceSpecialVars({ text, user }: { text: string; user?: t.TUse
     return result;
   }
 
-  // e.g., "2024-04-29 (1)" where dayjs().day() uses 0=Sunday..6=Saturday
-  const currentDate = dayjs().format('YYYY-MM-DD');
-  const dayNumber = dayjs().day();
-  const combinedDate = `${currentDate} (${dayNumber})`;
-  result = result.replace(/{{current_date}}/gi, combinedDate);
+  const now = dayjs();
+  const weekdayName = now.format('dddd');
 
-  const weekdayName = dayjs().format('dddd');
-  const currentDatetime = dayjs().format('YYYY-MM-DD HH:mm:ss Z');
-  result = result.replace(/{{current_datetime}}/gi, `${currentDatetime} (weekday=${weekdayName})`);
+  const currentDate = now.format('YYYY-MM-DD');
+  result = result.replace(/{{current_date}}/gi, `${currentDate} (${weekdayName})`);
 
-  const isoDatetime = dayjs().toISOString();
+  const currentDatetime = now.format('YYYY-MM-DD HH:mm:ss Z');
+  result = result.replace(/{{current_datetime}}/gi, `${currentDatetime} (${weekdayName})`);
+
+  const isoDatetime = now.toISOString();
   result = result.replace(/{{iso_datetime}}/gi, isoDatetime);
 
   if (user && user.name) {


### PR DESCRIPTION
Originally #12009 

## Summary

Replaced the numeric weekday suffix on `{{current_date}}` and `{{current_datetime}}` special variables with the full English weekday name, and added a UTC offset to `{{current_datetime}}`, giving LLMs unambiguous temporal context.

- Replaced the numeric weekday suffix (e.g., `(1)`) with a named weekday (e.g., `(Monday)`) for both `{{current_date}}` and `{{current_datetime}}` in `replaceSpecialVars`.
- Added UTC offset to `{{current_datetime}}` output via dayjs's `Z` format token, producing strings like `2024-04-29 12:34:56 +00:00 (Monday)`.
- Consolidated five separate `dayjs()` instantiations into a single `const now = dayjs()`, eliminating redundant object creation and a theoretical midnight-boundary edge case where multiple `new Date()` calls could span a day rollover.
- Hardened the dayjs mock in `parsers.spec.ts` to throw on any unhandled format string rather than silently returning the format string itself as a value, preventing future tests from passing with garbage output.
- Removed the dead `day()` mock property from the test mock, which was no longer called after `dayNumber` was eliminated.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Set a system prompt containing `{{current_date}}` and `{{current_datetime}}` and send a message. Verify the injected values in the outgoing request contain a named weekday (e.g., `Monday`) rather than a number, and that `{{current_datetime}}` includes a UTC offset (e.g., `+00:00` on a UTC-hosted server). Unit tests in `packages/data-provider/specs/parsers.spec.ts` cover all variable substitutions and can be run with:

```bash
cd packages/data-provider && npx jest parsers
```

### **Test Configuration**:
- Node.js v20+
- `TZ` environment variable unset (defaults to UTC) to confirm offset output

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
