### PR TITLE
🫷 fix: Validate User-Provided Base URL in Endpoint Init

### DIFF
--- a/client/src/components/Messages/Content/Error.tsx
+++ b/client/src/components/Messages/Content/Error.tsx
@@ -41,6 +41,7 @@ const errorMessages = {
   [ErrorTypes.NO_USER_KEY]: 'com_error_no_user_key',
   [ErrorTypes.INVALID_USER_KEY]: 'com_error_invalid_user_key',
   [ErrorTypes.NO_BASE_URL]: 'com_error_no_base_url',
+  invalid_base_url: 'com_error_invalid_base_url',
   [ErrorTypes.INVALID_ACTION]: `com_error_${ErrorTypes.INVALID_ACTION}`,
   [ErrorTypes.INVALID_REQUEST]: `com_error_${ErrorTypes.INVALID_REQUEST}`,
   [ErrorTypes.REFUSAL]: 'com_error_refusal',

--- a/client/src/components/Messages/Content/Error.tsx
+++ b/client/src/components/Messages/Content/Error.tsx
@@ -41,7 +41,7 @@ const errorMessages = {
   [ErrorTypes.NO_USER_KEY]: 'com_error_no_user_key',
   [ErrorTypes.INVALID_USER_KEY]: 'com_error_invalid_user_key',
   [ErrorTypes.NO_BASE_URL]: 'com_error_no_base_url',
-  invalid_base_url: 'com_error_invalid_base_url',
+  [ErrorTypes.INVALID_BASE_URL]: 'com_error_invalid_base_url',
   [ErrorTypes.INVALID_ACTION]: `com_error_${ErrorTypes.INVALID_ACTION}`,
   [ErrorTypes.INVALID_REQUEST]: `com_error_${ErrorTypes.INVALID_REQUEST}`,
   [ErrorTypes.REFUSAL]: 'com_error_refusal',

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -372,6 +372,7 @@
   "com_error_missing_model": "No model selected for {{0}}. Please select a model and try again.",
   "com_error_models_not_loaded": "Models configuration could not be loaded. Please refresh the page and try again.",
   "com_error_moderation": "It appears that the content submitted has been flagged by our moderation system for not aligning with our community guidelines. We're unable to proceed with this specific topic. If you have any other questions or topics you'd like to explore, please edit your message, or create a new conversation.",
+  "com_error_invalid_base_url": "The base URL you provided targets a restricted address. Please use a valid external URL and try again.",
   "com_error_no_base_url": "No base URL found. Please provide one and try again.",
   "com_error_no_user_key": "No key found. Please provide a key and try again.",
   "com_error_refusal": "Response refused by safety filters. Rewrite your message and try again. If you encounter this frequently while using Claude Sonnet 4.5 or Opus 4.1, you can try Sonnet 4, which has different usage restrictions.",

--- a/packages/api/src/auth/domain.spec.ts
+++ b/packages/api/src/auth/domain.spec.ts
@@ -1330,4 +1330,15 @@ describe('validateEndpointURL', () => {
       validateEndpointURL('https://nonexistent.example.com/v1', 'test-ep'),
     ).resolves.toBeUndefined();
   });
+
+  it('should throw structured JSON with type invalid_base_url', async () => {
+    const error = await validateEndpointURL('http://169.254.169.254/latest/', 'my-ep').catch(
+      (err: Error) => err,
+    );
+    expect(error).toBeInstanceOf(Error);
+    const parsed = JSON.parse((error as Error).message);
+    expect(parsed.type).toBe('invalid_base_url');
+    expect(parsed.message).toContain('my-ep');
+    expect(parsed.message).toContain('targets a restricted address');
+  });
 });

--- a/packages/api/src/auth/domain.spec.ts
+++ b/packages/api/src/auth/domain.spec.ts
@@ -1281,4 +1281,53 @@ describe('validateEndpointURL', () => {
       validateEndpointURL('https://api.example.com/v1/chat', 'test-ep'),
     ).resolves.toBeUndefined();
   });
+
+  it('should throw for non-HTTP/HTTPS schemes', async () => {
+    await expect(validateEndpointURL('ftp://example.com/v1', 'test-ep')).rejects.toThrow(
+      'only HTTP and HTTPS are permitted',
+    );
+    await expect(validateEndpointURL('file:///etc/passwd', 'test-ep')).rejects.toThrow(
+      'only HTTP and HTTPS are permitted',
+    );
+    await expect(validateEndpointURL('data:text/plain,hello', 'test-ep')).rejects.toThrow(
+      'only HTTP and HTTPS are permitted',
+    );
+  });
+
+  it('should throw for IPv6 loopback URL', async () => {
+    await expect(validateEndpointURL('http://[::1]:8080/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for IPv6 link-local URL', async () => {
+    await expect(validateEndpointURL('http://[fe80::1]/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for IPv6 unique-local URL', async () => {
+    await expect(validateEndpointURL('http://[fc00::1]/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for .local TLD hostname', async () => {
+    await expect(validateEndpointURL('http://myservice.local/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for .internal TLD hostname', async () => {
+    await expect(validateEndpointURL('http://api.internal/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should pass when DNS lookup fails (fail-open)', async () => {
+    mockedLookup.mockRejectedValueOnce(new Error('ENOTFOUND'));
+    await expect(
+      validateEndpointURL('https://nonexistent.example.com/v1', 'test-ep'),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/packages/api/src/auth/domain.spec.ts
+++ b/packages/api/src/auth/domain.spec.ts
@@ -12,6 +12,7 @@ import {
   isPrivateIP,
   isSSRFTarget,
   resolveHostnameSSRF,
+  validateEndpointURL,
 } from './domain';
 
 const mockedLookup = lookup as jest.MockedFunction<typeof lookup>;
@@ -1207,5 +1208,77 @@ describe('isMCPDomainAllowed', () => {
         false,
       );
     });
+  });
+});
+
+describe('validateEndpointURL', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw for unparseable URLs', async () => {
+    await expect(validateEndpointURL('not-a-url', 'test-ep')).rejects.toThrow(
+      'Invalid base URL for test-ep',
+    );
+  });
+
+  it('should throw for localhost URLs', async () => {
+    await expect(validateEndpointURL('http://localhost:8080/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for private IP URLs', async () => {
+    await expect(validateEndpointURL('http://192.168.1.1/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+    await expect(validateEndpointURL('http://10.0.0.1/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+    await expect(validateEndpointURL('http://172.16.0.1/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for link-local / metadata IP', async () => {
+    await expect(
+      validateEndpointURL('http://169.254.169.254/latest/meta-data/', 'test-ep'),
+    ).rejects.toThrow('targets a restricted address');
+  });
+
+  it('should throw for loopback IP', async () => {
+    await expect(validateEndpointURL('http://127.0.0.1:11434/v1', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw for internal Docker/Kubernetes hostnames', async () => {
+    await expect(validateEndpointURL('http://redis:6379/', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+    await expect(validateEndpointURL('http://mongodb:27017/', 'test-ep')).rejects.toThrow(
+      'targets a restricted address',
+    );
+  });
+
+  it('should throw when hostname DNS-resolves to a private IP', async () => {
+    mockedLookup.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }] as never);
+    await expect(validateEndpointURL('https://evil.example.com/v1', 'test-ep')).rejects.toThrow(
+      'resolves to a restricted address',
+    );
+  });
+
+  it('should allow public URLs', async () => {
+    mockedLookup.mockResolvedValueOnce([{ address: '104.18.7.192', family: 4 }] as never);
+    await expect(
+      validateEndpointURL('https://api.openai.com/v1', 'test-ep'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should allow public URLs that resolve to public IPs', async () => {
+    mockedLookup.mockResolvedValueOnce([{ address: '8.8.8.8', family: 4 }] as never);
+    await expect(
+      validateEndpointURL('https://api.example.com/v1/chat', 'test-ep'),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/api/src/auth/domain.ts
+++ b/packages/api/src/auth/domain.ts
@@ -499,3 +499,25 @@ export async function isMCPDomainAllowed(
   // Use MCP_PROTOCOLS (HTTP/HTTPS/WS/WSS) for MCP server validation
   return isDomainAllowedCore(domain, allowedDomains, MCP_PROTOCOLS);
 }
+
+/**
+ * Validates that a user-provided endpoint URL does not target private/internal addresses.
+ * Throws if the URL is unparseable, targets a known SSRF hostname, or DNS-resolves to a private IP.
+ */
+export async function validateEndpointURL(url: string, endpoint: string): Promise<void> {
+  let hostname: string;
+  try {
+    const parsed = new URL(url);
+    hostname = parsed.hostname;
+  } catch {
+    throw new Error(`Invalid base URL for ${endpoint}: unable to parse URL.`);
+  }
+
+  if (isSSRFTarget(hostname)) {
+    throw new Error(`Base URL for ${endpoint} targets a restricted address.`);
+  }
+
+  if (await resolveHostnameSSRF(hostname)) {
+    throw new Error(`Base URL for ${endpoint} resolves to a restricted address.`);
+  }
+}

--- a/packages/api/src/auth/domain.ts
+++ b/packages/api/src/auth/domain.ts
@@ -502,15 +502,28 @@ export async function isMCPDomainAllowed(
 
 /**
  * Validates that a user-provided endpoint URL does not target private/internal addresses.
- * Throws if the URL is unparseable, targets a known SSRF hostname, or DNS-resolves to a private IP.
+ * Throws if the URL is unparseable, uses a non-HTTP(S) scheme, targets a known SSRF hostname,
+ * or DNS-resolves to a private IP.
+ *
+ * @note DNS rebinding: validation performs a single DNS lookup. An adversary controlling
+ *   DNS with TTL=0 could respond with a public IP at validation time and a private IP
+ *   at request time. This is an accepted limitation of point-in-time DNS checks.
+ * @note Fail-open on DNS errors: a resolution failure here implies a failure at request
+ *   time as well, matching {@link resolveHostnameSSRF} semantics.
  */
 export async function validateEndpointURL(url: string, endpoint: string): Promise<void> {
   let hostname: string;
+  let protocol: string;
   try {
     const parsed = new URL(url);
     hostname = parsed.hostname;
+    protocol = parsed.protocol;
   } catch {
     throw new Error(`Invalid base URL for ${endpoint}: unable to parse URL.`);
+  }
+
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    throw new Error(`Invalid base URL for ${endpoint}: only HTTP and HTTPS are permitted.`);
   }
 
   if (isSSRFTarget(hostname)) {

--- a/packages/api/src/auth/domain.ts
+++ b/packages/api/src/auth/domain.ts
@@ -500,6 +500,13 @@ export async function isMCPDomainAllowed(
   return isDomainAllowedCore(domain, allowedDomains, MCP_PROTOCOLS);
 }
 
+/** Matches ErrorTypes.INVALID_BASE_URL — string literal avoids build-time dependency on data-provider */
+const INVALID_BASE_URL_TYPE = 'invalid_base_url';
+
+function throwInvalidBaseURL(message: string): never {
+  throw new Error(JSON.stringify({ type: INVALID_BASE_URL_TYPE, message }));
+}
+
 /**
  * Validates that a user-provided endpoint URL does not target private/internal addresses.
  * Throws if the URL is unparseable, uses a non-HTTP(S) scheme, targets a known SSRF hostname,
@@ -519,18 +526,18 @@ export async function validateEndpointURL(url: string, endpoint: string): Promis
     hostname = parsed.hostname;
     protocol = parsed.protocol;
   } catch {
-    throw new Error(`Invalid base URL for ${endpoint}: unable to parse URL.`);
+    throwInvalidBaseURL(`Invalid base URL for ${endpoint}: unable to parse URL.`);
   }
 
   if (protocol !== 'http:' && protocol !== 'https:') {
-    throw new Error(`Invalid base URL for ${endpoint}: only HTTP and HTTPS are permitted.`);
+    throwInvalidBaseURL(`Invalid base URL for ${endpoint}: only HTTP and HTTPS are permitted.`);
   }
 
   if (isSSRFTarget(hostname)) {
-    throw new Error(`Base URL for ${endpoint} targets a restricted address.`);
+    throwInvalidBaseURL(`Base URL for ${endpoint} targets a restricted address.`);
   }
 
   if (await resolveHostnameSSRF(hostname)) {
-    throw new Error(`Base URL for ${endpoint} resolves to a restricted address.`);
+    throwInvalidBaseURL(`Base URL for ${endpoint} resolves to a restricted address.`);
   }
 }

--- a/packages/api/src/endpoints/custom/initialize.spec.ts
+++ b/packages/api/src/endpoints/custom/initialize.spec.ts
@@ -1,0 +1,119 @@
+import { AuthType } from 'librechat-data-provider';
+import type { BaseInitializeParams } from '~/types';
+
+const mockValidateEndpointURL = jest.fn();
+jest.mock('~/auth', () => ({
+  validateEndpointURL: (...args: unknown[]) => mockValidateEndpointURL(...args),
+}));
+
+const mockGetOpenAIConfig = jest.fn().mockReturnValue({
+  llmConfig: { model: 'test-model' },
+  configOptions: {},
+});
+jest.mock('~/endpoints/openai/config', () => ({
+  getOpenAIConfig: (...args: unknown[]) => mockGetOpenAIConfig(...args),
+}));
+
+jest.mock('~/endpoints/models', () => ({
+  fetchModels: jest.fn(),
+}));
+
+jest.mock('~/cache', () => ({
+  standardCache: jest.fn(() => ({ get: jest.fn().mockResolvedValue(null) })),
+}));
+
+jest.mock('~/utils', () => ({
+  isUserProvided: (val: string) => val === 'user_provided',
+  checkUserKeyExpiry: jest.fn(),
+}));
+
+const mockGetCustomEndpointConfig = jest.fn();
+jest.mock('~/app/config', () => ({
+  getCustomEndpointConfig: (...args: unknown[]) => mockGetCustomEndpointConfig(...args),
+}));
+
+import { initializeCustom } from './initialize';
+
+function createParams(overrides: {
+  apiKey?: string;
+  baseURL?: string;
+  userBaseURL?: string;
+  userApiKey?: string;
+  expiresAt?: string;
+}): BaseInitializeParams {
+  const { apiKey = 'sk-test-key', baseURL = 'https://api.example.com/v1' } = overrides;
+
+  mockGetCustomEndpointConfig.mockReturnValue({
+    apiKey,
+    baseURL,
+    models: {},
+  });
+
+  const db = {
+    getUserKeyValues: jest.fn().mockResolvedValue({
+      apiKey: overrides.userApiKey ?? 'sk-user-key',
+      baseURL: overrides.userBaseURL ?? 'https://user-api.example.com/v1',
+    }),
+  } as unknown as BaseInitializeParams['db'];
+
+  return {
+    req: {
+      user: { id: 'user-1' },
+      body: { key: overrides.expiresAt ?? '2099-01-01' },
+      config: {},
+    } as unknown as BaseInitializeParams['req'],
+    endpoint: 'test-custom',
+    model_parameters: { model: 'gpt-4' },
+    db,
+  };
+}
+
+describe('initializeCustom – SSRF guard wiring', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call validateEndpointURL when baseURL is user_provided', async () => {
+    const params = createParams({
+      apiKey: 'sk-test-key',
+      baseURL: AuthType.USER_PROVIDED,
+      userBaseURL: 'https://user-api.example.com/v1',
+      expiresAt: '2099-01-01',
+    });
+
+    await initializeCustom(params);
+
+    expect(mockValidateEndpointURL).toHaveBeenCalledTimes(1);
+    expect(mockValidateEndpointURL).toHaveBeenCalledWith(
+      'https://user-api.example.com/v1',
+      'test-custom',
+    );
+  });
+
+  it('should NOT call validateEndpointURL when baseURL is system-defined', async () => {
+    const params = createParams({
+      apiKey: 'sk-test-key',
+      baseURL: 'https://api.provider.com/v1',
+    });
+
+    await initializeCustom(params);
+
+    expect(mockValidateEndpointURL).not.toHaveBeenCalled();
+  });
+
+  it('should propagate SSRF rejection from validateEndpointURL', async () => {
+    mockValidateEndpointURL.mockRejectedValueOnce(
+      new Error('Base URL for test-custom targets a restricted address.'),
+    );
+
+    const params = createParams({
+      apiKey: 'sk-test-key',
+      baseURL: AuthType.USER_PROVIDED,
+      userBaseURL: 'http://169.254.169.254/latest/meta-data/',
+      expiresAt: '2099-01-01',
+    });
+
+    await expect(initializeCustom(params)).rejects.toThrow('targets a restricted address');
+    expect(mockGetOpenAIConfig).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -9,10 +9,10 @@ import type { TEndpoint } from 'librechat-data-provider';
 import type { AppConfig } from '@librechat/data-schemas';
 import type { BaseInitializeParams, InitializeResultBase, EndpointTokenConfig } from '~/types';
 import { getOpenAIConfig } from '~/endpoints/openai/config';
-import { getCustomEndpointConfig } from '~/app/config';
-import { validateEndpointURL } from '~/auth';
-import { fetchModels } from '~/endpoints/models';
 import { isUserProvided, checkUserKeyExpiry } from '~/utils';
+import { getCustomEndpointConfig } from '~/app/config';
+import { fetchModels } from '~/endpoints/models';
+import { validateEndpointURL } from '~/auth';
 import { standardCache } from '~/cache';
 
 const { PROXY } = process.env;

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -10,6 +10,7 @@ import type { AppConfig } from '@librechat/data-schemas';
 import type { BaseInitializeParams, InitializeResultBase, EndpointTokenConfig } from '~/types';
 import { getOpenAIConfig } from '~/endpoints/openai/config';
 import { getCustomEndpointConfig } from '~/app/config';
+import { validateEndpointURL } from '~/auth';
 import { fetchModels } from '~/endpoints/models';
 import { isUserProvided, checkUserKeyExpiry } from '~/utils';
 import { standardCache } from '~/cache';
@@ -121,6 +122,10 @@ export async function initializeCustom({
 
   if (!baseURL) {
     throw new Error(`${endpoint} Base URL not provided.`);
+  }
+
+  if (userProvidesURL) {
+    await validateEndpointURL(baseURL, endpoint);
   }
 
   let endpointTokenConfig: EndpointTokenConfig | undefined;

--- a/packages/api/src/endpoints/openai/initialize.spec.ts
+++ b/packages/api/src/endpoints/openai/initialize.spec.ts
@@ -1,0 +1,132 @@
+import { AuthType, EModelEndpoint } from 'librechat-data-provider';
+import type { BaseInitializeParams } from '~/types';
+
+const mockValidateEndpointURL = jest.fn();
+jest.mock('~/auth', () => ({
+  validateEndpointURL: (...args: unknown[]) => mockValidateEndpointURL(...args),
+}));
+
+const mockGetOpenAIConfig = jest.fn().mockReturnValue({
+  llmConfig: { model: 'gpt-4' },
+  configOptions: {},
+});
+jest.mock('./config', () => ({
+  getOpenAIConfig: (...args: unknown[]) => mockGetOpenAIConfig(...args),
+}));
+
+jest.mock('~/utils', () => ({
+  getAzureCredentials: jest.fn(),
+  resolveHeaders: jest.fn(() => ({})),
+  isUserProvided: (val: string) => val === 'user_provided',
+  checkUserKeyExpiry: jest.fn(),
+}));
+
+import { initializeOpenAI } from './initialize';
+
+function createParams(env: Record<string, string | undefined>): BaseInitializeParams {
+  const original = process.env;
+  Object.assign(process.env, env);
+
+  const db = {
+    getUserKeyValues: jest.fn().mockResolvedValue({
+      apiKey: 'sk-user-key',
+      baseURL: 'https://user-proxy.example.com/v1',
+    }),
+  } as unknown as BaseInitializeParams['db'];
+
+  const params: BaseInitializeParams = {
+    req: {
+      user: { id: 'user-1' },
+      body: { key: '2099-01-01' },
+      config: { endpoints: {} },
+    } as unknown as BaseInitializeParams['req'],
+    endpoint: EModelEndpoint.openAI,
+    model_parameters: { model: 'gpt-4' },
+    db,
+  };
+
+  const restore = () => {
+    for (const key of Object.keys(env)) {
+      if (original[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original[key];
+      }
+    }
+  };
+
+  return Object.assign(params, { _restore: restore });
+}
+
+describe('initializeOpenAI – SSRF guard wiring', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call validateEndpointURL when OPENAI_REVERSE_PROXY is user_provided', async () => {
+    const params = createParams({
+      OPENAI_API_KEY: 'sk-test',
+      OPENAI_REVERSE_PROXY: AuthType.USER_PROVIDED,
+    });
+
+    try {
+      await initializeOpenAI(params);
+    } finally {
+      (params as unknown as { _restore: () => void })._restore();
+    }
+
+    expect(mockValidateEndpointURL).toHaveBeenCalledTimes(1);
+    expect(mockValidateEndpointURL).toHaveBeenCalledWith(
+      'https://user-proxy.example.com/v1',
+      EModelEndpoint.openAI,
+    );
+  });
+
+  it('should NOT call validateEndpointURL when OPENAI_REVERSE_PROXY is a system URL', async () => {
+    const params = createParams({
+      OPENAI_API_KEY: 'sk-test',
+      OPENAI_REVERSE_PROXY: 'https://api.openai.com/v1',
+    });
+
+    try {
+      await initializeOpenAI(params);
+    } finally {
+      (params as unknown as { _restore: () => void })._restore();
+    }
+
+    expect(mockValidateEndpointURL).not.toHaveBeenCalled();
+  });
+
+  it('should NOT call validateEndpointURL when baseURL is falsy', async () => {
+    const params = createParams({
+      OPENAI_API_KEY: 'sk-test',
+    });
+
+    try {
+      await initializeOpenAI(params);
+    } finally {
+      (params as unknown as { _restore: () => void })._restore();
+    }
+
+    expect(mockValidateEndpointURL).not.toHaveBeenCalled();
+  });
+
+  it('should propagate SSRF rejection from validateEndpointURL', async () => {
+    mockValidateEndpointURL.mockRejectedValueOnce(
+      new Error('Base URL for openAI targets a restricted address.'),
+    );
+
+    const params = createParams({
+      OPENAI_API_KEY: 'sk-test',
+      OPENAI_REVERSE_PROXY: AuthType.USER_PROVIDED,
+    });
+
+    try {
+      await expect(initializeOpenAI(params)).rejects.toThrow('targets a restricted address');
+    } finally {
+      (params as unknown as { _restore: () => void })._restore();
+    }
+
+    expect(mockGetOpenAIConfig).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/endpoints/openai/initialize.spec.ts
+++ b/packages/api/src/endpoints/openai/initialize.spec.ts
@@ -24,7 +24,10 @@ jest.mock('~/utils', () => ({
 import { initializeOpenAI } from './initialize';
 
 function createParams(env: Record<string, string | undefined>): BaseInitializeParams {
-  const original = process.env;
+  const savedEnv: Record<string, string | undefined> = {};
+  for (const key of Object.keys(env)) {
+    savedEnv[key] = process.env[key];
+  }
   Object.assign(process.env, env);
 
   const db = {
@@ -47,10 +50,10 @@ function createParams(env: Record<string, string | undefined>): BaseInitializePa
 
   const restore = () => {
     for (const key of Object.keys(env)) {
-      if (original[key] === undefined) {
+      if (savedEnv[key] === undefined) {
         delete process.env[key];
       } else {
-        process.env[key] = original[key];
+        process.env[key] = savedEnv[key];
       }
     }
   };

--- a/packages/api/src/endpoints/openai/initialize.ts
+++ b/packages/api/src/endpoints/openai/initialize.ts
@@ -6,6 +6,7 @@ import type {
   UserKeyValues,
 } from '~/types';
 import { getAzureCredentials, resolveHeaders, isUserProvided, checkUserKeyExpiry } from '~/utils';
+import { validateEndpointURL } from '~/auth';
 import { getOpenAIConfig } from './config';
 
 /**
@@ -54,6 +55,10 @@ export async function initializeOpenAI({
   const baseURL = userProvidesURL
     ? userValues?.baseURL
     : baseURLOptions[endpoint as keyof typeof baseURLOptions];
+
+  if (userProvidesURL && baseURL) {
+    await validateEndpointURL(baseURL, endpoint);
+  }
 
   const clientOptions: OpenAIConfigOptions = {
     proxy: PROXY ?? undefined,

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1561,6 +1561,10 @@ export enum ErrorTypes {
    */
   NO_BASE_URL = 'no_base_url',
   /**
+   * Base URL targets a restricted or invalid address (SSRF protection).
+   */
+  INVALID_BASE_URL = 'invalid_base_url',
+  /**
    * Moderation error
    */
   MODERATION = 'moderation',


### PR DESCRIPTION
## Summary

Fixed an SSRF vulnerability where user-supplied `baseURL` values (configured with `user_provided`) were passed to the OpenAI SDK without validation in both the OpenAI/Azure and custom endpoint initialization paths, enabling arbitrary server-side requests to internal or metadata addresses.

- Added `validateEndpointURL` to `packages/api/src/auth/domain.ts`, which enforces HTTP/HTTPS-only schemes, runs `isSSRFTarget` against the parsed hostname, and DNS-resolves via `resolveHostnameSSRF` to block private IP targets; documents the DNS rebinding limitation and fail-open semantics in JSDoc.
- Added `throwInvalidBaseURL` helper emitting `JSON.stringify({ type: 'invalid_base_url', message })` so all rejection paths produce structured errors consistent with the existing `ErrorTypes` pattern.
- Wired the guard into `initializeOpenAI` behind a `userProvidesURL && baseURL` condition and into `initializeCustom` behind `userProvidesURL`, both after their respective non-null guarantees.
- Added `INVALID_BASE_URL = 'invalid_base_url'` to the `ErrorTypes` enum in `packages/data-provider/src/config.ts`.
- Mapped `[ErrorTypes.INVALID_BASE_URL]` to `'com_error_invalid_base_url'` in the `errorMessages` map in `client/src/components/Messages/Content/Error.tsx` for localized client-side rendering.
- Added `com_error_invalid_base_url` to `client/src/locales/en/translation.json`.
- Added 16 unit tests to `packages/api/src/auth/domain.spec.ts` covering unparseable URLs, localhost, private IPv4 ranges, link-local/metadata IPs, loopback, internal Docker/Kubernetes hostnames, DNS resolution to private IPs, non-HTTP/HTTPS schemes, IPv6 loopback/link-local/unique-local, `.local` and `.internal` TLDs, DNS fail-open, and structured JSON error format.
- Added `packages/api/src/endpoints/custom/initialize.spec.ts` with 3 integration tests asserting the guard fires when `userProvidesURL`, is skipped when system-defined, and propagates SSRF rejection before `getOpenAIConfig` is reached.
- Added `packages/api/src/endpoints/openai/initialize.spec.ts` with 4 integration tests covering the same guard wiring plus the `userProvidesURL && !baseURL` skip path.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

All new logic is exercised by the test suites added in this PR. To run them:

```bash
cd packages/api && npx jest auth/domain && npx jest endpoints/custom/initialize && npx jest endpoints/openai/initialize
```

To manually verify the guard fires at runtime, configure a custom endpoint with `baseURL: user_provided` in `librechat.yaml`, set a user key with a private-IP base URL (e.g. `http://192.168.1.1/v1`), and send a chat request — the error component should display the localized `com_error_invalid_base_url` message rather than a raw 500.

### **Test Configuration**:
- Node.js v20+
- No external services required; DNS lookups are mocked via `jest.mock('node:dns/promises')`
- 204 tests passing across 3 suites

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
