### PR TITLE
📎 fix: Respect fileConfig.disabled for Agents Endpoint Upload Button

### DIFF
--- a/client/src/components/Chat/Input/Files/AttachFileChat.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileChat.tsx
@@ -91,7 +91,7 @@ function AttachFileChat({
 
   if (isAssistants && endpointSupportsFiles && !isUploadDisabled) {
     return <AttachFile disabled={disableInputs} />;
-  } else if (isAgents || (endpointSupportsFiles && !isUploadDisabled)) {
+  } else if ((isAgents || endpointSupportsFiles) && !isUploadDisabled) {
     return (
       <AttachFileMenu
         endpoint={endpoint}

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileChat.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileChat.spec.tsx
@@ -178,6 +178,20 @@ describe('AttachFileChat', () => {
       expect(screen.getByTestId('attach-file')).toBeInTheDocument();
     });
 
+    it('renders AttachFileMenu when provider-specific config overrides agents disabled', () => {
+      mockFileConfig = mergeFileConfig({
+        endpoints: {
+          Moonshot: { disabled: false, fileLimit: 5 },
+          [EModelEndpoint.agents]: { disabled: true },
+        },
+      });
+      mockAgentsMap = {
+        'agent-1': { provider: 'Moonshot', model_parameters: {} } as Partial<Agent>,
+      };
+      renderComponent({ endpoint: EModelEndpoint.agents, agent_id: 'agent-1' });
+      expect(screen.getByTestId('attach-file-menu')).toBeInTheDocument();
+    });
+
     it('renders null for assistants endpoint when fileConfig.assistants.disabled is true', () => {
       mockFileConfig = mergeFileConfig({
         endpoints: {

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileChat.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileChat.spec.tsx
@@ -13,13 +13,15 @@ const mockEndpointsConfig: TEndpointsConfig = {
   Moonshot: { type: EModelEndpoint.custom, userProvide: false, order: 9999 },
 };
 
-const mockFileConfig = mergeFileConfig({
+const defaultFileConfig = mergeFileConfig({
   endpoints: {
     Moonshot: { fileLimit: 5 },
     [EModelEndpoint.agents]: { fileLimit: 20 },
     default: { fileLimit: 10 },
   },
 });
+
+let mockFileConfig = defaultFileConfig;
 
 let mockAgentsMap: Record<string, Partial<Agent>> = {};
 let mockAgentQueryData: Partial<Agent> | undefined;
@@ -65,6 +67,7 @@ function renderComponent(conversation: Record<string, unknown> | null, disableIn
 
 describe('AttachFileChat', () => {
   beforeEach(() => {
+    mockFileConfig = defaultFileConfig;
     mockAgentsMap = {};
     mockAgentQueryData = undefined;
     mockAttachFileMenuProps = {};
@@ -145,6 +148,46 @@ describe('AttachFileChat', () => {
       const agentType = mockAttachFileMenuProps.endpointType;
 
       expect(directType).toBe(agentType);
+    });
+  });
+
+  describe('upload disabled rendering', () => {
+    it('renders null for agents endpoint when fileConfig.agents.disabled is true', () => {
+      mockFileConfig = mergeFileConfig({
+        endpoints: {
+          [EModelEndpoint.agents]: { disabled: true },
+        },
+      });
+      const { container } = renderComponent({
+        endpoint: EModelEndpoint.agents,
+        agent_id: 'agent-1',
+      });
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders null for agents endpoint when disableInputs is true', () => {
+      const { container } = renderComponent(
+        { endpoint: EModelEndpoint.agents, agent_id: 'agent-1' },
+        true,
+      );
+      expect(container.innerHTML).toBe('');
+    });
+
+    it('renders AttachFile for assistants endpoint when not disabled', () => {
+      renderComponent({ endpoint: EModelEndpoint.assistants });
+      expect(screen.getByTestId('attach-file')).toBeInTheDocument();
+    });
+
+    it('renders null for assistants endpoint when fileConfig.assistants.disabled is true', () => {
+      mockFileConfig = mergeFileConfig({
+        endpoints: {
+          [EModelEndpoint.assistants]: { disabled: true },
+        },
+      });
+      const { container } = renderComponent({
+        endpoint: EModelEndpoint.assistants,
+      });
+      expect(container.innerHTML).toBe('');
     });
   });
 

--- a/client/src/components/SidePanel/Agents/__tests__/AgentFileConfig.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentFileConfig.spec.tsx
@@ -18,13 +18,15 @@ const mockEndpointsConfig: TEndpointsConfig = {
   'Some Endpoint': { type: EModelEndpoint.custom, userProvide: false, order: 9999 },
 };
 
-let mockFileConfig = mergeFileConfig({
+const defaultFileConfig = mergeFileConfig({
   endpoints: {
     Moonshot: { fileLimit: 5 },
     [EModelEndpoint.agents]: { fileLimit: 20 },
     default: { fileLimit: 10 },
   },
 });
+
+let mockFileConfig = defaultFileConfig;
 
 jest.mock('~/data-provider', () => ({
   useGetEndpointsQuery: () => ({ data: mockEndpointsConfig }),
@@ -118,13 +120,16 @@ describe('AgentPanel file config resolution (useAgentFileConfig)', () => {
   });
 
   describe('disabled state', () => {
+    beforeEach(() => {
+      mockFileConfig = defaultFileConfig;
+    });
+
     it('reports not disabled for standard config', () => {
       render(<TestWrapper provider="Moonshot" />);
       expect(screen.getByTestId('disabled').textContent).toBe('false');
     });
 
     it('reports disabled when provider-specific config is disabled', () => {
-      const original = mockFileConfig;
       mockFileConfig = mergeFileConfig({
         endpoints: {
           Moonshot: { disabled: true },
@@ -135,8 +140,44 @@ describe('AgentPanel file config resolution (useAgentFileConfig)', () => {
 
       render(<TestWrapper provider="Moonshot" />);
       expect(screen.getByTestId('disabled').textContent).toBe('true');
+    });
 
-      mockFileConfig = original;
+    it('reports disabled when agents config is disabled and no provider set', () => {
+      mockFileConfig = mergeFileConfig({
+        endpoints: {
+          [EModelEndpoint.agents]: { disabled: true },
+          default: { fileLimit: 10 },
+        },
+      });
+
+      render(<TestWrapper />);
+      expect(screen.getByTestId('disabled').textContent).toBe('true');
+    });
+
+    it('reports disabled when agents is disabled and provider has no specific config', () => {
+      mockFileConfig = mergeFileConfig({
+        endpoints: {
+          [EModelEndpoint.agents]: { disabled: true },
+          default: { fileLimit: 10 },
+        },
+      });
+
+      render(<TestWrapper provider="Some Endpoint" />);
+      expect(screen.getByTestId('disabled').textContent).toBe('true');
+    });
+
+    it('provider-specific enabled overrides agents disabled', () => {
+      mockFileConfig = mergeFileConfig({
+        endpoints: {
+          Moonshot: { disabled: false, fileLimit: 5 },
+          [EModelEndpoint.agents]: { disabled: true },
+          default: { fileLimit: 10 },
+        },
+      });
+
+      render(<TestWrapper provider="Moonshot" />);
+      expect(screen.getByTestId('disabled').textContent).toBe('false');
+      expect(screen.getByTestId('fileLimit').textContent).toBe('5');
     });
   });
 


### PR DESCRIPTION


## Summary

Fixed a boolean operator precedence bug in `AttachFileChat` that caused `fileConfig.endpoints.agents.disabled` to have no effect, and added regression tests covering the upload guard for both the agents and assistants endpoints.

- Regrouped the `else if` condition in `AttachFileChat.tsx` from `isAgents || (endpointSupportsFiles && !isUploadDisabled)` to `(isAgents || endpointSupportsFiles) && !isUploadDisabled`, ensuring the `!isUploadDisabled` guard applies to both branches.
- Refactored `mockFileConfig` in `AttachFileChat.spec.tsx` from a `const` to a mutable `let` with a `beforeEach` reset, matching the existing pattern used for `mockAgentsMap` and `mockAgentQueryData`.
- Added four regression tests in a new `upload disabled rendering` describe block: agents endpoint with `fileConfig.agents.disabled: true` returning null, agents endpoint with `disableInputs: true` returning null, assistants endpoint without disabled config rendering `AttachFile` as a positive control, and assistants endpoint with `fileConfig.assistants.disabled: true` returning null.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified via the new unit tests in `AttachFileChat.spec.tsx`. To reproduce the bug manually before this fix: configure `fileConfig.endpoints.agents.disabled: true` in `librechat.yaml`, start the app, switch to an agents conversation, and confirm the attach file button no longer renders.

### **Test Configuration**:

Run from the `client` workspace:

```bash
npx jest AttachFileChat
```

All 20 tests in `AttachFileChat.spec.tsx` should pass, including the 4 new tests in the `upload disabled rendering` block.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes