### PR TITLE
📦 chore: Bump `@librechat/agents` to v3.1.55

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.54",
+    "@librechat/agents": "^3.1.55",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.54",
+        "@librechat/agents": "^3.1.55",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -12184,9 +12184,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.54",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.54.tgz",
-      "integrity": "sha512-OdsE8kDgtIhxs0sR0rG7I5WynbZKAH/j/50OCZEjLdv//jR8Lj6fpL9RCEzRGnu44MjUZgRkSgf2JV3LHsCJiQ==",
+      "version": "3.1.55",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.55.tgz",
+      "integrity": "sha512-impxeKpCDlPkAVQFWnA6u6xkxDSBR/+H8uYq7rZomBeu0rUh/OhJLiI1fAwPhKXP33udNtHA8GyDi0QJj78R9w==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -12206,6 +12206,7 @@
         "@langfuse/otel": "^4.3.0",
         "@langfuse/tracing": "^4.3.0",
         "@opentelemetry/sdk-node": "^0.207.0",
+        "@scarf/scarf": "^1.4.0",
         "axios": "^1.13.5",
         "cheerio": "^1.0.0",
         "dotenv": "^16.4.7",
@@ -19384,6 +19385,13 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -44186,7 +44194,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.54",
+        "@librechat/agents": "^3.1.55",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -90,7 +90,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.54",
+    "@librechat/agents": "^3.1.55",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@smithy/node-http-handler": "^4.4.5",


### PR DESCRIPTION
## `v3.1.55`

Focused release hardening Vertex AI thinking-model support.

---

### 🔧 Fix: Thought Signature Attachment for Tool-Calling Round-Trips

`@langchain/google-common` fails to re-attach `thoughtSignature` to `functionCall` parts whenever there's a length mismatch between signatures and parts (common with streaming or omitted signatures). This caused hard API errors on multi-turn tool use with Gemini 3 thinking models.

A new `fixThoughtSignatures()` function now correlates AI messages to their formatted `"model"` content blocks by order and re-attaches any missing non-empty signatures. Full invoke + stream round-trip tests added across all current Gemini 3 preview models.

---

### 🔧 Fix: `thinkingConfig` Not Applied at Connection Construction Time

`buildConnection()` is called from `super()` before `this.thinkingConfig` is assigned, so both connection instances were silently built without it. Now reads `fields?.thinkingConfig ?? this.thinkingConfig` to correctly capture the constructor-time value.

---

### 🔧 Fix: `thinkingLevel` and `thinkingBudget` Cannot Coexist

The Vertex AI API rejects requests containing both fields. `thinkingBudget` is now explicitly stripped from `generationConfig.thinkingConfig` whenever `thinkingLevel` is set.

---

### ✨ New: Vertex AI Thinking Integration Script

`src/scripts/thinking-vertexai.ts` — a runnable two-turn harness for local end-to-end verification of the thinking feature (`thinkingLevel: 'HIGH'`, `gemini-3-flash-preview`). Logs reasoning deltas, final messages, and collected usage.

---

### 📦 Dependency Updates

| Package | Change |
|---|---|
| `rollup` | `4.34.6` → `4.59.0` |
| `fast-xml-parser` | → `5.3.8` |
| `ajv` | added `6.14.0` |
| `minimatch` | added `3.1.4` |
| `@scarf/scarf` | added `1.4.0` |

---

**Full Changelog**: https://github.com/danny-avila/agents/compare/v3.1.54...v3.1.55