### PR TITLE
🔍 fix: only show Searchbar if enabled

### DIFF
--- a/client/src/components/UnifiedSidebar/ConversationsSection.tsx
+++ b/client/src/components/UnifiedSidebar/ConversationsSection.tsx
@@ -120,7 +120,7 @@ const ConversationsSection = memo(() => {
             <BookmarkNav tags={tags} setTags={setTags} />
           </Suspense>
         )}
-        <SearchBar isSmallScreen={isSmallScreen} />
+        {search.enabled && <SearchBar isSmallScreen={isSmallScreen} />}
       </div>
       {isSmallScreen && (
         <div


### PR DESCRIPTION
## Summary

The search bar was showing even if you have no search capability; now it respects the `enabled` field.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested it with search disabled to verify that the search bar would not appear.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes