### PR TITLE
🏁 fix: Invalidate Message Cache on Stream 404 Instead of Showing Error

### DIFF
--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
-import { Constants, ErrorTypes, LocalStorageKeys } from 'librechat-data-provider';
+import { Constants, LocalStorageKeys } from 'librechat-data-provider';
 import type { TSubmission } from 'librechat-data-provider';
 
 type SSEEventListener = (e: Partial<MessageEvent> & { responseCode?: number }) => void;

--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -34,7 +34,13 @@ jest.mock('sse.js', () => ({
 }));
 
 const mockSetQueryData = jest.fn();
-const mockQueryClient = { setQueryData: mockSetQueryData };
+const mockInvalidateQueries = jest.fn();
+const mockRemoveQueries = jest.fn();
+const mockQueryClient = {
+  setQueryData: mockSetQueryData,
+  invalidateQueries: mockInvalidateQueries,
+  removeQueries: mockRemoveQueries,
+};
 
 jest.mock('@tanstack/react-query', () => ({
   ...jest.requireActual('@tanstack/react-query'),
@@ -63,6 +69,7 @@ jest.mock('~/data-provider', () => ({
   useGetStartupConfig: () => ({ data: { balance: { enabled: false } } }),
   useGetUserBalance: () => ({ refetch: jest.fn() }),
   queueTitleGeneration: jest.fn(),
+  streamStatusQueryKey: (conversationId: string) => ['streamStatus', conversationId],
 }));
 
 const mockErrorHandler = jest.fn();
@@ -162,6 +169,11 @@ describe('useResumableSSE - 404 error path', () => {
   beforeEach(() => {
     mockSSEInstances.length = 0;
     localStorage.clear();
+    mockErrorHandler.mockClear();
+    mockClearStepMaps.mockClear();
+    mockSetIsSubmitting.mockClear();
+    mockInvalidateQueries.mockClear();
+    mockRemoveQueries.mockClear();
   });
 
   const seedDraft = (conversationId: string) => {
@@ -200,19 +212,18 @@ describe('useResumableSSE - 404 error path', () => {
     unmount();
   });
 
-  it('calls errorHandler with STREAM_EXPIRED error type on 404', async () => {
+  it('invalidates message cache and clears stream status on 404 instead of showing error', async () => {
     const { unmount } = await render404Scenario(CONV_ID);
 
-    expect(mockErrorHandler).toHaveBeenCalledTimes(1);
-    const call = mockErrorHandler.mock.calls[0][0];
-    expect(call.data).toBeDefined();
-    const parsed = JSON.parse(call.data.text);
-    expect(parsed.type).toBe(ErrorTypes.STREAM_EXPIRED);
-    expect(call.submission).toEqual(
-      expect.objectContaining({
-        conversation: expect.objectContaining({ conversationId: CONV_ID }),
-      }),
-    );
+    expect(mockErrorHandler).not.toHaveBeenCalled();
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['messages', CONV_ID],
+    });
+    expect(mockRemoveQueries).toHaveBeenCalledWith({
+      queryKey: ['streamStatus', CONV_ID],
+    });
+    expect(mockClearStepMaps).toHaveBeenCalled();
+    expect(mockSetIsSubmitting).toHaveBeenCalledWith(false);
     unmount();
   });
 

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -16,7 +16,12 @@ import {
 } from 'librechat-data-provider';
 import type { TMessage, TPayload, TSubmission, EventSubmission } from 'librechat-data-provider';
 import type { EventHandlerParams } from './useEventHandlers';
-import { useGetStartupConfig, useGetUserBalance, queueTitleGeneration } from '~/data-provider';
+import {
+  useGetStartupConfig,
+  useGetUserBalance,
+  queueTitleGeneration,
+  streamStatusQueryKey,
+} from '~/data-provider';
 import type { ActiveJobsResponse } from '~/data-provider';
 import { useAuthContext } from '~/hooks/AuthContext';
 import useEventHandlers from './useEventHandlers';
@@ -343,18 +348,20 @@ export default function useResumableSSE(
         /* @ts-ignore - sse.js types don't expose responseCode */
         const responseCode = e.responseCode;
 
-        // 404 means job doesn't exist (completed/deleted) - don't retry
+        // 404 → job completed & was cleaned up; messages are persisted in DB.
+        // Invalidate cache once so react-query refetches instead of showing an error.
         if (responseCode === 404) {
-          console.log('[ResumableSSE] Stream not found (404) - job completed or expired');
+          const convoId = currentSubmission.conversation?.conversationId;
+          console.log('[ResumableSSE] Stream 404, invalidating messages for:', convoId);
           sse.close();
           removeActiveJob(currentStreamId);
-          clearAllDrafts(currentSubmission.conversation?.conversationId);
-          errorHandler({
-            data: {
-              text: JSON.stringify({ type: ErrorTypes.STREAM_EXPIRED }),
-            } as unknown as Parameters<typeof errorHandler>[0]['data'],
-            submission: currentSubmission as EventSubmission,
-          });
+          clearAllDrafts(convoId);
+          clearStepMaps();
+          if (convoId) {
+            queryClient.invalidateQueries({ queryKey: [QueryKeys.messages, convoId] });
+            queryClient.removeQueries({ queryKey: streamStatusQueryKey(convoId) });
+          }
+          setIsSubmitting(false);
           setShowStopButton(false);
           setStreamId(null);
           reconnectAttemptRef.current = 0;

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -551,6 +551,7 @@ export default function useResumableSSE(
       startupConfig?.balance?.enabled,
       balanceQuery,
       removeActiveJob,
+      queryClient,
     ],
   );
 

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -17,8 +17,8 @@ import {
 import type { TMessage, TPayload, TSubmission, EventSubmission } from 'librechat-data-provider';
 import type { EventHandlerParams } from './useEventHandlers';
 import {
-  useGetStartupConfig,
   useGetUserBalance,
+  useGetStartupConfig,
   queueTitleGeneration,
   streamStatusQueryKey,
 } from '~/data-provider';

--- a/client/src/hooks/SSE/useResumeOnLoad.ts
+++ b/client/src/hooks/SSE/useResumeOnLoad.ts
@@ -125,7 +125,11 @@ export default function useResumeOnLoad(
     conversationId !== Constants.NEW_CONVO &&
     processedConvoRef.current !== conversationId; // Don't re-check processed convos
 
-  const { data: streamStatus, isSuccess } = useStreamStatus(conversationId, shouldCheck);
+  const {
+    data: streamStatus,
+    isSuccess,
+    isFetching,
+  } = useStreamStatus(conversationId, shouldCheck);
 
   useEffect(() => {
     console.log('[ResumeOnLoad] Effect check', {
@@ -135,6 +139,7 @@ export default function useResumeOnLoad(
       hasCurrentSubmission: !!currentSubmission,
       currentSubmissionConvoId: currentSubmission?.conversation?.conversationId,
       isSuccess,
+      isFetching,
       streamStatusActive: streamStatus?.active,
       streamStatusStreamId: streamStatus?.streamId,
       processedConvoRef: processedConvoRef.current,
@@ -171,8 +176,9 @@ export default function useResumeOnLoad(
       );
     }
 
-    // Wait for stream status query to complete
-    if (!isSuccess || !streamStatus) {
+    // Wait for stream status query to complete (including background refetches
+    // that may replace a stale cached result with fresh data)
+    if (!isSuccess || !streamStatus || isFetching) {
       console.log('[ResumeOnLoad] Waiting for stream status query');
       return;
     }
@@ -183,15 +189,12 @@ export default function useResumeOnLoad(
       return;
     }
 
-    // Check if there's an active job to resume
-    // DON'T mark as processed here - only mark when we actually create a submission
-    // This prevents stale cache data from blocking subsequent resume attempts
     if (!streamStatus.active || !streamStatus.streamId) {
       console.log('[ResumeOnLoad] No active job to resume for:', conversationId);
+      processedConvoRef.current = conversationId;
       return;
     }
 
-    // Mark as processed NOW - we verified there's an active job and will create submission
     processedConvoRef.current = conversationId;
 
     console.log('[ResumeOnLoad] Found active job, creating submission...', {
@@ -241,6 +244,7 @@ export default function useResumeOnLoad(
     submissionConvoId,
     currentSubmission,
     isSuccess,
+    isFetching,
     streamStatus,
     getMessages,
     setSubmission,


### PR DESCRIPTION

## Summary

Fixed a UX bug where returning to a completed conversation triggered a `STREAM_EXPIRED` error message, and addressed two related reliability issues in the resumable SSE resume flow.

- Replaced the `errorHandler` call on SSE 404 with a `queryClient.invalidateQueries` on the messages cache, causing React Query to refetch the persisted messages from the DB instead of injecting an error into the UI. The generation completed successfully — the messages are already there.
- Added `clearStepMaps()` to the 404 code path, matching every other terminal path in the hook. The omission caused run-step and tool-call map entries to leak for the lifetime of the hook instance when a stream was found completed on resume.
- Removed the stale stream status cache entry on 404 via `queryClient.removeQueries`, preventing `useResumeOnLoad` from re-attempting a resume against a cached (and now invalid) status.
- Marked the conversation as processed in `useResumeOnLoad` when the stream status returns inactive, eliminating repeated status checks on the same conversation within the same session. Navigation away resets the ref, so returning to the conversation re-checks correctly.
- Added an `isFetching` guard to the `useResumeOnLoad` effect so it waits for the `refetchOnMount` background fetch to settle before acting. Without this, a stale cached `active: false` result would mark the conversation as processed before the fresh response arrived, silently suppressing a valid resume.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Updated the `useResumableSSE` spec to cover the new 404 behavior with explicit assertions:

- `mockErrorHandler` is not called
- `mockInvalidateQueries` is called with `{ queryKey: ['messages', CONV_ID] }`
- `mockRemoveQueries` is called with `{ queryKey: ['streamStatus', CONV_ID] }`
- `mockClearStepMaps` is called
- `mockSetIsSubmitting` is called with `false`

### **Test Configuration**:

For manual verification:

1. Start a generation in conversation A, let it complete fully, navigate to conversation B, navigate back to A — messages should load cleanly with no `STREAM_EXPIRED` error banner.
2. Start a generation in conversation A mid-stream, navigate to conversation B before it finishes, navigate back to A — stream should resume from where it left off.
3. Navigate to conversation A (no active stream) rapidly after starting a generation — confirm the `isFetching` guard prevents an early `active: false` result from suppressing the resume when the background refetch returns `active: true`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes