### PR TITLE
feat: add MiniMax as a known custom provider

### DIFF
--- a/api/server/services/Endpoints/index.js
+++ b/api/server/services/Endpoints/index.js
@@ -12,7 +12,7 @@ const initGoogle = require('~/server/services/Endpoints/google/initialize');
  * @returns {boolean} - True if the provider is a known custom provider, false otherwise
  */
 function isKnownCustomProvider(provider) {
-  return [Providers.XAI, Providers.DEEPSEEK, Providers.OPENROUTER, Providers.MOONSHOT].includes(
+  return [Providers.XAI, Providers.DEEPSEEK, Providers.OPENROUTER, Providers.MOONSHOT, 'minimax'].includes(
     provider?.toLowerCase() || '',
   );
 }
@@ -22,6 +22,7 @@ const providerConfigMap = {
   [Providers.DEEPSEEK]: initCustom,
   [Providers.MOONSHOT]: initCustom,
   [Providers.OPENROUTER]: initCustom,
+  minimax: initCustom,
   [EModelEndpoint.openAI]: initOpenAI,
   [EModelEndpoint.google]: initGoogle,
   [EModelEndpoint.azureOpenAI]: initOpenAI,

--- a/client/public/assets/minimax.svg
+++ b/client/public/assets/minimax.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none">
+  <rect width="100" height="100" rx="20" fill="#1A1A2E"/>
+  <path d="M20 70V40L35 55L50 40V70" stroke="#E94560" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M50 70V40L65 55L80 40V70" stroke="#0F3460" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/hooks/Endpoint/UnknownIcon.tsx
+++ b/client/src/hooks/Endpoint/UnknownIcon.tsx
@@ -24,6 +24,7 @@ const knownEndpointAssets = {
   [KnownEndpoints.shuttleai]: 'assets/shuttleai.png',
   [KnownEndpoints['together.ai']]: 'assets/together.png',
   [KnownEndpoints.unify]: 'assets/unify.webp',
+  [KnownEndpoints.minimax]: 'assets/minimax.svg',
 };
 
 const knownEndpointClasses = {

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -394,6 +394,19 @@ endpoints:
       # NOTE: For Mistral, it is necessary to drop the following parameters or you will encounter a 422 Error:
       dropParams: ['stop', 'user', 'frequency_penalty', 'presence_penalty']
 
+    # MiniMax Example
+    # API Docs: https://platform.minimaxi.com/document/Guides
+    - name: 'MiniMax'
+      apiKey: '${MINIMAX_API_KEY}'
+      baseURL: 'https://api.minimax.io/v1'
+      models:
+        default: ['MiniMax-M2.5', 'MiniMax-M2.5-highspeed']
+        fetch: true
+      titleConvo: true
+      titleModel: 'MiniMax-M2.5-highspeed'
+      modelDisplayLabel: 'MiniMax'
+      dropParams: ['response_format']
+
     # OpenRouter Example
     - name: 'OpenRouter'
       # For `apiKey` and `baseURL`, you can use environment variables that you define.

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -134,6 +134,7 @@ const customProviders = new Set([
   Providers.DEEPSEEK,
   Providers.MOONSHOT,
   Providers.OPENROUTER,
+  'minimax',
   KnownEndpoints.ollama,
 ]);
 

--- a/packages/api/src/endpoints/config.ts
+++ b/packages/api/src/endpoints/config.ts
@@ -21,7 +21,7 @@ export type InitializeFn = (params: BaseInitializeParams) => Promise<InitializeR
  * @returns True if the provider is a known custom provider, false otherwise
  */
 export function isKnownCustomProvider(provider?: string): boolean {
-  return [Providers.XAI, Providers.DEEPSEEK, Providers.OPENROUTER, Providers.MOONSHOT].includes(
+  return [Providers.XAI, Providers.DEEPSEEK, Providers.OPENROUTER, Providers.MOONSHOT, 'minimax'].includes(
     (provider?.toLowerCase() ?? '') as Providers,
   );
 }
@@ -34,6 +34,7 @@ export const providerConfigMap: Record<string, InitializeFn> = {
   [Providers.DEEPSEEK]: initializeCustom,
   [Providers.MOONSHOT]: initializeCustom,
   [Providers.OPENROUTER]: initializeCustom,
+  minimax: initializeCustom,
   [EModelEndpoint.openAI]: initializeOpenAI,
   [EModelEndpoint.google]: initializeGoogle,
   [EModelEndpoint.bedrock]: initializeBedrock,

--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -15,6 +15,7 @@ const RECOGNIZED_PROVIDERS = new Set([
   'openrouter',
   'xai',
   'deepseek',
+  'minimax',
   'ollama',
   'bedrock',
 ]);

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -80,6 +80,7 @@ export type Provider =
   | 'openrouter'
   | 'xai'
   | 'deepseek'
+  | 'minimax'
   | 'ollama'
   | 'bedrock';
 

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -302,6 +302,12 @@ const bedrockModels = {
   ...anthropicModels,
 };
 
+const minimaxModels = {
+  minimax: 204800,
+  'minimax-m2.5': 204800,
+  'minimax-m2.5-highspeed': 204800,
+};
+
 const xAIModels = {
   grok: 131072,
   'grok-beta': 131072,
@@ -338,6 +344,7 @@ const aggregateModels = {
   'gpt-oss:120b': 131000,
   'gpt-oss-120b': 131000,
   ...qwenModels,
+  ...minimaxModels,
   ...xAIModels,
   ...googleModels,
   ...bedrockModels,
@@ -401,11 +408,17 @@ const deepseekMaxOutputs = {
   'deepseek.r1': 64000,
 };
 
+const minimaxMaxOutputs = {
+  minimax: 192000,
+  'minimax-m2.5': 192000,
+  'minimax-m2.5-highspeed': 192000,
+};
+
 export const maxOutputTokensMap = {
   [EModelEndpoint.anthropic]: anthropicMaxOutputs,
   [EModelEndpoint.azureOpenAI]: modelMaxOutputs,
-  [EModelEndpoint.openAI]: { ...modelMaxOutputs, ...deepseekMaxOutputs },
-  [EModelEndpoint.custom]: { ...modelMaxOutputs, ...deepseekMaxOutputs },
+  [EModelEndpoint.openAI]: { ...modelMaxOutputs, ...deepseekMaxOutputs, ...minimaxMaxOutputs },
+  [EModelEndpoint.custom]: { ...modelMaxOutputs, ...deepseekMaxOutputs, ...minimaxMaxOutputs },
 };
 
 /** Finds the longest matching key in the tokens map via substring match. */

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1063,6 +1063,7 @@ export enum KnownEndpoints {
   unify = 'unify',
   vercel = 'vercel',
   xai = 'xai',
+  minimax = 'minimax',
 }
 
 export enum FetchTokenConfig {
@@ -1096,6 +1097,7 @@ export const alternateName = {
   [KnownEndpoints.deepseek]: 'DeepSeek',
   [KnownEndpoints.moonshot]: 'Moonshot',
   [KnownEndpoints.xai]: 'xAI',
+  [KnownEndpoints.minimax]: 'MiniMax',
   [KnownEndpoints.vercel]: 'Vercel',
   [KnownEndpoints.helicone]: 'Helicone',
 };

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -230,6 +230,8 @@ export const getResponseSender = (endpointOption: Partial<t.TEndpointOption>): s
       return 'Kimi';
     } else if (model && model.includes('moonshot')) {
       return 'Moonshot';
+    } else if (model && model.toLowerCase().includes('minimax')) {
+      return 'MiniMax';
     } else if (model && model.includes('gpt-')) {
       const gptVersion = extractGPTVersion(model);
       return gptVersion || 'GPT';
@@ -271,6 +273,8 @@ export const getResponseSender = (endpointOption: Partial<t.TEndpointOption>): s
       return 'Kimi';
     } else if (model && model.includes('moonshot')) {
       return 'Moonshot';
+    } else if (model && model.toLowerCase().includes('minimax')) {
+      return 'MiniMax';
     } else if (model && model.includes('gpt-')) {
       const gptVersion = extractGPTVersion(model);
       return gptVersion || 'GPT';

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -41,6 +41,7 @@ export enum Providers {
   MOONSHOT = 'moonshot',
   OPENROUTER = 'openrouter',
   XAI = 'xai',
+  MINIMAX = 'minimax',
 }
 
 /**
@@ -61,6 +62,7 @@ export const documentSupportedProviders = new Set<string>([
   Providers.MOONSHOT,
   Providers.OPENROUTER,
   Providers.XAI,
+  Providers.MINIMAX,
 ]);
 
 const openAILikeProviders = new Set<string>([
@@ -73,6 +75,7 @@ const openAILikeProviders = new Set<string>([
   Providers.MOONSHOT,
   Providers.OPENROUTER,
   Providers.XAI,
+  Providers.MINIMAX,
 ]);
 
 export const isOpenAILikeProvider = (provider?: string | null): boolean => {


### PR DESCRIPTION
## Summary

Registers [MiniMax](https://api.minimax.io/v1) as a first-class known custom provider, following the same pattern used for DeepSeek, Moonshot, xAI, and OpenRouter.

### Changes

- **Provider registration**: Added `MINIMAX` to `Providers` enum, `documentSupportedProviders`, and `openAILikeProviders` sets (`schemas.ts`)
- **Endpoint config**: Added `minimax` to `KnownEndpoints` enum and `alternateName` map (`config.ts`)
- **Provider routing**: Registered `minimax` in `providerConfigMap` and `isKnownCustomProvider()` in both TS (`packages/api/src/endpoints/config.ts`) and legacy JS (`api/server/services/Endpoints/index.js`)
- **Agent system**: Added `minimax` to the `customProviders` set in `agents/run.ts`
- **MCP support**: Added `minimax` to `RECOGNIZED_PROVIDERS` and `Provider` type in MCP parsers/types
- **Token configuration**: Added MiniMax context window (204,800 tokens) and max output (192,000 tokens) maps in `tokens.ts`
- **Model label detection**: Added MiniMax model name detection in `parsers.ts` for both OpenAI and custom endpoint blocks
- **UI icon**: Added MiniMax SVG icon and registered it in `UnknownIcon.tsx`
- **YAML example**: Added MiniMax configuration example in `librechat.example.yaml` with `dropParams: ['response_format']`

### MiniMax API Details

- **Base URL**: `https://api.minimax.io/v1` (OpenAI-compatible)
- **Models**: `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`
- **Context window**: 204,800 tokens
- **Max output**: 192,000 tokens
- **Note**: `response_format` parameter is not supported and must be dropped

## Test Plan

- [ ] Verify MiniMax appears in provider selection when configured via `librechat.yaml`
- [ ] Verify MiniMax icon displays correctly in the UI
- [ ] Verify chat completion works with MiniMax API key configured
- [ ] Verify model label shows 'MiniMax' for MiniMax model names
- [ ] Verify agent system recognizes MiniMax as a custom provider

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>