### PR TITLE
📦 chore: Update `underscore` to v1.13.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42207,9 +42207,9 @@
       "dev": true
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -168,7 +168,8 @@
     "langsmith": "0.4.12",
     "eslint": {
       "ajv": "6.14.0"
-    }
+    },
+    "underscore": "1.13.8"
   },
   "nodemonConfig": {
     "ignore": [


### PR DESCRIPTION


- Bumped `underscore` version from 1.13.7 to 1.13.8 to incorporate the latest improvements and fixes.
- Updated package-lock.json to reflect the new version and ensure consistency across dependencies.
