### PR TITLE
🧬 feat: Allow Agent Editors to Duplicate Agents

### DIFF
--- a/api/server/routes/agents/v1.js
+++ b/api/server/routes/agents/v1.js
@@ -117,7 +117,7 @@ router.post(
   '/:id/duplicate',
   checkAgentCreate,
   canAccessAgentResource({
-    requiredPermission: PermissionBits.VIEW,
+    requiredPermission: PermissionBits.EDIT,
     resourceIdParam: 'id',
   }),
   v1.duplicateAgent,

--- a/client/src/components/SidePanel/Agents/AgentFooter.tsx
+++ b/client/src/components/SidePanel/Agents/AgentFooter.tsx
@@ -57,6 +57,7 @@ export default function AgentFooter({
     useResourcePermissions(ResourceType.REMOTE_AGENT, agent?._id || '');
 
   const canShareThisAgent = hasPermission(PermissionBits.SHARE);
+  const canEditThisAgent = hasPermission(PermissionBits.EDIT);
   const canDeleteThisAgent = hasPermission(PermissionBits.DELETE);
   const canShareRemoteAgent = hasRemoteAgentPermission(PermissionBits.SHARE);
   const isSaving = createMutation.isLoading || updateMutation.isLoading || isAvatarUploading;
@@ -118,7 +119,7 @@ export default function AgentFooter({
               </button>
             </GenericGrantAccessDialog>
           )}
-        {agent && agent.author === user?.id && <DuplicateAgent agent_id={agent_id} />}
+        {(agent?.author === user?.id || canEditThisAgent) && <DuplicateAgent agent_id={agent_id} />}
         {/* Submit Button */}
         <button
           className="btn btn-primary focus:shadow-outline flex h-9 w-full items-center justify-center px-4 py-2 font-semibold text-white hover:bg-green-600 focus:border-green-500"

--- a/client/src/components/SidePanel/Agents/AgentFooter.tsx
+++ b/client/src/components/SidePanel/Agents/AgentFooter.tsx
@@ -119,7 +119,8 @@ export default function AgentFooter({
               </button>
             </GenericGrantAccessDialog>
           )}
-        {(agent?.author === user?.id || canEditThisAgent) && <DuplicateAgent agent_id={agent_id} />}
+        {(agent?.author === user?.id || user?.role === SystemRoles.ADMIN || canEditThisAgent) &&
+          !permissionsLoading && <DuplicateAgent agent_id={agent_id} />}
         {/* Submit Button */}
         <button
           className="btn btn-primary focus:shadow-outline flex h-9 w-full items-center justify-center px-4 py-2 font-semibold text-white hover:bg-green-600 focus:border-green-500"

--- a/client/src/components/SidePanel/Agents/DeleteButton.tsx
+++ b/client/src/components/SidePanel/Agents/DeleteButton.tsx
@@ -88,6 +88,7 @@ export default function DeleteButton({
           size="sm"
           variant="outline"
           aria-label={localize('com_ui_delete_agent')}
+          title={localize('com_ui_delete_agent')}
           type="button"
         >
           <div className="flex w-full items-center justify-center gap-2 text-red-500">

--- a/client/src/components/SidePanel/Agents/DuplicateAgent.tsx
+++ b/client/src/components/SidePanel/Agents/DuplicateAgent.tsx
@@ -37,6 +37,7 @@ export default function DuplicateAgent({ agent_id }: { agent_id: string }) {
       size="sm"
       variant="outline"
       aria-label={localize('com_ui_duplicate_agent')}
+      title={localize('com_ui_duplicate_agent')}
       type="button"
       onClick={handleDuplicate}
     >

--- a/client/src/components/SidePanel/Agents/__tests__/AgentFooter.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentFooter.spec.tsx
@@ -362,9 +362,15 @@ describe('AgentFooter', () => {
         }
         return undefined;
       });
+      mockUseHasAccess.mockReturnValue(true);
+      mockUseResourcePermissions.mockReturnValue({
+        hasPermission: () => false,
+        isLoading: false,
+        permissionBits: 0,
+      });
       render(<AgentFooter {...defaultProps} />);
-      expect(screen.queryByTestId('grant-access-dialog-agent')).toBeInTheDocument(); // Still shows because hasAccess is true
-      expect(screen.queryByTestId('duplicate-agent')).not.toBeInTheDocument(); // Should not show for different author
+      expect(screen.queryByTestId('grant-access-dialog-agent')).not.toBeInTheDocument(); // No share permission
+      expect(screen.queryByTestId('duplicate-button')).not.toBeInTheDocument(); // No edit permission
     });
 
     test('adjusts UI based on permissions', () => {

--- a/client/src/components/SidePanel/Agents/__tests__/AgentFooter.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentFooter.spec.tsx
@@ -420,7 +420,84 @@ describe('AgentFooter', () => {
       render(<AgentFooter {...defaultProps} />);
       expect(screen.queryByTestId('delete-button')).not.toBeInTheDocument();
       expect(screen.queryByTestId('grant-access-dialog-agent')).not.toBeInTheDocument();
-      // Duplicate button should still show as it doesn't depend on permissions loading
+      expect(screen.queryByTestId('duplicate-button')).not.toBeInTheDocument();
+    });
+
+    test('shows duplicate button for non-owner with EDIT permission', () => {
+      mockUseAuthContext.mockReturnValue(createAuthContext(mockUsers.different));
+      mockUseWatch.mockImplementation(({ name }) => {
+        if (name === 'agent') {
+          return {
+            _id: 'agent-db-123',
+            name: 'Test Agent',
+            author: 'user-123',
+            projectIds: ['project-1'],
+            isCollaborative: false,
+          };
+        }
+        if (name === 'id') {
+          return 'agent-123';
+        }
+        return undefined;
+      });
+      mockUseResourcePermissions.mockReturnValue({
+        hasPermission: (bit: number) => bit === 2,
+        isLoading: false,
+        permissionBits: 2,
+      });
+      render(<AgentFooter {...defaultProps} />);
+      expect(screen.getByTestId('duplicate-button')).toBeInTheDocument();
+    });
+
+    test('hides duplicate button for non-owner with only VIEW permission', () => {
+      mockUseAuthContext.mockReturnValue(createAuthContext(mockUsers.different));
+      mockUseWatch.mockImplementation(({ name }) => {
+        if (name === 'agent') {
+          return {
+            _id: 'agent-db-123',
+            name: 'Test Agent',
+            author: 'user-123',
+            projectIds: ['project-1'],
+            isCollaborative: false,
+          };
+        }
+        if (name === 'id') {
+          return 'agent-123';
+        }
+        return undefined;
+      });
+      mockUseResourcePermissions.mockReturnValue({
+        hasPermission: () => false,
+        isLoading: false,
+        permissionBits: 1,
+      });
+      render(<AgentFooter {...defaultProps} />);
+      expect(screen.queryByTestId('duplicate-button')).not.toBeInTheDocument();
+    });
+
+    test('shows duplicate button for admin who is not the author', () => {
+      mockUseAuthContext.mockReturnValue(createAuthContext(mockUsers.admin));
+      mockUseWatch.mockImplementation(({ name }) => {
+        if (name === 'agent') {
+          return {
+            _id: 'agent-db-123',
+            name: 'Test Agent',
+            author: 'user-123',
+            projectIds: ['project-1'],
+            isCollaborative: false,
+          };
+        }
+        if (name === 'id') {
+          return 'agent-123';
+        }
+        return undefined;
+      });
+      mockUseResourcePermissions.mockReturnValue({
+        hasPermission: () => false,
+        isLoading: false,
+        permissionBits: 0,
+      });
+      render(<AgentFooter {...defaultProps} />);
       expect(screen.getByTestId('duplicate-button')).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary

It would be nice to allow users with the ability to edit an agent to duplicate that agent (they already have access to all of the contents to copy/paste over anyway). 

One related discussion: https://github.com/danny-avila/LibreChat/issues/5864

In the future, it might be nice to expand these permissions further, but this would be a nice improvement for users today.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

* Tested as owner of an agent
* Tested duplicating an agent that user had edit permissions
* Tested not being able to view agent configuration as viewer

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
