### PR TITLE
💎 fix: Handle `usage_metadata` in Title Transaction for Gemini Models

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1120,6 +1120,9 @@ class AgentClient extends BaseClient {
         } else if (item.tokenUsage) {
           input_tokens = item.tokenUsage.promptTokens;
           output_tokens = item.tokenUsage.completionTokens;
+        } else if (item.usage_metadata) {
+          input_tokens = item.usage_metadata.input_tokens;
+          output_tokens = item.usage_metadata.output_tokens;          
         }
 
         return {

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -1122,7 +1122,7 @@ class AgentClient extends BaseClient {
           output_tokens = item.tokenUsage.completionTokens;
         } else if (item.usage_metadata) {
           input_tokens = item.usage_metadata.input_tokens;
-          output_tokens = item.usage_metadata.output_tokens;          
+          output_tokens = item.usage_metadata.output_tokens;
         }
 
         return {


### PR DESCRIPTION


## Summary

I fixed a bug where title generation token transactions were silently skipped for Gemini models because the `collectedUsage` mapping in `titleConvo` did not account for Gemini's `usage_metadata` response format.

- Add an `else if (item.usage_metadata)` branch in the `titleConvo` method's `collectedUsage` mapping to extract `input_tokens` and `output_tokens` from Gemini's `usage_metadata` object.
- Resolve an issue where Gemini models return token usage via `usage_metadata` instead of the `usage` or `tokenUsage` keys that the existing code handled, causing the token values to remain `undefined` and the title generation transaction to be silently dropped.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Configure a Gemini model (e.g., `gemini-2.0-flash`) as the title generation model via `titleModel` or as the active agent model.
- Send a message to trigger a conversation and title generation.
- Verify that the title generation transaction is recorded in the database with correct `input_tokens` and `output_tokens` values (previously these would be `undefined`, causing the transaction to be skipped).
- Confirm that non-Gemini models (OpenAI, Anthropic, etc.) continue to record title transactions correctly through the existing `usage` and `tokenUsage` branches.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings