### PR TITLE
🪢 feat: Forward Agent Identity to Langfuse Traces

### DIFF
--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -160,6 +160,20 @@ describe('OpenAIChatCompletionController', () => {
     };
   });
 
+  describe('processStream config', () => {
+    it('should pass agent_id and dynamic runName in config.configurable', async () => {
+      const api = require('@librechat/api');
+      await OpenAIChatCompletionController(req, res);
+
+      const run = await api.createRun.mock.results[0].value;
+      const config = run.processStream.mock.calls[0][1];
+
+      expect(config.runName).toBe('gpt-4');
+      expect(config.configurable.agent_id).toBe('agent-123');
+      expect(config.configurable).not.toHaveProperty('agent_name');
+    });
+  });
+
   describe('token usage recording', () => {
     it('should call recordCollectedUsage after successful non-streaming completion', async () => {
       await OpenAIChatCompletionController(req, res);

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -189,6 +189,20 @@ describe('createResponse controller', () => {
     };
   });
 
+  describe('processStream config', () => {
+    it('should pass agent_id, agent_name, and dynamic runName in config.configurable', async () => {
+      const api = require('@librechat/api');
+      await createResponse(req, res);
+
+      const run = await api.createRun.mock.results[0].value;
+      const config = run.processStream.mock.calls[0][1];
+
+      expect(config.runName).toBe('Test Agent');
+      expect(config.configurable.agent_id).toBe('agent-123');
+      expect(config.configurable.agent_name).toBe('Test Agent');
+    });
+  });
+
   describe('token usage recording - non-streaming', () => {
     it('should call recordCollectedUsage after successful non-streaming completion', async () => {
       await createResponse(req, res);

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -725,7 +725,7 @@ class AgentClient extends BaseClient {
       const agentsEConfig = appConfig.endpoints?.[EModelEndpoint.agents];
 
       config = {
-        runName: 'AgentRun',
+        runName: this.options.agent.name || this.model || 'AgentRun',
         configurable: {
           thread_id: this.conversationId,
           last_agent_index: this.agentConfigs?.size ?? 0,

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -732,7 +732,7 @@ class AgentClient extends BaseClient {
           user_id: this.user ?? this.options.req.user?.id,
           hide_sequential_outputs: this.options.agent.hide_sequential_outputs,
           agent_id: this.options.agent.id,
-          agent_name: this.options.agent.name,
+          ...(this.options.agent.name != null && { agent_name: this.options.agent.name }),
           requestBody: {
             messageId: this.responseMessageId,
             conversationId: this.conversationId,

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -731,6 +731,8 @@ class AgentClient extends BaseClient {
           last_agent_index: this.agentConfigs?.size ?? 0,
           user_id: this.user ?? this.options.req.user?.id,
           hide_sequential_outputs: this.options.agent.hide_sequential_outputs,
+          agent_id: this.options.agent.id,
+          agent_name: this.options.agent.name,
           requestBody: {
             messageId: this.responseMessageId,
             conversationId: this.conversationId,

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -466,7 +466,7 @@ const OpenAIChatCompletionController = async (req, res) => {
 
     // Process the stream
     const config = {
-      runName: 'AgentRun',
+      runName: agent.name || agent.model_parameters?.model || 'AgentRun',
       configurable: {
         thread_id: conversationId,
         user_id: userId,

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -470,6 +470,8 @@ const OpenAIChatCompletionController = async (req, res) => {
       configurable: {
         thread_id: conversationId,
         user_id: userId,
+        agent_id: agent.id,
+        agent_name: agent.name,
         user: createSafeUser(req.user),
         requestBody: {
           messageId: responseId,

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -471,7 +471,7 @@ const OpenAIChatCompletionController = async (req, res) => {
         thread_id: conversationId,
         user_id: userId,
         agent_id: agent.id,
-        agent_name: agent.name,
+        ...(agent.name != null && { agent_name: agent.name }),
         user: createSafeUser(req.user),
         requestBody: {
           messageId: responseId,

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -482,7 +482,7 @@ const createResponse = async (req, res) => {
 
       // Process the stream
       const config = {
-        runName: 'AgentRun',
+        runName: agent.name || agent.model_parameters?.model || 'AgentRun',
         configurable: {
           thread_id: conversationId,
           user_id: userId,
@@ -638,7 +638,7 @@ const createResponse = async (req, res) => {
       }
 
       const config = {
-        runName: 'AgentRun',
+        runName: agent.name || agent.model_parameters?.model || 'AgentRun',
         configurable: {
           thread_id: conversationId,
           user_id: userId,

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -487,7 +487,7 @@ const createResponse = async (req, res) => {
           thread_id: conversationId,
           user_id: userId,
           agent_id: agent.id,
-          agent_name: agent.name,
+          ...(agent.name != null && { agent_name: agent.name }),
           user: createSafeUser(req.user),
           requestBody: {
             messageId: responseId,
@@ -643,7 +643,7 @@ const createResponse = async (req, res) => {
           thread_id: conversationId,
           user_id: userId,
           agent_id: agent.id,
-          agent_name: agent.name,
+          ...(agent.name != null && { agent_name: agent.name }),
           user: createSafeUser(req.user),
           requestBody: {
             messageId: responseId,

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -486,6 +486,8 @@ const createResponse = async (req, res) => {
         configurable: {
           thread_id: conversationId,
           user_id: userId,
+          agent_id: agent.id,
+          agent_name: agent.name,
           user: createSafeUser(req.user),
           requestBody: {
             messageId: responseId,
@@ -640,6 +642,8 @@ const createResponse = async (req, res) => {
         configurable: {
           thread_id: conversationId,
           user_id: userId,
+          agent_id: agent.id,
+          agent_name: agent.name,
           user: createSafeUser(req.user),
           requestBody: {
             messageId: responseId,


### PR DESCRIPTION
## Summary

This PR improves the metadata + tagging for traces viewable within Langfuse.

- Pass `agent_id` and `agent_name` through `config.configurable` so `@librechat/agents` can include them in Langfuse trace metadata, tags, and filtering
- Replace hardcoded `runName: 'AgentRun'` with a dynamic fallback: agent name → model name → `'AgentRun'`, so Langfuse traces show a meaningful name instead of the generic default



### Note

This  is a sibling PR to https://github.com/danny-avila/agents/pull/67

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

<img width="1726" height="959" alt="Screenshot 2026-03-06 at 11 00 02 AM" src="https://github.com/user-attachments/assets/4d69f9c3-846b-473d-ae0a-c9d0e274c88d" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes