### PR TITLE
🔒 chore: Bump MongoDB from 8.0.17 to 8.0.20 in Docker Compose Files

### DIFF
--- a/deploy-compose.yml
+++ b/deploy-compose.yml
@@ -46,7 +46,7 @@ services:
     container_name: chat-mongodb
     # ports:  # Uncomment this to access mongodb from outside docker, not safe in deployment
     #   - 27018:27017
-    image: mongo:8.0.17
+    image: mongo:8.0.20
     restart: always
     volumes:
       - ./data-node:/data/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ./logs:/app/logs
   mongodb:
     container_name: chat-mongodb
-    image: mongo:8.0.17
+    image: mongo:8.0.20
     restart: always
     user: "${UID}:${GID}"
     volumes:


### PR DESCRIPTION
## Summary
- Bumps MongoDB image from `8.0.17` to `8.0.20` in `docker-compose.yml` and `deploy-compose.yml`
- Fixes vulnerabilities disclosed in [CERTFR-2026-AVI-0310](https://www.cert.ssi.gouv.fr/avis/CERTFR-2026-AVI-0310/):
  - **Blocker/P1** — Improper object lifecycle management of MD5 hash state in core cryptographic operations
  - **Major/P3** — Use-after-free in `ExpressionContext` during pipeline cloning with nested `$unionWith` stages

## Test plan
- [ ] Verify containers start successfully with `docker compose up`
- [ ] Confirm MongoDB version is 8.0.20 via `mongosh --eval "db.version()"`