### PR TITLE
🪪 fix: Enforce Conversation Ownership Checks in Remote Agent Controllers

### DIFF
--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -99,6 +99,7 @@ jest.mock('~/server/services/PermissionService', () => ({
 
 jest.mock('~/models/Conversation', () => ({
   getConvoFiles: jest.fn().mockResolvedValue([]),
+  getConvo: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('~/models/Agent', () => ({
@@ -158,6 +159,77 @@ describe('OpenAIChatCompletionController', () => {
       end: jest.fn(),
       write: jest.fn(),
     };
+  });
+
+  describe('conversation ownership validation', () => {
+    it('should skip ownership check when conversation_id is not provided', async () => {
+      const { getConvo } = require('~/models/Conversation');
+      await OpenAIChatCompletionController(req, res);
+      expect(getConvo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when conversation_id is not a string', async () => {
+      const { validateRequest } = require('@librechat/api');
+      validateRequest.mockReturnValueOnce({
+        request: { model: 'agent-123', messages: [], stream: false, conversation_id: { $gt: '' } },
+      });
+
+      await OpenAIChatCompletionController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('should return 404 when conversation is not owned by user', async () => {
+      const { validateRequest } = require('@librechat/api');
+      const { getConvo } = require('~/models/Conversation');
+      validateRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          messages: [],
+          stream: false,
+          conversation_id: 'convo-abc',
+        },
+      });
+      getConvo.mockResolvedValueOnce(null);
+
+      await OpenAIChatCompletionController(req, res);
+      expect(getConvo).toHaveBeenCalledWith('user-123', 'convo-abc');
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('should proceed when conversation is owned by user', async () => {
+      const { validateRequest } = require('@librechat/api');
+      const { getConvo } = require('~/models/Conversation');
+      validateRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          messages: [],
+          stream: false,
+          conversation_id: 'convo-abc',
+        },
+      });
+      getConvo.mockResolvedValueOnce({ conversationId: 'convo-abc', user: 'user-123' });
+
+      await OpenAIChatCompletionController(req, res);
+      expect(getConvo).toHaveBeenCalledWith('user-123', 'convo-abc');
+      expect(res.status).not.toHaveBeenCalledWith(404);
+    });
+
+    it('should return 500 when getConvo throws a DB error', async () => {
+      const { validateRequest } = require('@librechat/api');
+      const { getConvo } = require('~/models/Conversation');
+      validateRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          messages: [],
+          stream: false,
+          conversation_id: 'convo-abc',
+        },
+      });
+      getConvo.mockRejectedValueOnce(new Error('DB connection failed'));
+
+      await OpenAIChatCompletionController(req, res);
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
   });
 
   describe('token usage recording', () => {

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -189,6 +189,102 @@ describe('createResponse controller', () => {
     };
   });
 
+  describe('conversation ownership validation', () => {
+    it('should skip ownership check when previous_response_id is not provided', async () => {
+      const { getConvo } = require('~/models/Conversation');
+      await createResponse(req, res);
+      expect(getConvo).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when previous_response_id is not a string', async () => {
+      const { validateResponseRequest, sendResponsesErrorResponse } = require('@librechat/api');
+      validateResponseRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          input: 'Hello',
+          stream: false,
+          previous_response_id: { $gt: '' },
+        },
+      });
+
+      await createResponse(req, res);
+      expect(sendResponsesErrorResponse).toHaveBeenCalledWith(
+        res,
+        400,
+        'previous_response_id must be a string',
+        'invalid_request',
+      );
+    });
+
+    it('should return 404 when conversation is not owned by user', async () => {
+      const { validateResponseRequest, sendResponsesErrorResponse } = require('@librechat/api');
+      const { getConvo } = require('~/models/Conversation');
+      validateResponseRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          input: 'Hello',
+          stream: false,
+          previous_response_id: 'resp_abc',
+        },
+      });
+      getConvo.mockResolvedValueOnce(null);
+
+      await createResponse(req, res);
+      expect(getConvo).toHaveBeenCalledWith('user-123', 'resp_abc');
+      expect(sendResponsesErrorResponse).toHaveBeenCalledWith(
+        res,
+        404,
+        'Conversation not found',
+        'not_found',
+      );
+    });
+
+    it('should proceed when conversation is owned by user', async () => {
+      const { validateResponseRequest, sendResponsesErrorResponse } = require('@librechat/api');
+      const { getConvo } = require('~/models/Conversation');
+      validateResponseRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          input: 'Hello',
+          stream: false,
+          previous_response_id: 'resp_abc',
+        },
+      });
+      getConvo.mockResolvedValueOnce({ conversationId: 'resp_abc', user: 'user-123' });
+
+      await createResponse(req, res);
+      expect(getConvo).toHaveBeenCalledWith('user-123', 'resp_abc');
+      expect(sendResponsesErrorResponse).not.toHaveBeenCalledWith(
+        res,
+        404,
+        expect.any(String),
+        expect.any(String),
+      );
+    });
+
+    it('should return 500 when getConvo throws a DB error', async () => {
+      const { validateResponseRequest, sendResponsesErrorResponse } = require('@librechat/api');
+      const { getConvo } = require('~/models/Conversation');
+      validateResponseRequest.mockReturnValueOnce({
+        request: {
+          model: 'agent-123',
+          input: 'Hello',
+          stream: false,
+          previous_response_id: 'resp_abc',
+        },
+      });
+      getConvo.mockRejectedValueOnce(new Error('DB connection failed'));
+
+      await createResponse(req, res);
+      expect(sendResponsesErrorResponse).toHaveBeenCalledWith(
+        res,
+        500,
+        expect.any(String),
+        expect.any(String),
+      );
+    });
+  });
+
   describe('token usage recording - non-streaming', () => {
     it('should call recordCollectedUsage after successful non-streaming completion', async () => {
       await createResponse(req, res);

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -26,7 +26,7 @@ const { createToolEndCallback } = require('~/server/controllers/agents/callbacks
 const { findAccessibleResources } = require('~/server/services/PermissionService');
 const { spendTokens, spendStructuredTokens } = require('~/models/spendTokens');
 const { getMultiplier, getCacheMultiplier } = require('~/models/tx');
-const { getConvoFiles } = require('~/models/Conversation');
+const { getConvoFiles, getConvo } = require('~/models/Conversation');
 const { getAgent, getAgents } = require('~/models/Agent');
 const db = require('~/models');
 
@@ -151,6 +151,14 @@ const OpenAIChatCompletionController = async (req, res) => {
   }
 
   const responseId = `chatcmpl-${nanoid()}`;
+
+  if (request.conversation_id != null) {
+    const convo = await getConvo(req.user?.id, request.conversation_id);
+    if (!convo) {
+      return sendErrorResponse(res, 404, 'Conversation not found', 'invalid_request_error');
+    }
+  }
+
   const conversationId = request.conversation_id ?? nanoid();
   const parentMessageId = request.parent_message_id ?? null;
   const created = Math.floor(Date.now() / 1000);

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -151,16 +151,6 @@ const OpenAIChatCompletionController = async (req, res) => {
   }
 
   const responseId = `chatcmpl-${nanoid()}`;
-
-  if (request.conversation_id != null) {
-    const convo = await getConvo(req.user?.id, request.conversation_id);
-    if (!convo) {
-      return sendErrorResponse(res, 404, 'Conversation not found', 'invalid_request_error');
-    }
-  }
-
-  const conversationId = request.conversation_id ?? nanoid();
-  const parentMessageId = request.parent_message_id ?? null;
   const created = Math.floor(Date.now() / 1000);
 
   /** @type {import('@librechat/api').OpenAIResponseContext} — key must be `requestId` to match the type used by createChunk/buildNonStreamingResponse */
@@ -186,6 +176,23 @@ const OpenAIChatCompletionController = async (req, res) => {
   });
 
   try {
+    if (request.conversation_id != null) {
+      if (typeof request.conversation_id !== 'string') {
+        return sendErrorResponse(
+          res,
+          400,
+          'conversation_id must be a string',
+          'invalid_request_error',
+        );
+      }
+      if (!(await getConvo(req.user?.id, request.conversation_id))) {
+        return sendErrorResponse(res, 404, 'Conversation not found', 'invalid_request_error');
+      }
+    }
+
+    const conversationId = request.conversation_id ?? nanoid();
+    const parentMessageId = request.parent_message_id ?? null;
+
     // Build allowed providers set
     const allowedProviders = new Set(
       appConfig?.endpoints?.[EModelEndpoint.agents]?.allowedProviders,

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -292,6 +292,14 @@ const createResponse = async (req, res) => {
 
   // Generate IDs
   const responseId = generateResponseId();
+
+  if (request.previous_response_id != null) {
+    const convo = await getConvo(req.user?.id, request.previous_response_id);
+    if (!convo) {
+      return sendResponsesErrorResponse(res, 404, 'Conversation not found', 'not_found');
+    }
+  }
+
   const conversationId = request.previous_response_id ?? uuidv4();
   const parentMessageId = null;
 

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -292,18 +292,6 @@ const createResponse = async (req, res) => {
 
   // Generate IDs
   const responseId = generateResponseId();
-
-  if (request.previous_response_id != null) {
-    const convo = await getConvo(req.user?.id, request.previous_response_id);
-    if (!convo) {
-      return sendResponsesErrorResponse(res, 404, 'Conversation not found', 'not_found');
-    }
-  }
-
-  const conversationId = request.previous_response_id ?? uuidv4();
-  const parentMessageId = null;
-
-  // Create response context
   const context = createResponseContext(request, responseId);
 
   logger.debug(
@@ -322,6 +310,23 @@ const createResponse = async (req, res) => {
   });
 
   try {
+    if (request.previous_response_id != null) {
+      if (typeof request.previous_response_id !== 'string') {
+        return sendResponsesErrorResponse(
+          res,
+          400,
+          'previous_response_id must be a string',
+          'invalid_request',
+        );
+      }
+      if (!(await getConvo(req.user?.id, request.previous_response_id))) {
+        return sendResponsesErrorResponse(res, 404, 'Conversation not found', 'not_found');
+      }
+    }
+
+    const conversationId = request.previous_response_id ?? uuidv4();
+    const parentMessageId = null;
+
     // Build allowed providers set
     const allowedProviders = new Set(
       appConfig?.endpoints?.[EModelEndpoint.agents]?.allowedProviders,

--- a/packages/api/src/agents/openai/service.ts
+++ b/packages/api/src/agents/openai/service.ts
@@ -289,6 +289,14 @@ export function validateRequest(body: unknown): ChatCompletionValidationResult {
     }
   }
 
+  if (request.conversation_id !== undefined && typeof request.conversation_id !== 'string') {
+    return { valid: false, error: 'conversation_id must be a string' };
+  }
+
+  if (request.parent_message_id !== undefined && typeof request.parent_message_id !== 'string') {
+    return { valid: false, error: 'parent_message_id must be a string' };
+  }
+
   return { valid: true, request: request as unknown as ChatCompletionRequest };
 }
 

--- a/packages/api/src/agents/responses/service.ts
+++ b/packages/api/src/agents/responses/service.ts
@@ -84,6 +84,13 @@ export function validateResponseRequest(body: unknown): RequestValidationResult 
     }
   }
 
+  if (
+    request.previous_response_id !== undefined &&
+    typeof request.previous_response_id !== 'string'
+  ) {
+    return { valid: false, error: 'previous_response_id must be a string' };
+  }
+
   return { valid: true, request: request as unknown as ResponseRequest };
 }
 


### PR DESCRIPTION


## Summary

Fixed an IDOR vulnerability in the remote agent API endpoints where a client-supplied `conversation_id` or `previous_response_id` was used without ownership verification, enabling cross-tenant file and message loading via the unscoped `getConvoFiles` call downstream.

- Added user-scoped ownership checks via `getConvo(req.user.id, id)` in both `OpenAIChatCompletionController` (`openai.js`) and `createResponse` (`responses.js`) before consuming the client-supplied conversation ID.
- Added `typeof !== 'string'` guards before each `getConvo` call to block NoSQL operator injection (e.g., `{ "$gt": "" }`), which would have passed the ownership check while flowing as an operator object into the unscoped `getConvoFiles` query.
- Moved both ownership checks inside the existing `try/catch` blocks so MongoDB failures produce structured JSON error responses instead of unhandled promise rejections.
- Hardened the upstream TypeScript request validators in `packages/api/src/agents/openai/service.ts` and `packages/api/src/agents/responses/service.ts` as defense-in-depth, rejecting non-string values for `conversation_id` and `previous_response_id` at the validation layer before they reach the controller.
- Fixed the broken `~/models/Conversation` mock in `openai.spec.js`, which was missing `getConvo` entirely and would have thrown `TypeError: getConvo is not a function` on any test exercising the new guard.
- Added 10 unit tests across both controller test files (5 per controller) covering: owned conversation proceeds normally, unowned conversation returns 404, non-string ID returns 400, absent ID skips the check, and DB error returns a structured 500.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Unit tests were added directly to the existing controller test files and cover every branch of the new ownership guard. To reproduce:

```bash
cd api && npx jest server/controllers/agents/__tests__/openai.spec.js
cd api && npx jest server/controllers/agents/__tests__/responses.unit.spec.js
```

**Manual verification of the injection vector (before fix):** POST to `/v1/chat/completions` or `/v1/responses` with `"conversation_id": { "$gt": "" }` — the operator object passed the original `getConvo` check (matching the attacker's own first conversation) and flowed into `getConvoFiles` without user scoping, returning files from an arbitrary matched document.

**After fix:** the `typeof !== 'string'` guard returns a 400 before `getConvo` is called, and the TS validator rejects the same value at the parse layer. A valid string ID belonging to another user returns a 404 from `getConvo`.

### Test Configuration

- Node.js v20+
- MongoDB via `mongodb-memory-server` (per workspace test setup)
- No external services required; all DB interactions are mocked at the controller test level

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes