### PR TITLE
fix: add screen reader-only context for convo date groupings

### DIFF
--- a/client/src/components/Conversations/Conversations.tsx
+++ b/client/src/components/Conversations/Conversations.tsx
@@ -102,6 +102,7 @@ const DateLabel: FC<{ groupName: string; isFirst?: boolean }> = memo(({ groupNam
       className={cn('pl-1 pt-1 text-text-secondary', isFirst === true ? 'mt-0' : 'mt-2')}
       style={{ fontSize: '0.7rem' }}
     >
+      <span className="sr-only">{localize('com_ui_chats_date_label_screen_reader_prefix')}</span>{' '}
       {localize(groupName as TranslationKeys) || groupName}
     </h2>
   );

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -806,6 +806,7 @@
   "com_ui_chat": "Chat",
   "com_ui_chat_history": "Chat History",
   "com_ui_chats": "Chats",
+  "com_ui_chats_date_label_screen_reader_prefix": "Chats from",
   "com_ui_check_internet": "Check your internet connection",
   "com_ui_clear": "Clear",
   "com_ui_clear_all": "Clear all",


### PR DESCRIPTION
## Summary

Otherwise, the screen reader simply says something like "today" or "previous 7 days" without any other context, which is confusing (especially since this is a heading, so theoretically something you'd navigate to directly).

Visually it's identical to before, but screen readers have added context now.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I visually tested that it looks no different in the app, then ran it through a screen reader to make sure the new text appears where expected.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes