### PR TITLE
Fix Bedrock system prompt handling with attachments

### DIFF
--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -1,4 +1,4 @@
-import type { SummarizationConfig } from 'librechat-data-provider';
+import { EModelEndpoint, type SummarizationConfig } from 'librechat-data-provider';
 import { createRun } from '~/agents/run';
 
 // Mock winston logger
@@ -207,6 +207,28 @@ describe('summarizationEnabled resolution', () => {
     const config = agents[0].summarizationConfig as Record<string, unknown>;
     expect(config.provider).toBe('openAI');
     expect(config.model).toBe('gpt-4o');
+  });
+});
+
+describe('Bedrock system instruction handoff', () => {
+  it('merges Bedrock system into instructions and clears clientOptions.system', async () => {
+    const agents = await callAndCapture({
+      agents: [
+        makeAgent({
+          provider: EModelEndpoint.bedrock,
+          endpoint: EModelEndpoint.bedrock,
+          model: 'global.anthropic.claude-sonnet-4-6',
+          instructions: 'Attached document(s): file context',
+          model_parameters: {
+            model: 'global.anthropic.claude-sonnet-4-6',
+            system: 'You talk like a pirate',
+          },
+        }),
+      ],
+    });
+
+    expect(agents[0].instructions).toBe('You talk like a pirate\n\nAttached document(s): file context');
+    expect((agents[0].clientOptions as Record<string, unknown>).system).toBeUndefined();
   });
 });
 

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1,5 +1,5 @@
 import { Run, Providers, Constants } from '@librechat/agents';
-import { providerEndpointMap, KnownEndpoints } from 'librechat-data-provider';
+import { providerEndpointMap, KnownEndpoints, EModelEndpoint } from 'librechat-data-provider';
 import type {
   SummarizationConfig as AgentSummarizationConfig,
   MultiAgentGraphConfig,
@@ -318,17 +318,23 @@ export async function createRun({
       agent.model_parameters,
     );
 
+    const bedrockSystemInstruction =
+      agent.provider === EModelEndpoint.bedrock && typeof llmConfig.system === 'string'
+        ? llmConfig.system.trim()
+        : '';
+
     const systemMessage = Object.values(agent.toolContextMap ?? {})
       .join('\n')
       .trim();
 
     const systemContent = [
+      bedrockSystemInstruction,
       systemMessage,
       agent.instructions ?? '',
       agent.additional_instructions ?? '',
     ]
-      .join('\n')
-      .trim();
+      .filter(isNonEmptyString)
+      .join('\n\n');
 
     /**
      * Resolve request-based headers for Custom Endpoints. Note: if this is added to
@@ -351,6 +357,10 @@ export async function createRun({
     ) {
       llmConfig.streamUsage = false;
       llmConfig.usage = true;
+    }
+
+    if (bedrockSystemInstruction) {
+      delete llmConfig.system;
     }
 
     /**

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -359,7 +359,7 @@ export async function createRun({
       llmConfig.usage = true;
     }
 
-    if (bedrockSystemInstruction) {
+    if (agent.provider === EModelEndpoint.bedrock && typeof llmConfig.system === 'string') {
       delete llmConfig.system;
     }
 

--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -115,6 +115,45 @@ describe('initializeBedrock', () => {
         sessionToken: 'test-session-token',
       });
     });
+
+    it('should keep top-level system when additionalModelRequestFields has stale system', async () => {
+      const params = createMockParams({
+        model_parameters: {
+          model: 'global.anthropic.claude-sonnet-4-6-20260215-v1:0',
+          system: 'Use current system prompt',
+          additionalModelRequestFields: {
+            system: 'stale system prompt',
+          },
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+      const amrf = result.llmConfig.additionalModelRequestFields as
+        | Record<string, unknown>
+        | undefined;
+
+      expect(result.llmConfig.system).toBe('Use current system prompt');
+      expect(amrf?.system).toBeUndefined();
+    });
+
+    it('should migrate legacy additionalModelRequestFields.system into top-level system', async () => {
+      const params = createMockParams({
+        model_parameters: {
+          model: 'global.anthropic.claude-sonnet-4-6-20260215-v1:0',
+          additionalModelRequestFields: {
+            system: 'legacy system prompt',
+          },
+        },
+      });
+
+      const result = (await initializeBedrock(params)) as BedrockLLMConfigResult;
+      const amrf = result.llmConfig.additionalModelRequestFields as
+        | Record<string, unknown>
+        | undefined;
+
+      expect(result.llmConfig.system).toBe('legacy system prompt');
+      expect(amrf?.system).toBeUndefined();
+    });
   });
 
   describe('GuardrailConfig', () => {

--- a/packages/data-provider/src/bedrock.ts
+++ b/packages/data-provider/src/bedrock.ts
@@ -299,8 +299,10 @@ export const bedrockInputParser = s.tConversationSchema
       typedData.additionalModelRequestFields != null
     ) {
       const amrf = typedData.additionalModelRequestFields as Record<string, unknown>;
-      if (typedData.system == null && typeof amrf.system === 'string' && amrf.system !== '') {
-        typedData.system = amrf.system;
+      const amrfSystem =
+        typeof amrf.system === 'string' ? amrf.system.trim() : undefined;
+      if (typedData.system == null && typeof amrfSystem === 'string' && amrfSystem !== '') {
+        typedData.system = amrfSystem;
       }
       reservedBedrockAdditionalFields.forEach((key) => {
         delete amrf[key];

--- a/packages/data-provider/src/bedrock.ts
+++ b/packages/data-provider/src/bedrock.ts
@@ -18,6 +18,8 @@ type AnthropicInput = BedrockConverseInput & {
     AnthropicReasoning;
 };
 
+const reservedBedrockAdditionalFields = new Set<string>(['system']);
+
 /** Extracts opus major/minor version from both naming formats */
 function parseOpusVersion(model: string): { major: number; minor: number } | null {
   const nameFirst = model.match(/claude-opus[-.]?(\d+)(?:[-.](\d+))?/);
@@ -173,6 +175,7 @@ export const bedrockInputParser = s.tConversationSchema
     maxContextTokens: true,
     /* Bedrock params; optionType: 'model' */
     region: true,
+    system: true,
     model: true,
     maxTokens: true,
     temperature: true,
@@ -200,6 +203,7 @@ export const bedrockInputParser = s.tConversationSchema
       'artifacts',
       'additionalModelRequestFields',
       'region',
+      'system',
       'model',
       'maxTokens',
       'temperature',
@@ -295,6 +299,13 @@ export const bedrockInputParser = s.tConversationSchema
       typedData.additionalModelRequestFields != null
     ) {
       const amrf = typedData.additionalModelRequestFields as Record<string, unknown>;
+      if (typedData.system == null && typeof amrf.system === 'string' && amrf.system !== '') {
+        typedData.system = amrf.system;
+      }
+      reservedBedrockAdditionalFields.forEach((key) => {
+        delete amrf[key];
+      });
+
       if (!isAnthropicModel) {
         delete amrf.anthropic_beta;
         delete amrf.thinking;
@@ -393,19 +404,24 @@ export const bedrockOutputParser = (data: Record<string, unknown>) => {
     typeof data.additionalModelRequestFields === 'object' &&
     data.additionalModelRequestFields !== null
   ) {
-    Object.entries(data.additionalModelRequestFields as Record<string, unknown>).forEach(
-      ([key, value]) => {
-        if (knownKeys.includes(key)) {
-          if (key === 'top_k') {
-            result['topK'] = value;
-          } else if (key === 'thinking' || key === 'thinkingBudget') {
-            return;
-          } else {
+    const amrf = data.additionalModelRequestFields as Record<string, unknown>;
+    Object.entries(amrf).forEach(([key, value]) => {
+      if (knownKeys.includes(key)) {
+        if (key === 'top_k') {
+          if (result.topK === undefined) {
+            result.topK = value;
+          }
+        } else if (key === 'thinking' || key === 'thinkingBudget') {
+          return;
+        } else {
+          if (result[key] === undefined) {
             result[key] = value;
           }
         }
-      },
-    );
+
+        delete amrf[key];
+      }
+    });
   }
 
   // Handle maxTokens and maxOutputTokens


### PR DESCRIPTION
Preserve Bedrock custom instructions when files or tools are present by promoting and sanitizing system fields and merging the Bedrock system prompt into agent instructions before runtime handoff.

Includes regression coverage for both Bedrock config parsing and agent-run instruction assembly.

## Summary

When I set "Custom Instructions" in Amazon Bedrock together with Tools and/or Files I get this error:

> Something went wrong. Here's the specific error message we encountered: An error occurred while processing the request: The additional field system conflicts with an existing field. Remove system and try again.

Custom Instructions alone, as well as Tools or Files alone work fine.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

1. Select some Bedrock Anthropic model
2. Set Custom instruction (e.g. "Always talk like a pirate")
3. Upload an image
4. Ask what's on the image

It should work and not return the above error

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
