### PR TITLE
🛤️ fix: Base URL Fallback for Path-based OAuth Discovery in Token Refresh

### DIFF
--- a/packages/api/src/mcp/__tests__/handler.test.ts
+++ b/packages/api/src/mcp/__tests__/handler.test.ts
@@ -1439,5 +1439,154 @@ describe('MCPOAuthHandler - Configurable OAuth Metadata', () => {
         }),
       );
     });
+
+    describe('path-based URL origin fallback', () => {
+      it('retries with origin URL when path-based discovery fails (stored clientInfo path)', async () => {
+        const metadata = {
+          serverName: 'sentry',
+          serverUrl: 'https://mcp.sentry.dev/mcp',
+          clientInfo: {
+            client_id: 'test-client-id',
+            client_secret: 'test-client-secret',
+            grant_types: ['authorization_code', 'refresh_token'],
+          },
+        };
+
+        const originMetadata = {
+          issuer: 'https://mcp.sentry.dev/',
+          authorization_endpoint: 'https://mcp.sentry.dev/oauth/authorize',
+          token_endpoint: 'https://mcp.sentry.dev/oauth/token',
+          token_endpoint_auth_methods_supported: ['client_secret_post'],
+          response_types_supported: ['code'],
+          jwks_uri: 'https://mcp.sentry.dev/.well-known/jwks.json',
+          subject_types_supported: ['public'],
+          id_token_signing_alg_values_supported: ['RS256'],
+        } as AuthorizationServerMetadata;
+
+        // First call (path-based URL) fails, second call (origin URL) succeeds
+        mockDiscoverAuthorizationServerMetadata
+          .mockResolvedValueOnce(undefined)
+          .mockResolvedValueOnce(originMetadata);
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            access_token: 'new-access-token',
+            refresh_token: 'new-refresh-token',
+            expires_in: 3600,
+          }),
+        } as Response);
+
+        const result = await MCPOAuthHandler.refreshOAuthTokens(
+          'test-refresh-token',
+          metadata,
+          {},
+          {},
+        );
+
+        // Discovery attempted twice: once with path URL, once with origin URL
+        expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenCalledTimes(2);
+        expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenNthCalledWith(
+          1,
+          new URL('https://mcp.sentry.dev/mcp'),
+          expect.any(Object),
+        );
+        expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenNthCalledWith(
+          2,
+          new URL('https://mcp.sentry.dev/'),
+          expect.any(Object),
+        );
+
+        // Token endpoint from origin discovery metadata is used
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://mcp.sentry.dev/oauth/token',
+          expect.objectContaining({ method: 'POST' }),
+        );
+        expect(result.access_token).toBe('new-access-token');
+      });
+
+      it('retries with origin URL when path-based discovery fails (auto-discovered path)', async () => {
+        // No clientInfo — uses the auto-discovered branch
+        const metadata = {
+          serverName: 'sentry',
+          serverUrl: 'https://mcp.sentry.dev/mcp',
+        };
+
+        const originMetadata = {
+          issuer: 'https://mcp.sentry.dev/',
+          authorization_endpoint: 'https://mcp.sentry.dev/oauth/authorize',
+          token_endpoint: 'https://mcp.sentry.dev/oauth/token',
+          response_types_supported: ['code'],
+          jwks_uri: 'https://mcp.sentry.dev/.well-known/jwks.json',
+          subject_types_supported: ['public'],
+          id_token_signing_alg_values_supported: ['RS256'],
+        } as AuthorizationServerMetadata;
+
+        // First call (path-based URL) fails, second call (origin URL) succeeds
+        mockDiscoverAuthorizationServerMetadata
+          .mockResolvedValueOnce(undefined)
+          .mockResolvedValueOnce(originMetadata);
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            access_token: 'new-access-token',
+            refresh_token: 'new-refresh-token',
+            expires_in: 3600,
+          }),
+        } as Response);
+
+        const result = await MCPOAuthHandler.refreshOAuthTokens(
+          'test-refresh-token',
+          metadata,
+          {},
+          {},
+        );
+
+        // Discovery attempted twice: once with path URL, once with origin URL
+        expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenCalledTimes(2);
+        expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenNthCalledWith(
+          1,
+          new URL('https://mcp.sentry.dev/mcp'),
+          expect.any(Object),
+        );
+        expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenNthCalledWith(
+          2,
+          new URL('https://mcp.sentry.dev/'),
+          expect.any(Object),
+        );
+
+        // Token endpoint from origin discovery metadata is used
+        expect(mockFetch).toHaveBeenCalledWith(
+          new URL('https://mcp.sentry.dev/oauth/token'),
+          expect.objectContaining({ method: 'POST' }),
+        );
+        expect(result.access_token).toBe('new-access-token');
+      });
+
+      it('does not retry with origin when server URL has no path (root URL)', async () => {
+        const metadata = {
+          serverName: 'test-server',
+          serverUrl: 'https://auth.example.com/',
+          clientInfo: {
+            client_id: 'test-client-id',
+            client_secret: 'test-client-secret',
+          },
+        };
+
+        // Root URL discovery fails — no retry
+        mockDiscoverAuthorizationServerMetadata.mockResolvedValueOnce(undefined);
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
+        } as Response);
+
+        await MCPOAuthHandler.refreshOAuthTokens('test-refresh-token', metadata, {}, {});
+
+        // Only one discovery attempt for a root URL
+        expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });

--- a/packages/api/src/mcp/__tests__/handler.test.ts
+++ b/packages/api/src/mcp/__tests__/handler.test.ts
@@ -1488,20 +1488,26 @@ describe('MCPOAuthHandler - Configurable OAuth Metadata', () => {
         expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenCalledTimes(2);
         expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenNthCalledWith(
           1,
-          new URL('https://mcp.sentry.dev/mcp'),
+          expect.any(URL),
           expect.any(Object),
         );
         expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenNthCalledWith(
           2,
-          new URL('https://mcp.sentry.dev/'),
+          expect.any(URL),
           expect.any(Object),
         );
+        const firstDiscoveryUrl = mockDiscoverAuthorizationServerMetadata.mock.calls[0][0] as URL;
+        const secondDiscoveryUrl = mockDiscoverAuthorizationServerMetadata.mock.calls[1][0] as URL;
+        expect(firstDiscoveryUrl).toBeInstanceOf(URL);
+        expect(firstDiscoveryUrl.href).toBe('https://mcp.sentry.dev/mcp');
+        expect(secondDiscoveryUrl).toBeInstanceOf(URL);
+        expect(secondDiscoveryUrl.href).toBe('https://mcp.sentry.dev/');
 
         // Token endpoint from origin discovery metadata is used
-        expect(mockFetch).toHaveBeenCalledWith(
-          'https://mcp.sentry.dev/oauth/token',
-          expect.objectContaining({ method: 'POST' }),
-        );
+        expect(mockFetch).toHaveBeenCalled();
+        const [fetchUrl, fetchOptions] = mockFetch.mock.calls[0];
+        expect(String(fetchUrl)).toBe('https://mcp.sentry.dev/oauth/token');
+        expect(fetchOptions).toEqual(expect.objectContaining({ method: 'POST' }));
         expect(result.access_token).toBe('new-access-token');
       });
 
@@ -1547,20 +1553,27 @@ describe('MCPOAuthHandler - Configurable OAuth Metadata', () => {
         expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenCalledTimes(2);
         expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenNthCalledWith(
           1,
-          new URL('https://mcp.sentry.dev/mcp'),
+          expect.any(URL),
           expect.any(Object),
         );
         expect(mockDiscoverAuthorizationServerMetadata).toHaveBeenNthCalledWith(
           2,
-          new URL('https://mcp.sentry.dev/'),
+          expect.any(URL),
           expect.any(Object),
         );
+        const firstDiscoveryUrl = mockDiscoverAuthorizationServerMetadata.mock.calls[0][0] as URL;
+        const secondDiscoveryUrl = mockDiscoverAuthorizationServerMetadata.mock.calls[1][0] as URL;
+        expect(firstDiscoveryUrl).toBeInstanceOf(URL);
+        expect(firstDiscoveryUrl.href).toBe('https://mcp.sentry.dev/mcp');
+        expect(secondDiscoveryUrl).toBeInstanceOf(URL);
+        expect(secondDiscoveryUrl.href).toBe('https://mcp.sentry.dev/');
 
         // Token endpoint from origin discovery metadata is used
-        expect(mockFetch).toHaveBeenCalledWith(
-          new URL('https://mcp.sentry.dev/oauth/token'),
-          expect.objectContaining({ method: 'POST' }),
-        );
+        expect(mockFetch).toHaveBeenCalled();
+        const [fetchUrl, fetchOptions] = mockFetch.mock.calls[0];
+        expect(fetchUrl).toBeInstanceOf(URL);
+        expect(fetchUrl.toString()).toBe('https://mcp.sentry.dev/oauth/token');
+        expect(fetchOptions).toEqual(expect.objectContaining({ method: 'POST' }));
         expect(result.access_token).toBe('new-access-token');
       });
 

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -735,9 +735,21 @@ export class MCPOAuthHandler {
           throw new Error('No token URL available for refresh');
         } else {
           /** Auto-discover OAuth configuration for refresh */
-          const oauthMetadata = await discoverAuthorizationServerMetadata(metadata.serverUrl, {
-            fetchFn: this.createOAuthFetch(oauthHeaders),
-          });
+          const serverUrl = new URL(metadata.serverUrl);
+          const fetchFn = this.createOAuthFetch(oauthHeaders);
+          let oauthMetadata = await discoverAuthorizationServerMetadata(serverUrl, { fetchFn });
+
+          // If discovery failed and we're using a path-based URL, try the base URL
+          if (!oauthMetadata && serverUrl.pathname !== '/') {
+            const baseUrl = new URL(serverUrl.origin);
+            logger.debug(
+              `[MCPOAuth] Discovery failed with path, trying base URL: ${sanitizeUrlForLogging(baseUrl)}`,
+            );
+            oauthMetadata = await discoverAuthorizationServerMetadata(baseUrl, {
+              fetchFn,
+            });
+          }
+
           if (!oauthMetadata) {
             /**
              * No metadata discovered - use fallback /token endpoint.
@@ -911,9 +923,20 @@ export class MCPOAuthHandler {
       }
 
       /** Auto-discover OAuth configuration for refresh */
-      const oauthMetadata = await discoverAuthorizationServerMetadata(metadata.serverUrl, {
-        fetchFn: this.createOAuthFetch(oauthHeaders),
-      });
+      const serverUrl = new URL(metadata.serverUrl);
+      const fetchFn = this.createOAuthFetch(oauthHeaders);
+      let oauthMetadata = await discoverAuthorizationServerMetadata(serverUrl, { fetchFn });
+
+      // If discovery failed and we're using a path-based URL, try the base URL
+      if (!oauthMetadata && serverUrl.pathname !== '/') {
+        const baseUrl = new URL(serverUrl.origin);
+        logger.debug(
+          `[MCPOAuth] Discovery failed with path, trying base URL: ${sanitizeUrlForLogging(baseUrl)}`,
+        );
+        oauthMetadata = await discoverAuthorizationServerMetadata(baseUrl, {
+          fetchFn,
+        });
+      }
 
       let tokenUrl: URL;
       if (!oauthMetadata?.token_endpoint) {

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -161,20 +161,7 @@ export class MCPOAuthHandler {
     logger.debug(
       `[MCPOAuth] Discovering OAuth metadata from ${sanitizeUrlForLogging(authServerUrl)}`,
     );
-    let rawMetadata = await discoverAuthorizationServerMetadata(authServerUrl, {
-      fetchFn,
-    });
-
-    // If discovery failed and we're using a path-based URL, try the base URL
-    if (!rawMetadata && authServerUrl.pathname !== '/') {
-      const baseUrl = new URL(authServerUrl.origin);
-      logger.debug(
-        `[MCPOAuth] Discovery failed with path, trying base URL: ${sanitizeUrlForLogging(baseUrl)}`,
-      );
-      rawMetadata = await discoverAuthorizationServerMetadata(baseUrl, {
-        fetchFn,
-      });
-    }
+    const rawMetadata = await this.discoverWithOriginFallback(authServerUrl, fetchFn);
 
     if (!rawMetadata) {
       /**

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -222,6 +222,27 @@ export class MCPOAuthHandler {
   }
 
   /**
+   * Discovers OAuth authorization server metadata with origin-URL fallback.
+   * If discovery fails for a path-based URL, retries with just the origin.
+   * Mirrors the fallback behavior in `discoverMetadata` and `initiateOAuthFlow`.
+   */
+  private static async discoverWithOriginFallback(
+    serverUrl: URL,
+    fetchFn: FetchLike,
+  ): ReturnType<typeof discoverAuthorizationServerMetadata> {
+    const metadata = await discoverAuthorizationServerMetadata(serverUrl, { fetchFn });
+    // If discovery failed and we're using a path-based URL, try the base URL
+    if (!metadata && serverUrl.pathname !== '/') {
+      const baseUrl = new URL(serverUrl.origin);
+      logger.debug(
+        `[MCPOAuth] Discovery failed with path, trying base URL: ${sanitizeUrlForLogging(baseUrl)}`,
+      );
+      return discoverAuthorizationServerMetadata(baseUrl, { fetchFn });
+    }
+    return metadata;
+  }
+
+  /**
    * Registers an OAuth client dynamically
    */
   private static async registerOAuthClient(
@@ -737,18 +758,7 @@ export class MCPOAuthHandler {
           /** Auto-discover OAuth configuration for refresh */
           const serverUrl = new URL(metadata.serverUrl);
           const fetchFn = this.createOAuthFetch(oauthHeaders);
-          let oauthMetadata = await discoverAuthorizationServerMetadata(serverUrl, { fetchFn });
-
-          // If discovery failed and we're using a path-based URL, try the base URL
-          if (!oauthMetadata && serverUrl.pathname !== '/') {
-            const baseUrl = new URL(serverUrl.origin);
-            logger.debug(
-              `[MCPOAuth] Discovery failed with path, trying base URL: ${sanitizeUrlForLogging(baseUrl)}`,
-            );
-            oauthMetadata = await discoverAuthorizationServerMetadata(baseUrl, {
-              fetchFn,
-            });
-          }
+          const oauthMetadata = await this.discoverWithOriginFallback(serverUrl, fetchFn);
 
           if (!oauthMetadata) {
             /**
@@ -925,18 +935,7 @@ export class MCPOAuthHandler {
       /** Auto-discover OAuth configuration for refresh */
       const serverUrl = new URL(metadata.serverUrl);
       const fetchFn = this.createOAuthFetch(oauthHeaders);
-      let oauthMetadata = await discoverAuthorizationServerMetadata(serverUrl, { fetchFn });
-
-      // If discovery failed and we're using a path-based URL, try the base URL
-      if (!oauthMetadata && serverUrl.pathname !== '/') {
-        const baseUrl = new URL(serverUrl.origin);
-        logger.debug(
-          `[MCPOAuth] Discovery failed with path, trying base URL: ${sanitizeUrlForLogging(baseUrl)}`,
-        );
-        oauthMetadata = await discoverAuthorizationServerMetadata(baseUrl, {
-          fetchFn,
-        });
-      }
+      const oauthMetadata = await this.discoverWithOriginFallback(serverUrl, fetchFn);
 
       let tokenUrl: URL;
       if (!oauthMetadata?.token_endpoint) {


### PR DESCRIPTION
## Summary

- The two `refreshOAuthTokens` paths in `MCPOAuthHandler` were missing the origin-URL fallback that `initiateOAuthFlow` already had (added in #10920).
- With MCP SDK 1.27.1, `buildDiscoveryUrls` appends the server path to the `.well-known` URL (e.g. `/.well-known/oauth-authorization-server/mcp`), which returns 404 for servers like Sentry whose discovery endpoint is at the root (`/.well-known/oauth-authorization-server`).
- Without the fallback, discovery returns `null` during refresh → the token endpoint falls back to `/token` (wrong URL) → the refresh request fails → users are re-prompted to authenticate every time their access token expires instead of it being silently exchanged.

Both refresh paths now mirror the `initiateOAuthFlow` pattern exactly: if discovery fails and the server URL has a non-root path, retry with just the origin URL.

Affected servers: any MCP server with a path-based URL that relies on root-level OAuth discovery (confirmed: Sentry `https://mcp.sentry.dev/mcp`).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

**Setup**: Sentry MCP server configured as `streamable-http` with `requiresOAuth: true`.

**Steps to reproduce the bug (before fix)**:
1. Authenticate with Sentry MCP — succeeds and tools become available.
2. Wait for the access token to expire (~1 hour), or delete the `mcp:sentry` token document from MongoDB to force an immediate refresh.
3. Make an MCP call — observe re-authentication prompt instead of silent refresh.
4. In logs: `[MCPOAuth] No OAuth metadata discovered for token refresh, using fallback /token endpoint` followed by a 4xx error.

**Steps to verify the fix**:
1. Apply the patch and run the backend locally.
2. Authenticate with Sentry MCP.
3. Delete the access token from MongoDB to force refresh: `db.tokens.deleteOne({ identifier: "mcp:sentry" })`.
4. Make an MCP call — token refresh completes silently, no re-auth prompt.
5. In logs: `[MCPOAuth] Discovery failed with path, trying base URL: https://mcp.sentry.dev/` followed by successful token exchange.

### **Test Configuration**:

```yaml
# librechat.yaml
sentry:
  type: streamable-http
  url: "https://mcp.sentry.dev/mcp"
  requiresOAuth: true
  startup: false
  timeout: 60000
  initTimeout: 150000
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings