### PR TITLE
fix: Strip useResponsesApi from custom provider LLM configs

### DIFF
--- a/packages/api/src/endpoints/custom/initialize.spec.ts
+++ b/packages/api/src/endpoints/custom/initialize.spec.ts
@@ -117,3 +117,48 @@ describe('initializeCustom – SSRF guard wiring', () => {
     expect(mockGetOpenAIConfig).not.toHaveBeenCalled();
   });
 });
+
+describe('initializeCustom – useResponsesApi stripping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should strip useResponsesApi from llmConfig when returned by getOpenAIConfig', async () => {
+    mockGetOpenAIConfig.mockReturnValueOnce({
+      llmConfig: { model: 'grok-3', useResponsesApi: true },
+      configOptions: {},
+    });
+
+    const params = createParams({ apiKey: 'sk-test-key' });
+    const result = await initializeCustom(params);
+
+    expect(result.llmConfig).not.toHaveProperty('useResponsesApi');
+    expect(result.llmConfig).toHaveProperty('model', 'grok-3');
+  });
+
+  it('should strip useResponsesApi even when set via model_parameters', async () => {
+    mockGetOpenAIConfig.mockReturnValueOnce({
+      llmConfig: { model: 'grok-3', useResponsesApi: true, streaming: true },
+      configOptions: {},
+    });
+
+    const params = createParams({ apiKey: 'sk-test-key' });
+    params.model_parameters = { model: 'grok-3', useResponsesApi: true };
+    const result = await initializeCustom(params);
+
+    expect(result.llmConfig).not.toHaveProperty('useResponsesApi');
+  });
+
+  it('should not break when useResponsesApi is absent', async () => {
+    mockGetOpenAIConfig.mockReturnValueOnce({
+      llmConfig: { model: 'grok-3', streaming: true },
+      configOptions: {},
+    });
+
+    const params = createParams({ apiKey: 'sk-test-key' });
+    const result = await initializeCustom(params);
+
+    expect(result.llmConfig).not.toHaveProperty('useResponsesApi');
+    expect(result.llmConfig).toHaveProperty('model', 'grok-3');
+  });
+});

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -175,6 +175,12 @@ export async function initializeCustom({
     (options as InitializeResultBase).endpointTokenConfig = endpointTokenConfig;
   }
 
+  /** Custom providers don't support the Responses API — strip the flag to prevent
+   *  @librechat/agents from choosing the wrong streaming path (flat tool format). */
+  if (options.llmConfig && 'useResponsesApi' in options.llmConfig) {
+    delete (options.llmConfig as Record<string, unknown>).useResponsesApi;
+  }
+
   const streamRate = clientOptions.streamRate as number | undefined;
   if (streamRate) {
     (options.llmConfig as Record<string, unknown>)._lc_stream_delay = streamRate;


### PR DESCRIPTION
## Summary

Agents with tools fail with a **422 error** when using custom providers (xAI/Grok, DeepSeek, Moonshot, OpenRouter):

```
422 Failed to deserialize the JSON body into the target type:
tools[0]: missing field `function` at line 1 column 2993
```

**Root cause:** `useResponsesApi: true` leaks into custom provider LLM configs through two paths:

1. **Agent `model_parameters`** — marketplace agents may have `useResponsesApi: true` baked in, which flows through `getOpenAILLMConfig` → `getOpenAIConfig` → `initializeCustom`.
2. **Web search enablement** — `getOpenAILLMConfig` (line 273) sets `useResponsesApi = true` when `enableWebSearch` is truthy for non-OpenRouter providers.

When `useResponsesApi` reaches `@librechat/agents`, `ChatOpenAI` uses the Responses API streaming path which sends tools in **flat format** (`{type, name, parameters}`). Custom providers only support Chat Completions, which expects **nested format** (`{type, function: {name, parameters}}`).

**Fix:** Strip `useResponsesApi` from `llmConfig` after `getOpenAIConfig()` returns in `initializeCustom`. All custom providers (`providerConfigMap` in `config.ts`) route through this function, so this is the single chokepoint. OpenAI and Azure use `initializeOpenAI` and are unaffected.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Unit tests added

Three new tests in `packages/api/src/endpoints/custom/initialize.spec.ts`:

1. `useResponsesApi: true` returned by `getOpenAIConfig` is stripped from the result
2. `useResponsesApi: true` set via `model_parameters` is also stripped (second leak path)
3. Absent `useResponsesApi` causes no issues (no-op safety check)

### Ran existing test suites — no regressions

```
PASS src/endpoints/custom/initialize.spec.ts (6/6 tests)
PASS src/endpoints/openai/llm.spec.ts (53/53 tests)
```

### Test Configuration

- Node.js v22
- macOS

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes