### PR TITLE
fix: include conversation_starters in agent list projection

### DIFF
--- a/api/models/Agent.js
+++ b/api/models/Agent.js
@@ -717,6 +717,7 @@ const getListAgentsByAccess = async ({
     category: 1,
     support_contact: 1,
     is_promoted: 1,
+    conversation_starters: 1,
   }).sort({ updatedAt: -1, _id: 1 });
 
   // Only apply limit if pagination is requested


### PR DESCRIPTION
## Summary
- The `getListAgentsByAccess` query in `api/models/Agent.js` uses an explicit field projection that was missing `conversation_starters`
- This meant the field was never returned to the client, so agent conversation starters could never render in the `ConversationStarters` component — even when correctly set in the database
- Adds `conversation_starters: 1` to the projection

## Context
The original conversation starters feature (PR #3699) was built for assistants, which use a separate `documents` endpoint. When agents were added later, the agent list projection was written with a hardcoded field list that never included `conversation_starters`.

## Test plan
- Set `conversation_starters` on an agent in MongoDB
- Verify the field is returned by `GET /api/agents`
- Confirm starters render on the landing page when selecting that agent