### PR TITLE
🪪 feat: Admin Roles API Endpoints

### DIFF
--- a/api/server/index.js
+++ b/api/server/index.js
@@ -145,6 +145,7 @@ const startServer = async () => {
   app.use('/api/admin', routes.adminAuth);
   app.use('/api/admin/config', routes.adminConfig);
   app.use('/api/admin/groups', routes.adminGroups);
+  app.use('/api/admin/roles', routes.adminRoles);
   app.use('/api/actions', routes.actions);
   app.use('/api/keys', routes.keys);
   app.use('/api/api-keys', routes.apiKeys);

--- a/api/server/routes/admin/roles.js
+++ b/api/server/routes/admin/roles.js
@@ -14,10 +14,10 @@ const requireManageRoles = requireCapability(SystemCapabilities.MANAGE_ROLES);
 const handlers = createAdminRolesHandlers({
   listRoles: db.listRoles,
   getRoleByName: db.getRoleByName,
-  createRole: db.createRole,
+  createRoleByName: db.createRoleByName,
   updateRoleByName: db.updateRoleByName,
   updateAccessPermissions: db.updateAccessPermissions,
-  deleteRole: db.deleteRole,
+  deleteRoleByName: db.deleteRoleByName,
   findUser: db.findUser,
   updateUser: db.updateUser,
   listUsersByRole: db.listUsersByRole,

--- a/api/server/routes/admin/roles.js
+++ b/api/server/routes/admin/roles.js
@@ -13,6 +13,7 @@ const requireManageRoles = requireCapability(SystemCapabilities.MANAGE_ROLES);
 
 const handlers = createAdminRolesHandlers({
   listRoles: db.listRoles,
+  countRoles: db.countRoles,
   getRoleByName: db.getRoleByName,
   createRoleByName: db.createRoleByName,
   updateRoleByName: db.updateRoleByName,

--- a/api/server/routes/admin/roles.js
+++ b/api/server/routes/admin/roles.js
@@ -22,6 +22,8 @@ const handlers = createAdminRolesHandlers({
   findUser: db.findUser,
   updateUser: db.updateUser,
   updateUsersByRole: db.updateUsersByRole,
+  findUserIdsByRole: db.findUserIdsByRole,
+  updateUsersRoleByIds: db.updateUsersRoleByIds,
   listUsersByRole: db.listUsersByRole,
   countUsersByRole: db.countUsersByRole,
 });

--- a/api/server/routes/admin/roles.js
+++ b/api/server/routes/admin/roles.js
@@ -11,21 +11,6 @@ const requireAdminAccess = requireCapability(SystemCapabilities.ACCESS_ADMIN);
 const requireReadRoles = requireCapability(SystemCapabilities.READ_ROLES);
 const requireManageRoles = requireCapability(SystemCapabilities.MANAGE_ROLES);
 
-async function listUsersByRole(roleName) {
-  const mongoose = require('mongoose');
-  const User = mongoose.models.User;
-  const users = await User.find({ role: roleName })
-    .select('_id name email avatar createdAt')
-    .lean();
-  return users.map((u) => ({
-    userId: String(u._id),
-    name: u.name ?? String(u._id),
-    email: u.email ?? '',
-    avatarUrl: u.avatar,
-    joinedAt: u.createdAt ? u.createdAt.toISOString() : new Date().toISOString(),
-  }));
-}
-
 const handlers = createAdminRolesHandlers({
   listRoles: db.listRoles,
   getRoleByName: db.getRoleByName,
@@ -35,8 +20,7 @@ const handlers = createAdminRolesHandlers({
   deleteRole: db.deleteRole,
   findUser: db.findUser,
   updateUser: db.updateUser,
-  countUsers: db.countUsers,
-  listUsersByRole,
+  listUsersByRole: db.listUsersByRole,
 });
 
 router.use(requireJwtAuth, requireAdminAccess);

--- a/api/server/routes/admin/roles.js
+++ b/api/server/routes/admin/roles.js
@@ -20,7 +20,9 @@ const handlers = createAdminRolesHandlers({
   deleteRoleByName: db.deleteRoleByName,
   findUser: db.findUser,
   updateUser: db.updateUser,
+  updateUsersByRole: db.updateUsersByRole,
   listUsersByRole: db.listUsersByRole,
+  countUsersByRole: db.countUsersByRole,
 });
 
 router.use(requireJwtAuth, requireAdminAccess);

--- a/api/server/routes/admin/roles.js
+++ b/api/server/routes/admin/roles.js
@@ -1,0 +1,54 @@
+const express = require('express');
+const { createAdminRolesHandlers } = require('@librechat/api');
+const { SystemCapabilities } = require('@librechat/data-schemas');
+const { requireCapability } = require('~/server/middleware/roles/capabilities');
+const { requireJwtAuth } = require('~/server/middleware');
+const db = require('~/models');
+
+const router = express.Router();
+
+const requireAdminAccess = requireCapability(SystemCapabilities.ACCESS_ADMIN);
+const requireReadRoles = requireCapability(SystemCapabilities.READ_ROLES);
+const requireManageRoles = requireCapability(SystemCapabilities.MANAGE_ROLES);
+
+async function listUsersByRole(roleName) {
+  const mongoose = require('mongoose');
+  const User = mongoose.models.User;
+  const users = await User.find({ role: roleName })
+    .select('_id name email avatar createdAt')
+    .lean();
+  return users.map((u) => ({
+    userId: String(u._id),
+    name: u.name ?? String(u._id),
+    email: u.email ?? '',
+    avatarUrl: u.avatar,
+    joinedAt: u.createdAt ? u.createdAt.toISOString() : new Date().toISOString(),
+  }));
+}
+
+const handlers = createAdminRolesHandlers({
+  listRoles: db.listRoles,
+  getRoleByName: db.getRoleByName,
+  createRole: db.createRole,
+  updateRoleByName: db.updateRoleByName,
+  updateAccessPermissions: db.updateAccessPermissions,
+  deleteRole: db.deleteRole,
+  findUser: db.findUser,
+  updateUser: db.updateUser,
+  countUsers: db.countUsers,
+  listUsersByRole,
+});
+
+router.use(requireJwtAuth, requireAdminAccess);
+
+router.get('/', requireReadRoles, handlers.listRoles);
+router.post('/', requireManageRoles, handlers.createRole);
+router.get('/:name', requireReadRoles, handlers.getRole);
+router.patch('/:name', requireManageRoles, handlers.updateRole);
+router.delete('/:name', requireManageRoles, handlers.deleteRole);
+router.patch('/:name/permissions', requireManageRoles, handlers.updateRolePermissions);
+router.get('/:name/members', requireReadRoles, handlers.getRoleMembers);
+router.post('/:name/members', requireManageRoles, handlers.addRoleMember);
+router.delete('/:name/members/:userId', requireManageRoles, handlers.removeRoleMember);
+
+module.exports = router;

--- a/api/server/routes/index.js
+++ b/api/server/routes/index.js
@@ -4,6 +4,7 @@ const categories = require('./categories');
 const adminAuth = require('./admin/auth');
 const adminConfig = require('./admin/config');
 const adminGroups = require('./admin/groups');
+const adminRoles = require('./admin/roles');
 const endpoints = require('./endpoints');
 const staticRoute = require('./static');
 const messages = require('./messages');
@@ -35,6 +36,7 @@ module.exports = {
   adminAuth,
   adminConfig,
   adminGroups,
+  adminRoles,
   keys,
   apiKeys,
   user,

--- a/packages/api/src/admin/groups.ts
+++ b/packages/api/src/admin/groups.ts
@@ -13,6 +13,7 @@ import type { FilterQuery, ClientSession, DeleteResult } from 'mongoose';
 import type { Response } from 'express';
 import type { ValidationError } from '~/types/error';
 import type { ServerRequest } from '~/types/http';
+import { parsePagination } from './pagination';
 
 type GroupListFilter = Pick<GroupFilterOptions, 'source' | 'search'>;
 
@@ -119,8 +120,7 @@ export function createAdminGroupsHandlers(deps: AdminGroupsDeps) {
       if (search) {
         filter.search = search;
       }
-      const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200);
-      const offset = Math.max(Number(req.query.offset) || 0, 0);
+      const { limit, offset } = parsePagination(req.query);
       const [groups, total] = await Promise.all([
         listGroups({ ...filter, limit, offset }),
         countGroups(filter),
@@ -348,8 +348,7 @@ export function createAdminGroupsHandlers(deps: AdminGroupsDeps) {
        */
       const allMemberIds = [...new Set(group.memberIds || [])];
       const total = allMemberIds.length;
-      const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200);
-      const offset = Math.max(Number(req.query.offset) || 0, 0);
+      const { limit, offset } = parsePagination(req.query);
 
       if (total === 0 || offset >= total) {
         return res.status(200).json({ members: [], total, limit, offset });

--- a/packages/api/src/admin/index.ts
+++ b/packages/api/src/admin/index.ts
@@ -1,4 +1,6 @@
 export { createAdminConfigHandlers } from './config';
 export { createAdminGroupsHandlers } from './groups';
+export { createAdminRolesHandlers } from './roles';
 export type { AdminConfigDeps } from './config';
 export type { AdminGroupsDeps } from './groups';
+export type { AdminRolesDeps } from './roles';

--- a/packages/api/src/admin/pagination.ts
+++ b/packages/api/src/admin/pagination.ts
@@ -5,8 +5,13 @@ export function parsePagination(query: { limit?: string; offset?: string }): {
   limit: number;
   offset: number;
 } {
+  const rawLimit = parseInt(query.limit ?? '', 10);
+  const rawOffset = parseInt(query.offset ?? '', 10);
   return {
-    limit: Math.min(Math.max(Number(query.limit) || DEFAULT_PAGE_LIMIT, 1), MAX_PAGE_LIMIT),
-    offset: Math.max(Number(query.offset) || 0, 0),
+    limit: Math.min(
+      Math.max(Number.isNaN(rawLimit) ? DEFAULT_PAGE_LIMIT : rawLimit, 1),
+      MAX_PAGE_LIMIT,
+    ),
+    offset: Math.max(Number.isNaN(rawOffset) ? 0 : rawOffset, 0),
   };
 }

--- a/packages/api/src/admin/pagination.ts
+++ b/packages/api/src/admin/pagination.ts
@@ -1,0 +1,12 @@
+export const DEFAULT_PAGE_LIMIT = 50;
+export const MAX_PAGE_LIMIT = 200;
+
+export function parsePagination(query: { limit?: string; offset?: string }): {
+  limit: number;
+  offset: number;
+} {
+  return {
+    limit: Math.min(Math.max(Number(query.limit) || DEFAULT_PAGE_LIMIT, 1), MAX_PAGE_LIMIT),
+    offset: Math.max(Number(query.offset) || 0, 0),
+  };
+}

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -67,6 +67,8 @@ function createDeps(overrides: Partial<AdminRolesDeps> = {}): AdminRolesDeps {
     findUser: jest.fn().mockResolvedValue(null),
     updateUser: jest.fn().mockResolvedValue(mockUser()),
     updateUsersByRole: jest.fn().mockResolvedValue(undefined),
+    findUserIdsByRole: jest.fn().mockResolvedValue(['uid-1', 'uid-2']),
+    updateUsersRoleByIds: jest.fn().mockResolvedValue(undefined),
     listUsersByRole: jest.fn().mockResolvedValue([]),
     countUsersByRole: jest.fn().mockResolvedValue(0),
     ...overrides,
@@ -455,6 +457,10 @@ describe('createAdminRolesHandlers', () => {
       const callOrder: string[] = [];
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
+        findUserIdsByRole: jest.fn().mockImplementation(() => {
+          callOrder.push('findUserIdsByRole');
+          return Promise.resolve(['uid-1']);
+        }),
         updateUsersByRole: jest.fn().mockImplementation(() => {
           callOrder.push('updateUsersByRole');
           return Promise.resolve();
@@ -473,8 +479,9 @@ describe('createAdminRolesHandlers', () => {
       await handlers.updateRole(req, res);
 
       expect(status).toHaveBeenCalledWith(200);
+      expect(deps.findUserIdsByRole).toHaveBeenCalledWith('editor');
       expect(deps.updateUsersByRole).toHaveBeenCalledWith('editor', 'new-name');
-      expect(callOrder).toEqual(['updateUsersByRole', 'updateRoleByName']);
+      expect(callOrder).toEqual(['findUserIdsByRole', 'updateUsersByRole', 'updateRoleByName']);
     });
 
     it('does not rename role when user migration fails', async () => {
@@ -655,8 +662,10 @@ describe('createAdminRolesHandlers', () => {
     });
 
     it('rolls back user migration when rename fails', async () => {
+      const ids = ['uid-1', 'uid-2'];
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
+        findUserIdsByRole: jest.fn().mockResolvedValue(ids),
         updateRoleByName: jest.fn().mockResolvedValue(null),
       });
       const handlers = createAdminRolesHandlers(deps);
@@ -669,14 +678,16 @@ describe('createAdminRolesHandlers', () => {
 
       expect(status).toHaveBeenCalledWith(404);
       expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
-      expect(deps.updateUsersByRole).toHaveBeenCalledTimes(2);
-      expect(deps.updateUsersByRole).toHaveBeenNthCalledWith(1, 'editor', 'new-name');
-      expect(deps.updateUsersByRole).toHaveBeenNthCalledWith(2, 'new-name', 'editor');
+      expect(deps.updateUsersByRole).toHaveBeenCalledTimes(1);
+      expect(deps.updateUsersByRole).toHaveBeenCalledWith('editor', 'new-name');
+      expect(deps.updateUsersRoleByIds).toHaveBeenCalledWith(ids, 'editor');
     });
 
     it('rolls back user migration when rename throws', async () => {
+      const ids = ['uid-1', 'uid-2'];
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
+        findUserIdsByRole: jest.fn().mockResolvedValue(ids),
         updateRoleByName: jest.fn().mockRejectedValue(new Error('db crash')),
       });
       const handlers = createAdminRolesHandlers(deps);
@@ -688,18 +699,16 @@ describe('createAdminRolesHandlers', () => {
       await handlers.updateRole(req, res);
 
       expect(status).toHaveBeenCalledWith(500);
-      expect(deps.updateUsersByRole).toHaveBeenCalledTimes(2);
-      expect(deps.updateUsersByRole).toHaveBeenNthCalledWith(1, 'editor', 'new-name');
-      expect(deps.updateUsersByRole).toHaveBeenNthCalledWith(2, 'new-name', 'editor');
+      expect(deps.updateUsersByRole).toHaveBeenCalledTimes(1);
+      expect(deps.updateUsersByRole).toHaveBeenCalledWith('editor', 'new-name');
+      expect(deps.updateUsersRoleByIds).toHaveBeenCalledWith(ids, 'editor');
     });
 
     it('logs rollback failure and still returns 500', async () => {
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
-        updateUsersByRole: jest
-          .fn()
-          .mockResolvedValueOnce(undefined)
-          .mockRejectedValueOnce(new Error('rollback failed')),
+        findUserIdsByRole: jest.fn().mockResolvedValue(['uid-1']),
+        updateUsersRoleByIds: jest.fn().mockRejectedValue(new Error('rollback failed')),
         updateRoleByName: jest.fn().mockRejectedValue(new Error('rename failed')),
       });
       const handlers = createAdminRolesHandlers(deps);
@@ -711,7 +720,8 @@ describe('createAdminRolesHandlers', () => {
       await handlers.updateRole(req, res);
 
       expect(status).toHaveBeenCalledWith(500);
-      expect(deps.updateUsersByRole).toHaveBeenCalledTimes(2);
+      expect(deps.updateUsersByRole).toHaveBeenCalledTimes(1);
+      expect(deps.updateUsersRoleByIds).toHaveBeenCalledTimes(1);
     });
 
     it('returns 400 when description exceeds max length', async () => {

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -117,6 +117,46 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.listRoles).toHaveBeenCalledWith({ limit: 200, offset: 0 });
     });
 
+    it('clamps negative offset to 0', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res } = createReqRes({ query: { offset: '-5' } });
+
+      await handlers.listRoles(req, res);
+
+      expect(deps.listRoles).toHaveBeenCalledWith({ limit: 50, offset: 0 });
+    });
+
+    it('treats non-numeric limit as default', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res } = createReqRes({ query: { limit: 'abc' } });
+
+      await handlers.listRoles(req, res);
+
+      expect(deps.listRoles).toHaveBeenCalledWith({ limit: 50, offset: 0 });
+    });
+
+    it('clamps limit=0 to 1', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res } = createReqRes({ query: { limit: '0' } });
+
+      await handlers.listRoles(req, res);
+
+      expect(deps.listRoles).toHaveBeenCalledWith({ limit: 1, offset: 0 });
+    });
+
+    it('truncates float offset to integer', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res } = createReqRes({ query: { offset: '1.7' } });
+
+      await handlers.listRoles(req, res);
+
+      expect(deps.listRoles).toHaveBeenCalledWith({ limit: 50, offset: 1 });
+    });
+
     it('returns 500 on error', async () => {
       const deps = createDeps({ listRoles: jest.fn().mockRejectedValue(new Error('db down')) });
       const handlers = createAdminRolesHandlers(deps);
@@ -187,6 +227,25 @@ describe('createAdminRolesHandlers', () => {
       });
     });
 
+    it('passes provided permissions to createRoleByName', async () => {
+      const perms = { chat: { read: true, write: false } } as unknown as IRole['permissions'];
+      const role = mockRole({ permissions: perms });
+      const deps = createDeps({ createRoleByName: jest.fn().mockResolvedValue(role) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { name: 'editor', permissions: perms },
+      });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(201);
+      expect(json).toHaveBeenCalledWith({ role });
+      expect(deps.createRoleByName).toHaveBeenCalledWith({
+        name: 'editor',
+        permissions: perms,
+      });
+    });
+
     it('returns 400 when name is missing', async () => {
       const deps = createDeps();
       const handlers = createAdminRolesHandlers(deps);
@@ -208,6 +267,30 @@ describe('createAdminRolesHandlers', () => {
 
       expect(status).toHaveBeenCalledWith(400);
       expect(json).toHaveBeenCalledWith({ error: 'name is required' });
+    });
+
+    it('returns 400 when name contains control characters', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: { name: 'bad\x00name' } });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'name contains invalid characters' });
+      expect(deps.createRoleByName).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when name is a reserved path segment', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: { name: 'members' } });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'name is a reserved path segment' });
+      expect(deps.createRoleByName).not.toHaveBeenCalled();
     });
 
     it('returns 400 when name exceeds max length', async () => {
@@ -426,6 +509,29 @@ describe('createAdminRolesHandlers', () => {
       await handlers.updateRole(req, res);
 
       expect(deps.updateUsersByRole).not.toHaveBeenCalled();
+    });
+
+    it('renames and updates description in a single request', async () => {
+      const role = mockRole({ name: 'senior-editor', description: 'Updated desc' });
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
+        updateRoleByName: jest.fn().mockResolvedValue(role),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: 'senior-editor', description: 'Updated desc' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ role });
+      expect(deps.updateUsersByRole).toHaveBeenCalledWith('editor', 'senior-editor');
+      expect(deps.updateRoleByName).toHaveBeenCalledWith('editor', {
+        name: 'senior-editor',
+        description: 'Updated desc',
+      });
     });
 
     it('returns 403 when renaming a system role', async () => {
@@ -696,10 +802,13 @@ describe('createAdminRolesHandlers', () => {
   });
 
   describe('updateRolePermissions', () => {
-    it('updates permissions and returns 200', async () => {
+    it('updates permissions and returns 200 with updated role', async () => {
       const role = mockRole();
+      const updatedRole = mockRole({
+        permissions: { chat: { read: true, write: true } } as IRole['permissions'],
+      });
       const deps = createDeps({
-        getRoleByName: jest.fn().mockResolvedValue(role),
+        getRoleByName: jest.fn().mockResolvedValueOnce(role).mockResolvedValueOnce(updatedRole),
       });
       const handlers = createAdminRolesHandlers(deps);
       const perms = { chat: { read: true, write: true } };
@@ -712,7 +821,7 @@ describe('createAdminRolesHandlers', () => {
 
       expect(deps.updateAccessPermissions).toHaveBeenCalledWith('editor', perms, role);
       expect(status).toHaveBeenCalledWith(200);
-      expect(json).toHaveBeenCalledWith({ role: expect.objectContaining({ name: 'editor' }) });
+      expect(json).toHaveBeenCalledWith({ role: updatedRole });
     });
 
     it('returns 400 when permissions is missing', async () => {
@@ -1073,6 +1182,20 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.updateUser).toHaveBeenCalledWith(validUserId, { role: SystemRoles.USER });
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('returns 403 when removing from a non-ADMIN system role', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: SystemRoles.USER, userId: validUserId },
+      });
+
+      await handlers.removeRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(403);
+      expect(json).toHaveBeenCalledWith({ error: 'Cannot remove members from a system role' });
+      expect(deps.getRoleByName).not.toHaveBeenCalled();
     });
 
     it('returns 400 for invalid ObjectId', async () => {

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -286,11 +286,19 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.updateRoleByName).toHaveBeenCalledWith('editor', { name: 'trimmed' });
     });
 
-    it('migrates users after rename', async () => {
+    it('migrates users before renaming role', async () => {
       const role = mockRole({ name: 'new-name' });
+      const callOrder: string[] = [];
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
-        updateRoleByName: jest.fn().mockResolvedValue(role),
+        updateUsersByRole: jest.fn().mockImplementation(() => {
+          callOrder.push('updateUsersByRole');
+          return Promise.resolve();
+        }),
+        updateRoleByName: jest.fn().mockImplementation(() => {
+          callOrder.push('updateRoleByName');
+          return Promise.resolve(role);
+        }),
       });
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status } = createReqRes({
@@ -302,6 +310,24 @@ describe('createAdminRolesHandlers', () => {
 
       expect(status).toHaveBeenCalledWith(200);
       expect(deps.updateUsersByRole).toHaveBeenCalledWith('editor', 'new-name');
+      expect(callOrder).toEqual(['updateUsersByRole', 'updateRoleByName']);
+    });
+
+    it('does not rename role when user migration fails', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
+        updateUsersByRole: jest.fn().mockRejectedValue(new Error('migration failed')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: 'new-name' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(deps.updateRoleByName).not.toHaveBeenCalled();
     });
 
     it('does not migrate users when name unchanged', async () => {

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -247,7 +247,7 @@ describe('createAdminRolesHandlers', () => {
       await handlers.createRole(req, res);
 
       expect(status).toHaveBeenCalledWith(500);
-      expect(json).toHaveBeenCalledWith({ error: 'db crash' });
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to create role' });
     });
 
     it('does not classify unrelated errors as 409', async () => {
@@ -556,6 +556,58 @@ describe('createAdminRolesHandlers', () => {
 
       expect(status).toHaveBeenCalledWith(500);
       expect(json).toHaveBeenCalledWith({ error: 'Failed to update role' });
+    });
+
+    it('does not roll back when error occurs before user migration', async () => {
+      const deps = createDeps({
+        getRoleByName: jest
+          .fn()
+          .mockResolvedValueOnce(mockRole())
+          .mockRejectedValueOnce(new Error('db crash')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: 'new-name' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(deps.updateUsersByRole).not.toHaveBeenCalled();
+    });
+
+    it('returns existing role early when update body has no changes', async () => {
+      const role = mockRole();
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(role),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: {},
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ role });
+      expect(deps.updateRoleByName).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid description before making DB calls', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { description: 123 },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'description must be a string' });
+      expect(deps.getRoleByName).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -58,6 +58,7 @@ function createReqRes(
 function createDeps(overrides: Partial<AdminRolesDeps> = {}): AdminRolesDeps {
   return {
     listRoles: jest.fn().mockResolvedValue([]),
+    countRoles: jest.fn().mockResolvedValue(0),
     getRoleByName: jest.fn().mockResolvedValue(null),
     createRoleByName: jest.fn().mockResolvedValue(mockRole()),
     updateRoleByName: jest.fn().mockResolvedValue(mockRole()),
@@ -74,16 +75,46 @@ function createDeps(overrides: Partial<AdminRolesDeps> = {}): AdminRolesDeps {
 
 describe('createAdminRolesHandlers', () => {
   describe('listRoles', () => {
-    it('returns roles with 200', async () => {
+    it('returns paginated roles with 200', async () => {
       const roles = [mockRole()];
-      const deps = createDeps({ listRoles: jest.fn().mockResolvedValue(roles) });
+      const deps = createDeps({
+        listRoles: jest.fn().mockResolvedValue(roles),
+        countRoles: jest.fn().mockResolvedValue(1),
+      });
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes();
 
       await handlers.listRoles(req, res);
 
       expect(status).toHaveBeenCalledWith(200);
-      expect(json).toHaveBeenCalledWith({ roles });
+      expect(json).toHaveBeenCalledWith({ roles, total: 1, limit: 50, offset: 0 });
+      expect(deps.listRoles).toHaveBeenCalledWith({ limit: 50, offset: 0 });
+    });
+
+    it('passes custom limit and offset from query', async () => {
+      const deps = createDeps({
+        countRoles: jest.fn().mockResolvedValue(100),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        query: { limit: '25', offset: '50' },
+      });
+
+      await handlers.listRoles(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ roles: [], total: 100, limit: 25, offset: 50 });
+      expect(deps.listRoles).toHaveBeenCalledWith({ limit: 25, offset: 50 });
+    });
+
+    it('clamps limit to 200', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res } = createReqRes({ query: { limit: '999' } });
+
+      await handlers.listRoles(req, res);
+
+      expect(deps.listRoles).toHaveBeenCalledWith({ limit: 200, offset: 0 });
     });
 
     it('returns 500 on error', async () => {

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -6,6 +6,8 @@ import type { ServerRequest } from '~/types/http';
 import type { AdminRolesDeps } from './roles';
 import { createAdminRolesHandlers } from './roles';
 
+const { RoleConflictError } = jest.requireActual('@librechat/data-schemas');
+
 jest.mock('@librechat/data-schemas', () => ({
   ...jest.requireActual('@librechat/data-schemas'),
   logger: { error: jest.fn() },
@@ -209,7 +211,9 @@ describe('createAdminRolesHandlers', () => {
 
     it('returns 409 when role already exists', async () => {
       const deps = createDeps({
-        createRoleByName: jest.fn().mockRejectedValue(new Error('Role "editor" already exists')),
+        createRoleByName: jest
+          .fn()
+          .mockRejectedValue(new RoleConflictError('Role "editor" already exists')),
       });
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes({ body: { name: 'editor' } });
@@ -224,7 +228,9 @@ describe('createAdminRolesHandlers', () => {
       const deps = createDeps({
         createRoleByName: jest
           .fn()
-          .mockRejectedValue(new Error('Cannot create role with reserved system name: ADMIN')),
+          .mockRejectedValue(
+            new RoleConflictError('Cannot create role with reserved system name: ADMIN'),
+          ),
       });
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes({ body: { name: 'ADMIN' } });
@@ -262,6 +268,34 @@ describe('createAdminRolesHandlers', () => {
       await handlers.createRole(req, res);
 
       expect(status).toHaveBeenCalledWith(500);
+    });
+
+    it('returns 400 when description is not a string', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { name: 'editor', description: 123 },
+      });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'description must be a string' });
+      expect(deps.createRoleByName).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when permissions is an array', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { name: 'editor', permissions: [1, 2, 3] },
+      });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'permissions must be an object' });
+      expect(deps.createRoleByName).not.toHaveBeenCalled();
     });
   });
 
@@ -522,10 +556,29 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.updateUsersByRole).toHaveBeenNthCalledWith(2, 'new-name', 'editor');
     });
 
-    it('returns 400 when description exceeds max length', async () => {
+    it('logs rollback failure and still returns 500', async () => {
       const deps = createDeps({
-        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
+        updateUsersByRole: jest
+          .fn()
+          .mockResolvedValueOnce(undefined)
+          .mockRejectedValueOnce(new Error('rollback failed')),
+        updateRoleByName: jest.fn().mockRejectedValue(new Error('rename failed')),
       });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: 'new-name' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(deps.updateUsersByRole).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns 400 when description exceeds max length', async () => {
+      const deps = createDeps();
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes({
         params: { name: 'editor' },
@@ -538,7 +591,7 @@ describe('createAdminRolesHandlers', () => {
       expect(json).toHaveBeenCalledWith({
         error: 'description must not exceed 2000 characters',
       });
-      expect(deps.updateRoleByName).not.toHaveBeenCalled();
+      expect(deps.getRoleByName).not.toHaveBeenCalled();
     });
 
     it('returns 500 on unexpected error', async () => {

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -777,6 +777,24 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.updateUsersByRole).not.toHaveBeenCalled();
     });
 
+    it('does not migrate users when findUserIdsByRole throws', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
+        findUserIdsByRole: jest.fn().mockRejectedValue(new Error('db crash')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: 'new-name' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(deps.updateUsersByRole).not.toHaveBeenCalled();
+      expect(deps.updateUsersRoleByIds).not.toHaveBeenCalled();
+    });
+
     it('returns existing role early when update body has no changes', async () => {
       const role = mockRole();
       const deps = createDeps({
@@ -1214,6 +1232,42 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.updateUser).toHaveBeenLastCalledWith(validUserId, { role: SystemRoles.ADMIN });
       expect(status).toHaveBeenCalledWith(400);
       expect(json).toHaveBeenCalledWith({ error: 'Cannot remove the last admin user' });
+    });
+
+    it('returns 403 when adding to a non-ADMIN system role', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: SystemRoles.USER },
+        body: { userId: validUserId },
+      });
+
+      await handlers.addRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(403);
+      expect(json).toHaveBeenCalledWith({
+        error: 'Cannot directly assign members to a system role',
+      });
+      expect(deps.updateUser).not.toHaveBeenCalled();
+    });
+
+    it('allows promoting a non-admin user to the ADMIN role', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole({ name: SystemRoles.ADMIN })),
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: 'editor' })),
+        updateUser: jest.fn().mockResolvedValue(mockUser({ role: SystemRoles.ADMIN })),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: SystemRoles.ADMIN },
+        body: { userId: validUserId },
+      });
+
+      await handlers.addRoleMember(req, res);
+
+      expect(deps.updateUser).toHaveBeenCalledWith(validUserId, { role: SystemRoles.ADMIN });
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ success: true });
     });
 
     it('returns 500 on unexpected error', async () => {

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -443,7 +443,7 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.getRoleByName).not.toHaveBeenCalled();
     });
 
-    it('returns 409 when renaming to a system role name', async () => {
+    it('returns 403 when renaming to a system role name', async () => {
       const deps = createDeps();
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes({
@@ -453,8 +453,8 @@ describe('createAdminRolesHandlers', () => {
 
       await handlers.updateRole(req, res);
 
-      expect(status).toHaveBeenCalledWith(409);
-      expect(json).toHaveBeenCalledWith({ error: 'Cannot rename to a reserved system role name' });
+      expect(status).toHaveBeenCalledWith(403);
+      expect(json).toHaveBeenCalledWith({ error: 'Cannot use a reserved system role name' });
     });
 
     it('returns 409 when target name already exists', async () => {

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -467,6 +467,26 @@ describe('createAdminRolesHandlers', () => {
       expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
     });
 
+    it('rolls back user migration when rename fails', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
+        updateRoleByName: jest.fn().mockResolvedValue(null),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: 'new-name' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
+      expect(deps.updateUsersByRole).toHaveBeenCalledTimes(2);
+      expect(deps.updateUsersByRole).toHaveBeenNthCalledWith(1, 'editor', 'new-name');
+      expect(deps.updateUsersByRole).toHaveBeenNthCalledWith(2, 'new-name', 'editor');
+    });
+
     it('returns 500 on unexpected error', async () => {
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValue(mockRole()),

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -1196,6 +1196,28 @@ describe('createAdminRolesHandlers', () => {
       });
     });
 
+    it('returns 400 even when rollback updateUser throws', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole({ name: SystemRoles.ADMIN })),
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: SystemRoles.ADMIN })),
+        countUsersByRole: jest.fn().mockResolvedValueOnce(2).mockResolvedValueOnce(0),
+        updateUser: jest
+          .fn()
+          .mockResolvedValueOnce(mockUser({ role: SystemRoles.USER }))
+          .mockRejectedValueOnce(new Error('rollback failed')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: SystemRoles.ADMIN, userId: validUserId },
+      });
+
+      await handlers.removeRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Cannot remove the last admin user' });
+      expect(deps.updateUser).toHaveBeenCalledTimes(2);
+    });
+
     it('returns 500 on unexpected error', async () => {
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValue(mockRole()),

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -191,6 +191,22 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.createRoleByName).not.toHaveBeenCalled();
     });
 
+    it('returns 400 when description exceeds max length', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { name: 'editor', description: 'a'.repeat(2001) },
+      });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({
+        error: 'description must not exceed 2000 characters',
+      });
+      expect(deps.createRoleByName).not.toHaveBeenCalled();
+    });
+
     it('returns 409 when role already exists', async () => {
       const deps = createDeps({
         createRoleByName: jest.fn().mockRejectedValue(new Error('Role "editor" already exists')),
@@ -487,6 +503,44 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.updateUsersByRole).toHaveBeenNthCalledWith(2, 'new-name', 'editor');
     });
 
+    it('rolls back user migration when rename throws', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
+        updateRoleByName: jest.fn().mockRejectedValue(new Error('db crash')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: 'new-name' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(deps.updateUsersByRole).toHaveBeenCalledTimes(2);
+      expect(deps.updateUsersByRole).toHaveBeenNthCalledWith(1, 'editor', 'new-name');
+      expect(deps.updateUsersByRole).toHaveBeenNthCalledWith(2, 'new-name', 'editor');
+    });
+
+    it('returns 400 when description exceeds max length', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { description: 'a'.repeat(2001) },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({
+        error: 'description must not exceed 2000 characters',
+      });
+      expect(deps.updateRoleByName).not.toHaveBeenCalled();
+    });
+
     it('returns 500 on unexpected error', async () => {
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValue(mockRole()),
@@ -586,7 +640,7 @@ describe('createAdminRolesHandlers', () => {
 
   describe('deleteRole', () => {
     it('deletes role and returns 200', async () => {
-      const deps = createDeps({ getRoleByName: jest.fn().mockResolvedValue(mockRole()) });
+      const deps = createDeps();
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes({ params: { name: 'editor' } });
 
@@ -610,7 +664,7 @@ describe('createAdminRolesHandlers', () => {
     });
 
     it('returns 404 when role not found', async () => {
-      const deps = createDeps({ getRoleByName: jest.fn().mockResolvedValue(null) });
+      const deps = createDeps({ deleteRoleByName: jest.fn().mockResolvedValue(null) });
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes({ params: { name: 'nonexistent' } });
 
@@ -622,7 +676,6 @@ describe('createAdminRolesHandlers', () => {
 
     it('returns 500 on error', async () => {
       const deps = createDeps({
-        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
         deleteRoleByName: jest.fn().mockRejectedValue(new Error('db down')),
       });
       const handlers = createAdminRolesHandlers(deps);

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -1,0 +1,628 @@
+import { Types } from 'mongoose';
+import { SystemRoles } from 'librechat-data-provider';
+import type { IRole, IUser } from '@librechat/data-schemas';
+import type { ServerRequest } from '~/types/http';
+import type { AdminRolesDeps } from './roles';
+import type { Response } from 'express';
+import { createAdminRolesHandlers } from './roles';
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+const validUserId = new Types.ObjectId().toString();
+
+function mockRole(overrides: Partial<IRole> = {}): IRole {
+  return {
+    name: 'editor',
+    description: 'Can edit content',
+    permissions: {},
+    ...overrides,
+  } as IRole;
+}
+
+function mockUser(overrides: Partial<IUser> = {}): IUser {
+  return {
+    _id: new Types.ObjectId(validUserId),
+    name: 'Test User',
+    email: 'test@example.com',
+    avatar: 'https://example.com/avatar.png',
+    role: 'editor',
+    ...overrides,
+  } as IUser;
+}
+
+function createReqRes(
+  overrides: {
+    params?: Record<string, string>;
+    query?: Record<string, string>;
+    body?: Record<string, unknown>;
+  } = {},
+) {
+  const req = {
+    params: overrides.params ?? {},
+    query: overrides.query ?? {},
+    body: overrides.body ?? {},
+  } as unknown as ServerRequest;
+
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  const res = { status, json } as unknown as Response;
+
+  return { req, res, status, json };
+}
+
+function createDeps(overrides: Partial<AdminRolesDeps> = {}): AdminRolesDeps {
+  return {
+    listRoles: jest.fn().mockResolvedValue([]),
+    getRoleByName: jest.fn().mockResolvedValue(null),
+    createRoleByName: jest.fn().mockResolvedValue(mockRole()),
+    updateRoleByName: jest.fn().mockResolvedValue(mockRole()),
+    updateAccessPermissions: jest.fn().mockResolvedValue(undefined),
+    deleteRoleByName: jest.fn().mockResolvedValue(mockRole()),
+    findUser: jest.fn().mockResolvedValue(null),
+    updateUser: jest.fn().mockResolvedValue(mockUser()),
+    listUsersByRole: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+describe('createAdminRolesHandlers', () => {
+  describe('listRoles', () => {
+    it('returns roles with 200', async () => {
+      const roles = [mockRole()];
+      const deps = createDeps({ listRoles: jest.fn().mockResolvedValue(roles) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.listRoles(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ roles });
+    });
+
+    it('returns 500 on error', async () => {
+      const deps = createDeps({ listRoles: jest.fn().mockRejectedValue(new Error('db down')) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.listRoles(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to list roles' });
+    });
+  });
+
+  describe('getRole', () => {
+    it('returns role with 200', async () => {
+      const role = mockRole();
+      const deps = createDeps({ getRoleByName: jest.fn().mockResolvedValue(role) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: 'editor' } });
+
+      await handlers.getRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ role });
+    });
+
+    it('returns 404 when role not found', async () => {
+      const deps = createDeps({ getRoleByName: jest.fn().mockResolvedValue(null) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: 'nonexistent' } });
+
+      await handlers.getRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
+    });
+  });
+
+  describe('createRole', () => {
+    it('creates role and returns 201', async () => {
+      const role = mockRole();
+      const deps = createDeps({ createRoleByName: jest.fn().mockResolvedValue(role) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { name: 'editor', description: 'Can edit' },
+      });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(201);
+      expect(json).toHaveBeenCalledWith({ role });
+      expect(deps.createRoleByName).toHaveBeenCalledWith({
+        name: 'editor',
+        description: 'Can edit',
+        permissions: {},
+      });
+    });
+
+    it('returns 400 when name is missing', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: {} });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'name is required' });
+      expect(deps.createRoleByName).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when name is whitespace-only', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: { name: '   ' } });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'name is required' });
+    });
+
+    it('returns 409 when role already exists', async () => {
+      const deps = createDeps({
+        createRoleByName: jest.fn().mockRejectedValue(new Error('Role "editor" already exists')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: { name: 'editor' } });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(409);
+      expect(json).toHaveBeenCalledWith({ error: 'Role "editor" already exists' });
+    });
+
+    it('returns 409 when name is reserved system role', async () => {
+      const deps = createDeps({
+        createRoleByName: jest
+          .fn()
+          .mockRejectedValue(new Error('Cannot create role with reserved system name: ADMIN')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: { name: 'ADMIN' } });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(409);
+      expect(json).toHaveBeenCalledWith({
+        error: 'Cannot create role with reserved system name: ADMIN',
+      });
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      const deps = createDeps({
+        createRoleByName: jest.fn().mockRejectedValue(new Error('db crash')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: { name: 'editor' } });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'db crash' });
+    });
+  });
+
+  describe('updateRole', () => {
+    it('updates role and returns 200', async () => {
+      const role = mockRole({ name: 'senior-editor' });
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        updateRoleByName: jest.fn().mockResolvedValue(role),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: 'senior-editor' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ role });
+    });
+
+    it('returns 400 when name is empty string', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: '' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'name must be a non-empty string' });
+      expect(deps.getRoleByName).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when name is whitespace-only', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: '   ' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'name must be a non-empty string' });
+    });
+
+    it('returns 409 when renaming to a system role', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: SystemRoles.ADMIN },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(409);
+      expect(json).toHaveBeenCalledWith({ error: 'Cannot rename to a reserved system role name' });
+    });
+
+    it('returns 404 when role not found', async () => {
+      const deps = createDeps({ getRoleByName: jest.fn().mockResolvedValue(null) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'nonexistent' },
+        body: { description: 'updated' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        updateRoleByName: jest.fn().mockRejectedValue(new Error('db error')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { description: 'updated' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to update role' });
+    });
+  });
+
+  describe('updateRolePermissions', () => {
+    it('updates permissions and returns 200', async () => {
+      const role = mockRole();
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(role),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const perms = { chat: { read: true, write: true } };
+      const { req, res, status } = createReqRes({
+        params: { name: 'editor' },
+        body: { permissions: perms },
+      });
+
+      await handlers.updateRolePermissions(req, res);
+
+      expect(deps.updateAccessPermissions).toHaveBeenCalledWith('editor', perms, role);
+      expect(status).toHaveBeenCalledWith(200);
+    });
+
+    it('returns 400 when permissions is missing', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: {},
+      });
+
+      await handlers.updateRolePermissions(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'permissions object is required' });
+    });
+
+    it('returns 404 when role not found', async () => {
+      const deps = createDeps({ getRoleByName: jest.fn().mockResolvedValue(null) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'nonexistent' },
+        body: { permissions: { chat: { read: true } } },
+      });
+
+      await handlers.updateRolePermissions(req, res);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
+    });
+  });
+
+  describe('deleteRole', () => {
+    it('deletes role and returns 200', async () => {
+      const deps = createDeps({ getRoleByName: jest.fn().mockResolvedValue(mockRole()) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: 'editor' } });
+
+      await handlers.deleteRole(req, res);
+
+      expect(deps.deleteRoleByName).toHaveBeenCalledWith('editor');
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('returns 403 for system role', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: SystemRoles.ADMIN } });
+
+      await handlers.deleteRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(403);
+      expect(json).toHaveBeenCalledWith({ error: 'Cannot delete system role' });
+      expect(deps.deleteRoleByName).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when role not found', async () => {
+      const deps = createDeps({ getRoleByName: jest.fn().mockResolvedValue(null) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: 'nonexistent' } });
+
+      await handlers.deleteRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
+    });
+  });
+
+  describe('getRoleMembers', () => {
+    it('returns members with 200', async () => {
+      const user = mockUser();
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        listUsersByRole: jest.fn().mockResolvedValue([user]),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: 'editor' } });
+
+      await handlers.getRoleMembers(req, res);
+
+      expect(deps.listUsersByRole).toHaveBeenCalledWith('editor');
+      expect(status).toHaveBeenCalledWith(200);
+      const members = json.mock.calls[0][0].members;
+      expect(members).toHaveLength(1);
+      expect(members[0]).toEqual({
+        userId: validUserId,
+        name: 'Test User',
+        email: 'test@example.com',
+        avatarUrl: 'https://example.com/avatar.png',
+      });
+    });
+
+    it('does not include joinedAt in response', async () => {
+      const user = mockUser({ createdAt: new Date() } as Partial<IUser>);
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        listUsersByRole: jest.fn().mockResolvedValue([user]),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, json } = createReqRes({ params: { name: 'editor' } });
+
+      await handlers.getRoleMembers(req, res);
+
+      const member = json.mock.calls[0][0].members[0];
+      expect(member).not.toHaveProperty('joinedAt');
+    });
+
+    it('returns empty array when no members', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        listUsersByRole: jest.fn().mockResolvedValue([]),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: 'editor' } });
+
+      await handlers.getRoleMembers(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ members: [] });
+    });
+
+    it('returns 404 when role not found', async () => {
+      const deps = createDeps({ getRoleByName: jest.fn().mockResolvedValue(null) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: 'nonexistent' } });
+
+      await handlers.getRoleMembers(req, res);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
+    });
+  });
+
+  describe('addRoleMember', () => {
+    it('adds member and returns 200', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        findUser: jest.fn().mockResolvedValue(mockUser()),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { userId: validUserId },
+      });
+
+      await handlers.addRoleMember(req, res);
+
+      expect(deps.updateUser).toHaveBeenCalledWith(validUserId, { role: 'editor' });
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('returns 400 when userId is missing', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: {},
+      });
+
+      await handlers.addRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'userId is required' });
+    });
+
+    it('returns 400 for invalid ObjectId', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { userId: 'not-valid' },
+      });
+
+      await handlers.addRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid user ID format' });
+    });
+
+    it('returns 404 when role not found', async () => {
+      const deps = createDeps({ getRoleByName: jest.fn().mockResolvedValue(null) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'nonexistent' },
+        body: { userId: validUserId },
+      });
+
+      await handlers.addRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
+    });
+
+    it('returns 404 when user not found', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        findUser: jest.fn().mockResolvedValue(null),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { userId: validUserId },
+      });
+
+      await handlers.addRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(json).toHaveBeenCalledWith({ error: 'User not found' });
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        findUser: jest.fn().mockResolvedValue(mockUser()),
+        updateUser: jest.fn().mockRejectedValue(new Error('timeout')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { userId: validUserId },
+      });
+
+      await handlers.addRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to add role member' });
+    });
+  });
+
+  describe('removeRoleMember', () => {
+    it('removes member and returns 200', async () => {
+      const deps = createDeps({
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: 'editor' })),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor', userId: validUserId },
+      });
+
+      await handlers.removeRoleMember(req, res);
+
+      expect(deps.updateUser).toHaveBeenCalledWith(validUserId, { role: SystemRoles.USER });
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('returns 400 for invalid ObjectId', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor', userId: 'bad' },
+      });
+
+      await handlers.removeRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid user ID format' });
+      expect(deps.findUser).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when user not found', async () => {
+      const deps = createDeps({ findUser: jest.fn().mockResolvedValue(null) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor', userId: validUserId },
+      });
+
+      await handlers.removeRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(json).toHaveBeenCalledWith({ error: 'User not found' });
+    });
+
+    it('returns 400 when user is not a member of the role', async () => {
+      const deps = createDeps({
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: 'other-role' })),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor', userId: validUserId },
+      });
+
+      await handlers.removeRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'User is not a member of this role' });
+      expect(deps.updateUser).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      const deps = createDeps({
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: 'editor' })),
+        updateUser: jest.fn().mockRejectedValue(new Error('timeout')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor', userId: validUserId },
+      });
+
+      await handlers.removeRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to remove role member' });
+    });
+  });
+});

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -1086,6 +1086,42 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.updateUser).not.toHaveBeenCalled();
     });
 
