### PR TITLE
🐍 refactor: Normalize Non-Standard Browser MIME Type Aliases in `inferMimeType`

### DIFF
--- a/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
@@ -180,21 +180,4 @@ describe('DragDropModal - Provider Detection', () => {
       expect(inferredType).toBe('');
     });
   });
-
-  describe('MIME type alias normalization', () => {
-    it('should normalize text/x-python-script to text/x-python', () => {
-      const inferredType = inferMimeType('test.py', 'text/x-python-script');
-      expect(inferredType).toBe('text/x-python');
-    });
-
-    it('should pass through standard text/x-python unchanged', () => {
-      const inferredType = inferMimeType('test.py', 'text/x-python');
-      expect(inferredType).toBe('text/x-python');
-    });
-
-    it('should pass through unknown browser types unchanged', () => {
-      const inferredType = inferMimeType('data.bin', 'application/octet-stream');
-      expect(inferredType).toBe('application/octet-stream');
-    });
-  });
 });

--- a/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
@@ -180,4 +180,21 @@ describe('DragDropModal - Provider Detection', () => {
       expect(inferredType).toBe('');
     });
   });
+
+  describe('MIME type alias normalization', () => {
+    it('should normalize text/x-python-script to text/x-python', () => {
+      const inferredType = inferMimeType('test.py', 'text/x-python-script');
+      expect(inferredType).toBe('text/x-python');
+    });
+
+    it('should pass through standard text/x-python unchanged', () => {
+      const inferredType = inferMimeType('test.py', 'text/x-python');
+      expect(inferredType).toBe('text/x-python');
+    });
+
+    it('should pass through unknown browser types unchanged', () => {
+      const inferredType = inferMimeType('data.bin', 'application/octet-stream');
+      expect(inferredType).toBe('application/octet-stream');
+    });
+  });
 });

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -3,12 +3,40 @@ import {
   fileConfig as baseFileConfig,
   getEndpointFileConfig,
   mergeFileConfig,
+  inferMimeType,
+  textMimeTypes,
   applicationMimeTypes,
   defaultOCRMimeTypes,
   documentParserMimeTypes,
   supportedMimeTypes,
 } from './file-config';
 import { EModelEndpoint } from './schemas';
