### PR TITLE
refactor(mcp): let callers declare OpenAI-compatible endpoints in formatToolContent

### DIFF
--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -778,6 +778,7 @@ Please follow these instructions when using tools from the respective MCP server
     serverConfig: providedConfig,
     toolName,
     provider,
+    providerIsOpenAICompatible,
     toolArguments,
     options,
     tokenMethods,
@@ -797,6 +798,12 @@ Please follow these instructions when using tools from the respective MCP server
     serverConfig?: t.ParsedServerConfig;
     toolName: string;
     provider: t.Provider;
+    /**
+     * Whether `provider` speaks the OpenAI message format. Custom endpoints are
+     * OpenAI-compatible by definition but arrive under their own name, which
+     * `formatToolContent` cannot infer on its own.
+     */
+    providerIsOpenAICompatible?: boolean;
     toolArguments?: Record<string, unknown>;
     options?: RequestOptions;
     requestBody?: RequestBody;
@@ -1135,7 +1142,9 @@ Please follow these instructions when using tools from the respective MCP server
           await this.updateUserLastActivity(userId);
         }
         this.checkIdleConnections();
-        return formatToolContent(result as t.MCPToolCallResponse, provider);
+        return formatToolContent(result as t.MCPToolCallResponse, provider, {
+          openAICompatible: providerIsOpenAICompatible,
+        });
       } catch (error) {
         if (error instanceof OAuthRecoveryTakeoverRequired) {
           recoveryTakeoverConsumed = true;

--- a/packages/api/src/mcp/__tests__/parsers.test.ts
+++ b/packages/api/src/mcp/__tests__/parsers.test.ts
@@ -1,5 +1,5 @@
-import { formatToolContent } from '../parsers';
 import type * as t from '../types';
+import { formatToolContent } from '../parsers';
 
 describe('formatToolContent', () => {
   describe('unrecognized providers', () => {
@@ -502,6 +502,75 @@ describe('formatToolContent', () => {
       const [content, artifacts] = formatToolContent(result, 'google');
       expect(content).toBe('Response with metadata');
       expect(artifacts).toBeUndefined();
+    });
+  });
+
+  describe('caller-declared OpenAI-compatible custom endpoints', () => {
+    it('formats structured content for a declared-compatible custom endpoint', () => {
+      const result: t.MCPToolCallResponse = {
+        content: [
+          { type: 'text', text: 'First text' },
+          { type: 'text', text: 'Second text' },
+        ],
+      };
+
+      // scaleway is a custom OpenAI-compatible endpoint: not in RECOGNIZED_PROVIDERS,
+      // so the caller has to declare the compatibility.
+      const [content, artifacts] = formatToolContent(result, 'scaleway' as t.Provider, {
+        openAICompatible: true,
+      });
+      expect(content).toBe('First text\n\nSecond text');
+      expect(artifacts).toBeUndefined();
+    });
+
+    it('extracts images to artifacts for a declared-compatible custom endpoint', () => {
+      const result: t.MCPToolCallResponse = {
+        content: [
+          { type: 'text', text: 'Before image' },
+          { type: 'image', data: 'base64data', mimeType: 'image/png' },
+          { type: 'text', text: 'After image' },
+        ],
+      };
+
+      // Another custom endpoint (e.g. together, perplexity) is treated like OpenAI.
+      const [content, artifacts] = formatToolContent(result, 'together' as t.Provider, {
+        openAICompatible: true,
+      });
+      expect(content).toBe('Before image\n\nAfter image');
+      expect(artifacts).toEqual({
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,base64data' },
+          },
+        ],
+      });
+    });
+
+    it('ignores the claim for providers known not to be OpenAI-compatible', () => {
+      const result: t.MCPToolCallResponse = {
+        content: [{ type: 'text', text: 'Test content' }],
+      };
+
+      // bedrock is in NON_OPENAI_PROVIDERS but also in RECOGNIZED_PROVIDERS, so it is
+      // recognized via the allowlist and keeps unified string output - and a caller
+      // claiming OpenAI compatibility for it must not change that.
+      const [content, artifacts] = formatToolContent(result, 'bedrock' as t.Provider, {
+        openAICompatible: true,
+      });
+      expect(typeof content).toBe('string');
+      expect(content).toBe('Test content');
+      expect(artifacts).toBeUndefined();
+    });
+
+    it('keeps the conservative string fallback when the caller says nothing', () => {
+      const result: t.MCPToolCallResponse = {
+        content: [{ type: 'image', data: 'base64data', mimeType: 'image/png' }],
+      };
+
+      const [content, artifacts] = formatToolContent(result, 'scaleway' as t.Provider);
+      expect(artifacts).toBeUndefined();
+      expect(content).toContain('base64data');
     });
   });
 });

--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -66,6 +66,30 @@ const RECOGNIZED_PROVIDERS = new Set([
   'bedrock',
 ]);
 
+/**
+ * Providers known NOT to speak the OpenAI message format. Used only to reject a caller's
+ * `openAICompatible` claim that contradicts a provider we already know about.
+ */
+const NON_OPENAI_PROVIDERS = new Set(['google', 'anthropic', 'bedrock', 'ollama']);
+
+/**
+ * Whether a provider should get structured content formatting for MCP tool results.
+ *
+ * A custom endpoint reaches this function under its own name ("scaleway", "together",
+ * "perplexity", ...) and never as "openai", so the allowlist cannot recognize it and the
+ * result silently degrades to `parseAsString` - images included, which is how an MCP image
+ * tool ends up returning base64 as chat text on a custom endpoint.
+ *
+ * The provider string alone cannot answer this, so the caller declares it via
+ * `openAICompatible`. Unset keeps the conservative allowlist behaviour.
+ */
+function isRecognizedProvider(provider: t.Provider, openAICompatible?: boolean): boolean {
+  if (RECOGNIZED_PROVIDERS.has(provider)) {
+    return true;
+  }
+  return openAICompatible === true && !NON_OPENAI_PROVIDERS.has(provider);
+}
+
 const imageFormatters: Record<string, undefined | t.ImageFormatter> = {
   // google: (item) => ({
   //   type: 'image',
@@ -141,8 +165,16 @@ function parseAsString(result: t.MCPToolCallResponse): string {
 export function formatToolContent(
   result: t.MCPToolCallResponse,
   provider: t.Provider,
+  options?: {
+    /**
+     * Set when the caller knows this provider speaks the OpenAI message format - notably a
+     * custom endpoint, which is OpenAI-compatible by definition but arrives under its own
+     * name. Without it, unknown providers keep the conservative string fallback.
+     */
+    openAICompatible?: boolean;
+  },
 ): t.FormattedContentResult {
-  if (!RECOGNIZED_PROVIDERS.has(provider)) {
+  if (!isRecognizedProvider(provider, options?.openAICompatible)) {
     return [parseAsString(result), undefined];
   }
 


### PR DESCRIPTION
style: sort imports in the parser test

Signed-off-by: JumpLink <pascal@artandcode.studio>

refactor(mcp): let callers declare OpenAI-compatible endpoints in formatToolContent

`formatToolContent` decides between structured content and a flat string via an
allowlist of provider names. A custom endpoint never appears in it: it arrives
under its own name ("scaleway", "together", "perplexity", ...) and never as
"openai", so every custom OpenAI-compatible endpoint silently falls back to
`parseAsString`.

The visible effect is that an MCP tool returning an image gives the user base64
as chat text instead of an image, on a provider that would have accepted the
structured form.

The provider string cannot answer this question by itself, so this adds an
explicit `openAICompatible` option instead of guessing:

```ts
formatToolContent(result, provider, { openAICompatible: true });
```

- unset keeps today's behaviour exactly, including the conservative string
  fallback for genuinely unknown providers (upstream's existing test for that
  still passes untouched)
- a claim is ignored for providers already known not to speak the format
  (google, anthropic, bedrock, ollama), so it cannot break Bedrock by mistake
- `MCPManager.callTool` gains a matching `providerIsOpenAICompatible` pass-through

**Open question for review, deliberately not decided here:** who sets the flag.
A custom endpoint is OpenAI-compatible by definition, so the natural source is
the endpoint config — e.g. resolving `provider` against the configured custom
endpoint names in `appConfig` at the point where the MCP tool is created. That
touches the tool-loading chain, so I would rather agree the shape first than push
a guess. Happy to add whichever wiring you prefer.

Supersedes the previous version of this PR, which inverted the default (treat
anything not known-incompatible as compatible). That contradicted the existing
"unrecognized providers" test, and on reflection the caller should say so