### PR TITLE
🧮 refactor: Cache Tool Schema Token Counts

### DIFF
--- a/api/cache/getLogStores.js
+++ b/api/cache/getLogStores.js
@@ -56,6 +56,7 @@ const namespaces = {
     CacheKeys.ADMIN_OAUTH_EXCHANGE,
     Time.THIRTY_SECONDS,
   ),
+  [CacheKeys.TOOL_TOKENS]: standardCache(CacheKeys.TOOL_TOKENS, Time.THIRTY_MINUTES),
 };
 
 /**

--- a/api/cache/getLogStores.js
+++ b/api/cache/getLogStores.js
@@ -56,7 +56,6 @@ const namespaces = {
     CacheKeys.ADMIN_OAUTH_EXCHANGE,
     Time.THIRTY_SECONDS,
   ),
-  [CacheKeys.TOOL_TOKENS]: standardCache(CacheKeys.TOOL_TOKENS, Time.THIRTY_MINUTES),
 };
 
 /**

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -1,19 +1,39 @@
 import type { AppConfig } from '@librechat/data-schemas';
+import { ToolMessage } from '@librechat/agents/langchain/messages';
+import type { BaseMessage } from '@librechat/agents/langchain/messages';
 import type { SummarizationConfig, TEndpoint } from 'librechat-data-provider';
 import { EModelEndpoint, FileSources } from 'librechat-data-provider';
 import { createRun } from '~/agents/run';
 
 // Mock winston logger
-jest.mock('winston', () => ({
-  createLogger: jest.fn(() => ({
-    debug: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    info: jest.fn(),
-  })),
-  format: { combine: jest.fn(), colorize: jest.fn(), simple: jest.fn() },
-  transports: { Console: jest.fn() },
-}));
+jest.mock('winston', () => {
+  const format = jest.fn(() => jest.fn(() => ({})));
+  Object.assign(format, {
+    colorize: jest.fn(() => ({})),
+    combine: jest.fn(() => ({})),
+    errors: jest.fn(() => ({})),
+    json: jest.fn(() => ({})),
+    printf: jest.fn(() => ({})),
+    simple: jest.fn(() => ({})),
+    splat: jest.fn(() => ({})),
+    timestamp: jest.fn(() => ({})),
+  });
+
+  return {
+    addColors: jest.fn(),
+    createLogger: jest.fn(() => ({
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    })),
+    format,
+    transports: {
+      Console: jest.fn(),
+      DailyRotateFile: jest.fn(),
+    },
+  };
+});
 
 // Mock env utilities so header resolution doesn't fail
 jest.mock('~/utils/env', () => ({
@@ -60,6 +80,7 @@ async function callAndCapture(
     summarizationConfig?: SummarizationConfig;
     initialSummary?: { text: string; tokenCount: number };
     appConfig?: AppConfig;
+    messages?: BaseMessage[];
   } = {},
 ) {
   const agents = opts.agents ?? [makeAgent()];
@@ -71,6 +92,7 @@ async function callAndCapture(
     summarizationConfig: opts.summarizationConfig,
     initialSummary: opts.initialSummary,
     appConfig: opts.appConfig,
+    messages: opts.messages,
     streaming: true,
     streamUsage: true,
   });
@@ -939,6 +961,58 @@ describe('subagentConfigs', () => {
     };
     expect(childInputs.initialSummary).toBeUndefined();
     expect(childInputs.discoveredTools).toBeUndefined();
+  });
+
+  it('keeps discovered root tools from leaking into the same object used as a subagent', async () => {
+    const deferredTool = {
+      name: 'deferred_tool',
+      description: 'Deferred tool',
+      parameters: {},
+      defer_loading: true,
+      allowed_callers: ['direct'],
+    };
+    const child = makeAgent({
+      id: 'agent_child',
+      name: 'Child',
+      hasDeferredTools: true,
+      toolRegistry: new Map([['deferred_tool', deferredTool]]),
+      toolDefinitions: [deferredTool],
+    });
+    const parent = makeAgent({
+      id: 'agent_parent',
+      subagents: { enabled: true, allowSelf: false, agent_ids: ['agent_child'] },
+      subagentAgentConfigs: [child],
+    });
+
+    const agents = await callAndCapture({
+      agents: [parent, child],
+      messages: [
+        new ToolMessage({
+          name: 'tool_search',
+          tool_call_id: 'call_1',
+          content: JSON.stringify({ tools: [{ name: 'deferred_tool' }] }),
+        }),
+      ],
+    });
+
+    const rootChild = agents.find((agent) => agent.agentId === 'agent_child');
+    expect((rootChild?.toolDefinitions as Array<Record<string, unknown>>)[0].defer_loading).toBe(
+      false,
+    );
+
+    const rootParent = agents.find((agent) => agent.agentId === 'agent_parent');
+    const childConfig = (rootParent?.subagentConfigs as Array<Record<string, unknown>>)[0];
+    const childInputs = childConfig.agentInputs as {
+      discoveredTools?: unknown;
+      toolDefinitions?: Array<Record<string, unknown>>;
+    };
+    expect(childInputs.discoveredTools).toBeUndefined();
+    expect(childInputs.toolDefinitions?.[0].defer_loading).toBe(true);
+    expect(deferredTool.defer_loading).toBe(true);
+    expect(
+      (child.toolRegistry as Map<string, Record<string, unknown>>).get('deferred_tool')
+        ?.defer_loading,
+    ).toBe(true);
   });
 });
 

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -25,3 +25,4 @@ export * from './tools';
 export * from './validation';
 export * from './added';
 export * from './load';
+export * from './toolTokens';

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -863,7 +863,6 @@ export async function createRun({
       agent.maxContextTokens,
     );
 
-    /** Resolve cached or computed tool schema tokens */
     let toolSchemaTokens: number | undefined;
     if (tokenCounter) {
       toolSchemaTokens = await getOrComputeToolTokens({

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -203,6 +203,26 @@ export function overrideDeferLoadingForDiscoveredTools(
   return overrideCount;
 }
 
+function cloneToolRegistry(toolRegistry?: LCToolRegistry): LCToolRegistry | undefined {
+  if (!toolRegistry) {
+    return undefined;
+  }
+
+  const cloned = new Map<string, LCTool>();
+  for (const [name, tool] of toolRegistry.entries()) {
+    cloned.set(name, { ...tool });
+  }
+  return cloned;
+}
+
+function cloneToolDefinitions(toolDefinitions: LCTool[] | undefined): LCTool[] {
+  if (!toolDefinitions) {
+    return [];
+  }
+
+  return toolDefinitions.map((def) => ({ ...def }));
+}
+
 const customProviders = new Set([
   Providers.XAI,
   Providers.DEEPSEEK,
@@ -630,16 +650,10 @@ async function buildSubagentConfigs(
     }
     /**
      * `buildAgentInput` applies parent-run context (initialSummary +
-     * discoveredTools) to the returned AgentInputs *and* to the
-     * passed-in agent's `toolRegistry` / `toolDefinitions` — flipping
-     * `defer_loading: true → false` on tools the parent had previously
-     * searched for, and injecting those tools' definitions into the
-     * child's `toolDefinitions`. Clearing fields on the returned
-     * object post-hoc would leave those side-effects in place, leaking
-     * the parent's tool-search state into an "isolated" subagent and
-     * inflating the child's prompt/token budget. The `isSubagent` flag
-     * skips both the field stamping and the registry mutation at the
-     * source so children truly start fresh.
+     * discoveredTools) to returned top-level AgentInputs. The `isSubagent`
+     * flag skips that field stamping so child agents start from an isolated
+     * context even when the same initialized agent object also appears in the
+     * outer top-level run list.
      */
     const childInputs = await toInput(child, { isSubagent: true });
     /**
@@ -812,6 +826,24 @@ export async function createRun({
     }
 
     /**
+     * Clone mutable tool metadata before any deferred-tool override. The same
+     * initialized agent object can be used both as a top-level root and as a
+     * subagent child, and root inputs are built in parallel for latency. If the
+     * root path mutates `agent.toolRegistry` directly, a sibling parent building
+     * this object as a subagent can observe the flipped `defer_loading` flags
+     * and lose isolation. Cloning only when a mutation/isolation boundary exists
+     * keeps the common no-discovery path allocation-light.
+     */
+    const shouldCloneToolState =
+      agent.toolRegistry != null && (isSubagent || discoveredTools.size > 0);
+    const toolRegistry = shouldCloneToolState
+      ? cloneToolRegistry(agent.toolRegistry)
+      : agent.toolRegistry;
+    let toolDefinitions = shouldCloneToolState
+      ? cloneToolDefinitions(agent.toolDefinitions)
+      : (agent.toolDefinitions ?? []);
+
+    /**
      * Override defer_loading for tools that were discovered in previous
      * turns. This prevents the LLM from having to re-discover tools via
      * tool_search. Also add the discovered tools' definitions so the
@@ -820,15 +852,15 @@ export async function createRun({
      * Skipped for subagent children (`isSubagent`) — they run in an
      * isolated context by contract, so inheriting the parent's
      * tool-search state leaks unrelated history and pre-loads tools the
-     * child shouldn't care about. Mutations on `agent.toolRegistry`
-     * and additions to `toolDefinitions` both happen here, so the flag
-     * has to gate the whole block (clearing fields post-return can't
-     * undo registry writes).
+     * child shouldn't care about.
      */
-    let toolDefinitions = agent.toolDefinitions ?? [];
-    let toolRegistry = agent.toolRegistry;
-    if (!isSubagent && discoveredTools.size > 0 && agent.toolRegistry) {
-      overrideDeferLoadingForDiscoveredTools(agent.toolRegistry, discoveredTools);
+    if (!isSubagent && discoveredTools.size > 0 && toolRegistry) {
+      overrideDeferLoadingForDiscoveredTools(toolRegistry, discoveredTools);
+      toolDefinitions = toolDefinitions.map((def) =>
+        discoveredTools.has(def.name) && def.defer_loading === true
+          ? { ...def, defer_loading: false }
+          : def,
+      );
 
       /** Add discovered tools' definitions so the LLM can see their schemas */
       const existingToolNames = new Set(toolDefinitions.map((d) => d.name));
@@ -836,30 +868,11 @@ export async function createRun({
         if (existingToolNames.has(toolName)) {
           continue;
         }
-        const toolDef = agent.toolRegistry.get(toolName);
+        const toolDef = toolRegistry.get(toolName);
         if (toolDef) {
           toolDefinitions = [...toolDefinitions, toolDef];
         }
       }
-    } else if (isSubagent && agent.toolRegistry) {
-      /**
-       * Subagent children: hand the child a deep-enough clone of the
-       * registry so later parent-graph builds (e.g. when the same
-       * agent also appears as a handoff target in the outer loop)
-       * can't mutate `defer_loading` on tool definitions the child
-       * already holds a reference to. Clone the `Map` *and* each
-       * `LCTool` — `overrideDeferLoadingForDiscoveredTools` writes
-       * through to the tool object itself, so a shallow Map copy
-       * alone wouldn't isolate the flag.
-       */
-      toolRegistry = new Map();
-      for (const [name, tool] of agent.toolRegistry.entries()) {
-        toolRegistry.set(name, { ...tool });
-      }
-      /** Child's own `toolDefinitions` list gets the same shallow-
-       *  copied view so any later parent mutation of shared definitions
-       *  is contained to the parent-graph path. */
-      toolDefinitions = toolDefinitions.map((def) => ({ ...def }));
     }
 
     const effectiveMaxContextTokens = computeEffectiveMaxContextTokens(

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -650,7 +650,12 @@ async function buildSubagentConfigs(
      * `subagentConfigs`, and that only runs for the outer agents in
      * `agents[]`. Cycle-safe via `nextAncestors`.
      */
-    const grandchildConfigs = await buildSubagentConfigs(child, childInputs, toInput, nextAncestors);
+    const grandchildConfigs = await buildSubagentConfigs(
+      child,
+      childInputs,
+      toInput,
+      nextAncestors,
+    );
     if (grandchildConfigs.length > 0) {
       childInputs.subagentConfigs = grandchildConfigs;
     }
@@ -865,14 +870,23 @@ export async function createRun({
 
     let toolSchemaTokens: number | undefined;
     if (tokenCounter) {
-      toolSchemaTokens = await getOrComputeToolTokens({
-        tools: agent.tools,
-        toolDefinitions,
-        provider,
-        clientOptions: llmConfig,
-        tokenCounter,
-        tenantId: user?.tenantId,
-      });
+      try {
+        toolSchemaTokens = await getOrComputeToolTokens({
+          tools: agent.tools,
+          toolDefinitions,
+          provider,
+          clientOptions: llmConfig,
+          tokenCounter,
+          tenantId: user?.tenantId,
+          toolRegistry,
+          discoveredTools: isSubagent ? undefined : discoveredTools,
+        });
+      } catch (err) {
+        logger.warn(
+          `[createRun] Failed to precompute tool schema tokens for agent ${agent.id}; falling back to AgentContext calculation`,
+          err,
+        );
+      }
     }
 
     const reasoningKey = getReasoningKey(provider, llmConfig, agent.endpoint);
@@ -909,33 +923,7 @@ export async function createRun({
     return agentInput;
   };
 
-  const settled = await Promise.allSettled(agents.map(buildRootAgentInput));
-  const agentInputs: AgentInputs[] = [];
-  for (let i = 0; i < settled.length; i++) {
-    const result = settled[i];
-    if (result.status === 'fulfilled') {
-      agentInputs.push(result.value);
-    } else {
-      logger.error(`[createRun] buildAgentInput failed for agent ${agents[i].id}`, result.reason);
-    }
-  }
-
-  if (agentInputs.length === 0) {
-    throw new Error(
-      `[createRun] All ${agents.length} agent(s) failed to initialize; cannot create run`,
-    );
-  }
-
-  const hasEdges = (agents[0].edges?.length ?? 0) > 0;
-  if (agentInputs.length < agents.length && hasEdges) {
-    const failedIds = agents
-      .filter((_, i) => settled[i].status === 'rejected')
-      .map((agent) => agent.id)
-      .join(', ');
-    throw new Error(
-      `[createRun] Agent(s) [${failedIds}] failed in a routed multi-agent run; cannot proceed with partial graph`,
-    );
-  }
+  const agentInputs = await Promise.all(agents.map(buildRootAgentInput));
 
   const graphConfig: RunConfig['graphConfig'] = {
     signal,

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -33,6 +33,7 @@ import { getProviderConfig } from '~/endpoints/config/providers';
 import { resolveHeaders, createSafeUser } from '~/utils/env';
 import { getOpenAIConfig } from '~/endpoints/openai/config';
 import { isUserProvided } from '~/utils/common';
+import { getOrComputeToolTokens } from './toolTokens';
 
 /** Expected shape of JSON tool search results */
 interface ToolSearchJsonResult {
@@ -589,12 +590,12 @@ function anyAgentHasCodeEnv(agents: RunAgent[], visited: Set<string> = new Set()
  * explicit child agents loaded in `agent.subagentAgentConfigs`. Returns an empty
  * array when subagents are disabled or no spawn targets are available.
  */
-function buildSubagentConfigs(
+async function buildSubagentConfigs(
   agent: RunAgent,
   agentInput: AgentInputs,
-  toInput: (child: RunAgent, opts?: { isSubagent?: boolean }) => AgentInputs,
+  toInput: (child: RunAgent, opts?: { isSubagent?: boolean }) => Promise<AgentInputs>,
   ancestors: Set<string> = new Set(),
-): SubagentConfig[] {
+): Promise<SubagentConfig[]> {
   if (!agent.subagents?.enabled) {
     return [];
   }
@@ -640,7 +641,7 @@ function buildSubagentConfigs(
      * skips both the field stamping and the registry mutation at the
      * source so children truly start fresh.
      */
-    const childInputs = toInput(child, { isSubagent: true });
+    const childInputs = await toInput(child, { isSubagent: true });
     /**
      * Recursively resolve the child's own spawn targets so multi-level
      * delegation (A → B → C) works. Without this, a child whose own
@@ -649,7 +650,7 @@ function buildSubagentConfigs(
      * `subagentConfigs`, and that only runs for the outer agents in
      * `agents[]`. Cycle-safe via `nextAncestors`.
      */
-    const grandchildConfigs = buildSubagentConfigs(child, childInputs, toInput, nextAncestors);
+    const grandchildConfigs = await buildSubagentConfigs(child, childInputs, toInput, nextAncestors);
     if (grandchildConfigs.length > 0) {
       childInputs.subagentConfigs = grandchildConfigs;
     }
@@ -737,7 +738,10 @@ export async function createRun({
       ? extractDiscoveredToolsFromHistory(messages)
       : new Set<string>();
 
-  const buildAgentInput = (agent: RunAgent, opts: { isSubagent?: boolean } = {}): AgentInputs => {
+  const buildAgentInput = async (
+    agent: RunAgent,
+    opts: { isSubagent?: boolean } = {},
+  ): Promise<AgentInputs> => {
     const isSubagent = opts.isSubagent === true;
     const provider =
       (providerEndpointMap[
@@ -859,11 +863,25 @@ export async function createRun({
       agent.maxContextTokens,
     );
 
+    /** Resolve cached or computed tool schema tokens */
+    let toolSchemaTokens: number | undefined;
+    if (tokenCounter) {
+      toolSchemaTokens = await getOrComputeToolTokens({
+        tools: agent.tools,
+        toolDefinitions,
+        provider,
+        clientOptions: llmConfig,
+        tokenCounter,
+        tenantId: user?.tenantId,
+      });
+    }
+
     const reasoningKey = getReasoningKey(provider, llmConfig, agent.endpoint);
     return {
       provider,
       reasoningKey,
       toolDefinitions,
+      toolSchemaTokens,
       agentId: agent.id,
       tools: agent.tools,
       clientOptions: llmConfig,
@@ -883,14 +901,41 @@ export async function createRun({
     };
   };
 
-  const agentInputs: AgentInputs[] = [];
-  for (const agent of agents) {
-    const agentInput = buildAgentInput(agent);
-    const subagentConfigs = buildSubagentConfigs(agent, agentInput, buildAgentInput);
+  const buildRootAgentInput = async (agent: RunAgent): Promise<AgentInputs> => {
+    const agentInput = await buildAgentInput(agent);
+    const subagentConfigs = await buildSubagentConfigs(agent, agentInput, buildAgentInput);
     if (subagentConfigs.length > 0) {
       agentInput.subagentConfigs = subagentConfigs;
     }
-    agentInputs.push(agentInput);
+    return agentInput;
+  };
+
+  const settled = await Promise.allSettled(agents.map(buildRootAgentInput));
+  const agentInputs: AgentInputs[] = [];
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i];
+    if (result.status === 'fulfilled') {
+      agentInputs.push(result.value);
+    } else {
+      logger.error(`[createRun] buildAgentInput failed for agent ${agents[i].id}`, result.reason);
+    }
+  }
+
+  if (agentInputs.length === 0) {
+    throw new Error(
+      `[createRun] All ${agents.length} agent(s) failed to initialize; cannot create run`,
+    );
+  }
+
+  const hasEdges = (agents[0].edges?.length ?? 0) > 0;
+  if (agentInputs.length < agents.length && hasEdges) {
+    const failedIds = agents
+      .filter((_, i) => settled[i].status === 'rejected')
+      .map((agent) => agent.id)
+      .join(', ');
+    throw new Error(
+      `[createRun] Agent(s) [${failedIds}] failed in a routed multi-agent run; cannot proceed with partial graph`,
+    );
   }
 
   const graphConfig: RunConfig['graphConfig'] = {

--- a/packages/api/src/agents/toolTokens.spec.ts
+++ b/packages/api/src/agents/toolTokens.spec.ts
@@ -1,0 +1,377 @@
+import { z } from 'zod';
+import { SystemMessage } from '@langchain/core/messages';
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import {
+  Providers,
+  ANTHROPIC_TOOL_TOKEN_MULTIPLIER,
+  DEFAULT_TOOL_TOKEN_MULTIPLIER,
+} from '@librechat/agents';
+import type { GenericTool, LCTool, TokenCounter } from '@librechat/agents';
+import { getToolFingerprint, computeToolSchemaTokens, getOrComputeToolTokens } from './toolTokens';
+
+/* ---------- Mock standardCache to use a plain Map (no Redis) ---------- */
+const mockCacheStore = new Map<string, unknown>();
+jest.mock('~/cache', () => ({
+  standardCache: jest.fn(() => ({
+    get: jest.fn((key: string) => Promise.resolve(mockCacheStore.get(key))),
+    set: jest.fn((key: string, value: unknown) => {
+      mockCacheStore.set(key, value);
+      return Promise.resolve(true);
+    }),
+  })),
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn(), info: jest.fn() },
+}));
+
+/* ---------- Helpers ---------- */
+
+function makeTool(name: string, description = `${name} description`): GenericTool {
+  return new DynamicStructuredTool({
+    name,
+    description,
+    schema: z.object({ input: z.string().optional() }),
+    func: async () => 'ok',
+  }) as unknown as GenericTool;
+}
+
+function makeToolDef(name: string, description?: string): LCTool {
+  return {
+    name,
+    description: description ?? `${name} description`,
+    parameters: { type: 'object', properties: { input: { type: 'string' } } },
+  };
+}
+
+/** Token counter that returns the string length of message content (deterministic). */
+const fakeTokenCounter: TokenCounter = (msg) => {
+  const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+  return content.length;
+};
+
+beforeEach(() => {
+  mockCacheStore.clear();
+});
+
+/* ========================================================================= */
+/*  getToolFingerprint                                                       */
+/* ========================================================================= */
+
+describe('getToolFingerprint', () => {
+  it('returns empty string when no tools or definitions provided', () => {
+    expect(getToolFingerprint()).toBe('');
+    expect(getToolFingerprint([], [])).toBe('');
+  });
+
+  it('returns sorted names with count from GenericTool array', () => {
+    const tools = [makeTool('beta'), makeTool('alpha')];
+    expect(getToolFingerprint(tools)).toBe('alpha,beta|2');
+  });
+
+  it('returns sorted names with count from LCTool definitions', () => {
+    const defs = [makeToolDef('zulu'), makeToolDef('alpha')];
+    expect(getToolFingerprint(undefined, defs)).toBe('alpha,zulu|2');
+  });
+
+  it('deduplicates names across tools and toolDefinitions', () => {
+    const tools = [makeTool('shared'), makeTool('only_tool')];
+    const defs = [makeToolDef('shared'), makeToolDef('only_def')];
+    expect(getToolFingerprint(tools, defs)).toBe('only_def,only_tool,shared|3');
+  });
+
+  it('is stable regardless of input ordering', () => {
+    const a = getToolFingerprint([makeTool('x'), makeTool('a'), makeTool('m')]);
+    const b = getToolFingerprint([makeTool('m'), makeTool('x'), makeTool('a')]);
+    expect(a).toBe(b);
+    expect(a).toBe('a,m,x|3');
+  });
+});
+
+/* ========================================================================= */
+/*  computeToolSchemaTokens                                                  */
+/* ========================================================================= */
+
+describe('computeToolSchemaTokens', () => {
+  it('returns 0 when no tools provided', () => {
+    expect(
+      computeToolSchemaTokens(undefined, undefined, Providers.OPENAI, undefined, fakeTokenCounter),
+    ).toBe(0);
+    expect(computeToolSchemaTokens([], [], Providers.OPENAI, undefined, fakeTokenCounter)).toBe(0);
+  });
+
+  it('counts tokens from GenericTool schemas', () => {
+    const tools = [makeTool('test_tool')];
+    const result = computeToolSchemaTokens(
+      tools,
+      undefined,
+      Providers.OPENAI,
+      undefined,
+      fakeTokenCounter,
+    );
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('counts tokens from LCTool definitions', () => {
+    const defs = [makeToolDef('test_def')];
+    const result = computeToolSchemaTokens(
+      undefined,
+      defs,
+      Providers.OPENAI,
+      undefined,
+      fakeTokenCounter,
+    );
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('deduplicates: tool counted from tools array is skipped in toolDefinitions', () => {
+    const tools = [makeTool('shared')];
+    const defs = [makeToolDef('shared')];
+
+    const toolsOnly = computeToolSchemaTokens(
+      tools,
+      undefined,
+      Providers.OPENAI,
+      undefined,
+      fakeTokenCounter,
+    );
+    const both = computeToolSchemaTokens(
+      tools,
+      defs,
+      Providers.OPENAI,
+      undefined,
+      fakeTokenCounter,
+    );
+
+    expect(both).toBe(toolsOnly);
+  });
+
+  it('applies Anthropic multiplier for Anthropic provider', () => {
+    const defs = [makeToolDef('tool')];
+    const openai = computeToolSchemaTokens(
+      undefined,
+      defs,
+      Providers.OPENAI,
+      undefined,
+      fakeTokenCounter,
+    );
+    const anthropic = computeToolSchemaTokens(
+      undefined,
+      defs,
+      Providers.ANTHROPIC,
+      undefined,
+      fakeTokenCounter,
+    );
+
+    const expectedRatio = ANTHROPIC_TOOL_TOKEN_MULTIPLIER / DEFAULT_TOOL_TOKEN_MULTIPLIER;
+    expect(anthropic / openai).toBeCloseTo(expectedRatio, 1);
+  });
+
+  it('applies Anthropic multiplier when model name contains "claude"', () => {
+    const defs = [makeToolDef('tool')];
+    const clientOptions = { model: 'claude-3-opus' };
+    const result = computeToolSchemaTokens(
+      undefined,
+      defs,
+      Providers.OPENAI,
+      clientOptions,
+      fakeTokenCounter,
+    );
+
+    const defaultResult = computeToolSchemaTokens(
+      undefined,
+      defs,
+      Providers.OPENAI,
+      undefined,
+      fakeTokenCounter,
+    );
+    expect(result).toBeGreaterThan(defaultResult);
+  });
+
+  it('does not apply Anthropic multiplier for Bedrock even with claude model', () => {
+    const defs = [makeToolDef('tool')];
+    const clientOptions = { model: 'claude-3-opus' };
+    const bedrock = computeToolSchemaTokens(
+      undefined,
+      defs,
+      Providers.BEDROCK,
+      clientOptions,
+      fakeTokenCounter,
+    );
+    const defaultResult = computeToolSchemaTokens(
+      undefined,
+      defs,
+      Providers.OPENAI,
+      undefined,
+      fakeTokenCounter,
+    );
+
+    expect(bedrock).toBe(defaultResult);
+  });
+});
+
+/* ========================================================================= */
+/*  getOrComputeToolTokens                                                   */
+/* ========================================================================= */
+
+describe('getOrComputeToolTokens', () => {
+  it('returns 0 when no tools provided', async () => {
+    const result = await getOrComputeToolTokens({
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+    expect(result).toBe(0);
+  });
+
+  it('computes and caches tokens on first call', async () => {
+    const defs = [makeToolDef('tool_a'), makeToolDef('tool_b')];
+    const result = await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    expect(result).toBeGreaterThan(0);
+    expect(mockCacheStore.size).toBe(1);
+
+    const cachedValue = Array.from(mockCacheStore.values())[0];
+    expect(cachedValue).toBe(result);
+  });
+
+  it('returns cached value on second call without recomputing', async () => {
+    const defs = [makeToolDef('tool_a')];
+    const counter = jest.fn(fakeTokenCounter);
+
+    const first = await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: counter,
+    });
+
+    const callCountAfterFirst = counter.mock.calls.length;
+
+    const second = await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: counter,
+    });
+
+    expect(second).toBe(first);
+    expect(counter.mock.calls.length).toBe(callCountAfterFirst);
+  });
+
+  it('caches separately for different providers with different multipliers', async () => {
+    const defs = [makeToolDef('tool')];
+
+    const openai = await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    const anthropic = await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.ANTHROPIC,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    expect(openai).not.toBe(anthropic);
+    expect(mockCacheStore.size).toBe(2);
+  });
+
+  it('shares cache for same provider+tools across calls with different agents', async () => {
+    const defs = [makeToolDef('shared_tool')];
+
+    const first = await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    const second = await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    expect(first).toBe(second);
+    expect(mockCacheStore.size).toBe(1);
+  });
+
+  it('recomputes when tool set changes', async () => {
+    const first = await getOrComputeToolTokens({
+      toolDefinitions: [makeToolDef('tool_a')],
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    const second = await getOrComputeToolTokens({
+      toolDefinitions: [makeToolDef('tool_a'), makeToolDef('tool_b')],
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    expect(second).not.toBe(first);
+    expect(second).toBeGreaterThan(first);
+    expect(mockCacheStore.size).toBe(2);
+  });
+
+  it('falls back to compute when cache read throws', async () => {
+    const { standardCache } = jest.requireMock('~/cache') as { standardCache: jest.Mock };
+    const failingCache = {
+      get: jest.fn(() => Promise.reject(new Error('Redis down'))),
+      set: jest.fn(() => Promise.resolve(true)),
+    };
+    standardCache.mockReturnValueOnce(failingCache);
+
+    /** Reset the module-level cache so it picks up the failing mock */
+    jest.resetModules();
+    const { getOrComputeToolTokens: freshGetOrCompute } = await import('./toolTokens');
+
+    const defs = [makeToolDef('tool')];
+    const result = await freshGetOrCompute({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('does not throw when cache write fails', async () => {
+    const { standardCache } = jest.requireMock('~/cache') as { standardCache: jest.Mock };
+    const writeFailCache = {
+      get: jest.fn(() => Promise.resolve(undefined)),
+      set: jest.fn(() => Promise.reject(new Error('Redis write error'))),
+    };
+    standardCache.mockReturnValueOnce(writeFailCache);
+
+    jest.resetModules();
+    const { getOrComputeToolTokens: freshGetOrCompute } = await import('./toolTokens');
+
+    const defs = [makeToolDef('tool')];
+    const result = await freshGetOrCompute({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it('uses GenericTool tools for fingerprint and token counting', async () => {
+    const tools = [makeTool('alpha'), makeTool('beta')];
+
+    const result = await getOrComputeToolTokens({
+      tools,
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    expect(result).toBeGreaterThan(0);
+    expect(mockCacheStore.size).toBe(1);
+
+    const key = Array.from(mockCacheStore.keys())[0];
+    expect(key).toContain('alpha,beta|2');
+  });
+});

--- a/packages/api/src/agents/toolTokens.spec.ts
+++ b/packages/api/src/agents/toolTokens.spec.ts
@@ -37,11 +37,18 @@ function makeTool(name: string, description = `${name} description`): GenericToo
   }) as unknown as GenericTool;
 }
 
-function makeToolDef(name: string, description?: string): LCTool {
+function makeMcpTool(name: string): GenericTool {
+  const tool = makeTool(name) as unknown as Record<string, unknown>;
+  tool.mcp = true;
+  return tool as unknown as GenericTool;
+}
+
+function makeToolDef(name: string, opts?: Partial<LCTool>): LCTool {
   return {
     name,
-    description: description ?? `${name} description`,
-    parameters: { type: 'object', properties: { input: { type: 'string' } } },
+    description: opts?.description ?? `${name} description`,
+    parameters: opts?.parameters ?? { type: 'object', properties: { input: { type: 'string' } } },
+    ...opts,
   };
 }
 
@@ -65,34 +72,45 @@ beforeEach(() => {
 /* ========================================================================= */
 
 describe('collectToolSchemas', () => {
-  it('returns empty map when no tools provided', () => {
-    expect(collectToolSchemas().size).toBe(0);
-    expect(collectToolSchemas([], []).size).toBe(0);
+  it('returns empty array when no tools provided', () => {
+    expect(collectToolSchemas()).toHaveLength(0);
+    expect(collectToolSchemas([], [])).toHaveLength(0);
   });
 
-  it('collects schemas from GenericTool array keyed by name', () => {
-    const tools = [makeTool('alpha'), makeTool('beta')];
-    const schemas = collectToolSchemas(tools);
-    expect(schemas.size).toBe(2);
-    expect(schemas.has('alpha')).toBe(true);
-    expect(schemas.has('beta')).toBe(true);
+  it('collects entries from GenericTool array', () => {
+    const entries = collectToolSchemas([makeTool('alpha'), makeTool('beta')]);
+    expect(entries).toHaveLength(2);
+    expect(entries.map((e) => e.cacheKey)).toEqual(
+      expect.arrayContaining(['alpha:builtin', 'beta:builtin']),
+    );
   });
 
-  it('collects schemas from LCTool definitions', () => {
-    const defs = [makeToolDef('x'), makeToolDef('y')];
-    const schemas = collectToolSchemas(undefined, defs);
-    expect(schemas.size).toBe(2);
-    expect(schemas.has('x')).toBe(true);
-    expect(schemas.has('y')).toBe(true);
+  it('collects entries from LCTool definitions with toolType', () => {
+    const defs = [makeToolDef('x', { toolType: 'mcp' }), makeToolDef('y', { toolType: 'action' })];
+    const entries = collectToolSchemas(undefined, defs);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].cacheKey).toBe('x:mcp');
+    expect(entries[1].cacheKey).toBe('y:action');
+  });
+
+  it('defaults toolType to builtin for LCTool without toolType', () => {
+    const entries = collectToolSchemas(undefined, [makeToolDef('z')]);
+    expect(entries[0].cacheKey).toBe('z:builtin');
+  });
+
+  it('uses mcp type for GenericTool with mcp flag', () => {
+    const entries = collectToolSchemas([makeMcpTool('search')]);
+    expect(entries[0].cacheKey).toBe('search:mcp');
   });
 
   it('deduplicates: GenericTool takes precedence over matching toolDefinition', () => {
     const tools = [makeTool('shared')];
     const defs = [makeToolDef('shared'), makeToolDef('only_def')];
-    const schemas = collectToolSchemas(tools, defs);
-    expect(schemas.size).toBe(2);
-    expect(schemas.has('shared')).toBe(true);
-    expect(schemas.has('only_def')).toBe(true);
+    const entries = collectToolSchemas(tools, defs);
+    expect(entries).toHaveLength(2);
+    const keys = entries.map((e) => e.cacheKey);
+    expect(keys).toContain('shared:builtin');
+    expect(keys).toContain('only_def:builtin');
   });
 });
 
@@ -109,9 +127,8 @@ describe('computeToolSchemaTokens', () => {
   });
 
   it('counts tokens from GenericTool schemas', () => {
-    const tools = [makeTool('test_tool')];
     const result = computeToolSchemaTokens(
-      tools,
+      [makeTool('test_tool')],
       undefined,
       Providers.OPENAI,
       undefined,
@@ -121,10 +138,9 @@ describe('computeToolSchemaTokens', () => {
   });
 
   it('counts tokens from LCTool definitions', () => {
-    const defs = [makeToolDef('test_def')];
     const result = computeToolSchemaTokens(
       undefined,
-      defs,
+      [makeToolDef('test_def')],
       Providers.OPENAI,
       undefined,
       fakeTokenCounter,
@@ -150,7 +166,6 @@ describe('computeToolSchemaTokens', () => {
       undefined,
       fakeTokenCounter,
     );
-
     expect(both).toBe(toolsOnly);
   });
 
@@ -170,19 +185,17 @@ describe('computeToolSchemaTokens', () => {
       undefined,
       fakeTokenCounter,
     );
-
     const expectedRatio = ANTHROPIC_TOOL_TOKEN_MULTIPLIER / DEFAULT_TOOL_TOKEN_MULTIPLIER;
     expect(anthropic / openai).toBeCloseTo(expectedRatio, 1);
   });
 
   it('applies Anthropic multiplier when model name contains "claude"', () => {
     const defs = [makeToolDef('tool')];
-    const clientOptions = { model: 'claude-3-opus' };
     const result = computeToolSchemaTokens(
       undefined,
       defs,
       Providers.OPENAI,
-      clientOptions,
+      { model: 'claude-3-opus' },
       fakeTokenCounter,
     );
     const defaultResult = computeToolSchemaTokens(
@@ -197,12 +210,11 @@ describe('computeToolSchemaTokens', () => {
 
   it('does not apply Anthropic multiplier for Bedrock even with claude model', () => {
     const defs = [makeToolDef('tool')];
-    const clientOptions = { model: 'claude-3-opus' };
     const bedrock = computeToolSchemaTokens(
       undefined,
       defs,
       Providers.BEDROCK,
-      clientOptions,
+      { model: 'claude-3-opus' },
       fakeTokenCounter,
     );
     const defaultResult = computeToolSchemaTokens(
@@ -212,7 +224,6 @@ describe('computeToolSchemaTokens', () => {
       undefined,
       fakeTokenCounter,
     );
-
     expect(bedrock).toBe(defaultResult);
   });
 });
@@ -239,8 +250,8 @@ describe('getOrComputeToolTokens', () => {
     });
 
     expect(result).toBeGreaterThan(0);
-    expect(mockCacheStore.has('tool_a')).toBe(true);
-    expect(mockCacheStore.has('tool_b')).toBe(true);
+    expect(mockCacheStore.has('tool_a:builtin')).toBe(true);
+    expect(mockCacheStore.has('tool_b:builtin')).toBe(true);
     expect(mockCacheStore.size).toBe(2);
   });
 
@@ -282,7 +293,6 @@ describe('getOrComputeToolTokens', () => {
     });
 
     expect(openai).not.toBe(anthropic);
-    // Only one cache entry — raw count is provider-agnostic
     expect(mockCacheStore.size).toBe(1);
   });
 
@@ -302,17 +312,63 @@ describe('getOrComputeToolTokens', () => {
       tokenCounter: counter,
     });
 
-    // Only one new tokenCounter call for tool_b
     expect(counter.mock.calls.length).toBe(callsAfterFirst + 1);
     expect(mockCacheStore.size).toBe(2);
+  });
+
+  it('scopes cache keys by tenantId when provided', async () => {
+    const defs = [makeToolDef('tool')];
+
+    await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+      tenantId: 'tenant_123',
+    });
+
+    expect(mockCacheStore.has('tenant_123:tool:builtin')).toBe(true);
+  });
+
+  it('separates cache entries for different tenants', async () => {
+    const defs = [makeToolDef('tool')];
+
+    const t1 = await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+      tenantId: 'tenant_1',
+    });
+
+    const t2 = await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+      tenantId: 'tenant_2',
+    });
+
+    expect(t1).toBe(t2);
+    expect(mockCacheStore.has('tenant_1:tool:builtin')).toBe(true);
+    expect(mockCacheStore.has('tenant_2:tool:builtin')).toBe(true);
+    expect(mockCacheStore.size).toBe(2);
+  });
+
+  it('caches mcp tools with mcp type in key', async () => {
+    const defs = [makeToolDef('search', { toolType: 'mcp' })];
+
+    await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    expect(mockCacheStore.has('search:mcp')).toBe(true);
   });
 
   it('falls back to compute when cache read throws', async () => {
     mockGet.mockRejectedValueOnce(new Error('Redis down'));
 
-    const defs = [makeToolDef('tool')];
     const result = await getOrComputeToolTokens({
-      toolDefinitions: defs,
+      toolDefinitions: [makeToolDef('tool')],
       provider: Providers.OPENAI,
       tokenCounter: fakeTokenCounter,
     });
@@ -324,29 +380,14 @@ describe('getOrComputeToolTokens', () => {
   it('does not throw when cache write fails', async () => {
     mockSet.mockRejectedValueOnce(new Error('Redis write error'));
 
-    const defs = [makeToolDef('tool_write_fail')];
     const result = await getOrComputeToolTokens({
-      toolDefinitions: defs,
+      toolDefinitions: [makeToolDef('tool_write_fail')],
       provider: Providers.OPENAI,
       tokenCounter: fakeTokenCounter,
     });
 
     expect(result).toBeGreaterThan(0);
     expect(mockSet).toHaveBeenCalled();
-  });
-
-  it('uses GenericTool tools for per-tool caching', async () => {
-    const tools = [makeTool('alpha'), makeTool('beta')];
-
-    const result = await getOrComputeToolTokens({
-      tools,
-      provider: Providers.OPENAI,
-      tokenCounter: fakeTokenCounter,
-    });
-
-    expect(result).toBeGreaterThan(0);
-    expect(mockCacheStore.has('alpha')).toBe(true);
-    expect(mockCacheStore.has('beta')).toBe(true);
   });
 
   it('matches computeToolSchemaTokens output for same inputs', async () => {

--- a/packages/api/src/agents/toolTokens.spec.ts
+++ b/packages/api/src/agents/toolTokens.spec.ts
@@ -1,24 +1,25 @@
 import { z } from 'zod';
-import { SystemMessage } from '@langchain/core/messages';
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import {
   Providers,
   ANTHROPIC_TOOL_TOKEN_MULTIPLIER,
   DEFAULT_TOOL_TOKEN_MULTIPLIER,
 } from '@librechat/agents';
+
 import type { GenericTool, LCTool, TokenCounter } from '@librechat/agents';
+
 import { getToolFingerprint, computeToolSchemaTokens, getOrComputeToolTokens } from './toolTokens';
 
-/* ---------- Mock standardCache to use a plain Map (no Redis) ---------- */
+/* ---------- Mock standardCache with hoisted get/set for per-test overrides ---------- */
 const mockCacheStore = new Map<string, unknown>();
+const mockGet = jest.fn((key: string) => Promise.resolve(mockCacheStore.get(key)));
+const mockSet = jest.fn((key: string, value: unknown) => {
+  mockCacheStore.set(key, value);
+  return Promise.resolve(true);
+});
+
 jest.mock('~/cache', () => ({
-  standardCache: jest.fn(() => ({
-    get: jest.fn((key: string) => Promise.resolve(mockCacheStore.get(key))),
-    set: jest.fn((key: string, value: unknown) => {
-      mockCacheStore.set(key, value);
-      return Promise.resolve(true);
-    }),
-  })),
+  standardCache: jest.fn(() => ({ get: mockGet, set: mockSet })),
 }));
 
 jest.mock('@librechat/data-schemas', () => ({
@@ -52,6 +53,11 @@ const fakeTokenCounter: TokenCounter = (msg) => {
 
 beforeEach(() => {
   mockCacheStore.clear();
+  mockGet.mockImplementation((key: string) => Promise.resolve(mockCacheStore.get(key)));
+  mockSet.mockImplementation((key: string, value: unknown) => {
+    mockCacheStore.set(key, value);
+    return Promise.resolve(true);
+  });
 });
 
 /* ========================================================================= */
@@ -177,7 +183,6 @@ describe('computeToolSchemaTokens', () => {
       clientOptions,
       fakeTokenCounter,
     );
-
     const defaultResult = computeToolSchemaTokens(
       undefined,
       defs,
@@ -317,46 +322,31 @@ describe('getOrComputeToolTokens', () => {
   });
 
   it('falls back to compute when cache read throws', async () => {
-    const { standardCache } = jest.requireMock('~/cache') as { standardCache: jest.Mock };
-    const failingCache = {
-      get: jest.fn(() => Promise.reject(new Error('Redis down'))),
-      set: jest.fn(() => Promise.resolve(true)),
-    };
-    standardCache.mockReturnValueOnce(failingCache);
-
-    /** Reset the module-level cache so it picks up the failing mock */
-    jest.resetModules();
-    const { getOrComputeToolTokens: freshGetOrCompute } = await import('./toolTokens');
+    mockGet.mockRejectedValueOnce(new Error('Redis down'));
 
     const defs = [makeToolDef('tool')];
-    const result = await freshGetOrCompute({
+    const result = await getOrComputeToolTokens({
       toolDefinitions: defs,
       provider: Providers.OPENAI,
       tokenCounter: fakeTokenCounter,
     });
 
     expect(result).toBeGreaterThan(0);
+    expect(mockGet).toHaveBeenCalled();
   });
 
   it('does not throw when cache write fails', async () => {
-    const { standardCache } = jest.requireMock('~/cache') as { standardCache: jest.Mock };
-    const writeFailCache = {
-      get: jest.fn(() => Promise.resolve(undefined)),
-      set: jest.fn(() => Promise.reject(new Error('Redis write error'))),
-    };
-    standardCache.mockReturnValueOnce(writeFailCache);
+    mockSet.mockRejectedValueOnce(new Error('Redis write error'));
 
-    jest.resetModules();
-    const { getOrComputeToolTokens: freshGetOrCompute } = await import('./toolTokens');
-
-    const defs = [makeToolDef('tool')];
-    const result = await freshGetOrCompute({
+    const defs = [makeToolDef('tool_write_fail')];
+    const result = await getOrComputeToolTokens({
       toolDefinitions: defs,
       provider: Providers.OPENAI,
       tokenCounter: fakeTokenCounter,
     });
 
     expect(result).toBeGreaterThan(0);
+    expect(mockSet).toHaveBeenCalled();
   });
 
   it('uses GenericTool tools for fingerprint and token counting', async () => {

--- a/packages/api/src/agents/toolTokens.spec.ts
+++ b/packages/api/src/agents/toolTokens.spec.ts
@@ -8,7 +8,7 @@ import {
 
 import type { GenericTool, LCTool, TokenCounter } from '@librechat/agents';
 
-import { getToolFingerprint, computeToolSchemaTokens, getOrComputeToolTokens } from './toolTokens';
+import { collectToolSchemas, computeToolSchemaTokens, getOrComputeToolTokens } from './toolTokens';
 
 /* ---------- Mock standardCache with hoisted get/set for per-test overrides ---------- */
 const mockCacheStore = new Map<string, unknown>();
@@ -61,36 +61,38 @@ beforeEach(() => {
 });
 
 /* ========================================================================= */
-/*  getToolFingerprint                                                       */
+/*  collectToolSchemas                                                       */
 /* ========================================================================= */
 
-describe('getToolFingerprint', () => {
-  it('returns empty string when no tools or definitions provided', () => {
-    expect(getToolFingerprint()).toBe('');
-    expect(getToolFingerprint([], [])).toBe('');
+describe('collectToolSchemas', () => {
+  it('returns empty map when no tools provided', () => {
+    expect(collectToolSchemas().size).toBe(0);
+    expect(collectToolSchemas([], []).size).toBe(0);
   });
 
-  it('returns sorted names with count from GenericTool array', () => {
-    const tools = [makeTool('beta'), makeTool('alpha')];
-    expect(getToolFingerprint(tools)).toBe('alpha,beta|2');
+  it('collects schemas from GenericTool array keyed by name', () => {
+    const tools = [makeTool('alpha'), makeTool('beta')];
+    const schemas = collectToolSchemas(tools);
+    expect(schemas.size).toBe(2);
+    expect(schemas.has('alpha')).toBe(true);
+    expect(schemas.has('beta')).toBe(true);
   });
 
-  it('returns sorted names with count from LCTool definitions', () => {
-    const defs = [makeToolDef('zulu'), makeToolDef('alpha')];
-    expect(getToolFingerprint(undefined, defs)).toBe('alpha,zulu|2');
+  it('collects schemas from LCTool definitions', () => {
+    const defs = [makeToolDef('x'), makeToolDef('y')];
+    const schemas = collectToolSchemas(undefined, defs);
+    expect(schemas.size).toBe(2);
+    expect(schemas.has('x')).toBe(true);
+    expect(schemas.has('y')).toBe(true);
   });
 
-  it('deduplicates names across tools and toolDefinitions', () => {
-    const tools = [makeTool('shared'), makeTool('only_tool')];
+  it('deduplicates: GenericTool takes precedence over matching toolDefinition', () => {
+    const tools = [makeTool('shared')];
     const defs = [makeToolDef('shared'), makeToolDef('only_def')];
-    expect(getToolFingerprint(tools, defs)).toBe('only_def,only_tool,shared|3');
-  });
-
-  it('is stable regardless of input ordering', () => {
-    const a = getToolFingerprint([makeTool('x'), makeTool('a'), makeTool('m')]);
-    const b = getToolFingerprint([makeTool('m'), makeTool('x'), makeTool('a')]);
-    expect(a).toBe(b);
-    expect(a).toBe('a,m,x|3');
+    const schemas = collectToolSchemas(tools, defs);
+    expect(schemas.size).toBe(2);
+    expect(schemas.has('shared')).toBe(true);
+    expect(schemas.has('only_def')).toBe(true);
   });
 });
 
@@ -228,7 +230,7 @@ describe('getOrComputeToolTokens', () => {
     expect(result).toBe(0);
   });
 
-  it('computes and caches tokens on first call', async () => {
+  it('computes and caches each tool individually on first call', async () => {
     const defs = [makeToolDef('tool_a'), makeToolDef('tool_b')];
     const result = await getOrComputeToolTokens({
       toolDefinitions: defs,
@@ -237,13 +239,12 @@ describe('getOrComputeToolTokens', () => {
     });
 
     expect(result).toBeGreaterThan(0);
-    expect(mockCacheStore.size).toBe(1);
-
-    const cachedValue = Array.from(mockCacheStore.values())[0];
-    expect(cachedValue).toBe(result);
+    expect(mockCacheStore.has('tool_a')).toBe(true);
+    expect(mockCacheStore.has('tool_b')).toBe(true);
+    expect(mockCacheStore.size).toBe(2);
   });
 
-  it('returns cached value on second call without recomputing', async () => {
+  it('uses cached per-tool values on second call without recomputing', async () => {
     const defs = [makeToolDef('tool_a')];
     const counter = jest.fn(fakeTokenCounter);
 
@@ -265,7 +266,7 @@ describe('getOrComputeToolTokens', () => {
     expect(counter.mock.calls.length).toBe(callCountAfterFirst);
   });
 
-  it('caches separately for different providers with different multipliers', async () => {
+  it('applies different multipliers for different providers on same cached raw counts', async () => {
     const defs = [makeToolDef('tool')];
 
     const openai = await getOrComputeToolTokens({
@@ -281,43 +282,28 @@ describe('getOrComputeToolTokens', () => {
     });
 
     expect(openai).not.toBe(anthropic);
-    expect(mockCacheStore.size).toBe(2);
-  });
-
-  it('shares cache for same provider+tools across calls with different agents', async () => {
-    const defs = [makeToolDef('shared_tool')];
-
-    const first = await getOrComputeToolTokens({
-      toolDefinitions: defs,
-      provider: Providers.OPENAI,
-      tokenCounter: fakeTokenCounter,
-    });
-
-    const second = await getOrComputeToolTokens({
-      toolDefinitions: defs,
-      provider: Providers.OPENAI,
-      tokenCounter: fakeTokenCounter,
-    });
-
-    expect(first).toBe(second);
+    // Only one cache entry — raw count is provider-agnostic
     expect(mockCacheStore.size).toBe(1);
   });
 
-  it('recomputes when tool set changes', async () => {
-    const first = await getOrComputeToolTokens({
+  it('only computes new tools when tool set grows', async () => {
+    const counter = jest.fn(fakeTokenCounter);
+
+    await getOrComputeToolTokens({
       toolDefinitions: [makeToolDef('tool_a')],
       provider: Providers.OPENAI,
-      tokenCounter: fakeTokenCounter,
+      tokenCounter: counter,
     });
+    const callsAfterFirst = counter.mock.calls.length;
 
-    const second = await getOrComputeToolTokens({
+    await getOrComputeToolTokens({
       toolDefinitions: [makeToolDef('tool_a'), makeToolDef('tool_b')],
       provider: Providers.OPENAI,
-      tokenCounter: fakeTokenCounter,
+      tokenCounter: counter,
     });
 
-    expect(second).not.toBe(first);
-    expect(second).toBeGreaterThan(first);
+    // Only one new tokenCounter call for tool_b
+    expect(counter.mock.calls.length).toBe(callsAfterFirst + 1);
     expect(mockCacheStore.size).toBe(2);
   });
 
@@ -349,7 +335,7 @@ describe('getOrComputeToolTokens', () => {
     expect(mockSet).toHaveBeenCalled();
   });
 
-  it('uses GenericTool tools for fingerprint and token counting', async () => {
+  it('uses GenericTool tools for per-tool caching', async () => {
     const tools = [makeTool('alpha'), makeTool('beta')];
 
     const result = await getOrComputeToolTokens({
@@ -359,9 +345,27 @@ describe('getOrComputeToolTokens', () => {
     });
 
     expect(result).toBeGreaterThan(0);
-    expect(mockCacheStore.size).toBe(1);
+    expect(mockCacheStore.has('alpha')).toBe(true);
+    expect(mockCacheStore.has('beta')).toBe(true);
+  });
 
-    const key = Array.from(mockCacheStore.keys())[0];
-    expect(key).toContain('alpha,beta|2');
+  it('matches computeToolSchemaTokens output for same inputs', async () => {
+    const defs = [makeToolDef('a'), makeToolDef('b'), makeToolDef('c')];
+
+    const cached = await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    const direct = computeToolSchemaTokens(
+      undefined,
+      defs,
+      Providers.OPENAI,
+      undefined,
+      fakeTokenCounter,
+    );
+
+    expect(cached).toBe(direct);
   });
 });

--- a/packages/api/src/agents/toolTokens.spec.ts
+++ b/packages/api/src/agents/toolTokens.spec.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_TOOL_TOKEN_MULTIPLIER,
 } from '@librechat/agents';
 
-import type { GenericTool, LCTool, TokenCounter } from '@librechat/agents';
+import type { GenericTool, LCTool, LCToolRegistry, TokenCounter } from '@librechat/agents';
 
 import { collectToolSchemas, computeToolSchemaTokens, getOrComputeToolTokens } from './toolTokens';
 
@@ -57,6 +57,14 @@ const fakeTokenCounter: TokenCounter = (msg) => {
   const content = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
   return content.length;
 };
+
+function cacheKeys(): string[] {
+  return Array.from(mockCacheStore.keys());
+}
+
+function hasCacheKey(fragment: string): boolean {
+  return cacheKeys().some((key) => key.includes(fragment));
+}
 
 beforeEach(() => {
   mockCacheStore.clear();
@@ -111,6 +119,52 @@ describe('collectToolSchemas', () => {
     const keys = entries.map((e) => e.cacheKey);
     expect(keys).toContain('shared:builtin');
     expect(keys).toContain('only_def:builtin');
+  });
+
+  it('excludes tool definitions that AgentContext would not bind directly', () => {
+    const defs = [
+      makeToolDef('active'),
+      makeToolDef('deferred', { defer_loading: true }),
+      makeToolDef('programmatic', { allowed_callers: ['code_execution'] }),
+    ];
+
+    const entries = collectToolSchemas(undefined, defs);
+
+    expect(entries.map((entry) => entry.cacheKey)).toEqual(['active:builtin']);
+  });
+
+  it('includes deferred tool definitions once discovered', () => {
+    const defs = [makeToolDef('deferred', { defer_loading: true })];
+
+    const entries = collectToolSchemas(undefined, defs, {
+      discoveredTools: new Set(['deferred']),
+    });
+
+    expect(entries.map((entry) => entry.cacheKey)).toEqual(['deferred:builtin']);
+  });
+
+  it('filters instance tools in non-event-driven mode using toolRegistry', () => {
+    const tools = [makeTool('active'), makeTool('deferred'), makeTool('programmatic')];
+    const toolRegistry: LCToolRegistry = new Map([
+      ['active', makeToolDef('active')],
+      ['deferred', makeToolDef('deferred', { defer_loading: true })],
+      ['programmatic', makeToolDef('programmatic', { allowed_callers: ['code_execution'] })],
+    ]);
+
+    const entries = collectToolSchemas(tools, undefined, { toolRegistry });
+
+    expect(entries.map((entry) => entry.cacheKey)).toEqual(['active:builtin']);
+  });
+
+  it('does not filter instance tools when event-driven tool definitions are present', () => {
+    const tools = [makeTool('native')];
+    const toolRegistry: LCToolRegistry = new Map([
+      ['native', makeToolDef('native', { defer_loading: true })],
+    ]);
+
+    const entries = collectToolSchemas(tools, [makeToolDef('defined')], { toolRegistry });
+
+    expect(entries.map((entry) => entry.cacheKey)).toEqual(['native:builtin', 'defined:builtin']);
   });
 });
 
@@ -250,8 +304,8 @@ describe('getOrComputeToolTokens', () => {
     });
 
     expect(result).toBeGreaterThan(0);
-    expect(mockCacheStore.has('tool_a:builtin')).toBe(true);
-    expect(mockCacheStore.has('tool_b:builtin')).toBe(true);
+    expect(hasCacheKey('tool_a:builtin')).toBe(true);
+    expect(hasCacheKey('tool_b:builtin')).toBe(true);
     expect(mockCacheStore.size).toBe(2);
   });
 
@@ -277,7 +331,7 @@ describe('getOrComputeToolTokens', () => {
     expect(counter.mock.calls.length).toBe(callCountAfterFirst);
   });
 
-  it('applies different multipliers for different providers on same cached raw counts', async () => {
+  it('applies different multipliers while separating provider namespaces', async () => {
     const defs = [makeToolDef('tool')];
 
     const openai = await getOrComputeToolTokens({
@@ -293,7 +347,7 @@ describe('getOrComputeToolTokens', () => {
     });
 
     expect(openai).not.toBe(anthropic);
-    expect(mockCacheStore.size).toBe(1);
+    expect(mockCacheStore.size).toBe(2);
   });
 
   it('only computes new tools when tool set grows', async () => {
@@ -316,6 +370,77 @@ describe('getOrComputeToolTokens', () => {
     expect(mockCacheStore.size).toBe(2);
   });
 
+  it('recomputes when a same-name tool schema changes', async () => {
+    const counter = jest.fn(fakeTokenCounter);
+    const shortSchema = [
+      makeToolDef('tool', {
+        parameters: { type: 'object', properties: { input: { type: 'string' } } },
+      }),
+    ];
+    const longSchema = [
+      makeToolDef('tool', {
+        parameters: {
+          type: 'object',
+          properties: {
+            input: { type: 'string' },
+            detail: {
+              type: 'string',
+              description: 'A detailed field that makes the serialized schema longer',
+            },
+          },
+        },
+      }),
+    ];
+
+    const first = await getOrComputeToolTokens({
+      toolDefinitions: shortSchema,
+      provider: Providers.OPENAI,
+      tokenCounter: counter,
+    });
+    const callsAfterFirst = counter.mock.calls.length;
+
+    const second = await getOrComputeToolTokens({
+      toolDefinitions: longSchema,
+      provider: Providers.OPENAI,
+      tokenCounter: counter,
+    });
+
+    expect(second).toBeGreaterThan(first);
+    expect(counter.mock.calls.length).toBe(callsAfterFirst + 1);
+    expect(mockCacheStore.size).toBe(2);
+  });
+
+  it('separates cache namespaces when provider or model changes', async () => {
+    const counter = jest.fn(fakeTokenCounter);
+    const defs = [makeToolDef('tool')];
+
+    await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      clientOptions: { model: 'gpt-4o' },
+      tokenCounter: counter,
+    });
+    const callsAfterFirst = counter.mock.calls.length;
+
+    await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      clientOptions: { model: 'gpt-4o' },
+      tokenCounter: counter,
+    });
+    expect(counter.mock.calls.length).toBe(callsAfterFirst);
+
+    await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      clientOptions: { model: 'claude-3-opus' },
+      tokenCounter: counter,
+    });
+
+    expect(counter.mock.calls.length).toBe(callsAfterFirst + 1);
+    expect(mockCacheStore.size).toBe(2);
+  });
+
   it('scopes cache keys by tenantId when provided', async () => {
     const defs = [makeToolDef('tool')];
 
@@ -326,7 +451,9 @@ describe('getOrComputeToolTokens', () => {
       tenantId: 'tenant_123',
     });
 
-    expect(mockCacheStore.has('tenant_123:tool:builtin')).toBe(true);
+    expect(
+      cacheKeys().some((key) => key.startsWith('tenant_123:') && key.includes('tool:builtin')),
+    ).toBe(true);
   });
 
   it('separates cache entries for different tenants', async () => {
@@ -347,8 +474,12 @@ describe('getOrComputeToolTokens', () => {
     });
 
     expect(t1).toBe(t2);
-    expect(mockCacheStore.has('tenant_1:tool:builtin')).toBe(true);
-    expect(mockCacheStore.has('tenant_2:tool:builtin')).toBe(true);
+    expect(
+      cacheKeys().some((key) => key.startsWith('tenant_1:') && key.includes('tool:builtin')),
+    ).toBe(true);
+    expect(
+      cacheKeys().some((key) => key.startsWith('tenant_2:') && key.includes('tool:builtin')),
+    ).toBe(true);
     expect(mockCacheStore.size).toBe(2);
   });
 
@@ -361,7 +492,7 @@ describe('getOrComputeToolTokens', () => {
       tokenCounter: fakeTokenCounter,
     });
 
-    expect(mockCacheStore.has('search:mcp')).toBe(true);
+    expect(hasCacheKey('search:mcp')).toBe(true);
   });
 
   it('falls back to compute when cache read throws', async () => {

--- a/packages/api/src/agents/toolTokens.spec.ts
+++ b/packages/api/src/agents/toolTokens.spec.ts
@@ -10,16 +10,30 @@ import type { GenericTool, LCTool, LCToolRegistry, TokenCounter } from '@librech
 
 import { collectToolSchemas, computeToolSchemaTokens, getOrComputeToolTokens } from './toolTokens';
 
-/* ---------- Mock standardCache with hoisted get/set for per-test overrides ---------- */
+/* ---------- Mock standardCache with hoisted methods for per-test overrides ---------- */
 const mockCacheStore = new Map<string, unknown>();
 const mockGet = jest.fn((key: string) => Promise.resolve(mockCacheStore.get(key)));
+const mockGetMany = jest.fn((keys: string[]) =>
+  Promise.resolve(keys.map((key) => mockCacheStore.get(key))),
+);
 const mockSet = jest.fn((key: string, value: unknown) => {
   mockCacheStore.set(key, value);
   return Promise.resolve(true);
 });
+const mockSetMany = jest.fn((entries: Array<{ key: string; value: unknown }>) => {
+  for (const { key, value } of entries) {
+    mockCacheStore.set(key, value);
+  }
+  return Promise.resolve(entries.map(() => true));
+});
 
 jest.mock('~/cache', () => ({
-  standardCache: jest.fn(() => ({ get: mockGet, set: mockSet })),
+  standardCache: jest.fn(() => ({
+    get: mockGet,
+    getMany: mockGetMany,
+    set: mockSet,
+    setMany: mockSetMany,
+  })),
 }));
 
 jest.mock('@librechat/data-schemas', () => ({
@@ -68,10 +82,23 @@ function hasCacheKey(fragment: string): boolean {
 
 beforeEach(() => {
   mockCacheStore.clear();
+  mockGet.mockClear();
+  mockGetMany.mockClear();
+  mockSet.mockClear();
+  mockSetMany.mockClear();
   mockGet.mockImplementation((key: string) => Promise.resolve(mockCacheStore.get(key)));
+  mockGetMany.mockImplementation((keys: string[]) =>
+    Promise.resolve(keys.map((key) => mockCacheStore.get(key))),
+  );
   mockSet.mockImplementation((key: string, value: unknown) => {
     mockCacheStore.set(key, value);
     return Promise.resolve(true);
+  });
+  mockSetMany.mockImplementation((entries: Array<{ key: string; value: unknown }>) => {
+    for (const { key, value } of entries) {
+      mockCacheStore.set(key, value);
+    }
+    return Promise.resolve(entries.map(() => true));
   });
 });
 
@@ -331,23 +358,38 @@ describe('getOrComputeToolTokens', () => {
     expect(counter.mock.calls.length).toBe(callCountAfterFirst);
   });
 
-  it('applies different multipliers while separating provider namespaces', async () => {
+  it('applies different multipliers while reusing raw tokenizer counts', async () => {
     const defs = [makeToolDef('tool')];
+    const counter = jest.fn(fakeTokenCounter);
 
     const openai = await getOrComputeToolTokens({
       toolDefinitions: defs,
       provider: Providers.OPENAI,
-      tokenCounter: fakeTokenCounter,
+      tokenCounter: counter,
     });
+    const callsAfterOpenAI = counter.mock.calls.length;
 
     const anthropic = await getOrComputeToolTokens({
       toolDefinitions: defs,
       provider: Providers.ANTHROPIC,
-      tokenCounter: fakeTokenCounter,
+      tokenCounter: counter,
     });
 
     expect(openai).not.toBe(anthropic);
-    expect(mockCacheStore.size).toBe(2);
+    expect(counter.mock.calls.length).toBe(callsAfterOpenAI);
+    expect(mockCacheStore.size).toBe(1);
+  });
+
+  it('reads per-tool cache entries in one batch', async () => {
+    await getOrComputeToolTokens({
+      toolDefinitions: [makeToolDef('tool_a'), makeToolDef('tool_b')],
+      provider: Providers.OPENAI,
+      tokenCounter: fakeTokenCounter,
+    });
+
+    expect(mockGetMany).toHaveBeenCalledTimes(1);
+    expect(mockGetMany.mock.calls[0][0]).toHaveLength(2);
+    expect(mockGet).not.toHaveBeenCalled();
   });
 
   it('only computes new tools when tool set grows', async () => {
@@ -410,7 +452,7 @@ describe('getOrComputeToolTokens', () => {
     expect(mockCacheStore.size).toBe(2);
   });
 
-  it('separates cache namespaces when provider or model changes', async () => {
+  it('reuses cache across models with the same tokenizer namespace', async () => {
     const counter = jest.fn(fakeTokenCounter);
     const defs = [makeToolDef('tool')];
 
@@ -425,7 +467,7 @@ describe('getOrComputeToolTokens', () => {
     await getOrComputeToolTokens({
       toolDefinitions: defs,
       provider: Providers.OPENAI,
-      clientOptions: { model: 'gpt-4o' },
+      clientOptions: { model: 'gpt-4.1' },
       tokenCounter: counter,
     });
     expect(counter.mock.calls.length).toBe(callsAfterFirst);
@@ -439,6 +481,43 @@ describe('getOrComputeToolTokens', () => {
 
     expect(counter.mock.calls.length).toBe(callsAfterFirst + 1);
     expect(mockCacheStore.size).toBe(2);
+  });
+
+  it('separates raw cache entries across tokenizer namespaces', async () => {
+    const counter = jest.fn(fakeTokenCounter);
+    const defs = [makeToolDef('tool')];
+
+    await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.OPENAI,
+      clientOptions: { model: 'gpt-4o' },
+      tokenCounter: counter,
+    });
+    const callsAfterFirst = counter.mock.calls.length;
+
+    await getOrComputeToolTokens({
+      toolDefinitions: defs,
+      provider: Providers.BEDROCK,
+      clientOptions: { model: 'anthropic.claude-3-5-sonnet-20241022-v2:0' },
+      tokenCounter: counter,
+    });
+
+    expect(counter.mock.calls.length).toBe(callsAfterFirst + 1);
+    expect(mockCacheStore.size).toBe(2);
+  });
+
+  it('ignores invalid cached values and recomputes', async () => {
+    mockGetMany.mockResolvedValueOnce(['not-a-number']);
+    const counter = jest.fn(fakeTokenCounter);
+
+    const result = await getOrComputeToolTokens({
+      toolDefinitions: [makeToolDef('tool')],
+      provider: Providers.OPENAI,
+      tokenCounter: counter,
+    });
+
+    expect(result).toBeGreaterThan(0);
+    expect(counter).toHaveBeenCalledTimes(1);
   });
 
   it('scopes cache keys by tenantId when provided', async () => {
@@ -496,7 +575,7 @@ describe('getOrComputeToolTokens', () => {
   });
 
   it('falls back to compute when cache read throws', async () => {
-    mockGet.mockRejectedValueOnce(new Error('Redis down'));
+    mockGetMany.mockRejectedValueOnce(new Error('Redis down'));
 
     const result = await getOrComputeToolTokens({
       toolDefinitions: [makeToolDef('tool')],
@@ -505,11 +584,11 @@ describe('getOrComputeToolTokens', () => {
     });
 
     expect(result).toBeGreaterThan(0);
-    expect(mockGet).toHaveBeenCalled();
+    expect(mockGetMany).toHaveBeenCalled();
   });
 
   it('does not throw when cache write fails', async () => {
-    mockSet.mockRejectedValueOnce(new Error('Redis write error'));
+    mockSetMany.mockRejectedValueOnce(new Error('Redis write error'));
 
     const result = await getOrComputeToolTokens({
       toolDefinitions: [makeToolDef('tool_write_fail')],
@@ -518,7 +597,7 @@ describe('getOrComputeToolTokens', () => {
     });
 
     expect(result).toBeGreaterThan(0);
-    expect(mockSet).toHaveBeenCalled();
+    expect(mockSetMany).toHaveBeenCalled();
   });
 
   it('matches computeToolSchemaTokens output for same inputs', async () => {

--- a/packages/api/src/agents/toolTokens.ts
+++ b/packages/api/src/agents/toolTokens.ts
@@ -23,7 +23,7 @@ function getCache(): Keyv {
   return toolTokenCache;
 }
 
-function getToolTokenMultiplier(provider: Providers, clientOptions?: ClientOptions): number {
+export function getToolTokenMultiplier(provider: Providers, clientOptions?: ClientOptions): number {
   const isAnthropic =
     provider !== Providers.BEDROCK &&
     (provider === Providers.ANTHROPIC ||
@@ -33,81 +33,69 @@ function getToolTokenMultiplier(provider: Providers, clientOptions?: ClientOptio
   return isAnthropic ? ANTHROPIC_TOOL_TOKEN_MULTIPLIER : DEFAULT_TOOL_TOKEN_MULTIPLIER;
 }
 
+/** Serializes a GenericTool to a JSON string for token counting. Returns null if no schema. */
+function serializeGenericTool(tool: GenericTool): { name: string; json: string } | null {
+  const genericTool = tool as unknown as Record<string, unknown>;
+  const toolName = (genericTool.name as string | undefined) ?? '';
+  if (genericTool.schema == null || typeof genericTool.schema !== 'object') {
+    return null;
+  }
+  const jsonSchema = toJsonSchema(
+    genericTool.schema,
+    toolName,
+    (genericTool.description as string | undefined) ?? '',
+  );
+  return { name: toolName, json: JSON.stringify(jsonSchema) };
+}
+
+/** Serializes an LCTool definition to a JSON string for token counting. */
+function serializeToolDef(def: LCTool): string {
+  return JSON.stringify({
+    type: 'function',
+    function: {
+      name: def.name,
+      description: def.description ?? '',
+      parameters: def.parameters ?? {},
+    },
+  });
+}
+
 /**
- * Single pass over tools and toolDefinitions. Collects:
- * - `names`: deduplicated, sorted tool names for fingerprinting.
- * - `schemas`: pre-serialized JSON strings for token counting.
- *
- * `nameSet` tracks all tool names (for the fingerprint). `countedNames`
- * tracks which tools contributed a schema from the `tools` array — a
- * toolDefinition whose name is in `countedNames` is skipped to avoid
- * double-counting, mirroring AgentContext.calculateInstructionTokens().
+ * Builds a map of tool name → serialized schema JSON. Deduplicates: a tool
+ * present in `tools` (with a schema) takes precedence over a matching
+ * `toolDefinitions` entry, mirroring AgentContext.calculateInstructionTokens().
  */
-function collectToolData(
+export function collectToolSchemas(
   tools?: GenericTool[],
   toolDefinitions?: LCTool[],
-): { names: string[]; schemas: string[] } {
-  const nameSet = new Set<string>();
-  const countedNames = new Set<string>();
-  const schemas: string[] = [];
+): Map<string, string> {
+  const schemas = new Map<string, string>();
 
   if (tools) {
     for (const tool of tools) {
-      const genericTool = tool as unknown as Record<string, unknown>;
-      const toolName = (genericTool.name as string | undefined) ?? '';
-      if (toolName) {
-        nameSet.add(toolName);
-      }
-      if (genericTool.schema != null && typeof genericTool.schema === 'object') {
-        schemas.push(
-          JSON.stringify(
-            toJsonSchema(
-              genericTool.schema,
-              toolName,
-              (genericTool.description as string | undefined) ?? '',
-            ),
-          ),
-        );
-        if (toolName) {
-          countedNames.add(toolName);
-        }
+      const result = serializeGenericTool(tool);
+      if (result && result.name) {
+        schemas.set(result.name, result.json);
       }
     }
   }
 
   if (toolDefinitions) {
     for (const def of toolDefinitions) {
-      if (def.name) {
-        nameSet.add(def.name);
-      }
-      if (countedNames.has(def.name)) {
+      if (!def.name || schemas.has(def.name)) {
         continue;
       }
-      schemas.push(
-        JSON.stringify({
-          type: 'function',
-          function: {
-            name: def.name,
-            description: def.description ?? '',
-            parameters: def.parameters ?? {},
-          },
-        }),
-      );
+      schemas.set(def.name, serializeToolDef(def));
     }
   }
 
-  const names = nameSet.size > 0 ? Array.from(nameSet).sort() : [];
-  return { names, schemas };
+  return schemas;
 }
 
-export function getToolFingerprint(tools?: GenericTool[], toolDefinitions?: LCTool[]): string {
-  const { names } = collectToolData(tools, toolDefinitions);
-  if (names.length === 0) {
-    return '';
-  }
-  return names.join(',') + '|' + names.length;
-}
-
+/**
+ * Computes tool schema tokens from scratch using the provided token counter.
+ * Mirrors the logic in AgentContext.calculateInstructionTokens().
+ */
 export function computeToolSchemaTokens(
   tools: GenericTool[] | undefined,
   toolDefinitions: LCTool[] | undefined,
@@ -115,20 +103,22 @@ export function computeToolSchemaTokens(
   clientOptions: ClientOptions | undefined,
   tokenCounter: TokenCounter,
 ): number {
-  const { schemas } = collectToolData(tools, toolDefinitions);
-  let toolTokens = 0;
-  for (const schema of schemas) {
-    toolTokens += tokenCounter(new SystemMessage(schema));
+  const schemas = collectToolSchemas(tools, toolDefinitions);
+  let rawTokens = 0;
+  for (const json of schemas.values()) {
+    rawTokens += tokenCounter(new SystemMessage(json));
   }
   const multiplier = getToolTokenMultiplier(provider, clientOptions);
-  return Math.ceil(toolTokens * multiplier);
+  return Math.ceil(rawTokens * multiplier);
 }
 
 /**
- * Returns cached tool schema tokens or computes them on miss.
+ * Returns tool schema tokens, using per-tool caching to avoid redundant
+ * token counting. Each tool's raw (pre-multiplier) token count is cached
+ * individually by name, so adding/removing a tool only requires computing
+ * the new one. The provider-specific multiplier is applied to the sum.
+ *
  * Returns 0 if there are no tools.
- * Single pass over tool arrays: builds fingerprint and serialized schemas
- * together, then only runs the token counter if the cache misses.
  */
 export async function getOrComputeToolTokens({
   tools,
@@ -143,45 +133,51 @@ export async function getOrComputeToolTokens({
   clientOptions?: ClientOptions;
   tokenCounter: TokenCounter;
 }): Promise<number> {
-  const { names, schemas } = collectToolData(tools, toolDefinitions);
-  if (names.length === 0) {
+  const schemas = collectToolSchemas(tools, toolDefinitions);
+  if (schemas.size === 0) {
     return 0;
   }
 
-  const fingerprint = names.join(',') + '|' + names.length;
-  const multiplier = getToolTokenMultiplier(provider, clientOptions);
-  const multiplierKey = multiplier === ANTHROPIC_TOOL_TOKEN_MULTIPLIER ? 'anthropic' : 'default';
-  const cacheKey = `${provider}:${multiplierKey}:${fingerprint}`;
-
+  let cache: Keyv | undefined;
   try {
-    const cache = getCache();
-    const cached = (await cache.get(cacheKey)) as number | undefined;
-    if (cached != null && cached > 0) {
-      return cached;
-    }
+    cache = getCache();
   } catch (err) {
-    logger.debug('[toolTokens] Cache read failed, computing fresh', err);
+    logger.debug('[toolTokens] Cache init failed, computing fresh', err);
   }
 
-  // Inline token count — not delegating to computeToolSchemaTokens to avoid
-  // a second collectToolData pass; schemas are already built above.
-  let toolTokens = 0;
-  for (const schema of schemas) {
-    toolTokens += tokenCounter(new SystemMessage(schema));
-  }
-  const tokens = Math.ceil(toolTokens * multiplier);
+  let rawTotal = 0;
+  const toWrite: Array<{ key: string; value: number }> = [];
 
-  if (tokens > 0) {
-    try {
-      getCache()
-        .set(cacheKey, tokens)
-        .catch((err: unknown) => {
-          logger.debug('[toolTokens] Cache write failed', err);
-        });
-    } catch {
-      // getCache() init failure on write path — non-fatal
+  for (const [name, json] of schemas) {
+    let rawCount: number | undefined;
+
+    if (cache) {
+      try {
+        rawCount = (await cache.get(name)) as number | undefined;
+      } catch {
+        // Cache read failed for this tool — will compute fresh
+      }
+    }
+
+    if (rawCount == null || rawCount <= 0) {
+      rawCount = tokenCounter(new SystemMessage(json));
+      if (rawCount > 0 && cache) {
+        toWrite.push({ key: name, value: rawCount });
+      }
+    }
+
+    rawTotal += rawCount;
+  }
+
+  // Fire-and-forget cache writes for newly computed tools
+  if (cache && toWrite.length > 0) {
+    for (const { key, value } of toWrite) {
+      cache.set(key, value).catch((err: unknown) => {
+        logger.debug(`[toolTokens] Cache write failed for ${key}`, err);
+      });
     }
   }
 
-  return tokens;
+  const multiplier = getToolTokenMultiplier(provider, clientOptions);
+  return Math.ceil(rawTotal * multiplier);
 }

--- a/packages/api/src/agents/toolTokens.ts
+++ b/packages/api/src/agents/toolTokens.ts
@@ -1,0 +1,169 @@
+import { SystemMessage } from '@langchain/core/messages';
+import {
+  Providers,
+  toJsonSchema,
+  ANTHROPIC_TOOL_TOKEN_MULTIPLIER,
+  DEFAULT_TOOL_TOKEN_MULTIPLIER,
+} from '@librechat/agents';
+import { CacheKeys, Time } from 'librechat-data-provider';
+import { standardCache } from '~/cache';
+import type { Keyv } from 'keyv';
+import type { GenericTool, LCTool, TokenCounter, ClientOptions } from '@librechat/agents';
+
+/** Module-level cache instance, lazily initialized. */
+let toolTokenCache: Keyv | undefined;
+
+function getCache(): Keyv {
+  if (!toolTokenCache) {
+    toolTokenCache = standardCache(CacheKeys.TOOL_TOKENS, Time.THIRTY_MINUTES);
+  }
+  return toolTokenCache;
+}
+
+/**
+ * Builds a lightweight fingerprint from tool names.
+ * Sorted and deduplicated to ensure stability regardless of tool ordering.
+ */
+export function getToolFingerprint(tools?: GenericTool[], toolDefinitions?: LCTool[]): string {
+  const names = new Set<string>();
+
+  if (tools) {
+    for (const tool of tools) {
+      const name = (tool as unknown as Record<string, unknown>).name;
+      if (typeof name === 'string' && name) {
+        names.add(name);
+      }
+    }
+  }
+
+  if (toolDefinitions) {
+    for (const def of toolDefinitions) {
+      if (def.name) {
+        names.add(def.name);
+      }
+    }
+  }
+
+  if (names.size === 0) {
+    return '';
+  }
+
+  const sorted = Array.from(names).sort();
+  return sorted.join(',') + '|' + sorted.length;
+}
+
+/**
+ * Determines the provider-specific token multiplier for tool schemas.
+ */
+function getToolTokenMultiplier(provider: Providers, clientOptions?: ClientOptions): number {
+  const isAnthropic =
+    provider !== Providers.BEDROCK &&
+    (provider === Providers.ANTHROPIC ||
+      /anthropic|claude/i.test(
+        String((clientOptions as { model?: string } | undefined)?.model ?? ''),
+      ));
+  return isAnthropic ? ANTHROPIC_TOOL_TOKEN_MULTIPLIER : DEFAULT_TOOL_TOKEN_MULTIPLIER;
+}
+
+/**
+ * Computes tool schema tokens from scratch using the provided token counter.
+ * Mirrors the logic in AgentContext.calculateInstructionTokens().
+ */
+export function computeToolSchemaTokens(
+  tools: GenericTool[] | undefined,
+  toolDefinitions: LCTool[] | undefined,
+  provider: Providers,
+  clientOptions: ClientOptions | undefined,
+  tokenCounter: TokenCounter,
+): number {
+  let toolTokens = 0;
+  const countedToolNames = new Set<string>();
+
+  if (tools && tools.length > 0) {
+    for (const tool of tools) {
+      const genericTool = tool as unknown as Record<string, unknown>;
+      if (genericTool.schema != null && typeof genericTool.schema === 'object') {
+        const toolName = (genericTool.name as string | undefined) ?? '';
+        const jsonSchema = toJsonSchema(
+          genericTool.schema,
+          toolName,
+          (genericTool.description as string | undefined) ?? '',
+        );
+        toolTokens += tokenCounter(new SystemMessage(JSON.stringify(jsonSchema)));
+        if (toolName) {
+          countedToolNames.add(toolName);
+        }
+      }
+    }
+  }
+
+  if (toolDefinitions && toolDefinitions.length > 0) {
+    for (const def of toolDefinitions) {
+      if (countedToolNames.has(def.name)) {
+        continue;
+      }
+      const schema = {
+        type: 'function',
+        function: {
+          name: def.name,
+          description: def.description ?? '',
+          parameters: def.parameters ?? {},
+        },
+      };
+      toolTokens += tokenCounter(new SystemMessage(JSON.stringify(schema)));
+    }
+  }
+
+  const multiplier = getToolTokenMultiplier(provider, clientOptions);
+  return Math.ceil(toolTokens * multiplier);
+}
+
+/**
+ * Returns cached tool schema tokens if the fingerprint matches,
+ * otherwise computes them, caches the result (fire-and-forget), and returns.
+ *
+ * Returns 0 if there are no tools (no caching needed).
+ */
+export async function getOrComputeToolTokens({
+  tools,
+  toolDefinitions,
+  provider,
+  clientOptions,
+  tokenCounter,
+}: {
+  tools?: GenericTool[];
+  toolDefinitions?: LCTool[];
+  provider: Providers;
+  clientOptions?: ClientOptions;
+  tokenCounter: TokenCounter;
+}): Promise<number> {
+  const fingerprint = getToolFingerprint(tools, toolDefinitions);
+  if (!fingerprint) {
+    return 0;
+  }
+
+  const cacheKey = `${provider}:${fingerprint}`;
+  const cache = getCache();
+
+  const cached = (await cache.get(cacheKey)) as number | undefined;
+  if (cached != null && cached > 0) {
+    return cached;
+  }
+
+  const tokens = computeToolSchemaTokens(
+    tools,
+    toolDefinitions,
+    provider,
+    clientOptions,
+    tokenCounter,
+  );
+
+  if (tokens > 0) {
+    /** Fire-and-forget write — don't block the run on cache persistence */
+    cache.set(cacheKey, tokens).catch(() => {
+      /* swallow cache write errors */
+    });
+  }
+
+  return tokens;
+}

--- a/packages/api/src/agents/toolTokens.ts
+++ b/packages/api/src/agents/toolTokens.ts
@@ -6,9 +6,12 @@ import {
   DEFAULT_TOOL_TOKEN_MULTIPLIER,
 } from '@librechat/agents';
 import { CacheKeys, Time } from 'librechat-data-provider';
-import { standardCache } from '~/cache';
-import type { Keyv } from 'keyv';
+
 import type { GenericTool, LCTool, TokenCounter, ClientOptions } from '@librechat/agents';
+import type { Keyv } from 'keyv';
+
+import { logger } from '@librechat/data-schemas';
+import { standardCache } from '~/cache';
 
 /** Module-level cache instance, lazily initialized. */
 let toolTokenCache: Keyv | undefined;
@@ -20,10 +23,6 @@ function getCache(): Keyv {
   return toolTokenCache;
 }
 
-/**
- * Builds a lightweight fingerprint from tool names.
- * Sorted and deduplicated to ensure stability regardless of tool ordering.
- */
 export function getToolFingerprint(tools?: GenericTool[], toolDefinitions?: LCTool[]): string {
   const names = new Set<string>();
 
@@ -52,9 +51,6 @@ export function getToolFingerprint(tools?: GenericTool[], toolDefinitions?: LCTo
   return sorted.join(',') + '|' + sorted.length;
 }
 
-/**
- * Determines the provider-specific token multiplier for tool schemas.
- */
 function getToolTokenMultiplier(provider: Providers, clientOptions?: ClientOptions): number {
   const isAnthropic =
     provider !== Providers.BEDROCK &&
@@ -65,10 +61,6 @@ function getToolTokenMultiplier(provider: Providers, clientOptions?: ClientOptio
   return isAnthropic ? ANTHROPIC_TOOL_TOKEN_MULTIPLIER : DEFAULT_TOOL_TOKEN_MULTIPLIER;
 }
 
-/**
- * Computes tool schema tokens from scratch using the provided token counter.
- * Mirrors the logic in AgentContext.calculateInstructionTokens().
- */
 export function computeToolSchemaTokens(
   tools: GenericTool[] | undefined,
   toolDefinitions: LCTool[] | undefined,
@@ -119,10 +111,10 @@ export function computeToolSchemaTokens(
 }
 
 /**
- * Returns cached tool schema tokens if the fingerprint matches,
- * otherwise computes them, caches the result (fire-and-forget), and returns.
- *
- * Returns 0 if there are no tools (no caching needed).
+ * Returns cached tool schema tokens or computes them on miss.
+ * Returns 0 if there are no tools.
+ * Cache errors are non-fatal — falls through to compute on read failure,
+ * logs on write failure.
  */
 export async function getOrComputeToolTokens({
   tools,
@@ -142,12 +134,18 @@ export async function getOrComputeToolTokens({
     return 0;
   }
 
-  const cacheKey = `${provider}:${fingerprint}`;
+  const multiplier = getToolTokenMultiplier(provider, clientOptions);
+  const multiplierKey = multiplier === ANTHROPIC_TOOL_TOKEN_MULTIPLIER ? 'anthropic' : 'default';
+  const cacheKey = `${provider}:${multiplierKey}:${fingerprint}`;
   const cache = getCache();
 
-  const cached = (await cache.get(cacheKey)) as number | undefined;
-  if (cached != null && cached > 0) {
-    return cached;
+  try {
+    const cached = (await cache.get(cacheKey)) as number | undefined;
+    if (cached != null && cached > 0) {
+      return cached;
+    }
+  } catch (err) {
+    logger.debug('[toolTokens] Cache read failed, computing fresh', err);
   }
 
   const tokens = computeToolSchemaTokens(
@@ -159,9 +157,8 @@ export async function getOrComputeToolTokens({
   );
 
   if (tokens > 0) {
-    /** Fire-and-forget write — don't block the run on cache persistence */
-    cache.set(cacheKey, tokens).catch(() => {
-      /* swallow cache write errors */
+    cache.set(cacheKey, tokens).catch((err: unknown) => {
+      logger.debug('[toolTokens] Cache write failed', err);
     });
   }
 

--- a/packages/api/src/agents/toolTokens.ts
+++ b/packages/api/src/agents/toolTokens.ts
@@ -126,17 +126,21 @@ export async function getOrComputeToolTokens({
   provider,
   clientOptions,
   tokenCounter,
+  tenantId,
 }: {
   tools?: GenericTool[];
   toolDefinitions?: LCTool[];
   provider: Providers;
   clientOptions?: ClientOptions;
   tokenCounter: TokenCounter;
+  tenantId?: string;
 }): Promise<number> {
   const schemas = collectToolSchemas(tools, toolDefinitions);
   if (schemas.size === 0) {
     return 0;
   }
+
+  const keyPrefix = tenantId ? `${tenantId}:` : '';
 
   let cache: Keyv | undefined;
   try {
@@ -149,11 +153,12 @@ export async function getOrComputeToolTokens({
   const toWrite: Array<{ key: string; value: number }> = [];
 
   for (const [name, json] of schemas) {
+    const cacheKey = `${keyPrefix}${name}`;
     let rawCount: number | undefined;
 
     if (cache) {
       try {
-        rawCount = (await cache.get(name)) as number | undefined;
+        rawCount = (await cache.get(cacheKey)) as number | undefined;
       } catch {
         // Cache read failed for this tool — will compute fresh
       }
@@ -162,7 +167,7 @@ export async function getOrComputeToolTokens({
     if (rawCount == null || rawCount <= 0) {
       rawCount = tokenCounter(new SystemMessage(json));
       if (rawCount > 0 && cache) {
-        toWrite.push({ key: name, value: rawCount });
+        toWrite.push({ key: cacheKey, value: rawCount });
       }
     }
 

--- a/packages/api/src/agents/toolTokens.ts
+++ b/packages/api/src/agents/toolTokens.ts
@@ -6,11 +6,11 @@ import {
   DEFAULT_TOOL_TOKEN_MULTIPLIER,
 } from '@librechat/agents';
 import { CacheKeys, Time } from 'librechat-data-provider';
+import { logger } from '@librechat/data-schemas';
 
 import type { GenericTool, LCTool, TokenCounter, ClientOptions } from '@librechat/agents';
 import type { Keyv } from 'keyv';
 
-import { logger } from '@librechat/data-schemas';
 import { standardCache } from '~/cache';
 
 /** Module-level cache instance, lazily initialized. */
@@ -34,10 +34,14 @@ function getToolTokenMultiplier(provider: Providers, clientOptions?: ClientOptio
 }
 
 /**
- * Single pass over tools and toolDefinitions. Collects deduplicated sorted
- * tool names (for fingerprint) and pre-serialized schemas (for token
- * counting on cache miss), mirroring the dedup logic in
- * AgentContext.calculateInstructionTokens().
+ * Single pass over tools and toolDefinitions. Collects:
+ * - `names`: deduplicated, sorted tool names for fingerprinting.
+ * - `schemas`: pre-serialized JSON strings for token counting.
+ *
+ * `nameSet` tracks all tool names (for the fingerprint). `countedNames`
+ * tracks which tools contributed a schema from the `tools` array — a
+ * toolDefinition whose name is in `countedNames` is skipped to avoid
+ * double-counting, mirroring AgentContext.calculateInstructionTokens().
  */
 function collectToolData(
   tools?: GenericTool[],
@@ -148,9 +152,9 @@ export async function getOrComputeToolTokens({
   const multiplier = getToolTokenMultiplier(provider, clientOptions);
   const multiplierKey = multiplier === ANTHROPIC_TOOL_TOKEN_MULTIPLIER ? 'anthropic' : 'default';
   const cacheKey = `${provider}:${multiplierKey}:${fingerprint}`;
-  const cache = getCache();
 
   try {
+    const cache = getCache();
     const cached = (await cache.get(cacheKey)) as number | undefined;
     if (cached != null && cached > 0) {
       return cached;
@@ -159,6 +163,8 @@ export async function getOrComputeToolTokens({
     logger.debug('[toolTokens] Cache read failed, computing fresh', err);
   }
 
+  // Inline token count — not delegating to computeToolSchemaTokens to avoid
+  // a second collectToolData pass; schemas are already built above.
   let toolTokens = 0;
   for (const schema of schemas) {
     toolTokens += tokenCounter(new SystemMessage(schema));
@@ -166,9 +172,15 @@ export async function getOrComputeToolTokens({
   const tokens = Math.ceil(toolTokens * multiplier);
 
   if (tokens > 0) {
-    cache.set(cacheKey, tokens).catch((err: unknown) => {
-      logger.debug('[toolTokens] Cache write failed', err);
-    });
+    try {
+      getCache()
+        .set(cacheKey, tokens)
+        .catch((err: unknown) => {
+          logger.debug('[toolTokens] Cache write failed', err);
+        });
+    } catch {
+      // getCache() init failure on write path — non-fatal
+    }
   }
 
   return tokens;

--- a/packages/api/src/agents/toolTokens.ts
+++ b/packages/api/src/agents/toolTokens.ts
@@ -1,12 +1,12 @@
+import { logger } from '@librechat/data-schemas';
 import { SystemMessage } from '@langchain/core/messages';
+import { CacheKeys, Time } from 'librechat-data-provider';
 import {
   Providers,
   toJsonSchema,
   ANTHROPIC_TOOL_TOKEN_MULTIPLIER,
   DEFAULT_TOOL_TOKEN_MULTIPLIER,
 } from '@librechat/agents';
-import { CacheKeys, Time } from 'librechat-data-provider';
-import { logger } from '@librechat/data-schemas';
 
 import type { GenericTool, LCTool, TokenCounter, ClientOptions } from '@librechat/agents';
 import type { Keyv } from 'keyv';

--- a/packages/api/src/agents/toolTokens.ts
+++ b/packages/api/src/agents/toolTokens.ts
@@ -23,34 +23,6 @@ function getCache(): Keyv {
   return toolTokenCache;
 }
 
-export function getToolFingerprint(tools?: GenericTool[], toolDefinitions?: LCTool[]): string {
-  const names = new Set<string>();
-
-  if (tools) {
-    for (const tool of tools) {
-      const name = (tool as unknown as Record<string, unknown>).name;
-      if (typeof name === 'string' && name) {
-        names.add(name);
-      }
-    }
-  }
-
-  if (toolDefinitions) {
-    for (const def of toolDefinitions) {
-      if (def.name) {
-        names.add(def.name);
-      }
-    }
-  }
-
-  if (names.size === 0) {
-    return '';
-  }
-
-  const sorted = Array.from(names).sort();
-  return sorted.join(',') + '|' + sorted.length;
-}
-
 function getToolTokenMultiplier(provider: Providers, clientOptions?: ClientOptions): number {
   const isAnthropic =
     provider !== Providers.BEDROCK &&
@@ -61,6 +33,77 @@ function getToolTokenMultiplier(provider: Providers, clientOptions?: ClientOptio
   return isAnthropic ? ANTHROPIC_TOOL_TOKEN_MULTIPLIER : DEFAULT_TOOL_TOKEN_MULTIPLIER;
 }
 
+/**
+ * Single pass over tools and toolDefinitions. Collects deduplicated sorted
+ * tool names (for fingerprint) and pre-serialized schemas (for token
+ * counting on cache miss), mirroring the dedup logic in
+ * AgentContext.calculateInstructionTokens().
+ */
+function collectToolData(
+  tools?: GenericTool[],
+  toolDefinitions?: LCTool[],
+): { names: string[]; schemas: string[] } {
+  const nameSet = new Set<string>();
+  const countedNames = new Set<string>();
+  const schemas: string[] = [];
+
+  if (tools) {
+    for (const tool of tools) {
+      const genericTool = tool as unknown as Record<string, unknown>;
+      const toolName = (genericTool.name as string | undefined) ?? '';
+      if (toolName) {
+        nameSet.add(toolName);
+      }
+      if (genericTool.schema != null && typeof genericTool.schema === 'object') {
+        schemas.push(
+          JSON.stringify(
+            toJsonSchema(
+              genericTool.schema,
+              toolName,
+              (genericTool.description as string | undefined) ?? '',
+            ),
+          ),
+        );
+        if (toolName) {
+          countedNames.add(toolName);
+        }
+      }
+    }
+  }
+
+  if (toolDefinitions) {
+    for (const def of toolDefinitions) {
+      if (def.name) {
+        nameSet.add(def.name);
+      }
+      if (countedNames.has(def.name)) {
+        continue;
+      }
+      schemas.push(
+        JSON.stringify({
+          type: 'function',
+          function: {
+            name: def.name,
+            description: def.description ?? '',
+            parameters: def.parameters ?? {},
+          },
+        }),
+      );
+    }
+  }
+
+  const names = nameSet.size > 0 ? Array.from(nameSet).sort() : [];
+  return { names, schemas };
+}
+
+export function getToolFingerprint(tools?: GenericTool[], toolDefinitions?: LCTool[]): string {
+  const { names } = collectToolData(tools, toolDefinitions);
+  if (names.length === 0) {
+    return '';
+  }
+  return names.join(',') + '|' + names.length;
+}
+
 export function computeToolSchemaTokens(
   tools: GenericTool[] | undefined,
   toolDefinitions: LCTool[] | undefined,
@@ -68,44 +111,11 @@ export function computeToolSchemaTokens(
   clientOptions: ClientOptions | undefined,
   tokenCounter: TokenCounter,
 ): number {
+  const { schemas } = collectToolData(tools, toolDefinitions);
   let toolTokens = 0;
-  const countedToolNames = new Set<string>();
-
-  if (tools && tools.length > 0) {
-    for (const tool of tools) {
-      const genericTool = tool as unknown as Record<string, unknown>;
-      if (genericTool.schema != null && typeof genericTool.schema === 'object') {
-        const toolName = (genericTool.name as string | undefined) ?? '';
-        const jsonSchema = toJsonSchema(
-          genericTool.schema,
-          toolName,
-          (genericTool.description as string | undefined) ?? '',
-        );
-        toolTokens += tokenCounter(new SystemMessage(JSON.stringify(jsonSchema)));
-        if (toolName) {
-          countedToolNames.add(toolName);
-        }
-      }
-    }
+  for (const schema of schemas) {
+    toolTokens += tokenCounter(new SystemMessage(schema));
   }
-
-  if (toolDefinitions && toolDefinitions.length > 0) {
-    for (const def of toolDefinitions) {
-      if (countedToolNames.has(def.name)) {
-        continue;
-      }
-      const schema = {
-        type: 'function',
-        function: {
-          name: def.name,
-          description: def.description ?? '',
-          parameters: def.parameters ?? {},
-        },
-      };
-      toolTokens += tokenCounter(new SystemMessage(JSON.stringify(schema)));
-    }
-  }
-
   const multiplier = getToolTokenMultiplier(provider, clientOptions);
   return Math.ceil(toolTokens * multiplier);
 }
@@ -113,8 +123,8 @@ export function computeToolSchemaTokens(
 /**
  * Returns cached tool schema tokens or computes them on miss.
  * Returns 0 if there are no tools.
- * Cache errors are non-fatal — falls through to compute on read failure,
- * logs on write failure.
+ * Single pass over tool arrays: builds fingerprint and serialized schemas
+ * together, then only runs the token counter if the cache misses.
  */
 export async function getOrComputeToolTokens({
   tools,
@@ -129,11 +139,12 @@ export async function getOrComputeToolTokens({
   clientOptions?: ClientOptions;
   tokenCounter: TokenCounter;
 }): Promise<number> {
-  const fingerprint = getToolFingerprint(tools, toolDefinitions);
-  if (!fingerprint) {
+  const { names, schemas } = collectToolData(tools, toolDefinitions);
+  if (names.length === 0) {
     return 0;
   }
 
+  const fingerprint = names.join(',') + '|' + names.length;
   const multiplier = getToolTokenMultiplier(provider, clientOptions);
   const multiplierKey = multiplier === ANTHROPIC_TOOL_TOKEN_MULTIPLIER ? 'anthropic' : 'default';
   const cacheKey = `${provider}:${multiplierKey}:${fingerprint}`;
@@ -148,13 +159,11 @@ export async function getOrComputeToolTokens({
     logger.debug('[toolTokens] Cache read failed, computing fresh', err);
   }
 
-  const tokens = computeToolSchemaTokens(
-    tools,
-    toolDefinitions,
-    provider,
-    clientOptions,
-    tokenCounter,
-  );
+  let toolTokens = 0;
+  for (const schema of schemas) {
+    toolTokens += tokenCounter(new SystemMessage(schema));
+  }
+  const tokens = Math.ceil(toolTokens * multiplier);
 
   if (tokens > 0) {
     cache.set(cacheKey, tokens).catch((err: unknown) => {

--- a/packages/api/src/agents/toolTokens.ts
+++ b/packages/api/src/agents/toolTokens.ts
@@ -13,6 +13,11 @@ import type { Keyv } from 'keyv';
 
 import { standardCache } from '~/cache';
 
+interface ToolEntry {
+  cacheKey: string;
+  json: string;
+}
+
 /** Module-level cache instance, lazily initialized. */
 let toolTokenCache: Keyv | undefined;
 
@@ -61,35 +66,43 @@ function serializeToolDef(def: LCTool): string {
 }
 
 /**
- * Builds a map of tool name → serialized schema JSON. Deduplicates: a tool
- * present in `tools` (with a schema) takes precedence over a matching
- * `toolDefinitions` entry, mirroring AgentContext.calculateInstructionTokens().
+ * Builds a list of tool entries with cache keys and serialized schemas.
+ * Deduplicates: a tool present in `tools` (with a schema) takes precedence
+ * over a matching `toolDefinitions` entry.
+ *
+ * Cache key includes toolType when available (from LCTool) to differentiate
+ * builtin/mcp/action tools that may share a name.
+ * GenericTool entries use the `mcp` flag when present.
  */
-export function collectToolSchemas(
-  tools?: GenericTool[],
-  toolDefinitions?: LCTool[],
-): Map<string, string> {
-  const schemas = new Map<string, string>();
+export function collectToolSchemas(tools?: GenericTool[], toolDefinitions?: LCTool[]): ToolEntry[] {
+  const seen = new Set<string>();
+  const entries: ToolEntry[] = [];
 
   if (tools) {
     for (const tool of tools) {
       const result = serializeGenericTool(tool);
-      if (result && result.name) {
-        schemas.set(result.name, result.json);
+      if (!result || !result.name) {
+        continue;
       }
+      seen.add(result.name);
+      const toolType =
+        (tool as unknown as Record<string, unknown>).mcp === true ? 'mcp' : 'builtin';
+      entries.push({ cacheKey: `${result.name}:${toolType}`, json: result.json });
     }
   }
 
   if (toolDefinitions) {
     for (const def of toolDefinitions) {
-      if (!def.name || schemas.has(def.name)) {
+      if (!def.name || seen.has(def.name)) {
         continue;
       }
-      schemas.set(def.name, serializeToolDef(def));
+      seen.add(def.name);
+      const toolType = def.toolType ?? 'builtin';
+      entries.push({ cacheKey: `${def.name}:${toolType}`, json: serializeToolDef(def) });
     }
   }
 
-  return schemas;
+  return entries;
 }
 
 /**
@@ -103,9 +116,9 @@ export function computeToolSchemaTokens(
   clientOptions: ClientOptions | undefined,
   tokenCounter: TokenCounter,
 ): number {
-  const schemas = collectToolSchemas(tools, toolDefinitions);
+  const entries = collectToolSchemas(tools, toolDefinitions);
   let rawTokens = 0;
-  for (const json of schemas.values()) {
+  for (const { json } of entries) {
     rawTokens += tokenCounter(new SystemMessage(json));
   }
   const multiplier = getToolTokenMultiplier(provider, clientOptions);
@@ -115,8 +128,8 @@ export function computeToolSchemaTokens(
 /**
  * Returns tool schema tokens, using per-tool caching to avoid redundant
  * token counting. Each tool's raw (pre-multiplier) token count is cached
- * individually by name, so adding/removing a tool only requires computing
- * the new one. The provider-specific multiplier is applied to the sum.
+ * individually, keyed by `{tenantId}:{name}:{toolType}` (or `{name}:{toolType}`
+ * without tenant). The provider-specific multiplier is applied to the sum.
  *
  * Returns 0 if there are no tools.
  */
@@ -135,8 +148,8 @@ export async function getOrComputeToolTokens({
   tokenCounter: TokenCounter;
   tenantId?: string;
 }): Promise<number> {
-  const schemas = collectToolSchemas(tools, toolDefinitions);
-  if (schemas.size === 0) {
+  const entries = collectToolSchemas(tools, toolDefinitions);
+  if (entries.length === 0) {
     return 0;
   }
 
@@ -152,13 +165,13 @@ export async function getOrComputeToolTokens({
   let rawTotal = 0;
   const toWrite: Array<{ key: string; value: number }> = [];
 
-  for (const [name, json] of schemas) {
-    const cacheKey = `${keyPrefix}${name}`;
+  for (const { cacheKey, json } of entries) {
+    const fullKey = `${keyPrefix}${cacheKey}`;
     let rawCount: number | undefined;
 
     if (cache) {
       try {
-        rawCount = (await cache.get(cacheKey)) as number | undefined;
+        rawCount = (await cache.get(fullKey)) as number | undefined;
       } catch {
         // Cache read failed for this tool — will compute fresh
       }
@@ -167,7 +180,7 @@ export async function getOrComputeToolTokens({
     if (rawCount == null || rawCount <= 0) {
       rawCount = tokenCounter(new SystemMessage(json));
       if (rawCount > 0 && cache) {
-        toWrite.push({ key: cacheKey, value: rawCount });
+        toWrite.push({ key: fullKey, value: rawCount });
       }
     }
 

--- a/packages/api/src/agents/toolTokens.ts
+++ b/packages/api/src/agents/toolTokens.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { logger } from '@librechat/data-schemas';
 import { SystemMessage } from '@librechat/agents/langchain/messages';
 import { CacheKeys, Time } from 'librechat-data-provider';
@@ -8,7 +9,13 @@ import {
   DEFAULT_TOOL_TOKEN_MULTIPLIER,
 } from '@librechat/agents';
 
-import type { GenericTool, LCTool, TokenCounter, ClientOptions } from '@librechat/agents';
+import type {
+  GenericTool,
+  LCTool,
+  TokenCounter,
+  ClientOptions,
+  LCToolRegistry,
+} from '@librechat/agents';
 import type { Keyv } from 'keyv';
 
 import { standardCache } from '~/cache';
@@ -16,6 +23,11 @@ import { standardCache } from '~/cache';
 interface ToolEntry {
   cacheKey: string;
   json: string;
+}
+
+interface CollectToolSchemasOptions {
+  toolRegistry?: LCToolRegistry;
+  discoveredTools?: ReadonlySet<string>;
 }
 
 /** Module-level cache instance, lazily initialized. */
@@ -36,6 +48,51 @@ export function getToolTokenMultiplier(provider: Providers, clientOptions?: Clie
         String((clientOptions as { model?: string } | undefined)?.model ?? ''),
       ));
   return isAnthropic ? ANTHROPIC_TOOL_TOKEN_MULTIPLIER : DEFAULT_TOOL_TOKEN_MULTIPLIER;
+}
+
+function hashForCache(value: string): string {
+  return createHash('sha256').update(value).digest('base64url').slice(0, 16);
+}
+
+function getCounterNamespace(provider: Providers, clientOptions?: ClientOptions): string {
+  const model = String((clientOptions as { model?: string } | undefined)?.model ?? '');
+  return hashForCache(`${provider}:${model}`);
+}
+
+function isDirectToolDefinition(def: LCTool, discoveredTools?: ReadonlySet<string>): boolean {
+  const allowedCallers = def.allowed_callers ?? ['direct'];
+  if (!allowedCallers.includes('direct')) {
+    return false;
+  }
+  return def.defer_loading !== true || discoveredTools?.has(def.name) === true;
+}
+
+function isDirectInstanceTool(
+  tool: GenericTool,
+  hasToolDefinitions: boolean,
+  toolRegistry?: LCToolRegistry,
+  discoveredTools?: ReadonlySet<string>,
+): boolean {
+  if (hasToolDefinitions || !toolRegistry || !('name' in tool)) {
+    return true;
+  }
+
+  const toolName = (tool as unknown as { name?: unknown }).name;
+  if (typeof toolName !== 'string') {
+    return true;
+  }
+
+  const def = toolRegistry.get(toolName);
+  if (!def) {
+    return true;
+  }
+
+  const allowedCallers = def.allowed_callers ?? ['direct'];
+  if (!allowedCallers.includes('direct')) {
+    return false;
+  }
+
+  return def.defer_loading !== true || discoveredTools?.has(toolName) === true;
 }
 
 /** Serializes a GenericTool to a JSON string for token counting. Returns null if no schema. */
@@ -74,12 +131,21 @@ function serializeToolDef(def: LCTool): string {
  * builtin/mcp/action tools that may share a name.
  * GenericTool entries use the `mcp` flag when present.
  */
-export function collectToolSchemas(tools?: GenericTool[], toolDefinitions?: LCTool[]): ToolEntry[] {
+export function collectToolSchemas(
+  tools?: GenericTool[],
+  toolDefinitions?: LCTool[],
+  options: CollectToolSchemasOptions = {},
+): ToolEntry[] {
   const seen = new Set<string>();
   const entries: ToolEntry[] = [];
+  const hasToolDefinitions = (toolDefinitions?.length ?? 0) > 0;
+  const { toolRegistry, discoveredTools } = options;
 
   if (tools) {
     for (const tool of tools) {
+      if (!isDirectInstanceTool(tool, hasToolDefinitions, toolRegistry, discoveredTools)) {
+        continue;
+      }
       const result = serializeGenericTool(tool);
       if (!result || !result.name) {
         continue;
@@ -93,7 +159,7 @@ export function collectToolSchemas(tools?: GenericTool[], toolDefinitions?: LCTo
 
   if (toolDefinitions) {
     for (const def of toolDefinitions) {
-      if (!def.name || seen.has(def.name)) {
+      if (!def.name || seen.has(def.name) || !isDirectToolDefinition(def, discoveredTools)) {
         continue;
       }
       seen.add(def.name);
@@ -115,8 +181,9 @@ export function computeToolSchemaTokens(
   provider: Providers,
   clientOptions: ClientOptions | undefined,
   tokenCounter: TokenCounter,
+  options?: CollectToolSchemasOptions,
 ): number {
-  const entries = collectToolSchemas(tools, toolDefinitions);
+  const entries = collectToolSchemas(tools, toolDefinitions, options);
   let rawTokens = 0;
   for (const { json } of entries) {
     rawTokens += tokenCounter(new SystemMessage(json));
@@ -128,8 +195,8 @@ export function computeToolSchemaTokens(
 /**
  * Returns tool schema tokens, using per-tool caching to avoid redundant
  * token counting. Each tool's raw (pre-multiplier) token count is cached
- * individually, keyed by `{tenantId}:{name}:{toolType}` (or `{name}:{toolType}`
- * without tenant). The provider-specific multiplier is applied to the sum.
+ * individually, keyed by tenant, provider/model namespace, tool name/type, and
+ * schema fingerprint. The provider-specific multiplier is applied to the sum.
  *
  * Returns 0 if there are no tools.
  */
@@ -140,6 +207,8 @@ export async function getOrComputeToolTokens({
   clientOptions,
   tokenCounter,
   tenantId,
+  toolRegistry,
+  discoveredTools,
 }: {
   tools?: GenericTool[];
   toolDefinitions?: LCTool[];
@@ -147,13 +216,16 @@ export async function getOrComputeToolTokens({
   clientOptions?: ClientOptions;
   tokenCounter: TokenCounter;
   tenantId?: string;
+  toolRegistry?: LCToolRegistry;
+  discoveredTools?: ReadonlySet<string>;
 }): Promise<number> {
-  const entries = collectToolSchemas(tools, toolDefinitions);
+  const entries = collectToolSchemas(tools, toolDefinitions, { toolRegistry, discoveredTools });
   if (entries.length === 0) {
     return 0;
   }
 
   const keyPrefix = tenantId ? `${tenantId}:` : '';
+  const counterNamespace = getCounterNamespace(provider, clientOptions);
 
   let cache: Keyv | undefined;
   try {
@@ -166,7 +238,7 @@ export async function getOrComputeToolTokens({
   const toWrite: Array<{ key: string; value: number }> = [];
 
   for (const { cacheKey, json } of entries) {
-    const fullKey = `${keyPrefix}${cacheKey}`;
+    const fullKey = `${keyPrefix}${counterNamespace}:${cacheKey}:${hashForCache(json)}`;
     let rawCount: number | undefined;
 
     if (cache) {

--- a/packages/api/src/agents/toolTokens.ts
+++ b/packages/api/src/agents/toolTokens.ts
@@ -1,5 +1,5 @@
 import { logger } from '@librechat/data-schemas';
-import { SystemMessage } from '@langchain/core/messages';
+import { SystemMessage } from '@librechat/agents/langchain/messages';
 import { CacheKeys, Time } from 'librechat-data-provider';
 import {
   Providers,

--- a/packages/api/src/agents/toolTokens.ts
+++ b/packages/api/src/agents/toolTokens.ts
@@ -54,9 +54,14 @@ function hashForCache(value: string): string {
   return createHash('sha256').update(value).digest('base64url').slice(0, 16);
 }
 
-function getCounterNamespace(provider: Providers, clientOptions?: ClientOptions): string {
+/** Mirrors @librechat/agents encodingForModel; raw cached counts are tokenizer-scoped. */
+function getCounterNamespace(clientOptions?: ClientOptions): string {
   const model = String((clientOptions as { model?: string } | undefined)?.model ?? '');
-  return hashForCache(`${provider}:${model}`);
+  return model.toLowerCase().includes('claude') ? 'claude' : 'o200k_base';
+}
+
+function isPositiveFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
 function isDirectToolDefinition(def: LCTool, discoveredTools?: ReadonlySet<string>): boolean {
@@ -195,7 +200,7 @@ export function computeToolSchemaTokens(
 /**
  * Returns tool schema tokens, using per-tool caching to avoid redundant
  * token counting. Each tool's raw (pre-multiplier) token count is cached
- * individually, keyed by tenant, provider/model namespace, tool name/type, and
+ * individually, keyed by tenant, tokenizer namespace, tool name/type, and
  * schema fingerprint. The provider-specific multiplier is applied to the sum.
  *
  * Returns 0 if there are no tools.
@@ -225,7 +230,7 @@ export async function getOrComputeToolTokens({
   }
 
   const keyPrefix = tenantId ? `${tenantId}:` : '';
-  const counterNamespace = getCounterNamespace(provider, clientOptions);
+  const counterNamespace = getCounterNamespace(clientOptions);
 
   let cache: Keyv | undefined;
   try {
@@ -234,38 +239,47 @@ export async function getOrComputeToolTokens({
     logger.debug('[toolTokens] Cache init failed, computing fresh', err);
   }
 
+  const keyedEntries = entries.map(({ cacheKey, json }) => ({
+    key: `${keyPrefix}${counterNamespace}:${cacheKey}:${hashForCache(json)}`,
+    json,
+  }));
+  const cachedCounts: Array<number | undefined> = new Array(keyedEntries.length);
+
+  if (cache) {
+    const activeCache = cache;
+    try {
+      const readResults = await activeCache.getMany<number>(keyedEntries.map(({ key }) => key));
+      for (let i = 0; i < readResults.length; i++) {
+        if (isPositiveFiniteNumber(readResults[i])) {
+          cachedCounts[i] = readResults[i];
+        }
+      }
+    } catch (err) {
+      logger.debug('[toolTokens] Cache batch read failed, computing misses fresh', err);
+    }
+  }
+
   let rawTotal = 0;
   const toWrite: Array<{ key: string; value: number }> = [];
 
-  for (const { cacheKey, json } of entries) {
-    const fullKey = `${keyPrefix}${counterNamespace}:${cacheKey}:${hashForCache(json)}`;
-    let rawCount: number | undefined;
+  for (let i = 0; i < keyedEntries.length; i++) {
+    const { key, json } = keyedEntries[i];
+    let rawCount = cachedCounts[i];
 
-    if (cache) {
-      try {
-        rawCount = (await cache.get(fullKey)) as number | undefined;
-      } catch {
-        // Cache read failed for this tool — will compute fresh
-      }
-    }
-
-    if (rawCount == null || rawCount <= 0) {
+    if (rawCount == null) {
       rawCount = tokenCounter(new SystemMessage(json));
       if (rawCount > 0 && cache) {
-        toWrite.push({ key: fullKey, value: rawCount });
+        toWrite.push({ key, value: rawCount });
       }
     }
 
     rawTotal += rawCount;
   }
 
-  // Fire-and-forget cache writes for newly computed tools
   if (cache && toWrite.length > 0) {
-    for (const { key, value } of toWrite) {
-      cache.set(key, value).catch((err: unknown) => {
-        logger.debug(`[toolTokens] Cache write failed for ${key}`, err);
-      });
-    }
+    cache.setMany(toWrite).catch((err: unknown) => {
+      logger.debug('[toolTokens] Cache batch write failed', err);
+    });
   }
 
   const multiplier = getToolTokenMultiplier(provider, clientOptions);

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1837,6 +1837,11 @@ export enum CacheKeys {
    * Key for admin panel OAuth exchange codes (one-time-use, short TTL).
    */
   ADMIN_OAUTH_EXCHANGE = 'ADMIN_OAUTH_EXCHANGE',
+  /**
+   * Key for cached tool schema token counts.
+   * Keyed by provider + tool fingerprint to avoid redundant token counting.
+   */
+  TOOL_TOKENS = 'TOOL_TOKENS',
 }
 
 /**

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1839,7 +1839,7 @@ export enum CacheKeys {
   ADMIN_OAUTH_EXCHANGE = 'ADMIN_OAUTH_EXCHANGE',
   /**
    * Key for cached tool schema token counts.
-   * Keyed by provider + tool fingerprint to avoid redundant token counting.
+   * Entries are keyed by tenant, provider/model namespace, tool name/type, and schema fingerprint.
    */
   TOOL_TOKENS = 'TOOL_TOKENS',
 }

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1839,7 +1839,7 @@ export enum CacheKeys {
   ADMIN_OAUTH_EXCHANGE = 'ADMIN_OAUTH_EXCHANGE',
   /**
    * Key for cached tool schema token counts.
-   * Entries are keyed by tenant, provider/model namespace, tool name/type, and schema fingerprint.
+   * Entries are keyed by tenant, tokenizer namespace, tool name/type, and schema fingerprint.
    */
   TOOL_TOKENS = 'TOOL_TOKENS',
 }


### PR DESCRIPTION
## Summary
- Adds time-based caching (30min TTL) for tool schema token counts using the existing Keyv/Redis infrastructure, avoiding expensive recalculation on every agent run
- Cache is keyed by `{provider}:{multiplierKey}:{fingerprint}` where multiplierKey is `anthropic` or `default` and fingerprint = sorted tool names + count, so agents sharing the same tools and multiplier class share the cached value
- New reusable utility module (`packages/api/src/agents/toolTokens.ts`) with `getToolFingerprint`, `computeToolSchemaTokens`, and `getOrComputeToolTokens`
- `buildAgentContext` in `createRun` is now async with `Promise.allSettled` for parallel cache lookups; includes guards for empty results and partial multi-agent routing failures

## Companion PR
Requires https://github.com/danny-avila/agents/commit/8e0ff93 (`@librechat/agents` changes: `toolSchemaTokens` on `AgentInputs`, exported multiplier constants, `fromConfig()` short-circuit)

## Test plan
- [x] Unit tests for `getToolFingerprint`, `computeToolSchemaTokens`, `getOrComputeToolTokens` (21 tests)
- [ ] Verify first agent run computes + caches tool tokens, second run hits cache
- [ ] Verify tool set change (add/remove tool) causes cache miss and recomputation
- [ ] Verify two agents sharing the same tools share the cached entry
- [ ] Verify Anthropic and non-Anthropic providers cache independently (different multipliers)
- [ ] Existing tests pass with no regressions