### PR TITLE
🗝️ fix: Resolve User-Provided API Key in Agents API Flow

### DIFF
--- a/packages/api/src/endpoints/custom/initialize.spec.ts
+++ b/packages/api/src/endpoints/custom/initialize.spec.ts
@@ -68,6 +68,50 @@ function createParams(overrides: {
   };
 }
 
+describe('initializeCustom – Agents API user key resolution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch user key even when expiresAt is not in request body (Agents API flow)', async () => {
+    const params = createParams({
+      apiKey: AuthType.USER_PROVIDED,
+      baseURL: 'https://api.example.com/v1',
+      userApiKey: 'sk-user-key',
+      expiresAt: undefined as unknown as string,
+    });
+    // Simulate Agents API request body (no `key` field)
+    params.req.body = { model: 'agent_123', messages: [] };
+
+    await initializeCustom(params);
+
+    expect(params.db.getUserKeyValues).toHaveBeenCalledWith({
+      userId: 'user-1',
+      name: 'test-custom',
+    });
+    expect(mockGetOpenAIConfig).toHaveBeenCalledWith(
+      'sk-user-key',
+      expect.any(Object),
+      'test-custom',
+    );
+  });
+
+  it('should still check key expiry when expiresAt is provided (UI flow)', async () => {
+    const { checkUserKeyExpiry } = jest.requireMock('~/utils');
+    const params = createParams({
+      apiKey: AuthType.USER_PROVIDED,
+      baseURL: 'https://api.example.com/v1',
+      userApiKey: 'sk-user-key',
+      expiresAt: '2099-01-01',
+    });
+
+    await initializeCustom(params);
+
+    expect(checkUserKeyExpiry).toHaveBeenCalledWith('2099-01-01', 'test-custom');
+    expect(params.db.getUserKeyValues).toHaveBeenCalled();
+  });
+});
+
 describe('initializeCustom – SSRF guard wiring', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/api/src/endpoints/custom/initialize.spec.ts
+++ b/packages/api/src/endpoints/custom/initialize.spec.ts
@@ -1,4 +1,4 @@
-import { AuthType } from 'librechat-data-provider';
+import { AuthType, ErrorTypes } from 'librechat-data-provider';
 import type { BaseInitializeParams } from '~/types';
 
 const mockValidateEndpointURL = jest.fn();
@@ -132,8 +132,8 @@ describe('initializeCustom – Agents API user key resolution', () => {
 
   it('should throw EXPIRED_USER_KEY when expiresAt is expired', async () => {
     const { checkUserKeyExpiry } = jest.requireMock('~/utils');
-    checkUserKeyExpiry.mockImplementation(() => {
-      throw new Error(JSON.stringify({ type: 'expired_user_key' }));
+    checkUserKeyExpiry.mockImplementationOnce(() => {
+      throw new Error(JSON.stringify({ type: ErrorTypes.EXPIRED_USER_KEY }));
     });
 
     const params = createParams({
@@ -143,7 +143,18 @@ describe('initializeCustom – Agents API user key resolution', () => {
       expiresAt: '2020-01-01',
     });
 
-    await expect(initializeCustom(params)).rejects.toThrow('expired_user_key');
+    await expect(initializeCustom(params)).rejects.toThrow(ErrorTypes.EXPIRED_USER_KEY);
+    expect(params.db.getUserKeyValues).not.toHaveBeenCalled();
+  });
+
+  it('should NOT call getUserKeyValues when key and URL are system-defined', async () => {
+    const params = createParams({
+      apiKey: 'sk-system-key',
+      baseURL: 'https://api.provider.com/v1',
+    });
+
+    await initializeCustom(params);
+
     expect(params.db.getUserKeyValues).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/endpoints/custom/initialize.spec.ts
+++ b/packages/api/src/endpoints/custom/initialize.spec.ts
@@ -74,11 +74,11 @@ describe('initializeCustom – Agents API user key resolution', () => {
   });
 
   it('should fetch user key even when expiresAt is not in request body (Agents API flow)', async () => {
+    const { checkUserKeyExpiry } = jest.requireMock('~/utils');
     const params = createParams({
       apiKey: AuthType.USER_PROVIDED,
       baseURL: 'https://api.example.com/v1',
       userApiKey: 'sk-user-key',
-      expiresAt: undefined as unknown as string,
     });
     // Simulate Agents API request body (no `key` field)
     params.req.body = { model: 'agent_123', messages: [] };
@@ -89,11 +89,30 @@ describe('initializeCustom – Agents API user key resolution', () => {
       userId: 'user-1',
       name: 'test-custom',
     });
+    expect(checkUserKeyExpiry).not.toHaveBeenCalled();
     expect(mockGetOpenAIConfig).toHaveBeenCalledWith(
       'sk-user-key',
       expect.any(Object),
       'test-custom',
     );
+  });
+
+  it('should fetch user key for user-provided URL without expiresAt (Agents API flow)', async () => {
+    const { checkUserKeyExpiry } = jest.requireMock('~/utils');
+    const params = createParams({
+      apiKey: 'sk-system-key',
+      baseURL: AuthType.USER_PROVIDED,
+      userBaseURL: 'https://user-api.example.com/v1',
+    });
+    params.req.body = { model: 'agent_123', messages: [] };
+
+    await initializeCustom(params);
+
+    expect(params.db.getUserKeyValues).toHaveBeenCalledWith({
+      userId: 'user-1',
+      name: 'test-custom',
+    });
+    expect(checkUserKeyExpiry).not.toHaveBeenCalled();
   });
 
   it('should still check key expiry when expiresAt is provided (UI flow)', async () => {
@@ -109,6 +128,23 @@ describe('initializeCustom – Agents API user key resolution', () => {
 
     expect(checkUserKeyExpiry).toHaveBeenCalledWith('2099-01-01', 'test-custom');
     expect(params.db.getUserKeyValues).toHaveBeenCalled();
+  });
+
+  it('should throw EXPIRED_USER_KEY when expiresAt is expired', async () => {
+    const { checkUserKeyExpiry } = jest.requireMock('~/utils');
+    checkUserKeyExpiry.mockImplementation(() => {
+      throw new Error(JSON.stringify({ type: 'expired_user_key' }));
+    });
+
+    const params = createParams({
+      apiKey: AuthType.USER_PROVIDED,
+      baseURL: 'https://api.example.com/v1',
+      userApiKey: 'sk-user-key',
+      expiresAt: '2020-01-01',
+    });
+
+    await expect(initializeCustom(params)).rejects.toThrow('expired_user_key');
+    expect(params.db.getUserKeyValues).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -91,11 +91,15 @@ export async function initializeCustom({
   const userProvidesKey = isUserProvided(CUSTOM_API_KEY);
   const userProvidesURL = isUserProvided(CUSTOM_BASE_URL);
 
+  // Expiry is only checked when present: the Agents API sends an OpenAI-compatible
+  // request body that does not include `key` (the expiry timestamp), so expiresAt
+  // will be undefined in that flow. The key is still fetched regardless.
+  if (expiresAt && (userProvidesKey || userProvidesURL)) {
+    checkUserKeyExpiry(expiresAt, endpoint);
+  }
+
   let userValues = null;
   if (userProvidesKey || userProvidesURL) {
-    if (expiresAt) {
-      checkUserKeyExpiry(expiresAt, endpoint);
-    }
     userValues = await db.getUserKeyValues({ userId: req.user?.id ?? '', name: endpoint });
   }
 

--- a/packages/api/src/endpoints/custom/initialize.ts
+++ b/packages/api/src/endpoints/custom/initialize.ts
@@ -92,8 +92,10 @@ export async function initializeCustom({
   const userProvidesURL = isUserProvided(CUSTOM_BASE_URL);
 
   let userValues = null;
-  if (expiresAt && (userProvidesKey || userProvidesURL)) {
-    checkUserKeyExpiry(expiresAt, endpoint);
+  if (userProvidesKey || userProvidesURL) {
+    if (expiresAt) {
+      checkUserKeyExpiry(expiresAt, endpoint);
+    }
     userValues = await db.getUserKeyValues({ userId: req.user?.id ?? '', name: endpoint });
   }
 


### PR DESCRIPTION
## Summary

- Fixes the `no_user_key` error when the Agents API (`/api/agents/v1/chat/completions`) is used with a custom endpoint configured with `apiKey: "user_provided"`
- The root cause was that `getUserKeyValues` was gated behind `req.body.key` (expiry timestamp), which is only sent by the UI chat flow — the Agents API sends an OpenAI-compatible body without this field
- Decouples the key fetch from the expiry check so the key is always retrieved when needed

## Changes

**`packages/api/src/endpoints/custom/initialize.ts`**
```diff
  let userValues = null;
- if (expiresAt && (userProvidesKey || userProvidesURL)) {
-   checkUserKeyExpiry(expiresAt, endpoint);
+ if (userProvidesKey || userProvidesURL) {
+   if (expiresAt) {
+     checkUserKeyExpiry(expiresAt, endpoint);
+   }
    userValues = await db.getUserKeyValues({ userId: req.user?.id ?? '', name: endpoint });
  }
```

**`packages/api/src/endpoints/custom/initialize.spec.ts`**
- Added test: key is fetched when `expiresAt` is absent (Agents API flow)
- Added test: expiry is still checked when `expiresAt` is present (UI flow)

## Test plan

- [x] Added unit tests covering both Agents API (no `expiresAt`) and UI (with `expiresAt`) flows
- [ ] Manual test: call `/api/agents/v1/chat/completions` with an agent backed by a `user_provided` custom endpoint

Fixes #12389