### PR TITLE
🔑 fix: Type-Safe User Context Forwarding for Non-OAuth Tool Discovery

### DIFF
--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -58,9 +58,13 @@ export class MCPConnectionFactory {
    */
   static async discoverTools(
     basic: t.BasicConnectionOptions,
-    oauth?: Omit<t.OAuthConnectionOptions, 'returnOnOAuth'>,
+    options?: Omit<t.OAuthConnectionOptions, 'returnOnOAuth'> | t.UserConnectionContext,
   ): Promise<ToolDiscoveryResult> {
-    const factory = new this(basic, oauth ? { ...oauth, returnOnOAuth: true } : undefined);
+    if (options != null && 'useOAuth' in options) {
+      const factory = new this(basic, { ...options, returnOnOAuth: true });
+      return factory.discoverToolsInternal();
+    }
+    const factory = new this(basic, options);
     return factory.discoverToolsInternal();
   }
 
@@ -187,31 +191,36 @@ export class MCPConnectionFactory {
     return null;
   }
 
-  protected constructor(basic: t.BasicConnectionOptions, oauth?: t.OAuthConnectionOptions) {
+  protected constructor(
+    basic: t.BasicConnectionOptions,
+    options?: t.OAuthConnectionOptions | t.UserConnectionContext,
+  ) {
     this.serverConfig = processMCPEnv({
-      user: oauth?.user,
-      body: oauth?.requestBody,
+      user: options?.user,
+      body: options?.requestBody,
       dbSourced: basic.dbSourced,
       options: basic.serverConfig,
-      customUserVars: oauth?.customUserVars,
+      customUserVars: options?.customUserVars,
     });
     this.serverName = basic.serverName;
-    this.useOAuth = !!oauth?.useOAuth;
     this.useSSRFProtection = basic.useSSRFProtection === true;
     this.allowedDomains = basic.allowedDomains;
-    this.connectionTimeout = oauth?.connectionTimeout;
-    this.logPrefix = oauth?.user
-      ? `[MCP][${basic.serverName}][${oauth.user.id}]`
+    this.connectionTimeout = options?.connectionTimeout;
+    this.logPrefix = options?.user
+      ? `[MCP][${basic.serverName}][${options.user.id}]`
       : `[MCP][${basic.serverName}]`;
 
-    if (oauth?.useOAuth) {
-      this.userId = oauth.user?.id;
-      this.flowManager = oauth.flowManager;
-      this.tokenMethods = oauth.tokenMethods;
-      this.signal = oauth.signal;
-      this.oauthStart = oauth.oauthStart;
-      this.oauthEnd = oauth.oauthEnd;
-      this.returnOnOAuth = oauth.returnOnOAuth;
+    if (options != null && 'useOAuth' in options) {
+      this.useOAuth = true;
+      this.userId = options.user?.id;
+      this.flowManager = options.flowManager;
+      this.tokenMethods = options.tokenMethods;
+      this.signal = options.signal;
+      this.oauthStart = options.oauthStart;
+      this.oauthEnd = options.oauthEnd;
+      this.returnOnOAuth = options.returnOnOAuth;
+    } else {
+      this.useOAuth = false;
     }
   }
 

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -114,10 +114,11 @@ export class MCPManager extends UserConnectionManager {
 
     if (!useOAuth) {
       const result = await MCPConnectionFactory.discoverTools(basic, {
-        useOAuth: false,
         user: args.user,
         customUserVars: args.customUserVars,
-      } as unknown as Omit<t.OAuthConnectionOptions, 'returnOnOAuth'>);
+        requestBody: args.requestBody,
+        connectionTimeout: args.connectionTimeout,
+      });
       return {
         tools: result.tools,
         oauthRequired: result.oauthRequired,

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -113,7 +113,11 @@ export class MCPManager extends UserConnectionManager {
     };
 
     if (!useOAuth) {
-      const result = await MCPConnectionFactory.discoverTools(basic);
+      const result = await MCPConnectionFactory.discoverTools(basic, {
+        useOAuth: false,
+        user: args.user,
+        customUserVars: args.customUserVars,
+      } as unknown as Omit<t.OAuthConnectionOptions, 'returnOnOAuth'>);
       return {
         tools: result.tools,
         oauthRequired: result.oauthRequired,

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -764,6 +764,39 @@ describe('MCPConnectionFactory', () => {
       expect(result.connection).toBe(mockConnectionInstance);
     });
 
+    it('should forward user context to processMCPEnv for non-OAuth discovery', async () => {
+      const serverConfig: t.MCPOptions = {
+        type: 'streamable-http',
+        url: 'https://my-mcp.server.com?key={{MY_CUSTOM_KEY}}',
+      } as t.MCPOptions;
+
+      const basicOptions = {
+        serverName: 'test-server',
+        serverConfig,
+      };
+
+      const userContext = {
+        user: mockUser,
+        customUserVars: { MY_CUSTOM_KEY: 'c527bd0abc123' },
+        connectionTimeout: 10000,
+      };
+
+      mockConnectionInstance.connect.mockResolvedValue(undefined);
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+      mockConnectionInstance.fetchTools = jest.fn().mockResolvedValue(mockTools);
+
+      const result = await MCPConnectionFactory.discoverTools(basicOptions, userContext);
+
+      expect(result.tools).toEqual(mockTools);
+      expect(mockProcessMCPEnv).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user: mockUser,
+          options: serverConfig,
+          customUserVars: { MY_CUSTOM_KEY: 'c527bd0abc123' },
+        }),
+      );
+    });
+
     it('should detect OAuth required without generating URL in discovery mode', async () => {
       const basicOptions = {
         serverName: 'test-server',

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -847,6 +847,46 @@ describe('MCPManager', () => {
       expect(MCPConnectionFactory.discoverTools).toHaveBeenCalled();
     });
 
+    it('should forward user, customUserVars, requestBody, and connectionTimeout to discoverTools in the non-OAuth path', async () => {
+      const mockUser = { id: 'user123', email: 'test@example.com' } as unknown as IUser;
+      const customUserVars = { MY_CUSTOM_KEY: 'c527bd0abc123' };
+
+      mockAppConnections({
+        get: jest.fn().mockResolvedValue(null),
+      });
+
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'https://my-mcp.server.com?key={{MY_CUSTOM_KEY}}',
+      });
+
+      (MCPConnectionFactory.discoverTools as jest.Mock).mockResolvedValue({
+        tools: mockTools,
+        connection: null,
+        oauthRequired: false,
+        oauthUrl: null,
+      });
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      await manager.discoverServerTools({
+        serverName,
+        user: mockUser,
+        customUserVars,
+        requestBody: { conversationId: 'conv-123' } as t.ToolDiscoveryOptions['requestBody'],
+        connectionTimeout: 10000,
+      });
+
+      expect(MCPConnectionFactory.discoverTools).toHaveBeenCalledWith(
+        expect.objectContaining({ serverName }),
+        expect.objectContaining({
+          user: mockUser,
+          customUserVars,
+          requestBody: { conversationId: 'conv-123' },
+          connectionTimeout: 10000,
+        }),
+      );
+    });
+
     it('should return null tools when server config not found', async () => {
       mockAppConnections({
         get: jest.fn().mockResolvedValue(null),

--- a/packages/api/src/mcp/__tests__/customUserVars.integration.test.ts
+++ b/packages/api/src/mcp/__tests__/customUserVars.integration.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Integration test exercising real processMCPEnv for the non-OAuth
+ * customUserVars scenario: a streamable-http server whose URL contains
+ * a {{PLACEHOLDER}} that must be resolved from per-user custom variables.
+ *
+ * This is the exact bug scenario from PR #12348 — without the fix,
+ * the literal string `{{MY_CUSTOM_KEY}}` would be sent to the MCP
+ * server endpoint instead of the substituted value.
+ */
+import type { IUser } from '@librechat/data-schemas';
+import type * as t from '~/mcp/types';
+import { processMCPEnv } from '~/utils/env';
+
+describe('processMCPEnv — customUserVars placeholder resolution', () => {
+  const mockUser = { id: 'user-abc', email: 'test@example.com' } as IUser;
+
+  it('should resolve {{CUSTOM_VAR}} in a streamable-http URL', () => {
+    const serverConfig: t.MCPOptions = {
+      type: 'streamable-http',
+      url: 'https://my-mcp.server.com/server?key={{MY_CUSTOM_KEY}}',
+    } as t.MCPOptions;
+
+    const result = processMCPEnv({
+      options: serverConfig,
+      user: mockUser,
+      customUserVars: { MY_CUSTOM_KEY: 'c527bd0abc123' },
+    });
+
+    expect((result as t.StreamableHTTPOptions).url).toBe(
+      'https://my-mcp.server.com/server?key=c527bd0abc123',
+    );
+  });
+
+  it('should resolve multiple placeholders in URL and headers simultaneously', () => {
+    const serverConfig: t.MCPOptions = {
+      type: 'streamable-http',
+      url: 'https://my-mcp.server.com/server?key={{API_KEY}}&project={{PROJECT_ID}}',
+      headers: {
+        Authorization: 'Bearer {{AUTH_TOKEN}}',
+        'X-Project': '{{PROJECT_ID}}',
+      },
+    } as t.MCPOptions;
+
+    const result = processMCPEnv({
+      options: serverConfig,
+      user: mockUser,
+      customUserVars: {
+        API_KEY: 'key-123',
+        PROJECT_ID: 'proj-456',
+        AUTH_TOKEN: 'tok-789',
+      },
+    });
+
+    const typed = result as t.StreamableHTTPOptions;
+    expect(typed.url).toBe('https://my-mcp.server.com/server?key=key-123&project=proj-456');
+    expect(typed.headers).toEqual({
+      Authorization: 'Bearer tok-789',
+      'X-Project': 'proj-456',
+    });
+  });
+
+  it('should leave unmatched placeholders as literal strings when customUserVars is undefined', () => {
+    const serverConfig: t.MCPOptions = {
+      type: 'streamable-http',
+      url: 'https://my-mcp.server.com/server?key={{MY_CUSTOM_KEY}}',
+    } as t.MCPOptions;
+
+    const result = processMCPEnv({
+      options: serverConfig,
+    });
+
+    expect((result as t.StreamableHTTPOptions).url).toContain('{{MY_CUSTOM_KEY}}');
+  });
+});

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -174,18 +174,22 @@ export interface BasicConnectionOptions {
   dbSourced?: boolean;
 }
 
-export interface OAuthConnectionOptions {
+/** User context for placeholder resolution in MCP connections (non-OAuth and OAuth alike) */
+export interface UserConnectionContext {
   user?: IUser;
-  useOAuth: true;
-  requestBody?: RequestBody;
   customUserVars?: Record<string, string>;
+  requestBody?: RequestBody;
+  connectionTimeout?: number;
+}
+
+export interface OAuthConnectionOptions extends UserConnectionContext {
+  useOAuth: true;
   flowManager: FlowStateManager<o.MCPOAuthTokens | null>;
   tokenMethods?: TokenMethods;
   signal?: AbortSignal;
   oauthStart?: (authURL: string) => Promise<void>;
   oauthEnd?: () => Promise<void>;
   returnOnOAuth?: boolean;
-  connectionTimeout?: number;
 }
 
 export interface ToolDiscoveryOptions {


### PR DESCRIPTION
## Summary

This PR fixes a bug that prevents MCP servers from being shared by multiple users when user-specific API keys / authentication are passed via `customUserVars` inside URL query parameters or headers (e.g., `?key={{user_api_key}}`). 

Previously, during unauthenticated tool discovery, [MCPManager.ts](cci:7://file:///d:/LibreChat/packages/api/src/mcp/MCPManager.ts:0:0-0:0) omitted the `user` and `customUserVars` parameters when calling `MCPConnectionFactory.discoverTools()`. Because of this bug, dynamic placeholders in the server config URL were never replaced with the corresponding user's tokens. This resulted in literal strings like `?key={{user_api_key}}` being sent backward to the MCP server endpoint, causing connection request parameters to error out and fail.

By explicitly forwarding the `customUserVars` and `user` properties into the config options for [discoverTools](cci:1://file:///d:/LibreChat/packages/api/src/mcp/MCPConnectionFactory.ts:53:2-64:3), shared MCP servers relying on per-user custom variables now successfully substitute credentials and work perfectly as intended for all users.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

**Test Configuration**:
1. Configure an MCP server in [librechat.yaml](cci:7://file:///d:/LibreChat/librechat.yaml:0:0-0:0) with `requiresOAuth: false`.
2. Define a `customUserVars` for the user API Key, and map it via a placeholder in the connection `url` (e.g., `url: "https://my-mcp.server.com/server?key={{MY_CUSTOM_KEY}}"`).
3. From the UI, enter the specific API key for that server under the User profile and hit 'Reinstall' / 'refresh tools'.

**Result Status**:
* **Without this PR**: The literal string `{{MY_CUSTOM_KEY}}` is passed across the `streamable-http` client transport, resulting in a Server-side `[PARAM_ERROR]` / empty parameter rejection from the MCP backend.
* **With this PR**: The substituted value correctly materializes (e.g. `?key=c527bd0...`) resulting in a successful HTTP 200 payload and successful tool discovery.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] Local unit tests pass with my changes
