### PR TITLE
🔒 fix: Request interceptor for Shared Link Page Scenarios

### DIFF
--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -10,7 +10,7 @@ import {
 import { debounce } from 'lodash';
 import { useRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
-import { setTokenHeader, SystemRoles } from 'librechat-data-provider';
+import { setTokenHeader, SystemRoles, buildLoginRedirectUrl } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { ReactNode } from 'react';
 import {
@@ -20,8 +20,8 @@ import {
   useLogoutUserMutation,
   useRefreshTokenMutation,
 } from '~/data-provider';
-import { SESSION_KEY, isSafeRedirect, buildLoginRedirectUrl, getPostLoginRedirect } from '~/utils';
 import { TAuthConfig, TUserContext, TAuthContext, TResError } from '~/common';
+import { SESSION_KEY, isSafeRedirect, getPostLoginRedirect } from '~/utils';
 import useTimeout from './useTimeout';
 import store from '~/store';
 

--- a/client/src/routes/useAuthRedirect.ts
+++ b/client/src/routes/useAuthRedirect.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { buildLoginRedirectUrl } from '~/utils';
+import { buildLoginRedirectUrl } from 'librechat-data-provider';
 import { useAuthContext } from '~/hooks';
 
 export default function useAuthRedirect() {

--- a/client/src/utils/__tests__/redirect.test.ts
+++ b/client/src/utils/__tests__/redirect.test.ts
@@ -1,8 +1,7 @@
 import {
-  isSafeRedirect,
-  buildLoginRedirectUrl,
-  getPostLoginRedirect,
   persistRedirectToSession,
+  getPostLoginRedirect,
+  isSafeRedirect,
   SESSION_KEY,
 } from '../redirect';
 
@@ -57,87 +56,6 @@ describe('isSafeRedirect', () => {
 
   it('accepts the root path', () => {
     expect(isSafeRedirect('/')).toBe(true);
-  });
-});
-
-describe('buildLoginRedirectUrl', () => {
-  const originalLocation = window.location;
-
-  beforeEach(() => {
-    Object.defineProperty(window, 'location', {
-      value: { pathname: '/c/abc123', search: '?model=gpt-4', hash: '#msg-5' },
-      writable: true,
-    });
-  });
-
-  afterEach(() => {
-    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
-  });
-
-  it('builds a login URL from explicit args', () => {
-    const result = buildLoginRedirectUrl('/c/new', '?q=hello', '');
-    expect(result).toBe('/login?redirect_to=%2Fc%2Fnew%3Fq%3Dhello');
-  });
-
-  it('encodes complex paths with query and hash', () => {
-    const result = buildLoginRedirectUrl('/c/new', '?q=hello&submit=true', '#section');
-    expect(result).toContain('redirect_to=');
-    const encoded = result.split('redirect_to=')[1];
-    expect(decodeURIComponent(encoded)).toBe('/c/new?q=hello&submit=true#section');
-  });
-
-  it('falls back to window.location when no args provided', () => {
-    const result = buildLoginRedirectUrl();
-    const encoded = result.split('redirect_to=')[1];
-    expect(decodeURIComponent(encoded)).toBe('/c/abc123?model=gpt-4#msg-5');
-  });
-
-  it('falls back to "/" when all location parts are empty', () => {
-    Object.defineProperty(window, 'location', {
-      value: { pathname: '', search: '', hash: '' },
-      writable: true,
-    });
-    const result = buildLoginRedirectUrl();
-    expect(result).toBe('/login?redirect_to=%2F');
-  });
-
-  it('returns plain /login when pathname is /login (prevents recursive redirect)', () => {
-    const result = buildLoginRedirectUrl('/login', '?redirect_to=%2Fc%2Fnew', '');
-    expect(result).toBe('/login');
-  });
-
-  it('returns plain /login when window.location is already /login', () => {
-    Object.defineProperty(window, 'location', {
-      value: { pathname: '/login', search: '?redirect_to=%2Fc%2Fabc', hash: '' },
-      writable: true,
-    });
-    const result = buildLoginRedirectUrl();
-    expect(result).toBe('/login');
-  });
-
-  it('returns plain /login for /login sub-paths', () => {
-    const result = buildLoginRedirectUrl('/login/2fa', '', '');
-    expect(result).toBe('/login');
-  });
-
-  it('returns plain /login for basename-prefixed /login (e.g. /librechat/login)', () => {
-    Object.defineProperty(window, 'location', {
-      value: { pathname: '/librechat/login', search: '?redirect_to=%2Fc%2Fabc', hash: '' },
-      writable: true,
-    });
-    const result = buildLoginRedirectUrl();
-    expect(result).toBe('/login');
-  });
-
-  it('returns plain /login for basename-prefixed /login sub-paths', () => {
-    const result = buildLoginRedirectUrl('/librechat/login/2fa', '', '');
-    expect(result).toBe('/login');
-  });
-
-  it('does NOT match paths where "login" is a substring of a segment', () => {
-    const result = buildLoginRedirectUrl('/c/loginhistory', '', '');
-    expect(result).toContain('redirect_to=');
-    expect(decodeURIComponent(result.split('redirect_to=')[1])).toBe('/c/loginhistory');
   });
 });
 

--- a/client/src/utils/redirect.ts
+++ b/client/src/utils/redirect.ts
@@ -1,13 +1,11 @@
-import { buildLoginRedirectUrl } from 'librechat-data-provider';
-
-const REDIRECT_PARAM = 'redirect_to';
-const SESSION_KEY = 'post_login_redirect_to';
+export const REDIRECT_PARAM = 'redirect_to';
+export const SESSION_KEY = 'post_login_redirect_to';
 
 /** Matches `/login` as a full path segment, with optional basename prefix (e.g. `/librechat/login/2fa`) */
 const LOGIN_PATH_RE = /(?:^|\/)login(?:\/|$)/;
 
 /** Validates that a redirect target is a safe relative path (not an absolute or protocol-relative URL) */
-function isSafeRedirect(url: string): boolean {
+export function isSafeRedirect(url: string): boolean {
   if (!url.startsWith('/') || url.startsWith('//')) {
     return false;
   }
@@ -19,7 +17,7 @@ function isSafeRedirect(url: string): boolean {
  * Resolves the post-login redirect from URL params and sessionStorage,
  * cleans up both sources, and returns the validated target (or null).
  */
-function getPostLoginRedirect(searchParams: URLSearchParams): string | null {
+export function getPostLoginRedirect(searchParams: URLSearchParams): string | null {
   const urlRedirect = searchParams.get(REDIRECT_PARAM);
   const storedRedirect = sessionStorage.getItem(SESSION_KEY);
 
@@ -36,17 +34,8 @@ function getPostLoginRedirect(searchParams: URLSearchParams): string | null {
   return target;
 }
 
-function persistRedirectToSession(value: string): void {
+export function persistRedirectToSession(value: string): void {
   if (isSafeRedirect(value)) {
     sessionStorage.setItem(SESSION_KEY, value);
   }
 }
-
-export {
-  SESSION_KEY,
-  REDIRECT_PARAM,
-  isSafeRedirect,
-  persistRedirectToSession,
-  buildLoginRedirectUrl,
-  getPostLoginRedirect,
-};

--- a/client/src/utils/redirect.ts
+++ b/client/src/utils/redirect.ts
@@ -1,3 +1,5 @@
+import { buildLoginRedirectUrl } from 'librechat-data-provider';
+
 const REDIRECT_PARAM = 'redirect_to';
 const SESSION_KEY = 'post_login_redirect_to';
 
@@ -11,22 +13,6 @@ function isSafeRedirect(url: string): boolean {
   }
   const path = url.split('?')[0].split('#')[0];
   return !LOGIN_PATH_RE.test(path);
-}
-
-/**
- * Builds a `/login?redirect_to=...` URL from the given or current location.
- * Returns plain `/login` (no param) when already on a login route to prevent recursive nesting.
- */
-function buildLoginRedirectUrl(pathname?: string, search?: string, hash?: string): string {
-  const p = pathname ?? window.location.pathname;
-  if (LOGIN_PATH_RE.test(p)) {
-    return '/login';
-  }
-  const s = search ?? window.location.search;
-  const h = hash ?? window.location.hash;
-  const currentPath = `${p}${s}${h}`;
-  const encoded = encodeURIComponent(currentPath || '/');
-  return `/login?${REDIRECT_PARAM}=${encoded}`;
 }
 
 /**

--- a/packages/data-provider/specs/api-endpoints.spec.ts
+++ b/packages/data-provider/specs/api-endpoints.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+import { buildLoginRedirectUrl } from '../src/api-endpoints';
+
+describe('buildLoginRedirectUrl', () => {
+  let savedLocation: Location;
+
+  beforeEach(() => {
+    savedLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/c/abc123', search: '?model=gpt-4', hash: '#msg-5' },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: savedLocation, writable: true });
+  });
+
+  it('builds a login URL from explicit args', () => {
+    const result = buildLoginRedirectUrl('/c/new', '?q=hello', '');
+    expect(result).toBe('/login?redirect_to=%2Fc%2Fnew%3Fq%3Dhello');
+  });
+
+  it('encodes complex paths with query and hash', () => {
+    const result = buildLoginRedirectUrl('/c/new', '?q=hello&submit=true', '#section');
+    expect(result).toContain('redirect_to=');
+    const encoded = result.split('redirect_to=')[1];
+    expect(decodeURIComponent(encoded)).toBe('/c/new?q=hello&submit=true#section');
+  });
+
+  it('falls back to window.location when no args provided', () => {
+    const result = buildLoginRedirectUrl();
+    const encoded = result.split('redirect_to=')[1];
+    expect(decodeURIComponent(encoded)).toBe('/c/abc123?model=gpt-4#msg-5');
+  });
+
+  it('falls back to "/" when all location parts are empty', () => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '', search: '', hash: '' },
+      writable: true,
+    });
+    const result = buildLoginRedirectUrl();
+    expect(result).toBe('/login?redirect_to=%2F');
+  });
+
+  it('returns plain /login when pathname is /login (prevents recursive redirect)', () => {
+    const result = buildLoginRedirectUrl('/login', '?redirect_to=%2Fc%2Fnew', '');
+    expect(result).toBe('/login');
+  });
+
+  it('returns plain /login when window.location is already /login', () => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/login', search: '?redirect_to=%2Fc%2Fabc', hash: '' },
+      writable: true,
+    });
+    const result = buildLoginRedirectUrl();
+    expect(result).toBe('/login');
+  });
+
+  it('returns plain /login for /login sub-paths', () => {
+    const result = buildLoginRedirectUrl('/login/2fa', '', '');
+    expect(result).toBe('/login');
+  });
+
+  it('returns plain /login for basename-prefixed /login (e.g. /librechat/login)', () => {
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/librechat/login', search: '?redirect_to=%2Fc%2Fabc', hash: '' },
+      writable: true,
+    });
+    const result = buildLoginRedirectUrl();
+    expect(result).toBe('/login');
+  });
+
+  it('returns plain /login for basename-prefixed /login sub-paths', () => {
+    const result = buildLoginRedirectUrl('/librechat/login/2fa', '', '');
+    expect(result).toBe('/login');
+  });
+
+  it('does NOT match paths where "login" is a substring of a segment', () => {
+    const result = buildLoginRedirectUrl('/c/loginhistory', '', '');
+    expect(result).toContain('redirect_to=');
+    expect(decodeURIComponent(result.split('redirect_to=')[1])).toBe('/c/loginhistory');
+  });
+});

--- a/packages/data-provider/specs/request-interceptor.spec.ts
+++ b/packages/data-provider/specs/request-interceptor.spec.ts
@@ -13,20 +13,20 @@ import { setTokenHeader } from '../src/headers-helpers';
  * a refresh POST or is immediately rejected.
  */
 
-/** Mock the axios adapter to simulate responses without HTTP */
 const mockAdapter = jest.fn();
 let originalAdapter: typeof axios.defaults.adapter;
+let savedLocation: Location;
 
 beforeAll(async () => {
   originalAdapter = axios.defaults.adapter;
   axios.defaults.adapter = mockAdapter;
 
-  /** Import triggers interceptor registration */
   await import('../src/request');
 });
 
 beforeEach(() => {
   mockAdapter.mockReset();
+  savedLocation = window.location;
 });
 
 afterAll(() => {
@@ -35,14 +35,24 @@ afterAll(() => {
 
 afterEach(() => {
   delete axios.defaults.headers.common['Authorization'];
+  Object.defineProperty(window, 'location', {
+    value: savedLocation,
+    writable: true,
+  });
 });
+
+function setWindowLocation(overrides: Partial<Location>) {
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, ...overrides },
+    writable: true,
+  });
+}
 
 describe('axios 401 interceptor — Authorization header guard', () => {
   it('skips refresh and rejects when Authorization header is cleared', async () => {
-    /** Simulate a cleared header (as done by setTokenHeader(undefined) during logout) */
+    expect.assertions(1);
     setTokenHeader(undefined);
 
-    /** Set up adapter: first call returns 401, second would be the refresh */
     mockAdapter.mockRejectedValueOnce({
       response: { status: 401 },
       config: { url: '/api/messages', headers: {} },
@@ -54,23 +64,25 @@ describe('axios 401 interceptor — Authorization header guard', () => {
       // expected rejection
     }
 
-    /**
-     * If the interceptor skipped refresh, only 1 call was made (the original).
-     * If it attempted refresh, there would be 2+ calls (original + refresh POST).
-     */
     expect(mockAdapter).toHaveBeenCalledTimes(1);
   });
 
-  it('attempts refresh when Authorization header is present', async () => {
-    setTokenHeader('valid-token');
+  it('attempts refresh on shared link page even without Authorization header', async () => {
+    expect.assertions(2);
+    setTokenHeader(undefined);
 
-    /** First call: 401 on the original request */
+    setWindowLocation({
+      href: 'http://localhost/share/abc123',
+      pathname: '/share/abc123',
+      search: '',
+      hash: '',
+    } as Partial<Location>);
+
     mockAdapter.mockRejectedValueOnce({
       response: { status: 401 },
-      config: { url: '/api/messages', headers: {}, _retry: false },
+      config: { url: '/api/share/abc123', headers: {} },
     });
 
-    /** Second call: the refresh endpoint succeeds */
     mockAdapter.mockResolvedValueOnce({
       data: { token: 'new-token' },
       status: 200,
@@ -78,7 +90,194 @@ describe('axios 401 interceptor — Authorization header guard', () => {
       config: {},
     });
 
-    /** Third call: retried original request succeeds */
+    mockAdapter.mockResolvedValueOnce({
+      data: { sharedLink: {} },
+      status: 200,
+      headers: {},
+      config: {},
+    });
+
+    try {
+      await axios.get('/api/share/abc123');
+    } catch {
+      // may reject depending on exact flow
+    }
+
+    expect(mockAdapter.mock.calls.length).toBe(3);
+
+    const refreshCall = mockAdapter.mock.calls[1];
+    expect(refreshCall[0].url).toContain('api/auth/refresh');
+  });
+
+  it('does not bypass guard when share/ appears only in query params', async () => {
+    expect.assertions(1);
+    setTokenHeader(undefined);
+
+    setWindowLocation({
+      href: 'http://localhost/c/chat?ref=share/token',
+      pathname: '/c/chat',
+      search: '?ref=share/token',
+      hash: '',
+    } as Partial<Location>);
+
+    mockAdapter.mockRejectedValueOnce({
+      response: { status: 401 },
+      config: { url: '/api/messages', headers: {} },
+    });
+
+    try {
+      await axios.get('/api/messages');
+    } catch {
+      // expected rejection
+    }
+
+    expect(mockAdapter).toHaveBeenCalledTimes(1);
+  });
+
+  it('redirects to login with redirect_to when unauthenticated on share page and refresh fails', async () => {
+    expect.assertions(1);
+    setTokenHeader(undefined);
+
+    setWindowLocation({
+      href: 'http://localhost/share/abc123',
+      pathname: '/share/abc123',
+      search: '',
+      hash: '',
+    } as Partial<Location>);
+
+    mockAdapter.mockRejectedValueOnce({
+      response: { status: 401 },
+      config: { url: '/api/share/abc123', headers: {} },
+    });
+
+    mockAdapter.mockResolvedValueOnce({
+      data: { token: '' },
+      status: 200,
+      headers: {},
+      config: {},
+    });
+
+    try {
+      await axios.get('/api/share/abc123');
+    } catch {
+      // expected rejection
+    }
+
+    expect(window.location.href).toBe('/login?redirect_to=%2Fshare%2Fabc123');
+  });
+
+  it('redirects to login with redirect_to when authenticated and refresh returns no token on share page', async () => {
+    expect.assertions(1);
+    setTokenHeader('some-token');
+
+    setWindowLocation({
+      href: 'http://localhost/share/abc123',
+      pathname: '/share/abc123',
+      search: '',
+      hash: '',
+    } as Partial<Location>);
+
+    mockAdapter.mockRejectedValueOnce({
+      response: { status: 401 },
+      config: { url: '/api/share/abc123', headers: {} },
+    });
+
+    mockAdapter.mockResolvedValueOnce({
+      data: { token: '' },
+      status: 200,
+      headers: {},
+      config: {},
+    });
+
+    try {
+      await axios.get('/api/share/abc123');
+    } catch {
+      // expected rejection
+    }
+
+    expect(window.location.href).toBe('/login?redirect_to=%2Fshare%2Fabc123');
+  });
+
+  it('redirects to login with redirect_to when refresh returns no token on regular page', async () => {
+    expect.assertions(1);
+    setTokenHeader('some-token');
+
+    setWindowLocation({
+      href: 'http://localhost/c/some-conversation',
+      pathname: '/c/some-conversation',
+      search: '',
+      hash: '',
+    } as Partial<Location>);
+
+    mockAdapter.mockRejectedValueOnce({
+      response: { status: 401 },
+      config: { url: '/api/messages', headers: {} },
+    });
+
+    mockAdapter.mockResolvedValueOnce({
+      data: { token: '' },
+      status: 200,
+      headers: {},
+      config: {},
+    });
+
+    try {
+      await axios.get('/api/messages');
+    } catch {
+      // expected rejection
+    }
+
+    expect(window.location.href).toBe('/login?redirect_to=%2Fc%2Fsome-conversation');
+  });
+
+  it('redirects to plain /login without redirect_to when already on a login path', async () => {
+    expect.assertions(1);
+    setTokenHeader('some-token');
+
+    setWindowLocation({
+      href: 'http://localhost/login/2fa',
+      pathname: '/login/2fa',
+      search: '',
+      hash: '',
+    } as Partial<Location>);
+
+    mockAdapter.mockRejectedValueOnce({
+      response: { status: 401 },
+      config: { url: '/api/messages', headers: {} },
+    });
+
+    mockAdapter.mockResolvedValueOnce({
+      data: { token: '' },
+      status: 200,
+      headers: {},
+      config: {},
+    });
+
+    try {
+      await axios.get('/api/messages');
+    } catch {
+      // expected rejection
+    }
+
+    expect(window.location.href).toBe('/login');
+  });
+
+  it('attempts refresh when Authorization header is present', async () => {
+    expect.assertions(2);
+    setTokenHeader('valid-token');
+
+    mockAdapter.mockRejectedValueOnce({
+      response: { status: 401 },
+      config: { url: '/api/messages', headers: {}, _retry: false },
+    });
+
+    mockAdapter.mockResolvedValueOnce({
+      data: { token: 'new-token' },
+      status: 200,
+      headers: {},
+      config: {},
+    });
+
     mockAdapter.mockResolvedValueOnce({
       data: { messages: [] },
       status: 200,
@@ -92,10 +291,8 @@ describe('axios 401 interceptor — Authorization header guard', () => {
       // may reject depending on exact flow
     }
 
-    /** More than 1 call means the interceptor attempted refresh */
-    expect(mockAdapter.mock.calls.length).toBeGreaterThan(1);
+    expect(mockAdapter.mock.calls.length).toBe(3);
 
-    /** Verify the second call targeted the refresh endpoint */
     const refreshCall = mockAdapter.mock.calls[1];
     expect(refreshCall[0].url).toContain('api/auth/refresh');
   });

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -164,6 +164,25 @@ export const verifyEmail = () => `${BASE_URL}/api/user/verify`;
 export const loginPage = () => `${BASE_URL}/login`;
 export const registerPage = () => `${BASE_URL}/register`;
 
+const REDIRECT_PARAM = 'redirect_to';
+const LOGIN_PATH_RE = /(?:^|\/)login(?:\/|$)/;
+
+/**
+ * Builds a `/login?redirect_to=...` URL from the given or current location.
+ * Returns plain `/login` (no param) when already on a login route to prevent recursive nesting.
+ */
+export function buildLoginRedirectUrl(pathname?: string, search?: string, hash?: string): string {
+  const p = pathname ?? window.location.pathname;
+  if (LOGIN_PATH_RE.test(p)) {
+    return `${BASE_URL}/login`;
+  }
+  const s = search ?? window.location.search;
+  const h = hash ?? window.location.hash;
+  const currentPath = `${p}${s}${h}`;
+  const encoded = encodeURIComponent(currentPath || '/');
+  return `${BASE_URL}/login?${REDIRECT_PARAM}=${encoded}`;
+}
+
 export const resendVerificationEmail = () => `${BASE_URL}/api/user/verify/resend`;
 
 export const plugins = () => `${BASE_URL}/api/plugins`;

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -34,7 +34,7 @@ export * from './accessPermissions';
 export * from './keys';
 /* api call helpers */
 export * from './headers-helpers';
-export { loginPage, registerPage, apiBaseUrl } from './api-endpoints';
+export { loginPage, registerPage, apiBaseUrl, buildLoginRedirectUrl } from './api-endpoints';
 export { default as request } from './request';
 export { dataService };
 import * as dataService from './data-service';

--- a/packages/data-provider/src/request.ts
+++ b/packages/data-provider/src/request.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import axios, { AxiosError, AxiosRequestConfig } from 'axios';
-import * as endpoints from './api-endpoints';
 import { setTokenHeader } from './headers-helpers';
+import * as endpoints from './api-endpoints';
 import type * as t from './types';
 
 async function _get<T>(url: string, options?: AxiosRequestConfig): Promise<T> {
@@ -99,8 +99,12 @@ if (typeof window !== 'undefined') {
         return Promise.reject(error);
       }
 
-      /** Skip refresh when the Authorization header has been cleared (e.g. during logout) */
-      if (!axios.defaults.headers.common['Authorization']) {
+      /** Skip refresh when the Authorization header has been cleared (e.g. during logout),
+       *  but allow shared link requests to proceed so auth recovery/redirect can happen */
+      if (
+        !axios.defaults.headers.common['Authorization'] &&
+        !window.location.pathname.startsWith('/share/')
+      ) {
         return Promise.reject(error);
       }
 
@@ -135,12 +139,9 @@ if (typeof window !== 'undefined') {
             dispatchTokenUpdatedEvent(token);
             processQueue(null, token);
             return await axios(originalRequest);
-          } else if (window.location.href.includes('share/')) {
-            console.log(
-              `Refresh token failed from shared link, attempting request to ${originalRequest.url}`,
-            );
           } else {
-            window.location.href = endpoints.loginPage();
+            processQueue(error, null);
+            window.location.href = endpoints.buildLoginRedirectUrl();
           }
         } catch (err) {
           processQueue(err as AxiosError, null);


### PR DESCRIPTION
- Closes #12033
- Added tests to verify that the interceptor attempts a token refresh on shared link pages, even when the Authorization header is absent.
- Implemented logic to redirect users to the login page with a preserved redirect parameter if the refresh token request fails.
- Updated the request interceptor to allow shared link requests to proceed for authentication recovery, while still skipping refresh for other requests without an Authorization header.