### PR TITLE
🧭 fix: Restore Post-Auth Navigation After Silent Token Refresh

### DIFF
--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -20,7 +20,7 @@ import {
   useLogoutUserMutation,
   useRefreshTokenMutation,
 } from '~/data-provider';
-import { isSafeRedirect, buildLoginRedirectUrl, getPostLoginRedirect } from '~/utils';
+import { SESSION_KEY, isSafeRedirect, buildLoginRedirectUrl, getPostLoginRedirect } from '~/utils';
 import { TAuthConfig, TUserContext, TAuthContext, TResError } from '~/common';
 import useTimeout from './useTimeout';
 import store from '~/store';
@@ -166,7 +166,16 @@ const AuthContextProvider = ({
         }
         const { user, token = '' } = data ?? {};
         if (token) {
-          setUserContext({ token, isAuthenticated: true, user });
+          const storedRedirect = sessionStorage.getItem(SESSION_KEY);
+          if (storedRedirect) {
+            sessionStorage.removeItem(SESSION_KEY);
+          }
+          setUserContext({
+            user,
+            token,
+            isAuthenticated: true,
+            redirect: storedRedirect ?? '/c/new',
+          });
           return;
         }
         console.log('Token is not present. User is not authenticated.');

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -167,14 +167,12 @@ const AuthContextProvider = ({
         const { user, token = '' } = data ?? {};
         if (token) {
           const storedRedirect = sessionStorage.getItem(SESSION_KEY);
-          if (storedRedirect) {
-            sessionStorage.removeItem(SESSION_KEY);
-          }
+          sessionStorage.removeItem(SESSION_KEY);
           setUserContext({
             user,
             token,
             isAuthenticated: true,
-            redirect: storedRedirect ?? '/c/new',
+            redirect: storedRedirect && isSafeRedirect(storedRedirect) ? storedRedirect : '/c/new',
           });
           return;
         }

--- a/client/src/hooks/__tests__/AuthContext.spec.tsx
+++ b/client/src/hooks/__tests__/AuthContext.spec.tsx
@@ -7,6 +7,7 @@ import { MemoryRouter } from 'react-router-dom';
 import type { TAuthConfig } from '~/common';
 
 import { AuthContextProvider, useAuthContext } from '../AuthContext';
+import { SESSION_KEY } from '~/utils';
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -277,8 +278,6 @@ describe('AuthContextProvider — logout onSuccess/onError handling', () => {
 });
 
 describe('AuthContextProvider — silentRefresh post-login redirect', () => {
-  const SESSION_KEY = 'post_login_redirect_to';
-
   beforeEach(() => {
     jest.clearAllMocks();
     sessionStorage.clear();
@@ -294,8 +293,11 @@ describe('AuthContextProvider — silentRefresh post-login redirect', () => {
 
     renderProviderLive();
 
-    const refreshCall = mockRefreshMutate.mock.calls[0];
-    const refreshOptions = refreshCall[1] as { onSuccess: (data: unknown) => void };
+    expect(mockRefreshMutate).toHaveBeenCalledTimes(1);
+    const [, refreshOptions] = mockRefreshMutate.mock.calls[0] as [
+      unknown,
+      { onSuccess: (data: unknown) => void },
+    ];
 
     act(() => {
       refreshOptions.onSuccess({ user: { id: '1', role: 'USER' }, token: 'new-token' });
@@ -316,8 +318,11 @@ describe('AuthContextProvider — silentRefresh post-login redirect', () => {
 
     renderProviderLive();
 
-    const refreshCall = mockRefreshMutate.mock.calls[0];
-    const refreshOptions = refreshCall[1] as { onSuccess: (data: unknown) => void };
+    expect(mockRefreshMutate).toHaveBeenCalledTimes(1);
+    const [, refreshOptions] = mockRefreshMutate.mock.calls[0] as [
+      unknown,
+      { onSuccess: (data: unknown) => void },
+    ];
 
     act(() => {
       refreshOptions.onSuccess({ user: { id: '1', role: 'USER' }, token: 'new-token' });
@@ -336,8 +341,11 @@ describe('AuthContextProvider — silentRefresh post-login redirect', () => {
 
     renderProviderLive();
 
-    const refreshCall = mockRefreshMutate.mock.calls[0];
-    const refreshOptions = refreshCall[1] as { onSuccess: (data: unknown) => void };
+    expect(mockRefreshMutate).toHaveBeenCalledTimes(1);
+    const [, refreshOptions] = mockRefreshMutate.mock.calls[0] as [
+      unknown,
+      { onSuccess: (data: unknown) => void },
+    ];
     mockRefreshMutate.mockClear();
 
     act(() => {
@@ -353,14 +361,17 @@ describe('AuthContextProvider — silentRefresh post-login redirect', () => {
     jest.useRealTimers();
   });
 
-  it('does not navigate to unsafe stored redirect', () => {
+  it('falls back to /c/new for unsafe stored redirect', () => {
     jest.useFakeTimers();
     sessionStorage.setItem(SESSION_KEY, 'https://evil.com/steal');
 
     renderProviderLive();
 
-    const refreshCall = mockRefreshMutate.mock.calls[0];
-    const refreshOptions = refreshCall[1] as { onSuccess: (data: unknown) => void };
+    expect(mockRefreshMutate).toHaveBeenCalledTimes(1);
+    const [, refreshOptions] = mockRefreshMutate.mock.calls[0] as [
+      unknown,
+      { onSuccess: (data: unknown) => void },
+    ];
 
     act(() => {
       refreshOptions.onSuccess({ user: { id: '1', role: 'USER' }, token: 'new-token' });
@@ -369,6 +380,7 @@ describe('AuthContextProvider — silentRefresh post-login redirect', () => {
       jest.advanceTimersByTime(100);
     });
 
+    expect(mockNavigate).toHaveBeenCalledWith('/c/new', { replace: true });
     expect(mockNavigate).not.toHaveBeenCalledWith('https://evil.com/steal', expect.anything());
     expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
     jest.useRealTimers();

--- a/client/src/hooks/__tests__/AuthContext.spec.tsx
+++ b/client/src/hooks/__tests__/AuthContext.spec.tsx
@@ -274,6 +274,132 @@ describe('AuthContextProvider — logout onSuccess/onError handling', () => {
     expect(window.location.replace).toHaveBeenCalled();
     expect(mockRefreshMutate).not.toHaveBeenCalled();
   });
+});
+
+describe('AuthContextProvider — silentRefresh post-login redirect', () => {
+  const SESSION_KEY = 'post_login_redirect_to';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('navigates to stored sessionStorage redirect after successful token refresh', () => {
+    jest.useFakeTimers();
+    sessionStorage.setItem(SESSION_KEY, '/c/new?endpoint=bedrock&model=claude-sonnet-4-6');
+
+    renderProviderLive();
+
+    const refreshCall = mockRefreshMutate.mock.calls[0];
+    const refreshOptions = refreshCall[1] as { onSuccess: (data: unknown) => void };
+
+    act(() => {
+      refreshOptions.onSuccess({ user: { id: '1', role: 'USER' }, token: 'new-token' });
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/c/new?endpoint=bedrock&model=claude-sonnet-4-6', {
+      replace: true,
+    });
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+    jest.useRealTimers();
+  });
+
+  it('navigates to /c/new when no stored redirect exists', () => {
+    jest.useFakeTimers();
+
+    renderProviderLive();
+
+    const refreshCall = mockRefreshMutate.mock.calls[0];
+    const refreshOptions = refreshCall[1] as { onSuccess: (data: unknown) => void };
+
+    act(() => {
+      refreshOptions.onSuccess({ user: { id: '1', role: 'USER' }, token: 'new-token' });
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/c/new', { replace: true });
+    jest.useRealTimers();
+  });
+
+  it('does not re-trigger silentRefresh after successful redirect', () => {
+    jest.useFakeTimers();
+    sessionStorage.setItem(SESSION_KEY, '/c/abc?endpoint=bedrock');
+
+    renderProviderLive();
+
+    const refreshCall = mockRefreshMutate.mock.calls[0];
+    const refreshOptions = refreshCall[1] as { onSuccess: (data: unknown) => void };
+    mockRefreshMutate.mockClear();
+
+    act(() => {
+      refreshOptions.onSuccess({ user: { id: '1', role: 'USER' }, token: 'new-token' });
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/c/abc?endpoint=bedrock', { replace: true });
+    expect(mockRefreshMutate).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it('does not navigate to unsafe stored redirect', () => {
+    jest.useFakeTimers();
+    sessionStorage.setItem(SESSION_KEY, 'https://evil.com/steal');
+
+    renderProviderLive();
+
+    const refreshCall = mockRefreshMutate.mock.calls[0];
+    const refreshOptions = refreshCall[1] as { onSuccess: (data: unknown) => void };
+
+    act(() => {
+      refreshOptions.onSuccess({ user: { id: '1', role: 'USER' }, token: 'new-token' });
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalledWith('https://evil.com/steal', expect.anything());
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+    jest.useRealTimers();
+  });
+});
+
+describe('AuthContextProvider — logout error handling', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...originalLocation,
+        pathname: '/c/some-chat',
+        search: '',
+        hash: '',
+        replace: jest.fn(),
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
 
   it('clears auth state on logout error without external redirect', () => {
     jest.useFakeTimers();

--- a/client/src/routes/__tests__/StartupLayout.spec.tsx
+++ b/client/src/routes/__tests__/StartupLayout.spec.tsx
@@ -2,8 +2,8 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import StartupLayout from '~/routes/Layouts/Startup';
 import { SESSION_KEY } from '~/utils';
-import StartupLayout from '../Layouts/Startup';
 
 if (typeof Request === 'undefined') {
   global.Request = class Request {


### PR DESCRIPTION

## Summary

Fixed a bug where users authenticated via OIDC silent refresh were left stranded with no post-login navigation when no `SESSION_KEY` was pre-populated in sessionStorage and no `redirect_to` URL parameter was present.

- Consumed `SESSION_KEY` from sessionStorage eagerly in `silentRefresh.onSuccess`, before the debounced `setUserContext` call fires, preventing the debounce from coalescing it away.
- Validated the stored redirect with `isSafeRedirect` at the call site, defaulting to `/c/new` for absent or unsafe values, rather than using `??` which would have passed unsafe URLs through to `setUserContext`.
- Removed the `if (storedRedirect)` guard around `sessionStorage.removeItem(SESSION_KEY)`, as `removeItem` on a missing key is a no-op per the Web Storage spec.
- Added four unit tests covering: navigation to a stored safe redirect, default `/c/new` navigation when no key exists, no silentRefresh re-trigger after redirect, and fallback to `/c/new` for an unsafe stored URL.
- Imported `SESSION_KEY` from `~/utils` in `AuthContext.spec.tsx` instead of redeclaring it as a hardcoded string literal, keeping it coupled to the canonical source.
- Added `expect(mockRefreshMutate).toHaveBeenCalledTimes(1)` guards before `mock.calls[0]` access in all four new tests to produce clear failures rather than opaque `TypeError`s on setup regressions.
- Fixed the `StartupLayout` import path in its test file from a relative path to the `~/routes/Layouts/Startup` alias, consistent with project conventions.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Covered by the four new unit tests in `AuthContext.spec.tsx` under `describe('AuthContextProvider — silentRefresh post-login redirect')`. To reproduce the original bug manually: configure an OIDC provider, navigate directly to `/c/new?endpoint=bedrock&model=some-model`, complete the OIDC login flow, and verify you land on `/c/new?endpoint=bedrock&model=some-model` rather than remaining on the OIDC callback URL with no navigation.

### **Test Configuration**:

- OIDC provider configured (e.g., Keycloak or any compliant IdP)
- `SESSION_KEY` (`post_login_redirect_to`) populated in sessionStorage prior to the OIDC redirect to simulate a preserved deep link

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes