### PR TITLE
📦 chore: Update `fast-xml-parser` to v5.5.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27093,9 +27093,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
-      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
+      "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
       "funding": [
         {
           "type": "github",
@@ -27106,7 +27106,7 @@
       "dependencies": {
         "fast-xml-builder": "^1.1.4",
         "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.1.2"
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"

--- a/package.json
+++ b/package.json
@@ -139,13 +139,13 @@
     "@librechat/agents": {
       "@langchain/anthropic": {
         "@anthropic-ai/sdk": "0.73.0",
-        "fast-xml-parser": "5.5.6"
+        "fast-xml-parser": "5.5.7"
       },
       "@anthropic-ai/sdk": "0.73.0",
-      "fast-xml-parser": "5.5.6"
+      "fast-xml-parser": "5.5.7"
     },
     "elliptic": "^6.6.1",
-    "fast-xml-parser": "5.5.6",
+    "fast-xml-parser": "5.5.7",
     "form-data": "^4.0.4",
     "tslib": "^2.8.1",
     "mdast-util-gfm-autolink-literal": "2.0.0",


### PR DESCRIPTION
- Bump fast-xml-parser dependency from 5.5.6 to 5.5.7 for improved functionality and compatibility.
- Update corresponding entries in both package.json and package-lock.json to reflect the new version.