### PR TITLE
🧩 fix: Expand Toolkit Definitions to Include Child Tools in Event-Driven Mode

### DIFF
--- a/api/app/clients/tools/util/handleTools.js
+++ b/api/app/clients/tools/util/handleTools.js
@@ -371,8 +371,15 @@ const loadTools = async ({
     }
 
     const toolKey = customConstructors[tool] ? tool : toolkitParent[tool];
-    if (toolKey && customConstructors[toolKey] && !requestedTools[toolKey]) {
-      requestedTools[toolKey] = async () => customConstructors[toolKey](toolContextMap);
+    if (toolKey && customConstructors[toolKey]) {
+      if (!requestedTools[toolKey]) {
+        let cached;
+        requestedTools[toolKey] = async () => {
+          cached ??= customConstructors[toolKey](toolContextMap);
+          return cached;
+        };
+      }
+      requestedTools[tool] = requestedTools[toolKey];
       continue;
     }
 


### PR DESCRIPTION

## Summary

Fixed a bug where `image_edit_oai` was never surfaced to the LLM in event-driven agent mode, even when an agent had `image_gen_oai` configured. The `image_gen_oai` toolkit bundles two tools — `image_gen_oai` and `image_edit_oai` — but the definitions-only path only emitted the parent, leaving the child invisible to the model and causing tool-not-found failures at runtime when the LLM tried to call it.

- Introduced `toolkitExpansion` (parent → children) and `toolkitParent` (child → parent) maps in a new `packages/api/src/tools/toolkits/mapping.ts` module, typed as immutable with `as const satisfies Readonly<...>`.
- Updated `loadToolDefinitions` to walk `toolkitExpansion` after processing a parent toolkit key, pushing each child's definition into `builtInToolDefs` and `toolRegistry`.
- Updated `loadTools` in `handleTools.js` to resolve child tool names to their parent constructor via `toolkitParent`, using a memoized factory (`cached ??= ...`) shared across all names that resolve to the same toolkit — ensuring the constructor runs at most once per `loadTools` call regardless of how many child names appear in the tools array.
- Eliminated ~165 lines of duplicated schema and description strings from `registry/definitions.ts` by deriving `image_gen_oai`, `image_edit_oai`, and `gemini_image_gen` registry entries directly from their respective toolkit objects (`oaiToolkit`, `geminiToolkit`), making env-var description overrides (`IMAGE_EDIT_OAI_DESCRIPTION`, etc.) respected in all code paths.
- Moved `toolkitExpansion` and `toolkitParent` out of `registry/definitions.ts` into `toolkits/mapping.ts` and re-exported from `toolkits/index.ts`, placing toolkit relationship metadata in the correct architectural layer.
- Added 4 unit tests to `definitions.spec.ts`: toolkit expansion happy path, deduplication guard, `toolkitParent` inverse-mapping invariant, and definition integrity (every expansion entry references a known registry definition).
- Improved the tool-not-found warning in `handlers.ts` to quote each available tool name individually for clearer log output.
- Removed the stale `"toolkit": true` field from the `gemini_image_gen` manifest entry.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified via the new unit test suite in `packages/api/src/tools/definitions.spec.ts`. The four added tests cover:

1. **Expansion**: `tools: ['image_gen_oai']` produces definitions for both `image_gen_oai` and `image_edit_oai`, with both present in `toolRegistry`.
2. **No duplication**: `image_edit_oai` appears exactly once in `toolDefinitions` when only the parent is in the tools list.
3. **Inverse mapping invariant**: `toolkitParent['image_edit_oai'] === 'image_gen_oai'` and the key set of `toolkitParent` exactly equals the flattened children of `toolkitExpansion`.
4. **Definition integrity**: Every key and child in `toolkitExpansion` resolves to a known entry in the tool definition registry.

For manual verification, configure an agent with the `image_gen_oai` toolkit and confirm the LLM receives both `image_gen_oai` and `image_edit_oai` in its tool list, and that calling `image_edit_oai` with `image_ids` executes successfully without a tool-not-found error.

### **Test Configuration**:
- Agent with `image_gen_oai` toolkit enabled
- OpenAI API key configured
- Event-driven mode active (`deferredToolsEnabled`)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes