### PR TITLE
fix(helm): default MongoDB image tag to "latest" (fixes #11568)

### DIFF
--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -293,6 +293,8 @@ mongodb:
   enabled: true
   auth:
     enabled: false
+  image:
+    tag: "latest"  # Bitnami removed versioned tags from Docker Hub (see #11568)
   databases:
    - LibreChat
 #  persistence: 


### PR DESCRIPTION
Add image tag for MongoDB configuration in values.yaml

## Problem
Fresh Helm installs fail with `ImagePullBackOff` because the Bitnami MongoDB sub-chart references a versioned image tag (e.g. `8.0.13-debian-12-r0`) that no longer exists on Docker Hub. Bitnami removed all versioned tags from their `bitnami/mongodb` repository.

## Fix
Set `mongodb.image.tag: "latest"` in the chart's default `values.yaml` so installs work out of the box.

## Risk
`latest` is unpinned — a future Bitnami push could introduce breaking changes. For production, users should pin to a SHA256 digest. A longer-term fix could switch to the official `mongo` image or pin a stable digest.

## Related Issues
Fixes #11568
Related: #11516, #10587, #10247, #10242

## Summary

Bitnami removed all versioned MongoDB tags from Docker Hub, breaking fresh Helm installs. This one-line change defaults `mongodb.image.tag` to `"latest"` so the chart works without user overrides.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Deployed LibreChat via Helm on a Kubernetes cluster. MongoDB pod starts successfully with `bitnami/mongodb:latest`.

### **Test Configuration**:
- Kubernetes v1.33.5
- Helm v3.17.0
- LibreChat Helm chart v2.0.0

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings