### PR TITLE
🕰️ fix: Preserve `updatedAt` Timestamps During Meilisearch Batch Sync

### DIFF
--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1098,7 +1098,15 @@ describe('Meilisearch Mongoose plugin', () => {
         },
       ]);
 
+      const beforeSync = await messageModel.find({}).lean();
+      for (const doc of beforeSync) {
+        expect(new Date(doc.updatedAt as Date).getTime()).toBe(pastDate.getTime());
+      }
+
       await messageModel.syncWithMeili();
+
+      const indexedCount = await messageModel.countDocuments({ _meiliIndex: true });
+      expect(indexedCount).toBe(2);
 
       const afterSync = await messageModel.find({}).lean();
       for (const doc of afterSync) {

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -1016,6 +1016,97 @@ describe('Meilisearch Mongoose plugin', () => {
     });
   });
 
+  describe('processSyncBatch does not modify updatedAt timestamps', () => {
+    test('syncWithMeili preserves original updatedAt on conversations', async () => {
+      const conversationModel = createConversationModel(mongoose) as SchemaWithMeiliMethods;
+      await conversationModel.deleteMany({});
+      mockAddDocumentsInBatches.mockClear();
+
+      const pastDate = new Date('2024-01-15T12:00:00Z');
+
+      // Insert documents with specific updatedAt timestamps using raw collection
+      await conversationModel.collection.insertMany([
+        {
+          conversationId: new mongoose.Types.ObjectId().toString(),
+          user: new mongoose.Types.ObjectId(),
+          title: 'Old Conversation 1',
+          endpoint: EModelEndpoint.openAI,
+          _meiliIndex: false,
+          expiredAt: null,
+          createdAt: pastDate,
+          updatedAt: pastDate,
+        },
+        {
+          conversationId: new mongoose.Types.ObjectId().toString(),
+          user: new mongoose.Types.ObjectId(),
+          title: 'Old Conversation 2',
+          endpoint: EModelEndpoint.openAI,
+          _meiliIndex: false,
+          expiredAt: null,
+          createdAt: pastDate,
+          updatedAt: pastDate,
+        },
+      ]);
+
+      // Verify timestamps before sync
+      const beforeSync = await conversationModel.find({}).lean();
+      for (const doc of beforeSync) {
+        expect(new Date(doc.updatedAt as Date).getTime()).toBe(pastDate.getTime());
+      }
+
+      // Run sync which calls processSyncBatch internally
+      await conversationModel.syncWithMeili();
+
+      // Verify _meiliIndex was updated
+      const indexedCount = await conversationModel.countDocuments({ _meiliIndex: true });
+      expect(indexedCount).toBe(2);
+
+      // Verify updatedAt was NOT modified
+      const afterSync = await conversationModel.find({}).lean();
+      for (const doc of afterSync) {
+        expect(new Date(doc.updatedAt as Date).getTime()).toBe(pastDate.getTime());
+      }
+    });
+
+    test('syncWithMeili preserves original updatedAt on messages', async () => {
+      const messageModel = createMessageModel(mongoose) as SchemaWithMeiliMethods;
+      await messageModel.deleteMany({});
+      mockAddDocumentsInBatches.mockClear();
+
+      const pastDate = new Date('2023-06-01T08:30:00Z');
+
+      await messageModel.collection.insertMany([
+        {
+          messageId: new mongoose.Types.ObjectId().toString(),
+          conversationId: new mongoose.Types.ObjectId().toString(),
+          user: new mongoose.Types.ObjectId(),
+          isCreatedByUser: true,
+          _meiliIndex: false,
+          expiredAt: null,
+          createdAt: pastDate,
+          updatedAt: pastDate,
+        },
+        {
+          messageId: new mongoose.Types.ObjectId().toString(),
+          conversationId: new mongoose.Types.ObjectId().toString(),
+          user: new mongoose.Types.ObjectId(),
+          isCreatedByUser: false,
+          _meiliIndex: false,
+          expiredAt: null,
+          createdAt: pastDate,
+          updatedAt: pastDate,
+        },
+      ]);
+
+      await messageModel.syncWithMeili();
+
+      const afterSync = await messageModel.find({}).lean();
+      for (const doc of afterSync) {
+        expect(new Date(doc.updatedAt as Date).getTime()).toBe(pastDate.getTime());
+      }
+    });
+  });
+
   describe('Missing _meiliIndex property handling in sync process', () => {
     test('syncWithMeili includes documents with missing _meiliIndex', async () => {
       const conversationModel = createConversationModel(mongoose) as SchemaWithMeiliMethods;

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -257,7 +257,9 @@ const createMeiliMongooseModel = ({
         // Add documents to MeiliSearch
         await index.addDocumentsInBatches(formattedDocs);
 
-        // Update MongoDB to mark documents as indexed
+        // Update MongoDB to mark documents as indexed.
+        // { timestamps: false } prevents Mongoose from touching updatedAt, preserving
+        // original conversation/message timestamps (fixes sidebar chronological sort).
         const docsIds = documents.map((doc) => doc._id);
         await this.updateMany(
           { _id: { $in: docsIds } },

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -259,7 +259,11 @@ const createMeiliMongooseModel = ({
 
         // Update MongoDB to mark documents as indexed
         const docsIds = documents.map((doc) => doc._id);
-        await this.updateMany({ _id: { $in: docsIds } }, { $set: { _meiliIndex: true } });
+        await this.updateMany(
+          { _id: { $in: docsIds } },
+          { $set: { _meiliIndex: true } },
+          { timestamps: false },
+        );
       } catch (error) {
         logger.error('[processSyncBatch] Error processing batch:', error);
         throw error;


### PR DESCRIPTION
Closes https://github.com/danny-avila/LibreChat/issues/12071

## Summary

Fixed a bug where running `npm run reset-meili-sync` caused Mongoose to silently overwrite the `updatedAt` timestamp on every conversation and message in MongoDB, collapsing the sidebar's entire chat history into a single "Today" group and burying genuinely recent conversations.

- Added `{ timestamps: false }` to the `updateMany` call in `processSyncBatch`, suppressing Mongoose's automatic timestamp injection during the internal `_meiliIndex` bookkeeping update (closes #12071).
- Added an inline comment anchoring why the option is required, preventing future regression from a well-intentioned cleanup.
- Added integration tests for both the conversation and message models that insert documents with known past timestamps via raw `collection.insertMany`, run `syncWithMeili`, and assert that `_meiliIndex` was set to `true` and that `updatedAt` was not modified.
- Added pre-sync timestamp guards to validate test setup integrity before the sync runs.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Two integration tests were added to `mongoMeili.spec.ts` under the `processSyncBatch does not modify updatedAt timestamps` describe block. Both use `mongodb-memory-server` for an in-memory MongoDB instance and mock the MeiliSearch client.

### **Test Configuration**:

- `MEILI_HOST=foo`, `MEILI_MASTER_KEY=bar` (env vars set in `beforeAll` to activate the plugin)
- Documents inserted directly via `collection.insertMany` with `updatedAt` set to a fixed past date (`2024-01-15` for conversations, `2023-06-01` for messages)
- Pre-sync assertion confirms the test setup persisted the expected timestamps
- Post-sync assertions confirm both that `_meiliIndex: true` was set on all documents and that `updatedAt` was not changed

To run:
```sh
cd packages/data-schemas && npx jest mongoMeili
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
