### PR TITLE
⚡ refactor: Parallelize CI Workflows with Isolated Caching and Fan-Out Test Jobs

### DIFF
--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -31,7 +31,14 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            api/node_modules
+            client/node_modules
+            packages/api/node_modules
+            packages/client/node_modules
+            packages/data-provider/node_modules
+            packages/data-schemas/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
@@ -109,7 +116,14 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            api/node_modules
+            client/node_modules
+            packages/api/node_modules
+            packages/client/node_modules
+            packages/data-provider/node_modules
+            packages/data-schemas/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
@@ -173,7 +187,14 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            api/node_modules
+            client/node_modules
+            packages/api/node_modules
+            packages/client/node_modules
+            packages/data-provider/node_modules
+            packages/data-schemas/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
@@ -226,7 +247,14 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            api/node_modules
+            client/node_modules
+            packages/api/node_modules
+            packages/client/node_modules
+            packages/data-provider/node_modules
+            packages/data-schemas/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
@@ -259,7 +287,14 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            api/node_modules
+            client/node_modules
+            packages/api/node_modules
+            packages/client/node_modules
+            packages/data-provider/node_modules
+            packages/data-schemas/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
@@ -298,7 +333,14 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            api/node_modules
+            client/node_modules
+            packages/api/node_modules
+            packages/client/node_modules
+            packages/data-provider/node_modules
+            packages/data-schemas/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies

--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
@@ -39,31 +39,58 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Restore build cache
-        id: build-cache
+      - name: Restore data-provider build cache
+        id: cache-data-provider
         uses: actions/cache@v4
         with:
-          path: |
-            packages/data-provider/dist
-            packages/data-schemas/dist
-            packages/api/dist
-          key: build-${{ runner.os }}-${{ hashFiles('packages/data-provider/src/**', 'packages/data-schemas/src/**', 'packages/api/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-schemas/tsconfig*.json', 'packages/api/tsconfig*.json', 'packages/data-provider/rollup.config.js', 'packages/data-schemas/rollup.config.js', 'packages/api/server-rollup.config.js', 'packages/data-provider/package.json', 'packages/data-schemas/package.json', 'packages/api/package.json') }}
+          path: packages/data-provider/dist
+          key: build-data-provider-${{ runner.os }}-${{ hashFiles('packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/rollup.config.js', 'packages/data-provider/package.json') }}
 
-      - name: Build packages
-        if: steps.build-cache.outputs.cache-hit != 'true'
-        run: |
-          npm run build:data-provider
-          npm run build:data-schemas
-          npm run build:api
+      - name: Build data-provider
+        if: steps.cache-data-provider.outputs.cache-hit != 'true'
+        run: npm run build:data-provider
 
-      - name: Upload build artifacts
+      - name: Restore data-schemas build cache
+        id: cache-data-schemas
+        uses: actions/cache@v4
+        with:
+          path: packages/data-schemas/dist
+          key: build-data-schemas-${{ runner.os }}-${{ hashFiles('packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/rollup.config.js', 'packages/data-schemas/package.json', 'packages/data-provider/src/**') }}
+
+      - name: Build data-schemas
+        if: steps.cache-data-schemas.outputs.cache-hit != 'true'
+        run: npm run build:data-schemas
+
+      - name: Restore api build cache
+        id: cache-api
+        uses: actions/cache@v4
+        with:
+          path: packages/api/dist
+          key: build-api-${{ runner.os }}-${{ hashFiles('packages/api/src/**', 'packages/api/tsconfig*.json', 'packages/api/server-rollup.config.js', 'packages/api/package.json', 'packages/data-provider/src/**', 'packages/data-schemas/src/**') }}
+
+      - name: Build api
+        if: steps.cache-api.outputs.cache-hit != 'true'
+        run: npm run build:api
+
+      - name: Upload data-provider build
         uses: actions/upload-artifact@v4
         with:
-          name: package-builds
-          path: |
-            packages/data-provider/dist
-            packages/data-schemas/dist
-            packages/api/dist
+          name: build-data-provider
+          path: packages/data-provider/dist
+          retention-days: 1
+
+      - name: Upload data-schemas build
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-data-schemas
+          path: packages/data-schemas/dist
+          retention-days: 1
+
+      - name: Upload api build
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-api
+          path: packages/api/dist
           retention-days: 1
 
   circular-deps:
@@ -74,7 +101,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
@@ -86,7 +113,20 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: package-builds
+          name: build-data-provider
+          path: packages/data-provider/dist
+
+      - name: Download data-schemas build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-data-schemas
+          path: packages/data-schemas/dist
+
+      - name: Download api build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-api
+          path: packages/api/dist
 
       - name: Detect circular dependencies in @librechat/api build
         run: |
@@ -115,7 +155,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
@@ -124,10 +164,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifacts
+      - name: Download data-provider build
         uses: actions/download-artifact@v4
         with:
-          name: package-builds
+          name: build-data-provider
+          path: packages/data-provider/dist
+
+      - name: Download data-schemas build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-data-schemas
+          path: packages/data-schemas/dist
+
+      - name: Download api build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-api
+          path: packages/api/dist
 
       - name: Create empty auth.json file
         run: |
@@ -148,7 +201,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
@@ -157,10 +210,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifacts
+      - name: Download data-provider build
         uses: actions/download-artifact@v4
         with:
-          name: package-builds
+          name: build-data-provider
+          path: packages/data-provider/dist
 
       - name: Run unit tests
         run: cd packages/data-provider && npm run test:ci
@@ -173,7 +227,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
@@ -182,10 +236,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifacts
+      - name: Download data-provider build
         uses: actions/download-artifact@v4
         with:
-          name: package-builds
+          name: build-data-provider
+          path: packages/data-provider/dist
+
+      - name: Download data-schemas build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-data-schemas
+          path: packages/data-schemas/dist
 
       - name: Run unit tests
         run: cd packages/data-schemas && npm run test:ci
@@ -198,7 +259,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js 20.x
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
@@ -207,10 +268,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Download build artifacts
+      - name: Download data-provider build
         uses: actions/download-artifact@v4
         with:
-          name: package-builds
+          name: build-data-provider
+          path: packages/data-provider/dist
+
+      - name: Download data-schemas build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-data-schemas
+          path: packages/data-schemas/dist
+
+      - name: Download api build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-api
+          path: packages/api/dist
 
       - name: Run unit tests
         run: cd packages/api && npm run test:ci

--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -34,9 +34,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
-          cache: 'npm'
+
+      - name: Restore node_modules cache
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Restore data-provider build cache
@@ -105,12 +112,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
-          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Download build artifacts
+      - name: Download data-provider build
         uses: actions/download-artifact@v4
         with:
           name: build-data-provider
@@ -159,10 +168,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
-          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Download data-provider build
         uses: actions/download-artifact@v4
@@ -205,10 +216,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
-          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Download data-provider build
         uses: actions/download-artifact@v4
@@ -231,10 +244,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
-          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Download data-provider build
         uses: actions/download-artifact@v4
@@ -263,10 +278,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
-          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Download data-provider build
         uses: actions/download-artifact@v4

--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -13,14 +13,6 @@ on:
 env:
   NODE_ENV: CI
   NODE_OPTIONS: '--max-old-space-size=${{ secrets.NODE_MAX_OLD_SPACE_SIZE || 6144 }}'
-  MONGO_URI: ${{ secrets.MONGO_URI }}
-  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-  JWT_SECRET: ${{ secrets.JWT_SECRET }}
-  CREDS_KEY: ${{ secrets.CREDS_KEY }}
-  CREDS_IV: ${{ secrets.CREDS_IV }}
-  BAN_VIOLATIONS: ${{ secrets.BAN_VIOLATIONS }}
-  BAN_DURATION: ${{ secrets.BAN_DURATION }}
-  BAN_INTERVAL: ${{ secrets.BAN_INTERVAL }}
 
 jobs:
   build:
@@ -30,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Use Node.js 20.19
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
@@ -62,7 +54,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packages/data-schemas/dist
-          key: build-data-schemas-${{ runner.os }}-${{ hashFiles('packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/rollup.config.js', 'packages/data-schemas/package.json', 'packages/data-provider/src/**') }}
+          key: build-data-schemas-${{ runner.os }}-${{ hashFiles('packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/rollup.config.js', 'packages/data-schemas/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/rollup.config.js', 'packages/data-provider/package.json') }}
 
       - name: Build data-schemas
         if: steps.cache-data-schemas.outputs.cache-hit != 'true'
@@ -73,7 +65,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packages/api/dist
-          key: build-api-${{ runner.os }}-${{ hashFiles('packages/api/src/**', 'packages/api/tsconfig*.json', 'packages/api/server-rollup.config.js', 'packages/api/package.json', 'packages/data-provider/src/**', 'packages/data-schemas/src/**') }}
+          key: build-api-${{ runner.os }}-${{ hashFiles('packages/api/src/**', 'packages/api/tsconfig*.json', 'packages/api/server-rollup.config.js', 'packages/api/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/rollup.config.js', 'packages/data-provider/package.json', 'packages/data-schemas/src/**', 'packages/data-schemas/tsconfig*.json', 'packages/data-schemas/rollup.config.js', 'packages/data-schemas/package.json') }}
 
       - name: Build api
         if: steps.cache-api.outputs.cache-hit != 'true'
@@ -84,21 +76,21 @@ jobs:
         with:
           name: build-data-provider
           path: packages/data-provider/dist
-          retention-days: 1
+          retention-days: 2
 
       - name: Upload data-schemas build
         uses: actions/upload-artifact@v4
         with:
           name: build-data-schemas
           path: packages/data-schemas/dist
-          retention-days: 1
+          retention-days: 2
 
       - name: Upload api build
         uses: actions/upload-artifact@v4
         with:
           name: build-api
           path: packages/api/dist
-          retention-days: 1
+          retention-days: 2
 
   circular-deps:
     name: Circular dependency checks
@@ -108,16 +100,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Use Node.js 20.19
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
 
       - name: Restore node_modules cache
+        id: cache-node-modules
         uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Download data-provider build
         uses: actions/download-artifact@v4
@@ -131,13 +128,7 @@ jobs:
           name: build-data-schemas
           path: packages/data-schemas/dist
 
-      - name: Download api build
-        uses: actions/download-artifact@v4
-        with:
-          name: build-api
-          path: packages/api/dist
-
-      - name: Detect circular dependencies in @librechat/api build
+      - name: Rebuild @librechat/api and check for circular dependencies
         run: |
           output=$(npm run build:api 2>&1)
           echo "$output"
@@ -161,19 +152,33 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      MONGO_URI: ${{ secrets.MONGO_URI }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      CREDS_KEY: ${{ secrets.CREDS_KEY }}
+      CREDS_IV: ${{ secrets.CREDS_IV }}
+      BAN_VIOLATIONS: ${{ secrets.BAN_VIOLATIONS }}
+      BAN_DURATION: ${{ secrets.BAN_DURATION }}
+      BAN_INTERVAL: ${{ secrets.BAN_INTERVAL }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Use Node.js 20.19
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
 
       - name: Restore node_modules cache
+        id: cache-node-modules
         uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Download data-provider build
         uses: actions/download-artifact@v4
@@ -212,16 +217,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Use Node.js 20.19
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
 
       - name: Restore node_modules cache
+        id: cache-node-modules
         uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Download data-provider build
         uses: actions/download-artifact@v4
@@ -240,16 +250,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Use Node.js 20.19
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
 
       - name: Restore node_modules cache
+        id: cache-node-modules
         uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Download data-provider build
         uses: actions/download-artifact@v4
@@ -274,16 +289,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Use Node.js 20.19
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
 
       - name: Restore node_modules cache
+        id: cache-node-modules
         uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Download data-provider build
         uses: actions/download-artifact@v4

--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -9,40 +9,86 @@ on:
     paths:
       - 'api/**'
       - 'packages/**'
+
+env:
+  NODE_ENV: CI
+  NODE_OPTIONS: '--max-old-space-size=${{ secrets.NODE_MAX_OLD_SPACE_SIZE || 6144 }}'
+  MONGO_URI: ${{ secrets.MONGO_URI }}
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  JWT_SECRET: ${{ secrets.JWT_SECRET }}
+  CREDS_KEY: ${{ secrets.CREDS_KEY }}
+  CREDS_IV: ${{ secrets.CREDS_IV }}
+  BAN_VIOLATIONS: ${{ secrets.BAN_VIOLATIONS }}
+  BAN_DURATION: ${{ secrets.BAN_DURATION }}
+  BAN_INTERVAL: ${{ secrets.BAN_INTERVAL }}
+
 jobs:
-  tests_Backend:
-    name: Run Backend unit tests
-    timeout-minutes: 60
+  build:
+    name: Build packages
     runs-on: ubuntu-latest
-    env:
-      MONGO_URI: ${{ secrets.MONGO_URI }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      CREDS_KEY: ${{ secrets.CREDS_KEY }}
-      CREDS_IV: ${{ secrets.CREDS_IV }}
-      BAN_VIOLATIONS: ${{ secrets.BAN_VIOLATIONS }}
-      BAN_DURATION: ${{ secrets.BAN_DURATION }}
-      BAN_INTERVAL: ${{ secrets.BAN_INTERVAL }}
-      NODE_ENV: CI
-      NODE_OPTIONS: '--max-old-space-size=${{ secrets.NODE_MAX_OLD_SPACE_SIZE || 6144 }}'
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: '20.19'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Data Provider Package
-        run: npm run build:data-provider
+      - name: Restore build cache
+        id: build-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/data-provider/dist
+            packages/data-schemas/dist
+            packages/api/dist
+          key: build-${{ runner.os }}-${{ hashFiles('packages/data-provider/src/**', 'packages/data-schemas/src/**', 'packages/api/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-schemas/tsconfig*.json', 'packages/api/tsconfig*.json', 'packages/data-provider/rollup.config.js', 'packages/data-schemas/rollup.config.js', 'packages/api/server-rollup.config.js', 'packages/data-provider/package.json', 'packages/data-schemas/package.json', 'packages/api/package.json') }}
 
-      - name: Install Data Schemas Package
-        run: npm run build:data-schemas
+      - name: Build packages
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: |
+          npm run build:data-provider
+          npm run build:data-schemas
+          npm run build:api
 
-      - name: Build API Package & Detect Circular Dependencies
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-builds
+          path: |
+            packages/data-provider/dist
+            packages/data-schemas/dist
+            packages/api/dist
+          retention-days: 1
+
+  circular-deps:
+    name: Circular dependency checks
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: package-builds
+
+      - name: Detect circular dependencies in @librechat/api build
         run: |
           output=$(npm run build:api 2>&1)
           echo "$output"
@@ -51,12 +97,7 @@ jobs:
             exit 1
           fi
 
-      - name: Create empty auth.json file
-        run: |
-          mkdir -p api/data
-          echo '{}' > api/data/auth.json
-
-      - name: Check for Circular dependency in rollup
+      - name: Detect circular dependencies in rollup
         working-directory: ./packages/data-provider
         run: |
           output=$(npm run rollup:api)
@@ -66,17 +107,110 @@ jobs:
             exit 1
           fi
 
+  test-api:
+    name: 'Tests: api'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: package-builds
+
+      - name: Create empty auth.json file
+        run: |
+          mkdir -p api/data
+          echo '{}' > api/data/auth.json
+
       - name: Prepare .env.test file
         run: cp api/test/.env.test.example api/test/.env.test
 
       - name: Run unit tests
         run: cd api && npm run test:ci
 
-      - name: Run librechat-data-provider unit tests
+  test-data-provider:
+    name: 'Tests: data-provider'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: package-builds
+
+      - name: Run unit tests
         run: cd packages/data-provider && npm run test:ci
 
-      - name: Run @librechat/data-schemas unit tests
+  test-data-schemas:
+    name: 'Tests: data-schemas'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: package-builds
+
+      - name: Run unit tests
         run: cd packages/data-schemas && npm run test:ci
 
-      - name: Run @librechat/api unit tests
+  test-packages-api:
+    name: 'Tests: @librechat/api'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: package-builds
+
+      - name: Run unit tests
         run: cd packages/api && npm run test:ci

--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -39,7 +39,7 @@ jobs:
             packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -124,7 +124,7 @@ jobs:
             packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -195,7 +195,7 @@ jobs:
             packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -255,7 +255,7 @@ jobs:
             packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -295,7 +295,7 @@ jobs:
             packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -341,7 +341,7 @@ jobs:
             packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/backend-review.yml
+++ b/.github/workflows/backend-review.yml
@@ -34,12 +34,10 @@ jobs:
           path: |
             node_modules
             api/node_modules
-            client/node_modules
             packages/api/node_modules
-            packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
+          key: node-modules-backend-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -119,12 +117,10 @@ jobs:
           path: |
             node_modules
             api/node_modules
-            client/node_modules
             packages/api/node_modules
-            packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
+          key: node-modules-backend-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -190,12 +186,10 @@ jobs:
           path: |
             node_modules
             api/node_modules
-            client/node_modules
             packages/api/node_modules
-            packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
+          key: node-modules-backend-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -250,12 +244,10 @@ jobs:
           path: |
             node_modules
             api/node_modules
-            client/node_modules
             packages/api/node_modules
-            packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
+          key: node-modules-backend-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -290,12 +282,10 @@ jobs:
           path: |
             node_modules
             api/node_modules
-            client/node_modules
             packages/api/node_modules
-            packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
+          key: node-modules-backend-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -336,12 +326,10 @@ jobs:
           path: |
             node_modules
             api/node_modules
-            client/node_modules
             packages/api/node_modules
-            packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
+          key: node-modules-backend-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Use Node.js 20.19
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
@@ -54,7 +54,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packages/client/dist
-          key: build-client-package-${{ runner.os }}-${{ hashFiles('packages/client/src/**', 'packages/client/tsconfig*.json', 'packages/client/rollup.config.js', 'packages/client/package.json', 'packages/data-provider/src/**') }}
+          key: build-client-package-${{ runner.os }}-${{ hashFiles('packages/client/src/**', 'packages/client/tsconfig*.json', 'packages/client/rollup.config.js', 'packages/client/package.json', 'packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/rollup.config.js', 'packages/data-provider/package.json') }}
 
       - name: Build client-package
         if: steps.cache-client-package.outputs.cache-hit != 'true'
@@ -65,14 +65,14 @@ jobs:
         with:
           name: build-data-provider
           path: packages/data-provider/dist
-          retention-days: 1
+          retention-days: 2
 
       - name: Upload client-package build
         uses: actions/upload-artifact@v4
         with:
           name: build-client-package
           path: packages/client/dist
-          retention-days: 1
+          retention-days: 2
 
   test-ubuntu:
     name: 'Tests: Ubuntu'
@@ -82,16 +82,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Use Node.js 20.19
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
 
       - name: Restore node_modules cache
+        id: cache-node-modules
         uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Download data-provider build
         uses: actions/download-artifact@v4
@@ -117,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Use Node.js 20.19
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
@@ -157,16 +162,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Use Node.js 20.19
         uses: actions/setup-node@v4
         with:
           node-version: '20.19'
 
       - name: Restore node_modules cache
+        id: cache-node-modules
         uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Download data-provider build
         uses: actions/download-artifact@v4

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -31,7 +31,14 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            api/node_modules
+            client/node_modules
+            packages/api/node_modules
+            packages/client/node_modules
+            packages/data-provider/node_modules
+            packages/data-schemas/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
@@ -91,7 +98,14 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            api/node_modules
+            client/node_modules
+            packages/api/node_modules
+            packages/client/node_modules
+            packages/data-provider/node_modules
+            packages/data-schemas/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
@@ -131,7 +145,14 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            api/node_modules
+            client/node_modules
+            packages/api/node_modules
+            packages/client/node_modules
+            packages/data-provider/node_modules
+            packages/data-schemas/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
@@ -171,7 +192,14 @@ jobs:
         id: cache-node-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            api/node_modules
+            client/node_modules
+            packages/api/node_modules
+            packages/client/node_modules
+            packages/data-provider/node_modules
+            packages/data-schemas/node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -39,7 +39,7 @@ jobs:
             packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -106,7 +106,7 @@ jobs:
             packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -153,7 +153,7 @@ jobs:
             packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -200,7 +200,7 @@ jobs:
             packages/client/node_modules
             packages/data-provider/node_modules
             packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -2,7 +2,7 @@ name: Frontend Unit Tests
 
 on:
   pull_request:
-    branches: 
+    branches:
       - main
       - dev
       - dev-staging
@@ -11,51 +11,174 @@ on:
       - 'client/**'
       - 'packages/data-provider/**'
 
+env:
+  NODE_OPTIONS: '--max-old-space-size=${{ secrets.NODE_MAX_OLD_SPACE_SIZE || 6144 }}'
+
 jobs:
-  tests_frontend_ubuntu:
-    name: Run frontend unit tests on Ubuntu
-    timeout-minutes: 60
+  build:
+    name: Build packages
     runs-on: ubuntu-latest
-    env:
-      NODE_OPTIONS: '--max-old-space-size=${{ secrets.NODE_MAX_OLD_SPACE_SIZE || 6144 }}'
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: 'npm'
+          node-version: '20.19'
+
+      - name: Restore node_modules cache
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Build Client
-        run: npm run frontend:ci
+      - name: Restore data-provider build cache
+        id: cache-data-provider
+        uses: actions/cache@v4
+        with:
+          path: packages/data-provider/dist
+          key: build-data-provider-${{ runner.os }}-${{ hashFiles('packages/data-provider/src/**', 'packages/data-provider/tsconfig*.json', 'packages/data-provider/rollup.config.js', 'packages/data-provider/package.json') }}
+
+      - name: Build data-provider
+        if: steps.cache-data-provider.outputs.cache-hit != 'true'
+        run: npm run build:data-provider
+
+      - name: Restore client-package build cache
+        id: cache-client-package
+        uses: actions/cache@v4
+        with:
+          path: packages/client/dist
+          key: build-client-package-${{ runner.os }}-${{ hashFiles('packages/client/src/**', 'packages/client/tsconfig*.json', 'packages/client/rollup.config.js', 'packages/client/package.json', 'packages/data-provider/src/**') }}
+
+      - name: Build client-package
+        if: steps.cache-client-package.outputs.cache-hit != 'true'
+        run: npm run build:client-package
+
+      - name: Upload data-provider build
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-data-provider
+          path: packages/data-provider/dist
+          retention-days: 1
+
+      - name: Upload client-package build
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-client-package
+          path: packages/client/dist
+          retention-days: 1
+
+  test-ubuntu:
+    name: 'Tests: Ubuntu'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19'
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Download data-provider build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-data-provider
+          path: packages/data-provider/dist
+
+      - name: Download client-package build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-client-package
+          path: packages/client/dist
 
       - name: Run unit tests
         run: npm run test:ci --verbose
         working-directory: client
 
-  tests_frontend_windows:
-    name: Run frontend unit tests on Windows
-    timeout-minutes: 60
+  test-windows:
+    name: 'Tests: Windows'
+    needs: build
     runs-on: windows-latest
-    env:
-      NODE_OPTIONS: '--max-old-space-size=${{ secrets.NODE_MAX_OLD_SPACE_SIZE || 6144 }}'
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
+
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: 'npm'
+          node-version: '20.19'
+
+      - name: Restore node_modules cache
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Build Client
-        run: npm run frontend:ci
+      - name: Download data-provider build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-data-provider
+          path: packages/data-provider/dist
+
+      - name: Download client-package build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-client-package
+          path: packages/client/dist
 
       - name: Run unit tests
         run: npm run test:ci --verbose
         working-directory: client
+
+  build-verify:
+    name: Vite build verification
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19'
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Download data-provider build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-data-provider
+          path: packages/data-provider/dist
+
+      - name: Download client-package build
+        uses: actions/download-artifact@v4
+        with:
+          name: build-client-package
+          path: packages/client/dist
+
+      - name: Build client
+        run: cd client && npm run build:ci

--- a/.github/workflows/frontend-review.yml
+++ b/.github/workflows/frontend-review.yml
@@ -33,13 +33,10 @@ jobs:
         with:
           path: |
             node_modules
-            api/node_modules
             client/node_modules
-            packages/api/node_modules
             packages/client/node_modules
             packages/data-provider/node_modules
-            packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
+          key: node-modules-frontend-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -100,13 +97,10 @@ jobs:
         with:
           path: |
             node_modules
-            api/node_modules
             client/node_modules
-            packages/api/node_modules
             packages/client/node_modules
             packages/data-provider/node_modules
-            packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
+          key: node-modules-frontend-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -147,13 +141,10 @@ jobs:
         with:
           path: |
             node_modules
-            api/node_modules
             client/node_modules
-            packages/api/node_modules
             packages/client/node_modules
             packages/data-provider/node_modules
-            packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
+          key: node-modules-frontend-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
@@ -194,13 +185,10 @@ jobs:
         with:
           path: |
             node_modules
-            api/node_modules
             client/node_modules
-            packages/api/node_modules
             packages/client/node_modules
             packages/data-provider/node_modules
-            packages/data-schemas/node_modules
-          key: node-modules-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
+          key: node-modules-frontend-${{ runner.os }}-20.19-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'

--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   clearMocks: true,
   roots: ['<rootDir>'],
   coverageDirectory: 'coverage',
+  maxWorkers: '50%',
   testTimeout: 30000, // 30 seconds timeout for all tests
   setupFiles: ['./test/jestSetup.js', './test/__mocks__/logger.js'],
   moduleNameMapper: {

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -32,6 +32,7 @@ module.exports = {
     '^librechat-data-provider/react-query$':
       '<rootDir>/../node_modules/librechat-data-provider/src/react-query',
   },
+  maxWorkers: '50%',
   restoreMocks: true,
   testResultsProcessor: 'jest-junit',
   coverageReporters: ['text', 'cobertura', 'lcov'],

--- a/packages/api/jest.config.mjs
+++ b/packages/api/jest.config.mjs
@@ -33,6 +33,7 @@ export default {
   //     lines: 57,
   //   },
   // },
+  maxWorkers: '50%',
   restoreMocks: true,
   testTimeout: 15000,
 };

--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -16,6 +16,7 @@ export default {
   //     lines: 57,
   //   },
   // },
+  maxWorkers: '50%',
   restoreMocks: true,
   testTimeout: 15000,
   // React component testing requires jsdom environment

--- a/packages/data-provider/jest.config.js
+++ b/packages/data-provider/jest.config.js
@@ -14,5 +14,6 @@ module.exports = {
   //     lines: 57,
   //   },
   // },
+  maxWorkers: '50%',
   restoreMocks: true,
 };

--- a/packages/data-schemas/jest.config.mjs
+++ b/packages/data-schemas/jest.config.mjs
@@ -15,6 +15,7 @@ export default {
   //     lines: 57,
   //   },
   // },
+  maxWorkers: '50%',
   restoreMocks: true,
   testTimeout: 15000,
 };


### PR DESCRIPTION


## Summary

Refactored both the backend and frontend GitHub Actions CI workflows from single monolithic serial jobs into parallelized fan-out architectures, with a shared build job, isolated dependency caching, and separate downstream test jobs per package.

- Replaced the single `tests_Backend` and `tests_frontend_ubuntu/windows` jobs with a `build` job that compiles all packages, uploads build artifacts, and feeds all downstream jobs via `needs: build`.
- Added discrete downstream jobs — `circular-deps`, `test-api`, `test-data-provider`, `test-data-schemas`, `test-packages-api` (backend) and `test-ubuntu`, `test-windows`, `build-verify` (frontend) — enabling parallel execution across all test suites.
- Scoped sensitive secrets (`MONGO_URI`, `JWT_SECRET`, `CREDS_KEY`, `CREDS_IV`, `OPENAI_API_KEY`, `BAN_*`) exclusively to the `test-api` job-level `env`, removing them from the workflow-level `env` where they were unnecessarily exposed to all jobs.
- Implemented `node_modules` caching with workflow-isolated keys (`node-modules-backend-` / `node-modules-frontend-`) to prevent cross-workflow cache collisions, scoping each cache to only the workspace directories relevant to that workflow.
- Included the Node.js version (`20.19`) in all `node_modules` cache keys to prevent ABI mismatch restores when the version changes.
- Added conditional `npm ci` fallback on every job so dependency installation self-heals on any cache miss.
- Extended build artifact `retention-days` from 1 to 2 on all uploads.
- Expanded build cache keys for `data-schemas` and `packages/api` to include upstream dependency config files (`tsconfig*.json`, `rollup.config.js`, `package.json`), preventing stale cached builds from config-only changes.
- Pinned `node-version` to `'20.19'` across all jobs in both workflows, replacing the previous loose `20` specifier.
- Added `maxWorkers: '50%'` to all 6 Jest configs (`api`, `packages/api`, `packages/data-schemas`, `packages/data-provider`, `client`, `packages/client`) for consistent worker-count behavior across all test suites.

## Change Type

- [ ] New feature (non-breaking change which adds functionality)

## Testing

CI workflow changes are validated by observing the GitHub Actions runs triggered by this PR. Verify the following on a passing run:

- `build` job completes and all three artifacts (`build-data-provider`, `build-data-schemas`, `build-api`) appear in the run's artifact list.
- `circular-deps`, `test-api`, `test-data-provider`, `test-data-schemas`, `test-packages-api` all run in parallel after `build` completes.
- `test-api` is the only job with `MONGO_URI` / `JWT_SECRET` / credential env vars visible in its step environment.
- A second run against the same lockfile and source confirms cache hits on `node_modules` and all build caches, skipping `npm ci` and the build steps.

### **Test Configuration**:

- Runner: `ubuntu-latest` (backend + frontend Ubuntu jobs), `windows-latest` (frontend Windows job)
- Node.js: `20.19`
- `NODE_ENV`: `CI`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings