### PR TITLE
🔏 fix: Remove Federated Tokens from OpenID Refresh Response

### DIFF
--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -119,7 +119,8 @@ const refreshController = async (req, res) => {
 
       const token = setOpenIDAuthTokens(tokenset, req, res, user._id.toString(), refreshToken);
 
-      return res.status(200).send({ token, user });
+      const { password: _pw, __v: _v, totpSecret: _ts, backupCodes: _bc, ...safeUser } = user;
+      return res.status(200).send({ token, user: safeUser });
     } catch (error) {
       logger.error('[refreshController] OpenID token refresh error', error);
       return res.status(403).send('Invalid OpenID refresh token');

--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -119,13 +119,6 @@ const refreshController = async (req, res) => {
 
       const token = setOpenIDAuthTokens(tokenset, req, res, user._id.toString(), refreshToken);
 
-      user.federatedTokens = {
-        access_token: tokenset.access_token,
-        id_token: tokenset.id_token,
-        refresh_token: refreshToken,
-        expires_at: claims.exp,
-      };
-
       return res.status(200).send({ token, user });
     } catch (error) {
       logger.error('[refreshController] OpenID token refresh error', error);

--- a/api/server/controllers/AuthController.spec.js
+++ b/api/server/controllers/AuthController.spec.js
@@ -243,6 +243,24 @@ describe('refreshController – OpenID path', () => {
     );
   });
 
+  it('should not expose federatedTokens in refresh response user payload', async () => {
+    const user = {
+      _id: 'user-db-id',
+      email: baseClaims.email,
+      openidId: baseClaims.sub,
+    };
+    findOpenIDUser.mockResolvedValue({ user, error: null, migration: false });
+
+    await refreshController(req, res);
+
+    expect(res.send).toHaveBeenCalledWith({
+      token: 'new-app-token',
+      user: expect.not.objectContaining({
+        federatedTokens: expect.anything(),
+      }),
+    });
+  });
+
   it('should update openidId when migration is triggered on refresh', async () => {
     const user = { _id: 'user-db-id', email: baseClaims.email, openidId: null };
     findOpenIDUser.mockResolvedValue({ user, error: null, migration: true });

--- a/api/server/controllers/AuthController.spec.js
+++ b/api/server/controllers/AuthController.spec.js
@@ -163,6 +163,16 @@ describe('refreshController – OpenID path', () => {
     exp: 9999999999,
   };
 
+  const defaultUser = {
+    _id: 'user-db-id',
+    email: baseClaims.email,
+    openidId: baseClaims.sub,
+    password: '$2b$10$hashedpassword',
+    __v: 0,
+    totpSecret: 'encrypted-totp-secret',
+    backupCodes: ['hashed-code-1', 'hashed-code-2'],
+  };
+
   let req, res;
 
   beforeEach(() => {
@@ -174,6 +184,7 @@ describe('refreshController – OpenID path', () => {
     mockTokenset.claims.mockReturnValue(baseClaims);
     getOpenIdEmail.mockReturnValue(baseClaims.email);
     setOpenIDAuthTokens.mockReturnValue('new-app-token');
+    findOpenIDUser.mockResolvedValue({ user: { ...defaultUser }, error: null, migration: false });
     updateUser.mockResolvedValue({});
 
     req = {
@@ -189,13 +200,6 @@ describe('refreshController – OpenID path', () => {
   });
 
   it('should call getOpenIdEmail with token claims and use result for findOpenIDUser', async () => {
-    const user = {
-      _id: 'user-db-id',
-      email: baseClaims.email,
-      openidId: baseClaims.sub,
-    };
-    findOpenIDUser.mockResolvedValue({ user, error: null, migration: false });
-
     await refreshController(req, res);
 
     expect(getOpenIdEmail).toHaveBeenCalledWith(baseClaims);
@@ -229,13 +233,6 @@ describe('refreshController – OpenID path', () => {
   it('should fall back to claims.email when configured claim is absent from token claims', async () => {
     getOpenIdEmail.mockReturnValue(baseClaims.email);
 
-    const user = {
-      _id: 'user-db-id',
-      email: baseClaims.email,
-      openidId: baseClaims.sub,
-    };
-    findOpenIDUser.mockResolvedValue({ user, error: null, migration: false });
-
     await refreshController(req, res);
 
     expect(findOpenIDUser).toHaveBeenCalledWith(
@@ -243,22 +240,23 @@ describe('refreshController – OpenID path', () => {
     );
   });
 
-  it('should not expose federatedTokens in refresh response user payload', async () => {
-    const user = {
-      _id: 'user-db-id',
-      email: baseClaims.email,
-      openidId: baseClaims.sub,
-    };
-    findOpenIDUser.mockResolvedValue({ user, error: null, migration: false });
-
+  it('should not expose sensitive fields or federatedTokens in refresh response', async () => {
     await refreshController(req, res);
 
-    expect(res.send).toHaveBeenCalledWith({
+    const sentPayload = res.send.mock.calls[0][0];
+    expect(sentPayload).toEqual({
       token: 'new-app-token',
-      user: expect.not.objectContaining({
-        federatedTokens: expect.anything(),
+      user: expect.objectContaining({
+        _id: 'user-db-id',
+        email: baseClaims.email,
+        openidId: baseClaims.sub,
       }),
     });
+    expect(sentPayload.user).not.toHaveProperty('federatedTokens');
+    expect(sentPayload.user).not.toHaveProperty('password');
+    expect(sentPayload.user).not.toHaveProperty('totpSecret');
+    expect(sentPayload.user).not.toHaveProperty('backupCodes');
+    expect(sentPayload.user).not.toHaveProperty('__v');
   });
 
   it('should update openidId when migration is triggered on refresh', async () => {


### PR DESCRIPTION
## Summary

Fixed two credential-exposure bugs in the OpenID `refreshController` response path where server-side-protected tokens and sensitive user fields were being serialized into the JSON response body.

- Removed the explicit `user.federatedTokens` assignment before `res.send({ token, user })` in the OpenID refresh path, which was leaking `access_token`, `id_token`, `refresh_token`, and `expires_at` into the response body — tokens already stored server-side by `setOpenIDAuthTokens` (express session + HttpOnly cookies) and re-attached to `req.user` by the JWT strategy on every authenticated request.
- Destructured out `password`, `__v`, `totpSecret`, and `backupCodes` from the `findOpenIDUser` result before serializing, aligning the OpenID path with the non-OpenID path's explicit `getUserById` projection (`-password -__v -totpSecret -backupCodes`), which previously left 2FA secrets and password hashes exposed for migrated users.
- Strengthened the regression test: replaced `expect.not.objectContaining({ federatedTokens: expect.anything() })` with `not.toHaveProperty(...)` calls (which correctly catch `null`/`undefined` values), added a positive `objectContaining` shape assertion to prevent false-green passes on empty response objects, populated `defaultUser` with realistic sensitive field values, and extracted the duplicated mock fixture into a shared `defaultUser` constant with `findOpenIDUser` setup moved to `beforeEach`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified with the Jest suite in the `api` workspace (`cd api && npx jest AuthController`). The updated `refreshController – OpenID path` describe block covers the fix via the `should not expose sensitive fields or federatedTokens in refresh response` test, which:

- Seeds `findOpenIDUser` with a `defaultUser` containing populated `password`, `totpSecret`, `backupCodes`, and `__v` fields
- Asserts the sent payload contains the expected safe fields (`_id`, `email`, `openidId`) via `objectContaining`
- Asserts all five sensitive properties are absent via `not.toHaveProperty`, catching both omission and explicit `null`/`undefined` assignment

### **Test Configuration**:

- `OPENID_REUSE_TOKENS=true` (simulated via `isEnabled.mockReturnValue(true)`)
- No live IdP required — `openid-client`, `@librechat/api`, and all model dependencies are mocked

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes