### PR TITLE
🕵️ fix: `remoteAgents` Field Omitted from Config

### DIFF
--- a/packages/api/src/app/permissions.spec.ts
+++ b/packages/api/src/app/permissions.spec.ts
@@ -2100,4 +2100,98 @@ describe('updateInterfacePermissions - permissions', () => {
     expect(userCall[1][PermissionTypes.MCP_SERVERS]).toHaveProperty(Permissions.SHARE_PUBLIC);
     expect(userCall[1][PermissionTypes.MCP_SERVERS]).not.toHaveProperty(Permissions.SHARE);
   });
+
+  it('should apply explicit remoteAgents config to USER permissions (regression: loadDefaultInterface omission)', async () => {
+    const config = {
+      interface: {
+        remoteAgents: { use: true, create: true, share: false, public: false },
+      },
+    };
+    const configDefaults = { interface: {} } as TConfigDefaults;
+    const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+    const appConfig = { config, interfaceConfig } as unknown as AppConfig;
+
+    await updateInterfacePermissions({
+      appConfig,
+      getRoleByName: mockGetRoleByName,
+      updateAccessPermissions: mockUpdateAccessPermissions,
+    });
+
+    const userCall = mockUpdateAccessPermissions.mock.calls.find(
+      (call) => call[0] === SystemRoles.USER,
+    );
+    const adminCall = mockUpdateAccessPermissions.mock.calls.find(
+      (call) => call[0] === SystemRoles.ADMIN,
+    );
+
+    expect(userCall[1][PermissionTypes.REMOTE_AGENTS]).toEqual({
+      [Permissions.USE]: true,
+      [Permissions.CREATE]: true,
+      [Permissions.SHARE]: false,
+      [Permissions.SHARE_PUBLIC]: false,
+    });
+
+    expect(adminCall[1][PermissionTypes.REMOTE_AGENTS]).toEqual({
+      [Permissions.USE]: true,
+      [Permissions.CREATE]: true,
+      [Permissions.SHARE]: false,
+      [Permissions.SHARE_PUBLIC]: false,
+    });
+  });
+
+  it('should enable all remoteAgents permissions when fully enabled in config', async () => {
+    const config = {
+      interface: {
+        remoteAgents: { use: true, create: true, share: true, public: true },
+      },
+    };
+    const configDefaults = { interface: {} } as TConfigDefaults;
+    const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+    const appConfig = { config, interfaceConfig } as unknown as AppConfig;
+
+    await updateInterfacePermissions({
+      appConfig,
+      getRoleByName: mockGetRoleByName,
+      updateAccessPermissions: mockUpdateAccessPermissions,
+    });
+
+    const userCall = mockUpdateAccessPermissions.mock.calls.find(
+      (call) => call[0] === SystemRoles.USER,
+    );
+
+    expect(userCall[1][PermissionTypes.REMOTE_AGENTS]).toEqual({
+      [Permissions.USE]: true,
+      [Permissions.CREATE]: true,
+      [Permissions.SHARE]: true,
+      [Permissions.SHARE_PUBLIC]: true,
+    });
+  });
+
+  it('should use role defaults for remoteAgents when not configured (all false for USER)', async () => {
+    const config = {
+      interface: {
+        bookmarks: true,
+      },
+    };
+    const configDefaults = { interface: {} } as TConfigDefaults;
+    const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
+    const appConfig = { config, interfaceConfig } as unknown as AppConfig;
+
+    await updateInterfacePermissions({
+      appConfig,
+      getRoleByName: mockGetRoleByName,
+      updateAccessPermissions: mockUpdateAccessPermissions,
+    });
+
+    const userCall = mockUpdateAccessPermissions.mock.calls.find(
+      (call) => call[0] === SystemRoles.USER,
+    );
+
+    expect(userCall[1][PermissionTypes.REMOTE_AGENTS]).toEqual({
+      [Permissions.USE]: false,
+      [Permissions.CREATE]: false,
+      [Permissions.SHARE]: false,
+      [Permissions.SHARE_PUBLIC]: false,
+    });
+  });
 });

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -55,6 +55,7 @@ export async function loadDefaultInterface({
     fileCitations: interfaceConfig?.fileCitations,
     peoplePicker: interfaceConfig?.peoplePicker,
     marketplace: interfaceConfig?.marketplace,
+    remoteAgents: interfaceConfig?.remoteAgents,
   });
 
   return loadedInterface;


### PR DESCRIPTION
## Summary

Greetings.

The `loadDefaultInterface` function was not passing the [`remoteAgents`](https://www.librechat.ai/docs/configuration/librechat_yaml/object_structure/interface#remoteagents) configuration from `librechat.yaml` to the permission system, causing `remoteAgents` permissions to never update from the YAML config even when explicitly configured.

This fix adds the missing `remoteAgents` field to the returned `loadedInterface` object, allowing the permission update system to properly detect and apply `remoteAgents` configuration from the YAML file.

Fixes remote agents (API) configuration not being applied from librechat.yaml

Fixes #12149 

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
   ```yaml
   # librechat.yaml
   interface:
     remoteAgents:
       use: true
       create: true
       share: true
       public: true
   ```
   - Start backend and the logs show "No changes needed for USER" for RemoteAgents
   - Check DB and you'll see USER role has `remoteAgents` all false.
   - On the UI as an USER you can't generate API Keys or use the Remote Access Interface.


## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
