### PR TITLE
fix: pass along error message when OCR fails

### DIFF
--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -437,7 +437,8 @@ router.post('/', async (req, res) => {
     if (
       error.message?.includes('Invalid file format') ||
       error.message?.includes('No OCR result') ||
-      error.message?.includes('exceeds token limit')
+      error.message?.includes('exceeds token limit') ||
+      error.message?.includes('Unable to extract text from')
     ) {
       message = error.message;
     }


### PR DESCRIPTION
## Summary

Right now, if OCR fails, it just says "Error processing file" which isn't very helpful.

The `error.message` does has helpful information in it, but our filter wasn't including the right case to pass it along. Now it does!

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I used the native document_parser OCR, which doesn't support actual image OCR. Then I provided a PDF which has images in it (but no actual text), which fails parsing (since it's "empty" of text).

I verified that the error message was more descriptive after the change.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
