### PR TITLE
Improve conversation search to include message content and titles

### DIFF
--- a/api/models/Conversation.js
+++ b/api/models/Conversation.js
@@ -1,7 +1,8 @@
 const { logger } = require('@librechat/data-schemas');
 const { createTempChatExpirationDate } = require('@librechat/api');
+const { searchConversationsAndMessages } = require('./search');
 const { getMessages, deleteMessages } = require('./Message');
-const { Conversation, Message } = require('~/db/models');
+const { Conversation } = require('~/db/models');
 
 /**
  * Searches for a conversation by conversationId and returns a lean document with only conversationId and user.
@@ -187,24 +188,8 @@ module.exports = {
 
     if (search) {
       try {
-        // Search both conversation titles AND message content
-        const conversationIdsSet = new Set();
-
-        const [meiliResults, messageResults] = await Promise.all([
-          Conversation.meiliSearch(search, {
-            filter: `user = "${user}"`,
-          }),
-          Message.meiliSearch(search, { filter: `user = "${user}"` }),
-        ]);
-        if (Array.isArray(meiliResults.hits)) {
-          meiliResults.hits.forEach((result) => conversationIdsSet.add(result.conversationId));
-        }
-        if (Array.isArray(messageResults.hits)) {
-          messageResults.hits.forEach((result) => conversationIdsSet.add(result.conversationId));
-        }
-
-        // Combine results from both searches
-        const matchingIds = Array.from(conversationIdsSet);
+        const { conversationIds } = await searchConversationsAndMessages(search, user);
+        const matchingIds = Array.from(conversationIds);
         if (!matchingIds.length) {
           return { conversations: [], nextCursor: null };
         }

--- a/api/models/Conversation.js
+++ b/api/models/Conversation.js
@@ -1,7 +1,7 @@
 const { logger } = require('@librechat/data-schemas');
 const { createTempChatExpirationDate } = require('@librechat/api');
 const { getMessages, deleteMessages } = require('./Message');
-const { Conversation } = require('~/db/models');
+const { Conversation, Message } = require('~/db/models');
 
 /**
  * Searches for a conversation by conversationId and returns a lean document with only conversationId and user.
@@ -187,10 +187,24 @@ module.exports = {
 
     if (search) {
       try {
-        const meiliResults = await Conversation.meiliSearch(search, { filter: `user = "${user}"` });
-        const matchingIds = Array.isArray(meiliResults.hits)
-          ? meiliResults.hits.map((result) => result.conversationId)
-          : [];
+        // Search both conversation titles AND message content
+        const conversationIdsSet = new Set();
+
+        const [meiliResults, messageResults] = await Promise.all([
+          Conversation.meiliSearch(search, {
+            filter: `user = "${user}"`,
+          }),
+          Message.meiliSearch(search, { filter: `user = "${user}"` }),
+        ]);
+        if (Array.isArray(meiliResults.hits)) {
+          meiliResults.hits.forEach((result) => conversationIdsSet.add(result.conversationId));
+        }
+        if (Array.isArray(messageResults.hits)) {
+          messageResults.hits.forEach((result) => conversationIdsSet.add(result.conversationId));
+        }
+
+        // Combine results from both searches
+        const matchingIds = Array.from(conversationIdsSet);
         if (!matchingIds.length) {
           return { conversations: [], nextCursor: null };
         }

--- a/api/models/Conversation.spec.js
+++ b/api/models/Conversation.spec.js
@@ -36,15 +36,16 @@ describe('Conversation Operations', () => {
   });
 
   beforeEach(async () => {
-    // Clear database
     await Conversation.deleteMany({});
-
-    // Reset mocks
     jest.clearAllMocks();
-
-    // Default mock implementations
     getMessages.mockResolvedValue([]);
     deleteMessages.mockResolvedValue({ deletedCount: 0 });
+    if (!Conversation.meiliSearch) {
+      Conversation.meiliSearch = () => Promise.resolve({ hits: [] });
+    }
+    if (!Message.meiliSearch) {
+      Message.meiliSearch = () => Promise.resolve({ hits: [] });
+    }
 
     mockReq = {
       user: { id: 'user123' },
@@ -532,24 +533,26 @@ describe('Conversation Operations', () => {
         updatedAt: new Date('2026-01-03T00:00:00.000Z'),
       });
 
-      const originalConvoMeiliSearch = Conversation.meiliSearch;
-      const convoSearchMock = jest
-        .fn()
+      const convoSearchSpy = jest
+        .spyOn(Conversation, 'meiliSearch')
         .mockResolvedValue({ hits: [{ conversationId: convoIdFromConvo }] });
-      Conversation.meiliSearch = convoSearchMock;
-      const originalMessageMeiliSearch = Message.meiliSearch;
-      const messageSearchMock = jest
-        .fn()
+      const messageSearchSpy = jest
+        .spyOn(Message, 'meiliSearch')
         .mockResolvedValue({ hits: [{ conversationId: convoIdFromMessage }] });
-      Message.meiliSearch = messageSearchMock;
       const findSpy = jest.spyOn(Conversation, 'find');
 
-      const result = await getConvosByCursor('user123', { search: 'hello' });
-
-      expect(convoSearchMock).toHaveBeenCalledWith('hello', { filter: 'user = "user123"' });
-      expect(messageSearchMock).toHaveBeenCalledWith('hello', { filter: 'user = "user123"' });
-
       try {
+        const result = await getConvosByCursor('user123', { search: 'hello' });
+
+        expect(convoSearchSpy).toHaveBeenCalledWith('hello', { filter: 'user = "user123"' });
+        expect(messageSearchSpy).toHaveBeenCalledWith(
+          'hello',
+          {
+            filter: 'user = "user123"',
+          },
+          false,
+        );
+
         const findArg = findSpy.mock.calls[0]?.[0];
         const conversationIdFilter = findArg?.$and?.find((clause) => clause?.conversationId?.$in);
         expect(conversationIdFilter).toBeTruthy();
@@ -560,9 +563,54 @@ describe('Conversation Operations', () => {
         expect(resultIds).toEqual(expect.arrayContaining([convoIdFromConvo, convoIdFromMessage]));
         expect(resultIds).not.toContain(extraId);
       } finally {
+        convoSearchSpy.mockRestore();
+        messageSearchSpy.mockRestore();
         findSpy.mockRestore();
-        Conversation.meiliSearch = originalConvoMeiliSearch;
-        Message.meiliSearch = originalMessageMeiliSearch;
+      }
+    });
+
+    it('should filter out null conversationIds from search hits', async () => {
+      const validConvoId = uuidv4();
+
+      await Conversation.create({
+        conversationId: validConvoId,
+        user: 'user123',
+        title: 'Valid conversation',
+        endpoint: EModelEndpoint.openAI,
+        expiredAt: null,
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      });
+
+      const convoSearchSpy = jest
+        .spyOn(Conversation, 'meiliSearch')
+        .mockResolvedValue({ hits: [{ conversationId: validConvoId }] });
+      const messageSearchSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({
+        hits: [{ conversationId: null }, { conversationId: undefined }],
+      });
+
+      try {
+        const result = await getConvosByCursor('user123', { search: 'hello' });
+        expect(result.conversations).toHaveLength(1);
+        expect(result.conversations[0].conversationId).toBe(validConvoId);
+      } finally {
+        convoSearchSpy.mockRestore();
+        messageSearchSpy.mockRestore();
+      }
+    });
+
+    it('should return empty when both searches return no hits', async () => {
+      const convoSearchSpy = jest
+        .spyOn(Conversation, 'meiliSearch')
+        .mockResolvedValue({ hits: [] });
+      const messageSearchSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({ hits: [] });
+
+      try {
+        const result = await getConvosByCursor('user123', { search: 'nonexistent' });
+        expect(result.conversations).toHaveLength(0);
+        expect(result.nextCursor).toBeNull();
+      } finally {
+        convoSearchSpy.mockRestore();
+        messageSearchSpy.mockRestore();
       }
     });
   });

--- a/api/models/Conversation.spec.js
+++ b/api/models/Conversation.spec.js
@@ -13,6 +13,7 @@ const {
   saveConvo,
   getConvo,
 } = require('./Conversation');
+const { clearSearchCache } = require('./search');
 jest.mock('~/server/services/Config/app');
 jest.mock('./Message');
 const { getMessages, deleteMessages } = require('./Message');
@@ -38,6 +39,7 @@ describe('Conversation Operations', () => {
   beforeEach(async () => {
     await Conversation.deleteMany({});
     jest.clearAllMocks();
+    clearSearchCache();
     getMessages.mockResolvedValue([]);
     deleteMessages.mockResolvedValue({ deletedCount: 0 });
     if (!Conversation.meiliSearch) {

--- a/api/models/Conversation.spec.js
+++ b/api/models/Conversation.spec.js
@@ -17,7 +17,7 @@ jest.mock('~/server/services/Config/app');
 jest.mock('./Message');
 const { getMessages, deleteMessages } = require('./Message');
 
-const { Conversation } = require('~/db/models');
+const { Conversation, Message } = require('~/db/models');
 
 describe('Conversation Operations', () => {
   let mongoServer;
@@ -496,6 +496,74 @@ describe('Conversation Operations', () => {
     it('should return "New Chat" if conversation not found', async () => {
       const result = await getConvoTitle('user123', 'non-existent-id');
       expect(result).toBe('New Chat');
+    });
+  });
+
+  describe('getConvosByCursor search', () => {
+    it('should merge conversation IDs from conversation and message search', async () => {
+      const convoIdFromConvo = uuidv4();
+      const convoIdFromMessage = uuidv4();
+      const extraId = uuidv4();
+
+      await Conversation.create({
+        conversationId: convoIdFromConvo,
+        user: 'user123',
+        title: 'Matched by convo search',
+        endpoint: EModelEndpoint.openAI,
+        expiredAt: null,
+        updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+      });
+
+      await Conversation.create({
+        conversationId: convoIdFromMessage,
+        user: 'user123',
+        title: 'Matched by message search',
+        endpoint: EModelEndpoint.openAI,
+        expiredAt: null,
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      });
+
+      await Conversation.create({
+        conversationId: extraId,
+        user: 'user123',
+        title: 'Unmatched',
+        endpoint: EModelEndpoint.openAI,
+        expiredAt: null,
+        updatedAt: new Date('2026-01-03T00:00:00.000Z'),
+      });
+
+      const originalConvoMeiliSearch = Conversation.meiliSearch;
+      const convoSearchMock = jest
+        .fn()
+        .mockResolvedValue({ hits: [{ conversationId: convoIdFromConvo }] });
+      Conversation.meiliSearch = convoSearchMock;
+      const originalMessageMeiliSearch = Message.meiliSearch;
+      const messageSearchMock = jest
+        .fn()
+        .mockResolvedValue({ hits: [{ conversationId: convoIdFromMessage }] });
+      Message.meiliSearch = messageSearchMock;
+      const findSpy = jest.spyOn(Conversation, 'find');
+
+      const result = await getConvosByCursor('user123', { search: 'hello' });
+
+      expect(convoSearchMock).toHaveBeenCalledWith('hello', { filter: 'user = "user123"' });
+      expect(messageSearchMock).toHaveBeenCalledWith('hello', { filter: 'user = "user123"' });
+
+      try {
+        const findArg = findSpy.mock.calls[0]?.[0];
+        const conversationIdFilter = findArg?.$and?.find((clause) => clause?.conversationId?.$in);
+        expect(conversationIdFilter).toBeTruthy();
+        expect(new Set(conversationIdFilter.conversationId.$in)).toEqual(
+          new Set([convoIdFromConvo, convoIdFromMessage]),
+        );
+        const resultIds = result.conversations.map((convo) => convo.conversationId);
+        expect(resultIds).toEqual(expect.arrayContaining([convoIdFromConvo, convoIdFromMessage]));
+        expect(resultIds).not.toContain(extraId);
+      } finally {
+        findSpy.mockRestore();
+        Conversation.meiliSearch = originalConvoMeiliSearch;
+        Message.meiliSearch = originalMessageMeiliSearch;
+      }
     });
   });
 

--- a/api/models/search.js
+++ b/api/models/search.js
@@ -1,0 +1,37 @@
+const { Conversation, Message } = require('~/db/models');
+
+/**
+ * Runs parallel Meilisearch queries against Conversation and Message indices,
+ * returning the raw results and a merged Set of matching conversation IDs.
+ *
+ * @param {string} search - The search query string.
+ * @param {string} user - The user ID to scope results to.
+ * @param {boolean} [populateMessages=false] - Whether to populate message results.
+ * @returns {Promise<{ convoHits: Array, messageHits: Array, conversationIds: Set<string> }>}
+ */
+const searchConversationsAndMessages = async (search, user, populateMessages = false) => {
+  const [convoResults, messageResults] = await Promise.all([
+    Conversation.meiliSearch(search, { filter: `user = "${user}"` }),
+    Message.meiliSearch(search, { filter: `user = "${user}"` }, populateMessages),
+  ]);
+
+  const conversationIds = new Set();
+
+  const convoHits = Array.isArray(convoResults.hits) ? convoResults.hits : [];
+  for (const hit of convoHits) {
+    if (hit.conversationId) {
+      conversationIds.add(hit.conversationId);
+    }
+  }
+
+  const messageHits = Array.isArray(messageResults.hits) ? messageResults.hits : [];
+  for (const hit of messageHits) {
+    if (hit.conversationId) {
+      conversationIds.add(hit.conversationId);
+    }
+  }
+
+  return { convoHits, messageHits, conversationIds };
+};
+
+module.exports = { searchConversationsAndMessages };

