### PR TITLE
📸 fix: Snapshot Options to Prevent Mid-Await Client Disposal Crash

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -487,7 +487,12 @@ class BaseClient {
         }
         delete userMessage.image_urls;
       }
-      userMessagePromise = this.saveMessageToDatabase(userMessage, saveOptions, user);
+      userMessagePromise = this.saveMessageToDatabase(userMessage, saveOptions, user).catch(
+        (err) => {
+          logger.error('[BaseClient] Failed to save user message:', err);
+          return {};
+        },
+      );
       this.savedMessageIds.add(userMessage.messageId);
       if (typeof opts?.getReqData === 'function') {
         opts.getReqData({
@@ -727,8 +732,12 @@ class BaseClient {
    * @param {string | null} user
    */
   async saveMessageToDatabase(message, endpointOptions, user = null) {
-    if (!this.options) {
-      logger.warn('[BaseClient] saveMessageToDatabase called after client disposal, skipping save');
+    // Snapshot options before any await; disposeClient may set client.options = null
+    // while this method is suspended at an I/O boundary, but the local reference
+    // remains valid (disposeClient nulls the property, not the object itself).
+    const options = this.options;
+    if (!options) {
+      logger.error('[BaseClient] saveMessageToDatabase: client disposed before save, skipping');
       return {};
     }
 
@@ -736,17 +745,17 @@ class BaseClient {
       throw new Error('User mismatch.');
     }
 
-    const hasAddedConvo = this.options?.req?.body?.addedConvo != null;
+    const hasAddedConvo = options?.req?.body?.addedConvo != null;
     const reqCtx = {
-      userId: this.options?.req?.user?.id,
-      isTemporary: this.options?.req?.body?.isTemporary,
-      interfaceConfig: this.options?.req?.config?.interfaceConfig,
+      userId: options?.req?.user?.id,
+      isTemporary: options?.req?.body?.isTemporary,
+      interfaceConfig: options?.req?.config?.interfaceConfig,
     };
     const savedMessage = await db.saveMessage(
       reqCtx,
       {
         ...message,
-        endpoint: this.options.endpoint,
+        endpoint: options.endpoint,
         unfinished: false,
         user,
         ...(hasAddedConvo && { addedConvo: true }),
@@ -760,20 +769,20 @@ class BaseClient {
 
     const fieldsToKeep = {
       conversationId: message.conversationId,
-      endpoint: this.options.endpoint,
-      endpointType: this.options.endpointType,
+      endpoint: options.endpoint,
+      endpointType: options.endpointType,
       ...endpointOptions,
     };
 
     const existingConvo =
       this.fetchedConvo === true
         ? null
-        : await db.getConvo(this.options?.req?.user?.id, message.conversationId);
+        : await db.getConvo(options?.req?.user?.id, message.conversationId);
 
     const unsetFields = {};
     const exceptions = new Set(['spec', 'iconURL']);
     const hasNonEphemeralAgent =
-      isAgentsEndpoint(this.options.endpoint) &&
+      isAgentsEndpoint(options.endpoint) &&
       endpointOptions?.agent_id &&
       !isEphemeralAgentId(endpointOptions.agent_id);
     if (hasNonEphemeralAgent) {

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -727,6 +727,11 @@ class BaseClient {
    * @param {string | null} user
    */
   async saveMessageToDatabase(message, endpointOptions, user = null) {
+    if (!this.options) {
+      logger.warn('[BaseClient] saveMessageToDatabase called after client disposal, skipping save');
+      return {};
+    }
+
     if (this.user && user !== this.user) {
       throw new Error('User mismatch.');
     }

--- a/api/app/clients/specs/BaseClient.test.js
+++ b/api/app/clients/specs/BaseClient.test.js
@@ -38,7 +38,7 @@ jest.mock('~/models', () => ({
   updateFileUsage: jest.fn(),
 }));
 
-const { getConvo, saveConvo } = require('~/models');
+const { getConvo, saveConvo, saveMessage } = require('~/models');
 
 jest.mock('@librechat/agents', () => {
   const actual = jest.requireActual('@librechat/agents');
@@ -904,6 +904,52 @@ describe('BaseClient', () => {
           conversationId: expect.any(String),
         }),
       );
+    });
+
+    test('saveMessageToDatabase returns early when this.options is null (client disposed)', async () => {
+      const savedOptions = TestClient.options;
+      TestClient.options = null;
+      saveMessage.mockClear();
+
+      const result = await TestClient.saveMessageToDatabase(
+        { messageId: 'msg-1', conversationId: 'conv-1', isCreatedByUser: true, text: 'hi' },
+        {},
+        null,
+      );
+
+      expect(result).toEqual({});
+      expect(saveMessage).not.toHaveBeenCalled();
+
+      TestClient.options = savedOptions;
+    });
+
+    test('saveMessageToDatabase uses snapshot of options, immune to mid-await disposal', async () => {
+      const savedOptions = TestClient.options;
+      saveMessage.mockClear();
+      saveConvo.mockClear();
+
+      // Make db.saveMessage yield, simulating I/O suspension during which disposal occurs
+      saveMessage.mockImplementation(async (_reqCtx, msgData) => {
+        // Simulate disposeClient nullifying client.options while awaiting
+        TestClient.options = null;
+        return msgData;
+      });
+      saveConvo.mockResolvedValue({ conversationId: 'conv-1' });
+
+      const result = await TestClient.saveMessageToDatabase(
+        { messageId: 'msg-1', conversationId: 'conv-1', isCreatedByUser: true, text: 'hi' },
+        { endpoint: 'openAI' },
+        null,
+      );
+
+      // Should complete without TypeError, using the snapshotted options
+      expect(result).toHaveProperty('message');
+      expect(result).toHaveProperty('conversation');
+      expect(saveMessage).toHaveBeenCalled();
+
+      TestClient.options = savedOptions;
+      saveMessage.mockReset();
+      saveConvo.mockReset();
     });
 
     test('userMessagePromise is awaited before saving response message', async () => {


### PR DESCRIPTION
## Summary

- Fixes an uncaught `TypeError: Cannot read properties of null (reading 'endpoint')` that crashes the Node process when a user exhausts their token balance
- **Root cause**: race condition where `sendMessage()` fires an async `userMessagePromise` via `saveMessageToDatabase()` (without awaiting it), then `checkBalance()` throws, and the error handler calls `disposeClient()` which sets `client.options = null` — while the DB save promise is still suspended at an `await`
- **Fix**: snapshot `this.options` into a local `const options` before any `await` in `saveMessageToDatabase()`, then use the local reference throughout. `disposeClient` sets `client.options = null` (nulling the property on the client), but the local variable retains its reference to the original object — immune to external mutation
- Also adds `.catch()` on `userMessagePromise` in `sendMessage()` to prevent unhandled rejections if the promise rejects after `checkBalance` throws (since no one awaits it on the error path)
- Adds two regression tests: one for the null-guard at entry, one that simulates mid-await disposal and verifies no crash

## Test plan

- [x] `saveMessageToDatabase` returns `{}` early when `this.options` is null at entry
- [x] `saveMessageToDatabase` completes without TypeError when `this.options` is nullified mid-await (snapshot protects all post-await accesses)
- [x] All 60 BaseClient tests pass (58 existing + 2 new)
- [ ] Manual: enable balance with low limits, exhaust token balance mid-conversation, verify server does not crash