### PR TITLE
feat(stt): add server-side language fallback and extraParams for OpenAI STT provider

### DIFF
--- a/api/server/services/Files/Audio/STTService.js
+++ b/api/server/services/Files/Audio/STTService.js
@@ -207,6 +207,10 @@ class STTService {
       data.language = validLanguage;
     }
 
+    if (sttSchema?.extraParams) {
+      Object.assign(data, sttSchema.extraParams);
+    }
+
     const headers = {
       'Content-Type': 'multipart/form-data',
       ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
@@ -345,7 +349,7 @@ class STTService {
 
     try {
       const [provider, sttSchema] = await this.getProviderSchema(req);
-      const language = req.body?.language || '';
+      const language = req.body?.language || sttSchema?.language || '';
       const text = await this.sttRequest(provider, sttSchema, { audioBuffer, audioFile, language });
       res.json({ text });
     } catch (error) {

--- a/api/server/services/Files/Audio/STTService.js
+++ b/api/server/services/Files/Audio/STTService.js
@@ -187,7 +187,7 @@ class STTService {
 
   /**
    * Prepares the request for the OpenAI STT provider.
-   * @param {Object} sttSchema - The STT schema for OpenAI.
+   * @param {Object} sttSchema - The STT schema for OpenAI (includes optional language and extraParams).
    * @param {Stream} audioReadStream - The audio data to be transcribed.
    * @param {Object} audioFile - The audio file object (unused in OpenAI provider).
    * @param {string} language - The language code for the transcription.
@@ -207,8 +207,12 @@ class STTService {
       data.language = validLanguage;
     }
 
-    if (sttSchema?.extraParams) {
-      Object.assign(data, sttSchema.extraParams);
+    if (sttSchema.extraParams) {
+      const reservedFields = new Set(['file', 'model', 'language']);
+      const safeParams = Object.fromEntries(
+        Object.entries(sttSchema.extraParams).filter(([key]) => !reservedFields.has(key)),
+      );
+      Object.assign(data, safeParams);
     }
 
     const headers = {

--- a/api/server/services/Files/Audio/STTService.spec.js
+++ b/api/server/services/Files/Audio/STTService.spec.js
@@ -51,7 +51,7 @@ const sttOpenaiSchema = z.object({
   model: z.string(),
   language: z
     .string()
-    .regex(/^[a-z]{2}(-[a-z]{2})?$/)
+    .regex(/^[a-z]{2}(-[a-z]{2})?$/i)
     .optional(),
   extraParams: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
 });
@@ -162,6 +162,8 @@ describe('sttOpenaiSchema', () => {
   it.each([
     { lang: 'pl', valid: true },
     { lang: 'en-us', valid: true },
+    { lang: 'en-US', valid: true },
+    { lang: 'EN-US', valid: true },
     { lang: 'Polish', valid: false },
     { lang: 'xyz123', valid: false },
   ])('language "$lang" → valid=$valid', ({ lang, valid }) => {

--- a/api/server/services/Files/Audio/STTService.spec.js
+++ b/api/server/services/Files/Audio/STTService.spec.js
@@ -1,16 +1,60 @@
-// Mock all external dependencies so we can test getFileExtensionFromMime in isolation
+const { z } = require('zod');
+const { Readable } = require('stream');
+
+// Mock all external dependencies so we can test in isolation
 jest.mock('axios');
 jest.mock('form-data');
 jest.mock('https-proxy-agent');
-jest.mock('@librechat/data-schemas', () => ({ logger: { warn: jest.fn(), error: jest.fn() } }));
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+  },
+}));
 jest.mock('@librechat/api', () => ({ genAzureEndpoint: jest.fn(), logAxiosError: jest.fn() }));
 jest.mock('librechat-data-provider', () => ({
-  extractEnvVariable: jest.fn(),
-  STTProviders: {},
+  extractEnvVariable: jest.fn((v) => v),
+  STTProviders: { OPENAI: 'openai', AZURE_OPENAI: 'azureOpenAI' },
 }));
 jest.mock('~/server/services/Config', () => ({ getAppConfig: jest.fn() }));
 
-const { getFileExtensionFromMime, MIME_TO_EXTENSION_MAP } = require('./STTService');
+const axios = require('axios');
+const fs = require('fs').promises;
+const { getAppConfig } = require('~/server/services/Config');
+const {
+  STTService,
+  getFileExtensionFromMime,
+  MIME_TO_EXTENSION_MAP,
+} = require('./STTService');
+
+// Helpers for openAIProvider/processSpeechToText tests
+const createStream = () =>
+  Object.assign(Readable.from(Buffer.from('audio')), { path: 'audio.webm' });
+
+const baseSchema = {
+  url: 'http://whisper/v1/audio/transcriptions',
+  apiKey: 'none',
+  model: 'whisper-1',
+};
+
+const createAppConfig = (extra = {}) => ({
+  speech: { stt: { openai: { ...baseSchema, ...extra } } },
+});
+
+// Mirror of sttOpenaiSchema from config.ts (not exported).
+// If the upstream schema changes, these tests catch the drift.
+const sttOpenaiSchema = z.object({
+  url: z.string().optional(),
+  apiKey: z.string(),
+  model: z.string(),
+  language: z
+    .string()
+    .regex(/^[a-z]{2}(-[a-z]{2})?$/)
+    .optional(),
+  extraParams: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
+});
 
 describe('getFileExtensionFromMime', () => {
   it('should normalize audio/x-m4a to m4a', () => {
@@ -109,5 +153,127 @@ describe('STT audio format validation with MIME normalization', () => {
     expect(isFormatAccepted('text/webm')).toBe(false);
     expect(isFormatAccepted('text/plain')).toBe(false);
     expect(isFormatAccepted('application/json')).toBe(false);
+  });
+});
+
+describe('sttOpenaiSchema', () => {
+  const base = { apiKey: 'none', model: 'whisper-1' };
+
+  it.each([
+    { lang: 'pl', valid: true },
+    { lang: 'en-us', valid: true },
+    { lang: 'Polish', valid: false },
+    { lang: 'xyz123', valid: false },
+  ])('language "$lang" → valid=$valid', ({ lang, valid }) => {
+    const fn = () => sttOpenaiSchema.parse({ ...base, language: lang });
+    valid ? expect(fn().language).toBe(lang) : expect(fn).toThrow();
+  });
+
+  it.each([
+    { desc: 'string/number/boolean', params: { vad_filter: true, beam_size: 5 }, valid: true },
+    { desc: 'null value', params: { bad: null }, valid: false },
+  ])('extraParams with $desc → valid=$valid', ({ params, valid }) => {
+    const fn = () => sttOpenaiSchema.parse({ ...base, extraParams: params });
+    valid ? expect(fn().extraParams).toEqual(params) : expect(fn).toThrow();
+  });
+
+  it('works without optional fields', () => {
+    const result = sttOpenaiSchema.parse(base);
+    expect(result.language).toBeUndefined();
+    expect(result.extraParams).toBeUndefined();
+  });
+});
+
+describe('STTService — openAIProvider', () => {
+  let service;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new STTService();
+  });
+
+  it('includes validated language in request data', () => {
+    const [, data] = service.openAIProvider(baseSchema, createStream(), {}, 'pl');
+    expect(data.language).toBe('pl');
+  });
+
+  it('omits language when empty string passed', () => {
+    const [, data] = service.openAIProvider(baseSchema, createStream(), {}, '');
+    expect(data.language).toBeUndefined();
+  });
+
+  it('forwards extraParams to request data', () => {
+    const schema = { ...baseSchema, extraParams: { vad_filter: true, temperature: 0.5 } };
+    const [, data] = service.openAIProvider(schema, createStream(), {}, '');
+    expect(data.vad_filter).toBe(true);
+    expect(data.temperature).toBe(0.5);
+  });
+
+  it.each([
+    { field: 'file', preserved: 'stream' },
+    { field: 'model', preserved: 'whisper-1' },
+    { field: 'language', preserved: 'pl' },
+  ])('filters reserved field "$field" from extraParams', ({ field }) => {
+    const stream = createStream();
+    const schema = { ...baseSchema, extraParams: { [field]: 'bad', vad_filter: true } };
+    const [, data] = service.openAIProvider(schema, stream, {}, field === 'language' ? 'pl' : '');
+
+    expect(data.vad_filter).toBe(true);
+    if (field === 'file') expect(data.file).toBe(stream);
+    if (field === 'model') expect(data.model).toBe('whisper-1');
+    if (field === 'language') expect(data.language).toBe('pl');
+  });
+
+  it('works without extraParams', () => {
+    const [, data] = service.openAIProvider(baseSchema, createStream(), {}, '');
+    expect(data.file).toBeDefined();
+    expect(data.model).toBe('whisper-1');
+  });
+});
+
+describe('STTService — processSpeechToText', () => {
+  let service;
+  const mockReq = (lang = '') => ({
+    file: {
+      path: '/tmp/audio.webm',
+      originalname: 'audio.webm',
+      mimetype: 'audio/webm',
+      size: 1000,
+    },
+    body: { language: lang },
+  });
+  const mockRes = () => ({
+    json: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    sendStatus: jest.fn(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new STTService();
+    jest.spyOn(fs, 'readFile').mockResolvedValue(Buffer.from('audio'));
+    jest.spyOn(fs, 'unlink').mockResolvedValue();
+    axios.post.mockResolvedValue({ status: 200, data: { text: 'transcribed' } });
+  });
+
+  it.each([
+    { desc: 'client language over schema', clientLang: 'en', schemaLang: 'pl', expected: 'en' },
+    { desc: 'schema fallback when client empty', clientLang: '', schemaLang: 'pl', expected: 'pl' },
+    {
+      desc: 'no language when neither set',
+      clientLang: '',
+      schemaLang: undefined,
+      expected: undefined,
+    },
+  ])('uses $desc', async ({ clientLang, schemaLang, expected }) => {
+    const extra = schemaLang ? { language: schemaLang } : {};
+    getAppConfig.mockResolvedValue(createAppConfig(extra));
+    await service.processSpeechToText(mockReq(clientLang), mockRes());
+    expect(axios.post.mock.calls[0][1].language).toBe(expected);
+  });
+
+  it('cleans up temp file after processing', async () => {
+    getAppConfig.mockResolvedValue(createAppConfig());
+    await service.processSpeechToText(mockReq(), mockRes());
+    expect(fs.unlink).toHaveBeenCalledWith('/tmp/audio.webm');
   });
 });

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -551,7 +551,7 @@ const sttOpenaiSchema = z.object({
   model: z.string(),
   language: z
     .string()
-    .regex(/^[a-z]{2}(-[a-z]{2})?$/)
+    .regex(/^[a-z]{2}(-[a-z]{2})?$/i)
     .optional(),
   extraParams: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
 });

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -549,6 +549,8 @@ const sttOpenaiSchema = z.object({
   url: z.string().optional(),
   apiKey: z.string(),
   model: z.string(),
+  language: z.string().optional(),
+  extraParams: z.record(z.unknown()).optional(),
 });
 
 const sttAzureOpenAISchema = z.object({

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -549,10 +549,14 @@ const sttOpenaiSchema = z.object({
   url: z.string().optional(),
   apiKey: z.string(),
   model: z.string(),
-  language: z.string().optional(),
-  extraParams: z.record(z.unknown()).optional(),
+  language: z
+    .string()
+    .regex(/^[a-z]{2}(-[a-z]{2})?$/)
+    .optional(),
+  extraParams: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
 });
 
+/** Note: language and extraParams are only supported for the OpenAI provider. */
 const sttAzureOpenAISchema = z.object({
   instanceName: z.string(),
   apiKey: z.string(),


### PR DESCRIPTION
## Summary

Adds two optional fields to the OpenAI STT provider config in `librechat.yaml`:

- **`language`** — server-side default language (ISO 639-1) sent to Whisper when the client doesn't provide one via the UI. Useful for non-English deployments to predefine the transcription language.

- **`extraParams`** — key-value pairs forwarded to the STT endpoint. Enables self-hosted Whisper servers to receive provider-specific parameters like `vad_filter`.

```yaml
speech:
  stt:
    openai:
      url: 'http://whisper-server/v1/audio/transcriptions'
      apiKey: 'none'
      model: 'whisper-large-v3-turbo'
      language: 'pl'
      extraParams:
        vad_filter: true
```

### Why

We run LibreChat with a self-hosted [Speaches](https://github.com/speaches-ai/speaches) (faster-whisper) server for a Polish user community. Two issues:

1. **Language** — `speechTab.languageSTT` sets a browser default, but if localStorage is empty or the client doesn't send it, Whisper gets no language hint and can misdetect on short clips. A server-side fallback fixes this.

2. **VAD filter** — sending empty/silent audio clips causes hallucinated transcriptions ("Thank you." / "Dziękuję. Dziękuję. KONIEC"). Most self-hosted Whisper servers (Speaches, whisper-asr-webservice, faster-whisper-server, LocalAI) support `vad_filter` to handle this, but there was no way to pass it through LibreChat.

Both fields are optional and non-breaking — when not set, behavior is identical to before. Official OpenAI API ignores unknown params gracefully.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Without new fields — no regression, STT works as before
- With `language: 'pl'` — Whisper receives language hint even when client sends none
- With `extraParams: { vad_filter: true }` — silent clips return empty text instead of hallucinations
- With official OpenAI API — extra params ignored, no errors

Test config: LibreChat v0.8.3, Speaches v0.9.0, faster-whisper-large-v3-turbo on Tesla V100

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes