### PR TITLE
🛡️ fix: Add Permission Guard for Temporary Chat Visibility

### DIFF
--- a/client/src/components/Chat/Header.tsx
+++ b/client/src/components/Chat/Header.tsx
@@ -35,6 +35,11 @@ function Header() {
     permission: Permissions.USE,
   });
 
+  const hasAccessToTemporaryChat = useHasAccess({
+    permissionType: PermissionTypes.TEMPORARY_CHAT,
+    permission: Permissions.USE,
+  });
+
   const isSmallScreen = useMediaQuery('(max-width: 768px)');
 
   return (
@@ -73,7 +78,7 @@ function Header() {
                   <ExportAndShareMenu
                     isSharedButtonEnabled={startupConfig?.sharedLinksEnabled ?? false}
                   />
-                  <TemporaryChat />
+                  {hasAccessToTemporaryChat === true && <TemporaryChat />}
                 </>
               )}
             </div>
@@ -85,7 +90,7 @@ function Header() {
             <ExportAndShareMenu
               isSharedButtonEnabled={startupConfig?.sharedLinksEnabled ?? false}
             />
-            <TemporaryChat />
+            {hasAccessToTemporaryChat === true && <TemporaryChat />}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

This pull request updates the `Header` component to ensure that the `TemporaryChat` feature is only displayed to users who have the appropriate permission. The main changes involve checking for the `TEMPORARY_CHAT` permission before rendering the `TemporaryChat` component.

Fixes #12106 

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Open `librechat.yaml` configuration file
2. Set `temporaryChat` under the `interface` section to `false` or `true`
   ```yaml
   interface:
     temporaryChat: false
   ```
3. Restart LibreChat
4. Log into LibreChat
5. In the header the Temporary Chat should appear or not as intented based on the configuration.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
