### PR TITLE
🩺 refactor: Surface Descriptive OCR Error Messages to Client

### DIFF
--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -2,7 +2,7 @@ const fs = require('fs').promises;
 const express = require('express');
 const { EnvVar } = require('@librechat/agents');
 const { logger } = require('@librechat/data-schemas');
-const { verifyAgentUploadPermission } = require('@librechat/api');
+const { verifyAgentUploadPermission, resolveUploadErrorMessage } = require('@librechat/api');
 const {
   Time,
   isUUID,
@@ -394,21 +394,8 @@ router.post('/', async (req, res) => {
 
     return await processAgentFileUpload({ req, res, metadata });
   } catch (error) {
-    let message = 'Error processing file';
+    const message = resolveUploadErrorMessage(error);
     logger.error('[/files] Error processing file:', error);
-
-    if (error.message?.includes('file_ids')) {
-      message += ': ' + error.message;
-    }
-
-    if (
-      error.message?.includes('Invalid file format') ||
-      error.message?.includes('No OCR result') ||
-      error.message?.includes('exceeds token limit') ||
-      error.message?.includes('Unable to extract text from')
-    ) {
-      message = error.message;
-    }
 
     try {
       await fs.unlink(req.file.path);

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -404,7 +404,8 @@ router.post('/', async (req, res) => {
     if (
       error.message?.includes('Invalid file format') ||
       error.message?.includes('No OCR result') ||
-      error.message?.includes('exceeds token limit')
+      error.message?.includes('exceeds token limit') ||
+      error.message?.includes('Unable to extract text from')
     ) {
       message = error.message;
     }

--- a/api/server/routes/files/images.js
+++ b/api/server/routes/files/images.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require('fs').promises;
 const express = require('express');
 const { logger } = require('@librechat/data-schemas');
-const { verifyAgentUploadPermission } = require('@librechat/api');
+const { verifyAgentUploadPermission, resolveUploadErrorMessage } = require('@librechat/api');
 const { isAssistantsEndpoint } = require('librechat-data-provider');
 const {
   processAgentFileUpload,
@@ -43,15 +43,7 @@ router.post('/', async (req, res) => {
     // TODO: delete remote file if it exists
     logger.error('[/files/images] Error processing file:', error);
 
-    let message = 'Error processing file';
-
-    if (
-      error.message?.includes('Invalid file format') ||
-      error.message?.includes('No OCR result') ||
-      error.message?.includes('exceeds token limit')
-    ) {
-      message = error.message;
-    }
+    const message = resolveUploadErrorMessage(error);
 
     try {
       const filepath = path.join(

--- a/packages/api/src/utils/files.spec.ts
+++ b/packages/api/src/utils/files.spec.ts
@@ -1,4 +1,4 @@
-import { sanitizeFilename } from './files';
+import { sanitizeFilename, resolveUploadErrorMessage } from './files';
 
 jest.mock('node:crypto', () => {
   const actualModule = jest.requireActual('node:crypto');
@@ -49,6 +49,59 @@ describe('sanitizeFilename', () => {
 
   test('handles input with only special characters', () => {
     expect(sanitizeFilename('@#$%^&*')).toBe('_______');
+  });
+});
+
+describe('resolveUploadErrorMessage', () => {
+  test('returns default message for null error', () => {
+    expect(resolveUploadErrorMessage(null)).toBe('Error processing file');
+  });
+
+  test('returns default message for undefined error', () => {
+    expect(resolveUploadErrorMessage(undefined)).toBe('Error processing file');
+  });
+
+  test('returns default message when error has no message property', () => {
+    expect(resolveUploadErrorMessage({})).toBe('Error processing file');
+  });
+
+  test('returns default message for unrecognized error', () => {
+    expect(resolveUploadErrorMessage({ message: 'ENOENT: no such file or directory' })).toBe(
+      'Error processing file',
+    );
+  });
+
+  test('prepends default message for file_ids errors', () => {
+    expect(resolveUploadErrorMessage({ message: 'max file_ids reached' })).toBe(
+      'Error processing file: max file_ids reached',
+    );
+  });
+
+  test('surfaces "Invalid file format" errors', () => {
+    expect(resolveUploadErrorMessage({ message: 'Invalid file format: .xyz' })).toBe(
+      'Invalid file format: .xyz',
+    );
+  });
+
+  test('surfaces "exceeds token limit" errors', () => {
+    expect(resolveUploadErrorMessage({ message: 'Content exceeds token limit' })).toBe(
+      'Content exceeds token limit',
+    );
+  });
+
+  test('surfaces "Unable to extract text from" errors', () => {
+    const msg = 'Unable to extract text from "doc.pdf". The document may be image-based.';
+    expect(resolveUploadErrorMessage({ message: msg })).toBe(msg);
+  });
+
+  test('accepts a custom default message', () => {
+    expect(resolveUploadErrorMessage(null, 'Custom default')).toBe('Custom default');
+  });
+
+  test('uses custom default in file_ids prepend', () => {
+    expect(resolveUploadErrorMessage({ message: 'file_ids limit' }, 'Upload failed')).toBe(
+      'Upload failed: file_ids limit',
+    );
   });
 });
 

--- a/packages/api/src/utils/files.ts
+++ b/packages/api/src/utils/files.ts
@@ -3,6 +3,39 @@ import crypto from 'node:crypto';
 import { createReadStream } from 'fs';
 import { readFile, stat } from 'fs/promises';
 
+const USER_FACING_UPLOAD_ERRORS = [
+  'Invalid file format',
+  'exceeds token limit',
+  'Unable to extract text from',
+] as const;
+
+/**
+ * Resolves a user-facing error message from a file upload error.
+ * Returns the error's own message if it matches a known user-facing pattern,
+ * otherwise returns the default message.
+ */
+export function resolveUploadErrorMessage(
+  error: { message?: string } | null | undefined,
+  defaultMessage = 'Error processing file',
+): string {
+  const errorMessage = error?.message;
+  if (!errorMessage) {
+    return defaultMessage;
+  }
+
+  if (errorMessage.includes('file_ids')) {
+    return `${defaultMessage}: ${errorMessage}`;
+  }
+
+  for (const fragment of USER_FACING_UPLOAD_ERRORS) {
+    if (errorMessage.includes(fragment)) {
+      return errorMessage;
+    }
+  }
+
+  return defaultMessage;
+}
+
 /**
  * Sanitize a filename by removing any directory components, replacing non-alphanumeric characters
  * @param inputName


### PR DESCRIPTION
## Summary

- Surfaces the `'Unable to extract text from...'` error to the client when OCR fails, instead of the opaque `"Error processing file"` (original fix by @dlew in #12157)
- Applies the same fix to the **images** upload route (`images.js`), which calls the same `processAgentFileUpload` function but was missed
- Extracts the duplicated error-message filter into a shared `resolveUploadErrorMessage` utility in `packages/api` so both routes stay in sync

Closes #12157

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Same test procedure as #12157: configure `document_parser` OCR (which doesn't support actual image-based PDFs), upload an image-only PDF, and verify the descriptive error message appears in the client response for both the `/files` and `/files/images` routes.