### PR TITLE
🛂 fix: Validate `types` Query Param in People Picker Access Middleware

### DIFF
--- a/api/server/middleware/checkPeoplePickerAccess.js
+++ b/api/server/middleware/checkPeoplePickerAccess.js
@@ -2,10 +2,20 @@ const { logger } = require('@librechat/data-schemas');
 const { PrincipalType, PermissionTypes, Permissions } = require('librechat-data-provider');
 const { getRoleByName } = require('~/models/Role');
 
+const VALID_PRINCIPAL_TYPES = new Set([
+  PrincipalType.USER,
+  PrincipalType.GROUP,
+  PrincipalType.ROLE,
+]);
+
 /**
  * Middleware to check if user has permission to access people picker functionality.
- * Validates both `type` (singular) and `types` (comma-separated or array) query parameters
- * against the caller's role permissions.
+ * Validates requested principal types via `type` (singular) and `types` (comma-separated or array)
+ * query parameters against the caller's role permissions:
+ * - user: requires VIEW_USERS permission
+ * - group: requires VIEW_GROUPS permission
+ * - role: requires VIEW_ROLES permission
+ * - no type filter (mixed search): requires at least one of the above
  */
 const checkPeoplePickerAccess = async (req, res, next) => {
   try {
@@ -46,17 +56,16 @@ const checkPeoplePickerAccess = async (req, res, next) => {
       },
     };
 
-    const validTypes = new Set(Object.keys(permissionChecks));
     const requestedTypes = new Set();
 
-    if (type && validTypes.has(type)) {
+    if (type && VALID_PRINCIPAL_TYPES.has(type)) {
       requestedTypes.add(type);
     }
 
     if (types) {
       const typesArray = Array.isArray(types) ? types : types.split(',');
       for (const t of typesArray) {
-        if (validTypes.has(t)) {
+        if (VALID_PRINCIPAL_TYPES.has(t)) {
           requestedTypes.add(t);
         }
       }
@@ -82,7 +91,7 @@ const checkPeoplePickerAccess = async (req, res, next) => {
     next();
   } catch (error) {
     logger.error(
-      `[checkPeoplePickerAccess][${req.user?.id}] checkPeoplePickerAccess error for req.query.type = ${req.query.type}`,
+      `[checkPeoplePickerAccess][${req.user?.id}] error for type=${req.query.type}, types=${req.query.types}`,
       error,
     );
     return res.status(500).json({

--- a/api/server/middleware/checkPeoplePickerAccess.js
+++ b/api/server/middleware/checkPeoplePickerAccess.js
@@ -3,12 +3,9 @@ const { PrincipalType, PermissionTypes, Permissions } = require('librechat-data-
 const { getRoleByName } = require('~/models/Role');
 
 /**
- * Middleware to check if user has permission to access people picker functionality
- * Checks specific permission based on the 'type' query parameter:
- * - type=user: requires VIEW_USERS permission
- * - type=group: requires VIEW_GROUPS permission
- * - type=role: requires VIEW_ROLES permission
- * - no type (mixed search): requires either VIEW_USERS OR VIEW_GROUPS OR VIEW_ROLES
+ * Middleware to check if user has permission to access people picker functionality.
+ * Validates both `type` (singular) and `types` (comma-separated or array) query parameters
+ * against the caller's role permissions.
  */
 const checkPeoplePickerAccess = async (req, res, next) => {
   try {
@@ -28,7 +25,7 @@ const checkPeoplePickerAccess = async (req, res, next) => {
       });
     }
 
-    const { type } = req.query;
+    const { type, types } = req.query;
     const peoplePickerPerms = role.permissions[PermissionTypes.PEOPLE_PICKER] || {};
     const canViewUsers = peoplePickerPerms[Permissions.VIEW_USERS] === true;
     const canViewGroups = peoplePickerPerms[Permissions.VIEW_GROUPS] === true;
@@ -49,15 +46,33 @@ const checkPeoplePickerAccess = async (req, res, next) => {
       },
     };
 
-    const check = permissionChecks[type];
-    if (check && !check.hasPermission) {
-      return res.status(403).json({
-        error: 'Forbidden',
-        message: check.message,
-      });
+    const validTypes = new Set(Object.keys(permissionChecks));
+    const requestedTypes = new Set();
+
+    if (type && validTypes.has(type)) {
+      requestedTypes.add(type);
     }
 
-    if (!type && !canViewUsers && !canViewGroups && !canViewRoles) {
+    if (types) {
+      const typesArray = Array.isArray(types) ? types : types.split(',');
+      for (const t of typesArray) {
+        if (validTypes.has(t)) {
+          requestedTypes.add(t);
+        }
+      }
+    }
+
+    for (const requested of requestedTypes) {
+      const check = permissionChecks[requested];
+      if (!check.hasPermission) {
+        return res.status(403).json({
+          error: 'Forbidden',
+          message: check.message,
+        });
+      }
+    }
+
+    if (requestedTypes.size === 0 && !canViewUsers && !canViewGroups && !canViewRoles) {
       return res.status(403).json({
         error: 'Forbidden',
         message: 'Insufficient permissions to search for users, groups, or roles',

--- a/api/server/middleware/checkPeoplePickerAccess.spec.js
+++ b/api/server/middleware/checkPeoplePickerAccess.spec.js
@@ -210,6 +210,10 @@ describe('checkPeoplePickerAccess', () => {
     await checkPeoplePickerAccess(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Forbidden',
+      message: 'Insufficient permissions to search for roles',
+    });
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -276,6 +280,64 @@ describe('checkPeoplePickerAccess', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it('should treat all-invalid types values as mixed search', async () => {
+    req.query.types = 'foobar';
+    getRoleByName.mockResolvedValue({
+      permissions: {
+        [PermissionTypes.PEOPLE_PICKER]: {
+          [Permissions.VIEW_USERS]: true,
+          [Permissions.VIEW_GROUPS]: false,
+          [Permissions.VIEW_ROLES]: false,
+        },
+      },
+    });
+
+    await checkPeoplePickerAccess(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should deny when types is empty string and user has no permissions', async () => {
+    req.query.types = '';
+    getRoleByName.mockResolvedValue({
+      permissions: {
+        [PermissionTypes.PEOPLE_PICKER]: {
+          [Permissions.VIEW_USERS]: false,
+          [Permissions.VIEW_GROUPS]: false,
+          [Permissions.VIEW_ROLES]: false,
+        },
+      },
+    });
+
+    await checkPeoplePickerAccess(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Forbidden',
+      message: 'Insufficient permissions to search for users, groups, or roles',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should treat types=public as mixed search since PUBLIC is not a searchable principal type', async () => {
+    req.query.types = PrincipalType.PUBLIC;
+    getRoleByName.mockResolvedValue({
+      permissions: {
+        [PermissionTypes.PEOPLE_PICKER]: {
+          [Permissions.VIEW_USERS]: true,
+          [Permissions.VIEW_GROUPS]: false,
+          [Permissions.VIEW_ROLES]: false,
+        },
+      },
+    });
+
+    await checkPeoplePickerAccess(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
   it('should allow mixed search when user has at least one permission', async () => {
     // No type specified = mixed search
     req.query.type = undefined;
@@ -325,7 +387,7 @@ describe('checkPeoplePickerAccess', () => {
     await checkPeoplePickerAccess(req, res, next);
 
     expect(logger.error).toHaveBeenCalledWith(
-      '[checkPeoplePickerAccess][user123] checkPeoplePickerAccess error for req.query.type = undefined',
+      '[checkPeoplePickerAccess][user123] error for type=undefined, types=undefined',
       error,
     );
     expect(res.status).toHaveBeenCalledWith(500);

--- a/api/server/middleware/checkPeoplePickerAccess.spec.js
+++ b/api/server/middleware/checkPeoplePickerAccess.spec.js
@@ -173,6 +173,109 @@ describe('checkPeoplePickerAccess', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it('should deny access when using types param to bypass type-specific check', async () => {
+    req.query.types = PrincipalType.GROUP;
+    getRoleByName.mockResolvedValue({
+      permissions: {
+        [PermissionTypes.PEOPLE_PICKER]: {
+          [Permissions.VIEW_USERS]: true,
+          [Permissions.VIEW_GROUPS]: false,
+          [Permissions.VIEW_ROLES]: false,
+        },
+      },
+    });
+
+    await checkPeoplePickerAccess(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Forbidden',
+      message: 'Insufficient permissions to search for groups',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should deny access when types contains any unpermitted type', async () => {
+    req.query.types = `${PrincipalType.USER},${PrincipalType.ROLE}`;
+    getRoleByName.mockResolvedValue({
+      permissions: {
+        [PermissionTypes.PEOPLE_PICKER]: {
+          [Permissions.VIEW_USERS]: true,
+          [Permissions.VIEW_GROUPS]: false,
+          [Permissions.VIEW_ROLES]: false,
+        },
+      },
+    });
+
+    await checkPeoplePickerAccess(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should allow access when all requested types are permitted', async () => {
+    req.query.types = `${PrincipalType.USER},${PrincipalType.GROUP}`;
+    getRoleByName.mockResolvedValue({
+      permissions: {
+        [PermissionTypes.PEOPLE_PICKER]: {
+          [Permissions.VIEW_USERS]: true,
+          [Permissions.VIEW_GROUPS]: true,
+          [Permissions.VIEW_ROLES]: false,
+        },
+      },
+    });
+
+    await checkPeoplePickerAccess(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should validate types when provided as array (Express qs parsing)', async () => {
+    req.query.types = [PrincipalType.GROUP, PrincipalType.ROLE];
+    getRoleByName.mockResolvedValue({
+      permissions: {
+        [PermissionTypes.PEOPLE_PICKER]: {
+          [Permissions.VIEW_USERS]: true,
+          [Permissions.VIEW_GROUPS]: false,
+          [Permissions.VIEW_ROLES]: true,
+        },
+      },
+    });
+
+    await checkPeoplePickerAccess(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Forbidden',
+      message: 'Insufficient permissions to search for groups',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should enforce permissions for combined type and types params', async () => {
+    req.query.type = PrincipalType.USER;
+    req.query.types = PrincipalType.GROUP;
+    getRoleByName.mockResolvedValue({
+      permissions: {
+        [PermissionTypes.PEOPLE_PICKER]: {
+          [Permissions.VIEW_USERS]: true,
+          [Permissions.VIEW_GROUPS]: false,
+          [Permissions.VIEW_ROLES]: false,
+        },
+      },
+    });
+
+    await checkPeoplePickerAccess(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Forbidden',
+      message: 'Insufficient permissions to search for groups',
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('should allow mixed search when user has at least one permission', async () => {
     // No type specified = mixed search
     req.query.type = undefined;

--- a/packages/data-provider/src/accessPermissions.ts
+++ b/packages/data-provider/src/accessPermissions.ts
@@ -200,9 +200,9 @@ export type TUpdateResourcePermissionsResponse = z.infer<
  * Principal search request parameters
  */
 export type TPrincipalSearchParams = {
-  q: string; // search query (required)
-  limit?: number; // max results (1-50, default 10)
-  type?: PrincipalType.USER | PrincipalType.GROUP | PrincipalType.ROLE; // filter by type (optional)
+  q: string;
+  limit?: number;
+  types?: Array<PrincipalType.USER | PrincipalType.GROUP | PrincipalType.ROLE>;
 };
 
 /**
@@ -228,7 +228,7 @@ export type TPrincipalSearchResult = {
 export type TPrincipalSearchResponse = {
   query: string;
   limit: number;
-  type?: PrincipalType.USER | PrincipalType.GROUP | PrincipalType.ROLE;
+  types?: Array<PrincipalType.USER | PrincipalType.GROUP | PrincipalType.ROLE> | null;
   results: TPrincipalSearchResult[];
   count: number;
   sources: {


### PR DESCRIPTION

## Summary

Fixed an authorization bypass in `checkPeoplePickerAccess` where the middleware only inspected `req.query.type` (singular) while the controller exclusively consumed `req.query.types` (plural). An authenticated caller could send `?types=group` to skip type-specific permission enforcement entirely, receiving principal data their role was not permitted to access.

- Replaced the single `type`-only check with a unified collection step that reads both `type` and `types` from `req.query` and validates every collected principal type against the caller's role permissions before calling `next()`.
- Adjusted the mixed-search fallback condition from `!type` to `requestedTypes.size === 0` so it correctly triggers when neither parameter contributes a recognized type.
- Hoisted `VALID_PRINCIPAL_TYPES` to a module-level `Set` constant, eliminating a per-request `Object.keys()` allocation that previously rebuilt the same three-element structure on every call.
- Updated the `catch` block error log to include both `type` and `types` query values, replacing the previous entry that always showed `type = undefined` for `types`-only requests.
- Restored the JSDoc comment with explicit per-type permission requirements (`user` → VIEW_USERS, `group` → VIEW_GROUPS, `role` → VIEW_ROLES, no type → any of the above), which was lost in the initial fix commit.
- Corrected `TPrincipalSearchParams` in `accessPermissions.ts` from the stale `type?: PrincipalType` (singular) to `types?: Array<PrincipalType.USER | PrincipalType.GROUP | PrincipalType.ROLE>`, aligning the shared type with the actual controller API.
- Corrected `TPrincipalSearchResponse` in `accessPermissions.ts` from the stale `type?:` (singular) to `types?: Array<...> | null`, where `null` accurately represents the controller setting `typeFilters = null` when all provided type values are invalid, distinct from `undefined` when the parameter is absent entirely.
- Added 8 new unit tests covering: the `types`-param bypass scenario, comma-separated multi-type strings, array-format `types` (Express `qs` parsing), combined `type` + `types` params, all-invalid type values falling through to mixed search, empty-string `types` with no permissions, `PrincipalType.PUBLIC` treated as mixed search, and a missing `.json()` assertion on an existing partial-denial test.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified with Jest unit tests in `api/server/middleware/checkPeoplePickerAccess.spec.js`. All 20 tests pass.

Key scenarios exercised:

- `?types=group` with VIEW_GROUPS=false → 403 (the original bypass, now blocked)
- `?types=user,role` with VIEW_ROLES=false → 403 on `role`
- `?types=user,group` with both VIEW_USERS=true and VIEW_GROUPS=true → 200
- `?types[]=group&types[]=role` (array form) with VIEW_GROUPS=false → 403
- `?type=user&types=group` with VIEW_GROUPS=false → 403
- `?types=foobar` → mixed-search fallback, `next()` called when user has any VIEW permission
- `?types=` (empty string) with all permissions false → 403
- `?types=public` → mixed-search fallback, `next()` called (PUBLIC absent from valid types)

### Test Configuration

- No external services required
- Run from `api/` workspace: `npx jest checkPeoplePickerAccess`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes