### PR TITLE
🚰 fix: Prevent Env Var Exfil via User-Controlled Placeholders

### DIFF
--- a/packages/api/src/utils/env.spec.ts
+++ b/packages/api/src/utils/env.spec.ts
@@ -515,6 +515,45 @@ describe('resolveHeaders', () => {
     expect(result['X-Boolean']).toBe('true');
   });
 
+  describe('env-var injection through user-controlled values', () => {
+    const envKey = 'LIBRECHAT_TEST_INJECTION_CANARY';
+    let originalValue: string | undefined;
+
+    beforeEach(() => {
+      originalValue = process.env[envKey];
+      process.env[envKey] = 'leaked-secret';
+    });
+
+    afterEach(() => {
+      if (originalValue === undefined) {
+        delete process.env[envKey];
+      } else {
+        process.env[envKey] = originalValue;
+      }
+    });
+
+    it('should not expand env vars introduced through user placeholders', () => {
+      const user = { name: `\${${envKey}}` };
+      const headers = { 'X-User-Name': '{{LIBRECHAT_USER_NAME}}' };
+      const result = resolveHeaders({ headers, user });
+      expect(result['X-User-Name']).toBe(`\${${envKey}}`);
+    });
+
+    it('should not expand env vars introduced through customUserVars', () => {
+      const customUserVars = { MCP_API_KEY: `\${${envKey}}` };
+      const headers = { Authorization: 'Bearer {{MCP_API_KEY}}' };
+      const result = resolveHeaders({ headers, customUserVars });
+      expect(result['Authorization']).toBe(`Bearer \${${envKey}}`);
+    });
+
+    it('should not expand env vars introduced through body placeholders', () => {
+      const body = { conversationId: `\${${envKey}}` };
+      const headers = { 'X-Conv': '{{LIBRECHAT_BODY_CONVERSATIONID}}' };
+      const result = resolveHeaders({ headers, body });
+      expect(result['X-Conv']).toBe(`\${${envKey}}`);
+    });
+  });
+
   it('should process LIBRECHAT_BODY placeholders', () => {
     const body = {
       conversationId: 'conv-123',

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -226,6 +226,10 @@ function processSingleValue({
 
   let value = originalValue;
 
+  if (!dbSourced) {
+    value = extractEnvVariable(value);
+  }
+
   if (customUserVars) {
     for (const [varName, varVal] of Object.entries(customUserVars)) {
       /** Escaped varName for use in regex to avoid issues with special characters */
@@ -249,8 +253,6 @@ function processSingleValue({
   if (body) {
     value = processBodyPlaceholders(value, body);
   }
-
-  value = extractEnvVariable(value);
 
   return value;
 }


### PR DESCRIPTION

## Summary

Fixed a security vulnerability where user-controlled values could inject `${ENV_VAR}` patterns into the placeholder pipeline that `extractEnvVariable` would subsequently expand against `process.env`, leaking server secrets through outbound MCP headers, URLs, and environment arguments.

- Moved `extractEnvVariable` to the top of `processSingleValue`, before any user-controlled substitution takes place, so env expansion operates exclusively on the raw operator-defined template string.
- Gated env expansion behind `!dbSourced` to preserve existing behavior for DB-sourced servers, which already skip env expansion via early return.
- Added a `describe('env-var injection through user-controlled values')` regression block covering all three injection surfaces: user profile field placeholders (`{{LIBRECHAT_USER_NAME}}`), custom user vars (`{{MCP_API_KEY}}`), and body placeholders (`{{LIBRECHAT_BODY_CONVERSATIONID}}`).
- Used a namespaced canary env var (`LIBRECHAT_TEST_INJECTION_CANARY`) with proper `beforeEach`/`afterEach` save-and-restore, consistent with surrounding test patterns in the file.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The three new regression tests in `describe('env-var injection through user-controlled values')` each set `LIBRECHAT_TEST_INJECTION_CANARY=leaked-secret`, inject `${LIBRECHAT_TEST_INJECTION_CANARY}` through a specific user-controlled substitution surface, and assert that the literal string `${LIBRECHAT_TEST_INJECTION_CANARY}` is returned in the resolved output — not `leaked-secret`. All pre-existing `processMCPEnv`, `resolveHeaders`, and `resolveNestedObject` tests continue to pass, confirming that legitimate operator-defined `${ENV_VAR}` templates still resolve correctly.

### **Test Configuration**:

```
cd packages/api && npx jest env.spec
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes