### PR TITLE
📑 fix: Sanitize Markdown Artifacts

### DIFF
--- a/client/src/hooks/Artifacts/__tests__/useArtifactProps.test.ts
+++ b/client/src/hooks/Artifacts/__tests__/useArtifactProps.test.ts
@@ -122,6 +122,7 @@ describe('useArtifactProps', () => {
 
       expect(result.current.sharedProps.customSetup?.dependencies).toHaveProperty('react-markdown');
       expect(result.current.sharedProps.customSetup?.dependencies).toHaveProperty('remark-gfm');
+      expect(result.current.sharedProps.customSetup?.dependencies).toHaveProperty('remark-breaks');
     });
 
     it('should update files when content changes', () => {

--- a/client/src/hooks/Artifacts/__tests__/useArtifactProps.test.ts
+++ b/client/src/hooks/Artifacts/__tests__/useArtifactProps.test.ts
@@ -112,7 +112,7 @@ describe('useArtifactProps', () => {
       expect(result.current.files['content.md']).toBe('# No content provided');
     });
 
-    it('should provide marked-react dependency', () => {
+    it('should provide react-markdown dependency', () => {
       const artifact = createArtifact({
         type: 'text/markdown',
         content: '# Test',
@@ -120,7 +120,8 @@ describe('useArtifactProps', () => {
 
       const { result } = renderHook(() => useArtifactProps({ artifact }));
 
-      expect(result.current.sharedProps.customSetup?.dependencies).toHaveProperty('marked-react');
+      expect(result.current.sharedProps.customSetup?.dependencies).toHaveProperty('react-markdown');
+      expect(result.current.sharedProps.customSetup?.dependencies).toHaveProperty('remark-gfm');
     });
 
     it('should update files when content changes', () => {

--- a/client/src/utils/__tests__/markdown.test.ts
+++ b/client/src/utils/__tests__/markdown.test.ts
@@ -1,4 +1,72 @@
-import { getMarkdownFiles } from '../markdown';
+import { isSafeUrl, getMarkdownFiles } from '../markdown';
+
+describe('isSafeUrl', () => {
+  it('allows https URLs', () => {
+    expect(isSafeUrl('https://example.com')).toBe(true);
+  });
+
+  it('allows http URLs', () => {
+    expect(isSafeUrl('http://example.com/path')).toBe(true);
+  });
+
+  it('allows mailto links', () => {
+    expect(isSafeUrl('mailto:user@example.com')).toBe(true);
+  });
+
+  it('allows tel links', () => {
+    expect(isSafeUrl('tel:+1234567890')).toBe(true);
+  });
+
+  it('allows relative paths', () => {
+    expect(isSafeUrl('/path/to/page')).toBe(true);
+    expect(isSafeUrl('./relative')).toBe(true);
+    expect(isSafeUrl('../parent')).toBe(true);
+  });
+
+  it('allows anchor links', () => {
+    expect(isSafeUrl('#section')).toBe(true);
+  });
+
+  it('blocks javascript: protocol', () => {
+    expect(isSafeUrl('javascript:alert(1)')).toBe(false);
+  });
+
+  it('blocks javascript: with leading whitespace', () => {
+    expect(isSafeUrl('  javascript:alert(1)')).toBe(false);
+  });
+
+  it('blocks javascript: with mixed case', () => {
+    expect(isSafeUrl('JavaScript:alert(1)')).toBe(false);
+  });
+
+  it('blocks data: protocol', () => {
+    expect(isSafeUrl('data:text/html,<b>x</b>')).toBe(false);
+  });
+
+  it('blocks blob: protocol', () => {
+    expect(isSafeUrl('blob:http://example.com/uuid')).toBe(false);
+  });
+
+  it('blocks vbscript: protocol', () => {
+    expect(isSafeUrl('vbscript:MsgBox("xss")')).toBe(false);
+  });
+
+  it('blocks file: protocol', () => {
+    expect(isSafeUrl('file:///etc/passwd')).toBe(false);
+  });
+
+  it('blocks empty strings', () => {
+    expect(isSafeUrl('')).toBe(false);
+  });
+
+  it('blocks whitespace-only strings', () => {
+    expect(isSafeUrl('   ')).toBe(false);
+  });
+
+  it('blocks unknown/custom protocols', () => {
+    expect(isSafeUrl('custom:payload')).toBe(false);
+  });
+});
 
 describe('markdown artifacts', () => {
   describe('getMarkdownFiles', () => {
@@ -167,8 +235,12 @@ describe('markdown artifacts', () => {
       const rendererCode = files['/components/ui/MarkdownRenderer.tsx'];
 
       expect(rendererCode).toContain("import ReactMarkdown from 'react-markdown'");
+      expect(rendererCode).toContain("import remarkBreaks from 'remark-breaks'");
       expect(rendererCode).toContain('skipHtml={true}');
+      expect(rendererCode).toContain('SAFE_PROTOCOLS');
+      expect(rendererCode).toContain('isSafeUrl');
       expect(rendererCode).toContain("urlTransform={(url) => (isSafeUrl(url) ? url : '')}");
+      expect(rendererCode).toContain('remarkPlugins={remarkPlugins}');
     });
 
     it('should pass markdown content to the Markdown component', () => {

--- a/client/src/utils/__tests__/markdown.test.ts
+++ b/client/src/utils/__tests__/markdown.test.ts
@@ -41,7 +41,7 @@ describe('markdown artifacts', () => {
       const markdown = '# Test';
       const files = getMarkdownFiles(markdown);
 
-      expect(files['/components/ui/MarkdownRenderer.tsx']).toContain('import Markdown from');
+      expect(files['/components/ui/MarkdownRenderer.tsx']).toContain('import ReactMarkdown from');
       expect(files['/components/ui/MarkdownRenderer.tsx']).toContain('MarkdownRendererProps');
       expect(files['/components/ui/MarkdownRenderer.tsx']).toContain(
         'export default MarkdownRenderer',
@@ -162,13 +162,13 @@ describe('markdown artifacts', () => {
   });
 
   describe('markdown component structure', () => {
-    it('should generate a MarkdownRenderer component that uses marked-react', () => {
+    it('should generate a MarkdownRenderer component with safe markdown rendering', () => {
       const files = getMarkdownFiles('# Test');
       const rendererCode = files['/components/ui/MarkdownRenderer.tsx'];
 
-      // Verify the component imports and uses Markdown from marked-react
-      expect(rendererCode).toContain("import Markdown from 'marked-react'");
-      expect(rendererCode).toContain('<Markdown gfm={true} breaks={true}>{content}</Markdown>');
+      expect(rendererCode).toContain("import ReactMarkdown from 'react-markdown'");
+      expect(rendererCode).toContain('skipHtml={true}');
+      expect(rendererCode).toContain("urlTransform={(url) => (isSafeUrl(url) ? url : '')}");
     });
 
     it('should pass markdown content to the Markdown component', () => {

--- a/client/src/utils/__tests__/markdown.test.ts
+++ b/client/src/utils/__tests__/markdown.test.ts
@@ -239,8 +239,20 @@ describe('markdown artifacts', () => {
       expect(rendererCode).toContain('skipHtml={true}');
       expect(rendererCode).toContain('SAFE_PROTOCOLS');
       expect(rendererCode).toContain('isSafeUrl');
-      expect(rendererCode).toContain("urlTransform={(url) => (isSafeUrl(url) ? url : '')}");
+      expect(rendererCode).toContain('urlTransform={urlTransform}');
       expect(rendererCode).toContain('remarkPlugins={remarkPlugins}');
+      expect(rendererCode).toContain('isSafeUrl(url) ? url : null');
+    });
+
+    it('should embed isSafeUrl logic matching the exported version', () => {
+      const files = getMarkdownFiles('# Test');
+      const rendererCode = files['/components/ui/MarkdownRenderer.tsx'];
+
+      expect(rendererCode).toContain("new Set(['http:', 'https:', 'mailto:', 'tel:'])");
+      expect(rendererCode).toContain('new URL(trimmed).protocol');
+      expect(rendererCode).toContain("trimmed.startsWith('/')");
+      expect(rendererCode).toContain("trimmed.startsWith('#')");
+      expect(rendererCode).toContain("trimmed.startsWith('.')");
     });
 
     it('should pass markdown content to the Markdown component', () => {

--- a/client/src/utils/artifacts.ts
+++ b/client/src/utils/artifacts.ts
@@ -108,8 +108,9 @@ const mermaidDependencies = {
 };
 
 const markdownDependencies = {
-  'react-markdown': '^9.0.1',
   'remark-gfm': '^4.0.0',
+  'remark-breaks': '^4.0.0',
+  'react-markdown': '^9.0.1',
 };
 
 const dependenciesMap: Record<

--- a/client/src/utils/artifacts.ts
+++ b/client/src/utils/artifacts.ts
@@ -108,7 +108,8 @@ const mermaidDependencies = {
 };
 
 const markdownDependencies = {
-  'marked-react': '^2.0.0',
+  'react-markdown': '^9.0.1',
+  'remark-gfm': '^4.0.0',
 };
 
 const dependenciesMap: Record<

--- a/client/src/utils/markdown.ts
+++ b/client/src/utils/markdown.ts
@@ -1,11 +1,17 @@
 import dedent from 'dedent';
 
-const markdownRenderer = dedent(`import React, { useEffect, useState } from 'react';
-import Markdown from 'marked-react';
+const markdownRenderer = dedent(`import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 interface MarkdownRendererProps {
   content: string;
 }
+
+const isSafeUrl = (url: string): boolean => {
+  const normalizedUrl = url.trim().toLowerCase();
+  return !normalizedUrl.startsWith('javascript:') && !normalizedUrl.startsWith('data:');
+};
 
 const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
   return (
@@ -17,7 +23,13 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
         minHeight: '100vh'
       }}
     >
-      <Markdown gfm={true} breaks={true}>{content}</Markdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        skipHtml={true}
+        urlTransform={(url) => (isSafeUrl(url) ? url : '')}
+      >
+        {content}
+      </ReactMarkdown>
     </div>
   );
 };

--- a/client/src/utils/markdown.ts
+++ b/client/src/utils/markdown.ts
@@ -2,6 +2,11 @@ import dedent from 'dedent';
 
 const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
 
+/**
+ * Allowlist-based URL validator for markdown artifact rendering.
+ * Mirrored verbatim in the markdownRenderer template string below —
+ * any logic change MUST be applied to both copies.
+ */
 export const isSafeUrl = (url: string): boolean => {
   const trimmed = url.trim();
   if (!trimmed) {
@@ -26,6 +31,7 @@ interface MarkdownRendererProps {
   content: string;
 }
 
+/** Mirror of the exported isSafeUrl in markdown.ts — keep in sync. */
 const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
 
 const isSafeUrl = (url: string): boolean => {
@@ -40,6 +46,7 @@ const isSafeUrl = (url: string): boolean => {
 };
 
 const remarkPlugins = [remarkGfm, remarkBreaks];
+const urlTransform = (url: string) => (isSafeUrl(url) ? url : null);
 
 const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
   return (
@@ -54,7 +61,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
       <ReactMarkdown
         remarkPlugins={remarkPlugins}
         skipHtml={true}
-        urlTransform={(url) => (isSafeUrl(url) ? url : '')}
+        urlTransform={urlTransform}
       >
         {content}
       </ReactMarkdown>

--- a/client/src/utils/markdown.ts
+++ b/client/src/utils/markdown.ts
@@ -1,30 +1,58 @@
 import dedent from 'dedent';
 
+const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+
+export const isSafeUrl = (url: string): boolean => {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed.startsWith('/') || trimmed.startsWith('#') || trimmed.startsWith('.')) {
+    return true;
+  }
+  try {
+    return SAFE_PROTOCOLS.has(new URL(trimmed).protocol);
+  } catch {
+    return false;
+  }
+};
+
 const markdownRenderer = dedent(`import React from 'react';
-import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
+import ReactMarkdown from 'react-markdown';
 
 interface MarkdownRendererProps {
   content: string;
 }
 
+const SAFE_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+
 const isSafeUrl = (url: string): boolean => {
-  const normalizedUrl = url.trim().toLowerCase();
-  return !normalizedUrl.startsWith('javascript:') && !normalizedUrl.startsWith('data:');
+  const trimmed = url.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith('/') || trimmed.startsWith('#') || trimmed.startsWith('.')) return true;
+  try {
+    return SAFE_PROTOCOLS.has(new URL(trimmed).protocol);
+  } catch {
+    return false;
+  }
 };
+
+const remarkPlugins = [remarkGfm, remarkBreaks];
 
 const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
   return (
     <div
       className="markdown-body"
       style={{
-        padding: '2rem',        
+        padding: '2rem',
         margin: '1rem',
         minHeight: '100vh'
       }}
     >
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={remarkPlugins}
         skipHtml={true}
         urlTransform={(url) => (isSafeUrl(url) ? url : '')}
       >


### PR DESCRIPTION
Replace marked-react with react-markdown + remark-gfm for artifact markdown preview. react-markdown's skipHtml strips raw HTML tags, and a urlTransform guard blocks javascript: and data: protocol links.