### PR TITLE
🚪 fix: Complete OIDC RP-Initiated Logout With id_token_hint and Redirect Race Fix

### DIFF
--- a/api/server/controllers/auth/LogoutController.js
+++ b/api/server/controllers/auth/LogoutController.js
@@ -8,13 +8,16 @@ const logoutController = async (req, res) => {
   const parsedCookies = req.headers.cookie ? cookies.parse(req.headers.cookie) : {};
   const isOpenIdUser = req.user?.openidId != null && req.user?.provider === 'openid';
 
-  /** For OpenID users, read refresh token from session; for others, use cookie */
+  /** For OpenID users, read tokens from session; for others, use cookie */
   let refreshToken;
+  let idToken;
   if (isOpenIdUser && req.session?.openidTokens) {
     refreshToken = req.session.openidTokens.refreshToken;
+    idToken = req.session.openidTokens.idToken;
     delete req.session.openidTokens;
   }
   refreshToken = refreshToken || parsedCookies.refreshToken;
+  idToken = idToken || parsedCookies.openid_id_token;
 
   try {
     const logout = await logoutUser(req, refreshToken);
@@ -46,6 +49,14 @@ const logoutController = async (req, res) => {
           const postLogoutRedirectUri =
             process.env.OPENID_POST_LOGOUT_REDIRECT_URI || `${process.env.DOMAIN_CLIENT}/login`;
           endSessionUrl.searchParams.set('post_logout_redirect_uri', postLogoutRedirectUri);
+
+          /** Add id_token_hint (preferred) or client_id for OIDC spec compliance */
+          if (idToken) {
+            endSessionUrl.searchParams.set('id_token_hint', idToken);
+          } else {
+            endSessionUrl.searchParams.set('client_id', process.env.OPENID_CLIENT_ID);
+          }
+
           response.redirect = endSessionUrl.toString();
         } else {
           logger.warn(

--- a/api/server/controllers/auth/LogoutController.js
+++ b/api/server/controllers/auth/LogoutController.js
@@ -8,7 +8,7 @@ const logoutController = async (req, res) => {
   const parsedCookies = req.headers.cookie ? cookies.parse(req.headers.cookie) : {};
   const isOpenIdUser = req.user?.openidId != null && req.user?.provider === 'openid';
 
-  /** For OpenID users, read tokens from session; for others, use cookie */
+  /** For OpenID users, read tokens from session (with cookie fallback) */
   let refreshToken;
   let idToken;
   if (isOpenIdUser && req.session?.openidTokens) {
@@ -53,8 +53,13 @@ const logoutController = async (req, res) => {
           /** Add id_token_hint (preferred) or client_id for OIDC spec compliance */
           if (idToken) {
             endSessionUrl.searchParams.set('id_token_hint', idToken);
-          } else {
+          } else if (process.env.OPENID_CLIENT_ID) {
             endSessionUrl.searchParams.set('client_id', process.env.OPENID_CLIENT_ID);
+          } else {
+            logger.warn(
+              '[logoutController] Neither id_token_hint nor OPENID_CLIENT_ID is available. ' +
+                'The OIDC end-session request may be rejected by the identity provider.',
+            );
           }
 
           response.redirect = endSessionUrl.toString();

--- a/api/server/controllers/auth/LogoutController.js
+++ b/api/server/controllers/auth/LogoutController.js
@@ -34,15 +34,14 @@ const logoutController = async (req, res) => {
       isEnabled(process.env.OPENID_USE_END_SESSION_ENDPOINT) &&
       process.env.OPENID_ISSUER
     ) {
-      const openIdConfig = getOpenIdConfig();
-      if (!openIdConfig) {
-        logger.warn(
-          '[logoutController] OpenID config not found. Please verify that the open id configuration and initialization are correct.',
-        );
-      } else {
-        const endSessionEndpoint = openIdConfig
-          ? openIdConfig.serverMetadata().end_session_endpoint
-          : null;
+      let openIdConfig;
+      try {
+        openIdConfig = getOpenIdConfig();
+      } catch (err) {
+        logger.warn('[logoutController] OpenID config not available:', err.message);
+      }
+      if (openIdConfig) {
+        const endSessionEndpoint = openIdConfig.serverMetadata().end_session_endpoint;
         if (endSessionEndpoint) {
           const endSessionUrl = new URL(endSessionEndpoint);
           /** Redirect back to app's login page after IdP logout */
@@ -58,6 +57,7 @@ const logoutController = async (req, res) => {
           } else {
             logger.warn(
               '[logoutController] Neither id_token_hint nor OPENID_CLIENT_ID is available. ' +
+                'To enable id_token_hint, set OPENID_REUSE_TOKENS=true. ' +
                 'The OIDC end-session request may be rejected by the identity provider.',
             );
           }

--- a/api/server/controllers/auth/LogoutController.spec.js
+++ b/api/server/controllers/auth/LogoutController.spec.js
@@ -1,0 +1,256 @@
+const cookies = require('cookie');
+
+const mockLogoutUser = jest.fn();
+const mockLogger = { warn: jest.fn(), error: jest.fn() };
+const mockIsEnabled = jest.fn();
+const mockGetOpenIdConfig = jest.fn();
+
+jest.mock('cookie');
+jest.mock('@librechat/api', () => ({ isEnabled: (...args) => mockIsEnabled(...args) }));
+jest.mock('@librechat/data-schemas', () => ({ logger: mockLogger }));
+jest.mock('~/server/services/AuthService', () => ({
+  logoutUser: (...args) => mockLogoutUser(...args),
+}));
+jest.mock('~/strategies', () => ({ getOpenIdConfig: () => mockGetOpenIdConfig() }));
+
+const { logoutController } = require('./LogoutController');
+
+function buildReq(overrides = {}) {
+  return {
+    user: { _id: 'user1', openidId: 'oid1', provider: 'openid' },
+    headers: { cookie: 'refreshToken=rt1' },
+    session: {
+      openidTokens: { refreshToken: 'srt', idToken: 'small-id-token' },
+      destroy: jest.fn(),
+    },
+    ...overrides,
+  };
+}
+
+function buildRes() {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    clearCookie: jest.fn(),
+  };
+  return res;
+}
+
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env = {
+    ...ORIGINAL_ENV,
+    OPENID_USE_END_SESSION_ENDPOINT: 'true',
+    OPENID_ISSUER: 'https://idp.example.com',
+    OPENID_CLIENT_ID: 'my-client-id',
+    DOMAIN_CLIENT: 'https://app.example.com',
+  };
+  cookies.parse.mockReturnValue({ refreshToken: 'cookie-rt' });
+  mockLogoutUser.mockResolvedValue({ status: 200, message: 'Logout successful' });
+  mockIsEnabled.mockReturnValue(true);
+  mockGetOpenIdConfig.mockReturnValue({
+    serverMetadata: () => ({
+      end_session_endpoint: 'https://idp.example.com/logout',
+    }),
+  });
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe('LogoutController', () => {
+  describe('id_token_hint from session', () => {
+    it('sets id_token_hint when session has idToken', async () => {
+      const req = buildReq();
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      const body = res.send.mock.calls[0][0];
+      expect(body.redirect).toContain('id_token_hint=small-id-token');
+      expect(body.redirect).not.toContain('client_id=');
+    });
+  });
+
+  describe('id_token_hint from cookie fallback', () => {
+    it('uses cookie id_token when session has no tokens', async () => {
+      cookies.parse.mockReturnValue({
+        refreshToken: 'cookie-rt',
+        openid_id_token: 'cookie-id-token',
+      });
+      const req = buildReq({ session: { destroy: jest.fn() } });
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      const body = res.send.mock.calls[0][0];
+      expect(body.redirect).toContain('id_token_hint=cookie-id-token');
+    });
+  });
+
+  describe('client_id fallback', () => {
+    it('falls back to client_id when no idToken is available', async () => {
+      cookies.parse.mockReturnValue({ refreshToken: 'cookie-rt' });
+      const req = buildReq({ session: { destroy: jest.fn() } });
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      const body = res.send.mock.calls[0][0];
+      expect(body.redirect).toContain('client_id=my-client-id');
+      expect(body.redirect).not.toContain('id_token_hint=');
+    });
+
+    it('does not produce client_id=undefined when OPENID_CLIENT_ID is unset', async () => {
+      delete process.env.OPENID_CLIENT_ID;
+      cookies.parse.mockReturnValue({ refreshToken: 'cookie-rt' });
+      const req = buildReq({ session: { destroy: jest.fn() } });
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      const body = res.send.mock.calls[0][0];
+      expect(body.redirect).not.toContain('client_id=');
+      expect(body.redirect).not.toContain('undefined');
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Neither id_token_hint nor OPENID_CLIENT_ID'),
+      );
+    });
+  });
+
+  describe('OPENID_USE_END_SESSION_ENDPOINT disabled', () => {
+    it('does not include redirect when disabled', async () => {
+      mockIsEnabled.mockReturnValue(false);
+      const req = buildReq();
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      const body = res.send.mock.calls[0][0];
+      expect(body.redirect).toBeUndefined();
+    });
+  });
+
+  describe('OPENID_ISSUER unset', () => {
+    it('does not include redirect when OPENID_ISSUER is missing', async () => {
+      delete process.env.OPENID_ISSUER;
+      const req = buildReq();
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      const body = res.send.mock.calls[0][0];
+      expect(body.redirect).toBeUndefined();
+    });
+  });
+
+  describe('non-OpenID user', () => {
+    it('does not include redirect for non-OpenID users', async () => {
+      const req = buildReq({
+        user: { _id: 'user1', provider: 'local' },
+      });
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      const body = res.send.mock.calls[0][0];
+      expect(body.redirect).toBeUndefined();
+    });
+  });
+
+  describe('post_logout_redirect_uri', () => {
+    it('uses OPENID_POST_LOGOUT_REDIRECT_URI when set', async () => {
+      process.env.OPENID_POST_LOGOUT_REDIRECT_URI = 'https://custom.example.com/logged-out';
+      const req = buildReq();
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      const body = res.send.mock.calls[0][0];
+      const url = new URL(body.redirect);
+      expect(url.searchParams.get('post_logout_redirect_uri')).toBe(
+        'https://custom.example.com/logged-out',
+      );
+    });
+
+    it('defaults to DOMAIN_CLIENT/login when OPENID_POST_LOGOUT_REDIRECT_URI is unset', async () => {
+      delete process.env.OPENID_POST_LOGOUT_REDIRECT_URI;
+      const req = buildReq();
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      const body = res.send.mock.calls[0][0];
+      const url = new URL(body.redirect);
+      expect(url.searchParams.get('post_logout_redirect_uri')).toBe(
+        'https://app.example.com/login',
+      );
+    });
+  });
+
+  describe('OpenID config not found', () => {
+    it('warns and returns no redirect when getOpenIdConfig returns null', async () => {
+      mockGetOpenIdConfig.mockReturnValue(null);
+      const req = buildReq();
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      const body = res.send.mock.calls[0][0];
+      expect(body.redirect).toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('OpenID config not found'),
+      );
+    });
+  });
+
+  describe('end_session_endpoint not in metadata', () => {
+    it('warns and returns no redirect when end_session_endpoint is missing', async () => {
+      mockGetOpenIdConfig.mockReturnValue({
+        serverMetadata: () => ({}),
+      });
+      const req = buildReq();
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      const body = res.send.mock.calls[0][0];
+      expect(body.redirect).toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('end_session_endpoint not found'),
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 on logoutUser error', async () => {
+      mockLogoutUser.mockRejectedValue(new Error('session error'));
+      const req = buildReq();
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: 'session error' });
+    });
+  });
+
+  describe('cookie clearing', () => {
+    it('clears all auth cookies on successful logout', async () => {
+      const req = buildReq();
+      const res = buildRes();
+
+      await logoutController(req, res);
+
+      expect(res.clearCookie).toHaveBeenCalledWith('refreshToken');
+      expect(res.clearCookie).toHaveBeenCalledWith('openid_access_token');
+      expect(res.clearCookie).toHaveBeenCalledWith('openid_id_token');
+      expect(res.clearCookie).toHaveBeenCalledWith('openid_user_id');
+      expect(res.clearCookie).toHaveBeenCalledWith('token_provider');
+    });
+  });
+});

--- a/api/server/controllers/auth/LogoutController.spec.js
+++ b/api/server/controllers/auth/LogoutController.spec.js
@@ -192,9 +192,11 @@ describe('LogoutController', () => {
     });
   });
 
-  describe('OpenID config not found', () => {
-    it('warns and returns no redirect when getOpenIdConfig returns null', async () => {
-      mockGetOpenIdConfig.mockReturnValue(null);
+  describe('OpenID config not available', () => {
+    it('warns and returns no redirect when getOpenIdConfig throws', async () => {
+      mockGetOpenIdConfig.mockImplementation(() => {
+        throw new Error('OpenID configuration has not been initialized');
+      });
       const req = buildReq();
       const res = buildRes();
 
@@ -203,7 +205,8 @@ describe('LogoutController', () => {
       const body = res.send.mock.calls[0][0];
       expect(body.redirect).toBeUndefined();
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('OpenID config not found'),
+        expect.stringContaining('OpenID config not available'),
+        'OpenID configuration has not been initialized',
       );
     });
   });

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -106,11 +106,15 @@ const AuthContextProvider = ({
   });
   const logoutUser = useLogoutUserMutation({
     onSuccess: (data) => {
+      if (data.redirect) {
+        window.location.replace(data.redirect);
+        return;
+      }
       setUserContext({
         token: undefined,
         isAuthenticated: false,
         user: undefined,
-        redirect: data.redirect ?? '/login',
+        redirect: '/login',
       });
     },
     onError: (error) => {

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -34,11 +34,12 @@ const AuthContextProvider = ({
   authConfig?: TAuthConfig;
   children: ReactNode;
 }) => {
+  const isExternalRedirectRef = useRef(false);
   const [user, setUser] = useRecoilState(store.user);
+  const logoutRedirectRef = useRef<string | undefined>(undefined);
   const [token, setToken] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | undefined>(undefined);
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
-  const logoutRedirectRef = useRef<string | undefined>(undefined);
 
   const { data: userRole = null } = useGetRole(SystemRoles.USER, {
     enabled: !!(isAuthenticated && (user?.role ?? '')),
@@ -55,7 +56,6 @@ const AuthContextProvider = ({
         const { token, isAuthenticated, user, redirect } = userContext;
         setUser(user);
         setToken(token);
-        //@ts-ignore - ok for token to be undefined initially
         setTokenHeader(token);
         setIsAuthenticated(isAuthenticated);
 
@@ -107,6 +107,12 @@ const AuthContextProvider = ({
   const logoutUser = useLogoutUserMutation({
     onSuccess: (data) => {
       if (data.redirect) {
+        /** data.redirect is the IdP's end_session_endpoint URL — an absolute URL generated
+         * server-side from trusted IdP metadata (not user input), so isSafeRedirect is bypassed.
+         * setUserContext is debounced (50ms) and won't fire before page unload, so clear the
+         * axios Authorization header synchronously to prevent in-flight requests. */
+        isExternalRedirectRef.current = true;
+        setTokenHeader(undefined);
         window.location.replace(data.redirect);
         return;
       }
@@ -150,8 +156,14 @@ const AuthContextProvider = ({
       console.log('Test mode. Skipping silent refresh.');
       return;
     }
+    if (isExternalRedirectRef.current) {
+      return;
+    }
     refreshToken.mutate(undefined, {
       onSuccess: (data: t.TRefreshTokenResponse | undefined) => {
+        if (isExternalRedirectRef.current) {
+          return;
+        }
         const { user, token = '' } = data ?? {};
         if (token) {
           setUserContext({ token, isAuthenticated: true, user });
@@ -164,6 +176,9 @@ const AuthContextProvider = ({
         navigate(buildLoginRedirectUrl());
       },
       onError: (error) => {
+        if (isExternalRedirectRef.current) {
+          return;
+        }
         console.log('refreshToken mutation error:', error);
         if (authConfig?.test === true) {
           return;
@@ -175,6 +190,9 @@ const AuthContextProvider = ({
   }, []);
 
   useEffect(() => {
+    if (isExternalRedirectRef.current) {
+      return;
+    }
     if (userQuery.data) {
       setUser(userQuery.data);
     } else if (userQuery.isError) {

--- a/client/src/hooks/__tests__/AuthContext.spec.tsx
+++ b/client/src/hooks/__tests__/AuthContext.spec.tsx
@@ -84,6 +84,25 @@ function renderProvider() {
   );
 }
 
+/** Renders without test:true so silentRefresh actually runs */
+function renderProviderLive() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RecoilRoot>
+        <MemoryRouter>
+          <AuthContextProvider authConfig={{ loginRedirect: '/login' }}>
+            <TestConsumer />
+          </AuthContextProvider>
+        </MemoryRouter>
+      </RecoilRoot>
+    </QueryClientProvider>,
+  );
+}
+
 describe('AuthContextProvider — login onError redirect handling', () => {
   const originalLocation = window.location;
 
@@ -242,7 +261,7 @@ describe('AuthContextProvider — logout onSuccess/onError handling', () => {
   });
 
   it('does not trigger silentRefresh after OIDC redirect', () => {
-    renderProvider();
+    renderProviderLive();
     mockRefreshMutate.mockClear();
 
     act(() => {
@@ -256,15 +275,19 @@ describe('AuthContextProvider — logout onSuccess/onError handling', () => {
     expect(mockRefreshMutate).not.toHaveBeenCalled();
   });
 
-  it('navigates to /login on logout error', () => {
-    renderProvider();
+  it('clears auth state on logout error without external redirect', () => {
+    jest.useFakeTimers();
+    const { getByTestId } = renderProvider();
 
     act(() => {
       mockCapturedLogoutOptions.onError(new Error('Logout failed'));
     });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
 
-    // The debounced setUserContext eventually calls navigate with /login
-    // but we can verify the error handler was called without throwing
     expect(window.location.replace).not.toHaveBeenCalled();
+    expect(getByTestId('consumer').getAttribute('data-authenticated')).toBe('false');
+    jest.useRealTimers();
   });
 });

--- a/client/src/hooks/__tests__/AuthContext.spec.tsx
+++ b/client/src/hooks/__tests__/AuthContext.spec.tsx
@@ -29,6 +29,8 @@ let mockCapturedLogoutOptions: {
   onError: (...args: unknown[]) => void;
 };
 
+const mockRefreshMutate = jest.fn();
+
 jest.mock('~/data-provider', () => ({
   useLoginUserMutation: jest.fn(
     (options: {
@@ -48,7 +50,7 @@ jest.mock('~/data-provider', () => ({
       return { mutate: jest.fn() };
     },
   ),
-  useRefreshTokenMutation: jest.fn(() => ({ mutate: jest.fn() })),
+  useRefreshTokenMutation: jest.fn(() => ({ mutate: mockRefreshMutate })),
   useGetUserQuery: jest.fn(() => ({
     data: undefined,
     isError: false,
@@ -237,6 +239,21 @@ describe('AuthContextProvider — logout onSuccess/onError handling', () => {
     });
 
     expect(window.location.replace).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger silentRefresh after OIDC redirect', () => {
+    renderProvider();
+    mockRefreshMutate.mockClear();
+
+    act(() => {
+      mockCapturedLogoutOptions.onSuccess({
+        message: 'Logout successful',
+        redirect: 'https://idp.example.com/logout?id_token_hint=abc',
+      });
+    });
+
+    expect(window.location.replace).toHaveBeenCalled();
+    expect(mockRefreshMutate).not.toHaveBeenCalled();
   });
 
   it('navigates to /login on logout error', () => {

--- a/client/src/hooks/__tests__/AuthContext.spec.tsx
+++ b/client/src/hooks/__tests__/AuthContext.spec.tsx
@@ -24,6 +24,11 @@ let mockCapturedLoginOptions: {
   onError: (...args: unknown[]) => void;
 };
 
+let mockCapturedLogoutOptions: {
+  onSuccess: (...args: unknown[]) => void;
+  onError: (...args: unknown[]) => void;
+};
+
 jest.mock('~/data-provider', () => ({
   useLoginUserMutation: jest.fn(
     (options: {
@@ -34,7 +39,15 @@ jest.mock('~/data-provider', () => ({
       return { mutate: jest.fn() };
     },
   ),
-  useLogoutUserMutation: jest.fn(() => ({ mutate: jest.fn() })),
+  useLogoutUserMutation: jest.fn(
+    (options: {
+      onSuccess: (...args: unknown[]) => void;
+      onError: (...args: unknown[]) => void;
+    }) => {
+      mockCapturedLogoutOptions = options;
+      return { mutate: jest.fn() };
+    },
+  ),
   useRefreshTokenMutation: jest.fn(() => ({ mutate: jest.fn() })),
   useGetUserQuery: jest.fn(() => ({
     data: undefined,
@@ -170,5 +183,71 @@ describe('AuthContextProvider — login onError redirect handling', () => {
     const navigatedUrl = mockNavigate.mock.calls[0][0] as string;
     const params = new URLSearchParams(navigatedUrl.split('?')[1]);
     expect(decodeURIComponent(params.get('redirect_to')!)).toBe(target);
+  });
+});
+
+describe('AuthContextProvider — logout onSuccess/onError handling', () => {
+  const originalLocation = window.location;
+  const mockSetTokenHeader = jest.requireMock('librechat-data-provider').setTokenHeader;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...originalLocation,
+        pathname: '/c/some-chat',
+        search: '',
+        hash: '',
+        replace: jest.fn(),
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('calls window.location.replace and setTokenHeader(undefined) when redirect is present', () => {
+    renderProvider();
+
+    act(() => {
+      mockCapturedLogoutOptions.onSuccess({
+        message: 'Logout successful',
+        redirect: 'https://idp.example.com/logout?id_token_hint=abc',
+      });
+    });
+
+    expect(window.location.replace).toHaveBeenCalledWith(
+      'https://idp.example.com/logout?id_token_hint=abc',
+    );
+    expect(mockSetTokenHeader).toHaveBeenCalledWith(undefined);
+  });
+
+  it('does not call window.location.replace when redirect is absent', async () => {
+    renderProvider();
+
+    act(() => {
+      mockCapturedLogoutOptions.onSuccess({ message: 'Logout successful' });
+    });
+
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+
+  it('navigates to /login on logout error', () => {
+    renderProvider();
+
+    act(() => {
+      mockCapturedLogoutOptions.onError(new Error('Logout failed'));
+    });
+
+    // The debounced setUserContext eventually calls navigate with /login
+    // but we can verify the error handler was called without throwing
+    expect(window.location.replace).not.toHaveBeenCalled();
   });
 });

--- a/packages/data-provider/specs/headers-helpers.spec.ts
+++ b/packages/data-provider/specs/headers-helpers.spec.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import { setTokenHeader } from '../src/headers-helpers';
+
+describe('setTokenHeader', () => {
+  afterEach(() => {
+    delete axios.defaults.headers.common['Authorization'];
+  });
+
+  it('sets the Authorization header with a Bearer token', () => {
+    setTokenHeader('my-token');
+    expect(axios.defaults.headers.common['Authorization']).toBe('Bearer my-token');
+  });
+
+  it('deletes the Authorization header when called with undefined', () => {
+    axios.defaults.headers.common['Authorization'] = 'Bearer old-token';
+    setTokenHeader(undefined);
+    expect(axios.defaults.headers.common['Authorization']).toBeUndefined();
+  });
+
+  it('is a no-op when clearing an already absent header', () => {
+    setTokenHeader(undefined);
+    expect(axios.defaults.headers.common['Authorization']).toBeUndefined();
+  });
+});

--- a/packages/data-provider/specs/request-interceptor.spec.ts
+++ b/packages/data-provider/specs/request-interceptor.spec.ts
@@ -15,8 +15,10 @@ import { setTokenHeader } from '../src/headers-helpers';
 
 /** Mock the axios adapter to simulate responses without HTTP */
 const mockAdapter = jest.fn();
+let originalAdapter: typeof axios.defaults.adapter;
 
 beforeAll(async () => {
+  originalAdapter = axios.defaults.adapter;
   axios.defaults.adapter = mockAdapter;
 
   /** Import triggers interceptor registration */
@@ -25,6 +27,10 @@ beforeAll(async () => {
 
 beforeEach(() => {
   mockAdapter.mockReset();
+});
+
+afterAll(() => {
+  axios.defaults.adapter = originalAdapter;
 });
 
 afterEach(() => {
@@ -88,5 +94,9 @@ describe('axios 401 interceptor — Authorization header guard', () => {
 
     /** More than 1 call means the interceptor attempted refresh */
     expect(mockAdapter.mock.calls.length).toBeGreaterThan(1);
+
+    /** Verify the second call targeted the refresh endpoint */
+    const refreshCall = mockAdapter.mock.calls[1];
+    expect(refreshCall[0].url).toContain('api/auth/refresh');
   });
 });

--- a/packages/data-provider/specs/request-interceptor.spec.ts
+++ b/packages/data-provider/specs/request-interceptor.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+import axios from 'axios';
+import { setTokenHeader } from '../src/headers-helpers';
+
+/**
+ * The response interceptor in request.ts registers at import time when
+ * `typeof window !== 'undefined'` (jsdom provides window).
+ *
+ * We use axios's built-in request adapter mock to avoid real HTTP calls,
+ * and verify the interceptor's behavior by observing whether a 401 triggers
+ * a refresh POST or is immediately rejected.
+ */
+
+/** Mock the axios adapter to simulate responses without HTTP */
+const mockAdapter = jest.fn();
+
+beforeAll(async () => {
+  axios.defaults.adapter = mockAdapter;
+
+  /** Import triggers interceptor registration */
+  await import('../src/request');
+});
+
+beforeEach(() => {
+  mockAdapter.mockReset();
+});
+
+afterEach(() => {
+  delete axios.defaults.headers.common['Authorization'];
+});
+
+describe('axios 401 interceptor — Authorization header guard', () => {
+  it('skips refresh and rejects when Authorization header is cleared', async () => {
+    /** Simulate a cleared header (as done by setTokenHeader(undefined) during logout) */
+    setTokenHeader(undefined);
+
+    /** Set up adapter: first call returns 401, second would be the refresh */
+    mockAdapter.mockRejectedValueOnce({
+      response: { status: 401 },
+      config: { url: '/api/messages', headers: {} },
+    });
+
+    try {
+      await axios.get('/api/messages');
+    } catch {
+      // expected rejection
+    }
+
+    /**
+     * If the interceptor skipped refresh, only 1 call was made (the original).
+     * If it attempted refresh, there would be 2+ calls (original + refresh POST).
+     */
+    expect(mockAdapter).toHaveBeenCalledTimes(1);
+  });
+
+  it('attempts refresh when Authorization header is present', async () => {
+    setTokenHeader('valid-token');
+
+    /** First call: 401 on the original request */
+    mockAdapter.mockRejectedValueOnce({
+      response: { status: 401 },
+      config: { url: '/api/messages', headers: {}, _retry: false },
+    });
+
+    /** Second call: the refresh endpoint succeeds */
+    mockAdapter.mockResolvedValueOnce({
+      data: { token: 'new-token' },
+      status: 200,
+      headers: {},
+      config: {},
+    });
+
+    /** Third call: retried original request succeeds */
+    mockAdapter.mockResolvedValueOnce({
+      data: { messages: [] },
+      status: 200,
+      headers: {},
+      config: {},
+    });
+
+    try {
+      await axios.get('/api/messages');
+    } catch {
+      // may reject depending on exact flow
+    }
+
+    /** More than 1 call means the interceptor attempted refresh */
+    expect(mockAdapter.mock.calls.length).toBeGreaterThan(1);
+  });
+});

--- a/packages/data-provider/src/headers-helpers.ts
+++ b/packages/data-provider/src/headers-helpers.ts
@@ -4,6 +4,10 @@ export function setAcceptLanguageHeader(value: string): void {
   axios.defaults.headers.common['Accept-Language'] = value;
 }
 
-export function setTokenHeader(token: string) {
-  axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
+export function setTokenHeader(token: string | undefined) {
+  if (token === undefined) {
+    delete axios.defaults.headers.common['Authorization'];
+  } else {
+    axios.defaults.headers.common['Authorization'] = 'Bearer ' + token;
+  }
 }

--- a/packages/data-provider/src/request.ts
+++ b/packages/data-provider/src/request.ts
@@ -99,6 +99,11 @@ if (typeof window !== 'undefined') {
         return Promise.reject(error);
       }
 
+      /** Skip refresh when the Authorization header has been cleared (e.g. during logout) */
+      if (!axios.defaults.headers.common['Authorization']) {
+        return Promise.reject(error);
+      }
+
       if (error.response.status === 401 && !originalRequest._retry) {
         console.warn('401 error, refreshing token');
         originalRequest._retry = true;


### PR DESCRIPTION
Originally #12008

---

## Summary

Fixed a broken OIDC RP-initiated logout implementation that was silently failing in two distinct ways: the backend was omitting required identity parameters from the IdP end-session URL, and the frontend was discarding the redirect entirely through an overly strict URL validator. Also resolved a race condition where an in-flight token refresh could cancel the navigation to the IdP's logout endpoint.

- Fixed `LogoutController` to extract `id_token_hint` from `req.session.openidTokens.idToken` (set when `OPENID_REUSE_TOKENS=true`) with a cookie fallback (`openid_id_token`), appending it to the OIDC `end_session_endpoint` URL for spec-compliant RP-initiated logout.
- Added `client_id` as a fallback when no `id_token_hint` is available, with a warning log naming `OPENID_REUSE_TOKENS=true` as the path to enabling `id_token_hint`.
- Replaced the unreachable `if (!openIdConfig)` null-guard (previously dead code — `getOpenIdConfig()` throws, never returns `null`) with a `try/catch`, allowing graceful degradation without an HTTP 500 when the OpenID config is unavailable at logout time.
- Removed the dead `openIdConfig ? ... : null` ternary inside the `else` block where `openIdConfig` is guaranteed truthy.
- Extended `setTokenHeader` in `headers-helpers.ts` to accept `string | undefined`, deleting the `Authorization` header instead of setting it to `"Bearer undefined"`, and removed the `@ts-ignore` workaround in `AuthContext`.
- Added an early-return guard in the axios 401 response interceptor (`request.ts`) that skips the token refresh flow when the `Authorization` header has been cleared, preventing a successful refresh from canceling an in-progress `window.location.replace()` navigation.
- Replaced the `isSafeRedirect` check in `AuthContext.tsx` with a direct `window.location.replace(data.redirect)` call for OIDC logout redirects — `isSafeRedirect` was designed for user-input validation and rejects all absolute URLs, which caused the IdP redirect to be silently dropped on every OIDC logout.
- Introduced `isExternalRedirectRef` in `AuthContextProvider` to suppress `silentRefresh`, its `onSuccess`/`onError` callbacks, and the `userQuery` side-effect `useEffect` during the brief window between `window.location.replace()` being called and the page unloading.
- Cleared the axios `Authorization` header synchronously (via `setTokenHeader(undefined)`) before calling `window.location.replace()` so that any 401s fired by React Query's post-mutation cleanup are rejected immediately by the interceptor guard rather than triggering a token refresh that would re-establish the header and potentially abort the redirect.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)


- **`id_token_hint` path**: Log in via OIDC with `OPENID_REUSE_TOKENS=true`, log out — verify the IdP end-session URL contains `id_token_hint=<jwt>` and the IdP session is terminated.
- **`client_id` fallback path**: Repeat without `OPENID_REUSE_TOKENS=true` — verify the URL contains `client_id=your-client-id` and the warn log is emitted mentioning `OPENID_REUSE_TOKENS`.
- **Race condition**: With browser devtools network throttling enabled (slow 3G), initiate logout — confirm the page navigates to the IdP end-session endpoint and does not stay on the LibreChat login page due to a token refresh completing mid-redirect.
- **Unit tests**: `cd api && npx jest LogoutController.spec`, `cd packages/data-provider && npx jest headers-helpers.spec request-interceptor.spec`, `cd client && npx jest AuthContext.spec`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes