### PR TITLE
✨ feat: Add -y flag to delete-user script for non-interactive use

### DIFF
--- a/config/delete-user.js
+++ b/config/delete-user.js
@@ -44,12 +44,24 @@ async function gracefulExit(code = 0) {
 (async () => {
   await connect();
 
+  const args = process.argv.slice(2);
+  let yesCount = 0;
+  const filteredArgs = args.filter((arg) => {
+    if (arg === '-y') {
+      yesCount++;
+      return false;
+    }
+    return true;
+  });
+  const confirmDelete = yesCount >= 1;
+  const confirmTxDelete = yesCount >= 2;
+
   console.purple('---------------');
   console.purple('Deleting a user and all related data');
   console.purple('---------------');
 
   // 1) Get email
-  let email = process.argv[2]?.trim();
+  let email = filteredArgs[0]?.trim();
   if (!email) {
     email = (await askQuestion('Email:')).trim();
   }
@@ -62,17 +74,22 @@ async function gracefulExit(code = 0) {
   }
 
   // 3) Confirm full deletion
-  const confirmAll = await askQuestion(
-    `Really delete user ${user.email} (${user._id}) and ALL their data? (y/N)`,
-  );
-  if (confirmAll.toLowerCase() !== 'y') {
-    console.yellow('Aborted.');
-    return gracefulExit(0);
+  if (!confirmDelete) {
+    const confirmAll = await askQuestion(
+      `Really delete user ${user.email} (${user._id}) and ALL their data? (y/N)`,
+    );
+    if (confirmAll.toLowerCase() !== 'y') {
+      console.yellow('Aborted.');
+      return gracefulExit(0);
+    }
   }
 
   // 4) Ask specifically about transactions
-  const confirmTx = await askQuestion('Also delete all transaction history for this user? (y/N)');
-  const deleteTx = confirmTx.toLowerCase() === 'y';
+  let deleteTx = confirmTxDelete;
+  if (!confirmTxDelete) {
+    const confirmTx = await askQuestion('Also delete all transaction history for this user? (y/N)');
+    deleteTx = confirmTx.toLowerCase() === 'y';
+  }
 
   const uid = user._id.toString();
 


### PR DESCRIPTION
## Summary
- Adds `-y` flag support to `config/delete-user.js` to skip interactive confirmation prompts
- First `-y` skips the "Really delete user?" confirmation
- Second `-y` also skips the "Delete transaction history?" prompt (defaults to yes)
- Without any `-y` flags, the script behaves exactly as before (interactive prompts)

## Why
The delete-user script currently requires interactive input, making it unusable in CI/CD pipelines or automation scripts. This change enables non-interactive execution while preserving the existing interactive behavior as the default.

## Usage
```bash
# Interactive (unchanged behavior)
npm run delete-user

# Skip deletion confirmation only
npm run delete-user -- -y user@example.com

# Skip both confirmations (full automation)
npm run delete-user -- -y -y user@example.com
```