### PR TITLE
🛰️ fix: Cross-Replica Created Event Delivery

### DIFF
--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -879,8 +879,7 @@ class GenerationJobManagerClass {
       return;
     }
 
-    // Track user message from created event
-    this.trackUserMessage(streamId, event);
+    await this.trackUserMessage(streamId, event);
 
     // For Redis mode, persist chunk for later reconstruction (fire-and-forget for resumability)
     if (this._isRedis) {
@@ -964,9 +963,12 @@ class GenerationJobManagerClass {
   }
 
   /**
-   * Track user message from created event.
+   * Persist user message metadata from the created event.
+   * Awaited in emitChunk so the HSET commits before the PUBLISH,
+   * guaranteeing any cross-replica getJob() after the pub/sub window
+   * finds userMessage in Redis.
    */
-  private trackUserMessage(streamId: string, event: t.ServerSentEvent): void {
+  private async trackUserMessage(streamId: string, event: t.ServerSentEvent): Promise<void> {
     const data = event as Record<string, unknown>;
     if (!data.created || !data.message) {
       return;
@@ -986,7 +988,7 @@ class GenerationJobManagerClass {
       updates.conversationId = message.conversationId as string;
     }
 
-    this.jobStore.updateJob(streamId, updates);
+    await this.jobStore.updateJob(streamId, updates);
   }
 
   /**

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -969,23 +969,22 @@ class GenerationJobManagerClass {
    * finds userMessage in Redis.
    */
   private async trackUserMessage(streamId: string, event: t.ServerSentEvent): Promise<void> {
-    const data = event as Record<string, unknown>;
-    if (!data.created || !data.message) {
+    if (!('created' in event)) {
       return;
     }
 
-    const message = data.message as Record<string, unknown>;
+    const { message } = event;
     const updates: Partial<SerializableJobData> = {
       userMessage: {
-        messageId: message.messageId as string,
-        parentMessageId: message.parentMessageId as string | undefined,
-        conversationId: message.conversationId as string | undefined,
-        text: message.text as string | undefined,
+        messageId: message.messageId,
+        parentMessageId: message.parentMessageId,
+        conversationId: message.conversationId,
+        text: message.text,
       },
     };
 
     if (message.conversationId) {
-      updates.conversationId = message.conversationId as string;
+      updates.conversationId = message.conversationId;
     }
 
     await this.jobStore.updateJob(streamId, updates);

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -656,7 +656,7 @@ class GenerationJobManagerClass {
       aborted: true,
       // Flag for early abort - no messages saved, frontend should go to new chat
       earlyAbort: isEarlyAbort,
-    } as unknown as t.ServerSentEvent;
+    } satisfies t.FinalEvent as t.ServerSentEvent;
 
     if (runtime) {
       runtime.finalEvent = abortFinalEvent;
@@ -792,7 +792,7 @@ class GenerationJobManagerClass {
         logger.debug(
           `[GenerationJobManager] Cross-replica subscribe: emitting created event from metadata for ${streamId}`,
         );
-        const createdEvent = {
+        const createdEvent: t.CreatedEvent = {
           created: true,
           message: {
             ...jobData.userMessage,
@@ -801,7 +801,7 @@ class GenerationJobManagerClass {
           },
           streamId,
         };
-        onChunk(createdEvent as unknown as t.ServerSentEvent);
+        onChunk(createdEvent);
       }
 
       this.eventTransport.syncReorderBuffer?.(streamId);

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -782,6 +782,13 @@ class GenerationJobManagerClass {
         }
         runtime.earlyEventBuffer = [];
       } else if (this._isRedis && !options?.skipBufferReplay && jobData?.userMessage) {
+        /**
+         * Cross-replica fallback: the created event was buffered on the generating
+         * instance and published via Redis pub/sub before this subscriber was active.
+         * Reconstruct from persisted metadata. Only fields stored by trackUserMessage()
+         * are available (messageId, parentMessageId, conversationId, text);
+         * sender/isCreatedByUser are invariant for user messages and added back here.
+         */
         logger.debug(
           `[GenerationJobManager] Cross-replica subscribe: emitting created event from metadata for ${streamId}`,
         );

--- a/packages/api/src/stream/GenerationJobManager.ts
+++ b/packages/api/src/stream/GenerationJobManager.ts
@@ -781,6 +781,20 @@ class GenerationJobManagerClass {
           }
         }
         runtime.earlyEventBuffer = [];
+      } else if (this._isRedis && !options?.skipBufferReplay && jobData?.userMessage) {
+        logger.debug(
+          `[GenerationJobManager] Cross-replica subscribe: emitting created event from metadata for ${streamId}`,
+        );
+        const createdEvent = {
+          created: true,
+          message: {
+            ...jobData.userMessage,
+            sender: 'User',
+            isCreatedByUser: true,
+          },
+          streamId,
+        };
+        onChunk(createdEvent as unknown as t.ServerSentEvent);
       }
 
       this.eventTransport.syncReorderBuffer?.(streamId);

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -853,6 +853,47 @@ describe('GenerationJobManager Integration Tests', () => {
       await GenerationJobManager.destroy();
       await replicaAJobStore.destroy();
     });
+
+    test('should NOT emit created event when skipBufferReplay is true (resume path)', async () => {
+      const replicaAJobStore = new RedisJobStore(ioredisClient!);
+      await replicaAJobStore.initialize();
+
+      const streamId = `cross-no-replay-${Date.now()}`;
+      await replicaAJobStore.createJob(streamId, 'test-user');
+      await replicaAJobStore.updateJob(streamId, {
+        userMessage: {
+          messageId: 'msg-456',
+          conversationId: streamId,
+          text: 'hi',
+        },
+      });
+
+      jest.resetModules();
+
+      const services = createStreamServices({
+        useRedis: true,
+        redisClient: ioredisClient,
+      });
+
+      GenerationJobManager.configure(services);
+      GenerationJobManager.initialize();
+
+      const received: unknown[] = [];
+      const subscription = await GenerationJobManager.subscribe(
+        streamId,
+        (event) => received.push(event),
+        undefined,
+        undefined,
+        { skipBufferReplay: true },
+      );
+
+      expect(subscription).not.toBeNull();
+      expect(received.length).toBe(0);
+
+      subscription?.unsubscribe();
+      await GenerationJobManager.destroy();
+      await replicaAJobStore.destroy();
+    });
   });
 
   describeRedis('Sequential Event Ordering (Redis)', () => {

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -2156,7 +2156,8 @@ describe('GenerationJobManager Integration Tests', () => {
       await new Promise((resolve) => setTimeout(resolve, 700));
 
       expect(receivedOnA.length).toBe(4);
-      expect(receivedOnB.length).toBe(3);
+      expect(receivedOnB.length).toBe(4);
+      expect((receivedOnB[0] as CreatedEvent).created).toBe(true);
 
       subA?.unsubscribe();
       subB?.unsubscribe();

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -1,6 +1,6 @@
 /* eslint jest/no-standalone-expect: ["error", { "additionalTestBlockFunctions": ["testRedis"] }] */
 import type { Redis, Cluster } from 'ioredis';
-import type { ServerSentEvent } from '~/types/events';
+import type { ServerSentEvent, StreamEvent, CreatedEvent } from '~/types/events';
 import { InMemoryEventTransport } from '~/stream/implementations/InMemoryEventTransport';
 import { RedisEventTransport } from '~/stream/implementations/RedisEventTransport';
 import { InMemoryJobStore } from '~/stream/implementations/InMemoryJobStore';
@@ -808,15 +808,13 @@ describe('GenerationJobManager Integration Tests', () => {
       expect(subscription).not.toBeNull();
       expect(received.length).toBe(1);
 
-      const created = received[0] as Record<string, unknown>;
+      const created = received[0] as CreatedEvent;
       expect(created.created).toBe(true);
       expect(created.streamId).toBe(streamId);
-
-      const msg = created.message as Record<string, unknown>;
-      expect(msg.messageId).toBe('msg-123');
-      expect(msg.conversationId).toBe(streamId);
-      expect(msg.sender).toBe('User');
-      expect(msg.isCreatedByUser).toBe(true);
+      expect(created.message.messageId).toBe('msg-123');
+      expect(created.message.conversationId).toBe(streamId);
+      expect(created.message.sender).toBe('User');
+      expect(created.message.isCreatedByUser).toBe(true);
 
       subscription?.unsubscribe();
       await GenerationJobManager.destroy();
@@ -1163,7 +1161,7 @@ describe('GenerationJobManager Integration Tests', () => {
         created: true,
         message: { text: 'hello' },
         streamId,
-      } as unknown as ServerSentEvent);
+      } as CreatedEvent);
       await manager.emitChunk(streamId, {
         event: 'on_message_delta',
         data: { delta: { content: { type: 'text', text: 'First chunk' } } },
@@ -1200,7 +1198,7 @@ describe('GenerationJobManager Integration Tests', () => {
         created: true,
         message: { text: 'hello' },
         streamId,
-      } as unknown as ServerSentEvent);
+      } as CreatedEvent);
       await manager.emitChunk(streamId, {
         event: 'on_message_delta',
         data: { delta: { content: { type: 'text', text: 'First' } } },
@@ -1246,7 +1244,7 @@ describe('GenerationJobManager Integration Tests', () => {
           created: true,
           message: { text: 'hello' },
           streamId,
-        } as unknown as ServerSentEvent);
+        } as CreatedEvent);
         await manager.emitChunk(streamId, {
           event: 'on_run_step',
           data: { id: 'step-1', type: 'message_creation', index: 0 },
@@ -1351,7 +1349,7 @@ describe('GenerationJobManager Integration Tests', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 20));
       expect(resumeEvents.length).toBe(1);
-      expect(resumeEvents[0].event).toBe('on_message_delta');
+      expect((resumeEvents[0] as StreamEvent).event).toBe('on_message_delta');
 
       sub2?.unsubscribe();
       await manager.destroy();
@@ -1385,7 +1383,7 @@ describe('GenerationJobManager Integration Tests', () => {
       await new Promise((resolve) => setTimeout(resolve, 20));
 
       expect(sub2Events.length).toBe(1);
-      expect(sub2Events[0].event).toBe('on_message_delta');
+      expect((sub2Events[0] as StreamEvent).event).toBe('on_message_delta');
 
       sub2?.unsubscribe();
       await manager.destroy();
@@ -1550,7 +1548,7 @@ describe('GenerationJobManager Integration Tests', () => {
 
       await new Promise((resolve) => setTimeout(resolve, 200));
       expect(resumeEvents.length).toBe(1);
-      expect(resumeEvents[0].event).toBe('on_message_delta');
+      expect((resumeEvents[0] as StreamEvent).event).toBe('on_message_delta');
 
       sub2?.unsubscribe();
       await manager.destroy();
@@ -1581,7 +1579,7 @@ describe('GenerationJobManager Integration Tests', () => {
         await new Promise((resolve) => setTimeout(resolve, 200));
 
         expect(sub2Events.length).toBe(1);
-        expect(sub2Events[0].event).toBe('on_message_delta');
+        expect((sub2Events[0] as StreamEvent).event).toBe('on_message_delta');
 
         sub2?.unsubscribe();
         await manager.destroy();
@@ -2120,7 +2118,7 @@ describe('GenerationJobManager Integration Tests', () => {
         created: true,
         message: { text: 'hello' },
         streamId,
-      } as unknown as ServerSentEvent);
+      } as CreatedEvent);
 
       const receivedOnA: unknown[] = [];
       const subA = await replicaA.subscribe(streamId, (event: unknown) => receivedOnA.push(event));

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -1,6 +1,6 @@
 /* eslint jest/no-standalone-expect: ["error", { "additionalTestBlockFunctions": ["testRedis"] }] */
 import type { Redis, Cluster } from 'ioredis';
-import type { ServerSentEvent, StreamEvent, CreatedEvent } from '~/types/events';
+import type { ServerSentEvent, StreamEvent, CreatedEvent } from '~/types';
 import { InMemoryEventTransport } from '~/stream/implementations/InMemoryEventTransport';
 import { RedisEventTransport } from '~/stream/implementations/RedisEventTransport';
 import { InMemoryJobStore } from '~/stream/implementations/InMemoryJobStore';

--- a/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
+++ b/packages/api/src/stream/__tests__/GenerationJobManager.stream_integration.spec.ts
@@ -771,6 +771,88 @@ describe('GenerationJobManager Integration Tests', () => {
       await GenerationJobManager.destroy();
       await jobStore.destroy();
     });
+
+    test('should emit created event from metadata on cross-replica subscribe', async () => {
+      const replicaAJobStore = new RedisJobStore(ioredisClient!);
+      await replicaAJobStore.initialize();
+
+      const streamId = `cross-created-${Date.now()}`;
+      const userId = 'test-user';
+
+      await replicaAJobStore.createJob(streamId, userId);
+      await replicaAJobStore.updateJob(streamId, {
+        userMessage: {
+          messageId: 'msg-123',
+          parentMessageId: '00000000-0000-0000-0000-000000000000',
+          conversationId: streamId,
+          text: 'hello world',
+        },
+      });
+
+      jest.resetModules();
+
+      const services = createStreamServices({
+        useRedis: true,
+        redisClient: ioredisClient,
+      });
+
+      GenerationJobManager.configure(services);
+      GenerationJobManager.initialize();
+
+      const received: unknown[] = [];
+      const subscription = await GenerationJobManager.subscribe(
+        streamId,
+        (event) => received.push(event),
+      );
+
+      expect(subscription).not.toBeNull();
+      expect(received.length).toBe(1);
+
+      const created = received[0] as Record<string, unknown>;
+      expect(created.created).toBe(true);
+      expect(created.streamId).toBe(streamId);
+
+      const msg = created.message as Record<string, unknown>;
+      expect(msg.messageId).toBe('msg-123');
+      expect(msg.conversationId).toBe(streamId);
+      expect(msg.sender).toBe('User');
+      expect(msg.isCreatedByUser).toBe(true);
+
+      subscription?.unsubscribe();
+      await GenerationJobManager.destroy();
+      await replicaAJobStore.destroy();
+    });
+
+    test('should NOT emit created event from metadata when userMessage is not set', async () => {
+      const replicaAJobStore = new RedisJobStore(ioredisClient!);
+      await replicaAJobStore.initialize();
+
+      const streamId = `cross-no-created-${Date.now()}`;
+      await replicaAJobStore.createJob(streamId, 'test-user');
+
+      jest.resetModules();
+
+      const services = createStreamServices({
+        useRedis: true,
+        redisClient: ioredisClient,
+      });
+
+      GenerationJobManager.configure(services);
+      GenerationJobManager.initialize();
+
+      const received: unknown[] = [];
+      const subscription = await GenerationJobManager.subscribe(
+        streamId,
+        (event) => received.push(event),
+      );
+
+      expect(subscription).not.toBeNull();
+      expect(received.length).toBe(0);
+
+      subscription?.unsubscribe();
+      await GenerationJobManager.destroy();
+      await replicaAJobStore.destroy();
+    });
   });
 
   describeRedis('Sequential Event Ordering (Redis)', () => {

--- a/packages/api/src/types/events.ts
+++ b/packages/api/src/types/events.ts
@@ -18,16 +18,30 @@ export type CreatedEvent = {
   streamId: string;
 };
 
+export type FinalMessageFields = {
+  messageId?: string;
+  parentMessageId?: string;
+  conversationId?: string;
+  text?: string;
+  content?: unknown[];
+  sender?: string;
+  isCreatedByUser?: boolean;
+  unfinished?: boolean;
+  error?: boolean | string;
+  [key: string]: unknown;
+};
+
 /** Terminal event emitted when generation completes or is aborted */
 export type FinalEvent = {
   final: true;
-  requestMessage?: Record<string, unknown> | null;
-  responseMessage?: Record<string, unknown> | null;
-  conversation?: Record<string, unknown> | null;
+  requestMessage?: FinalMessageFields | null;
+  responseMessage?: FinalMessageFields | null;
+  conversation?: { conversationId?: string; [key: string]: unknown } | null;
   title?: string;
   aborted?: boolean;
   earlyAbort?: boolean;
-  runMessages?: Record<string, unknown>[];
+  runMessages?: FinalMessageFields[];
+  error?: { message: string };
 };
 
 export type ServerSentEvent = StreamEvent | CreatedEvent | FinalEvent;

--- a/packages/api/src/types/events.ts
+++ b/packages/api/src/types/events.ts
@@ -27,6 +27,7 @@ export type FinalMessageFields = {
   sender?: string;
   isCreatedByUser?: boolean;
   unfinished?: boolean;
+  /** Per-message error flag — matches TMessage.error (boolean or error text) */
   error?: boolean | string;
   [key: string]: unknown;
 };
@@ -41,6 +42,7 @@ export type FinalEvent = {
   aborted?: boolean;
   earlyAbort?: boolean;
   runMessages?: FinalMessageFields[];
+  /** Top-level event error (abort-during-completion edge case) */
   error?: { message: string };
 };
 

--- a/packages/api/src/types/events.ts
+++ b/packages/api/src/types/events.ts
@@ -1,4 +1,26 @@
-export type ServerSentEvent = {
+/** SSE streaming event (on_run_step, on_message_delta, etc.) */
+export type StreamEvent = {
+  event: string;
   data: string | Record<string, unknown>;
-  event?: string;
 };
+
+/** Control event emitted when user message is created and generation starts */
+export type CreatedEvent = {
+  created: true;
+  message: Record<string, unknown>;
+  streamId: string;
+};
+
+/** Terminal event emitted when generation completes or is aborted */
+export type FinalEvent = {
+  final: true;
+  requestMessage?: Record<string, unknown> | null;
+  responseMessage?: Record<string, unknown> | null;
+  conversation?: Record<string, unknown> | null;
+  title?: string;
+  aborted?: boolean;
+  earlyAbort?: boolean;
+  runMessages?: Record<string, unknown>[];
+};
+
+export type ServerSentEvent = StreamEvent | CreatedEvent | FinalEvent;

--- a/packages/api/src/types/events.ts
+++ b/packages/api/src/types/events.ts
@@ -7,7 +7,14 @@ export type StreamEvent = {
 /** Control event emitted when user message is created and generation starts */
 export type CreatedEvent = {
   created: true;
-  message: Record<string, unknown>;
+  message: {
+    messageId: string;
+    parentMessageId?: string;
+    conversationId?: string;
+    text?: string;
+    sender: string;
+    isCreatedByUser: boolean;
+  };
   streamId: string;
 };
 

--- a/packages/api/src/utils/events.ts
+++ b/packages/api/src/utils/events.ts
@@ -2,11 +2,8 @@ import type { Response as ServerResponse } from 'express';
 import type { ServerSentEvent } from '~/types';
 
 /**
- * Sends message data in Server Sent Events format.
- * @param res - The server response.
- * @param event - The message event.
- * @param event.event - The type of event.
- * @param event.data - The message to be sent.
+ * Sends a Server-Sent Event to the client.
+ * Empty-string StreamEvent data is silently dropped.
  */
 export function sendEvent(res: ServerResponse, event: ServerSentEvent): void {
   if ('data' in event && typeof event.data === 'string' && event.data.length === 0) {

--- a/packages/api/src/utils/events.ts
+++ b/packages/api/src/utils/events.ts
@@ -9,7 +9,7 @@ import type { ServerSentEvent } from '~/types';
  * @param event.data - The message to be sent.
  */
 export function sendEvent(res: ServerResponse, event: ServerSentEvent): void {
-  if (typeof event.data === 'string' && event.data.length === 0) {
+  if ('data' in event && typeof event.data === 'string' && event.data.length === 0) {
     return;
   }
   res.write(`event: message\ndata: ${JSON.stringify(event)}\n\n`);


### PR DESCRIPTION


## Summary

Fixed a silent event loss in horizontally-scaled Redis deployments where the `created` event — which drives sidebar conversation creation on the frontend — was never received by clients whose SSE connection landed on a different replica than the one running generation. Restructured the ordering guarantee between the Redis HSET and PUBLISH, and replaced the `ServerSentEvent` opaque type with a discriminated union to eliminate all unsafe casts introduced by the fix.

- Fixed the cross-replica `created` event loss by adding a fallback in `subscribe()`: when the subscribing replica has an empty `earlyEventBuffer`, is in Redis mode, and finds `userMessage` already committed to the job hash, it reconstructs and emits the `created` event directly from stored metadata before any live events arrive.
- Added a JSDoc block on the fallback branch documenting which fields are preserved by `trackUserMessage()`, why `sender`/`isCreatedByUser` are hardcoded at reconstruction time, and the pub/sub timing gap that necessitates the fallback.
- Made the HSET-before-PUBLISH ordering structural by converting `trackUserMessage()` from fire-and-forget to `async` and awaiting it in `emitChunk()` before the Redis PUBLISH fires, guaranteeing any cross-replica `getJob()` after the pub/sub window always finds `userMessage` in Redis. The fast path (every non-`created` event) returns before any `await`, so there is zero cost on the hot path.
- Split `ServerSentEvent` from a single opaque `{ data, event? }` type into a discriminated union — `StreamEvent | CreatedEvent | FinalEvent` — eliminating all `as unknown as t.ServerSentEvent` casts and giving the three event shapes statically verified contracts.
- Typed `CreatedEvent.message` with its full explicit shape (`messageId`, `parentMessageId`, `conversationId`, `text`, `sender`, `isCreatedByUser`) matching `trackUserMessage()`'s storage contract.
- Introduced `FinalMessageFields` with explicit known fields and an index signature for `TMessage` passthrough, replacing `Record<string, unknown>` on `requestMessage`/`responseMessage`/`runMessages` in `FinalEvent`; typed `conversation` as `{ conversationId?: string; [key: string]: unknown }` and added `error?: { message: string }` for the abort-during-completion edge case.
- Updated `sendEvent()` with a `'data' in event` guard to correctly narrow the union before the empty-string check, ensuring `CreatedEvent` and `FinalEvent` are never silently dropped.
- Refactored `trackUserMessage()` to narrow via `'created' in event` using the discriminated union instead of casting to `Record<string, unknown>` and re-casting every field.
- Added three integration tests in `describeRedis('Cross-Replica Support (Redis)')`: a positive case (`userMessage` present → `created` emitted), a negative case (`userMessage` absent → nothing emitted), and a regression guard (`skipBufferReplay: true` → nothing emitted, protecting the duplication fix from PR #12225).
- Updated the existing `should deliver buffered events locally AND publish live events cross-replica` test to assert Replica B receives 4 events (`created` + 3 deltas) and that `receivedOnB[0].created === true`, reflecting the now-correct behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Integration tests covering the fix require a running Redis instance and are gated behind `USE_REDIS=true`.

```bash
cd packages/api
USE_REDIS=true npx jest GenerationJobManager.stream_integration
```

All tests in `describeRedis('Cross-Replica Support (Redis)')` exercise the fix directly. The three new tests isolate the condition branches of the `else if` fallback. The updated live streaming test confirms end-to-end event count and ordering for Replica B.

### Test Configuration

| Variable | Value |
|---|---|
| `USE_REDIS` | `true` |
| `REDIS_URI` | `redis://127.0.0.1:6379` |

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes