### PR TITLE
🔌 fix: Isolate Code-Server HTTP Agents to Prevent Socket Pool Contamination

### DIFF
--- a/api/server/services/Files/Code/__tests__/process-traversal.spec.js
+++ b/api/server/services/Files/Code/__tests__/process-traversal.spec.js
@@ -10,10 +10,16 @@ jest.mock('@librechat/agents', () => ({
 
 const mockSanitizeFilename = jest.fn();
 
+const mockAxios = jest.fn().mockResolvedValue({
+  data: Buffer.from('file-content'),
+});
+mockAxios.post = jest.fn();
+
 jest.mock('@librechat/api', () => ({
   logAxiosError: jest.fn(),
   getBasePath: jest.fn(() => ''),
   sanitizeFilename: mockSanitizeFilename,
+  createAxiosInstance: jest.fn(() => mockAxios),
 }));
 
 jest.mock('librechat-data-provider', () => ({
@@ -52,12 +58,6 @@ jest.mock('~/server/services/Files/images/convert', () => ({
 jest.mock('~/server/utils', () => ({
   determineFileType: jest.fn().mockResolvedValue({ mime: 'text/csv' }),
 }));
-
-jest.mock('axios', () =>
-  jest.fn().mockResolvedValue({
-    data: Buffer.from('file-content'),
-  }),
-);
 
 const { createFile } = require('~/models');
 const { processCodeOutput } = require('../process');

--- a/api/server/services/Files/Code/__tests__/process-traversal.spec.js
+++ b/api/server/services/Files/Code/__tests__/process-traversal.spec.js
@@ -15,12 +15,18 @@ const mockAxios = jest.fn().mockResolvedValue({
 });
 mockAxios.post = jest.fn();
 
-jest.mock('@librechat/api', () => ({
-  logAxiosError: jest.fn(),
-  getBasePath: jest.fn(() => ''),
-  sanitizeFilename: mockSanitizeFilename,
-  createAxiosInstance: jest.fn(() => mockAxios),
-}));
+jest.mock('@librechat/api', () => {
+  const http = require('http');
+  const https = require('https');
+  return {
+    logAxiosError: jest.fn(),
+    getBasePath: jest.fn(() => ''),
+    sanitizeFilename: mockSanitizeFilename,
+    createAxiosInstance: jest.fn(() => mockAxios),
+    codeServerHttpAgent: new http.Agent({ keepAlive: false }),
+    codeServerHttpsAgent: new https.Agent({ keepAlive: false }),
+  };
+});
 
 jest.mock('librechat-data-provider', () => ({
   ...jest.requireActual('librechat-data-provider'),

--- a/api/server/services/Files/Code/agents.js
+++ b/api/server/services/Files/Code/agents.js
@@ -1,0 +1,13 @@
+const http = require('http');
+const https = require('https');
+
+/**
+ * Dedicated agents for code-server requests, preventing socket pool contamination.
+ * follow-redirects (used by axios) leaks `socket.destroy` as a timeout listener;
+ * on Node 19+ (keepAlive: true by default), tainted sockets re-enter the global pool
+ * and kill unrelated requests (e.g., node-fetch in CodeExecutor) after the idle timeout.
+ */
+const codeServerHttpAgent = new http.Agent({ keepAlive: false });
+const codeServerHttpsAgent = new https.Agent({ keepAlive: false });
+
+module.exports = { codeServerHttpAgent, codeServerHttpsAgent };

--- a/api/server/services/Files/Code/crud.js
+++ b/api/server/services/Files/Code/crud.js
@@ -1,19 +1,9 @@
-const http = require('http');
-const https = require('https');
 const FormData = require('form-data');
 const { getCodeBaseURL } = require('@librechat/agents');
 const { createAxiosInstance, logAxiosError } = require('@librechat/api');
+const { codeServerHttpAgent, codeServerHttpsAgent } = require('./agents');
 
 const axios = createAxiosInstance();
-
-/**
- * Dedicated agents for code-server requests, preventing socket pool contamination.
- * follow-redirects (used by axios) leaks `socket.destroy` as a timeout listener;
- * on Node 19+ (keepAlive: true by default), tainted sockets re-enter the global pool
- * and kill unrelated requests (e.g., node-fetch in CodeExecutor) after the idle timeout.
- */
-const codeServerHttpAgent = new http.Agent({ keepAlive: false });
-const codeServerHttpsAgent = new https.Agent({ keepAlive: false });
 
 const MAX_FILE_SIZE = 150 * 1024 * 1024;
 
@@ -84,6 +74,7 @@ async function uploadCodeEnvFile({ req, stream, filename, apiKey, entity_id = ''
       },
       httpAgent: codeServerHttpAgent,
       httpsAgent: codeServerHttpsAgent,
+      timeout: 120000,
       maxContentLength: MAX_FILE_SIZE,
       maxBodyLength: MAX_FILE_SIZE,
     };

--- a/api/server/services/Files/Code/crud.js
+++ b/api/server/services/Files/Code/crud.js
@@ -1,8 +1,19 @@
+const http = require('http');
+const https = require('https');
 const FormData = require('form-data');
 const { getCodeBaseURL } = require('@librechat/agents');
 const { createAxiosInstance, logAxiosError } = require('@librechat/api');
 
 const axios = createAxiosInstance();
+
+/**
+ * Dedicated agents for code-server requests, preventing socket pool contamination.
+ * follow-redirects (used by axios) leaks `socket.destroy` as a timeout listener;
+ * on Node 19+ (keepAlive: true by default), tainted sockets re-enter the global pool
+ * and kill unrelated requests (e.g., node-fetch in CodeExecutor) after the idle timeout.
+ */
+const codeServerHttpAgent = new http.Agent({ keepAlive: false });
+const codeServerHttpsAgent = new https.Agent({ keepAlive: false });
 
 const MAX_FILE_SIZE = 150 * 1024 * 1024;
 
@@ -25,6 +36,8 @@ async function getCodeOutputDownloadStream(fileIdentifier, apiKey) {
         'User-Agent': 'LibreChat/1.0',
         'X-API-Key': apiKey,
       },
+      httpAgent: codeServerHttpAgent,
+      httpsAgent: codeServerHttpsAgent,
       timeout: 15000,
     };
 
@@ -69,6 +82,8 @@ async function uploadCodeEnvFile({ req, stream, filename, apiKey, entity_id = ''
         'User-Id': req.user.id,
         'X-API-Key': apiKey,
       },
+      httpAgent: codeServerHttpAgent,
+      httpsAgent: codeServerHttpsAgent,
       maxContentLength: MAX_FILE_SIZE,
       maxBodyLength: MAX_FILE_SIZE,
     };

--- a/api/server/services/Files/Code/crud.js
+++ b/api/server/services/Files/Code/crud.js
@@ -1,7 +1,11 @@
 const FormData = require('form-data');
 const { getCodeBaseURL } = require('@librechat/agents');
-const { createAxiosInstance, logAxiosError } = require('@librechat/api');
-const { codeServerHttpAgent, codeServerHttpsAgent } = require('./agents');
+const {
+  logAxiosError,
+  createAxiosInstance,
+  codeServerHttpAgent,
+  codeServerHttpsAgent,
+} = require('@librechat/api');
 
 const axios = createAxiosInstance();
 

--- a/api/server/services/Files/Code/crud.spec.js
+++ b/api/server/services/Files/Code/crud.spec.js
@@ -1,0 +1,143 @@
+const http = require('http');
+const https = require('https');
+const { Readable } = require('stream');
+
+const mockAxios = jest.fn();
+mockAxios.post = jest.fn();
+
+jest.mock('@librechat/agents', () => ({
+  getCodeBaseURL: jest.fn(() => 'https://code-api.example.com'),
+}));
+
+jest.mock('@librechat/api', () => ({
+  logAxiosError: jest.fn(({ message }) => message),
+  createAxiosInstance: jest.fn(() => mockAxios),
+}));
+
+const { codeServerHttpAgent, codeServerHttpsAgent } = require('./agents');
+const { getCodeOutputDownloadStream, uploadCodeEnvFile } = require('./crud');
+
+describe('Code CRUD', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getCodeOutputDownloadStream', () => {
+    it('should pass dedicated keepAlive:false agents to axios', async () => {
+      const mockResponse = { data: Readable.from(['chunk']) };
+      mockAxios.mockResolvedValue(mockResponse);
+
+      await getCodeOutputDownloadStream('session-1/file-1', 'test-key');
+
+      const callConfig = mockAxios.mock.calls[0][0];
+      expect(callConfig.httpAgent).toBe(codeServerHttpAgent);
+      expect(callConfig.httpsAgent).toBe(codeServerHttpsAgent);
+      expect(callConfig.httpAgent).toBeInstanceOf(http.Agent);
+      expect(callConfig.httpsAgent).toBeInstanceOf(https.Agent);
+      expect(callConfig.httpAgent.keepAlive).toBe(false);
+      expect(callConfig.httpsAgent.keepAlive).toBe(false);
+    });
+
+    it('should request stream response from the correct URL', async () => {
+      mockAxios.mockResolvedValue({ data: Readable.from(['chunk']) });
+
+      await getCodeOutputDownloadStream('session-1/file-1', 'test-key');
+
+      const callConfig = mockAxios.mock.calls[0][0];
+      expect(callConfig.url).toBe('https://code-api.example.com/download/session-1/file-1');
+      expect(callConfig.responseType).toBe('stream');
+      expect(callConfig.timeout).toBe(15000);
+      expect(callConfig.headers['X-API-Key']).toBe('test-key');
+    });
+
+    it('should throw on network error', async () => {
+      mockAxios.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(getCodeOutputDownloadStream('s/f', 'key')).rejects.toThrow();
+    });
+  });
+
+  describe('uploadCodeEnvFile', () => {
+    const baseUploadParams = {
+      req: { user: { id: 'user-123' } },
+      stream: Readable.from(['file-content']),
+      filename: 'data.csv',
+      apiKey: 'test-key',
+    };
+
+    it('should pass dedicated keepAlive:false agents to axios', async () => {
+      mockAxios.post.mockResolvedValue({
+        data: {
+          message: 'success',
+          session_id: 'sess-1',
+          files: [{ fileId: 'fid-1', filename: 'data.csv' }],
+        },
+      });
+
+      await uploadCodeEnvFile(baseUploadParams);
+
+      const callConfig = mockAxios.post.mock.calls[0][2];
+      expect(callConfig.httpAgent).toBe(codeServerHttpAgent);
+      expect(callConfig.httpsAgent).toBe(codeServerHttpsAgent);
+      expect(callConfig.httpAgent).toBeInstanceOf(http.Agent);
+      expect(callConfig.httpsAgent).toBeInstanceOf(https.Agent);
+      expect(callConfig.httpAgent.keepAlive).toBe(false);
+      expect(callConfig.httpsAgent.keepAlive).toBe(false);
+    });
+
+    it('should set a timeout on upload requests', async () => {
+      mockAxios.post.mockResolvedValue({
+        data: {
+          message: 'success',
+          session_id: 'sess-1',
+          files: [{ fileId: 'fid-1', filename: 'data.csv' }],
+        },
+      });
+
+      await uploadCodeEnvFile(baseUploadParams);
+
+      const callConfig = mockAxios.post.mock.calls[0][2];
+      expect(callConfig.timeout).toBe(120000);
+    });
+
+    it('should return fileIdentifier on success', async () => {
+      mockAxios.post.mockResolvedValue({
+        data: {
+          message: 'success',
+          session_id: 'sess-1',
+          files: [{ fileId: 'fid-1', filename: 'data.csv' }],
+        },
+      });
+
+      const result = await uploadCodeEnvFile(baseUploadParams);
+      expect(result).toBe('sess-1/fid-1');
+    });
+
+    it('should append entity_id query param when provided', async () => {
+      mockAxios.post.mockResolvedValue({
+        data: {
+          message: 'success',
+          session_id: 'sess-1',
+          files: [{ fileId: 'fid-1', filename: 'data.csv' }],
+        },
+      });
+
+      const result = await uploadCodeEnvFile({ ...baseUploadParams, entity_id: 'agent-42' });
+      expect(result).toBe('sess-1/fid-1?entity_id=agent-42');
+    });
+
+    it('should throw when server returns non-success message', async () => {
+      mockAxios.post.mockResolvedValue({
+        data: { message: 'quota_exceeded', session_id: 's', files: [] },
+      });
+
+      await expect(uploadCodeEnvFile(baseUploadParams)).rejects.toThrow('quota_exceeded');
+    });
+
+    it('should throw on network error', async () => {
+      mockAxios.post.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(uploadCodeEnvFile(baseUploadParams)).rejects.toThrow();
+    });
+  });
+});

--- a/api/server/services/Files/Code/crud.spec.js
+++ b/api/server/services/Files/Code/crud.spec.js
@@ -9,12 +9,18 @@ jest.mock('@librechat/agents', () => ({
   getCodeBaseURL: jest.fn(() => 'https://code-api.example.com'),
 }));
 
-jest.mock('@librechat/api', () => ({
-  logAxiosError: jest.fn(({ message }) => message),
-  createAxiosInstance: jest.fn(() => mockAxios),
-}));
+jest.mock('@librechat/api', () => {
+  const http = require('http');
+  const https = require('https');
+  return {
+    logAxiosError: jest.fn(({ message }) => message),
+    createAxiosInstance: jest.fn(() => mockAxios),
+    codeServerHttpAgent: new http.Agent({ keepAlive: false }),
+    codeServerHttpsAgent: new https.Agent({ keepAlive: false }),
+  };
+});
 
-const { codeServerHttpAgent, codeServerHttpsAgent } = require('./agents');
+const { codeServerHttpAgent, codeServerHttpsAgent } = require('@librechat/api');
 const { getCodeOutputDownloadStream, uploadCodeEnvFile } = require('./crud');
 
 describe('Code CRUD', () => {

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -1,9 +1,20 @@
+const http = require('http');
+const https = require('https');
 const path = require('path');
 const { v4 } = require('uuid');
 const axios = require('axios');
 const { logger } = require('@librechat/data-schemas');
 const { getCodeBaseURL } = require('@librechat/agents');
 const { logAxiosError, getBasePath, sanitizeFilename } = require('@librechat/api');
+
+/**
+ * Dedicated agents for code-server requests, preventing socket pool contamination.
+ * follow-redirects (used by axios) leaks `socket.destroy` as a timeout listener;
+ * on Node 19+ (keepAlive: true by default), tainted sockets re-enter the global pool
+ * and kill unrelated requests (e.g., node-fetch in CodeExecutor) after the idle timeout.
+ */
+const codeServerHttpAgent = new http.Agent({ keepAlive: false });
+const codeServerHttpsAgent = new https.Agent({ keepAlive: false });
 const {
   Tools,
   megabyte,
@@ -102,6 +113,8 @@ const processCodeOutput = async ({
         'User-Agent': 'LibreChat/1.0',
         'X-API-Key': apiKey,
       },
+      httpAgent: codeServerHttpAgent,
+      httpsAgent: codeServerHttpsAgent,
       timeout: 15000,
     });
 
@@ -300,6 +313,8 @@ async function getSessionInfo(fileIdentifier, apiKey) {
         'User-Agent': 'LibreChat/1.0',
         'X-API-Key': apiKey,
       },
+      httpAgent: codeServerHttpAgent,
+      httpsAgent: codeServerHttpsAgent,
       timeout: 5000,
     });
 

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -2,7 +2,12 @@ const path = require('path');
 const { v4 } = require('uuid');
 const { logger } = require('@librechat/data-schemas');
 const { getCodeBaseURL } = require('@librechat/agents');
-const { logAxiosError, getBasePath, sanitizeFilename, createAxiosInstance } = require('@librechat/api');
+const {
+  logAxiosError,
+  getBasePath,
+  sanitizeFilename,
+  createAxiosInstance,
+} = require('@librechat/api');
 const {
   Tools,
   megabyte,
@@ -16,11 +21,11 @@ const {
   mergeFileConfig,
   getEndpointFileConfig,
 } = require('librechat-data-provider');
-const { codeServerHttpAgent, codeServerHttpsAgent } = require('./agents');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
 const { createFile, getFiles, updateFile, claimCodeFile } = require('~/models');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
+const { codeServerHttpAgent, codeServerHttpsAgent } = require('./agents');
 const { determineFileType } = require('~/server/utils');
 
 const axios = createAxiosInstance();
@@ -454,5 +459,6 @@ const primeFiles = async (options, apiKey) => {
 
 module.exports = {
   primeFiles,
+  getSessionInfo,
   processCodeOutput,
 };

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -3,10 +3,12 @@ const { v4 } = require('uuid');
 const { logger } = require('@librechat/data-schemas');
 const { getCodeBaseURL } = require('@librechat/agents');
 const {
-  logAxiosError,
   getBasePath,
+  logAxiosError,
   sanitizeFilename,
   createAxiosInstance,
+  codeServerHttpAgent,
+  codeServerHttpsAgent,
 } = require('@librechat/api');
 const {
   Tools,
@@ -25,7 +27,6 @@ const { filterFilesByAgentAccess } = require('~/server/services/Files/permission
 const { createFile, getFiles, updateFile, claimCodeFile } = require('~/models');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
-const { codeServerHttpAgent, codeServerHttpsAgent } = require('./agents');
 const { determineFileType } = require('~/server/utils');
 
 const axios = createAxiosInstance();

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -1,20 +1,8 @@
-const http = require('http');
-const https = require('https');
 const path = require('path');
 const { v4 } = require('uuid');
-const axios = require('axios');
 const { logger } = require('@librechat/data-schemas');
 const { getCodeBaseURL } = require('@librechat/agents');
-const { logAxiosError, getBasePath, sanitizeFilename } = require('@librechat/api');
-
-/**
- * Dedicated agents for code-server requests, preventing socket pool contamination.
- * follow-redirects (used by axios) leaks `socket.destroy` as a timeout listener;
- * on Node 19+ (keepAlive: true by default), tainted sockets re-enter the global pool
- * and kill unrelated requests (e.g., node-fetch in CodeExecutor) after the idle timeout.
- */
-const codeServerHttpAgent = new http.Agent({ keepAlive: false });
-const codeServerHttpsAgent = new https.Agent({ keepAlive: false });
+const { logAxiosError, getBasePath, sanitizeFilename, createAxiosInstance } = require('@librechat/api');
 const {
   Tools,
   megabyte,
@@ -28,11 +16,14 @@ const {
   mergeFileConfig,
   getEndpointFileConfig,
 } = require('librechat-data-provider');
+const { codeServerHttpAgent, codeServerHttpsAgent } = require('./agents');
 const { filterFilesByAgentAccess } = require('~/server/services/Files/permissions');
 const { createFile, getFiles, updateFile, claimCodeFile } = require('~/models');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
 const { determineFileType } = require('~/server/utils');
+
+const axios = createAxiosInstance();
 
 /**
  * Creates a fallback download URL response when file cannot be processed locally.

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -41,12 +41,18 @@ const mockAxios = jest.fn();
 mockAxios.post = jest.fn();
 mockAxios.isAxiosError = jest.fn(() => false);
 
-jest.mock('@librechat/api', () => ({
-  logAxiosError: jest.fn(),
-  getBasePath: jest.fn(() => ''),
-  sanitizeFilename: jest.fn((name) => name),
-  createAxiosInstance: jest.fn(() => mockAxios),
-}));
+jest.mock('@librechat/api', () => {
+  const http = require('http');
+  const https = require('https');
+  return {
+    logAxiosError: jest.fn(),
+    getBasePath: jest.fn(() => ''),
+    sanitizeFilename: jest.fn((name) => name),
+    createAxiosInstance: jest.fn(() => mockAxios),
+    codeServerHttpAgent: new http.Agent({ keepAlive: false }),
+    codeServerHttpsAgent: new https.Agent({ keepAlive: false }),
+  };
+});
 
 jest.mock('@librechat/data-schemas', () => ({
   logger: {
@@ -96,7 +102,7 @@ const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
 const { determineFileType } = require('~/server/utils');
 const { logger } = require('@librechat/data-schemas');
-const { codeServerHttpAgent, codeServerHttpsAgent } = require('./agents');
+const { codeServerHttpAgent, codeServerHttpsAgent } = require('@librechat/api');
 
 const { processCodeOutput, getSessionInfo } = require('./process');
 

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -36,11 +36,18 @@ jest.mock('uuid', () => ({
   v4: jest.fn(() => 'mock-uuid-1234'),
 }));
 
-// Mock axios
-jest.mock('axios');
-const axios = require('axios');
+// Mock axios — process.js now uses createAxiosInstance() from @librechat/api
+const mockAxios = jest.fn();
+mockAxios.post = jest.fn();
+mockAxios.isAxiosError = jest.fn(() => false);
 
-// Mock logger
+jest.mock('@librechat/api', () => ({
+  logAxiosError: jest.fn(),
+  getBasePath: jest.fn(() => ''),
+  sanitizeFilename: jest.fn((name) => name),
+  createAxiosInstance: jest.fn(() => mockAxios),
+}));
+
 jest.mock('@librechat/data-schemas', () => ({
   logger: {
     warn: jest.fn(),
@@ -49,16 +56,8 @@ jest.mock('@librechat/data-schemas', () => ({
   },
 }));
 
-// Mock getCodeBaseURL
 jest.mock('@librechat/agents', () => ({
   getCodeBaseURL: jest.fn(() => 'https://code-api.example.com'),
-}));
-
-// Mock logAxiosError and getBasePath
-jest.mock('@librechat/api', () => ({
-  logAxiosError: jest.fn(),
-  getBasePath: jest.fn(() => ''),
-  sanitizeFilename: jest.fn((name) => name),
 }));
 
 // Mock models
@@ -90,14 +89,16 @@ jest.mock('~/server/utils', () => ({
   determineFileType: jest.fn(),
 }));
 
+const http = require('http');
+const https = require('https');
 const { createFile, getFiles } = require('~/models');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { convertImage } = require('~/server/services/Files/images/convert');
 const { determineFileType } = require('~/server/utils');
 const { logger } = require('@librechat/data-schemas');
+const { codeServerHttpAgent, codeServerHttpsAgent } = require('./agents');
 
-// Import after mocks
-const { processCodeOutput } = require('./process');
+const { processCodeOutput, getSessionInfo } = require('./process');
 
 describe('Code Process', () => {
   const mockReq = {
@@ -145,7 +146,7 @@ describe('Code Process', () => {
       });
 
       const smallBuffer = Buffer.alloc(100);
-      axios.mockResolvedValue({ data: smallBuffer });
+      mockAxios.mockResolvedValue({ data: smallBuffer });
 
       const result = await processCodeOutput(baseParams);
 
@@ -168,7 +169,7 @@ describe('Code Process', () => {
       });
 
       const smallBuffer = Buffer.alloc(100);
-      axios.mockResolvedValue({ data: smallBuffer });
+      mockAxios.mockResolvedValue({ data: smallBuffer });
 
       const result = await processCodeOutput(baseParams);
 
@@ -182,7 +183,7 @@ describe('Code Process', () => {
       it('should process image files using convertImage', async () => {
         const imageParams = { ...baseParams, name: 'chart.png' };
         const imageBuffer = Buffer.alloc(500);
-        axios.mockResolvedValue({ data: imageBuffer });
+        mockAxios.mockResolvedValue({ data: imageBuffer });
 
         const convertedFile = {
           filepath: '/uploads/converted-image.webp',
@@ -212,7 +213,7 @@ describe('Code Process', () => {
         });
 
         const imageBuffer = Buffer.alloc(500);
-        axios.mockResolvedValue({ data: imageBuffer });
+        mockAxios.mockResolvedValue({ data: imageBuffer });
         convertImage.mockResolvedValue({ filepath: '/images/user-123/existing-img-id.webp' });
 
         const result = await processCodeOutput(imageParams);
@@ -235,7 +236,7 @@ describe('Code Process', () => {
     describe('non-image file processing', () => {
       it('should process non-image files using saveBuffer', async () => {
         const smallBuffer = Buffer.alloc(100);
-        axios.mockResolvedValue({ data: smallBuffer });
+        mockAxios.mockResolvedValue({ data: smallBuffer });
 
         const mockSaveBuffer = jest.fn().mockResolvedValue('/uploads/saved-file.txt');
         getStrategyFunctions.mockReturnValue({ saveBuffer: mockSaveBuffer });
@@ -256,7 +257,7 @@ describe('Code Process', () => {
 
       it('should detect MIME type from buffer', async () => {
         const smallBuffer = Buffer.alloc(100);
-        axios.mockResolvedValue({ data: smallBuffer });
+        mockAxios.mockResolvedValue({ data: smallBuffer });
         determineFileType.mockResolvedValue({ mime: 'application/pdf' });
 
         const result = await processCodeOutput({ ...baseParams, name: 'document.pdf' });
@@ -267,7 +268,7 @@ describe('Code Process', () => {
 
       it('should fallback to application/octet-stream for unknown types', async () => {
         const smallBuffer = Buffer.alloc(100);
-        axios.mockResolvedValue({ data: smallBuffer });
+        mockAxios.mockResolvedValue({ data: smallBuffer });
         determineFileType.mockResolvedValue(null);
 
         const result = await processCodeOutput({ ...baseParams, name: 'unknown.xyz' });
@@ -282,7 +283,7 @@ describe('Code Process', () => {
         fileSizeLimitConfig.value = 1000; // 1KB limit
 
         const largeBuffer = Buffer.alloc(5000); // 5KB - exceeds 1KB limit
-        axios.mockResolvedValue({ data: largeBuffer });
+        mockAxios.mockResolvedValue({ data: largeBuffer });
 
         const result = await processCodeOutput(baseParams);
 
@@ -300,7 +301,7 @@ describe('Code Process', () => {
     describe('fallback behavior', () => {
       it('should fallback to download URL when saveBuffer is not available', async () => {
         const smallBuffer = Buffer.alloc(100);
-        axios.mockResolvedValue({ data: smallBuffer });
+        mockAxios.mockResolvedValue({ data: smallBuffer });
         getStrategyFunctions.mockReturnValue({ saveBuffer: null });
 
         const result = await processCodeOutput(baseParams);
@@ -313,7 +314,7 @@ describe('Code Process', () => {
       });
 
       it('should fallback to download URL on axios error', async () => {
-        axios.mockRejectedValue(new Error('Network error'));
+        mockAxios.mockRejectedValue(new Error('Network error'));
 
         const result = await processCodeOutput(baseParams);
 
@@ -327,7 +328,7 @@ describe('Code Process', () => {
     describe('usage counter increment', () => {
       it('should set usage to 1 for new files', async () => {
         const smallBuffer = Buffer.alloc(100);
-        axios.mockResolvedValue({ data: smallBuffer });
+        mockAxios.mockResolvedValue({ data: smallBuffer });
 
         const result = await processCodeOutput(baseParams);
 
@@ -341,7 +342,7 @@ describe('Code Process', () => {
           createdAt: '2024-01-01',
         });
         const smallBuffer = Buffer.alloc(100);
-        axios.mockResolvedValue({ data: smallBuffer });
+        mockAxios.mockResolvedValue({ data: smallBuffer });
 
         const result = await processCodeOutput(baseParams);
 
@@ -354,7 +355,7 @@ describe('Code Process', () => {
           createdAt: '2024-01-01',
         });
         const smallBuffer = Buffer.alloc(100);
-        axios.mockResolvedValue({ data: smallBuffer });
+        mockAxios.mockResolvedValue({ data: smallBuffer });
 
         const result = await processCodeOutput(baseParams);
 
@@ -365,7 +366,7 @@ describe('Code Process', () => {
     describe('metadata and file properties', () => {
       it('should include fileIdentifier in metadata', async () => {
         const smallBuffer = Buffer.alloc(100);
-        axios.mockResolvedValue({ data: smallBuffer });
+        mockAxios.mockResolvedValue({ data: smallBuffer });
 
         const result = await processCodeOutput(baseParams);
 
@@ -376,7 +377,7 @@ describe('Code Process', () => {
 
       it('should set correct context for code-generated files', async () => {
         const smallBuffer = Buffer.alloc(100);
-        axios.mockResolvedValue({ data: smallBuffer });
+        mockAxios.mockResolvedValue({ data: smallBuffer });
 
         const result = await processCodeOutput(baseParams);
 
@@ -385,7 +386,7 @@ describe('Code Process', () => {
 
       it('should include toolCallId and messageId in result', async () => {
         const smallBuffer = Buffer.alloc(100);
-        axios.mockResolvedValue({ data: smallBuffer });
+        mockAxios.mockResolvedValue({ data: smallBuffer });
 
         const result = await processCodeOutput(baseParams);
 
@@ -395,7 +396,7 @@ describe('Code Process', () => {
 
       it('should call createFile with upsert enabled', async () => {
         const smallBuffer = Buffer.alloc(100);
-        axios.mockResolvedValue({ data: smallBuffer });
+        mockAxios.mockResolvedValue({ data: smallBuffer });
 
         await processCodeOutput(baseParams);
 
@@ -406,6 +407,37 @@ describe('Code Process', () => {
           }),
           true, // upsert flag
         );
+      });
+    });
+
+    describe('socket pool isolation', () => {
+      it('should pass dedicated keepAlive:false agents to axios for processCodeOutput', async () => {
+        const smallBuffer = Buffer.alloc(100);
+        mockAxios.mockResolvedValue({ data: smallBuffer });
+
+        await processCodeOutput(baseParams);
+
+        const callConfig = mockAxios.mock.calls[0][0];
+        expect(callConfig.httpAgent).toBe(codeServerHttpAgent);
+        expect(callConfig.httpsAgent).toBe(codeServerHttpsAgent);
+        expect(callConfig.httpAgent).toBeInstanceOf(http.Agent);
+        expect(callConfig.httpsAgent).toBeInstanceOf(https.Agent);
+        expect(callConfig.httpAgent.keepAlive).toBe(false);
+        expect(callConfig.httpsAgent.keepAlive).toBe(false);
+      });
+
+      it('should pass dedicated keepAlive:false agents to axios for getSessionInfo', async () => {
+        mockAxios.mockResolvedValue({
+          data: [{ name: 'sess/fid', lastModified: new Date().toISOString() }],
+        });
+
+        await getSessionInfo('sess/fid', 'api-key');
+
+        const callConfig = mockAxios.mock.calls[0][0];
+        expect(callConfig.httpAgent).toBe(codeServerHttpAgent);
+        expect(callConfig.httpsAgent).toBe(codeServerHttpsAgent);
+        expect(callConfig.httpAgent.keepAlive).toBe(false);
+        expect(callConfig.httpsAgent.keepAlive).toBe(false);
       });
     });
   });

--- a/packages/api/src/utils/code.ts
+++ b/packages/api/src/utils/code.ts
@@ -1,5 +1,5 @@
-const http = require('http');
-const https = require('https');
+import http from 'http';
+import https from 'https';
 
 /**
  * Dedicated agents for code-server requests, preventing socket pool contamination.
@@ -7,7 +7,5 @@ const https = require('https');
  * on Node 19+ (keepAlive: true by default), tainted sockets re-enter the global pool
  * and kill unrelated requests (e.g., node-fetch in CodeExecutor) after the idle timeout.
  */
-const codeServerHttpAgent = new http.Agent({ keepAlive: false });
-const codeServerHttpsAgent = new https.Agent({ keepAlive: false });
-
-module.exports = { codeServerHttpAgent, codeServerHttpsAgent };
+export const codeServerHttpAgent = new http.Agent({ keepAlive: false });
+export const codeServerHttpsAgent = new https.Agent({ keepAlive: false });

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './axios';
 export * from './azure';
+export * from './code';
 export * from './common';
 export * from './content';
 export * from './email';


### PR DESCRIPTION


## Summary

Fixes a "socket hang up" after ~5 seconds on Node 19+ when the code executor processes file attachments, and hardens the surrounding infrastructure with a shared agent module, proxy parity, a missing upload timeout, and regression test coverage.

- Introduces dedicated `http.Agent` / `https.Agent` instances with `keepAlive: false` for all four axios call sites targeting `CODE_BASEURL` (`getCodeOutputDownloadStream`, `uploadCodeEnvFile`, `processCodeOutput`, `getSessionInfo`), preventing tainted sockets from re-entering the global pool and destroying active `node-fetch` requests in `CodeExecutor`.
- Extracts the shared agent construction and its explanatory JSDoc into a new `agents.js` module, eliminating the DRY violation that would have existed across `crud.js` and `process.js`.
- Migrates `process.js` from a raw `require('axios')` call to `createAxiosInstance()` from `@librechat/api`, aligning proxy configuration behavior with `crud.js`.
- Adds a `120s` timeout to `uploadCodeEnvFile`, which was the only code-server axios call without one.
- Adds `crud.spec.js` covering `getCodeOutputDownloadStream` and `uploadCodeEnvFile` with agent option assertions, timeout verification, URL correctness, success/error paths, and `entity_id` query parameter behavior.
- Extends `process.spec.js` with a `socket pool isolation` describe block that asserts the exact agent instances, their types, and `keepAlive: false` are forwarded to axios for `processCodeOutput`.
- Updates `process-traversal.spec.js` and existing `process.spec.js` mocks to reflect the `createAxiosInstance()` migration.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran the existing and new unit tests from the `api` workspace:

```bash
cd api && npx jest server/services/Files/Code
```

Covers:
- `crud.spec.js` — agent isolation, `keepAlive: false`, timeout, URL, `entity_id` param, success/error paths for both CRUD functions
- `process.spec.js` — full existing suite (atomic claim, image/non-image processing, size limits, fallback behavior, usage counters, metadata) plus the new `socket pool isolation` block asserting agents are forwarded correctly
- `__tests__/process-traversal.spec.js` — path traversal protection, unaffected by the changes

To reproduce the underlying bug manually: run LibreChat on Node 20+ with a code executor configured, attach a file to a conversation, and trigger code execution. Without this fix, the download or session-info request will hang up after ~5 seconds. With it, requests complete cleanly.

### **Test Configuration**:
- Node.js v20.19.0+
- Code executor (`CODE_BASEURL`) configured and reachable
- File attachment present in the conversation before triggering execution

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes


Closes #12298