### PR TITLE
📬 docs: Add Forwarded Headers to Nginx SSL Proxy Template

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -86,9 +86,15 @@ server {
 
 #    location /api {
 #        proxy_pass http://api:3080/api;
+#        proxy_set_header X-Forwarded-Proto $scheme;
+#        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#        proxy_set_header Host $host;
 #    }
 
 #    location / {
 #        proxy_pass http://api:3080;
+#        proxy_set_header X-Forwarded-Proto $scheme;
+#        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#        proxy_set_header Host $host;
 #    }
 #}


### PR DESCRIPTION
## Summary

Add X-Forwarded-Proto, X-Forwarded-For and Host headers in nginx proxy config. Addresses #12378, which prevents secure cookies from being set properly. This breaks OIDC authentication workflows.

## Change Type

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

 - Configure a deployment using `deploy-compose.yml`, and an OIDC workflow. 
 - Attempt to log in. The request to `oauth/openid` should include the `connect.sid` cookie. If this cookie is missing, LibreChat thinks it cannot set secure cookies, and the auth flow will fail. 

## Checklist

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code