### PR TITLE
🔒 refactor: Set `ALLOW_SHARED_LINKS_PUBLIC` to `false` by Default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -677,6 +677,7 @@ AZURE_CONTAINER_NAME=files
 #========================#
 
 ALLOW_SHARED_LINKS=true
+# Allows unauthenticated access to shared links. Defaults to false (auth required) if not set.
 ALLOW_SHARED_LINKS_PUBLIC=false
 
 #==============================#

--- a/.env.example
+++ b/.env.example
@@ -677,7 +677,7 @@ AZURE_CONTAINER_NAME=files
 #========================#
 
 ALLOW_SHARED_LINKS=true
-ALLOW_SHARED_LINKS_PUBLIC=true
+ALLOW_SHARED_LINKS_PUBLIC=false
 
 #==============================#
 # Static File Cache Control    #

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -16,9 +16,7 @@ const sharedLinksEnabled =
   process.env.ALLOW_SHARED_LINKS === undefined || isEnabled(process.env.ALLOW_SHARED_LINKS);
 
 const publicSharedLinksEnabled =
-  sharedLinksEnabled &&
-  (process.env.ALLOW_SHARED_LINKS_PUBLIC === undefined ||
-    isEnabled(process.env.ALLOW_SHARED_LINKS_PUBLIC));
+  sharedLinksEnabled && isEnabled(process.env.ALLOW_SHARED_LINKS_PUBLIC);
 
 const sharePointFilePickerEnabled = isEnabled(process.env.ENABLE_SHAREPOINT_FILEPICKER);
 const openidReuseTokens = isEnabled(process.env.OPENID_REUSE_TOKENS);

--- a/api/server/routes/share.js
+++ b/api/server/routes/share.js
@@ -19,9 +19,7 @@ const allowSharedLinks =
   process.env.ALLOW_SHARED_LINKS === undefined || isEnabled(process.env.ALLOW_SHARED_LINKS);
 
 if (allowSharedLinks) {
-  const allowSharedLinksPublic =
-    process.env.ALLOW_SHARED_LINKS_PUBLIC === undefined ||
-    isEnabled(process.env.ALLOW_SHARED_LINKS_PUBLIC);
+  const allowSharedLinksPublic = isEnabled(process.env.ALLOW_SHARED_LINKS_PUBLIC);
   router.get(
     '/:shareId',
     allowSharedLinksPublic ? (req, res, next) => next() : requireJwtAuth,


### PR DESCRIPTION
## Summary

Shared links were publicly accessible by default when ALLOW_SHARED_LINKS_PUBLIC was not explicitly set, which could lead to unintentional data exposure. Users may assume their authentication settings protect shared links when they do not.

This changes the default behavior so shared links require JWT authentication unless ALLOW_SHARED_LINKS_PUBLIC is explicitly set to true.

This may cause an inconvenience for stacks that did not explicitly set the flag and cause a soft break of their functionality but that is to the benefit of secure by default.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

1. Make sure `ALLOW_SHARED_LINKS_PUBLIC` is not set in `librechat.yaml` or `.env`
2. Create a conversation in LibreChat with authentication enabled
3. Create a shareable link for that conversation
4. Open the link in a browser with incognito mode enabled
5. You should NOT see the conversation, instead you see the login page

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] A pull request for updating the documentation has been submitted: https://github.com/LibreChat-AI/librechat.ai/pull/524
