### PR TITLE
🪤 fix: Fail-Closed MCP Domain Validation for Unparseable URLs

### DIFF
--- a/packages/api/src/auth/domain.spec.ts
+++ b/packages/api/src/auth/domain.spec.ts
@@ -1023,22 +1023,36 @@ describe('isMCPDomainAllowed', () => {
   });
 
   describe('invalid URL handling', () => {
-    it('should reject config with invalid URL', async () => {
+    it('should reject invalid URL when allowlist is configured', async () => {
       const config = { url: 'not-a-valid-url' };
       expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(false);
     });
 
-    it('should reject config with templated URL that cannot be parsed', async () => {
+    it('should reject templated URL when allowlist is configured', async () => {
       const config = { url: 'http://{{CUSTOM_HOST}}/mcp' };
       expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(false);
     });
 
-    it('should allow config with whitespace-only URL (effectively no URL)', async () => {
-      const config = { url: '   ' };
+    it('should allow invalid URL when no allowlist is configured (defers to connection-level SSRF)', async () => {
+      const config = { url: 'http://{{CUSTOM_HOST}}/mcp' };
+      expect(await isMCPDomainAllowed(config, null)).toBe(true);
+      expect(await isMCPDomainAllowed(config, undefined)).toBe(true);
       expect(await isMCPDomainAllowed(config, [])).toBe(true);
     });
 
-    it('should still allow config with no url property (stdio)', async () => {
+    it('should allow config with whitespace-only URL (treated as absent)', async () => {
+      const config = { url: '   ' };
+      expect(await isMCPDomainAllowed(config, [])).toBe(true);
+      expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(true);
+      expect(await isMCPDomainAllowed(config, null)).toBe(true);
+    });
+
+    it('should allow config with empty string URL (treated as absent)', async () => {
+      const config = { url: '' };
+      expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(true);
+    });
+
+    it('should allow config with no url property (stdio)', async () => {
       const config = { command: 'node', args: ['server.js'] };
       expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(true);
     });

--- a/packages/api/src/auth/domain.spec.ts
+++ b/packages/api/src/auth/domain.spec.ts
@@ -1023,8 +1023,23 @@ describe('isMCPDomainAllowed', () => {
   });
 
   describe('invalid URL handling', () => {
-    it('should allow config with invalid URL (treated as stdio)', async () => {
+    it('should reject config with invalid URL', async () => {
       const config = { url: 'not-a-valid-url' };
+      expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(false);
+    });
+
+    it('should reject config with templated URL that cannot be parsed', async () => {
+      const config = { url: 'http://{{CUSTOM_HOST}}/mcp' };
+      expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(false);
+    });
+
+    it('should allow config with whitespace-only URL (effectively no URL)', async () => {
+      const config = { url: '   ' };
+      expect(await isMCPDomainAllowed(config, [])).toBe(true);
+    });
+
+    it('should still allow config with no url property (stdio)', async () => {
+      const config = { command: 'node', args: ['server.js'] };
       expect(await isMCPDomainAllowed(config, ['example.com'])).toBe(true);
     });
   });

--- a/packages/api/src/auth/domain.ts
+++ b/packages/api/src/auth/domain.ts
@@ -428,7 +428,10 @@ export async function isActionDomainAllowed(
 /**
  * Extracts full domain spec (protocol://hostname:port) from MCP server config URL.
  * Returns the full origin for proper protocol/port matching against allowedDomains.
- * Returns null for stdio transports (no URL) or invalid URLs.
+ * @returns The full origin string, or null when:
+ *   - No `url` property, non-string, or empty (stdio transport — always allowed upstream)
+ *   - URL string present but cannot be parsed (rejected fail-closed upstream when allowlist active)
+ *   Callers must distinguish these two null cases; see {@link isMCPDomainAllowed}.
  * @param config - MCP server configuration (accepts any config with optional url field)
  */
 export function extractMCPServerDomain(config: Record<string, unknown>): string | null {
@@ -452,6 +455,11 @@ export function extractMCPServerDomain(config: Record<string, unknown>): string 
  * Validates MCP server domain against allowedDomains.
  * Supports HTTP, HTTPS, WS, and WSS protocols (per MCP specification).
  * Stdio transports (no URL) are always allowed.
+ * Configs with a non-empty URL that cannot be parsed are rejected fail-closed when an
+ * allowlist is active, preventing template placeholders (e.g. `{{HOST}}`) from bypassing
+ * domain validation after `processMCPEnv` resolves them at connection time.
+ * When no allowlist is configured, unparseable URLs fall through to connection-level
+ * SSRF protection (`createSSRFSafeUndiciConnect`).
  * @param config - MCP server configuration with optional url field
  * @param allowedDomains - List of allowed domains (with wildcard support)
  */
@@ -460,8 +468,16 @@ export async function isMCPDomainAllowed(
   allowedDomains?: string[] | null,
 ): Promise<boolean> {
   const domain = extractMCPServerDomain(config);
+  const hasAllowlist = Array.isArray(allowedDomains) && allowedDomains.length > 0;
 
-  // Stdio transports don't have domains - always allowed
+  const hasExplicitUrl =
+    Object.hasOwn(config, 'url') && typeof config.url === 'string' && config.url.trim().length > 0;
+
+  if (!domain && hasExplicitUrl && hasAllowlist) {
+    return false;
+  }
+
+  // Stdio transports (no URL) are always allowed
   if (!domain) {
     return true;
   }


### PR DESCRIPTION


## Summary

Fixed a fail-open bypass in `isMCPDomainAllowed` where configs containing an unparseable URL (e.g., unresolved template placeholders like `{{CUSTOM_HOST}}`) were silently allowed through the domain allowlist by falling into the stdio transport path.

- `isMCPDomainAllowed` returned `true` when `extractMCPServerDomain` returned `null` for an unparseable URL string, treating it identically to a stdio transport (no `url` property). A YAML config with `url: 'http://{{CUSTOM_HOST}}/mcp'` bypassed the allowlist entirely, then `processMCPEnv` resolved the placeholder to an arbitrary — potentially disallowed — host at connection time.
- Introduced `hasExplicitUrl` to distinguish "no URL present" (stdio, always allowed) from "URL present but unparseable" (ambiguous, requires gating), combined with a `hasAllowlist` guard so the fail-closed rejection only fires when an allowlist is actually configured. Without an allowlist, unparseable URLs fall through to connection-level SSRF protection (`createSSRFSafeUndiciConnect`), preserving legitimate `customUserVars` + template-URL server configs.
- Replaced `Object.prototype.hasOwnProperty.call` with `Object.hasOwn` (Node 20+).
- Updated `isMCPDomainAllowed` JSDoc to document the fail-closed behavior, when it applies, and the fallback to connection-level SSRF protection when no allowlist is configured.
- Updated `extractMCPServerDomain` JSDoc to document the two semantically distinct `null` cases (absent URL vs. unparseable URL) and cross-reference `isMCPDomainAllowed`.
- Expanded the `invalid URL handling` test block from 4 to 6 cases: covers allowlist-active rejection for both invalid and template URLs, allowlist-inactive passthrough for all three no-allowlist variants (`null`, `undefined`, `[]`), whitespace-only URL across all allowedDomains configurations, and empty-string URL.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

All tests are in `packages/api/src/auth/domain.spec.ts` under the `isMCPDomainAllowed` → `invalid URL handling` describe block.

### **Test Configuration**:

Run from the `packages/api` workspace:

```bash
npx jest domain.spec --testPathPattern=auth/domain
```

Key cases to verify:
- `{ url: 'http://{{CUSTOM_HOST}}/mcp' }` with an active allowlist → `false`
- `{ url: 'http://{{CUSTOM_HOST}}/mcp' }` with `null`/`undefined`/`[]` → `true` (defers to connection-level SSRF)
- `{ url: '   ' }` and `{ url: '' }` with any allowedDomains config → `true` (treated as absent)
- `{ command: 'node', args: ['server.js'] }` (stdio) → `true`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes