### PR TITLE
🛡️ fix: Validate User-provided URLs for Web Search

### DIFF
--- a/packages/api/src/web/web.spec.ts
+++ b/packages/api/src/web/web.spec.ts
@@ -1314,6 +1314,9 @@ describe('web.ts', () => {
       });
 
       expect(result.authResult.firecrawlApiUrl).toBeUndefined();
+      expect(result.authenticated).toBe(true);
+      const scrapersAuth = result.authTypes.find(([c]) => c === 'scrapers')?.[1];
+      expect(scrapersAuth).toBe(AuthType.USER_PROVIDED);
     });
 
     it('should block user-provided searxngInstanceUrl targeting metadata endpoint', async () => {
@@ -1353,43 +1356,47 @@ describe('web.ts', () => {
       mockIsSSRFTarget.mockReturnValue(true);
 
       const originalEnv = process.env;
-      process.env = {
-        ...originalEnv,
-        JINA_API_KEY: 'system-jina-key',
-        JINA_API_URL: 'http://jina-internal:8080/rerank',
-      };
+      try {
+        process.env = {
+          ...originalEnv,
+          JINA_API_KEY: 'system-jina-key',
+          JINA_API_URL: 'http://jina-internal:8080/rerank',
+        };
 
-      const webSearchConfig: TCustomConfig['webSearch'] = {
-        serperApiKey: '${SERPER_API_KEY}',
-        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
-        jinaApiKey: '${JINA_API_KEY}',
-        jinaApiUrl: '${JINA_API_URL}',
-        safeSearch: SafeSearchTypes.MODERATE,
-        rerankerType: 'jina' as RerankerTypes,
-      };
+        const webSearchConfig: TCustomConfig['webSearch'] = {
+          serperApiKey: '${SERPER_API_KEY}',
+          firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+          jinaApiKey: '${JINA_API_KEY}',
+          jinaApiUrl: '${JINA_API_URL}',
+          safeSearch: SafeSearchTypes.MODERATE,
+          rerankerType: 'jina' as RerankerTypes,
+        };
 
-      mockLoadAuthValues.mockImplementation(({ authFields }) => {
-        const result: Record<string, string> = {};
-        authFields.forEach((field: string) => {
-          if (field === 'JINA_API_KEY') {
-            result[field] = 'system-jina-key';
-          } else if (field === 'JINA_API_URL') {
-            result[field] = 'http://jina-internal:8080/rerank';
-          } else {
-            result[field] = 'test-api-key';
-          }
+        mockLoadAuthValues.mockImplementation(({ authFields }) => {
+          const result: Record<string, string> = {};
+          authFields.forEach((field: string) => {
+            if (field === 'JINA_API_KEY') {
+              result[field] = 'system-jina-key';
+            } else if (field === 'JINA_API_URL') {
+              result[field] = 'http://jina-internal:8080/rerank';
+            } else {
+              result[field] = 'test-api-key';
+            }
+          });
+          return Promise.resolve(result);
         });
-        return Promise.resolve(result);
-      });
 
-      const result = await loadWebSearchAuth({
-        userId,
-        webSearchConfig,
-        loadAuthValues: mockLoadAuthValues,
-      });
+        const result = await loadWebSearchAuth({
+          userId,
+          webSearchConfig,
+          loadAuthValues: mockLoadAuthValues,
+        });
 
-      expect(result.authResult.jinaApiUrl).toBe('http://jina-internal:8080/rerank');
-      process.env = originalEnv;
+        expect(result.authResult.jinaApiUrl).toBe('http://jina-internal:8080/rerank');
+        expect(result.authenticated).toBe(true);
+      } finally {
+        process.env = originalEnv;
+      }
     });
 
     it('should reject URLs with invalid format', async () => {
@@ -1421,6 +1428,41 @@ describe('web.ts', () => {
       });
 
       expect(result.authResult.firecrawlApiUrl).toBeUndefined();
+      expect(result.authenticated).toBe(true);
+      const scrapersAuth = result.authTypes.find(([c]) => c === 'scrapers')?.[1];
+      expect(scrapersAuth).toBe(AuthType.USER_PROVIDED);
+    });
+
+    it('should reject non-HTTP schemes like file://', async () => {
+      const webSearchConfig: TCustomConfig['webSearch'] = {
+        serperApiKey: '${SERPER_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        jinaApiKey: '${JINA_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        scraperProvider: 'firecrawl' as ScraperProviders,
+      };
+
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          if (field === 'FIRECRAWL_API_URL') {
+            result[field] = 'file:///etc/passwd';
+          } else {
+            result[field] = 'test-api-key';
+          }
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authResult.firecrawlApiUrl).toBeUndefined();
+      expect(result.authenticated).toBe(true);
     });
 
     it('should allow legitimate external URLs', async () => {

--- a/packages/api/src/web/web.spec.ts
+++ b/packages/api/src/web/web.spec.ts
@@ -1538,5 +1538,53 @@ describe('web.ts', () => {
       )?.[1];
       expect(providersAuthType).toBe(AuthType.USER_PROVIDED);
     });
+
+    it('should report SYSTEM_DEFINED when only user-provided field is a stripped SSRF URL', async () => {
+      mockIsSSRFTarget.mockImplementation((hostname: string) => hostname === 'localhost');
+
+      const originalEnv = process.env;
+      try {
+        process.env = {
+          ...originalEnv,
+          JINA_API_KEY: 'system-jina-key',
+        };
+
+        const webSearchConfig: TCustomConfig['webSearch'] = {
+          serperApiKey: '${SERPER_API_KEY}',
+          firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+          jinaApiKey: '${JINA_API_KEY}',
+          jinaApiUrl: '${JINA_API_URL}',
+          safeSearch: SafeSearchTypes.MODERATE,
+          rerankerType: 'jina' as RerankerTypes,
+        };
+
+        mockLoadAuthValues.mockImplementation(({ authFields }) => {
+          const result: Record<string, string> = {};
+          authFields.forEach((field: string) => {
+            if (field === 'JINA_API_KEY') {
+              result[field] = 'system-jina-key';
+            } else if (field === 'JINA_API_URL') {
+              result[field] = 'http://localhost:9999/rerank';
+            } else {
+              result[field] = 'test-api-key';
+            }
+          });
+          return Promise.resolve(result);
+        });
+
+        const result = await loadWebSearchAuth({
+          userId,
+          webSearchConfig,
+          loadAuthValues: mockLoadAuthValues,
+        });
+
+        expect(result.authResult.jinaApiUrl).toBeUndefined();
+        expect(result.authenticated).toBe(true);
+        const rerankersAuth = result.authTypes.find(([c]) => c === 'rerankers')?.[1];
+        expect(rerankersAuth).toBe(AuthType.SYSTEM_DEFINED);
+      } finally {
+        process.env = originalEnv;
+      }
+    });
   });
 });

--- a/packages/api/src/web/web.spec.ts
+++ b/packages/api/src/web/web.spec.ts
@@ -18,6 +18,14 @@ jest.mock('../utils', () => ({
   },
 }));
 
