### PR TITLE
🖼️ fix: Correct ToolMessage Response Format for Agent-Mode Image Tools

### DIFF
--- a/api/app/clients/tools/structured/DALLE3.js
+++ b/api/app/clients/tools/structured/DALLE3.js
@@ -52,6 +52,7 @@ class DALLE3 extends Tool {
     /** @type {boolean} */
     this.isAgent = fields.isAgent;
     if (this.isAgent) {
+      /** Ensures LangChain maps [content, artifact] tuple to ToolMessage fields instead of serializing it into content. */
       this.responseFormat = 'content_and_artifact';
     }
     if (fields.processFileURL) {

--- a/api/app/clients/tools/structured/DALLE3.js
+++ b/api/app/clients/tools/structured/DALLE3.js
@@ -51,6 +51,9 @@ class DALLE3 extends Tool {
     this.fileStrategy = fields.fileStrategy;
     /** @type {boolean} */
     this.isAgent = fields.isAgent;
+    if (this.isAgent) {
+      this.responseFormat = 'content_and_artifact';
+    }
     if (fields.processFileURL) {
       /** @type {processFileURL} Necessary for output to contain all image metadata. */
       this.processFileURL = fields.processFileURL.bind(this);

--- a/api/app/clients/tools/structured/FluxAPI.js
+++ b/api/app/clients/tools/structured/FluxAPI.js
@@ -113,6 +113,9 @@ class FluxAPI extends Tool {
 
     /** @type {boolean} **/
     this.isAgent = fields.isAgent;
+    if (this.isAgent) {
+      this.responseFormat = 'content_and_artifact';
+    }
     this.returnMetadata = fields.returnMetadata ?? false;
 
     if (fields.processFileURL) {

--- a/api/app/clients/tools/structured/FluxAPI.js
+++ b/api/app/clients/tools/structured/FluxAPI.js
@@ -114,6 +114,7 @@ class FluxAPI extends Tool {
     /** @type {boolean} **/
     this.isAgent = fields.isAgent;
     if (this.isAgent) {
+      /** Ensures LangChain maps [content, artifact] tuple to ToolMessage fields instead of serializing it into content. */
       this.responseFormat = 'content_and_artifact';
     }
     this.returnMetadata = fields.returnMetadata ?? false;
@@ -527,9 +528,39 @@ class FluxAPI extends Tool {
       return this.returnValue('No image data received from Flux API.');
     }
 
-    // Try saving the image locally
     const imageUrl = resultData.sample;
     const imageName = `img-${uuidv4()}.png`;
+
+    if (this.isAgent) {
+      try {
+        const fetchOptions = {};
+        if (process.env.PROXY) {
+          fetchOptions.agent = new HttpsProxyAgent(process.env.PROXY);
+        }
+        const imageResponse = await fetch(imageUrl, fetchOptions);
+        const arrayBuffer = await imageResponse.arrayBuffer();
+        const base64 = Buffer.from(arrayBuffer).toString('base64');
+        const content = [
+          {
+            type: ContentTypes.IMAGE_URL,
+            image_url: {
+              url: `data:image/png;base64,${base64}`,
+            },
+          },
+        ];
+
+        const response = [
+          {
+            type: ContentTypes.TEXT,
+            text: displayMessage,
+          },
+        ];
+        return [response, { content }];
+      } catch (error) {
+        logger.error('[FluxAPI] Error processing finetuned image for agent:', error);
+        return this.returnValue(`Failed to process the finetuned image. ${error.message}`);
+      }
+    }
 
     try {
       logger.debug('[FluxAPI] Saving finetuned image:', imageUrl);
@@ -544,12 +575,9 @@ class FluxAPI extends Tool {
 
       logger.debug('[FluxAPI] Finetuned image saved to path:', result.filepath);
 
-      // Calculate cost based on endpoint
       const endpointKey = endpoint.includes('ultra')
         ? 'FLUX_PRO_1_1_ULTRA_FINETUNED'
         : 'FLUX_PRO_FINETUNED';
-      const cost = FluxAPI.PRICING[endpointKey] || 0;
-      // Return the result based on returnMetadata flag
       this.result = this.returnMetadata ? result : this.wrapInMarkdown(result.filepath);
       return this.returnValue(this.result);
     } catch (error) {

--- a/api/app/clients/tools/structured/FluxAPI.js
+++ b/api/app/clients/tools/structured/FluxAPI.js
@@ -575,9 +575,6 @@ class FluxAPI extends Tool {
 
       logger.debug('[FluxAPI] Finetuned image saved to path:', result.filepath);
 
-      const endpointKey = endpoint.includes('ultra')
-        ? 'FLUX_PRO_1_1_ULTRA_FINETUNED'
-        : 'FLUX_PRO_FINETUNED';
       this.result = this.returnMetadata ? result : this.wrapInMarkdown(result.filepath);
       return this.returnValue(this.result);
     } catch (error) {

--- a/api/app/clients/tools/structured/StableDiffusion.js
+++ b/api/app/clients/tools/structured/StableDiffusion.js
@@ -44,6 +44,7 @@ class StableDiffusionAPI extends Tool {
     /** @type {boolean} */
     this.isAgent = fields.isAgent;
     if (this.isAgent) {
+      /** Ensures LangChain maps [content, artifact] tuple to ToolMessage fields instead of serializing it into content. */
       this.responseFormat = 'content_and_artifact';
     }
     if (fields.uploadImageBuffer) {
@@ -118,7 +119,7 @@ class StableDiffusionAPI extends Tool {
       generationResponse = await axios.post(`${url}/sdapi/v1/txt2img`, payload);
     } catch (error) {
       logger.error('[StableDiffusion] Error while generating image:', error);
-      return 'Error making API request.';
+      return this.returnValue('Error making API request.');
     }
     const image = generationResponse.data.images[0];
 

--- a/api/app/clients/tools/structured/StableDiffusion.js
+++ b/api/app/clients/tools/structured/StableDiffusion.js
@@ -43,6 +43,9 @@ class StableDiffusionAPI extends Tool {
     this.returnMetadata = fields.returnMetadata ?? false;
     /** @type {boolean} */
     this.isAgent = fields.isAgent;
+    if (this.isAgent) {
+      this.responseFormat = 'content_and_artifact';
+    }
     if (fields.uploadImageBuffer) {
       /** @type {uploadImageBuffer} Necessary for output to contain all image metadata. */
       this.uploadImageBuffer = fields.uploadImageBuffer.bind(this);

--- a/api/app/clients/tools/structured/specs/imageTools-agent.spec.js
+++ b/api/app/clients/tools/structured/specs/imageTools-agent.spec.js
@@ -102,12 +102,18 @@ describe('image tools - agent mode ToolMessage format', () => {
     it('invoke() returns ToolMessage with base64 in artifact, not serialized in content', async () => {
       const dalle = new DALLE3({ isAgent: true });
       const result = await dalle.invoke(
-        makeToolCall('dalle', { prompt: 'a box', quality: 'standard', size: '1024x1024', style: 'vivid' }),
+        makeToolCall('dalle', {
+          prompt: 'a box',
+          quality: 'standard',
+          size: '1024x1024',
+          style: 'vivid',
+        }),
       );
 
       expect(result).toBeInstanceOf(ToolMessage);
 
-      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      const contentStr =
+        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
       expect(contentStr).not.toContain(FAKE_BASE64);
 
       expect(result.artifact).toBeDefined();
@@ -124,11 +130,17 @@ describe('image tools - agent mode ToolMessage format', () => {
 
       const dalle = new DALLE3({ isAgent: true });
       const result = await dalle.invoke(
-        makeToolCall('dalle', { prompt: 'a box', quality: 'standard', size: '1024x1024', style: 'vivid' }),
+        makeToolCall('dalle', {
+          prompt: 'a box',
+          quality: 'standard',
+          size: '1024x1024',
+          style: 'vivid',
+        }),
       );
 
       expect(result).toBeInstanceOf(ToolMessage);
-      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      const contentStr =
+        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
       expect(contentStr).toContain('Something went wrong');
       expect(result.artifact).toBeDefined();
     });
@@ -162,12 +174,15 @@ describe('image tools - agent mode ToolMessage format', () => {
 
     it('invoke() returns ToolMessage with base64 in artifact, not serialized in content', async () => {
       const flux = new FluxAPI({ isAgent: true });
-      const invokePromise = flux.invoke(makeToolCall('flux', { prompt: 'a box', endpoint: '/v1/flux-dev' }));
+      const invokePromise = flux.invoke(
+        makeToolCall('flux', { prompt: 'a box', endpoint: '/v1/flux-dev' }),
+      );
       await jest.runAllTimersAsync();
       const result = await invokePromise;
 
       expect(result).toBeInstanceOf(ToolMessage);
-      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      const contentStr =
+        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
       expect(contentStr).not.toContain(FAKE_BASE64);
 
       expect(result.artifact).toBeDefined();
@@ -191,7 +206,8 @@ describe('image tools - agent mode ToolMessage format', () => {
       const result = await invokePromise;
 
       expect(result).toBeInstanceOf(ToolMessage);
-      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      const contentStr =
+        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
       expect(contentStr).not.toContain(FAKE_BASE64);
 
       expect(result.artifact).toBeDefined();
@@ -205,12 +221,15 @@ describe('image tools - agent mode ToolMessage format', () => {
       axios.post.mockRejectedValue(new Error('Network error'));
 
       const flux = new FluxAPI({ isAgent: true });
-      const invokePromise = flux.invoke(makeToolCall('flux', { prompt: 'a box', endpoint: '/v1/flux-dev' }));
+      const invokePromise = flux.invoke(
+        makeToolCall('flux', { prompt: 'a box', endpoint: '/v1/flux-dev' }),
+      );
       await jest.runAllTimersAsync();
       const result = await invokePromise;
 
       expect(result).toBeInstanceOf(ToolMessage);
-      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      const contentStr =
+        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
       expect(contentStr).toContain('Something went wrong');
       expect(result.artifact).toBeDefined();
     });
@@ -232,7 +251,11 @@ describe('image tools - agent mode ToolMessage format', () => {
     });
 
     it('does not set responseFormat when isAgent is false', () => {
-      const sd = new StableDiffusionAPI({ isAgent: false, override: true, uploadImageBuffer: jest.fn() });
+      const sd = new StableDiffusionAPI({
+        isAgent: false,
+        override: true,
+        uploadImageBuffer: jest.fn(),
+      });
       expect(sd.responseFormat).not.toBe('content_and_artifact');
     });
 
@@ -243,7 +266,8 @@ describe('image tools - agent mode ToolMessage format', () => {
       );
 
       expect(result).toBeInstanceOf(ToolMessage);
-      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      const contentStr =
+        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
       expect(contentStr).not.toContain(FAKE_BASE64);
 
       expect(result.artifact).toBeDefined();
@@ -262,7 +286,8 @@ describe('image tools - agent mode ToolMessage format', () => {
       );
 
       expect(result).toBeInstanceOf(ToolMessage);
-      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      const contentStr =
+        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
       expect(contentStr).toContain('Error making API request');
     });
   });

--- a/api/app/clients/tools/structured/specs/imageTools-agent.spec.js
+++ b/api/app/clients/tools/structured/specs/imageTools-agent.spec.js
@@ -1,0 +1,205 @@
+/**
+ * Regression tests for image tool agent mode - verifies that invoke() returns
+ * a proper ToolMessage with base64 in artifact.content, not serialized into content.
+ *
+ * Root cause of original bug: DALLE3/FluxAPI/StableDiffusion extend LangChain's Tool
+ * but did not set responseFormat = 'content_and_artifact'. LangChain's invoke() would
+ * then JSON.stringify the entire [content, artifact] tuple into ToolMessage.content,
+ * dumping the base64 string directly into token counting and causing context exhaustion.
+ */
+
+const OpenAI = require('openai');
+const axios = require('axios');
+const nodeFetch = require('node-fetch');
+const undici = require('undici');
+const { ToolMessage } = require('@langchain/core/messages');
+const { ContentTypes } = require('librechat-data-provider');
+const DALLE3 = require('../DALLE3');
+const FluxAPI = require('../FluxAPI');
+const StableDiffusionAPI = require('../StableDiffusion');
+
+jest.mock('openai');
+jest.mock('axios');
+jest.mock('node-fetch');
+jest.mock('undici', () => ({
+  ProxyAgent: jest.fn(),
+  fetch: jest.fn(),
+}));
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() },
+}));
+jest.mock('path', () => ({
+  resolve: jest.fn(),
+  join: jest.fn().mockReturnValue('/mock/path'),
+  relative: jest.fn().mockReturnValue('relative/path'),
+  extname: jest.fn().mockReturnValue('.png'),
+}));
+jest.mock('fs', () => ({
+  existsSync: jest.fn().mockReturnValue(true),
+  mkdirSync: jest.fn(),
+  promises: { writeFile: jest.fn(), readFile: jest.fn(), unlink: jest.fn() },
+}));
+
+const FAKE_BASE64 = 'aGVsbG8=';
+
+const makeToolCall = (name, args) => ({
+  id: 'call_test_123',
+  name,
+  args,
+  type: 'tool_call',
+});
+
+describe('image tools - agent mode ToolMessage format', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.DALLE_API_KEY = 'test-key';
+    process.env.FLUX_API_KEY = 'test-key';
+    process.env.SD_WEBUI_URL = 'http://localhost:7860';
+  });
+
+  describe('DALLE3', () => {
+    let generate;
+
+    beforeEach(() => {
+      generate = jest.fn().mockResolvedValue({
+        data: [{ url: 'https://example.com/image.png' }],
+      });
+      OpenAI.mockImplementation(() => ({ images: { generate } }));
+      undici.fetch.mockResolvedValue({
+        arrayBuffer: () => Promise.resolve(Buffer.from(FAKE_BASE64, 'base64')),
+      });
+    });
+
+    it('sets responseFormat to content_and_artifact when isAgent is true', () => {
+      const dalle = new DALLE3({ isAgent: true });
+      expect(dalle.responseFormat).toBe('content_and_artifact');
+    });
+
+    it('does not set responseFormat when isAgent is false', () => {
+      const dalle = new DALLE3({ isAgent: false, processFileURL: jest.fn() });
+      expect(dalle.responseFormat).not.toBe('content_and_artifact');
+    });
+
+    it('invoke() returns ToolMessage with base64 in artifact, not serialized in content', async () => {
+      const dalle = new DALLE3({ isAgent: true });
+      const toolCall = makeToolCall('dalle', {
+        prompt: 'a box',
+        quality: 'standard',
+        size: '1024x1024',
+        style: 'vivid',
+      });
+
+      const result = await dalle.invoke(toolCall);
+
+      expect(result).toBeInstanceOf(ToolMessage);
+
+      const contentStr =
+        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      expect(contentStr).not.toContain('base64');
+      expect(contentStr).not.toContain(FAKE_BASE64);
+
+      expect(result.artifact).toBeDefined();
+      const artifactContent = result.artifact?.content;
+      expect(Array.isArray(artifactContent)).toBe(true);
+      expect(artifactContent[0].type).toBe(ContentTypes.IMAGE_URL);
+      expect(artifactContent[0].image_url.url).toContain('base64');
+    });
+  });
+
+  describe('FluxAPI', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      axios.post.mockResolvedValue({ data: { id: 'task-123' } });
+      axios.get.mockResolvedValue({
+        data: { status: 'Ready', result: { sample: 'https://example.com/image.png' } },
+      });
+      nodeFetch.mockResolvedValue({
+        arrayBuffer: () => Promise.resolve(Buffer.from(FAKE_BASE64, 'base64')),
+      });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('sets responseFormat to content_and_artifact when isAgent is true', () => {
+      const flux = new FluxAPI({ isAgent: true });
+      expect(flux.responseFormat).toBe('content_and_artifact');
+    });
+
+    it('does not set responseFormat when isAgent is false', () => {
+      const flux = new FluxAPI({ isAgent: false, processFileURL: jest.fn() });
+      expect(flux.responseFormat).not.toBe('content_and_artifact');
+    });
+
+    it('invoke() returns ToolMessage with base64 in artifact, not serialized in content', async () => {
+      const flux = new FluxAPI({ isAgent: true });
+      const toolCall = makeToolCall('flux', { prompt: 'a box', endpoint: '/v1/flux-dev' });
+
+      const invokePromise = flux.invoke(toolCall);
+      await jest.runAllTimersAsync();
+      const result = await invokePromise;
+
+      expect(result).toBeInstanceOf(ToolMessage);
+
+      const contentStr =
+        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      expect(contentStr).not.toContain('base64');
+      expect(contentStr).not.toContain(FAKE_BASE64);
+
+      expect(result.artifact).toBeDefined();
+      const artifactContent = result.artifact?.content;
+      expect(Array.isArray(artifactContent)).toBe(true);
+      expect(artifactContent[0].type).toBe(ContentTypes.IMAGE_URL);
+      expect(artifactContent[0].image_url.url).toContain('base64');
+    });
+  });
+
+  describe('StableDiffusion', () => {
+    beforeEach(() => {
+      axios.post.mockResolvedValue({
+        data: {
+          images: [FAKE_BASE64],
+          info: JSON.stringify({ height: 1024, width: 1024, seed: 42, infotexts: [] }),
+        },
+      });
+    });
+
+    it('sets responseFormat to content_and_artifact when isAgent is true', () => {
+      const sd = new StableDiffusionAPI({ isAgent: true, override: true });
+      expect(sd.responseFormat).toBe('content_and_artifact');
+    });
+
+    it('does not set responseFormat when isAgent is false', () => {
+      const sd = new StableDiffusionAPI({
+        isAgent: false,
+        override: true,
+        uploadImageBuffer: jest.fn(),
+      });
+      expect(sd.responseFormat).not.toBe('content_and_artifact');
+    });
+
+    it('invoke() returns ToolMessage with base64 in artifact, not serialized in content', async () => {
+      const sd = new StableDiffusionAPI({ isAgent: true, override: true, userId: 'user-1' });
+      const toolCall = makeToolCall('stable-diffusion', {
+        prompt: 'a box',
+        negative_prompt: '',
+      });
+
+      const result = await sd.invoke(toolCall);
+
+      expect(result).toBeInstanceOf(ToolMessage);
+
+      const contentStr =
+        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      expect(contentStr).not.toContain('base64');
+      expect(contentStr).not.toContain(FAKE_BASE64);
+
+      expect(result.artifact).toBeDefined();
+      const artifactContent = result.artifact?.content;
+      expect(Array.isArray(artifactContent)).toBe(true);
+      expect(artifactContent[0].type).toBe(ContentTypes.IMAGE_URL);
+      expect(artifactContent[0].image_url.url).toContain('base64');
+    });
+  });
+});

--- a/api/app/clients/tools/structured/specs/imageTools-agent.spec.js
+++ b/api/app/clients/tools/structured/specs/imageTools-agent.spec.js
@@ -9,14 +9,14 @@
  */
 
 const axios = require('axios');
-const fetch = require('node-fetch');
 const OpenAI = require('openai');
 const undici = require('undici');
+const fetch = require('node-fetch');
 const { ToolMessage } = require('@langchain/core/messages');
 const { ContentTypes } = require('librechat-data-provider');
-const DALLE3 = require('../DALLE3');
-const FluxAPI = require('../FluxAPI');
 const StableDiffusionAPI = require('../StableDiffusion');
+const FluxAPI = require('../FluxAPI');
+const DALLE3 = require('../DALLE3');
 
 jest.mock('axios');
 jest.mock('openai');

--- a/api/app/clients/tools/structured/specs/imageTools-agent.spec.js
+++ b/api/app/clients/tools/structured/specs/imageTools-agent.spec.js
@@ -1,16 +1,16 @@
 /**
- * Regression tests for image tool agent mode - verifies that invoke() returns
- * a proper ToolMessage with base64 in artifact.content, not serialized into content.
+ * Regression tests for image tool agent mode — verifies that invoke() returns
+ * a ToolMessage with base64 in artifact.content rather than serialized into content.
  *
- * Root cause of original bug: DALLE3/FluxAPI/StableDiffusion extend LangChain's Tool
- * but did not set responseFormat = 'content_and_artifact'. LangChain's invoke() would
- * then JSON.stringify the entire [content, artifact] tuple into ToolMessage.content,
- * dumping the base64 string directly into token counting and causing context exhaustion.
+ * Root cause: DALLE3/FluxAPI/StableDiffusion extend LangChain's Tool but did not
+ * set responseFormat = 'content_and_artifact'. LangChain's invoke() would then
+ * JSON.stringify the entire [content, artifact] tuple into ToolMessage.content,
+ * dumping base64 into token counting and causing context exhaustion.
  */
 
-const OpenAI = require('openai');
 const axios = require('axios');
-const nodeFetch = require('node-fetch');
+const fetch = require('node-fetch');
+const OpenAI = require('openai');
 const undici = require('undici');
 const { ToolMessage } = require('@langchain/core/messages');
 const { ContentTypes } = require('librechat-data-provider');
@@ -18,8 +18,8 @@ const DALLE3 = require('../DALLE3');
 const FluxAPI = require('../FluxAPI');
 const StableDiffusionAPI = require('../StableDiffusion');
 
-jest.mock('openai');
 jest.mock('axios');
+jest.mock('openai');
 jest.mock('node-fetch');
 jest.mock('undici', () => ({
   ProxyAgent: jest.fn(),
@@ -50,21 +50,40 @@ const makeToolCall = (name, args) => ({
 });
 
 describe('image tools - agent mode ToolMessage format', () => {
+  const ENV_KEYS = ['DALLE_API_KEY', 'FLUX_API_KEY', 'SD_WEBUI_URL', 'PROXY'];
+  let savedEnv = {};
+
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.DALLE_API_KEY = 'test-key';
-    process.env.FLUX_API_KEY = 'test-key';
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env.DALLE_API_KEY = 'test-dalle-key';
+    process.env.FLUX_API_KEY = 'test-flux-key';
     process.env.SD_WEBUI_URL = 'http://localhost:7860';
+    delete process.env.PROXY;
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    savedEnv = {};
   });
 
   describe('DALLE3', () => {
-    let generate;
-
     beforeEach(() => {
-      generate = jest.fn().mockResolvedValue({
-        data: [{ url: 'https://example.com/image.png' }],
-      });
-      OpenAI.mockImplementation(() => ({ images: { generate } }));
+      OpenAI.mockImplementation(() => ({
+        images: {
+          generate: jest.fn().mockResolvedValue({
+            data: [{ url: 'https://example.com/image.png' }],
+          }),
+        },
+      }));
       undici.fetch.mockResolvedValue({
         arrayBuffer: () => Promise.resolve(Buffer.from(FAKE_BASE64, 'base64')),
       });
@@ -82,20 +101,13 @@ describe('image tools - agent mode ToolMessage format', () => {
 
     it('invoke() returns ToolMessage with base64 in artifact, not serialized in content', async () => {
       const dalle = new DALLE3({ isAgent: true });
-      const toolCall = makeToolCall('dalle', {
-        prompt: 'a box',
-        quality: 'standard',
-        size: '1024x1024',
-        style: 'vivid',
-      });
-
-      const result = await dalle.invoke(toolCall);
+      const result = await dalle.invoke(
+        makeToolCall('dalle', { prompt: 'a box', quality: 'standard', size: '1024x1024', style: 'vivid' }),
+      );
 
       expect(result).toBeInstanceOf(ToolMessage);
 
-      const contentStr =
-        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
-      expect(contentStr).not.toContain('base64');
+      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
       expect(contentStr).not.toContain(FAKE_BASE64);
 
       expect(result.artifact).toBeDefined();
@@ -103,6 +115,22 @@ describe('image tools - agent mode ToolMessage format', () => {
       expect(Array.isArray(artifactContent)).toBe(true);
       expect(artifactContent[0].type).toBe(ContentTypes.IMAGE_URL);
       expect(artifactContent[0].image_url.url).toContain('base64');
+    });
+
+    it('invoke() returns ToolMessage with error string in content when API fails', async () => {
+      OpenAI.mockImplementation(() => ({
+        images: { generate: jest.fn().mockRejectedValue(new Error('API error')) },
+      }));
+
+      const dalle = new DALLE3({ isAgent: true });
+      const result = await dalle.invoke(
+        makeToolCall('dalle', { prompt: 'a box', quality: 'standard', size: '1024x1024', style: 'vivid' }),
+      );
+
+      expect(result).toBeInstanceOf(ToolMessage);
+      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      expect(contentStr).toContain('Something went wrong');
+      expect(result.artifact).toBeDefined();
     });
   });
 
@@ -113,7 +141,7 @@ describe('image tools - agent mode ToolMessage format', () => {
       axios.get.mockResolvedValue({
         data: { status: 'Ready', result: { sample: 'https://example.com/image.png' } },
       });
-      nodeFetch.mockResolvedValue({
+      fetch.mockResolvedValue({
         arrayBuffer: () => Promise.resolve(Buffer.from(FAKE_BASE64, 'base64')),
       });
     });
@@ -134,17 +162,12 @@ describe('image tools - agent mode ToolMessage format', () => {
 
     it('invoke() returns ToolMessage with base64 in artifact, not serialized in content', async () => {
       const flux = new FluxAPI({ isAgent: true });
-      const toolCall = makeToolCall('flux', { prompt: 'a box', endpoint: '/v1/flux-dev' });
-
-      const invokePromise = flux.invoke(toolCall);
+      const invokePromise = flux.invoke(makeToolCall('flux', { prompt: 'a box', endpoint: '/v1/flux-dev' }));
       await jest.runAllTimersAsync();
       const result = await invokePromise;
 
       expect(result).toBeInstanceOf(ToolMessage);
-
-      const contentStr =
-        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
-      expect(contentStr).not.toContain('base64');
+      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
       expect(contentStr).not.toContain(FAKE_BASE64);
 
       expect(result.artifact).toBeDefined();
@@ -152,6 +175,44 @@ describe('image tools - agent mode ToolMessage format', () => {
       expect(Array.isArray(artifactContent)).toBe(true);
       expect(artifactContent[0].type).toBe(ContentTypes.IMAGE_URL);
       expect(artifactContent[0].image_url.url).toContain('base64');
+    });
+
+    it('invoke() returns ToolMessage with base64 in artifact for generate_finetuned action', async () => {
+      const flux = new FluxAPI({ isAgent: true });
+      const invokePromise = flux.invoke(
+        makeToolCall('flux', {
+          action: 'generate_finetuned',
+          prompt: 'a box',
+          finetune_id: 'ft-abc123',
+          endpoint: '/v1/flux-pro-finetuned',
+        }),
+      );
+      await jest.runAllTimersAsync();
+      const result = await invokePromise;
+
+      expect(result).toBeInstanceOf(ToolMessage);
+      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      expect(contentStr).not.toContain(FAKE_BASE64);
+
+      expect(result.artifact).toBeDefined();
+      const artifactContent = result.artifact?.content;
+      expect(Array.isArray(artifactContent)).toBe(true);
+      expect(artifactContent[0].type).toBe(ContentTypes.IMAGE_URL);
+      expect(artifactContent[0].image_url.url).toContain('base64');
+    });
+
+    it('invoke() returns ToolMessage with error string in content when task submission fails', async () => {
+      axios.post.mockRejectedValue(new Error('Network error'));
+
+      const flux = new FluxAPI({ isAgent: true });
+      const invokePromise = flux.invoke(makeToolCall('flux', { prompt: 'a box', endpoint: '/v1/flux-dev' }));
+      await jest.runAllTimersAsync();
+      const result = await invokePromise;
+
+      expect(result).toBeInstanceOf(ToolMessage);
+      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      expect(contentStr).toContain('Something went wrong');
+      expect(result.artifact).toBeDefined();
     });
   });
 
@@ -171,28 +232,18 @@ describe('image tools - agent mode ToolMessage format', () => {
     });
 
     it('does not set responseFormat when isAgent is false', () => {
-      const sd = new StableDiffusionAPI({
-        isAgent: false,
-        override: true,
-        uploadImageBuffer: jest.fn(),
-      });
+      const sd = new StableDiffusionAPI({ isAgent: false, override: true, uploadImageBuffer: jest.fn() });
       expect(sd.responseFormat).not.toBe('content_and_artifact');
     });
 
     it('invoke() returns ToolMessage with base64 in artifact, not serialized in content', async () => {
       const sd = new StableDiffusionAPI({ isAgent: true, override: true, userId: 'user-1' });
-      const toolCall = makeToolCall('stable-diffusion', {
-        prompt: 'a box',
-        negative_prompt: '',
-      });
-
-      const result = await sd.invoke(toolCall);
+      const result = await sd.invoke(
+        makeToolCall('stable-diffusion', { prompt: 'a box', negative_prompt: '' }),
+      );
 
       expect(result).toBeInstanceOf(ToolMessage);
-
-      const contentStr =
-        typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
-      expect(contentStr).not.toContain('base64');
+      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
       expect(contentStr).not.toContain(FAKE_BASE64);
 
       expect(result.artifact).toBeDefined();
@@ -200,6 +251,19 @@ describe('image tools - agent mode ToolMessage format', () => {
       expect(Array.isArray(artifactContent)).toBe(true);
       expect(artifactContent[0].type).toBe(ContentTypes.IMAGE_URL);
       expect(artifactContent[0].image_url.url).toContain('base64');
+    });
+
+    it('invoke() returns ToolMessage with error string in content when API fails', async () => {
+      axios.post.mockRejectedValue(new Error('Connection refused'));
+
+      const sd = new StableDiffusionAPI({ isAgent: true, override: true, userId: 'user-1' });
+      const result = await sd.invoke(
+        makeToolCall('stable-diffusion', { prompt: 'a box', negative_prompt: '' }),
+      );
+
+      expect(result).toBeInstanceOf(ToolMessage);
+      const contentStr = typeof result.content === 'string' ? result.content : JSON.stringify(result.content);
+      expect(contentStr).toContain('Error making API request');
     });
   });
 });


### PR DESCRIPTION

## Summary

Fixed a context-exhaustion bug where DALL-E 3, FluxAPI, and Stable Diffusion image tools, when invoked in agent mode, were serializing the full base64 image payload directly into `ToolMessage.content` instead of routing it to `artifact.content`.

- Set `this.responseFormat = 'content_and_artifact'` in the constructors of `DALLE3`, `FluxAPI`, and `StableDiffusionAPI` when `isAgent` is `true`, so LangChain's `Tool.invoke()` correctly maps the `[content, artifact]` tuple returned by `_call()` onto the respective `ToolMessage` fields rather than `JSON.stringify`-ing the entire tuple into `content`.
- Added a JSDoc comment at each `responseFormat` assignment explaining why LangChain requires the property for correct `ToolMessage` construction.
- Fixed `FluxAPI.generateFinetunedImage()`, which had no `isAgent` branch and would unconditionally call `this.processFileURL` — a method that is never set in agent context — causing a silent `TypeError` and a failed generation with no image returned.
- Fixed `StableDiffusionAPI._call()` error path, which was returning a raw string on `axios` failure, bypassing `returnValue()` and breaking the `content_and_artifact` tuple contract when `isAgent` is `true`.
- Added `imageTools-agent.spec.js` with 13 regression tests covering `responseFormat` assignment, happy-path `invoke()` for all three tools (including the `generate_finetuned` FluxAPI action), and error-path `invoke()` for all three tools, verifying the `ToolMessage` structure in every case.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified via the new `api/app/clients/tools/structured/specs/imageTools-agent.spec.js` regression suite. Run from the `api` workspace:

```bash
cd api && npx jest imageTools-agent
```

### **Test Configuration**:

- No external services required — OpenAI SDK, `axios`, `node-fetch`, and `undici` are all mocked.
- Tests cover: `responseFormat` set/not-set on construction, `invoke()` returning a `ToolMessage` with base64 confined to `artifact.content` on success, `invoke()` returning a well-formed `ToolMessage` with an error string in `content` on upstream API failure, and the `generate_finetuned` FluxAPI action path in agent mode.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes