### PR TITLE
🫙 fix: Force MeiliSearch Full Sync on Empty Index State

### DIFF
--- a/api/db/indexSync.js
+++ b/api/db/indexSync.js
@@ -236,8 +236,14 @@ async function performSync(flowManager, flowId, flowType) {
       const messageCount = messageProgress.totalDocuments;
       const messagesIndexed = messageProgress.totalProcessed;
       const unindexedMessages = messageCount - messagesIndexed;
+      const freshIndex = messagesIndexed === 0 && unindexedMessages > 0;
 
-      if (settingsUpdated || unindexedMessages > syncThreshold) {
+      if (settingsUpdated || freshIndex || unindexedMessages > syncThreshold) {
+        if (freshIndex) {
+          logger.info(
+            `[indexSync] Fresh MeiliSearch index detected for messages, forcing full sync`,
+          );
+        }
         logger.info(`[indexSync] Starting message sync (${unindexedMessages} unindexed)`);
         await Message.syncWithMeili();
         messagesSync = true;
@@ -261,9 +267,13 @@ async function performSync(flowManager, flowId, flowType) {
 
       const convoCount = convoProgress.totalDocuments;
       const convosIndexed = convoProgress.totalProcessed;
-
       const unindexedConvos = convoCount - convosIndexed;
-      if (settingsUpdated || unindexedConvos > syncThreshold) {
+      const freshConvoIndex = convosIndexed === 0 && unindexedConvos > 0;
+
+      if (settingsUpdated || freshConvoIndex || unindexedConvos > syncThreshold) {
+        if (freshConvoIndex) {
+          logger.info(`[indexSync] Fresh MeiliSearch index detected for convos, forcing full sync`);
+        }
         logger.info(`[indexSync] Starting convos sync (${unindexedConvos} unindexed)`);
         await Conversation.syncWithMeili();
         convosSync = true;

--- a/api/db/indexSync.js
+++ b/api/db/indexSync.js
@@ -236,13 +236,11 @@ async function performSync(flowManager, flowId, flowType) {
       const messageCount = messageProgress.totalDocuments;
       const messagesIndexed = messageProgress.totalProcessed;
       const unindexedMessages = messageCount - messagesIndexed;
-      const freshIndex = messagesIndexed === 0 && unindexedMessages > 0;
+      const noneIndexed = messagesIndexed === 0 && unindexedMessages > 0;
 
-      if (settingsUpdated || freshIndex || unindexedMessages > syncThreshold) {
-        if (freshIndex) {
-          logger.info(
-            `[indexSync] Fresh MeiliSearch index detected for messages, forcing full sync`,
-          );
+      if (settingsUpdated || noneIndexed || unindexedMessages > syncThreshold) {
+        if (noneIndexed && !settingsUpdated) {
+          logger.info('[indexSync] No messages marked as indexed, forcing full sync');
         }
         logger.info(`[indexSync] Starting message sync (${unindexedMessages} unindexed)`);
         await Message.syncWithMeili();
@@ -268,11 +266,11 @@ async function performSync(flowManager, flowId, flowType) {
       const convoCount = convoProgress.totalDocuments;
       const convosIndexed = convoProgress.totalProcessed;
       const unindexedConvos = convoCount - convosIndexed;
-      const freshConvoIndex = convosIndexed === 0 && unindexedConvos > 0;
+      const noneConvosIndexed = convosIndexed === 0 && unindexedConvos > 0;
 
-      if (settingsUpdated || freshConvoIndex || unindexedConvos > syncThreshold) {
-        if (freshConvoIndex) {
-          logger.info(`[indexSync] Fresh MeiliSearch index detected for convos, forcing full sync`);
+      if (settingsUpdated || noneConvosIndexed || unindexedConvos > syncThreshold) {
+        if (noneConvosIndexed && !settingsUpdated) {
+          logger.info('[indexSync] No conversations marked as indexed, forcing full sync');
         }
         logger.info(`[indexSync] Starting convos sync (${unindexedConvos} unindexed)`);
         await Conversation.syncWithMeili();

--- a/api/db/indexSync.spec.js
+++ b/api/db/indexSync.spec.js
@@ -463,18 +463,16 @@ describe('performSync() - syncThreshold logic', () => {
     expect(mockLogger.info).toHaveBeenCalledWith('[indexSync] Starting convos sync (50 unindexed)');
   });
 
-  test('forces sync on fresh MeiliSearch index (zero indexed) even if below threshold', async () => {
-    process.env.MEILI_SYNC_THRESHOLD = '1000';
-
+  test('forces sync when zero documents indexed (reset scenario) even if below threshold', async () => {
     Message.getSyncProgress.mockResolvedValue({
       totalProcessed: 0,
-      totalDocuments: 680, // 680 unindexed, all need syncing but < 1000 threshold
+      totalDocuments: 680,
       isComplete: false,
     });
 
     Conversation.getSyncProgress.mockResolvedValue({
       totalProcessed: 0,
-      totalDocuments: 76, // 76 unindexed, all need syncing but < 1000 threshold
+      totalDocuments: 76,
       isComplete: false,
     });
 
@@ -487,31 +485,27 @@ describe('performSync() - syncThreshold logic', () => {
     expect(Message.syncWithMeili).toHaveBeenCalledTimes(1);
     expect(Conversation.syncWithMeili).toHaveBeenCalledTimes(1);
     expect(mockLogger.info).toHaveBeenCalledWith(
-      '[indexSync] Fresh MeiliSearch index detected for messages, forcing full sync',
+      '[indexSync] No messages marked as indexed, forcing full sync',
     );
     expect(mockLogger.info).toHaveBeenCalledWith(
       '[indexSync] Starting message sync (680 unindexed)',
     );
     expect(mockLogger.info).toHaveBeenCalledWith(
-      '[indexSync] Fresh MeiliSearch index detected for convos, forcing full sync',
+      '[indexSync] No conversations marked as indexed, forcing full sync',
     );
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      '[indexSync] Starting convos sync (76 unindexed)',
-    );
+    expect(mockLogger.info).toHaveBeenCalledWith('[indexSync] Starting convos sync (76 unindexed)');
   });
 
   test('does NOT force sync when some documents already indexed and below threshold', async () => {
-    process.env.MEILI_SYNC_THRESHOLD = '1000';
-
     Message.getSyncProgress.mockResolvedValue({
       totalProcessed: 630,
-      totalDocuments: 680, // 50 unindexed, below threshold, partial sync state
+      totalDocuments: 680,
       isComplete: false,
     });
 
     Conversation.getSyncProgress.mockResolvedValue({
       totalProcessed: 70,
-      totalDocuments: 76, // 6 unindexed, below threshold
+      totalDocuments: 76,
       isComplete: false,
     });
 
@@ -520,6 +514,12 @@ describe('performSync() - syncThreshold logic', () => {
 
     expect(Message.syncWithMeili).not.toHaveBeenCalled();
     expect(Conversation.syncWithMeili).not.toHaveBeenCalled();
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      '[indexSync] No messages marked as indexed, forcing full sync',
+    );
+    expect(mockLogger.info).not.toHaveBeenCalledWith(
+      '[indexSync] No conversations marked as indexed, forcing full sync',
+    );
     expect(mockLogger.info).toHaveBeenCalledWith(
       '[indexSync] 50 messages unindexed (below threshold: 1000, skipping)',
     );

--- a/api/db/indexSync.spec.js
+++ b/api/db/indexSync.spec.js
@@ -462,4 +462,69 @@ describe('performSync() - syncThreshold logic', () => {
     );
     expect(mockLogger.info).toHaveBeenCalledWith('[indexSync] Starting convos sync (50 unindexed)');
   });
+
+  test('forces sync on fresh MeiliSearch index (zero indexed) even if below threshold', async () => {
+    process.env.MEILI_SYNC_THRESHOLD = '1000';
+
+    Message.getSyncProgress.mockResolvedValue({
+      totalProcessed: 0,
+      totalDocuments: 680, // 680 unindexed, all need syncing but < 1000 threshold
+      isComplete: false,
+    });
+
+    Conversation.getSyncProgress.mockResolvedValue({
+      totalProcessed: 0,
+      totalDocuments: 76, // 76 unindexed, all need syncing but < 1000 threshold
+      isComplete: false,
+    });
+
+    Message.syncWithMeili.mockResolvedValue(undefined);
+    Conversation.syncWithMeili.mockResolvedValue(undefined);
+
+    const indexSync = require('./indexSync');
+    await indexSync();
+
+    expect(Message.syncWithMeili).toHaveBeenCalledTimes(1);
+    expect(Conversation.syncWithMeili).toHaveBeenCalledTimes(1);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      '[indexSync] Fresh MeiliSearch index detected for messages, forcing full sync',
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      '[indexSync] Starting message sync (680 unindexed)',
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      '[indexSync] Fresh MeiliSearch index detected for convos, forcing full sync',
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      '[indexSync] Starting convos sync (76 unindexed)',
+    );
+  });
+
+  test('does NOT force sync when some documents already indexed and below threshold', async () => {
+    process.env.MEILI_SYNC_THRESHOLD = '1000';
+
+    Message.getSyncProgress.mockResolvedValue({
+      totalProcessed: 630,
+      totalDocuments: 680, // 50 unindexed, below threshold, partial sync state
+      isComplete: false,
+    });
+
+    Conversation.getSyncProgress.mockResolvedValue({
+      totalProcessed: 70,
+      totalDocuments: 76, // 6 unindexed, below threshold
+      isComplete: false,
+    });
+
+    const indexSync = require('./indexSync');
+    await indexSync();
+
+    expect(Message.syncWithMeili).not.toHaveBeenCalled();
+    expect(Conversation.syncWithMeili).not.toHaveBeenCalled();
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      '[indexSync] 50 messages unindexed (below threshold: 1000, skipping)',
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      '[indexSync] 6 convos unindexed (below threshold: 1000, skipping)',
+    );
+  });
 });

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -581,7 +581,6 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
   /** Create index only if it doesn't exist */
   const index = client.index<MeiliIndexable>(indexName);
 
-  // Check if index exists and create if needed
   (async () => {
     try {
       await index.getRawInfo();
@@ -591,18 +590,26 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
       if (errorCode === 'index_not_found') {
         try {
           logger.info(`[mongoMeili] Creating new index: ${indexName}`);
-          await client.createIndex(indexName, { primaryKey });
+          const enqueued = await client.createIndex(indexName, { primaryKey });
+          const task = await client.waitForTask(enqueued.taskUid, {
+            timeOutMs: 10000,
+            intervalMs: 100,
+          });
+          logger.info(`[mongoMeili] Index ${indexName} creation task:`, task);
           logger.info(`[mongoMeili] Successfully created index: ${indexName}`);
         } catch (createError) {
-          // Index might have been created by another instance
-          logger.debug(`[mongoMeili] Index ${indexName} may already exist:`, createError);
+          const createCode = (createError as { code?: string })?.code;
+          if (createCode === 'index_already_exists') {
+            logger.debug(`[mongoMeili] Index ${indexName} was created by another instance`);
+          } else {
+            logger.warn(`[mongoMeili] Error creating index ${indexName}:`, createError);
+          }
         }
       } else {
         logger.error(`[mongoMeili] Error checking index ${indexName}:`, error);
       }
     }
 
-    // Configure index settings to make 'user' field filterable
     try {
       await index.updateSettings({
         filterableAttributes: ['user'],

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -596,7 +596,7 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
             intervalMs: 100,
           });
           logger.debug(`[mongoMeili] Index ${indexName} creation task:`, task);
-          if (task.status === 'failed') {
+          if (task.status !== 'succeeded') {
             const taskError = task.error as MeiliSearchErrorInfo | null;
             if (taskError?.code === 'index_already_exists') {
               logger.debug(`[mongoMeili] Index ${indexName} was created by another instance`);

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
-import { MeiliSearch } from 'meilisearch';
 import { parseTextParts } from 'librechat-data-provider';
-import type { SearchResponse, SearchParams, Index } from 'meilisearch';
+import { MeiliSearch, MeiliSearchTimeOutError } from 'meilisearch';
+import type { SearchResponse, SearchParams, Index, MeiliSearchErrorInfo } from 'meilisearch';
 import type {
   CallbackWithoutResultAndOptionalError,
   FilterQuery,
@@ -595,12 +595,20 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
             timeOutMs: 10000,
             intervalMs: 100,
           });
-          logger.info(`[mongoMeili] Index ${indexName} creation task:`, task);
-          logger.info(`[mongoMeili] Successfully created index: ${indexName}`);
+          logger.debug(`[mongoMeili] Index ${indexName} creation task:`, task);
+          if (task.status === 'failed') {
+            const taskError = task.error as MeiliSearchErrorInfo | null;
+            if (taskError?.code === 'index_already_exists') {
+              logger.debug(`[mongoMeili] Index ${indexName} was created by another instance`);
+            } else {
+              logger.warn(`[mongoMeili] Index ${indexName} creation failed:`, taskError);
+            }
+          } else {
+            logger.info(`[mongoMeili] Successfully created index: ${indexName}`);
+          }
         } catch (createError) {
-          const createCode = (createError as { code?: string })?.code;
-          if (createCode === 'index_already_exists') {
-            logger.debug(`[mongoMeili] Index ${indexName} was created by another instance`);
+          if (createError instanceof MeiliSearchTimeOutError) {
+            logger.warn(`[mongoMeili] Timed out waiting for index ${indexName} creation`);
           } else {
             logger.warn(`[mongoMeili] Error creating index ${indexName}:`, createError);
           }


### PR DESCRIPTION
## Summary

Fixed a bug where MeiliSearch sync was silently skipped at startup when all documents were unindexed but their count fell below `MEILI_SYNC_THRESHOLD`, leaving a fresh or reset index permanently empty. Also hardened index creation in the `mongoMeili` plugin to correctly handle async task outcomes and timeout races.

- Added `noneIndexed` and `noneConvosIndexed` bypass conditions in `performSync` that force a full sync when `totalProcessed === 0` and unindexed documents exist, regardless of whether their count exceeds the threshold.
- Guarded the "none indexed" log message with `!settingsUpdated` to prevent redundant log noise when a settings-triggered re-sync already accounts for the same condition.
- Replaced `waitForTask`-adjacent success logging in `mongoMeili` with a `task.status !== 'succeeded'` check, ensuring the "Successfully created index" message only fires on a confirmed succeeded task and not on `failed` or `canceled` outcomes.
- Handled the async `index_already_exists` race condition via `task.error.code` rather than only the synchronous `createIndex` throw, which is the actual path MeiliSearch surfaces in concurrent-instance scenarios.
- Replaced the bare `as { code?: string }` cast in the timeout catch with `instanceof MeiliSearchTimeOutError`, and used the `MeiliSearchErrorInfo` type for `task.error` narrowing.
- Demoted the verbose task object log from `info` to `debug` level.
- Added two new tests: one asserting sync is forced when zero documents are marked as indexed, and one asserting sync is correctly skipped when a partial indexed state exists below threshold.
- Removed redundant per-test `MEILI_SYNC_THRESHOLD` assignments already covered by `beforeEach`, and added negative `not.toHaveBeenCalledWith` assertions for the "none indexed" log in the partial-sync test.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Two new Jest tests cover the introduced behavior directly in `api/db/indexSync.spec.js`:

1. **`forces sync when zero documents indexed (reset scenario) even if below threshold`** — sets `totalProcessed: 0` with documents present below the 1000 threshold, asserts both `syncWithMeili` calls fire and the correct log messages appear.
2. **`does NOT force sync when some documents already indexed and below threshold`** — sets a partial indexed state (`totalProcessed: 630/680`), asserts no sync fires, the "none indexed" log does not appear, and the "below threshold, skipping" log does.

### **Test Configuration**:

- `MEILI_SYNC_THRESHOLD=1000`
- `SEARCH=true`
- `MEILI_HOST=http://localhost:7700`
- `MEILI_MASTER_KEY=test-key`

Run from the `api` workspace: `npx jest indexSync`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes