### PR TITLE
feat: make agent run timeout configurable via AGENT_RUN_TIMEOUT_MS env var

### DIFF
--- a/api/server/services/Runs/handle.js
+++ b/api/server/services/Runs/handle.js
@@ -65,7 +65,7 @@ async function waitForRun({
   thread_id,
   runManager,
   pollIntervalMs = 2000,
-  timeout = 60000 * 3,
+  timeout = Number(process.env.AGENT_RUN_TIMEOUT_MS) || 60000 * 3,
 }) {
   let timeElapsed = 0;
   let run;


### PR DESCRIPTION
## Problem

The `waitForRun` function in `api/server/services/Runs/handle.js` has a hard-coded 3-minute timeout:
```javascript
timeout = 60000 * 3, // 180 seconds
```

This causes agent-invoked MCP tool calls to fail with timeout errors, even when the MCP server's YAML `timeout` is set much higher. The same MCP tools work fine when called directly (non-agent context), confirming that the agent run polling timeout is the bottleneck.

Related: #8563

## Solution

Make the timeout configurable via environment variable with backward-compatible default:
```javascript
timeout = Number(process.env.AGENT_RUN_TIMEOUT_MS) || 60000 * 3,
```

### Usage
```env
AGENT_RUN_TIMEOUT_MS=10800000  # 3 hours for long-running MCP tools
```

## Why This Matters

- Many MCP tools (research pipelines, AI-assisted analysis, deep research) need more than 3 minutes
- Agent → agent handoff workflows compound the issue
- Current workaround requires modifying source code, lost on every update
- Without the env variable, behavior is unchanged (3-minute default)

## Testing

Verified in production with:
- FastMCP servers (Python, streamable-http transport)
- Agent handoff chains (orchestrator → specialist agent → MCP tool)
- Long-running tools (5-30 min processing time)
- `AGENT_RUN_TIMEOUT_MS=10800000` resolves the timeout completely