### PR TITLE
🕐 fix: Use client timezone for special variable date formatting

### DIFF
--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -208,6 +208,7 @@ export default function useChatFunctions({
       text,
       sender: 'User',
       clientTimestamp: new Date().toLocaleString('sv').replace(' ', 'T'),
+      clientTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       isCreatedByUser: true,
       parentMessageId,
       conversationId,

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -403,6 +403,7 @@ export async function initializeAgent(
     agent.instructions = replaceSpecialVars({
       text: agent.instructions,
       user: req.user ? (req.user as unknown as TUser) : null,
+      timezone: req.body?.clientTimezone,
     });
   }
 

--- a/packages/api/src/types/http.ts
+++ b/packages/api/src/types/http.ts
@@ -16,6 +16,7 @@ export type RequestBody = {
   model?: string;
   key?: string;
   endpointOption?: Partial<TEndpointOption>;
+  clientTimezone?: string;
 };
 
 export type ServerRequest = Request<unknown, unknown, RequestBody> & {

--- a/packages/data-provider/specs/parsers.spec.ts
+++ b/packages/data-provider/specs/parsers.spec.ts
@@ -7,13 +7,13 @@ import type { TUser, TConversation } from '../src/types';
 
 // Mock dayjs module with consistent date/time values regardless of environment
 jest.mock('dayjs', () => {
-  const mockDayjs = () => ({
+  const makeMock = (offset: string) => ({
     format: (format: string) => {
       if (format === 'YYYY-MM-DD') {
         return '2024-04-29';
       }
       if (format === 'YYYY-MM-DD HH:mm:ss Z') {
-        return '2024-04-29 12:34:56 -04:00';
+        return `2024-04-29 12:34:56 ${offset}`;
       }
       if (format === 'dddd') {
         return 'Monday';
@@ -23,8 +23,19 @@ jest.mock('dayjs', () => {
       );
     },
     toISOString: () => '2024-04-29T16:34:56.000Z',
+    isValid: () => true,
+    tz: (timezone: string) => {
+      if (timezone === 'America/New_York') {
+        return makeMock('-04:00');
+      }
+      if (timezone === 'Asia/Tokyo') {
+        return makeMock('+09:00');
+      }
+      return { isValid: () => false };
+    },
   });
 
+  const mockDayjs = () => makeMock('-04:00');
   mockDayjs.extend = jest.fn();
 
   return mockDayjs;
@@ -125,6 +136,56 @@ describe('replaceSpecialVars', () => {
     expect(result).toContain('2024-04-29 12:34:56 -04:00 (Monday)'); // current_datetime
     expect(result).toContain('2024-04-29T16:34:56.000Z'); // iso_datetime
     expect(result).toContain('Test User'); // current_user
+  });
+
+  test('should use provided timezone for date formatting', () => {
+    const result = replaceSpecialVars({
+      text: 'Now is {{current_datetime}}',
+      timezone: 'Asia/Tokyo',
+    });
+    expect(result).toBe('Now is 2024-04-29 12:34:56 +09:00 (Monday)');
+  });
+
+  test('should fall back to default when no timezone is provided', () => {
+    const result = replaceSpecialVars({
+      text: 'Now is {{current_datetime}}',
+    });
+    expect(result).toBe('Now is 2024-04-29 12:34:56 -04:00 (Monday)');
+  });
+
+  test('should fall back to default for invalid timezone', () => {
+    const result = replaceSpecialVars({
+      text: 'Now is {{current_datetime}}',
+      timezone: 'Invalid/Timezone',
+    });
+    expect(result).toBe('Now is 2024-04-29 12:34:56 -04:00 (Monday)');
+  });
+
+  test('should apply timezone to {{current_date}} formatting', () => {
+    const result = replaceSpecialVars({
+      text: 'Today is {{current_date}}',
+      timezone: 'Asia/Tokyo',
+    });
+    expect(result).toBe('Today is 2024-04-29 (Monday)');
+  });
+
+  test('should not affect {{iso_datetime}} regardless of timezone', () => {
+    const result = replaceSpecialVars({
+      text: 'ISO: {{iso_datetime}}',
+      timezone: 'Asia/Tokyo',
+    });
+    expect(result).toBe('ISO: 2024-04-29T16:34:56.000Z');
+  });
+
+  test('should handle all variables with timezone and user combined', () => {
+    const result = replaceSpecialVars({
+      text: '{{current_user}} - {{current_date}} - {{current_datetime}} - {{iso_datetime}}',
+      user: mockUser,
+      timezone: 'Asia/Tokyo',
+    });
+    expect(result).toBe(
+      'Test User - 2024-04-29 (Monday) - 2024-04-29 12:34:56 +09:00 (Monday) - 2024-04-29T16:34:56.000Z',
+    );
   });
 });
 

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -1,5 +1,10 @@
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import tz from 'dayjs/plugin/timezone';
 import type { ZodIssue } from 'zod';
+
+dayjs.extend(utc);
+dayjs.extend(tz);
 import type * as a from './types/assistants';
 import type * as s from './schemas';
 import type * as t from './types';
@@ -402,13 +407,24 @@ export function findLastSeparatorIndex(text: string, separators = SEPARATORS): n
   return lastIndex;
 }
 
-export function replaceSpecialVars({ text, user }: { text: string; user?: t.TUser | null }) {
+export function replaceSpecialVars({
+  text,
+  user,
+  timezone,
+}: {
+  text: string;
+  user?: t.TUser | null;
+  timezone?: string;
+}) {
   let result = text;
   if (!result) {
     return result;
   }
 
-  const now = dayjs();
+  let now = timezone ? dayjs().tz(timezone) : dayjs();
+  if (!now.isValid()) {
+    now = dayjs();
+  }
   const weekdayName = now.format('dddd');
 
   const currentDate = now.format('YYYY-MM-DD');

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -611,6 +611,7 @@ export const tMessageSchema = z.object({
   isCreatedByUser: z.boolean(),
   error: z.boolean().optional(),
   clientTimestamp: z.string().optional(),
+  clientTimezone: z.string().optional(),
   createdAt: z
     .string()
     .optional()
@@ -686,6 +687,7 @@ export type TMessage = z.input<typeof tMessageSchema> & {
   siblingIndex?: number;
   attachments?: TAttachment[];
   clientTimestamp?: string;
+  clientTimezone?: string;
   feedback?: TFeedback;
 };
 


### PR DESCRIPTION
## Summary

`replaceSpecialVars` uses `dayjs()` which defaults to the server's timezone (UTC in Docker), causing `{{current_datetime}}` and `{{current_date}}` to always show `+00:00` regardless of the user's location.

This is inconsistent with `append_current_datetime` for assistants, which already handles client timezone via `clientTimestamp`.

This PR adds dayjs timezone plugin support and an optional `timezone` parameter to `replaceSpecialVars`. The client sends its IANA timezone string (`Intl.DateTimeFormat().resolvedOptions().timeZone`) alongside the existing `clientTimestamp`, and the agent initialization flow passes it through to produce timezone-aware date formatting.

### Changes

| File | Change |
|---|---|
| `packages/data-provider/src/parsers.ts` | Import dayjs `utc`/`timezone` plugins; add `timezone?` param; use `dayjs().tz(timezone)` with `.isValid()` fallback |
| `packages/data-provider/src/schemas.ts` | Add `clientTimezone` to `tMessageSchema` and `TMessage` type |
| `client/src/hooks/Chat/useChatFunctions.ts` | Send `Intl.DateTimeFormat().resolvedOptions().timeZone` alongside `clientTimestamp` |
| `packages/api/src/types/http.ts` | Add `clientTimezone?` to `RequestBody` |
| `packages/api/src/agents/initialize.ts` | Pass `req.body?.clientTimezone` to `replaceSpecialVars` |
| `packages/data-provider/specs/parsers.spec.ts` | Update dayjs mock for `.tz()` chain; add 6 timezone tests |

Fully backward compatible — when `timezone` is omitted, behavior is identical to before.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Unit tests

```bash
cd packages/data-provider && npx jest parsers
```

46 tests pass, including 6 new timezone-specific tests:
- `{{current_datetime}}` with valid timezone — offset changes
- `{{current_datetime}}` with no timezone — backward compatible
- `{{current_datetime}}` with invalid timezone — graceful fallback
- `{{current_date}}` with timezone — date formatting respects timezone
- `{{iso_datetime}}` unaffected by timezone — ISO stays UTC
- All variables combined with timezone + user — full integration

### Manual testing

1. Build and run the stack with Docker (`docker compose up -d --build`)
2. Create an agent with `{{current_datetime}}` in its instructions
3. Send a message — the response should reflect the browser's timezone instead of `+00:00`

### Test Configuration

- Docker deployment (server timezone = UTC)
- Browser in a non-UTC timezone
- Agent with `{{current_datetime}}` in instructions

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes