### PR TITLE
🔧 fix: clearAppConfigCache targets wrong cache store and key

### DIFF
--- a/api/server/services/Config/app.js
+++ b/api/server/services/Config/app.js
@@ -73,9 +73,8 @@ async function getAppConfig(options = {}) {
  * @returns {Promise<boolean>}
  */
 async function clearAppConfigCache() {
-  const cache = getLogStores(CacheKeys.CONFIG_STORE);
-  const cacheKey = CacheKeys.APP_CONFIG;
-  return await cache.delete(cacheKey);
+  const cache = getLogStores(CacheKeys.APP_CONFIG);
+  return await cache.delete(BASE_CONFIG_KEY);
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

`clearAppConfigCache()` in `api/server/services/Config/app.js` deletes from `CONFIG_STORE` namespace with key `APP_CONFIG`, but `getAppConfig()` writes to `APP_CONFIG` namespace with key `_BASE_`. This mismatch was introduced in #9558 when `APP_CONFIG` was promoted to a dedicated cache store.

As a result, `clearAppConfigCache()` is effectively a no-op — it never clears the actual cached config.

## Fix

Align the store and key in `clearAppConfigCache()` to match `getAppConfig()`:
- Store: `CacheKeys.CONFIG_STORE` → `CacheKeys.APP_CONFIG`
- Key: `CacheKeys.APP_CONFIG` → `BASE_CONFIG_KEY` (`'_BASE_'`)

## Test plan

- [ ] Verify `getAppConfig({ refresh: false })` returns cached value
- [ ] Call `clearAppConfigCache()`
- [ ] Verify next `getAppConfig()` call re-initializes (logs "App configuration not initialized")