+
+describe('inferMimeType', () => {
+  it('should normalize text/x-python-script to text/x-python', () => {
+    expect(inferMimeType('test.py', 'text/x-python-script')).toBe('text/x-python');
+  });
+
+  it('should return a type that matches textMimeTypes after normalization', () => {
+    const normalized = inferMimeType('test.py', 'text/x-python-script');
+    expect(textMimeTypes.test(normalized)).toBe(true);
+  });
+
+  it('should pass through standard browser types unchanged', () => {
+    expect(inferMimeType('test.py', 'text/x-python')).toBe('text/x-python');
+    expect(inferMimeType('doc.pdf', 'application/pdf')).toBe('application/pdf');
+  });
+
+  it('should infer from extension when browser type is empty', () => {
+    expect(inferMimeType('test.py', '')).toBe('text/x-python');
+    expect(inferMimeType('code.js', '')).toBe('text/javascript');
+    expect(inferMimeType('photo.heic', '')).toBe('image/heic');
+  });
+
+  it('should return empty string for unknown extension with no browser type', () => {
+    expect(inferMimeType('file.xyz', '')).toBe('');
+  });
+});
 
 describe('applicationMimeTypes', () => {
   const odfTypes = [

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -1,14 +1,14 @@
 import type { FileConfig } from './types/files';
 import {
   fileConfig as baseFileConfig,
+  documentParserMimeTypes,
   getEndpointFileConfig,
+  applicationMimeTypes,
+  defaultOCRMimeTypes,
+  supportedMimeTypes,
   mergeFileConfig,
   inferMimeType,
   textMimeTypes,
-  applicationMimeTypes,
-  defaultOCRMimeTypes,
-  documentParserMimeTypes,
-  supportedMimeTypes,
 } from './file-config';
 import { EModelEndpoint } from './schemas';
 
@@ -35,6 +35,15 @@ describe('inferMimeType', () => {
 
   it('should return empty string for unknown extension with no browser type', () => {
     expect(inferMimeType('file.xyz', '')).toBe('');
+  });
+
+  it('should produce a type accepted by checkType after normalizing text/x-python-script', () => {
+    const normalized = inferMimeType('test.py', 'text/x-python-script');
+    expect(baseFileConfig.checkType(normalized)).toBe(true);
+  });
+
+  it('should reject raw text/x-python-script without normalization', () => {
+    expect(baseFileConfig.checkType('text/x-python-script')).toBe(false);
   });
 });
 

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -357,15 +357,18 @@ export const imageTypeMapping: { [key: string]: string } = {
   heif: 'image/heif',
 };
 
+/** Normalizes non-standard MIME types that browsers may report to their canonical forms */
+export const mimeTypeAliases: Record<string, string> = {
+  'text/x-python-script': 'text/x-python',
+};
+
 /**
- * Infers the MIME type from a file's extension when the browser doesn't recognize it
- * @param fileName - The name of the file including extension
- * @param currentType - The current MIME type reported by the browser (may be empty)
- * @returns The inferred MIME type if browser didn't provide one, otherwise the original type
+ * Infers the MIME type from a file's extension when the browser doesn't recognize it,
+ * and normalizes known non-standard MIME type variants to canonical forms.
  */
 export function inferMimeType(fileName: string, currentType: string): string {
   if (currentType) {
-    return currentType;
+    return mimeTypeAliases[currentType] ?? currentType;
   }
 
   const extension = fileName.split('.').pop()?.toLowerCase() ?? '';

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -358,13 +358,16 @@ export const imageTypeMapping: { [key: string]: string } = {
 };
 
 /** Normalizes non-standard MIME types that browsers may report to their canonical forms */
-export const mimeTypeAliases: Record<string, string> = {
+export const mimeTypeAliases: Readonly<Record<string, string>> = {
   'text/x-python-script': 'text/x-python',
 };
 
 /**
  * Infers the MIME type from a file's extension when the browser doesn't recognize it,
- * and normalizes known non-standard MIME type variants to canonical forms.
+ * and normalizes known non-standard MIME type aliases to their canonical forms.
+ * @param fileName - The file name including its extension
+ * @param currentType - The MIME type reported by the browser (may be empty string)
+ * @returns The normalized or inferred MIME type; empty string if unresolvable
  */
 export function inferMimeType(fileName: string, currentType: string): string {
   if (currentType) {


### PR DESCRIPTION


## Summary

Fixes Python file uploads being rejected on macOS, where Chrome and Firefox report `.py` files as `text/x-python-script` instead of the canonical `text/x-python`, causing client-side MIME validation to fail.

- Introduces a `mimeTypeAliases` constant (`Readonly<Record<string, string>>`) in `file-config.ts` that maps known non-standard browser-reported MIME types to their canonical equivalents.
- Extends `inferMimeType` to apply alias normalization before returning when the browser provides a non-empty type, so the corrected type propagates through both client-side validation and the upload form payload.
- Restores and improves the `inferMimeType` JSDoc with `@param` and `@returns` annotations, including documenting the empty-string return case.
- Adds two `checkType` integration tests that assert the before/after validation boundary directly: the raw `text/x-python-script` is rejected without normalization, and the normalized `text/x-python` is accepted.
- Removes three redundant `inferMimeType` unit tests from `DragDropModal.spec.tsx` that duplicated coverage already present in `file-config.spec.ts`.
- Corrects import sort order in `file-config.spec.ts` to longest-to-shortest per project conventions.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran the full `packages/data-provider` test suite. The two new integration tests explicitly cover the broken state (raw `text/x-python-script` fails `checkType`) and the fixed state (normalized `text/x-python` passes `checkType`).

To reproduce the original bug manually: on macOS, open Chrome or Firefox, navigate to the chat input, and attempt to attach a `.py` file. Without this fix, the upload is rejected with an unsupported file type error. With this fix, the file is accepted and uploaded as `text/x-python`.

### **Test Configuration**:

- macOS (Chrome or Firefox) to reproduce the original browser MIME type behavior
- `cd packages/data-provider && npx jest inferMimeType` to run the targeted unit and integration tests

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes