### PR TITLE
🧭 fix: Subdirectory Deployment Auth Redirect Path Doubling

### DIFF
--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -10,7 +10,12 @@ import {
 import { debounce } from 'lodash';
 import { useRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
-import { setTokenHeader, SystemRoles, buildLoginRedirectUrl } from 'librechat-data-provider';
+import {
+  apiBaseUrl,
+  SystemRoles,
+  setTokenHeader,
+  buildLoginRedirectUrl,
+} from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { ReactNode } from 'react';
 import {
@@ -168,7 +173,11 @@ const AuthContextProvider = ({
         if (token) {
           const storedRedirect = sessionStorage.getItem(SESSION_KEY);
           sessionStorage.removeItem(SESSION_KEY);
-          const currentUrl = `${window.location.pathname}${window.location.search}`;
+          const baseUrl = apiBaseUrl();
+          const rawPath = window.location.pathname;
+          const strippedPath =
+            baseUrl && rawPath.startsWith(baseUrl) ? rawPath.slice(baseUrl.length) || '/' : rawPath;
+          const currentUrl = `${strippedPath}${window.location.search}`;
           const fallbackRedirect = isSafeRedirect(currentUrl) ? currentUrl : '/c/new';
           const redirect =
             storedRedirect && isSafeRedirect(storedRedirect) ? storedRedirect : fallbackRedirect;

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -176,7 +176,9 @@ const AuthContextProvider = ({
           const baseUrl = apiBaseUrl();
           const rawPath = window.location.pathname;
           const strippedPath =
-            baseUrl && rawPath.startsWith(baseUrl) ? rawPath.slice(baseUrl.length) || '/' : rawPath;
+            baseUrl && (rawPath === baseUrl || rawPath.startsWith(baseUrl + '/'))
+              ? rawPath.slice(baseUrl.length) || '/'
+              : rawPath;
           const currentUrl = `${strippedPath}${window.location.search}`;
           const fallbackRedirect = isSafeRedirect(currentUrl) ? currentUrl : '/c/new';
           const redirect =

--- a/client/src/hooks/__tests__/AuthContext.spec.tsx
+++ b/client/src/hooks/__tests__/AuthContext.spec.tsx
@@ -18,9 +18,12 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
+const mockApiBaseUrl = jest.fn(() => '');
+
 jest.mock('librechat-data-provider', () => ({
   ...jest.requireActual('librechat-data-provider'),
   setTokenHeader: jest.fn(),
+  apiBaseUrl: () => mockApiBaseUrl(),
 }));
 
 let mockCapturedLoginOptions: {
@@ -348,6 +351,69 @@ describe('AuthContextProvider — silentRefresh post-login redirect', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/c/new', { replace: true });
     expect(mockNavigate).not.toHaveBeenCalledWith('https://evil.com/steal', expect.anything());
     expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+    jest.useRealTimers();
+  });
+});
+
+describe('AuthContextProvider — silentRefresh subdirectory deployment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    mockApiBaseUrl.mockReturnValue('/chat');
+  });
+
+  afterEach(() => {
+    mockApiBaseUrl.mockReturnValue('');
+    sessionStorage.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('strips base path from window.location.pathname before navigating (prevents /chat/chat doubling)', () => {
+    jest.useFakeTimers();
+    window.history.replaceState({}, '', '/chat/c/abc123?model=gpt-4');
+
+    renderProviderLive();
+
+    expect(mockRefreshMutate).toHaveBeenCalledTimes(1);
+    const [, refreshOptions] = mockRefreshMutate.mock.calls[0] as [
+      unknown,
+      { onSuccess: (data: unknown) => void },
+    ];
+
+    act(() => {
+      refreshOptions.onSuccess({ user: { id: '1', role: 'USER' }, token: 'new-token' });
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/c/abc123?model=gpt-4', { replace: true });
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      expect.stringContaining('/chat/c/'),
+      expect.anything(),
+    );
+    jest.useRealTimers();
+  });
+
+  it('falls back to root when window.location.pathname equals the base path', () => {
+    jest.useFakeTimers();
+    window.history.replaceState({}, '', '/chat');
+
+    renderProviderLive();
+
+    const [, refreshOptions] = mockRefreshMutate.mock.calls[0] as [
+      unknown,
+      { onSuccess: (data: unknown) => void },
+    ];
+
+    act(() => {
+      refreshOptions.onSuccess({ user: { id: '1', role: 'USER' }, token: 'new-token' });
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
     jest.useRealTimers();
   });
 });

--- a/client/src/routes/__tests__/useAuthRedirect.spec.tsx
+++ b/client/src/routes/__tests__/useAuthRedirect.spec.tsx
@@ -251,7 +251,13 @@ describe('useAuthRedirect', () => {
       isAuthenticated: false,
     });
 
-    /** Simulate subdirectory deployment with a deep route */
+    /**
+     * Validates that React Router's useLocation() strips the basename before
+     * buildLoginRedirectUrl receives it, so redirect_to never contains
+     * the base prefix. The BASE_URL stripping logic inside buildLoginRedirectUrl
+     * (for callers using window.location.pathname) is tested in
+     * api-endpoints-subdir.spec.ts.
+     */
     const router = createTestRouter('/librechat', '/librechat/c/abc123');
     render(<RouterProvider router={router} />);
 

--- a/client/src/routes/__tests__/useAuthRedirect.spec.tsx
+++ b/client/src/routes/__tests__/useAuthRedirect.spec.tsx
@@ -245,6 +245,31 @@ describe('useAuthRedirect', () => {
     );
   });
 
+  it('should not include basename in redirect_to param (prevents path doubling)', async () => {
+    (useAuthContext as jest.Mock).mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+    });
+
+    /** Simulate subdirectory deployment with a deep route */
+    const router = createTestRouter('/librechat', '/librechat/c/abc123');
+    render(<RouterProvider router={router} />);
+
+    await waitFor(
+      () => {
+        expect(router.state.location.pathname).toBe('/librechat/login');
+        const search = router.state.location.search;
+        const params = new URLSearchParams(search);
+        const redirectTo = decodeURIComponent(params.get('redirect_to')!);
+        /** redirect_to should be /c/abc123, NOT /librechat/c/abc123
+         * because navigate() with basename will re-add the prefix */
+        expect(redirectTo).toBe('/c/abc123');
+        expect(redirectTo).not.toContain('/librechat/');
+      },
+      { timeout: 1000 },
+    );
+  });
+
   it('should not append redirect_to when already on /login', async () => {
     (useAuthContext as jest.Mock).mockReturnValue({
       user: null,

--- a/config/test-subdirectory-setup.sh
+++ b/config/test-subdirectory-setup.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Test script for verifying subdirectory deployment (e.g., /chat/)
+#
+# Prerequisites:
+#   - nginx installed: sudo apt install nginx
+#   - LibreChat backend running on port 3080
+#
+# Usage:
+#   1. Start the backend:    npm run backend:dev
+#   2. Start the frontend:   npm run frontend:dev   (runs on port 3090)
+#   3. Run this script:      bash test-subdirectory-setup.sh start
+#   4. Open browser:         http://localhost:8080/chat/
+#   5. Cleanup:              bash test-subdirectory-setup.sh stop
+#
+# What to verify:
+#   - Accessing http://localhost:8080/chat/ should redirect to /chat/login
+#     (NOT /chat/chat/login)
+#   - After login, navigating to protected routes should work
+#   - Logging out and being redirected should not double the path
+# =============================================================================
+
+set -euo pipefail
+
+NGINX_CONF="/tmp/librechat-subdir-test-nginx.conf"
+NGINX_PID="/tmp/librechat-subdir-test-nginx.pid"
+
+ENV_FILE="/home/danny/LibreChat/.env"
+
+write_nginx_conf() {
+  cat > "$NGINX_CONF" << 'NGINX'
+worker_processes 1;
+pid /tmp/librechat-subdir-test-nginx.pid;
+error_log /tmp/librechat-subdir-test-nginx-error.log warn;
+
+events {
+    worker_connections 64;
+}
+
+http {
+    access_log /tmp/librechat-subdir-test-nginx-access.log;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    server {
+        listen 8080;
+        server_name localhost;
+
+        # Subdirectory proxy: strip /chat/ prefix and forward to backend
+        location /chat/ {
+            proxy_pass http://127.0.0.1:3080/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # Redirect bare /chat to /chat/
+        location = /chat {
+            return 301 /chat/;
+        }
+    }
+}
+NGINX
+}
+
+start() {
+    echo "--- Setting up subdirectory test environment ---"
+
+    # Backup .env if it exists and doesn't have our marker
+    if [ -f "$ENV_FILE" ] && ! grep -q '## SUBDIR_TEST_MARKER' "$ENV_FILE"; then
+        cp "$ENV_FILE" "${ENV_FILE}.bak-subdir-test"
+        echo "Backed up .env to .env.bak-subdir-test"
+    fi
+
+    # Ensure DOMAIN_CLIENT and DOMAIN_SERVER are set for subdirectory
+    if ! grep -q 'DOMAIN_CLIENT=http://localhost:8080/chat' "$ENV_FILE" 2>/dev/null; then
+        echo ""
+        echo "You need to set these in your .env file:"
+        echo "  DOMAIN_CLIENT=http://localhost:8080/chat"
+        echo "  DOMAIN_SERVER=http://localhost:8080/chat"
+        echo ""
+        echo "Then restart the backend: npm run backend:dev"
+        echo ""
+    fi
+
+    # Write and start nginx
+    write_nginx_conf
+    echo "Starting nginx on port 8080 with subdirectory /chat/ ..."
+
+    # Stop any existing test nginx
+    if [ -f "$NGINX_PID" ] && kill -0 "$(cat "$NGINX_PID")" 2>/dev/null; then
+        nginx -c "$NGINX_CONF" -s stop 2>/dev/null || true
+        sleep 1
+    fi
+
+    nginx -c "$NGINX_CONF"
+    echo "nginx started (PID: $(cat "$NGINX_PID" 2>/dev/null || echo 'unknown'))"
+    echo ""
+    echo "=== Test URLs ==="
+    echo "  Main:     http://localhost:8080/chat/"
+    echo "  Login:    http://localhost:8080/chat/login"
+    echo "  Expect:   Redirects should go to /chat/login, NOT /chat/chat/login"
+    echo ""
+    echo "=== Logs ==="
+    echo "  Access: /tmp/librechat-subdir-test-nginx-access.log"
+    echo "  Error:  /tmp/librechat-subdir-test-nginx-error.log"
+    echo ""
+    echo "Run '$0 stop' to clean up."
+}
+
+stop() {
+    echo "--- Cleaning up subdirectory test environment ---"
+
+    if [ -f "$NGINX_PID" ] && kill -0 "$(cat "$NGINX_PID")" 2>/dev/null; then
+        nginx -c "$NGINX_CONF" -s stop
+        echo "nginx stopped."
+    else
+        echo "nginx not running."
+    fi
+
+    rm -f "$NGINX_CONF" /tmp/librechat-subdir-test-nginx-*.log
+
+    if [ -f "${ENV_FILE}.bak-subdir-test" ]; then
+        echo "Restore .env backup: cp ${ENV_FILE}.bak-subdir-test ${ENV_FILE}"
+    fi
+}
+
+case "${1:-}" in
+    start) start ;;
+    stop)  stop ;;
+    *)
+        echo "Usage: $0 {start|stop}"
+        exit 1
+        ;;
+esac

--- a/config/test-subdirectory-setup.sh
+++ b/config/test-subdirectory-setup.sh
@@ -88,7 +88,7 @@ start() {
         echo "  DOMAIN_CLIENT=http://localhost:8080/chat"
         echo "  DOMAIN_SERVER=http://localhost:8080/chat"
         echo ""
-        echo "Then restart the backend: npm run backend:dev"
+        echo "Then restart the backend: npm run backend"
         echo ""
     fi
 

--- a/config/test-subdirectory-setup.sh
+++ b/config/test-subdirectory-setup.sh
@@ -4,14 +4,14 @@
 #
 # Prerequisites:
 #   - nginx installed: sudo apt install nginx
-#   - LibreChat backend running on port 3080
+#   - LibreChat built:  npm run build
+#   - Backend running:  npm run backend (serves built SPA + API on port 3080)
 #
 # Usage:
-#   1. Start the backend:    npm run backend:dev
-#   2. Start the frontend:   npm run frontend:dev   (runs on port 3090)
-#   3. Run this script:      bash test-subdirectory-setup.sh start
-#   4. Open browser:         http://localhost:8080/chat/
-#   5. Cleanup:              bash test-subdirectory-setup.sh stop
+#   1. Build + start:        npm run build && npm run backend
+#   2. Run this script:      bash config/test-subdirectory-setup.sh start
+#   3. Open browser:         http://localhost:8080/chat/
+#   4. Cleanup:              bash config/test-subdirectory-setup.sh stop
 #
 # What to verify:
 #   - Accessing http://localhost:8080/chat/ should redirect to /chat/login
@@ -22,10 +22,11 @@
 
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 NGINX_CONF="/tmp/librechat-subdir-test-nginx.conf"
 NGINX_PID="/tmp/librechat-subdir-test-nginx.pid"
 
-ENV_FILE="/home/danny/LibreChat/.env"
+ENV_FILE="${REPO_ROOT}/.env"
 
 write_nginx_conf() {
   cat > "$NGINX_CONF" << 'NGINX'

--- a/packages/data-provider/specs/api-endpoints-subdir.spec.ts
+++ b/packages/data-provider/specs/api-endpoints-subdir.spec.ts
@@ -18,20 +18,20 @@ function loadModuleWithBase(baseHref: string) {
   document.head.appendChild(base);
 
   const proc = process as typeof process & { browser?: boolean };
-  proc.browser = true;
+  const originalBrowser = proc.browser;
 
   let mod: typeof import('../src/api-endpoints');
   try {
+    proc.browser = true;
     jest.isolateModules(() => {
       // eslint-disable-next-line @typescript-eslint/no-require-imports -- static import not usable inside isolateModules
       mod = require('../src/api-endpoints');
     });
+    return mod!;
   } finally {
-    proc.browser = false;
+    proc.browser = originalBrowser;
     document.head.removeChild(base);
   }
-
-  return mod!;
 }
 
 describe('buildLoginRedirectUrl — subdirectory deployment (BASE_URL = /chat)', () => {

--- a/packages/data-provider/specs/api-endpoints-subdir.spec.ts
+++ b/packages/data-provider/specs/api-endpoints-subdir.spec.ts
@@ -73,10 +73,10 @@ describe('buildLoginRedirectUrl — subdirectory deployment (BASE_URL = /chat)',
     expect(buildLoginRedirectUrl('/chat/login/2fa', '', '')).toBe('/login');
   });
 
-  it('redirect_to falls back to "/" when base prefix is the entire pathname', () => {
+  it('returns plain /login when stripped path is root (no pointless redirect_to=/)', () => {
     const result = buildLoginRedirectUrl('/chat', '', '');
-    const redirectTo = decodeURIComponent(result.split('redirect_to=')[1]);
-    expect(redirectTo).toBe('/');
+    expect(result).toBe('/login');
+    expect(result).not.toContain('redirect_to');
   });
 
   it('composes correct full URL for window.location.href (apiBaseUrl + buildLoginRedirectUrl)', () => {

--- a/packages/data-provider/specs/api-endpoints-subdir.spec.ts
+++ b/packages/data-provider/specs/api-endpoints-subdir.spec.ts
@@ -26,7 +26,7 @@ function loadModuleWithBase(baseHref: string) {
     mod = require('../src/api-endpoints');
   });
 
-  delete proc.browser;
+  proc.browser = false;
   document.head.removeChild(base);
 
   return mod!;

--- a/packages/data-provider/specs/api-endpoints-subdir.spec.ts
+++ b/packages/data-provider/specs/api-endpoints-subdir.spec.ts
@@ -21,13 +21,15 @@ function loadModuleWithBase(baseHref: string) {
   proc.browser = true;
 
   let mod: typeof import('../src/api-endpoints');
-  jest.isolateModules(() => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports -- static import not usable inside isolateModules
-    mod = require('../src/api-endpoints');
-  });
-
-  proc.browser = false;
-  document.head.removeChild(base);
+  try {
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports -- static import not usable inside isolateModules
+      mod = require('../src/api-endpoints');
+    });
+  } finally {
+    proc.browser = false;
+    document.head.removeChild(base);
+  }
 
   return mod!;
 }

--- a/packages/data-provider/specs/api-endpoints-subdir.spec.ts
+++ b/packages/data-provider/specs/api-endpoints-subdir.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Tests for buildLoginRedirectUrl and apiBaseUrl under subdirectory deployments.
+ *
+ * Uses jest.isolateModules to re-import api-endpoints with a <base href="/chat/">
+ * element present, simulating a subdirectory deployment where BASE_URL = '/chat'.
+ *
+ * Tests that need to override window.location use explicit function arguments
+ * instead of mocking the global, since jsdom 26+ does not allow redefining it.
+ */
+
+function loadModuleWithBase(baseHref: string) {
+  const base = document.createElement('base');
+  base.setAttribute('href', baseHref);
+  document.head.appendChild(base);
+
+  const proc = process as typeof process & { browser?: boolean };
+  proc.browser = true;
+
+  let mod: typeof import('../src/api-endpoints');
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    mod = require('../src/api-endpoints');
+  });
+
+  proc.browser = undefined;
+  document.head.removeChild(base);
+
+  return mod!;
+}
+
+describe('buildLoginRedirectUrl — subdirectory deployment (BASE_URL = /chat)', () => {
+  let buildLoginRedirectUrl: typeof import('../src/api-endpoints').buildLoginRedirectUrl;
+  let apiBaseUrl: typeof import('../src/api-endpoints').apiBaseUrl;
+
+  beforeAll(() => {
+    const mod = loadModuleWithBase('/chat/');
+    buildLoginRedirectUrl = mod.buildLoginRedirectUrl;
+    apiBaseUrl = mod.apiBaseUrl;
+  });
+
+  it('sets BASE_URL to "/chat" (trailing slash stripped)', () => {
+    expect(apiBaseUrl()).toBe('/chat');
+  });
+
+  it('returns "/login" without base prefix (compatible with React Router navigate)', () => {
+    const result = buildLoginRedirectUrl('/chat/c/new', '', '');
+    expect(result).toMatch(/^\/login/);
+    expect(result).not.toMatch(/^\/chat/);
+  });
+
+  it('strips base prefix from redirect_to when pathname includes base', () => {
+    const result = buildLoginRedirectUrl('/chat/c/abc123', '?model=gpt-4', '');
+    const redirectTo = decodeURIComponent(result.split('redirect_to=')[1]);
+    expect(redirectTo).toBe('/c/abc123?model=gpt-4');
+    expect(redirectTo).not.toContain('/chat/');
+  });
+
+  it('works with pathnames that do not include the base prefix', () => {
+    const result = buildLoginRedirectUrl('/c/new', '', '');
+    const redirectTo = decodeURIComponent(result.split('redirect_to=')[1]);
+    expect(redirectTo).toBe('/c/new');
+  });
+
+  it('returns plain /login for base-prefixed login path', () => {
+    expect(buildLoginRedirectUrl('/chat/login', '', '')).toBe('/login');
+  });
+
+  it('returns plain /login for base-prefixed login sub-path', () => {
+    expect(buildLoginRedirectUrl('/chat/login/2fa', '', '')).toBe('/login');
+  });
+
+  it('redirect_to falls back to "/" when base prefix is the entire pathname', () => {
+    const result = buildLoginRedirectUrl('/chat', '', '');
+    const redirectTo = decodeURIComponent(result.split('redirect_to=')[1]);
+    expect(redirectTo).toBe('/');
+  });
+
+  it('composes correct full URL for window.location.href (apiBaseUrl + buildLoginRedirectUrl)', () => {
+    const fullUrl = apiBaseUrl() + buildLoginRedirectUrl('/chat/c/abc123', '', '');
+    expect(fullUrl).toBe('/chat/login?redirect_to=%2Fc%2Fabc123');
+    expect(fullUrl).not.toContain('/chat/chat/');
+  });
+
+  it('encodes query params and hash correctly after stripping base', () => {
+    const result = buildLoginRedirectUrl('/chat/c/deep', '?q=hello&submit=true', '#section');
+    const redirectTo = decodeURIComponent(result.split('redirect_to=')[1]);
+    expect(redirectTo).toBe('/c/deep?q=hello&submit=true#section');
+  });
+});
+
+describe('buildLoginRedirectUrl — deep subdirectory (BASE_URL = /app/chat)', () => {
+  let buildLoginRedirectUrl: typeof import('../src/api-endpoints').buildLoginRedirectUrl;
+  let apiBaseUrl: typeof import('../src/api-endpoints').apiBaseUrl;
+
+  beforeAll(() => {
+    const mod = loadModuleWithBase('/app/chat/');
+    buildLoginRedirectUrl = mod.buildLoginRedirectUrl;
+    apiBaseUrl = mod.apiBaseUrl;
+  });
+
+  it('sets BASE_URL to "/app/chat"', () => {
+    expect(apiBaseUrl()).toBe('/app/chat');
+  });
+
+  it('strips deep base prefix from redirect_to', () => {
+    const result = buildLoginRedirectUrl('/app/chat/c/abc123', '', '');
+    const redirectTo = decodeURIComponent(result.split('redirect_to=')[1]);
+    expect(redirectTo).toBe('/c/abc123');
+  });
+
+  it('full URL does not double the base prefix', () => {
+    const fullUrl = apiBaseUrl() + buildLoginRedirectUrl('/app/chat/c/abc123', '', '');
+    expect(fullUrl).toBe('/app/chat/login?redirect_to=%2Fc%2Fabc123');
+    expect(fullUrl).not.toContain('/app/chat/app/chat/');
+  });
+});

--- a/packages/data-provider/specs/api-endpoints-subdir.spec.ts
+++ b/packages/data-provider/specs/api-endpoints-subdir.spec.ts
@@ -22,11 +22,11 @@ function loadModuleWithBase(baseHref: string) {
 
   let mod: typeof import('../src/api-endpoints');
   jest.isolateModules(() => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- static import not usable inside isolateModules
     mod = require('../src/api-endpoints');
   });
 
-  proc.browser = undefined;
+  delete proc.browser;
   document.head.removeChild(base);
 
   return mod!;
@@ -90,6 +90,18 @@ describe('buildLoginRedirectUrl — subdirectory deployment (BASE_URL = /chat)',
     const redirectTo = decodeURIComponent(result.split('redirect_to=')[1]);
     expect(redirectTo).toBe('/c/deep?q=hello&submit=true#section');
   });
+
+  it('does not strip base when path shares a prefix but is not a segment match', () => {
+    const result = buildLoginRedirectUrl('/chatroom/c/abc123', '', '');
+    const redirectTo = decodeURIComponent(result.split('redirect_to=')[1]);
+    expect(redirectTo).toBe('/chatroom/c/abc123');
+  });
+
+  it('does not strip base from /chatbot path', () => {
+    const result = buildLoginRedirectUrl('/chatbot', '', '');
+    const redirectTo = decodeURIComponent(result.split('redirect_to=')[1]);
+    expect(redirectTo).toBe('/chatbot');
+  });
 });
 
 describe('buildLoginRedirectUrl — deep subdirectory (BASE_URL = /app/chat)', () => {
@@ -116,5 +128,11 @@ describe('buildLoginRedirectUrl — deep subdirectory (BASE_URL = /app/chat)', (
     const fullUrl = apiBaseUrl() + buildLoginRedirectUrl('/app/chat/c/abc123', '', '');
     expect(fullUrl).toBe('/app/chat/login?redirect_to=%2Fc%2Fabc123');
     expect(fullUrl).not.toContain('/app/chat/app/chat/');
+  });
+
+  it('does not strip from /app/chatroom (segment boundary check)', () => {
+    const result = buildLoginRedirectUrl('/app/chatroom/page', '', '');
+    const redirectTo = decodeURIComponent(result.split('redirect_to=')[1]);
+    expect(redirectTo).toBe('/app/chatroom/page');
   });
 });

--- a/packages/data-provider/specs/api-endpoints.spec.ts
+++ b/packages/data-provider/specs/api-endpoints.spec.ts
@@ -4,18 +4,8 @@
 import { buildLoginRedirectUrl } from '../src/api-endpoints';
 
 describe('buildLoginRedirectUrl', () => {
-  let savedLocation: Location;
-
-  beforeEach(() => {
-    savedLocation = window.location;
-    Object.defineProperty(window, 'location', {
-      value: { pathname: '/c/abc123', search: '?model=gpt-4', hash: '#msg-5' },
-      writable: true,
-    });
-  });
-
   afterEach(() => {
-    Object.defineProperty(window, 'location', { value: savedLocation, writable: true });
+    window.history.replaceState({}, '', '/');
   });
 
   it('builds a login URL from explicit args', () => {
@@ -31,18 +21,16 @@ describe('buildLoginRedirectUrl', () => {
   });
 
   it('falls back to window.location when no args provided', () => {
+    window.history.replaceState({}, '', '/c/abc123?model=gpt-4#msg-5');
     const result = buildLoginRedirectUrl();
     const encoded = result.split('redirect_to=')[1];
     expect(decodeURIComponent(encoded)).toBe('/c/abc123?model=gpt-4#msg-5');
   });
 
-  it('falls back to "/" when all location parts are empty', () => {
-    Object.defineProperty(window, 'location', {
-      value: { pathname: '', search: '', hash: '' },
-      writable: true,
-    });
+  it('returns plain /login when all location parts are empty (root)', () => {
+    window.history.replaceState({}, '', '/');
     const result = buildLoginRedirectUrl();
-    expect(result).toBe('/login?redirect_to=%2F');
+    expect(result).toBe('/login');
   });
 
   it('returns plain /login when pathname is /login (prevents recursive redirect)', () => {
@@ -51,10 +39,7 @@ describe('buildLoginRedirectUrl', () => {
   });
 
   it('returns plain /login when window.location is already /login', () => {
-    Object.defineProperty(window, 'location', {
-      value: { pathname: '/login', search: '?redirect_to=%2Fc%2Fabc', hash: '' },
-      writable: true,
-    });
+    window.history.replaceState({}, '', '/login?redirect_to=%2Fc%2Fabc');
     const result = buildLoginRedirectUrl();
     expect(result).toBe('/login');
   });
@@ -65,10 +50,7 @@ describe('buildLoginRedirectUrl', () => {
   });
 
   it('returns plain /login for basename-prefixed /login (e.g. /librechat/login)', () => {
-    Object.defineProperty(window, 'location', {
-      value: { pathname: '/librechat/login', search: '?redirect_to=%2Fc%2Fabc', hash: '' },
-      writable: true,
-    });
+    window.history.replaceState({}, '', '/librechat/login?redirect_to=%2Fc%2Fabc');
     const result = buildLoginRedirectUrl();
     expect(result).toBe('/login');
   });
@@ -76,6 +58,12 @@ describe('buildLoginRedirectUrl', () => {
   it('returns plain /login for basename-prefixed /login sub-paths', () => {
     const result = buildLoginRedirectUrl('/librechat/login/2fa', '', '');
     expect(result).toBe('/login');
+  });
+
+  it('returns plain /login for root path (no pointless redirect_to=/)', () => {
+    const result = buildLoginRedirectUrl('/', '', '');
+    expect(result).toBe('/login');
+    expect(result).not.toContain('redirect_to');
   });
 
   it('does NOT match paths where "login" is a substring of a segment', () => {

--- a/packages/data-provider/specs/request-interceptor.spec.ts
+++ b/packages/data-provider/specs/request-interceptor.spec.ts
@@ -1,16 +1,19 @@
 /**
- * @jest-environment jsdom
+ * @jest-environment @happy-dom/jest-environment
  */
 import axios from 'axios';
 import { setTokenHeader } from '../src/headers-helpers';
 
 /**
  * The response interceptor in request.ts registers at import time when
- * `typeof window !== 'undefined'` (jsdom provides window).
+ * `typeof window !== 'undefined'` (happy-dom provides window).
  *
  * We use axios's built-in request adapter mock to avoid real HTTP calls,
  * and verify the interceptor's behavior by observing whether a 401 triggers
  * a refresh POST or is immediately rejected.
+ *
+ * happy-dom is used instead of jsdom because it allows overriding
+ * window.location via Object.defineProperty, which jsdom 26+ blocks.
  */
 
 const mockAdapter = jest.fn();
@@ -38,6 +41,7 @@ afterEach(() => {
   Object.defineProperty(window, 'location', {
     value: savedLocation,
     writable: true,
+    configurable: true,
   });
 });
 
@@ -45,6 +49,7 @@ function setWindowLocation(overrides: Partial<Location>) {
   Object.defineProperty(window, 'location', {
     value: { ...window.location, ...overrides },
     writable: true,
+    configurable: true,
   });
 }
 

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -179,8 +179,10 @@ export function buildLoginRedirectUrl(pathname?: string, search?: string, hash?:
   const s = search ?? window.location.search;
   const h = hash ?? window.location.hash;
 
-  const stripBase = BASE_URL && BASE_URL !== '/' ? BASE_URL : '';
-  const stripped = stripBase && p.startsWith(stripBase) ? p.slice(stripBase.length) || '/' : p;
+  const stripped =
+    BASE_URL && (p === BASE_URL || p.startsWith(BASE_URL + '/'))
+      ? p.slice(BASE_URL.length) || '/'
+      : p;
   const currentPath = `${stripped}${s}${h}`;
   const encoded = encodeURIComponent(currentPath || '/');
   return `/login?${REDIRECT_PARAM}=${encoded}`;

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -184,8 +184,10 @@ export function buildLoginRedirectUrl(pathname?: string, search?: string, hash?:
       ? p.slice(BASE_URL.length) || '/'
       : p;
   const currentPath = `${stripped}${s}${h}`;
-  const encoded = encodeURIComponent(currentPath || '/');
-  return `/login?${REDIRECT_PARAM}=${encoded}`;
+  if (!currentPath || currentPath === '/') {
+    return '/login';
+  }
+  return `/login?${REDIRECT_PARAM}=${encodeURIComponent(currentPath)}`;
 }
 
 export const resendVerificationEmail = () => `${BASE_URL}/api/user/verify/resend`;

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -174,13 +174,16 @@ const LOGIN_PATH_RE = /(?:^|\/)login(?:\/|$)/;
 export function buildLoginRedirectUrl(pathname?: string, search?: string, hash?: string): string {
   const p = pathname ?? window.location.pathname;
   if (LOGIN_PATH_RE.test(p)) {
-    return `${BASE_URL}/login`;
+    return '/login';
   }
   const s = search ?? window.location.search;
   const h = hash ?? window.location.hash;
-  const currentPath = `${p}${s}${h}`;
+
+  const stripBase = BASE_URL && BASE_URL !== '/' ? BASE_URL : '';
+  const stripped = stripBase && p.startsWith(stripBase) ? p.slice(stripBase.length) || '/' : p;
+  const currentPath = `${stripped}${s}${h}`;
   const encoded = encodeURIComponent(currentPath || '/');
-  return `${BASE_URL}/login?${REDIRECT_PARAM}=${encoded}`;
+  return `/login?${REDIRECT_PARAM}=${encoded}`;
 }
 
 export const resendVerificationEmail = () => `${BASE_URL}/api/user/verify/resend`;

--- a/packages/data-provider/src/request.ts
+++ b/packages/data-provider/src/request.ts
@@ -141,7 +141,7 @@ if (typeof window !== 'undefined') {
             return await axios(originalRequest);
           } else {
             processQueue(error, null);
-            window.location.href = endpoints.buildLoginRedirectUrl();
+            window.location.href = endpoints.apiBaseUrl() + endpoints.buildLoginRedirectUrl();
           }
         } catch (err) {
           processQueue(err as AxiosError, null);


### PR DESCRIPTION

## Summary

Fixed an auth redirect path-doubling bug affecting subdirectory deployments (e.g., `DOMAIN_CLIENT=http://host/chat/`) where `BASE_URL` was being embedded inside URLs returned by `buildLoginRedirectUrl`, causing React Router's `navigate()` to re-apply the basename on top of it and produce paths like `/chat/chat/login`.

- Rewrote `buildLoginRedirectUrl` to always return a base-stripped `/login?redirect_to=...` path, compatible with React Router's `navigate()`, which re-applies the basename automatically.
- Updated the Axios 401 interceptor in `request.ts` to compose hard-redirect URLs as `apiBaseUrl() + buildLoginRedirectUrl()`, so `window.location.href` assignments correctly include the base prefix for full-page navigation.
- Stripped `apiBaseUrl()` from `window.location.pathname` inside `silentRefresh` in `AuthContext.tsx` before computing the post-login navigation target, preventing doubled base prefixes when the browser URL includes the base path.
- Added a path-segment boundary guard (`p === BASE_URL || p.startsWith(BASE_URL + '/')`) to prevent false-positive stripping of sibling paths (e.g., `/chatroom/...` under a `/chat` base).
- Optimized `buildLoginRedirectUrl` to return plain `/login` for root-path destinations, eliminating the pointless `redirect_to=%2F` since `/` immediately redirects to `/c/new` post-login.
- Exported `apiBaseUrl` from `librechat-data-provider` for consumption in `AuthContext.tsx`.
- Added `packages/data-provider/specs/api-endpoints-subdir.spec.ts` covering `buildLoginRedirectUrl` and `apiBaseUrl` under single-level and nested subdirectory bases, including segment-boundary regression cases for `/chatroom`, `/chatbot`, and `/app/chatroom`.
- Migrated `api-endpoints.spec.ts` from `Object.defineProperty(window, 'location')` to `window.history.replaceState`, resolving jsdom 26+ incompatibility across the existing test suite.
- Migrated `request-interceptor.spec.ts` to `@happy-dom/jest-environment`, which permits `Object.defineProperty` on `window.location` that jsdom 26+ blocks.
- Added subdirectory-specific test groups to `AuthContext.spec.tsx` and `useAuthRedirect.spec.tsx` validating that base paths are stripped before navigation and that `redirect_to` never contains the router basename.
- Added `config/test-subdirectory-setup.sh`, an nginx-based manual QA script for end-to-end verification of subdirectory deployments.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Unit tests cover all changed code paths across three workspaces:

```sh
# packages/data-provider
cd packages/data-provider && npx jest api-endpoints api-endpoints-subdir request-interceptor

# client
cd client && npx jest AuthContext useAuthRedirect
```

### **Test Configuration**:

To verify the fix end-to-end in a real subdirectory deployment:

1. Set in `.env`:
   ```
   DOMAIN_CLIENT=http://localhost:8080/chat
   DOMAIN_SERVER=http://localhost:8080/chat
   ```
2. Build and start the backend:
   ```sh
   npm run build && npm run backend
   ```
3. Start the nginx subdirectory proxy:
   ```sh
   bash config/test-subdirectory-setup.sh start
   ```
4. Open `http://localhost:8080/chat/` and confirm:
   - Unauthenticated access redirects to `/chat/login`, **not** `/chat/chat/login`
   - Accessing a deep route (e.g., `/chat/c/abc123`) redirects to `/chat/login?redirect_to=%2Fc%2Fabc123`
   - Post-login navigation lands on the correct route without path doubling
   - Logout redirects to `/chat/login`, not `/chat/chat/login`
5. Cleanup:
   ```sh
   bash config/test-subdirectory-setup.sh stop
   ```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
