### PR TITLE
🐳 chore: Upgrade Alpine packages in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Base node image
 FROM node:20-alpine AS node
 
-# Install jemalloc
+RUN apk upgrade --no-cache
 RUN apk add --no-cache jemalloc
 RUN apk add --no-cache python3 py3-pip uv
 

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -6,7 +6,7 @@ ARG NODE_MAX_OLD_SPACE_SIZE=6144
 
 # Base for all builds
 FROM node:20-alpine AS base-min
-# Install jemalloc
+RUN apk upgrade --no-cache
 RUN apk add --no-cache jemalloc
 # Set environment variable to use jemalloc
 ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2


### PR DESCRIPTION
- Added `apk upgrade --no-cache` to both Dockerfile and Dockerfile.multi to ensure all installed packages are up to date.
- Maintained the installation of `jemalloc` and other dependencies without changes.