### PR TITLE
🧪 chore: MCP Reconnect Storm Follow-Up Fixes and Integration Tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,15 @@ Multi-line imports count total character length across all lines. Consolidate va
 - Run tests from their workspace directory: `cd api && npx jest <pattern>`, `cd packages/api && npx jest <pattern>`, etc.
 - Frontend tests: `__tests__` directories alongside components; use `test/layout-test-utils` for rendering.
 - Cover loading, success, and error states for UI/data flows.
-- Mock data-provider hooks and external dependencies.
+
+### Philosophy
+
+- **Real logic over mocks.** Exercise actual code paths with real dependencies. Mocking is a last resort.
+- **Spies over mocks.** Assert that real functions are called with expected arguments and frequency without replacing underlying logic.
+- **MongoDB**: use `mongodb-memory-server` for a real in-memory MongoDB instance. Test actual queries and schema validation, not mocked DB calls.
+- **MCP**: use real `@modelcontextprotocol/sdk` exports for servers, transports, and tool definitions. Mirror real scenarios, don't stub SDK internals.
+- Only mock what you cannot control: external HTTP APIs, rate-limited services, non-deterministic system calls.
+- Heavy mocking is a code smell, not a testing strategy.
 
 ---
 

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -34,11 +34,27 @@ const { reinitMCPServer } = require('./Tools/mcp');
 const { getAppConfig } = require('./Config');
 const { getLogStores } = require('~/cache');
 
+const MAX_CACHE_SIZE = 1000;
 const lastReconnectAttempts = new Map();
 const RECONNECT_THROTTLE_MS = 10_000;
 
 const missingToolCache = new Map();
 const MISSING_TOOL_TTL_MS = 10_000;
+
+function evictStale(map, ttl) {
+  if (map.size <= MAX_CACHE_SIZE) {
+    return;
+  }
+  const now = Date.now();
+  for (const [key, timestamp] of map) {
+    if (now - timestamp >= ttl) {
+      map.delete(key);
+    }
+    if (map.size <= MAX_CACHE_SIZE) {
+      return;
+    }
+  }
+}
 
 const unavailableMsg =
   "This tool's MCP server is temporarily unavailable. Please try again shortly.";
@@ -253,6 +269,7 @@ async function reconnectServer({
     return null;
   }
   lastReconnectAttempts.set(throttleKey, now);
+  evictStale(lastReconnectAttempts, RECONNECT_THROTTLE_MS);
 
   const runId = Constants.USE_PRELIM_RESPONSE_MESSAGE_ID;
   const flowId = `${user.id}:${serverName}:${Date.now()}`;
@@ -473,6 +490,7 @@ async function createMCPTool({
 
     if (!toolDefinition) {
       missingToolCache.set(toolKey, Date.now());
+      evictStale(missingToolCache, MISSING_TOOL_TTL_MS);
     }
   }
 

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -49,7 +49,7 @@ const unavailableMsg =
  */
 function createUnavailableToolStub(toolName, serverName) {
   const normalizedToolKey = `${toolName}${Constants.mcp_delimiter}${normalizeServerName(serverName)}`;
-  const _call = async () => unavailableMsg;
+  const _call = async () => [unavailableMsg, null];
   const toolInstance = tool(_call, {
     schema: {
       type: 'object',
@@ -373,6 +373,10 @@ async function createMCPTools({
     userMCPAuthMap,
     streamId,
   });
+  if (result === null) {
+    logger.debug(`[MCP][${serverName}] Reconnect throttled, skipping tool creation.`);
+    return [];
+  }
   if (!result || !result.tools) {
     logger.warn(`[MCP][${serverName}] Failed to reinitialize MCP server.`);
     return [];

--- a/api/server/services/MCP.spec.js
+++ b/api/server/services/MCP.spec.js
@@ -45,6 +45,7 @@ const {
   getMCPSetupData,
   checkOAuthFlowStatus,
   getServerConnectionStatus,
+  createUnavailableToolStub,
 } = require('./MCP');
 
 jest.mock('./Config', () => ({
@@ -1095,6 +1096,188 @@ describe('User parameter passing tests', () => {
       // Verify getAppConfig was called with correct roles
       expect(mockGetAppConfig).toHaveBeenNthCalledWith(1, { role: 'admin' });
       expect(mockGetAppConfig).toHaveBeenNthCalledWith(2, { role: 'user' });
+    });
+  });
+
+  describe('createUnavailableToolStub', () => {
+    it('should return a tool whose _call returns a valid CONTENT_AND_ARTIFACT two-tuple', async () => {
+      const stub = createUnavailableToolStub('myTool', 'myServer');
+      // invoke() goes through langchain's base tool, which checks responseFormat.
+      // CONTENT_AND_ARTIFACT requires [content, artifact] — a bare string would throw:
+      //   "Tool response format is "content_and_artifact" but the output was not a two-tuple"
+      const result = await stub.invoke({});
+      // If we reach here without throwing, the two-tuple format is correct.
+      // invoke() returns the content portion of [content, artifact] as a string.
+      expect(result).toContain('temporarily unavailable');
+    });
+  });
+
+  describe('negative tool cache and throttle interaction', () => {
+    it('should cache tool as missing even when throttled (cross-user dedup)', async () => {
+      const mockUser = { id: 'throttle-test-user' };
+      const mockRes = { write: jest.fn(), flush: jest.fn() };
+
+      // First call: reconnect succeeds but tool not found
+      mockReinitMCPServer.mockResolvedValueOnce({
+        availableTools: {},
+      });
+
+      await createMCPTool({
+        res: mockRes,
+        user: mockUser,
+        toolKey: `missing-tool${D}cache-dedup-server`,
+        provider: 'openai',
+        userMCPAuthMap: {},
+        availableTools: undefined,
+      });
+
+      // Second call within 10s for DIFFERENT tool on same server:
+      // reconnect is throttled (returns null), tool is still cached as missing.
+      // This is intentional: the cache acts as cross-user dedup since the
+      // throttle is per-user-per-server and can't prevent N different users
+      // from each triggering their own reconnect.
+      const result2 = await createMCPTool({
+        res: mockRes,
+        user: mockUser,
+        toolKey: `other-tool${D}cache-dedup-server`,
+        provider: 'openai',
+        userMCPAuthMap: {},
+        availableTools: undefined,
+      });
+
+      expect(result2).toBeDefined();
+      expect(result2.name).toContain('other-tool');
+      expect(mockReinitMCPServer).toHaveBeenCalledTimes(1);
+    });
+
+    it('should prevent user B from triggering reconnect when user A already cached the tool', async () => {
+      const userA = { id: 'cache-user-A' };
+      const userB = { id: 'cache-user-B' };
+      const mockRes = { write: jest.fn(), flush: jest.fn() };
+
+      // User A: real reconnect, tool not found → cached
+      mockReinitMCPServer.mockResolvedValueOnce({
+        availableTools: {},
+      });
+
+      await createMCPTool({
+        res: mockRes,
+        user: userA,
+        toolKey: `shared-tool${D}cross-user-server`,
+        provider: 'openai',
+        userMCPAuthMap: {},
+        availableTools: undefined,
+      });
+
+      expect(mockReinitMCPServer).toHaveBeenCalledTimes(1);
+
+      // User B requests the SAME tool within 10s.
+      // The negative cache is keyed by toolKey (no user prefix), so user B
+      // gets a cache hit and no reconnect fires. This is the cross-user
+      // storm protection: without this, user B's unthrottled first request
+      // would trigger a second reconnect to the same server.
+      const result = await createMCPTool({
+        res: mockRes,
+        user: userB,
+        toolKey: `shared-tool${D}cross-user-server`,
+        provider: 'openai',
+        userMCPAuthMap: {},
+        availableTools: undefined,
+      });
+
+      expect(result).toBeDefined();
+      expect(result.name).toContain('shared-tool');
+      // reinitMCPServer still called only once — user B hit the cache
+      expect(mockReinitMCPServer).toHaveBeenCalledTimes(1);
+    });
+
+    it('should prevent user B from triggering reconnect for throttle-cached tools', async () => {
+      const userA = { id: 'storm-user-A' };
+      const userB = { id: 'storm-user-B' };
+      const mockRes = { write: jest.fn(), flush: jest.fn() };
+
+      // User A: real reconnect for tool-1, tool not found → cached
+      mockReinitMCPServer.mockResolvedValueOnce({
+        availableTools: {},
+      });
+
+      await createMCPTool({
+        res: mockRes,
+        user: userA,
+        toolKey: `tool-1${D}storm-server`,
+        provider: 'openai',
+        userMCPAuthMap: {},
+        availableTools: undefined,
+      });
+
+      // User A: tool-2 on same server within 10s → throttled → cached from throttle
+      await createMCPTool({
+        res: mockRes,
+        user: userA,
+        toolKey: `tool-2${D}storm-server`,
+        provider: 'openai',
+        userMCPAuthMap: {},
+        availableTools: undefined,
+      });
+
+      expect(mockReinitMCPServer).toHaveBeenCalledTimes(1);
+
+      // User B requests tool-2 — gets cache hit from the throttle-cached entry.
+      // Without this caching, user B would trigger a real reconnect since
+      // user B has their own throttle key and hasn't reconnected yet.
+      const result = await createMCPTool({
+        res: mockRes,
+        user: userB,
+        toolKey: `tool-2${D}storm-server`,
+        provider: 'openai',
+        userMCPAuthMap: {},
+        availableTools: undefined,
+      });
+
+      expect(result).toBeDefined();
+      expect(result.name).toContain('tool-2');
+      // Still only 1 real reconnect — user B was protected by the cache
+      expect(mockReinitMCPServer).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('createMCPTools throttle handling', () => {
+    it('should return empty array with debug log when reconnect is throttled', async () => {
+      const mockUser = { id: 'throttle-tools-user' };
+      const mockRes = { write: jest.fn(), flush: jest.fn() };
+
+      // First call: real reconnect
+      mockReinitMCPServer.mockResolvedValueOnce({
+        tools: [{ name: 'tool1' }],
+        availableTools: {
+          [`tool1${D}throttle-tools-server`]: {
+            function: { description: 'Tool 1', parameters: {} },
+          },
+        },
+      });
+
+      await createMCPTools({
+        res: mockRes,
+        user: mockUser,
+        serverName: 'throttle-tools-server',
+        provider: 'openai',
+        userMCPAuthMap: {},
+      });
+
+      // Second call within 10s — throttled
+      const result = await createMCPTools({
+        res: mockRes,
+        user: mockUser,
+        serverName: 'throttle-tools-server',
+        provider: 'openai',
+        userMCPAuthMap: {},
+      });
+
+      expect(result).toEqual([]);
+      // reinitMCPServer called only once — second was throttled
+      expect(mockReinitMCPServer).toHaveBeenCalledTimes(1);
+      // Should log at debug level (not warn) for throttled case
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Reconnect throttled'));
     });
   });
 

--- a/packages/api/src/mcp/__tests__/reconnection-storm.test.ts
+++ b/packages/api/src/mcp/__tests__/reconnection-storm.test.ts
@@ -6,13 +6,23 @@
  * per test suite and MCPConnection talks to it through a genuine HTTP stack.
  */
 import http from 'http';
-import express from 'express';
 import { randomUUID } from 'crypto';
+import express from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { Socket } from 'net';
 import { OAuthReconnectionTracker } from '~/mcp/oauth/OAuthReconnectionTracker';
 import { MCPConnection } from '~/mcp/connection';
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                           */
@@ -22,6 +32,22 @@ interface TestServer {
   url: string;
   httpServer: http.Server;
   close: () => Promise<void>;
+}
+
+function trackSockets(httpServer: http.Server): () => Promise<void> {
+  const sockets = new Set<Socket>();
+  httpServer.on('connection', (socket: Socket) => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
+  return () =>
+    new Promise<void>((resolve) => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      sockets.clear();
+      httpServer.close(() => resolve());
+    });
 }
 
 function startMCPServer(): Promise<TestServer> {
@@ -80,17 +106,17 @@ function startMCPServer(): Promise<TestServer> {
 
   return new Promise((resolve) => {
     const httpServer = app.listen(0, '127.0.0.1', () => {
+      const destroySockets = trackSockets(httpServer);
       const addr = httpServer.address() as { port: number };
       resolve({
         url: `http://127.0.0.1:${addr.port}/mcp`,
         httpServer,
-        close: () =>
-          new Promise<void>((r) => {
-            for (const t of Object.values(transports)) {
-              t.close().catch(() => {});
-            }
-            httpServer.close(() => r());
-          }),
+        close: async () => {
+          for (const t of Object.values(transports)) {
+            t.close().catch(() => {});
+          }
+          await destroySockets();
+        },
       });
     });
   });
@@ -103,11 +129,6 @@ function createConnection(serverName: string, url: string, initTimeout = 5000): 
   });
 }
 
-/**
- * Cleanly shut down an MCPConnection so no background handleReconnection
- * timers leak. Sets shouldStopReconnecting before disconnect so that
- * the transport close event doesn't trigger a reconnection loop.
- */
 async function teardownConnection(conn: MCPConnection): Promise<void> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (conn as any).shouldStopReconnecting = true;
@@ -152,8 +173,7 @@ describe('Fix #2: Circuit breaker stops rapid reconnect cycling', () => {
 });
 
 /* ------------------------------------------------------------------ */
-/*  Fix #3 — SSE 400/405 with no session now short-circuits            */
-/*  (returns early, no connectionChange 'error' emitted)               */
+/*  Fix #3 — SSE 400/405 handled in same branch as 404                */
 /* ------------------------------------------------------------------ */
 describe('Fix #3: SSE 400/405 handled in same branch as 404', () => {
   it('400 with active session triggers reconnection (session lost)', async () => {
@@ -161,7 +181,6 @@ describe('Fix #3: SSE 400/405 handled in same branch as 404', () => {
     const conn = createConnection('sse-400', srv.url);
     await conn.connect();
 
-    // Prevent background handleReconnection from spawning timers
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (conn as any).shouldStopReconnecting = true;
 
@@ -172,9 +191,6 @@ describe('Fix #3: SSE 400/405 handled in same branch as 404', () => {
     const transport = (conn as any).transport;
     transport.onerror({ message: 'Failed to open SSE stream', code: 400 });
 
-    // With a session, 400 falls through to emit error (triggering reconnection).
-    // Previously only 404 entered this code path; 400/405 were unhandled and
-    // would also emit error but without the session-lost detection logic.
     expect(changes).toContain('error');
 
     await teardownConnection(conn);
@@ -215,14 +231,12 @@ describe('Fix #4: Circuit breaker state persists across instance replacement', (
     await conn1.connect();
     await teardownConnection(conn1);
 
-    // conn1's disconnect(false) inside connect() recorded a cycle in the static Map
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cbAfterConn1 = (MCPConnection as any).circuitBreakers.get('replace');
     expect(cbAfterConn1).toBeDefined();
     const cyclesAfterConn1 = cbAfterConn1.cycleCount;
     expect(cyclesAfterConn1).toBeGreaterThan(0);
 
-    // New instance for same server inherits the cycle count
     const conn2 = createConnection('replace', srv.url);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const cbFromConn2 = (conn2 as any).getCircuitBreaker();
@@ -265,8 +279,6 @@ describe('Fix #5: Dead server triggers circuit breaker', () => {
       }
     }
 
-    // First 3 reach client.connect and fail (recordFailedRound each time).
-    // After 3rd failure backoff kicks in; attempts 4-5 are blocked at isCircuitOpen.
     expect(spy.mock.calls.length).toBe(3);
     expect(errors).toHaveLength(5);
     expect(errors.filter((m) => m.includes('Circuit breaker is open'))).toHaveLength(2);
@@ -277,7 +289,6 @@ describe('Fix #5: Dead server triggers circuit breaker', () => {
   it('user B is immediately blocked when user A already tripped the breaker for the same server', async () => {
     const deadUrl = 'http://127.0.0.1:1/mcp';
 
-    // User A connects 3 times and trips the breaker
     const userA = new MCPConnection({
       serverName: 'shared-dead',
       serverConfig: { url: deadUrl, type: 'streamable-http', initTimeout: 1000 } as never,
@@ -288,14 +299,10 @@ describe('Fix #5: Dead server triggers circuit breaker', () => {
       try {
         await userA.connect();
       } catch {
-        // expected failures
+        // expected
       }
     }
 
-    // User B's very first attempt is blocked — the breaker is per-server, not per-user.
-    // This is intentional: when a server is down, it's down for everyone. Blocking
-    // immediately prevents O(N×3) storms where each of N users independently discovers
-    // the server is unreachable.
     const userB = new MCPConnection({
       serverName: 'shared-dead',
       serverConfig: { url: deadUrl, type: 'streamable-http', initTimeout: 1000 } as never,
@@ -311,7 +318,6 @@ describe('Fix #5: Dead server triggers circuit breaker', () => {
     }
 
     expect(blockedMessage).toContain('Circuit breaker is open');
-    // User B's client.connect was never called — blocked before reaching the SDK
     expect(spyB).toHaveBeenCalledTimes(0);
 
     await userA.disconnect();
@@ -321,7 +327,6 @@ describe('Fix #5: Dead server triggers circuit breaker', () => {
   it('clearCooldown after user retry unblocks all users', async () => {
     const deadUrl = 'http://127.0.0.1:1/mcp';
 
-    // Trip the breaker
     const userA = new MCPConnection({
       serverName: 'shared-dead-clear',
       serverConfig: { url: deadUrl, type: 'streamable-http', initTimeout: 1000 } as never,
@@ -335,7 +340,6 @@ describe('Fix #5: Dead server triggers circuit breaker', () => {
       }
     }
 
-    // Breaker is open for everyone
     const userB = new MCPConnection({
       serverName: 'shared-dead-clear',
       serverConfig: { url: deadUrl, type: 'streamable-http', initTimeout: 1000 } as never,
@@ -347,11 +351,8 @@ describe('Fix #5: Dead server triggers circuit breaker', () => {
       expect((e as Error).message).toContain('Circuit breaker is open');
     }
 
-    // User A explicitly retries (forceNew) — clears the breaker for everyone
     MCPConnection.clearCooldown('shared-dead-clear');
 
-    // User B can now attempt to connect again (will fail because server is
-    // still dead, but the point is the breaker no longer blocks the attempt)
     const spyB = jest.spyOn(userB.client, 'connect');
     try {
       await userB.connect();
@@ -359,7 +360,6 @@ describe('Fix #5: Dead server triggers circuit breaker', () => {
       // expected — server is still dead
     }
 
-    // User B's attempt reached the SDK this time — not blocked by breaker
     expect(spyB).toHaveBeenCalledTimes(1);
 
     await userA.disconnect();
@@ -422,7 +422,6 @@ describe('Fix #6: OAuth failure uses cooldown-based retry', () => {
     jest.advanceTimersByTime(20 * 60 * 1000);
     expect(tracker.isFailed('u1', 'srv')).toBe(false);
 
-    // 4th failure: 30 min cap — still blocked at 29m, clear at 30m
     tracker.setFailed('u1', 'srv');
     jest.advanceTimersByTime(29 * 60 * 1000);
     expect(tracker.isFailed('u1', 'srv')).toBe(true);
@@ -442,20 +441,6 @@ describe('Fix #6: OAuth failure uses cooldown-based retry', () => {
     tracker.setFailed('u1', 'srv');
     jest.advanceTimersByTime(5 * 60 * 1000);
     expect(tracker.isFailed('u1', 'srv')).toBe(false);
-  });
-});
-
-/* ------------------------------------------------------------------ */
-/*  Fix #8 — Default initTimeout reduced from 120s to 30s              */
-/* ------------------------------------------------------------------ */
-describe('Fix #8: Default initTimeout is 30s', () => {
-  it('options.initTimeout is undefined, code falls back to DEFAULT_INIT_TIMEOUT (30s)', () => {
-    const conn = new MCPConnection({
-      serverName: 'prod',
-      serverConfig: { url: 'http://127.0.0.1:1/mcp', type: 'streamable-http' } as never,
-    });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((conn as any).options.initTimeout).toBeUndefined();
   });
 });
 

--- a/packages/api/src/mcp/__tests__/reconnection-storm.test.ts
+++ b/packages/api/src/mcp/__tests__/reconnection-storm.test.ts
@@ -1,0 +1,536 @@
+/**
+ * Reconnection storm regression tests for PR #12162.
+ *
+ * Validates circuit breaker, throttling, cooldown, and timeout fixes using real
+ * MCP SDK transports (no mocked stubs). A real StreamableHTTP server is spun up
+ * per test suite and MCPConnection talks to it through a genuine HTTP stack.
+ */
+import http from 'http';
+import express from 'express';
+import { randomUUID } from 'crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { OAuthReconnectionTracker } from '~/mcp/oauth/OAuthReconnectionTracker';
+import { MCPConnection } from '~/mcp/connection';
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+interface TestServer {
+  url: string;
+  httpServer: http.Server;
+  close: () => Promise<void>;
+}
+
+function startMCPServer(): Promise<TestServer> {
+  const app = express();
+  app.use(express.json());
+
+  const transports: Record<string, StreamableHTTPServerTransport> = {};
+
+  function createServer(): McpServer {
+    const server = new McpServer({ name: 'test-server', version: '1.0.0' });
+    server.tool('echo', 'echoes input', { message: { type: 'string' } as never }, async (args) => {
+      const msg = (args as Record<string, string>).message ?? '';
+      return { content: [{ type: 'text', text: msg }] };
+    });
+    return server;
+  }
+
+  app.all('/mcp', async (req, res) => {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+    if (sessionId && transports[sessionId]) {
+      await transports[sessionId].handleRequest(req, res, req.body);
+      return;
+    }
+
+    if (!sessionId && isInitializeRequest(req.body)) {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (sid) => {
+          transports[sid] = transport;
+        },
+      });
+      transport.onclose = () => {
+        const sid = transport.sessionId;
+        if (sid) {
+          delete transports[sid];
+        }
+      };
+      const server = createServer();
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    if (req.method === 'GET') {
+      res.status(404).send('Not Found');
+      return;
+    }
+
+    res.status(400).json({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Bad Request: No valid session ID provided' },
+      id: null,
+    });
+  });
+
+  return new Promise((resolve) => {
+    const httpServer = app.listen(0, '127.0.0.1', () => {
+      const addr = httpServer.address() as { port: number };
+      resolve({
+        url: `http://127.0.0.1:${addr.port}/mcp`,
+        httpServer,
+        close: () =>
+          new Promise<void>((r) => {
+            for (const t of Object.values(transports)) {
+              t.close().catch(() => {});
+            }
+            httpServer.close(() => r());
+          }),
+      });
+    });
+  });
+}
+
+function createConnection(serverName: string, url: string, initTimeout = 5000): MCPConnection {
+  return new MCPConnection({
+    serverName,
+    serverConfig: { url, type: 'streamable-http', initTimeout } as never,
+  });
+}
+
+/**
+ * Cleanly shut down an MCPConnection so no background handleReconnection
+ * timers leak. Sets shouldStopReconnecting before disconnect so that
+ * the transport close event doesn't trigger a reconnection loop.
+ */
+async function teardownConnection(conn: MCPConnection): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (conn as any).shouldStopReconnecting = true;
+  conn.removeAllListeners();
+  await conn.disconnect();
+}
+
+afterEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (MCPConnection as any).circuitBreakers.clear();
+});
+
+/* ------------------------------------------------------------------ */
+/*  Fix #2 — Circuit breaker trips after rapid connect/disconnect      */
+/*  cycles (5 cycles within 60s -> 30s cooldown)                       */
+/* ------------------------------------------------------------------ */
+describe('Fix #2: Circuit breaker stops rapid reconnect cycling', () => {
+  it('blocks connection after 5 rapid cycles via static circuit breaker', async () => {
+    const srv = await startMCPServer();
+    const conn = createConnection('cycling-server', srv.url);
+
+    let completedCycles = 0;
+    let breakerMessage = '';
+    for (let cycle = 0; cycle < 10; cycle++) {
+      try {
+        await conn.connect();
+        await teardownConnection(conn);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (conn as any).shouldStopReconnecting = false;
+        completedCycles++;
+      } catch (e) {
+        breakerMessage = (e as Error).message;
+        break;
+      }
+    }
+
+    expect(breakerMessage).toContain('Circuit breaker is open');
+    expect(completedCycles).toBeLessThanOrEqual(5);
+
+    await srv.close();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Fix #3 — SSE 400/405 with no session now short-circuits            */
+/*  (returns early, no connectionChange 'error' emitted)               */
+/* ------------------------------------------------------------------ */
+describe('Fix #3: SSE 400/405 handled in same branch as 404', () => {
+  it('400 with active session triggers reconnection (session lost)', async () => {
+    const srv = await startMCPServer();
+    const conn = createConnection('sse-400', srv.url);
+    await conn.connect();
+
+    // Prevent background handleReconnection from spawning timers
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (conn as any).shouldStopReconnecting = true;
+
+    const changes: string[] = [];
+    conn.on('connectionChange', (s: string) => changes.push(s));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const transport = (conn as any).transport;
+    transport.onerror({ message: 'Failed to open SSE stream', code: 400 });
+
+    // With a session, 400 falls through to emit error (triggering reconnection).
+    // Previously only 404 entered this code path; 400/405 were unhandled and
+    // would also emit error but without the session-lost detection logic.
+    expect(changes).toContain('error');
+
+    await teardownConnection(conn);
+    await srv.close();
+  });
+
+  it('405 with active session triggers reconnection (session lost)', async () => {
+    const srv = await startMCPServer();
+    const conn = createConnection('sse-405', srv.url);
+    await conn.connect();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (conn as any).shouldStopReconnecting = true;
+
+    const changes: string[] = [];
+    conn.on('connectionChange', (s: string) => changes.push(s));
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const transport = (conn as any).transport;
+    transport.onerror({ message: 'Method Not Allowed', code: 405 });
+
+    expect(changes).toContain('error');
+
+    await teardownConnection(conn);
+    await srv.close();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Fix #4 — Circuit breaker state persists in static Map across       */
+/*  instance replacements                                              */
+/* ------------------------------------------------------------------ */
+describe('Fix #4: Circuit breaker state persists across instance replacement', () => {
+  it('new MCPConnection for same serverName inherits breaker state from static Map', async () => {
+    const srv = await startMCPServer();
+
+    const conn1 = createConnection('replace', srv.url);
+    await conn1.connect();
+    await teardownConnection(conn1);
+
+    // conn1's disconnect(false) inside connect() recorded a cycle in the static Map
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cbAfterConn1 = (MCPConnection as any).circuitBreakers.get('replace');
+    expect(cbAfterConn1).toBeDefined();
+    const cyclesAfterConn1 = cbAfterConn1.cycleCount;
+    expect(cyclesAfterConn1).toBeGreaterThan(0);
+
+    // New instance for same server inherits the cycle count
+    const conn2 = createConnection('replace', srv.url);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cbFromConn2 = (conn2 as any).getCircuitBreaker();
+    expect(cbFromConn2.cycleCount).toBe(cyclesAfterConn1);
+
+    await teardownConnection(conn2);
+    await srv.close();
+  });
+
+  it('clearCooldown resets static state so explicit retry proceeds', () => {
+    const conn = createConnection('replace', 'http://127.0.0.1:1/mcp');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = (conn as any).getCircuitBreaker();
+    cb.cooldownUntil = Date.now() + 999_999;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((conn as any).isCircuitOpen()).toBe(true);
+
+    MCPConnection.clearCooldown('replace');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((conn as any).isCircuitOpen()).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Fix #5 — Dead servers now trigger circuit breaker via              */
+/*  recordFailedRound() in the catch path                              */
+/* ------------------------------------------------------------------ */
+describe('Fix #5: Dead server triggers circuit breaker', () => {
+  it('3 failures trigger backoff, blocking subsequent attempts before they reach the SDK', async () => {
+    const conn = createConnection('dead', 'http://127.0.0.1:1/mcp', 1000);
+    const spy = jest.spyOn(conn.client, 'connect');
+
+    const errors: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      try {
+        await conn.connect();
+      } catch (e) {
+        errors.push((e as Error).message);
+      }
+    }
+
+    // First 3 reach client.connect and fail (recordFailedRound each time).
+    // After 3rd failure backoff kicks in; attempts 4-5 are blocked at isCircuitOpen.
+    expect(spy.mock.calls.length).toBe(3);
+    expect(errors).toHaveLength(5);
+    expect(errors.filter((m) => m.includes('Circuit breaker is open'))).toHaveLength(2);
+
+    await conn.disconnect();
+  });
+
+  it('user B is immediately blocked when user A already tripped the breaker for the same server', async () => {
+    const deadUrl = 'http://127.0.0.1:1/mcp';
+
+    // User A connects 3 times and trips the breaker
+    const userA = new MCPConnection({
+      serverName: 'shared-dead',
+      serverConfig: { url: deadUrl, type: 'streamable-http', initTimeout: 1000 } as never,
+      userId: 'user-A',
+    });
+
+    for (let i = 0; i < 3; i++) {
+      try {
+        await userA.connect();
+      } catch {
+        // expected failures
+      }
+    }
+
+    // User B's very first attempt is blocked — the breaker is per-server, not per-user.
+    // This is intentional: when a server is down, it's down for everyone. Blocking
+    // immediately prevents O(N×3) storms where each of N users independently discovers
+    // the server is unreachable.
+    const userB = new MCPConnection({
+      serverName: 'shared-dead',
+      serverConfig: { url: deadUrl, type: 'streamable-http', initTimeout: 1000 } as never,
+      userId: 'user-B',
+    });
+    const spyB = jest.spyOn(userB.client, 'connect');
+
+    let blockedMessage = '';
+    try {
+      await userB.connect();
+    } catch (e) {
+      blockedMessage = (e as Error).message;
+    }
+
+    expect(blockedMessage).toContain('Circuit breaker is open');
+    // User B's client.connect was never called — blocked before reaching the SDK
+    expect(spyB).toHaveBeenCalledTimes(0);
+
+    await userA.disconnect();
+    await userB.disconnect();
+  });
+
+  it('clearCooldown after user retry unblocks all users', async () => {
+    const deadUrl = 'http://127.0.0.1:1/mcp';
+
+    // Trip the breaker
+    const userA = new MCPConnection({
+      serverName: 'shared-dead-clear',
+      serverConfig: { url: deadUrl, type: 'streamable-http', initTimeout: 1000 } as never,
+      userId: 'user-A',
+    });
+    for (let i = 0; i < 3; i++) {
+      try {
+        await userA.connect();
+      } catch {
+        // expected
+      }
+    }
+
+    // Breaker is open for everyone
+    const userB = new MCPConnection({
+      serverName: 'shared-dead-clear',
+      serverConfig: { url: deadUrl, type: 'streamable-http', initTimeout: 1000 } as never,
+      userId: 'user-B',
+    });
+    try {
+      await userB.connect();
+    } catch (e) {
+      expect((e as Error).message).toContain('Circuit breaker is open');
+    }
+
+    // User A explicitly retries (forceNew) — clears the breaker for everyone
+    MCPConnection.clearCooldown('shared-dead-clear');
+
+    // User B can now attempt to connect again (will fail because server is
+    // still dead, but the point is the breaker no longer blocks the attempt)
+    const spyB = jest.spyOn(userB.client, 'connect');
+    try {
+      await userB.connect();
+    } catch {
+      // expected — server is still dead
+    }
+
+    // User B's attempt reached the SDK this time — not blocked by breaker
+    expect(spyB).toHaveBeenCalledTimes(1);
+
+    await userA.disconnect();
+    await userB.disconnect();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Fix #5b — disconnect(false) preserves cycle tracking               */
+/* ------------------------------------------------------------------ */
+describe('Fix #5b: disconnect(false) preserves cycle tracking', () => {
+  it('connect() passes false to disconnect, which calls recordCycle()', async () => {
+    const srv = await startMCPServer();
+    const conn = createConnection('wipe', srv.url);
+    const spy = jest.spyOn(conn, 'disconnect');
+
+    await conn.connect();
+    expect(spy).toHaveBeenCalledWith(false);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cb = (MCPConnection as any).circuitBreakers.get('wipe');
+    expect(cb).toBeDefined();
+    expect(cb.cycleCount).toBeGreaterThan(0);
+
+    await teardownConnection(conn);
+    await srv.close();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Fix #6 — OAuth failure uses cooldown-based retry                   */
+/* ------------------------------------------------------------------ */
+describe('Fix #6: OAuth failure uses cooldown-based retry', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('isFailed expires after first cooldown of 5 min', () => {
+    jest.setSystemTime(Date.now());
+    const tracker = new OAuthReconnectionTracker();
+    tracker.setFailed('u1', 'srv');
+
+    expect(tracker.isFailed('u1', 'srv')).toBe(true);
+    jest.advanceTimersByTime(5 * 60 * 1000);
+    expect(tracker.isFailed('u1', 'srv')).toBe(false);
+  });
+
+  it('progressive cooldown: 5m, 10m, 20m, 30m (capped)', () => {
+    jest.setSystemTime(Date.now());
+    const tracker = new OAuthReconnectionTracker();
+
+    tracker.setFailed('u1', 'srv');
+    jest.advanceTimersByTime(5 * 60 * 1000);
+    expect(tracker.isFailed('u1', 'srv')).toBe(false);
+
+    tracker.setFailed('u1', 'srv');
+    jest.advanceTimersByTime(10 * 60 * 1000);
+    expect(tracker.isFailed('u1', 'srv')).toBe(false);
+
+    tracker.setFailed('u1', 'srv');
+    jest.advanceTimersByTime(20 * 60 * 1000);
+    expect(tracker.isFailed('u1', 'srv')).toBe(false);
+
+    // 4th failure: 30 min cap — still blocked at 29m, clear at 30m
+    tracker.setFailed('u1', 'srv');
+    jest.advanceTimersByTime(29 * 60 * 1000);
+    expect(tracker.isFailed('u1', 'srv')).toBe(true);
+    jest.advanceTimersByTime(1 * 60 * 1000);
+    expect(tracker.isFailed('u1', 'srv')).toBe(false);
+  });
+
+  it('removeFailed resets attempt count so next failure starts at 5m', () => {
+    jest.setSystemTime(Date.now());
+    const tracker = new OAuthReconnectionTracker();
+
+    tracker.setFailed('u1', 'srv');
+    tracker.setFailed('u1', 'srv');
+    tracker.setFailed('u1', 'srv');
+    tracker.removeFailed('u1', 'srv');
+
+    tracker.setFailed('u1', 'srv');
+    jest.advanceTimersByTime(5 * 60 * 1000);
+    expect(tracker.isFailed('u1', 'srv')).toBe(false);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Fix #8 — Default initTimeout reduced from 120s to 30s              */
+/* ------------------------------------------------------------------ */
+describe('Fix #8: Default initTimeout is 30s', () => {
+  it('options.initTimeout is undefined, code falls back to DEFAULT_INIT_TIMEOUT (30s)', () => {
+    const conn = new MCPConnection({
+      serverName: 'prod',
+      serverConfig: { url: 'http://127.0.0.1:1/mcp', type: 'streamable-http' } as never,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((conn as any).options.initTimeout).toBeUndefined();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Integration: Circuit breaker caps rapid cycling with real transport */
+/* ------------------------------------------------------------------ */
+describe('Cascade: Circuit breaker caps rapid cycling', () => {
+  it('breaker trips before 10 cycles complete against a live server', async () => {
+    const srv = await startMCPServer();
+    const conn = createConnection('cascade', srv.url);
+    const spy = jest.spyOn(conn.client, 'connect');
+
+    let completedCycles = 0;
+    for (let i = 0; i < 10; i++) {
+      try {
+        await conn.connect();
+        await teardownConnection(conn);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (conn as any).shouldStopReconnecting = false;
+        completedCycles++;
+      } catch (e) {
+        if ((e as Error).message.includes('Circuit breaker is open')) {
+          break;
+        }
+        throw e;
+      }
+    }
+
+    expect(completedCycles).toBeLessThanOrEqual(5);
+    expect(spy.mock.calls.length).toBeLessThanOrEqual(5);
+
+    await srv.close();
+  });
+
+  it('breaker bounds failures against a killed server', async () => {
+    const srv = await startMCPServer();
+    const conn = createConnection('cascade-die', srv.url, 2000);
+
+    await conn.connect();
+    await teardownConnection(conn);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (conn as any).shouldStopReconnecting = false;
+    await srv.close();
+
+    let breakerTripped = false;
+    for (let i = 0; i < 10; i++) {
+      try {
+        await conn.connect();
+      } catch (e) {
+        if ((e as Error).message.includes('Circuit breaker is open')) {
+          breakerTripped = true;
+          break;
+        }
+      }
+    }
+
+    expect(breakerTripped).toBe(true);
+  }, 30_000);
+});
+
+/* ------------------------------------------------------------------ */
+/*  Sanity: Real transport works end-to-end                            */
+/* ------------------------------------------------------------------ */
+describe('Sanity: Real MCP SDK transport works correctly', () => {
+  it('connects, lists tools, and disconnects cleanly', async () => {
+    const srv = await startMCPServer();
+    const conn = createConnection('sanity', srv.url);
+
+    await conn.connect();
+    expect(await conn.isConnected()).toBe(true);
+
+    const tools = await conn.fetchTools();
+    expect(tools).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'echo' })]));
+
+    await teardownConnection(conn);
+    await srv.close();
+  });
+});


### PR DESCRIPTION


## Summary

Addressed four code review findings from PR #12162, adding correctness fixes, test infrastructure improvements, and a new integration test suite validating the circuit breaker and storm prevention behavior end-to-end.

- Fixed `createUnavailableToolStub` to return `[unavailableMsg, null]` instead of a bare string, satisfying LangChain's `content_and_artifact` two-tuple contract — a bare string caused `"Tool response format is content_and_artifact but the output was not a two-tuple"` at invocation time.
- Separated the throttled-reconnect return path in `createMCPTools` from the genuine failure path, logging at `debug` level with "Reconnect throttled" instead of emitting a misleading `warn` of "Failed to reinitialize MCP server."
- Added `reconnection-storm.test.ts` using real `@modelcontextprotocol/sdk` `StreamableHTTPServerTransport` with a live Express server — no transport mocking — covering: cycle-based circuit breaker tripping, dead-server failure backoff blocking `client.connect()` before it reaches the SDK, cross-user breaker sharing and `clearCooldown()` unblocking, `disconnect(false)` cycle recording, static state persistence across instance replacements, SSE 400/405 session-lost reconnection triggering, and progressive OAuth cooldown schedule.
- Added `trackSockets()` to `startMCPServer` to force-destroy lingering keep-alive connections on server close, preventing test hangs when a test fails before `teardownConnection` runs.
- Added `jest.mock('@librechat/data-schemas')` with a silent logger, matching the pattern in peer integration test files and guarding against module initialization side effects in CI.
- Deleted the `Fix #8` placeholder test that asserted `options.initTimeout` is `undefined` — a trivially true check that provided no signal about the actual 30s fallback behavior.
- Added `MCP.spec.js` tests covering: `stub.invoke({})` completing without throwing (proving the two-tuple fix), negative cache cross-user dedup (user B hitting the cache after user A's reconnect), throttle-cached entries blocking user B's unthrottled first request, and `createMCPTools` returning `[]` with a `debug` log when throttled.
- Updated `AGENTS.md` with an explicit testing philosophy: real logic over mocks, spies over stubs, `mongodb-memory-server` for DB tests, real MCP SDK exports for MCP tests.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

```
cd packages/api && npx jest reconnection-storm
cd api && npx jest MCP.spec
```

No external services required — all network traffic is loopback (`127.0.0.1`).

### Test Configuration

Node.js v20.19.0+, MongoDB not required for these test suites.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes