### PR TITLE
🪢 fix: Action Domain Encoding Collision for HTTPS URLs

### DIFF
--- a/api/server/routes/agents/actions.js
+++ b/api/server/routes/agents/actions.js
@@ -123,14 +123,13 @@ router.post(
         return res.status(400).json({ message: 'Domain not allowed' });
       }
 
-      let { domain } = metadata;
-      domain = await domainParser(domain, true);
+      const encodedDomain = await domainParser(metadata.domain, true);
 
-      if (!domain) {
+      if (!encodedDomain) {
         return res.status(400).json({ message: 'No domain provided' });
       }
 
-      const legacyDomain = await legacyDomainEncode(metadata.domain);
+      const legacyDomain = legacyDomainEncode(metadata.domain);
 
       const action_id = _action_id ?? nanoid();
       const initialPromises = [];
@@ -166,21 +165,25 @@ router.post(
         actions.push(action);
       }
 
-      actions.push(`${domain}${actionDelimiter}${action_id}`);
+      actions.push(`${encodedDomain}${actionDelimiter}${action_id}`);
 
       /** @type {string[]}} */
       const { tools: _tools = [] } = agent;
 
-      const shouldRemoveTool = (tool) => {
+      const shouldRemoveAgentTool = (tool) => {
         if (!tool) {
           return false;
         }
-        return tool.includes(domain) || tool.includes(legacyDomain) || tool.includes(action_id);
+        return (
+          tool.includes(encodedDomain) || tool.includes(legacyDomain) || tool.includes(action_id)
+        );
       };
 
       const tools = _tools
-        .filter((tool) => !shouldRemoveTool(tool))
-        .concat(functions.map((tool) => `${tool.function.name}${actionDelimiter}${domain}`));
+        .filter((tool) => !shouldRemoveAgentTool(tool))
+        .concat(
+          functions.map((tool) => `${tool.function.name}${actionDelimiter}${encodedDomain}`),
+        );
 
       // Force version update since actions are changing
       const updatedAgent = await updateAgent(

--- a/api/server/routes/agents/actions.js
+++ b/api/server/routes/agents/actions.js
@@ -181,9 +181,7 @@ router.post(
 
       const tools = _tools
         .filter((tool) => !shouldRemoveAgentTool(tool))
-        .concat(
-          functions.map((tool) => `${tool.function.name}${actionDelimiter}${encodedDomain}`),
-        );
+        .concat(functions.map((tool) => `${tool.function.name}${actionDelimiter}${encodedDomain}`));
 
       // Force version update since actions are changing
       const updatedAgent = await updateAgent(

--- a/api/server/routes/agents/actions.js
+++ b/api/server/routes/agents/actions.js
@@ -12,7 +12,11 @@ const {
   validateActionDomain,
   validateAndParseOpenAPISpec,
 } = require('librechat-data-provider');
-const { encryptMetadata, domainParser } = require('~/server/services/ActionService');
+const {
+  legacyDomainEncode,
+  encryptMetadata,
+  domainParser,
+} = require('~/server/services/ActionService');
 const { findAccessibleResources } = require('~/server/services/PermissionService');
 const { getAgent, updateAgent, getListAgentsByAccess } = require('~/models/Agent');
 const { updateAction, getActions, deleteAction } = require('~/models/Action');
@@ -126,6 +130,8 @@ router.post(
         return res.status(400).json({ message: 'No domain provided' });
       }
 
+      const legacyDomain = await legacyDomainEncode(metadata.domain);
+
       const action_id = _action_id ?? nanoid();
       const initialPromises = [];
 
@@ -165,8 +171,15 @@ router.post(
       /** @type {string[]}} */
       const { tools: _tools = [] } = agent;
 
+      const shouldRemoveTool = (tool) => {
+        if (!tool) {
+          return false;
+        }
+        return tool.includes(domain) || tool.includes(legacyDomain) || tool.includes(action_id);
+      };
+
       const tools = _tools
-        .filter((tool) => !(tool && (tool.includes(domain) || tool.includes(action_id))))
+        .filter((tool) => !shouldRemoveTool(tool))
         .concat(functions.map((tool) => `${tool.function.name}${actionDelimiter}${domain}`));
 
       // Force version update since actions are changing
@@ -231,22 +244,22 @@ router.delete(
 
       const { tools = [], actions = [] } = agent;
 
-      let domain = '';
+      let storedDomain = '';
       const updatedActions = actions.filter((action) => {
         if (action.includes(action_id)) {
-          [domain] = action.split(actionDelimiter);
+          [storedDomain] = action.split(actionDelimiter);
           return false;
         }
         return true;
       });
 
-      domain = await domainParser(domain, true);
-
-      if (!domain) {
+      if (!storedDomain) {
         return res.status(400).json({ message: 'No domain provided' });
       }
 
-      const updatedTools = tools.filter((tool) => !(tool && tool.includes(domain)));
+      const updatedTools = tools.filter(
+        (tool) => !(tool && (tool.includes(storedDomain) || tool.includes(action_id))),
+      );
 
       // Force version update since actions are being removed
       await updateAgent(

--- a/api/server/routes/assistants/actions.js
+++ b/api/server/routes/assistants/actions.js
@@ -43,14 +43,13 @@ router.post('/:assistant_id', async (req, res) => {
       return res.status(400).json({ message: 'Domain not allowed' });
     }
 
-    let { domain } = metadata;
-    domain = await domainParser(domain, true);
+    const encodedDomain = await domainParser(metadata.domain, true);
 
-    if (!domain) {
+    if (!encodedDomain) {
       return res.status(400).json({ message: 'No domain provided' });
     }
 
-    const legacyDomain = await legacyDomainEncode(metadata.domain);
+    const legacyDomain = legacyDomainEncode(metadata.domain);
 
     const action_id = _action_id ?? nanoid();
     const initialPromises = [];
@@ -87,27 +86,29 @@ router.post('/:assistant_id', async (req, res) => {
       actions.push(action);
     }
 
-    actions.push(`${domain}${actionDelimiter}${action_id}`);
+    actions.push(`${encodedDomain}${actionDelimiter}${action_id}`);
 
     /** @type {{ tools: FunctionTool[] | { type: 'code_interpreter'|'retrieval'}[]}} */
     const { tools: _tools = [] } = assistant;
 
-    const shouldRemoveTool = (tool) => {
+    const shouldRemoveAssistantTool = (tool) => {
       if (!tool.function) {
         return false;
       }
       const name = tool.function.name;
-      return name.includes(domain) || name.includes(legacyDomain) || name.includes(action_id);
+      return (
+        name.includes(encodedDomain) || name.includes(legacyDomain) || name.includes(action_id)
+      );
     };
 
     const tools = _tools
-      .filter((tool) => !shouldRemoveTool(tool))
+      .filter((tool) => !shouldRemoveAssistantTool(tool))
       .concat(
         functions.map((tool) => ({
           ...tool,
           function: {
             ...tool.function,
-            name: `${tool.function.name}${actionDelimiter}${domain}`,
+            name: `${tool.function.name}${actionDelimiter}${encodedDomain}`,
           },
         })),
       );

--- a/api/server/routes/assistants/actions.js
+++ b/api/server/routes/assistants/actions.js
@@ -3,7 +3,11 @@ const { nanoid } = require('nanoid');
 const { logger } = require('@librechat/data-schemas');
 const { isActionDomainAllowed } = require('@librechat/api');
 const { actionDelimiter, EModelEndpoint, removeNullishValues } = require('librechat-data-provider');
-const { encryptMetadata, domainParser } = require('~/server/services/ActionService');
+const {
+  legacyDomainEncode,
+  encryptMetadata,
+  domainParser,
+} = require('~/server/services/ActionService');
 const { getOpenAIClient } = require('~/server/controllers/assistants/helpers');
 const { updateAction, getActions, deleteAction } = require('~/models/Action');
 const { updateAssistantDoc, getAssistant } = require('~/models/Assistant');
@@ -46,6 +50,8 @@ router.post('/:assistant_id', async (req, res) => {
       return res.status(400).json({ message: 'No domain provided' });
     }
 
+    const legacyDomain = await legacyDomainEncode(metadata.domain);
+
     const action_id = _action_id ?? nanoid();
     const initialPromises = [];
 
@@ -86,14 +92,16 @@ router.post('/:assistant_id', async (req, res) => {
     /** @type {{ tools: FunctionTool[] | { type: 'code_interpreter'|'retrieval'}[]}} */
     const { tools: _tools = [] } = assistant;
 
+    const shouldRemoveTool = (tool) => {
+      if (!tool.function) {
+        return false;
+      }
+      const name = tool.function.name;
+      return name.includes(domain) || name.includes(legacyDomain) || name.includes(action_id);
+    };
+
     const tools = _tools
-      .filter(
-        (tool) =>
-          !(
-            tool.function &&
-            (tool.function.name.includes(domain) || tool.function.name.includes(action_id))
-          ),
-      )
+      .filter((tool) => !shouldRemoveTool(tool))
       .concat(
         functions.map((tool) => ({
           ...tool,
@@ -171,23 +179,25 @@ router.delete('/:assistant_id/:action_id/:model', async (req, res) => {
     const { actions = [] } = assistant_data ?? {};
     const { tools = [] } = assistant ?? {};
 
-    let domain = '';
+    let storedDomain = '';
     const updatedActions = actions.filter((action) => {
       if (action.includes(action_id)) {
-        [domain] = action.split(actionDelimiter);
+        [storedDomain] = action.split(actionDelimiter);
         return false;
       }
       return true;
     });
 
-    domain = await domainParser(domain, true);
-
-    if (!domain) {
+    if (!storedDomain) {
       return res.status(400).json({ message: 'No domain provided' });
     }
 
     const updatedTools = tools.filter(
-      (tool) => !(tool.function && tool.function.name.includes(domain)),
+      (tool) =>
+        !(
+          tool.function &&
+          (tool.function.name.includes(storedDomain) || tool.function.name.includes(action_id))
+        ),
     );
 
     await openai.beta.assistants.update(assistant_id, { tools: updatedTools });

--- a/api/server/services/ActionService.js
+++ b/api/server/services/ActionService.js
@@ -28,6 +28,7 @@ const { getLogStores } = require('~/cache');
 
 const JWT_SECRET = process.env.JWT_SECRET;
 const toolNameRegex = /^[a-zA-Z0-9_-]+$/;
+const protocolRegex = /^https?:\/\//;
 const replaceSeparatorRegex = new RegExp(actionDomainSeparator, 'g');
 
 /**
@@ -48,7 +49,11 @@ const validateAndUpdateTool = async ({ req, tool, assistant_id }) => {
     actions = await getActions({ assistant_id, user: req.user.id }, true);
     const matchingActions = actions.filter((action) => {
       const metadata = action.metadata;
-      return metadata && metadata.domain === domain;
+      if (!metadata) {
+        return false;
+      }
+      const strippedMetaDomain = metadata.domain.replace(protocolRegex, '');
+      return strippedMetaDomain === domain || metadata.domain === domain;
     });
     const action = matchingActions[0];
     if (!action) {
@@ -66,10 +71,34 @@ const validateAndUpdateTool = async ({ req, tool, assistant_id }) => {
   return tool;
 };
 
+/** @param {string} domain */
+function stripProtocol(domain) {
+  return domain.replace(protocolRegex, '');
+}
+
+/**
+ * Encodes a domain using the legacy scheme (full URL including protocol).
+ * Used for backward-compatible matching against agents saved before the collision fix.
+ * @param {string} domain
+ * @returns {Promise<string>}
+ */
+async function legacyDomainEncode(domain) {
+  if (!domain) {
+    return '';
+  }
+  if (domain.length <= Constants.ENCODED_DOMAIN_LENGTH) {
+    return domain.replace(/\./g, actionDomainSeparator);
+  }
+  const modifiedDomain = Buffer.from(domain).toString('base64');
+  return modifiedDomain.substring(0, Constants.ENCODED_DOMAIN_LENGTH);
+}
+
 /**
  * Encodes or decodes a domain name to/from base64, or replacing periods with a custom separator.
  *
  * Necessary due to `[a-zA-Z0-9_-]*` Regex Validation, limited to a 64-character maximum.
+ * Strips protocol prefix before encoding to prevent base64 collisions
+ * (all `https://` URLs share the same 10-char base64 prefix).
  *
  * @param {string} domain - The domain name to encode/decode.
  * @param {boolean} inverse - False to decode from base64, true to encode to base64.
@@ -79,23 +108,27 @@ async function domainParser(domain, inverse = false) {
   if (!domain) {
     return;
   }
-  const domainsCache = getLogStores(CacheKeys.ENCODED_DOMAINS);
-  const cachedDomain = await domainsCache.get(domain);
-  if (inverse && cachedDomain) {
-    return domain;
-  }
 
-  if (inverse && domain.length <= Constants.ENCODED_DOMAIN_LENGTH) {
-    return domain.replace(/\./g, actionDomainSeparator);
-  }
+  const domainsCache = getLogStores(CacheKeys.ENCODED_DOMAINS);
 
   if (inverse) {
-    const modifiedDomain = Buffer.from(domain).toString('base64');
+    const hostname = stripProtocol(domain);
+    const cachedDomain = await domainsCache.get(hostname);
+    if (cachedDomain) {
+      return hostname;
+    }
+
+    if (hostname.length <= Constants.ENCODED_DOMAIN_LENGTH) {
+      return hostname.replace(/\./g, actionDomainSeparator);
+    }
+
+    const modifiedDomain = Buffer.from(hostname).toString('base64');
     const key = modifiedDomain.substring(0, Constants.ENCODED_DOMAIN_LENGTH);
     await domainsCache.set(key, modifiedDomain);
     return key;
   }
 
+  const cachedDomain = await domainsCache.get(domain);
   if (!cachedDomain) {
     return domain.replace(replaceSeparatorRegex, '.');
   }
@@ -456,9 +489,11 @@ const deleteAssistantActions = async ({ req, assistant_id }) => {
 module.exports = {
   deleteAssistantActions,
   validateAndUpdateTool,
+  legacyDomainEncode,
   createActionTool,
   encryptMetadata,
   decryptMetadata,
+  stripProtocol,
   loadActionSets,
   domainParser,
 };

--- a/api/server/services/ActionService.js
+++ b/api/server/services/ActionService.js
@@ -80,7 +80,7 @@ function stripProtocol(domain) {
  * Encodes a domain using the legacy scheme (full URL including protocol).
  * Used for backward-compatible matching against agents saved before the collision fix.
  * @param {string} domain
- * @returns {Promise<string>}
+ * @returns {string}
  */
 function legacyDomainEncode(domain) {
   if (!domain) {
@@ -493,7 +493,6 @@ module.exports = {
   createActionTool,
   encryptMetadata,
   decryptMetadata,
-  stripProtocol,
   loadActionSets,
   domainParser,
 };

--- a/api/server/services/ActionService.js
+++ b/api/server/services/ActionService.js
@@ -82,7 +82,7 @@ function stripProtocol(domain) {
  * @param {string} domain
  * @returns {Promise<string>}
  */
-async function legacyDomainEncode(domain) {
+function legacyDomainEncode(domain) {
   if (!domain) {
     return '';
   }

--- a/api/server/services/ActionService.js
+++ b/api/server/services/ActionService.js
@@ -52,7 +52,7 @@ const validateAndUpdateTool = async ({ req, tool, assistant_id }) => {
       if (!metadata) {
         return false;
       }
-      const strippedMetaDomain = metadata.domain.replace(protocolRegex, '');
+      const strippedMetaDomain = stripProtocol(metadata.domain);
       return strippedMetaDomain === domain || metadata.domain === domain;
     });
     const action = matchingActions[0];
@@ -73,7 +73,9 @@ const validateAndUpdateTool = async ({ req, tool, assistant_id }) => {
 
 /** @param {string} domain */
 function stripProtocol(domain) {
-  return domain.replace(protocolRegex, '');
+  const stripped = domain.replace(protocolRegex, '');
+  const pathIdx = stripped.indexOf('/');
+  return pathIdx === -1 ? stripped : stripped.substring(0, pathIdx);
 }
 
 /**

--- a/api/server/services/ActionService.spec.js
+++ b/api/server/services/ActionService.spec.js
@@ -109,6 +109,11 @@ describe('domainParser', () => {
       const result = await domainParser('https://a.b.c', true);
       expect(result).toBe(`a${SEP}b${SEP}c`);
     });
+
+    it('strips path and query from full URL before encoding', async () => {
+      const result = await domainParser('https://api.example.com/v1/endpoint?foo=bar', true);
+      expect(result).toBe(await domainParser('api.example.com', true));
+    });
   });
 
   describe('unicode domains', () => {

--- a/api/server/services/ActionService.spec.js
+++ b/api/server/services/ActionService.spec.js
@@ -1,7 +1,23 @@
-const { Constants, actionDelimiter, actionDomainSeparator } = require('librechat-data-provider');
-const { domainParser, legacyDomainEncode, stripProtocol } = require('./ActionService');
+const {
+  Constants,
+  actionDelimiter,
+  actionDomainSeparator,
+} = require('librechat-data-provider');
+const {
+  domainParser,
+  stripProtocol,
+  legacyDomainEncode,
+  validateAndUpdateTool,
+} = require('./ActionService');
 
 jest.mock('keyv');
+
+jest.mock('~/models/Action', () => ({
+  getActions: jest.fn(),
+  deleteActions: jest.fn(),
+}));
+
+const { getActions } = require('~/models/Action');
 
 let mockDomainCache = {};
 jest.mock('~/cache/getLogStores', () => {
@@ -16,6 +32,7 @@ jest.mock('~/cache/getLogStores', () => {
 
 beforeEach(() => {
   mockDomainCache = {};
+  getActions.mockReset();
 });
 
 const SEP = actionDomainSeparator;
@@ -121,6 +138,29 @@ describe('domainParser', () => {
     });
   });
 
+  describe('unicode domains', () => {
+    it('encodes unicode hostname via base64 path', async () => {
+      const domain = 'täst.example.com';
+      const result = await domainParser(domain, true);
+      expect(result).toHaveLength(MAX);
+      expect(result).toBe(
+        Buffer.from(domain).toString('base64').substring(0, MAX),
+      );
+    });
+
+    it('round-trips unicode hostname through encode then decode', async () => {
+      const domain = 'täst.example.com';
+      const key = await domainParser(domain, true);
+      expect(await domainParser(key, false)).toBe(domain);
+    });
+
+    it('strips protocol before encoding unicode hostname', async () => {
+      const withProto = 'https://täst.example.com';
+      const bare = 'täst.example.com';
+      expect(await domainParser(withProto, true)).toBe(await domainParser(bare, true));
+    });
+  });
+
   describe('decode path', () => {
     it('short-path encoded domain decodes via separator replacement', async () => {
       expect(await domainParser(`examp${SEP}com`, false)).toBe('examp.com');
@@ -136,52 +176,133 @@ describe('domainParser', () => {
       expect(await domainParser('not_base64_encoded', false)).toBe('not_base64_encoded');
     });
 
-    it('handles corrupt base64 cache entries gracefully', async () => {
-      mockDomainCache['corrupt_key'] = '!!!not-valid-base64!!!';
+    it('returns a string without throwing for corrupt cache entries', async () => {
+      mockDomainCache['corrupt_key'] = '!!!';
       const result = await domainParser('corrupt_key', false);
-      expect(result).toBeDefined();
+      expect(typeof result).toBe('string');
     });
   });
 });
 
 describe('legacyDomainEncode', () => {
-  it.each(['', null, undefined])('returns empty string for %j', async (input) => {
-    expect(await legacyDomainEncode(input)).toBe('');
+  it.each(['', null, undefined])('returns empty string for %j', (input) => {
+    expect(legacyDomainEncode(input)).toBe('');
   });
 
-  it('uses dot-replacement for short domains', async () => {
-    expect(await legacyDomainEncode('examp.com')).toBe(`examp${SEP}com`);
+  it('is synchronous (returns a string, not a Promise)', () => {
+    const result = legacyDomainEncode('examp.com');
+    expect(result).toBe(`examp${SEP}com`);
+    expect(result).not.toBeInstanceOf(Promise);
   });
 
-  it('uses base64 prefix of full input for long domains', async () => {
+  it('uses dot-replacement for short domains', () => {
+    expect(legacyDomainEncode('examp.com')).toBe(`examp${SEP}com`);
+  });
+
+  it('uses base64 prefix of full input for long domains', () => {
     const domain = 'https://swapi.tech';
     const expected = Buffer.from(domain).toString('base64').substring(0, MAX);
-    expect(await legacyDomainEncode(domain)).toBe(expected);
+    expect(legacyDomainEncode(domain)).toBe(expected);
   });
 
-  it('all https:// URLs collide to the same key', async () => {
-    const results = await Promise.all([
+  it('all https:// URLs collide to the same key', () => {
+    const results = [
       legacyDomainEncode('https://api.example.com'),
       legacyDomainEncode('https://api.weather.com'),
       legacyDomainEncode('https://totally.different.host'),
-    ]);
+    ];
     expect(new Set(results).size).toBe(1);
   });
 
-  it('matches what old domainParser would have produced', async () => {
+  it('matches what old domainParser would have produced', () => {
     const domain = 'https://api.example.com';
-    const legacy = await legacyDomainEncode(domain);
+    const legacy = legacyDomainEncode(domain);
     expect(legacy).toBe(Buffer.from(domain).toString('base64').substring(0, MAX));
+  });
+
+  it('produces same result as new domainParser for short bare hostnames', async () => {
+    const domain = 'swapi.tech';
+    expect(legacyDomainEncode(domain)).toBe(await domainParser(domain, true));
+  });
+});
+
+describe('validateAndUpdateTool', () => {
+  const mockReq = { user: { id: 'user123' } };
+
+  it('returns tool unchanged when name passes tool-name regex', async () => {
+    const tool = { function: { name: 'getPeople_action_swapi---tech' } };
+    const result = await validateAndUpdateTool({
+      req: mockReq,
+      tool,
+      assistant_id: 'asst_1',
+    });
+    expect(result).toEqual(tool);
+    expect(getActions).not.toHaveBeenCalled();
+  });
+
+  it('matches action when metadata.domain has https:// prefix and tool domain is bare hostname', async () => {
+    getActions.mockResolvedValue([
+      { metadata: { domain: 'https://api.example.com' } },
+    ]);
+
+    const tool = { function: { name: `getPeople${DELIM}api.example.com` } };
+    const result = await validateAndUpdateTool({
+      req: mockReq,
+      tool,
+      assistant_id: 'asst_1',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.function.name).toMatch(/^getPeople_action_/);
+    expect(result.function.name).not.toContain('.');
+  });
+
+  it('matches action when metadata.domain has no protocol', async () => {
+    getActions.mockResolvedValue([
+      { metadata: { domain: 'api.example.com' } },
+    ]);
+
+    const tool = { function: { name: `getPeople${DELIM}api.example.com` } };
+    const result = await validateAndUpdateTool({
+      req: mockReq,
+      tool,
+      assistant_id: 'asst_1',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.function.name).toMatch(/^getPeople_action_/);
+  });
+
+  it('returns null when no action matches the domain', async () => {
+    getActions.mockResolvedValue([
+      { metadata: { domain: 'https://other.domain.com' } },
+    ]);
+
+    const tool = { function: { name: `getPeople${DELIM}api.example.com` } };
+    const result = await validateAndUpdateTool({
+      req: mockReq,
+      tool,
+      assistant_id: 'asst_1',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when action has no metadata', async () => {
+    getActions.mockResolvedValue([{ metadata: null }]);
+
+    const tool = { function: { name: `getPeople${DELIM}api.example.com` } };
+    const result = await validateAndUpdateTool({
+      req: mockReq,
+      tool,
+      assistant_id: 'asst_1',
+    });
+
+    expect(result).toBeNull();
   });
 });
 
 describe('backward-compatible tool name matching', () => {
-  /**
-   * Simulates the matching logic in getActionToolDefinitions and loadActionToolsForExecution.
-   * These tests verify that the real domain encoding + normalization patterns
-   * produce tool names that match against both old and new stored formats.
-   */
-
   function normalizeToolName(name) {
     return name.replace(domainSepRegex, '_');
   }
@@ -204,7 +325,7 @@ describe('backward-compatible tool name matching', () => {
 
     it('legacy encoding matches agent tools stored with legacy encoding', async () => {
       const metadataDomain = 'https://swapi.tech';
-      const legacy = await legacyDomainEncode(metadataDomain);
+      const legacy = legacyDomainEncode(metadataDomain);
       const legacyNormalized = normalizeToolName(legacy);
 
       const storedTool = buildToolName('getPeople', legacy);
@@ -216,7 +337,7 @@ describe('backward-compatible tool name matching', () => {
     it('new definition matches old stored tools via legacy fallback', async () => {
       const metadataDomain = 'https://swapi.tech';
       const newDomain = await domainParser(metadataDomain, true);
-      const legacyDomain = await legacyDomainEncode(metadataDomain);
+      const legacyDomain = legacyDomainEncode(metadataDomain);
       const newNorm = normalizeToolName(newDomain);
       const legacyNorm = normalizeToolName(legacyDomain);
 
@@ -227,6 +348,25 @@ describe('backward-compatible tool name matching', () => {
       const storedNormalized = normalizeToolName(oldStoredTool);
       const hasMatch = storedNormalized === newToolName || storedNormalized === legacyToolName;
       expect(hasMatch).toBe(true);
+    });
+
+    it('pre-normalized Set eliminates per-tool normalization', async () => {
+      const metadataDomain = 'https://api.example.com';
+      const domain = await domainParser(metadataDomain, true);
+      const legacyDomain = legacyDomainEncode(metadataDomain);
+      const normalizedDomain = normalizeToolName(domain);
+      const legacyNormalized = normalizeToolName(legacyDomain);
+
+      const storedTools = [
+        buildToolName('getWeather', legacyDomain),
+        buildToolName('getForecast', domain),
+      ];
+
+      const preNormalized = new Set(storedTools.map((t) => normalizeToolName(t)));
+
+      const toolName = `getWeather${DELIM}${normalizedDomain}`;
+      const legacyToolName = `getWeather${DELIM}${legacyNormalized}`;
+      expect(preNormalized.has(toolName) || preNormalized.has(legacyToolName)).toBe(true);
     });
   });
 
@@ -258,7 +398,7 @@ describe('backward-compatible tool name matching', () => {
     it('model-called tool name resolves via legacy entry in normalizedToDomain map', async () => {
       const metadataDomain = 'https://api.example.com';
       const domain = await domainParser(metadataDomain, true);
-      const legacyDomain = await legacyDomainEncode(metadataDomain);
+      const legacyDomain = legacyDomainEncode(metadataDomain);
       const legacyNorm = normalizeToolName(legacyDomain);
 
       const normalizedToDomain = new Map();
@@ -277,13 +417,90 @@ describe('backward-compatible tool name matching', () => {
 
       expect(matched).toBe(domain);
     });
+
+    it('legacy guard skips duplicate map entry for short bare hostnames', async () => {
+      const domain = 'swapi.tech';
+      const newEncoding = await domainParser(domain, true);
+      const legacyEncoding = legacyDomainEncode(domain);
+
+      expect(newEncoding).toBe(legacyEncoding);
+
+      const normalizedToDomain = new Map();
+      normalizedToDomain.set(newEncoding, newEncoding);
+      if (legacyEncoding !== newEncoding) {
+        normalizedToDomain.set(legacyEncoding, newEncoding);
+      }
+      expect(normalizedToDomain.size).toBe(1);
+    });
+  });
+
+  describe('processRequiredActions matching (assistants path)', () => {
+    it('legacy tool from OpenAI matches via normalizedToDomain with both encodings', async () => {
+      const metadataDomain = 'https://swapi.tech';
+      const domain = await domainParser(metadataDomain, true);
+      const legacyDomain = legacyDomainEncode(metadataDomain);
+
+      const normalizedToDomain = new Map();
+      normalizedToDomain.set(domain, domain);
+      if (legacyDomain !== domain) {
+        normalizedToDomain.set(legacyDomain, domain);
+      }
+
+      const legacyToolName = buildToolName('getPeople', legacyDomain);
+
+      let currentDomain = '';
+      let matchedKey = '';
+      for (const [key, canonical] of normalizedToDomain.entries()) {
+        if (legacyToolName.includes(key)) {
+          currentDomain = canonical;
+          matchedKey = key;
+          break;
+        }
+      }
+
+      expect(currentDomain).toBe(domain);
+      expect(matchedKey).toBe(legacyDomain);
+
+      const functionName = legacyToolName.replace(`${DELIM}${matchedKey}`, '');
+      expect(functionName).toBe('getPeople');
+    });
+
+    it('new tool name matches via the canonical domain key', async () => {
+      const metadataDomain = 'https://swapi.tech';
+      const domain = await domainParser(metadataDomain, true);
+      const legacyDomain = legacyDomainEncode(metadataDomain);
+
+      const normalizedToDomain = new Map();
+      normalizedToDomain.set(domain, domain);
+      if (legacyDomain !== domain) {
+        normalizedToDomain.set(legacyDomain, domain);
+      }
+
+      const newToolName = buildToolName('getPeople', domain);
+
+      let currentDomain = '';
+      let matchedKey = '';
+      for (const [key, canonical] of normalizedToDomain.entries()) {
+        if (newToolName.includes(key)) {
+          currentDomain = canonical;
+          matchedKey = key;
+          break;
+        }
+      }
+
+      expect(currentDomain).toBe(domain);
+      expect(matchedKey).toBe(domain);
+
+      const functionName = newToolName.replace(`${DELIM}${matchedKey}`, '');
+      expect(functionName).toBe('getPeople');
+    });
   });
 
   describe('save-route cleanup', () => {
     it('tool filter removes tools matching new encoding', async () => {
       const metadataDomain = 'https://swapi.tech';
       const domain = await domainParser(metadataDomain, true);
-      const legacyDomain = await legacyDomainEncode(metadataDomain);
+      const legacyDomain = legacyDomainEncode(metadataDomain);
 
       const tools = [
         buildToolName('getPeople', domain),
@@ -298,7 +515,7 @@ describe('backward-compatible tool name matching', () => {
     it('tool filter removes tools matching legacy encoding', async () => {
       const metadataDomain = 'https://swapi.tech';
       const domain = await domainParser(metadataDomain, true);
-      const legacyDomain = await legacyDomainEncode(metadataDomain);
+      const legacyDomain = legacyDomainEncode(metadataDomain);
 
       const tools = [
         buildToolName('getPeople', legacyDomain),
@@ -339,9 +556,9 @@ describe('backward-compatible tool name matching', () => {
       expect(tool1).not.toBe(tool2);
     });
 
-    it('two https:// actions used to collide in legacy encoding', async () => {
-      const legacy1 = await legacyDomainEncode('https://api.weather.com');
-      const legacy2 = await legacyDomainEncode('https://api.spacex.com');
+    it('two https:// actions used to collide in legacy encoding', () => {
+      const legacy1 = legacyDomainEncode('https://api.weather.com');
+      const legacy2 = legacyDomainEncode('https://api.spacex.com');
 
       const tool1 = buildToolName('getData', legacy1);
       const tool2 = buildToolName('getData', legacy2);

--- a/api/server/services/ActionService.spec.js
+++ b/api/server/services/ActionService.spec.js
@@ -1,14 +1,5 @@
-const {
-  Constants,
-  actionDelimiter,
-  actionDomainSeparator,
-} = require('librechat-data-provider');
-const {
-  domainParser,
-  stripProtocol,
-  legacyDomainEncode,
-  validateAndUpdateTool,
-} = require('./ActionService');
+const { Constants, actionDelimiter, actionDomainSeparator } = require('librechat-data-provider');
+const { domainParser, legacyDomainEncode, validateAndUpdateTool } = require('./ActionService');
 
 jest.mock('keyv');
 
@@ -39,24 +30,6 @@ const SEP = actionDomainSeparator;
 const DELIM = actionDelimiter;
 const MAX = Constants.ENCODED_DOMAIN_LENGTH;
 const domainSepRegex = new RegExp(SEP, 'g');
-
-describe('stripProtocol', () => {
-  it.each([
-    ['https://swapi.tech', 'swapi.tech'],
-    ['http://api.example.com', 'api.example.com'],
-    ['https://192.168.1.1', '192.168.1.1'],
-    ['http://localhost:3000', 'localhost:3000'],
-  ])('strips protocol from %s', (input, expected) => {
-    expect(stripProtocol(input)).toBe(expected);
-  });
-
-  it.each(['swapi.tech', 'api.example.com', 'localhost', ''])(
-    'leaves %j unchanged when no protocol present',
-    (input) => {
-      expect(stripProtocol(input)).toBe(input);
-    },
-  );
-});
 
 describe('domainParser', () => {
   describe('nullish input', () => {
@@ -143,9 +116,7 @@ describe('domainParser', () => {
       const domain = 'täst.example.com';
       const result = await domainParser(domain, true);
       expect(result).toHaveLength(MAX);
-      expect(result).toBe(
-        Buffer.from(domain).toString('base64').substring(0, MAX),
-      );
+      expect(result).toBe(Buffer.from(domain).toString('base64').substring(0, MAX));
     });
 
     it('round-trips unicode hostname through encode then decode', async () => {
@@ -241,9 +212,7 @@ describe('validateAndUpdateTool', () => {
   });
 
   it('matches action when metadata.domain has https:// prefix and tool domain is bare hostname', async () => {
-    getActions.mockResolvedValue([
-      { metadata: { domain: 'https://api.example.com' } },
-    ]);
+    getActions.mockResolvedValue([{ metadata: { domain: 'https://api.example.com' } }]);
 
     const tool = { function: { name: `getPeople${DELIM}api.example.com` } };
     const result = await validateAndUpdateTool({
@@ -258,9 +227,7 @@ describe('validateAndUpdateTool', () => {
   });
 
   it('matches action when metadata.domain has no protocol', async () => {
-    getActions.mockResolvedValue([
-      { metadata: { domain: 'api.example.com' } },
-    ]);
+    getActions.mockResolvedValue([{ metadata: { domain: 'api.example.com' } }]);
 
     const tool = { function: { name: `getPeople${DELIM}api.example.com` } };
     const result = await validateAndUpdateTool({
@@ -274,9 +241,7 @@ describe('validateAndUpdateTool', () => {
   });
 
   it('returns null when no action matches the domain', async () => {
-    getActions.mockResolvedValue([
-      { metadata: { domain: 'https://other.domain.com' } },
-    ]);
+    getActions.mockResolvedValue([{ metadata: { domain: 'https://other.domain.com' } }]);
 
     const tool = { function: { name: `getPeople${DELIM}api.example.com` } };
     const result = await validateAndUpdateTool({

--- a/api/server/services/ActionService.spec.js
+++ b/api/server/services/ActionService.spec.js
@@ -1,175 +1,352 @@
-const { Constants, actionDomainSeparator } = require('librechat-data-provider');
-const { domainParser } = require('./ActionService');
+const { Constants, actionDelimiter, actionDomainSeparator } = require('librechat-data-provider');
+const { domainParser, legacyDomainEncode, stripProtocol } = require('./ActionService');
 
 jest.mock('keyv');
 
-const globalCache = {};
+let mockDomainCache = {};
 jest.mock('~/cache/getLogStores', () => {
-  return jest.fn().mockImplementation(() => {
-    const EventEmitter = require('events');
-    const { CacheKeys } = require('librechat-data-provider');
+  return jest.fn().mockImplementation(() => ({
+    get: async (key) => mockDomainCache[key] ?? null,
+    set: async (key, value) => {
+      mockDomainCache[key] = value;
+      return true;
+    },
+  }));
+});
 
-    class KeyvMongo extends EventEmitter {
-      constructor(url = 'mongodb://127.0.0.1:27017', options) {
-        super();
-        this.ttlSupport = false;
-        url = url ?? {};
-        if (typeof url === 'string') {
-          url = { url };
-        }
-        if (url.uri) {
-          url = { url: url.uri, ...url };
-        }
-        this.opts = {
-          url,
-          collection: 'keyv',
-          ...url,
-          ...options,
-        };
-      }
+beforeEach(() => {
+  mockDomainCache = {};
+});
 
-      get = async (key) => {
-        return new Promise((resolve) => {
-          resolve(globalCache[key] || null);
-        });
-      };
+const SEP = actionDomainSeparator;
+const DELIM = actionDelimiter;
+const MAX = Constants.ENCODED_DOMAIN_LENGTH;
+const domainSepRegex = new RegExp(SEP, 'g');
 
-      set = async (key, value) => {
-        return new Promise((resolve) => {
-          globalCache[key] = value;
-          resolve(true);
-        });
-      };
-    }
+describe('stripProtocol', () => {
+  it.each([
+    ['https://swapi.tech', 'swapi.tech'],
+    ['http://api.example.com', 'api.example.com'],
+    ['https://192.168.1.1', '192.168.1.1'],
+    ['http://localhost:3000', 'localhost:3000'],
+  ])('strips protocol from %s', (input, expected) => {
+    expect(stripProtocol(input)).toBe(expected);
+  });
 
-    return new KeyvMongo('', {
-      namespace: CacheKeys.ENCODED_DOMAINS,
-      ttl: 0,
+  it.each(['swapi.tech', 'api.example.com', 'localhost', ''])(
+    'leaves %j unchanged when no protocol present',
+    (input) => {
+      expect(stripProtocol(input)).toBe(input);
+    },
+  );
+});
+
+describe('domainParser', () => {
+  describe('nullish input', () => {
+    it.each([null, undefined, ''])('returns undefined for %j', async (input) => {
+      expect(await domainParser(input, true)).toBeUndefined();
+      expect(await domainParser(input, false)).toBeUndefined();
+    });
+  });
+
+  describe('short-path encoding (hostname ≤ threshold)', () => {
+    it.each([
+      ['examp.com', `examp${SEP}com`],
+      ['swapi.tech', `swapi${SEP}tech`],
+      ['a.b', `a${SEP}b`],
+    ])('replaces dots in %s → %s', async (domain, expected) => {
+      expect(await domainParser(domain, true)).toBe(expected);
+    });
+
+    it('handles domain exactly at threshold length', async () => {
+      const domain = 'a'.repeat(MAX - 4) + '.com';
+      expect(domain).toHaveLength(MAX);
+      const result = await domainParser(domain, true);
+      expect(result).toBe(domain.replace(/\./g, SEP));
+    });
+  });
+
+  describe('base64-path encoding (hostname > threshold)', () => {
+    it('produces a key of exactly ENCODED_DOMAIN_LENGTH chars', async () => {
+      const result = await domainParser('api.example.com', true);
+      expect(result).toHaveLength(MAX);
+    });
+
+    it('encodes hostname, not full URL', async () => {
+      const hostname = 'api.example.com';
+      const expectedKey = Buffer.from(hostname).toString('base64').substring(0, MAX);
+      expect(await domainParser(hostname, true)).toBe(expectedKey);
+    });
+
+    it('populates decode cache for round-trip', async () => {
+      const hostname = 'longdomainname.com';
+      const key = await domainParser(hostname, true);
+
+      expect(mockDomainCache[key]).toBe(Buffer.from(hostname).toString('base64'));
+      expect(await domainParser(key, false)).toBe(hostname);
+    });
+  });
+
+  describe('protocol stripping', () => {
+    it('https:// URL and bare hostname produce identical encoding', async () => {
+      const encoded = await domainParser('https://swapi.tech', true);
+      expect(encoded).toBe(await domainParser('swapi.tech', true));
+      expect(encoded).toBe(`swapi${SEP}tech`);
+    });
+
+    it('http:// URL and bare hostname produce identical encoding', async () => {
+      const encoded = await domainParser('http://api.example.com', true);
+      expect(encoded).toBe(await domainParser('api.example.com', true));
+    });
+
+    it('different https:// domains produce unique keys', async () => {
+      const keys = await Promise.all([
+        domainParser('https://api.example.com', true),
+        domainParser('https://api.weather.com', true),
+        domainParser('https://data.github.com', true),
+      ]);
+      const unique = new Set(keys);
+      expect(unique.size).toBe(keys.length);
+    });
+
+    it('long hostname after stripping still uses base64 path', async () => {
+      const result = await domainParser('https://api.example.com', true);
+      expect(result).toHaveLength(MAX);
+      expect(result).not.toContain(SEP);
+    });
+
+    it('short hostname after stripping uses dot-replacement path', async () => {
+      const result = await domainParser('https://a.b.c', true);
+      expect(result).toBe(`a${SEP}b${SEP}c`);
+    });
+  });
+
+  describe('decode path', () => {
+    it('short-path encoded domain decodes via separator replacement', async () => {
+      expect(await domainParser(`examp${SEP}com`, false)).toBe('examp.com');
+    });
+
+    it('base64-path encoded domain decodes via cache lookup', async () => {
+      const hostname = 'api.example.com';
+      const key = await domainParser(hostname, true);
+      expect(await domainParser(key, false)).toBe(hostname);
+    });
+
+    it('returns input unchanged for unknown non-separator strings', async () => {
+      expect(await domainParser('not_base64_encoded', false)).toBe('not_base64_encoded');
+    });
+
+    it('handles corrupt base64 cache entries gracefully', async () => {
+      mockDomainCache['corrupt_key'] = '!!!not-valid-base64!!!';
+      const result = await domainParser('corrupt_key', false);
+      expect(result).toBeDefined();
     });
   });
 });
 
-describe('domainParser', () => {
-  const TLD = '.com';
-
-  // Non-azure request
-  it('does not return domain as is if not azure', async () => {
-    const domain = `example.com${actionDomainSeparator}test${actionDomainSeparator}`;
-    const result1 = await domainParser(domain, false);
-    const result2 = await domainParser(domain, true);
-    expect(result1).not.toEqual(domain);
-    expect(result2).not.toEqual(domain);
+describe('legacyDomainEncode', () => {
+  it.each(['', null, undefined])('returns empty string for %j', async (input) => {
+    expect(await legacyDomainEncode(input)).toBe('');
   });
 
-  // Test for Empty or Null Inputs
-  it('returns undefined for null domain input', async () => {
-    const result = await domainParser(null, true);
-    expect(result).toBeUndefined();
+  it('uses dot-replacement for short domains', async () => {
+    expect(await legacyDomainEncode('examp.com')).toBe(`examp${SEP}com`);
   });
 
-  it('returns undefined for empty domain input', async () => {
-    const result = await domainParser('', true);
-    expect(result).toBeUndefined();
+  it('uses base64 prefix of full input for long domains', async () => {
+    const domain = 'https://swapi.tech';
+    const expected = Buffer.from(domain).toString('base64').substring(0, MAX);
+    expect(await legacyDomainEncode(domain)).toBe(expected);
   });
 
-  // Verify Correct Caching Behavior
-  it('caches encoded domain correctly', async () => {
-    const domain = 'longdomainname.com';
-    const encodedDomain = Buffer.from(domain)
-      .toString('base64')
-      .substring(0, Constants.ENCODED_DOMAIN_LENGTH);
-
-    await domainParser(domain, true);
-
-    const cachedValue = await globalCache[encodedDomain];
-    expect(cachedValue).toEqual(Buffer.from(domain).toString('base64'));
+  it('all https:// URLs collide to the same key', async () => {
+    const results = await Promise.all([
+      legacyDomainEncode('https://api.example.com'),
+      legacyDomainEncode('https://api.weather.com'),
+      legacyDomainEncode('https://totally.different.host'),
+    ]);
+    expect(new Set(results).size).toBe(1);
   });
 
-  // Test for Edge Cases Around Length Threshold
-  it('encodes domain exactly at threshold without modification', async () => {
-    const domain = 'a'.repeat(Constants.ENCODED_DOMAIN_LENGTH - TLD.length) + TLD;
-    const expected = domain.replace(/\./g, actionDomainSeparator);
-    const result = await domainParser(domain, true);
-    expect(result).toEqual(expected);
+  it('matches what old domainParser would have produced', async () => {
+    const domain = 'https://api.example.com';
+    const legacy = await legacyDomainEncode(domain);
+    expect(legacy).toBe(Buffer.from(domain).toString('base64').substring(0, MAX));
+  });
+});
+
+describe('backward-compatible tool name matching', () => {
+  /**
+   * Simulates the matching logic in getActionToolDefinitions and loadActionToolsForExecution.
+   * These tests verify that the real domain encoding + normalization patterns
+   * produce tool names that match against both old and new stored formats.
+   */
+
+  function normalizeToolName(name) {
+    return name.replace(domainSepRegex, '_');
+  }
+
+  function buildToolName(functionName, encodedDomain) {
+    return `${functionName}${DELIM}${encodedDomain}`;
+  }
+
+  describe('definition-phase matching', () => {
+    it('new encoding matches agent tools stored with new encoding', async () => {
+      const metadataDomain = 'https://swapi.tech';
+      const encoded = await domainParser(metadataDomain, true);
+      const normalized = normalizeToolName(encoded);
+
+      const storedTool = buildToolName('getPeople', encoded);
+      const defToolName = `getPeople${DELIM}${normalized}`;
+
+      expect(normalizeToolName(storedTool)).toBe(defToolName);
+    });
+
+    it('legacy encoding matches agent tools stored with legacy encoding', async () => {
+      const metadataDomain = 'https://swapi.tech';
+      const legacy = await legacyDomainEncode(metadataDomain);
+      const legacyNormalized = normalizeToolName(legacy);
+
+      const storedTool = buildToolName('getPeople', legacy);
+      const legacyDefName = `getPeople${DELIM}${legacyNormalized}`;
+
+      expect(normalizeToolName(storedTool)).toBe(legacyDefName);
+    });
+
+    it('new definition matches old stored tools via legacy fallback', async () => {
+      const metadataDomain = 'https://swapi.tech';
+      const newDomain = await domainParser(metadataDomain, true);
+      const legacyDomain = await legacyDomainEncode(metadataDomain);
+      const newNorm = normalizeToolName(newDomain);
+      const legacyNorm = normalizeToolName(legacyDomain);
+
+      const oldStoredTool = buildToolName('getPeople', legacyDomain);
+      const newToolName = `getPeople${DELIM}${newNorm}`;
+      const legacyToolName = `getPeople${DELIM}${legacyNorm}`;
+
+      const storedNormalized = normalizeToolName(oldStoredTool);
+      const hasMatch = storedNormalized === newToolName || storedNormalized === legacyToolName;
+      expect(hasMatch).toBe(true);
+    });
   });
 
-  it('encodes domain just below threshold without modification', async () => {
-    const domain = 'a'.repeat(Constants.ENCODED_DOMAIN_LENGTH - 1 - TLD.length) + TLD;
-    const expected = domain.replace(/\./g, actionDomainSeparator);
-    const result = await domainParser(domain, true);
-    expect(result).toEqual(expected);
+  describe('execution-phase tool lookup', () => {
+    it('model-called tool name resolves via normalizedToDomain map (new encoding)', async () => {
+      const metadataDomain = 'https://api.example.com';
+      const domain = await domainParser(metadataDomain, true);
+      const normalized = normalizeToolName(domain);
+
+      const normalizedToDomain = new Map();
+      normalizedToDomain.set(normalized, domain);
+
+      const modelToolName = `getWeather${DELIM}${normalized}`;
+
+      let matched = '';
+      for (const [norm, canonical] of normalizedToDomain.entries()) {
+        if (modelToolName.includes(norm)) {
+          matched = canonical;
+          break;
+        }
+      }
+
+      expect(matched).toBe(domain);
+
+      const functionName = modelToolName.replace(`${DELIM}${normalizeToolName(matched)}`, '');
+      expect(functionName).toBe('getWeather');
+    });
+
+    it('model-called tool name resolves via legacy entry in normalizedToDomain map', async () => {
+      const metadataDomain = 'https://api.example.com';
+      const domain = await domainParser(metadataDomain, true);
+      const legacyDomain = await legacyDomainEncode(metadataDomain);
+      const legacyNorm = normalizeToolName(legacyDomain);
+
+      const normalizedToDomain = new Map();
+      normalizedToDomain.set(normalizeToolName(domain), domain);
+      normalizedToDomain.set(legacyNorm, domain);
+
+      const legacyModelToolName = `getWeather${DELIM}${legacyNorm}`;
+
+      let matched = '';
+      for (const [norm, canonical] of normalizedToDomain.entries()) {
+        if (legacyModelToolName.includes(norm)) {
+          matched = canonical;
+          break;
+        }
+      }
+
+      expect(matched).toBe(domain);
+    });
   });
 
-  // Test for Unicode Domain Names
-  it('handles unicode characters in domain names correctly when encoding', async () => {
-    const unicodeDomain = 'täst.example.com';
-    const encodedDomain = Buffer.from(unicodeDomain)
-      .toString('base64')
-      .substring(0, Constants.ENCODED_DOMAIN_LENGTH);
-    const result = await domainParser(unicodeDomain, true);
-    expect(result).toEqual(encodedDomain);
+  describe('save-route cleanup', () => {
+    it('tool filter removes tools matching new encoding', async () => {
+      const metadataDomain = 'https://swapi.tech';
+      const domain = await domainParser(metadataDomain, true);
+      const legacyDomain = await legacyDomainEncode(metadataDomain);
+
+      const tools = [
+        buildToolName('getPeople', domain),
+        buildToolName('unrelated', 'other---domain'),
+      ];
+
+      const filtered = tools.filter((t) => !t.includes(domain) && !t.includes(legacyDomain));
+
+      expect(filtered).toEqual([buildToolName('unrelated', 'other---domain')]);
+    });
+
+    it('tool filter removes tools matching legacy encoding', async () => {
+      const metadataDomain = 'https://swapi.tech';
+      const domain = await domainParser(metadataDomain, true);
+      const legacyDomain = await legacyDomainEncode(metadataDomain);
+
+      const tools = [
+        buildToolName('getPeople', legacyDomain),
+        buildToolName('unrelated', 'other---domain'),
+      ];
+
+      const filtered = tools.filter((t) => !t.includes(domain) && !t.includes(legacyDomain));
+
+      expect(filtered).toEqual([buildToolName('unrelated', 'other---domain')]);
+    });
   });
 
-  it('decodes unicode domain names correctly', async () => {
-    const unicodeDomain = 'täst.example.com';
-    const encodedDomain = Buffer.from(unicodeDomain).toString('base64');
-    globalCache[encodedDomain.substring(0, Constants.ENCODED_DOMAIN_LENGTH)] = encodedDomain; // Simulate caching
+  describe('delete-route domain extraction', () => {
+    it('domain extracted from actions array is usable as-is for tool filtering', async () => {
+      const metadataDomain = 'https://api.example.com';
+      const domain = await domainParser(metadataDomain, true);
+      const actionId = 'abc123';
+      const actionEntry = `${domain}${DELIM}${actionId}`;
 
-    const result = await domainParser(
-      encodedDomain.substring(0, Constants.ENCODED_DOMAIN_LENGTH),
-      false,
-    );
-    expect(result).toEqual(unicodeDomain);
+      const [storedDomain] = actionEntry.split(DELIM);
+      expect(storedDomain).toBe(domain);
+
+      const tools = [buildToolName('getWeather', domain), buildToolName('getPeople', 'other')];
+
+      const filtered = tools.filter((t) => !t.includes(storedDomain));
+      expect(filtered).toEqual([buildToolName('getPeople', 'other')]);
+    });
   });
 
-  // Core Functionality Tests
-  it('returns domain with replaced separators if no cached domain exists', async () => {
-    const domain = 'example.com';
-    const withSeparator = domain.replace(/\./g, actionDomainSeparator);
-    const result = await domainParser(withSeparator, false);
-    expect(result).toEqual(domain);
-  });
+  describe('multi-action agents (collision scenario)', () => {
+    it('two https:// actions now produce distinct tool names', async () => {
+      const domain1 = await domainParser('https://api.weather.com', true);
+      const domain2 = await domainParser('https://api.spacex.com', true);
 
-  it('returns domain with replaced separators when inverse is false and under encoding length', async () => {
-    const domain = 'examp.com';
-    const withSeparator = domain.replace(/\./g, actionDomainSeparator);
-    const result = await domainParser(withSeparator, false);
-    expect(result).toEqual(domain);
-  });
+      const tool1 = buildToolName('getData', domain1);
+      const tool2 = buildToolName('getData', domain2);
 
-  it('replaces periods with actionDomainSeparator when inverse is true and under encoding length', async () => {
-    const domain = 'examp.com';
-    const expected = domain.replace(/\./g, actionDomainSeparator);
-    const result = await domainParser(domain, true);
-    expect(result).toEqual(expected);
-  });
+      expect(tool1).not.toBe(tool2);
+    });
 
-  it('encodes domain when length is above threshold and inverse is true', async () => {
-    const domain = 'a'.repeat(Constants.ENCODED_DOMAIN_LENGTH + 1).concat('.com');
-    const result = await domainParser(domain, true);
-    expect(result).not.toEqual(domain);
-    expect(result.length).toBeLessThanOrEqual(Constants.ENCODED_DOMAIN_LENGTH);
-  });
+    it('two https:// actions used to collide in legacy encoding', async () => {
+      const legacy1 = await legacyDomainEncode('https://api.weather.com');
+      const legacy2 = await legacyDomainEncode('https://api.spacex.com');
 
-  it('returns encoded value if no encoded value is cached, and inverse is false', async () => {
-    const originalDomain = 'example.com';
-    const encodedDomain = Buffer.from(
-      originalDomain.replace(/\./g, actionDomainSeparator),
-    ).toString('base64');
-    const result = await domainParser(encodedDomain, false);
-    expect(result).toEqual(encodedDomain);
-  });
+      const tool1 = buildToolName('getData', legacy1);
+      const tool2 = buildToolName('getData', legacy2);
 
-  it('decodes encoded value if cached and encoded value is provided, and inverse is false', async () => {
-    const originalDomain = 'example.com';
-    const encodedDomain = await domainParser(originalDomain, true);
-    const result = await domainParser(encodedDomain, false);
-    expect(result).toEqual(originalDomain);
-  });
-
-  it('handles invalid base64 encoded values gracefully', async () => {
-    const invalidBase64Domain = 'not_base64_encoded';
-    const result = await domainParser(invalidBase64Domain, false);
-    expect(result).toEqual(invalidBase64Domain);
+      expect(tool1).toBe(tool2);
+    });
   });
 });

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -175,8 +175,7 @@ async function processRequiredActions(client, requiredActions) {
 
   const promises = [];
 
-  /** @type {Action[]} */
-  let actionSets = [];
+  let actionSetsData = null;
   let isActionTool = false;
   const ActionToolMap = {};
   const ActionBuildersMap = {};
@@ -262,9 +261,9 @@ async function processRequiredActions(client, requiredActions) {
     if (!tool) {
       // throw new Error(`Tool ${currentAction.tool} not found.`);
 
-      // Load all action sets once if not already loaded
-      if (!actionSets.length) {
-        actionSets =
+      if (!actionSetsData) {
+        /** @type {Action[]} */
+        const actionSets =
           (await loadActionSets({
             assistant_id: client.req.body.assistant_id,
           })) ?? [];
@@ -272,15 +271,15 @@ async function processRequiredActions(client, requiredActions) {
         // Process all action sets once
         // Map domains to their processed action sets
         const processedDomains = new Map();
-        const normalizedToDomain = new Map();
+        const domainLookupMap = new Map();
 
         for (const action of actionSets) {
           const domain = await domainParser(action.metadata.domain, true);
-          normalizedToDomain.set(domain, domain);
+          domainLookupMap.set(domain, domain);
 
           const legacyDomain = legacyDomainEncode(action.metadata.domain);
           if (legacyDomain !== domain) {
-            normalizedToDomain.set(legacyDomain, domain);
+            domainLookupMap.set(legacyDomain, domain);
           }
 
           const isDomainAllowed = await isActionDomainAllowed(
@@ -336,14 +335,12 @@ async function processRequiredActions(client, requiredActions) {
           ActionBuildersMap[action.metadata.domain] = requestBuilders;
         }
 
-        // Update actionSets reference to use the domain map
-        actionSets = { normalizedToDomain, processedDomains };
+        actionSetsData = { domainLookupMap, processedDomains };
       }
 
-      // Find the matching domain for this tool
       let currentDomain = '';
       let matchedKey = '';
-      for (const [key, canonical] of actionSets.normalizedToDomain.entries()) {
+      for (const [key, canonical] of actionSetsData.domainLookupMap.entries()) {
         if (currentAction.tool.includes(key)) {
           currentDomain = canonical;
           matchedKey = key;
@@ -351,11 +348,12 @@ async function processRequiredActions(client, requiredActions) {
         }
       }
 
-      if (!currentDomain || !actionSets.processedDomains.has(currentDomain)) {
+      if (!currentDomain || !actionSetsData.processedDomains.has(currentDomain)) {
         continue;
       }
 
-      const { action, requestBuilders, encrypted } = actionSets.processedDomains.get(currentDomain);
+      const { action, requestBuilders, encrypted } =
+        actionSetsData.processedDomains.get(currentDomain);
       const functionName = currentAction.tool.replace(`${actionDelimiter}${matchedKey}`, '');
       const requestBuilder = requestBuilders[functionName];
 
@@ -594,6 +592,9 @@ async function loadToolDefinitionsWrapper({ req, res, agent, streamId = null, to
 
     const definitions = [];
     const allowedDomains = appConfig?.actions?.allowedDomains;
+    const normalizedToolNames = new Set(
+      actionToolNames.map((n) => n.replace(domainSeparatorRegex, '_')),
+    );
 
     for (const action of actionSets) {
       const domain = await domainParser(action.metadata.domain, true);
@@ -622,11 +623,7 @@ async function loadToolDefinitionsWrapper({ req, res, agent, streamId = null, to
       for (const sig of functionSignatures) {
         const toolName = `${sig.name}${actionDelimiter}${normalizedDomain}`;
         const legacyToolName = `${sig.name}${actionDelimiter}${legacyNormalized}`;
-        const hasMatch = actionToolNames.some((name) => {
-          const normalized = name.replace(domainSeparatorRegex, '_');
-          return normalized === toolName || normalized === legacyToolName;
-        });
-        if (!hasMatch) {
+        if (!normalizedToolNames.has(toolName) && !normalizedToolNames.has(legacyToolName)) {
           continue;
         }
 
@@ -1006,15 +1003,15 @@ async function loadAgentTools({
   }
 
   const processedActionSets = new Map();
-  const normalizedToDomain = new Map();
+  const domainLookupMap = new Map();
 
   for (const action of actionSets) {
     const domain = await domainParser(action.metadata.domain, true);
-    normalizedToDomain.set(domain, domain);
+    domainLookupMap.set(domain, domain);
 
     const legacyDomain = legacyDomainEncode(action.metadata.domain);
     if (legacyDomain !== domain) {
-      normalizedToDomain.set(legacyDomain, domain);
+      domainLookupMap.set(legacyDomain, domain);
     }
     const isDomainAllowed = await isActionDomainAllowed(
       action.metadata.domain,
@@ -1079,7 +1076,7 @@ async function loadAgentTools({
 
     let currentDomain = '';
     let matchedKey = '';
-    for (const [key, canonical] of normalizedToDomain.entries()) {
+    for (const [key, canonical] of domainLookupMap.entries()) {
       if (toolName.includes(key)) {
         currentDomain = canonical;
         matchedKey = key;
@@ -1407,14 +1404,8 @@ async function loadActionToolsForExecution({
       continue;
     }
 
-    const {
-      action,
-      encrypted,
-      zodSchemas,
-      requestBuilders,
-      functionSignatures,
-      legacyNormalized,
-    } = processedActionSets.get(currentDomain);
+    const { action, encrypted, zodSchemas, requestBuilders, functionSignatures, legacyNormalized } =
+      processedActionSets.get(currentDomain);
     const normalizedDomain = currentDomain.replace(domainSeparatorRegex, '_');
     const functionName = toolName.replace(`${actionDelimiter}${normalizedDomain}`, '');
     const functionSig = functionSignatures.find((sig) => sig.name === functionName);

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -42,6 +42,7 @@ const {
 } = require('librechat-data-provider');
 const {
   createActionTool,
+  legacyDomainEncode,
   decryptMetadata,
   loadActionSets,
   domainParser,
@@ -592,6 +593,9 @@ async function loadToolDefinitionsWrapper({ req, res, agent, streamId = null, to
       const domain = await domainParser(action.metadata.domain, true);
       const normalizedDomain = domain.replace(domainSeparatorRegex, '_');
 
+      const legacyDomain = await legacyDomainEncode(action.metadata.domain);
+      const legacyNormalized = legacyDomain.replace(domainSeparatorRegex, '_');
+
       const isDomainAllowed = await isActionDomainAllowed(action.metadata.domain, allowedDomains);
       if (!isDomainAllowed) {
         logger.warn(
@@ -611,7 +615,12 @@ async function loadToolDefinitionsWrapper({ req, res, agent, streamId = null, to
 
       for (const sig of functionSignatures) {
         const toolName = `${sig.name}${actionDelimiter}${normalizedDomain}`;
-        if (!actionToolNames.some((name) => name.replace(domainSeparatorRegex, '_') === toolName)) {
+        const legacyToolName = `${sig.name}${actionDelimiter}${legacyNormalized}`;
+        const hasMatch = actionToolNames.some((name) => {
+          const normalized = name.replace(domainSeparatorRegex, '_');
+          return normalized === toolName || normalized === legacyToolName;
+        });
+        if (!hasMatch) {
           continue;
         }
 
@@ -1310,12 +1319,21 @@ async function loadActionToolsForExecution({
   }
 
   const processedActionSets = new Map();
-  const domainMap = new Map();
+  /** Maps both new and legacy normalized domains to their canonical (new) domain key */
+  const normalizedToDomain = new Map();
   const allowedDomains = appConfig?.actions?.allowedDomains;
+  const domainSeparatorRegex = new RegExp(actionDomainSeparator, 'g');
 
   for (const action of actionSets) {
     const domain = await domainParser(action.metadata.domain, true);
-    domainMap.set(domain, action);
+    const normalizedDomain = domain.replace(domainSeparatorRegex, '_');
+    normalizedToDomain.set(normalizedDomain, domain);
+
+    const legacyDomain = await legacyDomainEncode(action.metadata.domain);
+    const legacyNormalized = legacyDomain.replace(domainSeparatorRegex, '_');
+    if (legacyNormalized !== normalizedDomain) {
+      normalizedToDomain.set(legacyNormalized, domain);
+    }
 
     const isDomainAllowed = await isActionDomainAllowed(action.metadata.domain, allowedDomains);
     if (!isDomainAllowed) {
@@ -1367,13 +1385,11 @@ async function loadActionToolsForExecution({
     });
   }
 
-  const domainSeparatorRegex = new RegExp(actionDomainSeparator, 'g');
   for (const toolName of actionToolNames) {
     let currentDomain = '';
-    for (const domain of domainMap.keys()) {
-      const normalizedDomain = domain.replace(domainSeparatorRegex, '_');
+    for (const [normalizedDomain, canonicalDomain] of normalizedToDomain.entries()) {
       if (toolName.includes(normalizedDomain)) {
-        currentDomain = domain;
+        currentDomain = canonicalDomain;
         break;
       }
     }
@@ -1391,6 +1407,27 @@ async function loadActionToolsForExecution({
     const zodSchema = zodSchemas[functionName];
 
     if (!requestBuilder) {
+      const legacyDomain = await legacyDomainEncode(action.metadata.domain);
+      const legacyNormalized = legacyDomain.replace(domainSeparatorRegex, '_');
+      const legacyFnName = toolName.replace(`${actionDelimiter}${legacyNormalized}`, '');
+      if (legacyFnName !== toolName && requestBuilders[legacyFnName]) {
+        const legacyTool = await createActionTool({
+          userId: req.user.id,
+          res,
+          action,
+          streamId,
+          encrypted,
+          requestBuilder: requestBuilders[legacyFnName],
+          zodSchema: zodSchemas[legacyFnName],
+          name: toolName,
+          description:
+            functionSignatures.find((sig) => sig.name === legacyFnName)?.description ?? '',
+          useSSRFProtection: !Array.isArray(allowedDomains) || allowedDomains.length === 0,
+        });
+        if (legacyTool) {
+          loadedActionTools.push(legacyTool);
+        }
+      }
       continue;
     }
 

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -66,6 +66,8 @@ const { findPluginAuthsByKeys } = require('~/models');
 const { getFlowStateManager } = require('~/config');
 const { getLogStores } = require('~/cache');
 
+const domainSeparatorRegex = new RegExp(actionDomainSeparator, 'g');
+
 /**
  * Resolves the set of enabled agent capabilities from endpoints config,
  * falling back to app-level or default capabilities for ephemeral agents.
@@ -270,11 +272,16 @@ async function processRequiredActions(client, requiredActions) {
         // Process all action sets once
         // Map domains to their processed action sets
         const processedDomains = new Map();
-        const domainMap = new Map();
+        const normalizedToDomain = new Map();
 
         for (const action of actionSets) {
           const domain = await domainParser(action.metadata.domain, true);
-          domainMap.set(domain, action);
+          normalizedToDomain.set(domain, domain);
+
+          const legacyDomain = legacyDomainEncode(action.metadata.domain);
+          if (legacyDomain !== domain) {
+            normalizedToDomain.set(legacyDomain, domain);
+          }
 
           const isDomainAllowed = await isActionDomainAllowed(
             action.metadata.domain,
@@ -330,26 +337,26 @@ async function processRequiredActions(client, requiredActions) {
         }
 
         // Update actionSets reference to use the domain map
-        actionSets = { domainMap, processedDomains };
+        actionSets = { normalizedToDomain, processedDomains };
       }
 
       // Find the matching domain for this tool
       let currentDomain = '';
-      for (const domain of actionSets.domainMap.keys()) {
-        if (currentAction.tool.includes(domain)) {
-          currentDomain = domain;
+      let matchedKey = '';
+      for (const [key, canonical] of actionSets.normalizedToDomain.entries()) {
+        if (currentAction.tool.includes(key)) {
+          currentDomain = canonical;
+          matchedKey = key;
           break;
         }
       }
 
       if (!currentDomain || !actionSets.processedDomains.has(currentDomain)) {
-        // TODO: try `function` if no action set is found
-        // throw new Error(`Tool ${currentAction.tool} not found.`);
         continue;
       }
 
       const { action, requestBuilders, encrypted } = actionSets.processedDomains.get(currentDomain);
-      const functionName = currentAction.tool.replace(`${actionDelimiter}${currentDomain}`, '');
+      const functionName = currentAction.tool.replace(`${actionDelimiter}${matchedKey}`, '');
       const requestBuilder = requestBuilders[functionName];
 
       if (!requestBuilder) {
@@ -587,13 +594,12 @@ async function loadToolDefinitionsWrapper({ req, res, agent, streamId = null, to
 
     const definitions = [];
     const allowedDomains = appConfig?.actions?.allowedDomains;
-    const domainSeparatorRegex = new RegExp(actionDomainSeparator, 'g');
 
     for (const action of actionSets) {
       const domain = await domainParser(action.metadata.domain, true);
       const normalizedDomain = domain.replace(domainSeparatorRegex, '_');
 
-      const legacyDomain = await legacyDomainEncode(action.metadata.domain);
+      const legacyDomain = legacyDomainEncode(action.metadata.domain);
       const legacyNormalized = legacyDomain.replace(domainSeparatorRegex, '_');
 
       const isDomainAllowed = await isActionDomainAllowed(action.metadata.domain, allowedDomains);
@@ -999,15 +1005,17 @@ async function loadAgentTools({
     };
   }
 
-  // Process each action set once (validate spec, decrypt metadata)
   const processedActionSets = new Map();
-  const domainMap = new Map();
+  const normalizedToDomain = new Map();
 
   for (const action of actionSets) {
     const domain = await domainParser(action.metadata.domain, true);
-    domainMap.set(domain, action);
+    normalizedToDomain.set(domain, domain);
 
-    // Check if domain is allowed (do this once per action set)
+    const legacyDomain = legacyDomainEncode(action.metadata.domain);
+    if (legacyDomain !== domain) {
+      normalizedToDomain.set(legacyDomain, domain);
+    }
     const isDomainAllowed = await isActionDomainAllowed(
       action.metadata.domain,
       appConfig?.actions?.allowedDomains,
@@ -1069,11 +1077,12 @@ async function loadAgentTools({
       continue;
     }
 
-    // Find the matching domain for this tool
     let currentDomain = '';
-    for (const domain of domainMap.keys()) {
-      if (toolName.includes(domain)) {
-        currentDomain = domain;
+    let matchedKey = '';
+    for (const [key, canonical] of normalizedToDomain.entries()) {
+      if (toolName.includes(key)) {
+        currentDomain = canonical;
+        matchedKey = key;
         break;
       }
     }
@@ -1084,7 +1093,7 @@ async function loadAgentTools({
 
     const { action, encrypted, zodSchemas, requestBuilders, functionSignatures } =
       processedActionSets.get(currentDomain);
-    const functionName = toolName.replace(`${actionDelimiter}${currentDomain}`, '');
+    const functionName = toolName.replace(`${actionDelimiter}${matchedKey}`, '');
     const functionSig = functionSignatures.find((sig) => sig.name === functionName);
     const requestBuilder = requestBuilders[functionName];
     const zodSchema = zodSchemas[functionName];
@@ -1322,14 +1331,13 @@ async function loadActionToolsForExecution({
   /** Maps both new and legacy normalized domains to their canonical (new) domain key */
   const normalizedToDomain = new Map();
   const allowedDomains = appConfig?.actions?.allowedDomains;
-  const domainSeparatorRegex = new RegExp(actionDomainSeparator, 'g');
 
   for (const action of actionSets) {
     const domain = await domainParser(action.metadata.domain, true);
     const normalizedDomain = domain.replace(domainSeparatorRegex, '_');
     normalizedToDomain.set(normalizedDomain, domain);
 
-    const legacyDomain = await legacyDomainEncode(action.metadata.domain);
+    const legacyDomain = legacyDomainEncode(action.metadata.domain);
     const legacyNormalized = legacyDomain.replace(domainSeparatorRegex, '_');
     if (legacyNormalized !== normalizedDomain) {
       normalizedToDomain.set(legacyNormalized, domain);
@@ -1382,6 +1390,7 @@ async function loadActionToolsForExecution({
       functionSignatures,
       zodSchemas,
       encrypted,
+      legacyNormalized,
     });
   }
 
@@ -1398,8 +1407,14 @@ async function loadActionToolsForExecution({
       continue;
     }
 
-    const { action, encrypted, zodSchemas, requestBuilders, functionSignatures } =
-      processedActionSets.get(currentDomain);
+    const {
+      action,
+      encrypted,
+      zodSchemas,
+      requestBuilders,
+      functionSignatures,
+      legacyNormalized,
+    } = processedActionSets.get(currentDomain);
     const normalizedDomain = currentDomain.replace(domainSeparatorRegex, '_');
     const functionName = toolName.replace(`${actionDelimiter}${normalizedDomain}`, '');
     const functionSig = functionSignatures.find((sig) => sig.name === functionName);
@@ -1407,8 +1422,6 @@ async function loadActionToolsForExecution({
     const zodSchema = zodSchemas[functionName];
 
     if (!requestBuilder) {
-      const legacyDomain = await legacyDomainEncode(action.metadata.domain);
-      const legacyNormalized = legacyDomain.replace(domainSeparatorRegex, '_');
       const legacyFnName = toolName.replace(`${actionDelimiter}${legacyNormalized}`, '');
       if (legacyFnName !== toolName && requestBuilders[legacyFnName]) {
         const legacyTool = await createActionTool({


### PR DESCRIPTION


## Summary

Fixed a base64 key collision in `domainParser` where all `https://` (and `http://`) domains produced the same 10-character truncated key (`aHR0cHM6Ly`) due to the protocol prefix dominating the `ENCODED_DOMAIN_LENGTH`-truncated base64 output. This caused tool name collisions for agents and assistants with multiple actions pointing to different domains. Added full backward-compatibility support for actions stored before this fix.

- Fixed `domainParser` to strip the protocol prefix before base64-encoding, so the key is derived from the hostname rather than the full URL.
- Added `legacyDomainEncode` to reproduce the old (broken) encoding, used exclusively for backward-compatible matching of actions stored before this fix.
- Updated `loadActionToolsForExecution` to register both new and legacy normalized domain keys in `normalizedToDomain`, with `legacyNormalized` stored in `processedActionSets` to avoid redundant recomputation in the per-tool fallback path.
- Updated `getActionToolDefinitions` to match stored tool names against both new and legacy encodings; pre-normalized `actionToolNames` into a `Set<string>` before the loop, replacing O(signatures × tools) `.some()` + `.replace()` with O(1) `.has()` lookups.
- Fixed `processRequiredActions` (assistants execution path) — it previously built `domainMap` with new-encoding keys only, silently dropping all tool calls for assistants with legacy-encoded tools stored in OpenAI. Replaced with `domainLookupMap` carrying both encodings; function name is now extracted via `matchedKey` rather than the canonical domain.
- Fixed `loadAgentTools` `definitionsOnly=false` path with the same `domainLookupMap` + `matchedKey` pattern.
- Fixed pre-existing bug in `processRequiredActions` where the `!actionSets.length` guard re-triggered on every missing-tool iteration after the array was reassigned to a plain object. Replaced with a `null`-initialized `actionSetsData` variable and a null-check.
- Fixed agent and assistant save routes to filter tools matching both new and legacy domain encodings, preventing stale tool entries when an action's encoding changes on update.
- Fixed agent and assistant delete routes to use the domain stored verbatim in the actions array rather than re-encoding it through `domainParser`, which was producing incorrect keys and leaving orphaned tool entries.
- Made `legacyDomainEncode` synchronous — it contains no I/O or async operations.
- Hoisted `domainSeparatorRegex` to module level in `ToolService.js`.
- Renamed the `domain` variable to `encodedDomain` in both action route save handlers to separate the raw URL from the encoded key.
- Renamed `shouldRemoveTool` to `shouldRemoveAgentTool` / `shouldRemoveAssistantTool` to make the distinct data-shape guards explicit.
- Renamed `normalizedToDomain` to `domainLookupMap` in the two functions where map keys are raw encoded domains rather than normalized ones.
- Removed `stripProtocol` from `ActionService` exports; it is an internal helper whose behavior is fully covered by the `domainParser` protocol-stripping tests.
- Updated `validateAndUpdateTool` to match actions where `metadata.domain` carries an `https://` prefix against tool names carrying only the bare hostname.
- Rewrote `ActionService.spec.js` with 50 tests covering: `domainParser` encode/decode round-trips, protocol stripping, unicode hostnames, `legacyDomainEncode` synchronicity and collision behavior, `validateAndUpdateTool` matching logic, backward-compatible tool name matching at both definition and execution phases, save-route cleanup of old and new encodings, delete-route domain extraction, and the multi-action collision scenario.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The collision fix and backward-compatibility layer are covered by the rewritten unit test suite in `api/server/services/ActionService.spec.js` (50 tests). The following scenarios are explicitly exercised:

- Two `https://` actions on the same agent previously produced identical tool names; they now produce distinct keys.
- A legacy-encoded tool name (e.g., `getPeople---aHR0cHM6Ly`) resolves correctly to the right action and function name via the `domainLookupMap`/`matchedKey` pattern.
- A new-encoded tool name resolves correctly through the same path.
- Save routes remove tools matching both the new and legacy encoding of the updated domain.
- Delete routes extract the domain verbatim from the stored actions array without re-encoding it.
- `domainParser` with `https://` input and bare-hostname input produce identical output.
- Unicode hostnames encode, decode, and round-trip correctly.

**Test Configuration**: Run from the `api` workspace:

```bash
cd api && npx jest ActionService.spec
```

### Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