+    it('returns 400 when removing the last admin user', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole({ name: SystemRoles.ADMIN })),
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: SystemRoles.ADMIN })),
+        countUsersByRole: jest.fn().mockResolvedValue(1),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: SystemRoles.ADMIN, userId: validUserId },
+      });
+
+      await handlers.removeRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Cannot remove the last admin user' });
+      expect(deps.updateUser).not.toHaveBeenCalled();
+    });
+
+    it('allows removing an admin when multiple admins exist', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole({ name: SystemRoles.ADMIN })),
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: SystemRoles.ADMIN })),
+        countUsersByRole: jest.fn().mockResolvedValue(3),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: SystemRoles.ADMIN, userId: validUserId },
+      });
+
+      await handlers.removeRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ success: true });
+      expect(deps.updateUser).toHaveBeenCalledWith(validUserId, { role: SystemRoles.USER });
+    });
+
     it('returns 500 on unexpected error', async () => {
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValue(mockRole()),

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -703,7 +703,7 @@ describe('createAdminRolesHandlers', () => {
       });
       const handlers = createAdminRolesHandlers(deps);
       const perms = { chat: { read: true, write: true } };
-      const { req, res, status } = createReqRes({
+      const { req, res, status, json } = createReqRes({
         params: { name: 'editor' },
         body: { permissions: perms },
       });
@@ -712,6 +712,7 @@ describe('createAdminRolesHandlers', () => {
 
       expect(deps.updateAccessPermissions).toHaveBeenCalledWith('editor', perms, role);
       expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ role: expect.objectContaining({ name: 'editor' }) });
     });
 
     it('returns 400 when permissions is missing', async () => {
@@ -945,7 +946,7 @@ describe('createAdminRolesHandlers', () => {
     it('adds member and returns 200', async () => {
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValue(mockRole()),
-        findUser: jest.fn().mockResolvedValue(mockUser()),
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: 'viewer' })),
       });
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes({
@@ -958,6 +959,24 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.updateUser).toHaveBeenCalledWith(validUserId, { role: 'editor' });
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('skips DB write when user already has the target role', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: 'editor' })),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { userId: validUserId },
+      });
+
+      await handlers.addRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ success: true });
+      expect(deps.updateUser).not.toHaveBeenCalled();
     });
 
     it('returns 400 when userId is missing', async () => {
@@ -1022,7 +1041,7 @@ describe('createAdminRolesHandlers', () => {
     it('returns 500 on unexpected error', async () => {
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValue(mockRole()),
-        findUser: jest.fn().mockResolvedValue(mockUser()),
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: 'viewer' })),
         updateUser: jest.fn().mockRejectedValue(new Error('timeout')),
       });
       const handlers = createAdminRolesHandlers(deps);
@@ -1151,6 +1170,30 @@ describe('createAdminRolesHandlers', () => {
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith({ success: true });
       expect(deps.updateUser).toHaveBeenCalledWith(validUserId, { role: SystemRoles.USER });
+    });
+
+    it('rolls back removal when post-write check finds zero admins', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole({ name: SystemRoles.ADMIN })),
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: SystemRoles.ADMIN })),
+        countUsersByRole: jest.fn().mockResolvedValueOnce(2).mockResolvedValueOnce(0),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: SystemRoles.ADMIN, userId: validUserId },
+      });
+
+      await handlers.removeRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Cannot remove the last admin user' });
+      expect(deps.updateUser).toHaveBeenCalledTimes(2);
+      expect(deps.updateUser).toHaveBeenNthCalledWith(1, validUserId, {
+        role: SystemRoles.USER,
+      });
+      expect(deps.updateUser).toHaveBeenNthCalledWith(2, validUserId, {
+        role: SystemRoles.ADMIN,
+      });
     });
 
     it('returns 500 on unexpected error', async () => {

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -1,16 +1,14 @@
 import { Types } from 'mongoose';
 import { SystemRoles } from 'librechat-data-provider';
 import type { IRole, IUser } from '@librechat/data-schemas';
+import type { Response } from 'express';
 import type { ServerRequest } from '~/types/http';
 import type { AdminRolesDeps } from './roles';
-import type { Response } from 'express';
 import { createAdminRolesHandlers } from './roles';
 
 jest.mock('@librechat/data-schemas', () => ({
   ...jest.requireActual('@librechat/data-schemas'),
-  logger: {
-    error: jest.fn(),
-  },
+  logger: { error: jest.fn() },
 }));
 
 const validUserId = new Types.ObjectId().toString();
@@ -65,7 +63,9 @@ function createDeps(overrides: Partial<AdminRolesDeps> = {}): AdminRolesDeps {
     deleteRoleByName: jest.fn().mockResolvedValue(mockRole()),
     findUser: jest.fn().mockResolvedValue(null),
     updateUser: jest.fn().mockResolvedValue(mockUser()),
+    updateUsersByRole: jest.fn().mockResolvedValue(undefined),
     listUsersByRole: jest.fn().mockResolvedValue([]),
+    countUsersByRole: jest.fn().mockResolvedValue(0),
     ...overrides,
   };
 }
@@ -119,6 +119,19 @@ describe('createAdminRolesHandlers', () => {
       expect(status).toHaveBeenCalledWith(404);
       expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
     });
+
+    it('returns 500 on error', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockRejectedValue(new Error('db down')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: 'editor' } });
+
+      await handlers.getRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to get role' });
+    });
   });
 
   describe('createRole', () => {
@@ -164,6 +177,20 @@ describe('createAdminRolesHandlers', () => {
       expect(json).toHaveBeenCalledWith({ error: 'name is required' });
     });
 
+    it('returns 400 when name exceeds max length', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { name: 'a'.repeat(501) },
+      });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'name must not exceed 500 characters' });
+      expect(deps.createRoleByName).not.toHaveBeenCalled();
+    });
+
     it('returns 409 when role already exists', async () => {
       const deps = createDeps({
         createRoleByName: jest.fn().mockRejectedValue(new Error('Role "editor" already exists')),
@@ -206,13 +233,27 @@ describe('createAdminRolesHandlers', () => {
       expect(status).toHaveBeenCalledWith(500);
       expect(json).toHaveBeenCalledWith({ error: 'db crash' });
     });
+
+    it('does not classify unrelated errors as 409', async () => {
+      const deps = createDeps({
+        createRoleByName: jest
+          .fn()
+          .mockRejectedValue(new Error('Disk space reserved for system use')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status } = createReqRes({ body: { name: 'test' } });
+
+      await handlers.createRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+    });
   });
 
   describe('updateRole', () => {
     it('updates role and returns 200', async () => {
       const role = mockRole({ name: 'senior-editor' });
       const deps = createDeps({
-        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
         updateRoleByName: jest.fn().mockResolvedValue(role),
       });
       const handlers = createAdminRolesHandlers(deps);
@@ -225,6 +266,104 @@ describe('createAdminRolesHandlers', () => {
 
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith({ role });
+      expect(deps.updateRoleByName).toHaveBeenCalledWith('editor', { name: 'senior-editor' });
+    });
+
+    it('trims name before storage', async () => {
+      const role = mockRole({ name: 'trimmed' });
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
+        updateRoleByName: jest.fn().mockResolvedValue(role),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: '  trimmed  ' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(deps.updateRoleByName).toHaveBeenCalledWith('editor', { name: 'trimmed' });
+    });
+
+    it('migrates users after rename', async () => {
+      const role = mockRole({ name: 'new-name' });
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValueOnce(mockRole()).mockResolvedValueOnce(null),
+        updateRoleByName: jest.fn().mockResolvedValue(role),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: 'new-name' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(deps.updateUsersByRole).toHaveBeenCalledWith('editor', 'new-name');
+    });
+
+    it('does not migrate users when name unchanged', async () => {
+      const role = mockRole({ description: 'updated' });
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        updateRoleByName: jest.fn().mockResolvedValue(role),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res } = createReqRes({
+        params: { name: 'editor' },
+        body: { description: 'updated' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(deps.updateUsersByRole).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when renaming a system role', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: SystemRoles.ADMIN },
+        body: { name: 'custom-admin' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(403);
+      expect(json).toHaveBeenCalledWith({ error: 'Cannot rename system role' });
+      expect(deps.getRoleByName).not.toHaveBeenCalled();
+    });
+
+    it('returns 409 when renaming to a system role name', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: SystemRoles.ADMIN },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(409);
+      expect(json).toHaveBeenCalledWith({ error: 'Cannot rename to a reserved system role name' });
+    });
+
+    it('returns 409 when target name already exists', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { name: 'viewer' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(409);
+      expect(json).toHaveBeenCalledWith({ error: 'Role "viewer" already exists' });
     });
 
     it('returns 400 when name is empty string', async () => {
@@ -256,18 +395,19 @@ describe('createAdminRolesHandlers', () => {
       expect(json).toHaveBeenCalledWith({ error: 'name must be a non-empty string' });
     });
 
-    it('returns 409 when renaming to a system role', async () => {
+    it('returns 400 when name exceeds max length', async () => {
       const deps = createDeps();
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes({
         params: { name: 'editor' },
-        body: { name: SystemRoles.ADMIN },
+        body: { name: 'a'.repeat(501) },
       });
 
       await handlers.updateRole(req, res);
 
-      expect(status).toHaveBeenCalledWith(409);
-      expect(json).toHaveBeenCalledWith({ error: 'Cannot rename to a reserved system role name' });
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'name must not exceed 500 characters' });
+      expect(deps.getRoleByName).not.toHaveBeenCalled();
     });
 
     it('returns 404 when role not found', async () => {
@@ -275,6 +415,23 @@ describe('createAdminRolesHandlers', () => {
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes({
         params: { name: 'nonexistent' },
+        body: { description: 'updated' },
+      });
+
+      await handlers.updateRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
+    });
+
+    it('returns 404 when updateRoleByName returns null', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        updateRoleByName: jest.fn().mockResolvedValue(null),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
         body: { description: 'updated' },
       });
 
@@ -335,6 +492,20 @@ describe('createAdminRolesHandlers', () => {
       expect(json).toHaveBeenCalledWith({ error: 'permissions object is required' });
     });
 
+    it('returns 400 when permissions is an array', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { permissions: [1, 2, 3] },
+      });
+
+      await handlers.updateRolePermissions(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'permissions object is required' });
+    });
+
     it('returns 404 when role not found', async () => {
       const deps = createDeps({ getRoleByName: jest.fn().mockResolvedValue(null) });
       const handlers = createAdminRolesHandlers(deps);
@@ -347,6 +518,23 @@ describe('createAdminRolesHandlers', () => {
 
       expect(status).toHaveBeenCalledWith(404);
       expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
+    });
+
+    it('returns 500 on error', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        updateAccessPermissions: jest.fn().mockRejectedValue(new Error('db down')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { permissions: { chat: { read: true } } },
+      });
+
+      await handlers.updateRolePermissions(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to update role permissions' });
     });
   });
 
@@ -385,37 +573,89 @@ describe('createAdminRolesHandlers', () => {
       expect(status).toHaveBeenCalledWith(404);
       expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
     });
+
+    it('returns 500 on error', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        deleteRoleByName: jest.fn().mockRejectedValue(new Error('db down')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: 'editor' } });
+
+      await handlers.deleteRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to delete role' });
+    });
   });
 
   describe('getRoleMembers', () => {
-    it('returns members with 200', async () => {
+    it('returns paginated members with 200', async () => {
       const user = mockUser();
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValue(mockRole()),
         listUsersByRole: jest.fn().mockResolvedValue([user]),
+        countUsersByRole: jest.fn().mockResolvedValue(1),
       });
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes({ params: { name: 'editor' } });
 
       await handlers.getRoleMembers(req, res);
 
-      expect(deps.listUsersByRole).toHaveBeenCalledWith('editor');
+      expect(deps.listUsersByRole).toHaveBeenCalledWith('editor', { limit: 50, offset: 0 });
+      expect(deps.countUsersByRole).toHaveBeenCalledWith('editor');
       expect(status).toHaveBeenCalledWith(200);
-      const members = json.mock.calls[0][0].members;
-      expect(members).toHaveLength(1);
-      expect(members[0]).toEqual({
+      const response = json.mock.calls[0][0];
+      expect(response.members).toHaveLength(1);
+      expect(response.members[0]).toEqual({
         userId: validUserId,
         name: 'Test User',
         email: 'test@example.com',
         avatarUrl: 'https://example.com/avatar.png',
       });
+      expect(response.total).toBe(1);
+      expect(response.limit).toBe(50);
+      expect(response.offset).toBe(0);
+    });
+
+    it('passes pagination parameters from query', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        countUsersByRole: jest.fn().mockResolvedValue(0),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res } = createReqRes({
+        params: { name: 'editor' },
+        query: { limit: '10', offset: '20' },
+      });
+
+      await handlers.getRoleMembers(req, res);
+
+      expect(deps.listUsersByRole).toHaveBeenCalledWith('editor', { limit: 10, offset: 20 });
+    });
+
+    it('clamps limit to 200', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        countUsersByRole: jest.fn().mockResolvedValue(0),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res } = createReqRes({
+        params: { name: 'editor' },
+        query: { limit: '999' },
+      });
+
+      await handlers.getRoleMembers(req, res);
+
+      expect(deps.listUsersByRole).toHaveBeenCalledWith('editor', { limit: 200, offset: 0 });
     });
 
     it('does not include joinedAt in response', async () => {
-      const user = mockUser({ createdAt: new Date() } as Partial<IUser>);
+      const user = mockUser();
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValue(mockRole()),
         listUsersByRole: jest.fn().mockResolvedValue([user]),
+        countUsersByRole: jest.fn().mockResolvedValue(1),
       });
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, json } = createReqRes({ params: { name: 'editor' } });
@@ -429,7 +669,7 @@ describe('createAdminRolesHandlers', () => {
     it('returns empty array when no members', async () => {
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValue(mockRole()),
-        listUsersByRole: jest.fn().mockResolvedValue([]),
+        countUsersByRole: jest.fn().mockResolvedValue(0),
       });
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes({ params: { name: 'editor' } });
@@ -437,7 +677,7 @@ describe('createAdminRolesHandlers', () => {
       await handlers.getRoleMembers(req, res);
 
       expect(status).toHaveBeenCalledWith(200);
-      expect(json).toHaveBeenCalledWith({ members: [] });
+      expect(json).toHaveBeenCalledWith({ members: [], total: 0, limit: 50, offset: 0 });
     });
 
     it('returns 404 when role not found', async () => {
@@ -449,6 +689,20 @@ describe('createAdminRolesHandlers', () => {
 
       expect(status).toHaveBeenCalledWith(404);
       expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
+    });
+
+    it('returns 500 on error', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        listUsersByRole: jest.fn().mockRejectedValue(new Error('db down')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: 'editor' } });
+
+      await handlers.getRoleMembers(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to get role members' });
     });
   });
 
@@ -552,6 +806,7 @@ describe('createAdminRolesHandlers', () => {
   describe('removeRoleMember', () => {
     it('removes member and returns 200', async () => {
       const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
         findUser: jest.fn().mockResolvedValue(mockUser({ role: 'editor' })),
       });
       const handlers = createAdminRolesHandlers(deps);
@@ -580,8 +835,25 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.findUser).not.toHaveBeenCalled();
     });
 
+    it('returns 404 when role not found', async () => {
+      const deps = createDeps({ getRoleByName: jest.fn().mockResolvedValue(null) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'nonexistent', userId: validUserId },
+      });
+
+      await handlers.removeRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
+      expect(deps.findUser).not.toHaveBeenCalled();
+    });
+
     it('returns 404 when user not found', async () => {
-      const deps = createDeps({ findUser: jest.fn().mockResolvedValue(null) });
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
+        findUser: jest.fn().mockResolvedValue(null),
+      });
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status, json } = createReqRes({
         params: { name: 'editor', userId: validUserId },
@@ -595,6 +867,7 @@ describe('createAdminRolesHandlers', () => {
 
     it('returns 400 when user is not a member of the role', async () => {
       const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
         findUser: jest.fn().mockResolvedValue(mockUser({ role: 'other-role' })),
       });
       const handlers = createAdminRolesHandlers(deps);
@@ -611,6 +884,7 @@ describe('createAdminRolesHandlers', () => {
 
     it('returns 500 on unexpected error', async () => {
       const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole()),
         findUser: jest.fn().mockResolvedValue(mockUser({ role: 'editor' })),
         updateUser: jest.fn().mockRejectedValue(new Error('timeout')),
       });

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -1157,6 +1157,44 @@ describe('createAdminRolesHandlers', () => {
       expect(json).toHaveBeenCalledWith({ error: 'User not found' });
     });
 
+    it('returns 400 when reassigning the last admin to another role', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole({ name: 'editor' })),
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: SystemRoles.ADMIN })),
+        countUsersByRole: jest.fn().mockResolvedValue(1),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { userId: validUserId },
+      });
+
+      await handlers.addRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Cannot remove the last admin user' });
+      expect(deps.updateUser).not.toHaveBeenCalled();
+    });
+
+    it('allows reassigning an admin when multiple admins exist', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole({ name: 'editor' })),
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: SystemRoles.ADMIN })),
+        countUsersByRole: jest.fn().mockResolvedValue(3),
+        updateUser: jest.fn().mockResolvedValue(mockUser({ role: 'editor' })),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status } = createReqRes({
+        params: { name: 'editor' },
+        body: { userId: validUserId },
+      });
+
+      await handlers.addRoleMember(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(deps.updateUser).toHaveBeenCalledWith(validUserId, { role: 'editor' });
+    });
+
     it('returns 500 on unexpected error', async () => {
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValue(mockRole()),

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -1195,6 +1195,27 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.updateUser).toHaveBeenCalledWith(validUserId, { role: 'editor' });
     });
 
+    it('rolls back assignment when post-write admin count is zero', async () => {
+      const deps = createDeps({
+        getRoleByName: jest.fn().mockResolvedValue(mockRole({ name: 'editor' })),
+        findUser: jest.fn().mockResolvedValue(mockUser({ role: SystemRoles.ADMIN })),
+        countUsersByRole: jest.fn().mockResolvedValueOnce(2).mockResolvedValueOnce(0),
+        updateUser: jest.fn().mockResolvedValue(mockUser()),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { name: 'editor' },
+        body: { userId: validUserId },
+      });
+
+      await handlers.addRoleMember(req, res);
+
+      expect(deps.updateUser).toHaveBeenCalledTimes(2);
+      expect(deps.updateUser).toHaveBeenLastCalledWith(validUserId, { role: SystemRoles.ADMIN });
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Cannot remove the last admin user' });
+    });
+
     it('returns 500 on unexpected error', async () => {
       const deps = createDeps({
         getRoleByName: jest.fn().mockResolvedValue(mockRole()),

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -6,8 +6,11 @@ import type { Response } from 'express';
 import type { ServerRequest } from '~/types/http';
 import { parsePagination } from './pagination';
 
+const systemRoleValues = new Set<string>(Object.values(SystemRoles));
 const MAX_NAME_LENGTH = 500;
 const MAX_DESCRIPTION_LENGTH = 2000;
+const CONTROL_CHAR_RE = /\p{Cc}/u;
+const RESERVED_ROLE_NAMES = new Set(['members', 'permissions']);
 
 function validateNameParam(name: string): string | null {
   if (!name || typeof name !== 'string') {
@@ -20,17 +23,20 @@ function validateNameParam(name: string): string | null {
 }
 
 function validateRoleName(name: unknown, required: boolean): string | null {
-  if (required) {
-    if (!name || typeof name !== 'string' || !(name as string).trim()) {
-      return 'name is required';
-    }
-  } else if (name !== undefined) {
-    if (!name || typeof name !== 'string' || !(name as string).trim()) {
-      return 'name must be a non-empty string';
-    }
+  if (name === undefined) {
+    return required ? 'name is required' : null;
   }
-  if (name !== undefined && typeof name === 'string' && name.trim().length > MAX_NAME_LENGTH) {
+  if (typeof name !== 'string' || !name.trim()) {
+    return required ? 'name is required' : 'name must be a non-empty string';
+  }
+  if (name.trim().length > MAX_NAME_LENGTH) {
     return `name must not exceed ${MAX_NAME_LENGTH} characters`;
+  }
+  if (CONTROL_CHAR_RE.test(name)) {
+    return 'name contains invalid characters';
+  }
+  if (RESERVED_ROLE_NAMES.has(name.trim().toLowerCase())) {
+    return 'name is a reserved path segment';
   }
   return null;
 }
@@ -176,7 +182,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         try {
           await updateUsersByRole(newName, currentName);
         } catch (rollbackError) {
-          logger.error('[adminRoles] rollback failed (role not found path):', rollbackError);
+          logger.error(
+            `[adminRoles] CRITICAL: rename rollback failed — users have dangling role "${newName}":`,
+            rollbackError,
+          );
         }
       }
       return role;
@@ -184,7 +193,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       try {
         await updateUsersByRole(newName, currentName);
       } catch (rollbackError) {
-        logger.error('[adminRoles] rollback failed after updateRole error:', rollbackError);
+        logger.error(
+          `[adminRoles] CRITICAL: rename rollback failed — users have dangling role "${newName}":`,
+          rollbackError,
+        );
       }
       throw error;
     }
@@ -210,10 +222,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       const trimmedName = body.name?.trim() ?? '';
       const isRename = trimmedName !== '' && trimmedName !== name;
 
-      if (isRename && SystemRoles[name as keyof typeof SystemRoles]) {
+      if (isRename && systemRoleValues.has(name)) {
         return res.status(403).json({ error: 'Cannot rename system role' });
       }
-      if (isRename && SystemRoles[trimmedName as keyof typeof SystemRoles]) {
+      if (isRename && systemRoleValues.has(trimmedName)) {
         return res.status(403).json({ error: 'Cannot use a reserved system role name' });
       }
 
@@ -310,7 +322,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       if (paramError) {
         return res.status(400).json({ error: paramError });
       }
-      if (SystemRoles[name as keyof typeof SystemRoles]) {
+      if (systemRoleValues.has(name)) {
         return res.status(403).json({ error: 'Cannot delete system role' });
       }
 
@@ -403,6 +415,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       }
       if (!isValidObjectIdString(userId)) {
         return res.status(400).json({ error: 'Invalid user ID format' });
+      }
+
+      if (systemRoleValues.has(name) && name !== SystemRoles.ADMIN) {
+        return res.status(403).json({ error: 'Cannot remove members from a system role' });
       }
 
       const existing = await getRoleByName(name);

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -337,6 +337,13 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(400).json({ error: 'User is not a member of this role' });
       }
 
+      if (name === SystemRoles.ADMIN) {
+        const adminCount = await countUsersByRole(SystemRoles.ADMIN);
+        if (adminCount <= 1) {
+          return res.status(400).json({ error: 'Cannot remove the last admin user' });
+        }
+      }
+
       await updateUser(userId, { role: SystemRoles.USER });
       return res.status(200).json({ success: true });
     } catch (error) {

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -85,6 +85,8 @@ export interface AdminRolesDeps {
   ) => Promise<IUser | null>;
   updateUser: (userId: string, data: Partial<IUser>) => Promise<IUser | null>;
   updateUsersByRole: (oldRole: string, newRole: string) => Promise<void>;
+  findUserIdsByRole: (roleName: string) => Promise<string[]>;
+  updateUsersRoleByIds: (userIds: string[], newRole: string) => Promise<void>;
   listUsersByRole: (
     roleName: string,
     options?: { limit?: number; offset?: number },
@@ -104,6 +106,8 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
     findUser,
     updateUser,
     updateUsersByRole,
+    findUserIdsByRole,
+    updateUsersRoleByIds,
     listUsersByRole,
     countUsersByRole,
   } = deps;
@@ -176,35 +180,40 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
     }
   }
 
+  async function rollbackMigratedUsers(
+    migratedIds: string[],
+    currentName: string,
+    newName: string,
+  ): Promise<void> {
+    if (migratedIds.length === 0) {
+      return;
+    }
+    try {
+      await updateUsersRoleByIds(migratedIds, currentName);
+    } catch (rollbackError) {
+      logger.error(
+        `[adminRoles] CRITICAL: rename rollback failed — ${migratedIds.length} users have dangling role "${newName}":`,
+        rollbackError,
+      );
+    }
+  }
+
   async function renameRole(
     currentName: string,
     newName: string,
     extraUpdates?: Partial<IRole>,
   ): Promise<IRole | null> {
+    const migratedIds = await findUserIdsByRole(currentName);
     await updateUsersByRole(currentName, newName);
     try {
       const updates: Partial<IRole> = { name: newName, ...extraUpdates };
       const role = await updateRoleByName(currentName, updates);
       if (!role) {
-        try {
-          await updateUsersByRole(newName, currentName);
-        } catch (rollbackError) {
-          logger.error(
-            `[adminRoles] CRITICAL: rename rollback failed — users have dangling role "${newName}":`,
-            rollbackError,
-          );
-        }
+        await rollbackMigratedUsers(migratedIds, currentName, newName);
       }
       return role;
     } catch (error) {
-      try {
-        await updateUsersByRole(newName, currentName);
-      } catch (rollbackError) {
-        logger.error(
-          `[adminRoles] CRITICAL: rename rollback failed — users have dangling role "${newName}":`,
-          rollbackError,
-        );
-      }
+      await rollbackMigratedUsers(migratedIds, currentName, newName);
       throw error;
     }
   }

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -1,0 +1,246 @@
+import { SystemRoles } from 'librechat-data-provider';
+import { logger } from '@librechat/data-schemas';
+import type { IRole, IUser } from '@librechat/data-schemas';
+import type { FilterQuery } from 'mongoose';
+import type { Response } from 'express';
+import type { ServerRequest } from '~/types/http';
+
+interface RoleNameParams {
+  name: string;
+}
+
+interface RoleMemberParams extends RoleNameParams {
+  userId: string;
+}
+
+interface AdminMember {
+  userId: string;
+  name: string;
+  email: string;
+  avatarUrl?: string;
+  joinedAt: string;
+}
+
+export interface AdminRolesDeps {
+  listRoles: () => Promise<IRole[]>;
+  getRoleByName: (
+    name: string,
+    fields?: string | string[] | null,
+  ) => Promise<IRole | null>;
+  createRole: (roleData: Partial<IRole>) => Promise<IRole>;
+  updateRoleByName: (name: string, updates: Partial<IRole>) => Promise<IRole | null>;
+  updateAccessPermissions: (
+    name: string,
+    perms: Record<string, Record<string, boolean>>,
+    roleData?: IRole,
+  ) => Promise<void>;
+  deleteRole: (name: string) => Promise<IRole | null>;
+  findUser: (
+    criteria: FilterQuery<IUser>,
+    fields?: string | string[] | null,
+  ) => Promise<IUser | null>;
+  updateUser: (userId: string, data: Partial<IUser>) => Promise<IUser | null>;
+  countUsers: (filter?: FilterQuery<IUser>) => Promise<number>;
+  listUsersByRole: (roleName: string) => Promise<AdminMember[]>;
+}
+
+export function createAdminRolesHandlers(deps: AdminRolesDeps) {
+  const {
+    listRoles,
+    getRoleByName,
+    createRole,
+    updateRoleByName,
+    updateAccessPermissions,
+    deleteRole,
+    findUser,
+    updateUser,
+    countUsers,
+  } = deps;
+
+  async function listRolesHandler(_req: ServerRequest, res: Response) {
+    try {
+      const roles = await listRoles();
+      return res.status(200).json({ roles });
+    } catch (error) {
+      logger.error('[adminRoles] listRoles error:', error);
+      return res.status(500).json({ error: 'Failed to list roles' });
+    }
+  }
+
+  async function getRoleHandler(req: ServerRequest, res: Response) {
+    try {
+      const { name } = req.params as RoleNameParams;
+      const role = await getRoleByName(name);
+      if (!role) {
+        return res.status(404).json({ error: 'Role not found' });
+      }
+      return res.status(200).json({ role });
+    } catch (error) {
+      logger.error('[adminRoles] getRole error:', error);
+      return res.status(500).json({ error: 'Failed to get role' });
+    }
+  }
+
+  async function createRoleHandler(req: ServerRequest, res: Response) {
+    try {
+      const { name, permissions } = req.body as { name?: string; permissions?: IRole['permissions'] };
+      if (!name || typeof name !== 'string' || !name.trim()) {
+        return res.status(400).json({ error: 'name is required' });
+      }
+      const role = await createRole({
+        name: name.trim(),
+        permissions: permissions || {},
+      });
+      return res.status(201).json({ role });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to create role';
+      logger.error('[adminRoles] createRole error:', error);
+      const status = message.includes('already exists') || message.includes('reserved') ? 409 : 500;
+      return res.status(status).json({ error: message });
+    }
+  }
+
+  async function updateRoleHandler(req: ServerRequest, res: Response) {
+    try {
+      const { name } = req.params as RoleNameParams;
+      const body = req.body as Partial<IRole>;
+
+      const existing = await getRoleByName(name);
+      if (!existing) {
+        return res.status(404).json({ error: 'Role not found' });
+      }
+
+      const updates: Partial<IRole> = {};
+      if (body.name !== undefined) {
+        updates.name = body.name;
+      }
+
+      const role = await updateRoleByName(name, updates);
+      return res.status(200).json({ role });
+    } catch (error) {
+      logger.error('[adminRoles] updateRole error:', error);
+      return res.status(500).json({ error: 'Failed to update role' });
+    }
+  }
+
+  async function updateRolePermissionsHandler(req: ServerRequest, res: Response) {
+    try {
+      const { name } = req.params as RoleNameParams;
+      const { permissions } = req.body as {
+        permissions: Record<string, Record<string, boolean>>;
+      };
+
+      if (!permissions || typeof permissions !== 'object') {
+        return res.status(400).json({ error: 'permissions object is required' });
+      }
+
+      const existing = await getRoleByName(name);
+      if (!existing) {
+        return res.status(404).json({ error: 'Role not found' });
+      }
+
+      await updateAccessPermissions(name, permissions, existing);
+      const updated = await getRoleByName(name);
+      return res.status(200).json({ role: updated });
+    } catch (error) {
+      logger.error('[adminRoles] updateRolePermissions error:', error);
+      return res.status(500).json({ error: 'Failed to update role permissions' });
+    }
+  }
+
+  async function deleteRoleHandler(req: ServerRequest, res: Response) {
+    try {
+      const { name } = req.params as RoleNameParams;
+      if (SystemRoles[name as keyof typeof SystemRoles]) {
+        return res.status(403).json({ error: 'Cannot delete system role' });
+      }
+
+      const existing = await getRoleByName(name);
+      if (!existing) {
+        return res.status(404).json({ error: 'Role not found' });
+      }
+
+      await deleteRole(name);
+      return res.status(200).json({ success: true });
+    } catch (error) {
+      logger.error('[adminRoles] deleteRole error:', error);
+      return res.status(500).json({ error: 'Failed to delete role' });
+    }
+  }
+
+  async function getRoleMembersHandler(req: ServerRequest, res: Response) {
+    try {
+      const { name } = req.params as RoleNameParams;
+      const existing = await getRoleByName(name);
+      if (!existing) {
+        return res.status(404).json({ error: 'Role not found' });
+      }
+
+      const members = await deps.listUsersByRole(name);
+      return res.status(200).json({ members });
+    } catch (error) {
+      logger.error('[adminRoles] getRoleMembers error:', error);
+      return res.status(500).json({ error: 'Failed to get role members' });
+    }
+  }
+
+  async function addRoleMemberHandler(req: ServerRequest, res: Response) {
+    try {
+      const { name } = req.params as RoleNameParams;
+      const { userId } = req.body as { userId: string };
+
+      if (!userId || typeof userId !== 'string') {
+        return res.status(400).json({ error: 'userId is required' });
+      }
+
+      const existing = await getRoleByName(name);
+      if (!existing) {
+        return res.status(404).json({ error: 'Role not found' });
+      }
+
+      const user = await findUser({ _id: userId });
+      if (!user) {
+        return res.status(404).json({ error: 'User not found' });
+      }
+
+      await updateUser(userId, { role: name });
+      return res.status(200).json({ success: true });
+    } catch (error) {
+      logger.error('[adminRoles] addRoleMember error:', error);
+      return res.status(500).json({ error: 'Failed to add role member' });
+    }
+  }
+
+  async function removeRoleMemberHandler(req: ServerRequest, res: Response) {
+    try {
+      const { name, userId } = req.params as RoleMemberParams;
+
+      const user = await findUser({ _id: userId });
+      if (!user) {
+        return res.status(404).json({ error: 'User not found' });
+      }
+
+      if (user.role !== name) {
+        return res.status(400).json({ error: 'User is not a member of this role' });
+      }
+
+      await updateUser(userId, { role: SystemRoles.USER });
+      return res.status(200).json({ success: true });
+    } catch (error) {
+      logger.error('[adminRoles] removeRoleMember error:', error);
+      return res.status(500).json({ error: 'Failed to remove role member' });
+    }
+  }
+
+  return {
+    listRoles: listRolesHandler,
+    getRole: getRoleHandler,
+    createRole: createRoleHandler,
+    updateRole: updateRoleHandler,
+    updateRolePermissions: updateRolePermissionsHandler,
+    deleteRole: deleteRoleHandler,
+    getRoleMembers: getRoleMembersHandler,
+    addRoleMember: addRoleMemberHandler,
+    removeRoleMember: removeRoleMemberHandler,
+  };
+}

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -17,7 +17,8 @@ interface RoleMemberParams extends RoleNameParams {
 }
 
 export interface AdminRolesDeps {
-  listRoles: () => Promise<IRole[]>;
+  listRoles: (options?: { limit?: number; offset?: number }) => Promise<IRole[]>;
+  countRoles: () => Promise<number>;
   getRoleByName: (name: string, fields?: string | string[] | null) => Promise<IRole | null>;
   createRoleByName: (roleData: Partial<IRole>) => Promise<IRole>;
   updateRoleByName: (name: string, updates: Partial<IRole>) => Promise<IRole | null>;
@@ -43,6 +44,7 @@ export interface AdminRolesDeps {
 export function createAdminRolesHandlers(deps: AdminRolesDeps) {
   const {
     listRoles,
+    countRoles,
     getRoleByName,
     createRoleByName,
     updateRoleByName,
@@ -55,10 +57,12 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
     countUsersByRole,
   } = deps;
 
-  async function listRolesHandler(_req: ServerRequest, res: Response) {
+  async function listRolesHandler(req: ServerRequest, res: Response) {
     try {
-      const roles = await listRoles();
-      return res.status(200).json({ roles });
+      const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200);
+      const offset = Math.max(Number(req.query.offset) || 0, 0);
+      const [roles, total] = await Promise.all([listRoles({ limit, offset }), countRoles()]);
+      return res.status(200).json({ roles, total, limit, offset });
     } catch (error) {
       logger.error('[adminRoles] listRoles error:', error);
       return res.status(500).json({ error: 'Failed to list roles' });
@@ -233,6 +237,9 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
 
       await updateAccessPermissions(name, permissions, existing);
       const updated = await getRoleByName(name);
+      if (!updated) {
+        return res.status(404).json({ error: 'Role not found' });
+      }
       return res.status(200).json({ role: updated });
     } catch (error) {
       logger.error('[adminRoles] updateRolePermissions error:', error);

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -1,7 +1,7 @@
 import { SystemRoles } from 'librechat-data-provider';
 import { logger, isValidObjectIdString, RoleConflictError } from '@librechat/data-schemas';
 import type { IRole, IUser, AdminMember } from '@librechat/data-schemas';
-import type { FilterQuery } from 'mongoose';
+import type { FilterQuery, Types } from 'mongoose';
 import type { Response } from 'express';
 import type { ServerRequest } from '~/types/http';
 import { parsePagination } from './pagination';
@@ -10,7 +10,12 @@ const systemRoleValues = new Set<string>(Object.values(SystemRoles));
 const MAX_NAME_LENGTH = 500;
 const MAX_DESCRIPTION_LENGTH = 2000;
 const CONTROL_CHAR_RE = /\p{Cc}/u;
-/** Role names that conflict with route sub-paths: /:name/members, /:name/permissions */
+/**
+ * Role names that would create semantically ambiguous URLs.
+ * e.g. GET /api/admin/roles/members — is that "list roles" or "get role named members"?
+ * Express routing resolves this correctly (single vs multi-segment), but the URLs
+ * are confusing for API consumers. Keep in sync with sub-path routes in routes/admin/roles.js.
+ */
 const RESERVED_ROLE_NAMES = new Set(['members', 'permissions']);
 
 function validateNameParam(name: string): string | null {
@@ -67,7 +72,7 @@ interface RoleMemberParams extends RoleNameParams {
   userId: string;
 }
 
-export type RoleListItem = { _id: unknown; name: string; description?: string };
+export type RoleListItem = { _id: Types.ObjectId | string; name: string; description?: string };
 
 export interface AdminRolesDeps {
   listRoles: (options?: { limit?: number; offset?: number }) => Promise<RoleListItem[]>;
@@ -194,7 +199,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       await updateUsersRoleByIds(migratedIds, currentName);
     } catch (rollbackError) {
       logger.error(
-        `[adminRoles] CRITICAL: rename rollback failed — ${migratedIds.length} users have dangling role "${newName}":`,
+        `[adminRoles] CRITICAL: rename rollback failed — ${migratedIds.length} users have dangling role "${newName}": [${migratedIds.join(', ')}]`,
         rollbackError,
       );
     }
@@ -229,13 +234,13 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
   }
 
   async function updateRoleHandler(req: ServerRequest, res: Response) {
-    const { name } = req.params as RoleNameParams;
-    const paramError = validateNameParam(name);
-    if (paramError) {
-      return res.status(400).json({ error: paramError });
-    }
-    const body = req.body as { name?: string; description?: string };
     try {
+      const { name } = req.params as RoleNameParams;
+      const paramError = validateNameParam(name);
+      if (paramError) {
+        return res.status(400).json({ error: paramError });
+      }
+      const body = req.body as { name?: string; description?: string };
       const nameError = validateRoleName(body.name, false);
       if (nameError) {
         return res.status(400).json({ error: nameError });
@@ -410,6 +415,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(400).json({ error: 'Invalid user ID format' });
       }
 
+      if (systemRoleValues.has(name) && name !== SystemRoles.ADMIN) {
+        return res.status(403).json({ error: 'Cannot directly assign members to a system role' });
+      }
+
       const existing = await getRoleByName(name);
       if (!existing) {
         return res.status(404).json({ error: 'Role not found' });
@@ -440,7 +449,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
             await updateUser(userId, { role: SystemRoles.ADMIN });
           } catch (rollbackError) {
             logger.error(
-              '[adminRoles] CRITICAL: admin rollback failed in addRoleMember:',
+              `[adminRoles] CRITICAL: admin rollback failed in addRoleMember for user ${userId}:`,
               rollbackError,
             );
           }
@@ -499,7 +508,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
           try {
             await updateUser(userId, { role: SystemRoles.ADMIN });
           } catch (rollbackError) {
-            logger.error('[adminRoles] CRITICAL: admin rollback failed:', rollbackError);
+            logger.error(
+              `[adminRoles] CRITICAL: admin rollback failed for user ${userId}:`,
+              rollbackError,
+            );
           }
           return res.status(400).json({ error: 'Cannot remove the last admin user' });
         }

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -1,9 +1,9 @@
-import { SystemRoles } from 'librechat-data-provider';
 import { logger } from '@librechat/data-schemas';
+import { SystemRoles } from 'librechat-data-provider';
 import type { IRole, IUser } from '@librechat/data-schemas';
+import type { ServerRequest } from '~/types/http';
 import type { FilterQuery } from 'mongoose';
 import type { Response } from 'express';
-import type { ServerRequest } from '~/types/http';
 
 interface RoleNameParams {
   name: string;
@@ -23,10 +23,7 @@ interface AdminMember {
 
 export interface AdminRolesDeps {
   listRoles: () => Promise<IRole[]>;
-  getRoleByName: (
-    name: string,
-    fields?: string | string[] | null,
-  ) => Promise<IRole | null>;
+  getRoleByName: (name: string, fields?: string | string[] | null) => Promise<IRole | null>;
   createRole: (roleData: Partial<IRole>) => Promise<IRole>;
   updateRoleByName: (name: string, updates: Partial<IRole>) => Promise<IRole | null>;
   updateAccessPermissions: (
@@ -40,8 +37,7 @@ export interface AdminRolesDeps {
     fields?: string | string[] | null,
   ) => Promise<IUser | null>;
   updateUser: (userId: string, data: Partial<IUser>) => Promise<IUser | null>;
-  countUsers: (filter?: FilterQuery<IUser>) => Promise<number>;
-  listUsersByRole: (roleName: string) => Promise<AdminMember[]>;
+  listUsersByRole: (roleName: string) => Promise<IUser[]>;
 }
 
 export function createAdminRolesHandlers(deps: AdminRolesDeps) {
@@ -54,7 +50,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
     deleteRole,
     findUser,
     updateUser,
-    countUsers,
+    listUsersByRole,
   } = deps;
 
   async function listRolesHandler(_req: ServerRequest, res: Response) {
@@ -83,7 +79,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
 
   async function createRoleHandler(req: ServerRequest, res: Response) {
     try {
-      const { name, permissions } = req.body as { name?: string; permissions?: IRole['permissions'] };
+      const { name, permissions } = req.body as {
+        name?: string;
+        permissions?: IRole['permissions'];
+      };
       if (!name || typeof name !== 'string' || !name.trim()) {
         return res.status(400).json({ error: 'name is required' });
       }
@@ -176,7 +175,14 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(404).json({ error: 'Role not found' });
       }
 
-      const members = await deps.listUsersByRole(name);
+      const users = await listUsersByRole(name);
+      const members: AdminMember[] = users.map((u) => ({
+        userId: u._id?.toString() ?? '',
+        name: u.name ?? u._id?.toString() ?? '',
+        email: u.email ?? '',
+        avatarUrl: u.avatar,
+        joinedAt: u.createdAt ? u.createdAt.toISOString() : new Date().toISOString(),
+      }));
       return res.status(200).json({ members });
     } catch (error) {
       logger.error('[adminRoles] getRoleMembers error:', error);

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -8,9 +8,15 @@ import type { ServerRequest } from '~/types/http';
 const MAX_NAME_LENGTH = 500;
 const MAX_DESCRIPTION_LENGTH = 2000;
 
-function parsePagination(query: Record<string, unknown>): { limit: number; offset: number } {
+const DEFAULT_PAGE_LIMIT = 50;
+const MAX_PAGE_LIMIT = 200;
+
+function parsePagination(query: { limit?: string; offset?: string }): {
+  limit: number;
+  offset: number;
+} {
   return {
-    limit: Math.min(Math.max(Number(query.limit) || 50, 1), 200),
+    limit: Math.min(Math.max(Number(query.limit) || DEFAULT_PAGE_LIMIT, 1), MAX_PAGE_LIMIT),
     offset: Math.max(Number(query.offset) || 0, 0),
   };
 }
@@ -417,7 +423,11 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       if (name === SystemRoles.ADMIN) {
         const postCount = await countUsersByRole(SystemRoles.ADMIN);
         if (postCount === 0) {
-          await updateUser(userId, { role: SystemRoles.ADMIN });
+          try {
+            await updateUser(userId, { role: SystemRoles.ADMIN });
+          } catch (rollbackError) {
+            logger.error('[adminRoles] CRITICAL: admin rollback failed:', rollbackError);
+          }
           return res.status(400).json({ error: 'Cannot remove the last admin user' });
         }
       }

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -10,6 +10,7 @@ const systemRoleValues = new Set<string>(Object.values(SystemRoles));
 const MAX_NAME_LENGTH = 500;
 const MAX_DESCRIPTION_LENGTH = 2000;
 const CONTROL_CHAR_RE = /\p{Cc}/u;
+/** Role names that conflict with route sub-paths: /:name/members, /:name/permissions */
 const RESERVED_ROLE_NAMES = new Set(['members', 'permissions']);
 
 function validateNameParam(name: string): string | null {
@@ -46,14 +47,13 @@ function validateRoleName(name: unknown, required: boolean): string | null {
 }
 
 function validateDescription(description: unknown): string | null {
-  if (description !== undefined && typeof description !== 'string') {
+  if (description === undefined) {
+    return null;
+  }
+  if (typeof description !== 'string') {
     return 'description must be a string';
   }
-  if (
-    description !== undefined &&
-    typeof description === 'string' &&
-    description.length > MAX_DESCRIPTION_LENGTH
-  ) {
+  if (description.length > MAX_DESCRIPTION_LENGTH) {
     return `description must not exceed ${MAX_DESCRIPTION_LENGTH} characters`;
   }
   return null;
@@ -67,8 +67,10 @@ interface RoleMemberParams extends RoleNameParams {
   userId: string;
 }
 
+export type RoleListItem = { _id: unknown; name: string; description?: string };
+
 export interface AdminRolesDeps {
-  listRoles: (options?: { limit?: number; offset?: number }) => Promise<IRole[]>;
+  listRoles: (options?: { limit?: number; offset?: number }) => Promise<RoleListItem[]>;
   countRoles: () => Promise<number>;
   getRoleByName: (name: string, fields?: string | string[] | null) => Promise<IRole | null>;
   createRoleByName: (roleData: Partial<IRole>) => Promise<IRole>;
@@ -198,6 +200,14 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
     }
   }
 
+  /**
+   * Renames a role by migrating users to the new name and updating the role document.
+   *
+   * The ID snapshot from `findUserIdsByRole` is a point-in-time read. Users assigned
+   * to `currentName` between the snapshot and the bulk `updateUsersByRole` write will
+   * be moved to `newName` but will NOT be reverted on rollback. This window is narrow
+   * and only relevant under concurrent admin operations during a rename.
+   */
   async function renameRole(
     currentName: string,
     newName: string,
@@ -422,6 +432,22 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       }
 
       await updateUser(userId, { role: name });
+
+      if (user.role === SystemRoles.ADMIN && name !== SystemRoles.ADMIN) {
+        const postCount = await countUsersByRole(SystemRoles.ADMIN);
+        if (postCount === 0) {
+          try {
+            await updateUser(userId, { role: SystemRoles.ADMIN });
+          } catch (rollbackError) {
+            logger.error(
+              '[adminRoles] CRITICAL: admin rollback failed in addRoleMember:',
+              rollbackError,
+            );
+          }
+          return res.status(400).json({ error: 'Cannot remove the last admin user' });
+        }
+      }
+
       return res.status(200).json({ success: true });
     } catch (error) {
       logger.error('[adminRoles] addRoleMember error:', error);

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -24,14 +24,14 @@ interface AdminMember {
 export interface AdminRolesDeps {
   listRoles: () => Promise<IRole[]>;
   getRoleByName: (name: string, fields?: string | string[] | null) => Promise<IRole | null>;
-  createRole: (roleData: Partial<IRole>) => Promise<IRole>;
+  createRoleByName: (roleData: Partial<IRole>) => Promise<IRole>;
   updateRoleByName: (name: string, updates: Partial<IRole>) => Promise<IRole | null>;
   updateAccessPermissions: (
     name: string,
     perms: Record<string, Record<string, boolean>>,
     roleData?: IRole,
   ) => Promise<void>;
-  deleteRole: (name: string) => Promise<IRole | null>;
+  deleteRoleByName: (name: string) => Promise<IRole | null>;
   findUser: (
     criteria: FilterQuery<IUser>,
     fields?: string | string[] | null,
@@ -44,10 +44,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
   const {
     listRoles,
     getRoleByName,
-    createRole,
+    createRoleByName,
     updateRoleByName,
     updateAccessPermissions,
-    deleteRole,
+    deleteRoleByName,
     findUser,
     updateUser,
     listUsersByRole,
@@ -86,7 +86,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       if (!name || typeof name !== 'string' || !name.trim()) {
         return res.status(400).json({ error: 'name is required' });
       }
-      const role = await createRole({
+      const role = await createRoleByName({
         name: name.trim(),
         permissions: permissions || {},
       });
@@ -159,7 +159,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(404).json({ error: 'Role not found' });
       }
 
-      await deleteRole(name);
+      await deleteRoleByName(name);
       return res.status(200).json({ success: true });
     } catch (error) {
       logger.error('[adminRoles] deleteRole error:', error);

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -1,4 +1,4 @@
-import { logger } from '@librechat/data-schemas';
+import { logger, isValidObjectIdString } from '@librechat/data-schemas';
 import { SystemRoles } from 'librechat-data-provider';
 import type { IRole, IUser } from '@librechat/data-schemas';
 import type { ServerRequest } from '~/types/http';
@@ -18,7 +18,6 @@ interface AdminMember {
   name: string;
   email: string;
   avatarUrl?: string;
-  joinedAt: string;
 }
 
 export interface AdminRolesDeps {
@@ -106,6 +105,16 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       const { name } = req.params as RoleNameParams;
       const body = req.body as Partial<IRole>;
 
+      if (
+        body.name !== undefined &&
+        (!body.name || typeof body.name !== 'string' || !body.name.trim())
+      ) {
+        return res.status(400).json({ error: 'name must be a non-empty string' });
+      }
+      if (body.name && SystemRoles[body.name.trim() as keyof typeof SystemRoles]) {
+        return res.status(409).json({ error: 'Cannot rename to a reserved system role name' });
+      }
+
       const existing = await getRoleByName(name);
       if (!existing) {
         return res.status(404).json({ error: 'Role not found' });
@@ -186,7 +195,6 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         name: u.name ?? u._id?.toString() ?? '',
         email: u.email ?? '',
         avatarUrl: u.avatar,
-        joinedAt: u.createdAt ? u.createdAt.toISOString() : new Date().toISOString(),
       }));
       return res.status(200).json({ members });
     } catch (error) {
@@ -202,6 +210,9 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
 
       if (!userId || typeof userId !== 'string') {
         return res.status(400).json({ error: 'userId is required' });
+      }
+      if (!isValidObjectIdString(userId)) {
+        return res.status(400).json({ error: 'Invalid user ID format' });
       }
 
       const existing = await getRoleByName(name);
@@ -225,6 +236,9 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
   async function removeRoleMemberHandler(req: ServerRequest, res: Response) {
     try {
       const { name, userId } = req.params as RoleMemberParams;
+      if (!isValidObjectIdString(userId)) {
+        return res.status(400).json({ error: 'Invalid user ID format' });
+      }
 
       const user = await findUser({ _id: userId });
       if (!user) {

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -19,6 +19,9 @@ function validateNameParam(name: string): string | null {
   if (name.length > MAX_NAME_LENGTH) {
     return `name must not exceed ${MAX_NAME_LENGTH} characters`;
   }
+  if (CONTROL_CHAR_RE.test(name)) {
+    return 'name contains invalid characters';
+  }
   return null;
 }
 
@@ -29,13 +32,14 @@ function validateRoleName(name: unknown, required: boolean): string | null {
   if (typeof name !== 'string' || !name.trim()) {
     return required ? 'name is required' : 'name must be a non-empty string';
   }
-  if (name.trim().length > MAX_NAME_LENGTH) {
+  const trimmed = name.trim();
+  if (trimmed.length > MAX_NAME_LENGTH) {
     return `name must not exceed ${MAX_NAME_LENGTH} characters`;
   }
-  if (CONTROL_CHAR_RE.test(name)) {
+  if (CONTROL_CHAR_RE.test(trimmed)) {
     return 'name contains invalid characters';
   }
-  if (RESERVED_ROLE_NAMES.has(name.trim().toLowerCase())) {
+  if (RESERVED_ROLE_NAMES.has(trimmed)) {
     return 'name is a reserved path segment';
   }
   return null;
@@ -154,11 +158,14 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       ) {
         return res.status(400).json({ error: 'permissions must be an object' });
       }
-      const role = await createRoleByName({
+      const roleData: Partial<IRole> = {
         name: (name as string).trim(),
-        description,
         permissions: permissions ?? {},
-      });
+      };
+      if (description !== undefined) {
+        roleData.description = description;
+      }
+      const role = await createRoleByName(roleData);
       return res.status(201).json({ role });
     } catch (error) {
       logger.error('[adminRoles] createRole error:', error);

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -1,9 +1,11 @@
-import { logger, isValidObjectIdString } from '@librechat/data-schemas';
 import { SystemRoles } from 'librechat-data-provider';
+import { logger, isValidObjectIdString } from '@librechat/data-schemas';
 import type { IRole, IUser } from '@librechat/data-schemas';
-import type { ServerRequest } from '~/types/http';
 import type { FilterQuery } from 'mongoose';
 import type { Response } from 'express';
+import type { ServerRequest } from '~/types/http';
+
+const MAX_NAME_LENGTH = 500;
 
 interface RoleNameParams {
   name: string;
@@ -36,7 +38,12 @@ export interface AdminRolesDeps {
     fields?: string | string[] | null,
   ) => Promise<IUser | null>;
   updateUser: (userId: string, data: Partial<IUser>) => Promise<IUser | null>;
-  listUsersByRole: (roleName: string) => Promise<IUser[]>;
+  updateUsersByRole: (oldRole: string, newRole: string) => Promise<void>;
+  listUsersByRole: (
+    roleName: string,
+    options?: { limit?: number; offset?: number },
+  ) => Promise<IUser[]>;
+  countUsersByRole: (roleName: string) => Promise<number>;
 }
 
 export function createAdminRolesHandlers(deps: AdminRolesDeps) {
@@ -49,7 +56,9 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
     deleteRoleByName,
     findUser,
     updateUser,
+    updateUsersByRole,
     listUsersByRole,
+    countUsersByRole,
   } = deps;
 
   async function listRolesHandler(_req: ServerRequest, res: Response) {
@@ -86,17 +95,25 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       if (!name || typeof name !== 'string' || !name.trim()) {
         return res.status(400).json({ error: 'name is required' });
       }
+      if (name.trim().length > MAX_NAME_LENGTH) {
+        return res
+          .status(400)
+          .json({ error: `name must not exceed ${MAX_NAME_LENGTH} characters` });
+      }
       const role = await createRoleByName({
         name: name.trim(),
         description: description ?? '',
-        permissions: permissions || {},
+        permissions: permissions ?? {},
       });
       return res.status(201).json({ role });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to create role';
       logger.error('[adminRoles] createRole error:', error);
-      const status = message.includes('already exists') || message.includes('reserved') ? 409 : 500;
-      return res.status(status).json({ error: message });
+      const is409 =
+        error instanceof Error &&
+        (error.message.startsWith('Role "') ||
+          error.message.startsWith('Cannot create role with reserved'));
+      return res.status(is409 ? 409 : 500).json({ error: message });
     }
   }
 
@@ -111,11 +128,19 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       ) {
         return res.status(400).json({ error: 'name must be a non-empty string' });
       }
-      if (
-        body.name &&
-        body.name.trim() !== name &&
-        SystemRoles[body.name.trim() as keyof typeof SystemRoles]
-      ) {
+      if (body.name !== undefined && body.name.trim().length > MAX_NAME_LENGTH) {
+        return res
+          .status(400)
+          .json({ error: `name must not exceed ${MAX_NAME_LENGTH} characters` });
+      }
+
+      const trimmedName = body.name?.trim();
+      const isRename = trimmedName !== undefined && trimmedName !== name;
+
+      if (isRename && SystemRoles[name as keyof typeof SystemRoles]) {
+        return res.status(403).json({ error: 'Cannot rename system role' });
+      }
+      if (isRename && SystemRoles[trimmedName as keyof typeof SystemRoles]) {
         return res.status(409).json({ error: 'Cannot rename to a reserved system role name' });
       }
 
@@ -124,15 +149,30 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(404).json({ error: 'Role not found' });
       }
 
+      if (isRename) {
+        const duplicate = await getRoleByName(trimmedName);
+        if (duplicate) {
+          return res.status(409).json({ error: `Role "${trimmedName}" already exists` });
+        }
+      }
+
       const updates: Partial<IRole> = {};
-      if (body.name !== undefined) {
-        updates.name = body.name;
+      if (trimmedName !== undefined) {
+        updates.name = trimmedName;
       }
       if (body.description !== undefined) {
         updates.description = body.description;
       }
 
       const role = await updateRoleByName(name, updates);
+      if (!role) {
+        return res.status(404).json({ error: 'Role not found' });
+      }
+
+      if (isRename) {
+        await updateUsersByRole(name, trimmedName);
+      }
+
       return res.status(200).json({ role });
     } catch (error) {
       logger.error('[adminRoles] updateRole error:', error);
@@ -147,7 +187,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         permissions: Record<string, Record<string, boolean>>;
       };
 
-      if (!permissions || typeof permissions !== 'object') {
+      if (!permissions || typeof permissions !== 'object' || Array.isArray(permissions)) {
         return res.status(400).json({ error: 'permissions object is required' });
       }
 
@@ -193,14 +233,20 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(404).json({ error: 'Role not found' });
       }
 
-      const users = await listUsersByRole(name);
+      const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200);
+      const offset = Math.max(Number(req.query.offset) || 0, 0);
+
+      const [users, total] = await Promise.all([
+        listUsersByRole(name, { limit, offset }),
+        countUsersByRole(name),
+      ]);
       const members: AdminMember[] = users.map((u) => ({
         userId: u._id?.toString() ?? '',
         name: u.name ?? u._id?.toString() ?? '',
         email: u.email ?? '',
         avatarUrl: u.avatar,
       }));
-      return res.status(200).json({ members });
+      return res.status(200).json({ members, total, limit, offset });
     } catch (error) {
       logger.error('[adminRoles] getRoleMembers error:', error);
       return res.status(500).json({ error: 'Failed to get role members' });
@@ -242,6 +288,11 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       const { name, userId } = req.params as RoleMemberParams;
       if (!isValidObjectIdString(userId)) {
         return res.status(400).json({ error: 'Invalid user ID format' });
+      }
+
+      const existing = await getRoleByName(name);
+      if (!existing) {
+        return res.status(404).json({ error: 'Role not found' });
       }
 
       const user = await findUser({ _id: userId });

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -509,7 +509,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         }
       }
 
-      await updateUser(userId, { role: SystemRoles.USER });
+      const removed = await updateUser(userId, { role: SystemRoles.USER });
+      if (!removed) {
+        return res.status(404).json({ error: 'User not found' });
+      }
 
       if (name === SystemRoles.ADMIN) {
         const postCount = await countUsersByRole(SystemRoles.ADMIN);

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -111,7 +111,11 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       ) {
         return res.status(400).json({ error: 'name must be a non-empty string' });
       }
-      if (body.name && SystemRoles[body.name.trim() as keyof typeof SystemRoles]) {
+      if (
+        body.name &&
+        body.name.trim() !== name &&
+        SystemRoles[body.name.trim() as keyof typeof SystemRoles]
+      ) {
         return res.status(409).json({ error: 'Cannot rename to a reserved system role name' });
       }
 

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -6,6 +6,7 @@ import type { Response } from 'express';
 import type { ServerRequest } from '~/types/http';
 
 const MAX_NAME_LENGTH = 500;
+const MAX_DESCRIPTION_LENGTH = 2000;
 
 interface RoleNameParams {
   name: string;
@@ -93,6 +94,14 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
           .status(400)
           .json({ error: `name must not exceed ${MAX_NAME_LENGTH} characters` });
       }
+      if (description !== undefined && typeof description !== 'string') {
+        return res.status(400).json({ error: 'description must be a string' });
+      }
+      if (description && description.length > MAX_DESCRIPTION_LENGTH) {
+        return res
+          .status(400)
+          .json({ error: `description must not exceed ${MAX_DESCRIPTION_LENGTH} characters` });
+      }
       const role = await createRoleByName({
         name: name.trim(),
         description: description ?? '',
@@ -111,10 +120,11 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
   }
 
   async function updateRoleHandler(req: ServerRequest, res: Response) {
+    const { name } = req.params as RoleNameParams;
+    const body = req.body as Partial<IRole>;
+    let isRename = false;
+    let trimmedName = '';
     try {
-      const { name } = req.params as RoleNameParams;
-      const body = req.body as Partial<IRole>;
-
       if (
         body.name !== undefined &&
         (!body.name || typeof body.name !== 'string' || !body.name.trim())
@@ -127,8 +137,8 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
           .json({ error: `name must not exceed ${MAX_NAME_LENGTH} characters` });
       }
 
-      const trimmedName = body.name?.trim();
-      const isRename = trimmedName !== undefined && trimmedName !== name;
+      trimmedName = body.name?.trim() ?? '';
+      isRename = trimmedName !== '' && trimmedName !== name;
 
       if (isRename && SystemRoles[name as keyof typeof SystemRoles]) {
         return res.status(403).json({ error: 'Cannot rename system role' });
@@ -149,8 +159,17 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         }
       }
 
+      if (body.description !== undefined && typeof body.description !== 'string') {
+        return res.status(400).json({ error: 'description must be a string' });
+      }
+      if (body.description && body.description.length > MAX_DESCRIPTION_LENGTH) {
+        return res
+          .status(400)
+          .json({ error: `description must not exceed ${MAX_DESCRIPTION_LENGTH} characters` });
+      }
+
       const updates: Partial<IRole> = {};
-      if (trimmedName !== undefined) {
+      if (isRename) {
         updates.name = trimmedName;
       }
       if (body.description !== undefined) {
@@ -171,6 +190,13 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
 
       return res.status(200).json({ role });
     } catch (error) {
+      if (isRename) {
+        try {
+          await updateUsersByRole(trimmedName, name);
+        } catch (rollbackError) {
+          logger.error('[adminRoles] rollback failed after updateRole error:', rollbackError);
+        }
+      }
       logger.error('[adminRoles] updateRole error:', error);
       return res.status(500).json({ error: 'Failed to update role' });
     }
@@ -208,12 +234,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(403).json({ error: 'Cannot delete system role' });
       }
 
-      const existing = await getRoleByName(name);
-      if (!existing) {
+      const deleted = await deleteRoleByName(name);
+      if (!deleted) {
         return res.status(404).json({ error: 'Role not found' });
       }
-
-      await deleteRoleByName(name);
       return res.status(200).json({ success: true });
     } catch (error) {
       logger.error('[adminRoles] deleteRole error:', error);

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -1,6 +1,6 @@
 import { SystemRoles } from 'librechat-data-provider';
 import { logger, isValidObjectIdString } from '@librechat/data-schemas';
-import type { IRole, IUser } from '@librechat/data-schemas';
+import type { IRole, IUser, AdminMember } from '@librechat/data-schemas';
 import type { FilterQuery } from 'mongoose';
 import type { Response } from 'express';
 import type { ServerRequest } from '~/types/http';
@@ -13,13 +13,6 @@ interface RoleNameParams {
 
 interface RoleMemberParams extends RoleNameParams {
   userId: string;
-}
-
-interface AdminMember {
-  userId: string;
-  name: string;
-  email: string;
-  avatarUrl?: string;
 }
 
 export interface AdminRolesDeps {
@@ -164,13 +157,13 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         updates.description = body.description;
       }
 
+      if (isRename) {
+        await updateUsersByRole(name, trimmedName);
+      }
+
       const role = await updateRoleByName(name, updates);
       if (!role) {
         return res.status(404).json({ error: 'Role not found' });
-      }
-
-      if (isRename) {
-        await updateUsersByRole(name, trimmedName);
       }
 
       return res.status(200).json({ role });

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -8,6 +8,53 @@ import type { ServerRequest } from '~/types/http';
 const MAX_NAME_LENGTH = 500;
 const MAX_DESCRIPTION_LENGTH = 2000;
 
+function parsePagination(query: Record<string, unknown>): { limit: number; offset: number } {
+  return {
+    limit: Math.min(Math.max(Number(query.limit) || 50, 1), 200),
+    offset: Math.max(Number(query.offset) || 0, 0),
+  };
+}
+
+function validateNameParam(name: string): string | null {
+  if (!name || typeof name !== 'string') {
+    return 'name parameter is required';
+  }
+  if (name.length > MAX_NAME_LENGTH) {
+    return `name must not exceed ${MAX_NAME_LENGTH} characters`;
+  }
+  return null;
+}
+
+function validateRoleName(name: unknown, required: boolean): string | null {
+  if (required) {
+    if (!name || typeof name !== 'string' || !(name as string).trim()) {
+      return 'name is required';
+    }
+  } else if (name !== undefined) {
+    if (!name || typeof name !== 'string' || !(name as string).trim()) {
+      return 'name must be a non-empty string';
+    }
+  }
+  if (name !== undefined && typeof name === 'string' && name.trim().length > MAX_NAME_LENGTH) {
+    return `name must not exceed ${MAX_NAME_LENGTH} characters`;
+  }
+  return null;
+}
+
+function validateDescription(description: unknown): string | null {
+  if (description !== undefined && typeof description !== 'string') {
+    return 'description must be a string';
+  }
+  if (
+    description !== undefined &&
+    typeof description === 'string' &&
+    description.length > MAX_DESCRIPTION_LENGTH
+  ) {
+    return `description must not exceed ${MAX_DESCRIPTION_LENGTH} characters`;
+  }
+  return null;
+}
+
 interface RoleNameParams {
   name: string;
 }
@@ -59,8 +106,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
 
   async function listRolesHandler(req: ServerRequest, res: Response) {
     try {
-      const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200);
-      const offset = Math.max(Number(req.query.offset) || 0, 0);
+      const { limit, offset } = parsePagination(req.query);
       const [roles, total] = await Promise.all([listRoles({ limit, offset }), countRoles()]);
       return res.status(200).json({ roles, total, limit, offset });
     } catch (error) {
@@ -72,6 +118,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
   async function getRoleHandler(req: ServerRequest, res: Response) {
     try {
       const { name } = req.params as RoleNameParams;
+      const paramError = validateNameParam(name);
+      if (paramError) {
+        return res.status(400).json({ error: paramError });
+      }
       const role = await getRoleByName(name);
       if (!role) {
         return res.status(404).json({ error: 'Role not found' });
@@ -90,21 +140,13 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         description?: string;
         permissions?: IRole['permissions'];
       };
-      if (!name || typeof name !== 'string' || !name.trim()) {
-        return res.status(400).json({ error: 'name is required' });
+      const nameError = validateRoleName(name, true);
+      if (nameError) {
+        return res.status(400).json({ error: nameError });
       }
-      if (name.trim().length > MAX_NAME_LENGTH) {
-        return res
-          .status(400)
-          .json({ error: `name must not exceed ${MAX_NAME_LENGTH} characters` });
-      }
-      if (description !== undefined && typeof description !== 'string') {
-        return res.status(400).json({ error: 'description must be a string' });
-      }
-      if (description && description.length > MAX_DESCRIPTION_LENGTH) {
-        return res
-          .status(400)
-          .json({ error: `description must not exceed ${MAX_DESCRIPTION_LENGTH} characters` });
+      const descError = validateDescription(description);
+      if (descError) {
+        return res.status(400).json({ error: descError });
       }
       if (
         permissions !== undefined &&
@@ -113,7 +155,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(400).json({ error: 'permissions must be an object' });
       }
       const role = await createRoleByName({
-        name: name.trim(),
+        name: (name as string).trim(),
         description: description ?? '',
         permissions: permissions ?? {},
       });
@@ -129,29 +171,22 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
 
   async function updateRoleHandler(req: ServerRequest, res: Response) {
     const { name } = req.params as RoleNameParams;
+    const paramError = validateNameParam(name);
+    if (paramError) {
+      return res.status(400).json({ error: paramError });
+    }
     const body = req.body as { name?: string; description?: string };
     let isRename = false;
     let trimmedName = '';
     let migrationRan = false;
     try {
-      if (
-        body.name !== undefined &&
-        (!body.name || typeof body.name !== 'string' || !body.name.trim())
-      ) {
-        return res.status(400).json({ error: 'name must be a non-empty string' });
+      const nameError = validateRoleName(body.name, false);
+      if (nameError) {
+        return res.status(400).json({ error: nameError });
       }
-      if (body.name !== undefined && body.name.trim().length > MAX_NAME_LENGTH) {
-        return res
-          .status(400)
-          .json({ error: `name must not exceed ${MAX_NAME_LENGTH} characters` });
-      }
-      if (body.description !== undefined && typeof body.description !== 'string') {
-        return res.status(400).json({ error: 'description must be a string' });
-      }
-      if (body.description && body.description.length > MAX_DESCRIPTION_LENGTH) {
-        return res
-          .status(400)
-          .json({ error: `description must not exceed ${MAX_DESCRIPTION_LENGTH} characters` });
+      const descError = validateDescription(body.description);
+      if (descError) {
+        return res.status(400).json({ error: descError });
       }
 
       trimmedName = body.name?.trim() ?? '';
@@ -214,6 +249,9 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
           logger.error('[adminRoles] rollback failed after updateRole error:', rollbackError);
         }
       }
+      if (error instanceof RoleConflictError) {
+        return res.status(409).json({ error: error.message });
+      }
       logger.error('[adminRoles] updateRole error:', error);
       return res.status(500).json({ error: 'Failed to update role' });
     }
@@ -222,6 +260,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
   async function updateRolePermissionsHandler(req: ServerRequest, res: Response) {
     try {
       const { name } = req.params as RoleNameParams;
+      const paramError = validateNameParam(name);
+      if (paramError) {
+        return res.status(400).json({ error: paramError });
+      }
       const { permissions } = req.body as {
         permissions: Record<string, Record<string, boolean>>;
       };
@@ -250,6 +292,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
   async function deleteRoleHandler(req: ServerRequest, res: Response) {
     try {
       const { name } = req.params as RoleNameParams;
+      const paramError = validateNameParam(name);
+      if (paramError) {
+        return res.status(400).json({ error: paramError });
+      }
       if (SystemRoles[name as keyof typeof SystemRoles]) {
         return res.status(403).json({ error: 'Cannot delete system role' });
       }
@@ -268,13 +314,16 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
   async function getRoleMembersHandler(req: ServerRequest, res: Response) {
     try {
       const { name } = req.params as RoleNameParams;
+      const paramError = validateNameParam(name);
+      if (paramError) {
+        return res.status(400).json({ error: paramError });
+      }
       const existing = await getRoleByName(name);
       if (!existing) {
         return res.status(404).json({ error: 'Role not found' });
       }
 
-      const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 200);
-      const offset = Math.max(Number(req.query.offset) || 0, 0);
+      const { limit, offset } = parsePagination(req.query);
 
       const [users, total] = await Promise.all([
         listUsersByRole(name, { limit, offset }),
@@ -296,6 +345,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
   async function addRoleMemberHandler(req: ServerRequest, res: Response) {
     try {
       const { name } = req.params as RoleNameParams;
+      const paramError = validateNameParam(name);
+      if (paramError) {
+        return res.status(400).json({ error: paramError });
+      }
       const { userId } = req.body as { userId: string };
 
       if (!userId || typeof userId !== 'string') {
@@ -315,6 +368,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(404).json({ error: 'User not found' });
       }
 
+      if (user.role === name) {
+        return res.status(200).json({ success: true });
+      }
+
       await updateUser(userId, { role: name });
       return res.status(200).json({ success: true });
     } catch (error) {
@@ -326,6 +383,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
   async function removeRoleMemberHandler(req: ServerRequest, res: Response) {
     try {
       const { name, userId } = req.params as RoleMemberParams;
+      const paramError = validateNameParam(name);
+      if (paramError) {
+        return res.status(400).json({ error: paramError });
+      }
       if (!isValidObjectIdString(userId)) {
         return res.status(400).json({ error: 'Invalid user ID format' });
       }
@@ -352,6 +413,15 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       }
 
       await updateUser(userId, { role: SystemRoles.USER });
+
+      if (name === SystemRoles.ADMIN) {
+        const postCount = await countUsersByRole(SystemRoles.ADMIN);
+        if (postCount === 0) {
+          await updateUser(userId, { role: SystemRoles.ADMIN });
+          return res.status(400).json({ error: 'Cannot remove the last admin user' });
+        }
+      }
+
       return res.status(200).json({ success: true });
     } catch (error) {
       logger.error('[adminRoles] removeRoleMember error:', error);

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -7,6 +7,12 @@ import type { ServerRequest } from '~/types/http';
 import { parsePagination } from './pagination';
 
 const systemRoleValues = new Set<string>(Object.values(SystemRoles));
+
+/** Case-insensitive check — the legacy roles route uppercases params. */
+function isSystemRoleName(name: string): boolean {
+  return systemRoleValues.has(name.toUpperCase());
+}
+
 const MAX_NAME_LENGTH = 500;
 const MAX_DESCRIPTION_LENGTH = 2000;
 const CONTROL_CHAR_RE = /\p{Cc}/u;
@@ -165,7 +171,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       }
       if (
         permissions !== undefined &&
-        (typeof permissions !== 'object' || Array.isArray(permissions))
+        (permissions === null || typeof permissions !== 'object' || Array.isArray(permissions))
       ) {
         return res.status(400).json({ error: 'permissions must be an object' });
       }
@@ -253,10 +259,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       const trimmedName = body.name?.trim() ?? '';
       const isRename = trimmedName !== '' && trimmedName !== name;
 
-      if (isRename && systemRoleValues.has(name)) {
+      if (isRename && isSystemRoleName(name)) {
         return res.status(403).json({ error: 'Cannot rename system role' });
       }
-      if (isRename && systemRoleValues.has(trimmedName)) {
+      if (isRename && isSystemRoleName(trimmedName)) {
         return res.status(403).json({ error: 'Cannot use a reserved system role name' });
       }
 
@@ -353,7 +359,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       if (paramError) {
         return res.status(400).json({ error: paramError });
       }
-      if (systemRoleValues.has(name)) {
+      if (isSystemRoleName(name)) {
         return res.status(403).json({ error: 'Cannot delete system role' });
       }
 
@@ -415,7 +421,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(400).json({ error: 'Invalid user ID format' });
       }
 
-      if (systemRoleValues.has(name) && name !== SystemRoles.ADMIN) {
+      if (isSystemRoleName(name) && name !== SystemRoles.ADMIN) {
         return res.status(403).json({ error: 'Cannot directly assign members to a system role' });
       }
 
@@ -440,7 +446,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         }
       }
 
-      await updateUser(userId, { role: name });
+      const updated = await updateUser(userId, { role: name });
+      if (!updated) {
+        return res.status(404).json({ error: 'User not found' });
+      }
 
       if (user.role === SystemRoles.ADMIN && name !== SystemRoles.ADMIN) {
         const postCount = await countUsersByRole(SystemRoles.ADMIN);
@@ -475,7 +484,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(400).json({ error: 'Invalid user ID format' });
       }
 
-      if (systemRoleValues.has(name) && name !== SystemRoles.ADMIN) {
+      if (isSystemRoleName(name) && name !== SystemRoles.ADMIN) {
         return res.status(403).json({ error: 'Cannot remove members from a system role' });
       }
 

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -4,22 +4,10 @@ import type { IRole, IUser, AdminMember } from '@librechat/data-schemas';
 import type { FilterQuery } from 'mongoose';
 import type { Response } from 'express';
 import type { ServerRequest } from '~/types/http';
+import { parsePagination } from './pagination';
 
 const MAX_NAME_LENGTH = 500;
 const MAX_DESCRIPTION_LENGTH = 2000;
-
-const DEFAULT_PAGE_LIMIT = 50;
-const MAX_PAGE_LIMIT = 200;
-
-function parsePagination(query: { limit?: string; offset?: string }): {
-  limit: number;
-  offset: number;
-} {
-  return {
-    limit: Math.min(Math.max(Number(query.limit) || DEFAULT_PAGE_LIMIT, 1), MAX_PAGE_LIMIT),
-    offset: Math.max(Number(query.offset) || 0, 0),
-  };
-}
 
 function validateNameParam(name: string): string | null {
   if (!name || typeof name !== 'string') {
@@ -162,7 +150,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       }
       const role = await createRoleByName({
         name: (name as string).trim(),
-        description: description ?? '',
+        description,
         permissions: permissions ?? {},
       });
       return res.status(201).json({ role });
@@ -175,6 +163,33 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
     }
   }
 
+  async function renameRole(
+    currentName: string,
+    newName: string,
+    extraUpdates?: Partial<IRole>,
+  ): Promise<IRole | null> {
+    await updateUsersByRole(currentName, newName);
+    try {
+      const updates: Partial<IRole> = { name: newName, ...extraUpdates };
+      const role = await updateRoleByName(currentName, updates);
+      if (!role) {
+        try {
+          await updateUsersByRole(newName, currentName);
+        } catch (rollbackError) {
+          logger.error('[adminRoles] rollback failed (role not found path):', rollbackError);
+        }
+      }
+      return role;
+    } catch (error) {
+      try {
+        await updateUsersByRole(newName, currentName);
+      } catch (rollbackError) {
+        logger.error('[adminRoles] rollback failed after updateRole error:', rollbackError);
+      }
+      throw error;
+    }
+  }
+
   async function updateRoleHandler(req: ServerRequest, res: Response) {
     const { name } = req.params as RoleNameParams;
     const paramError = validateNameParam(name);
@@ -182,9 +197,6 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       return res.status(400).json({ error: paramError });
     }
     const body = req.body as { name?: string; description?: string };
-    let isRename = false;
-    let trimmedName = '';
-    let migrationRan = false;
     try {
       const nameError = validateRoleName(body.name, false);
       if (nameError) {
@@ -195,14 +207,14 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(400).json({ error: descError });
       }
 
-      trimmedName = body.name?.trim() ?? '';
-      isRename = trimmedName !== '' && trimmedName !== name;
+      const trimmedName = body.name?.trim() ?? '';
+      const isRename = trimmedName !== '' && trimmedName !== name;
 
       if (isRename && SystemRoles[name as keyof typeof SystemRoles]) {
         return res.status(403).json({ error: 'Cannot rename system role' });
       }
       if (isRename && SystemRoles[trimmedName as keyof typeof SystemRoles]) {
-        return res.status(409).json({ error: 'Cannot rename to a reserved system role name' });
+        return res.status(403).json({ error: 'Cannot use a reserved system role name' });
       }
 
       const existing = await getRoleByName(name);
@@ -230,31 +242,21 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       }
 
       if (isRename) {
-        await updateUsersByRole(name, trimmedName);
-        migrationRan = true;
+        const descUpdate =
+          body.description !== undefined ? { description: body.description } : undefined;
+        const role = await renameRole(name, trimmedName, descUpdate);
+        if (!role) {
+          return res.status(404).json({ error: 'Role not found' });
+        }
+        return res.status(200).json({ role });
       }
 
       const role = await updateRoleByName(name, updates);
       if (!role) {
-        if (migrationRan) {
-          try {
-            await updateUsersByRole(trimmedName, name);
-          } catch (rollbackError) {
-            logger.error('[adminRoles] rollback failed (role not found path):', rollbackError);
-          }
-        }
         return res.status(404).json({ error: 'Role not found' });
       }
-
       return res.status(200).json({ role });
     } catch (error) {
-      if (migrationRan) {
-        try {
-          await updateUsersByRole(trimmedName, name);
-        } catch (rollbackError) {
-          logger.error('[adminRoles] rollback failed after updateRole error:', rollbackError);
-        }
-      }
       if (error instanceof RoleConflictError) {
         return res.status(409).json({ error: error.message });
       }
@@ -263,6 +265,12 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
     }
   }
 
+  /**
+   * The re-fetch via `getRoleByName` after `updateAccessPermissions` depends on the
+   * callee having written the updated document to the role cache. If the cache layer
+   * is refactored to stop writing from within `updateAccessPermissions`, this handler
+   * must be updated to perform an explicit uncached DB read.
+   */
   async function updateRolePermissionsHandler(req: ServerRequest, res: Response) {
     try {
       const { name } = req.params as RoleNameParams;

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -414,6 +414,13 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(200).json({ success: true });
       }
 
+      if (user.role === SystemRoles.ADMIN && name !== SystemRoles.ADMIN) {
+        const adminCount = await countUsersByRole(SystemRoles.ADMIN);
+        if (adminCount <= 1) {
+          return res.status(400).json({ error: 'Cannot remove the last admin user' });
+        }
+      }
+
       await updateUser(userId, { role: name });
       return res.status(200).json({ success: true });
     } catch (error) {

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -1,5 +1,5 @@
 import { SystemRoles } from 'librechat-data-provider';
-import { logger, isValidObjectIdString } from '@librechat/data-schemas';
+import { logger, isValidObjectIdString, RoleConflictError } from '@librechat/data-schemas';
 import type { IRole, IUser, AdminMember } from '@librechat/data-schemas';
 import type { FilterQuery } from 'mongoose';
 import type { Response } from 'express';
@@ -102,6 +102,12 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
           .status(400)
           .json({ error: `description must not exceed ${MAX_DESCRIPTION_LENGTH} characters` });
       }
+      if (
+        permissions !== undefined &&
+        (typeof permissions !== 'object' || Array.isArray(permissions))
+      ) {
+        return res.status(400).json({ error: 'permissions must be an object' });
+      }
       const role = await createRoleByName({
         name: name.trim(),
         description: description ?? '',
@@ -110,18 +116,16 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       return res.status(201).json({ role });
     } catch (error) {
       logger.error('[adminRoles] createRole error:', error);
-      const is409 =
-        error instanceof Error &&
-        (error.message.startsWith('Role "') ||
-          error.message.startsWith('Cannot create role with reserved'));
-      const message = is409 && error instanceof Error ? error.message : 'Failed to create role';
-      return res.status(is409 ? 409 : 500).json({ error: message });
+      if (error instanceof RoleConflictError) {
+        return res.status(409).json({ error: error.message });
+      }
+      return res.status(500).json({ error: 'Failed to create role' });
     }
   }
 
   async function updateRoleHandler(req: ServerRequest, res: Response) {
     const { name } = req.params as RoleNameParams;
-    const body = req.body as Partial<IRole>;
+    const body = req.body as { name?: string; description?: string };
     let isRename = false;
     let trimmedName = '';
     let migrationRan = false;
@@ -188,7 +192,11 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       const role = await updateRoleByName(name, updates);
       if (!role) {
         if (migrationRan) {
-          await updateUsersByRole(trimmedName, name);
+          try {
+            await updateUsersByRole(trimmedName, name);
+          } catch (rollbackError) {
+            logger.error('[adminRoles] rollback failed (role not found path):', rollbackError);
+          }
         }
         return res.status(404).json({ error: 'Role not found' });
       }

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -163,6 +163,9 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
 
       const role = await updateRoleByName(name, updates);
       if (!role) {
+        if (isRename) {
+          await updateUsersByRole(trimmedName, name);
+        }
         return res.status(404).json({ error: 'Role not found' });
       }
 

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -109,12 +109,12 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       });
       return res.status(201).json({ role });
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to create role';
       logger.error('[adminRoles] createRole error:', error);
       const is409 =
         error instanceof Error &&
         (error.message.startsWith('Role "') ||
           error.message.startsWith('Cannot create role with reserved'));
+      const message = is409 && error instanceof Error ? error.message : 'Failed to create role';
       return res.status(is409 ? 409 : 500).json({ error: message });
     }
   }
@@ -124,6 +124,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
     const body = req.body as Partial<IRole>;
     let isRename = false;
     let trimmedName = '';
+    let migrationRan = false;
     try {
       if (
         body.name !== undefined &&
@@ -135,6 +136,14 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res
           .status(400)
           .json({ error: `name must not exceed ${MAX_NAME_LENGTH} characters` });
+      }
+      if (body.description !== undefined && typeof body.description !== 'string') {
+        return res.status(400).json({ error: 'description must be a string' });
+      }
+      if (body.description && body.description.length > MAX_DESCRIPTION_LENGTH) {
+        return res
+          .status(400)
+          .json({ error: `description must not exceed ${MAX_DESCRIPTION_LENGTH} characters` });
       }
 
       trimmedName = body.name?.trim() ?? '';
@@ -159,15 +168,6 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         }
       }
 
-      if (body.description !== undefined && typeof body.description !== 'string') {
-        return res.status(400).json({ error: 'description must be a string' });
-      }
-      if (body.description && body.description.length > MAX_DESCRIPTION_LENGTH) {
-        return res
-          .status(400)
-          .json({ error: `description must not exceed ${MAX_DESCRIPTION_LENGTH} characters` });
-      }
-
       const updates: Partial<IRole> = {};
       if (isRename) {
         updates.name = trimmedName;
@@ -176,13 +176,18 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         updates.description = body.description;
       }
 
+      if (Object.keys(updates).length === 0) {
+        return res.status(200).json({ role: existing });
+      }
+
       if (isRename) {
         await updateUsersByRole(name, trimmedName);
+        migrationRan = true;
       }
 
       const role = await updateRoleByName(name, updates);
       if (!role) {
-        if (isRename) {
+        if (migrationRan) {
           await updateUsersByRole(trimmedName, name);
         }
         return res.status(404).json({ error: 'Role not found' });
@@ -190,7 +195,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
 
       return res.status(200).json({ role });
     } catch (error) {
-      if (isRename) {
+      if (migrationRan) {
         try {
           await updateUsersByRole(trimmedName, name);
         } catch (rollbackError) {

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -79,8 +79,9 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
 
   async function createRoleHandler(req: ServerRequest, res: Response) {
     try {
-      const { name, permissions } = req.body as {
+      const { name, description, permissions } = req.body as {
         name?: string;
+        description?: string;
         permissions?: IRole['permissions'];
       };
       if (!name || typeof name !== 'string' || !name.trim()) {
@@ -88,6 +89,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       }
       const role = await createRoleByName({
         name: name.trim(),
+        description: description ?? '',
         permissions: permissions || {},
       });
       return res.status(201).json({ role });
@@ -112,6 +114,9 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       const updates: Partial<IRole> = {};
       if (body.name !== undefined) {
         updates.name = body.name;
+      }
+      if (body.description !== undefined) {
+        updates.description = body.description;
       }
 
       const role = await updateRoleByName(name, updates);

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/data-schemas/src/index.ts
+++ b/packages/data-schemas/src/index.ts
@@ -7,6 +7,7 @@ export * from './utils';
 export { createModels } from './models';
 export {
   createMethods,
+  RoleConflictError,
   DEFAULT_REFRESH_TOKEN_EXPIRY,
   DEFAULT_SESSION_EXPIRY,
   tokenValues,

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -1,6 +1,7 @@
 import { createSessionMethods, DEFAULT_REFRESH_TOKEN_EXPIRY, type SessionMethods } from './session';
 import { createTokenMethods, type TokenMethods } from './token';
-import { createRoleMethods, RoleConflictError, type RoleMethods, type RoleDeps } from './role';
+import { createRoleMethods, RoleConflictError } from './role';
+import type { RoleMethods, RoleDeps } from './role';
 import { createUserMethods, DEFAULT_SESSION_EXPIRY, type UserMethods } from './user';
 import { createKeyMethods, type KeyMethods } from './key';
 import { createFileMethods, type FileMethods } from './file';

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -1,10 +1,9 @@
 import { createSessionMethods, DEFAULT_REFRESH_TOKEN_EXPIRY, type SessionMethods } from './session';
 import { createTokenMethods, type TokenMethods } from './token';
 import { createRoleMethods, RoleConflictError, type RoleMethods, type RoleDeps } from './role';
-export { RoleConflictError };
 import { createUserMethods, DEFAULT_SESSION_EXPIRY, type UserMethods } from './user';
 
-export { DEFAULT_REFRESH_TOKEN_EXPIRY, DEFAULT_SESSION_EXPIRY };
+export { RoleConflictError, DEFAULT_REFRESH_TOKEN_EXPIRY, DEFAULT_SESSION_EXPIRY };
 import { createKeyMethods, type KeyMethods } from './key';
 import { createFileMethods, type FileMethods } from './file';
 /* Memories */

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -1,6 +1,7 @@
 import { createSessionMethods, DEFAULT_REFRESH_TOKEN_EXPIRY, type SessionMethods } from './session';
 import { createTokenMethods, type TokenMethods } from './token';
-import { createRoleMethods, type RoleMethods, type RoleDeps } from './role';
+import { createRoleMethods, RoleConflictError, type RoleMethods, type RoleDeps } from './role';
+export { RoleConflictError };
 import { createUserMethods, DEFAULT_SESSION_EXPIRY, type UserMethods } from './user';
 
 export { DEFAULT_REFRESH_TOKEN_EXPIRY, DEFAULT_SESSION_EXPIRY };

--- a/packages/data-schemas/src/methods/index.ts
+++ b/packages/data-schemas/src/methods/index.ts
@@ -2,8 +2,6 @@ import { createSessionMethods, DEFAULT_REFRESH_TOKEN_EXPIRY, type SessionMethods
 import { createTokenMethods, type TokenMethods } from './token';
 import { createRoleMethods, RoleConflictError, type RoleMethods, type RoleDeps } from './role';
 import { createUserMethods, DEFAULT_SESSION_EXPIRY, type UserMethods } from './user';
-
-export { RoleConflictError, DEFAULT_REFRESH_TOKEN_EXPIRY, DEFAULT_SESSION_EXPIRY };
 import { createKeyMethods, type KeyMethods } from './key';
 import { createFileMethods, type FileMethods } from './file';
 /* Memories */
@@ -51,6 +49,7 @@ import { createAgentMethods, type AgentMethods, type AgentDeps } from './agent';
 /* Config */
 import { createConfigMethods, type ConfigMethods } from './config';
 
+export { RoleConflictError, DEFAULT_REFRESH_TOKEN_EXPIRY, DEFAULT_SESSION_EXPIRY };
 export { tokenValues, cacheTokenValues, premiumTokenValues, defaultRate };
 
 export type AllMethods = UserMethods &

--- a/packages/data-schemas/src/methods/role.methods.spec.ts
+++ b/packages/data-schemas/src/methods/role.methods.spec.ts
@@ -30,6 +30,8 @@ let deleteRoleByName: ReturnType<typeof createRoleMethods>['deleteRoleByName'];
 let updateUsersByRole: ReturnType<typeof createRoleMethods>['updateUsersByRole'];
 let listUsersByRole: ReturnType<typeof createRoleMethods>['listUsersByRole'];
 let countUsersByRole: ReturnType<typeof createRoleMethods>['countUsersByRole'];
+let listRoles: ReturnType<typeof createRoleMethods>['listRoles'];
+let countRoles: ReturnType<typeof createRoleMethods>['countRoles'];
 let mongoServer: MongoMemoryServer;
 
 beforeAll(async () => {
@@ -48,6 +50,8 @@ beforeAll(async () => {
   updateUsersByRole = methods.updateUsersByRole;
   listUsersByRole = methods.listUsersByRole;
   countUsersByRole = methods.countUsersByRole;
+  listRoles = methods.listRoles;
+  countRoles = methods.countRoles;
 });
 
 afterAll(async () => {
@@ -743,5 +747,114 @@ describe('countUsersByRole', () => {
 
   it('returns 0 when no users have the role', async () => {
     expect(await countUsersByRole('nonexistent')).toBe(0);
+  });
+});
+
+describe('listRoles', () => {
+  beforeEach(async () => {
+    await Role.deleteMany({});
+  });
+
+  it('returns roles sorted alphabetically by name', async () => {
+    await Role.create([
+      { name: 'zebra', permissions: {} },
+      { name: 'alpha', permissions: {} },
+      { name: 'middle', permissions: {} },
+    ]);
+
+    const roles = await listRoles();
+
+    expect(roles.map((r) => r.name)).toEqual(['alpha', 'middle', 'zebra']);
+  });
+
+  it('respects limit and offset for pagination', async () => {
+    await Role.create([
+      { name: 'a-role', permissions: {} },
+      { name: 'b-role', permissions: {} },
+      { name: 'c-role', permissions: {} },
+      { name: 'd-role', permissions: {} },
+      { name: 'e-role', permissions: {} },
+    ]);
+
+    const page1 = await listRoles({ limit: 2, offset: 0 });
+    const page2 = await listRoles({ limit: 2, offset: 2 });
+    const page3 = await listRoles({ limit: 2, offset: 4 });
+
+    expect(page1).toHaveLength(2);
+    expect(page1.map((r) => r.name)).toEqual(['a-role', 'b-role']);
+    expect(page2).toHaveLength(2);
+    expect(page2.map((r) => r.name)).toEqual(['c-role', 'd-role']);
+    expect(page3).toHaveLength(1);
+    expect(page3.map((r) => r.name)).toEqual(['e-role']);
+  });
+
+  it('defaults to limit 50 and offset 0', async () => {
+    await Role.create({ name: 'only-role', permissions: {} });
+
+    const roles = await listRoles();
+
+    expect(roles).toHaveLength(1);
+    expect(roles[0].name).toBe('only-role');
+  });
+
+  it('returns only name and description fields', async () => {
+    await Role.create({
+      name: 'editor',
+      description: 'Can edit',
+      permissions: { PROMPTS: { USE: true } },
+    });
+
+    const roles = await listRoles();
+
+    expect(roles).toHaveLength(1);
+    expect(roles[0].name).toBe('editor');
+    expect(roles[0].description).toBe('Can edit');
+    expect(roles[0]._id).toBeDefined();
+    expect('permissions' in roles[0]).toBe(false);
+  });
+
+  it('returns empty array when no roles exist', async () => {
+    const roles = await listRoles();
+    expect(roles).toEqual([]);
+  });
+});
+
+describe('countRoles', () => {
+  beforeEach(async () => {
+    await Role.deleteMany({});
+  });
+
+  it('returns the total number of roles', async () => {
+    await Role.create([
+      { name: 'a', permissions: {} },
+      { name: 'b', permissions: {} },
+      { name: 'c', permissions: {} },
+    ]);
+
+    expect(await countRoles()).toBe(3);
+  });
+
+  it('returns 0 when no roles exist', async () => {
+    expect(await countRoles()).toBe(0);
+  });
+});
+
+describe('createRoleByName - duplicate key race', () => {
+  beforeEach(async () => {
+    await Role.deleteMany({});
+  });
+
+  it('throws RoleConflictError on concurrent insert (11000)', async () => {
+    await createRoleByName({ name: 'editor' });
+
+    const insertSpy = jest.spyOn(Role.prototype, 'save').mockImplementationOnce(() => {
+      const err = new Error('E11000 duplicate key error') as Error & { code: number };
+      err.code = 11000;
+      throw err;
+    });
+
+    await expect(createRoleByName({ name: 'editor2' })).rejects.toThrow(/already exists/);
+
+    insertSpy.mockRestore();
   });
 });

--- a/packages/data-schemas/src/methods/role.methods.spec.ts
+++ b/packages/data-schemas/src/methods/role.methods.spec.ts
@@ -30,6 +30,7 @@ let deleteRoleByName: ReturnType<typeof createRoleMethods>['deleteRoleByName'];
 let updateUsersByRole: ReturnType<typeof createRoleMethods>['updateUsersByRole'];
 let listUsersByRole: ReturnType<typeof createRoleMethods>['listUsersByRole'];
 let countUsersByRole: ReturnType<typeof createRoleMethods>['countUsersByRole'];
+let updateRoleByName: ReturnType<typeof createRoleMethods>['updateRoleByName'];
 let listRoles: ReturnType<typeof createRoleMethods>['listRoles'];
 let countRoles: ReturnType<typeof createRoleMethods>['countRoles'];
 let mongoServer: MongoMemoryServer;
@@ -47,6 +48,7 @@ beforeAll(async () => {
   initializeRoles = methods.initializeRoles;
   createRoleByName = methods.createRoleByName;
   deleteRoleByName = methods.deleteRoleByName;
+  updateRoleByName = methods.updateRoleByName;
   updateUsersByRole = methods.updateUsersByRole;
   listUsersByRole = methods.listUsersByRole;
   countUsersByRole = methods.countUsersByRole;
@@ -630,12 +632,42 @@ describe('deleteRoleByName', () => {
     expect(mockCache.set).toHaveBeenCalledWith('editor', null);
   });
 
-  it('does not touch cache when role does not exist', async () => {
+  it('returns null and invalidates cache when role does not exist', async () => {
     mockCache.set.mockClear();
 
-    await deleteRoleByName('nonexistent');
+    const result = await deleteRoleByName('nonexistent');
 
-    expect(mockCache.set).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+    expect(mockCache.set).toHaveBeenCalledWith('nonexistent', null);
+  });
+});
+
+describe('updateRoleByName - cache on rename', () => {
+  it('invalidates old key and populates new key on rename', async () => {
+    await createRoleByName({ name: 'editor', description: 'Can edit' });
+    mockCache.set.mockClear();
+
+    const updated = await updateRoleByName('editor', { name: 'senior-editor' });
+
+    expect(updated.name).toBe('senior-editor');
+    expect(mockCache.set).toHaveBeenCalledWith('editor', null);
+    expect(mockCache.set).toHaveBeenCalledWith(
+      'senior-editor',
+      expect.objectContaining({ name: 'senior-editor' }),
+    );
+  });
+
+  it('writes same key when name unchanged', async () => {
+    await createRoleByName({ name: 'editor' });
+    mockCache.set.mockClear();
+
+    await updateRoleByName('editor', { description: 'Updated desc' });
+
+    expect(mockCache.set).toHaveBeenCalledWith(
+      'editor',
+      expect.objectContaining({ name: 'editor', description: 'Updated desc' }),
+    );
+    expect(mockCache.set).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/data-schemas/src/methods/role.methods.spec.ts
+++ b/packages/data-schemas/src/methods/role.methods.spec.ts
@@ -1,9 +1,16 @@
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { SystemRoles, Permissions, roleDefaults, PermissionTypes } from 'librechat-data-provider';
-import type { IRole, RolePermissions } from '..';
+import type { IRole, IUser, RolePermissions } from '..';
 import { createRoleMethods } from './role';
 import { createModels } from '../models';
+
+jest.mock('~/config/winston', () => ({
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+}));
 
 const mockCache = {
   get: jest.fn(),
@@ -14,9 +21,13 @@ const mockCache = {
 const mockGetCache = jest.fn().mockReturnValue(mockCache);
 
 let Role: mongoose.Model<IRole>;
+let User: mongoose.Model<IUser>;
 let getRoleByName: ReturnType<typeof createRoleMethods>['getRoleByName'];
 let updateAccessPermissions: ReturnType<typeof createRoleMethods>['updateAccessPermissions'];
 let initializeRoles: ReturnType<typeof createRoleMethods>['initializeRoles'];
+let createRoleByName: ReturnType<typeof createRoleMethods>['createRoleByName'];
+let deleteRoleByName: ReturnType<typeof createRoleMethods>['deleteRoleByName'];
+let listUsersByRole: ReturnType<typeof createRoleMethods>['listUsersByRole'];
 let mongoServer: MongoMemoryServer;
 
 beforeAll(async () => {
@@ -25,10 +36,14 @@ beforeAll(async () => {
   await mongoose.connect(mongoUri);
   createModels(mongoose);
   Role = mongoose.models.Role;
+  User = mongoose.models.User as mongoose.Model<IUser>;
   const methods = createRoleMethods(mongoose, { getCache: mockGetCache });
   getRoleByName = methods.getRoleByName;
   updateAccessPermissions = methods.updateAccessPermissions;
   initializeRoles = methods.initializeRoles;
+  createRoleByName = methods.createRoleByName;
+  deleteRoleByName = methods.deleteRoleByName;
+  listUsersByRole = methods.listUsersByRole;
 });
 
 afterAll(async () => {
@@ -38,6 +53,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await Role.deleteMany({});
+  await User.deleteMany({});
   mockGetCache.mockClear();
   mockCache.get.mockClear();
   mockCache.set.mockClear();
@@ -513,5 +529,144 @@ describe('initializeRoles', () => {
     const userRole = await getRoleByName(SystemRoles.USER);
     expect(userRole.permissions[PermissionTypes.MULTI_CONVO]).toBeDefined();
     expect(userRole.permissions[PermissionTypes.MULTI_CONVO]?.USE).toBeDefined();
+  });
+});
+
+describe('createRoleByName', () => {
+  it('creates a custom role and caches it', async () => {
+    const role = await createRoleByName({ name: 'editor', description: 'Can edit' });
+
+    expect(role.name).toBe('editor');
+    expect(role.description).toBe('Can edit');
+    expect(mockCache.set).toHaveBeenCalledWith(
+      'editor',
+      expect.objectContaining({ name: 'editor' }),
+    );
+
+    const persisted = await Role.findOne({ name: 'editor' }).lean();
+    expect(persisted).toBeTruthy();
+  });
+
+  it('trims whitespace from role name', async () => {
+    const role = await createRoleByName({ name: '  editor  ' });
+
+    expect(role.name).toBe('editor');
+  });
+
+  it('throws when name is empty', async () => {
+    await expect(createRoleByName({ name: '' })).rejects.toThrow('Role name is required');
+  });
+
+  it('throws when name is whitespace-only', async () => {
+    await expect(createRoleByName({ name: '   ' })).rejects.toThrow('Role name is required');
+  });
+
+  it('throws when name is undefined', async () => {
+    await expect(createRoleByName({})).rejects.toThrow('Role name is required');
+  });
+
+  it('throws for reserved system role names', async () => {
+    await expect(createRoleByName({ name: SystemRoles.ADMIN })).rejects.toThrow(
+      /reserved system name/,
+    );
+    await expect(createRoleByName({ name: SystemRoles.USER })).rejects.toThrow(
+      /reserved system name/,
+    );
+  });
+
+  it('throws when role already exists', async () => {
+    await createRoleByName({ name: 'editor' });
+
+    await expect(createRoleByName({ name: 'editor' })).rejects.toThrow(/already exists/);
+  });
+});
+
+describe('deleteRoleByName', () => {
+  it('deletes a custom role and reassigns users to USER', async () => {
+    await createRoleByName({ name: 'editor' });
+    await User.create([
+      { name: 'Alice', email: 'alice@test.com', role: 'editor', username: 'alice' },
+      { name: 'Bob', email: 'bob@test.com', role: 'editor', username: 'bob' },
+      { name: 'Carol', email: 'carol@test.com', role: SystemRoles.USER, username: 'carol' },
+    ]);
+
+    const deleted = await deleteRoleByName('editor');
+
+    expect(deleted).toBeTruthy();
+    expect(deleted!.name).toBe('editor');
+
+    const alice = await User.findOne({ email: 'alice@test.com' }).lean();
+    const bob = await User.findOne({ email: 'bob@test.com' }).lean();
+    const carol = await User.findOne({ email: 'carol@test.com' }).lean();
+    expect(alice!.role).toBe(SystemRoles.USER);
+    expect(bob!.role).toBe(SystemRoles.USER);
+    expect(carol!.role).toBe(SystemRoles.USER);
+  });
+
+  it('returns null when role does not exist', async () => {
+    const result = await deleteRoleByName('nonexistent');
+    expect(result).toBeNull();
+  });
+
+  it('throws for system roles', async () => {
+    await expect(deleteRoleByName(SystemRoles.ADMIN)).rejects.toThrow(/Cannot delete system role/);
+    await expect(deleteRoleByName(SystemRoles.USER)).rejects.toThrow(/Cannot delete system role/);
+  });
+
+  it('sets cache entry to null after deletion', async () => {
+    await createRoleByName({ name: 'editor' });
+    mockCache.set.mockClear();
+
+    await deleteRoleByName('editor');
+
+    expect(mockCache.set).toHaveBeenCalledWith('editor', null);
+  });
+
+  it('does not touch cache when role does not exist', async () => {
+    mockCache.set.mockClear();
+
+    await deleteRoleByName('nonexistent');
+
+    expect(mockCache.set).not.toHaveBeenCalled();
+  });
+});
+
+describe('listUsersByRole', () => {
+  it('returns users matching the role', async () => {
+    await User.create([
+      { name: 'Alice', email: 'alice@test.com', role: 'editor', username: 'alice' },
+      { name: 'Bob', email: 'bob@test.com', role: 'editor', username: 'bob' },
+      { name: 'Carol', email: 'carol@test.com', role: SystemRoles.USER, username: 'carol' },
+    ]);
+
+    const users = await listUsersByRole('editor');
+
+    expect(users).toHaveLength(2);
+    const names = users.map((u) => u.name).sort();
+    expect(names).toEqual(['Alice', 'Bob']);
+  });
+
+  it('returns empty array when no users have the role', async () => {
+    const users = await listUsersByRole('nonexistent');
+    expect(users).toEqual([]);
+  });
+
+  it('selects only expected fields', async () => {
+    await User.create({
+      name: 'Alice',
+      email: 'alice@test.com',
+      role: 'editor',
+      username: 'alice',
+      password: 'secret123',
+    });
+
+    const users = await listUsersByRole('editor');
+
+    expect(users).toHaveLength(1);
+    expect(users[0].name).toBe('Alice');
+    expect(users[0].email).toBe('alice@test.com');
+    expect(users[0]._id).toBeDefined();
+    expect('password' in users[0]).toBe(false);
+    expect('username' in users[0]).toBe(false);
   });
 });

--- a/packages/data-schemas/src/methods/role.methods.spec.ts
+++ b/packages/data-schemas/src/methods/role.methods.spec.ts
@@ -817,6 +817,16 @@ describe('listRoles', () => {
     const roles = await listRoles();
     expect(roles).toEqual([]);
   });
+
+  it('returns undefined description for pre-existing roles without the field', async () => {
+    await Role.collection.insertOne({ name: 'legacy', permissions: {} });
+
+    const roles = await listRoles();
+
+    expect(roles).toHaveLength(1);
+    expect(roles[0].name).toBe('legacy');
+    expect(roles[0].description).toBeUndefined();
+  });
 });
 
 describe('countRoles', () => {

--- a/packages/data-schemas/src/methods/role.methods.spec.ts
+++ b/packages/data-schemas/src/methods/role.methods.spec.ts
@@ -655,6 +655,27 @@ describe('listUsersByRole', () => {
     expect(users).toEqual([]);
   });
 
+  it('respects limit and offset for pagination', async () => {
+    await User.create([
+      { name: 'Alice', email: 'a@test.com', role: 'editor', username: 'a' },
+      { name: 'Bob', email: 'b@test.com', role: 'editor', username: 'b' },
+      { name: 'Carol', email: 'c@test.com', role: 'editor', username: 'c' },
+      { name: 'Dave', email: 'd@test.com', role: 'editor', username: 'd' },
+      { name: 'Eve', email: 'e@test.com', role: 'editor', username: 'e' },
+    ]);
+
+    const page1 = await listUsersByRole('editor', { limit: 2, offset: 0 });
+    const page2 = await listUsersByRole('editor', { limit: 2, offset: 2 });
+    const page3 = await listUsersByRole('editor', { limit: 2, offset: 4 });
+
+    expect(page1).toHaveLength(2);
+    expect(page2).toHaveLength(2);
+    expect(page3).toHaveLength(1);
+
+    const allIds = [...page1, ...page2, ...page3].map((u) => u._id!.toString());
+    expect(new Set(allIds).size).toBe(5);
+  });
+
   it('selects only expected fields', async () => {
     await User.create({
       name: 'Alice',

--- a/packages/data-schemas/src/methods/role.methods.spec.ts
+++ b/packages/data-schemas/src/methods/role.methods.spec.ts
@@ -27,7 +27,9 @@ let updateAccessPermissions: ReturnType<typeof createRoleMethods>['updateAccessP
 let initializeRoles: ReturnType<typeof createRoleMethods>['initializeRoles'];
 let createRoleByName: ReturnType<typeof createRoleMethods>['createRoleByName'];
 let deleteRoleByName: ReturnType<typeof createRoleMethods>['deleteRoleByName'];
+let updateUsersByRole: ReturnType<typeof createRoleMethods>['updateUsersByRole'];
 let listUsersByRole: ReturnType<typeof createRoleMethods>['listUsersByRole'];
+let countUsersByRole: ReturnType<typeof createRoleMethods>['countUsersByRole'];
 let mongoServer: MongoMemoryServer;
 
 beforeAll(async () => {
@@ -43,7 +45,9 @@ beforeAll(async () => {
   initializeRoles = methods.initializeRoles;
   createRoleByName = methods.createRoleByName;
   deleteRoleByName = methods.deleteRoleByName;
+  updateUsersByRole = methods.updateUsersByRole;
   listUsersByRole = methods.listUsersByRole;
+  countUsersByRole = methods.countUsersByRole;
 });
 
 afterAll(async () => {
@@ -668,5 +672,55 @@ describe('listUsersByRole', () => {
     expect(users[0]._id).toBeDefined();
     expect('password' in users[0]).toBe(false);
     expect('username' in users[0]).toBe(false);
+  });
+});
+
+describe('updateUsersByRole', () => {
+  it('migrates all users from one role to another', async () => {
+    await User.create([
+      { name: 'Alice', email: 'alice@test.com', role: 'editor', username: 'alice' },
+      { name: 'Bob', email: 'bob@test.com', role: 'editor', username: 'bob' },
+      { name: 'Carol', email: 'carol@test.com', role: SystemRoles.USER, username: 'carol' },
+    ]);
+
+    await updateUsersByRole('editor', 'senior-editor');
+
+    const alice = await User.findOne({ email: 'alice@test.com' }).lean();
+    const bob = await User.findOne({ email: 'bob@test.com' }).lean();
+    const carol = await User.findOne({ email: 'carol@test.com' }).lean();
+    expect(alice!.role).toBe('senior-editor');
+    expect(bob!.role).toBe('senior-editor');
+    expect(carol!.role).toBe(SystemRoles.USER);
+  });
+
+  it('is a no-op when no users have the source role', async () => {
+    await User.create({
+      name: 'Alice',
+      email: 'alice@test.com',
+      role: SystemRoles.USER,
+      username: 'alice',
+    });
+
+    await updateUsersByRole('nonexistent', 'new-role');
+
+    const alice = await User.findOne({ email: 'alice@test.com' }).lean();
+    expect(alice!.role).toBe(SystemRoles.USER);
+  });
+});
+
+describe('countUsersByRole', () => {
+  it('returns the count of users with the given role', async () => {
+    await User.create([
+      { name: 'Alice', email: 'alice@test.com', role: 'editor', username: 'alice' },
+      { name: 'Bob', email: 'bob@test.com', role: 'editor', username: 'bob' },
+      { name: 'Carol', email: 'carol@test.com', role: SystemRoles.USER, username: 'carol' },
+    ]);
+
+    expect(await countUsersByRole('editor')).toBe(2);
+    expect(await countUsersByRole(SystemRoles.USER)).toBe(1);
+  });
+
+  it('returns 0 when no users have the role', async () => {
+    expect(await countUsersByRole('nonexistent')).toBe(0);
   });
 });

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -364,14 +364,24 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
         name: name.trim(),
       }).save();
     } catch (err) {
+      /**
+       * The compound unique index `{ name: 1, tenantId: 1 }` on the role schema
+       * (roleSchema.index in schema/role.ts) triggers error 11000 when a concurrent
+       * request races past the findOne check above. This catch converts it into
+       * the same user-facing message as the application-level duplicate check.
+       */
       if (err && typeof err === 'object' && 'code' in err && err.code === 11000) {
         throw new Error(`Role "${name.trim()}" already exists`);
       }
       throw err;
     }
-    const cache = deps.getCache?.(CacheKeys.ROLES);
-    if (cache) {
-      await cache.set(role.name, role.toObject());
+    try {
+      const cache = deps.getCache?.(CacheKeys.ROLES);
+      if (cache) {
+        await cache.set(role.name, role.toObject());
+      }
+    } catch (cacheError) {
+      logger.error(`[createRoleByName] cache set failed for "${role.name}":`, cacheError);
     }
     return role.toObject() as IRole;
   }

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -9,6 +9,13 @@ import type { Model } from 'mongoose';
 import type { IRole, IUser } from '~/types';
 import logger from '~/config/winston';
 
+export class RoleConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RoleConflictError';
+  }
+}
+
 export interface RoleDeps {
   /** Returns a cache store for the given key. Injected from getLogStores. */
   getCache?: (key: string) => {
@@ -350,12 +357,12 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
       throw new Error('Role name is required');
     }
     if (SystemRoles[name.trim() as keyof typeof SystemRoles]) {
-      throw new Error(`Cannot create role with reserved system name: ${name}`);
+      throw new RoleConflictError(`Cannot create role with reserved system name: ${name}`);
     }
     const Role = mongoose.models.Role;
     const existing = await Role.findOne({ name: name.trim() }).lean();
     if (existing) {
-      throw new Error(`Role "${name.trim()}" already exists`);
+      throw new RoleConflictError(`Role "${name.trim()}" already exists`);
     }
     let role;
     try {
@@ -371,7 +378,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
        * the same user-facing message as the application-level duplicate check.
        */
       if (err && typeof err === 'object' && 'code' in err && err.code === 11000) {
-        throw new Error(`Role "${name.trim()}" already exists`);
+        throw new RoleConflictError(`Role "${name.trim()}" already exists`);
       }
       throw err;
     }
@@ -400,9 +407,13 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     }
     await getUserModel().updateMany({ role: roleName }, { $set: { role: SystemRoles.USER } });
     const deleted = await Role.findOneAndDelete({ name: roleName }).lean();
-    const cache = deps.getCache?.(CacheKeys.ROLES);
-    if (cache) {
-      await cache.set(roleName, null);
+    try {
+      const cache = deps.getCache?.(CacheKeys.ROLES);
+      if (cache) {
+        await cache.set(roleName, null);
+      }
+    } catch (cacheError) {
+      logger.error(`[deleteRoleByName] cache invalidation failed for "${roleName}":`, cacheError);
     }
     return deleted as IRole | null;
   }

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -452,6 +452,20 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     await User.updateMany({ role: oldRole }, { $set: { role: newRole } });
   }
 
+  async function findUserIdsByRole(roleName: string): Promise<string[]> {
+    const User = mongoose.models.User as Model<IUser>;
+    const users = await User.find({ role: roleName }).select('_id').lean();
+    return users.map((u) => u._id.toString());
+  }
+
+  async function updateUsersRoleByIds(userIds: string[], newRole: string): Promise<void> {
+    if (userIds.length === 0) {
+      return;
+    }
+    const User = mongoose.models.User as Model<IUser>;
+    await User.updateMany({ _id: { $in: userIds } }, { $set: { role: newRole } });
+  }
+
   async function listUsersByRole(
     roleName: string,
     options?: { limit?: number; offset?: number },
@@ -483,6 +497,8 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     createRoleByName,
     deleteRoleByName,
     updateUsersByRole,
+    findUserIdsByRole,
+    updateUsersRoleByIds,
     listUsersByRole,
     countUsersByRole,
   };

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -62,13 +62,12 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     const Role = mongoose.models.Role;
     const limit = options?.limit ?? 50;
     const offset = options?.offset ?? 0;
-    const results = await Role.find({})
+    return await Role.find({})
       .select('name description')
       .sort({ name: 1 })
       .skip(offset)
       .limit(limit)
-      .lean();
-    return results as unknown[] as IRole[];
+      .lean<IRole[]>();
   }
 
   async function countRoles(): Promise<number> {
@@ -137,7 +136,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
         const targetName = updates.name ?? roleName;
         throw new RoleConflictError(`Role "${targetName}" already exists`);
       }
-      throw new Error(`Failed to update role: ${(error as Error).message}`);
+      throw new Error(`Failed to update role: ${(error as Error).message}`, { cause: error });
     }
   }
 

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -55,9 +55,21 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
   /**
    * List all roles in the system.
    */
-  async function listRoles() {
+  async function listRoles(options?: { limit?: number; offset?: number }): Promise<IRole[]> {
     const Role = mongoose.models.Role;
-    return await Role.find({}).select('name description permissions').lean();
+    const limit = options?.limit ?? 50;
+    const offset = options?.offset ?? 0;
+    return await Role.find({})
+      .select('name description')
+      .sort({ name: 1 })
+      .skip(offset)
+      .limit(limit)
+      .lean();
+  }
+
+  async function countRoles(): Promise<number> {
+    const Role = mongoose.models.Role;
+    return await Role.countDocuments({});
   }
 
   /**
@@ -443,6 +455,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
 
   return {
     listRoles,
+    countRoles,
     initializeRoles,
     getRoleByName,
     updateRoleByName,

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -438,7 +438,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
   }
 
   async function countUsersByRole(roleName: string): Promise<number> {
-    return getUserModel().countDocuments({ role: roleName });
+    return await getUserModel().countDocuments({ role: roleName });
   }
 
   return {

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -342,6 +342,54 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     }
   }
 
+  /**
+   * Create a new custom role. Rejects names that match system roles.
+   */
+  async function createRole(roleData: Partial<IRole>): Promise<IRole> {
+    const { name } = roleData;
+    if (!name || typeof name !== 'string' || !name.trim()) {
+      throw new Error('Role name is required');
+    }
+    if (SystemRoles[name.trim() as keyof typeof SystemRoles]) {
+      throw new Error(`Cannot create role with reserved system name: ${name}`);
+    }
+    const Role = mongoose.models.Role;
+    const existing = await Role.findOne({ name: name.trim() }).lean();
+    if (existing) {
+      throw new Error(`Role "${name}" already exists`);
+    }
+    const role = await new Role({
+      ...roleData,
+      name: name.trim(),
+    }).save();
+    const cache = deps.getCache?.(CacheKeys.ROLES);
+    if (cache) {
+      await cache.set(role.name, role.toObject());
+    }
+    return role.toObject() as IRole;
+  }
+
+  /**
+   * Delete a role by name. Guards against deleting system roles.
+   * Reassigns all users with the deleted role back to USER.
+   */
+  async function deleteRole(roleName: string): Promise<IRole | null> {
+    if (SystemRoles[roleName as keyof typeof SystemRoles]) {
+      throw new Error(`Cannot delete system role: ${roleName}`);
+    }
+    const Role = mongoose.models.Role;
+    const User = mongoose.models.User;
+    const deleted = await Role.findOneAndDelete({ name: roleName }).lean();
+    if (deleted) {
+      await User.updateMany({ role: roleName }, { $set: { role: SystemRoles.USER } });
+      const cache = deps.getCache?.(CacheKeys.ROLES);
+      if (cache) {
+        await cache.set(roleName, null);
+      }
+    }
+    return deleted as IRole | null;
+  }
+
   return {
     listRoles,
     initializeRoles,
@@ -349,6 +397,8 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     updateRoleByName,
     updateAccessPermissions,
     migrateRoleSchema,
+    createRole,
+    deleteRole,
   };
 }
 

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -343,7 +343,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
   }
 
   /** Rejects names that match system roles. */
-  async function createRole(roleData: Partial<IRole>): Promise<IRole> {
+  async function createRoleByName(roleData: Partial<IRole>): Promise<IRole> {
     const { name } = roleData;
     if (!name || typeof name !== 'string' || !name.trim()) {
       throw new Error('Role name is required');
@@ -368,7 +368,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
   }
 
   /** Guards against deleting system roles. Reassigns affected users back to USER. */
-  async function deleteRole(roleName: string): Promise<IRole | null> {
+  async function deleteRoleByName(roleName: string): Promise<IRole | null> {
     if (SystemRoles[roleName as keyof typeof SystemRoles]) {
       throw new Error(`Cannot delete system role: ${roleName}`);
     }
@@ -399,8 +399,8 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     updateRoleByName,
     updateAccessPermissions,
     migrateRoleSchema,
-    createRole,
-    deleteRole,
+    createRoleByName,
+    deleteRoleByName,
     listUsersByRole,
   };
 }

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -382,6 +382,10 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
       throw new Error(`Cannot delete system role: ${roleName}`);
     }
     const Role = mongoose.models.Role;
+    const exists = await Role.findOne({ name: roleName }).lean();
+    if (!exists) {
+      return null;
+    }
     const User = mongoose.models.User as Model<IUser>;
     await User.updateMany({ role: roleName }, { $set: { role: SystemRoles.USER } });
     const deleted = await Role.findOneAndDelete({ name: roleName }).lean();
@@ -406,6 +410,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     const offset = options?.offset ?? 0;
     return await User.find({ role: roleName })
       .select('_id name email avatar')
+      .sort({ _id: 1 })
       .skip(offset)
       .limit(limit)
       .lean();

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -58,9 +58,12 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
   }
 
   /**
-   * List all roles in the system.
+   * List all roles in the system. Returns only name and description (projected).
    */
-  async function listRoles(options?: { limit?: number; offset?: number }): Promise<IRole[]> {
+  async function listRoles(options?: {
+    limit?: number;
+    offset?: number;
+  }): Promise<Pick<IRole, 'name' | 'description'>[]> {
     const Role = mongoose.models.Role;
     const limit = options?.limit ?? 50;
     const offset = options?.offset ?? 0;
@@ -69,7 +72,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
       .sort({ name: 1 })
       .skip(offset)
       .limit(limit)
-      .lean<IRole[]>();
+      .lean();
   }
 
   async function countRoles(): Promise<number> {
@@ -416,13 +419,15 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
    * Guards against deleting system roles. Reassigns affected users back to USER.
    *
    * No existence pre-check is performed: for a nonexistent role the `updateMany`
-   * is a harmless no-op and `findOneAndDelete` returns null. This is intentional
-   * so that calling delete after a partial failure still cleans up orphaned user
-   * references and cache entries (self-healing).
+   * is a harmless no-op and `findOneAndDelete` returns null. This makes the
+   * function idempotent — a retry after a partial failure will still clean up
+   * orphaned user references and cache entries.
    *
    * Without a MongoDB transaction the two writes are non-atomic — if the delete
    * fails after the reassignment, users will already have been moved to USER
-   * while the role document still exists.
+   * while the role document still exists. Recovery requires the caller to retry
+   * the delete call, which will succeed since the `updateMany` is a no-op on
+   * the second pass.
    */
   async function deleteRoleByName(roleName: string): Promise<IRole | null> {
     if (systemRoleValues.has(roleName)) {

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -419,10 +419,14 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
   /**
    * Guards against deleting system roles. Reassigns affected users back to USER.
    *
-   * Note: the user reassignment (`updateMany`) runs before `findOneAndDelete`.
-   * Without a MongoDB transaction these two operations are non-atomic — if the
-   * delete fails after the reassignment, users will already have been moved to
-   * USER while the role document still exists.
+   * No existence pre-check is performed: for a nonexistent role the `updateMany`
+   * is a harmless no-op and `findOneAndDelete` returns null. This is intentional
+   * so that calling delete after a partial failure still cleans up orphaned user
+   * references and cache entries (self-healing).
+   *
+   * Without a MongoDB transaction the two writes are non-atomic — if the delete
+   * fails after the reassignment, users will already have been moved to USER
+   * while the role document still exists.
    */
   async function deleteRoleByName(roleName: string): Promise<IRole | null> {
     if (systemRoleValues.has(roleName)) {

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -121,11 +121,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     const cache = deps.getCache?.(CacheKeys.ROLES);
     try {
       const Role = mongoose.models.Role;
-      const role = await Role.findOneAndUpdate(
-        { name: roleName },
-        { $set: updates },
-        { new: true, lean: true },
-      )
+      const role = await Role.findOneAndUpdate({ name: roleName }, { $set: updates }, { new: true })
         .select('-__v')
         .lean()
         .exec();
@@ -439,6 +435,9 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     try {
       const cache = deps.getCache?.(CacheKeys.ROLES);
       if (cache) {
+        // Setting null evicts the stale document. getRoleByName treats falsy cached
+        // values as a miss and falls through to the DB, so this does not provide
+        // negative caching — it only prevents serving the pre-deletion document.
         await cache.set(roleName, null);
       }
     } catch (cacheError) {

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -9,6 +9,8 @@ import type { Model } from 'mongoose';
 import type { IRole, IUser } from '~/types';
 import logger from '~/config/winston';
 
+const systemRoleValues = new Set<string>(Object.values(SystemRoles));
+
 export class RoleConflictError extends Error {
   constructor(message: string) {
     super(message);
@@ -96,7 +98,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
       }
       const role = await query.lean().exec();
 
-      if (!role && SystemRoles[roleName as keyof typeof SystemRoles]) {
+      if (!role && systemRoleValues.has(roleName)) {
         const newRole = await new Role(roleDefaults[roleName as keyof typeof roleDefaults]).save();
         if (cache) {
           await cache.set(roleName, newRole);
@@ -380,7 +382,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
       throw new Error('Role name is required');
     }
     const trimmed = name.trim();
-    if (SystemRoles[trimmed as keyof typeof SystemRoles]) {
+    if (systemRoleValues.has(trimmed)) {
       throw new RoleConflictError(`Cannot create role with reserved system name: ${name}`);
     }
     const Role = mongoose.models.Role;
@@ -414,9 +416,16 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     return role.toObject() as IRole;
   }
 
-  /** Guards against deleting system roles. Reassigns affected users back to USER. */
+  /**
+   * Guards against deleting system roles. Reassigns affected users back to USER.
+   *
+   * Note: the user reassignment (`updateMany`) runs before `findOneAndDelete`.
+   * Without a MongoDB transaction these two operations are non-atomic — if the
+   * delete fails after the reassignment, users will already have been moved to
+   * USER while the role document still exists.
+   */
   async function deleteRoleByName(roleName: string): Promise<IRole | null> {
-    if (SystemRoles[roleName as keyof typeof SystemRoles]) {
+    if (systemRoleValues.has(roleName)) {
       throw new Error(`Cannot delete system role: ${roleName}`);
     }
     const Role = mongoose.models.Role;

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -38,8 +38,11 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
       const defaultPerms = roleDefaults[roleName].permissions;
 
       if (!role) {
-        role = new Role(roleDefaults[roleName]);
+        role = new Role({ ...roleDefaults[roleName], description: '' });
       } else {
+        if (role.description == null) {
+          role.description = '';
+        }
         const permissions = role.toObject()?.permissions ?? {};
         role.permissions = role.permissions || {};
         for (const permType of Object.keys(defaultPerms)) {
@@ -59,12 +62,13 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     const Role = mongoose.models.Role;
     const limit = options?.limit ?? 50;
     const offset = options?.offset ?? 0;
-    return await Role.find({})
+    const results = await Role.find({})
       .select('name description')
       .sort({ name: 1 })
       .skip(offset)
       .limit(limit)
       .lean();
+    return results as unknown[] as IRole[];
   }
 
   async function countRoles(): Promise<number> {
@@ -129,6 +133,10 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
       }
       return role as unknown as IRole;
     } catch (error) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 11000) {
+        const targetName = updates.name ?? roleName;
+        throw new RoleConflictError(`Role "${targetName}" already exists`);
+      }
       throw new Error(`Failed to update role: ${(error as Error).message}`);
     }
   }

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -5,7 +5,7 @@ import {
   permissionsSchema,
   removeNullishValues,
 } from 'librechat-data-provider';
-import type { IRole } from '~/types';
+import type { IRole, IUser } from '~/types';
 import logger from '~/config/winston';
 
 export interface RoleDeps {
@@ -342,9 +342,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     }
   }
 
-  /**
-   * Create a new custom role. Rejects names that match system roles.
-   */
+  /** Rejects names that match system roles. */
   async function createRole(roleData: Partial<IRole>): Promise<IRole> {
     const { name } = roleData;
     if (!name || typeof name !== 'string' || !name.trim()) {
@@ -369,10 +367,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     return role.toObject() as IRole;
   }
 
-  /**
-   * Delete a role by name. Guards against deleting system roles.
-   * Reassigns all users with the deleted role back to USER.
-   */
+  /** Guards against deleting system roles. Reassigns affected users back to USER. */
   async function deleteRole(roleName: string): Promise<IRole | null> {
     if (SystemRoles[roleName as keyof typeof SystemRoles]) {
       throw new Error(`Cannot delete system role: ${roleName}`);
@@ -390,6 +385,13 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     return deleted as IRole | null;
   }
 
+  async function listUsersByRole(roleName: string): Promise<IUser[]> {
+    const User = mongoose.models.User;
+    return (await User.find({ role: roleName })
+      .select('_id name email avatar createdAt')
+      .lean()) as IUser[];
+  }
+
   return {
     listRoles,
     initializeRoles,
@@ -399,6 +401,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     migrateRoleSchema,
     createRole,
     deleteRole,
+    listUsersByRole,
   };
 }
 

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -63,7 +63,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
   async function listRoles(options?: {
     limit?: number;
     offset?: number;
-  }): Promise<Pick<IRole, 'name' | 'description'>[]> {
+  }): Promise<Pick<IRole, '_id' | 'name' | 'description'>[]> {
     const Role = mongoose.models.Role;
     const limit = options?.limit ?? 50;
     const offset = options?.offset ?? 0;

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -355,7 +355,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     const Role = mongoose.models.Role;
     const existing = await Role.findOne({ name: name.trim() }).lean();
     if (existing) {
-      throw new Error(`Role "${name}" already exists`);
+      throw new Error(`Role "${name.trim()}" already exists`);
     }
     let role;
     try {
@@ -376,6 +376,8 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     return role.toObject() as IRole;
   }
 
+  const getUserModel = () => mongoose.models.User as Model<IUser>;
+
   /** Guards against deleting system roles. Reassigns affected users back to USER. */
   async function deleteRoleByName(roleName: string): Promise<IRole | null> {
     if (SystemRoles[roleName as keyof typeof SystemRoles]) {
@@ -386,8 +388,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     if (!exists) {
       return null;
     }
-    const User = mongoose.models.User as Model<IUser>;
-    await User.updateMany({ role: roleName }, { $set: { role: SystemRoles.USER } });
+    await getUserModel().updateMany({ role: roleName }, { $set: { role: SystemRoles.USER } });
     const deleted = await Role.findOneAndDelete({ name: roleName }).lean();
     const cache = deps.getCache?.(CacheKeys.ROLES);
     if (cache) {
@@ -397,18 +398,17 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
   }
 
   async function updateUsersByRole(oldRole: string, newRole: string): Promise<void> {
-    const User = mongoose.models.User as Model<IUser>;
-    await User.updateMany({ role: oldRole }, { $set: { role: newRole } });
+    await getUserModel().updateMany({ role: oldRole }, { $set: { role: newRole } });
   }
 
   async function listUsersByRole(
     roleName: string,
     options?: { limit?: number; offset?: number },
   ): Promise<IUser[]> {
-    const User = mongoose.models.User as Model<IUser>;
     const limit = options?.limit ?? 50;
     const offset = options?.offset ?? 0;
-    return await User.find({ role: roleName })
+    return await getUserModel()
+      .find({ role: roleName })
       .select('_id name email avatar')
       .sort({ _id: 1 })
       .skip(offset)
@@ -417,8 +417,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
   }
 
   async function countUsersByRole(roleName: string): Promise<number> {
-    const User = mongoose.models.User as Model<IUser>;
-    return User.countDocuments({ role: roleName });
+    return getUserModel().countDocuments({ role: roleName });
   }
 
   return {

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -49,7 +49,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
    */
   async function listRoles() {
     const Role = mongoose.models.Role;
-    return await Role.find({}).select('name permissions').lean();
+    return await Role.find({}).select('name description permissions').lean();
   }
 
   /**

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -128,7 +128,11 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
         .lean()
         .exec();
       if (cache) {
-        await cache.set(roleName, role);
+        if (updates.name && updates.name !== roleName) {
+          await Promise.all([cache.set(roleName, null), cache.set(updates.name, role)]);
+        } else {
+          await cache.set(roleName, role);
+        }
       }
       return role as unknown as IRole;
     } catch (error) {
@@ -375,20 +379,18 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     if (!name || typeof name !== 'string' || !name.trim()) {
       throw new Error('Role name is required');
     }
-    if (SystemRoles[name.trim() as keyof typeof SystemRoles]) {
+    const trimmed = name.trim();
+    if (SystemRoles[trimmed as keyof typeof SystemRoles]) {
       throw new RoleConflictError(`Cannot create role with reserved system name: ${name}`);
     }
     const Role = mongoose.models.Role;
-    const existing = await Role.findOne({ name: name.trim() }).lean();
+    const existing = await Role.findOne({ name: trimmed }).lean();
     if (existing) {
-      throw new RoleConflictError(`Role "${name.trim()}" already exists`);
+      throw new RoleConflictError(`Role "${trimmed}" already exists`);
     }
     let role;
     try {
-      role = await new Role({
-        ...roleData,
-        name: name.trim(),
-      }).save();
+      role = await new Role({ ...roleData, name: trimmed }).save();
     } catch (err) {
       /**
        * The compound unique index `{ name: 1, tenantId: 1 }` on the role schema
@@ -397,7 +399,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
        * the same user-facing message as the application-level duplicate check.
        */
       if (err && typeof err === 'object' && 'code' in err && err.code === 11000) {
-        throw new RoleConflictError(`Role "${name.trim()}" already exists`);
+        throw new RoleConflictError(`Role "${trimmed}" already exists`);
       }
       throw err;
     }
@@ -412,19 +414,14 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     return role.toObject() as IRole;
   }
 
-  const getUserModel = () => mongoose.models.User as Model<IUser>;
-
   /** Guards against deleting system roles. Reassigns affected users back to USER. */
   async function deleteRoleByName(roleName: string): Promise<IRole | null> {
     if (SystemRoles[roleName as keyof typeof SystemRoles]) {
       throw new Error(`Cannot delete system role: ${roleName}`);
     }
     const Role = mongoose.models.Role;
-    const exists = await Role.findOne({ name: roleName }).lean();
-    if (!exists) {
-      return null;
-    }
-    await getUserModel().updateMany({ role: roleName }, { $set: { role: SystemRoles.USER } });
+    const User = mongoose.models.User as Model<IUser>;
+    await User.updateMany({ role: roleName }, { $set: { role: SystemRoles.USER } });
     const deleted = await Role.findOneAndDelete({ name: roleName }).lean();
     try {
       const cache = deps.getCache?.(CacheKeys.ROLES);
@@ -438,17 +435,18 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
   }
 
   async function updateUsersByRole(oldRole: string, newRole: string): Promise<void> {
-    await getUserModel().updateMany({ role: oldRole }, { $set: { role: newRole } });
+    const User = mongoose.models.User as Model<IUser>;
+    await User.updateMany({ role: oldRole }, { $set: { role: newRole } });
   }
 
   async function listUsersByRole(
     roleName: string,
     options?: { limit?: number; offset?: number },
   ): Promise<IUser[]> {
+    const User = mongoose.models.User as Model<IUser>;
     const limit = options?.limit ?? 50;
     const offset = options?.offset ?? 0;
-    return await getUserModel()
-      .find({ role: roleName })
+    return await User.find({ role: roleName })
       .select('_id name email avatar')
       .sort({ _id: 1 })
       .skip(offset)
@@ -457,7 +455,8 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
   }
 
   async function countUsersByRole(roleName: string): Promise<number> {
-    return await getUserModel().countDocuments({ role: roleName });
+    const User = mongoose.models.User as Model<IUser>;
+    return await User.countDocuments({ role: roleName });
   }
 
   return {

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -11,6 +11,11 @@ import logger from '~/config/winston';
 
 const systemRoleValues = new Set<string>(Object.values(SystemRoles));
 
+/** Case-insensitive check — the legacy roles route uppercases params. */
+function isSystemRoleName(name: string): boolean {
+  return systemRoleValues.has(name.toUpperCase());
+}
+
 export class RoleConflictError extends Error {
   constructor(message: string) {
     super(message);
@@ -381,7 +386,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
       throw new Error('Role name is required');
     }
     const trimmed = name.trim();
-    if (systemRoleValues.has(trimmed)) {
+    if (isSystemRoleName(trimmed)) {
       throw new RoleConflictError(`Cannot create role with reserved system name: ${name}`);
     }
     const Role = mongoose.models.Role;
@@ -430,7 +435,7 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
    * the second pass.
    */
   async function deleteRoleByName(roleName: string): Promise<IRole | null> {
-    if (systemRoleValues.has(roleName)) {
+    if (isSystemRoleName(roleName)) {
       throw new Error(`Cannot delete system role: ${roleName}`);
     }
     const Role = mongoose.models.Role;

--- a/packages/data-schemas/src/methods/role.ts
+++ b/packages/data-schemas/src/methods/role.ts
@@ -5,6 +5,7 @@ import {
   permissionsSchema,
   removeNullishValues,
 } from 'librechat-data-provider';
+import type { Model } from 'mongoose';
 import type { IRole, IUser } from '~/types';
 import logger from '~/config/winston';
 
@@ -356,10 +357,18 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     if (existing) {
       throw new Error(`Role "${name}" already exists`);
     }
-    const role = await new Role({
-      ...roleData,
-      name: name.trim(),
-    }).save();
+    let role;
+    try {
+      role = await new Role({
+        ...roleData,
+        name: name.trim(),
+      }).save();
+    } catch (err) {
+      if (err && typeof err === 'object' && 'code' in err && err.code === 11000) {
+        throw new Error(`Role "${name.trim()}" already exists`);
+      }
+      throw err;
+    }
     const cache = deps.getCache?.(CacheKeys.ROLES);
     if (cache) {
       await cache.set(role.name, role.toObject());
@@ -373,23 +382,38 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
       throw new Error(`Cannot delete system role: ${roleName}`);
     }
     const Role = mongoose.models.Role;
-    const User = mongoose.models.User;
+    const User = mongoose.models.User as Model<IUser>;
+    await User.updateMany({ role: roleName }, { $set: { role: SystemRoles.USER } });
     const deleted = await Role.findOneAndDelete({ name: roleName }).lean();
-    if (deleted) {
-      await User.updateMany({ role: roleName }, { $set: { role: SystemRoles.USER } });
-      const cache = deps.getCache?.(CacheKeys.ROLES);
-      if (cache) {
-        await cache.set(roleName, null);
-      }
+    const cache = deps.getCache?.(CacheKeys.ROLES);
+    if (cache) {
+      await cache.set(roleName, null);
     }
     return deleted as IRole | null;
   }
 
-  async function listUsersByRole(roleName: string): Promise<IUser[]> {
-    const User = mongoose.models.User;
-    return (await User.find({ role: roleName })
-      .select('_id name email avatar createdAt')
-      .lean()) as IUser[];
+  async function updateUsersByRole(oldRole: string, newRole: string): Promise<void> {
+    const User = mongoose.models.User as Model<IUser>;
+    await User.updateMany({ role: oldRole }, { $set: { role: newRole } });
+  }
+
+  async function listUsersByRole(
+    roleName: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<IUser[]> {
+    const User = mongoose.models.User as Model<IUser>;
+    const limit = options?.limit ?? 50;
+    const offset = options?.offset ?? 0;
+    return await User.find({ role: roleName })
+      .select('_id name email avatar')
+      .skip(offset)
+      .limit(limit)
+      .lean();
+  }
+
+  async function countUsersByRole(roleName: string): Promise<number> {
+    const User = mongoose.models.User as Model<IUser>;
+    return User.countDocuments({ role: roleName });
   }
 
   return {
@@ -401,7 +425,9 @@ export function createRoleMethods(mongoose: typeof import('mongoose'), deps: Rol
     migrateRoleSchema,
     createRoleByName,
     deleteRoleByName,
+    updateUsersByRole,
     listUsersByRole,
+    countUsersByRole,
   };
 }
 

--- a/packages/data-schemas/src/schema/role.ts
+++ b/packages/data-schemas/src/schema/role.ts
@@ -73,6 +73,7 @@ const rolePermissionsSchema = new Schema(
 
 const roleSchema: Schema<IRole> = new Schema({
   name: { type: String, required: true, index: true },
+  description: { type: String, default: '' },
   permissions: {
     type: rolePermissionsSchema,
   },

--- a/packages/data-schemas/src/schema/user.ts
+++ b/packages/data-schemas/src/schema/user.ts
@@ -64,7 +64,6 @@ const userSchema = new Schema<IUser>(
     role: {
       type: String,
       default: SystemRoles.USER,
-      index: true,
     },
     googleId: {
       type: String,
@@ -159,6 +158,7 @@ const userSchema = new Schema<IUser>(
 );
 
 userSchema.index({ email: 1, tenantId: 1 }, { unique: true });
+userSchema.index({ role: 1, tenantId: 1 });
 
 const oAuthIdFields = [
   'googleId',

--- a/packages/data-schemas/src/schema/user.ts
+++ b/packages/data-schemas/src/schema/user.ts
@@ -64,6 +64,7 @@ const userSchema = new Schema<IUser>(
     role: {
       type: String,
       default: SystemRoles.USER,
+      index: true,
     },
     googleId: {
       type: String,

--- a/packages/data-schemas/src/types/admin.ts
+++ b/packages/data-schemas/src/types/admin.ts
@@ -114,7 +114,7 @@ export type AdminMember = {
   name: string;
   email: string;
   avatarUrl?: string;
-  joinedAt: string;
+  joinedAt?: string;
 };
 
 /** Minimal user info returned by user search endpoints. */

--- a/packages/data-schemas/src/types/role.ts
+++ b/packages/data-schemas/src/types/role.ts
@@ -5,6 +5,7 @@ import { CursorPaginationParams } from '~/common';
 
 export interface IRole extends Document {
   name: string;
+  description?: string;
   permissions: {
     [PermissionTypes.BOOKMARKS]?: {
       [Permissions.USE]?: boolean;
@@ -74,11 +75,13 @@ export type RolePermissionsInput = DeepPartial<RolePermissions>;
 
 export interface CreateRoleRequest {
   name: string;
+  description?: string;
   permissions: RolePermissionsInput;
 }
 
 export interface UpdateRoleRequest {
   name?: string;
+  description?: string;
   permissions?: RolePermissionsInput;
 }
 

--- a/packages/data-schemas/src/types/role.ts
+++ b/packages/data-schemas/src/types/role.ts
@@ -5,7 +5,7 @@ import { CursorPaginationParams } from '~/common';
 
 export interface IRole extends Document {
   name: string;
-  description?: string;
+  description: string;
   permissions: {
     [PermissionTypes.BOOKMARKS]?: {
       [Permissions.USE]?: boolean;

--- a/packages/data-schemas/src/types/role.ts
+++ b/packages/data-schemas/src/types/role.ts
@@ -5,7 +5,7 @@ import { CursorPaginationParams } from '~/common';
 
 export interface IRole extends Document {
   name: string;
-  description: string;
+  description?: string;
   permissions: {
     [PermissionTypes.BOOKMARKS]?: {
       [Permissions.USE]?: boolean;


### PR DESCRIPTION
## Summary

This pull request adds new REST API endpoints for creating, updating, deleting, and managing roles and their members, along with supporting backend logic and data schema enhancements. 

**Major Features and API Enhancements:**

* Added a new `adminRoles` route with endpoints for listing, creating, updating, deleting roles, managing permissions, and assigning/removing users from roles. This includes all necessary middleware for authentication and capability checks.
* Implemented `createAdminRolesHandlers` in `packages/api` to provide handler functions for all new role management endpoints, supporting operations such as listing roles, CRUD for roles, permission updates, and member management.

**Backend and Data Model Changes:**

* Enhanced the role data model by adding a `description` field to `IRole` and the underlying Mongoose schema, and updated related TypeScript interfaces and request types to support role descriptions.
* Extended role methods with new functions: `createRoleByName` (rejects system role names, checks for duplicates, catches MongoDB 11000 duplicate key errors), `deleteRoleByName` (guards against deleting system roles, checks existence before reassigning users), `updateUsersByRole` (bulk user migration for role renames), `listUsersByRole` (paginated, sorted by `_id`), and `countUsersByRole` (for pagination totals). Also updated `listRoles` to include the `description` field.

**Safety and Validation:**

* System roles (ADMIN, USER) cannot be renamed or deleted.
* Role rename migrates users *before* renaming the role document — if migration fails, the role keeps its old name (consistent state). If the rename itself fails, users are rolled back to the original role name.
* Input validation: name trimming, max-length (500), duplicate name check on rename, `Array.isArray` guard on permissions, consistent nullish coalescing.
* Error classification uses prefix-based string matching instead of `String.includes` to avoid false 409s.
* Paginated member listing with limit/offset/total and deterministic `_id` sort.
* Shared `AdminMember` type imported from `@librechat/data-schemas` (with `joinedAt` made optional).

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- `packages/api/src/admin/roles.spec.ts` — **57 unit tests** covering all 9 handler functions (list, create, update, delete roles; get/update permissions; list/add/remove members), including input validation, error paths, ObjectId format checks, rename ordering verification, migration failure safety, and rollback on rename failure.
- `packages/data-schemas/src/methods/role.methods.spec.ts` — **40 data-layer tests** with mongodb-memory-server for `createRoleByName`, `deleteRoleByName` (existence gating, user reassignment, cache behavior), `listUsersByRole`, `updateUsersByRole`, `countUsersByRole`, `updateAccessPermissions`, and `initializeRoles`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.