### PR TITLE
🛂 fix: Reject OpenID Email Fallback When Stored `openidId` Mismatches Token Sub

### DIFF
--- a/api/strategies/openIdJwtStrategy.spec.js
+++ b/api/strategies/openIdJwtStrategy.spec.js
@@ -271,6 +271,32 @@ describe('openIdJwtStrategy – OPENID_EMAIL_CLAIM', () => {
     expect(user).toBe(false);
   });
 
+  it('should reject login when email fallback finds user with mismatched openidId', async () => {
+    const emailMatchWithDifferentSub = {
+      _id: 'user-id-2',
+      provider: 'openid',
+      openidId: 'different-sub',
+      email: payload.email,
+      role: SystemRoles.USER,
+    };
+
+    findUser.mockImplementation(async (query) => {
+      if (query.$or) {
+        return null;
+      }
+      if (query.email === payload.email) {
+        return emailMatchWithDifferentSub;
+      }
+      return null;
+    });
+
+    const req = { headers: { authorization: 'Bearer tok' }, session: {} };
+    const { user, info } = await invokeVerify(req, payload);
+
+    expect(user).toBe(false);
+    expect(info).toEqual({ message: 'auth_failed' });
+  });
+
   it('should trim whitespace from OPENID_EMAIL_CLAIM', async () => {
     process.env.OPENID_EMAIL_CLAIM = '  upn  ';
     findUser.mockResolvedValue(null);

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -356,6 +356,33 @@ describe('setupOpenId', () => {
     expect(updateUser).not.toHaveBeenCalled();
   });
 
+  it('should block login when email fallback finds user with mismatched openidId', async () => {
+    const existingUser = {
+      _id: 'existingUserId',
+      provider: 'openid',
+      openidId: 'different-sub-claim',
+      email: tokenset.claims().email,
+      username: 'existinguser',
+      name: 'Existing User',
+    };
+    findUser.mockImplementation(async (query) => {
+      if (query.$or) {
+        return null;
+      }
+      if (query.email === tokenset.claims().email) {
+        return existingUser;
+      }
+      return null;
+    });
+
+    const result = await validate(tokenset);
+
+    expect(result.user).toBe(false);
+    expect(result.details.message).toBe(ErrorTypes.AUTH_FAILED);
+    expect(createUser).not.toHaveBeenCalled();
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
   it('should enforce the required role and reject login if missing', async () => {
     // Arrange – simulate a token without the required role.
     jwtDecode.mockReturnValue({

--- a/packages/api/src/auth/openid.spec.ts
+++ b/packages/api/src/auth/openid.spec.ts
@@ -317,6 +317,7 @@ describe('findOpenIDUser', () => {
         openidId: 'existing_openid',
         email: 'user@example.com',
         username: 'testuser',
+        // No provider field — tests a different branch than openid-provider mismatch
       } as IUser;
 
       mockFindUser
@@ -455,6 +456,32 @@ describe('findOpenIDUser', () => {
           findUser: mockFindUser,
         }),
       ).rejects.toThrow('Database error');
+    });
+
+    it('should reject email fallback when openidId is empty and user has a stored openidId', async () => {
+      const mockUser: IUser = {
+        _id: 'user123',
+        provider: 'openid',
+        openidId: 'existing-real-id',
+        email: 'user@example.com',
+        username: 'testuser',
+      } as IUser;
+
+      mockFindUser.mockResolvedValueOnce(mockUser);
+
+      const result = await findOpenIDUser({
+        openidId: '',
+        findUser: mockFindUser,
+        email: 'user@example.com',
+      });
+
+      expect(mockFindUser).toHaveBeenCalledTimes(1);
+      expect(mockFindUser).toHaveBeenCalledWith({ email: 'user@example.com' });
+      expect(result).toEqual({
+        user: null,
+        error: ErrorTypes.AUTH_FAILED,
+        migration: false,
+      });
     });
   });
 });

--- a/packages/api/src/auth/openid.spec.ts
+++ b/packages/api/src/auth/openid.spec.ts
@@ -107,18 +107,18 @@ describe('findOpenIDUser', () => {
   });
 
   describe('Email-based searches', () => {
-    it('should find user by email when primary conditions fail', async () => {
+    it('should find user by email when primary conditions fail and openidId matches', async () => {
       const mockUser: IUser = {
         _id: 'user123',
         provider: 'openid',
-        openidId: 'openid_456',
+        openidId: 'openid_123',
         email: 'user@example.com',
         username: 'testuser',
       } as IUser;
 
       mockFindUser
-        .mockResolvedValueOnce(null) // Primary condition fails
-        .mockResolvedValueOnce(mockUser); // Email search succeeds
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockUser);
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
@@ -202,7 +202,7 @@ describe('findOpenIDUser', () => {
       });
     });
 
-    it('should allow login when user has openid provider', async () => {
+    it('should reject email fallback when existing openidId does not match token sub', async () => {
       const mockUser: IUser = {
         _id: 'user123',
         provider: 'openid',
@@ -212,8 +212,34 @@ describe('findOpenIDUser', () => {
       } as IUser;
 
       mockFindUser
-        .mockResolvedValueOnce(null) // Primary condition fails
-        .mockResolvedValueOnce(mockUser); // Email search finds user with openid provider
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockUser);
+
+      const result = await findOpenIDUser({
+        openidId: 'openid_123',
+        findUser: mockFindUser,
+        email: 'user@example.com',
+      });
+
+      expect(result).toEqual({
+        user: null,
+        error: ErrorTypes.AUTH_FAILED,
+        migration: false,
+      });
+    });
+
+    it('should allow email fallback when existing openidId matches token sub', async () => {
+      const mockUser: IUser = {
+        _id: 'user123',
+        provider: 'openid',
+        openidId: 'openid_123',
+        email: 'user@example.com',
+        username: 'testuser',
+      } as IUser;
+
+      mockFindUser
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockUser);
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
@@ -259,7 +285,7 @@ describe('findOpenIDUser', () => {
       });
     });
 
-    it('should not migrate user who already has openidId', async () => {
+    it('should reject when user already has a different openidId', async () => {
       const mockUser: IUser = {
         _id: 'user123',
         provider: 'openid',
@@ -269,8 +295,8 @@ describe('findOpenIDUser', () => {
       } as IUser;
 
       mockFindUser
-        .mockResolvedValueOnce(null) // Primary condition fails
-        .mockResolvedValueOnce(mockUser); // Email search finds user with existing openidId
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockUser);
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
@@ -279,24 +305,23 @@ describe('findOpenIDUser', () => {
       });
 
       expect(result).toEqual({
-        user: mockUser,
-        error: null,
+        user: null,
+        error: ErrorTypes.AUTH_FAILED,
         migration: false,
       });
     });
 
-    it('should handle user with no provider but existing openidId', async () => {
+    it('should reject when user has no provider but a different openidId', async () => {
       const mockUser: IUser = {
         _id: 'user123',
         openidId: 'existing_openid',
         email: 'user@example.com',
         username: 'testuser',
-        // No provider field
       } as IUser;
 
       mockFindUser
-        .mockResolvedValueOnce(null) // Primary condition fails
-        .mockResolvedValueOnce(mockUser); // Email search finds user
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockUser);
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
@@ -305,8 +330,8 @@ describe('findOpenIDUser', () => {
       });
 
       expect(result).toEqual({
-        user: mockUser,
-        error: null,
+        user: null,
+        error: ErrorTypes.AUTH_FAILED,
         migration: false,
       });
     });
@@ -398,14 +423,14 @@ describe('findOpenIDUser', () => {
       const mockUser: IUser = {
         _id: 'user123',
         provider: 'openid',
-        openidId: 'openid_456',
+        openidId: 'openid_123',
         email: 'user@example.com',
         username: 'testuser',
       } as IUser;
 
       mockFindUser
-        .mockResolvedValueOnce(null) // Primary condition fails
-        .mockResolvedValueOnce(mockUser); // Email search succeeds
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockUser);
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
@@ -413,7 +438,6 @@ describe('findOpenIDUser', () => {
         email: 'User@Example.COM',
       });
 
-      /** Email is passed as-is; findUser implementation handles normalization */
       expect(mockFindUser).toHaveBeenNthCalledWith(2, { email: 'User@Example.COM' });
       expect(result).toEqual({
         user: mockUser,

--- a/packages/api/src/auth/openid.ts
+++ b/packages/api/src/auth/openid.ts
@@ -47,7 +47,13 @@ export async function findOpenIDUser({
       return { user: null, error: ErrorTypes.AUTH_FAILED, migration: false };
     }
 
-    // If user found by email but doesn't have openidId, prepare for migration
+    if (user?.openidId && openidId && user.openidId !== openidId) {
+      logger.warn(
+        `[${strategyName}] Rejected email fallback for ${user.email}: stored openidId does not match token sub`,
+      );
+      return { user: null, error: ErrorTypes.AUTH_FAILED, migration: false };
+    }
+
     if (user && !user.openidId) {
       logger.info(
         `[${strategyName}] Preparing user ${user.email} for migration to OpenID with sub: ${openidId}`,

--- a/packages/api/src/auth/openid.ts
+++ b/packages/api/src/auth/openid.ts
@@ -47,7 +47,7 @@ export async function findOpenIDUser({
       return { user: null, error: ErrorTypes.AUTH_FAILED, migration: false };
     }
 
-    if (user?.openidId && openidId && user.openidId !== openidId) {
+    if (user?.openidId && user.openidId !== openidId) {
       logger.warn(
         `[${strategyName}] Rejected email fallback for ${user.email}: stored openidId does not match token sub`,
       );


### PR DESCRIPTION

## Summary

Closes an account-takeover vector in the OpenID email-fallback authentication path. When the primary `openidId`/`idOnTheSource` lookup fails and `findOpenIDUser` falls back to an email-based query, a JWT carrying a victim's email address but a different `sub` claim could previously authenticate as the victim — provided the email lookup returned a result and `OPENID_REUSE_TOKENS` was enabled.

- Adds a guard in `findOpenIDUser` (`packages/api/src/auth/openid.ts`) that rejects any email-matched user whose stored `openidId` differs from the incoming token `sub`, returning `AUTH_FAILED` immediately.
- Positions the guard between the existing non-OpenID provider check and the migration path so that users with no `openidId` yet (legitimate migration candidates) are unaffected.
- Removes a redundant `&& openidId` middle term from the guard condition that would have silently bypassed the check when the incoming `sub` was an empty string or `undefined`, as can occur from JavaScript callers passing `payload?.sub`.
- Corrects three pre-existing unit tests in `openid.spec.ts` whose expectations reflected the previous broken behavior (returning the matched user rather than `AUTH_FAILED`).
- Adds a regression test covering the falsy `openidId` bypass path: `openidId: ''` with an email lookup returning a user with a stored `openidId` now correctly yields `AUTH_FAILED`.
- Adds an integration test in `openIdJwtStrategy.spec.js` exercising the full JWT strategy verify callback with the real `findOpenIDUser`, asserting `user === false` and `info.message === 'auth_failed'` on mismatch.
- Adds an integration test in `openidStrategy.spec.js` exercising the mismatch rejection through the full `processOpenIDAuth` callback, confirming `createUser` and `updateUser` are never called on rejection.
- Restores an intent-documenting comment on the no-`provider` fixture to distinguish it from the provider-mismatch branch.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

All three modified files have direct test coverage for the new guard. Tests use real function logic per project convention — no stub replacements of `findOpenIDUser`.

**`packages/api/src/auth/openid.spec.ts`** (unit — `findOpenIDUser` directly):
- `should reject email fallback when existing openidId does not match token sub` — mismatched `openidId` returns `AUTH_FAILED`
- `should allow email fallback when existing openidId matches token sub` — matching `openidId` returns the user
- `should reject when user already has a different openidId` — pre-existing mismatch scenario
- `should reject when user has no provider but a different openidId` — no-provider variant
- `should reject email fallback when openidId is empty and user has a stored openidId` — falsy `sub` bypass regression

**`api/strategies/openIdJwtStrategy.spec.js`** (integration — JWT reuse path):
- `should reject login when email fallback finds user with mismatched openidId` — full verify callback with real `findOpenIDUser`, mocked `findUser`

**`api/strategies/openidStrategy.spec.js`** (integration — standard OIDC callback path):
- `should block login when email fallback finds user with mismatched openidId` — full `processOpenIDAuth` flow, asserts `createUser`/`updateUser` not called

### Test Configuration

```
cd packages/api && npx jest openid
cd api && npx jest openIdJwtStrategy
cd api && npx jest openidStrategy
```

All 121 tests pass (20 unit + 15 JWT strategy + 86 OpenID strategy).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes