### PR TITLE
🔑 fix: Respect Server's Token Endpoint Auth Method Preference Order

### DIFF
--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -277,7 +277,7 @@ export class MCPOAuthHandler {
       redirect_uris: [redirectUri || this.getDefaultRedirectUri()],
       grant_types: ['authorization_code'] as string[],
       response_types: ['code'] as string[],
-      token_endpoint_auth_method: 'client_secret_basic',
+      token_endpoint_auth_method: 'client_secret_post',
       scope: undefined as string | undefined,
       logo_uri: undefined as string | undefined,
       tos_uri: undefined as string | undefined,
@@ -302,20 +302,16 @@ export class MCPOAuthHandler {
 
     const forcedAuthMethod = this.getForcedTokenEndpointAuthMethod(tokenExchangeMethod);
 
+    const supportedAuthMethods = ['client_secret_post', 'client_secret_basic', 'none'];
+
     if (forcedAuthMethod) {
       clientMetadata.token_endpoint_auth_method = forcedAuthMethod;
     } else if (metadata.token_endpoint_auth_methods_supported) {
-      // Prefer client_secret_basic if supported, otherwise use the first supported method
-      if (metadata.token_endpoint_auth_methods_supported.includes('client_secret_basic')) {
-        clientMetadata.token_endpoint_auth_method = 'client_secret_basic';
-      } else if (metadata.token_endpoint_auth_methods_supported.includes('client_secret_post')) {
-        clientMetadata.token_endpoint_auth_method = 'client_secret_post';
-      } else if (metadata.token_endpoint_auth_methods_supported.includes('none')) {
-        clientMetadata.token_endpoint_auth_method = 'none';
-      } else {
-        clientMetadata.token_endpoint_auth_method =
-          metadata.token_endpoint_auth_methods_supported[0];
-      }
+      const serverPreferred = metadata.token_endpoint_auth_methods_supported.find((m) =>
+        supportedAuthMethods.includes(m),
+      );
+      clientMetadata.token_endpoint_auth_method =
+        serverPreferred ?? metadata.token_endpoint_auth_methods_supported[0];
     }
 
     const availableScopes = resourceMetadata?.scopes_supported || metadata.scopes_supported;


### PR DESCRIPTION
## Summary

This PR seeks to fix a problem where MCP servers using OAuth registration failed to connect when the server prefers `client_secret_post` for token endpoint authentication. 

During the OAuth callback, the token exchange request fails with `"Missing client_id"` because LibreChat always registers with `client_secret_basic` which sends `client_id` only in the `Authorization: Basic` header, not the POST body — regardless of what the server advertises in `token_endpoint_auth_methods_supported`. Servers like kapa.ai that expect `client_id` in the body reject the request.

This changes `registerOAuthClient()` to respect the server's advertised preference order instead of hardcoding `client_secret_basic` first. The first method from the server's `token_endpoint_auth_methods_supported` that LibreChat supports (`client_secret_post`, `client_secret_basic`, `none`) is now selected. 

The default is also changed to `client_secret_post`, which is the safer choice since all servers parse POST body parameters. Servers that only support `client_secret_basic` still get it since it remains in the supported list, and any explicit per-server `tokenExchangeMethod` config override still takes priority.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Before

https://github.com/user-attachments/assets/da6075dc-6e02-43d2-928b-f87d95f0d1b0

**Before** (token exchange fails after OAuth redirect):
```
[MCPOAuth] Failed to complete OAuth flow
[MCP OAuth] OAuth callback error Missing client_id
Error in OAuth authentication: Unknown OAuth error
```

### After

https://github.com/user-attachments/assets/9409bd96-d80f-4477-a403-8c693c3b5dbc

**After** (connection established successfully):
```
[MCP OAuth] OAuth flow completed, tokens received in callback route
[MCP][kapa][...] Loaded OAuth tokens
[MCP][User: ...][kapa] Connection successfully established
[MCP OAuth] Successfully reconnected kapa for user ...
```


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes