### PR TITLE
feat: 🚀 Per model spec balance

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -138,15 +138,17 @@ class BaseClient {
    * @param {number} promptTokens
    * @param {number} completionTokens
    * @param {string} [messageId]
+   * @param {string} [specName]
    * @returns {Promise<void>}
    */
-  async recordTokenUsage({ model, balance, promptTokens, completionTokens, messageId }) {
+  async recordTokenUsage({ model, balance, promptTokens, completionTokens, messageId, specName }) {
     logger.debug('[BaseClient] `recordTokenUsage` not implemented.', {
       model,
       balance,
       messageId,
       promptTokens,
       completionTokens,
+      specName,
     });
   }
 
@@ -700,6 +702,12 @@ class BaseClient {
       balanceConfig?.enabled &&
       supportsBalanceCheck[this.options.endpointType ?? this.options.endpoint]
     ) {
+      const specName = this.options.req?.body?.spec;
+      this.specName = specName ?? null;
+      const specBalance =
+        specName != null
+          ? appConfig?.modelSpecs?.list?.find((s) => s.name === specName)?.balance
+          : undefined;
       await checkBalance({
         req: this.options.req,
         res: this.options.res,
@@ -710,6 +718,8 @@ class BaseClient {
           endpoint: this.options.endpoint,
           model: this.modelOptions?.model ?? this.model,
           endpointTokenConfig: this.options.endpointTokenConfig,
+          specName,
+          specBalance,
         },
       });
     }
@@ -800,6 +810,7 @@ class BaseClient {
           /** Note: When using agents, responseMessage.model is the agent ID, not the model */
           model: this.model,
           messageId: this.responseMessageId,
+          specName: this.specName,
         });
       }
 

--- a/api/models/Transaction.js
+++ b/api/models/Transaction.js
@@ -18,45 +18,64 @@ function calculateTokenValue(txn) {
 }
 
 /**
- * New static method to create an auto-refill transaction that does NOT trigger a balance update.
+ * New static method to create an auto-refill transaction.
+ *
+ * When `specName` is provided the refill is applied to the per-spec bucket and the
+ * per-spec `lastRefill` timestamp is recorded via `perModelSpecLastRefillEntry`.
+ *
  * @param {object} txData - Transaction data.
  * @param {string} txData.user - The user ID.
  * @param {string} txData.tokenType - The type of token.
  * @param {string} txData.context - The context of the transaction.
  * @param {number} txData.rawAmount - The raw amount of tokens.
+ * @param {string} [txData.specName] - Active modelSpec name; routes refill to the per-spec bucket.
  * @returns {Promise<object>} - The created transaction.
  */
 async function createAutoRefillTransaction(txData) {
   if (txData.rawAmount != null && isNaN(txData.rawAmount)) {
     return;
   }
-  const transaction = new Transaction(txData);
+
+  const { specName, ...rest } = txData;
+
+  const transaction = new Transaction(rest);
   transaction.endpointTokenConfig = txData.endpointTokenConfig;
   transaction.inputTokenCount = txData.inputTokenCount;
   calculateTokenValue(transaction);
   await transaction.save();
 
+  const setValues =
+    specName != null
+      ? { perModelSpecLastRefillEntry: { specName, date: new Date() } }
+      : { lastRefill: new Date() };
+
   const balanceResponse = await updateBalance({
     user: transaction.user,
     incrementValue: txData.rawAmount,
-    setValues: { lastRefill: new Date() },
+    specName,
+    setValues,
   });
+
   const result = {
     rate: transaction.rate,
     user: transaction.user.toString(),
-    balance: balanceResponse.tokenCredits,
+    balance:
+      specName != null
+        ? ((balanceResponse?.perModelSpecTokenCredits ?? {})[specName] ?? 0)
+        : balanceResponse.tokenCredits,
   };
-  logger.debug('[Balance.check] Auto-refill performed', result);
+  logger.debug('[Balance.check] Auto-refill performed', { ...result, specName });
   result.transaction = transaction;
   return result;
 }
 
 /**
- * Static method to create a transaction and update the balance
+ * Static method to create a transaction and update the balance.
+ * When `specName` is present in `_txData`, the balance debit targets the per-spec bucket.
  * @param {txData} _txData - Transaction data.
  */
 async function createTransaction(_txData) {
-  const { balance, transactions, ...txData } = _txData;
+  const { balance, transactions, specName, ...txData } = _txData;
   if (txData.rawAmount != null && isNaN(txData.rawAmount)) {
     return;
   }
@@ -75,26 +94,33 @@ async function createTransaction(_txData) {
     return;
   }
 
-  let incrementValue = transaction.tokenValue;
+  const incrementValue = transaction.tokenValue;
   const balanceResponse = await updateBalance({
     user: transaction.user,
     incrementValue,
+    specName,
   });
+
+  const resolvedBalance =
+    specName != null
+      ? ((balanceResponse?.perModelSpecTokenCredits ?? {})[specName] ?? 0)
+      : balanceResponse.tokenCredits;
 
   return {
     rate: transaction.rate,
     user: transaction.user.toString(),
-    balance: balanceResponse.tokenCredits,
+    balance: resolvedBalance,
     [transaction.tokenType]: incrementValue,
   };
 }
 
 /**
- * Static method to create a structured transaction and update the balance
+ * Static method to create a structured transaction and update the balance.
+ * When `specName` is present in `_txData`, the balance debit targets the per-spec bucket.
  * @param {txData} _txData - Transaction data.
  */
 async function createStructuredTransaction(_txData) {
-  const { balance, transactions, ...txData } = _txData;
+  const { balance, transactions, specName, ...txData } = _txData;
   if (transactions?.enabled === false) {
     return;
   }
@@ -111,17 +137,23 @@ async function createStructuredTransaction(_txData) {
     return;
   }
 
-  let incrementValue = transaction.tokenValue;
+  const incrementValue = transaction.tokenValue;
 
   const balanceResponse = await updateBalance({
     user: transaction.user,
     incrementValue,
+    specName,
   });
+
+  const resolvedBalance =
+    specName != null
+      ? ((balanceResponse?.perModelSpecTokenCredits ?? {})[specName] ?? 0)
+      : balanceResponse.tokenCredits;
 
   return {
     rate: transaction.rate,
     user: transaction.user.toString(),
-    balance: balanceResponse.tokenCredits,
+    balance: resolvedBalance,
     [transaction.tokenType]: incrementValue,
   };
 }

