### PR TITLE
🤖 feat: `gemini-3.1-flash-lite-preview` Window & Pricing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,10 +196,10 @@ GOOGLE_KEY=user_provided
 # GOOGLE_AUTH_HEADER=true
 
 # Gemini API (AI Studio)
-# GOOGLE_MODELS=gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash,gemini-2.0-flash-lite
+# GOOGLE_MODELS=gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite-preview,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash,gemini-2.0-flash-lite
 
 # Vertex AI
-# GOOGLE_MODELS=gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001
+# GOOGLE_MODELS=gemini-3.1-pro-preview,gemini-3.1-pro-preview-customtools,gemini-3.1-flash-lite-preview,gemini-2.5-pro,gemini-2.5-flash,gemini-2.5-flash-lite,gemini-2.0-flash-001,gemini-2.0-flash-lite-001
 
 # GOOGLE_TITLE_MODEL=gemini-2.0-flash-lite-001
 

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -332,8 +332,9 @@ const cacheTokenValues = {
   'kimi-k2-0711-preview': { write: 0.6, read: 0.15 },
   'kimi-k2-thinking': { write: 0.6, read: 0.15 },
   'kimi-k2-thinking-turbo': { write: 1.15, read: 0.15 },
-  // Gemini 3.1 models - cache read: $0.20/1M (<=200k), cache write: standard input price
+  // Gemini 3.1 Pro - cache write: $2.00/1M, cache read: $0.20/1M
   'gemini-3.1': { write: 2, read: 0.2 },
+  // Gemini 3.1 Flash-Lite - cache write: $0.25/1M, cache read: $0.025/1M
   'gemini-3.1-flash-lite': { write: 0.25, read: 0.025 },
 };
 

--- a/api/models/tx.js
+++ b/api/models/tx.js
@@ -201,6 +201,7 @@ const tokenValues = Object.assign(
     'gemini-3': { prompt: 2, completion: 12 },
     'gemini-3-pro-image': { prompt: 2, completion: 120 },
     'gemini-3.1': { prompt: 2, completion: 12 },
+    'gemini-3.1-flash-lite': { prompt: 0.25, completion: 1.5 },
     'gemini-pro-vision': { prompt: 0.5, completion: 1.5 },
     grok: { prompt: 2.0, completion: 10.0 }, // Base pattern defaults to grok-2
     'grok-beta': { prompt: 5.0, completion: 15.0 },
@@ -333,6 +334,7 @@ const cacheTokenValues = {
   'kimi-k2-thinking-turbo': { write: 1.15, read: 0.15 },
   // Gemini 3.1 models - cache read: $0.20/1M (<=200k), cache write: standard input price
   'gemini-3.1': { write: 2, read: 0.2 },
+  'gemini-3.1-flash-lite': { write: 0.25, read: 0.025 },
 };
 
 /**

--- a/api/models/tx.spec.js
+++ b/api/models/tx.spec.js
@@ -1347,6 +1347,7 @@ describe('Google Model Tests', () => {
     'gemini-3',
     'gemini-3.1-pro-preview',
     'gemini-3.1-pro-preview-customtools',
+    'gemini-3.1-flash-lite-preview',
     'gemini-2.5-pro',
     'gemini-2.5-flash',
     'gemini-2.5-flash-lite',
@@ -1393,6 +1394,7 @@ describe('Google Model Tests', () => {
       'gemini-3': 'gemini-3',
       'gemini-3.1-pro-preview': 'gemini-3.1',
       'gemini-3.1-pro-preview-customtools': 'gemini-3.1',
+      'gemini-3.1-flash-lite-preview': 'gemini-3.1-flash-lite',
       'gemini-2.5-pro': 'gemini-2.5-pro',
       'gemini-2.5-flash': 'gemini-2.5-flash',
       'gemini-2.5-flash-lite': 'gemini-2.5-flash-lite',
@@ -1477,6 +1479,22 @@ describe('Google Model Tests', () => {
         cacheTokenValues['gemini-3.1'].read,
       );
     });
+  });
+
+  it('should return correct rates for Gemini 3.1 Flash-Lite', () => {
+    const model = 'gemini-3.1-flash-lite-preview';
+    expect(getMultiplier({ model, tokenType: 'prompt', endpoint: EModelEndpoint.google })).toBe(
+      tokenValues['gemini-3.1-flash-lite'].prompt,
+    );
+    expect(getMultiplier({ model, tokenType: 'completion', endpoint: EModelEndpoint.google })).toBe(
+      tokenValues['gemini-3.1-flash-lite'].completion,
+    );
+    expect(getCacheMultiplier({ model, cacheType: 'write' })).toBe(
+      cacheTokenValues['gemini-3.1-flash-lite'].write,
+    );
+    expect(getCacheMultiplier({ model, cacheType: 'read' })).toBe(
+      cacheTokenValues['gemini-3.1-flash-lite'].read,
+    );
   });
 });
 

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -107,6 +107,7 @@ const googleModels = {
   'gemini-3': 1000000, // 1M input tokens, 64k output tokens
   'gemini-3-pro-image': 1000000,
   'gemini-3.1': 1000000, // 1M input tokens, 64k output tokens
+  'gemini-3.1-flash-lite': 1000000, // 1M input tokens, 64k output tokens
   'gemini-2.5': 1000000, // 1M input tokens, 64k output tokens
   'gemini-2.5-pro': 1000000,
   'gemini-2.5-flash': 1000000,

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1196,6 +1196,7 @@ export const defaultModels = {
     // Gemini 3.1 Models
     'gemini-3.1-pro-preview',
     'gemini-3.1-pro-preview-customtools',
+    'gemini-3.1-flash-lite-preview',
     // Gemini 3 Models
     'gemini-3-pro-preview',
     'gemini-3-flash-preview',


### PR DESCRIPTION
- Updated `.env.example` to include `gemini-3.1-flash-lite-preview` in the list of available models.
- Enhanced `tx.js` to define token values for `gemini-3.1-flash-lite`.
- Adjusted `tokens.ts` to allocate input tokens for `gemini-3.1-flash-lite`.
- Modified `config.ts` to include `gemini-3.1-flash-lite-preview` in the default models list.