+const mockIsSSRFTarget = jest.fn().mockReturnValue(false);
+const mockResolveHostnameSSRF = jest.fn().mockResolvedValue(false);
+
+jest.mock('../auth', () => ({
+  isSSRFTarget: (...args: unknown[]) => mockIsSSRFTarget(...args),
+  resolveHostnameSSRF: (...args: unknown[]) => mockResolveHostnameSSRF(...args),
+}));
+
 describe('web.ts', () => {
   describe('extractWebSearchEnvVars', () => {
     it('should return empty array if config is undefined', () => {
@@ -1225,6 +1233,268 @@ describe('web.ts', () => {
       expect(result.authenticated).toBe(true);
       expect(result.authResult.scraperTimeout).toBe(7500); // Should use default timeout
       expect(result.authResult.firecrawlOptions).toBeUndefined(); // Should be undefined
+    });
+  });
+
+  describe('SSRF protection for user-provided URLs', () => {
+    const userId = 'test-user-id';
+    let mockLoadAuthValues: jest.Mock;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockLoadAuthValues = jest.fn();
+      mockIsSSRFTarget.mockReturnValue(false);
+      mockResolveHostnameSSRF.mockResolvedValue(false);
+    });
+
+    it('should block user-provided jinaApiUrl targeting localhost', async () => {
+      mockIsSSRFTarget.mockImplementation((hostname: string) => hostname === 'localhost');
+
+      const webSearchConfig: TCustomConfig['webSearch'] = {
+        serperApiKey: '${SERPER_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        jinaApiKey: '${JINA_API_KEY}',
+        jinaApiUrl: '${JINA_API_URL}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        rerankerType: 'jina' as RerankerTypes,
+      };
+
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          if (field === 'JINA_API_URL') {
+            result[field] = 'http://localhost:8080/rerank';
+          } else {
+            result[field] = 'test-api-key';
+          }
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authResult.jinaApiUrl).toBeUndefined();
+      expect(mockIsSSRFTarget).toHaveBeenCalledWith('localhost');
+    });
+
+    it('should block user-provided firecrawlApiUrl resolving to private IP', async () => {
+      mockResolveHostnameSSRF.mockImplementation((hostname: string) =>
+        Promise.resolve(hostname === 'evil.internal-service.com'),
+      );
+
+      const webSearchConfig: TCustomConfig['webSearch'] = {
+        serperApiKey: '${SERPER_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        jinaApiKey: '${JINA_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        scraperProvider: 'firecrawl' as ScraperProviders,
+      };
+
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          if (field === 'FIRECRAWL_API_URL') {
+            result[field] = 'https://evil.internal-service.com/scrape';
+          } else {
+            result[field] = 'test-api-key';
+          }
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authResult.firecrawlApiUrl).toBeUndefined();
+    });
+
+    it('should block user-provided searxngInstanceUrl targeting metadata endpoint', async () => {
+      mockIsSSRFTarget.mockImplementation((hostname: string) => hostname === '169.254.169.254');
+
+      const webSearchConfig: TCustomConfig['webSearch'] = {
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        jinaApiKey: '${JINA_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        searchProvider: 'searxng' as SearchProviders,
+      };
+
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          if (field === 'SEARXNG_INSTANCE_URL') {
+            result[field] = 'http://169.254.169.254/latest/meta-data';
+          } else {
+            result[field] = 'test-api-key';
+          }
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authResult.searxngInstanceUrl).toBeUndefined();
+      expect(result.authenticated).toBe(false);
+    });
+
+    it('should allow system-defined URLs even if they match SSRF patterns', async () => {
+      mockIsSSRFTarget.mockReturnValue(true);
+
+      const originalEnv = process.env;
+      process.env = {
+        ...originalEnv,
+        JINA_API_KEY: 'system-jina-key',
+        JINA_API_URL: 'http://jina-internal:8080/rerank',
+      };
+
+      const webSearchConfig: TCustomConfig['webSearch'] = {
+        serperApiKey: '${SERPER_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        jinaApiKey: '${JINA_API_KEY}',
+        jinaApiUrl: '${JINA_API_URL}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        rerankerType: 'jina' as RerankerTypes,
+      };
+
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          if (field === 'JINA_API_KEY') {
+            result[field] = 'system-jina-key';
+          } else if (field === 'JINA_API_URL') {
+            result[field] = 'http://jina-internal:8080/rerank';
+          } else {
+            result[field] = 'test-api-key';
+          }
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authResult.jinaApiUrl).toBe('http://jina-internal:8080/rerank');
+      process.env = originalEnv;
+    });
+
+    it('should reject URLs with invalid format', async () => {
+      const webSearchConfig: TCustomConfig['webSearch'] = {
+        serperApiKey: '${SERPER_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        jinaApiKey: '${JINA_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        scraperProvider: 'firecrawl' as ScraperProviders,
+      };
+
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          if (field === 'FIRECRAWL_API_URL') {
+            result[field] = 'not-a-valid-url';
+          } else {
+            result[field] = 'test-api-key';
+          }
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authResult.firecrawlApiUrl).toBeUndefined();
+    });
+
+    it('should allow legitimate external URLs', async () => {
+      const webSearchConfig: TCustomConfig['webSearch'] = {
+        serperApiKey: '${SERPER_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        jinaApiKey: '${JINA_API_KEY}',
+        jinaApiUrl: '${JINA_API_URL}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        scraperProvider: 'firecrawl' as ScraperProviders,
+        rerankerType: 'jina' as RerankerTypes,
+      };
+
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          if (field === 'FIRECRAWL_API_URL') {
+            result[field] = 'https://api.firecrawl.dev';
+          } else if (field === 'JINA_API_URL') {
+            result[field] = 'https://api.jina.ai/v1/rerank';
+          } else {
+            result[field] = 'test-api-key';
+          }
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authResult.firecrawlApiUrl).toBe('https://api.firecrawl.dev');
+      expect(result.authResult.jinaApiUrl).toBe('https://api.jina.ai/v1/rerank');
+      expect(result.authenticated).toBe(true);
+    });
+
+    it('should fail required URL field and mark category unauthenticated', async () => {
+      mockIsSSRFTarget.mockImplementation((hostname: string) => hostname === '127.0.0.1');
+
+      const webSearchConfig: TCustomConfig['webSearch'] = {
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        jinaApiKey: '${JINA_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        searchProvider: 'searxng' as SearchProviders,
+      };
+
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          if (field === 'SEARXNG_INSTANCE_URL') {
+            result[field] = 'http://127.0.0.1:8888/search';
+          } else {
+            result[field] = 'test-api-key';
+          }
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authenticated).toBe(false);
+      const providersAuthType = result.authTypes.find(
+        ([category]) => category === 'providers',
+      )?.[1];
+      expect(providersAuthType).toBe(AuthType.USER_PROVIDED);
     });
   });
 });

--- a/packages/api/src/web/web.ts
+++ b/packages/api/src/web/web.ts
@@ -15,24 +15,34 @@ import type {
 import type { TWebSearchKeys, TWebSearchCategories } from '@librechat/data-schemas';
 import { isSSRFTarget, resolveHostnameSSRF } from '../auth';
 
+/**
+ * URL-type keys in TWebSearchKeys (not API keys or version strings).
+ * Must stay in sync with URL-typed fields in webSearchAuth (packages/data-schemas).
+ */
 const WEB_SEARCH_URL_KEYS = new Set<TWebSearchKeys>([
   'searxngInstanceUrl',
   'firecrawlApiUrl',
   'jinaApiUrl',
 ]);
 
-/** Returns true if the URL targets a private/internal address (SSRF risk) */
+/**
+ * Returns true if the URL should be blocked for SSRF risk.
+ * Fail-closed: unparseable URLs and non-HTTP(S) schemes return true.
+ */
 async function isSSRFUrl(url: string): Promise<boolean> {
-  let hostname: string;
+  let parsed: URL;
   try {
-    hostname = new URL(url).hostname;
+    parsed = new URL(url);
   } catch {
     return true;
   }
-  if (isSSRFTarget(hostname)) {
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     return true;
   }
-  return resolveHostnameSSRF(hostname);
+  if (isSSRFTarget(parsed.hostname)) {
+    return true;
+  }
+  return resolveHostnameSSRF(parsed.hostname);
 }
 
 export function extractWebSearchEnvVars({
@@ -170,31 +180,26 @@ export async function loadWebSearchAuth({
           const field = allAuthFields[j];
           const value = authValues[field];
           const originalKey = allKeys[j];
-          if (originalKey) {
-            authResult[originalKey] = value;
-          }
+
           if (!optionalSet.has(field) && !value) {
             allFieldsAuthenticated = false;
             break;
           }
 
-          const isFieldUserProvided = process.env[field] !== value;
-          if (!isUserProvided && isFieldUserProvided) {
-            isUserProvided = true;
-          }
+          const isFieldUserProvided = value != null && process.env[field] !== value;
+          const isUrlKey = originalKey != null && WEB_SEARCH_URL_KEYS.has(originalKey);
 
-          if (
-            value &&
-            originalKey &&
-            isFieldUserProvided &&
-            WEB_SEARCH_URL_KEYS.has(originalKey as TWebSearchKeys) &&
-            (await isSSRFUrl(value))
-          ) {
-            delete authResult[originalKey];
+          if (isUrlKey && isFieldUserProvided && (await isSSRFUrl(value))) {
             if (!optionalSet.has(field)) {
               allFieldsAuthenticated = false;
               break;
             }
+          } else if (originalKey) {
+            authResult[originalKey] = value;
+          }
+
+          if (!isUserProvided && isFieldUserProvided) {
+            isUserProvided = true;
           }
         }
 

--- a/packages/api/src/web/web.ts
+++ b/packages/api/src/web/web.ts
@@ -13,6 +13,27 @@ import type {
   TWebSearchConfig,
 } from 'librechat-data-provider';
 import type { TWebSearchKeys, TWebSearchCategories } from '@librechat/data-schemas';
+import { isSSRFTarget, resolveHostnameSSRF } from '../auth';
+
+const WEB_SEARCH_URL_KEYS = new Set<TWebSearchKeys>([
+  'searxngInstanceUrl',
+  'firecrawlApiUrl',
+  'jinaApiUrl',
+]);
+
+/** Returns true if the URL targets a private/internal address (SSRF risk) */
+async function isSSRFUrl(url: string): Promise<boolean> {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return true;
+  }
+  if (isSSRFTarget(hostname)) {
+    return true;
+  }
+  return resolveHostnameSSRF(hostname);
+}
 
 export function extractWebSearchEnvVars({
   keys,
@@ -149,13 +170,31 @@ export async function loadWebSearchAuth({
           const field = allAuthFields[j];
           const value = authValues[field];
           const originalKey = allKeys[j];
-          if (originalKey) authResult[originalKey] = value;
+          if (originalKey) {
+            authResult[originalKey] = value;
+          }
           if (!optionalSet.has(field) && !value) {
             allFieldsAuthenticated = false;
             break;
           }
-          if (!isUserProvided && process.env[field] !== value) {
+
+          const isFieldUserProvided = process.env[field] !== value;
+          if (!isUserProvided && isFieldUserProvided) {
             isUserProvided = true;
+          }
+
+          if (
+            value &&
+            originalKey &&
+            isFieldUserProvided &&
+            WEB_SEARCH_URL_KEYS.has(originalKey as TWebSearchKeys) &&
+            (await isSSRFUrl(value))
+          ) {
+            delete authResult[originalKey];
+            if (!optionalSet.has(field)) {
+              allFieldsAuthenticated = false;
+              break;
+            }
           }
         }
 

--- a/packages/api/src/web/web.ts
+++ b/packages/api/src/web/web.ts
@@ -188,6 +188,7 @@ export async function loadWebSearchAuth({
 
           const isFieldUserProvided = value != null && process.env[field] !== value;
           const isUrlKey = originalKey != null && WEB_SEARCH_URL_KEYS.has(originalKey);
+          let contributed = false;
 
           if (isUrlKey && isFieldUserProvided && (await isSSRFUrl(value))) {
             if (!optionalSet.has(field)) {
@@ -196,9 +197,10 @@ export async function loadWebSearchAuth({
             }
           } else if (originalKey) {
             authResult[originalKey] = value;
+            contributed = true;
           }
 
-          if (!isUserProvided && isFieldUserProvided) {
+          if (!isUserProvided && isFieldUserProvided && contributed) {
             isUserProvided = true;
           }
         }


### PR DESCRIPTION
User-controlled URL fields (jinaApiUrl, firecrawlApiUrl, searxngInstanceUrl) flow from plugin auth into outbound HTTP requests without validation. Reuse existing isSSRFTarget/resolveHostnameSSRF to block private/internal targets while preserving admin-configured (env var) internal URLs.