### PR TITLE
🪄 refactor: Simplify MCP Tool Content Formatting to Unified String Output

### DIFF
--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -15,13 +15,7 @@ const {
   GenerationJobManager,
   resolveJsonSchemaRefs,
 } = require('@librechat/api');
-const {
-  Time,
-  CacheKeys,
-  Constants,
-  ContentTypes,
-  isAssistantsEndpoint,
-} = require('librechat-data-provider');
+const { Time, CacheKeys, Constants, isAssistantsEndpoint } = require('librechat-data-provider');
 const {
   getOAuthReconnectionManager,
   getMCPServersRegistry,
@@ -604,9 +598,6 @@ function createToolInstance({
 
       if (isAssistantsEndpoint(provider) && Array.isArray(result)) {
         return result[0];
-      }
-      if (isGoogle && Array.isArray(result[0]) && result[0][0]?.type === ContentTypes.TEXT) {
-        return [result[0][0].text, result[1]];
       }
       return result;
     } catch (error) {

--- a/packages/api/src/mcp/__tests__/parsers.test.ts
+++ b/packages/api/src/mcp/__tests__/parsers.test.ts
@@ -31,12 +31,22 @@ describe('formatToolContent', () => {
     });
   });
 
-  describe('recognized providers - content array providers', () => {
-    const contentArrayProviders: t.Provider[] = ['google', 'anthropic', 'openai', 'azureopenai'];
+  describe('recognized providers', () => {
+    const allProviders: t.Provider[] = [
+      'google',
+      'anthropic',
+      'openai',
+      'azureopenai',
+      'openrouter',
+      'xai',
+      'deepseek',
+      'ollama',
+      'bedrock',
+    ];
 
-    contentArrayProviders.forEach((provider) => {
+    allProviders.forEach((provider) => {
       describe(`${provider} provider`, () => {
-        it('should format text content as content array', () => {
+        it('should format text content as string', () => {
           const result: t.MCPToolCallResponse = {
             content: [
               { type: 'text', text: 'First text' },
@@ -45,11 +55,11 @@ describe('formatToolContent', () => {
           };
 
           const [content, artifacts] = formatToolContent(result, provider);
-          expect(content).toEqual([{ type: 'text', text: 'First text\n\nSecond text' }]);
+          expect(content).toBe('First text\n\nSecond text');
           expect(artifacts).toBeUndefined();
         });
 
-        it('should separate text blocks when images are present', () => {
+        it('should extract images to artifacts and keep text as string', () => {
           const result: t.MCPToolCallResponse = {
             content: [
               { type: 'text', text: 'Before image' },
@@ -59,10 +69,7 @@ describe('formatToolContent', () => {
           };
 
           const [content, artifacts] = formatToolContent(result, provider);
-          expect(content).toEqual([
-            { type: 'text', text: 'Before image' },
-            { type: 'text', text: 'After image' },
-          ]);
+          expect(content).toBe('Before image\n\nAfter image');
           expect(artifacts).toEqual({
             content: [
               {
@@ -76,49 +83,8 @@ describe('formatToolContent', () => {
         it('should handle empty content', () => {
           const result: t.MCPToolCallResponse = { content: [] };
           const [content, artifacts] = formatToolContent(result, provider);
-          expect(content).toEqual([{ type: 'text', text: '(No response)' }]);
+          expect(content).toBe('(No response)');
           expect(artifacts).toBeUndefined();
-        });
-      });
-    });
-  });
-
-  describe('recognized providers - string providers', () => {
-    const stringProviders: t.Provider[] = ['openrouter', 'xai', 'deepseek', 'ollama', 'bedrock'];
-
-    stringProviders.forEach((provider) => {
-      describe(`${provider} provider`, () => {
-        it('should format content as string', () => {
-          const result: t.MCPToolCallResponse = {
-            content: [
-              { type: 'text', text: 'First text' },
-              { type: 'text', text: 'Second text' },
-            ],
-          };
-
-          const [content, artifacts] = formatToolContent(result, provider);
-          expect(content).toBe('First text\n\nSecond text');
-          expect(artifacts).toBeUndefined();
-        });
-
-        it('should handle images with string output', () => {
-          const result: t.MCPToolCallResponse = {
-            content: [
-              { type: 'text', text: 'Some text' },
-              { type: 'image', data: 'base64data', mimeType: 'image/png' },
-            ],
-          };
-
-          const [content, artifacts] = formatToolContent(result, provider);
-          expect(content).toBe('Some text');
-          expect(artifacts).toEqual({
-            content: [
-              {
-                type: 'image_url',
-                image_url: { url: 'data:image/png;base64,base64data' },
-              },
-            ],
-          });
         });
       });
     });
@@ -130,7 +96,6 @@ describe('formatToolContent', () => {
         content: [{ type: 'image', data: 'https://example.com/image.png', mimeType: 'image/png' }],
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const [_content, artifacts] = formatToolContent(result, 'openai');
       expect(artifacts).toEqual({
         content: [
@@ -147,7 +112,6 @@ describe('formatToolContent', () => {
         content: [{ type: 'image', data: 'iVBORw0KGgoAAAA...', mimeType: 'image/png' }],
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const [_content, artifacts] = formatToolContent(result, 'openai');
       expect(artifacts).toEqual({
         content: [
@@ -176,13 +140,11 @@ describe('formatToolContent', () => {
       };
 
       const [content, artifacts] = formatToolContent(result, 'openai');
-      expect(Array.isArray(content)).toBe(true);
-      const textContent = Array.isArray(content) ? content[0] : { text: '' };
-      expect(textContent).toMatchObject({ type: 'text' });
-      expect(textContent.text).toContain('UI Resource ID:');
-      expect(textContent.text).toContain('UI Resource Marker: \\ui{');
-      expect(textContent.text).toContain('Resource URI: ui://carousel');
-      expect(textContent.text).toContain('Resource MIME Type: application/json');
+      expect(typeof content).toBe('string');
+      expect(content).toContain('UI Resource ID:');
+      expect(content).toContain('UI Resource Marker: \\ui{');
+      expect(content).toContain('Resource URI: ui://carousel');
+      expect(content).toContain('Resource MIME Type: application/json');
 
       const uiResourceArtifact = artifacts?.ui_resources?.data?.[0];
       expect(uiResourceArtifact).toBeTruthy();
@@ -209,15 +171,11 @@ describe('formatToolContent', () => {
       };
 
       const [content, artifacts] = formatToolContent(result, 'openai');
-      expect(content).toEqual([
-        {
-          type: 'text',
-          text:
-            'Resource Text: Document content\n' +
-            'Resource URI: file://document.pdf\n' +
-            'Resource MIME Type: application/pdf',
-        },
-      ]);
+      expect(content).toBe(
+        'Resource Text: Document content\n' +
+          'Resource URI: file://document.pdf\n' +
+          'Resource MIME Type: application/pdf',
+      );
       expect(artifacts).toBeUndefined();
     });
 
@@ -235,12 +193,7 @@ describe('formatToolContent', () => {
       };
 
       const [content, artifacts] = formatToolContent(result, 'openai');
-      expect(content).toEqual([
-        {
-          type: 'text',
-          text: 'Resource URI: https://example.com/resource',
-        },
-      ]);
+      expect(content).toBe('Resource URI: https://example.com/resource');
       expect(artifacts).toBeUndefined();
     });
 
@@ -267,14 +220,12 @@ describe('formatToolContent', () => {
       };
 
       const [content, artifacts] = formatToolContent(result, 'openai');
-      expect(Array.isArray(content)).toBe(true);
-      const textEntry = Array.isArray(content) ? content[0] : { text: '' };
-      expect(textEntry).toMatchObject({ type: 'text' });
-      expect(textEntry.text).toContain('Some text');
-      expect(textEntry.text).toContain('UI Resource Marker: \\ui{');
-      expect(textEntry.text).toContain('Resource URI: ui://button');
-      expect(textEntry.text).toContain('Resource MIME Type: application/json');
-      expect(textEntry.text).toContain('Resource URI: file://data.csv');
+      expect(typeof content).toBe('string');
+      expect(content).toContain('Some text');
+      expect(content).toContain('UI Resource Marker: \\ui{');
+      expect(content).toContain('Resource URI: ui://button');
+      expect(content).toContain('Resource MIME Type: application/json');
+      expect(content).toContain('Resource URI: file://data.csv');
 
       const uiResource = artifacts?.ui_resources?.data?.[0];
       expect(uiResource).toMatchObject({
@@ -302,14 +253,11 @@ describe('formatToolContent', () => {
       };
 
       const [content, artifacts] = formatToolContent(result, 'openai');
-      expect(Array.isArray(content)).toBe(true);
-      if (Array.isArray(content)) {
-        expect(content[0]).toMatchObject({ type: 'text', text: 'Content with multimedia' });
-        expect(content[1].type).toBe('text');
-        expect(content[1].text).toContain('UI Resource Marker: \\ui{');
-        expect(content[1].text).toContain('Resource URI: ui://graph');
-        expect(content[1].text).toContain('Resource MIME Type: application/json');
-      }
+      expect(typeof content).toBe('string');
+      expect(content).toContain('Content with multimedia');
+      expect(content).toContain('UI Resource Marker: \\ui{');
+      expect(content).toContain('Resource URI: ui://graph');
+      expect(content).toContain('Resource MIME Type: application/json');
       expect(artifacts).toEqual({
         content: [
           {
@@ -341,12 +289,9 @@ describe('formatToolContent', () => {
       };
 
       const [content, artifacts] = formatToolContent(result, 'openai');
-      expect(content).toEqual([
-        {
-          type: 'text',
-          text: 'Normal text\n\n' + JSON.stringify({ type: 'unknown', data: 'some data' }, null, 2),
-        },
-      ]);
+      expect(content).toBe(
+        'Normal text\n\n' + JSON.stringify({ type: 'unknown', data: 'some data' }, null, 2),
+      );
       expect(artifacts).toBeUndefined();
     });
   });
@@ -379,20 +324,16 @@ describe('formatToolContent', () => {
       };
 
       const [content, artifacts] = formatToolContent(result, 'anthropic');
-      expect(Array.isArray(content)).toBe(true);
-      if (Array.isArray(content)) {
-        expect(content[0]).toEqual({ type: 'text', text: 'Introduction' });
-        expect(content[1].type).toBe('text');
-        expect(content[1].text).toContain('Middle section');
-        expect(content[1].text).toContain('UI Resource ID:');
-        expect(content[1].text).toContain('UI Resource Marker: \\ui{');
-        expect(content[1].text).toContain('Resource URI: ui://chart');
-        expect(content[1].text).toContain('Resource MIME Type: application/json');
-        expect(content[1].text).toContain('Resource URI: https://api.example.com/data');
-        expect(content[2].type).toBe('text');
-        expect(content[2].text).toContain('Conclusion');
-        expect(content[2].text).toContain('UI Resource Markers Available:');
-      }
+      expect(typeof content).toBe('string');
+      expect(content).toContain('Introduction');
+      expect(content).toContain('Middle section');
+      expect(content).toContain('UI Resource ID:');
+      expect(content).toContain('UI Resource Marker: \\ui{');
+      expect(content).toContain('Resource URI: ui://chart');
+      expect(content).toContain('Resource MIME Type: application/json');
+      expect(content).toContain('Resource URI: https://api.example.com/data');
+      expect(content).toContain('Conclusion');
+      expect(content).toContain('UI Resource Markers Available:');
       expect(artifacts).toMatchObject({
         content: [
           {
@@ -424,7 +365,7 @@ describe('formatToolContent', () => {
       };
 
       const [content, artifacts] = formatToolContent(result, 'openai');
-      expect(content).toEqual([{ type: 'text', text: 'Error occurred' }]);
+      expect(content).toBe('Error occurred');
       expect(artifacts).toBeUndefined();
     });
 
@@ -435,7 +376,7 @@ describe('formatToolContent', () => {
       };
 
       const [content, artifacts] = formatToolContent(result, 'google');
-      expect(content).toEqual([{ type: 'text', text: 'Response with metadata' }]);
+      expect(content).toBe('Response with metadata');
       expect(artifacts).toBeUndefined();
     });
   });

--- a/packages/api/src/mcp/__tests__/parsers.test.ts
+++ b/packages/api/src/mcp/__tests__/parsers.test.ts
@@ -96,7 +96,8 @@ describe('formatToolContent', () => {
         content: [{ type: 'image', data: 'https://example.com/image.png', mimeType: 'image/png' }],
       };
 
-      const [_content, artifacts] = formatToolContent(result, 'openai');
+      const [content, artifacts] = formatToolContent(result, 'openai');
+      expect(content).toBe('');
       expect(artifacts).toEqual({
         content: [
           {
@@ -112,7 +113,8 @@ describe('formatToolContent', () => {
         content: [{ type: 'image', data: 'iVBORw0KGgoAAAA...', mimeType: 'image/png' }],
       };
 
-      const [_content, artifacts] = formatToolContent(result, 'openai');
+      const [content, artifacts] = formatToolContent(result, 'openai');
+      expect(content).toBe('');
       expect(artifacts).toEqual({
         content: [
           {
@@ -121,6 +123,29 @@ describe('formatToolContent', () => {
           },
         ],
       });
+    });
+
+    it('should return empty string for image-only content when artifacts exist', () => {
+      const result: t.MCPToolCallResponse = {
+        content: [{ type: 'image', data: 'base64data', mimeType: 'image/png' }],
+      };
+      const [content, artifacts] = formatToolContent(result, 'anthropic');
+      expect(content).toBe('');
+      expect(artifacts).toBeDefined();
+      expect(artifacts?.content).toHaveLength(1);
+    });
+
+    it('should handle multiple images without text', () => {
+      const result: t.MCPToolCallResponse = {
+        content: [
+          { type: 'image', data: 'https://example.com/a.png', mimeType: 'image/png' },
+          { type: 'image', data: 'https://example.com/b.jpg', mimeType: 'image/jpeg' },
+        ],
+      };
+      const [content, artifacts] = formatToolContent(result, 'google');
+      expect(content).toBe('');
+      expect(artifacts).toBeDefined();
+      expect(artifacts?.content).toHaveLength(2);
     });
   });
 

--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -83,6 +83,10 @@ function parseAsString(result: t.MCPToolCallResponse): string {
  * Converts MCPToolCallResponse content into a plain-text string plus optional artifacts
  * (images, UI resources). All providers receive string content; images are separated into
  * artifacts and merged back by the agents package via formatArtifactPayload / formatAnthropicArtifactContent.
+ *
+ * @param provider - Used only to distinguish recognized vs. unrecognized providers.
+ * All recognized providers currently produce identical string output;
+ * provider-specific artifact merging is delegated to the agents package.
  */
 export function formatToolContent(
   result: t.MCPToolCallResponse,
@@ -184,16 +188,16 @@ UI Resource Markers Available:
   }
 
   let artifacts: t.Artifacts = undefined;
-  if (imageUrls.length) {
+  if (imageUrls.length > 0) {
     artifacts = { content: imageUrls };
   }
 
-  if (uiResources.length) {
+  if (uiResources.length > 0) {
     artifacts = {
       ...artifacts,
       [Tools.ui_resources]: { data: uiResources },
     };
   }
 
-  return [currentTextBlock || '(No response)', artifacts];
+  return [currentTextBlock || (artifacts !== undefined ? '' : '(No response)'), artifacts];
 }

--- a/packages/api/src/mcp/parsers.ts
+++ b/packages/api/src/mcp/parsers.ts
@@ -18,7 +18,6 @@ const RECOGNIZED_PROVIDERS = new Set([
   'ollama',
   'bedrock',
 ]);
-const CONTENT_ARRAY_PROVIDERS = new Set(['google', 'anthropic', 'azureopenai', 'openai']);
 
 const imageFormatters: Record<string, undefined | t.ImageFormatter> = {
   // google: (item) => ({
@@ -81,13 +80,9 @@ function parseAsString(result: t.MCPToolCallResponse): string {
 }
 
 /**
- * Converts MCPToolCallResponse content into recognized content block types
- * First element: string or formatted content (excluding image_url)
- * Second element: Recognized types - "image", "image_url", "text", "json"
- *
- * @param  result - The MCPToolCallResponse object
- * @param provider - The provider name (google, anthropic, openai)
- * @returns Tuple of content and image_urls
+ * Converts MCPToolCallResponse content into a plain-text string plus optional artifacts
+ * (images, UI resources). All providers receive string content; images are separated into
+ * artifacts and merged back by the agents package via formatArtifactPayload / formatAnthropicArtifactContent.
  */
 export function formatToolContent(
   result: t.MCPToolCallResponse,
@@ -99,13 +94,12 @@ export function formatToolContent(
 
   const content = result?.content ?? [];
   if (!content.length) {
-    return [[{ type: 'text', text: '(No response)' }], undefined];
+    return ['(No response)', undefined];
   }
 
-  const formattedContent: t.FormattedContent[] = [];
   const imageUrls: t.FormattedContent[] = [];
-  let currentTextBlock = '';
   const uiResources: UIResource[] = [];
+  let currentTextBlock = '';
 
   type ContentHandler = undefined | ((item: t.ToolContentPart) => void);
 
@@ -122,17 +116,11 @@ export function formatToolContent(
       if (!isImageContent(item)) {
         return;
       }
-      if (CONTENT_ARRAY_PROVIDERS.has(provider) && currentTextBlock) {
-        formattedContent.push({ type: 'text', text: currentTextBlock });
-        currentTextBlock = '';
-      }
       const formatter = imageFormatters.default as t.ImageFormatter;
       const formattedImage = formatter(item);
 
       if (formattedImage.type === 'image_url') {
         imageUrls.push(formattedImage);
-      } else {
-        formattedContent.push(formattedImage);
       }
     },
 
@@ -195,10 +183,6 @@ UI Resource Markers Available:
     currentTextBlock += uiInstructions;
   }
 
-  if (CONTENT_ARRAY_PROVIDERS.has(provider) && currentTextBlock) {
-    formattedContent.push({ type: 'text', text: currentTextBlock });
-  }
-
   let artifacts: t.Artifacts = undefined;
   if (imageUrls.length) {
     artifacts = { content: imageUrls };
@@ -211,9 +195,5 @@ UI Resource Markers Available:
     };
   }
 
-  if (CONTENT_ARRAY_PROVIDERS.has(provider)) {
-    return [formattedContent, artifacts];
-  }
-
-  return [currentTextBlock, artifacts];
+  return [currentTextBlock || '(No response)', artifacts];
 }

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -138,7 +138,7 @@ export type Artifacts =
     }
   | undefined;
 
-export type FormattedContentResult = [string | FormattedContent[], undefined | Artifacts];
+export type FormattedContentResult = [string, Artifacts | undefined];
 
 export type ImageFormatter = (item: ImageContent) => FormattedContent;
 


### PR DESCRIPTION


## Summary

Unified `formatToolContent` to always return a plain `string` as the content element of its `[string, Artifacts | undefined]` tuple, removing the provider-specific `FormattedContent[]` array path that previously applied only to `google`, `anthropic`, `openai`, and `azureopenai`.

- Removed `CONTENT_ARRAY_PROVIDERS` set and all associated array-building logic (`formattedContent`, mid-stream flush on image, final `formattedContent` push, and array return branch) from `parsers.ts`.
- Fixed a regression where image-only tool responses (no text content) incorrectly returned `'(No response)'` as the content string despite a fully-populated `artifacts` object; fallback now evaluates `artifacts !== undefined` before applying the placeholder.
- Removed the Google-specific result-flattening branch in `MCP.js` (`isGoogle && Array.isArray(result[0]) && result[0][0]?.type === ContentTypes.TEXT`) that was converting the content array back to a string post-hoc, making it redundant with the new unified return path.
- Removed the now-unused `ContentTypes` import from `MCP.js`.
- Narrowed `FormattedContentResult` in `types/index.ts` from `[string | FormattedContent[], undefined | Artifacts]` to `[string, Artifacts | undefined]`.
- Added `@param provider` JSDoc to `formatToolContent` documenting that the parameter is used solely as a recognized-vs-unrecognized gate and that provider-specific artifact merging is delegated to the agents package via `formatArtifactPayload` / `formatAnthropicArtifactContent`.
- Standardized all `imageUrls.length` and `uiResources.length` guards to explicit `> 0` comparisons for consistency within the function.
- Merged the previously split `'recognized providers - content array providers'` and `'recognized providers - string providers'` test suites into a single `allProviders` loop covering all 9 recognized providers.
- Fixed both pre-existing image-only tests (`http URLs`, `base64 data`) to assert `content === ''` rather than silently ignoring the returned string via `_content`.
- Added two new image-handling tests: `'should return empty string for image-only content when artifacts exist'` and `'should handle multiple images without text'`, each with an explicit `expect(artifacts).toBeDefined()` guard before chained assertions.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Unit tests covering `formatToolContent` are in `packages/api/src/mcp/__tests__/parsers.test.ts`. Run from the workspace root:

```bash
cd packages/api && npx jest parsers
```

### **Test Configuration**:

No environment configuration required. All tests are pure unit tests with no external dependencies.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes