### PR TITLE
fix: display assistant name instead of raw ID in pinned favorites

### DIFF
--- a/client/src/components/Nav/Favorites/FavoriteItem.tsx
+++ b/client/src/components/Nav/Favorites/FavoriteItem.tsx
@@ -2,10 +2,12 @@ import React, { useState } from 'react';
 import * as Menu from '@ariakit/react/menu';
 import { Ellipsis, PinOff } from 'lucide-react';
 import { DropdownPopup } from '@librechat/client';
-import { EModelEndpoint } from 'librechat-data-provider';
+import { EModelEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
+import type { AssistantsEndpoint } from 'librechat-data-provider';
 import type { FavoriteModel } from '~/store/favorites';
 import type t from 'librechat-data-provider';
 import MinimalIcon from '~/components/Endpoints/MinimalIcon';
+import { useAssistantsMapContext } from '~/Providers';
 import { useFavorites, useLocalize } from '~/hooks';
 import { renderAgentAvatar, cn } from '~/utils';
 
@@ -30,6 +32,7 @@ export default function FavoriteItem({
   onRemoveFocus,
 }: FavoriteItemProps) {
   const localize = useLocalize();
+  const assistantsMap = useAssistantsMapContext();
   const { removeFavoriteAgent, removeFavoriteModel } = useFavorites();
   const [isPopoverActive, setIsPopoverActive] = useState(false);
 
@@ -87,7 +90,14 @@ export default function FavoriteItem({
     if (type === 'agent') {
       return (item as t.Agent).name ?? '';
     }
-    return (item as FavoriteModel).model;
+    const model = item as FavoriteModel;
+    if (isAssistantsEndpoint(model.endpoint) && assistantsMap) {
+      const assistant = assistantsMap[model.endpoint as AssistantsEndpoint]?.[model.model];
+      if (assistant?.name) {
+        return assistant.name;
+      }
+    }
+    return model.model;
   };
 
   const name = getName();


### PR DESCRIPTION
## Summary

When an Azure Assistant or OpenAI Assistant is pinned/favorited in the sidebar, the `FavoriteItem` component displays the raw assistant ID (e.g., `asst_toBJ8xlYgxGzlcs7...`) instead of the assistant's display name (e.g., "Data Analysis Assistant").

**Root cause**: `getName()` in `FavoriteItem.tsx` only handled the `'agent'` type for name resolution and fell back to the `model` field for everything else. For assistants, the `model` field stores the assistant ID, not a human-readable name.

**Fix**: Use `useAssistantsMapContext` to look up the assistant's name when the favorite's endpoint is an assistants endpoint (`assistants` or `azureAssistants`), falling back to the raw model ID if the assistant is not found in the map.

### Before / After

| Before | After |
|--------|-------|
| `asst_toBJ8xlYgxGzlcs7...` | Data Analysis Assistant |

## Test plan

- [ ] Pin an Azure Assistant → sidebar shows the assistant's display name
- [ ] Pin an OpenAI Assistant → sidebar shows the assistant's display name
- [ ] Pin a regular model (e.g., gpt-4) → sidebar still shows model ID as before
- [ ] Pin an agent → sidebar still shows agent name as before
- [ ] If assistant is deleted/unavailable, falls back to raw ID gracefully