### PR TITLE
feat: add Mistral `document_url` support for PDF uploads

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1146,7 +1146,8 @@ class BaseClient {
             !item.type ||
             item.type === ContentTypes.THINK ||
             item.type === ContentTypes.ERROR ||
-            item.type === ContentTypes.IMAGE_URL
+            item.type === ContentTypes.IMAGE_URL ||
+            item.type === 'document_url'
           ) {
             continue;
           }

--- a/packages/api/src/files/encode/document.spec.ts
+++ b/packages/api/src/files/encode/document.spec.ts
@@ -710,5 +710,90 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
         file_data: `data:application/pdf;base64,${mockContent}`,
       });
     });
+
+    it('should format Mistral document as document_url with MISTRALAI provider', async () => {
+      const req = createMockRequest(30) as ServerRequest;
+      const file = createMockFile(5);
+
+      const mockContent = Buffer.from('test-pdf-content').toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: mockContent,
+        metadata: file,
+      });
+
+      mockedValidatePdf.mockResolvedValue({ isValid: true });
+
+      const result = await encodeAndFormatDocuments(
+        req,
+        [file],
+        { provider: Providers.MISTRALAI },
+        mockStrategyFunctions,
+      );
+
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]).toMatchObject({
+        type: 'document_url',
+        document_url: `data:application/pdf;base64,${mockContent}`,
+      });
+    });
+
+    it('should format Mistral document as document_url with MISTRAL provider', async () => {
+      const req = createMockRequest(30) as ServerRequest;
+      const file = createMockFile(5);
+
+      const mockContent = Buffer.from('test-pdf-content').toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: mockContent,
+        metadata: file,
+      });
+
+      mockedValidatePdf.mockResolvedValue({ isValid: true });
+
+      const result = await encodeAndFormatDocuments(
+        req,
+        [file],
+        { provider: Providers.MISTRAL },
+        mockStrategyFunctions,
+      );
+
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]).toMatchObject({
+        type: 'document_url',
+        document_url: `data:application/pdf;base64,${mockContent}`,
+      });
+    });
+
+    it('should format Mistral document as document_url when endpoint name is "mistral"', async () => {
+      /**
+       * Custom endpoints configured as "Mistral" resolve to provider="openAI" internally.
+       * The endpoint name check ensures correct format is used in this case.
+       */
+      const req = createMockRequest(30) as ServerRequest;
+      const file = createMockFile(5);
+
+      const mockContent = Buffer.from('test-pdf-content').toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: mockContent,
+        metadata: file,
+      });
+
+      mockedValidatePdf.mockResolvedValue({ isValid: true });
+
+      const result = await encodeAndFormatDocuments(
+        req,
+        [file],
+        { provider: Providers.OPENAI, endpoint: 'Mistral' },
+        mockStrategyFunctions,
+      );
+
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]).toMatchObject({
+        type: 'document_url',
+        document_url: `data:application/pdf;base64,${mockContent}`,
+      });
+    });
   });
 });

--- a/packages/api/src/files/encode/document.ts
+++ b/packages/api/src/files/encode/document.ts
@@ -8,6 +8,7 @@ import {
 import type { IMongoFile } from '@librechat/data-schemas';
 import type {
   AnthropicDocumentBlock,
+  MistralDocumentBlock,
   StrategyFunctions,
   DocumentResult,
   ServerRequest,
@@ -156,6 +157,16 @@ export async function encodeAndFormatDocuments(
           mimeType: 'application/pdf',
           data: content,
         });
+      } else if (
+        provider === Providers.MISTRALAI ||
+        provider === Providers.MISTRAL ||
+        endpoint?.toLowerCase() === 'mistral'
+      ) {
+        const document: MistralDocumentBlock = {
+          type: 'document_url',
+          document_url: `data:application/pdf;base64,${content}`,
+        };
+        result.documents.push(document);
       } else if (isOpenAILikeProvider(provider) && provider != Providers.AZURE) {
         result.documents.push({
           type: 'file',

--- a/packages/api/src/types/files.ts
+++ b/packages/api/src/types/files.ts
@@ -108,12 +108,19 @@ export interface BedrockDocumentBlock {
   };
 }
 
+/** Mistral document_url block format for PDF/document uploads */
+export interface MistralDocumentBlock {
+  type: 'document_url';
+  document_url: string;
+}
+
 export type DocumentBlock =
   | AnthropicDocumentBlock
   | GoogleDocumentBlock
   | OpenAIFileBlock
   | OpenAIInputFileBlock
-  | BedrockDocumentBlock;
+  | BedrockDocumentBlock
+  | MistralDocumentBlock;
 
 export interface DocumentResult {
   documents: DocumentBlock[];


### PR DESCRIPTION
Mistral's chat/completions API expects PDFs as `document_url` content blocks with inline base64 data, not the OpenAI `file` format. Without this, PDF uploads to Mistral endpoints return 422 errors.

Changes:
- Add MistralDocumentBlock type for `document_url` content blocks
- Encode PDFs as `document_url` when provider is Mistral (also checks endpoint name for custom endpoint configurations where provider resolves to "openAI")
- Skip `document_url` blocks in token counting (Mistral processes documents server-side via OCR, so the base64 payload should not count against the local token budget)

Ref: https://docs.mistral.ai/capabilities/document/

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Tested with a custom Mistral endpoint (configured via librechat.yaml). Uploaded a PDF (~1MB), confirmed document_url format in API payload, and received a document-aware response from Mistral. Previously returned 422 from Mistral API.

### **Test Configuration**:

LibreChat with Mistral custom endpoint, mistral-medium-2508 model.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