--- a/api/models/search.js
+++ b/api/models/search.js
@@ -1,8 +1,26 @@
 const { Conversation, Message } = require('~/db/models');
 
+const SEARCH_CACHE_TTL_MS = 2000;
+const searchCache = new Map();
+
+/** @param {string} key */
+const getCachedSearch = (key) => {
+  const entry = searchCache.get(key);
+  if (!entry) {
+    return null;
+  }
+  if (Date.now() - entry.timestamp > SEARCH_CACHE_TTL_MS) {
+    searchCache.delete(key);
+    return null;
+  }
+  return entry.value;
+};
+
 /**
  * Runs parallel Meilisearch queries against Conversation and Message indices,
  * returning the raw results and a merged Set of matching conversation IDs.
+ * Results are cached for 2 seconds keyed on `search + user` to deduplicate
+ * concurrent requests from the conversations and messages endpoints.
  *
  * @param {string} search - The search query string.
  * @param {string} user - The user ID to scope results to.
@@ -10,6 +28,12 @@ const { Conversation, Message } = require('~/db/models');
  * @returns {Promise<{ convoHits: Array, messageHits: Array, conversationIds: Set<string> }>}
  */
 const searchConversationsAndMessages = async (search, user, populateMessages = false) => {
+  const cacheKey = `${user}:${search}`;
+  const cached = getCachedSearch(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
   const [convoResults, messageResults] = await Promise.all([
     Conversation.meiliSearch(search, { filter: `user = "${user}"` }),
     Message.meiliSearch(search, { filter: `user = "${user}"` }, populateMessages),
@@ -31,7 +55,53 @@ const searchConversationsAndMessages = async (search, user, populateMessages = f
     }
   }
 
-  return { convoHits, messageHits, conversationIds };
+  const result = { convoHits, messageHits, conversationIds };
+  searchCache.set(cacheKey, { value: result, timestamp: Date.now() });
+  return result;
 };
 
-module.exports = { searchConversationsAndMessages };
+/**
+ * Builds the aggregation pipeline that fetches the latest message per
+ * conversation for a set of title-only matched conversation IDs.
+ *
+ * @param {string} user - The user ID to scope results to.
+ * @param {string[]} conversationIds - Conversation IDs to fetch latest messages for.
+ * @returns {import('mongoose').PipelineStage[]}
+ */
+const buildLatestMessagePipeline = (user, conversationIds) => [
+  {
+    $match: {
+      user,
+      conversationId: { $in: conversationIds },
+    },
+  },
+  {
+    $project: {
+      conversationId: 1,
+      messageId: 1,
+      text: 1,
+      isCreatedByUser: 1,
+      endpoint: 1,
+      iconURL: 1,
+      model: 1,
+      updatedAt: 1,
+      _id: 0,
+    },
+  },
+  { $sort: { conversationId: 1, updatedAt: -1 } },
+  {
+    $group: {
+      _id: '$conversationId',
+      message: { $first: '$$ROOT' },
+    },
+  },
+];
+
+/** Exposed for testing; clears the short-lived search cache. */
+const clearSearchCache = () => searchCache.clear();
+
+module.exports = {
+  searchConversationsAndMessages,
+  buildLatestMessagePipeline,
+  clearSearchCache,
+};

--- a/api/models/search.spec.js
+++ b/api/models/search.spec.js
@@ -6,30 +6,30 @@ const { searchConversationsAndMessages } = require('./search');
 const { getConvosQueried } = require('./Conversation');
 const { Conversation, Message } = require('~/db/models');
 
+let mongoServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await Conversation.deleteMany({});
+  await Message.deleteMany({});
+  if (!Conversation.meiliSearch) {
+    Conversation.meiliSearch = () => Promise.resolve({ hits: [] });
+  }
+  if (!Message.meiliSearch) {
+    Message.meiliSearch = () => Promise.resolve({ hits: [] });
+  }
+});
+
 describe('searchConversationsAndMessages', () => {
-  let mongoServer;
-
-  beforeAll(async () => {
-    mongoServer = await MongoMemoryServer.create();
-    await mongoose.connect(mongoServer.getUri());
-  });
-
-  afterAll(async () => {
-    await mongoose.disconnect();
-    await mongoServer.stop();
-  });
-
-  beforeEach(async () => {
-    await Conversation.deleteMany({});
-    await Message.deleteMany({});
-    if (!Conversation.meiliSearch) {
-      Conversation.meiliSearch = () => Promise.resolve({ hits: [] });
-    }
-    if (!Message.meiliSearch) {
-      Message.meiliSearch = () => Promise.resolve({ hits: [] });
-    }
-  });
-
   it('should merge conversation IDs from both convo and message hits', async () => {
     const convoId1 = uuidv4();
     const convoId2 = uuidv4();
@@ -165,29 +165,6 @@ describe('searchConversationsAndMessages', () => {
 });
 
 describe('Search + getConvosQueried integration', () => {
-  let mongoServer;
-
-  beforeAll(async () => {
-    mongoServer = await MongoMemoryServer.create();
-    await mongoose.connect(mongoServer.getUri());
-  });
-
-  afterAll(async () => {
-    await mongoose.disconnect();
-    await mongoServer.stop();
-  });
-
-  beforeEach(async () => {
-    await Conversation.deleteMany({});
-    await Message.deleteMany({});
-    if (!Conversation.meiliSearch) {
-      Conversation.meiliSearch = () => Promise.resolve({ hits: [] });
-    }
-    if (!Message.meiliSearch) {
-      Message.meiliSearch = () => Promise.resolve({ hits: [] });
-    }
-  });
-
   it('should return message-matched conversations with correct convoMap', async () => {
     const convoId = uuidv4();
 
@@ -373,5 +350,174 @@ describe('Search + getConvosQueried integration', () => {
       convoSpy.mockRestore();
       msgSpy.mockRestore();
     }
+  });
+});
+
+describe('Message.aggregate pipeline for title-only conversations', () => {
+  const TITLE_ONLY_PIPELINE = (user, conversationIds) => [
+    {
+      $match: {
+        user,
+        conversationId: { $in: conversationIds },
+      },
+    },
+    {
+      $project: {
+        conversationId: 1,
+        messageId: 1,
+        text: 1,
+        isCreatedByUser: 1,
+        endpoint: 1,
+        iconURL: 1,
+        model: 1,
+        updatedAt: 1,
+        _id: 0,
+      },
+    },
+    { $sort: { conversationId: 1, updatedAt: -1 } },
+    {
+      $group: {
+        _id: '$conversationId',
+        message: { $first: '$$ROOT' },
+      },
+    },
+  ];
+
+  it('should return only projected fields with no _id or internal fields', async () => {
+    const convoId = uuidv4();
+
+    await Message.create({
+      messageId: uuidv4(),
+      conversationId: convoId,
+      user: 'user1',
+      text: 'Hello world',
+      isCreatedByUser: true,
+      endpoint: 'openAI',
+      iconURL: null,
+      model: 'gpt-4',
+    });
+
+    const results = await Message.aggregate(TITLE_ONLY_PIPELINE('user1', [convoId]));
+
+    expect(results).toHaveLength(1);
+    const msg = results[0].message;
+    expect(msg.conversationId).toBe(convoId);
+    expect(msg.messageId).toBeDefined();
+    expect(msg.text).toBe('Hello world');
+    expect(msg.isCreatedByUser).toBe(true);
+    expect(msg.endpoint).toBe('openAI');
+    expect(msg.model).toBe('gpt-4');
+    expect(msg.updatedAt).toBeDefined();
+    expect(msg._id).toBeUndefined();
+    expect(msg.__v).toBeUndefined();
+    expect(msg._meiliIndex).toBeUndefined();
+    expect(msg.content).toBeUndefined();
+    expect(msg.metadata).toBeUndefined();
+    expect(msg.addedConvo).toBeUndefined();
+  });
+
+  it('should return only the latest message per conversationId', async () => {
+    const convoId = uuidv4();
+
+    await Message.collection.insertMany([
+      {
+        messageId: uuidv4(),
+        conversationId: convoId,
+        user: 'user1',
+        text: 'Older message',
+        isCreatedByUser: true,
+        updatedAt: new Date('2025-01-01'),
+        createdAt: new Date('2025-01-01'),
+      },
+      {
+        messageId: uuidv4(),
+        conversationId: convoId,
+        user: 'user1',
+        text: 'Newer message',
+        isCreatedByUser: false,
+        updatedAt: new Date('2026-01-01'),
+        createdAt: new Date('2026-01-01'),
+      },
+    ]);
+
+    const results = await Message.aggregate(TITLE_ONLY_PIPELINE('user1', [convoId]));
+
+    expect(results).toHaveLength(1);
+    expect(results[0].message.text).toBe('Newer message');
+    expect(results[0].message.isCreatedByUser).toBe(false);
+  });
+
+  it('should group by conversationId across multiple conversations', async () => {
+    const convoA = uuidv4();
+    const convoB = uuidv4();
+
+    await Message.collection.insertMany([
+      {
+        messageId: uuidv4(),
+        conversationId: convoA,
+        user: 'user1',
+        text: 'Message A1',
+        isCreatedByUser: true,
+        updatedAt: new Date('2025-06-01'),
+        createdAt: new Date('2025-06-01'),
+      },
+      {
+        messageId: uuidv4(),
+        conversationId: convoA,
+        user: 'user1',
+        text: 'Message A2',
+        isCreatedByUser: false,
+        updatedAt: new Date('2026-06-01'),
+        createdAt: new Date('2026-06-01'),
+      },
+      {
+        messageId: uuidv4(),
+        conversationId: convoB,
+        user: 'user1',
+        text: 'Message B only',
+        isCreatedByUser: true,
+        updatedAt: new Date('2026-03-01'),
+        createdAt: new Date('2026-03-01'),
+      },
+    ]);
+
+    const results = await Message.aggregate(TITLE_ONLY_PIPELINE('user1', [convoA, convoB]));
+
+    expect(results).toHaveLength(2);
+    const byConvo = {};
+    for (const r of results) {
+      byConvo[r._id] = r.message;
+    }
+    expect(byConvo[convoA].text).toBe('Message A2');
+    expect(byConvo[convoB].text).toBe('Message B only');
+  });
+
+  it('should return empty array when no messages match', async () => {
+    const results = await Message.aggregate(TITLE_ONLY_PIPELINE('user1', [uuidv4()]));
+    expect(results).toHaveLength(0);
+  });
+
+  it('should scope results to the specified user', async () => {
+    const convoId = uuidv4();
+
+    await Message.create({
+      messageId: uuidv4(),
+      conversationId: convoId,
+      user: 'other-user',
+      text: 'Wrong user message',
+      isCreatedByUser: true,
+    });
+    await Message.create({
+      messageId: uuidv4(),
+      conversationId: convoId,
+      user: 'user1',
+      text: 'Correct user message',
+      isCreatedByUser: true,
+    });
+
+    const results = await Message.aggregate(TITLE_ONLY_PIPELINE('user1', [convoId]));
+
+    expect(results).toHaveLength(1);
+    expect(results[0].message.text).toBe('Correct user message');
   });
 });

--- a/api/models/search.spec.js
+++ b/api/models/search.spec.js
@@ -2,7 +2,11 @@ const mongoose = require('mongoose');
 const { v4: uuidv4 } = require('uuid');
 const { EModelEndpoint } = require('librechat-data-provider');
 const { MongoMemoryServer } = require('mongodb-memory-server');
-const { searchConversationsAndMessages } = require('./search');
+const {
+  searchConversationsAndMessages,
+  buildLatestMessagePipeline,
+  clearSearchCache,
+} = require('./search');
 const { getConvosQueried } = require('./Conversation');
 const { Conversation, Message } = require('~/db/models');
 
@@ -21,6 +25,7 @@ afterAll(async () => {
 beforeEach(async () => {
   await Conversation.deleteMany({});
   await Message.deleteMany({});
+  clearSearchCache();
   if (!Conversation.meiliSearch) {
     Conversation.meiliSearch = () => Promise.resolve({ hits: [] });
   }
@@ -157,6 +162,42 @@ describe('searchConversationsAndMessages', () => {
       await expect(searchConversationsAndMessages('test', 'user1')).rejects.toThrow(
         'Meilisearch unavailable',
       );
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+
+  it('should return cached results within TTL window', async () => {
+    const convoId = uuidv4();
+
+    const convoSpy = jest
+      .spyOn(Conversation, 'meiliSearch')
+      .mockResolvedValue({ hits: [{ conversationId: convoId }] });
+    const msgSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({ hits: [] });
+
+    try {
+      const first = await searchConversationsAndMessages('cached-query', 'user1');
+      const second = await searchConversationsAndMessages('cached-query', 'user1');
+
+      expect(first).toBe(second);
+      expect(convoSpy).toHaveBeenCalledTimes(1);
+      expect(msgSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+
+  it('should not share cache across different users', async () => {
+    const convoSpy = jest.spyOn(Conversation, 'meiliSearch').mockResolvedValue({ hits: [] });
+    const msgSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({ hits: [] });
+
+    try {
+      await searchConversationsAndMessages('query', 'user-a');
+      await searchConversationsAndMessages('query', 'user-b');
+
+      expect(convoSpy).toHaveBeenCalledTimes(2);
     } finally {
       convoSpy.mockRestore();
       msgSpy.mockRestore();
@@ -354,35 +395,6 @@ describe('Search + getConvosQueried integration', () => {
 });
 
 describe('Message.aggregate pipeline for title-only conversations', () => {
-  const TITLE_ONLY_PIPELINE = (user, conversationIds) => [
-    {
-      $match: {
-        user,
-        conversationId: { $in: conversationIds },
-      },
-    },
-    {
-      $project: {
-        conversationId: 1,
-        messageId: 1,
-        text: 1,
-        isCreatedByUser: 1,
-        endpoint: 1,
-        iconURL: 1,
-        model: 1,
-        updatedAt: 1,
-        _id: 0,
-      },
-    },
-    { $sort: { conversationId: 1, updatedAt: -1 } },
-    {
-      $group: {
-        _id: '$conversationId',
-        message: { $first: '$$ROOT' },
-      },
-    },
-  ];
-
   it('should return only projected fields with no _id or internal fields', async () => {
     const convoId = uuidv4();
 
@@ -397,7 +409,7 @@ describe('Message.aggregate pipeline for title-only conversations', () => {
       model: 'gpt-4',
     });
 
-    const results = await Message.aggregate(TITLE_ONLY_PIPELINE('user1', [convoId]));
+    const results = await Message.aggregate(buildLatestMessagePipeline('user1', [convoId]));
 
     expect(results).toHaveLength(1);
     const msg = results[0].message;
@@ -440,7 +452,7 @@ describe('Message.aggregate pipeline for title-only conversations', () => {
       },
     ]);
 
-    const results = await Message.aggregate(TITLE_ONLY_PIPELINE('user1', [convoId]));
+    const results = await Message.aggregate(buildLatestMessagePipeline('user1', [convoId]));
 
     expect(results).toHaveLength(1);
     expect(results[0].message.text).toBe('Newer message');
@@ -481,7 +493,7 @@ describe('Message.aggregate pipeline for title-only conversations', () => {
       },
     ]);
 
-    const results = await Message.aggregate(TITLE_ONLY_PIPELINE('user1', [convoA, convoB]));
+    const results = await Message.aggregate(buildLatestMessagePipeline('user1', [convoA, convoB]));
 
     expect(results).toHaveLength(2);
     const byConvo = {};
@@ -493,7 +505,7 @@ describe('Message.aggregate pipeline for title-only conversations', () => {
   });
 
   it('should return empty array when no messages match', async () => {
-    const results = await Message.aggregate(TITLE_ONLY_PIPELINE('user1', [uuidv4()]));
+    const results = await Message.aggregate(buildLatestMessagePipeline('user1', [uuidv4()]));
     expect(results).toHaveLength(0);
   });
 
@@ -515,9 +527,69 @@ describe('Message.aggregate pipeline for title-only conversations', () => {
       isCreatedByUser: true,
     });
 
-    const results = await Message.aggregate(TITLE_ONLY_PIPELINE('user1', [convoId]));
+    const results = await Message.aggregate(buildLatestMessagePipeline('user1', [convoId]));
 
     expect(results).toHaveLength(1);
     expect(results[0].message.text).toBe('Correct user message');
+  });
+});
+
+describe('Zero-message title-only conversation handling', () => {
+  it('should identify title-only conversations that have no messages in aggregation', async () => {
+    const withMsgsId = uuidv4();
+    const emptyConvoId = uuidv4();
+
+    await Conversation.create({
+      conversationId: withMsgsId,
+      user: 'user1',
+      title: 'Has messages',
+      endpoint: EModelEndpoint.openAI,
+      model: 'gpt-4',
+      expiredAt: null,
+    });
+    await Conversation.create({
+      conversationId: emptyConvoId,
+      user: 'user1',
+      title: 'Empty convo',
+      endpoint: EModelEndpoint.openAI,
+      model: 'gpt-4',
+      expiredAt: null,
+    });
+
+    await Message.create({
+      messageId: uuidv4(),
+      conversationId: withMsgsId,
+      user: 'user1',
+      text: 'A real message',
+      isCreatedByUser: true,
+    });
+
+    const convoSpy = jest.spyOn(Conversation, 'meiliSearch').mockResolvedValue({
+      hits: [{ conversationId: withMsgsId }, { conversationId: emptyConvoId }],
+    });
+    const msgSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({ hits: [] });
+
+    try {
+      const { conversationIds } = await searchConversationsAndMessages('test', 'user1');
+      const convoRefs = [...conversationIds].map((id) => ({ conversationId: id }));
+      const result = await getConvosQueried('user1', convoRefs, null, convoRefs.length);
+
+      const titleOnlyIds = [withMsgsId, emptyConvoId];
+      const aggregated = await Message.aggregate(buildLatestMessagePipeline('user1', titleOnlyIds));
+
+      const coveredIds = new Set(aggregated.map((e) => e._id));
+      expect(coveredIds.has(withMsgsId)).toBe(true);
+      expect(coveredIds.has(emptyConvoId)).toBe(false);
+
+      const uncoveredIds = titleOnlyIds.filter((id) => !coveredIds.has(id));
+      expect(uncoveredIds).toEqual([emptyConvoId]);
+
+      const convo = result.convoMap[emptyConvoId];
+      expect(convo).toBeDefined();
+      expect(convo.title).toBe('Empty convo');
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
   });
 });

--- a/api/models/search.spec.js
+++ b/api/models/search.spec.js
@@ -1,0 +1,377 @@
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+const { EModelEndpoint } = require('librechat-data-provider');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const { searchConversationsAndMessages } = require('./search');
+const { getConvosQueried } = require('./Conversation');
+const { Conversation, Message } = require('~/db/models');
+
+describe('searchConversationsAndMessages', () => {
+  let mongoServer;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  beforeEach(async () => {
+    await Conversation.deleteMany({});
+    await Message.deleteMany({});
+    if (!Conversation.meiliSearch) {
+      Conversation.meiliSearch = () => Promise.resolve({ hits: [] });
+    }
+    if (!Message.meiliSearch) {
+      Message.meiliSearch = () => Promise.resolve({ hits: [] });
+    }
+  });
+
+  it('should merge conversation IDs from both convo and message hits', async () => {
+    const convoId1 = uuidv4();
+    const convoId2 = uuidv4();
+
+    const convoSpy = jest
+      .spyOn(Conversation, 'meiliSearch')
+      .mockResolvedValue({ hits: [{ conversationId: convoId1 }] });
+    const msgSpy = jest
+      .spyOn(Message, 'meiliSearch')
+      .mockResolvedValue({ hits: [{ conversationId: convoId2 }] });
+
+    try {
+      const { conversationIds, convoHits, messageHits } = await searchConversationsAndMessages(
+        'test',
+        'user1',
+      );
+
+      expect(conversationIds).toEqual(new Set([convoId1, convoId2]));
+      expect(convoHits).toHaveLength(1);
+      expect(messageHits).toHaveLength(1);
+      expect(convoSpy).toHaveBeenCalledWith('test', { filter: 'user = "user1"' });
+      expect(msgSpy).toHaveBeenCalledWith('test', { filter: 'user = "user1"' }, false);
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+
+  it('should deduplicate overlapping conversation IDs', async () => {
+    const sharedId = uuidv4();
+
+    const convoSpy = jest
+      .spyOn(Conversation, 'meiliSearch')
+      .mockResolvedValue({ hits: [{ conversationId: sharedId }] });
+    const msgSpy = jest
+      .spyOn(Message, 'meiliSearch')
+      .mockResolvedValue({ hits: [{ conversationId: sharedId }] });
+
+    try {
+      const { conversationIds } = await searchConversationsAndMessages('test', 'user1');
+      expect(conversationIds.size).toBe(1);
+      expect(conversationIds.has(sharedId)).toBe(true);
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+
+  it('should filter out null and undefined conversationIds', async () => {
+    const validId = uuidv4();
+
+    const convoSpy = jest.spyOn(Conversation, 'meiliSearch').mockResolvedValue({
+      hits: [{ conversationId: validId }, { conversationId: null }],
+    });
+    const msgSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({
+      hits: [{ conversationId: undefined }, {}],
+    });
+
+    try {
+      const { conversationIds } = await searchConversationsAndMessages('test', 'user1');
+      expect(conversationIds.size).toBe(1);
+      expect(conversationIds.has(validId)).toBe(true);
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+
+  it('should return empty sets when both searches return no hits', async () => {
+    const convoSpy = jest.spyOn(Conversation, 'meiliSearch').mockResolvedValue({ hits: [] });
+    const msgSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({ hits: [] });
+
+    try {
+      const { conversationIds, convoHits, messageHits } = await searchConversationsAndMessages(
+        'test',
+        'user1',
+      );
+      expect(conversationIds.size).toBe(0);
+      expect(convoHits).toHaveLength(0);
+      expect(messageHits).toHaveLength(0);
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+
+  it('should handle non-array hits gracefully', async () => {
+    const convoSpy = jest.spyOn(Conversation, 'meiliSearch').mockResolvedValue({ hits: null });
+    const msgSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({});
+
+    try {
+      const { conversationIds, convoHits, messageHits } = await searchConversationsAndMessages(
+        'test',
+        'user1',
+      );
+      expect(conversationIds.size).toBe(0);
+      expect(convoHits).toHaveLength(0);
+      expect(messageHits).toHaveLength(0);
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+
+  it('should pass populateMessages flag to Message.meiliSearch', async () => {
+    const convoSpy = jest.spyOn(Conversation, 'meiliSearch').mockResolvedValue({ hits: [] });
+    const msgSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({ hits: [] });
+
+    try {
+      await searchConversationsAndMessages('test', 'user1', true);
+      expect(msgSpy).toHaveBeenCalledWith('test', { filter: 'user = "user1"' }, true);
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+
+  it('should propagate Meilisearch errors', async () => {
+    const convoSpy = jest
+      .spyOn(Conversation, 'meiliSearch')
+      .mockRejectedValue(new Error('Meilisearch unavailable'));
+    const msgSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({ hits: [] });
+
+    try {
+      await expect(searchConversationsAndMessages('test', 'user1')).rejects.toThrow(
+        'Meilisearch unavailable',
+      );
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+});
+
+describe('Search + getConvosQueried integration', () => {
+  let mongoServer;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  beforeEach(async () => {
+    await Conversation.deleteMany({});
+    await Message.deleteMany({});
+    if (!Conversation.meiliSearch) {
+      Conversation.meiliSearch = () => Promise.resolve({ hits: [] });
+    }
+    if (!Message.meiliSearch) {
+      Message.meiliSearch = () => Promise.resolve({ hits: [] });
+    }
+  });
+
+  it('should return message-matched conversations with correct convoMap', async () => {
+    const convoId = uuidv4();
+
+    await Conversation.create({
+      conversationId: convoId,
+      user: 'user1',
+      title: 'Test Convo',
+      endpoint: EModelEndpoint.openAI,
+      model: 'gpt-4',
+      expiredAt: null,
+    });
+
+    const convoSpy = jest.spyOn(Conversation, 'meiliSearch').mockResolvedValue({ hits: [] });
+    const msgSpy = jest
+      .spyOn(Message, 'meiliSearch')
+      .mockResolvedValue({ hits: [{ conversationId: convoId, messageId: 'msg-1' }] });
+
+    try {
+      const { conversationIds, messageHits } = await searchConversationsAndMessages(
+        'test',
+        'user1',
+        true,
+      );
+
+      const convoRefs = [...conversationIds].map((id) => ({ conversationId: id }));
+      const result = await getConvosQueried('user1', convoRefs, null, convoRefs.length);
+
+      expect(result.convoMap[convoId]).toBeDefined();
+      expect(result.convoMap[convoId].title).toBe('Test Convo');
+
+      const cleanedMessages = messageHits.filter((m) => result.convoMap[m.conversationId]);
+      expect(cleanedMessages).toHaveLength(1);
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+
+  it('should return title-matched conversations not in message hits', async () => {
+    const titleConvoId = uuidv4();
+    const msgConvoId = uuidv4();
+
+    await Conversation.create({
+      conversationId: titleConvoId,
+      user: 'user1',
+      title: 'Title Match',
+      endpoint: EModelEndpoint.openAI,
+      expiredAt: null,
+    });
+    await Conversation.create({
+      conversationId: msgConvoId,
+      user: 'user1',
+      title: 'Message Match',
+      endpoint: EModelEndpoint.openAI,
+      expiredAt: null,
+    });
+
+    const convoSpy = jest
+      .spyOn(Conversation, 'meiliSearch')
+      .mockResolvedValue({ hits: [{ conversationId: titleConvoId }] });
+    const msgSpy = jest
+      .spyOn(Message, 'meiliSearch')
+      .mockResolvedValue({ hits: [{ conversationId: msgConvoId, messageId: 'msg-1' }] });
+
+    try {
+      const { conversationIds, messageHits } = await searchConversationsAndMessages(
+        'test',
+        'user1',
+        true,
+      );
+
+      const convoRefs = [...conversationIds].map((id) => ({ conversationId: id }));
+      const result = await getConvosQueried('user1', convoRefs, null, convoRefs.length);
+
+      const messageConvoIds = new Set(messageHits.map((m) => m.conversationId));
+      const titleOnlyIds = result.conversations
+        .filter((c) => !messageConvoIds.has(c.conversationId))
+        .map((c) => c.conversationId);
+
+      expect(titleOnlyIds).toContain(titleConvoId);
+      expect(titleOnlyIds).not.toContain(msgConvoId);
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+
+  it('should return empty results when no search hits', async () => {
+    const convoSpy = jest.spyOn(Conversation, 'meiliSearch').mockResolvedValue({ hits: [] });
+    const msgSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({ hits: [] });
+
+    try {
+      const { conversationIds } = await searchConversationsAndMessages('test', 'user1', true);
+
+      expect(conversationIds.size).toBe(0);
+      const convoRefs = [...conversationIds].map((id) => ({ conversationId: id }));
+      const result = await getConvosQueried('user1', convoRefs, null, convoRefs.length);
+      expect(result.conversations).toHaveLength(0);
+      expect(result.nextCursor).toBeNull();
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+
+  it('should handle mixed overlap where convo and message match the same conversation', async () => {
+    const sharedId = uuidv4();
+    const titleOnlyId = uuidv4();
+
+    await Conversation.create({
+      conversationId: sharedId,
+      user: 'user1',
+      title: 'Both Match',
+      endpoint: EModelEndpoint.openAI,
+      expiredAt: null,
+    });
+    await Conversation.create({
+      conversationId: titleOnlyId,
+      user: 'user1',
+      title: 'Title Only',
+      endpoint: EModelEndpoint.openAI,
+      expiredAt: null,
+    });
+
+    const convoSpy = jest.spyOn(Conversation, 'meiliSearch').mockResolvedValue({
+      hits: [{ conversationId: sharedId }, { conversationId: titleOnlyId }],
+    });
+    const msgSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({
+      hits: [{ conversationId: sharedId, messageId: 'msg-1' }],
+    });
+
+    try {
+      const { conversationIds, messageHits } = await searchConversationsAndMessages(
+        'test',
+        'user1',
+        true,
+      );
+
+      expect(conversationIds.size).toBe(2);
+
+      const convoRefs = [...conversationIds].map((id) => ({ conversationId: id }));
+      const result = await getConvosQueried('user1', convoRefs, null, convoRefs.length);
+
+      expect(result.conversations).toHaveLength(2);
+
+      const messageConvoIds = new Set(messageHits.map((m) => m.conversationId));
+      const titleOnlyIds = result.conversations
+        .filter((c) => !messageConvoIds.has(c.conversationId))
+        .map((c) => c.conversationId);
+
+      expect(titleOnlyIds).toEqual([titleOnlyId]);
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+
+  it('should use null cursor so getConvosQueried does not apply date filtering', async () => {
+    const convoId = uuidv4();
+
+    await Conversation.create({
+      conversationId: convoId,
+      user: 'user1',
+      title: 'Old Convo',
+      endpoint: EModelEndpoint.openAI,
+      expiredAt: null,
+      updatedAt: new Date('2020-01-01'),
+    });
+
+    const convoSpy = jest
+      .spyOn(Conversation, 'meiliSearch')
+      .mockResolvedValue({ hits: [{ conversationId: convoId }] });
+    const msgSpy = jest.spyOn(Message, 'meiliSearch').mockResolvedValue({ hits: [] });
+
+    try {
+      const { conversationIds } = await searchConversationsAndMessages('test', 'user1');
+      const convoRefs = [...conversationIds].map((id) => ({ conversationId: id }));
+      const result = await getConvosQueried('user1', convoRefs, null, convoRefs.length);
+
+      expect(result.conversations).toHaveLength(1);
+      expect(result.convoMap[convoId]).toBeDefined();
+    } finally {
+      convoSpy.mockRestore();
+      msgSpy.mockRestore();
+    }
+  });
+});

--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -14,7 +14,7 @@ const {
 const { findAllArtifacts, replaceArtifactContent } = require('~/server/services/Artifacts/update');
 const { requireJwtAuth, validateMessageReq } = require('~/server/middleware');
 const { getConvosQueried } = require('~/models/Conversation');
-const { Message } = require('~/db/models');
+const { Message, Conversation } = require('~/db/models');
 
 const router = express.Router();
 router.use(requireJwtAuth);
@@ -63,21 +63,31 @@ router.get('/', async (req, res) => {
       }
       response = { messages, nextCursor };
     } else if (search) {
-      const searchResults = await Message.meiliSearch(search, { filter: `user = "${user}"` }, true);
+      const [searchResults, titleSearchResults] = await Promise.all([
+        Message.meiliSearch(search, { filter: `user = "${user}"` }, true),
+        Conversation.meiliSearch(search, { filter: `user = "${user}"` }),
+      ]);
 
       const messages = searchResults.hits || [];
+      const titleHits = titleSearchResults.hits || [];
 
-      const result = await getConvosQueried(req.user.id, messages, cursor);
+      const conversationIdsSet = new Set(
+        messages.filter((m) => m?.conversationId).map((m) => m.conversationId),
+      );
+      const convoRefs = [
+        ...conversationIdsSet,
+        ...titleHits
+          .filter((c) => c?.conversationId && !conversationIdsSet.has(c.conversationId))
+          .map((c) => {
+            conversationIdsSet.add(c.conversationId);
+            return c.conversationId;
+          }),
+      ].map((id) => ({ conversationId: id }));
 
-      const messageIds = [];
-      const cleanedMessages = [];
-      for (let i = 0; i < messages.length; i++) {
-        let message = messages[i];
-        if (result.convoMap[message.conversationId]) {
-          messageIds.push(message.messageId);
-          cleanedMessages.push(message);
-        }
-      }
+      const result = await getConvosQueried(req.user.id, convoRefs, cursor, convoRefs.length);
+
+      const cleanedMessages = messages.filter((m) => result.convoMap[m.conversationId]);
+      const messageIds = cleanedMessages.map((m) => m.messageId);
 
       const dbMessages = await getMessages({
         user,
@@ -104,6 +114,53 @@ router.get('/', async (req, res) => {
           iconURL: dbMessage?.iconURL,
         });
       }
+
+      const messageConversationIds = new Set(cleanedMessages.map((m) => m.conversationId));
+      const titleOnlyConversationIds = result.conversations
+        .filter((c) => !messageConversationIds.has(c.conversationId))
+        .map((c) => c.conversationId);
+
+      if (titleOnlyConversationIds.length > 0) {
+        const latestMessages = await Message.aggregate([
+          {
+            $match: {
+              user,
+              conversationId: { $in: titleOnlyConversationIds },
+            },
+          },
+          { $sort: { conversationId: 1, updatedAt: -1 } },
+          {
+            $group: {
+              _id: '$conversationId',
+              message: { $first: '$$ROOT' },
+            },
+          },
+        ]);
+
+        latestMessages
+          .map((entry) => entry?.message)
+          .filter((latest) => latest?.conversationId && result.convoMap[latest.conversationId])
+          .forEach((latest) => {
+            const convo = result.convoMap[latest.conversationId];
+            activeMessages.push({
+              ...latest,
+              title: convo.title,
+              conversationId: latest.conversationId,
+              model: convo.model,
+              isCreatedByUser: latest.isCreatedByUser,
+              endpoint: latest.endpoint,
+              iconURL: latest.iconURL,
+            });
+          });
+      }
+
+      // Ensure deterministic ordering of activeMessages (e.g., by most recently updated)
+      activeMessages.sort((a, b) => {
+        if (!a?.updatedAt || !b?.updatedAt) {
+          return 0;
+        }
+        return new Date(b.updatedAt) - new Date(a.updatedAt);
+      });
 
       response = { messages: activeMessages, nextCursor: null };
     } else {

--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -12,8 +12,8 @@ const {
   deleteMessages,
 } = require('~/models');
 const { findAllArtifacts, replaceArtifactContent } = require('~/server/services/Artifacts/update');
-const { searchConversationsAndMessages } = require('~/models/search');
 const { requireJwtAuth, validateMessageReq } = require('~/server/middleware');
+const { searchConversationsAndMessages } = require('~/models/search');
 const { getConvosQueried } = require('~/models/Conversation');
 const { Message } = require('~/db/models');
 

--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -12,9 +12,10 @@ const {
   deleteMessages,
 } = require('~/models');
 const { findAllArtifacts, replaceArtifactContent } = require('~/server/services/Artifacts/update');
+const { searchConversationsAndMessages } = require('~/models/search');
 const { requireJwtAuth, validateMessageReq } = require('~/server/middleware');
 const { getConvosQueried } = require('~/models/Conversation');
-const { Message, Conversation } = require('~/db/models');
+const { Message } = require('~/db/models');
 
 const router = express.Router();
 router.use(requireJwtAuth);
@@ -63,30 +64,16 @@ router.get('/', async (req, res) => {
       }
       response = { messages, nextCursor };
     } else if (search) {
-      const [searchResults, titleSearchResults] = await Promise.all([
-        Message.meiliSearch(search, { filter: `user = "${user}"` }, true),
-        Conversation.meiliSearch(search, { filter: `user = "${user}"` }),
-      ]);
-
-      const messages = searchResults.hits || [];
-      const titleHits = titleSearchResults.hits || [];
-
-      const conversationIdsSet = new Set(
-        messages.filter((m) => m?.conversationId).map((m) => m.conversationId),
+      const { messageHits, conversationIds } = await searchConversationsAndMessages(
+        search,
+        user,
+        true,
       );
-      const convoRefs = [
-        ...conversationIdsSet,
-        ...titleHits
-          .filter((c) => c?.conversationId && !conversationIdsSet.has(c.conversationId))
-          .map((c) => {
-            conversationIdsSet.add(c.conversationId);
-            return c.conversationId;
-          }),
-      ].map((id) => ({ conversationId: id }));
 
-      const result = await getConvosQueried(req.user.id, convoRefs, cursor, convoRefs.length);
+      const convoRefs = [...conversationIds].map((id) => ({ conversationId: id }));
+      const result = await getConvosQueried(req.user.id, convoRefs, null, convoRefs.length);
 
-      const cleanedMessages = messages.filter((m) => result.convoMap[m.conversationId]);
+      const cleanedMessages = messageHits.filter((m) => result.convoMap[m.conversationId]);
       const messageIds = cleanedMessages.map((m) => m.messageId);
 
       const dbMessages = await getMessages({
@@ -107,7 +94,6 @@ router.get('/', async (req, res) => {
         activeMessages.push({
           ...message,
           title: convo.title,
-          conversationId: message.conversationId,
           model: convo.model,
           isCreatedByUser: dbMessage?.isCreatedByUser,
           endpoint: dbMessage?.endpoint,
@@ -128,6 +114,19 @@ router.get('/', async (req, res) => {
               conversationId: { $in: titleOnlyConversationIds },
             },
           },
+          {
+            $project: {
+              conversationId: 1,
+              messageId: 1,
+              text: 1,
+              isCreatedByUser: 1,
+              endpoint: 1,
+              iconURL: 1,
+              model: 1,
+              updatedAt: 1,
+              _id: 0,
+            },
+          },
           { $sort: { conversationId: 1, updatedAt: -1 } },
           {
             $group: {
@@ -137,24 +136,20 @@ router.get('/', async (req, res) => {
           },
         ]);
 
-        latestMessages
-          .map((entry) => entry?.message)
-          .filter((latest) => latest?.conversationId && result.convoMap[latest.conversationId])
-          .forEach((latest) => {
-            const convo = result.convoMap[latest.conversationId];
-            activeMessages.push({
-              ...latest,
-              title: convo.title,
-              conversationId: latest.conversationId,
-              model: convo.model,
-              isCreatedByUser: latest.isCreatedByUser,
-              endpoint: latest.endpoint,
-              iconURL: latest.iconURL,
-            });
+        for (const entry of latestMessages) {
+          const latest = entry?.message;
+          if (!latest?.conversationId || !result.convoMap[latest.conversationId]) {
+            continue;
+          }
+          const convo = result.convoMap[latest.conversationId];
+          activeMessages.push({
+            ...latest,
+            title: convo.title,
+            model: convo.model,
           });
+        }
       }
 
-      // Ensure deterministic ordering of activeMessages (e.g., by most recently updated)
       activeMessages.sort((a, b) => {
         if (!a?.updatedAt || !b?.updatedAt) {
           return 0;

--- a/api/server/routes/messages.js
+++ b/api/server/routes/messages.js
@@ -13,7 +13,7 @@ const {
 } = require('~/models');
 const { findAllArtifacts, replaceArtifactContent } = require('~/server/services/Artifacts/update');
 const { requireJwtAuth, validateMessageReq } = require('~/server/middleware');
-const { searchConversationsAndMessages } = require('~/models/search');
+const { searchConversationsAndMessages, buildLatestMessagePipeline } = require('~/models/search');
 const { getConvosQueried } = require('~/models/Conversation');
 const { Message } = require('~/db/models');
 
@@ -107,45 +107,39 @@ router.get('/', async (req, res) => {
         .map((c) => c.conversationId);
 
       if (titleOnlyConversationIds.length > 0) {
-        const latestMessages = await Message.aggregate([
-          {
-            $match: {
-              user,
-              conversationId: { $in: titleOnlyConversationIds },
-            },
-          },
-          {
-            $project: {
-              conversationId: 1,
-              messageId: 1,
-              text: 1,
-              isCreatedByUser: 1,
-              endpoint: 1,
-              iconURL: 1,
-              model: 1,
-              updatedAt: 1,
-              _id: 0,
-            },
-          },
-          { $sort: { conversationId: 1, updatedAt: -1 } },
-          {
-            $group: {
-              _id: '$conversationId',
-              message: { $first: '$$ROOT' },
-            },
-          },
-        ]);
+        const latestMessages = await Message.aggregate(
+          buildLatestMessagePipeline(user, titleOnlyConversationIds),
+        );
 
+        const coveredConvoIds = new Set();
         for (const entry of latestMessages) {
           const latest = entry?.message;
           if (!latest?.conversationId || !result.convoMap[latest.conversationId]) {
             continue;
           }
+          coveredConvoIds.add(latest.conversationId);
           const convo = result.convoMap[latest.conversationId];
           activeMessages.push({
             ...latest,
             title: convo.title,
             model: convo.model,
+          });
+        }
+
+        for (const convoId of titleOnlyConversationIds) {
+          if (coveredConvoIds.has(convoId)) {
+            continue;
+          }
+          const convo = result.convoMap[convoId];
+          if (!convo) {
+            continue;
+          }
+          activeMessages.push({
+            conversationId: convoId,
+            title: convo.title,
+            model: convo.model,
+            endpoint: convo.endpoint,
+            updatedAt: convo.updatedAt,
           });
         }
       }

--- a/packages/data-schemas/src/schema/message.ts
+++ b/packages/data-schemas/src/schema/message.ts
@@ -151,6 +151,8 @@ const messageSchema: Schema<IMessage> = new Schema(
 messageSchema.index({ expiredAt: 1 }, { expireAfterSeconds: 0 });
 messageSchema.index({ createdAt: 1 });
 messageSchema.index({ messageId: 1, user: 1 }, { unique: true });
+/** Existing deployments with autoIndex disabled must create manually:
+ * db.messages.createIndex({ user: 1, conversationId: 1, updatedAt: -1 }) */
 messageSchema.index({ user: 1, conversationId: 1, updatedAt: -1 });
 
 // index for MeiliSearch sync operations

--- a/packages/data-schemas/src/schema/message.ts
+++ b/packages/data-schemas/src/schema/message.ts
@@ -151,6 +151,7 @@ const messageSchema: Schema<IMessage> = new Schema(
 messageSchema.index({ expiredAt: 1 }, { expireAfterSeconds: 0 });
 messageSchema.index({ createdAt: 1 });
 messageSchema.index({ messageId: 1, user: 1 }, { unique: true });
+messageSchema.index({ user: 1, conversationId: 1, updatedAt: -1 });
 
 // index for MeiliSearch sync operations
 messageSchema.index({ _meiliIndex: 1, expiredAt: 1 });


### PR DESCRIPTION
# Optimize Conversation Search Performance & Add Coverage

## 📋 Summary

This PR optimizes the conversation search endpoint by running parallel Meilisearch queries, adds test coverage for the merged search behavior, and introduces a database index to prevent slow aggregation queries.

## 🎯 Problem

The search currently matches both chat titles and chat body content, but the UI behavior is inconsistent and confusing for users: the right-hand panel is populated based on filtered keyword matches from message content, while conversations whose titles do not contain the keyword can still appear in results and render as blank, creating the impression of missing or broken data.

## ✨ Solution

### Search Results:
- Search results are now combined from both chat title matches and chat body matches, so users get a unified result set instead of separate or partially populated views.
- Conversations matched only by title now show their latest message (or conversation metadata if no messages exist yet) so they never render as blank entries.
- A shared `searchConversationsAndMessages` helper eliminates duplicated parallel Meilisearch logic across both the conversations and messages endpoints, with consistent null guarding and a short-lived cache to deduplicate concurrent queries.

### Test Coverage:
- Added unit tests in `search.spec.js` for the shared search helper (merge, dedup, null guard, cache, error propagation)
- Added integration tests composing the search helper with `getConvosQueried` (title-match, message-match, mixed overlap, zero-message conversations)
- Added tests exercising the `Message.aggregate` pipeline against real in-memory MongoDB (field projection, latest-per-conversation grouping, user scoping)
- Fixed mock teardown in `Conversation.spec.js` — moved all assertions inside `try/finally` and converted to `jest.spyOn`

### Query Index:
- Added compound index `{ user: 1, conversationId: 1, updatedAt: -1 }` to the Message schema
- Supports the aggregation pipeline that sorts messages by updatedAt after matching by user + conversationId
- Prevents in-memory sort for conversations with large message count
- **Note:** Existing deployments with `autoIndex: false` must create this index manually: `db.messages.createIndex({ user: 1, conversationId: 1, updatedAt: -1 })`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.