### PR TITLE
⚡ refactor: Fast-Fail MCP Tool Discovery on 401 for Non-OAuth Servers

### DIFF
--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -81,7 +81,7 @@ export class MCPConnectionFactory {
       useSSRFProtection: this.useSSRFProtection,
     });
 
-    const oauthHandler = async () => {
+    const oauthHandler = () => {
       logger.info(
         `${this.logPrefix} [Discovery] OAuth required; skipping URL generation in discovery mode`,
       );
@@ -89,9 +89,9 @@ export class MCPConnectionFactory {
       connection.emit('oauthFailed', new Error('OAuth required during tool discovery'));
     };
 
-    if (this.useOAuth) {
-      connection.on('oauthRequired', oauthHandler);
-    }
+    // Register unconditionally: non-OAuth servers that return 401 also emit 'oauthRequired',
+    // and without this listener, connectClient()'s oauthHandledPromise hangs for 30s+.
+    connection.once('oauthRequired', oauthHandler);
 
     try {
       const connectTimeout = this.connectionTimeout ?? this.serverConfig.initTimeout ?? 30000;
@@ -103,9 +103,7 @@ export class MCPConnectionFactory {
 
       if (await connection.isConnected()) {
         const tools = await connection.fetchTools();
-        if (this.useOAuth) {
-          connection.removeListener('oauthRequired', oauthHandler);
-        }
+        connection.removeListener('oauthRequired', oauthHandler);
         return { tools, connection, oauthRequired: false, oauthUrl: null };
       }
     } catch {
@@ -117,9 +115,7 @@ export class MCPConnectionFactory {
 
     try {
       const tools = await this.attemptUnauthenticatedToolListing();
-      if (this.useOAuth) {
-        connection.removeListener('oauthRequired', oauthHandler);
-      }
+      connection.removeListener('oauthRequired', oauthHandler);
       if (tools && tools.length > 0) {
         logger.info(
           `${this.logPrefix} [Discovery] Successfully discovered ${tools.length} tools without auth`,
@@ -137,9 +133,7 @@ export class MCPConnectionFactory {
       logger.debug(`${this.logPrefix} [Discovery] Unauthenticated tool listing failed:`, listError);
     }
 
-    if (this.useOAuth) {
-      connection.removeListener('oauthRequired', oauthHandler);
-    }
+    connection.removeListener('oauthRequired', oauthHandler);
 
     try {
       await connection.disconnect();

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -825,17 +825,17 @@ describe('MCPConnectionFactory', () => {
       mockConnectionInstance.isConnected.mockResolvedValue(false);
       mockConnectionInstance.disconnect = jest.fn().mockResolvedValue(undefined);
 
-      let oauthHandler: (() => Promise<void>) | undefined;
-      mockConnectionInstance.on.mockImplementation((event, handler) => {
+      let oauthHandler: (() => void) | undefined;
+      mockConnectionInstance.once.mockImplementation((event, handler) => {
         if (event === 'oauthRequired') {
-          oauthHandler = handler as () => Promise<void>;
+          oauthHandler = handler as () => void;
         }
         return mockConnectionInstance;
       });
 
       mockConnectionInstance.connect.mockImplementation(async () => {
         if (oauthHandler) {
-          await oauthHandler();
+          oauthHandler();
         }
         throw new Error('OAuth required');
       });
@@ -847,6 +847,46 @@ describe('MCPConnectionFactory', () => {
       expect(result.oauthRequired).toBe(true);
       expect(result.oauthUrl).toBeNull();
       expect(mockOAuthStart).not.toHaveBeenCalled();
+    });
+
+    it('should fast-fail discovery when non-OAuth server returns 401', async () => {
+      const basicOptions = {
+        serverName: 'github',
+        serverConfig: {
+          ...mockServerConfig,
+          url: 'https://api.githubcopilot.com/mcp/',
+          type: 'streamable-http' as const,
+          initTimeout: 30000,
+        } as t.StreamableHTTPOptions,
+      };
+
+      mockConnectionInstance.isConnected.mockResolvedValue(false);
+      mockConnectionInstance.disconnect = jest.fn().mockResolvedValue(undefined);
+
+      let oauthHandler: (() => void) | undefined;
+      mockConnectionInstance.once.mockImplementation((event, handler) => {
+        if (event === 'oauthRequired') {
+          oauthHandler = handler as () => void;
+        }
+        return mockConnectionInstance;
+      });
+
+      mockConnectionInstance.connect.mockImplementation(async () => {
+        if (oauthHandler) {
+          oauthHandler();
+        }
+        throw Object.assign(new Error('unauthorized'), { code: 401 });
+      });
+
+      const start = Date.now();
+      const result = await MCPConnectionFactory.discoverTools(basicOptions);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(5000);
+      expect(result.tools).toBeNull();
+      expect(result.oauthRequired).toBe(true);
+      expect(result.oauthUrl).toBeNull();
+      expect(result.connection).toBeNull();
     });
 
     it('should return null tools when discovery fails completely', async () => {

--- a/packages/api/src/mcp/__tests__/MCPOAuthConnectionEvents.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthConnectionEvents.test.ts
@@ -6,9 +6,11 @@
  */
 
 import { MCPConnection } from '~/mcp/connection';
+import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
 import { createOAuthMCPServer } from './helpers/oauthTestServer';
 import type { OAuthTestServer } from './helpers/oauthTestServer';
 import type { MCPOAuthTokens } from '~/mcp/oauth';
+import type { StreamableHTTPOptions } from '~/mcp/types';
 
 jest.mock('@librechat/data-schemas', () => ({
   logger: {
@@ -263,6 +265,33 @@ describe('MCPConnection OAuth Events — Real Server', () => {
 
       await connection.connect();
       expect(await connection.isConnected()).toBe(true);
+    });
+  });
+
+  describe('MCPConnectionFactory.discoverTools — non-OAuth 401 fast-fail', () => {
+    beforeEach(async () => {
+      server = await createOAuthMCPServer({ tokenTTLMs: 60000 });
+    });
+
+    it('should fast-fail when a non-OAuth discovery hits 401', async () => {
+      const basicOptions = {
+        serverName: 'test-server',
+        serverConfig: {
+          type: 'streamable-http',
+          url: server.url,
+          initTimeout: 15000,
+        } as StreamableHTTPOptions,
+      };
+
+      const start = Date.now();
+      const result = await MCPConnectionFactory.discoverTools(basicOptions);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(5000);
+      expect(result.tools).toBeNull();
+      expect(result.oauthRequired).toBe(true);
+      expect(result.oauthUrl).toBeNull();
+      expect(result.connection).toBeNull();
     });
   });
 });

--- a/packages/api/src/mcp/__tests__/MCPOAuthConnectionEvents.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthConnectionEvents.test.ts
@@ -9,8 +9,8 @@ import { MCPConnection } from '~/mcp/connection';
 import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
 import { createOAuthMCPServer } from './helpers/oauthTestServer';
 import type { OAuthTestServer } from './helpers/oauthTestServer';
-import type { MCPOAuthTokens } from '~/mcp/oauth';
 import type { StreamableHTTPOptions } from '~/mcp/types';
+import type { MCPOAuthTokens } from '~/mcp/oauth';
 
 jest.mock('@librechat/data-schemas', () => ({
   logger: {


### PR DESCRIPTION


## Summary

Fixed a 30-second hang during MCP tool discovery triggered when a non-OAuth server returns a 401. Previously, `connectClient()` emitted `oauthRequired` and awaited an internal `oauthHandledPromise`, but when `useOAuth` was `false`, no listener was registered to dispatch `oauthFailed` — leaving the promise unresolved until the outer `withTimeout` killed it after 30s (with an additional ~90s background floating execution and leaked `setTimeout`).

- Removed all `if (this.useOAuth)` guards around `connection.on`/`removeListener` calls in `discoverToolsInternal`, making `oauthHandler` registration unconditional.
- Changed `oauthHandler` from `async` to a plain synchronous function, ensuring `oauthFailed` is emitted synchronously within the `oauthRequired` dispatch and preventing an unhandled-rejection footgun for future maintainers.
- Replaced `connection.on('oauthRequired', oauthHandler)` with `connection.once(...)` to express the one-shot semantics of this event in the discovery lifecycle.
- Added an explanatory comment above the `once` registration documenting why it is unconditional, protecting the fix from being mistakenly reverted as dead code.
- Added a unit test in `MCPConnectionFactory.test.ts` verifying that `discoverTools` resolves in under 5 seconds with `{ tools: null, oauthRequired: true }` when a non-OAuth server returns 401.
- Added an integration test in `MCPOAuthConnectionEvents.test.ts` exercising the fix against a real OAuth-gated MCP server via `createOAuthMCPServer`, asserting sub-5s resolution and correct result shape.
- Updated the existing `oauthRequired` test in `MCPConnectionFactory.test.ts` to intercept `once` instead of `on` and invoke the handler synchronously, matching the new implementation.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified via two test layers:

**Unit test** (`MCPConnectionFactory.test.ts`): Mocks `MCPConnection` with `once` intercepting `oauthRequired`, simulates a 401 throw from `connect()`, and asserts the result resolves in under 5s with `{ tools: null, oauthRequired: true, oauthUrl: null, connection: null }`.

**Integration test** (`MCPOAuthConnectionEvents.test.ts`): Spins up a real OAuth-gated MCP server via `createOAuthMCPServer`, calls `MCPConnectionFactory.discoverTools` against it with no OAuth options (simulating a non-OAuth client hitting a protected server), and asserts sub-5s resolution with the correct result shape.

### **Test Configuration**:
- `packages/api` — `npx jest MCPConnectionFactory`
- `packages/api` — `npx jest MCPOAuthConnectionEvents`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes