### PR TITLE
feat: Add Custom Role Support

### DIFF
--- a/api/models/Role.js
+++ b/api/models/Role.js
@@ -1,9 +1,10 @@
 const {
   CacheKeys,
   SystemRoles,
-  roleDefaults,
   permissionsSchema,
   removeNullishValues,
+  CUSTOM_ROLE_NAME_REGEX,
+  getRoleDefaultPermissions,
 } = require('librechat-data-provider');
 const { logger } = require('@librechat/data-schemas');
 const getLogStores = require('~/cache/getLogStores');
@@ -11,8 +12,8 @@ const { Role } = require('~/db/models');
 
 /**
  * Retrieve a role by name and convert the found role document to a plain object.
- * If the role with the given name doesn't exist and the name is a system defined role,
- * create it and return the lean version.
+ * If the role doesn't exist and the name is valid (system role or valid custom format),
+ * auto-create it with appropriate defaults and return the lean version.
  *
  * @param {string} roleName - The name of the role to find or create.
  * @param {string|string[]} [fieldsToSelect] - The fields to include or exclude in the returned document.
@@ -31,10 +32,14 @@ const getRoleByName = async function (roleName, fieldsToSelect = null) {
     }
     let role = await query.lean().exec();
 
-    if (!role && SystemRoles[roleName]) {
-      role = await new Role(roleDefaults[roleName]).save();
+    if (!role && (SystemRoles[roleName] || CUSTOM_ROLE_NAME_REGEX.test(roleName))) {
+      role = await Role.findOneAndUpdate(
+        { name: roleName },
+        { $setOnInsert: getRoleDefaultPermissions(roleName) },
+        { upsert: true, new: true, lean: true },
+      );
       await cache.set(roleName, role);
-      return role.toObject();
+      return role;
     }
     await cache.set(roleName, role);
     return role;
@@ -296,8 +301,18 @@ const migrateRoleSchema = async function (roleName) {
   }
 };
 
+/**
+ * Get all role names from the database.
+ * @returns {Promise<string[]>} Array of role names.
+ */
+const getAllRoleNames = async function () {
+  const roles = await Role.find({}).select('name -_id').lean().exec();
+  return roles.map((r) => r.name);
+};
+
 module.exports = {
   getRoleByName,
+  getAllRoleNames,
   updateRoleByName,
   migrateRoleSchema,
   updateAccessPermissions,

--- a/api/models/Role.spec.js
+++ b/api/models/Role.spec.js
@@ -96,10 +96,10 @@ describe('updateAccessPermissions', () => {
   });
 
   it('should handle non-existent roles', async () => {
-    await updateAccessPermissions('NON_EXISTENT_ROLE', {
+    await updateAccessPermissions('invalid_role_name', {
       [PermissionTypes.PROMPTS]: { CREATE: true },
     });
-    const role = await Role.findOne({ name: 'NON_EXISTENT_ROLE' });
+    const role = await Role.findOne({ name: 'invalid_role_name' });
     expect(role).toBeNull();
   });
 

--- a/api/models/interface.js
+++ b/api/models/interface.js
@@ -1,6 +1,6 @@
 const { logger } = require('@librechat/data-schemas');
 const { updateInterfacePermissions: updateInterfacePerms } = require('@librechat/api');
-const { getRoleByName, updateAccessPermissions } = require('./Role');
+const { getRoleByName, updateAccessPermissions, getAllRoleNames } = require('./Role');
 
 /**
  * Update interface permissions based on app configuration.
@@ -13,6 +13,7 @@ async function updateInterfacePermissions(appConfig) {
       appConfig,
       getRoleByName,
       updateAccessPermissions,
+      getAllRoleNames,
     });
   } catch (error) {
     logger.error('Error updating interface permissions:', error);

--- a/api/server/routes/roles.js
+++ b/api/server/routes/roles.js
@@ -1,18 +1,20 @@
 const express = require('express');
 const {
   SystemRoles,
-  roleDefaults,
+  isSystemRole,
   PermissionTypes,
   agentPermissionsSchema,
   promptPermissionsSchema,
   memoryPermissionsSchema,
+  CUSTOM_ROLE_NAME_REGEX,
   mcpServersPermissionsSchema,
   marketplacePermissionsSchema,
   peoplePickerPermissionsSchema,
   remoteAgentsPermissionsSchema,
 } = require('librechat-data-provider');
 const { checkAdmin, requireJwtAuth } = require('~/server/middleware');
-const { updateRoleByName, getRoleByName } = require('~/models/Role');
+const { updateRoleByName, getRoleByName, getAllRoleNames } = require('~/models/Role');
+const { Role } = require('~/db/models');
 
 const router = express.Router();
 router.use(requireJwtAuth);
@@ -103,6 +105,51 @@ const createPermissionUpdateHandler = (permissionKey) => {
 };
 
 /**
+ * GET /api/roles
+ * List all role names (admin-only)
+ */
+router.get('/', checkAdmin, async (req, res) => {
+  try {
+    const roleNames = await getAllRoleNames();
+    res.status(200).send(roleNames);
+  } catch (error) {
+    return res.status(500).send({ message: 'Failed to list roles', error: error.message });
+  }
+});
+
+/**
+ * POST /api/roles
+ * Create a new custom role (admin-only)
+ */
+router.post('/', checkAdmin, async (req, res) => {
+  const { name } = req.body;
+  if (!name || typeof name !== 'string') {
+    return res.status(400).send({ message: 'Role name is required' });
+  }
+
+  const roleName = name.toUpperCase();
+
+  if (!CUSTOM_ROLE_NAME_REGEX.test(roleName)) {
+    return res.status(400).send({ message: 'Invalid role name format' });
+  }
+
+  if (isSystemRole(roleName)) {
+    return res.status(400).send({ message: 'Cannot create system roles' });
+  }
+
+  try {
+    const existing = await Role.findOne({ name: roleName }).lean().exec();
+    if (existing) {
+      return res.status(409).send({ message: 'Role already exists' });
+    }
+    const role = await getRoleByName(roleName);
+    res.status(201).send(role);
+  } catch (error) {
+    return res.status(500).send({ message: 'Failed to create role', error: error.message });
+  }
+});
+
+/**
  * GET /api/roles/:roleName
  * Get a specific role by name
  */
@@ -111,10 +158,10 @@ router.get('/:roleName', async (req, res) => {
   // TODO: TEMP, use a better parsing for roleName
   const roleName = _r.toUpperCase();
 
-  if (
-    (req.user.role !== SystemRoles.ADMIN && roleName === SystemRoles.ADMIN) ||
-    (req.user.role !== SystemRoles.ADMIN && !roleDefaults[roleName])
-  ) {
+  const isAdmin = req.user.role === SystemRoles.ADMIN;
+  const isOwnRole = req.user.role === roleName;
+  const isUserRole = roleName === SystemRoles.USER;
+  if (!isAdmin && !isOwnRole && !isUserRole) {
     return res.status(403).send({ message: 'Unauthorized' });
   }
 

--- a/client/src/components/Sharing/PeoplePickerAdminSettings.tsx
+++ b/client/src/components/Sharing/PeoplePickerAdminSettings.tsx
@@ -2,7 +2,13 @@ import { useMemo, useEffect, useState } from 'react';
 import * as Ariakit from '@ariakit/react';
 import { ShieldEllipsis } from 'lucide-react';
 import { useForm, Controller } from 'react-hook-form';
-import { Permissions, SystemRoles, roleDefaults, PermissionTypes } from 'librechat-data-provider';
+import {
+  Permissions,
+  SystemRoles,
+  roleDefaults,
+  PermissionTypes,
+  isSystemRole,
+} from 'librechat-data-provider';
 import {
   Button,
   Switch,
@@ -14,7 +20,11 @@ import {
   useToastContext,
 } from '@librechat/client';
 import type { Control, UseFormSetValue, UseFormGetValues } from 'react-hook-form';
-import { useUpdatePeoplePickerPermissionsMutation } from '~/data-provider';
+import {
+  useUpdatePeoplePickerPermissionsMutation,
+  useGetRole,
+  useListRoles,
+} from '~/data-provider';
 import { useLocalize, useAuthContext } from '~/hooks';
 
 type FormValues = {
@@ -81,15 +91,30 @@ const PeoplePickerAdminSettings = () => {
   });
 
   const [isRoleMenuOpen, setIsRoleMenuOpen] = useState(false);
-  const [selectedRole, setSelectedRole] = useState<SystemRoles>(SystemRoles.USER);
+  const [selectedRole, setSelectedRole] = useState<string>(SystemRoles.USER);
+
+  const { data: availableRoles } = useListRoles({
+    enabled: user?.role === SystemRoles.ADMIN,
+  });
+
+  const isSelectedCustomRole = !isSystemRole(selectedRole);
+  const { data: customRoleData = null } = useGetRole(selectedRole, {
+    enabled: isSelectedCustomRole,
+  });
 
   const defaultValues = useMemo(() => {
+    if (isSelectedCustomRole && customRoleData?.permissions) {
+      return customRoleData.permissions[PermissionTypes.PEOPLE_PICKER];
+    }
     const rolePerms = roles?.[selectedRole]?.permissions;
     if (rolePerms) {
       return rolePerms[PermissionTypes.PEOPLE_PICKER];
     }
-    return roleDefaults[selectedRole].permissions[PermissionTypes.PEOPLE_PICKER];
-  }, [roles, selectedRole]);
+    const defaults = isSystemRole(selectedRole)
+      ? roleDefaults[selectedRole as SystemRoles]
+      : roleDefaults[SystemRoles.USER];
+    return defaults.permissions[PermissionTypes.PEOPLE_PICKER];
+  }, [roles, selectedRole, isSelectedCustomRole, customRoleData]);
 
   const {
     reset,
@@ -104,13 +129,20 @@ const PeoplePickerAdminSettings = () => {
   });
 
   useEffect(() => {
-    const value = roles?.[selectedRole]?.permissions?.[PermissionTypes.PEOPLE_PICKER];
-    if (value) {
-      reset(value);
+    if (isSelectedCustomRole && customRoleData?.permissions?.[PermissionTypes.PEOPLE_PICKER]) {
+      reset(customRoleData.permissions[PermissionTypes.PEOPLE_PICKER]);
     } else {
-      reset(roleDefaults[selectedRole].permissions[PermissionTypes.PEOPLE_PICKER]);
+      const value = roles?.[selectedRole]?.permissions?.[PermissionTypes.PEOPLE_PICKER];
+      if (value) {
+        reset(value);
+      } else {
+        const defaults = isSystemRole(selectedRole)
+          ? roleDefaults[selectedRole as SystemRoles]
+          : roleDefaults[SystemRoles.USER];
+        reset(defaults.permissions[PermissionTypes.PEOPLE_PICKER]);
+      }
     }
-  }, [roles, selectedRole, reset]);
+  }, [roles, selectedRole, reset, isSelectedCustomRole, customRoleData]);
 
   if (user?.role !== SystemRoles.ADMIN) {
     return null;
@@ -138,20 +170,12 @@ const PeoplePickerAdminSettings = () => {
     mutate({ roleName: selectedRole, updates: data });
   };
 
-  const roleDropdownItems = [
-    {
-      label: SystemRoles.USER,
-      onClick: () => {
-        setSelectedRole(SystemRoles.USER);
-      },
-    },
-    {
-      label: SystemRoles.ADMIN,
-      onClick: () => {
-        setSelectedRole(SystemRoles.ADMIN);
-      },
-    },
-  ];
+  const roleDropdownItems = (availableRoles ?? [SystemRoles.USER, SystemRoles.ADMIN]).map(
+    (role) => ({
+      label: role,
+      onClick: () => setSelectedRole(role),
+    }),
+  );
 
   return (
     <OGDialog>

--- a/client/src/components/ui/AdminSettingsDialog.tsx
+++ b/client/src/components/ui/AdminSettingsDialog.tsx
@@ -2,7 +2,13 @@ import { useMemo, useEffect, useState } from 'react';
 import * as Ariakit from '@ariakit/react';
 import { ShieldEllipsis } from 'lucide-react';
 import { useForm, Controller } from 'react-hook-form';
-import { Permissions, SystemRoles, roleDefaults, PermissionTypes } from 'librechat-data-provider';
+import {
+  Permissions,
+  SystemRoles,
+  roleDefaults,
+  PermissionTypes,
+  isSystemRole,
+} from 'librechat-data-provider';
 import {
   OGDialog,
   OGDialogTitle,
@@ -14,6 +20,7 @@ import {
 } from '@librechat/client';
 import type { Control, UseFormSetValue, UseFormGetValues } from 'react-hook-form';
 import type { TranslationKeys } from '~/hooks/useLocalize';
+import { useGetRole, useListRoles } from '~/data-provider';
 import { useLocalize, useAuthContext } from '~/hooks';
 
 type FormValues = Record<Permissions, boolean>;
@@ -34,7 +41,7 @@ export interface AdminSettingsDialogProps {
   menuId: string;
   /** Mutation function and loading state from the permission update hook */
   mutation: {
-    mutate: (data: { roleName: SystemRoles; updates: Record<Permissions, boolean> }) => void;
+    mutate: (data: { roleName: string; updates: Record<Permissions, boolean> }) => void;
     isLoading: boolean;
   };
   /** Whether to show the admin access warning when ADMIN role and USE permission is displayed (default: true) */
@@ -112,14 +119,29 @@ const AdminSettingsDialog: React.FC<AdminSettingsDialogProps> = ({
   const { mutate, isLoading } = mutation;
 
   const [isRoleMenuOpen, setIsRoleMenuOpen] = useState(false);
-  const [selectedRole, setSelectedRole] = useState<SystemRoles>(SystemRoles.USER);
+  const [selectedRole, setSelectedRole] = useState<string>(SystemRoles.USER);
+
+  const { data: availableRoles } = useListRoles({
+    enabled: user?.role === SystemRoles.ADMIN,
+  });
+
+  const isSelectedCustomRole = !isSystemRole(selectedRole);
+  const { data: customRoleData = null } = useGetRole(selectedRole, {
+    enabled: isSelectedCustomRole,
+  });
 
   const defaultValues = useMemo(() => {
+    if (isSelectedCustomRole && customRoleData?.permissions) {
+      return customRoleData.permissions[permissionType];
+    }
     if (roles?.[selectedRole]?.permissions) {
       return roles[selectedRole]?.permissions[permissionType];
     }
-    return roleDefaults[selectedRole].permissions[permissionType];
-  }, [roles, selectedRole, permissionType]);
+    const defaults = isSystemRole(selectedRole)
+      ? roleDefaults[selectedRole as SystemRoles]
+      : roleDefaults[SystemRoles.USER];
+    return defaults.permissions[permissionType];
+  }, [roles, selectedRole, permissionType, isSelectedCustomRole, customRoleData]);
 
   const {
     reset,
@@ -134,12 +156,17 @@ const AdminSettingsDialog: React.FC<AdminSettingsDialogProps> = ({
   });
 
   useEffect(() => {
-    if (roles?.[selectedRole]?.permissions?.[permissionType]) {
+    if (isSelectedCustomRole && customRoleData?.permissions?.[permissionType]) {
+      reset(customRoleData.permissions[permissionType]);
+    } else if (roles?.[selectedRole]?.permissions?.[permissionType]) {
       reset(roles[selectedRole]?.permissions[permissionType]);
     } else {
-      reset(roleDefaults[selectedRole].permissions[permissionType]);
+      const defaults = isSystemRole(selectedRole)
+        ? roleDefaults[selectedRole as SystemRoles]
+        : roleDefaults[SystemRoles.USER];
+      reset(defaults.permissions[permissionType]);
     }
-  }, [roles, selectedRole, reset, permissionType]);
+  }, [roles, selectedRole, reset, permissionType, isSelectedCustomRole, customRoleData]);
 
   if (user?.role !== SystemRoles.ADMIN) {
     return null;
@@ -149,20 +176,12 @@ const AdminSettingsDialog: React.FC<AdminSettingsDialogProps> = ({
     mutate({ roleName: selectedRole, updates: data });
   };
 
-  const roleDropdownItems = [
-    {
-      label: SystemRoles.USER,
-      onClick: () => {
-        setSelectedRole(SystemRoles.USER);
-      },
-    },
-    {
-      label: SystemRoles.ADMIN,
-      onClick: () => {
-        setSelectedRole(SystemRoles.ADMIN);
-      },
-    },
-  ];
+  const roleDropdownItems = (availableRoles ?? [SystemRoles.USER, SystemRoles.ADMIN]).map(
+    (role) => ({
+      label: role,
+      onClick: () => setSelectedRole(role),
+    }),
+  );
 
   const defaultTrigger = (
     <Button

--- a/client/src/data-provider/roles.ts
+++ b/client/src/data-provider/roles.ts
@@ -29,6 +29,16 @@ export const useGetRole = (
   });
 };
 
+export const useListRoles = (config?: UseQueryOptions<string[]>): QueryObserverResult<string[]> => {
+  return useQuery<string[]>([QueryKeys.roles, 'list'], () => dataService.listRoles(), {
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchOnMount: false,
+    retry: false,
+    ...config,
+  });
+};
+
 export const useUpdatePromptPermissionsMutation = (
   options?: t.UpdatePromptPermOptions,
 ): UseMutationResult<

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -10,7 +10,7 @@ import {
 import { debounce } from 'lodash';
 import { useRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
-import { setTokenHeader, SystemRoles } from 'librechat-data-provider';
+import { setTokenHeader, SystemRoles, CUSTOM_ROLE_NAME_REGEX } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { ReactNode } from 'react';
 import {
@@ -45,6 +45,17 @@ const AuthContextProvider = ({
   });
   const { data: adminRole = null } = useGetRole(SystemRoles.ADMIN, {
     enabled: !!(isAuthenticated && user?.role === SystemRoles.ADMIN),
+  });
+
+  const customRoleName = user?.role ?? '';
+  const isCustomRole =
+    isAuthenticated &&
+    customRoleName !== '' &&
+    customRoleName !== SystemRoles.USER &&
+    customRoleName !== SystemRoles.ADMIN &&
+    CUSTOM_ROLE_NAME_REGEX.test(customRoleName);
+  const { data: customRole = null } = useGetRole(customRoleName, {
+    enabled: isCustomRole,
   });
 
   const navigate = useNavigate();
@@ -224,11 +235,22 @@ const AuthContextProvider = ({
       roles: {
         [SystemRoles.USER]: userRole,
         [SystemRoles.ADMIN]: adminRole,
+        ...(isCustomRole && customRoleName ? { [customRoleName]: customRole } : {}),
       },
       isAuthenticated,
     }),
 
-    [user, error, isAuthenticated, token, userRole, adminRole],
+    [
+      user,
+      error,
+      isAuthenticated,
+      token,
+      userRole,
+      adminRole,
+      isCustomRole,
+      customRoleName,
+      customRole,
+    ],
   );
 
   return <AuthContext.Provider value={memoedValue}>{children}</AuthContext.Provider>;

--- a/packages/api/src/app/permissions.ts
+++ b/packages/api/src/app/permissions.ts
@@ -3,6 +3,7 @@ import {
   SystemRoles,
   Permissions,
   roleDefaults,
+  isSystemRole,
   PermissionTypes,
   getConfigDefaults,
 } from 'librechat-data-provider';
@@ -54,6 +55,7 @@ export async function updateInterfacePermissions({
   appConfig,
   getRoleByName,
   updateAccessPermissions,
+  getAllRoleNames,
 }: {
   appConfig: AppConfig;
   getRoleByName: (roleName: string, fieldsToSelect?: string | string[]) => Promise<IRole | null>;
@@ -63,6 +65,7 @@ export async function updateInterfacePermissions({
 
     roleData?: IRole | null,
   ) => Promise<void>;
+  getAllRoleNames?: () => Promise<string[]>;
 }) {
   const loadedInterface = appConfig?.interfaceConfig;
   if (!loadedInterface) {
@@ -99,8 +102,16 @@ export async function updateInterfacePermissions({
   // 1. Explicit user configuration (from librechat.yaml)
   // 2. Role-specific defaults (from roleDefaults)
   // 3. Interface schema defaults (from interfaceSchema.default())
-  for (const roleName of [SystemRoles.USER, SystemRoles.ADMIN]) {
-    const defaultPerms = roleDefaults[roleName]?.permissions;
+  const roleNamesToProcess: string[] = getAllRoleNames
+    ? await getAllRoleNames()
+    : [SystemRoles.USER, SystemRoles.ADMIN];
+
+  for (const roleName of roleNamesToProcess) {
+    const defaultPerms = (
+      isSystemRole(roleName)
+        ? roleDefaults[roleName as SystemRoles]
+        : roleDefaults[SystemRoles.USER]
+    ).permissions;
 
     const existingRole = await getRoleByName(roleName);
     const existingPermissions = existingRole?.permissions as

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -914,6 +914,14 @@ export function updateMarketplacePermissions(
   return request.put(endpoints.updateMarketplacePermissions(variables.roleName), variables.updates);
 }
 
+export function listRoles(): Promise<string[]> {
+  return request.get(endpoints.roles());
+}
+
+export function createRole(data: { name: string }): Promise<r.TRole> {
+  return request.post(endpoints.roles(), data);
+}
+
 /* Tags */
 export function getConversationTags(): Promise<t.TConversationTagsResponse> {
   return request.get(endpoints.conversationTags());

--- a/packages/data-provider/src/roles.ts
+++ b/packages/data-provider/src/roles.ts
@@ -203,3 +203,28 @@ export const roleDefaults = defaultRolesSchema.parse({
     },
   },
 });
+
+/** Valid custom role name format: uppercase letters, digits, underscores; 1-50 chars */
+export const CUSTOM_ROLE_NAME_REGEX = /^[A-Z][A-Z0-9_]{0,49}$/;
+
+/** Returns true if the role name is a system-defined role (ADMIN or USER) */
+export function isSystemRole(roleName: string): boolean {
+  return roleName === SystemRoles.ADMIN || roleName === SystemRoles.USER;
+}
+
+/** Clones USER-level permissions with a custom role name */
+export function getCustomRoleDefaults(roleName: string): TRole {
+  const userPerms = roleDefaults[SystemRoles.USER].permissions;
+  return {
+    name: roleName,
+    permissions: JSON.parse(JSON.stringify(userPerms)),
+  };
+}
+
+/** Returns system defaults for ADMIN/USER, or USER-level defaults for any custom role */
+export function getRoleDefaultPermissions(roleName: string): TRole {
+  if (isSystemRole(roleName)) {
+    return roleDefaults[roleName as SystemRoles];
+  }
+  return getCustomRoleDefaults(roleName);
+}


### PR DESCRIPTION
## Summary

- Enable custom roles beyond hardcoded ADMIN/USER for finer-grained access control
- Custom roles (e.g. `AGENT_USER`, `VIEWER`) auto-create with USER-level permission defaults
- Admin API endpoints to list and create roles, dynamic role dropdowns in admin settings
- Addresses discussion: https://github.com/danny-avila/LibreChat/discussions/11985

## Changes

### Data Provider (`packages/data-provider/src/roles.ts`)
- Add `CUSTOM_ROLE_NAME_REGEX` (`/^[A-Z][A-Z0-9_]{0,49}$/`) for name validation
- Add `isSystemRole()`, `getCustomRoleDefaults()`, `getRoleDefaultPermissions()` utilities
- Add `listRoles()` and `createRole()` data-service functions

### Backend
- **`api/models/Role.js`**: `getRoleByName` auto-creates any role with valid name format using `findOneAndUpdate` with upsert (race-condition safe)
- **`api/server/routes/roles.js`**: Non-admins can fetch their own role; add `GET /api/roles` (admin-only list) and `POST /api/roles` (admin-only create)
- **`packages/api/src/app/permissions.ts`**: `updateInterfacePermissions` loops over all DB roles, not just USER/ADMIN
- **`api/models/interface.js`**: Passes `getAllRoleNames` callback

### Frontend
- **`AuthContext.tsx`**: Fetches custom role permissions with `CUSTOM_ROLE_NAME_REGEX` validation (prevents prototype pollution)
- **`roles.ts`**: Add `useListRoles` hook
- **`AdminSettingsDialog.tsx`** and **`PeoplePickerAdminSettings.tsx`**: Dynamic role dropdowns from API instead of hardcoded USER/ADMIN; on-demand role data fetching for custom roles

## Test plan

- [x] All 21 Role.spec.js tests pass
- [x] ESLint: 0 errors (2 pre-existing warnings in AuthContext)
- [x] Docker build succeeds
- [ ] Manual: Login as ADMIN/USER — no regressions
- [ ] Create custom role via `POST /api/roles` with `{"name": "AGENT_USER"}`
- [ ] Assign role to user, login — verify permissions work via `useHasAccess`
- [ ] Admin settings dropdowns show all roles, permission changes persist
- [ ] Restart server — `updateInterfacePermissions` syncs all roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)