### PR TITLE
🐳 chore: Update image registry references in Docker/Helm configurations

### DIFF
--- a/config/deployed-update.js
+++ b/config/deployed-update.js
@@ -41,7 +41,7 @@ const shouldRebase = process.argv.includes('--rebase');
   execSync(downCommand, { stdio: 'inherit' });
 
   console.purple('Removing all tags for LibreChat `deployed` images...');
-  const repositories = ['ghcr.io/danny-avila/librechat-dev-api', 'librechat-client'];
+  const repositories = ['registry.librechat.ai/danny-avila/librechat-dev-api', 'librechat-client'];
   repositories.forEach((repo) => {
     const tags = execSync(`sudo docker images ${repo} -q`, { encoding: 'utf8' })
       .split('\n')

--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -4,7 +4,7 @@ services:
     #   context: .
     #   dockerfile: Dockerfile.multi
     #   target: api-build
-    image: ghcr.io/danny-avila/librechat-dev-api:latest
+    image: registry.librechat.ai/danny-avila/librechat-dev-api:latest
     container_name: LibreChat-API
     ports:
       - 3080:3080
@@ -74,7 +74,7 @@ services:
     volumes:
       - pgdata2:/var/lib/postgresql/data
   rag_api:
-    image: ghcr.io/danny-avila/librechat-rag-api-dev-lite:latest
+    image: registry.librechat.ai/danny-avila/librechat-rag-api-dev-lite:latest
     environment:
       - DB_HOST=vectordb
       - RAG_PORT=${RAG_PORT:-8000}

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -17,7 +17,7 @@
 #     - type: bind
 #       source: ./librechat.yaml
 #       target: /app/librechat.yaml
-#     image: ghcr.io/danny-avila/librechat:latest
+#     image: registry.librechat.ai/danny-avila/librechat:latest
 
 # ---------------------------------------------------
 
@@ -39,19 +39,19 @@
 
 # # BUILD FROM LATEST IMAGE
 #   api:
-#     image: ghcr.io/danny-avila/librechat-dev:latest
+#     image: registry.librechat.ai/danny-avila/librechat-dev:latest
 
 # # BUILD FROM LATEST IMAGE (NUMBERED RELEASE)
 #   api:
-#     image: ghcr.io/danny-avila/librechat:latest
+#     image: registry.librechat.ai/danny-avila/librechat:latest
 
 # # BUILD FROM LATEST API IMAGE
 #   api:
-#     image: ghcr.io/danny-avila/librechat-dev-api:latest
+#     image: registry.librechat.ai/danny-avila/librechat-dev-api:latest
 
 # # BUILD FROM LATEST API IMAGE (NUMBERED RELEASE)
 #   api:
-#     image: ghcr.io/danny-avila/librechat-api:latest
+#     image: registry.librechat.ai/danny-avila/librechat-api:latest
 
 # # ADD SAML CERT FILE
 #   api:
@@ -104,7 +104,7 @@
 
 # # USE RAG API IMAGE WITH LOCAL EMBEDDINGS SUPPORT
 #  rag_api:
-#    image: ghcr.io/danny-avila/librechat-rag-api-dev:latest
+#    image: registry.librechat.ai/danny-avila/librechat-rag-api-dev:latest
 # # For Linux user:
 #    extra_hosts:
 #      - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - mongodb
       - rag_api
-    image: ghcr.io/danny-avila/librechat-dev:latest
+    image: registry.librechat.ai/danny-avila/librechat-dev:latest
     restart: always
     user: "${UID}:${GID}"
     extra_hosts:
@@ -58,7 +58,7 @@ services:
       - pgdata2:/var/lib/postgresql/data
   rag_api:
     container_name: rag_api
-    image: ghcr.io/danny-avila/librechat-rag-api-dev-lite:latest
+    image: registry.librechat.ai/danny-avila/librechat-rag-api-dev-lite:latest
     environment:
       - DB_HOST=vectordb
       - RAG_PORT=${RAG_PORT:-8000}

--- a/helm/librechat-rag-api/Chart.yaml
+++ b/helm/librechat-rag-api/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.5.3
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-# renovate: image=ghcr.io/danny-avila/librechat-rag-api-dev
+# renovate: image=registry.librechat.ai/danny-avila/librechat-rag-api-dev
 appVersion: "v0.4.0"
 
 home: https://www.librechat.ai

--- a/helm/librechat-rag-api/values.yaml
+++ b/helm/librechat-rag-api/values.yaml
@@ -9,7 +9,7 @@ rag:
 
 image:
   repository: danny-avila/librechat-rag-api-dev-lite # there is rag-api-dev and rag-api-dev-lite. currently only lite is docuimented
-  registry: ghcr.io
+  registry: registry.librechat.ai
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: latest

--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -22,7 +22,7 @@ version: 1.9.8
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 
-# renovate: image=ghcr.io/danny-avila/librechat
+# renovate: image=registry.librechat.ai/danny-avila/librechat
 appVersion: "v0.8.3-rc1"
 
 home: https://www.librechat.ai

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -118,7 +118,7 @@ librechat-rag-api:
 
 image:
   repository: danny-avila/librechat
-  registry: ghcr.io
+  registry: registry.librechat.ai
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/rag.yml
+++ b/rag.yml
@@ -13,7 +13,7 @@ services:
       - "5433:5432"
 
   rag_api:
-    image: ghcr.io/danny-avila/librechat-rag-api-dev:latest
+    image: registry.librechat.ai/danny-avila/librechat-rag-api-dev:latest
     environment:
       - DB_HOST=vectordb
       - DB_PORT=5432

--- a/utils/docker/test-compose.yml
+++ b/utils/docker/test-compose.yml
@@ -50,7 +50,7 @@ services:
     volumes:
       - pgdata2:/var/lib/postgresql/data
   rag_api:
-    image: ghcr.io/danny-avila/librechat-rag-api-dev-lite:latest
+    image: registry.librechat.ai/danny-avila/librechat-rag-api-dev-lite:latest
     environment:
       - DB_HOST=vectordb
       - RAG_PORT=${RAG_PORT:-8000}


### PR DESCRIPTION
- Changed image references from `ghcr.io` to `registry.librechat.ai` across multiple Docker and Helm files, ensuring consistency in image sourcing.
- Updated `deploy-compose.yml`, `docker-compose.override.yml.example`, `docker-compose.yml`, `rag.yml`, and various Helm chart files to reflect the new registry.