### PR TITLE
fix: Azure Assistants file download with non-ASCII filenames

### DIFF
--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -323,9 +323,11 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
 
     const setHeaders = () => {
       const cleanedFilename = cleanFileName(file.filename);
-      res.setHeader('Content-Disposition', `attachment; filename="${cleanedFilename}"`);
+      const encodedFilename = encodeURIComponent(cleanedFilename);
+      res.setHeader('Content-Disposition', `attachment; filename="${encodedFilename}"; filename*=UTF-8''${encodedFilename}`);
       res.setHeader('Content-Type', 'application/octet-stream');
-      res.setHeader('X-File-Metadata', JSON.stringify(file));
+      const fileMetaJson = JSON.stringify(file).replace(/[\u0080-\uffff]/g, (ch) => '\\u' + ('0000' + ch.charCodeAt(0).toString(16)).slice(-4));
+      res.setHeader('X-File-Metadata', fileMetaJson);
     };
 
     if (checkOpenAIStorage(file.source)) {

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -744,9 +744,11 @@ const processOpenAIFile = async ({
 }) => {
   const _file = await openai.files.retrieve(file_id);
   const originalName = filename ?? (_file.filename ? path.basename(_file.filename) : undefined);
-  const filepath = `${openai.baseURL}/files/${userId}/${file_id}${
-    originalName ? `/${originalName}` : ''
-  }`;
+  // Use ASCII-safe name in filepath to avoid URL-encoding issues with non-ASCII filenames
+  const fileExt = originalName ? path.extname(originalName) : '';
+  const isAscii = originalName ? /^[ -~]*$/.test(originalName) : false;
+  const safeName = isAscii ? originalName : file_id + fileExt;
+  const filepath = `files/${userId}/${file_id}/${safeName}`;
   const type = mime.getType(originalName ?? file_id);
   const source =
     openai.req.body.endpoint === EModelEndpoint.azureAssistants

--- a/api/server/services/Threads/manage.js
+++ b/api/server/services/Threads/manage.js
@@ -609,12 +609,16 @@ async function processMessages({ openai, client, messages = [] }) {
               unknownType: true,
             });
             if (file && file.filename) {
-              if (!sources.has(file.filename)) {
-                sources.set(file.filename, sources.size + 1);
+              if (file.context === 'assistants_output') {
+                replacementText = file.filepath;
+              } else {
+                if (!sources.has(file.filename)) {
+                  sources.set(file.filename, sources.size + 1);
+                }
+                replacementText = `${uniqueCitationStart}${sources.get(
+                  file.filename,
+                )}${uniqueCitationEnd}`;
               }
-              replacementText = `${uniqueCitationStart}${sources.get(
-                file.filename,
-              )}${uniqueCitationEnd}`;
             }
           }
 


### PR DESCRIPTION
## Summary

Fixes three related issues when downloading files generated by Azure Assistants API, particularly with Japanese and other non-ASCII filenames:

- **`process.js`**: Use ASCII-safe filepath for non-ASCII filenames in `processOpenAIFile`. When the original filename contains non-ASCII characters (e.g., Japanese), use `file_id + extension` instead to avoid URL-encoding issues in the download path.
- **`manage.js`**: Handle `FILE_CITATION` annotations for code-interpreter output files. When `file.context === 'assistants_output'`, use the file's filepath directly as a download link instead of replacing it with a citation marker (e.g., `^1^`).
- **`files.js`**: Fix `Content-Disposition` and `X-File-Metadata` headers for non-ASCII filenames. Apply RFC 5987 encoding (`filename*=UTF-8''`) and Unicode-escape non-ASCII characters in JSON metadata to prevent `Invalid character in header content` errors.

### Reproduction Steps

1. Use Azure Assistants API with code-interpreter enabled
2. Ask the assistant to generate a file with a Japanese filename (e.g., "売上分析.xlsx")
3. Try to download the generated file

**Expected**: File downloads with the correct filename
**Actual (before fix)**: 
- Download fails with URL-encoding errors for non-ASCII filenames
- Code-interpreter output files show as `^1^` citation markers instead of download links
- HTTP 500 error due to `Invalid character in header content` in response headers

## Test plan

- [ ] Upload and download files with ASCII filenames (regression test)
- [ ] Generate and download code-interpreter output files with Japanese filenames
- [ ] Verify `Content-Disposition` header uses RFC 5987 encoding for non-ASCII filenames
- [ ] Verify `X-File-Metadata` header safely encodes non-ASCII characters
- [ ] Verify code-interpreter output files render as download links, not citation markers