### PR TITLE
🔏 fix: Scope Agent-Author File Access to Attached Files Only

### DIFF
--- a/api/models/File.spec.js
+++ b/api/models/File.spec.js
@@ -190,6 +190,117 @@ describe('File Access Control', () => {
       expect(accessMap.get(fileIds[2])).toBe(false);
     });
 
+    it('should deny all access when agent has no tool_resources', async () => {
+      const authorId = new mongoose.Types.ObjectId();
+      const agentId = uuidv4();
+      const fileId = uuidv4();
+
+      await User.create({
+        _id: authorId,
+        email: 'author-no-resources@example.com',
+        emailVerified: true,
+        provider: 'local',
+      });
+
+      await createAgent({
+        id: agentId,
+        name: 'Bare Agent',
+        author: authorId,
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const { hasAccessToFilesViaAgent } = require('~/server/services/Files/permissions');
+      const accessMap = await hasAccessToFilesViaAgent({
+        userId: authorId,
+        role: SystemRoles.USER,
+        fileIds: [fileId],
+        agentId,
+      });
+
+      expect(accessMap.get(fileId)).toBe(false);
+    });
+
+    it('should grant access to files across multiple resource types', async () => {
+      const authorId = new mongoose.Types.ObjectId();
+      const agentId = uuidv4();
+      const fileIds = [uuidv4(), uuidv4(), uuidv4()];
+
+      await User.create({
+        _id: authorId,
+        email: 'author-multi@example.com',
+        emailVerified: true,
+        provider: 'local',
+      });
+
+      await createAgent({
+        id: agentId,
+        name: 'Multi Resource Agent',
+        author: authorId,
+        model: 'gpt-4',
+        provider: 'openai',
+        tool_resources: {
+          file_search: {
+            file_ids: [fileIds[0]],
+          },
+          execute_code: {
+            file_ids: [fileIds[1]],
+          },
+        },
+      });
+
+      const { hasAccessToFilesViaAgent } = require('~/server/services/Files/permissions');
+      const accessMap = await hasAccessToFilesViaAgent({
+        userId: authorId,
+        role: SystemRoles.USER,
+        fileIds,
+        agentId,
+      });
+
+      expect(accessMap.get(fileIds[0])).toBe(true);
+      expect(accessMap.get(fileIds[1])).toBe(true);
+      expect(accessMap.get(fileIds[2])).toBe(false);
+    });
+
+    it('should grant author access to attached files when isDelete is true', async () => {
+      const authorId = new mongoose.Types.ObjectId();
+      const agentId = uuidv4();
+      const attachedFileId = uuidv4();
+      const unattachedFileId = uuidv4();
+
+      await User.create({
+        _id: authorId,
+        email: 'author-delete@example.com',
+        emailVerified: true,
+        provider: 'local',
+      });
+
+      await createAgent({
+        id: agentId,
+        name: 'Delete Test Agent',
+        author: authorId,
+        model: 'gpt-4',
+        provider: 'openai',
+        tool_resources: {
+          file_search: {
+            file_ids: [attachedFileId],
+          },
+        },
+      });
+
+      const { hasAccessToFilesViaAgent } = require('~/server/services/Files/permissions');
+      const accessMap = await hasAccessToFilesViaAgent({
+        userId: authorId,
+        role: SystemRoles.USER,
+        fileIds: [attachedFileId, unattachedFileId],
+        agentId,
+        isDelete: true,
+      });
+
+      expect(accessMap.get(attachedFileId)).toBe(true);
+      expect(accessMap.get(unattachedFileId)).toBe(false);
+    });
+
     it('should handle non-existent agent gracefully', async () => {
       const userId = new mongoose.Types.ObjectId();
       const fileIds = [uuidv4(), uuidv4()];

--- a/api/models/File.spec.js
+++ b/api/models/File.spec.js
@@ -152,12 +152,11 @@ describe('File Access Control', () => {
       expect(accessMap.get(fileIds[3])).toBe(false);
     });
 
-    it('should grant access to all files when user is the agent author', async () => {
+    it('should only grant author access to files attached to the agent', async () => {
       const authorId = new mongoose.Types.ObjectId();
       const agentId = uuidv4();
       const fileIds = [uuidv4(), uuidv4(), uuidv4()];
 
-      // Create author user
       await User.create({
         _id: authorId,
         email: 'author@example.com',
@@ -165,7 +164,6 @@ describe('File Access Control', () => {
         provider: 'local',
       });
 
-      // Create agent
       await createAgent({
         id: agentId,
         name: 'Test Agent',
@@ -174,12 +172,11 @@ describe('File Access Control', () => {
         provider: 'openai',
         tool_resources: {
           file_search: {
-            file_ids: [fileIds[0]], // Only one file attached
+            file_ids: [fileIds[0]],
           },
         },
       });
 
-      // Check access as the author
       const { hasAccessToFilesViaAgent } = require('~/server/services/Files/permissions');
       const accessMap = await hasAccessToFilesViaAgent({
         userId: authorId,
@@ -188,10 +185,9 @@ describe('File Access Control', () => {
         agentId,
       });
 
-      // Author should have access to all files
       expect(accessMap.get(fileIds[0])).toBe(true);
-      expect(accessMap.get(fileIds[1])).toBe(true);
-      expect(accessMap.get(fileIds[2])).toBe(true);
+      expect(accessMap.get(fileIds[1])).toBe(false);
+      expect(accessMap.get(fileIds[2])).toBe(false);
     });
 
     it('should handle non-existent agent gracefully', async () => {

--- a/api/server/services/Files/permissions.js
+++ b/api/server/services/Files/permissions.js
@@ -3,8 +3,22 @@ const { PermissionBits, ResourceType } = require('librechat-data-provider');
 const { checkPermission } = require('~/server/services/PermissionService');
 const { getAgent } = require('~/models/Agent');
 
+/** Collects all file IDs attached to an agent's tool_resources */
+function getAttachedFileIds(agent) {
+  const attachedFileIds = new Set();
+  if (agent.tool_resources) {
+    for (const [_resourceType, resource] of Object.entries(agent.tool_resources)) {
+      if (resource?.file_ids && Array.isArray(resource.file_ids)) {
+        resource.file_ids.forEach((fileId) => attachedFileIds.add(fileId));
+      }
+    }
+  }
+  return attachedFileIds;
+}
+
 /**
- * Checks if a user has access to multiple files through a shared agent (batch operation)
+ * Checks if a user has access to multiple files through a shared agent (batch operation).
+ * Access is always scoped to files actually attached to the agent's tool_resources.
  * @param {Object} params - Parameters object
  * @param {string} params.userId - The user ID to check access for
  * @param {string} [params.role] - Optional user role to avoid DB query
@@ -16,7 +30,6 @@ const { getAgent } = require('~/models/Agent');
 const hasAccessToFilesViaAgent = async ({ userId, role, fileIds, agentId, isDelete }) => {
   const accessMap = new Map();
 
-  // Initialize all files as no access
   fileIds.forEach((fileId) => accessMap.set(fileId, false));
 
   try {
@@ -26,13 +39,17 @@ const hasAccessToFilesViaAgent = async ({ userId, role, fileIds, agentId, isDele
       return accessMap;
     }
 
-    // Check if user is the author - if so, grant access to all files
+    const attachedFileIds = getAttachedFileIds(agent);
+
     if (agent.author.toString() === userId.toString()) {
-      fileIds.forEach((fileId) => accessMap.set(fileId, true));
+      fileIds.forEach((fileId) => {
+        if (attachedFileIds.has(fileId)) {
+          accessMap.set(fileId, true);
+        }
+      });
       return accessMap;
     }
 
-    // Check if user has at least VIEW permission on the agent
     const hasViewPermission = await checkPermission({
       userId,
       role,
@@ -46,7 +63,6 @@ const hasAccessToFilesViaAgent = async ({ userId, role, fileIds, agentId, isDele
     }
 
     if (isDelete) {
-      // Check if user has EDIT permission (which would indicate collaborative access)
       const hasEditPermission = await checkPermission({
         userId,
         role,
@@ -55,23 +71,11 @@ const hasAccessToFilesViaAgent = async ({ userId, role, fileIds, agentId, isDele
         requiredPermission: PermissionBits.EDIT,
       });
 
-      // If user only has VIEW permission, they can't access files
-      // Only users with EDIT permission or higher can access agent files
       if (!hasEditPermission) {
         return accessMap;
       }
     }
 
-    const attachedFileIds = new Set();
-    if (agent.tool_resources) {
-      for (const [_resourceType, resource] of Object.entries(agent.tool_resources)) {
-        if (resource?.file_ids && Array.isArray(resource.file_ids)) {
-          resource.file_ids.forEach((fileId) => attachedFileIds.add(fileId));
-        }
-      }
-    }
-
-    // Grant access only to files that are attached to this agent
     fileIds.forEach((fileId) => {
       if (attachedFileIds.has(fileId)) {
         accessMap.set(fileId, true);

--- a/api/server/services/Files/permissions.js
+++ b/api/server/services/Files/permissions.js
@@ -3,13 +3,18 @@ const { PermissionBits, ResourceType } = require('librechat-data-provider');
 const { checkPermission } = require('~/server/services/PermissionService');
 const { getAgent } = require('~/models/Agent');
 
-/** Collects all file IDs attached to an agent's tool_resources */
+/**
+ * @param {Object} agent - The agent document (lean)
+ * @returns {Set<string>} All file IDs attached across all resource types
+ */
 function getAttachedFileIds(agent) {
   const attachedFileIds = new Set();
   if (agent.tool_resources) {
-    for (const [_resourceType, resource] of Object.entries(agent.tool_resources)) {
+    for (const resource of Object.values(agent.tool_resources)) {
       if (resource?.file_ids && Array.isArray(resource.file_ids)) {
-        resource.file_ids.forEach((fileId) => attachedFileIds.add(fileId));
+        for (const fileId of resource.file_ids) {
+          attachedFileIds.add(fileId);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixed an IDOR in `hasAccessToFilesViaAgent` where the agent-author path short-circuited access checks, granting the author unrestricted access to every file ID in the request body without verifying those files were attached to the agent's `tool_resources`. An authenticated author could supply their own `agent_id` alongside arbitrary file IDs to delete files they did not own.

- Extracted `getAttachedFileIds` helper that collects all `file_ids` across every resource type in `agent.tool_resources` into a `Set`, returning an empty set when `tool_resources` is absent (fail-closed by default).
- Replaced `Object.entries` with `Object.values` in `getAttachedFileIds` to eliminate the dead `_resourceType` binding and avoid unnecessary tuple allocation.
- Used `for...of` instead of `forEach` in the file ID iteration loop, per project conventions.
- Added `@param` and `@returns` JSDoc to `getAttachedFileIds` for IDE intellisense.
- Applied `attachedFileIds` gating to the author branch, matching the scoping already present in the non-author path and eliminating the duplicate inline computation there.
- Added three boundary-case integration tests to `File.spec.js`: agent with no `tool_resources` denies all access, files spread across multiple resource types are all reachable, and an author passing `isDelete: true` is still scoped to attached files only.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

All tests use `mongodb-memory-server` with real Mongoose models, real `PermissionService` calls, and real ACL entries — no mocked core logic.

The `hasAccessToFilesViaAgent` suite now covers:

| Scenario | Expected |
|---|---|
| Non-author with EDIT permission, attached files | `true` |
| Non-author with EDIT permission, unattached files | `false` |
| Author, attached file | `true` |
| Author, unattached file | `false` |
| Author, `isDelete: true`, attached file | `true` |
| Author, `isDelete: true`, unattached file | `false` |
| Agent with no `tool_resources` (author caller) | `false` |
| Files across `file_search` + `execute_code` resources | `true` for each |
| Non-existent agent | `false` |
| VIEW-only permission, `isDelete: true` | `false` |
| VIEW-only permission, no delete | `true` for attached |

### Test Configuration

```bash
cd api && npx jest File.spec
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
