### PR TITLE
🌊 refactor: Local Snapshot for Aggregate Key Cache to Avoid Redundant Redis GETs

### DIFF
--- a/packages/api/src/cache/cacheConfig.ts
+++ b/packages/api/src/cache/cacheConfig.ts
@@ -128,8 +128,13 @@ const cacheConfig = {
   REDIS_SCAN_COUNT: math(process.env.REDIS_SCAN_COUNT, 1000),
 
   /**
-   * TTL in milliseconds for MCP registry read-through cache.
-   * This cache reduces redundant lookups within a single request flow.
+   * TTL in milliseconds for MCP registry caches. Used by both:
+   * - `MCPServersRegistry` read-through caches (`readThroughCache`/`readThroughCacheAll`)
+   * - `ServerConfigsCacheRedisAggregateKey` local snapshot (avoids redundant Redis GETs)
+   *
+   * Both layers use this value, so the effective max cross-instance staleness is up
+   * to 2× this value in multi-instance deployments. Set to 0 to disable the local
+   * snapshot entirely (every `getAll()` hits Redis directly).
    * @default 5000 (5 seconds)
    */
   MCP_REGISTRY_CACHE_TTL: math(process.env.MCP_REGISTRY_CACHE_TTL, 5000),

--- a/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedisAggregateKey.ts
+++ b/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedisAggregateKey.ts
@@ -42,8 +42,15 @@ export class ServerConfigsCacheRedisAggregateKey
    * config lookup, per connection check) but the data doesn't change within a
    * request cycle. The snapshot collapses all reads within the TTL window into
    * a single Redis GET. Invalidated on every write (`add`, `update`, `remove`, `reset`).
+   *
+   * NOTE: In multi-instance deployments, the effective max staleness for cross-instance
+   * writes is up to 2×MCP_REGISTRY_CACHE_TTL. This happens when readThroughCacheAll
+   * (MCPServersRegistry) is populated from a snapshot that is nearly expired. For the
+   * default 5000ms TTL, worst-case cross-instance propagation is ~10s. This is acceptable
+   * given the single-writer invariant (leader-only initialization, rare manual reinspection).
    */
   private localSnapshot: Record<string, ParsedServerConfig> | null = null;
+  /** Milliseconds since epoch. 0 = epoch = always expired on first check. */
   private localSnapshotExpiry = 0;
 
   constructor(namespace: string, leaderOnly: boolean) {
@@ -105,6 +112,9 @@ export class ServerConfigsCacheRedisAggregateKey
   public async add(serverName: string, config: ParsedServerConfig): Promise<AddServerResult> {
     if (this.leaderOnly) await this.leaderCheck('add MCP servers');
     return this.withWriteLock(async () => {
+      // Force fresh Redis read so the read-modify-write uses current data,
+      // not a snapshot that may predate this write. Distinct from the finally-block
+      // invalidation which cleans up after the write completes or throws.
       this.invalidateLocalSnapshot();
       const all = await this.getAll();
       if (all[serverName]) {
@@ -123,7 +133,7 @@ export class ServerConfigsCacheRedisAggregateKey
   public async update(serverName: string, config: ParsedServerConfig): Promise<void> {
     if (this.leaderOnly) await this.leaderCheck('update MCP servers');
     return this.withWriteLock(async () => {
-      this.invalidateLocalSnapshot();
+      this.invalidateLocalSnapshot(); // Force fresh Redis read (see add() comment)
       const all = await this.getAll();
       if (!all[serverName]) {
         throw new Error(
@@ -139,7 +149,7 @@ export class ServerConfigsCacheRedisAggregateKey
   public async remove(serverName: string): Promise<void> {
     if (this.leaderOnly) await this.leaderCheck('remove MCP servers');
     return this.withWriteLock(async () => {
-      this.invalidateLocalSnapshot();
+      this.invalidateLocalSnapshot(); // Force fresh Redis read (see add() comment)
       const all = await this.getAll();
       if (!all[serverName]) {
         throw new Error(`Failed to remove server "${serverName}" in cache.`);
@@ -154,6 +164,10 @@ export class ServerConfigsCacheRedisAggregateKey
    * Resets the aggregate key directly instead of using SCAN-based `cache.clear()`.
    * Only one key (`__all__`) ever exists in this namespace, so a targeted delete is
    * more efficient and consistent with the PR's goal of eliminating SCAN operations.
+   *
+   * NOTE: Intentionally not serialized via `withWriteLock`. `reset()` is only called
+   * during lifecycle transitions (test teardown, full reinitialization via
+   * `MCPServersInitializer`) where no concurrent writes are in flight.
    */
   public override async reset(): Promise<void> {
     if (this.leaderOnly) {

--- a/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedisAggregateKey.ts
+++ b/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedisAggregateKey.ts
@@ -1,4 +1,3 @@
-import { logger } from '@librechat/data-schemas';
 import type Keyv from 'keyv';
 import type { IServerConfigsRepositoryInterface } from '~/mcp/registry/ServerConfigsRepositoryInterface';
 import type { ParsedServerConfig, AddServerResult } from '~/mcp/types';
@@ -37,9 +36,25 @@ export class ServerConfigsCacheRedisAggregateKey
   protected readonly cache: Keyv;
   private writeLock: Promise<void> = Promise.resolve();
 
+  /**
+   * In-memory snapshot of the aggregate key to avoid redundant Redis GETs.
+   * `getAll()` is called 20+ times per chat request (once per tool, per server
+   * config lookup, per connection check) but the data doesn't change within a
+   * request cycle. The snapshot collapses all reads within the TTL window into
+   * a single Redis GET. Invalidated on every write (`add`, `update`, `remove`, `reset`).
+   */
+  private localSnapshot: Record<string, ParsedServerConfig> | null = null;
+  private localSnapshotExpiry = 0;
+  private static readonly LOCAL_TTL_MS = 5_000;
+
   constructor(namespace: string, leaderOnly: boolean) {
     super(leaderOnly);
     this.cache = standardCache(`${this.PREFIX}::Servers::${namespace}`);
+  }
+
+  private invalidateLocalSnapshot(): void {
+    this.localSnapshot = null;
+    this.localSnapshotExpiry = 0;
   }
 
   /**
@@ -61,15 +76,18 @@ export class ServerConfigsCacheRedisAggregateKey
   }
 
   public async getAll(): Promise<Record<string, ParsedServerConfig>> {
-    const startTime = Date.now();
-    const result = (await this.cache.get(AGGREGATE_KEY)) as
-      | Record<string, ParsedServerConfig>
-      | undefined;
-    const elapsed = Date.now() - startTime;
-    logger.debug(
-      `[ServerConfigsCacheRedisAggregateKey] getAll: fetched ${result ? Object.keys(result).length : 0} configs in ${elapsed}ms`,
-    );
-    return result ?? {};
+    const now = Date.now();
+    if (this.localSnapshot !== null && now < this.localSnapshotExpiry) {
+      return this.localSnapshot;
+    }
+
+    const result =
+      ((await this.cache.get(AGGREGATE_KEY)) as Record<string, ParsedServerConfig> | undefined) ??
+      {};
+
+    this.localSnapshot = result;
+    this.localSnapshotExpiry = now + ServerConfigsCacheRedisAggregateKey.LOCAL_TTL_MS;
+    return result;
   }
 
   public async get(serverName: string): Promise<ParsedServerConfig | undefined> {
@@ -80,6 +98,7 @@ export class ServerConfigsCacheRedisAggregateKey
   public async add(serverName: string, config: ParsedServerConfig): Promise<AddServerResult> {
     if (this.leaderOnly) await this.leaderCheck('add MCP servers');
     return this.withWriteLock(async () => {
+      this.invalidateLocalSnapshot();
       const all = await this.getAll();
       if (all[serverName]) {
         throw new Error(
@@ -90,6 +109,7 @@ export class ServerConfigsCacheRedisAggregateKey
       all[serverName] = storedConfig;
       const success = await this.cache.set(AGGREGATE_KEY, all);
       this.successCheck(`add App server "${serverName}"`, success);
+      this.invalidateLocalSnapshot();
       return { serverName, config: storedConfig };
     });
   }
@@ -97,6 +117,7 @@ export class ServerConfigsCacheRedisAggregateKey
   public async update(serverName: string, config: ParsedServerConfig): Promise<void> {
     if (this.leaderOnly) await this.leaderCheck('update MCP servers');
     return this.withWriteLock(async () => {
+      this.invalidateLocalSnapshot();
       const all = await this.getAll();
       if (!all[serverName]) {
         throw new Error(
@@ -106,12 +127,14 @@ export class ServerConfigsCacheRedisAggregateKey
       all[serverName] = { ...config, updatedAt: Date.now() };
       const success = await this.cache.set(AGGREGATE_KEY, all);
       this.successCheck(`update App server "${serverName}"`, success);
+      this.invalidateLocalSnapshot();
     });
   }
 
   public async remove(serverName: string): Promise<void> {
     if (this.leaderOnly) await this.leaderCheck('remove MCP servers');
     return this.withWriteLock(async () => {
+      this.invalidateLocalSnapshot();
       const all = await this.getAll();
       if (!all[serverName]) {
         throw new Error(`Failed to remove server "${serverName}" in cache.`);
@@ -119,6 +142,7 @@ export class ServerConfigsCacheRedisAggregateKey
       delete all[serverName];
       const success = await this.cache.set(AGGREGATE_KEY, all);
       this.successCheck(`remove App server "${serverName}"`, success);
+      this.invalidateLocalSnapshot();
     });
   }
 
@@ -132,5 +156,6 @@ export class ServerConfigsCacheRedisAggregateKey
       await this.leaderCheck('reset App MCP servers cache');
     }
     await this.cache.delete(AGGREGATE_KEY);
+    this.invalidateLocalSnapshot();
   }
 }

--- a/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedisAggregateKey.ts
+++ b/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedisAggregateKey.ts
@@ -58,8 +58,19 @@ export class ServerConfigsCacheRedisAggregateKey
   }
 
   /**
+   * Populates the local snapshot with the committed state after a successful write.
+   * Avoids an unnecessary Redis GET on the next read by caching the known-good state.
+   */
+  private populateLocalSnapshot(data: Record<string, ParsedServerConfig>): void {
+    this.localSnapshot = data;
+    this.localSnapshotExpiry = Date.now() + ServerConfigsCacheRedisAggregateKey.LOCAL_TTL_MS;
+  }
+
+  /**
    * Serializes write operations to prevent concurrent read-modify-write races.
    * Reads (`get`, `getAll`) are not serialized — they can run concurrently.
+   * Always invalidates the local snapshot in `finally` to guarantee cleanup
+   * even when the write callback throws (e.g., Redis SET failure).
    */
   private async withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
     const previousLock = this.writeLock;
@@ -71,6 +82,7 @@ export class ServerConfigsCacheRedisAggregateKey
       await previousLock;
       return await fn();
     } finally {
+      this.invalidateLocalSnapshot();
       resolve();
     }
   }
@@ -86,7 +98,7 @@ export class ServerConfigsCacheRedisAggregateKey
       {};
 
     this.localSnapshot = result;
-    this.localSnapshotExpiry = now + ServerConfigsCacheRedisAggregateKey.LOCAL_TTL_MS;
+    this.localSnapshotExpiry = Date.now() + ServerConfigsCacheRedisAggregateKey.LOCAL_TTL_MS;
     return result;
   }
 
@@ -106,10 +118,10 @@ export class ServerConfigsCacheRedisAggregateKey
         );
       }
       const storedConfig = { ...config, updatedAt: Date.now() };
-      all[serverName] = storedConfig;
-      const success = await this.cache.set(AGGREGATE_KEY, all);
+      const newAll = { ...all, [serverName]: storedConfig };
+      const success = await this.cache.set(AGGREGATE_KEY, newAll);
       this.successCheck(`add App server "${serverName}"`, success);
-      this.invalidateLocalSnapshot();
+      this.populateLocalSnapshot(newAll);
       return { serverName, config: storedConfig };
     });
   }
@@ -124,10 +136,10 @@ export class ServerConfigsCacheRedisAggregateKey
           `Server "${serverName}" does not exist in cache. Use add() to create new configs.`,
         );
       }
-      all[serverName] = { ...config, updatedAt: Date.now() };
-      const success = await this.cache.set(AGGREGATE_KEY, all);
+      const newAll = { ...all, [serverName]: { ...config, updatedAt: Date.now() } };
+      const success = await this.cache.set(AGGREGATE_KEY, newAll);
       this.successCheck(`update App server "${serverName}"`, success);
-      this.invalidateLocalSnapshot();
+      this.populateLocalSnapshot(newAll);
     });
   }
 
@@ -139,10 +151,10 @@ export class ServerConfigsCacheRedisAggregateKey
       if (!all[serverName]) {
         throw new Error(`Failed to remove server "${serverName}" in cache.`);
       }
-      delete all[serverName];
-      const success = await this.cache.set(AGGREGATE_KEY, all);
+      const { [serverName]: _, ...newAll } = all;
+      const success = await this.cache.set(AGGREGATE_KEY, newAll);
       this.successCheck(`remove App server "${serverName}"`, success);
-      this.invalidateLocalSnapshot();
+      this.populateLocalSnapshot(newAll);
     });
   }
 

--- a/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedisAggregateKey.ts
+++ b/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedisAggregateKey.ts
@@ -2,7 +2,7 @@ import type Keyv from 'keyv';
 import type { IServerConfigsRepositoryInterface } from '~/mcp/registry/ServerConfigsRepositoryInterface';
 import type { ParsedServerConfig, AddServerResult } from '~/mcp/types';
 import { BaseRegistryCache } from './BaseRegistryCache';
-import { standardCache } from '~/cache';
+import { cacheConfig, standardCache } from '~/cache';
 
 /**
  * Redis-backed MCP server configs cache that stores all entries under a single aggregate key.
@@ -45,7 +45,6 @@ export class ServerConfigsCacheRedisAggregateKey
    */
   private localSnapshot: Record<string, ParsedServerConfig> | null = null;
   private localSnapshotExpiry = 0;
-  private static readonly LOCAL_TTL_MS = 5_000;
 
   constructor(namespace: string, leaderOnly: boolean) {
     super(leaderOnly);
@@ -79,17 +78,22 @@ export class ServerConfigsCacheRedisAggregateKey
   }
 
   public async getAll(): Promise<Record<string, ParsedServerConfig>> {
-    const now = Date.now();
-    if (this.localSnapshot !== null && now < this.localSnapshotExpiry) {
-      return this.localSnapshot;
+    const ttl = cacheConfig.MCP_REGISTRY_CACHE_TTL;
+    if (ttl > 0) {
+      const now = Date.now();
+      if (this.localSnapshot !== null && now < this.localSnapshotExpiry) {
+        return this.localSnapshot;
+      }
     }
 
     const result =
       ((await this.cache.get(AGGREGATE_KEY)) as Record<string, ParsedServerConfig> | undefined) ??
       {};
 
-    this.localSnapshot = result;
-    this.localSnapshotExpiry = Date.now() + ServerConfigsCacheRedisAggregateKey.LOCAL_TTL_MS;
+    if (ttl > 0) {
+      this.localSnapshot = result;
+      this.localSnapshotExpiry = Date.now() + ttl;
+    }
     return result;
   }
 

--- a/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedisAggregateKey.ts
+++ b/packages/api/src/mcp/registry/cache/ServerConfigsCacheRedisAggregateKey.ts
@@ -58,15 +58,6 @@ export class ServerConfigsCacheRedisAggregateKey
   }
 
   /**
-   * Populates the local snapshot with the committed state after a successful write.
-   * Avoids an unnecessary Redis GET on the next read by caching the known-good state.
-   */
-  private populateLocalSnapshot(data: Record<string, ParsedServerConfig>): void {
-    this.localSnapshot = data;
-    this.localSnapshotExpiry = Date.now() + ServerConfigsCacheRedisAggregateKey.LOCAL_TTL_MS;
-  }
-
-  /**
    * Serializes write operations to prevent concurrent read-modify-write races.
    * Reads (`get`, `getAll`) are not serialized — they can run concurrently.
    * Always invalidates the local snapshot in `finally` to guarantee cleanup
@@ -121,7 +112,6 @@ export class ServerConfigsCacheRedisAggregateKey
       const newAll = { ...all, [serverName]: storedConfig };
       const success = await this.cache.set(AGGREGATE_KEY, newAll);
       this.successCheck(`add App server "${serverName}"`, success);
-      this.populateLocalSnapshot(newAll);
       return { serverName, config: storedConfig };
     });
   }
@@ -139,7 +129,6 @@ export class ServerConfigsCacheRedisAggregateKey
       const newAll = { ...all, [serverName]: { ...config, updatedAt: Date.now() } };
       const success = await this.cache.set(AGGREGATE_KEY, newAll);
       this.successCheck(`update App server "${serverName}"`, success);
-      this.populateLocalSnapshot(newAll);
     });
   }
 
@@ -154,7 +143,6 @@ export class ServerConfigsCacheRedisAggregateKey
       const { [serverName]: _, ...newAll } = all;
       const success = await this.cache.set(AGGREGATE_KEY, newAll);
       this.successCheck(`remove App server "${serverName}"`, success);
-      this.populateLocalSnapshot(newAll);
     });
   }
 

--- a/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts
@@ -245,17 +245,24 @@ describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
   });
 
   describe('local snapshot behavior', () => {
-    it('should return consistent results across rapid successive getAll calls', async () => {
+    it('should collapse repeated getAll calls into a single Redis GET within TTL', async () => {
       await cache.add('server1', mockConfig1);
       await cache.add('server2', mockConfig2);
 
-      const result1 = await cache.getAll();
-      const result2 = await cache.getAll();
-      const result3 = await cache.getAll();
+      // Prime the snapshot
+      await cache.getAll();
 
-      expect(result1).toEqual(result2);
-      expect(result2).toEqual(result3);
-      expect(Object.keys(result1).length).toBe(2);
+      // Spy on the underlying Keyv cache to count Redis calls
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cacheGetSpy = jest.spyOn((cache as any).cache, 'get');
+
+      await cache.getAll();
+      await cache.getAll();
+      await cache.getAll();
+
+      // Snapshot should be served; Redis should NOT have been called
+      expect(cacheGetSpy).not.toHaveBeenCalled();
+      cacheGetSpy.mockRestore();
     });
 
     it('should invalidate snapshot after add', async () => {
@@ -268,14 +275,15 @@ describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
       expect(Object.keys(after).length).toBe(2);
     });
 
-    it('should invalidate snapshot after update', async () => {
+    it('should invalidate snapshot after update and preserve other entries', async () => {
       await cache.add('server1', mockConfig1);
-      const before = await cache.get('server1');
-      expect(before).toMatchObject(mockConfig1);
+      await cache.add('server2', mockConfig2);
+      expect((await cache.getAll()).server1).toMatchObject(mockConfig1);
 
-      await cache.update('server1', mockConfig2);
-      const after = await cache.get('server1');
-      expect(after).toMatchObject(mockConfig2);
+      await cache.update('server1', mockConfig3);
+      const after = await cache.getAll();
+      expect(after.server1).toMatchObject(mockConfig3);
+      expect(after.server2).toMatchObject(mockConfig2);
     });
 
     it('should invalidate snapshot after remove', async () => {
@@ -287,6 +295,7 @@ describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
       const after = await cache.getAll();
       expect(Object.keys(after).length).toBe(1);
       expect(after.server1).toBeUndefined();
+      expect(after.server2).toMatchObject(mockConfig2);
     });
 
     it('should invalidate snapshot after reset', async () => {
@@ -295,6 +304,19 @@ describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
 
       await cache.reset();
       expect(Object.keys(await cache.getAll()).length).toBe(0);
+    });
+
+    it('should not expose uncommitted writes to concurrent readers', async () => {
+      await cache.add('server1', mockConfig1);
+
+      // Prime the snapshot
+      const snapshot = await cache.getAll();
+      expect(Object.keys(snapshot).length).toBe(1);
+
+      // Add a second server — the original snapshot reference should be unmodified
+      await cache.add('server2', mockConfig2);
+      expect(Object.keys(snapshot).length).toBe(1);
+      expect(snapshot.server2).toBeUndefined();
     });
   });
 });

--- a/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts
@@ -306,7 +306,7 @@ describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
       expect(Object.keys(await cache.getAll()).length).toBe(0);
     });
 
-    it('should not expose uncommitted writes to concurrent readers', async () => {
+    it('should not retroactively modify previously returned snapshot references', async () => {
       await cache.add('server1', mockConfig1);
 
       // Prime the snapshot
@@ -317,6 +317,22 @@ describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
       await cache.add('server2', mockConfig2);
       expect(Object.keys(snapshot).length).toBe(1);
       expect(snapshot.server2).toBeUndefined();
+    });
+
+    it('should hit Redis again after snapshot TTL expires', async () => {
+      await cache.add('server1', mockConfig1);
+      await cache.getAll(); // prime snapshot
+
+      // Force-expire the snapshot without sleeping
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (cache as any).localSnapshotExpiry = Date.now() - 1;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cacheGetSpy = jest.spyOn((cache as any).cache, 'get');
+      const result = await cache.getAll();
+      expect(cacheGetSpy).toHaveBeenCalledTimes(1);
+      expect(Object.keys(result).length).toBe(1);
+      cacheGetSpy.mockRestore();
     });
   });
 });

--- a/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts
+++ b/packages/api/src/mcp/registry/cache/__tests__/ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts
@@ -243,4 +243,58 @@ describe('ServerConfigsCacheRedisAggregateKey Integration Tests', () => {
       expect(Object.keys(result).length).toBe(0);
     });
   });
+
+  describe('local snapshot behavior', () => {
+    it('should return consistent results across rapid successive getAll calls', async () => {
+      await cache.add('server1', mockConfig1);
+      await cache.add('server2', mockConfig2);
+
+      const result1 = await cache.getAll();
+      const result2 = await cache.getAll();
+      const result3 = await cache.getAll();
+
+      expect(result1).toEqual(result2);
+      expect(result2).toEqual(result3);
+      expect(Object.keys(result1).length).toBe(2);
+    });
+
+    it('should invalidate snapshot after add', async () => {
+      await cache.add('server1', mockConfig1);
+      const before = await cache.getAll();
+      expect(Object.keys(before).length).toBe(1);
+
+      await cache.add('server2', mockConfig2);
+      const after = await cache.getAll();
+      expect(Object.keys(after).length).toBe(2);
+    });
+
+    it('should invalidate snapshot after update', async () => {
+      await cache.add('server1', mockConfig1);
+      const before = await cache.get('server1');
+      expect(before).toMatchObject(mockConfig1);
+
+      await cache.update('server1', mockConfig2);
+      const after = await cache.get('server1');
+      expect(after).toMatchObject(mockConfig2);
+    });
+
+    it('should invalidate snapshot after remove', async () => {
+      await cache.add('server1', mockConfig1);
+      await cache.add('server2', mockConfig2);
+      expect(Object.keys(await cache.getAll()).length).toBe(2);
+
+      await cache.remove('server1');
+      const after = await cache.getAll();
+      expect(Object.keys(after).length).toBe(1);
+      expect(after.server1).toBeUndefined();
+    });
+
+    it('should invalidate snapshot after reset', async () => {
+      await cache.add('server1', mockConfig1);
+      expect(Object.keys(await cache.getAll()).length).toBe(1);
+
+      await cache.reset();
+      expect(Object.keys(await cache.getAll()).length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION


## Summary

Added a short-lived in-memory snapshot to `ServerConfigsCacheRedisAggregateKey` that collapses the 20+ `getAll()` Redis GETs fired per chat request into a single GET, and removed the per-call debug log that was spamming output at log level debug.

- Introduces a local snapshot with a configurable TTL (default 5s, via `MCP_REGISTRY_CACHE_TTL` env var) — when `MCP_REGISTRY_CACHE_TTL=0`, the snapshot is disabled entirely and every `getAll()` hits Redis.
- Reads `cacheConfig.MCP_REGISTRY_CACHE_TTL` directly per-call rather than capturing it at construction time, so operators and tests can adjust the value without restarting or re-instantiating.
- Builds a new object via spread on every write (`add`, `update`, `remove`) instead of mutating the cached reference in-place, ensuring concurrent readers never observe uncommitted state.
- Moves `invalidateLocalSnapshot()` into `withWriteLock`'s `finally` block so snapshot cleanup is guaranteed even when `successCheck` throws on a Redis SET failure.
- Captures the TTL expiry timestamp via `Date.now()` after the Redis `await` resolves, so the full TTL window is available regardless of Redis latency.
- Removes the `logger.debug` call from `getAll()` that emitted one log line per call, producing 20+ noisy lines per chat request at debug log level.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Verified with the integration test suite in `ServerConfigsCacheRedisAggregateKey.cache_integration.spec.ts` against a live Redis cluster. The `local snapshot behavior` describe block covers:

- Spying on the underlying Keyv `cache.get` to assert exactly 0 Redis calls on subsequent `getAll()` calls within the TTL window after the snapshot is primed.
- Snapshot reference immutability — a reference captured before a write is unmodified after the write completes.
- Snapshot invalidation after each write operation (`add`, `update`, `remove`, `reset`), with sibling-entry preservation verified on `update` and `remove`.

### **Test Configuration**:
- `USE_REDIS=true`, `USE_REDIS_CLUSTER=true`
- `REDIS_URI=redis://127.0.0.1:7001,redis://127.0.0.1:7002,redis://127.0.0.1:7003`
- Run: `cd packages/api && npx jest --testPathPatterns="AggregateKey.cache_integration" --coverage=false`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes