### PR TITLE
fix: persist modelLabel to DB and derive from spec as fallback

### DIFF
--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -441,6 +441,7 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
     endpointType: endpointOption.endpointType,
     resendFiles: primaryConfig.resendFiles ?? true,
     maxContextTokens: primaryConfig.maxContextTokens,
+    modelLabel: endpointOption.model_parameters?.modelLabel,
     endpoint: isEphemeralAgentId(primaryConfig.id) ? primaryConfig.endpoint : EModelEndpoint.agents,
   });
 

--- a/client/src/hooks/Conversations/useGetSender.ts
+++ b/client/src/hooks/Conversations/useGetSender.ts
@@ -1,15 +1,21 @@
 import { useCallback } from 'react';
 import { getResponseSender } from 'librechat-data-provider';
 import type { TEndpointOption, TEndpointsConfig } from 'librechat-data-provider';
-import { useGetEndpointsQuery } from '~/data-provider';
+import { useGetEndpointsQuery, useGetStartupConfig } from '~/data-provider';
 
 export default function useGetSender() {
   const { data: endpointsConfig = {} as TEndpointsConfig } = useGetEndpointsQuery();
+  const { data: startupConfig } = useGetStartupConfig();
   return useCallback(
     (endpointOption: TEndpointOption) => {
       const { modelDisplayLabel } = endpointsConfig?.[endpointOption.endpoint ?? ''] ?? {};
-      return getResponseSender({ ...endpointOption, modelDisplayLabel });
+      let { modelLabel } = endpointOption;
+      if (!modelLabel && endpointOption.spec) {
+        const spec = startupConfig?.modelSpecs?.list?.find((s) => s.name === endpointOption.spec);
+        modelLabel = spec?.preset?.modelLabel ?? spec?.label ?? null;
+      }
+      return getResponseSender({ ...endpointOption, modelLabel, modelDisplayLabel });
     },
-    [endpointsConfig],
+    [endpointsConfig, startupConfig],
   );
 }


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                        
                                                                                                                                                                                                                                    
  - Persists `modelLabel` to the database so it survives page reloads and conversation history
  - In `useGetSender`, when `modelLabel` is absent but a `spec` name is present, looks up the matching model spec and uses its `preset.modelLabel` or `label` as a fallback
  - Passes `modelLabel` through to agent initialization so the sender label is correctly resolved for agent-based endpoints

  ## Test plan

  - [ ] Start a conversation using a model spec that has a `label` or `preset.modelLabel` configured
  - [ ] Verify the sender name in the chat displays the spec label rather than the raw model ID
  - [ ] Reload the page and confirm the label persists in conversation history
  - [ ] Verify conversations without a spec still display correctly
  - [ ] Verify agent-based endpoints show the correct model label