### PR TITLE
🧵 feat: ALS Context Middleware, Tenant Threading, and Config Cache Invalidation

### DIFF
--- a/api/server/controllers/PluginController.js
+++ b/api/server/controllers/PluginController.js
@@ -15,7 +15,7 @@ const getAvailablePluginsController = async (req, res) => {
       return;
     }
 
-    const appConfig = await getAppConfig({ role: req.user?.role });
+    const appConfig = await getAppConfig({ role: req.user?.role, tenantId: req.user?.tenantId });
     /** @type {{ filteredTools: string[], includedTools: string[] }} */
     const { filteredTools = [], includedTools = [] } = appConfig;
     /** @type {import('@librechat/api').LCManifestTool[]} */
@@ -66,7 +66,8 @@ const getAvailableTools = async (req, res) => {
     const cache = getLogStores(CacheKeys.TOOL_CACHE);
     const cachedToolsArray = await cache.get(CacheKeys.TOOLS);
 
-    const appConfig = req.config ?? (await getAppConfig({ role: req.user?.role }));
+    const appConfig =
+      req.config ?? (await getAppConfig({ role: req.user?.role, tenantId: req.user?.tenantId }));
 
     // Return early if we have cached tools
     if (cachedToolsArray != null) {

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -26,7 +26,7 @@ const { getLogStores } = require('~/cache');
 const db = require('~/models');
 
 const getUserController = async (req, res) => {
-  const appConfig = await getAppConfig({ role: req.user?.role });
+  const appConfig = await getAppConfig({ role: req.user?.role, tenantId: req.user?.tenantId });
   /** @type {IUser} */
   const userData = req.user.toObject != null ? req.user.toObject() : { ...req.user };
   /**
@@ -165,7 +165,7 @@ const deleteUserMcpServers = async (userId) => {
 };
 
 const updateUserPluginsController = async (req, res) => {
-  const appConfig = await getAppConfig({ role: req.user?.role });
+  const appConfig = await getAppConfig({ role: req.user?.role, tenantId: req.user?.tenantId });
   const { user } = req;
   const { pluginKey, action, auth, isEntityTool } = req.body;
   try {

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -8,7 +8,7 @@ const express = require('express');
 const passport = require('passport');
 const compression = require('compression');
 const cookieParser = require('cookie-parser');
-const { logger } = require('@librechat/data-schemas');
+const { logger, runAsSystem } = require('@librechat/data-schemas');
 const mongoSanitize = require('express-mongo-sanitize');
 const {
   isEnabled,
@@ -62,8 +62,10 @@ const startServer = async () => {
   await seedDatabase();
   const appConfig = await getAppConfig({ baseOnly: true });
   initializeFileStorage(appConfig);
-  await performStartupChecks(appConfig);
-  await updateInterfacePermissions({ appConfig, getRoleByName, updateAccessPermissions });
+  await runAsSystem(async () => {
+    await performStartupChecks(appConfig);
+    await updateInterfacePermissions({ appConfig, getRoleByName, updateAccessPermissions });
+  });
 
   const indexPath = path.join(appConfig.paths.dist, 'index.html');
   let indexHTML = fs.readFileSync(indexPath, 'utf8');
@@ -205,8 +207,10 @@ const startServer = async () => {
       logger.info(`Server listening at http://${host == '0.0.0.0' ? 'localhost' : host}:${port}`);
     }
 
-    await initializeMCPs();
-    await initializeOAuthReconnectManager();
+    await runAsSystem(async () => {
+      await initializeMCPs();
+      await initializeOAuthReconnectManager();
+    });
     await checkMigrations();
 
     // Configure stream services (auto-detects Redis from USE_REDIS env var)

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -8,7 +8,7 @@ const express = require('express');
 const passport = require('passport');
 const compression = require('compression');
 const cookieParser = require('cookie-parser');
-const { logger, runAsSystem } = require('@librechat/data-schemas');
+const { logger } = require('@librechat/data-schemas');
 const mongoSanitize = require('express-mongo-sanitize');
 const {
   isEnabled,
@@ -61,13 +61,10 @@ const startServer = async () => {
   app.set('trust proxy', trusted_proxy);
 
   await seedDatabase();
-  const appConfig = await runAsSystem(async () => {
-    const config = await getAppConfig();
-    initializeFileStorage(config);
-    await performStartupChecks(config);
-    await updateInterfacePermissions({ appConfig: config, getRoleByName, updateAccessPermissions });
-    return config;
-  });
+  const appConfig = await getAppConfig({ baseOnly: true });
+  initializeFileStorage(appConfig);
+  await performStartupChecks(appConfig);
+  await updateInterfacePermissions({ appConfig, getRoleByName, updateAccessPermissions });
 
   const indexPath = path.join(appConfig.paths.dist, 'index.html');
   let indexHTML = fs.readFileSync(indexPath, 'utf8');
@@ -212,10 +209,8 @@ const startServer = async () => {
       logger.info(`Server listening at http://${host == '0.0.0.0' ? 'localhost' : host}:${port}`);
     }
 
-    await runAsSystem(async () => {
-      await initializeMCPs();
-      await initializeOAuthReconnectManager();
-    });
+    await initializeMCPs();
+    await initializeOAuthReconnectManager();
     await checkMigrations();
 
     // Configure stream services (auto-detects Redis from USE_REDIS env var)

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -8,7 +8,7 @@ const express = require('express');
 const passport = require('passport');
 const compression = require('compression');
 const cookieParser = require('cookie-parser');
-const { logger } = require('@librechat/data-schemas');
+const { logger, runAsSystem } = require('@librechat/data-schemas');
 const mongoSanitize = require('express-mongo-sanitize');
 const {
   isEnabled,
@@ -21,6 +21,7 @@ const {
   createStreamServices,
   initializeFileStorage,
   updateInterfacePermissions,
+  tenantContextMiddleware,
 } = require('@librechat/api');
 const { connectDb, indexSync } = require('~/db');
 const initializeOAuthReconnectManager = require('./services/initializeOAuthReconnectManager');
@@ -60,10 +61,13 @@ const startServer = async () => {
   app.set('trust proxy', trusted_proxy);
 
   await seedDatabase();
-  const appConfig = await getAppConfig();
-  initializeFileStorage(appConfig);
-  await performStartupChecks(appConfig);
-  await updateInterfacePermissions({ appConfig, getRoleByName, updateAccessPermissions });
+  const appConfig = await runAsSystem(async () => {
+    const config = await getAppConfig();
+    initializeFileStorage(config);
+    await performStartupChecks(config);
+    await updateInterfacePermissions({ appConfig: config, getRoleByName, updateAccessPermissions });
+    return config;
+  });
 
   const indexPath = path.join(appConfig.paths.dist, 'index.html');
   let indexHTML = fs.readFileSync(indexPath, 'utf8');
@@ -137,6 +141,9 @@ const startServer = async () => {
   /* Per-request capability cache — must be registered before any route that calls hasCapability */
   app.use(capabilityContextMiddleware);
 
+  /* Per-request tenant context — propagates tenantId into AsyncLocalStorage for Mongoose isolation */
+  app.use(tenantContextMiddleware);
+
   app.use('/oauth', routes.oauth);
   /* API Endpoints */
   app.use('/api/auth', routes.auth);
@@ -205,8 +212,10 @@ const startServer = async () => {
       logger.info(`Server listening at http://${host == '0.0.0.0' ? 'localhost' : host}:${port}`);
     }
 
-    await initializeMCPs();
-    await initializeOAuthReconnectManager();
+    await runAsSystem(async () => {
+      await initializeMCPs();
+      await initializeOAuthReconnectManager();
+    });
     await checkMigrations();
 
     // Configure stream services (auto-detects Redis from USE_REDIS env var)

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -21,7 +21,6 @@ const {
   createStreamServices,
   initializeFileStorage,
   updateInterfacePermissions,
-  tenantContextMiddleware,
 } = require('@librechat/api');
 const { connectDb, indexSync } = require('~/db');
 const initializeOAuthReconnectManager = require('./services/initializeOAuthReconnectManager');
@@ -137,9 +136,6 @@ const startServer = async () => {
 
   /* Per-request capability cache — must be registered before any route that calls hasCapability */
   app.use(capabilityContextMiddleware);
-
-  /* Per-request tenant context — propagates tenantId into AsyncLocalStorage for Mongoose isolation */
-  app.use(tenantContextMiddleware);
 
   app.use('/oauth', routes.oauth);
   /* API Endpoints */

--- a/api/server/index.js
+++ b/api/server/index.js
@@ -8,8 +8,8 @@ const express = require('express');
 const passport = require('passport');
 const compression = require('compression');
 const cookieParser = require('cookie-parser');
-const { logger, runAsSystem } = require('@librechat/data-schemas');
 const mongoSanitize = require('express-mongo-sanitize');
+const { logger, runAsSystem } = require('@librechat/data-schemas');
 const {
   isEnabled,
   apiNotFound,

--- a/api/server/middleware/__tests__/requireJwtAuth.spec.js
+++ b/api/server/middleware/__tests__/requireJwtAuth.spec.js
@@ -12,9 +12,14 @@ const { getTenantId } = require('@librechat/data-schemas');
 
 // ── Mocks ──────────────────────────────────────────────────────────────
 
+let mockPassportError = null;
+
 jest.mock('passport', () => ({
   authenticate: jest.fn(() => {
     return (req, _res, done) => {
+      if (mockPassportError) {
+        return done(mockPassportError);
+      }
       if (req._mockUser) {
         req.user = req._mockUser;
       }
@@ -67,6 +72,22 @@ function runAuth(user) {
 // ── Tests ──────────────────────────────────────────────────────────────
 
 describe('requireJwtAuth tenant context chaining', () => {
+  afterEach(() => {
+    mockPassportError = null;
+  });
+
+  it('forwards passport errors to next() without entering tenant middleware', async () => {
+    mockPassportError = new Error('JWT signature invalid');
+    const req = mockReq(undefined);
+    const res = mockRes();
+    const err = await new Promise((resolve) => {
+      requireJwtAuth(req, res, (e) => resolve(e));
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe('JWT signature invalid');
+    expect(getTenantId()).toBeUndefined();
+  });
+
   it('sets ALS tenant context after passport auth succeeds', async () => {
     const tenantId = await runAuth({ tenantId: 'tenant-abc', role: 'user' });
     expect(tenantId).toBe('tenant-abc');

--- a/api/server/middleware/__tests__/requireJwtAuth.spec.js
+++ b/api/server/middleware/__tests__/requireJwtAuth.spec.js
@@ -1,0 +1,95 @@
+/**
+ * Integration test: verifies that requireJwtAuth chains tenantContextMiddleware
+ * after successful passport authentication, so ALS tenant context is set for
+ * all downstream middleware and route handlers.
+ *
+ * This catches the ordering bug from Finding 1 — if tenantContextMiddleware is
+ * ever removed from the chain, these tests fail.
+ */
+
+const { getTenantId } = require('@librechat/data-schemas');
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+jest.mock('passport', () => ({
+  authenticate: jest.fn(() => {
+    return (req, _res, done) => {
+      if (req._mockUser) {
+        req.user = req._mockUser;
+      }
+      done();
+    };
+  }),
+}));
+
+// Mock @librechat/api — must use require() inside the factory to avoid
+// out-of-scope variable restrictions.
+jest.mock('@librechat/api', () => {
+  const { tenantStorage } = require('@librechat/data-schemas');
+  return {
+    isEnabled: jest.fn(() => false),
+    tenantContextMiddleware: (req, res, next) => {
+      const user = req.user;
+      if (!user || !user.tenantId) {
+        next();
+        return;
+      }
+      tenantStorage.run({ tenantId: user.tenantId }, async () => {
+        next();
+      });
+    },
+  };
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+const requireJwtAuth = require('../requireJwtAuth');
+
+function mockReq(user) {
+  return { headers: {}, _mockUser: user };
+}
+
+function mockRes() {
+  return { status: jest.fn().mockReturnThis(), json: jest.fn().mockReturnThis() };
+}
+
+/** Runs requireJwtAuth and returns the tenantId observed inside next(). */
+function runAuth(user) {
+  return new Promise((resolve) => {
+    const req = mockReq(user);
+    const res = mockRes();
+    requireJwtAuth(req, res, () => {
+      resolve(getTenantId());
+    });
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+describe('requireJwtAuth tenant context chaining', () => {
+  it('sets ALS tenant context after passport auth succeeds', async () => {
+    const tenantId = await runAuth({ tenantId: 'tenant-abc', role: 'user' });
+    expect(tenantId).toBe('tenant-abc');
+  });
+
+  it('ALS tenant context is NOT set when user has no tenantId', async () => {
+    const tenantId = await runAuth({ role: 'user' });
+    expect(tenantId).toBeUndefined();
+  });
+
+  it('ALS tenant context is NOT set when user is undefined', async () => {
+    const tenantId = await runAuth(undefined);
+    expect(tenantId).toBeUndefined();
+  });
+
+  it('concurrent requests get isolated tenant contexts', async () => {
+    const results = await Promise.all(
+      ['tenant-1', 'tenant-2', 'tenant-3'].map((tid) => runAuth({ tenantId: tid, role: 'user' })),
+    );
+    expect(results).toEqual(['tenant-1', 'tenant-2', 'tenant-3']);
+  });
+
+  it('ALS context is not set at top-level scope (outside any request)', () => {
+    expect(getTenantId()).toBeUndefined();
+  });
+});

--- a/api/server/middleware/__tests__/requireJwtAuth.spec.js
+++ b/api/server/middleware/__tests__/requireJwtAuth.spec.js
@@ -3,8 +3,9 @@
  * after successful passport authentication, so ALS tenant context is set for
  * all downstream middleware and route handlers.
  *
- * This catches the ordering bug from Finding 1 — if tenantContextMiddleware is
- * ever removed from the chain, these tests fail.
+ * requireJwtAuth must chain tenantContextMiddleware after passport populates
+ * req.user (not at global app.use() scope where req.user is undefined).
+ * If the chaining is removed, these tests fail.
  */
 
 const { getTenantId } = require('@librechat/data-schemas');
@@ -22,21 +23,20 @@ jest.mock('passport', () => ({
   }),
 }));
 
-// Mock @librechat/api — must use require() inside the factory to avoid
-// out-of-scope variable restrictions.
+// Mock @librechat/api — the real tenantContextMiddleware is TS and cannot be
+// required directly from CJS tests. This thin wrapper mirrors the real logic
+// (read req.user.tenantId, call tenantStorage.run) using the same data-schemas
+// primitives. The real implementation is covered by packages/api tenant.spec.ts.
 jest.mock('@librechat/api', () => {
   const { tenantStorage } = require('@librechat/data-schemas');
   return {
     isEnabled: jest.fn(() => false),
     tenantContextMiddleware: (req, res, next) => {
-      const user = req.user;
-      if (!user || !user.tenantId) {
-        next();
-        return;
+      const tenantId = req.user?.tenantId;
+      if (!tenantId) {
+        return next();
       }
-      tenantStorage.run({ tenantId: user.tenantId }, async () => {
-        next();
-      });
+      return tenantStorage.run({ tenantId }, async () => next());
     },
   };
 });

--- a/api/server/middleware/checkDomainAllowed.js
+++ b/api/server/middleware/checkDomainAllowed.js
@@ -18,6 +18,7 @@ const checkDomainAllowed = async (req, res, next) => {
     const email = req?.user?.email;
     const appConfig = await getAppConfig({
       role: req?.user?.role,
+      tenantId: req?.user?.tenantId,
     });
 
     if (email && !isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {

--- a/api/server/middleware/requireJwtAuth.js
+++ b/api/server/middleware/requireJwtAuth.js
@@ -17,7 +17,10 @@ const requireJwtAuth = (req, res, next) => {
   const strategy =
     tokenProvider === 'openid' && isEnabled(process.env.OPENID_REUSE_TOKENS) ? 'openidJwt' : 'jwt';
 
-  passport.authenticate(strategy, { session: false })(req, res, () => {
+  passport.authenticate(strategy, { session: false })(req, res, (err) => {
+    if (err) {
+      return next(err);
+    }
     // req.user is now populated by passport — set up tenant ALS context
     tenantContextMiddleware(req, res, next);
   });

--- a/api/server/middleware/requireJwtAuth.js
+++ b/api/server/middleware/requireJwtAuth.js
@@ -1,20 +1,27 @@
 const cookies = require('cookie');
 const passport = require('passport');
 const { isEnabled } = require('@librechat/api');
+const { tenantContextMiddleware } = require('@librechat/api');
 
 /**
- * Custom Middleware to handle JWT authentication, with support for OpenID token reuse
- * Switches between JWT and OpenID authentication based on cookies and environment settings
+ * Custom Middleware to handle JWT authentication, with support for OpenID token reuse.
+ * Switches between JWT and OpenID authentication based on cookies and environment settings.
+ *
+ * After successful authentication (req.user populated), automatically chains into
+ * `tenantContextMiddleware` to propagate `req.user.tenantId` into AsyncLocalStorage
+ * for downstream Mongoose tenant isolation.
  */
 const requireJwtAuth = (req, res, next) => {
   const cookieHeader = req.headers.cookie;
   const tokenProvider = cookieHeader ? cookies.parse(cookieHeader).token_provider : null;
 
-  if (tokenProvider === 'openid' && isEnabled(process.env.OPENID_REUSE_TOKENS)) {
-    return passport.authenticate('openidJwt', { session: false })(req, res, next);
-  }
+  const strategy =
+    tokenProvider === 'openid' && isEnabled(process.env.OPENID_REUSE_TOKENS) ? 'openidJwt' : 'jwt';
 
-  return passport.authenticate('jwt', { session: false })(req, res, next);
+  passport.authenticate(strategy, { session: false })(req, res, () => {
+    // req.user is now populated by passport — set up tenant ALS context
+    tenantContextMiddleware(req, res, next);
+  });
 };
 
 module.exports = requireJwtAuth;

--- a/api/server/middleware/requireJwtAuth.js
+++ b/api/server/middleware/requireJwtAuth.js
@@ -1,7 +1,6 @@
 const cookies = require('cookie');
 const passport = require('passport');
-const { isEnabled } = require('@librechat/api');
-const { tenantContextMiddleware } = require('@librechat/api');
+const { isEnabled, tenantContextMiddleware } = require('@librechat/api');
 
 /**
  * Custom Middleware to handle JWT authentication, with support for OpenID token reuse.

--- a/api/server/routes/admin/config.js
+++ b/api/server/routes/admin/config.js
@@ -5,7 +5,7 @@ const {
   hasConfigCapability,
   requireCapability,
 } = require('~/server/middleware/roles/capabilities');
-const { getAppConfig } = require('~/server/services/Config');
+const { getAppConfig, invalidateConfigCaches } = require('~/server/services/Config');
 const { requireJwtAuth } = require('~/server/middleware');
 const db = require('~/models');
 
@@ -23,6 +23,7 @@ const handlers = createAdminConfigHandlers({
   toggleConfigActive: db.toggleConfigActive,
   hasConfigCapability,
   getAppConfig,
+  invalidateConfigCaches,
 });
 
 router.use(requireJwtAuth, requireAdminAccess);

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -37,7 +37,7 @@ router.get('/', async function (req, res) {
   const ldap = getLdapConfig();
 
   try {
-    const appConfig = await getAppConfig({ role: req.user?.role });
+    const appConfig = await getAppConfig({ role: req.user?.role, tenantId: req.user?.tenantId });
 
     const isOpenIdEnabled =
       !!process.env.OPENID_CLIENT_ID &&

--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -3,7 +3,6 @@ const jwt = require('jsonwebtoken');
 const { webcrypto } = require('node:crypto');
 const {
   logger,
-  runAsSystem,
   DEFAULT_SESSION_EXPIRY,
   DEFAULT_REFRESH_TOKEN_EXPIRY,
 } = require('@librechat/data-schemas');
@@ -190,7 +189,7 @@ const registerUser = async (user, additionalData = {}) => {
 
   let newUserId;
   try {
-    const appConfig = await runAsSystem(async () => getAppConfig());
+    const appConfig = await getAppConfig({ baseOnly: true });
     if (!isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {
       const errorMessage =
         'The email address provided cannot be used. Please use a different email address.';
@@ -261,7 +260,7 @@ const registerUser = async (user, additionalData = {}) => {
  */
 const requestPasswordReset = async (req) => {
   const { email } = req.body;
-  const appConfig = await runAsSystem(async () => getAppConfig());
+  const appConfig = await getAppConfig({ baseOnly: true });
   if (!isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {
     const error = new Error(ErrorTypes.AUTH_FAILED);
     error.code = ErrorTypes.AUTH_FAILED;

--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -3,6 +3,7 @@ const jwt = require('jsonwebtoken');
 const { webcrypto } = require('node:crypto');
 const {
   logger,
+  runAsSystem,
   DEFAULT_SESSION_EXPIRY,
   DEFAULT_REFRESH_TOKEN_EXPIRY,
 } = require('@librechat/data-schemas');
@@ -189,7 +190,7 @@ const registerUser = async (user, additionalData = {}) => {
 
   let newUserId;
   try {
-    const appConfig = await getAppConfig();
+    const appConfig = await runAsSystem(async () => getAppConfig());
     if (!isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {
       const errorMessage =
         'The email address provided cannot be used. Please use a different email address.';
@@ -260,7 +261,7 @@ const registerUser = async (user, additionalData = {}) => {
  */
 const requestPasswordReset = async (req) => {
   const { email } = req.body;
-  const appConfig = await getAppConfig();
+  const appConfig = await runAsSystem(async () => getAppConfig());
   if (!isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {
     const error = new Error(ErrorTypes.AUTH_FAILED);
     error.code = ErrorTypes.AUTH_FAILED;

--- a/api/server/services/Config/__tests__/invalidateConfigCaches.spec.js
+++ b/api/server/services/Config/__tests__/invalidateConfigCaches.spec.js
@@ -118,16 +118,10 @@ describe('invalidateConfigCaches', () => {
         ),
     );
 
-    const start = Date.now();
     await invalidateConfigCaches();
-    const elapsed = Date.now() - start;
 
+    // All four should have been called (parallel execution via Promise.all)
     expect(order).toHaveLength(4);
-    expect(order).toContain('base');
-    expect(order).toContain('override');
-    expect(order).toContain('tools');
-    expect(order).toContain('endpoint');
-    // If sequential: ~40ms. Parallel: ~10ms. Use generous threshold.
-    expect(elapsed).toBeLessThan(35);
+    expect(new Set(order)).toEqual(new Set(['base', 'override', 'tools', 'endpoint']));
   });
 });

--- a/api/server/services/Config/__tests__/invalidateConfigCaches.spec.js
+++ b/api/server/services/Config/__tests__/invalidateConfigCaches.spec.js
@@ -120,8 +120,18 @@ describe('invalidateConfigCaches', () => {
 
     await invalidateConfigCaches();
 
-    // All four should have been called (parallel execution via Promise.all)
+    // All four should have been called (parallel execution via Promise.allSettled)
     expect(order).toHaveLength(4);
     expect(new Set(order)).toEqual(new Set(['base', 'override', 'tools', 'endpoint']));
+  });
+
+  it('resolves even when clearAppConfigCache throws (partial failure)', async () => {
+    mockClearAppConfigCache.mockRejectedValueOnce(new Error('cache connection lost'));
+
+    await expect(invalidateConfigCaches()).resolves.not.toThrow();
+
+    // Other caches should still have been invalidated despite the failure
+    expect(mockClearOverrideCache).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateCachedTools).toHaveBeenCalledWith({ invalidateGlobal: true });
   });
 });

--- a/api/server/services/Config/__tests__/invalidateConfigCaches.spec.js
+++ b/api/server/services/Config/__tests__/invalidateConfigCaches.spec.js
@@ -1,0 +1,133 @@
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+const mockConfigStoreDelete = jest.fn().mockResolvedValue(true);
+const mockClearAppConfigCache = jest.fn().mockResolvedValue(undefined);
+const mockClearOverrideCache = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('~/cache/getLogStores', () => {
+  return jest.fn(() => ({
+    delete: mockConfigStoreDelete,
+  }));
+});
+
+jest.mock('~/server/services/start/tools', () => ({
+  loadAndFormatTools: jest.fn(() => ({})),
+}));
+
+jest.mock('../loadCustomConfig', () => jest.fn().mockResolvedValue({}));
+
+jest.mock('@librechat/data-schemas', () => {
+  const actual = jest.requireActual('@librechat/data-schemas');
+  return { ...actual, AppService: jest.fn(() => ({ availableTools: {} })) };
+});
+
+jest.mock('~/models', () => ({
+  getApplicableConfigs: jest.fn().mockResolvedValue([]),
+  getUserPrincipals: jest.fn().mockResolvedValue([]),
+}));
+
+const mockInvalidateCachedTools = jest.fn().mockResolvedValue(undefined);
+jest.mock('../getCachedTools', () => ({
+  setCachedTools: jest.fn().mockResolvedValue(undefined),
+  invalidateCachedTools: mockInvalidateCachedTools,
+}));
+
+jest.mock('@librechat/api', () => ({
+  createAppConfigService: jest.fn(() => ({
+    getAppConfig: jest.fn().mockResolvedValue({ availableTools: {} }),
+    clearAppConfigCache: mockClearAppConfigCache,
+    clearOverrideCache: mockClearOverrideCache,
+  })),
+}));
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+const { CacheKeys } = require('librechat-data-provider');
+const { invalidateConfigCaches } = require('../app');
+
+describe('invalidateConfigCaches', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('clears all four caches', async () => {
+    await invalidateConfigCaches();
+
+    expect(mockClearAppConfigCache).toHaveBeenCalledTimes(1);
+    expect(mockClearOverrideCache).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateCachedTools).toHaveBeenCalledWith({ invalidateGlobal: true });
+    expect(mockConfigStoreDelete).toHaveBeenCalledWith(CacheKeys.ENDPOINT_CONFIG);
+  });
+
+  it('passes tenantId through to clearOverrideCache', async () => {
+    await invalidateConfigCaches('tenant-a');
+
+    expect(mockClearOverrideCache).toHaveBeenCalledWith('tenant-a');
+    expect(mockClearAppConfigCache).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateCachedTools).toHaveBeenCalledWith({ invalidateGlobal: true });
+  });
+
+  it('does not throw when CONFIG_STORE.delete fails', async () => {
+    mockConfigStoreDelete.mockRejectedValueOnce(new Error('store not found'));
+
+    await expect(invalidateConfigCaches()).resolves.not.toThrow();
+
+    // Other caches should still have been invalidated
+    expect(mockClearAppConfigCache).toHaveBeenCalledTimes(1);
+    expect(mockClearOverrideCache).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateCachedTools).toHaveBeenCalledWith({ invalidateGlobal: true });
+  });
+
+  it('all operations run in parallel (not sequentially)', async () => {
+    const order = [];
+
+    mockClearAppConfigCache.mockImplementation(
+      () =>
+        new Promise((r) =>
+          setTimeout(() => {
+            order.push('base');
+            r();
+          }, 10),
+        ),
+    );
+    mockClearOverrideCache.mockImplementation(
+      () =>
+        new Promise((r) =>
+          setTimeout(() => {
+            order.push('override');
+            r();
+          }, 10),
+        ),
+    );
+    mockInvalidateCachedTools.mockImplementation(
+      () =>
+        new Promise((r) =>
+          setTimeout(() => {
+            order.push('tools');
+            r();
+          }, 10),
+        ),
+    );
+    mockConfigStoreDelete.mockImplementation(
+      () =>
+        new Promise((r) =>
+          setTimeout(() => {
+            order.push('endpoint');
+            r();
+          }, 10),
+        ),
+    );
+
+    const start = Date.now();
+    await invalidateConfigCaches();
+    const elapsed = Date.now() - start;
+
+    expect(order).toHaveLength(4);
+    expect(order).toContain('base');
+    expect(order).toContain('override');
+    expect(order).toContain('tools');
+    expect(order).toContain('endpoint');
+    // If sequential: ~40ms. Parallel: ~10ms. Use generous threshold.
+    expect(elapsed).toBeLessThan(35);
+  });
+});

--- a/api/server/services/Config/app.js
+++ b/api/server/services/Config/app.js
@@ -1,5 +1,5 @@
 const { CacheKeys } = require('librechat-data-provider');
-const { AppService } = require('@librechat/data-schemas');
+const { AppService, logger } = require('@librechat/data-schemas');
 const { createAppConfigService } = require('@librechat/api');
 const { loadAndFormatTools } = require('~/server/services/start/tools');
 const loadCustomConfig = require('./loadCustomConfig');
@@ -46,12 +46,23 @@ async function clearEndpointConfigCache() {
  * @param {string} [tenantId] - Optional tenant ID to scope override cache clearing.
  */
 async function invalidateConfigCaches(tenantId) {
-  await Promise.all([
+  const results = await Promise.allSettled([
     clearAppConfigCache(),
     clearOverrideCache(tenantId),
     invalidateCachedTools({ invalidateGlobal: true }),
     clearEndpointConfigCache(),
   ]);
+  const labels = [
+    'clearAppConfigCache',
+    'clearOverrideCache',
+    'invalidateCachedTools',
+    'clearEndpointConfigCache',
+  ];
+  for (let i = 0; i < results.length; i++) {
+    if (results[i].status === 'rejected') {
+      logger.error(`[invalidateConfigCaches] ${labels[i]} failed:`, results[i].reason);
+    }
+  }
 }
 
 module.exports = {

--- a/api/server/services/Config/app.js
+++ b/api/server/services/Config/app.js
@@ -29,12 +29,7 @@ const { getAppConfig, clearAppConfigCache, clearOverrideCache } = createAppConfi
   getUserPrincipals: db.getUserPrincipals,
 });
 
-/**
- * Invalidate all config-related caches after an admin config mutation.
- * Clears the base config, per-principal override caches, tool caches,
- * and the endpoints config cache.
- * @param {string} [tenantId] - Optional tenant ID to scope override cache clearing.
- */
+/** Deletes the ENDPOINT_CONFIG entry from CONFIG_STORE. Failures are non-critical and swallowed. */
 async function clearEndpointConfigCache() {
   try {
     const configStore = getLogStores(CacheKeys.CONFIG_STORE);
@@ -44,6 +39,12 @@ async function clearEndpointConfigCache() {
   }
 }
 
+/**
+ * Invalidate all config-related caches after an admin config mutation.
+ * Clears the base config, per-principal override caches, tool caches,
+ * and the endpoints config cache.
+ * @param {string} [tenantId] - Optional tenant ID to scope override cache clearing.
+ */
 async function invalidateConfigCaches(tenantId) {
   await Promise.all([
     clearAppConfigCache(),

--- a/api/server/services/Config/app.js
+++ b/api/server/services/Config/app.js
@@ -35,19 +35,21 @@ const { getAppConfig, clearAppConfigCache, clearOverrideCache } = createAppConfi
  * and the endpoints config cache.
  * @param {string} [tenantId] - Optional tenant ID to scope override cache clearing.
  */
+async function clearEndpointConfigCache() {
+  try {
+    const configStore = getLogStores(CacheKeys.CONFIG_STORE);
+    await configStore.delete(CacheKeys.ENDPOINT_CONFIG);
+  } catch {
+    // CONFIG_STORE or ENDPOINT_CONFIG may not exist — not critical
+  }
+}
+
 async function invalidateConfigCaches(tenantId) {
   await Promise.all([
     clearAppConfigCache(),
     clearOverrideCache(tenantId),
     invalidateCachedTools({ invalidateGlobal: true }),
-    (async () => {
-      try {
-        const configStore = getLogStores(CacheKeys.CONFIG_STORE);
-        await configStore.delete(CacheKeys.ENDPOINT_CONFIG);
-      } catch {
-        // CONFIG_STORE or ENDPOINT_CONFIG may not exist — not critical
-      }
-    })(),
+    clearEndpointConfigCache(),
   ]);
 }
 

--- a/api/server/services/Config/app.js
+++ b/api/server/services/Config/app.js
@@ -3,7 +3,7 @@ const { AppService } = require('@librechat/data-schemas');
 const { createAppConfigService } = require('@librechat/api');
 const { loadAndFormatTools } = require('~/server/services/start/tools');
 const loadCustomConfig = require('./loadCustomConfig');
-const { setCachedTools } = require('./getCachedTools');
+const { setCachedTools, invalidateCachedTools } = require('./getCachedTools');
 const getLogStores = require('~/cache/getLogStores');
 const paths = require('~/config/paths');
 const db = require('~/models');
@@ -19,8 +19,6 @@ const loadBaseConfig = async () => {
   });
   return AppService({ config, paths, systemTools });
 };
-
-const { invalidateCachedTools } = require('./getCachedTools');
 
 const { getAppConfig, clearAppConfigCache, clearOverrideCache } = createAppConfigService({
   loadBaseConfig,
@@ -38,20 +36,23 @@ const { getAppConfig, clearAppConfigCache, clearOverrideCache } = createAppConfi
  * @param {string} [tenantId] - Optional tenant ID to scope override cache clearing.
  */
 async function invalidateConfigCaches(tenantId) {
-  await clearAppConfigCache();
-  await clearOverrideCache(tenantId);
-  await invalidateCachedTools({ invalidateGlobal: true });
-  try {
-    const configStore = getLogStores(CacheKeys.CONFIG_STORE);
-    await configStore.delete(CacheKeys.ENDPOINT_CONFIG);
-  } catch {
-    // CONFIG_STORE or ENDPOINT_CONFIG may not exist — not critical
-  }
+  await Promise.all([
+    clearAppConfigCache(),
+    clearOverrideCache(tenantId),
+    invalidateCachedTools({ invalidateGlobal: true }),
+    (async () => {
+      try {
+        const configStore = getLogStores(CacheKeys.CONFIG_STORE);
+        await configStore.delete(CacheKeys.ENDPOINT_CONFIG);
+      } catch {
+        // CONFIG_STORE or ENDPOINT_CONFIG may not exist — not critical
+      }
+    })(),
+  ]);
 }
 
 module.exports = {
   getAppConfig,
   clearAppConfigCache,
-  clearOverrideCache,
   invalidateConfigCaches,
 };

--- a/api/server/services/Config/app.js
+++ b/api/server/services/Config/app.js
@@ -20,7 +20,9 @@ const loadBaseConfig = async () => {
   return AppService({ config, paths, systemTools });
 };
 
-const { getAppConfig, clearAppConfigCache } = createAppConfigService({
+const { invalidateCachedTools } = require('./getCachedTools');
+
+const { getAppConfig, clearAppConfigCache, clearOverrideCache } = createAppConfigService({
   loadBaseConfig,
   setCachedTools,
   getCache: getLogStores,
@@ -29,7 +31,27 @@ const { getAppConfig, clearAppConfigCache } = createAppConfigService({
   getUserPrincipals: db.getUserPrincipals,
 });
 
+/**
+ * Invalidate all config-related caches after an admin config mutation.
+ * Clears the base config, per-principal override caches, tool caches,
+ * and the endpoints config cache.
+ * @param {string} [tenantId] - Optional tenant ID to scope override cache clearing.
+ */
+async function invalidateConfigCaches(tenantId) {
+  await clearAppConfigCache();
+  await clearOverrideCache(tenantId);
+  await invalidateCachedTools({ invalidateGlobal: true });
+  try {
+    const configStore = getLogStores(CacheKeys.CONFIG_STORE);
+    await configStore.delete(CacheKeys.ENDPOINT_CONFIG);
+  } catch {
+    // CONFIG_STORE or ENDPOINT_CONFIG may not exist — not critical
+  }
+}
+
 module.exports = {
   getAppConfig,
   clearAppConfigCache,
+  clearOverrideCache,
+  invalidateConfigCaches,
 };

--- a/api/server/services/Config/app.js
+++ b/api/server/services/Config/app.js
@@ -1,9 +1,9 @@
 const { CacheKeys } = require('librechat-data-provider');
-const { AppService, logger } = require('@librechat/data-schemas');
 const { createAppConfigService } = require('@librechat/api');
+const { AppService, logger } = require('@librechat/data-schemas');
+const { setCachedTools, invalidateCachedTools } = require('./getCachedTools');
 const { loadAndFormatTools } = require('~/server/services/start/tools');
 const loadCustomConfig = require('./loadCustomConfig');
-const { setCachedTools, invalidateCachedTools } = require('./getCachedTools');
 const getLogStores = require('~/cache/getLogStores');
 const paths = require('~/config/paths');
 const db = require('~/models');

--- a/api/server/services/Config/getEndpointsConfig.js
+++ b/api/server/services/Config/getEndpointsConfig.js
@@ -26,7 +26,8 @@ async function getEndpointsConfig(req) {
     }
   }
 
-  const appConfig = req.config ?? (await getAppConfig({ role: req.user?.role }));
+  const appConfig =
+    req.config ?? (await getAppConfig({ role: req.user?.role, tenantId: req.user?.tenantId }));
   const defaultEndpointsConfig = await loadDefaultEndpointsConfig(appConfig);
   const customEndpointsConfig = loadCustomEndpointsConfig(appConfig?.endpoints?.custom);
 

--- a/api/server/services/Config/loadConfigModels.js
+++ b/api/server/services/Config/loadConfigModels.js
@@ -12,7 +12,7 @@ const { getAppConfig } = require('./app');
  * @param {ServerRequest} req - The Express request object.
  */
 async function loadConfigModels(req) {
-  const appConfig = await getAppConfig({ role: req.user?.role });
+  const appConfig = await getAppConfig({ role: req.user?.role, tenantId: req.user?.tenantId });
   if (!appConfig) {
     return {};
   }

--- a/api/server/services/Config/loadDefaultModels.js
+++ b/api/server/services/Config/loadDefaultModels.js
@@ -16,7 +16,8 @@ const { getAppConfig } = require('./app');
  */
 async function loadDefaultModels(req) {
   try {
-    const appConfig = req.config ?? (await getAppConfig({ role: req.user?.role }));
+    const appConfig =
+      req.config ?? (await getAppConfig({ role: req.user?.role, tenantId: req.user?.tenantId }));
     const vertexConfig = appConfig?.endpoints?.[EModelEndpoint.anthropic]?.vertexConfig;
 
     const [openAI, anthropic, azureOpenAI, assistants, azureAssistants, google, bedrock] =

--- a/api/server/services/Files/Audio/STTService.js
+++ b/api/server/services/Files/Audio/STTService.js
@@ -142,6 +142,7 @@ class STTService {
       req.config ??
       (await getAppConfig({
         role: req?.user?.role,
+        tenantId: req?.user?.tenantId,
       }));
     const sttSchema = appConfig?.speech?.stt;
     if (!sttSchema) {

--- a/api/server/services/Files/Audio/TTSService.js
+++ b/api/server/services/Files/Audio/TTSService.js
@@ -297,6 +297,7 @@ class TTSService {
       req.config ??
       (await getAppConfig({
         role: req.user?.role,
+        tenantId: req.user?.tenantId,
       }));
     try {
       res.setHeader('Content-Type', 'audio/mpeg');
@@ -365,6 +366,7 @@ class TTSService {
       req.config ??
       (await getAppConfig({
         role: req.user?.role,
+        tenantId: req.user?.tenantId,
       }));
     const provider = this.getProvider(appConfig);
     const ttsSchema = appConfig?.speech?.tts?.[provider];

--- a/api/server/services/Files/Audio/getCustomConfigSpeech.js
+++ b/api/server/services/Files/Audio/getCustomConfigSpeech.js
@@ -17,6 +17,7 @@ async function getCustomConfigSpeech(req, res) {
   try {
     const appConfig = await getAppConfig({
       role: req.user?.role,
+      tenantId: req.user?.tenantId,
     });
 
     if (!appConfig) {

--- a/api/server/services/Files/Audio/getVoices.js
+++ b/api/server/services/Files/Audio/getVoices.js
@@ -18,6 +18,7 @@ async function getVoices(req, res) {
       req.config ??
       (await getAppConfig({
         role: req.user?.role,
+        tenantId: req.user?.tenantId,
       }));
 
     const ttsSchema = appConfig?.speech?.tts;

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -367,7 +367,7 @@ async function createMCPTools({
   const serverConfig =
     config ?? (await getMCPServersRegistry().getServerConfig(serverName, user?.id));
   if (serverConfig?.url) {
-    const appConfig = await getAppConfig({ role: user?.role });
+    const appConfig = await getAppConfig({ role: user?.role, tenantId: user?.tenantId });
     const allowedDomains = appConfig?.mcpSettings?.allowedDomains;
     const isDomainAllowed = await isMCPDomainAllowed(serverConfig, allowedDomains);
     if (!isDomainAllowed) {
@@ -449,7 +449,7 @@ async function createMCPTool({
   const serverConfig =
     config ?? (await getMCPServersRegistry().getServerConfig(serverName, user?.id));
   if (serverConfig?.url) {
-    const appConfig = await getAppConfig({ role: user?.role });
+    const appConfig = await getAppConfig({ role: user?.role, tenantId: user?.tenantId });
     const allowedDomains = appConfig?.mcpSettings?.allowedDomains;
     const isDomainAllowed = await isMCPDomainAllowed(serverConfig, allowedDomains);
     if (!isDomainAllowed) {

--- a/api/server/services/initializeMCPs.js
+++ b/api/server/services/initializeMCPs.js
@@ -7,7 +7,7 @@ const { createMCPServersRegistry, createMCPManager } = require('~/config');
  * Initialize MCP servers
  */
 async function initializeMCPs() {
-  const appConfig = await getAppConfig();
+  const appConfig = await getAppConfig({ baseOnly: true });
   const mcpServers = appConfig.mcpConfig;
 
   try {

--- a/api/strategies/ldapStrategy.js
+++ b/api/strategies/ldapStrategy.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const LdapStrategy = require('passport-ldapauth');
-const { logger, runAsSystem } = require('@librechat/data-schemas');
+const { logger } = require('@librechat/data-schemas');
 const { SystemRoles, ErrorTypes } = require('librechat-data-provider');
 const { isEnabled, getBalanceConfig, isEmailDomainAllowed } = require('@librechat/api');
 const { createUser, findUser, updateUser, countUsers } = require('~/models');
@@ -122,7 +122,7 @@ const ldapLogin = new LdapStrategy(ldapOptions, async (userinfo, done) => {
       );
     }
 
-    const appConfig = await runAsSystem(async () => getAppConfig());
+    const appConfig = await getAppConfig({ baseOnly: true });
     if (!isEmailDomainAllowed(mail, appConfig?.registration?.allowedDomains)) {
       logger.error(
         `[LDAP Strategy] Authentication blocked - email domain not allowed [Email: ${mail}]`,

--- a/api/strategies/ldapStrategy.js
+++ b/api/strategies/ldapStrategy.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const LdapStrategy = require('passport-ldapauth');
-const { logger } = require('@librechat/data-schemas');
+const { logger, runAsSystem } = require('@librechat/data-schemas');
 const { SystemRoles, ErrorTypes } = require('librechat-data-provider');
 const { isEnabled, getBalanceConfig, isEmailDomainAllowed } = require('@librechat/api');
 const { createUser, findUser, updateUser, countUsers } = require('~/models');
@@ -122,7 +122,7 @@ const ldapLogin = new LdapStrategy(ldapOptions, async (userinfo, done) => {
       );
     }
 
-    const appConfig = await getAppConfig();
+    const appConfig = await runAsSystem(async () => getAppConfig());
     if (!isEmailDomainAllowed(mail, appConfig?.registration?.allowedDomains)) {
       logger.error(
         `[LDAP Strategy] Authentication blocked - email domain not allowed [Email: ${mail}]`,

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -5,7 +5,7 @@ const passport = require('passport');
 const client = require('openid-client');
 const jwtDecode = require('jsonwebtoken/decode');
 const { HttpsProxyAgent } = require('https-proxy-agent');
-const { hashToken, logger, runAsSystem } = require('@librechat/data-schemas');
+const { hashToken, logger } = require('@librechat/data-schemas');
 const { Strategy: OpenIDStrategy } = require('openid-client/passport');
 const { CacheKeys, ErrorTypes, SystemRoles } = require('librechat-data-provider');
 const {
@@ -468,7 +468,7 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
     Object.assign(userinfo, providerUserinfo);
   }
 
-  const appConfig = await runAsSystem(async () => getAppConfig());
+  const appConfig = await getAppConfig({ baseOnly: true });
   const email = getOpenIdEmail(userinfo);
   if (!isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {
     logger.error(

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -5,7 +5,7 @@ const passport = require('passport');
 const client = require('openid-client');
 const jwtDecode = require('jsonwebtoken/decode');
 const { HttpsProxyAgent } = require('https-proxy-agent');
-const { hashToken, logger } = require('@librechat/data-schemas');
+const { hashToken, logger, runAsSystem } = require('@librechat/data-schemas');
 const { Strategy: OpenIDStrategy } = require('openid-client/passport');
 const { CacheKeys, ErrorTypes, SystemRoles } = require('librechat-data-provider');
 const {
@@ -468,7 +468,7 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
     Object.assign(userinfo, providerUserinfo);
   }
 
-  const appConfig = await getAppConfig();
+  const appConfig = await runAsSystem(async () => getAppConfig());
   const email = getOpenIdEmail(userinfo);
   if (!isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {
     logger.error(

--- a/api/strategies/samlStrategy.js
+++ b/api/strategies/samlStrategy.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fetch = require('node-fetch');
 const passport = require('passport');
 const { ErrorTypes } = require('librechat-data-provider');
-const { hashToken, logger } = require('@librechat/data-schemas');
+const { hashToken, logger, runAsSystem } = require('@librechat/data-schemas');
 const { Strategy: SamlStrategy } = require('@node-saml/passport-saml');
 const { getBalanceConfig, isEmailDomainAllowed } = require('@librechat/api');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
@@ -193,7 +193,7 @@ async function setupSaml() {
           logger.debug('[samlStrategy] SAML profile:', profile);
 
           const userEmail = getEmail(profile) || '';
-          const appConfig = await getAppConfig();
+          const appConfig = await runAsSystem(async () => getAppConfig());
 
           if (!isEmailDomainAllowed(userEmail, appConfig?.registration?.allowedDomains)) {
             logger.error(

--- a/api/strategies/samlStrategy.js
+++ b/api/strategies/samlStrategy.js
@@ -3,7 +3,7 @@ const path = require('path');
 const fetch = require('node-fetch');
 const passport = require('passport');
 const { ErrorTypes } = require('librechat-data-provider');
-const { hashToken, logger, runAsSystem } = require('@librechat/data-schemas');
+const { hashToken, logger } = require('@librechat/data-schemas');
 const { Strategy: SamlStrategy } = require('@node-saml/passport-saml');
 const { getBalanceConfig, isEmailDomainAllowed } = require('@librechat/api');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
@@ -193,7 +193,7 @@ async function setupSaml() {
           logger.debug('[samlStrategy] SAML profile:', profile);
 
           const userEmail = getEmail(profile) || '';
-          const appConfig = await runAsSystem(async () => getAppConfig());
+          const appConfig = await getAppConfig({ baseOnly: true });
 
           if (!isEmailDomainAllowed(userEmail, appConfig?.registration?.allowedDomains)) {
             logger.error(

--- a/api/strategies/socialLogin.js
+++ b/api/strategies/socialLogin.js
@@ -1,4 +1,4 @@
-const { logger } = require('@librechat/data-schemas');
+const { logger, runAsSystem } = require('@librechat/data-schemas');
 const { ErrorTypes } = require('librechat-data-provider');
 const { isEnabled, isEmailDomainAllowed } = require('@librechat/api');
 const { createSocialUser, handleExistingUser } = require('./process');
@@ -13,7 +13,7 @@ const socialLogin =
         profile,
       });
 
-      const appConfig = await getAppConfig();
+      const appConfig = await runAsSystem(async () => getAppConfig());
 
       if (!isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {
         logger.error(

--- a/api/strategies/socialLogin.js
+++ b/api/strategies/socialLogin.js
@@ -1,4 +1,4 @@
-const { logger, runAsSystem } = require('@librechat/data-schemas');
+const { logger } = require('@librechat/data-schemas');
 const { ErrorTypes } = require('librechat-data-provider');
 const { isEnabled, isEmailDomainAllowed } = require('@librechat/api');
 const { createSocialUser, handleExistingUser } = require('./process');
@@ -13,7 +13,7 @@ const socialLogin =
         profile,
       });
 
-      const appConfig = await runAsSystem(async () => getAppConfig());
+      const appConfig = await getAppConfig({ baseOnly: true });
 
       if (!isEmailDomainAllowed(email, appConfig?.registration?.allowedDomains)) {
         logger.error(

--- a/packages/api/src/admin/config.ts
+++ b/packages/api/src/admin/config.ts
@@ -283,7 +283,9 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
         priority ?? DEFAULT_PRIORITY,
       );
 
-      await invalidateConfigCaches?.(user.tenantId);
+      invalidateConfigCaches?.(user.tenantId)?.catch((err) =>
+        logger.error('[adminConfig] Cache invalidation failed after upsert:', err),
+      );
       return res.status(config?.configVersion === 1 ? 201 : 200).json({ config });
     } catch (error) {
       logger.error('[adminConfig] upsertConfigOverrides error:', error);
@@ -373,7 +375,9 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
         priority ?? existing?.priority ?? DEFAULT_PRIORITY,
       );
 
-      await invalidateConfigCaches?.(user.tenantId);
+      invalidateConfigCaches?.(user.tenantId)?.catch((err) =>
+        logger.error('[adminConfig] Cache invalidation failed after patch:', err),
+      );
       return res.status(200).json({ config });
     } catch (error) {
       logger.error('[adminConfig] patchConfigField error:', error);
@@ -421,7 +425,9 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
         return res.status(404).json({ error: 'Config not found' });
       }
 
-      await invalidateConfigCaches?.(user.tenantId);
+      invalidateConfigCaches?.(user.tenantId)?.catch((err) =>
+        logger.error('[adminConfig] Cache invalidation failed after field delete:', err),
+      );
       return res.status(200).json({ config });
     } catch (error) {
       logger.error('[adminConfig] deleteConfigField error:', error);
@@ -457,7 +463,9 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
         return res.status(404).json({ error: 'Config not found' });
       }
 
-      await invalidateConfigCaches?.(user.tenantId);
+      invalidateConfigCaches?.(user.tenantId)?.catch((err) =>
+        logger.error('[adminConfig] Cache invalidation failed after config delete:', err),
+      );
       return res.status(200).json({ success: true });
     } catch (error) {
       logger.error('[adminConfig] deleteConfigOverrides error:', error);
@@ -498,7 +506,9 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
         return res.status(404).json({ error: 'Config not found' });
       }
 
-      await invalidateConfigCaches?.(user.tenantId);
+      invalidateConfigCaches?.(user.tenantId)?.catch((err) =>
+        logger.error('[adminConfig] Cache invalidation failed after toggle:', err),
+      );
       return res.status(200).json({ config });
     } catch (error) {
       logger.error('[adminConfig] toggleConfig error:', error);

--- a/packages/api/src/admin/config.ts
+++ b/packages/api/src/admin/config.ts
@@ -77,6 +77,8 @@ export interface AdminConfigDeps {
     userId?: string;
     tenantId?: string;
   }) => Promise<AppConfig>;
+  /** Invalidate all config-related caches after a mutation. */
+  invalidateConfigCaches?: (tenantId?: string) => Promise<void>;
 }
 
 // ── Validation helpers ───────────────────────────────────────────────
@@ -133,6 +135,7 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
     toggleConfigActive,
     hasConfigCapability,
     getAppConfig,
+    invalidateConfigCaches,
   } = deps;
 
   /**
@@ -176,7 +179,10 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
         return res.status(501).json({ error: 'Base config endpoint not configured' });
       }
 
-      const appConfig = await getAppConfig();
+      const appConfig = await getAppConfig({
+        role: user.role,
+        tenantId: user.tenantId,
+      });
       return res.status(200).json({ config: appConfig });
     } catch (error) {
       logger.error('[adminConfig] getBaseConfig error:', error);
@@ -278,6 +284,7 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
         priority ?? DEFAULT_PRIORITY,
       );
 
+      await invalidateConfigCaches?.(user.tenantId);
       return res.status(config?.configVersion === 1 ? 201 : 200).json({ config });
     } catch (error) {
       logger.error('[adminConfig] upsertConfigOverrides error:', error);
@@ -367,6 +374,7 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
         priority ?? existing?.priority ?? DEFAULT_PRIORITY,
       );
 
+      await invalidateConfigCaches?.(user.tenantId);
       return res.status(200).json({ config });
     } catch (error) {
       logger.error('[adminConfig] patchConfigField error:', error);
@@ -414,6 +422,7 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
         return res.status(404).json({ error: 'Config not found' });
       }
 
+      await invalidateConfigCaches?.(user.tenantId);
       return res.status(200).json({ config });
     } catch (error) {
       logger.error('[adminConfig] deleteConfigField error:', error);
@@ -449,6 +458,7 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
         return res.status(404).json({ error: 'Config not found' });
       }
 
+      await invalidateConfigCaches?.(user.tenantId);
       return res.status(200).json({ success: true });
     } catch (error) {
       logger.error('[adminConfig] deleteConfigOverrides error:', error);
@@ -489,6 +499,7 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
         return res.status(404).json({ error: 'Config not found' });
       }
 
+      await invalidateConfigCaches?.(user.tenantId);
       return res.status(200).json({ config });
     } catch (error) {
       logger.error('[adminConfig] toggleConfig error:', error);

--- a/packages/api/src/admin/config.ts
+++ b/packages/api/src/admin/config.ts
@@ -180,7 +180,6 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
       }
 
       const appConfig = await getAppConfig({
-        role: user.role,
         tenantId: user.tenantId,
       });
       return res.status(200).json({ config: appConfig });

--- a/packages/api/src/app/service.spec.ts
+++ b/packages/api/src/app/service.spec.ts
@@ -60,6 +60,23 @@ describe('createAppConfigService', () => {
       expect(deps.loadBaseConfig).toHaveBeenCalledTimes(1);
     });
 
+    it('baseOnly returns YAML config without DB queries', async () => {
+      const deps = createDeps({
+        getApplicableConfigs: jest
+          .fn()
+          .mockResolvedValue([
+            { priority: 10, overrides: { interface: { endpointsMenu: false } }, isActive: true },
+          ]),
+      });
+      const { getAppConfig } = createAppConfigService(deps);
+
+      const config = await getAppConfig({ baseOnly: true });
+
+      expect(deps.loadBaseConfig).toHaveBeenCalledTimes(1);
+      expect(deps.getApplicableConfigs).not.toHaveBeenCalled();
+      expect(config).toEqual(deps._baseConfig);
+    });
+
     it('reloads base config when refresh is true', async () => {
       const deps = createDeps();
       const { getAppConfig } = createAppConfigService(deps);

--- a/packages/api/src/app/service.spec.ts
+++ b/packages/api/src/app/service.spec.ts
@@ -1,15 +1,20 @@
 import { createAppConfigService } from './service';
 
-function createMockCache() {
+/**
+ * Creates a mock cache that simulates Keyv's namespace behavior.
+ * Keyv stores keys internally as `namespace:key` but its API (get/set/delete)
+ * accepts un-namespaced keys and auto-prepends the namespace.
+ */
+function createMockCache(namespace = 'app_config') {
   const store = new Map();
   return {
-    get: jest.fn((key) => Promise.resolve(store.get(key))),
+    get: jest.fn((key) => Promise.resolve(store.get(`${namespace}:${key}`))),
     set: jest.fn((key, value) => {
-      store.set(key, value);
+      store.set(`${namespace}:${key}`, value);
       return Promise.resolve(undefined);
     }),
     delete: jest.fn((key) => {
-      store.delete(key);
+      store.delete(`${namespace}:${key}`);
       return Promise.resolve(true);
     }),
     /** Mimic Keyv's opts.store structure for key enumeration in clearOverrideCache */
@@ -163,8 +168,8 @@ describe('createAppConfigService', () => {
       await getAppConfig({ userId: 'uid1' });
 
       const cachedKeys = [...deps._cache._store.keys()];
-      const overrideKey = cachedKeys.find((k) => k.startsWith('_OVERRIDE_:'));
-      expect(overrideKey).toBe('_OVERRIDE_:__default__:uid1');
+      const overrideKey = cachedKeys.find((k) => k.includes('_OVERRIDE_:'));
+      expect(overrideKey).toBe('app_config:_OVERRIDE_:__default__:uid1');
     });
 
     it('tenantId is included in cache key to prevent cross-tenant contamination', async () => {

--- a/packages/api/src/app/service.spec.ts
+++ b/packages/api/src/app/service.spec.ts
@@ -320,5 +320,15 @@ describe('createAppConfigService', () => {
       // Base config should still be cached
       expect(deps.loadBaseConfig).toHaveBeenCalledTimes(1);
     });
+
+    it('does not throw when store.keys is unavailable (Redis fallback to TTL expiry)', async () => {
+      const deps = createDeps();
+      // Remove store.keys to simulate Redis-backed cache
+      deps._cache.opts = {};
+      const { clearOverrideCache } = createAppConfigService(deps);
+
+      // Should not throw — logs warning and relies on TTL expiry
+      await expect(clearOverrideCache()).resolves.toBeUndefined();
+    });
   });
 });

--- a/packages/api/src/app/service.spec.ts
+++ b/packages/api/src/app/service.spec.ts
@@ -12,6 +12,8 @@ function createMockCache() {
       store.delete(key);
       return Promise.resolve(true);
     }),
+    /** Mimic Keyv's opts.store structure for key enumeration in clearOverrideCache */
+    opts: { store: { keys: () => store.keys() } },
     _store: store,
   };
 }
@@ -239,6 +241,62 @@ describe('createAppConfigService', () => {
       await clearAppConfigCache();
       await getAppConfig();
       expect(deps.loadBaseConfig).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('clearOverrideCache', () => {
+    it('clears all override caches when no tenantId is provided', async () => {
+      const deps = createDeps({
+        getApplicableConfigs: jest
+          .fn()
+          .mockResolvedValue([{ priority: 10, overrides: { x: 1 }, isActive: true }]),
+      });
+      const { getAppConfig, clearOverrideCache } = createAppConfigService(deps);
+
+      await getAppConfig({ role: 'ADMIN', tenantId: 'tenant-a' });
+      await getAppConfig({ role: 'ADMIN', tenantId: 'tenant-b' });
+      expect(deps.getApplicableConfigs).toHaveBeenCalledTimes(2);
+
+      await clearOverrideCache();
+
+      // After clearing, both tenants should re-query DB
+      await getAppConfig({ role: 'ADMIN', tenantId: 'tenant-a' });
+      await getAppConfig({ role: 'ADMIN', tenantId: 'tenant-b' });
+      expect(deps.getApplicableConfigs).toHaveBeenCalledTimes(4);
+    });
+
+    it('clears only specified tenant override caches', async () => {
+      const deps = createDeps({
+        getApplicableConfigs: jest
+          .fn()
+          .mockResolvedValue([{ priority: 10, overrides: { x: 1 }, isActive: true }]),
+      });
+      const { getAppConfig, clearOverrideCache } = createAppConfigService(deps);
+
+      await getAppConfig({ role: 'ADMIN', tenantId: 'tenant-a' });
+      await getAppConfig({ role: 'ADMIN', tenantId: 'tenant-b' });
+      expect(deps.getApplicableConfigs).toHaveBeenCalledTimes(2);
+
+      await clearOverrideCache('tenant-a');
+
+      // tenant-a should re-query, tenant-b should be cached
+      await getAppConfig({ role: 'ADMIN', tenantId: 'tenant-a' });
+      await getAppConfig({ role: 'ADMIN', tenantId: 'tenant-b' });
+      expect(deps.getApplicableConfigs).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not clear base config', async () => {
+      const deps = createDeps();
+      const { getAppConfig, clearOverrideCache } = createAppConfigService(deps);
+
+      await getAppConfig();
+      expect(deps.loadBaseConfig).toHaveBeenCalledTimes(1);
+
+      await clearOverrideCache();
+
+      await getAppConfig();
+      // Base config should still be cached
+      expect(deps.loadBaseConfig).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/api/src/app/service.ts
+++ b/packages/api/src/app/service.ts
@@ -95,17 +95,10 @@ export function createAppConfigService(deps: AppConfigServiceDeps) {
   }
 
   /**
-   * Get the app configuration, optionally merged with DB overrides for the given principal.
-   *
-   * The base config (from YAML + AppService) is cached indefinitely. Per-principal merged
-   * configs are cached with a short TTL (`overrideCacheTtl`, default 60s). On cache miss,
-   * `getApplicableConfigs` queries the DB for matching overrides and merges them by priority.
+   * Ensure the YAML-derived base config is loaded and cached.
+   * Returns the `_BASE_` config (YAML + AppService). No DB queries.
    */
-  async function getAppConfig(
-    options: { role?: string; userId?: string; tenantId?: string; refresh?: boolean } = {},
-  ): Promise<AppConfig> {
-    const { role, userId, tenantId, refresh } = options;
-
+  async function ensureBaseConfig(refresh?: boolean): Promise<AppConfig> {
     let baseConfig = (await cache.get(BASE_CONFIG_KEY)) as AppConfig | undefined;
     if (!baseConfig || refresh) {
       logger.info('[getAppConfig] Loading base configuration...');
@@ -120,6 +113,36 @@ export function createAppConfigService(deps: AppConfigServiceDeps) {
       }
 
       await cache.set(BASE_CONFIG_KEY, baseConfig);
+    }
+    return baseConfig;
+  }
+
+  /**
+   * Get the app configuration, optionally merged with DB overrides for the given principal.
+   *
+   * The base config (from YAML + AppService) is cached indefinitely. Per-principal merged
+   * configs are cached with a short TTL (`overrideCacheTtl`, default 60s). On cache miss,
+   * `getApplicableConfigs` queries the DB for matching overrides and merges them by priority.
+   *
+   * When `baseOnly` is true, returns the YAML-derived config without any DB queries.
+   * Use this for startup, auth strategies, and other pre-tenant code paths.
+   */
+  async function getAppConfig(
+    options: {
+      role?: string;
+      userId?: string;
+      tenantId?: string;
+      refresh?: boolean;
+      /** When true, return only the YAML-derived base config — no DB override queries. */
+      baseOnly?: boolean;
+    } = {},
+  ): Promise<AppConfig> {
+    const { role, userId, tenantId, refresh, baseOnly } = options;
+
+    const baseConfig = await ensureBaseConfig(refresh);
+
+    if (baseOnly) {
+      return baseConfig;
     }
 
     const cacheKey = overrideCacheKey(role, userId, tenantId);

--- a/packages/api/src/app/service.ts
+++ b/packages/api/src/app/service.ts
@@ -196,11 +196,17 @@ export function createAppConfigService(deps: AppConfigServiceDeps) {
       );
       return;
     }
-    const prefix = tenantId ? `_OVERRIDE_:${tenantId}:` : '_OVERRIDE_:';
+    // Keyv stores keys with a namespace prefix (e.g. "APP_CONFIG:_OVERRIDE_:...").
+    // We match on the namespaced key but delete using the un-namespaced key
+    // because Keyv.delete() auto-prepends the namespace.
+    const namespace = cacheKeys.APP_CONFIG;
+    const overrideSegment = tenantId ? `_OVERRIDE_:${tenantId}:` : '_OVERRIDE_:';
+    const namespacedPrefix = `${namespace}:${overrideSegment}`;
     const toDelete: string[] = [];
     for (const key of store.keys()) {
-      if (key.startsWith(prefix)) {
-        toDelete.push(key);
+      if (key.startsWith(namespacedPrefix)) {
+        // Strip namespace prefix for Keyv.delete() which re-adds it
+        toDelete.push(key.slice(namespace.length + 1));
       }
     }
     if (toDelete.length > 0) {

--- a/packages/api/src/app/service.ts
+++ b/packages/api/src/app/service.ts
@@ -13,6 +13,12 @@ interface CacheStore {
   get: (key: string) => Promise<unknown>;
   set: (key: string, value: unknown, ttl?: number) => Promise<unknown>;
   delete: (key: string) => Promise<boolean>;
+  /** Keyv options — used for key enumeration when clearing override caches. */
+  opts?: {
+    store?: {
+      keys?: () => IterableIterator<string>;
+    };
+  };
 }
 
 export interface AppConfigServiceDeps {
@@ -41,6 +47,12 @@ export interface AppConfigServiceDeps {
 
 function overrideCacheKey(role?: string, userId?: string, tenantId?: string): string {
   const tenant = tenantId || '__default__';
+  if (!tenantId && process.env.TENANT_ISOLATION_STRICT === 'true') {
+    logger.warn(
+      '[overrideCacheKey] No tenantId in strict mode — falling back to __default__. ' +
+        'This likely indicates a code path that bypasses the tenant context middleware.',
+    );
+  }
   if (userId && role) {
     return `_OVERRIDE_:${tenant}:${role}:${userId}`;
   }
@@ -146,9 +158,32 @@ export function createAppConfigService(deps: AppConfigServiceDeps) {
     await cache.delete(BASE_CONFIG_KEY);
   }
 
+  /**
+   * Clear per-principal override caches. When `tenantId` is provided, only caches
+   * matching `_OVERRIDE_:${tenantId}:*` are deleted. When omitted, ALL override
+   * caches are cleared.
+   */
+  async function clearOverrideCache(tenantId?: string): Promise<void> {
+    const store = (cache as CacheStore).opts?.store;
+    if (!store || typeof store.keys !== 'function') {
+      return;
+    }
+    const prefix = tenantId ? `_OVERRIDE_:${tenantId}:` : '_OVERRIDE_:';
+    const keys = Array.from(store.keys());
+    const toDelete = keys.filter((key) => key.includes(prefix));
+    if (toDelete.length > 0) {
+      await Promise.all(toDelete.map((key) => cache.delete(key)));
+      logger.info(
+        `[clearOverrideCache] Cleared ${toDelete.length} override cache entries` +
+          (tenantId ? ` for tenant ${tenantId}` : ''),
+      );
+    }
+  }
+
   return {
     getAppConfig,
     clearAppConfigCache,
+    clearOverrideCache,
   };
 }
 

--- a/packages/api/src/app/service.ts
+++ b/packages/api/src/app/service.ts
@@ -198,34 +198,43 @@ export function createAppConfigService(deps: AppConfigServiceDeps) {
    * caches are cleared.
    */
   async function clearOverrideCache(tenantId?: string): Promise<void> {
-    const store = (cache as CacheStore).opts?.store;
-    if (!store || typeof store.keys !== 'function') {
-      logger.warn(
-        '[clearOverrideCache] Cache store does not support key enumeration (e.g. Redis). ' +
-          'Override caches will not be cleared — they will expire naturally via TTL.',
-      );
-      return;
-    }
-    // Keyv stores keys with a namespace prefix (e.g. "APP_CONFIG:_OVERRIDE_:...").
-    // We match on the namespaced key but delete using the un-namespaced key
-    // because Keyv.delete() auto-prepends the namespace.
     const namespace = cacheKeys.APP_CONFIG;
     const overrideSegment = tenantId ? `_OVERRIDE_:${tenantId}:` : '_OVERRIDE_:';
-    const namespacedPrefix = `${namespace}:${overrideSegment}`;
-    const toDelete: string[] = [];
-    for (const key of store.keys()) {
-      if (key.startsWith(namespacedPrefix)) {
-        // Strip namespace prefix for Keyv.delete() which re-adds it
-        toDelete.push(key.slice(namespace.length + 1));
+
+    // In-memory store — enumerate keys directly.
+    // APP_CONFIG defaults to FORCED_IN_MEMORY_CACHE_NAMESPACES, so this is the
+    // standard path. Redis SCAN is intentionally avoided here — it can cause 60s+
+    // stalls under concurrent load (see #12410). When APP_CONFIG is Redis-backed
+    // and store.keys() is unavailable, overrides expire naturally via TTL.
+    const store = (cache as CacheStore).opts?.store;
+    if (store && typeof store.keys === 'function') {
+      // Keyv stores keys with a namespace prefix (e.g. "APP_CONFIG:_OVERRIDE_:...").
+      // We match on the namespaced key but delete using the un-namespaced key
+      // because Keyv.delete() auto-prepends the namespace.
+      const namespacedPrefix = `${namespace}:${overrideSegment}`;
+      const toDelete: string[] = [];
+      for (const key of store.keys()) {
+        if (key.startsWith(namespacedPrefix)) {
+          toDelete.push(key.slice(namespace.length + 1));
+        }
       }
+      if (toDelete.length > 0) {
+        await Promise.all(toDelete.map((key) => cache.delete(key)));
+        logger.info(
+          `[clearOverrideCache] Cleared ${toDelete.length} override cache entries` +
+            (tenantId ? ` for tenant ${tenantId}` : ''),
+        );
+      }
+      return;
     }
-    if (toDelete.length > 0) {
-      await Promise.all(toDelete.map((key) => cache.delete(key)));
-      logger.info(
-        `[clearOverrideCache] Cleared ${toDelete.length} override cache entries` +
-          (tenantId ? ` for tenant ${tenantId}` : ''),
-      );
-    }
+
+    logger.warn(
+      '[clearOverrideCache] Cache store does not support key enumeration. ' +
+        'Override caches will expire naturally via TTL (%dms). ' +
+        'This is expected when APP_CONFIG is Redis-backed — Redis SCAN is avoided ' +
+        'for performance reasons (see #12410).',
+      overrideCacheTtl,
+    );
   }
 
   return {

--- a/packages/api/src/app/service.ts
+++ b/packages/api/src/app/service.ts
@@ -45,9 +45,19 @@ export interface AppConfigServiceDeps {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
+let _strictOverride: boolean | undefined;
+function isStrictOverrideMode(): boolean {
+  return (_strictOverride ??= process.env.TENANT_ISOLATION_STRICT === 'true');
+}
+
+/** @internal Resets the cached strict-override flag. Exposed for test teardown only. */
+export function _resetOverrideStrictCache(): void {
+  _strictOverride = undefined;
+}
+
 function overrideCacheKey(role?: string, userId?: string, tenantId?: string): string {
   const tenant = tenantId || '__default__';
-  if (!tenantId && process.env.TENANT_ISOLATION_STRICT === 'true') {
+  if (!tenantId && isStrictOverrideMode()) {
     logger.warn(
       '[overrideCacheKey] No tenantId in strict mode — falling back to __default__. ' +
         'This likely indicates a code path that bypasses the tenant context middleware.',
@@ -101,7 +111,7 @@ export function createAppConfigService(deps: AppConfigServiceDeps) {
   async function ensureBaseConfig(refresh?: boolean): Promise<AppConfig> {
     let baseConfig = (await cache.get(BASE_CONFIG_KEY)) as AppConfig | undefined;
     if (!baseConfig || refresh) {
-      logger.info('[getAppConfig] Loading base configuration...');
+      logger.info('[ensureBaseConfig] Loading base configuration...');
       baseConfig = await loadBaseConfig();
 
       if (!baseConfig) {

--- a/packages/api/src/app/service.ts
+++ b/packages/api/src/app/service.ts
@@ -125,6 +125,7 @@ export function createAppConfigService(deps: AppConfigServiceDeps) {
    * `getApplicableConfigs` queries the DB for matching overrides and merges them by priority.
    *
    * When `baseOnly` is true, returns the YAML-derived config without any DB queries.
+   * `role`, `userId`, and `tenantId` are ignored in this mode.
    * Use this for startup, auth strategies, and other pre-tenant code paths.
    */
   async function getAppConfig(

--- a/packages/api/src/app/service.ts
+++ b/packages/api/src/app/service.ts
@@ -189,11 +189,19 @@ export function createAppConfigService(deps: AppConfigServiceDeps) {
   async function clearOverrideCache(tenantId?: string): Promise<void> {
     const store = (cache as CacheStore).opts?.store;
     if (!store || typeof store.keys !== 'function') {
+      logger.warn(
+        '[clearOverrideCache] Cache store does not support key enumeration (e.g. Redis). ' +
+          'Override caches will not be cleared — they will expire naturally via TTL.',
+      );
       return;
     }
     const prefix = tenantId ? `_OVERRIDE_:${tenantId}:` : '_OVERRIDE_:';
-    const keys = Array.from(store.keys());
-    const toDelete = keys.filter((key) => key.includes(prefix));
+    const toDelete: string[] = [];
+    for (const key of store.keys()) {
+      if (key.startsWith(prefix)) {
+        toDelete.push(key);
+      }
+    }
     if (toDelete.length > 0) {
       await Promise.all(toDelete.map((key) => cache.delete(key)));
       logger.info(

--- a/packages/api/src/app/service.ts
+++ b/packages/api/src/app/service.ts
@@ -51,13 +51,17 @@ function isStrictOverrideMode(): boolean {
 }
 
 /** @internal Resets the cached strict-override flag. Exposed for test teardown only. */
+let _warnedNoTenantInStrictMode = false;
+
 export function _resetOverrideStrictCache(): void {
   _strictOverride = undefined;
+  _warnedNoTenantInStrictMode = false;
 }
 
 function overrideCacheKey(role?: string, userId?: string, tenantId?: string): string {
   const tenant = tenantId || '__default__';
-  if (!tenantId && isStrictOverrideMode()) {
+  if (!tenantId && isStrictOverrideMode() && !_warnedNoTenantInStrictMode) {
+    _warnedNoTenantInStrictMode = true;
     logger.warn(
       '[overrideCacheKey] No tenantId in strict mode — falling back to __default__. ' +
         'This likely indicates a code path that bypasses the tenant context middleware.',

--- a/packages/api/src/middleware/__tests__/tenant.spec.ts
+++ b/packages/api/src/middleware/__tests__/tenant.spec.ts
@@ -1,0 +1,99 @@
+import { getTenantId } from '@librechat/data-schemas';
+import { tenantContextMiddleware, _resetTenantMiddlewareStrictCache } from '../tenant';
+import type { Response, NextFunction } from 'express';
+import type { ServerRequest } from '~/types/http';
+
+function mockReq(user?: Record<string, unknown>): ServerRequest {
+  return { user } as unknown as ServerRequest;
+}
+
+function mockRes(): Response {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  return res as unknown as Response;
+}
+
+/** Runs the middleware and returns a Promise that resolves when next() is called. */
+function runMiddleware(req: ServerRequest, res: Response): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    const next: NextFunction = () => {
+      resolve(getTenantId());
+    };
+    tenantContextMiddleware(req, res, next);
+  });
+}
+
+describe('tenantContextMiddleware', () => {
+  afterEach(() => {
+    _resetTenantMiddlewareStrictCache();
+    delete process.env.TENANT_ISOLATION_STRICT;
+  });
+
+  it('sets ALS tenant context for authenticated requests with tenantId', async () => {
+    const req = mockReq({ tenantId: 'tenant-x', role: 'user' });
+    const res = mockRes();
+
+    const tenantId = await runMiddleware(req, res);
+    expect(tenantId).toBe('tenant-x');
+  });
+
+  it('is a no-op for unauthenticated requests (no user)', async () => {
+    const req = mockReq();
+    const res = mockRes();
+
+    const tenantId = await runMiddleware(req, res);
+    expect(tenantId).toBeUndefined();
+  });
+
+  it('passes through without ALS when user has no tenantId in non-strict mode', async () => {
+    const req = mockReq({ role: 'user' });
+    const res = mockRes();
+
+    const tenantId = await runMiddleware(req, res);
+    expect(tenantId).toBeUndefined();
+  });
+
+  it('returns 403 when user has no tenantId in strict mode', () => {
+    process.env.TENANT_ISOLATION_STRICT = 'true';
+    _resetTenantMiddlewareStrictCache();
+
+    const req = mockReq({ role: 'user' });
+    const res = mockRes();
+    const next: NextFunction = jest.fn();
+
+    tenantContextMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining('Tenant context required') }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows authenticated requests with tenantId in strict mode', async () => {
+    process.env.TENANT_ISOLATION_STRICT = 'true';
+    _resetTenantMiddlewareStrictCache();
+
+    const req = mockReq({ tenantId: 'tenant-y', role: 'admin' });
+    const res = mockRes();
+
+    const tenantId = await runMiddleware(req, res);
+    expect(tenantId).toBe('tenant-y');
+  });
+
+  it('different requests get independent tenant contexts', async () => {
+    const runRequest = (tid: string) => {
+      const req = mockReq({ tenantId: tid, role: 'user' });
+      const res = mockRes();
+      return runMiddleware(req, res);
+    };
+
+    const results = await Promise.all([runRequest('tenant-1'), runRequest('tenant-2')]);
+
+    expect(results).toHaveLength(2);
+    expect(results).toContain('tenant-1');
+    expect(results).toContain('tenant-2');
+  });
+});

--- a/packages/api/src/middleware/__tests__/tenant.spec.ts
+++ b/packages/api/src/middleware/__tests__/tenant.spec.ts
@@ -1,9 +1,9 @@
 import { getTenantId } from '@librechat/data-schemas';
+import type { Response, NextFunction } from 'express';
+import type { ServerRequest } from '~/types/http';
 // Import directly from source file — _resetTenantMiddlewareStrictCache is intentionally
 // excluded from the public barrel export (index.ts).
 import { tenantContextMiddleware, _resetTenantMiddlewareStrictCache } from '../tenant';
-import type { Response, NextFunction } from 'express';
-import type { ServerRequest } from '~/types/http';
 
 function mockReq(user?: Record<string, unknown>): ServerRequest {
   return { user } as unknown as ServerRequest;

--- a/packages/api/src/middleware/__tests__/tenant.spec.ts
+++ b/packages/api/src/middleware/__tests__/tenant.spec.ts
@@ -1,4 +1,6 @@
 import { getTenantId } from '@librechat/data-schemas';
+// Import directly from source file — _resetTenantMiddlewareStrictCache is intentionally
+// excluded from the public barrel export (index.ts).
 import { tenantContextMiddleware, _resetTenantMiddlewareStrictCache } from '../tenant';
 import type { Response, NextFunction } from 'express';
 import type { ServerRequest } from '~/types/http';

--- a/packages/api/src/middleware/balance.ts
+++ b/packages/api/src/middleware/balance.ts
@@ -92,7 +92,10 @@ export function createSetBalanceConfig({
   return async (req: ServerRequest, res: ServerResponse, next: NextFunction): Promise<void> => {
     try {
       const user = req.user as IUser & { _id: string | ObjectId };
-      const appConfig = await getAppConfig({ role: user?.role });
+      const appConfig = await getAppConfig({
+        role: user?.role,
+        tenantId: (user as IUser & { tenantId?: string })?.tenantId,
+      });
       const balanceConfig = getBalanceConfig(appConfig);
       if (!balanceConfig?.enabled) {
         return next();

--- a/packages/api/src/middleware/balance.ts
+++ b/packages/api/src/middleware/balance.ts
@@ -12,7 +12,11 @@ import type { BalanceUpdateFields } from '~/types';
 import { getBalanceConfig } from '~/app/config';
 
 export interface BalanceMiddlewareOptions {
-  getAppConfig: (options?: { role?: string; refresh?: boolean }) => Promise<AppConfig>;
+  getAppConfig: (options?: {
+    role?: string;
+    tenantId?: string;
+    refresh?: boolean;
+  }) => Promise<AppConfig>;
   findBalanceByUser: (userId: string) => Promise<IBalance | null>;
   upsertBalanceFields: (userId: string, fields: IBalanceUpdate) => Promise<IBalance | null>;
 }
@@ -94,7 +98,7 @@ export function createSetBalanceConfig({
       const user = req.user as IUser & { _id: string | ObjectId };
       const appConfig = await getAppConfig({
         role: user?.role,
-        tenantId: (user as IUser & { tenantId?: string })?.tenantId,
+        tenantId: user?.tenantId,
       });
       const balanceConfig = getBalanceConfig(appConfig);
       if (!balanceConfig?.enabled) {

--- a/packages/api/src/middleware/index.ts
+++ b/packages/api/src/middleware/index.ts
@@ -5,5 +5,6 @@ export * from './notFound';
 export * from './balance';
 export * from './json';
 export * from './capabilities';
+export * from './tenant';
 export * from './concurrency';
 export * from './checkBalance';

--- a/packages/api/src/middleware/index.ts
+++ b/packages/api/src/middleware/index.ts
@@ -5,6 +5,6 @@ export * from './notFound';
 export * from './balance';
 export * from './json';
 export * from './capabilities';
-export * from './tenant';
+export { tenantContextMiddleware } from './tenant';
 export * from './concurrency';
 export * from './checkBalance';

--- a/packages/api/src/middleware/tenant.ts
+++ b/packages/api/src/middleware/tenant.ts
@@ -64,7 +64,7 @@ export function tenantContextMiddleware(
     return;
   }
 
-  return tenantStorage.run({ tenantId }, async () => {
+  return void tenantStorage.run({ tenantId }, async () => {
     next();
   });
 }

--- a/packages/api/src/middleware/tenant.ts
+++ b/packages/api/src/middleware/tenant.ts
@@ -1,0 +1,64 @@
+import { isMainThread } from 'worker_threads';
+import { tenantStorage, logger } from '@librechat/data-schemas';
+import type { Response, NextFunction } from 'express';
+import type { ServerRequest } from '~/types/http';
+
+let _strictMode: boolean | undefined;
+
+function isStrict(): boolean {
+  return (_strictMode ??= process.env.TENANT_ISOLATION_STRICT === 'true');
+}
+
+/** Resets the cached strict-mode flag. Exposed for test teardown only. */
+export function _resetTenantMiddlewareStrictCache(): void {
+  _strictMode = undefined;
+}
+
+/**
+ * Express middleware that propagates the authenticated user's `tenantId` into
+ * the AsyncLocalStorage context used by the Mongoose tenant-isolation plugin.
+ *
+ * **Placement**: After `requireJwtAuth` / `capabilityContextMiddleware`, before
+ * route handlers.
+ *
+ * Behaviour:
+ * - Authenticated request with `tenantId` → wraps downstream in `tenantStorage.run({ tenantId })`
+ * - Authenticated request **without** `tenantId`:
+ *   - Strict mode (`TENANT_ISOLATION_STRICT=true`) → responds 403
+ *   - Non-strict (default) → passes through without ALS context (backward compat)
+ * - Unauthenticated request → no-op (calls `next()` directly)
+ */
+export function tenantContextMiddleware(
+  req: ServerRequest,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (!isMainThread) {
+    logger.error(
+      '[tenantContextMiddleware] Mounted in a worker thread — ' +
+        'ALS context will not propagate. This middleware should only run in the main Express process.',
+    );
+  }
+
+  const user = req.user as { tenantId?: string } | undefined;
+
+  if (!user) {
+    next();
+    return;
+  }
+
+  const tenantId = user.tenantId;
+
+  if (!tenantId) {
+    if (isStrict()) {
+      res.status(403).json({ error: 'Tenant context required in strict isolation mode' });
+      return;
+    }
+    next();
+    return;
+  }
+
+  tenantStorage.run({ tenantId }, async () => {
+    next();
+  });
+}

--- a/packages/api/src/middleware/tenant.ts
+++ b/packages/api/src/middleware/tenant.ts
@@ -3,12 +3,7 @@ import { tenantStorage, logger } from '@librechat/data-schemas';
 import type { Response, NextFunction } from 'express';
 import type { ServerRequest } from '~/types/http';
 
-if (!isMainThread) {
-  logger.error(
-    '[tenantContextMiddleware] Loaded in a worker thread — ' +
-      'ALS context will not propagate. This middleware must only run in the main Express process.',
-  );
-}
+let _checkedThread = false;
 
 let _strictMode: boolean | undefined;
 
@@ -41,6 +36,16 @@ export function tenantContextMiddleware(
   res: Response,
   next: NextFunction,
 ): void {
+  if (!_checkedThread) {
+    _checkedThread = true;
+    if (!isMainThread) {
+      logger.error(
+        '[tenantContextMiddleware] Running in a worker thread — ' +
+          'ALS context will not propagate. This middleware must only run in the main Express process.',
+      );
+    }
+  }
+
   const user = req.user as { tenantId?: string } | undefined;
 
   if (!user) {

--- a/packages/api/src/middleware/tenant.ts
+++ b/packages/api/src/middleware/tenant.ts
@@ -59,7 +59,7 @@ export function tenantContextMiddleware(
     return;
   }
 
-  tenantStorage.run({ tenantId }, async () => {
+  return tenantStorage.run({ tenantId }, async () => {
     next();
   });
 }

--- a/packages/api/src/middleware/tenant.ts
+++ b/packages/api/src/middleware/tenant.ts
@@ -3,6 +3,13 @@ import { tenantStorage, logger } from '@librechat/data-schemas';
 import type { Response, NextFunction } from 'express';
 import type { ServerRequest } from '~/types/http';
 
+if (!isMainThread) {
+  logger.error(
+    '[tenantContextMiddleware] Loaded in a worker thread — ' +
+      'ALS context will not propagate. This middleware must only run in the main Express process.',
+  );
+}
+
 let _strictMode: boolean | undefined;
 
 function isStrict(): boolean {
@@ -18,8 +25,9 @@ export function _resetTenantMiddlewareStrictCache(): void {
  * Express middleware that propagates the authenticated user's `tenantId` into
  * the AsyncLocalStorage context used by the Mongoose tenant-isolation plugin.
  *
- * **Placement**: After `requireJwtAuth` / `capabilityContextMiddleware`, before
- * route handlers.
+ * **Placement**: Chained automatically by `requireJwtAuth` after successful
+ * passport authentication (req.user is populated). Must NOT be registered at
+ * global `app.use()` scope — `req.user` is undefined at that stage.
  *
  * Behaviour:
  * - Authenticated request with `tenantId` → wraps downstream in `tenantStorage.run({ tenantId })`
@@ -33,13 +41,6 @@ export function tenantContextMiddleware(
   res: Response,
   next: NextFunction,
 ): void {
-  if (!isMainThread) {
-    logger.error(
-      '[tenantContextMiddleware] Mounted in a worker thread — ' +
-        'ALS context will not propagate. This middleware should only run in the main Express process.',
-    );
-  }
-
   const user = req.user as { tenantId?: string } | undefined;
 
   if (!user) {

--- a/packages/data-schemas/src/methods/userGroup.ts
+++ b/packages/data-schemas/src/methods/userGroup.ts
@@ -245,11 +245,13 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')) {
    * @returns Array of principal objects with type and id
    */
   /**
-   * TODO(#12091): This method has no tenantId parameter — it returns ALL group
-   * memberships for a user regardless of tenant. In multi-tenant mode, group
-   * principals from other tenants will be included in capability checks, which
-   * could grant cross-tenant capabilities. Add tenantId filtering here when
-   * tenant isolation is activated.
+   * Tenant filtering for group memberships is handled automatically by the
+   * `applyTenantIsolation` Mongoose plugin on the Group schema. When the
+   * `tenantContextMiddleware` sets the ALS context for the current request,
+   * `getUserGroups()` → `findGroupsByMemberId()` queries are scoped to the
+   * requesting tenant. No explicit tenantId parameter is needed here.
+   *
+   * Ref: #12091 (resolved by tenant context middleware)
    */
   async function getUserPrincipals(
     params: {

--- a/packages/data-schemas/src/methods/userGroup.ts
+++ b/packages/data-schemas/src/methods/userGroup.ts
@@ -236,15 +236,9 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')) {
   }
 
   /**
-   * Get a list of all principal identifiers for a user (user ID + group IDs + public)
-   * For use in permission checks
-   * @param params - Parameters object
-   * @param params.userId - The user ID
-   * @param params.role - Optional user role (if not provided, will query from DB)
-   * @param session - Optional MongoDB session for transactions
-   * @returns Array of principal objects with type and id
-   */
-  /**
+   * Get a list of all principal identifiers for a user (user ID + group IDs + public).
+   * For use in permission checks.
+   *
    * Tenant filtering for group memberships is handled automatically by the
    * `applyTenantIsolation` Mongoose plugin on the Group schema. The
    * `tenantContextMiddleware` (chained by `requireJwtAuth` after passport auth)
@@ -257,6 +251,12 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')) {
    * reject such queries.
    *
    * Ref: #12091 (resolved by tenant context middleware in requireJwtAuth)
+   *
+   * @param params - Parameters object
+   * @param params.userId - The user ID
+   * @param params.role - Optional user role (if not provided, will query from DB)
+   * @param session - Optional MongoDB session for transactions
+   * @returns Array of principal objects with type and id
    */
   async function getUserPrincipals(
     params: {

--- a/packages/data-schemas/src/methods/userGroup.ts
+++ b/packages/data-schemas/src/methods/userGroup.ts
@@ -246,12 +246,17 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')) {
    */
   /**
    * Tenant filtering for group memberships is handled automatically by the
-   * `applyTenantIsolation` Mongoose plugin on the Group schema. When the
-   * `tenantContextMiddleware` sets the ALS context for the current request,
-   * `getUserGroups()` → `findGroupsByMemberId()` queries are scoped to the
-   * requesting tenant. No explicit tenantId parameter is needed here.
+   * `applyTenantIsolation` Mongoose plugin on the Group schema. The
+   * `tenantContextMiddleware` (chained by `requireJwtAuth` after passport auth)
+   * sets the ALS context, so `getUserGroups()` → `findGroupsByMemberId()` queries
+   * are scoped to the requesting tenant. No explicit tenantId parameter is needed.
    *
-   * Ref: #12091 (resolved by tenant context middleware)
+   * IMPORTANT: This relies on the ALS tenant context being active. If this
+   * function is called outside a request context (e.g. startup, background jobs),
+   * group queries will be unscoped. In strict mode, the Mongoose plugin will
+   * reject such queries.
+   *
+   * Ref: #12091 (resolved by tenant context middleware in requireJwtAuth)
    */
   async function getUserPrincipals(
     params: {


### PR DESCRIPTION

### Summary

Completes the multi-tenancy story started in #12354 by activating the ALS-based tenant isolation
infrastructure and wiring all outstanding follow-up items.

- Introduces `tenantContextMiddleware` in `packages/api` that propagates `req.user.tenantId` into
  `AsyncLocalStorage`, activating the `applyTenantIsolation` Mongoose plugin for all downstream DB
  queries scoped to the request.
- Chains `tenantContextMiddleware` directly inside `requireJwtAuth` after passport populates
  `req.user`, ensuring ALS context is set on every authenticated request without a global
  `app.use()` registration.
- Adds `baseOnly` option to `getAppConfig` that returns the YAML-derived config with zero DB
  queries, used by all pre-tenant code paths (server startup, auth strategies, MCP initialization).
- Wraps `performStartupChecks`, `updateInterfacePermissions`, `initializeMCPs`, and
  `initializeOAuthReconnectManager` in `runAsSystem()` for strict-mode compatibility.
- Threads `tenantId` from `req.user` into `getAppConfig` across 14 call sites (controllers,
  middleware, routes, audio services, MCP services) to ensure correct per-tenant cache key
  resolution.
- Scopes the `GET /api/admin/config/base` endpoint to the requesting admin's tenant instead of
  returning an unscoped config.
- Adds `clearOverrideCache(tenantId?)` to `createAppConfigService`, which enumerates Keyv store
  keys and deletes all matching `_OVERRIDE_:${tenantId}:*` entries (with a documented TTL-fallback
  warning for Redis deployments that do not expose `keys()`).
- Adds `invalidateConfigCaches(tenantId?)` in `app.js` that clears the base config, override
  caches, tool caches, and the `ENDPOINT_CONFIG` cache entry in a single `Promise.all`, wired as
  fire-and-forget (with error logging) into all five admin config mutation handlers.
- Enforces strict mode: `tenantContextMiddleware` returns 403 when `TENANT_ISOLATION_STRICT=true`
  and the authenticated user carries no `tenantId`.
- Resolves the `TODO(#12091)` on `getUserPrincipals` — group membership queries are now
  automatically tenant-scoped via the ALS context set by `tenantContextMiddleware`.
- Adds 25 tests across three new spec files covering ALS propagation, concurrent request isolation,
  strict/non-strict mode paths, `clearOverrideCache` scoping, and `invalidateConfigCaches`
  parallelism and partial-failure handling.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

New automated tests cover the core paths:

- **`packages/api/src/middleware/__tests__/tenant.spec.ts`** (6 tests): ALS context set for
  authenticated requests with `tenantId`; no-op for unauthenticated requests; 403 returned in
  strict mode without `tenantId`; concurrent requests receive independent ALS contexts.
- **`api/server/middleware/__tests__/requireJwtAuth.spec.js`** (5 tests): ALS tenant context is
  present inside `next()` after passport auth; absent when user has no `tenantId` or is undefined;
  concurrent requests are isolated; top-level scope has no ALS context.
- **`packages/api/src/app/service.spec.ts`** — `clearOverrideCache` suite (3 tests): clears all
  override caches when no `tenantId` is provided; clears only the specified tenant's caches; does
  not clear the base config.
- **`api/server/services/Config/__tests__/invalidateConfigCaches.spec.js`** (4 tests): all four
  caches are cleared; `tenantId` is forwarded to `clearOverrideCache`; a `CONFIG_STORE` failure
  does not prevent other caches from clearing; all operations execute in parallel via `Promise.all`.

### Test Configuration

Run per-workspace:
```sh
cd packages/api && npx jest tenant --testPathPattern="tenant|service"
cd api && npx jest requireJwtAuth invalidateConfigCaches
```

For manual strict-mode verification:
1. Set `TENANT_ISOLATION_STRICT=true` in `.env`.
2. Start the server and make an authenticated request with a user that has no `tenantId` — expect
   `403 { "error": "Tenant context required in strict isolation mode" }`.
3. Perform an admin config mutation (`PUT /api/admin/config/:type/:id`) and confirm that a
   subsequent `GET /api/config` reflects the updated config immediately (cache invalidated).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules
