### PR TITLE
🐛 fix: Resolve MeiliSearch Startup Sync Failure from Model Loading Order

### DIFF
--- a/api/db/index.js
+++ b/api/db/index.js
@@ -2,6 +2,10 @@ const mongoose = require('mongoose');
 const { createModels } = require('@librechat/data-schemas');
 const { connectDb } = require('./connect');
 
+// createModels MUST run before requiring indexSync.
+// indexSync.js captures mongoose.models.Message and mongoose.models.Conversation
+// at module load time. If those models are not registered first, all MeiliSearch
+// sync operations will silently fail on every startup.
 createModels(mongoose);
 
 const indexSync = require('./indexSync');

--- a/api/db/index.js
+++ b/api/db/index.js
@@ -1,8 +1,9 @@
 const mongoose = require('mongoose');
 const { createModels } = require('@librechat/data-schemas');
 const { connectDb } = require('./connect');
-const indexSync = require('./indexSync');
 
 createModels(mongoose);
+
+const indexSync = require('./indexSync');
 
 module.exports = { connectDb, indexSync };

--- a/api/db/index.spec.js
+++ b/api/db/index.spec.js
@@ -1,31 +1,26 @@
-jest.mock('./connect', () => ({
-  connectDb: jest.fn(),
-}));
-
-jest.mock('./indexSync', () => jest.fn());
-
-jest.mock('@librechat/data-schemas', () => ({
-  createModels: jest.fn((mongooseInstance) => {
-    // Simulate what createModels does: register models on mongoose
-    if (!mongooseInstance.models.Message) {
-      mongooseInstance.models.Message = { name: 'Message' };
-    }
-    if (!mongooseInstance.models.Conversation) {
-      mongooseInstance.models.Conversation = { name: 'Conversation' };
-    }
-  }),
-}));
-
 describe('api/db/index.js', () => {
-  test('models are registered before indexSync is loaded', () => {
-    const mongoose = require('mongoose');
-    delete mongoose.models.Message;
-    delete mongoose.models.Conversation;
+  test('createModels is called before indexSync is loaded', () => {
+    jest.resetModules();
 
-    // This is the contract: requiring the db index should produce valid models
+    const callOrder = [];
+
+    jest.mock('@librechat/data-schemas', () => ({
+      createModels: jest.fn((m) => {
+        callOrder.push('createModels');
+        m.models.Message = { name: 'Message' };
+        m.models.Conversation = { name: 'Conversation' };
+      }),
+    }));
+
+    jest.mock('./indexSync', () => {
+      callOrder.push('indexSync');
+      return jest.fn();
+    });
+
+    jest.mock('./connect', () => ({ connectDb: jest.fn() }));
+
     require('./index');
 
-    expect(mongoose.models.Message).toBeDefined();
-    expect(mongoose.models.Conversation).toBeDefined();
+    expect(callOrder).toEqual(['createModels', 'indexSync']);
   });
 });

--- a/api/db/index.spec.js
+++ b/api/db/index.spec.js
@@ -1,0 +1,31 @@
+jest.mock('./connect', () => ({
+  connectDb: jest.fn(),
+}));
+
+jest.mock('./indexSync', () => jest.fn());
+
+jest.mock('@librechat/data-schemas', () => ({
+  createModels: jest.fn((mongooseInstance) => {
+    // Simulate what createModels does: register models on mongoose
+    if (!mongooseInstance.models.Message) {
+      mongooseInstance.models.Message = { name: 'Message' };
+    }
+    if (!mongooseInstance.models.Conversation) {
+      mongooseInstance.models.Conversation = { name: 'Conversation' };
+    }
+  }),
+}));
+
+describe('api/db/index.js', () => {
+  test('models are registered before indexSync is loaded', () => {
+    const mongoose = require('mongoose');
+    delete mongoose.models.Message;
+    delete mongoose.models.Conversation;
+
+    // This is the contract: requiring the db index should produce valid models
+    require('./index');
+
+    expect(mongoose.models.Message).toBeDefined();
+    expect(mongoose.models.Conversation).toBeDefined();
+  });
+});

--- a/api/db/indexSync.js
+++ b/api/db/indexSync.js
@@ -6,9 +6,6 @@ const { isEnabled, FlowStateManager } = require('@librechat/api');
 const { getLogStores } = require('~/cache');
 const { batchResetMeiliFlags } = require('./utils');
 
-const Conversation = mongoose.models.Conversation;
-const Message = mongoose.models.Message;
-
 const searchEnabled = isEnabled(process.env.SEARCH);
 const indexingDisabled = isEnabled(process.env.MEILI_NO_SYNC);
 let currentTimeout = null;
@@ -200,6 +197,14 @@ async function performSync(flowManager, flowId, flowType) {
       return { messagesSync: false, convosSync: false };
     }
 
+    const Message = mongoose.models.Message;
+    const Conversation = mongoose.models.Conversation;
+    if (!Message || !Conversation) {
+      throw new Error(
+        '[indexSync] Models not registered. Ensure createModels() has been called before indexSync.',
+      );
+    }
+
     const client = MeiliSearchClient.getInstance();
 
     const { status } = await client.health();
@@ -349,6 +354,8 @@ async function indexSync() {
       logger.debug('[indexSync] Creating indices...');
       currentTimeout = setTimeout(async () => {
         try {
+          const Message = mongoose.models.Message;
+          const Conversation = mongoose.models.Conversation;
           await Message.syncWithMeili();
           await Conversation.syncWithMeili();
         } catch (err) {

--- a/api/db/indexSync.js
+++ b/api/db/indexSync.js
@@ -356,6 +356,11 @@ async function indexSync() {
         try {
           const Message = mongoose.models.Message;
           const Conversation = mongoose.models.Conversation;
+          if (!Message || !Conversation) {
+            throw new Error(
+              '[indexSync] Models not registered. Ensure createModels() has been called before indexSync.',
+            );
+          }
           await Message.syncWithMeili();
           await Conversation.syncWithMeili();
         } catch (err) {


### PR DESCRIPTION
## Summary

- Fixed a regression from #11830 where MeiliSearch startup sync silently fails on every server start because `indexSync.js` captures `mongoose.models.Message` and `mongoose.models.Conversation` as `undefined` at module load time
- Root cause: in `api/db/index.js`, `require('./indexSync')` ran **before** `createModels(mongoose)`, so models were not yet registered when `indexSync.js` saved its references
- Fix: move `require('./indexSync')` below `createModels(mongoose)` — a one-line reorder

## Root Cause

PR #11830 consolidated all Mongoose models into `@librechat/data-schemas` via `createModels()`. However, `api/db/index.js` was not updated to account for the new loading order:

```js
// BEFORE (broken): indexSync captures undefined references
const indexSync = require('./indexSync');  // <- captures mongoose.models.Message (undefined!)
createModels(mongoose);                   // <- registers models too late

// AFTER (fixed): models registered before indexSync loads
createModels(mongoose);                   // <- registers models first
const indexSync = require('./indexSync');  // <- captures valid model references
```

`indexSync.js` lines 9-10 capture `mongoose.models.Conversation` and `mongoose.models.Message` at require time. Since `createModels()` hadn't been called yet, both were always `undefined`, causing `getSyncProgress` to throw on every startup.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

**Before fix** — every server start produces:
```
[indexSync] Starting index synchronization check...
[indexSync] Requesting message sync progress...
[indexSync] error Cannot read properties of undefined (reading 'getSyncProgress')
```

**After fix** — sync runs successfully:
```
[indexSync] Starting index synchronization check...
[indexSync] Requesting message sync progress...
[indexSync] Messages need syncing: 0/4601 indexed
[indexSync] No messages marked as indexed, forcing full sync
[indexSync] Starting message sync (4601 unindexed)
[indexSync] Conversations need syncing: 0/385 indexed
[indexSync] No conversations marked as indexed, forcing full sync
[indexSync] Starting convos sync (385 unindexed)
[indexSync] Sync completed successfully
```

**Verified by:**
1. Confirmed `mongoose.models.Message` is `undefined` before `createModels()` and valid after
2. Rebuilt Docker image, restarted container, confirmed sync logs
3. Existing `indexSync.spec.js` tests continue to pass (they inject mock models into `mongoose.models` in `beforeAll`, so are unaffected by this ordering)

### **Test Configuration**:

- LibreChat built from source (commit 5a373825a on main)
- Docker: custom image with `SEARCH=true`, MeiliSearch v1.35.1
- MongoDB 8.0.17

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes