### PR TITLE
🪝 fix: Safe Hook Fallbacks for Tool-Call Components in Search Route

### DIFF
--- a/client/src/Providers/MessagesViewContext.tsx
+++ b/client/src/Providers/MessagesViewContext.tsx
@@ -140,6 +140,36 @@ export function useMessagesOperations() {
   );
 }
 
+const noopAsync = () => Promise.resolve();
+const noopReturn = () => [];
+const noop = () => {
+  /* noop */
+};
+
+/** Hook for components that need message operations but may render outside MessagesViewProvider (e.g. search route) */
+export function useOptionalMessagesOperations() {
+  const context = useContext(MessagesViewContext);
+  return useMemo(
+    () =>
+      context
+        ? {
+            ask: context.ask,
+            regenerate: context.regenerate,
+            handleContinue: context.handleContinue,
+            getMessages: context.getMessages,
+            setMessages: context.setMessages,
+          }
+        : {
+            ask: noopAsync as MessagesViewContextValue['ask'],
+            regenerate: noopAsync as MessagesViewContextValue['regenerate'],
+            handleContinue: noopAsync as MessagesViewContextValue['handleContinue'],
+            getMessages: noopReturn as MessagesViewContextValue['getMessages'],
+            setMessages: noop as MessagesViewContextValue['setMessages'],
+          },
+    [context],
+  );
+}
+
 /** Hook for components that only need message state */
 export function useMessagesState() {
   const { index, latestMessageId, latestMessageDepth, setLatestMessage } = useMessagesViewContext();

--- a/client/src/Providers/MessagesViewContext.tsx
+++ b/client/src/Providers/MessagesViewContext.tsx
@@ -140,14 +140,26 @@ export function useMessagesOperations() {
   );
 }
 
-const noop = () => undefined;
+type OptionalMessagesOps = Pick<
+  MessagesViewContextValue,
+  'ask' | 'regenerate' | 'handleContinue' | 'getMessages' | 'setMessages'
+>;
+
+const NOOP_OPS: OptionalMessagesOps = {
+  ask: () => {},
+  regenerate: () => {},
+  handleContinue: () => {},
+  getMessages: () => undefined,
+  setMessages: () => {},
+};
 
 /**
  * Hook for components that need message operations but may render outside MessagesViewProvider
  * (e.g. the /search route). Returns no-op stubs when the provider is absent — UI actions will
- * be silently discarded rather than crashing.
+ * be silently discarded rather than crashing. Callers must use optional chaining on
+ * `getMessages()` results, as it returns `undefined` outside the provider.
  */
-export function useOptionalMessagesOperations() {
+export function useOptionalMessagesOperations(): OptionalMessagesOps {
   const context = useContext(MessagesViewContext);
   const ask = context?.ask;
   const regenerate = context?.regenerate;
@@ -156,12 +168,11 @@ export function useOptionalMessagesOperations() {
   const setMessages = context?.setMessages;
   return useMemo(
     () => ({
-      ask: ask ?? (noop as unknown as MessagesViewContextValue['ask']),
-      regenerate: regenerate ?? (noop as unknown as MessagesViewContextValue['regenerate']),
-      handleContinue:
-        handleContinue ?? (noop as unknown as MessagesViewContextValue['handleContinue']),
-      getMessages: getMessages ?? (noop as unknown as MessagesViewContextValue['getMessages']),
-      setMessages: setMessages ?? (noop as unknown as MessagesViewContextValue['setMessages']),
+      ask: ask ?? NOOP_OPS.ask,
+      regenerate: regenerate ?? NOOP_OPS.regenerate,
+      handleContinue: handleContinue ?? NOOP_OPS.handleContinue,
+      getMessages: getMessages ?? NOOP_OPS.getMessages,
+      setMessages: setMessages ?? NOOP_OPS.setMessages,
     }),
     [ask, regenerate, handleContinue, getMessages, setMessages],
   );

--- a/client/src/Providers/MessagesViewContext.tsx
+++ b/client/src/Providers/MessagesViewContext.tsx
@@ -140,34 +140,42 @@ export function useMessagesOperations() {
   );
 }
 
-const noopAsync = () => Promise.resolve();
-const noopReturn = () => [];
-const noop = () => {
-  /* noop */
-};
+const noop = () => undefined;
 
-/** Hook for components that need message operations but may render outside MessagesViewProvider (e.g. search route) */
+/**
+ * Hook for components that need message operations but may render outside MessagesViewProvider
+ * (e.g. the /search route). Returns no-op stubs when the provider is absent — UI actions will
+ * be silently discarded rather than crashing.
+ */
 export function useOptionalMessagesOperations() {
   const context = useContext(MessagesViewContext);
+  const ask = context?.ask;
+  const regenerate = context?.regenerate;
+  const handleContinue = context?.handleContinue;
+  const getMessages = context?.getMessages;
+  const setMessages = context?.setMessages;
   return useMemo(
-    () =>
-      context
-        ? {
-            ask: context.ask,
-            regenerate: context.regenerate,
-            handleContinue: context.handleContinue,
-            getMessages: context.getMessages,
-            setMessages: context.setMessages,
-          }
-        : {
-            ask: noopAsync as MessagesViewContextValue['ask'],
-            regenerate: noopAsync as MessagesViewContextValue['regenerate'],
-            handleContinue: noopAsync as MessagesViewContextValue['handleContinue'],
-            getMessages: noopReturn as MessagesViewContextValue['getMessages'],
-            setMessages: noop as MessagesViewContextValue['setMessages'],
-          },
-    [context],
+    () => ({
+      ask: ask ?? (noop as unknown as MessagesViewContextValue['ask']),
+      regenerate: regenerate ?? (noop as unknown as MessagesViewContextValue['regenerate']),
+      handleContinue:
+        handleContinue ?? (noop as unknown as MessagesViewContextValue['handleContinue']),
+      getMessages: getMessages ?? (noop as unknown as MessagesViewContextValue['getMessages']),
+      setMessages: setMessages ?? (noop as unknown as MessagesViewContextValue['setMessages']),
+    }),
+    [ask, regenerate, handleContinue, getMessages, setMessages],
   );
+}
+
+/**
+ * Hook for components that need conversation data but may render outside MessagesViewProvider
+ * (e.g. the /search route). Returns `undefined` for both fields when the provider is absent.
+ */
+export function useOptionalMessagesConversation() {
+  const context = useContext(MessagesViewContext);
+  const conversation = context?.conversation;
+  const conversationId = context?.conversationId;
+  return useMemo(() => ({ conversation, conversationId }), [conversation, conversationId]);
 }
 
 /** Hook for components that only need message state */

--- a/client/src/Providers/__tests__/MessagesViewContext.spec.tsx
+++ b/client/src/Providers/__tests__/MessagesViewContext.spec.tsx
@@ -1,0 +1,53 @@
+import { renderHook } from '@testing-library/react';
+import {
+  useOptionalMessagesOperations,
+  useOptionalMessagesConversation,
+} from '../MessagesViewContext';
+
+describe('useOptionalMessagesOperations', () => {
+  it('returns noop stubs when rendered outside MessagesViewProvider', () => {
+    const { result } = renderHook(() => useOptionalMessagesOperations());
+
+    expect(result.current.ask).toBeInstanceOf(Function);
+    expect(result.current.regenerate).toBeInstanceOf(Function);
+    expect(result.current.handleContinue).toBeInstanceOf(Function);
+    expect(result.current.getMessages).toBeInstanceOf(Function);
+    expect(result.current.setMessages).toBeInstanceOf(Function);
+  });
+
+  it('noop stubs do not throw when called', () => {
+    const { result } = renderHook(() => useOptionalMessagesOperations());
+
+    expect(() => result.current.ask({} as never)).not.toThrow();
+    expect(() => result.current.regenerate({} as never)).not.toThrow();
+    expect(() => result.current.handleContinue({} as never)).not.toThrow();
+    expect(() => result.current.setMessages([])).not.toThrow();
+  });
+
+  it('getMessages returns undefined outside the provider', () => {
+    const { result } = renderHook(() => useOptionalMessagesOperations());
+    expect(result.current.getMessages()).toBeUndefined();
+  });
+
+  it('returns stable references across re-renders', () => {
+    const { result, rerender } = renderHook(() => useOptionalMessagesOperations());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});
+
+describe('useOptionalMessagesConversation', () => {
+  it('returns undefined fields when rendered outside MessagesViewProvider', () => {
+    const { result } = renderHook(() => useOptionalMessagesConversation());
+    expect(result.current.conversation).toBeUndefined();
+    expect(result.current.conversationId).toBeUndefined();
+  });
+
+  it('returns stable references across re-renders', () => {
+    const { result, rerender } = renderHook(() => useOptionalMessagesConversation());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/client/src/components/Chat/Messages/Content/ToolCallInfo.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCallInfo.tsx
@@ -5,7 +5,7 @@ import { UIResourceRenderer } from '@mcp-ui/client';
 import type { TAttachment, UIResource } from 'librechat-data-provider';
 import { useLocalize, useExpandCollapse } from '~/hooks';
 import UIResourceCarousel from './UIResourceCarousel';
-import { useMessagesOperations } from '~/Providers';
+import { useOptionalMessagesOperations } from '~/Providers';
 import { OutputRenderer } from './ToolOutput';
 import { handleUIAction, cn } from '~/utils';
 
@@ -102,7 +102,7 @@ export default function ToolCallInfo({
   attachments?: TAttachment[];
 }) {
   const localize = useLocalize();
-  const { ask } = useMessagesOperations();
+  const { ask } = useOptionalMessagesOperations();
   const [showParams, setShowParams] = useState(false);
   const { style: paramsExpandStyle, ref: paramsExpandRef } = useExpandCollapse(showParams);
 

--- a/client/src/components/Chat/Messages/Content/ToolCallInfo.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCallInfo.tsx
@@ -3,11 +3,11 @@ import { ChevronDown } from 'lucide-react';
 import { Tools } from 'librechat-data-provider';
 import { UIResourceRenderer } from '@mcp-ui/client';
 import type { TAttachment, UIResource } from 'librechat-data-provider';
+import { useOptionalMessagesOperations } from '~/Providers';
 import { useLocalize, useExpandCollapse } from '~/hooks';
 import UIResourceCarousel from './UIResourceCarousel';
-import { useOptionalMessagesOperations } from '~/Providers';
-import { OutputRenderer } from './ToolOutput';
 import { handleUIAction, cn } from '~/utils';
+import { OutputRenderer } from './ToolOutput';
 
 function isSimpleObject(obj: unknown): obj is Record<string, string | number | boolean | null> {
   if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {

--- a/client/src/components/Chat/Messages/Content/UIResourceCarousel.tsx
+++ b/client/src/components/Chat/Messages/Content/UIResourceCarousel.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { UIResourceRenderer } from '@mcp-ui/client';
 import type { UIResource } from 'librechat-data-provider';
-import { useMessagesOperations } from '~/Providers';
+import { useOptionalMessagesOperations } from '~/Providers';
 import { handleUIAction } from '~/utils';
 
 interface UIResourceCarouselProps {
@@ -13,7 +13,7 @@ const UIResourceCarousel: React.FC<UIResourceCarouselProps> = React.memo(({ uiRe
   const [showRightArrow, setShowRightArrow] = useState(true);
   const [isContainerHovered, setIsContainerHovered] = useState(false);
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);
-  const { ask } = useMessagesOperations();
+  const { ask } = useOptionalMessagesOperations();
 
   const handleScroll = React.useCallback(() => {
     if (!scrollContainerRef.current) return;

--- a/client/src/components/Chat/Messages/Content/__tests__/Markdown.mcpui.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/Markdown.mcpui.test.tsx
@@ -3,7 +3,11 @@ import { render, screen } from '@testing-library/react';
 import Markdown from '../Markdown';
 import { RecoilRoot } from 'recoil';
 import { UI_RESOURCE_MARKER } from '~/components/MCPUIResource/plugin';
-import { useMessageContext, useMessagesConversation, useMessagesOperations } from '~/Providers';
+import {
+  useMessageContext,
+  useOptionalMessagesConversation,
+  useOptionalMessagesOperations,
+} from '~/Providers';
 import { useGetMessagesByConvoId } from '~/data-provider';
 import { useLocalize } from '~/hooks';
 
@@ -12,8 +16,8 @@ import { useLocalize } from '~/hooks';
 jest.mock('~/Providers', () => ({
   ...jest.requireActual('~/Providers'),
   useMessageContext: jest.fn(),
-  useMessagesConversation: jest.fn(),
-  useMessagesOperations: jest.fn(),
+  useOptionalMessagesConversation: jest.fn(),
+  useOptionalMessagesOperations: jest.fn(),
 }));
 jest.mock('~/data-provider');
 jest.mock('~/hooks');
@@ -26,11 +30,11 @@ jest.mock('@mcp-ui/client', () => ({
 }));
 
 const mockUseMessageContext = useMessageContext as jest.MockedFunction<typeof useMessageContext>;
-const mockUseMessagesConversation = useMessagesConversation as jest.MockedFunction<
-  typeof useMessagesConversation
+const mockUseMessagesConversation = useOptionalMessagesConversation as jest.MockedFunction<
+  typeof useOptionalMessagesConversation
 >;
-const mockUseMessagesOperations = useMessagesOperations as jest.MockedFunction<
-  typeof useMessagesOperations
+const mockUseMessagesOperations = useOptionalMessagesOperations as jest.MockedFunction<
+  typeof useOptionalMessagesOperations
 >;
 const mockUseGetMessagesByConvoId = useGetMessagesByConvoId as jest.MockedFunction<
   typeof useGetMessagesByConvoId

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCallInfo.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCallInfo.test.tsx
@@ -25,7 +25,7 @@ jest.mock('~/hooks', () => ({
 }));
 
 jest.mock('~/Providers', () => ({
-  useMessagesOperations: () => ({
+  useOptionalMessagesOperations: () => ({
     ask: jest.fn(),
   }),
 }));

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCallInfo.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCallInfo.test.tsx
@@ -25,7 +25,7 @@ jest.mock('~/hooks', () => ({
 }));
 
 jest.mock('~/Providers', () => ({
-  useOptionalMessagesOperations: () => ({
+  useMessagesOperations: () => ({
     ask: jest.fn(),
   }),
 }));

--- a/client/src/components/Chat/Messages/Content/__tests__/UIResourceCarousel.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/UIResourceCarousel.test.tsx
@@ -13,10 +13,10 @@ jest.mock('@mcp-ui/client', () => ({
   ),
 }));
 
-// Mock useMessagesOperations hook
+// Mock useOptionalMessagesOperations hook
 const mockAsk = jest.fn();
 jest.mock('~/Providers', () => ({
-  useMessagesOperations: () => ({
+  useOptionalMessagesOperations: () => ({
     ask: mockAsk,
   }),
 }));

--- a/client/src/components/Chat/Messages/Content/__tests__/UIResourceCarousel.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/UIResourceCarousel.test.tsx
@@ -13,10 +13,10 @@ jest.mock('@mcp-ui/client', () => ({
   ),
 }));
 
-// Mock useOptionalMessagesOperations hook
+// Mock useMessagesOperations hook
 const mockAsk = jest.fn();
 jest.mock('~/Providers', () => ({
-  useOptionalMessagesOperations: () => ({
+  useMessagesOperations: () => ({
     ask: mockAsk,
   }),
 }));

--- a/client/src/components/MCPUIResource/MCPUIResource.tsx
+++ b/client/src/components/MCPUIResource/MCPUIResource.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { UIResourceRenderer } from '@mcp-ui/client';
 import { handleUIAction } from '~/utils';
 import { useConversationUIResources } from '~/hooks/Messages/useConversationUIResources';
-import { useMessagesConversation, useMessagesOperations } from '~/Providers';
+import { useOptionalMessagesConversation, useOptionalMessagesOperations } from '~/Providers';
 import { useLocalize } from '~/hooks';
 
 interface MCPUIResourceProps {
@@ -20,8 +20,8 @@ interface MCPUIResourceProps {
 export function MCPUIResource(props: MCPUIResourceProps) {
   const { resourceId } = props.node.properties;
   const localize = useLocalize();
-  const { ask } = useMessagesOperations();
-  const { conversation } = useMessagesConversation();
+  const { ask } = useOptionalMessagesOperations();
+  const { conversation } = useOptionalMessagesConversation();
 
   const conversationResourceMap = useConversationUIResources(
     conversation?.conversationId ?? undefined,

--- a/client/src/components/MCPUIResource/MCPUIResource.tsx
+++ b/client/src/components/MCPUIResource/MCPUIResource.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { UIResourceRenderer } from '@mcp-ui/client';
-import { handleUIAction } from '~/utils';
-import { useConversationUIResources } from '~/hooks/Messages/useConversationUIResources';
 import { useOptionalMessagesConversation, useOptionalMessagesOperations } from '~/Providers';
+import { useConversationUIResources } from '~/hooks/Messages/useConversationUIResources';
+import { handleUIAction } from '~/utils';
 import { useLocalize } from '~/hooks';
 
 interface MCPUIResourceProps {

--- a/client/src/components/MCPUIResource/MCPUIResource.tsx
+++ b/client/src/components/MCPUIResource/MCPUIResource.tsx
@@ -13,19 +13,14 @@ interface MCPUIResourceProps {
   };
 }
 
-/**
- * Component that renders an MCP UI resource based on its resource ID.
- * Works in both main app and share view.
- */
+/** Renders an MCP UI resource based on its resource ID. Works in chat, share, and search views. */
 export function MCPUIResource(props: MCPUIResourceProps) {
   const { resourceId } = props.node.properties;
   const localize = useLocalize();
   const { ask } = useOptionalMessagesOperations();
-  const { conversation } = useOptionalMessagesConversation();
+  const { conversationId } = useOptionalMessagesConversation();
 
-  const conversationResourceMap = useConversationUIResources(
-    conversation?.conversationId ?? undefined,
-  );
+  const conversationResourceMap = useConversationUIResources(conversationId ?? undefined);
 
   const uiResource = conversationResourceMap.get(resourceId ?? '');
 

--- a/client/src/components/MCPUIResource/MCPUIResourceCarousel.tsx
+++ b/client/src/components/MCPUIResource/MCPUIResourceCarousel.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react';
-import { useConversationUIResources } from '~/hooks/Messages/useConversationUIResources';
-import { useOptionalMessagesConversation } from '~/Providers';
-import UIResourceCarousel from '../Chat/Messages/Content/UIResourceCarousel';
 import type { UIResource } from 'librechat-data-provider';
+import { useConversationUIResources } from '~/hooks/Messages/useConversationUIResources';
+import UIResourceCarousel from '../Chat/Messages/Content/UIResourceCarousel';
+import { useOptionalMessagesConversation } from '~/Providers';
 
 interface MCPUIResourceCarouselProps {
   node: {

--- a/client/src/components/MCPUIResource/MCPUIResourceCarousel.tsx
+++ b/client/src/components/MCPUIResource/MCPUIResourceCarousel.tsx
@@ -12,16 +12,11 @@ interface MCPUIResourceCarouselProps {
   };
 }
 
-/**
- * Component that renders multiple MCP UI resources in a carousel.
- * Works in both main app and share view.
- */
+/** Renders multiple MCP UI resources in a carousel. Works in chat, share, and search views. */
 export function MCPUIResourceCarousel(props: MCPUIResourceCarouselProps) {
-  const { conversation } = useOptionalMessagesConversation();
+  const { conversationId } = useOptionalMessagesConversation();
 
-  const conversationResourceMap = useConversationUIResources(
-    conversation?.conversationId ?? undefined,
-  );
+  const conversationResourceMap = useConversationUIResources(conversationId ?? undefined);
 
   const uiResources = useMemo(() => {
     const { resourceIds = [] } = props.node.properties;

--- a/client/src/components/MCPUIResource/MCPUIResourceCarousel.tsx
+++ b/client/src/components/MCPUIResource/MCPUIResourceCarousel.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { useConversationUIResources } from '~/hooks/Messages/useConversationUIResources';
-import { useMessagesConversation } from '~/Providers';
+import { useOptionalMessagesConversation } from '~/Providers';
 import UIResourceCarousel from '../Chat/Messages/Content/UIResourceCarousel';
 import type { UIResource } from 'librechat-data-provider';
 
@@ -17,7 +17,7 @@ interface MCPUIResourceCarouselProps {
  * Works in both main app and share view.
  */
 export function MCPUIResourceCarousel(props: MCPUIResourceCarouselProps) {
-  const { conversation } = useMessagesConversation();
+  const { conversation } = useOptionalMessagesConversation();
 
   const conversationResourceMap = useConversationUIResources(
     conversation?.conversationId ?? undefined,

--- a/client/src/components/MCPUIResource/__tests__/MCPUIResource.test.tsx
+++ b/client/src/components/MCPUIResource/__tests__/MCPUIResource.test.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { RecoilRoot } from 'recoil';
 import { MCPUIResource } from '../MCPUIResource';
-import { useMessageContext, useMessagesConversation, useMessagesOperations } from '~/Providers';
+import {
+  useMessageContext,
+  useOptionalMessagesConversation,
+  useOptionalMessagesOperations,
+} from '~/Providers';
 import { useLocalize } from '~/hooks';
 import { handleUIAction } from '~/utils';
 
@@ -22,11 +26,11 @@ jest.mock('@mcp-ui/client', () => ({
 }));
 
 const mockUseMessageContext = useMessageContext as jest.MockedFunction<typeof useMessageContext>;
-const mockUseMessagesConversation = useMessagesConversation as jest.MockedFunction<
-  typeof useMessagesConversation
+const mockUseMessagesConversation = useOptionalMessagesConversation as jest.MockedFunction<
+  typeof useOptionalMessagesConversation
 >;
-const mockUseMessagesOperations = useMessagesOperations as jest.MockedFunction<
-  typeof useMessagesOperations
+const mockUseMessagesOperations = useOptionalMessagesOperations as jest.MockedFunction<
+  typeof useOptionalMessagesOperations
 >;
 const mockUseLocalize = useLocalize as jest.MockedFunction<typeof useLocalize>;
 const mockHandleUIAction = handleUIAction as jest.MockedFunction<typeof handleUIAction>;

--- a/client/src/components/MCPUIResource/__tests__/MCPUIResourceCarousel.test.tsx
+++ b/client/src/components/MCPUIResource/__tests__/MCPUIResourceCarousel.test.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { RecoilRoot } from 'recoil';
 import { MCPUIResourceCarousel } from '../MCPUIResourceCarousel';
-import { useMessageContext, useMessagesConversation, useMessagesOperations } from '~/Providers';
+import {
+  useMessageContext,
+  useOptionalMessagesConversation,
+  useOptionalMessagesOperations,
+} from '~/Providers';
 
 // Mock dependencies
 jest.mock('~/Providers');
@@ -19,11 +23,11 @@ jest.mock('../../Chat/Messages/Content/UIResourceCarousel', () => ({
 }));
 
 const mockUseMessageContext = useMessageContext as jest.MockedFunction<typeof useMessageContext>;
-const mockUseMessagesConversation = useMessagesConversation as jest.MockedFunction<
-  typeof useMessagesConversation
+const mockUseMessagesConversation = useOptionalMessagesConversation as jest.MockedFunction<
+  typeof useOptionalMessagesConversation
 >;
-const mockUseMessagesOperations = useMessagesOperations as jest.MockedFunction<
-  typeof useMessagesOperations
+const mockUseMessagesOperations = useOptionalMessagesOperations as jest.MockedFunction<
+  typeof useOptionalMessagesOperations
 >;
 
 describe('MCPUIResourceCarousel', () => {

--- a/client/src/hooks/Messages/useConversationUIResources.ts
+++ b/client/src/hooks/Messages/useConversationUIResources.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
 import { Tools } from 'librechat-data-provider';
 import type { TAttachment, UIResource } from 'librechat-data-provider';
-import { useMessagesOperations } from '~/Providers';
+import { useOptionalMessagesOperations } from '~/Providers';
 import store from '~/store';
 
 /**
@@ -16,7 +16,7 @@ import store from '~/store';
 export function useConversationUIResources(
   conversationId: string | undefined,
 ): Map<string, UIResource> {
-  const { getMessages } = useMessagesOperations();
+  const { getMessages } = useOptionalMessagesOperations();
 
   const conversationAttachmentsMap = useRecoilValue(
     store.conversationAttachmentsSelector(conversationId),


### PR DESCRIPTION

## Summary

Fixes an unrecoverable crash on the `/search` route when search results contain messages with tool-call content parts, by introducing optional context hooks that return no-op stubs instead of throwing when `MessagesViewProvider` is absent.

- Identified the root cause: `ToolCallInfo`, `UIResourceCarousel`, `MCPUIResource`, and `MCPUIResourceCarousel` all called strict context hooks (`useMessagesOperations`, `useMessagesConversation`) which throw unconditionally when rendered outside `MessagesViewProvider` — a provider the `/search` route never mounts.
- Added `useOptionalMessagesOperations` to `MessagesViewContext.tsx`, which reads context via raw `useContext` and returns no-op stubs for `ask`, `regenerate`, `handleContinue`, `getMessages`, and `setMessages` when the provider is absent, rather than throwing.
- Added `useOptionalMessagesConversation` with the same fallback pattern, returning `undefined` for both `conversation` and `conversationId` outside the provider.
- Consolidated three noop variants (`noopAsync`, `noopReturn`, `noop`) into a single `const noop = () => undefined` with correct void/undefined semantics across all substituted function signatures.
- Narrowed the `useMemo` dependency array in `useOptionalMessagesOperations` from the full `context` object to the individual destructured operation references, preventing unnecessary re-renders on unrelated state changes (e.g., `isSubmitting`, `latestMessageId`) during active streaming.
- Switched `ToolCallInfo` and `UIResourceCarousel` to use `useOptionalMessagesOperations`.
- Switched `MCPUIResource` to use both `useOptionalMessagesOperations` and `useOptionalMessagesConversation`, covering a second crash path that existed because Markdown-embedded MCP UI resource components can appear in any view.
- Switched `MCPUIResourceCarousel` to use `useOptionalMessagesConversation`.
- Updated `~/Providers` mocks in `ToolCallInfo.test.tsx`, `UIResourceCarousel.test.tsx`, `MCPUIResource.test.tsx`, `MCPUIResourceCarousel.test.tsx`, and `Markdown.mcpui.test.tsx` to export the new hook names.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified by switching `~/Providers` mocks in all five affected test files to expose `useOptionalMessagesOperations` and `useOptionalMessagesConversation`. All existing unit tests pass with the updated mocks.

### **Test Configuration**:

- Navigate to `/search` and run a query that returns results containing messages with tool-call content parts (including MCP UI resource attachments if available) — the page should render without crashing.
- Open a normal conversation containing tool-call results and MCP UI resources — rendering and UI actions (intent, tool, prompt callbacks) should work as before.
- Trigger a UI action button inside an MCP UI resource from the search view — the action should be silently discarded with no error, as there is no active conversation context to submit to.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes