### PR TITLE
🌊 fix: Prevent Buffered Event Duplication on SSE Resume Connections

### DIFF
--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -87,9 +87,7 @@ router.get('/chat/stream/:streamId', async (req, res) => {
 
   const onDone = (event) => {
     writeEvent(event);
-    if (!res.writableEnded) {
-      res.end();
-    }
+    res.end();
   };
 
   const onError = (error) => {
@@ -108,17 +106,26 @@ router.get('/chat/stream/:streamId', async (req, res) => {
     const { subscription, resumeState, pendingEvents } =
       await GenerationJobManager.subscribeWithResume(streamId, writeEvent, onDone, onError);
 
-    if (resumeState && !res.writableEnded) {
-      res.write(
-        `event: message\ndata: ${JSON.stringify({ sync: true, resumeState, pendingEvents })}\n\n`,
-      );
-      if (typeof res.flush === 'function') {
-        res.flush();
+    if (!res.writableEnded) {
+      if (resumeState) {
+        res.write(
+          `event: message\ndata: ${JSON.stringify({ sync: true, resumeState, pendingEvents })}\n\n`,
+        );
+        if (typeof res.flush === 'function') {
+          res.flush();
+        }
+        GenerationJobManager.markSyncSent(streamId);
+        logger.debug(
+          `[AgentStream] Sent sync event for ${streamId} with ${resumeState.runSteps.length} run steps, ${pendingEvents.length} pending events`,
+        );
+      } else if (pendingEvents.length > 0) {
+        for (const event of pendingEvents) {
+          writeEvent(event);
+        }
+        logger.warn(
+          `[AgentStream] Resume state null for ${streamId}, replayed ${pendingEvents.length} gap events directly`,
+        );
       }
-      GenerationJobManager.markSyncSent(streamId);
-      logger.debug(
-        `[AgentStream] Sent sync event for ${streamId} with ${resumeState.runSteps.length} run steps, ${pendingEvents.length} pending events`,
-      );
     }
 
     result = subscription;

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -121,6 +121,7 @@ router.get('/chat/stream/:streamId', async (req, res) => {
         res.end();
       }
     },
+    isResume ? { skipBufferReplay: true } : undefined,
   );
 
   if (!result) {

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -76,52 +76,55 @@ router.get('/chat/stream/:streamId', async (req, res) => {
 
   logger.debug(`[AgentStream] Client subscribed to ${streamId}, resume: ${isResume}`);
 
-  let syncWasSent = false;
-  if (isResume) {
-    const resumeState = await GenerationJobManager.getResumeState(streamId);
-    if (resumeState && !res.writableEnded) {
-      res.write(`event: message\ndata: ${JSON.stringify({ sync: true, resumeState })}\n\n`);
+  const writeEvent = (event) => {
+    if (!res.writableEnded) {
+      res.write(`event: message\ndata: ${JSON.stringify(event)}\n\n`);
       if (typeof res.flush === 'function') {
         res.flush();
       }
-      syncWasSent = true;
+    }
+  };
+
+  const onDone = (event) => {
+    writeEvent(event);
+    if (!res.writableEnded) {
+      res.end();
+    }
+  };
+
+  const onError = (error) => {
+    if (!res.writableEnded) {
+      res.write(`event: error\ndata: ${JSON.stringify({ error })}\n\n`);
+      if (typeof res.flush === 'function') {
+        res.flush();
+      }
+      res.end();
+    }
+  };
+
+  let result;
+
+  if (isResume) {
+    const { subscription, resumeState, pendingEvents } =
+      await GenerationJobManager.subscribeWithResume(streamId, writeEvent, onDone, onError);
+
+    if (resumeState && !res.writableEnded) {
+      res.write(
+        `event: message\ndata: ${JSON.stringify({ sync: true, resumeState, pendingEvents })}\n\n`,
+      );
+      if (typeof res.flush === 'function') {
+        res.flush();
+      }
       GenerationJobManager.markSyncSent(streamId);
       logger.debug(
-        `[AgentStream] Sent sync event for ${streamId} with ${resumeState.runSteps.length} run steps`,
+        `[AgentStream] Sent sync event for ${streamId} with ${resumeState.runSteps.length} run steps, ${pendingEvents.length} pending events`,
       );
     }
-  }
 
-  const result = await GenerationJobManager.subscribe(
-    streamId,
-    (event) => {
-      if (!res.writableEnded) {
-        res.write(`event: message\ndata: ${JSON.stringify(event)}\n\n`);
-        if (typeof res.flush === 'function') {
-          res.flush();
-        }
-      }
-    },
-    (event) => {
-      if (!res.writableEnded) {
-        res.write(`event: message\ndata: ${JSON.stringify(event)}\n\n`);
-        if (typeof res.flush === 'function') {
-          res.flush();
-        }
-        res.end();
-      }
-    },
-    (error) => {
-      if (!res.writableEnded) {
-        res.write(`event: error\ndata: ${JSON.stringify({ error })}\n\n`);
-        if (typeof res.flush === 'function') {
-          res.flush();
-        }
-        res.end();
-      }
-    },
-    syncWasSent ? { skipBufferReplay: true } : undefined,
-  );
+    result = subscription;
+  } else {
+    result = await GenerationJobManager.subscribe(streamId, writeEvent, onDone, onError);
+  }
 
   if (!result) {
     return res.status(404).json({ error: 'Failed to subscribe to stream' });

--- a/api/server/routes/agents/index.js
+++ b/api/server/routes/agents/index.js
@@ -76,17 +76,16 @@ router.get('/chat/stream/:streamId', async (req, res) => {
 
   logger.debug(`[AgentStream] Client subscribed to ${streamId}, resume: ${isResume}`);
 
-  // Send sync event with resume state for ALL reconnecting clients
-  // This supports multi-tab scenarios where each tab needs run step data
+  let syncWasSent = false;
   if (isResume) {
     const resumeState = await GenerationJobManager.getResumeState(streamId);
     if (resumeState && !res.writableEnded) {
-      // Send sync event with run steps AND aggregatedContent
-      // Client will use aggregatedContent to initialize message state
       res.write(`event: message\ndata: ${JSON.stringify({ sync: true, resumeState })}\n\n`);
       if (typeof res.flush === 'function') {
         res.flush();
       }
+      syncWasSent = true;
+      GenerationJobManager.markSyncSent(streamId);
       logger.debug(
         `[AgentStream] Sent sync event for ${streamId} with ${resumeState.runSteps.length} run steps`,
       );
@@ -121,7 +120,7 @@ router.get('/chat/stream/:streamId', async (req, res) => {
         res.end();
       }
     },
-    isResume ? { skipBufferReplay: true } : undefined,
+    syncWasSent ? { skipBufferReplay: true } : undefined,
   );
 
   if (!result) {

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -291,19 +291,18 @@ export default function useResumableSSE(
                 syncStepMessage(updated[responseIdx]);
                 console.log('[ResumableSSE] SYNC complete, handlers synced');
               } else {
-                // Add new response message
                 const responseId = serverResponseId ?? `${userMsgId}_`;
-                setMessages([
-                  ...messages,
-                  {
-                    messageId: responseId,
-                    parentMessageId: userMsgId,
-                    conversationId: currentSubmission.conversation?.conversationId ?? '',
-                    text: '',
-                    content: data.resumeState.aggregatedContent,
-                    isCreatedByUser: false,
-                  } as TMessage,
-                ]);
+                const newMessage = {
+                  messageId: responseId,
+                  parentMessageId: userMsgId,
+                  conversationId: currentSubmission.conversation?.conversationId ?? '',
+                  text: '',
+                  content: data.resumeState.aggregatedContent,
+                  isCreatedByUser: false,
+                } as TMessage;
+                setMessages([...messages, newMessage]);
+                resetContentHandler();
+                syncStepMessage(newMessage);
               }
             }
 

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -226,12 +226,12 @@ export default function useResumableSSE(
           if (data.sync != null) {
             console.log('[ResumableSSE] SYNC received', {
               runSteps: data.resumeState?.runSteps?.length ?? 0,
+              pendingEvents: data.pendingEvents?.length ?? 0,
             });
 
             const runId = v4();
             setActiveRunId(runId);
 
-            // Replay run steps
             if (data.resumeState?.runSteps) {
               for (const runStep of data.resumeState.runSteps) {
                 stepHandler({ event: 'on_run_step', data: runStep }, {
@@ -241,19 +241,15 @@ export default function useResumableSSE(
               }
             }
 
-            // Set message content from aggregatedContent
             if (data.resumeState?.aggregatedContent && userMessage?.messageId) {
               const messages = getMessages() ?? [];
               const userMsgId = userMessage.messageId;
               const serverResponseId = data.resumeState.responseMessageId;
 
-              // Find the EXACT response message - prioritize responseMessageId from server
-              // This is critical when there are multiple responses to the same user message
               let responseIdx = -1;
               if (serverResponseId) {
                 responseIdx = messages.findIndex((m) => m.messageId === serverResponseId);
               }
-              // Fallback: find by parentMessageId pattern (for new messages)
               if (responseIdx < 0) {
                 responseIdx = messages.findIndex(
                   (m) =>
@@ -272,7 +268,6 @@ export default function useResumableSSE(
               });
 
               if (responseIdx >= 0) {
-                // Update existing response message with aggregatedContent
                 const updated = [...messages];
                 const oldContent = updated[responseIdx]?.content;
                 updated[responseIdx] = {
@@ -285,8 +280,6 @@ export default function useResumableSSE(
                   newContentLength: data.resumeState.aggregatedContent?.length,
                 });
                 setMessages(updated);
-                // Sync both content handler and step handler with the updated message
-                // so subsequent deltas build on synced content, not stale content
                 resetContentHandler();
                 syncStepMessage(updated[responseIdx]);
                 console.log('[ResumableSSE] SYNC complete, handlers synced');
@@ -303,6 +296,18 @@ export default function useResumableSSE(
                 setMessages([...messages, newMessage]);
                 resetContentHandler();
                 syncStepMessage(newMessage);
+              }
+            }
+
+            if (data.pendingEvents?.length > 0) {
+              console.log(`[ResumableSSE] Replaying ${data.pendingEvents.length} pending events`);
+              const submission = { ...currentSubmission, userMessage } as EventSubmission;
+              for (const pendingEvent of data.pendingEvents) {
+                if (pendingEvent.event != null) {
+                  stepHandler(pendingEvent, submission);
+                } else if (pendingEvent.type != null) {
+                  contentHandler({ data: pendingEvent, submission });
+                }
               }
             }
 

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -707,6 +707,7 @@ class GenerationJobManagerClass {
    * @param onChunk - Handler for chunk events (streamed tokens, run steps, etc.)
    * @param onDone - Handler for completion event (includes final message)
    * @param onError - Handler for error events
+   * @param options - Subscription configuration
    * @param options.skipBufferReplay - When true, skips replaying the earlyEventBuffer.
    *   Use this when a sync event was already sent (resume), since the sync's
    *   aggregatedContent already includes all buffered events.
@@ -717,7 +718,7 @@ class GenerationJobManagerClass {
     onChunk: t.ChunkHandler,
     onDone?: t.DoneHandler,
     onError?: t.ErrorHandler,
-    options?: { skipBufferReplay?: boolean },
+    options?: t.SubscribeOptions,
   ): Promise<{ unsubscribe: t.UnsubscribeFn } | null> {
     // Use lazy initialization to support cross-replica subscriptions
     const runtime = await this.getOrCreateRuntimeState(streamId);
@@ -769,7 +770,7 @@ class GenerationJobManagerClass {
       if (runtime.earlyEventBuffer.length > 0) {
         if (options?.skipBufferReplay) {
           logger.debug(
-            `[GenerationJobManager] Skipping ${runtime.earlyEventBuffer.length} buffered events for ${streamId} (sync already sent)`,
+            `[GenerationJobManager] Skipping ${runtime.earlyEventBuffer.length} buffered events for ${streamId} (skipBufferReplay)`,
           );
         } else {
           logger.debug(

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -707,6 +707,9 @@ class GenerationJobManagerClass {
    * @param onChunk - Handler for chunk events (streamed tokens, run steps, etc.)
    * @param onDone - Handler for completion event (includes final message)
    * @param onError - Handler for error events
+   * @param options.skipBufferReplay - When true, skips replaying the earlyEventBuffer.
+   *   Use this when a sync event was already sent (resume), since the sync's
+   *   aggregatedContent already includes all buffered events.
    * @returns Subscription object with unsubscribe function, or null if job not found
    */
   async subscribe(
@@ -714,6 +717,7 @@ class GenerationJobManagerClass {
     onChunk: t.ChunkHandler,
     onDone?: t.DoneHandler,
     onError?: t.ErrorHandler,
+    options?: { skipBufferReplay?: boolean },
   ): Promise<{ unsubscribe: t.UnsubscribeFn } | null> {
     // Use lazy initialization to support cross-replica subscriptions
     const runtime = await this.getOrCreateRuntimeState(streamId);
@@ -763,11 +767,17 @@ class GenerationJobManagerClass {
       runtime.hasSubscriber = true;
 
       if (runtime.earlyEventBuffer.length > 0) {
-        logger.debug(
-          `[GenerationJobManager] Replaying ${runtime.earlyEventBuffer.length} buffered events for ${streamId}`,
-        );
-        for (const bufferedEvent of runtime.earlyEventBuffer) {
-          onChunk(bufferedEvent);
+        if (options?.skipBufferReplay) {
+          logger.debug(
+            `[GenerationJobManager] Skipping ${runtime.earlyEventBuffer.length} buffered events for ${streamId} (sync already sent)`,
+          );
+        } else {
+          logger.debug(
+            `[GenerationJobManager] Replaying ${runtime.earlyEventBuffer.length} buffered events for ${streamId}`,
+          );
+          for (const bufferedEvent of runtime.earlyEventBuffer) {
+            onChunk(bufferedEvent);
+          }
         }
         runtime.earlyEventBuffer = [];
       }

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -797,6 +797,46 @@ class GenerationJobManagerClass {
   }
 
   /**
+   * Atomic resume + subscribe: snapshots resume state and drains the early event buffer
+   * in one synchronous step, then subscribes with skipBufferReplay.
+   *
+   * Closes the timing gap between separate `getResumeState()` and `subscribe()` calls
+   * where events could arrive in earlyEventBuffer after the snapshot but before subscribe
+   * clears the buffer.
+   *
+   * In-memory mode: drained buffer events are returned as `pendingEvents` since
+   * they exist nowhere else. The caller must deliver them after the sync payload.
+   * Redis mode: `pendingEvents` is empty — chunks are persisted via appendChunk
+   * and will appear in aggregatedContent on the next resume.
+   */
+  async subscribeWithResume(
+    streamId: string,
+    onChunk: t.ChunkHandler,
+    onDone?: t.DoneHandler,
+    onError?: t.ErrorHandler,
+  ): Promise<t.SubscribeWithResumeResult> {
+    const resumeState = await this.getResumeState(streamId);
+
+    let pendingEvents: t.ServerSentEvent[] = [];
+    if (!this._isRedis) {
+      const runtime = this.runtimeState.get(streamId);
+      if (runtime && runtime.earlyEventBuffer.length > 0) {
+        pendingEvents = [...runtime.earlyEventBuffer];
+        runtime.earlyEventBuffer = [];
+        logger.debug(
+          `[GenerationJobManager] Atomically drained ${pendingEvents.length} buffer events for ${streamId}`,
+        );
+      }
+    }
+
+    const subscription = await this.subscribe(streamId, onChunk, onDone, onError, {
+      skipBufferReplay: true,
+    });
+
+    return { subscription, resumeState, pendingEvents };
+  }
+
+  /**
    * Emit a chunk event to all subscribers.
    * Uses runtime state check for performance (avoids async job store lookup per token).
    *

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -815,17 +815,23 @@ class GenerationJobManagerClass {
     onDone?: t.DoneHandler,
     onError?: t.ErrorHandler,
   ): Promise<t.SubscribeWithResumeResult> {
+    const bufferLengthAtSnapshot = !this._isRedis
+      ? (this.runtimeState.get(streamId)?.earlyEventBuffer.length ?? 0)
+      : 0;
+
     const resumeState = await this.getResumeState(streamId);
 
     let pendingEvents: t.ServerSentEvent[] = [];
     if (!this._isRedis) {
       const runtime = this.runtimeState.get(streamId);
-      if (runtime && runtime.earlyEventBuffer.length > 0) {
-        pendingEvents = [...runtime.earlyEventBuffer];
+      if (runtime) {
+        pendingEvents = runtime.earlyEventBuffer.slice(bufferLengthAtSnapshot);
         runtime.earlyEventBuffer = [];
-        logger.debug(
-          `[GenerationJobManager] Atomically drained ${pendingEvents.length} buffer events for ${streamId}`,
-        );
+        if (pendingEvents.length > 0) {
+          logger.debug(
+            `[GenerationJobManager] Captured ${pendingEvents.length} gap events for ${streamId}`,
+          );
+        }
       }
     }
 

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -1466,6 +1466,171 @@ describe('GenerationJobManager Integration Tests', () => {
     );
   });
 
+  describe('Atomic subscribeWithResume', () => {
+    function createInMemoryManager(): GenerationJobManagerClass {
+      const manager = new GenerationJobManagerClass();
+      manager.configure({
+        jobStore: new InMemoryJobStore({ ttlAfterComplete: 60000 }),
+        eventTransport: new InMemoryEventTransport(),
+        isRedis: false,
+      });
+      manager.initialize();
+      return manager;
+    }
+
+    function createRedisManager(): GenerationJobManagerClass {
+      const manager = new GenerationJobManagerClass();
+      manager.configure(
+        createStreamServices({
+          useRedis: true,
+          redisClient: ioredisClient!,
+        }),
+      );
+      manager.initialize();
+      return manager;
+    }
+
+    test('should atomically drain buffer events into pendingEvents (in-memory)', async () => {
+      const manager = createInMemoryManager();
+      const streamId = `atomic-drain-${Date.now()}`;
+      await manager.createJob(streamId, 'user-1');
+
+      const sub1 = await manager.subscribe(streamId, () => {});
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      sub1?.unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      await manager.emitChunk(streamId, {
+        event: 'on_run_step',
+        data: { id: 'step-1', runId: 'run-1', index: 0, stepDetails: { type: 'message_creation' } },
+      });
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { id: 'step-1', delta: { content: { type: 'text', text: 'buffered' } } },
+      });
+
+      const liveEvents: ServerSentEvent[] = [];
+      const { subscription, resumeState, pendingEvents } = await manager.subscribeWithResume(
+        streamId,
+        (event) => liveEvents.push(event),
+      );
+
+      expect(resumeState).not.toBeNull();
+      expect(pendingEvents.length).toBe(2);
+      expect(pendingEvents[0].event).toBe('on_run_step');
+      expect(pendingEvents[1].event).toBe('on_message_delta');
+
+      expect(liveEvents.length).toBe(0);
+
+      subscription?.unsubscribe();
+      await manager.destroy();
+    });
+
+    test('should return empty pendingEvents when buffer is empty', async () => {
+      const manager = createInMemoryManager();
+      const streamId = `atomic-empty-${Date.now()}`;
+      await manager.createJob(streamId, 'user-1');
+
+      const sub1 = await manager.subscribe(streamId, () => {});
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { delta: { content: { type: 'text', text: 'delivered' } } },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      sub1?.unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      const { pendingEvents } = await manager.subscribeWithResume(streamId, () => {});
+
+      expect(pendingEvents.length).toBe(0);
+
+      await manager.destroy();
+    });
+
+    test('should deliver live events after subscribeWithResume', async () => {
+      const manager = createInMemoryManager();
+      const streamId = `atomic-live-${Date.now()}`;
+      await manager.createJob(streamId, 'user-1');
+
+      const sub1 = await manager.subscribe(streamId, () => {});
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      sub1?.unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { delta: { content: { type: 'text', text: 'buffered' } } },
+      });
+
+      const liveEvents: ServerSentEvent[] = [];
+      const { subscription, pendingEvents } = await manager.subscribeWithResume(streamId, (event) =>
+        liveEvents.push(event),
+      );
+
+      expect(pendingEvents.length).toBe(1);
+      expect(liveEvents.length).toBe(0);
+
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { delta: { content: { type: 'text', text: 'live-after' } } },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(liveEvents.length).toBe(1);
+      const liveEvent = liveEvents[0] as {
+        event: string;
+        data: { delta: { content: { text: string } } };
+      };
+      expect(liveEvent.data.delta.content.text).toBe('live-after');
+
+      subscription?.unsubscribe();
+      await manager.destroy();
+    });
+
+    testRedis(
+      'should return empty pendingEvents in Redis mode (chunks already persisted)',
+      async () => {
+        const manager = createRedisManager();
+        const streamId = `atomic-redis-${Date.now()}`;
+        await manager.createJob(streamId, 'user-1');
+
+        const sub1 = await manager.subscribe(streamId, () => {});
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        sub1?.unsubscribe();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        await manager.emitChunk(streamId, {
+          event: 'on_message_delta',
+          data: { delta: { content: { type: 'text', text: 'buffered-redis' } } },
+        });
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        const liveEvents: ServerSentEvent[] = [];
+        const { subscription, resumeState, pendingEvents } = await manager.subscribeWithResume(
+          streamId,
+          (event) => liveEvents.push(event),
+        );
+
+        expect(resumeState).not.toBeNull();
+        expect(pendingEvents.length).toBe(0);
+
+        await manager.emitChunk(streamId, {
+          event: 'on_message_delta',
+          data: { delta: { content: { type: 'text', text: 'live-redis' } } },
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        expect(liveEvents.length).toBe(1);
+
+        subscription?.unsubscribe();
+        await manager.destroy();
+      },
+    );
+  });
+
   describe('Error Preservation for Late Subscribers', () => {
     /**
      * These tests verify the fix for the race condition where errors

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -1213,20 +1213,14 @@ describe('GenerationJobManager Integration Tests', () => {
 
   describe('Resume: skipBufferReplay prevents duplication', () => {
     /**
-     * These tests verify the fix for duplicated content when navigating away
-     * from an in-progress conversation and navigating back.
-     *
-     * Root cause: When user navigates away, events accumulate in earlyEventBuffer.
-     * On resume, the backend sends a sync event with aggregatedContent (which
-     * includes all buffered events), then subscribe() replays the earlyEventBuffer.
-     * The same content is delivered twice → duplication.
-     *
-     * Fix: subscribe() accepts { skipBufferReplay: true } for resume connections.
-     * The sync event already contains all accumulated content, so buffer replay
-     * is redundant.
+     * Verifies the fix for duplicated content when navigating away from an
+     * in-progress conversation and back. Events accumulate in earlyEventBuffer
+     * while the subscriber is absent. On resume, the sync event delivers all
+     * accumulated content via aggregatedContent, so buffer replay must be
+     * skipped to prevent duplication.
      */
 
-    test('should NOT replay buffer when skipBufferReplay is true (resume scenario)', async () => {
+    function createInMemoryManager(): GenerationJobManagerClass {
       const manager = new GenerationJobManagerClass();
       manager.configure({
         jobStore: new InMemoryJobStore({ ttlAfterComplete: 60000 }),
@@ -1234,19 +1228,31 @@ describe('GenerationJobManager Integration Tests', () => {
         isRedis: false,
       });
       manager.initialize();
+      return manager;
+    }
 
-      const streamId = `skip-buf-${Date.now()}`;
-      await manager.createJob(streamId, 'user-1');
-
-      // 1. First subscriber connects and receives initial events
-      const firstSubscriberEvents: unknown[] = [];
-      const sub1 = await manager.subscribe(streamId, (event: unknown) =>
-        firstSubscriberEvents.push(event),
+    function createRedisManager(): GenerationJobManagerClass {
+      const manager = new GenerationJobManagerClass();
+      manager.configure(
+        createStreamServices({
+          useRedis: true,
+          redisClient: ioredisClient!,
+        }),
       );
+      manager.initialize();
+      return manager;
+    }
 
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    async function setupDisconnectedStream(
+      manager: GenerationJobManagerClass,
+      streamId: string,
+      delay: number,
+    ): Promise<ServerSentEvent[]> {
+      const firstEvents: ServerSentEvent[] = [];
+      const sub = await manager.subscribe(streamId, (event) => firstEvents.push(event));
 
-      // Emit events while subscriber is connected
+      await new Promise((resolve) => setTimeout(resolve, delay));
+
       await manager.emitChunk(streamId, {
         event: 'on_run_step',
         data: { id: 'step-1', runId: 'run-1', index: 0, stepDetails: { type: 'message_creation' } },
@@ -1256,14 +1262,12 @@ describe('GenerationJobManager Integration Tests', () => {
         data: { id: 'step-1', delta: { content: { type: 'text', text: 'Hello' } } },
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 20));
-      expect(firstSubscriberEvents.length).toBe(2);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      expect(firstEvents.length).toBe(2);
 
-      // 2. Subscriber disconnects (simulates navigation away)
-      sub1?.unsubscribe();
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      sub?.unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, delay));
 
-      // 3. More events arrive while no subscriber exists → go to earlyEventBuffer
       await manager.emitChunk(streamId, {
         event: 'on_message_delta',
         data: { id: 'step-1', delta: { content: { type: 'text', text: ' world' } } },
@@ -1273,23 +1277,33 @@ describe('GenerationJobManager Integration Tests', () => {
         data: { id: 'step-1', delta: { content: { type: 'text', text: '!' } } },
       });
 
-      // 4. Resume subscriber connects with skipBufferReplay (sync event was already sent)
-      const resumeEvents: unknown[] = [];
+      await new Promise((resolve) => setTimeout(resolve, delay));
+
+      return firstEvents;
+    }
+
+    test('should NOT replay buffer when skipBufferReplay is true (resume scenario)', async () => {
+      const manager = createInMemoryManager();
+      const streamId = `skip-buf-${Date.now()}`;
+      await manager.createJob(streamId, 'user-1');
+
+      await setupDisconnectedStream(manager, streamId, 10);
+
+      const resumeState = await manager.getResumeState(streamId);
+      expect(resumeState).not.toBeNull();
+
+      const resumeEvents: ServerSentEvent[] = [];
       const sub2 = await manager.subscribe(
         streamId,
-        (event: unknown) => resumeEvents.push(event),
+        (event) => resumeEvents.push(event),
         undefined,
         undefined,
         { skipBufferReplay: true },
       );
 
       await new Promise((resolve) => setTimeout(resolve, 20));
-
-      // Buffer should NOT have been replayed - resume subscriber gets zero buffered events
-      // (In real usage, the sync event already delivered the full aggregatedContent)
       expect(resumeEvents.length).toBe(0);
 
-      // 5. Live events after reconnection should still be delivered
       await manager.emitChunk(streamId, {
         event: 'on_message_delta',
         data: { id: 'step-1', delta: { content: { type: 'text', text: ' Live!' } } },
@@ -1297,27 +1311,19 @@ describe('GenerationJobManager Integration Tests', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 20));
       expect(resumeEvents.length).toBe(1);
-      expect((resumeEvents[0] as Record<string, unknown>).event).toBe('on_message_delta');
+      expect(resumeEvents[0].event).toBe('on_message_delta');
 
       sub2?.unsubscribe();
       await manager.destroy();
     });
 
-    test('should STILL replay buffer when skipBufferReplay is false (initial connection)', async () => {
-      const manager = new GenerationJobManagerClass();
-      manager.configure({
-        jobStore: new InMemoryJobStore({ ttlAfterComplete: 60000 }),
-        eventTransport: new InMemoryEventTransport(),
-        isRedis: false,
-      });
-      manager.initialize();
-
+    test('should replay buffer by default when no options are passed', async () => {
+      const manager = createInMemoryManager();
       const streamId = `replay-buf-${Date.now()}`;
       await manager.createJob(streamId, 'user-1');
 
-      // 1. First subscriber connects and disconnects
-      const sub1Events: unknown[] = [];
-      const sub1 = await manager.subscribe(streamId, (event: unknown) => sub1Events.push(event));
+      const sub1Events: ServerSentEvent[] = [];
+      const sub1 = await manager.subscribe(streamId, (event) => sub1Events.push(event));
       await new Promise((resolve) => setTimeout(resolve, 10));
 
       await manager.emitChunk(streamId, {
@@ -1329,43 +1335,32 @@ describe('GenerationJobManager Integration Tests', () => {
       sub1?.unsubscribe();
       await new Promise((resolve) => setTimeout(resolve, 20));
 
-      // 2. Events accumulate while no subscriber
       await manager.emitChunk(streamId, {
         event: 'on_message_delta',
         data: { id: 'step-1', delta: { content: { type: 'text', text: 'buffered' } } },
       });
 
-      // 3. New subscriber WITHOUT skipBufferReplay → buffer should be replayed
-      const sub2Events: unknown[] = [];
-      const sub2 = await manager.subscribe(streamId, (event: unknown) => sub2Events.push(event));
+      const sub2Events: ServerSentEvent[] = [];
+      const sub2 = await manager.subscribe(streamId, (event) => sub2Events.push(event));
       await new Promise((resolve) => setTimeout(resolve, 20));
 
       expect(sub2Events.length).toBe(1);
-      expect((sub2Events[0] as Record<string, unknown>).event).toBe('on_message_delta');
+      expect(sub2Events[0].event).toBe('on_message_delta');
 
       sub2?.unsubscribe();
       await manager.destroy();
     });
 
     test('should clear earlyEventBuffer even when skipping replay (no memory leak)', async () => {
-      const manager = new GenerationJobManagerClass();
-      manager.configure({
-        jobStore: new InMemoryJobStore({ ttlAfterComplete: 60000 }),
-        eventTransport: new InMemoryEventTransport(),
-        isRedis: false,
-      });
-      manager.initialize();
-
+      const manager = createInMemoryManager();
       const streamId = `buf-clear-${Date.now()}`;
       await manager.createJob(streamId, 'user-1');
 
-      // Subscribe and disconnect to reset hasSubscriber
       const sub1 = await manager.subscribe(streamId, () => {});
       await new Promise((resolve) => setTimeout(resolve, 10));
       sub1?.unsubscribe();
       await new Promise((resolve) => setTimeout(resolve, 20));
 
-      // Buffer events
       await manager.emitChunk(streamId, {
         event: 'on_message_delta',
         data: { delta: { content: { type: 'text', text: 'buf1' } } },
@@ -1375,11 +1370,10 @@ describe('GenerationJobManager Integration Tests', () => {
         data: { delta: { content: { type: 'text', text: 'buf2' } } },
       });
 
-      // Subscribe with skipBufferReplay
-      const sub2Events: unknown[] = [];
+      const sub2Events: ServerSentEvent[] = [];
       const sub2 = await manager.subscribe(
         streamId,
-        (event: unknown) => sub2Events.push(event),
+        (event) => sub2Events.push(event),
         undefined,
         undefined,
         { skipBufferReplay: true },
@@ -1390,23 +1384,94 @@ describe('GenerationJobManager Integration Tests', () => {
       sub2?.unsubscribe();
       await new Promise((resolve) => setTimeout(resolve, 20));
 
-      // After another disconnect/reconnect cycle, buffer should be empty
-      // (it was cleared on the previous subscribe even though replay was skipped)
       await manager.emitChunk(streamId, {
         event: 'on_message_delta',
         data: { delta: { content: { type: 'text', text: 'new-event' } } },
       });
 
-      const sub3Events: unknown[] = [];
-      const sub3 = await manager.subscribe(streamId, (event: unknown) => sub3Events.push(event));
+      const sub3Events: ServerSentEvent[] = [];
+      const sub3 = await manager.subscribe(streamId, (event) => sub3Events.push(event));
       await new Promise((resolve) => setTimeout(resolve, 20));
 
-      // Should only have the one new event, not the old buf1/buf2
       expect(sub3Events.length).toBe(1);
-      const data = (sub3Events[0] as Record<string, unknown>).data as Record<string, unknown>;
-      const delta = data.delta as Record<string, unknown>;
-      const content = delta.content as Record<string, unknown>;
-      expect(content.text).toBe('new-event');
+      const event = sub3Events[0] as { event: string; data: { delta: { content: { text: string } } } };
+      expect(event.data.delta.content.text).toBe('new-event');
+
+      sub3?.unsubscribe();
+      await manager.destroy();
+    });
+
+    test('should handle multiple disconnect/reconnect cycles with skipBufferReplay', async () => {
+      const manager = createInMemoryManager();
+      const streamId = `multi-reconnect-${Date.now()}`;
+      await manager.createJob(streamId, 'user-1');
+
+      const sub1 = await manager.subscribe(streamId, () => {});
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { delta: { content: { type: 'text', text: 'initial' } } },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      sub1?.unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { delta: { content: { type: 'text', text: 'buffered-1' } } },
+      });
+
+      const resumeState1 = await manager.getResumeState(streamId);
+      expect(resumeState1).not.toBeNull();
+
+      const sub2Events: ServerSentEvent[] = [];
+      const sub2 = await manager.subscribe(
+        streamId,
+        (event) => sub2Events.push(event),
+        undefined,
+        undefined,
+        { skipBufferReplay: true },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(sub2Events.length).toBe(0);
+
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { delta: { content: { type: 'text', text: 'live-1' } } },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(sub2Events.length).toBe(1);
+
+      sub2?.unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { delta: { content: { type: 'text', text: 'buffered-2' } } },
+      });
+
+      const resumeState2 = await manager.getResumeState(streamId);
+      expect(resumeState2).not.toBeNull();
+
+      const sub3Events: ServerSentEvent[] = [];
+      const sub3 = await manager.subscribe(
+        streamId,
+        (event) => sub3Events.push(event),
+        undefined,
+        undefined,
+        { skipBufferReplay: true },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(sub3Events.length).toBe(0);
+
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { delta: { content: { type: 'text', text: 'live-2' } } },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(sub3Events.length).toBe(1);
 
       sub3?.unsubscribe();
       await manager.destroy();
@@ -1418,75 +1483,28 @@ describe('GenerationJobManager Integration Tests', () => {
         return;
       }
 
-      const manager = new GenerationJobManagerClass();
-      const services = createStreamServices({
-        useRedis: true,
-        redisClient: ioredisClient,
-      });
-      manager.configure(services);
-      manager.initialize();
-
+      const manager = createRedisManager();
       const streamId = `skip-buf-redis-${Date.now()}`;
       await manager.createJob(streamId, 'user-1');
 
-      // 1. First subscriber connects and receives initial events
-      const firstSubscriberEvents: unknown[] = [];
-      const sub1 = await manager.subscribe(streamId, (event: unknown) =>
-        firstSubscriberEvents.push(event),
-      );
+      await setupDisconnectedStream(manager, streamId, 100);
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      // Emit events while subscriber is connected
-      await manager.emitChunk(streamId, {
-        event: 'on_run_step',
-        data: { id: 'step-1', runId: 'run-1', index: 0, stepDetails: { type: 'message_creation' } },
-      });
-      await manager.emitChunk(streamId, {
-        event: 'on_message_delta',
-        data: { id: 'step-1', delta: { content: { type: 'text', text: 'Hello' } } },
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      expect(firstSubscriberEvents.length).toBe(2);
-
-      // 2. Subscriber disconnects (simulates navigation away)
-      sub1?.unsubscribe();
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      // 3. More events arrive while no subscriber exists → go to earlyEventBuffer + Redis
-      await manager.emitChunk(streamId, {
-        event: 'on_message_delta',
-        data: { id: 'step-1', delta: { content: { type: 'text', text: ' world' } } },
-      });
-      await manager.emitChunk(streamId, {
-        event: 'on_message_delta',
-        data: { id: 'step-1', delta: { content: { type: 'text', text: '!' } } },
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      // 4. Verify aggregatedContent has everything (what sync event would send)
       const resumeState = await manager.getResumeState(streamId);
       expect(resumeState).not.toBeNull();
       expect(resumeState!.aggregatedContent?.length).toBeGreaterThan(0);
 
-      // 5. Resume subscriber connects with skipBufferReplay (sync event was already sent)
-      const resumeEvents: unknown[] = [];
+      const resumeEvents: ServerSentEvent[] = [];
       const sub2 = await manager.subscribe(
         streamId,
-        (event: unknown) => resumeEvents.push(event),
+        (event) => resumeEvents.push(event),
         undefined,
         undefined,
         { skipBufferReplay: true },
       );
 
       await new Promise((resolve) => setTimeout(resolve, 200));
-
-      // Buffer should NOT have been replayed
       expect(resumeEvents.length).toBe(0);
 
-      // 6. Live events after reconnection should still be delivered
       await manager.emitChunk(streamId, {
         event: 'on_message_delta',
         data: { id: 'step-1', delta: { content: { type: 'text', text: ' Live!' } } },
@@ -1494,7 +1512,7 @@ describe('GenerationJobManager Integration Tests', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 200));
       expect(resumeEvents.length).toBe(1);
-      expect((resumeEvents[0] as Record<string, unknown>).event).toBe('on_message_delta');
+      expect(resumeEvents[0].event).toBe('on_message_delta');
 
       sub2?.unsubscribe();
       await manager.destroy();
@@ -1506,24 +1524,15 @@ describe('GenerationJobManager Integration Tests', () => {
         return;
       }
 
-      const manager = new GenerationJobManagerClass();
-      const services = createStreamServices({
-        useRedis: true,
-        redisClient: ioredisClient,
-      });
-      manager.configure(services);
-      manager.initialize();
-
+      const manager = createRedisManager();
       const streamId = `replay-buf-redis-${Date.now()}`;
       await manager.createJob(streamId, 'user-1');
 
-      // 1. First subscriber connects and disconnects
       const sub1 = await manager.subscribe(streamId, () => {});
       await new Promise((resolve) => setTimeout(resolve, 100));
       sub1?.unsubscribe();
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      // 2. Events accumulate while no subscriber
       await manager.emitChunk(streamId, {
         event: 'on_message_delta',
         data: { delta: { content: { type: 'text', text: 'buffered-redis' } } },
@@ -1531,14 +1540,13 @@ describe('GenerationJobManager Integration Tests', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      // 3. Reconnect WITHOUT skipBufferReplay → buffer should be replayed
-      const sub2Events: unknown[] = [];
-      const sub2 = await manager.subscribe(streamId, (event: unknown) => sub2Events.push(event));
+      const sub2Events: ServerSentEvent[] = [];
+      const sub2 = await manager.subscribe(streamId, (event) => sub2Events.push(event));
 
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       expect(sub2Events.length).toBe(1);
-      expect((sub2Events[0] as Record<string, unknown>).event).toBe('on_message_delta');
+      expect(sub2Events[0].event).toBe('on_message_delta');
 
       sub2?.unsubscribe();
       await manager.destroy();

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -86,6 +86,68 @@ describe('GenerationJobManager Integration Tests', () => {
     process.env = originalEnv;
   });
 
+  function createInMemoryManager(): GenerationJobManagerClass {
+    const manager = new GenerationJobManagerClass();
+    manager.configure({
+      jobStore: new InMemoryJobStore({ ttlAfterComplete: 60000 }),
+      eventTransport: new InMemoryEventTransport(),
+      isRedis: false,
+    });
+    manager.initialize();
+    return manager;
+  }
+
+  function createRedisManager(): GenerationJobManagerClass {
+    const manager = new GenerationJobManagerClass();
+    manager.configure(
+      createStreamServices({
+        useRedis: true,
+        redisClient: ioredisClient!,
+      }),
+    );
+    manager.initialize();
+    return manager;
+  }
+
+  async function setupDisconnectedStream(
+    manager: GenerationJobManagerClass,
+    streamId: string,
+    delay: number,
+  ): Promise<ServerSentEvent[]> {
+    const firstEvents: ServerSentEvent[] = [];
+    const sub = await manager.subscribe(streamId, (event) => firstEvents.push(event));
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+
+    await manager.emitChunk(streamId, {
+      event: 'on_run_step',
+      data: { id: 'step-1', runId: 'run-1', index: 0, stepDetails: { type: 'message_creation' } },
+    });
+    await manager.emitChunk(streamId, {
+      event: 'on_message_delta',
+      data: { id: 'step-1', delta: { content: { type: 'text', text: 'Hello' } } },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    expect(firstEvents.length).toBe(2);
+
+    sub?.unsubscribe();
+    await new Promise((resolve) => setTimeout(resolve, delay));
+
+    await manager.emitChunk(streamId, {
+      event: 'on_message_delta',
+      data: { id: 'step-1', delta: { content: { type: 'text', text: ' world' } } },
+    });
+    await manager.emitChunk(streamId, {
+      event: 'on_message_delta',
+      data: { id: 'step-1', delta: { content: { type: 'text', text: '!' } } },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, delay));
+
+    return firstEvents;
+  }
+
   describe('In-Memory Mode', () => {
     test('should create and manage jobs', async () => {
       // Configure with in-memory
@@ -1137,68 +1199,6 @@ describe('GenerationJobManager Integration Tests', () => {
      * skipped to prevent duplication.
      */
 
-    function createInMemoryManager(): GenerationJobManagerClass {
-      const manager = new GenerationJobManagerClass();
-      manager.configure({
-        jobStore: new InMemoryJobStore({ ttlAfterComplete: 60000 }),
-        eventTransport: new InMemoryEventTransport(),
-        isRedis: false,
-      });
-      manager.initialize();
-      return manager;
-    }
-
-    function createRedisManager(): GenerationJobManagerClass {
-      const manager = new GenerationJobManagerClass();
-      manager.configure(
-        createStreamServices({
-          useRedis: true,
-          redisClient: ioredisClient!,
-        }),
-      );
-      manager.initialize();
-      return manager;
-    }
-
-    async function setupDisconnectedStream(
-      manager: GenerationJobManagerClass,
-      streamId: string,
-      delay: number,
-    ): Promise<ServerSentEvent[]> {
-      const firstEvents: ServerSentEvent[] = [];
-      const sub = await manager.subscribe(streamId, (event) => firstEvents.push(event));
-
-      await new Promise((resolve) => setTimeout(resolve, delay));
-
-      await manager.emitChunk(streamId, {
-        event: 'on_run_step',
-        data: { id: 'step-1', runId: 'run-1', index: 0, stepDetails: { type: 'message_creation' } },
-      });
-      await manager.emitChunk(streamId, {
-        event: 'on_message_delta',
-        data: { id: 'step-1', delta: { content: { type: 'text', text: 'Hello' } } },
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, delay));
-      expect(firstEvents.length).toBe(2);
-
-      sub?.unsubscribe();
-      await new Promise((resolve) => setTimeout(resolve, delay));
-
-      await manager.emitChunk(streamId, {
-        event: 'on_message_delta',
-        data: { id: 'step-1', delta: { content: { type: 'text', text: ' world' } } },
-      });
-      await manager.emitChunk(streamId, {
-        event: 'on_message_delta',
-        data: { id: 'step-1', delta: { content: { type: 'text', text: '!' } } },
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, delay));
-
-      return firstEvents;
-    }
-
     test('should NOT replay buffer when skipBufferReplay is true (resume scenario)', async () => {
       const manager = createInMemoryManager();
       const streamId = `skip-buf-${Date.now()}`;
@@ -1467,30 +1467,7 @@ describe('GenerationJobManager Integration Tests', () => {
   });
 
   describe('Atomic subscribeWithResume', () => {
-    function createInMemoryManager(): GenerationJobManagerClass {
-      const manager = new GenerationJobManagerClass();
-      manager.configure({
-        jobStore: new InMemoryJobStore({ ttlAfterComplete: 60000 }),
-        eventTransport: new InMemoryEventTransport(),
-        isRedis: false,
-      });
-      manager.initialize();
-      return manager;
-    }
-
-    function createRedisManager(): GenerationJobManagerClass {
-      const manager = new GenerationJobManagerClass();
-      manager.configure(
-        createStreamServices({
-          useRedis: true,
-          redisClient: ioredisClient!,
-        }),
-      );
-      manager.initialize();
-      return manager;
-    }
-
-    test('should atomically drain buffer events into pendingEvents (in-memory)', async () => {
+    test('should return empty pendingEvents for pre-snapshot buffer events (in-memory)', async () => {
       const manager = createInMemoryManager();
       const streamId = `atomic-drain-${Date.now()}`;
       await manager.createJob(streamId, 'user-1');
@@ -1516,10 +1493,7 @@ describe('GenerationJobManager Integration Tests', () => {
       );
 
       expect(resumeState).not.toBeNull();
-      expect(pendingEvents.length).toBe(2);
-      expect(pendingEvents[0].event).toBe('on_run_step');
-      expect(pendingEvents[1].event).toBe('on_message_delta');
-
+      expect(pendingEvents.length).toBe(0);
       expect(liveEvents.length).toBe(0);
 
       subscription?.unsubscribe();
@@ -1562,7 +1536,7 @@ describe('GenerationJobManager Integration Tests', () => {
 
       await manager.emitChunk(streamId, {
         event: 'on_message_delta',
-        data: { delta: { content: { type: 'text', text: 'buffered' } } },
+        data: { delta: { content: { type: 'text', text: 'buffered-pre-snapshot' } } },
       });
 
       const liveEvents: ServerSentEvent[] = [];
@@ -1570,7 +1544,7 @@ describe('GenerationJobManager Integration Tests', () => {
         liveEvents.push(event),
       );
 
-      expect(pendingEvents.length).toBe(1);
+      expect(pendingEvents.length).toBe(0);
       expect(liveEvents.length).toBe(0);
 
       await manager.emitChunk(streamId, {

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -1211,6 +1211,340 @@ describe('GenerationJobManager Integration Tests', () => {
     });
   });
 
+  describe('Resume: skipBufferReplay prevents duplication', () => {
+    /**
+     * These tests verify the fix for duplicated content when navigating away
+     * from an in-progress conversation and navigating back.
+     *
+     * Root cause: When user navigates away, events accumulate in earlyEventBuffer.
+     * On resume, the backend sends a sync event with aggregatedContent (which
+     * includes all buffered events), then subscribe() replays the earlyEventBuffer.
+     * The same content is delivered twice → duplication.
+     *
+     * Fix: subscribe() accepts { skipBufferReplay: true } for resume connections.
+     * The sync event already contains all accumulated content, so buffer replay
+     * is redundant.
+     */
+
+    test('should NOT replay buffer when skipBufferReplay is true (resume scenario)', async () => {
+      const manager = new GenerationJobManagerClass();
+      manager.configure({
+        jobStore: new InMemoryJobStore({ ttlAfterComplete: 60000 }),
+        eventTransport: new InMemoryEventTransport(),
+        isRedis: false,
+      });
+      manager.initialize();
+
+      const streamId = `skip-buf-${Date.now()}`;
+      await manager.createJob(streamId, 'user-1');
+
+      // 1. First subscriber connects and receives initial events
+      const firstSubscriberEvents: unknown[] = [];
+      const sub1 = await manager.subscribe(streamId, (event: unknown) =>
+        firstSubscriberEvents.push(event),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Emit events while subscriber is connected
+      await manager.emitChunk(streamId, {
+        event: 'on_run_step',
+        data: { id: 'step-1', runId: 'run-1', index: 0, stepDetails: { type: 'message_creation' } },
+      });
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { id: 'step-1', delta: { content: { type: 'text', text: 'Hello' } } },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(firstSubscriberEvents.length).toBe(2);
+
+      // 2. Subscriber disconnects (simulates navigation away)
+      sub1?.unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // 3. More events arrive while no subscriber exists → go to earlyEventBuffer
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { id: 'step-1', delta: { content: { type: 'text', text: ' world' } } },
+      });
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { id: 'step-1', delta: { content: { type: 'text', text: '!' } } },
+      });
+
+      // 4. Resume subscriber connects with skipBufferReplay (sync event was already sent)
+      const resumeEvents: unknown[] = [];
+      const sub2 = await manager.subscribe(
+        streamId,
+        (event: unknown) => resumeEvents.push(event),
+        undefined,
+        undefined,
+        { skipBufferReplay: true },
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // Buffer should NOT have been replayed - resume subscriber gets zero buffered events
+      // (In real usage, the sync event already delivered the full aggregatedContent)
+      expect(resumeEvents.length).toBe(0);
+
+      // 5. Live events after reconnection should still be delivered
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { id: 'step-1', delta: { content: { type: 'text', text: ' Live!' } } },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(resumeEvents.length).toBe(1);
+      expect((resumeEvents[0] as Record<string, unknown>).event).toBe('on_message_delta');
+
+      sub2?.unsubscribe();
+      await manager.destroy();
+    });
+
+    test('should STILL replay buffer when skipBufferReplay is false (initial connection)', async () => {
+      const manager = new GenerationJobManagerClass();
+      manager.configure({
+        jobStore: new InMemoryJobStore({ ttlAfterComplete: 60000 }),
+        eventTransport: new InMemoryEventTransport(),
+        isRedis: false,
+      });
+      manager.initialize();
+
+      const streamId = `replay-buf-${Date.now()}`;
+      await manager.createJob(streamId, 'user-1');
+
+      // 1. First subscriber connects and disconnects
+      const sub1Events: unknown[] = [];
+      const sub1 = await manager.subscribe(streamId, (event: unknown) => sub1Events.push(event));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      await manager.emitChunk(streamId, {
+        event: 'on_run_step',
+        data: { id: 'step-1', runId: 'run-1', index: 0, stepDetails: { type: 'message_creation' } },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      sub1?.unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // 2. Events accumulate while no subscriber
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { id: 'step-1', delta: { content: { type: 'text', text: 'buffered' } } },
+      });
+
+      // 3. New subscriber WITHOUT skipBufferReplay → buffer should be replayed
+      const sub2Events: unknown[] = [];
+      const sub2 = await manager.subscribe(streamId, (event: unknown) => sub2Events.push(event));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(sub2Events.length).toBe(1);
+      expect((sub2Events[0] as Record<string, unknown>).event).toBe('on_message_delta');
+
+      sub2?.unsubscribe();
+      await manager.destroy();
+    });
+
+    test('should clear earlyEventBuffer even when skipping replay (no memory leak)', async () => {
+      const manager = new GenerationJobManagerClass();
+      manager.configure({
+        jobStore: new InMemoryJobStore({ ttlAfterComplete: 60000 }),
+        eventTransport: new InMemoryEventTransport(),
+        isRedis: false,
+      });
+      manager.initialize();
+
+      const streamId = `buf-clear-${Date.now()}`;
+      await manager.createJob(streamId, 'user-1');
+
+      // Subscribe and disconnect to reset hasSubscriber
+      const sub1 = await manager.subscribe(streamId, () => {});
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      sub1?.unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // Buffer events
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { delta: { content: { type: 'text', text: 'buf1' } } },
+      });
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { delta: { content: { type: 'text', text: 'buf2' } } },
+      });
+
+      // Subscribe with skipBufferReplay
+      const sub2Events: unknown[] = [];
+      const sub2 = await manager.subscribe(
+        streamId,
+        (event: unknown) => sub2Events.push(event),
+        undefined,
+        undefined,
+        { skipBufferReplay: true },
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(sub2Events.length).toBe(0);
+
+      sub2?.unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // After another disconnect/reconnect cycle, buffer should be empty
+      // (it was cleared on the previous subscribe even though replay was skipped)
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { delta: { content: { type: 'text', text: 'new-event' } } },
+      });
+
+      const sub3Events: unknown[] = [];
+      const sub3 = await manager.subscribe(streamId, (event: unknown) => sub3Events.push(event));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // Should only have the one new event, not the old buf1/buf2
+      expect(sub3Events.length).toBe(1);
+      const data = (sub3Events[0] as Record<string, unknown>).data as Record<string, unknown>;
+      const delta = data.delta as Record<string, unknown>;
+      const content = delta.content as Record<string, unknown>;
+      expect(content.text).toBe('new-event');
+
+      sub3?.unsubscribe();
+      await manager.destroy();
+    });
+
+    test('should NOT replay buffer when skipBufferReplay is true (Redis)', async () => {
+      if (!ioredisClient) {
+        console.warn('Redis not available, skipping test');
+        return;
+      }
+
+      const manager = new GenerationJobManagerClass();
+      const services = createStreamServices({
+        useRedis: true,
+        redisClient: ioredisClient,
+      });
+      manager.configure(services);
+      manager.initialize();
+
+      const streamId = `skip-buf-redis-${Date.now()}`;
+      await manager.createJob(streamId, 'user-1');
+
+      // 1. First subscriber connects and receives initial events
+      const firstSubscriberEvents: unknown[] = [];
+      const sub1 = await manager.subscribe(streamId, (event: unknown) =>
+        firstSubscriberEvents.push(event),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Emit events while subscriber is connected
+      await manager.emitChunk(streamId, {
+        event: 'on_run_step',
+        data: { id: 'step-1', runId: 'run-1', index: 0, stepDetails: { type: 'message_creation' } },
+      });
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { id: 'step-1', delta: { content: { type: 'text', text: 'Hello' } } },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(firstSubscriberEvents.length).toBe(2);
+
+      // 2. Subscriber disconnects (simulates navigation away)
+      sub1?.unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // 3. More events arrive while no subscriber exists → go to earlyEventBuffer + Redis
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { id: 'step-1', delta: { content: { type: 'text', text: ' world' } } },
+      });
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { id: 'step-1', delta: { content: { type: 'text', text: '!' } } },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // 4. Verify aggregatedContent has everything (what sync event would send)
+      const resumeState = await manager.getResumeState(streamId);
+      expect(resumeState).not.toBeNull();
+      expect(resumeState!.aggregatedContent?.length).toBeGreaterThan(0);
+
+      // 5. Resume subscriber connects with skipBufferReplay (sync event was already sent)
+      const resumeEvents: unknown[] = [];
+      const sub2 = await manager.subscribe(
+        streamId,
+        (event: unknown) => resumeEvents.push(event),
+        undefined,
+        undefined,
+        { skipBufferReplay: true },
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Buffer should NOT have been replayed
+      expect(resumeEvents.length).toBe(0);
+
+      // 6. Live events after reconnection should still be delivered
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { id: 'step-1', delta: { content: { type: 'text', text: ' Live!' } } },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(resumeEvents.length).toBe(1);
+      expect((resumeEvents[0] as Record<string, unknown>).event).toBe('on_message_delta');
+
+      sub2?.unsubscribe();
+      await manager.destroy();
+    });
+
+    test('should replay buffer without skipBufferReplay after disconnect (Redis)', async () => {
+      if (!ioredisClient) {
+        console.warn('Redis not available, skipping test');
+        return;
+      }
+
+      const manager = new GenerationJobManagerClass();
+      const services = createStreamServices({
+        useRedis: true,
+        redisClient: ioredisClient,
+      });
+      manager.configure(services);
+      manager.initialize();
+
+      const streamId = `replay-buf-redis-${Date.now()}`;
+      await manager.createJob(streamId, 'user-1');
+
+      // 1. First subscriber connects and disconnects
+      const sub1 = await manager.subscribe(streamId, () => {});
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      sub1?.unsubscribe();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // 2. Events accumulate while no subscriber
+      await manager.emitChunk(streamId, {
+        event: 'on_message_delta',
+        data: { delta: { content: { type: 'text', text: 'buffered-redis' } } },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // 3. Reconnect WITHOUT skipBufferReplay → buffer should be replayed
+      const sub2Events: unknown[] = [];
+      const sub2 = await manager.subscribe(streamId, (event: unknown) => sub2Events.push(event));
+
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      expect(sub2Events.length).toBe(1);
+      expect((sub2Events[0] as Record<string, unknown>).event).toBe('on_message_delta');
+
+      sub2?.unsubscribe();
+      await manager.destroy();
+    });
+  });
+
   describe('Error Preservation for Late Subscribers', () => {
     /**
      * These tests verify the fix for the race condition where errors

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -1,3 +1,4 @@
+/* eslint jest/no-standalone-expect: ["error", { "additionalTestBlockFunctions": ["testRedis"] }] */
 import type { Redis, Cluster } from 'ioredis';
 import type { ServerSentEvent } from '~/types/events';
 import { InMemoryEventTransport } from '~/stream/implementations/InMemoryEventTransport';
@@ -27,6 +28,9 @@ describe('GenerationJobManager Integration Tests', () => {
   let dynamicKeyvClient: unknown = null;
   let dynamicKeyvReady: Promise<unknown> | null = null;
   const testPrefix = 'JobManager-Integration-Test';
+  const redisConfigured = process.env.USE_REDIS === 'true';
+  const describeRedis = redisConfigured ? describe : describe.skip;
+  const testRedis = redisConfigured ? test : test.skip;
 
   beforeAll(async () => {
     originalEnv = { ...process.env };
@@ -171,13 +175,8 @@ describe('GenerationJobManager Integration Tests', () => {
     });
   });
 
-  describe('Redis Mode', () => {
+  describeRedis('Redis Mode', () => {
     test('should create and manage jobs via Redis', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       // Create Redis services
       const services = createStreamServices({
         useRedis: true,
@@ -209,11 +208,6 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should persist chunks for cross-instance resume', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       const services = createStreamServices({
         useRedis: true,
         redisClient: ioredisClient,
@@ -264,11 +258,6 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should handle abort and return content', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       const services = createStreamServices({
         useRedis: true,
         redisClient: ioredisClient,
@@ -374,7 +363,7 @@ describe('GenerationJobManager Integration Tests', () => {
     });
   });
 
-  describe('Cross-Replica Support (Redis)', () => {
+  describeRedis('Cross-Replica Support (Redis)', () => {
     /**
      * Problem: In k8s with Redis and multiple replicas, when a user sends a message:
      * 1. POST /api/agents/chat hits Replica A, creates job
@@ -387,15 +376,10 @@ describe('GenerationJobManager Integration Tests', () => {
      * when the job exists in Redis but not in local memory.
      */
     test('should NOT return 404 when stream endpoint hits different replica than job creator', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       // === REPLICA A: Creates the job ===
       // Simulate Replica A creating the job directly in Redis
       // (In real scenario, this happens via GenerationJobManager.createJob on Replica A)
-      const replicaAJobStore = new RedisJobStore(ioredisClient);
+      const replicaAJobStore = new RedisJobStore(ioredisClient!);
       await replicaAJobStore.initialize();
 
       const streamId = `cross-replica-404-test-${Date.now()}`;
@@ -452,13 +436,8 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should lazily create runtime state for jobs created on other replicas', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       // Instance 1: Create the job directly in Redis (simulating another replica)
-      const jobStore = new RedisJobStore(ioredisClient);
+      const jobStore = new RedisJobStore(ioredisClient!);
       await jobStore.initialize();
 
       const streamId = `cross-replica-${Date.now()}`;
@@ -500,11 +479,6 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should persist syncSent to Redis for cross-replica consistency', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       const services = createStreamServices({
         useRedis: true,
         redisClient: ioredisClient,
@@ -539,11 +513,6 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should persist finalEvent to Redis for cross-replica access', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       const services = createStreamServices({
         useRedis: true,
         redisClient: ioredisClient,
@@ -581,11 +550,6 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should emit cross-replica abort signal via Redis pub/sub', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       const services = createStreamServices({
         useRedis: true,
         redisClient: ioredisClient,
@@ -620,16 +584,11 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should handle abort for lazily-initialized cross-replica jobs', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       // This test validates that jobs created on Replica A and lazily-initialized
       // on Replica B can still receive and handle abort signals.
 
       // === Replica A: Create job directly in Redis ===
-      const replicaAJobStore = new RedisJobStore(ioredisClient);
+      const replicaAJobStore = new RedisJobStore(ioredisClient!);
       await replicaAJobStore.initialize();
 
       const streamId = `lazy-abort-${Date.now()}`;
@@ -675,11 +634,6 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should abort generation when abort signal received from another replica', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       // This test simulates:
       // 1. Replica A creates a job and starts generation
       // 2. Replica B receives abort request and emits abort signal
@@ -729,13 +683,8 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should handle wasSyncSent for cross-replica scenarios', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       // Create job directly in Redis with syncSent: true
-      const jobStore = new RedisJobStore(ioredisClient);
+      const jobStore = new RedisJobStore(ioredisClient!);
       await jobStore.initialize();
 
       const streamId = `cross-sync-${Date.now()}`;
@@ -762,7 +711,7 @@ describe('GenerationJobManager Integration Tests', () => {
     });
   });
 
-  describe('Sequential Event Ordering (Redis)', () => {
+  describeRedis('Sequential Event Ordering (Redis)', () => {
     /**
      * These tests verify that events are delivered in strict sequential order
      * when using Redis mode. This is critical because:
@@ -773,11 +722,6 @@ describe('GenerationJobManager Integration Tests', () => {
      * The fix: emitChunk now awaits Redis publish to ensure ordered delivery.
      */
     test('should maintain strict order for rapid sequential emits', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       jest.resetModules();
 
       const services = createStreamServices({
@@ -823,11 +767,6 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should maintain order for tool call argument deltas', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       jest.resetModules();
 
       const services = createStreamServices({
@@ -882,11 +821,6 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should maintain order: on_run_step before on_run_step_delta', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       jest.resetModules();
 
       const services = createStreamServices({
@@ -945,11 +879,6 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should not block other streams when awaiting emitChunk', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       jest.resetModules();
 
       const services = createStreamServices({
@@ -1069,12 +998,7 @@ describe('GenerationJobManager Integration Tests', () => {
       await manager.destroy();
     });
 
-    test('should buffer and replay events emitted before subscribe (Redis)', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
+    testRedis('should buffer and replay events emitted before subscribe (Redis)', async () => {
       const manager = new GenerationJobManagerClass();
       const services = createStreamServices({
         useRedis: true,
@@ -1118,67 +1042,60 @@ describe('GenerationJobManager Integration Tests', () => {
       await manager.destroy();
     });
 
-    test('should not lose events when emitting before and after subscribe (Redis)', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
-      const manager = new GenerationJobManagerClass();
-      const services = createStreamServices({
-        useRedis: true,
-        redisClient: ioredisClient,
-      });
-
-      manager.configure(services);
-      manager.initialize();
-
-      const streamId = `no-loss-${Date.now()}`;
-      await manager.createJob(streamId, 'user-1');
-
-      await manager.emitChunk(streamId, {
-        created: true,
-        message: { text: 'hello' },
-        streamId,
-      } as unknown as ServerSentEvent);
-      await manager.emitChunk(streamId, {
-        event: 'on_run_step',
-        data: { id: 'step-1', type: 'message_creation', index: 0 },
-      });
-
-      const receivedEvents: unknown[] = [];
-      const subscription = await manager.subscribe(streamId, (event: unknown) =>
-        receivedEvents.push(event),
-      );
-
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      for (let i = 0; i < 10; i++) {
-        await manager.emitChunk(streamId, {
-          event: 'on_message_delta',
-          data: { delta: { content: { type: 'text', text: `word${i} ` } }, index: i },
+    testRedis(
+      'should not lose events when emitting before and after subscribe (Redis)',
+      async () => {
+        const manager = new GenerationJobManagerClass();
+        const services = createStreamServices({
+          useRedis: true,
+          redisClient: ioredisClient,
         });
-      }
 
-      await new Promise((resolve) => setTimeout(resolve, 300));
+        manager.configure(services);
+        manager.initialize();
 
-      expect(receivedEvents.length).toBe(12);
-      expect((receivedEvents[0] as Record<string, unknown>).created).toBe(true);
-      expect((receivedEvents[1] as Record<string, unknown>).event).toBe('on_run_step');
-      for (let i = 0; i < 10; i++) {
-        expect((receivedEvents[i + 2] as Record<string, unknown>).event).toBe('on_message_delta');
-      }
+        const streamId = `no-loss-${Date.now()}`;
+        await manager.createJob(streamId, 'user-1');
 
-      subscription?.unsubscribe();
-      await manager.destroy();
-    });
+        await manager.emitChunk(streamId, {
+          created: true,
+          message: { text: 'hello' },
+          streamId,
+        } as unknown as ServerSentEvent);
+        await manager.emitChunk(streamId, {
+          event: 'on_run_step',
+          data: { id: 'step-1', type: 'message_creation', index: 0 },
+        });
 
-    test('RedisEventTransport.subscribe() should return a ready promise', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
+        const receivedEvents: unknown[] = [];
+        const subscription = await manager.subscribe(streamId, (event: unknown) =>
+          receivedEvents.push(event),
+        );
 
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        for (let i = 0; i < 10; i++) {
+          await manager.emitChunk(streamId, {
+            event: 'on_message_delta',
+            data: { delta: { content: { type: 'text', text: `word${i} ` } }, index: i },
+          });
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 300));
+
+        expect(receivedEvents.length).toBe(12);
+        expect((receivedEvents[0] as Record<string, unknown>).created).toBe(true);
+        expect((receivedEvents[1] as Record<string, unknown>).event).toBe('on_run_step');
+        for (let i = 0; i < 10; i++) {
+          expect((receivedEvents[i + 2] as Record<string, unknown>).event).toBe('on_message_delta');
+        }
+
+        subscription?.unsubscribe();
+        await manager.destroy();
+      },
+    );
+
+    testRedis('RedisEventTransport.subscribe() should return a ready promise', async () => {
       const subscriber = (ioredisClient as unknown as { duplicate: () => unknown }).duplicate();
       const transport = new RedisEventTransport(ioredisClient as never, subscriber as never);
 
@@ -1394,7 +1311,10 @@ describe('GenerationJobManager Integration Tests', () => {
       await new Promise((resolve) => setTimeout(resolve, 20));
 
       expect(sub3Events.length).toBe(1);
-      const event = sub3Events[0] as { event: string; data: { delta: { content: { text: string } } } };
+      const event = sub3Events[0] as {
+        event: string;
+        data: { delta: { content: { text: string } } };
+      };
       expect(event.data.delta.content.text).toBe('new-event');
 
       sub3?.unsubscribe();
@@ -1477,12 +1397,7 @@ describe('GenerationJobManager Integration Tests', () => {
       await manager.destroy();
     });
 
-    test('should NOT replay buffer when skipBufferReplay is true (Redis)', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
+    testRedis('should NOT replay buffer when skipBufferReplay is true (Redis)', async () => {
       const manager = createRedisManager();
       const streamId = `skip-buf-redis-${Date.now()}`;
       await manager.createJob(streamId, 'user-1');
@@ -1518,39 +1433,37 @@ describe('GenerationJobManager Integration Tests', () => {
       await manager.destroy();
     });
 
-    test('should replay buffer without skipBufferReplay after disconnect (Redis)', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
+    testRedis(
+      'should replay buffer without skipBufferReplay after disconnect (Redis)',
+      async () => {
+        const manager = createRedisManager();
+        const streamId = `replay-buf-redis-${Date.now()}`;
+        await manager.createJob(streamId, 'user-1');
 
-      const manager = createRedisManager();
-      const streamId = `replay-buf-redis-${Date.now()}`;
-      await manager.createJob(streamId, 'user-1');
+        const sub1 = await manager.subscribe(streamId, () => {});
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        sub1?.unsubscribe();
+        await new Promise((resolve) => setTimeout(resolve, 100));
 
-      const sub1 = await manager.subscribe(streamId, () => {});
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      sub1?.unsubscribe();
-      await new Promise((resolve) => setTimeout(resolve, 100));
+        await manager.emitChunk(streamId, {
+          event: 'on_message_delta',
+          data: { delta: { content: { type: 'text', text: 'buffered-redis' } } },
+        });
 
-      await manager.emitChunk(streamId, {
-        event: 'on_message_delta',
-        data: { delta: { content: { type: 'text', text: 'buffered-redis' } } },
-      });
+        await new Promise((resolve) => setTimeout(resolve, 100));
 
-      await new Promise((resolve) => setTimeout(resolve, 100));
+        const sub2Events: ServerSentEvent[] = [];
+        const sub2 = await manager.subscribe(streamId, (event) => sub2Events.push(event));
 
-      const sub2Events: ServerSentEvent[] = [];
-      const sub2 = await manager.subscribe(streamId, (event) => sub2Events.push(event));
+        await new Promise((resolve) => setTimeout(resolve, 200));
 
-      await new Promise((resolve) => setTimeout(resolve, 200));
+        expect(sub2Events.length).toBe(1);
+        expect(sub2Events[0].event).toBe('on_message_delta');
 
-      expect(sub2Events.length).toBe(1);
-      expect(sub2Events[0].event).toBe('on_message_delta');
-
-      sub2?.unsubscribe();
-      await manager.destroy();
-    });
+        sub2?.unsubscribe();
+        await manager.destroy();
+      },
+    );
   });
 
   describe('Error Preservation for Late Subscribers', () => {
@@ -1711,14 +1624,9 @@ describe('GenerationJobManager Integration Tests', () => {
       await GenerationJobManager.destroy();
     });
 
-    test('should handle error preservation in Redis mode (cross-replica)', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
+    testRedis('should handle error preservation in Redis mode (cross-replica)', async () => {
       // === Replica A: Creates job and emits error ===
-      const replicaAJobStore = new RedisJobStore(ioredisClient);
+      const replicaAJobStore = new RedisJobStore(ioredisClient!);
       await replicaAJobStore.initialize();
 
       const streamId = `redis-error-${Date.now()}`;
@@ -1805,13 +1713,8 @@ describe('GenerationJobManager Integration Tests', () => {
     });
   });
 
-  describe('Cross-Replica Live Streaming (Redis)', () => {
+  describeRedis('Cross-Replica Live Streaming (Redis)', () => {
     test('should publish events to Redis even when no local subscriber exists', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       const replicaA = new GenerationJobManagerClass();
       const servicesA = createStreamServices({
         useRedis: true,
@@ -1831,7 +1734,7 @@ describe('GenerationJobManager Integration Tests', () => {
       const streamId = `cross-live-${Date.now()}`;
       await replicaA.createJob(streamId, 'user-1');
 
-      const replicaBJobStore = new RedisJobStore(ioredisClient);
+      const replicaBJobStore = new RedisJobStore(ioredisClient!);
       await replicaBJobStore.initialize();
       await replicaBJobStore.createJob(streamId, 'user-1');
 
@@ -1861,11 +1764,6 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should not cause data loss on cross-replica subscribers when local subscriber joins', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       const replicaA = new GenerationJobManagerClass();
       const servicesA = createStreamServices({
         useRedis: true,
@@ -1885,7 +1783,7 @@ describe('GenerationJobManager Integration Tests', () => {
       const streamId = `cross-seq-safe-${Date.now()}`;
 
       await replicaA.createJob(streamId, 'user-1');
-      const replicaBJobStore = new RedisJobStore(ioredisClient);
+      const replicaBJobStore = new RedisJobStore(ioredisClient!);
       await replicaBJobStore.initialize();
       await replicaBJobStore.createJob(streamId, 'user-1');
 
@@ -1945,11 +1843,6 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should deliver buffered events locally AND publish live events cross-replica', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       const replicaA = new GenerationJobManagerClass();
       const servicesA = createStreamServices({
         useRedis: true,
@@ -1983,7 +1876,7 @@ describe('GenerationJobManager Integration Tests', () => {
       replicaB.configure(servicesB);
       replicaB.initialize();
 
-      const replicaBJobStore = new RedisJobStore(ioredisClient);
+      const replicaBJobStore = new RedisJobStore(ioredisClient!);
       await replicaBJobStore.initialize();
       await replicaBJobStore.createJob(streamId, 'user-1');
 
@@ -2013,13 +1906,8 @@ describe('GenerationJobManager Integration Tests', () => {
     });
   });
 
-  describe('Concurrent Subscriber Readiness (Redis)', () => {
+  describeRedis('Concurrent Subscriber Readiness (Redis)', () => {
     test('should return ready promise to all concurrent subscribers for same stream', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       const subscriber = (
         ioredisClient as unknown as { duplicate: () => typeof ioredisClient }
       ).duplicate()!;
@@ -2048,13 +1936,8 @@ describe('GenerationJobManager Integration Tests', () => {
     });
   });
 
-  describe('Sequence Reset Safety (Redis)', () => {
+  describeRedis('Sequence Reset Safety (Redis)', () => {
     test('should not receive stale pre-subscribe events via Redis after sequence reset', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       const manager = new GenerationJobManagerClass();
       const services = createStreamServices({
         useRedis: true,
@@ -2116,11 +1999,6 @@ describe('GenerationJobManager Integration Tests', () => {
     });
 
     test('should not reset sequence when second subscriber joins mid-stream', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       const manager = new GenerationJobManagerClass();
       const services = createStreamServices({
         useRedis: true,
@@ -2179,13 +2057,8 @@ describe('GenerationJobManager Integration Tests', () => {
     });
   });
 
-  describe('Subscribe Error Recovery (Redis)', () => {
+  describeRedis('Subscribe Error Recovery (Redis)', () => {
     test('should allow resubscription after Redis subscribe failure', async () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
       const subscriber = (
         ioredisClient as unknown as { duplicate: () => typeof ioredisClient }
       ).duplicate()!;
@@ -2234,12 +2107,7 @@ describe('GenerationJobManager Integration Tests', () => {
   });
 
   describe('createStreamServices Auto-Detection', () => {
-    test('should use Redis when useRedis is true and client is available', () => {
-      if (!ioredisClient) {
-        console.warn('Redis not available, skipping test');
-        return;
-      }
-
+    testRedis('should use Redis when useRedis is true and client is available', () => {
       const services = createStreamServices({
         useRedis: true,
         redisClient: ioredisClient,

--- a/packages/api/src/types/stream.ts
+++ b/packages/api/src/types/stream.ts
@@ -56,3 +56,15 @@ export interface SubscribeOptions {
    */
   skipBufferReplay?: boolean;
 }
+
+/** Result of an atomic subscribe-with-resume operation */
+export interface SubscribeWithResumeResult {
+  subscription: { unsubscribe: UnsubscribeFn } | null;
+  resumeState: ResumeState | null;
+  /**
+   * Events that arrived between the resume snapshot and the subscribe call.
+   * In-memory mode: drained from earlyEventBuffer (only place they exist).
+   * Redis mode: empty — chunks are persisted to the store and appear in aggregatedContent on next resume.
+   */
+  pendingEvents: ServerSentEvent[];
+}

--- a/packages/api/src/types/stream.ts
+++ b/packages/api/src/types/stream.ts
@@ -47,3 +47,12 @@ export type ChunkHandler = (event: ServerSentEvent) => void;
 export type DoneHandler = (event: ServerSentEvent) => void;
 export type ErrorHandler = (error: string) => void;
 export type UnsubscribeFn = () => void;
+
+/** Options for subscribing to a job event stream */
+export interface SubscribeOptions {
+  /**
+   * When true, skips replaying the earlyEventBuffer.
+   * Use for resume connections after a sync event has been sent.
+   */
+  skipBufferReplay?: boolean;
+}


### PR DESCRIPTION
## Summary

Fixed a content duplication bug on resumable SSE connections where navigating away from and back to an in-progress agent conversation could cause buffered events to be delivered twice.

- Identified the root cause: when a subscriber disconnects, events accumulate in `earlyEventBuffer`; on reconnect, the route sends a sync event whose `aggregatedContent` already includes all buffered content, but `subscribe()` then replays the same buffer on top of it.
- Added a `syncWasSent` local boolean in the `/chat/stream/:streamId` route handler, set only after `res.write()` succeeds — `skipBufferReplay: true` is now passed to `subscribe()` conditionally on that flag rather than unconditionally on `isResume`.
- Wired `GenerationJobManager.markSyncSent()` into the route after a successful sync write, unifying the new call-site flag with the existing cross-replica `syncSent` Redis persistence mechanism that was previously never called.
- Added a `skipBufferReplay` option to `GenerationJobManager.subscribe()`, which skips replaying `earlyEventBuffer` while still clearing it to prevent memory accumulation.
- Extracted `SubscribeOptions` as a named, exported interface in `packages/api/src/types/stream.ts` and updated the `subscribe()` signature to use `t.SubscribeOptions`.
- Corrected a misleading debug log that stated `"(sync already sent)"` as fact when that was not guaranteed.
- Added a missing `@param options` parent entry to the `subscribe()` JSDoc.
- Extracted `createInMemoryManager()`, `createRedisManager()`, and `setupDisconnectedStream()` helpers in the integration test suite to eliminate repeated setup across all new tests.
- Added `getResumeState` invariant assertions before each resume subscription to verify accumulated content is available before the buffer is skipped.
- Added a multi-reconnect cycle test covering two sequential disconnect/resume cycles to verify state is correctly reset between rounds.
- Replaced `Record<string, unknown>` cast chains throughout the new tests with typed `ServerSentEvent[]` arrays and structured inline type assertions.
- Renamed the default-replay test from the inaccurate `"skipBufferReplay is false"` to `"replay buffer by default when no options are passed"`.
- Replaced the `if (!ioredisClient) { console.warn(...); return; }` pattern across the entire integration test file with `describeRedis` / `testRedis` wrappers (keyed to `process.env.USE_REDIS`) so Redis tests show as **skipped** rather than silently **passed** in environments without Redis, and added a file-level ESLint directive to permit `expect()` inside the custom `testRedis` block.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Integration tests are in `packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts` under the `Resume: skipBufferReplay prevents duplication` describe block.

To run in-memory tests only:
```bash
cd packages/api && npx jest GenerationJobManager.stream_integration
```

To run all tests including Redis:
```bash
cd packages/api && USE_REDIS=true REDIS_URI=redis://127.0.0.1:6379 npx jest GenerationJobManager.stream_integration
```

### Test Configuration

| Variable | Value |
|---|---|
| `USE_REDIS` | `true` to enable Redis tests, omit for in-memory only |
| `REDIS_URI` | `redis://127.0.0.1:6379` (default) |

Manual repro: open an agent conversation, navigate away mid-generation, then navigate back via `?resume=true`. Prior to this fix, content generated while the tab was inactive would appear twice in the message. After this fix, the sync event delivers the accumulated content once and buffer replay is suppressed.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes