### PR TITLE
🧯 fix: Add Pre-Parse File Size Guard to Document Parser

### DIFF
--- a/packages/api/src/files/documents/crud.spec.ts
+++ b/packages/api/src/files/documents/crud.spec.ts
@@ -122,6 +122,30 @@ describe('Document Parser', () => {
     await expect(parseDocument({ file })).rejects.toThrow('No text found in document');
   });
 
+  test('parseDocument() rejects files exceeding the pre-parse size limit', async () => {
+    const file = {
+      originalname: 'oversized.docx',
+      path: path.join(__dirname, 'sample.docx'),
+      mimetype: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      size: 16 * 1024 * 1024,
+    } as Express.Multer.File;
+
+    await expect(parseDocument({ file })).rejects.toThrow(
+      /exceeds the 15MB document parser limit \(16MB\)/,
+    );
+  });
+
+  test('parseDocument() allows files exactly at the size limit boundary', async () => {
+    const file = {
+      originalname: 'sample.docx',
+      path: path.join(__dirname, 'sample.docx'),
+      mimetype: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      size: 15 * 1024 * 1024,
+    } as Express.Multer.File;
+
+    await expect(parseDocument({ file })).resolves.toBeDefined();
+  });
+
   test('parseDocument() parses empty xlsx with only sheet name', async () => {
     const file = {
       originalname: 'empty.xlsx',

--- a/packages/api/src/files/documents/crud.ts
+++ b/packages/api/src/files/documents/crud.ts
@@ -1,34 +1,38 @@
 import * as fs from 'fs';
-import { excelMimeTypes, FileSources } from 'librechat-data-provider';
+import { megabyte, excelMimeTypes, FileSources } from 'librechat-data-provider';
 import type { TextItem } from 'pdfjs-dist/types/src/display/api';
 import type { MistralOCRUploadResult } from '~/types';
+
+type FileParseFn = (file: Express.Multer.File) => Promise<string>;
+
+const DOCUMENT_PARSER_MAX_FILE_SIZE = 15 * megabyte;
 
 /**
  * Parses an uploaded document and extracts its text content and metadata.
  * Handled types must stay in sync with `documentParserMimeTypes` from data-provider.
  *
- * @throws {Error} if `file.mimetype` is not handled or no text is found.
+ * @throws {Error} if `file.mimetype` is not handled, file exceeds size limit, or no text is found.
  */
 export async function parseDocument({
   file,
 }: {
   file: Express.Multer.File;
 }): Promise<MistralOCRUploadResult> {
-  let text: string;
-  if (file.mimetype === 'application/pdf') {
-    text = await pdfToText(file);
-  } else if (
-    file.mimetype === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-  ) {
-    text = await wordDocToText(file);
-  } else if (
-    excelMimeTypes.test(file.mimetype) ||
-    file.mimetype === 'application/vnd.oasis.opendocument.spreadsheet'
-  ) {
-    text = await excelSheetToText(file);
-  } else {
+  const parseFn = getParserForMimeType(file.mimetype);
+  if (!parseFn) {
     throw new Error(`Unsupported file type in document parser: ${file.mimetype}`);
   }
+
+  const fileSize = file.size ?? (file.path != null ? (await fs.promises.stat(file.path)).size : 0);
+  if (fileSize > DOCUMENT_PARSER_MAX_FILE_SIZE) {
+    const limitMB = DOCUMENT_PARSER_MAX_FILE_SIZE / megabyte;
+    const sizeMB = Math.ceil(fileSize / megabyte);
+    throw new Error(
+      `File "${file.originalname}" exceeds the ${limitMB}MB document parser limit (${sizeMB}MB).`,
+    );
+  }
+
+  const text = await parseFn(file);
 
   if (!text?.trim()) {
     throw new Error('No text found in document');
@@ -41,6 +45,23 @@ export async function parseDocument({
     text,
     images: [],
   };
+}
+
+/** Maps a MIME type to its document parser function, or `undefined` if unsupported. */
+function getParserForMimeType(mimetype: string): FileParseFn | undefined {
+  if (mimetype === 'application/pdf') {
+    return pdfToText;
+  }
+  if (mimetype === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
+    return wordDocToText;
+  }
+  if (
+    excelMimeTypes.test(mimetype) ||
+    mimetype === 'application/vnd.oasis.opendocument.spreadsheet'
+  ) {
+    return excelSheetToText;
+  }
+  return undefined;
 }
 
 /** Parses PDF, returns text inside. */


### PR DESCRIPTION

## Summary

Added a pre-parse file size guard to the document parser to close a memory exhaustion DoS vector between the 512 MB upload limit and the unbounded in-memory reads performed by the PDF, Word, and Excel parsers. Also refactored the MIME-type-to-parser dispatch into a dedicated helper for clarity.

- Added `DOCUMENT_PARSER_MAX_FILE_SIZE` (15 MB) derived from the shared `megabyte` constant imported from `librechat-data-provider`, replacing a locally duplicated definition.
- Enforced the size limit before any file read occurs in `parseDocument`, short-circuiting the `new Uint8Array(readFile(...))` and equivalent allocations for oversized files.
- Derived the limit value in the rejection error message directly from `DOCUMENT_PARSER_MAX_FILE_SIZE` so the message can never drift from the enforced constant.
- Used `Math.ceil` for the reported file size in the error message so files just over the limit never produce a misleading "exceeds 15MB limit (15MB)" string.
- Guarded the `fs.promises.stat()` fallback behind a `file.path != null` check to prevent a silent `TypeError` when `file.path` is undefined.
- Extracted the MIME-type-to-parser mapping into `getParserForMimeType()` with a JSDoc comment consistent with the surrounding helpers.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added unit tests to `packages/api/src/files/documents/crud.spec.ts`:

- Asserts that a file with `size: 16 * 1024 * 1024` is rejected with an error matching `/exceeds the 15MB document parser limit \(16MB\)/`.
- Asserts that a file with `size: 15 * 1024 * 1024` (exactly at the limit) resolves successfully, pinning the strictly-greater-than semantics of the guard.
- Existing passing tests (which omit `size`) exercise the `fs.promises.stat()` fallback path on real fixture files, validating that branch in the success direction.

### **Test Configuration**:

Run from the `packages/api` workspace:

```bash
cd packages/api && npx jest documents/crud
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