--- a/api/models/balanceMethods.js
+++ b/api/models/balanceMethods.js
@@ -10,8 +10,56 @@ function isInvalidDate(date) {
 }
 
 /**
+ * Adds a time interval to a given date.
+ * @param {Date} date - The starting date.
+ * @param {number} value - The numeric value of the interval.
+ * @param {'seconds'|'minutes'|'hours'|'days'|'weeks'|'months'} unit - The unit of time.
+ * @returns {Date} A new Date representing the starting date plus the interval.
+ */
+const addIntervalToDate = (date, value, unit) => {
+  const result = new Date(date);
+  switch (unit) {
+    case 'seconds':
+      result.setSeconds(result.getSeconds() + value);
+      break;
+    case 'minutes':
+      result.setMinutes(result.getMinutes() + value);
+      break;
+    case 'hours':
+      result.setHours(result.getHours() + value);
+      break;
+    case 'days':
+      result.setDate(result.getDate() + value);
+      break;
+    case 'weeks':
+      result.setDate(result.getDate() + value * 7);
+      break;
+    case 'months':
+      result.setMonth(result.getMonth() + value);
+      break;
+    default:
+      break;
+  }
+  return result;
+};
+
+/**
  * Simple check method that calculates token cost and returns balance info.
- * The auto-refill logic has been moved to balanceMethods.js to prevent circular dependencies.
+ *
+ * When `specName` is provided the function operates on the per-spec isolated credit
+ * bucket (`perModelSpecTokenCredits[specName]`) instead of the global `tokenCredits`.
+ * The per-spec bucket is lazily initialised on first use from `specBalance.startBalance`.
+ *
+ * @param {Object} params
+ * @param {string} params.user
+ * @param {string} params.model
+ * @param {string} params.endpoint
+ * @param {string} [params.valueKey]
+ * @param {string} params.tokenType
+ * @param {number} params.amount
+ * @param {Object} [params.endpointTokenConfig]
+ * @param {string} [params.specName] - Active modelSpec name.  When set, uses the per-spec bucket.
+ * @param {Object} [params.specBalance] - The `balance` block from the active modelSpec.
  */
 const checkBalanceRecord = async function ({
   user,
@@ -21,12 +69,103 @@ const checkBalanceRecord = async function ({
   tokenType,
   amount,
   endpointTokenConfig,
+  specName,
+  specBalance,
 }) {
   const multiplier = getMultiplier({ valueKey, tokenType, model, endpoint, endpointTokenConfig });
   const tokenCost = amount * multiplier;
 
-  // Retrieve the balance record
   let record = await Balance.findOne({ user }).lean();
+
+  if (specName != null) {
+    // ── Per-spec isolated bucket path ──────────────────────────────────────
+
+    // Mongoose Map fields are serialised as plain objects by .lean()
+    const specsMap = record?.perModelSpecTokenCredits ?? {};
+    const hasEntry = Object.prototype.hasOwnProperty.call(specsMap, specName);
+
+    let balance = hasEntry ? (specsMap[specName] ?? 0) : null;
+
+    // Lazy initialisation: create the bucket from the spec's startBalance on first use.
+    if (balance === null) {
+      const startBalance = specBalance?.startBalance ?? 0;
+      balance = startBalance;
+      try {
+        // Build a clean map (scalar entries only) merged with the new spec entry.
+        // Avoids dot-notation splitting and Mongoose Map hydration issues on old docs.
+        const currentMap = record?.perModelSpecTokenCredits ?? {};
+        const cleanMap = Object.fromEntries(
+          Object.entries(currentMap).filter(([, v]) => typeof v === 'number'),
+        );
+        cleanMap[specName] = startBalance;
+        await Balance.findOneAndUpdate(
+          { user },
+          { $set: { perModelSpecTokenCredits: cleanMap } },
+          { upsert: true },
+        );
+        logger.debug('[Balance.check] Lazily initialised per-spec bucket', {
+          user,
+          specName,
+          startBalance,
+        });
+      } catch (err) {
+        logger.error('[Balance.check] Failed to lazily initialise per-spec bucket', err);
+      }
+    }
+
+    logger.debug('[Balance.check] Per-spec initial state', {
+      user,
+      specName,
+      model,
+      endpoint,
+      balance,
+      tokenCost,
+    });
+
+    // Per-spec auto-refill
+    if (
+      balance - tokenCost <= 0 &&
+      specBalance?.autoRefillEnabled === true &&
+      specBalance?.refillAmount > 0 &&
+      specBalance?.refillIntervalValue != null &&
+      specBalance?.refillIntervalUnit != null
+    ) {
+      const lastRefillMap = record?.perModelSpecLastRefill ?? {};
+      const rawLastRefill = lastRefillMap[specName];
+      const lastRefillDate = rawLastRefill != null ? new Date(rawLastRefill) : null;
+      const now = new Date();
+
+      if (
+        lastRefillDate === null ||
+        isInvalidDate(lastRefillDate) ||
+        now >=
+          addIntervalToDate(
+            lastRefillDate,
+            specBalance.refillIntervalValue,
+            specBalance.refillIntervalUnit,
+          )
+      ) {
+        try {
+          const result = await createAutoRefillTransaction({
+            user,
+            tokenType: 'credits',
+            context: 'autoRefill',
+            rawAmount: specBalance.refillAmount,
+            specName,
+          });
+          balance = result.balance;
+        } catch (error) {
+          logger.error('[Balance.check] Failed to record per-spec auto-refill transaction', error);
+        }
+      }
+    }
+
+    logger.debug('[Balance.check] Per-spec token cost', { specName, tokenCost });
+    return { canSpend: balance >= tokenCost, balance, tokenCost };
+  }
+
+  // ── Global tokenCredits path (unchanged) ────────────────────────────────
+
   if (!record) {
     logger.debug('[Balance.check] No balance record found for user', { user });
     return {
@@ -78,40 +217,6 @@ const checkBalanceRecord = async function ({
 };
 
 /**
- * Adds a time interval to a given date.
- * @param {Date} date - The starting date.
- * @param {number} value - The numeric value of the interval.
- * @param {'seconds'|'minutes'|'hours'|'days'|'weeks'|'months'} unit - The unit of time.
- * @returns {Date} A new Date representing the starting date plus the interval.
- */
-const addIntervalToDate = (date, value, unit) => {
-  const result = new Date(date);
-  switch (unit) {
-    case 'seconds':
-      result.setSeconds(result.getSeconds() + value);
-      break;
-    case 'minutes':
-      result.setMinutes(result.getMinutes() + value);
-      break;
-    case 'hours':
-      result.setHours(result.getHours() + value);
-      break;
-    case 'days':
-      result.setDate(result.getDate() + value);
-      break;
-    case 'weeks':
-      result.setDate(result.getDate() + value * 7);
-      break;
-    case 'months':
-      result.setMonth(result.getMonth() + value);
-      break;
-    default:
-      break;
-  }
-  return result;
-};
-
-/**
  * Checks the balance for a user and determines if they can spend a certain amount.
  * If the user cannot spend the amount, it logs a violation and denies the request.
  *
@@ -126,6 +231,8 @@ const addIntervalToDate = (date, value, unit) => {
  * @param {number} params.txData.amount - The amount of tokens.
  * @param {string} params.txData.model - The model name or identifier.
  * @param {string} [params.txData.endpointTokenConfig] - The token configuration for the endpoint.
+ * @param {string} [params.txData.specName] - The active modelSpec name (enables per-spec balance).
+ * @param {Object} [params.txData.specBalance] - The balance config block of the active modelSpec.
  * @returns {Promise<boolean>} Throws error if the user cannot spend the amount.
  * @throws {Error} Throws an error if there's an issue with the balance check.
  */

--- a/api/server/controllers/Balance.js
+++ b/api/server/controllers/Balance.js
@@ -3,7 +3,7 @@ const { Balance } = require('~/db/models');
 async function balanceController(req, res) {
   const balanceData = await Balance.findOne(
     { user: req.user.id },
-    '-_id tokenCredits autoRefillEnabled refillIntervalValue refillIntervalUnit lastRefill refillAmount',
+    '-_id tokenCredits autoRefillEnabled refillIntervalValue refillIntervalUnit lastRefill refillAmount perModelSpecTokenCredits',
   ).lean();
 
   if (!balanceData) {

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -619,11 +619,13 @@ class AgentClient extends BaseClient {
    * @param {AppConfig['balance']} [params.balance]
    * @param {AppConfig['transactions']} [params.transactions]
    * @param {UsageMetadata[]} [params.collectedUsage=this.collectedUsage]
+   * @param {string} [params.specName]
    */
   async recordCollectedUsage({
     model,
     balance,
     transactions,
+    specName,
     context = 'message',
     collectedUsage = this.collectedUsage,
   }) {
@@ -644,6 +646,7 @@ class AgentClient extends BaseClient {
         balance,
         transactions,
         endpointTokenConfig: this.options.endpointTokenConfig,
+        specName,
       },
     );
 
@@ -887,6 +890,7 @@ class AgentClient extends BaseClient {
             context: 'message',
             balance: balanceConfig,
             transactions: transactionsConfig,
+            specName: this.options.req?.body?.spec,
           });
         } else {
           logger.debug(
@@ -1099,6 +1103,7 @@ class AgentClient extends BaseClient {
         balance: balanceConfig,
         transactions: transactionsConfig,
         messageId: this.responseMessageId,
+        specName: this.options.req?.body?.spec,
       }).catch((err) => {
         logger.error(
           '[api/server/controllers/agents/client.js #titleConvo] Error recording collected usage',
@@ -1121,6 +1126,7 @@ class AgentClient extends BaseClient {
    * @param {OpenAIUsageMetadata} [params.usage]
    * @param {AppConfig['balance']} [params.balance]
    * @param {string} [params.context='message']
+   * @param {string} [params.specName]
    * @returns {Promise<void>}
    */
   async recordTokenUsage({
@@ -1129,6 +1135,7 @@ class AgentClient extends BaseClient {
     balance,
     promptTokens,
     completionTokens,
+    specName,
     context = 'message',
   }) {
     try {
@@ -1137,6 +1144,7 @@ class AgentClient extends BaseClient {
           model,
           context,
           balance,
+          specName,
           messageId: this.responseMessageId,
           conversationId: this.conversationId,
           user: this.user ?? this.options.req.user?.id,
@@ -1155,6 +1163,7 @@ class AgentClient extends BaseClient {
           {
             model,
             balance,
+            specName,
             context: 'reasoning',
             messageId: this.responseMessageId,
             conversationId: this.conversationId,

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -562,6 +562,7 @@ const _LegacyAgentController = async (req, res, next, initializeClient, addTitle
       iconURL: endpointOption.iconURL,
       model: endpointOption.modelOptions?.model || endpointOption.model_parameters?.model,
       sender: client?.sender,
+      spec: endpointOption.spec,
     });
 
     // Store content parts reference for abort

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -525,6 +525,7 @@ const createResponse = async (req, res) => {
           balance: balanceConfig,
           transactions: transactionsConfig,
           model: primaryConfig.model || agent.model_parameters?.model,
+          specName: req.body?.spec,
         },
       ).catch((err) => {
         logger.error('[Responses API] Error recording usage:', err);
@@ -679,6 +680,7 @@ const createResponse = async (req, res) => {
           balance: balanceConfig,
           transactions: transactionsConfig,
           model: primaryConfig.model || agent.model_parameters?.model,
+          specName: req.body?.spec,
         },
       ).catch((err) => {
         logger.error('[Responses API] Error recording usage:', err);

--- a/api/server/controllers/assistants/chatV1.js
+++ b/api/server/controllers/assistants/chatV1.js
@@ -275,6 +275,11 @@ const chatV1 = async (req, res) => {
       // Count tokens up to the current context window
       promptTokens = Math.min(promptTokens, getModelMaxTokens(model));
 
+      const specName = endpointOption?.spec;
+      const specBalance =
+        specName != null
+          ? appConfig?.modelSpecs?.list?.find((s) => s.name === specName)?.balance
+          : undefined;
       await checkBalance({
         req,
         res,
@@ -283,6 +288,8 @@ const chatV1 = async (req, res) => {
           user: req.user.id,
           tokenType: 'prompt',
           amount: promptTokens,
+          specName,
+          specBalance,
         },
       });
     };

--- a/api/server/controllers/assistants/chatV2.js
+++ b/api/server/controllers/assistants/chatV2.js
@@ -148,6 +148,11 @@ const chatV2 = async (req, res) => {
       // Count tokens up to the current context window
       promptTokens = Math.min(promptTokens, getModelMaxTokens(model));
 
+      const specName = endpointOption?.spec;
+      const specBalance =
+        specName != null
+          ? appConfig?.modelSpecs?.list?.find((s) => s.name === specName)?.balance
+          : undefined;
       await checkBalance({
         req,
         res,
@@ -156,6 +161,8 @@ const chatV2 = async (req, res) => {
           user: req.user.id,
           tokenType: 'prompt',
           amount: promptTokens,
+          specName,
+          specBalance,
         },
       });
     };

--- a/api/server/middleware/abortMiddleware.js
+++ b/api/server/middleware/abortMiddleware.js
@@ -30,6 +30,7 @@ const { abortRun } = require('./abortRun');
  * @param {Array<Object>} params.collectedUsage - Usage metadata from all models
  * @param {string} [params.fallbackModel] - Fallback model name if not in usage
  * @param {string} [params.messageId] - The response message ID for transaction correlation
+ * @param {string} [params.specName] - The active modelSpec name for per-spec balance
  */
 async function spendCollectedUsage({
   userId,
@@ -37,6 +38,7 @@ async function spendCollectedUsage({
   collectedUsage,
   fallbackModel,
   messageId,
+  specName,
 }) {
   if (!collectedUsage || collectedUsage.length === 0) {
     return;
@@ -56,6 +58,7 @@ async function spendCollectedUsage({
       context: 'abort',
       messageId,
       model: fallbackModel,
+      specName,
     },
   );
 
@@ -120,11 +123,12 @@ async function abortMessage(req, res) {
       collectedUsage,
       fallbackModel: jobData?.model,
       messageId: jobData?.responseMessageId,
+      specName: jobData?.spec,
     });
   } else {
     // Fallback: no collected usage, use text-based token counting for primary model only
     await spendTokens(
-      { ...responseMessage, context: 'incomplete', user: userId },
+      { ...responseMessage, context: 'incomplete', user: userId, specName: jobData?.spec },
       { promptTokens, completionTokens },
     );
   }

--- a/client/src/components/Nav/AccountSettings.tsx
+++ b/client/src/components/Nav/AccountSettings.tsx
@@ -15,6 +15,12 @@ function AccountSettings() {
   const balanceQuery = useGetUserBalance({
     enabled: !!isAuthenticated && startupConfig?.balance?.enabled,
   });
+  const totalCredits = (startupConfig?.modelSpecs?.list ?? [])
+    .filter((spec) => spec.balance?.enabled === true)
+    .reduce(
+      (sum, spec) => sum + (balanceQuery.data?.perModelSpecTokenCredits?.[spec.name] ?? 0),
+      balanceQuery.data?.tokenCredits ?? 0,
+    );
   const [showSettings, setShowSettings] = useState(false);
   const [showFiles, setShowFiles] = useState(false);
   const accountSettingsButtonRef = useRef<HTMLButtonElement>(null);
@@ -54,7 +60,7 @@ function AccountSettings() {
           <>
             <div className="text-token-text-secondary ml-3 mr-2 py-2 text-sm" role="note">
               {localize('com_nav_balance')}:{' '}
-              {new Intl.NumberFormat().format(Math.round(balanceQuery.data.tokenCredits))}
+              {new Intl.NumberFormat().format(Math.round(totalCredits))}
             </div>
             <DropdownMenuSeparator />
           </>

--- a/client/src/components/Nav/SettingsTabs/Balance/Balance.tsx
+++ b/client/src/components/Nav/SettingsTabs/Balance/Balance.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Label } from '@librechat/client';
 import { useGetStartupConfig, useGetUserBalance } from '~/data-provider';
 import { useAuthContext, useLocalize } from '~/hooks';
 import TokenCreditsItem from './TokenCreditsItem';
@@ -22,6 +23,7 @@ function Balance() {
     refillAmount,
     refillIntervalUnit,
     refillIntervalValue,
+    perModelSpecTokenCredits,
   } = balanceData ?? {};
 
   // Check that all auto-refill props are present
@@ -31,11 +33,17 @@ function Balance() {
     refillIntervalUnit !== undefined &&
     refillIntervalValue !== undefined;
 
+  const specBalanceItems = (startupConfig?.modelSpecs?.list ?? [])
+    .filter((spec) => spec.balance?.enabled === true)
+    .map((spec) => ({
+      label: spec.label,
+      credits: perModelSpecTokenCredits?.[spec.name] ?? 0,
+    }));
+
   return (
     <div className="flex flex-col gap-4 p-4 text-sm text-text-primary">
       {/* Token credits display */}
       <TokenCreditsItem tokenCredits={tokenCredits} />
-
       {/* Auto-refill display */}
       {autoRefillEnabled ? (
         hasValidRefillSettings ? (
@@ -53,6 +61,20 @@ function Balance() {
       ) : (
         <div className="text-sm text-gray-600">
           {localize('com_nav_balance_auto_refill_disabled')}
+        </div>
+      )}
+      {/* Per-modelSpec balances */}
+      {specBalanceItems.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <Label className="font-medium">{localize('com_nav_balance_model_specs')}</Label>
+          {specBalanceItems.map((item) => (
+            <div key={item.label} className="flex items-center justify-between">
+              <Label className="font-light">{item.label}</Label>
+              <span className="text-sm font-medium text-gray-800 dark:text-gray-200" role="note">
+                {item.credits.toFixed(2)}
+              </span>
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -424,6 +424,7 @@
   "com_nav_balance_last_refill": "Last Refill:",
   "com_nav_balance_minute": "minute",
   "com_nav_balance_minutes": "minutes",
+  "com_nav_balance_model_specs": "Model Spec Balances",
   "com_nav_balance_month": "month",
   "com_nav_balance_months": "months",
   "com_nav_balance_next_refill": "Next Refill:",

--- a/config/add-balance.js
+++ b/config/add-balance.js
@@ -1,10 +1,10 @@
 const path = require('path');
 const mongoose = require('mongoose');
 const { getBalanceConfig } = require('@librechat/api');
-const { User } = require('@librechat/data-schemas').createModels(mongoose);
+const { User, Balance } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { createTransaction } = require('~/models/Transaction');
-const { getAppConfig } = require('~/server/services/Config');
+const loadCustomConfig = require('~/server/services/Config/loadCustomConfig');
 const { askQuestion, silentExit } = require('./helpers');
 const connect = require('./connect');
 
@@ -22,24 +22,30 @@ const connect = require('./connect');
    */
   let email = '';
   let amount = '';
+  let specName = '';
   // If we have the right number of arguments, lets use them
   if (process.argv.length >= 3) {
     email = process.argv[2];
     amount = process.argv[3];
+    specName = process.argv[4] ?? '';
   } else {
-    console.orange('Usage: npm run add-balance <email> <amount>');
+    console.orange('Usage: npm run add-balance <email> <amount> [specName]');
     console.orange('Note: if you do not pass in the arguments, you will be prompted for them.');
     console.purple('--------------------------');
-    // console.purple(`[DEBUG] Args Length: ${process.argv.length}`);
   }
 
-  const appConfig = await getAppConfig();
-  const balanceConfig = getBalanceConfig(appConfig);
-
+  const balanceConfig = getBalanceConfig();
   if (!balanceConfig?.enabled) {
     console.red('Error: Balance is not enabled. Use librechat.yaml to enable it');
     silentExit(1);
   }
+
+  // Load available modelSpecs from config (best-effort; non-fatal if yaml is absent)
+  const customConfig = await loadCustomConfig(false);
+  const availableSpecs = (customConfig?.modelSpecs?.list ?? []).map((s) => ({
+    name: s.name,
+    label: s.label,
+  }));
 
   /**
    * If we don't have the right number of arguments, lets prompt the user for them
@@ -54,11 +60,31 @@ const connect = require('./connect');
   }
 
   if (!amount) {
-    amount = await askQuestion('amount: (default is 1000 tokens if empty or 0)');
+    amount = await askQuestion('Amount: (default is 1000 tokens if empty or 0)');
   }
   // Validate the amount
   if (!amount) {
     amount = 1000;
+  }
+
+  // Prompt for specName if not provided via argv
+  if (specName === '') {
+    if (availableSpecs.length > 0) {
+      console.purple('Available specs (use the name, not the label):');
+      for (const s of availableSpecs) {
+        console.purple(`  name: ${s.name}  (label: ${s.label})`);
+      }
+    } else {
+      console.purple('No modelSpecs found in config.');
+    }
+    specName = await askQuestion('Spec name (leave blank for global balance):');
+  }
+
+  // Validate specName if provided
+  if (specName && availableSpecs.length > 0 && !availableSpecs.some((s) => s.name === specName)) {
+    console.red(`Error: "${specName}" was not found in modelSpecs config.`);
+    console.red(`Valid names: ${availableSpecs.map((s) => s.name).join(', ')}`);
+    silentExit(1);
   }
 
   // Validate the user
@@ -81,6 +107,7 @@ const connect = require('./connect');
       context: 'admin',
       rawAmount: +amount,
       balance: balanceConfig,
+      ...(specName ? { specName } : {}),
     });
   } catch (error) {
     console.red('Error: ' + error.message);
@@ -97,8 +124,11 @@ const connect = require('./connect');
 
   // Done!
   console.green('Transaction created successfully!');
-  console.purple(`Amount: ${amount}
-New Balance: ${result.balance}`);
+  if (specName) {
+    console.purple(`Spec: ${specName}\nAmount: ${amount}\nNew Spec Balance: ${result.balance}`);
+  } else {
+    console.purple(`Amount: ${amount}\nNew Balance: ${result.balance}`);
+  }
   silentExit(0);
 })();
 

--- a/config/set-balance.js
+++ b/config/set-balance.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const { getBalanceConfig } = require('@librechat/api');
 const { User, Balance } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
+const loadCustomConfig = require('~/server/services/Config/loadCustomConfig');
 const { askQuestion, silentExit } = require('./helpers');
 const connect = require('./connect');
 
@@ -20,15 +21,16 @@ const connect = require('./connect');
    */
   let email = '';
   let amount = '';
+  let specName = '';
   // If we have the right number of arguments, lets use them
   if (process.argv.length >= 3) {
     email = process.argv[2];
     amount = process.argv[3];
+    specName = process.argv[4] ?? '';
   } else {
-    console.orange('Usage: npm run set-balance <email> <amount>');
+    console.orange('Usage: npm run set-balance <email> <amount> [specName]');
     console.orange('Note: if you do not pass in the arguments, you will be prompted for them.');
     console.purple('--------------------------');
-    // console.purple(`[DEBUG] Args Length: ${process.argv.length}`);
   }
 
   const balanceConfig = getBalanceConfig();
@@ -36,6 +38,13 @@ const connect = require('./connect');
     console.red('Error: Balance is not enabled. Use librechat.yaml to enable it');
     silentExit(1);
   }
+
+  // Load available modelSpecs from config (best-effort; non-fatal if yaml is absent)
+  const customConfig = await loadCustomConfig(false);
+  const availableSpecs = (customConfig?.modelSpecs?.list ?? []).map((s) => ({
+    name: s.name,
+    label: s.label,
+  }));
 
   /**
    * If we don't have the right number of arguments, lets prompt the user for them
@@ -58,19 +67,47 @@ const connect = require('./connect');
     console.purple(`Found user: ${user.email}`);
   }
 
-  let balance = await Balance.findOne({ user: user._id }).lean();
+  const balance = await Balance.findOne({ user: user._id }).lean();
   if (!balance) {
     console.purple('User has no balance!');
   } else {
-    console.purple(`Current Balance: ${balance.tokenCredits}`);
+    console.purple(`Current Global Balance: ${balance.tokenCredits}`);
+    const specCredits = balance.perModelSpecTokenCredits ?? {};
+    const specEntries = Object.entries(specCredits);
+    if (specEntries.length > 0) {
+      console.purple('Current Spec Balances:');
+      for (const [name, credits] of specEntries) {
+        console.purple(`  ${name}: ${credits}`);
+      }
+    }
   }
 
   if (!amount) {
-    amount = await askQuestion('amount:');
+    amount = await askQuestion('Amount:');
   }
   // Validate the amount
   if (!amount) {
     console.red('Error: Please specify an amount!');
+    silentExit(1);
+  }
+
+  // Prompt for specName if not provided via argv
+  if (specName === '') {
+    if (availableSpecs.length > 0) {
+      console.purple('Available specs (use the name, not the label):');
+      for (const s of availableSpecs) {
+        console.purple(`  name: ${s.name}  (label: ${s.label})`);
+      }
+    } else {
+      console.purple('No modelSpecs found in config.');
+    }
+    specName = await askQuestion('Spec name (leave blank for global balance):');
+  }
+
+  // Validate specName if provided
+  if (specName && availableSpecs.length > 0 && !availableSpecs.some((s) => s.name === specName)) {
+    console.red(`Error: "${specName}" was not found in modelSpecs config.`);
+    console.red(`Valid names: ${availableSpecs.map((s) => s.name).join(', ')}`);
     silentExit(1);
   }
 
@@ -79,11 +116,32 @@ const connect = require('./connect');
    */
   let result;
   try {
-    result = await Balance.findOneAndUpdate(
-      { user: user._id },
-      { tokenCredits: amount },
-      { upsert: true, new: true },
-    ).lean();
+    if (specName) {
+      // Build the new map by merging the existing plain-object value with the new entry.
+      // We avoid dot-notation ($set with "perModelSpecTokenCredits.specName") because
+      // MongoDB splits on dots, corrupting spec names like "buzz-gpt-4.1".
+      // We also avoid relying on Mongoose Map hydration, which returns undefined for
+      // old documents that pre-date the field being added to the schema.
+      const existing = await Balance.findOne({ user: user._id }).lean();
+      const currentMap = existing?.perModelSpecTokenCredits ?? {};
+      // currentMap may itself be corrupted nested objects from prior dot-splitting;
+      // we only carry forward scalar (number) entries to avoid perpetuating corruption.
+      const cleanMap = Object.fromEntries(
+        Object.entries(currentMap).filter(([, v]) => typeof v === 'number'),
+      );
+      cleanMap[specName] = +amount;
+      result = await Balance.findOneAndUpdate(
+        { user: user._id },
+        { $set: { perModelSpecTokenCredits: cleanMap } },
+        { upsert: true, new: true },
+      ).lean();
+    } else {
+      result = await Balance.findOneAndUpdate(
+        { user: user._id },
+        { tokenCredits: +amount },
+        { upsert: true, new: true },
+      ).lean();
+    }
   } catch (error) {
     console.red('Error: ' + error.message);
     console.error(error);
@@ -91,15 +149,25 @@ const connect = require('./connect');
   }
 
   // Check the result
-  if (result?.tokenCredits == null) {
-    console.red('Error: Something went wrong while updating the balance!');
-    console.error(result);
-    silentExit(1);
+  if (specName) {
+    const newSpecCredits = (result?.perModelSpecTokenCredits ?? {})[specName];
+    if (newSpecCredits == null) {
+      console.red('Error: Something went wrong while updating the spec balance!');
+      console.error(result);
+      silentExit(1);
+    }
+    console.green('Spec balance set successfully!');
+    console.purple(`Spec: ${specName}\nNew Spec Balance: ${newSpecCredits}`);
+  } else {
+    if (result?.tokenCredits == null) {
+      console.red('Error: Something went wrong while updating the balance!');
+      console.error(result);
+      silentExit(1);
+    }
+    console.green('Balance set successfully!');
+    console.purple(`New Balance: ${result.tokenCredits}`);
   }
 
-  // Done!
-  console.green('Balance set successfully!');
-  console.purple(`New Balance: ${result.tokenCredits}`);
   silentExit(0);
 })();
 

--- a/packages/api/src/agents/transactions.ts
+++ b/packages/api/src/agents/transactions.ts
@@ -31,6 +31,8 @@ interface BaseTxData {
   endpointTokenConfig?: EndpointTokenConfig;
   balance?: Partial<TCustomConfig['balance']> | null;
   transactions?: Partial<TTransactionsConfig>;
+  /** Active modelSpec name — when set, debits the per-spec bucket instead of global credits */
+  specName?: string;
 }
 
 interface StandardTxData extends BaseTxData {
@@ -53,6 +55,7 @@ export interface PreparedEntry {
   doc: TransactionData;
   tokenValue: number;
   balance?: Partial<TCustomConfig['balance']> | null;
+  specName?: string;
 }
 
 export interface TokenUsage {
@@ -80,11 +83,17 @@ export interface TxMetadata {
   balance?: Partial<TCustomConfig['balance']> | null;
   transactions?: Partial<TTransactionsConfig>;
   endpointTokenConfig?: EndpointTokenConfig;
+  /** Active modelSpec name — when set, debits the per-spec bucket instead of global credits */
+  specName?: string;
 }
 
 export interface BulkWriteDeps {
   insertMany: (docs: TransactionData[]) => Promise<unknown>;
-  updateBalance: (params: { user: string; incrementValue: number }) => Promise<unknown>;
+  updateBalance: (params: {
+    user: string;
+    incrementValue: number;
+    specName?: string;
+  }) => Promise<unknown>;
 }
 
 function calculateTokenValue(
@@ -193,6 +202,7 @@ function prepareStandardTx(
     doc: { ...txData, tokenValue, rate },
     tokenValue,
     balance,
+    specName: txData.specName,
   };
 }
 
@@ -222,6 +232,7 @@ function prepareStructuredTx(
     },
     tokenValue,
     balance,
+    specName: txData.specName,
   };
 }
 
@@ -329,16 +340,20 @@ export async function bulkWriteTransactions(
 
   let totalTokenValue = 0;
   let balanceEnabled = false;
-  const plainDocs = docs.map(({ doc, tokenValue, balance }) => {
+  let specName: string | undefined;
+  const plainDocs = docs.map(({ doc, tokenValue, balance, specName: entrySpecName }) => {
     if (balance?.enabled) {
       balanceEnabled = true;
       totalTokenValue += tokenValue;
+    }
+    if (specName === undefined && entrySpecName) {
+      specName = entrySpecName;
     }
     return doc;
   });
 
   if (balanceEnabled) {
-    await dbOps.updateBalance({ user, incrementValue: totalTokenValue });
+    await dbOps.updateBalance({ user, incrementValue: totalTokenValue, specName });
   }
 
   await dbOps.insertMany(plainDocs);

--- a/packages/api/src/agents/usage.ts
+++ b/packages/api/src/agents/usage.ts
@@ -39,6 +39,8 @@ export interface RecordUsageParams {
   balance?: Partial<TCustomConfig['balance']> | null;
   transactions?: Partial<TTransactionsConfig>;
   endpointTokenConfig?: EndpointTokenConfig;
+  /** Active modelSpec name — when set, debits the per-spec bucket instead of global credits */
+  specName?: string;
 }
 
 export interface RecordUsageResult {
@@ -66,6 +68,7 @@ export async function recordCollectedUsage(
     conversationId,
     collectedUsage,
     endpointTokenConfig,
+    specName,
     context = 'message',
   } = params;
 
@@ -112,6 +115,7 @@ export async function recordCollectedUsage(
       transactions,
       conversationId,
       endpointTokenConfig,
+      specName,
       model: usage.model ?? model,
     };
 

--- a/packages/api/src/middleware/balance.spec.ts
+++ b/packages/api/src/middleware/balance.spec.ts
@@ -650,4 +650,243 @@ describe('createSetBalanceConfig', () => {
       },
     );
   });
+
+  describe('Per-Spec Balance Override', () => {
+    test('should use default spec balance config when a default spec has balance override', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const getAppConfig = jest.fn().mockResolvedValue({
+        balance: {
+          enabled: true,
+          startBalance: 1000,
+          autoRefillEnabled: false,
+          refillIntervalValue: 30,
+          refillIntervalUnit: 'days',
+          refillAmount: 500,
+        },
+        modelSpecs: {
+          enforce: false,
+          list: [
+            {
+              name: 'buzz-gpt-4',
+              label: 'Buzz GPT-4',
+              default: true,
+              preset: { endpoint: 'azureOpenAI', model: 'gpt-4' },
+              balance: {
+                startBalance: 999,
+                autoRefillEnabled: true,
+                refillIntervalValue: 1,
+                refillIntervalUnit: 'seconds',
+                refillAmount: 111,
+              },
+            },
+          ],
+        },
+      });
+
+      const middleware = createSetBalanceConfig({ getAppConfig, Balance });
+      const req = createMockRequest(userId);
+      const res = createMockResponse();
+
+      await middleware(req as ServerRequest, res as ServerResponse, mockNext);
+
+      const balanceRecord = await Balance.findOne({ user: userId });
+      expect(balanceRecord).toBeTruthy();
+      // startBalance from spec overrides global
+      expect(balanceRecord?.tokenCredits).toBe(999);
+      // auto-refill settings from spec
+      expect(balanceRecord?.autoRefillEnabled).toBe(true);
+      expect(balanceRecord?.refillIntervalValue).toBe(1);
+      expect(balanceRecord?.refillIntervalUnit).toBe('seconds');
+      expect(balanceRecord?.refillAmount).toBe(111);
+    });
+
+    test('should use first spec balance config in enforce mode with single spec', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const getAppConfig = jest.fn().mockResolvedValue({
+        balance: {
+          enabled: true,
+          startBalance: 1000,
+          autoRefillEnabled: false,
+          refillIntervalValue: 30,
+          refillIntervalUnit: 'days',
+          refillAmount: 500,
+        },
+        modelSpecs: {
+          enforce: true,
+          list: [
+            {
+              name: 'only-spec',
+              label: 'Only Spec',
+              preset: { endpoint: 'openAI', model: 'gpt-4o' },
+              balance: {
+                startBalance: 5000,
+                autoRefillEnabled: true,
+                refillIntervalValue: 7,
+                refillIntervalUnit: 'days',
+                refillAmount: 2500,
+              },
+            },
+          ],
+        },
+      });
+
+      const middleware = createSetBalanceConfig({ getAppConfig, Balance });
+      const req = createMockRequest(userId);
+      const res = createMockResponse();
+
+      await middleware(req as ServerRequest, res as ServerResponse, mockNext);
+
+      const balanceRecord = await Balance.findOne({ user: userId });
+      expect(balanceRecord?.tokenCredits).toBe(5000);
+      expect(balanceRecord?.autoRefillEnabled).toBe(true);
+      expect(balanceRecord?.refillIntervalValue).toBe(7);
+      expect(balanceRecord?.refillIntervalUnit).toBe('days');
+      expect(balanceRecord?.refillAmount).toBe(2500);
+    });
+
+    test('should fall back to global config when no spec has a default and enforce is false with multiple specs', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const getAppConfig = jest.fn().mockResolvedValue({
+        balance: {
+          enabled: true,
+          startBalance: 1000,
+          autoRefillEnabled: true,
+          refillIntervalValue: 30,
+          refillIntervalUnit: 'days',
+          refillAmount: 500,
+        },
+        modelSpecs: {
+          enforce: false,
+          list: [
+            {
+              name: 'spec-a',
+              label: 'Spec A',
+              preset: { endpoint: 'openAI', model: 'gpt-4o' },
+              balance: { startBalance: 9999 },
+            },
+            {
+              name: 'spec-b',
+              label: 'Spec B',
+              preset: { endpoint: 'anthropic', model: 'claude-3-5-sonnet' },
+              balance: { startBalance: 8888 },
+            },
+          ],
+        },
+      });
+
+      const middleware = createSetBalanceConfig({ getAppConfig, Balance });
+      const req = createMockRequest(userId);
+      const res = createMockResponse();
+
+      await middleware(req as ServerRequest, res as ServerResponse, mockNext);
+
+      const balanceRecord = await Balance.findOne({ user: userId });
+      // No default spec and not enforce — falls back to global startBalance
+      expect(balanceRecord?.tokenCredits).toBe(1000);
+      expect(balanceRecord?.refillIntervalValue).toBe(30);
+      expect(balanceRecord?.refillAmount).toBe(500);
+    });
+
+    test('should fall back to global config when no specs have a balance field', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const getAppConfig = jest.fn().mockResolvedValue({
+        balance: {
+          enabled: true,
+          startBalance: 1000,
+          autoRefillEnabled: true,
+          refillIntervalValue: 30,
+          refillIntervalUnit: 'days',
+          refillAmount: 500,
+        },
+        modelSpecs: {
+          enforce: false,
+          list: [
+            {
+              name: 'spec-no-balance',
+              label: 'Spec No Balance',
+              default: true,
+              preset: { endpoint: 'openAI', model: 'gpt-4o' },
+            },
+          ],
+        },
+      });
+
+      const middleware = createSetBalanceConfig({ getAppConfig, Balance });
+      const req = createMockRequest(userId);
+      const res = createMockResponse();
+
+      await middleware(req as ServerRequest, res as ServerResponse, mockNext);
+
+      const balanceRecord = await Balance.findOne({ user: userId });
+      expect(balanceRecord?.tokenCredits).toBe(1000);
+      expect(balanceRecord?.refillIntervalValue).toBe(30);
+      expect(balanceRecord?.refillAmount).toBe(500);
+    });
+
+    test('should fall back to global config when no modelSpecs are configured', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const getAppConfig = jest.fn().mockResolvedValue({
+        balance: {
+          enabled: true,
+          startBalance: 2000,
+          autoRefillEnabled: false,
+        },
+      });
+
+      const middleware = createSetBalanceConfig({ getAppConfig, Balance });
+      const req = createMockRequest(userId);
+      const res = createMockResponse();
+
+      await middleware(req as ServerRequest, res as ServerResponse, mockNext);
+
+      const balanceRecord = await Balance.findOne({ user: userId });
+      expect(balanceRecord?.tokenCredits).toBe(2000);
+    });
+
+    test('should merge spec balance over global — spec fields win, global fills gaps', async () => {
+      const userId = new mongoose.Types.ObjectId();
+      const getAppConfig = jest.fn().mockResolvedValue({
+        balance: {
+          enabled: true,
+          startBalance: 1000,
+          autoRefillEnabled: true,
+          refillIntervalValue: 30,
+          refillIntervalUnit: 'days',
+          refillAmount: 500,
+        },
+        modelSpecs: {
+          enforce: false,
+          list: [
+            {
+              name: 'partial-spec',
+              label: 'Partial Spec',
+              default: true,
+              preset: { endpoint: 'openAI', model: 'gpt-4o' },
+              // Only overrides refillAmount — other fields inherited from global
+              balance: {
+                autoRefillEnabled: true,
+                refillIntervalValue: 30,
+                refillIntervalUnit: 'days',
+                refillAmount: 9999,
+              },
+            },
+          ],
+        },
+      });
+
+      const middleware = createSetBalanceConfig({ getAppConfig, Balance });
+      const req = createMockRequest(userId);
+      const res = createMockResponse();
+
+      await middleware(req as ServerRequest, res as ServerResponse, mockNext);
+
+      const balanceRecord = await Balance.findOne({ user: userId });
+      // startBalance falls through from global since spec doesn't define it
+      expect(balanceRecord?.tokenCredits).toBe(1000);
+      // refillAmount comes from spec
+      expect(balanceRecord?.refillAmount).toBe(9999);
+      expect(balanceRecord?.refillIntervalValue).toBe(30);
+    });
+  });
+
 });

--- a/packages/api/src/middleware/balance.ts
+++ b/packages/api/src/middleware/balance.ts
@@ -1,6 +1,7 @@
 import { logger } from '@librechat/data-schemas';
 import type { NextFunction, Request as ServerRequest, Response as ServerResponse } from 'express';
 import type { IBalance, IUser, BalanceConfig, ObjectId, AppConfig } from '@librechat/data-schemas';
+import type { TSpecBalance } from 'librechat-data-provider';
 import type { Model } from 'mongoose';
 import type { BalanceUpdateFields } from '~/types';
 import { getBalanceConfig } from '~/app/config';
@@ -69,6 +70,33 @@ function buildUpdateFields(
 }
 
 /**
+ * Resolves the effective balance config by merging the active spec's balance override (if any)
+ * over the global config. Selects the default spec, or the sole spec when enforce mode is on
+ * with exactly one spec in the list. Falls back to the global config when no applicable spec
+ * balance override is found.
+ */
+function resolveEffectiveBalanceConfig(
+  globalConfig: BalanceConfig,
+  appConfig: AppConfig,
+): BalanceConfig {
+  const specsList = appConfig?.['modelSpecs']?.list;
+  if (!specsList?.length) {
+    return globalConfig;
+  }
+
+  const enforce: boolean = appConfig?.['modelSpecs']?.enforce ?? false;
+  const activeSpec =
+    specsList.find((s) => s.default) ?? (enforce && specsList.length === 1 ? specsList[0] : null);
+
+  const specBalance = (activeSpec as { balance?: TSpecBalance } | null)?.balance;
+  if (!specBalance) {
+    return globalConfig;
+  }
+
+  return { ...globalConfig, ...specBalance };
+}
+
+/**
  * Factory function to create middleware that synchronizes user balance settings with current balance configuration.
  * @param options - Options containing getBalanceConfig function and Balance model
  * @returns Express middleware function
@@ -85,17 +113,19 @@ export function createSetBalanceConfig({
     try {
       const user = req.user as IUser & { _id: string | ObjectId };
       const appConfig = await getAppConfig({ role: user?.role });
-      const balanceConfig = getBalanceConfig(appConfig);
-      if (!balanceConfig?.enabled) {
+      const globalBalanceConfig = getBalanceConfig(appConfig);
+      if (!globalBalanceConfig?.enabled) {
         return next();
       }
-      if (balanceConfig.startBalance == null) {
+      if (globalBalanceConfig.startBalance == null) {
         return next();
       }
 
       if (!user || !user._id) {
         return next();
       }
+
+      const balanceConfig = resolveEffectiveBalanceConfig(globalBalanceConfig, appConfig);
       const userId = typeof user._id === 'string' ? user._id : user._id.toString();
       const userBalanceRecord = await Balance.findOne({ user: userId }).lean();
       const updateFields = buildUpdateFields(balanceConfig, userBalanceRecord, userId);

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -943,6 +943,9 @@ class GenerationJobManagerClass {
     if (metadata.promptTokens !== undefined) {
       updates.promptTokens = metadata.promptTokens;
     }
+    if (metadata.spec) {
+      updates.spec = metadata.spec;
+    }
     await this.jobStore.updateJob(streamId, updates);
   }
 

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -43,6 +43,8 @@ export interface SerializableJobData {
   iconURL?: string;
   model?: string;
   promptTokens?: number;
+  /** Active modelSpec name for per-spec balance spend on abort */
+  spec?: string;
 }
 
 /**

--- a/packages/api/src/types/balance.ts
+++ b/packages/api/src/types/balance.ts
@@ -6,4 +6,8 @@ export interface BalanceUpdateFields {
   refillIntervalUnit?: string;
   refillAmount?: number;
   lastRefill?: Date;
+  /** Per-modelSpec isolated credit pools. Key is the modelSpec name. */
+  perModelSpecTokenCredits?: Record<string, number>;
+  /** Tracks the last auto-refill timestamp per modelSpec. Key is the modelSpec name. */
+  perModelSpecLastRefill?: Record<string, Date>;
 }

--- a/packages/api/src/types/stream.ts
+++ b/packages/api/src/types/stream.ts
@@ -19,6 +19,8 @@ export interface GenerationJobMetadata {
   model?: string;
   /** Prompt token count for abort token spending */
   promptTokens?: number;
+  /** Active modelSpec name for per-spec balance spend on abort */
+  spec?: string;
 }
 
 export type GenerationJobStatus = 'running' | 'complete' | 'error' | 'aborted';

--- a/packages/data-provider/src/models.ts
+++ b/packages/data-provider/src/models.ts
@@ -8,6 +8,20 @@ import {
   authTypeSchema,
 } from './schemas';
 
+/** Balance override for a specific model spec — all fields optional, no defaults. */
+export const specBalanceSchema = z.object({
+  enabled: z.boolean().optional(),
+  startBalance: z.number().optional(),
+  autoRefillEnabled: z.boolean().optional(),
+  refillIntervalValue: z.number().optional(),
+  refillIntervalUnit: z
+    .enum(['seconds', 'minutes', 'hours', 'days', 'weeks', 'months'])
+    .optional(),
+  refillAmount: z.number().optional(),
+});
+
+export type TSpecBalance = z.infer<typeof specBalanceSchema>;
+
 export type TModelSpec = {
   name: string;
   label: string;
@@ -37,6 +51,8 @@ export type TModelSpec = {
   executeCode?: boolean;
   artifacts?: string | boolean;
   mcpServers?: string[];
+  /** Per-spec balance configuration — overrides the global balance config for users of this spec. */
+  balance?: TSpecBalance;
 };
 
 export const tModelSpecSchema = z.object({
@@ -57,6 +73,7 @@ export const tModelSpecSchema = z.object({
   executeCode: z.boolean().optional(),
   artifacts: z.union([z.string(), z.boolean()]).optional(),
   mcpServers: z.array(z.string()).optional(),
+  balance: specBalanceSchema.optional(),
 });
 
 export const specsConfigSchema = z.object({

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -683,4 +683,6 @@ export type TBalanceResponse = {
   refillIntervalUnit?: 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks' | 'months';
   lastRefill?: Date;
   refillAmount?: number;
+  // Per-modelSpec isolated credit buckets
+  perModelSpecTokenCredits?: Record<string, number>;
 };

--- a/packages/data-schemas/src/methods/transaction.ts
+++ b/packages/data-schemas/src/methods/transaction.ts
@@ -4,11 +4,27 @@ import logger from '~/config/winston';
 interface UpdateBalanceParams {
   user: string;
   incrementValue: number;
-  setValues?: Partial<Pick<IBalance, 'tokenCredits' | 'lastRefill'>>;
+  /** When provided, debits/credits the per-spec bucket instead of the global tokenCredits. */
+  specName?: string;
+  /**
+   * The starting balance to use when the per-spec bucket does not yet exist (lazy init).
+   * Only used when specName is provided and the bucket key is missing from the document.
+   */
+  specStartBalance?: number;
+  setValues?: Partial<Pick<IBalance, 'tokenCredits' | 'lastRefill'>> & {
+    /** Used to record the per-spec last-refill timestamp when auto-refill fires for a spec. */
+    perModelSpecLastRefillEntry?: { specName: string; date: Date };
+  };
 }
 
 export function createTransactionMethods(mongoose: typeof import('mongoose')) {
-  async function updateBalance({ user, incrementValue, setValues }: UpdateBalanceParams) {
+  async function updateBalance({
+    user,
+    incrementValue,
+    specName,
+    specStartBalance,
+    setValues,
+  }: UpdateBalanceParams) {
     const maxRetries = 10;
     let delay = 50;
     let lastError: Error | null = null;
@@ -17,49 +33,127 @@ export function createTransactionMethods(mongoose: typeof import('mongoose')) {
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
         const currentBalanceDoc = await Balance.findOne({ user }).lean<IBalance>();
-        const currentCredits = currentBalanceDoc?.tokenCredits ?? 0;
-        const newCredits = Math.max(0, currentCredits + incrementValue);
 
-        const updatePayload = {
-          $set: {
-            tokenCredits: newCredits,
-            ...(setValues ?? {}),
-          },
-        };
+        if (specName != null) {
+          // --- Per-spec isolated bucket path ---
+          // Read the current map from the lean doc (plain object after .lean()).
+          // We avoid dot-notation ($set "perModelSpecTokenCredits.specName") because
+          // MongoDB splits on dots, corrupting spec names that contain them.
+          // We also avoid Mongoose Map hydration (.set/.get) because old documents
+          // that pre-date the field return undefined for the Map instance.
+          // Instead, we merge the full map as a plain object in a single $set.
+          const specsMap = (currentBalanceDoc?.perModelSpecTokenCredits ?? {}) as Record<
+            string,
+            unknown
+          >;
+          // Only carry forward scalar number entries to avoid perpetuating corruption
+          // from prior dot-splitting writes.
+          const cleanMap: Record<string, number> = Object.fromEntries(
+            Object.entries(specsMap).filter((e): e is [string, number] => typeof e[1] === 'number'),
+          );
+          const hasEntry = Object.prototype.hasOwnProperty.call(cleanMap, specName);
+          const currentSpecCredits = hasEntry ? (cleanMap[specName] ?? 0) : (specStartBalance ?? 0);
+          const newSpecCredits = Math.max(0, currentSpecCredits + incrementValue);
 
-        if (currentBalanceDoc) {
-          const updatedBalance = await Balance.findOneAndUpdate(
-            { user, tokenCredits: currentCredits },
-            updatePayload,
-            { new: true },
-          ).lean();
+          const setPayload: Record<string, unknown> = {
+            perModelSpecTokenCredits: { ...cleanMap, [specName]: newSpecCredits },
+          };
 
-          if (updatedBalance) {
-            return updatedBalance;
+          if (setValues?.perModelSpecLastRefillEntry?.specName === specName) {
+            // Same approach for the lastRefill map
+            const lastRefillMap = (currentBalanceDoc?.perModelSpecLastRefill ?? {}) as Record<
+              string,
+              unknown
+            >;
+            const cleanLastRefill: Record<string, Date> = Object.fromEntries(
+              Object.entries(lastRefillMap).filter(
+                (e): e is [string, Date] =>
+                  e[1] instanceof Date ||
+                  (typeof e[1] === 'string' && !isNaN(Date.parse(e[1] as string))),
+              ),
+            );
+            setPayload.perModelSpecLastRefill = {
+              ...cleanLastRefill,
+              [specName]: setValues.perModelSpecLastRefillEntry.date,
+            };
           }
-          lastError = new Error(`Concurrency conflict for user ${user} on attempt ${attempt}.`);
-        } else {
-          try {
-            const updatedBalance = await Balance.findOneAndUpdate({ user }, updatePayload, {
-              upsert: true,
-              new: true,
-            }).lean();
+
+          // Optimistic concurrency: re-read the live spec value and retry on conflict.
+          const liveDoc = await Balance.findOne({ user }).lean<IBalance>();
+          const liveMap = (liveDoc?.perModelSpecTokenCredits ?? {}) as Record<string, unknown>;
+          const liveCredits =
+            typeof liveMap[specName] === 'number'
+              ? (liveMap[specName] as number)
+              : (specStartBalance ?? 0);
+
+          if (hasEntry && liveCredits !== currentSpecCredits) {
+            lastError = new Error(
+              `Concurrency conflict for user ${user} spec ${specName} on attempt ${attempt}.`,
+            );
+          } else {
+            const updatedBalance = await Balance.findOneAndUpdate(
+              { user },
+              { $set: setPayload },
+              { upsert: true, new: true },
+            ).lean();
 
             if (updatedBalance) {
               return updatedBalance;
             }
             lastError = new Error(
-              `Upsert race condition suspected for user ${user} on attempt ${attempt}.`,
+              `Upsert race for user ${user} spec ${specName} on attempt ${attempt}.`,
             );
-          } catch (error: unknown) {
-            if (
-              error instanceof Error &&
-              'code' in error &&
-              (error as { code: number }).code === 11000
-            ) {
-              lastError = error;
-            } else {
-              throw error;
+          }
+        } else {
+          // --- Global tokenCredits path (unchanged behaviour) ---
+          const currentCredits = currentBalanceDoc?.tokenCredits ?? 0;
+          const newCredits = Math.max(0, currentCredits + incrementValue);
+
+          const updatePayload = {
+            $set: {
+              tokenCredits: newCredits,
+              ...(setValues != null
+                ? Object.fromEntries(
+                    Object.entries(setValues).filter(([k]) => k !== 'perModelSpecLastRefillEntry'),
+                  )
+                : {}),
+            },
+          };
+
+          if (currentBalanceDoc) {
+            const updatedBalance = await Balance.findOneAndUpdate(
+              { user, tokenCredits: currentCredits },
+              updatePayload,
+              { new: true },
+            ).lean();
+
+            if (updatedBalance) {
+              return updatedBalance;
+            }
+            lastError = new Error(`Concurrency conflict for user ${user} on attempt ${attempt}.`);
+          } else {
+            try {
+              const updatedBalance = await Balance.findOneAndUpdate({ user }, updatePayload, {
+                upsert: true,
+                new: true,
+              }).lean();
+
+              if (updatedBalance) {
+                return updatedBalance;
+              }
+              lastError = new Error(
+                `Upsert race condition suspected for user ${user} on attempt ${attempt}.`,
+              );
+            } catch (error: unknown) {
+              if (
+                error instanceof Error &&
+                'code' in error &&
+                (error as { code: number }).code === 11000
+              ) {
+                lastError = error;
+              } else {
+                throw error;
+              }
             }
           }
         }

--- a/packages/data-schemas/src/schema/balance.ts
+++ b/packages/data-schemas/src/schema/balance.ts
@@ -36,6 +36,18 @@ const balanceSchema = new Schema<t.IBalance>({
     type: Number,
     default: 0,
   },
+  /** Per-modelSpec isolated credit pools. Key is the modelSpec name. */
+  perModelSpecTokenCredits: {
+    type: Map,
+    of: Number,
+    default: {},
+  },
+  /** Tracks the last auto-refill timestamp per modelSpec. Key is the modelSpec name. */
+  perModelSpecLastRefill: {
+    type: Map,
+    of: Date,
+    default: {},
+  },
 });
 
 export default balanceSchema;

--- a/packages/data-schemas/src/types/balance.ts
+++ b/packages/data-schemas/src/types/balance.ts
@@ -9,4 +9,8 @@ export interface IBalance extends Document {
   refillIntervalUnit: 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks' | 'months';
   lastRefill: Date;
   refillAmount: number;
+  /** Per-modelSpec isolated credit pools. Key is the modelSpec name. */
+  perModelSpecTokenCredits?: Record<string, number>;
+  /** Tracks the last auto-refill timestamp per modelSpec. Key is the modelSpec name. */
+  perModelSpecLastRefill?: Record<string, Date>;
 }


### PR DESCRIPTION
# 🚀 feat: Per `modelSpecs` balance

## Configure a `modelSpec` to have his own balance

With this feature, you will be able to specify in the `librechat.yaml` file some `modelSpecs` to have their own balance.

Chats that are **not** issued from a `modelSpecs` marked with the `balance: { enabled: true }` flag will consume the general `tokenCredits` balance as normal.

This feature support the `autoRefill` mechanism at a **per-model-spec** basic as well.

### Here's an example of `librechat.yaml` configuration

```yml
modelSpecs:
  list:
    - name: "buzz-gpt-4-1"
      label: "Buzz GPT-4.1"
      description: "Most funny BuzzAI model"
      group: "BuzzAI"
      balance: {
        enabled: true # <===============
        startBalance: 10000
        autoRefillEnabled: false
        refillIntervalValue: 1
        refillIntervalUnit: 'days'
        refillAmount: 100
      },
      preset:
        endpoint: "azureOpenAI"
        model: "gpt-4.1"
```

### Here's some UI updates that have been made:

1. User menu
   - Balance display the general balance + all the `per-spec` ones
2. Balance settings tab
   - Display the general balance (same as user menu)
   - Display the list of `modelSpecs` balances
   - ![](https://iili.io/fpNI7El.png)

### The `config` scripts have been updated as well:

1. Accept a `spec` argument to specify to which `modelSpecs` you want to add/set balance to.
2. List the `modelsSpecs` with their balance

Examples:

```bash
npm run set-balance john.doe@gmail.com 999 my-cool-model-spec
npm run add-balance john.doe@gmail.com 100 my-cool-model-spec
```

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Translation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted.