### PR TITLE
⛩️ feat: Admin Grants API Endpoints

### DIFF
--- a/api/server/index.js
+++ b/api/server/index.js
@@ -154,6 +154,7 @@ const startServer = async () => {
   app.use('/api/auth', preAuthTenantMiddleware, routes.auth);
   app.use('/api/admin', routes.adminAuth);
   app.use('/api/admin/config', routes.adminConfig);
+  app.use('/api/admin/grants', routes.adminGrants);
   app.use('/api/admin/groups', routes.adminGroups);
   app.use('/api/admin/roles', routes.adminRoles);
   app.use('/api/actions', routes.actions);

--- a/api/server/routes/__tests__/grants.spec.js
+++ b/api/server/routes/__tests__/grants.spec.js
@@ -63,7 +63,6 @@ function createApp(user) {
   });
 
   const { createAdminGrantsHandlers, getCachedPrincipals } = require('@librechat/api');
-  const { SystemCapabilities } = require('@librechat/data-schemas');
 
   const handlers = createAdminGrantsHandlers({
     listGrants: db.listGrants,
@@ -182,7 +181,7 @@ describe('Admin Grants Routes — Integration', () => {
   it('POST / returns 401 without authenticated user', async () => {
     const app = createApp(undefined);
 
-    await request(app)
+    const res = await request(app)
       .post('/api/admin/grants')
       .send({
         principalType: PrincipalType.ROLE,
@@ -190,5 +189,7 @@ describe('Admin Grants Routes — Integration', () => {
         capability: 'read:users',
       })
       .expect(401);
+
+    expect(res.body).toHaveProperty('error', 'Authentication required');
   });
 });

--- a/api/server/routes/__tests__/grants.spec.js
+++ b/api/server/routes/__tests__/grants.spec.js
@@ -1,0 +1,194 @@
+const express = require('express');
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const { createModels, createMethods } = require('@librechat/data-schemas');
+const { PrincipalType, SystemRoles } = require('librechat-data-provider');
+
+/**
+ * Integration test for the admin grants routes.
+ *
+ * Validates the full Express wiring: route registration → middleware →
+ * handler → real MongoDB. Auth middleware is injected (matching the repo
+ * pattern in keys.spec.js) so we can control the caller identity without
+ * a real JWT, while the handler DI deps use real DB methods.
+ */
+
+jest.mock('~/server/middleware', () => ({
+  requireJwtAuth: (_req, _res, next) => next(),
+}));
+
+jest.mock('~/server/middleware/roles/capabilities', () => ({
+  requireCapability: () => (_req, _res, next) => next(),
+}));
+
+let mongoServer;
+let db;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+  createModels(mongoose);
+  db = createMethods(mongoose);
+  await db.seedSystemGrants();
+  await db.initializeRoles();
+  await db.seedDefaultRoles();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+afterEach(async () => {
+  const SystemGrant = mongoose.models.SystemGrant;
+  // Clean non-seed grants (keep admin seed)
+  await SystemGrant.deleteMany({
+    $or: [
+      { principalId: { $ne: SystemRoles.ADMIN } },
+      { principalType: { $ne: PrincipalType.ROLE } },
+    ],
+  });
+});
+
+function createApp(user) {
+  // Must re-require after mocks are set up; jest.resetModules is NOT
+  // called so the mock sticks across tests in this suite.
+  jest.isolateModules(() => {
+    // Patch ~/models to use our in-memory DB methods
+    jest.doMock('~/models', () => ({
+      ...db,
+      seedDatabase: jest.fn(),
+    }));
+  });
+
+  const { createAdminGrantsHandlers, getCachedPrincipals } = require('@librechat/api');
+  const { SystemCapabilities } = require('@librechat/data-schemas');
+
+  const handlers = createAdminGrantsHandlers({
+    listGrants: db.listGrants,
+    countGrants: db.countGrants,
+    getCapabilitiesForPrincipal: db.getCapabilitiesForPrincipal,
+    getCapabilitiesForPrincipals: db.getCapabilitiesForPrincipals,
+    grantCapability: db.grantCapability,
+    revokeCapability: db.revokeCapability,
+    getUserPrincipals: db.getUserPrincipals,
+    hasCapabilityForPrincipals: db.hasCapabilityForPrincipals,
+    getHeldCapabilities: db.getHeldCapabilities,
+    getCachedPrincipals,
+    checkRoleExists: async (name) => (await db.getRoleByName(name)) != null,
+  });
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = user;
+    next();
+  });
+
+  const router = express.Router();
+  router.get('/', handlers.listGrants);
+  router.get('/effective', handlers.getEffectiveCapabilities);
+  router.get('/:principalType/:principalId', handlers.getPrincipalGrants);
+  router.post('/', handlers.assignGrant);
+  router.delete('/:principalType/:principalId/:capability', handlers.revokeGrant);
+  app.use('/api/admin/grants', router);
+
+  return app;
+}
+
+describe('Admin Grants Routes — Integration', () => {
+  const adminUserId = new mongoose.Types.ObjectId();
+  const adminUser = {
+    _id: adminUserId,
+    id: adminUserId.toString(),
+    role: SystemRoles.ADMIN,
+  };
+
+  it('GET / returns seeded admin grants', async () => {
+    const app = createApp(adminUser);
+    const res = await request(app).get('/api/admin/grants').expect(200);
+
+    expect(res.body).toHaveProperty('grants');
+    expect(res.body).toHaveProperty('total');
+    expect(res.body.grants.length).toBeGreaterThan(0);
+    // Seeded grants are for the ADMIN role
+    expect(res.body.grants[0].principalType).toBe(PrincipalType.ROLE);
+  });
+
+  it('GET /effective returns capabilities for admin', async () => {
+    const app = createApp(adminUser);
+    const res = await request(app).get('/api/admin/grants/effective').expect(200);
+
+    expect(res.body).toHaveProperty('capabilities');
+    expect(res.body.capabilities).toContain('access:admin');
+    expect(res.body.capabilities).toContain('manage:roles');
+  });
+
+  it('POST / assigns a grant and DELETE / revokes it', async () => {
+    const app = createApp(adminUser);
+
+    // Assign
+    const assignRes = await request(app)
+      .post('/api/admin/grants')
+      .send({
+        principalType: PrincipalType.ROLE,
+        principalId: SystemRoles.USER,
+        capability: 'read:users',
+      })
+      .expect(201);
+
+    expect(assignRes.body.grant).toMatchObject({
+      principalType: PrincipalType.ROLE,
+      principalId: SystemRoles.USER,
+      capability: 'read:users',
+    });
+
+    // Verify via GET
+    const getRes = await request(app)
+      .get(`/api/admin/grants/${PrincipalType.ROLE}/${SystemRoles.USER}`)
+      .expect(200);
+
+    expect(getRes.body.grants.some((g) => g.capability === 'read:users')).toBe(true);
+
+    // Revoke
+    await request(app)
+      .delete(`/api/admin/grants/${PrincipalType.ROLE}/${SystemRoles.USER}/read:users`)
+      .expect(200);
+
+    // Verify revoked
+    const afterRes = await request(app)
+      .get(`/api/admin/grants/${PrincipalType.ROLE}/${SystemRoles.USER}`)
+      .expect(200);
+
+    expect(afterRes.body.grants.some((g) => g.capability === 'read:users')).toBe(false);
+  });
+
+  it('POST / returns 400 for non-existent role when checkRoleExists is wired', async () => {
+    const app = createApp(adminUser);
+
+    const res = await request(app)
+      .post('/api/admin/grants')
+      .send({
+        principalType: PrincipalType.ROLE,
+        principalId: 'nonexistent-role',
+        capability: 'read:users',
+      })
+      .expect(400);
+
+    expect(res.body.error).toBe('Role not found');
+  });
+
+  it('POST / returns 401 without authenticated user', async () => {
+    const app = createApp(undefined);
+
+    await request(app)
+      .post('/api/admin/grants')
+      .send({
+        principalType: PrincipalType.ROLE,
+        principalId: SystemRoles.USER,
+        capability: 'read:users',
+      })
+      .expect(401);
+  });
+});

--- a/api/server/routes/__tests__/grants.spec.js
+++ b/api/server/routes/__tests__/grants.spec.js
@@ -52,16 +52,6 @@ afterEach(async () => {
 });
 
 function createApp(user) {
-  // Must re-require after mocks are set up; jest.resetModules is NOT
-  // called so the mock sticks across tests in this suite.
-  jest.isolateModules(() => {
-    // Patch ~/models to use our in-memory DB methods
-    jest.doMock('~/models', () => ({
-      ...db,
-      seedDatabase: jest.fn(),
-    }));
-  });
-
   const { createAdminGrantsHandlers, getCachedPrincipals } = require('@librechat/api');
 
   const handlers = createAdminGrantsHandlers({

--- a/api/server/routes/admin/grants.js
+++ b/api/server/routes/admin/grants.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { createAdminGrantsHandlers } = require('@librechat/api');
+const { createAdminGrantsHandlers, getCachedPrincipals } = require('@librechat/api');
 const { SystemCapabilities } = require('@librechat/data-schemas');
 const { requireCapability } = require('~/server/middleware/roles/capabilities');
 const { requireJwtAuth } = require('~/server/middleware');
@@ -10,21 +10,23 @@ const router = express.Router();
 const requireAdminAccess = requireCapability(SystemCapabilities.ACCESS_ADMIN);
 
 const handlers = createAdminGrantsHandlers({
-  listAllGrants: db.listAllGrants,
+  listGrants: db.listGrants,
+  countGrants: db.countGrants,
   getCapabilitiesForPrincipal: db.getCapabilitiesForPrincipal,
   getCapabilitiesForPrincipals: db.getCapabilitiesForPrincipals,
   grantCapability: db.grantCapability,
   revokeCapability: db.revokeCapability,
   getUserPrincipals: db.getUserPrincipals,
   hasCapabilityForPrincipals: db.hasCapabilityForPrincipals,
+  getCachedPrincipals,
 });
 
 router.use(requireJwtAuth, requireAdminAccess);
 
-router.get('/', handlers.listAllGrants);
+router.get('/', handlers.listGrants);
 router.get('/effective', handlers.getEffectiveCapabilities);
 router.get('/:principalType/:principalId', handlers.getPrincipalGrants);
 router.post('/', handlers.assignGrant);
-router.delete('/:principalType/:principalId/:capability', handlers.revokeGrant);
+router.delete('/:principalType/:principalId', handlers.revokeGrant);
 
 module.exports = router;

--- a/api/server/routes/admin/grants.js
+++ b/api/server/routes/admin/grants.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const { createAdminGrantsHandlers } = require('@librechat/api');
+const { SystemCapabilities } = require('@librechat/data-schemas');
+const { requireCapability } = require('~/server/middleware/roles/capabilities');
+const { requireJwtAuth } = require('~/server/middleware');
+const db = require('~/models');
+
+const router = express.Router();
+
+const requireAdminAccess = requireCapability(SystemCapabilities.ACCESS_ADMIN);
+
+const handlers = createAdminGrantsHandlers({
+  getCapabilitiesForPrincipal: db.getCapabilitiesForPrincipal,
+  grantCapability: db.grantCapability,
+  revokeCapability: db.revokeCapability,
+  getUserPrincipals: db.getUserPrincipals,
+  hasCapabilityForPrincipals: db.hasCapabilityForPrincipals,
+});
+
+router.use(requireJwtAuth, requireAdminAccess);
+
+router.get('/effective', handlers.getEffectiveCapabilities);
+router.get('/:principalType/:principalId', handlers.getPrincipalGrants);
+router.post('/', handlers.assignGrant);
+router.delete('/', handlers.revokeGrant);
+
+module.exports = router;

--- a/api/server/routes/admin/grants.js
+++ b/api/server/routes/admin/grants.js
@@ -11,6 +11,7 @@ const requireAdminAccess = requireCapability(SystemCapabilities.ACCESS_ADMIN);
 
 const handlers = createAdminGrantsHandlers({
   getCapabilitiesForPrincipal: db.getCapabilitiesForPrincipal,
+  getCapabilitiesForPrincipals: db.getCapabilitiesForPrincipals,
   grantCapability: db.grantCapability,
   revokeCapability: db.revokeCapability,
   getUserPrincipals: db.getUserPrincipals,

--- a/api/server/routes/admin/grants.js
+++ b/api/server/routes/admin/grants.js
@@ -27,6 +27,6 @@ router.get('/', handlers.listGrants);
 router.get('/effective', handlers.getEffectiveCapabilities);
 router.get('/:principalType/:principalId', handlers.getPrincipalGrants);
 router.post('/', handlers.assignGrant);
-router.delete('/:principalType/:principalId', handlers.revokeGrant);
+router.delete('/:principalType/:principalId/:capability', handlers.revokeGrant);
 
 module.exports = router;

--- a/api/server/routes/admin/grants.js
+++ b/api/server/routes/admin/grants.js
@@ -20,6 +20,7 @@ const handlers = createAdminGrantsHandlers({
   hasCapabilityForPrincipals: db.hasCapabilityForPrincipals,
   getHeldCapabilities: db.getHeldCapabilities,
   getCachedPrincipals,
+  checkRoleExists: async (name) => (await db.getRoleByName(name)) != null,
 });
 
 router.use(requireJwtAuth, requireAdminAccess);
@@ -28,7 +29,7 @@ router.get('/', handlers.listGrants);
 router.get('/effective', handlers.getEffectiveCapabilities);
 router.get('/:principalType/:principalId', handlers.getPrincipalGrants);
 router.post('/', handlers.assignGrant);
-/** Callers must encodeURIComponent the capability (e.g. manage%3Aconfigs%3Aendpoints). */
+/** Callers should encodeURIComponent the capability for client compatibility (e.g. manage%3Aconfigs%3Aendpoints). */
 router.delete('/:principalType/:principalId/:capability', handlers.revokeGrant);
 
 module.exports = router;

--- a/api/server/routes/admin/grants.js
+++ b/api/server/routes/admin/grants.js
@@ -10,6 +10,7 @@ const router = express.Router();
 const requireAdminAccess = requireCapability(SystemCapabilities.ACCESS_ADMIN);
 
 const handlers = createAdminGrantsHandlers({
+  listAllGrants: db.listAllGrants,
   getCapabilitiesForPrincipal: db.getCapabilitiesForPrincipal,
   getCapabilitiesForPrincipals: db.getCapabilitiesForPrincipals,
   grantCapability: db.grantCapability,
@@ -20,6 +21,7 @@ const handlers = createAdminGrantsHandlers({
 
 router.use(requireJwtAuth, requireAdminAccess);
 
+router.get('/', handlers.listAllGrants);
 router.get('/effective', handlers.getEffectiveCapabilities);
 router.get('/:principalType/:principalId', handlers.getPrincipalGrants);
 router.post('/', handlers.assignGrant);

--- a/api/server/routes/admin/grants.js
+++ b/api/server/routes/admin/grants.js
@@ -18,6 +18,7 @@ const handlers = createAdminGrantsHandlers({
   revokeCapability: db.revokeCapability,
   getUserPrincipals: db.getUserPrincipals,
   hasCapabilityForPrincipals: db.hasCapabilityForPrincipals,
+  getHeldCapabilities: db.getHeldCapabilities,
   getCachedPrincipals,
 });
 
@@ -27,6 +28,7 @@ router.get('/', handlers.listGrants);
 router.get('/effective', handlers.getEffectiveCapabilities);
 router.get('/:principalType/:principalId', handlers.getPrincipalGrants);
 router.post('/', handlers.assignGrant);
+/** Callers must encodeURIComponent the capability (e.g. manage%3Aconfigs%3Aendpoints). */
 router.delete('/:principalType/:principalId/:capability', handlers.revokeGrant);
 
 module.exports = router;

--- a/api/server/routes/admin/grants.js
+++ b/api/server/routes/admin/grants.js
@@ -22,6 +22,6 @@ router.use(requireJwtAuth, requireAdminAccess);
 router.get('/effective', handlers.getEffectiveCapabilities);
 router.get('/:principalType/:principalId', handlers.getPrincipalGrants);
 router.post('/', handlers.assignGrant);
-router.delete('/', handlers.revokeGrant);
+router.delete('/:principalType/:principalId/:capability', handlers.revokeGrant);
 
 module.exports = router;

--- a/api/server/routes/admin/roles.js
+++ b/api/server/routes/admin/roles.js
@@ -26,6 +26,7 @@ const handlers = createAdminRolesHandlers({
   updateUsersRoleByIds: db.updateUsersRoleByIds,
   listUsersByRole: db.listUsersByRole,
   countUsersByRole: db.countUsersByRole,
+  deleteGrantsForPrincipal: db.deleteGrantsForPrincipal,
 });
 
 router.use(requireJwtAuth, requireAdminAccess);

--- a/api/server/routes/admin/roles.js
+++ b/api/server/routes/admin/roles.js
@@ -26,6 +26,8 @@ const handlers = createAdminRolesHandlers({
   updateUsersRoleByIds: db.updateUsersRoleByIds,
   listUsersByRole: db.listUsersByRole,
   countUsersByRole: db.countUsersByRole,
+  deleteConfig: db.deleteConfig,
+  deleteAclEntries: db.deleteAclEntries,
   deleteGrantsForPrincipal: db.deleteGrantsForPrincipal,
 });
 

--- a/api/server/routes/index.js
+++ b/api/server/routes/index.js
@@ -3,6 +3,7 @@ const assistants = require('./assistants');
 const categories = require('./categories');
 const adminAuth = require('./admin/auth');
 const adminConfig = require('./admin/config');
+const adminGrants = require('./admin/grants');
 const adminGroups = require('./admin/groups');
 const adminRoles = require('./admin/roles');
 const endpoints = require('./endpoints');
@@ -35,6 +36,7 @@ module.exports = {
   auth,
   adminAuth,
   adminConfig,
+  adminGrants,
   adminGroups,
   adminRoles,
   keys,

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -976,6 +976,19 @@ describe('createAdminGrantsHandlers', () => {
       expect(status).toHaveBeenCalledWith(201);
     });
 
+    it('returns 500 when checkRoleExists throws', async () => {
+      const deps = createDeps({
+        checkRoleExists: jest.fn().mockRejectedValue(new Error('db error')),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: validBody });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to assign grant' });
+    });
+
     it('returns 500 when grantCapability returns null', async () => {
       const deps = createDeps({
         grantCapability: jest.fn().mockResolvedValue(null),

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -67,6 +67,9 @@ function createDeps(overrides: Partial<AdminGrantsDeps> = {}): AdminGrantsDeps {
           SystemCapabilities.READ_ROLES,
           SystemCapabilities.READ_GROUPS,
           SystemCapabilities.READ_USERS,
+          SystemCapabilities.MANAGE_ROLES,
+          SystemCapabilities.MANAGE_GROUPS,
+          SystemCapabilities.MANAGE_USERS,
         ]),
       ),
     getCachedPrincipals: jest.fn().mockReturnValue(undefined),
@@ -186,6 +189,19 @@ describe('createAdminGrantsHandlers', () => {
     it('returns 500 on error', async () => {
       const deps = createDeps({
         listGrants: jest.fn().mockRejectedValue(new Error('db error')),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.listGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to list grants' });
+    });
+
+    it('returns 500 when getHeldCapabilities throws', async () => {
+      const deps = createDeps({
+        getHeldCapabilities: jest.fn().mockRejectedValue(new Error('db error')),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes();
@@ -402,6 +418,19 @@ describe('createAdminGrantsHandlers', () => {
       expect(status).toHaveBeenCalledWith(500);
       expect(json).toHaveBeenCalledWith({ error: 'Failed to get effective capabilities' });
     });
+
+    it('returns 500 when getCapabilitiesForPrincipals throws', async () => {
+      const deps = createDeps({
+        getCapabilitiesForPrincipals: jest.fn().mockRejectedValue(new Error('db error')),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.getEffectiveCapabilities(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to get effective capabilities' });
+    });
   });
 
   describe('getPrincipalGrants', () => {
@@ -510,7 +539,7 @@ describe('createAdminGrantsHandlers', () => {
       await handlers.getPrincipalGrants(req, res);
 
       expect(status).toHaveBeenCalledWith(400);
-      expect(json).toHaveBeenCalledWith({ error: 'principalId is required' });
+      expect(json).toHaveBeenCalledWith({ error: 'Principal ID is required' });
     });
 
     it('returns 400 for non-ObjectId group principalId', async () => {
@@ -650,7 +679,7 @@ describe('createAdminGrantsHandlers', () => {
 
       await handlers.assignGrant(req, res);
 
-      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+      expect(deps.getHeldCapabilities).toHaveBeenCalledWith(
         expect.objectContaining({ tenantId: 'tenant-1' }),
       );
       expect(deps.grantCapability).toHaveBeenCalledWith(
@@ -662,7 +691,14 @@ describe('createAdminGrantsHandlers', () => {
       const grant = mockGrant({
         capability: 'manage:configs:endpoints' as ISystemGrant['capability'],
       });
-      const deps = createDeps({ grantCapability: jest.fn().mockResolvedValue(grant) });
+      const deps = createDeps({
+        grantCapability: jest.fn().mockResolvedValue(grant),
+        getHeldCapabilities: jest
+          .fn()
+          .mockResolvedValue(
+            new Set([SystemCapabilities.MANAGE_ROLES, 'manage:configs:endpoints']),
+          ),
+      });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status } = createReqRes({
         body: { ...validBody, capability: 'manage:configs:endpoints' },
@@ -675,7 +711,12 @@ describe('createAdminGrantsHandlers', () => {
 
     it('accepts config assignment capabilities', async () => {
       const grant = mockGrant({ capability: 'assign:configs:group' as ISystemGrant['capability'] });
-      const deps = createDeps({ grantCapability: jest.fn().mockResolvedValue(grant) });
+      const deps = createDeps({
+        grantCapability: jest.fn().mockResolvedValue(grant),
+        getHeldCapabilities: jest
+          .fn()
+          .mockResolvedValue(new Set([SystemCapabilities.MANAGE_ROLES, 'assign:configs:group'])),
+      });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status } = createReqRes({
         body: { ...validBody, capability: 'assign:configs:group' },
@@ -735,7 +776,7 @@ describe('createAdminGrantsHandlers', () => {
       await handlers.assignGrant(req, res);
 
       expect(status).toHaveBeenCalledWith(400);
-      expect(json).toHaveBeenCalledWith({ error: 'principalId is required' });
+      expect(json).toHaveBeenCalledWith({ error: 'Principal ID is required' });
     });
 
     it('returns 400 for invalid capability', async () => {
@@ -783,7 +824,7 @@ describe('createAdminGrantsHandlers', () => {
 
     it('returns 403 when caller lacks manage capability', async () => {
       const deps = createDeps({
-        hasCapabilityForPrincipals: jest.fn().mockResolvedValue(false),
+        getHeldCapabilities: jest.fn().mockResolvedValue(new Set()),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({ body: validBody });
@@ -797,12 +838,9 @@ describe('createAdminGrantsHandlers', () => {
 
     it('returns 403 when caller lacks the capability being granted', async () => {
       const deps = createDeps({
-        hasCapabilityForPrincipals: jest.fn().mockImplementation(({ capability }) => {
-          if (capability === SystemCapabilities.MANAGE_ROLES) {
-            return Promise.resolve(true);
-          }
-          return Promise.resolve(false);
-        }),
+        getHeldCapabilities: jest
+          .fn()
+          .mockResolvedValue(new Set([SystemCapabilities.MANAGE_ROLES])),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({ body: validBody });
@@ -816,7 +854,11 @@ describe('createAdminGrantsHandlers', () => {
 
     it('allows granting an implied capability the caller holds transitively', async () => {
       const deps = createDeps({
-        hasCapabilityForPrincipals: jest.fn().mockResolvedValue(true),
+        getHeldCapabilities: jest
+          .fn()
+          .mockResolvedValue(
+            new Set([SystemCapabilities.MANAGE_ROLES, SystemCapabilities.READ_ROLES]),
+          ),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status } = createReqRes({
@@ -830,25 +872,41 @@ describe('createAdminGrantsHandlers', () => {
       await handlers.assignGrant(req, res);
 
       expect(status).toHaveBeenCalledWith(201);
-      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
-        expect.objectContaining({ capability: SystemCapabilities.READ_ROLES }),
+      expect(deps.getHeldCapabilities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          capabilities: expect.arrayContaining([SystemCapabilities.READ_ROLES]),
+        }),
       );
     });
 
     it('checks MANAGE_ROLES for role principal type', async () => {
-      const deps = createDeps();
+      const deps = createDeps({
+        getHeldCapabilities: jest
+          .fn()
+          .mockResolvedValue(
+            new Set([SystemCapabilities.MANAGE_ROLES, SystemCapabilities.READ_USERS]),
+          ),
+      });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res } = createReqRes({ body: validBody });
 
       await handlers.assignGrant(req, res);
 
-      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
-        expect.objectContaining({ capability: SystemCapabilities.MANAGE_ROLES }),
+      expect(deps.getHeldCapabilities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          capabilities: expect.arrayContaining([SystemCapabilities.MANAGE_ROLES]),
+        }),
       );
     });
 
     it('checks MANAGE_GROUPS for group principal type', async () => {
-      const deps = createDeps();
+      const deps = createDeps({
+        getHeldCapabilities: jest
+          .fn()
+          .mockResolvedValue(
+            new Set([SystemCapabilities.MANAGE_GROUPS, SystemCapabilities.READ_USERS]),
+          ),
+      });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res } = createReqRes({
         body: {
@@ -860,13 +918,21 @@ describe('createAdminGrantsHandlers', () => {
 
       await handlers.assignGrant(req, res);
 
-      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
-        expect.objectContaining({ capability: SystemCapabilities.MANAGE_GROUPS }),
+      expect(deps.getHeldCapabilities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          capabilities: expect.arrayContaining([SystemCapabilities.MANAGE_GROUPS]),
+        }),
       );
     });
 
     it('checks MANAGE_USERS for user principal type', async () => {
-      const deps = createDeps();
+      const deps = createDeps({
+        getHeldCapabilities: jest
+          .fn()
+          .mockResolvedValue(
+            new Set([SystemCapabilities.MANAGE_USERS, SystemCapabilities.READ_USERS]),
+          ),
+      });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res } = createReqRes({
         body: {
@@ -878,9 +944,36 @@ describe('createAdminGrantsHandlers', () => {
 
       await handlers.assignGrant(req, res);
 
-      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
-        expect.objectContaining({ capability: SystemCapabilities.MANAGE_USERS }),
+      expect(deps.getHeldCapabilities).toHaveBeenCalledWith(
+        expect.objectContaining({
+          capabilities: expect.arrayContaining([SystemCapabilities.MANAGE_USERS]),
+        }),
       );
+    });
+
+    it('returns 400 when role does not exist', async () => {
+      const deps = createDeps({
+        checkRoleExists: jest.fn().mockResolvedValue(false),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: validBody });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Role not found' });
+      expect(deps.grantCapability).not.toHaveBeenCalled();
+    });
+
+    it('skips role existence check when checkRoleExists is not provided', async () => {
+      const { checkRoleExists: _, ...depsWithoutCheck } = createDeps();
+      const deps = { ...depsWithoutCheck, checkRoleExists: undefined };
+      const handlers = createAdminGrantsHandlers(deps as AdminGrantsDeps);
+      const { req, res, status } = createReqRes({ body: validBody });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(201);
     });
 
     it('returns 500 when grantCapability returns null', async () => {
@@ -1012,7 +1105,7 @@ describe('createAdminGrantsHandlers', () => {
       await handlers.revokeGrant(req, res);
 
       expect(status).toHaveBeenCalledWith(400);
-      expect(json).toHaveBeenCalledWith({ error: 'principalId is required' });
+      expect(json).toHaveBeenCalledWith({ error: 'Principal ID is required' });
     });
 
     it('returns 400 for invalid capability', async () => {

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -49,6 +49,7 @@ function createReqRes(
 
 function createDeps(overrides: Partial<AdminGrantsDeps> = {}): AdminGrantsDeps {
   return {
+    listAllGrants: jest.fn().mockResolvedValue([]),
     getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
     getCapabilitiesForPrincipals: jest.fn().mockResolvedValue([]),
     grantCapability: jest.fn().mockResolvedValue(mockGrant()),
@@ -63,6 +64,86 @@ function createDeps(overrides: Partial<AdminGrantsDeps> = {}): AdminGrantsDeps {
 }
 
 describe('createAdminGrantsHandlers', () => {
+  describe('listAllGrants', () => {
+    it('returns all grants', async () => {
+      const grants = [mockGrant(), mockGrant({ capability: SystemCapabilities.MANAGE_ROLES })];
+      const deps = createDeps({ listAllGrants: jest.fn().mockResolvedValue(grants) });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.listAllGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ grants });
+    });
+
+    it('returns empty array when no grants exist', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.listAllGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ grants: [] });
+    });
+
+    it('filters grants to principal types the caller can read', async () => {
+      const roleGrant = mockGrant({
+        principalType: PrincipalType.ROLE,
+        capability: SystemCapabilities.READ_USERS,
+      });
+      const groupGrant = mockGrant({
+        principalType: PrincipalType.GROUP,
+        principalId: new Types.ObjectId().toString(),
+        capability: SystemCapabilities.READ_USERS,
+      });
+      const deps = createDeps({
+        listAllGrants: jest.fn().mockResolvedValue([roleGrant, groupGrant]),
+        hasCapabilityForPrincipals: jest.fn().mockImplementation(({ capability }) => {
+          if (capability === SystemCapabilities.READ_ROLES) {
+            return Promise.resolve(true);
+          }
+          return Promise.resolve(false);
+        }),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.listAllGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      const response = json.mock.calls[0][0];
+      expect(response.grants).toHaveLength(1);
+      expect(response.grants[0].principalType).toBe(PrincipalType.ROLE);
+    });
+
+    it('returns 401 when user is not authenticated', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+      (req as unknown as Record<string, unknown>).user = undefined;
+
+      await handlers.listAllGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Authentication required' });
+    });
+
+    it('returns 500 on error', async () => {
+      const deps = createDeps({
+        listAllGrants: jest.fn().mockRejectedValue(new Error('db error')),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.listAllGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to list grants' });
+    });
+  });
+
   describe('getEffectiveCapabilities', () => {
     it('returns expanded capabilities for the user', async () => {
       const manageRolesGrant = mockGrant({ capability: SystemCapabilities.MANAGE_ROLES });

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -133,6 +133,23 @@ describe('createAdminGrantsHandlers', () => {
       });
     });
 
+    it('returns empty capabilities when all principals lack principalId', async () => {
+      const deps = createDeps({
+        getUserPrincipals: jest.fn().mockResolvedValue([
+          { principalType: PrincipalType.PUBLIC },
+        ]),
+        getCapabilitiesForPrincipals: jest.fn().mockResolvedValue([]),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.getEffectiveCapabilities(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ capabilities: [] });
+      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledWith({ principals: [] });
+    });
+
     it('deduplicates capabilities across principals', async () => {
       const readUsersGrant = mockGrant({ capability: SystemCapabilities.READ_USERS });
       const deps = createDeps({
@@ -469,6 +486,27 @@ describe('createAdminGrantsHandlers', () => {
       expect(status).toHaveBeenCalledWith(403);
       expect(json).toHaveBeenCalledWith({ error: 'Cannot grant a capability you do not possess' });
       expect(deps.grantCapability).not.toHaveBeenCalled();
+    });
+
+    it('allows granting an implied capability the caller holds transitively', async () => {
+      const deps = createDeps({
+        hasCapabilityForPrincipals: jest.fn().mockResolvedValue(true),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status } = createReqRes({
+        body: {
+          principalType: PrincipalType.ROLE,
+          principalId: 'editor',
+          capability: SystemCapabilities.READ_ROLES,
+        },
+      });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(201);
+      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ capability: SystemCapabilities.READ_ROLES }),
+      );
     });
 
     it('checks MANAGE_ROLES for role principal type', async () => {

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -121,6 +121,23 @@ describe('createAdminGrantsHandlers', () => {
       );
     });
 
+    it('returns empty grants when caller has no read permissions', async () => {
+      const deps = createDeps({
+        hasCapabilityForPrincipals: jest.fn().mockResolvedValue(false),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.listGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      const response = json.mock.calls[0][0];
+      expect(response.grants).toEqual([]);
+      expect(response.total).toBe(0);
+      expect(deps.listGrants).not.toHaveBeenCalled();
+      expect(deps.countGrants).not.toHaveBeenCalled();
+    });
+
     it('passes limit and offset from query params', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
@@ -877,16 +894,26 @@ describe('createAdminGrantsHandlers', () => {
     const validParams = {
       principalType: PrincipalType.ROLE,
       principalId: 'editor',
+      capability: SystemCapabilities.READ_USERS,
     };
-    const validQuery = { capability: SystemCapabilities.READ_USERS };
+
+    it('returns 200 idempotently even if the grant does not exist', async () => {
+      const deps = createDeps({
+        revokeCapability: jest.fn().mockResolvedValue(undefined),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: validParams });
+
+      await handlers.revokeGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ success: true });
+    });
 
     it('revokes a grant and returns 200', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({
-        params: validParams,
-        query: validQuery,
-      });
+      const { req, res, status, json } = createReqRes({ params: validParams });
 
       await handlers.revokeGrant(req, res);
 
@@ -906,7 +933,6 @@ describe('createAdminGrantsHandlers', () => {
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res } = createReqRes({
         params: validParams,
-        query: validQuery,
         user: { _id: new Types.ObjectId(), role: 'admin', tenantId: 'tenant-1' },
       });
 
@@ -920,12 +946,11 @@ describe('createAdminGrantsHandlers', () => {
       );
     });
 
-    it('accepts section-level config capability in query', async () => {
+    it('accepts encoded section-level config capability in path', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status } = createReqRes({
-        params: validParams,
-        query: { capability: 'manage:configs:endpoints' },
+        params: { ...validParams, capability: 'manage:configs:endpoints' },
       });
 
       await handlers.revokeGrant(req, res);
@@ -940,8 +965,11 @@ describe('createAdminGrantsHandlers', () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
-        params: { principalType: '', principalId: 'editor' },
-        query: validQuery,
+        params: {
+          principalType: '',
+          principalId: 'editor',
+          capability: SystemCapabilities.READ_USERS,
+        },
       });
 
       await handlers.revokeGrant(req, res);
@@ -954,8 +982,11 @@ describe('createAdminGrantsHandlers', () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
-        params: { principalType: PrincipalType.ROLE, principalId: '' },
-        query: validQuery,
+        params: {
+          principalType: PrincipalType.ROLE,
+          principalId: '',
+          capability: SystemCapabilities.READ_USERS,
+        },
       });
 
       await handlers.revokeGrant(req, res);
@@ -968,8 +999,7 @@ describe('createAdminGrantsHandlers', () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
-        params: validParams,
-        query: { capability: 'fake' },
+        params: { ...validParams, capability: 'fake' },
       });
 
       await handlers.revokeGrant(req, res);
@@ -978,11 +1008,11 @@ describe('createAdminGrantsHandlers', () => {
       expect(json).toHaveBeenCalledWith({ error: 'Invalid capability' });
     });
 
-    it('returns 400 for missing capability query param', async () => {
+    it('returns 400 for missing capability param', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
-        params: validParams,
+        params: { principalType: PrincipalType.ROLE, principalId: 'editor' },
       });
 
       await handlers.revokeGrant(req, res);
@@ -994,10 +1024,7 @@ describe('createAdminGrantsHandlers', () => {
     it('returns 401 when user is not authenticated', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({
-        params: validParams,
-        query: validQuery,
-      });
+      const { req, res, status, json } = createReqRes({ params: validParams });
       (req as unknown as Record<string, unknown>).user = undefined;
 
       await handlers.revokeGrant(req, res);
@@ -1012,10 +1039,7 @@ describe('createAdminGrantsHandlers', () => {
         hasCapabilityForPrincipals: jest.fn().mockResolvedValue(false),
       });
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({
-        params: validParams,
-        query: validQuery,
-      });
+      const { req, res, status, json } = createReqRes({ params: validParams });
 
       await handlers.revokeGrant(req, res);
 
@@ -1028,8 +1052,11 @@ describe('createAdminGrantsHandlers', () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
-        params: { principalType: PrincipalType.USER, principalId: 'bad-id' },
-        query: validQuery,
+        params: {
+          principalType: PrincipalType.USER,
+          principalId: 'bad-id',
+          capability: SystemCapabilities.READ_USERS,
+        },
       });
 
       await handlers.revokeGrant(req, res);
@@ -1043,10 +1070,7 @@ describe('createAdminGrantsHandlers', () => {
         revokeCapability: jest.fn().mockRejectedValue(new Error('db error')),
       });
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({
-        params: validParams,
-        query: validQuery,
-      });
+      const { req, res, status, json } = createReqRes({ params: validParams });
 
       await handlers.revokeGrant(req, res);
 

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -60,6 +60,13 @@ function createDeps(overrides: Partial<AdminGrantsDeps> = {}): AdminGrantsDeps {
       { principalType: PrincipalType.ROLE, principalId: 'admin' },
     ]),
     hasCapabilityForPrincipals: jest.fn().mockResolvedValue(true),
+    getHeldCapabilities: jest.fn().mockResolvedValue(
+      new Set([
+        SystemCapabilities.READ_ROLES,
+        SystemCapabilities.READ_GROUPS,
+        SystemCapabilities.READ_USERS,
+      ]),
+    ),
     getCachedPrincipals: jest.fn().mockReturnValue(undefined),
     ...overrides,
   };
@@ -101,12 +108,9 @@ describe('createAdminGrantsHandlers', () => {
 
     it('passes principalTypes filter based on caller read permissions', async () => {
       const deps = createDeps({
-        hasCapabilityForPrincipals: jest.fn().mockImplementation(({ capability }) => {
-          if (capability === SystemCapabilities.READ_ROLES) {
-            return Promise.resolve(true);
-          }
-          return Promise.resolve(false);
-        }),
+        getHeldCapabilities: jest.fn().mockResolvedValue(
+          new Set([SystemCapabilities.READ_ROLES]),
+        ),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res } = createReqRes();
@@ -123,7 +127,7 @@ describe('createAdminGrantsHandlers', () => {
 
     it('returns empty grants when caller has no read permissions', async () => {
       const deps = createDeps({
-        hasCapabilityForPrincipals: jest.fn().mockResolvedValue(false),
+        getHeldCapabilities: jest.fn().mockResolvedValue(new Set()),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes();
@@ -159,7 +163,7 @@ describe('createAdminGrantsHandlers', () => {
 
       await handlers.listGrants(req, res);
 
-      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+      expect(deps.getHeldCapabilities).toHaveBeenCalledWith(
         expect.objectContaining({ tenantId: 'tenant-1' }),
       );
       expect(deps.listGrants).toHaveBeenCalledWith(
@@ -206,13 +210,32 @@ describe('createAdminGrantsHandlers', () => {
       await handlers.listGrants(req, res);
 
       expect(deps.getUserPrincipals).not.toHaveBeenCalled();
-      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+      expect(deps.getHeldCapabilities).toHaveBeenCalledWith(
         expect.objectContaining({ principals: cachedPrincipals }),
       );
     });
   });
 
   describe('getEffectiveCapabilities', () => {
+    it('uses cached principals when available', async () => {
+      const cachedPrincipals = [
+        { principalType: PrincipalType.USER, principalId: new Types.ObjectId() },
+        { principalType: PrincipalType.ROLE, principalId: 'admin' },
+      ];
+      const deps = createDeps({
+        getCachedPrincipals: jest.fn().mockReturnValue(cachedPrincipals),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes();
+
+      await handlers.getEffectiveCapabilities(req, res);
+
+      expect(deps.getUserPrincipals).not.toHaveBeenCalled();
+      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ principals: cachedPrincipals }),
+      );
+    });
+
     it('returns expanded capabilities for the user', async () => {
       const manageRolesGrant = mockGrant({ capability: SystemCapabilities.MANAGE_ROLES });
       const deps = createDeps({
@@ -303,7 +326,6 @@ describe('createAdminGrantsHandlers', () => {
     it('returns empty capabilities when all principals lack principalId', async () => {
       const deps = createDeps({
         getUserPrincipals: jest.fn().mockResolvedValue([{ principalType: PrincipalType.PUBLIC }]),
-        getCapabilitiesForPrincipals: jest.fn().mockResolvedValue([]),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes();
@@ -312,9 +334,7 @@ describe('createAdminGrantsHandlers', () => {
 
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith({ capabilities: [] });
-      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledWith(
-        expect.objectContaining({ principals: [] }),
-      );
+      expect(deps.getCapabilitiesForPrincipals).not.toHaveBeenCalled();
     });
 
     it('deduplicates capabilities across principals', async () => {

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -60,13 +60,15 @@ function createDeps(overrides: Partial<AdminGrantsDeps> = {}): AdminGrantsDeps {
       { principalType: PrincipalType.ROLE, principalId: 'admin' },
     ]),
     hasCapabilityForPrincipals: jest.fn().mockResolvedValue(true),
-    getHeldCapabilities: jest.fn().mockResolvedValue(
-      new Set([
-        SystemCapabilities.READ_ROLES,
-        SystemCapabilities.READ_GROUPS,
-        SystemCapabilities.READ_USERS,
-      ]),
-    ),
+    getHeldCapabilities: jest
+      .fn()
+      .mockResolvedValue(
+        new Set([
+          SystemCapabilities.READ_ROLES,
+          SystemCapabilities.READ_GROUPS,
+          SystemCapabilities.READ_USERS,
+        ]),
+      ),
     getCachedPrincipals: jest.fn().mockReturnValue(undefined),
     ...overrides,
   };
@@ -108,9 +110,7 @@ describe('createAdminGrantsHandlers', () => {
 
     it('passes principalTypes filter based on caller read permissions', async () => {
       const deps = createDeps({
-        getHeldCapabilities: jest.fn().mockResolvedValue(
-          new Set([SystemCapabilities.READ_ROLES]),
-        ),
+        getHeldCapabilities: jest.fn().mockResolvedValue(new Set([SystemCapabilities.READ_ROLES])),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res } = createReqRes();
@@ -966,7 +966,7 @@ describe('createAdminGrantsHandlers', () => {
       );
     });
 
-    it('accepts encoded section-level config capability in path', async () => {
+    it('accepts section-level config capability with colons', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status } = createReqRes({

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -1,0 +1,545 @@
+import { Types } from 'mongoose';
+import { PrincipalType } from 'librechat-data-provider';
+import { SystemCapabilities, expandImplications } from '@librechat/data-schemas';
+import type { ISystemGrant } from '@librechat/data-schemas';
+import type { Response } from 'express';
+import type { ServerRequest } from '~/types/http';
+import type { AdminGrantsDeps } from './grants';
+import { createAdminGrantsHandlers } from './grants';
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: { error: jest.fn() },
+}));
+
+const validObjectId = new Types.ObjectId().toString();
+
+function mockGrant(overrides: Partial<ISystemGrant> = {}): ISystemGrant {
+  return {
+    _id: new Types.ObjectId(),
+    principalType: PrincipalType.ROLE,
+    principalId: 'editor',
+    capability: SystemCapabilities.READ_USERS,
+    grantedAt: new Date(),
+    ...overrides,
+  } as ISystemGrant;
+}
+
+function createReqRes(
+  overrides: {
+    params?: Record<string, string>;
+    query?: Record<string, string>;
+    body?: Record<string, unknown>;
+    user?: { _id: Types.ObjectId; role: string };
+  } = {},
+) {
+  const req = {
+    params: overrides.params ?? {},
+    query: overrides.query ?? {},
+    body: overrides.body ?? {},
+    user: overrides.user ?? { _id: new Types.ObjectId(), role: 'admin' },
+  } as unknown as ServerRequest;
+
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  const res = { status, json } as unknown as Response;
+
+  return { req, res, status, json };
+}
+
+function createDeps(overrides: Partial<AdminGrantsDeps> = {}): AdminGrantsDeps {
+  return {
+    getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
+    grantCapability: jest.fn().mockResolvedValue(mockGrant()),
+    revokeCapability: jest.fn().mockResolvedValue(undefined),
+    getUserPrincipals: jest.fn().mockResolvedValue([
+      { principalType: PrincipalType.USER, principalId: new Types.ObjectId() },
+      { principalType: PrincipalType.ROLE, principalId: 'admin' },
+    ]),
+    hasCapabilityForPrincipals: jest.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+describe('createAdminGrantsHandlers', () => {
+  describe('getEffectiveCapabilities', () => {
+    it('returns expanded capabilities for the user', async () => {
+      const manageRolesGrant = mockGrant({ capability: SystemCapabilities.MANAGE_ROLES });
+      const deps = createDeps({
+        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([manageRolesGrant]),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.getEffectiveCapabilities(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      const response = json.mock.calls[0][0];
+      const expected = expandImplications([SystemCapabilities.MANAGE_ROLES]);
+      expect(response.capabilities).toEqual(expect.arrayContaining(expected));
+      expect(response.capabilities).toContain(SystemCapabilities.READ_ROLES);
+    });
+
+    it('returns empty capabilities when user has no grants', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.getEffectiveCapabilities(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ capabilities: [] });
+    });
+
+    it('queries each principal separately', async () => {
+      const userId = new Types.ObjectId();
+      const principals = [
+        { principalType: PrincipalType.USER, principalId: userId },
+        { principalType: PrincipalType.ROLE, principalId: 'editor' },
+      ];
+      const deps = createDeps({
+        getUserPrincipals: jest.fn().mockResolvedValue(principals),
+        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes();
+
+      await handlers.getEffectiveCapabilities(req, res);
+
+      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledTimes(2);
+      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledWith({
+        principalType: PrincipalType.USER,
+        principalId: userId,
+      });
+      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledWith({
+        principalType: PrincipalType.ROLE,
+        principalId: 'editor',
+      });
+    });
+
+    it('skips principals without principalId', async () => {
+      const principals = [
+        { principalType: PrincipalType.PUBLIC },
+        { principalType: PrincipalType.ROLE, principalId: 'editor' },
+      ];
+      const deps = createDeps({
+        getUserPrincipals: jest.fn().mockResolvedValue(principals),
+        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes();
+
+      await handlers.getEffectiveCapabilities(req, res);
+
+      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 401 when user is not authenticated', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+      (req as unknown as Record<string, unknown>).user = undefined;
+
+      await handlers.getEffectiveCapabilities(req, res);
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Authentication required' });
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      const deps = createDeps({
+        getUserPrincipals: jest.fn().mockRejectedValue(new Error('db error')),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.getEffectiveCapabilities(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to get effective capabilities' });
+    });
+  });
+
+  describe('getPrincipalGrants', () => {
+    it('returns grants for a role principal', async () => {
+      const grants = [mockGrant()];
+      const deps = createDeps({
+        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue(grants),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { principalType: PrincipalType.ROLE, principalId: 'editor' },
+      });
+
+      await handlers.getPrincipalGrants(req, res);
+
+      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledWith({
+        principalType: PrincipalType.ROLE,
+        principalId: 'editor',
+      });
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ grants });
+    });
+
+    it('returns grants for a group principal', async () => {
+      const deps = createDeps({
+        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { principalType: PrincipalType.GROUP, principalId: validObjectId },
+      });
+
+      await handlers.getPrincipalGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ grants: [] });
+    });
+
+    it('returns 400 for invalid principal type', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { principalType: 'invalid', principalId: 'abc' },
+      });
+
+      await handlers.getPrincipalGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principal type' });
+    });
+
+    it('returns 400 when principalId is missing', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { principalType: PrincipalType.ROLE, principalId: '' },
+      });
+
+      await handlers.getPrincipalGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'principalId is required' });
+    });
+
+    it('returns 400 for non-ObjectId group principalId', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { principalType: PrincipalType.GROUP, principalId: 'not-an-objectid' },
+      });
+
+      await handlers.getPrincipalGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principalId format' });
+    });
+
+    it('accepts string principalId for role type without ObjectId validation', async () => {
+      const deps = createDeps({
+        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status } = createReqRes({
+        params: { principalType: PrincipalType.ROLE, principalId: 'custom-role-name' },
+      });
+
+      await handlers.getPrincipalGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      const deps = createDeps({
+        getCapabilitiesForPrincipal: jest.fn().mockRejectedValue(new Error('db error')),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { principalType: PrincipalType.ROLE, principalId: 'editor' },
+      });
+
+      await handlers.getPrincipalGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to get grants' });
+    });
+  });
+
+  describe('assignGrant', () => {
+    const validBody = {
+      principalType: PrincipalType.ROLE,
+      principalId: 'editor',
+      capability: SystemCapabilities.READ_USERS,
+    };
+
+    it('assigns a grant and returns 200', async () => {
+      const grant = mockGrant();
+      const deps = createDeps({ grantCapability: jest.fn().mockResolvedValue(grant) });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: validBody });
+
+      await handlers.assignGrant(req, res);
+
+      expect(deps.grantCapability).toHaveBeenCalledWith(
+        expect.objectContaining({
+          principalType: PrincipalType.ROLE,
+          principalId: 'editor',
+          capability: SystemCapabilities.READ_USERS,
+        }),
+      );
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ grant });
+    });
+
+    it('passes grantedBy from the authenticated user', async () => {
+      const userId = new Types.ObjectId();
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes({ body: validBody, user: { _id: userId, role: 'admin' } });
+
+      await handlers.assignGrant(req, res);
+
+      expect(deps.grantCapability).toHaveBeenCalledWith(
+        expect.objectContaining({ grantedBy: userId.toString() }),
+      );
+    });
+
+    it('returns 400 for missing principalType', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { principalId: 'editor', capability: SystemCapabilities.READ_USERS },
+      });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principal type' });
+    });
+
+    it('returns 400 for invalid principalType', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { ...validBody, principalType: 'invalid' },
+      });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principal type' });
+    });
+
+    it('returns 400 for missing principalId', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { principalType: PrincipalType.ROLE, capability: SystemCapabilities.READ_USERS },
+      });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'principalId is required' });
+    });
+
+    it('returns 400 for invalid capability', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { ...validBody, capability: 'not:a:real:capability' },
+      });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid capability' });
+    });
+
+    it('returns 400 for invalid ObjectId on group principalId', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: {
+          principalType: PrincipalType.GROUP,
+          principalId: 'not-an-objectid',
+          capability: SystemCapabilities.READ_USERS,
+        },
+      });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principalId format' });
+    });
+
+    it('returns 403 when caller lacks manage capability', async () => {
+      const deps = createDeps({
+        hasCapabilityForPrincipals: jest.fn().mockResolvedValue(false),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: validBody });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(403);
+      expect(json).toHaveBeenCalledWith({ error: 'Insufficient permissions' });
+      expect(deps.grantCapability).not.toHaveBeenCalled();
+    });
+
+    it('checks MANAGE_ROLES for role principal type', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes({ body: validBody });
+
+      await handlers.assignGrant(req, res);
+
+      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ capability: SystemCapabilities.MANAGE_ROLES }),
+      );
+    });
+
+    it('checks MANAGE_GROUPS for group principal type', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes({
+        body: {
+          principalType: PrincipalType.GROUP,
+          principalId: validObjectId,
+          capability: SystemCapabilities.READ_USERS,
+        },
+      });
+
+      await handlers.assignGrant(req, res);
+
+      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ capability: SystemCapabilities.MANAGE_GROUPS }),
+      );
+    });
+
+    it('checks MANAGE_USERS for user principal type', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes({
+        body: {
+          principalType: PrincipalType.USER,
+          principalId: validObjectId,
+          capability: SystemCapabilities.READ_USERS,
+        },
+      });
+
+      await handlers.assignGrant(req, res);
+
+      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ capability: SystemCapabilities.MANAGE_USERS }),
+      );
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      const deps = createDeps({
+        grantCapability: jest.fn().mockRejectedValue(new Error('db error')),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: validBody });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to assign grant' });
+    });
+  });
+
+  describe('revokeGrant', () => {
+    const validBody = {
+      principalType: PrincipalType.ROLE,
+      principalId: 'editor',
+      capability: SystemCapabilities.READ_USERS,
+    };
+
+    it('revokes a grant and returns 200', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: validBody });
+
+      await handlers.revokeGrant(req, res);
+
+      expect(deps.revokeCapability).toHaveBeenCalledWith({
+        principalType: PrincipalType.ROLE,
+        principalId: 'editor',
+        capability: SystemCapabilities.READ_USERS,
+      });
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('returns 400 for missing principalType', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { principalId: 'editor', capability: SystemCapabilities.READ_USERS },
+      });
+
+      await handlers.revokeGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principal type' });
+    });
+
+    it('returns 400 for invalid capability', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { ...validBody, capability: 'fake' },
+      });
+
+      await handlers.revokeGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid capability' });
+    });
+
+    it('returns 403 when caller lacks manage capability', async () => {
+      const deps = createDeps({
+        hasCapabilityForPrincipals: jest.fn().mockResolvedValue(false),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: validBody });
+
+      await handlers.revokeGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(403);
+      expect(json).toHaveBeenCalledWith({ error: 'Insufficient permissions' });
+      expect(deps.revokeCapability).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for invalid user ObjectId', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: {
+          principalType: PrincipalType.USER,
+          principalId: 'bad-id',
+          capability: SystemCapabilities.READ_USERS,
+        },
+      });
+
+      await handlers.revokeGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principalId format' });
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      const deps = createDeps({
+        revokeCapability: jest.fn().mockRejectedValue(new Error('db error')),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: validBody });
+
+      await handlers.revokeGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to revoke grant' });
+    });
+  });
+});

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -30,7 +30,7 @@ function createReqRes(
     params?: Record<string, string>;
     query?: Record<string, string>;
     body?: Record<string, unknown>;
-    user?: { _id: Types.ObjectId; role: string };
+    user?: { _id: Types.ObjectId; role: string; tenantId?: string };
   } = {},
 ) {
   const req = {
@@ -49,7 +49,8 @@ function createReqRes(
 
 function createDeps(overrides: Partial<AdminGrantsDeps> = {}): AdminGrantsDeps {
   return {
-    listAllGrants: jest.fn().mockResolvedValue([]),
+    listGrants: jest.fn().mockResolvedValue([]),
+    countGrants: jest.fn().mockResolvedValue(0),
     getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
     getCapabilitiesForPrincipals: jest.fn().mockResolvedValue([]),
     grantCapability: jest.fn().mockResolvedValue(mockGrant()),
@@ -59,22 +60,30 @@ function createDeps(overrides: Partial<AdminGrantsDeps> = {}): AdminGrantsDeps {
       { principalType: PrincipalType.ROLE, principalId: 'admin' },
     ]),
     hasCapabilityForPrincipals: jest.fn().mockResolvedValue(true),
+    getCachedPrincipals: jest.fn().mockReturnValue(undefined),
     ...overrides,
   };
 }
 
 describe('createAdminGrantsHandlers', () => {
-  describe('listAllGrants', () => {
-    it('returns all grants', async () => {
+  describe('listGrants', () => {
+    it('returns grants with pagination metadata', async () => {
       const grants = [mockGrant(), mockGrant({ capability: SystemCapabilities.MANAGE_ROLES })];
-      const deps = createDeps({ listAllGrants: jest.fn().mockResolvedValue(grants) });
+      const deps = createDeps({
+        listGrants: jest.fn().mockResolvedValue(grants),
+        countGrants: jest.fn().mockResolvedValue(2),
+      });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes();
 
-      await handlers.listAllGrants(req, res);
+      await handlers.listGrants(req, res);
 
       expect(status).toHaveBeenCalledWith(200);
-      expect(json).toHaveBeenCalledWith({ grants });
+      const response = json.mock.calls[0][0];
+      expect(response.grants).toEqual(grants);
+      expect(response).toHaveProperty('total', 2);
+      expect(response).toHaveProperty('limit');
+      expect(response).toHaveProperty('offset');
     });
 
     it('returns empty array when no grants exist', async () => {
@@ -82,24 +91,16 @@ describe('createAdminGrantsHandlers', () => {
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes();
 
-      await handlers.listAllGrants(req, res);
+      await handlers.listGrants(req, res);
 
       expect(status).toHaveBeenCalledWith(200);
-      expect(json).toHaveBeenCalledWith({ grants: [] });
+      const response = json.mock.calls[0][0];
+      expect(response.grants).toEqual([]);
+      expect(response.total).toBe(0);
     });
 
-    it('filters grants to principal types the caller can read', async () => {
-      const roleGrant = mockGrant({
-        principalType: PrincipalType.ROLE,
-        capability: SystemCapabilities.READ_USERS,
-      });
-      const groupGrant = mockGrant({
-        principalType: PrincipalType.GROUP,
-        principalId: new Types.ObjectId().toString(),
-        capability: SystemCapabilities.READ_USERS,
-      });
+    it('passes principalTypes filter based on caller read permissions', async () => {
       const deps = createDeps({
-        listAllGrants: jest.fn().mockResolvedValue([roleGrant, groupGrant]),
         hasCapabilityForPrincipals: jest.fn().mockImplementation(({ capability }) => {
           if (capability === SystemCapabilities.READ_ROLES) {
             return Promise.resolve(true);
@@ -108,14 +109,45 @@ describe('createAdminGrantsHandlers', () => {
         }),
       });
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes();
+      const { req, res } = createReqRes();
 
-      await handlers.listAllGrants(req, res);
+      await handlers.listGrants(req, res);
 
-      expect(status).toHaveBeenCalledWith(200);
-      const response = json.mock.calls[0][0];
-      expect(response.grants).toHaveLength(1);
-      expect(response.grants[0].principalType).toBe(PrincipalType.ROLE);
+      expect(deps.listGrants).toHaveBeenCalledWith(
+        expect.objectContaining({ principalTypes: [PrincipalType.ROLE] }),
+      );
+      expect(deps.countGrants).toHaveBeenCalledWith(
+        expect.objectContaining({ principalTypes: [PrincipalType.ROLE] }),
+      );
+    });
+
+    it('passes limit and offset from query params', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes({ query: { limit: '10', offset: '20' } });
+
+      await handlers.listGrants(req, res);
+
+      expect(deps.listGrants).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 10, offset: 20 }),
+      );
+    });
+
+    it('passes tenantId to dep calls', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes({
+        user: { _id: new Types.ObjectId(), role: 'admin', tenantId: 'tenant-1' },
+      });
+
+      await handlers.listGrants(req, res);
+
+      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'tenant-1' }),
+      );
+      expect(deps.listGrants).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'tenant-1' }),
+      );
     });
 
     it('returns 401 when user is not authenticated', async () => {
@@ -124,7 +156,7 @@ describe('createAdminGrantsHandlers', () => {
       const { req, res, status, json } = createReqRes();
       (req as unknown as Record<string, unknown>).user = undefined;
 
-      await handlers.listAllGrants(req, res);
+      await handlers.listGrants(req, res);
 
       expect(status).toHaveBeenCalledWith(401);
       expect(json).toHaveBeenCalledWith({ error: 'Authentication required' });
@@ -132,15 +164,34 @@ describe('createAdminGrantsHandlers', () => {
 
     it('returns 500 on error', async () => {
       const deps = createDeps({
-        listAllGrants: jest.fn().mockRejectedValue(new Error('db error')),
+        listGrants: jest.fn().mockRejectedValue(new Error('db error')),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes();
 
-      await handlers.listAllGrants(req, res);
+      await handlers.listGrants(req, res);
 
       expect(status).toHaveBeenCalledWith(500);
       expect(json).toHaveBeenCalledWith({ error: 'Failed to list grants' });
+    });
+
+    it('uses cached principals when available', async () => {
+      const cachedPrincipals = [
+        { principalType: PrincipalType.USER, principalId: new Types.ObjectId() },
+        { principalType: PrincipalType.ROLE, principalId: 'admin' },
+      ];
+      const deps = createDeps({
+        getCachedPrincipals: jest.fn().mockReturnValue(cachedPrincipals),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes();
+
+      await handlers.listGrants(req, res);
+
+      expect(deps.getUserPrincipals).not.toHaveBeenCalled();
+      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ principals: cachedPrincipals }),
+      );
     });
   });
 
@@ -188,12 +239,28 @@ describe('createAdminGrantsHandlers', () => {
       await handlers.getEffectiveCapabilities(req, res);
 
       expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledTimes(1);
-      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledWith({
-        principals: [
-          { principalType: PrincipalType.USER, principalId: userId },
-          { principalType: PrincipalType.ROLE, principalId: 'editor' },
-        ],
+      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({
+          principals: [
+            { principalType: PrincipalType.USER, principalId: userId },
+            { principalType: PrincipalType.ROLE, principalId: 'editor' },
+          ],
+        }),
+      );
+    });
+
+    it('passes tenantId to getCapabilitiesForPrincipals', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes({
+        user: { _id: new Types.ObjectId(), role: 'admin', tenantId: 'tenant-1' },
       });
+
+      await handlers.getEffectiveCapabilities(req, res);
+
+      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'tenant-1' }),
+      );
     });
 
     it('skips principals without principalId', async () => {
@@ -209,16 +276,16 @@ describe('createAdminGrantsHandlers', () => {
 
       await handlers.getEffectiveCapabilities(req, res);
 
-      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledWith({
-        principals: [{ principalType: PrincipalType.ROLE, principalId: 'editor' }],
-      });
+      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({
+          principals: [{ principalType: PrincipalType.ROLE, principalId: 'editor' }],
+        }),
+      );
     });
 
     it('returns empty capabilities when all principals lack principalId', async () => {
       const deps = createDeps({
-        getUserPrincipals: jest.fn().mockResolvedValue([
-          { principalType: PrincipalType.PUBLIC },
-        ]),
+        getUserPrincipals: jest.fn().mockResolvedValue([{ principalType: PrincipalType.PUBLIC }]),
         getCapabilitiesForPrincipals: jest.fn().mockResolvedValue([]),
       });
       const handlers = createAdminGrantsHandlers(deps);
@@ -228,7 +295,9 @@ describe('createAdminGrantsHandlers', () => {
 
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith({ capabilities: [] });
-      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledWith({ principals: [] });
+      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ principals: [] }),
+      );
     });
 
     it('deduplicates capabilities across principals', async () => {
@@ -251,6 +320,25 @@ describe('createAdminGrantsHandlers', () => {
         (c: string) => c === SystemCapabilities.READ_USERS,
       ).length;
       expect(readUsersCount).toBe(1);
+    });
+
+    it('deduplicates when user holds both parent and implied capability', async () => {
+      const manageGrant = mockGrant({ capability: SystemCapabilities.MANAGE_ROLES });
+      const readGrant = mockGrant({ capability: SystemCapabilities.READ_ROLES });
+      const deps = createDeps({
+        getCapabilitiesForPrincipals: jest.fn().mockResolvedValue([manageGrant, readGrant]),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.getEffectiveCapabilities(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      const response = json.mock.calls[0][0];
+      const readRolesCount = response.capabilities.filter(
+        (c: string) => c === SystemCapabilities.READ_ROLES,
+      ).length;
+      expect(readRolesCount).toBe(1);
     });
 
     it('returns 401 when user is not authenticated', async () => {
@@ -292,10 +380,12 @@ describe('createAdminGrantsHandlers', () => {
 
       await handlers.getPrincipalGrants(req, res);
 
-      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledWith({
-        principalType: PrincipalType.ROLE,
-        principalId: 'editor',
-      });
+      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          principalType: PrincipalType.ROLE,
+          principalId: 'editor',
+        }),
+      );
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith({ grants });
     });
@@ -313,6 +403,51 @@ describe('createAdminGrantsHandlers', () => {
 
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith({ grants: [] });
+    });
+
+    it('returns grants for a user principal', async () => {
+      const grants = [mockGrant({ principalType: PrincipalType.USER, principalId: validObjectId })];
+      const deps = createDeps({
+        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue(grants),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { principalType: PrincipalType.USER, principalId: validObjectId },
+      });
+
+      await handlers.getPrincipalGrants(req, res);
+
+      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ capability: SystemCapabilities.READ_USERS }),
+      );
+      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          principalType: PrincipalType.USER,
+          principalId: validObjectId,
+        }),
+      );
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ grants });
+    });
+
+    it('passes tenantId to dep calls', async () => {
+      const deps = createDeps({
+        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes({
+        params: { principalType: PrincipalType.ROLE, principalId: 'editor' },
+        user: { _id: new Types.ObjectId(), role: 'admin', tenantId: 'tenant-1' },
+      });
+
+      await handlers.getPrincipalGrants(req, res);
+
+      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'tenant-1' }),
+      );
+      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'tenant-1' }),
+      );
     });
 
     it('returns 400 for invalid principal type', async () => {
@@ -346,6 +481,19 @@ describe('createAdminGrantsHandlers', () => {
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
         params: { principalType: PrincipalType.GROUP, principalId: 'not-an-objectid' },
+      });
+
+      await handlers.getPrincipalGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principalId format' });
+    });
+
+    it('returns 400 for non-ObjectId user principalId', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { principalType: PrincipalType.USER, principalId: 'not-an-objectid' },
       });
 
       await handlers.getPrincipalGrants(req, res);
@@ -455,6 +603,65 @@ describe('createAdminGrantsHandlers', () => {
       );
     });
 
+    it('passes tenantId to all dep calls', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes({
+        body: validBody,
+        user: { _id: new Types.ObjectId(), role: 'admin', tenantId: 'tenant-1' },
+      });
+
+      await handlers.assignGrant(req, res);
+
+      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'tenant-1' }),
+      );
+      expect(deps.grantCapability).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'tenant-1' }),
+      );
+    });
+
+    it('accepts section-level config capabilities', async () => {
+      const grant = mockGrant({
+        capability: 'manage:configs:endpoints' as ISystemGrant['capability'],
+      });
+      const deps = createDeps({ grantCapability: jest.fn().mockResolvedValue(grant) });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status } = createReqRes({
+        body: { ...validBody, capability: 'manage:configs:endpoints' },
+      });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(201);
+    });
+
+    it('accepts config assignment capabilities', async () => {
+      const grant = mockGrant({ capability: 'assign:configs:group' as ISystemGrant['capability'] });
+      const deps = createDeps({ grantCapability: jest.fn().mockResolvedValue(grant) });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status } = createReqRes({
+        body: { ...validBody, capability: 'assign:configs:group' },
+      });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(201);
+    });
+
+    it('returns 400 for invalid extended capability string', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        body: { ...validBody, capability: 'manage:configs:' },
+      });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid capability' });
+    });
+
     it('returns 400 for missing principalType', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
@@ -547,6 +754,7 @@ describe('createAdminGrantsHandlers', () => {
       await handlers.assignGrant(req, res);
 
       expect(status).toHaveBeenCalledWith(403);
+      expect(json).toHaveBeenCalledWith({ error: 'Insufficient permissions' });
       expect(deps.grantCapability).not.toHaveBeenCalled();
     });
 
@@ -669,34 +877,71 @@ describe('createAdminGrantsHandlers', () => {
     const validParams = {
       principalType: PrincipalType.ROLE,
       principalId: 'editor',
-      capability: SystemCapabilities.READ_USERS,
     };
+    const validQuery = { capability: SystemCapabilities.READ_USERS };
 
     it('revokes a grant and returns 200', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({ params: validParams });
+      const { req, res, status, json } = createReqRes({
+        params: validParams,
+        query: validQuery,
+      });
 
       await handlers.revokeGrant(req, res);
 
-      expect(deps.revokeCapability).toHaveBeenCalledWith({
-        principalType: PrincipalType.ROLE,
-        principalId: 'editor',
-        capability: SystemCapabilities.READ_USERS,
-      });
+      expect(deps.revokeCapability).toHaveBeenCalledWith(
+        expect.objectContaining({
+          principalType: PrincipalType.ROLE,
+          principalId: 'editor',
+          capability: SystemCapabilities.READ_USERS,
+        }),
+      );
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('passes tenantId to dep calls', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res } = createReqRes({
+        params: validParams,
+        query: validQuery,
+        user: { _id: new Types.ObjectId(), role: 'admin', tenantId: 'tenant-1' },
+      });
+
+      await handlers.revokeGrant(req, res);
+
+      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'tenant-1' }),
+      );
+      expect(deps.revokeCapability).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'tenant-1' }),
+      );
+    });
+
+    it('accepts section-level config capability in query', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status } = createReqRes({
+        params: validParams,
+        query: { capability: 'manage:configs:endpoints' },
+      });
+
+      await handlers.revokeGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(deps.revokeCapability).toHaveBeenCalledWith(
+        expect.objectContaining({ capability: 'manage:configs:endpoints' }),
+      );
     });
 
     it('returns 400 for missing principalType', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
-        params: {
-          principalType: '',
-          principalId: 'editor',
-          capability: SystemCapabilities.READ_USERS,
-        },
+        params: { principalType: '', principalId: 'editor' },
+        query: validQuery,
       });
 
       await handlers.revokeGrant(req, res);
@@ -709,11 +954,8 @@ describe('createAdminGrantsHandlers', () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
-        params: {
-          principalType: PrincipalType.ROLE,
-          principalId: '',
-          capability: SystemCapabilities.READ_USERS,
-        },
+        params: { principalType: PrincipalType.ROLE, principalId: '' },
+        query: validQuery,
       });
 
       await handlers.revokeGrant(req, res);
@@ -726,7 +968,21 @@ describe('createAdminGrantsHandlers', () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
-        params: { ...validParams, capability: 'fake' },
+        params: validParams,
+        query: { capability: 'fake' },
+      });
+
+      await handlers.revokeGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid capability' });
+    });
+
+    it('returns 400 for missing capability query param', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: validParams,
       });
 
       await handlers.revokeGrant(req, res);
@@ -738,7 +994,10 @@ describe('createAdminGrantsHandlers', () => {
     it('returns 401 when user is not authenticated', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({ params: validParams });
+      const { req, res, status, json } = createReqRes({
+        params: validParams,
+        query: validQuery,
+      });
       (req as unknown as Record<string, unknown>).user = undefined;
 
       await handlers.revokeGrant(req, res);
@@ -753,7 +1012,10 @@ describe('createAdminGrantsHandlers', () => {
         hasCapabilityForPrincipals: jest.fn().mockResolvedValue(false),
       });
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({ params: validParams });
+      const { req, res, status, json } = createReqRes({
+        params: validParams,
+        query: validQuery,
+      });
 
       await handlers.revokeGrant(req, res);
 
@@ -766,11 +1028,8 @@ describe('createAdminGrantsHandlers', () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
-        params: {
-          principalType: PrincipalType.USER,
-          principalId: 'bad-id',
-          capability: SystemCapabilities.READ_USERS,
-        },
+        params: { principalType: PrincipalType.USER, principalId: 'bad-id' },
+        query: validQuery,
       });
 
       await handlers.revokeGrant(req, res);
@@ -784,7 +1043,10 @@ describe('createAdminGrantsHandlers', () => {
         revokeCapability: jest.fn().mockRejectedValue(new Error('db error')),
       });
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({ params: validParams });
+      const { req, res, status, json } = createReqRes({
+        params: validParams,
+        query: validQuery,
+      });
 
       await handlers.revokeGrant(req, res);
 

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -50,6 +50,7 @@ function createReqRes(
 function createDeps(overrides: Partial<AdminGrantsDeps> = {}): AdminGrantsDeps {
   return {
     getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
+    getCapabilitiesForPrincipals: jest.fn().mockResolvedValue([]),
     grantCapability: jest.fn().mockResolvedValue(mockGrant()),
     revokeCapability: jest.fn().mockResolvedValue(undefined),
     getUserPrincipals: jest.fn().mockResolvedValue([
@@ -66,7 +67,7 @@ describe('createAdminGrantsHandlers', () => {
     it('returns expanded capabilities for the user', async () => {
       const manageRolesGrant = mockGrant({ capability: SystemCapabilities.MANAGE_ROLES });
       const deps = createDeps({
-        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([manageRolesGrant]),
+        getCapabilitiesForPrincipals: jest.fn().mockResolvedValue([manageRolesGrant]),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes();
@@ -91,7 +92,7 @@ describe('createAdminGrantsHandlers', () => {
       expect(json).toHaveBeenCalledWith({ capabilities: [] });
     });
 
-    it('queries each principal separately', async () => {
+    it('queries all principals in a single batch', async () => {
       const userId = new Types.ObjectId();
       const principals = [
         { principalType: PrincipalType.USER, principalId: userId },
@@ -99,21 +100,18 @@ describe('createAdminGrantsHandlers', () => {
       ];
       const deps = createDeps({
         getUserPrincipals: jest.fn().mockResolvedValue(principals),
-        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res } = createReqRes();
 
       await handlers.getEffectiveCapabilities(req, res);
 
-      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledTimes(2);
-      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledWith({
-        principalType: PrincipalType.USER,
-        principalId: userId,
-      });
-      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledWith({
-        principalType: PrincipalType.ROLE,
-        principalId: 'editor',
+      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledTimes(1);
+      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledWith({
+        principals: [
+          { principalType: PrincipalType.USER, principalId: userId },
+          { principalType: PrincipalType.ROLE, principalId: 'editor' },
+        ],
       });
     });
 
@@ -124,14 +122,15 @@ describe('createAdminGrantsHandlers', () => {
       ];
       const deps = createDeps({
         getUserPrincipals: jest.fn().mockResolvedValue(principals),
-        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res } = createReqRes();
 
       await handlers.getEffectiveCapabilities(req, res);
 
-      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledTimes(1);
+      expect(deps.getCapabilitiesForPrincipals).toHaveBeenCalledWith({
+        principals: [{ principalType: PrincipalType.ROLE, principalId: 'editor' }],
+      });
     });
 
     it('deduplicates capabilities across principals', async () => {
@@ -141,7 +140,7 @@ describe('createAdminGrantsHandlers', () => {
           { principalType: PrincipalType.USER, principalId: new Types.ObjectId() },
           { principalType: PrincipalType.ROLE, principalId: 'editor' },
         ]),
-        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([readUsersGrant]),
+        getCapabilitiesForPrincipals: jest.fn().mockResolvedValue([readUsersGrant, readUsersGrant]),
       });
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes();

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -134,6 +134,28 @@ describe('createAdminGrantsHandlers', () => {
       expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledTimes(1);
     });
 
+    it('deduplicates capabilities across principals', async () => {
+      const readUsersGrant = mockGrant({ capability: SystemCapabilities.READ_USERS });
+      const deps = createDeps({
+        getUserPrincipals: jest.fn().mockResolvedValue([
+          { principalType: PrincipalType.USER, principalId: new Types.ObjectId() },
+          { principalType: PrincipalType.ROLE, principalId: 'editor' },
+        ]),
+        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([readUsersGrant]),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes();
+
+      await handlers.getEffectiveCapabilities(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      const response = json.mock.calls[0][0];
+      const readUsersCount = response.capabilities.filter(
+        (c: string) => c === SystemCapabilities.READ_USERS,
+      ).length;
+      expect(readUsersCount).toBe(1);
+    });
+
     it('returns 401 when user is not authenticated', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
@@ -249,6 +271,38 @@ describe('createAdminGrantsHandlers', () => {
       expect(status).toHaveBeenCalledWith(200);
     });
 
+    it('returns 401 when user is not authenticated', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { principalType: PrincipalType.ROLE, principalId: 'editor' },
+      });
+      (req as unknown as Record<string, unknown>).user = undefined;
+
+      await handlers.getPrincipalGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Authentication required' });
+    });
+
+    it('returns 403 when caller lacks READ capability', async () => {
+      const deps = createDeps({
+        hasCapabilityForPrincipals: jest.fn().mockResolvedValue(false),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: { principalType: PrincipalType.ROLE, principalId: 'editor' },
+      });
+
+      await handlers.getPrincipalGrants(req, res);
+
+      expect(status).toHaveBeenCalledWith(403);
+      expect(json).toHaveBeenCalledWith({ error: 'Insufficient permissions' });
+      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
+        expect.objectContaining({ capability: SystemCapabilities.READ_ROLES }),
+      );
+    });
+
     it('returns 500 on unexpected error', async () => {
       const deps = createDeps({
         getCapabilitiesForPrincipal: jest.fn().mockRejectedValue(new Error('db error')),
@@ -272,7 +326,7 @@ describe('createAdminGrantsHandlers', () => {
       capability: SystemCapabilities.READ_USERS,
     };
 
-    it('assigns a grant and returns 200', async () => {
+    it('assigns a grant and returns 201', async () => {
       const grant = mockGrant();
       const deps = createDeps({ grantCapability: jest.fn().mockResolvedValue(grant) });
       const handlers = createAdminGrantsHandlers(deps);
@@ -287,7 +341,7 @@ describe('createAdminGrantsHandlers', () => {
           capability: SystemCapabilities.READ_USERS,
         }),
       );
-      expect(status).toHaveBeenCalledWith(200);
+      expect(status).toHaveBeenCalledWith(201);
       expect(json).toHaveBeenCalledWith({ grant });
     });
 
@@ -373,6 +427,19 @@ describe('createAdminGrantsHandlers', () => {
       expect(json).toHaveBeenCalledWith({ error: 'Invalid principalId format' });
     });
 
+    it('returns 401 when user is not authenticated', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: validBody });
+      (req as unknown as Record<string, unknown>).user = undefined;
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Authentication required' });
+      expect(deps.grantCapability).not.toHaveBeenCalled();
+    });
+
     it('returns 403 when caller lacks manage capability', async () => {
       const deps = createDeps({
         hasCapabilityForPrincipals: jest.fn().mockResolvedValue(false),
@@ -383,7 +450,25 @@ describe('createAdminGrantsHandlers', () => {
       await handlers.assignGrant(req, res);
 
       expect(status).toHaveBeenCalledWith(403);
-      expect(json).toHaveBeenCalledWith({ error: 'Insufficient permissions' });
+      expect(deps.grantCapability).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when caller lacks the capability being granted', async () => {
+      const deps = createDeps({
+        hasCapabilityForPrincipals: jest.fn().mockImplementation(({ capability }) => {
+          if (capability === SystemCapabilities.MANAGE_ROLES) {
+            return Promise.resolve(true);
+          }
+          return Promise.resolve(false);
+        }),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: validBody });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(403);
+      expect(json).toHaveBeenCalledWith({ error: 'Cannot grant a capability you do not possess' });
       expect(deps.grantCapability).not.toHaveBeenCalled();
     });
 
@@ -435,6 +520,19 @@ describe('createAdminGrantsHandlers', () => {
       );
     });
 
+    it('returns 500 when grantCapability returns null', async () => {
+      const deps = createDeps({
+        grantCapability: jest.fn().mockResolvedValue(null),
+      });
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ body: validBody });
+
+      await handlers.assignGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Failed to create grant' });
+    });
+
     it('returns 500 on unexpected error', async () => {
       const deps = createDeps({
         grantCapability: jest.fn().mockRejectedValue(new Error('db error')),
@@ -450,7 +548,7 @@ describe('createAdminGrantsHandlers', () => {
   });
 
   describe('revokeGrant', () => {
-    const validBody = {
+    const validParams = {
       principalType: PrincipalType.ROLE,
       principalId: 'editor',
       capability: SystemCapabilities.READ_USERS,
@@ -459,7 +557,7 @@ describe('createAdminGrantsHandlers', () => {
     it('revokes a grant and returns 200', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({ body: validBody });
+      const { req, res, status, json } = createReqRes({ params: validParams });
 
       await handlers.revokeGrant(req, res);
 
@@ -476,7 +574,11 @@ describe('createAdminGrantsHandlers', () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
-        body: { principalId: 'editor', capability: SystemCapabilities.READ_USERS },
+        params: {
+          principalType: '',
+          principalId: 'editor',
+          capability: SystemCapabilities.READ_USERS,
+        },
       });
 
       await handlers.revokeGrant(req, res);
@@ -485,11 +587,28 @@ describe('createAdminGrantsHandlers', () => {
       expect(json).toHaveBeenCalledWith({ error: 'Invalid principal type' });
     });
 
+    it('returns 400 for missing principalId', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: {
+          principalType: PrincipalType.ROLE,
+          principalId: '',
+          capability: SystemCapabilities.READ_USERS,
+        },
+      });
+
+      await handlers.revokeGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'principalId is required' });
+    });
+
     it('returns 400 for invalid capability', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
-        body: { ...validBody, capability: 'fake' },
+        params: { ...validParams, capability: 'fake' },
       });
 
       await handlers.revokeGrant(req, res);
@@ -498,12 +617,25 @@ describe('createAdminGrantsHandlers', () => {
       expect(json).toHaveBeenCalledWith({ error: 'Invalid capability' });
     });
 
+    it('returns 401 when user is not authenticated', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: validParams });
+      (req as unknown as Record<string, unknown>).user = undefined;
+
+      await handlers.revokeGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Authentication required' });
+      expect(deps.revokeCapability).not.toHaveBeenCalled();
+    });
+
     it('returns 403 when caller lacks manage capability', async () => {
       const deps = createDeps({
         hasCapabilityForPrincipals: jest.fn().mockResolvedValue(false),
       });
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({ body: validBody });
+      const { req, res, status, json } = createReqRes({ params: validParams });
 
       await handlers.revokeGrant(req, res);
 
@@ -516,7 +648,7 @@ describe('createAdminGrantsHandlers', () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
-        body: {
+        params: {
           principalType: PrincipalType.USER,
           principalId: 'bad-id',
           capability: SystemCapabilities.READ_USERS,
@@ -534,7 +666,7 @@ describe('createAdminGrantsHandlers', () => {
         revokeCapability: jest.fn().mockRejectedValue(new Error('db error')),
       });
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({ body: validBody });
+      const { req, res, status, json } = createReqRes({ params: validParams });
 
       await handlers.revokeGrant(req, res);
 

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -9,7 +9,7 @@ import { createAdminGrantsHandlers } from './grants';
 
 jest.mock('@librechat/data-schemas', () => ({
   ...jest.requireActual('@librechat/data-schemas'),
-  logger: { error: jest.fn() },
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
 }));
 
 const validObjectId = new Types.ObjectId().toString();
@@ -530,7 +530,7 @@ describe('createAdminGrantsHandlers', () => {
       await handlers.assignGrant(req, res);
 
       expect(status).toHaveBeenCalledWith(500);
-      expect(json).toHaveBeenCalledWith({ error: 'Failed to create grant' });
+      expect(json).toHaveBeenCalledWith({ error: 'Grant operation returned no result' });
     });
 
     it('returns 500 on unexpected error', async () => {

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -11,6 +11,7 @@ import type { Types } from 'mongoose';
 import type { ResolvedPrincipal } from '~/types/principal';
 import type { ServerRequest } from '~/types/http';
 
+/** Module-level: PrincipalType is from librechat-data-provider (never mocked by external tests). */
 const VALID_PRINCIPAL_TYPES = new Set<string>([
   PrincipalType.ROLE,
   PrincipalType.GROUP,
@@ -88,7 +89,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     if (!user) {
       return null;
     }
-    const userId = user._id?.toString();
+    const userId = user._id?.toString() ?? user.id;
     if (!userId || !user.role) {
       return null;
     }

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -11,8 +11,6 @@ import type { Types } from 'mongoose';
 import type { ResolvedPrincipal } from '~/types/principal';
 import type { ServerRequest } from '~/types/http';
 
-export type { ResolvedPrincipal };
-
 const VALID_PRINCIPAL_TYPES = new Set<string>([
   PrincipalType.ROLE,
   PrincipalType.GROUP,

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -334,6 +334,13 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         return res.status(403).json({ error: 'Cannot grant a capability you do not possess' });
       }
 
+      /*
+       * Role existence is validated when checkRoleExists is provided.
+       * GROUP and USER principals are ObjectId-validated by validatePrincipal
+       * but not existence-checked — orphan grants for deleted principals are
+       * accepted as a trade-off. Cascade cleanup on group/user deletion
+       * (deleteGrantsForPrincipal) handles the removal path.
+       */
       if (principalType === PrincipalType.ROLE && checkRoleExists) {
         const exists = await checkRoleExists(principalId);
         if (!exists) {

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -194,7 +194,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         return res.status(401).json({ error: 'Authentication required' });
       }
 
-      const readCap = READ_CAPABILITY_BY_TYPE[principalType as PrincipalType];
+      const readCap = READ_CAPABILITY_BY_TYPE[principalType as GrantPrincipalType];
       if (!readCap) {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
@@ -223,7 +223,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       }
 
       const { principalType, principalId, capability } = req.body as {
-        principalType: PrincipalType;
+        principalType: GrantPrincipalType;
         principalId: string;
         capability: SystemCapability;
       };
@@ -290,7 +290,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       }
 
       const principals = await getUserPrincipals(caller);
-      const manageCap = MANAGE_CAPABILITY_BY_TYPE[principalType as PrincipalType];
+      const manageCap = MANAGE_CAPABILITY_BY_TYPE[principalType as GrantPrincipalType];
       if (
         !manageCap ||
         !(await hasCapabilityForPrincipals({ principals, capability: manageCap }))

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -96,7 +96,9 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     [PrincipalType.USER]: SystemCapabilities.READ_USERS,
   };
 
-  const VALID_PRINCIPAL_TYPES = new Set<string>(Object.keys(MANAGE_CAPABILITY_BY_TYPE));
+  const VALID_PRINCIPAL_TYPES = new Set(
+    Object.keys(MANAGE_CAPABILITY_BY_TYPE) as GrantPrincipalType[],
+  );
 
   function resolveUser(
     req: ServerRequest,
@@ -131,7 +133,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
   }
 
   function validatePrincipal(principalType: string, principalId: string): string | null {
-    if (!principalType || !VALID_PRINCIPAL_TYPES.has(principalType)) {
+    if (!principalType || !VALID_PRINCIPAL_TYPES.has(principalType as GrantPrincipalType)) {
       return 'Invalid principal type';
     }
     if (!principalId) {
@@ -182,6 +184,9 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         .map(([type]) => type) as PrincipalType[];
 
       const { limit, offset } = parsePagination(req.query as { limit?: string; offset?: string });
+      if (!allowedTypes.length) {
+        return res.status(200).json({ grants: [], total: 0, limit, offset });
+      }
       const [grants, total] = await Promise.all([
         listGrants({ tenantId, principalTypes: allowedTypes, limit, offset }),
         countGrants({ tenantId, principalTypes: allowedTypes }),
@@ -226,6 +231,11 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
 
   async function getPrincipalGrantsHandler(req: ServerRequest, res: Response) {
     try {
+      const user = resolveUser(req);
+      if (!user) {
+        return res.status(401).json({ error: 'Authentication required' });
+      }
+
       const { principalType, principalId } = req.params as {
         principalType: string;
         principalId: string;
@@ -234,11 +244,6 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       const principalError = validatePrincipal(principalType, principalId);
       if (principalError) {
         return res.status(400).json({ error: principalError });
-      }
-
-      const user = resolveUser(req);
-      if (!user) {
-        return res.status(401).json({ error: 'Authentication required' });
       }
 
       const { tenantId } = user;
@@ -270,6 +275,11 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
 
   async function assignGrantHandler(req: ServerRequest, res: Response) {
     try {
+      const caller = resolveUser(req);
+      if (!caller) {
+        return res.status(401).json({ error: 'Authentication required' });
+      }
+
       const bodyError = validateGrantBody(req.body as GrantRequestBody);
       if (bodyError) {
         return res.status(400).json({ error: bodyError });
@@ -280,11 +290,6 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         principalId: string;
         capability: SystemCapability;
       };
-
-      const caller = resolveUser(req);
-      if (!caller) {
-        return res.status(401).json({ error: 'Authentication required' });
-      }
 
       const { tenantId } = caller;
       const principals = await resolvePrincipals(caller);
@@ -322,11 +327,16 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
    */
   async function revokeGrantHandler(req: ServerRequest, res: Response) {
     try {
-      const { principalType, principalId } = req.params as {
+      const caller = resolveUser(req);
+      if (!caller) {
+        return res.status(401).json({ error: 'Authentication required' });
+      }
+
+      const { principalType, principalId, capability } = req.params as {
         principalType: string;
         principalId: string;
+        capability?: string;
       };
-      const capability = (req.query as { capability?: string }).capability;
 
       const principalError = validatePrincipal(principalType, principalId);
       if (principalError) {
@@ -334,11 +344,6 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       }
       if (!capability || !isValidCapability(capability)) {
         return res.status(400).json({ error: 'Invalid capability' });
-      }
-
-      const caller = resolveUser(req);
-      if (!caller) {
-        return res.status(401).json({ error: 'Authentication required' });
       }
 
       const { tenantId } = caller;

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -36,7 +36,7 @@ export interface AdminGrantsDeps {
     tenantId?: string;
   }) => Promise<ISystemGrant[]>;
   getCapabilitiesForPrincipals: (params: {
-    principals: Array<{ principalType: string; principalId: string | Types.ObjectId }>;
+    principals: Array<{ principalType: PrincipalType; principalId: string | Types.ObjectId }>;
     tenantId?: string;
   }) => Promise<ISystemGrant[]>;
   grantCapability: (params: {
@@ -71,7 +71,10 @@ export interface AdminGrantsDeps {
     role: string;
     tenantId?: string;
   }) => ResolvedPrincipal[] | undefined;
+  checkRoleExists?: (roleId: string) => Promise<boolean>;
 }
+
+export type GrantPrincipalType = PrincipalType.ROLE | PrincipalType.GROUP | PrincipalType.USER;
 
 /** Creates admin grant handlers with dependency injection for the /api/admin/grants routes. */
 export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
@@ -86,9 +89,8 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     hasCapabilityForPrincipals,
     getHeldCapabilities,
     getCachedPrincipals,
+    checkRoleExists,
   } = deps;
-
-  type GrantPrincipalType = PrincipalType.ROLE | PrincipalType.GROUP | PrincipalType.USER;
 
   const MANAGE_CAPABILITY_BY_TYPE: Record<GrantPrincipalType, SystemCapability> = {
     [PrincipalType.ROLE]: SystemCapabilities.MANAGE_ROLES,
@@ -143,7 +145,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       return 'Invalid principal type';
     }
     if (!principalId) {
-      return 'principalId is required';
+      return 'Principal ID is required';
     }
     if (principalType !== PrincipalType.ROLE && !isValidObjectIdString(principalId)) {
       return 'Invalid principalId format';
@@ -157,10 +159,10 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       return 'Invalid principal type';
     }
     if (principalId == null) {
-      return 'principalId is required';
+      return 'Principal ID is required';
     }
     if (typeof principalId !== 'string') {
-      return 'principalId must be a string';
+      return 'Principal ID must be a string';
     }
     const principalError = validatePrincipal(principalType, principalId);
     if (principalError) {
@@ -179,6 +181,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         return res.status(401).json({ error: 'Authentication required' });
       }
 
+      const { limit, offset } = parsePagination(req.query as { limit?: string; offset?: string });
       const { tenantId } = user;
       const principals = await resolvePrincipals(user);
       const entries = Object.entries(READ_CAPABILITY_BY_TYPE) as [
@@ -195,7 +198,6 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         .filter(([, cap]) => heldCaps.has(cap))
         .map(([type]) => type) as PrincipalType[];
 
-      const { limit, offset } = parsePagination(req.query as { limit?: string; offset?: string });
       if (!allowedTypes.length) {
         return res.status(200).json({ grants: [], total: 0, limit, offset });
       }
@@ -304,18 +306,26 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         capability: SystemCapability;
       };
 
+      if (principalType === PrincipalType.ROLE && checkRoleExists) {
+        const exists = await checkRoleExists(principalId);
+        if (!exists) {
+          return res.status(400).json({ error: 'Role not found' });
+        }
+      }
+
       const { tenantId } = caller;
       const principals = await resolvePrincipals(caller);
 
       const manageCap = MANAGE_CAPABILITY_BY_TYPE[principalType];
-      const [hasManage, hasCap] = await Promise.all([
-        hasCapabilityForPrincipals({ principals, capability: manageCap, tenantId }),
-        hasCapabilityForPrincipals({ principals, capability, tenantId }),
-      ]);
-      if (!hasManage) {
+      const held = await getHeldCapabilities({
+        principals,
+        capabilities: [manageCap, capability],
+        tenantId,
+      });
+      if (!held.has(manageCap)) {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
-      if (!hasCap) {
+      if (!held.has(capability)) {
         return res.status(403).json({ error: 'Cannot grant a capability you do not possess' });
       }
 

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -55,6 +55,7 @@ export interface AdminGrantsDeps {
   getUserPrincipals: (params: {
     userId: string;
     role?: string | null;
+    tenantId?: string;
   }) => Promise<ResolvedPrincipal[]>;
   hasCapabilityForPrincipals: (params: {
     principals: ResolvedPrincipal[];
@@ -137,7 +138,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         return cached;
       }
     }
-    return getUserPrincipals({ userId: user.userId, role: user.role });
+    return getUserPrincipals({ userId: user.userId, role: user.role, tenantId: user.tenantId });
   }
 
   function validatePrincipal(principalType: string, principalId: string): string | null {

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -8,7 +8,10 @@ import {
 import type { ISystemGrant, SystemCapability } from '@librechat/data-schemas';
 import type { Response } from 'express';
 import type { Types } from 'mongoose';
+import type { ResolvedPrincipal } from '~/types/principal';
 import type { ServerRequest } from '~/types/http';
+
+export type { ResolvedPrincipal };
 
 const VALID_PRINCIPAL_TYPES = new Set<string>([
   PrincipalType.ROLE,
@@ -29,11 +32,6 @@ const READ_CAPABILITY_BY_TYPE: Partial<Record<PrincipalType, SystemCapability>> 
   [PrincipalType.GROUP]: SystemCapabilities.READ_GROUPS,
   [PrincipalType.USER]: SystemCapabilities.READ_USERS,
 };
-
-export interface ResolvedPrincipal {
-  principalType: string;
-  principalId?: string | Types.ObjectId;
-}
 
 interface GrantRequestBody {
   principalType?: unknown;

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -61,6 +61,11 @@ export interface AdminGrantsDeps {
     capability: SystemCapability;
     tenantId?: string;
   }) => Promise<boolean>;
+  getHeldCapabilities: (params: {
+    principals: ResolvedPrincipal[];
+    capabilities: SystemCapability[];
+    tenantId?: string;
+  }) => Promise<Set<SystemCapability>>;
   getCachedPrincipals?: (user: {
     id: string;
     role: string;
@@ -79,6 +84,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     revokeCapability,
     getUserPrincipals,
     hasCapabilityForPrincipals,
+    getHeldCapabilities,
     getCachedPrincipals,
   } = deps;
 
@@ -129,7 +135,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         return cached;
       }
     }
-    return getUserPrincipals(user);
+    return getUserPrincipals({ userId: user.userId, role: user.role });
   }
 
   function validatePrincipal(principalType: string, principalId: string): string | null {
@@ -150,8 +156,11 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     if (typeof principalType !== 'string') {
       return 'Invalid principal type';
     }
-    if (typeof principalId !== 'string') {
+    if (principalId == null) {
       return 'principalId is required';
+    }
+    if (typeof principalId !== 'string') {
+      return 'principalId must be a string';
     }
     const principalError = validatePrincipal(principalType, principalId);
     if (principalError) {
@@ -172,15 +181,18 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
 
       const { tenantId } = user;
       const principals = await resolvePrincipals(user);
-      const entries = Object.entries(READ_CAPABILITY_BY_TYPE) as [string, SystemCapability][];
+      const entries = Object.entries(READ_CAPABILITY_BY_TYPE) as [
+        GrantPrincipalType,
+        SystemCapability,
+      ][];
 
-      const checks = await Promise.all(
-        entries.map(([, cap]) =>
-          hasCapabilityForPrincipals({ principals, capability: cap, tenantId }),
-        ),
-      );
+      const heldCaps = await getHeldCapabilities({
+        principals,
+        capabilities: entries.map(([, cap]) => cap),
+        tenantId,
+      });
       const allowedTypes = entries
-        .filter((_, i) => checks[i])
+        .filter(([, cap]) => heldCaps.has(cap))
         .map(([type]) => type) as PrincipalType[];
 
       const { limit, offset } = parsePagination(req.query as { limit?: string; offset?: string });
@@ -211,6 +223,10 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         (p): p is ResolvedPrincipal & { principalId: string | Types.ObjectId } =>
           p.principalId != null,
       );
+
+      if (!filteredPrincipals.length) {
+        return res.status(200).json({ capabilities: [] });
+      }
 
       const grants = await getCapabilitiesForPrincipals({
         principals: filteredPrincipals,
@@ -248,9 +264,6 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
 
       const { tenantId } = user;
       const readCap = READ_CAPABILITY_BY_TYPE[principalType as GrantPrincipalType];
-      if (!readCap) {
-        return res.status(403).json({ error: 'Insufficient permissions' });
-      }
       const principals = await resolvePrincipals(user);
       const allowed = await hasCapabilityForPrincipals({
         principals,
@@ -295,11 +308,14 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       const principals = await resolvePrincipals(caller);
 
       const manageCap = MANAGE_CAPABILITY_BY_TYPE[principalType];
-      if (!(await hasCapabilityForPrincipals({ principals, capability: manageCap, tenantId }))) {
+      const [hasManage, hasCap] = await Promise.all([
+        hasCapabilityForPrincipals({ principals, capability: manageCap, tenantId }),
+        hasCapabilityForPrincipals({ principals, capability, tenantId }),
+      ]);
+      if (!hasManage) {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
-
-      if (!(await hasCapabilityForPrincipals({ principals, capability, tenantId }))) {
+      if (!hasCap) {
         return res.status(403).json({ error: 'Cannot grant a capability you do not possess' });
       }
 

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -18,6 +18,7 @@ interface GrantRequestBody {
 }
 
 export interface AdminGrantsDeps {
+  listAllGrants: (tenantId?: string) => Promise<ISystemGrant[]>;
   getCapabilitiesForPrincipal: (params: {
     principalType: PrincipalType;
     principalId: string | Types.ObjectId;
@@ -55,6 +56,7 @@ export interface AdminGrantsDeps {
  */
 export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
   const {
+    listAllGrants,
     getCapabilitiesForPrincipal,
     getCapabilitiesForPrincipals,
     grantCapability,
@@ -122,6 +124,30 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       return 'Invalid capability';
     }
     return null;
+  }
+
+  async function listAllGrantsHandler(req: ServerRequest, res: Response) {
+    try {
+      const user = resolveUser(req);
+      if (!user) {
+        return res.status(401).json({ error: 'Authentication required' });
+      }
+
+      const principals = await getUserPrincipals(user);
+      const allowedTypes = new Set<string>();
+      for (const [type, cap] of Object.entries(READ_CAPABILITY_BY_TYPE)) {
+        if (await hasCapabilityForPrincipals({ principals, capability: cap })) {
+          allowedTypes.add(type);
+        }
+      }
+
+      const allGrants = await listAllGrants();
+      const grants = allGrants.filter((g) => allowedTypes.has(g.principalType));
+      return res.status(200).json({ grants });
+    } catch (error) {
+      logger.error('[adminGrants] listAllGrants error:', error);
+      return res.status(500).json({ error: 'Failed to list grants' });
+    }
   }
 
   async function getEffectiveCapabilitiesHandler(req: ServerRequest, res: Response) {
@@ -285,6 +311,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
   }
 
   return {
+    listAllGrants: listAllGrantsHandler,
     getEffectiveCapabilities: getEffectiveCapabilitiesHandler,
     getPrincipalGrants: getPrincipalGrantsHandler,
     assignGrant: assignGrantHandler,

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -54,7 +54,11 @@ export interface AdminGrantsDeps {
   }) => Promise<boolean>;
 }
 
-/** Creates admin grant handlers with dependency injection for the /api/admin/grants routes. */
+/**
+ * Creates admin grant handlers with dependency injection for the /api/admin/grants routes.
+ * All operations are currently platform-scoped (no tenantId threading).
+ * Multi-tenant grant management will require threading req.user.tenantId through dep calls.
+ */
 export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
   const {
     getCapabilitiesForPrincipal,

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -14,9 +14,9 @@ import type { ServerRequest } from '~/types/http';
 import { parsePagination } from './pagination';
 
 interface GrantRequestBody {
-  principalType?: unknown;
-  principalId?: unknown;
-  capability?: unknown;
+  principalType?: string;
+  principalId?: string | null;
+  capability?: string;
 }
 
 export interface AdminGrantsDeps {

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -35,6 +35,12 @@ export interface ResolvedPrincipal {
   principalId?: string | Types.ObjectId;
 }
 
+interface GrantRequestBody {
+  principalType?: unknown;
+  principalId?: unknown;
+  capability?: unknown;
+}
+
 export interface AdminGrantsDeps {
   getCapabilitiesForPrincipal: (params: {
     principalType: PrincipalType;
@@ -77,7 +83,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     if (!user) {
       return null;
     }
-    const userId = (user.id ?? user._id)?.toString();
+    const userId = user._id?.toString();
     if (!userId || !user.role) {
       return null;
     }
@@ -97,7 +103,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     return null;
   }
 
-  function validateGrantBody(body: Record<string, unknown>): string | null {
+  function validateGrantBody(body: GrantRequestBody): string | null {
     const { principalType, principalId, capability } = body;
     if (typeof principalType !== 'string') {
       return 'Invalid principal type';
@@ -174,12 +180,13 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       }
 
       const readCap = READ_CAPABILITY_BY_TYPE[principalType as PrincipalType];
-      if (readCap) {
-        const principals = await getUserPrincipals(user);
-        const allowed = await hasCapabilityForPrincipals({ principals, capability: readCap });
-        if (!allowed) {
-          return res.status(403).json({ error: 'Insufficient permissions' });
-        }
+      if (!readCap) {
+        return res.status(403).json({ error: 'Insufficient permissions' });
+      }
+      const principals = await getUserPrincipals(user);
+      const allowed = await hasCapabilityForPrincipals({ principals, capability: readCap });
+      if (!allowed) {
+        return res.status(403).json({ error: 'Insufficient permissions' });
       }
 
       const grants = await getCapabilitiesForPrincipal({
@@ -195,7 +202,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
 
   async function assignGrantHandler(req: ServerRequest, res: Response) {
     try {
-      const bodyError = validateGrantBody(req.body as Record<string, unknown>);
+      const bodyError = validateGrantBody(req.body as GrantRequestBody);
       if (bodyError) {
         return res.status(400).json({ error: bodyError });
       }
@@ -232,7 +239,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         grantedBy: caller.userId,
       });
       if (!grant) {
-        return res.status(500).json({ error: 'Failed to create grant' });
+        return res.status(500).json({ error: 'Grant operation returned no result' });
       }
       return res.status(201).json({ grant });
     } catch (error) {
@@ -241,6 +248,11 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     }
   }
 
+  /**
+   * Revocation requires MANAGE on the target principal type but does NOT
+   * require the caller to possess the capability being revoked. This avoids
+   * a bootstrap deadlock where no one can clean up grants they don't hold.
+   */
   async function revokeGrantHandler(req: ServerRequest, res: Response) {
     try {
       const { principalType, principalId, capability } = req.params as {

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -17,20 +17,6 @@ const VALID_PRINCIPAL_TYPES = new Set<string>([
   PrincipalType.USER,
 ]);
 
-const VALID_CAPABILITIES = new Set<string>(Object.values(SystemCapabilities));
-
-const MANAGE_CAPABILITY_BY_TYPE: Partial<Record<PrincipalType, SystemCapability>> = {
-  [PrincipalType.ROLE]: SystemCapabilities.MANAGE_ROLES,
-  [PrincipalType.GROUP]: SystemCapabilities.MANAGE_GROUPS,
-  [PrincipalType.USER]: SystemCapabilities.MANAGE_USERS,
-};
-
-const READ_CAPABILITY_BY_TYPE: Partial<Record<PrincipalType, SystemCapability>> = {
-  [PrincipalType.ROLE]: SystemCapabilities.READ_ROLES,
-  [PrincipalType.GROUP]: SystemCapabilities.READ_GROUPS,
-  [PrincipalType.USER]: SystemCapabilities.READ_USERS,
-};
-
 interface GrantRequestBody {
   principalType?: unknown;
   principalId?: unknown;
@@ -78,6 +64,20 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     getUserPrincipals,
     hasCapabilityForPrincipals,
   } = deps;
+
+  const VALID_CAPABILITIES = new Set<string>(Object.values(SystemCapabilities));
+
+  const MANAGE_CAPABILITY_BY_TYPE: Partial<Record<PrincipalType, SystemCapability>> = {
+    [PrincipalType.ROLE]: SystemCapabilities.MANAGE_ROLES,
+    [PrincipalType.GROUP]: SystemCapabilities.MANAGE_GROUPS,
+    [PrincipalType.USER]: SystemCapabilities.MANAGE_USERS,
+  };
+
+  const READ_CAPABILITY_BY_TYPE: Partial<Record<PrincipalType, SystemCapability>> = {
+    [PrincipalType.ROLE]: SystemCapabilities.READ_ROLES,
+    [PrincipalType.GROUP]: SystemCapabilities.READ_GROUPS,
+    [PrincipalType.USER]: SystemCapabilities.READ_USERS,
+  };
 
   function resolveUser(req: ServerRequest): { userId: string; role: string } | null {
     const user = req.user;

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -306,13 +306,6 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         capability: SystemCapability;
       };
 
-      if (principalType === PrincipalType.ROLE && checkRoleExists) {
-        const exists = await checkRoleExists(principalId);
-        if (!exists) {
-          return res.status(400).json({ error: 'Role not found' });
-        }
-      }
-
       const { tenantId } = caller;
       const principals = await resolvePrincipals(caller);
 
@@ -327,6 +320,13 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       }
       if (!held.has(capability)) {
         return res.status(403).json({ error: 'Cannot grant a capability you do not possess' });
+      }
+
+      if (principalType === PrincipalType.ROLE && checkRoleExists) {
+        const exists = await checkRoleExists(principalId);
+        if (!exists) {
+          return res.status(400).json({ error: 'Role not found' });
+        }
       }
 
       const grant = await grantCapability({

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -1,0 +1,242 @@
+import { PrincipalType } from 'librechat-data-provider';
+import {
+  logger,
+  isValidObjectIdString,
+  SystemCapabilities,
+  expandImplications,
+} from '@librechat/data-schemas';
+import type { ISystemGrant, SystemCapability } from '@librechat/data-schemas';
+import type { Response } from 'express';
+import type { Types } from 'mongoose';
+import type { ServerRequest } from '~/types/http';
+
+const VALID_PRINCIPAL_TYPES = new Set<string>([
+  PrincipalType.ROLE,
+  PrincipalType.GROUP,
+  PrincipalType.USER,
+]);
+
+const VALID_CAPABILITIES = new Set<string>(Object.values(SystemCapabilities));
+
+const MANAGE_CAPABILITY_BY_TYPE: Partial<Record<PrincipalType, SystemCapability>> = {
+  [PrincipalType.ROLE]: SystemCapabilities.MANAGE_ROLES,
+  [PrincipalType.GROUP]: SystemCapabilities.MANAGE_GROUPS,
+  [PrincipalType.USER]: SystemCapabilities.MANAGE_USERS,
+};
+
+interface ResolvedPrincipal {
+  principalType: PrincipalType;
+  principalId?: string | Types.ObjectId;
+}
+
+export interface AdminGrantsDeps {
+  getCapabilitiesForPrincipal: (params: {
+    principalType: PrincipalType;
+    principalId: string | Types.ObjectId;
+    tenantId?: string;
+  }) => Promise<ISystemGrant[]>;
+  grantCapability: (params: {
+    principalType: PrincipalType;
+    principalId: string | Types.ObjectId;
+    capability: SystemCapability;
+    tenantId?: string;
+    grantedBy?: string | Types.ObjectId;
+  }) => Promise<ISystemGrant | null>;
+  revokeCapability: (params: {
+    principalType: PrincipalType;
+    principalId: string | Types.ObjectId;
+    capability: SystemCapability;
+    tenantId?: string;
+  }) => Promise<void>;
+  getUserPrincipals: (params: { userId: string; role: string }) => Promise<ResolvedPrincipal[]>;
+  hasCapabilityForPrincipals: (params: {
+    principals: ResolvedPrincipal[];
+    capability: SystemCapability;
+    tenantId?: string;
+  }) => Promise<boolean>;
+}
+
+export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
+  const {
+    getCapabilitiesForPrincipal,
+    grantCapability,
+    revokeCapability,
+    getUserPrincipals,
+    hasCapabilityForPrincipals,
+  } = deps;
+
+  function resolveUser(req: ServerRequest): { userId: string; role: string } | null {
+    const user = req.user;
+    if (!user) {
+      return null;
+    }
+    const userId = user._id?.toString();
+    if (!userId || !user.role) {
+      return null;
+    }
+    return { userId, role: user.role };
+  }
+
+  function validateGrantBody(body: Record<string, unknown>): string | null {
+    const { principalType, principalId, capability } = body;
+    if (
+      !principalType ||
+      typeof principalType !== 'string' ||
+      !VALID_PRINCIPAL_TYPES.has(principalType)
+    ) {
+      return 'Invalid principal type';
+    }
+    if (!principalId || typeof principalId !== 'string') {
+      return 'principalId is required';
+    }
+    if (principalType !== PrincipalType.ROLE && !isValidObjectIdString(principalId)) {
+      return 'Invalid principalId format';
+    }
+    if (!capability || typeof capability !== 'string' || !VALID_CAPABILITIES.has(capability)) {
+      return 'Invalid capability';
+    }
+    return null;
+  }
+
+  async function callerHasManageCapability(
+    req: ServerRequest,
+    principalType: PrincipalType,
+  ): Promise<boolean> {
+    const user = resolveUser(req);
+    if (!user) {
+      return false;
+    }
+    const capability = MANAGE_CAPABILITY_BY_TYPE[principalType];
+    if (!capability) {
+      return false;
+    }
+    const principals = await getUserPrincipals(user);
+    return hasCapabilityForPrincipals({ principals, capability });
+  }
+
+  async function getEffectiveCapabilitiesHandler(req: ServerRequest, res: Response) {
+    try {
+      const user = resolveUser(req);
+      if (!user) {
+        return res.status(401).json({ error: 'Authentication required' });
+      }
+
+      const principals = await getUserPrincipals(user);
+      const grantArrays = await Promise.all(
+        principals
+          .filter(
+            (p): p is ResolvedPrincipal & { principalId: string | Types.ObjectId } =>
+              p.principalId != null,
+          )
+          .map((p) =>
+            getCapabilitiesForPrincipal({
+              principalType: p.principalType,
+              principalId: p.principalId,
+            }),
+          ),
+      );
+
+      const directCaps = new Set<string>();
+      for (const grants of grantArrays) {
+        for (const grant of grants) {
+          directCaps.add(grant.capability);
+        }
+      }
+
+      return res.status(200).json({ capabilities: expandImplications(Array.from(directCaps)) });
+    } catch (error) {
+      logger.error('[adminGrants] getEffectiveCapabilities error:', error);
+      return res.status(500).json({ error: 'Failed to get effective capabilities' });
+    }
+  }
+
+  async function getPrincipalGrantsHandler(req: ServerRequest, res: Response) {
+    try {
+      const { principalType, principalId } = req.params as {
+        principalType: string;
+        principalId: string;
+      };
+
+      if (!VALID_PRINCIPAL_TYPES.has(principalType)) {
+        return res.status(400).json({ error: 'Invalid principal type' });
+      }
+      if (!principalId) {
+        return res.status(400).json({ error: 'principalId is required' });
+      }
+      if (principalType !== PrincipalType.ROLE && !isValidObjectIdString(principalId)) {
+        return res.status(400).json({ error: 'Invalid principalId format' });
+      }
+
+      const grants = await getCapabilitiesForPrincipal({
+        principalType: principalType as PrincipalType,
+        principalId,
+      });
+      return res.status(200).json({ grants });
+    } catch (error) {
+      logger.error('[adminGrants] getPrincipalGrants error:', error);
+      return res.status(500).json({ error: 'Failed to get grants' });
+    }
+  }
+
+  async function assignGrantHandler(req: ServerRequest, res: Response) {
+    try {
+      const bodyError = validateGrantBody(req.body as Record<string, unknown>);
+      if (bodyError) {
+        return res.status(400).json({ error: bodyError });
+      }
+
+      const { principalType, principalId, capability } = req.body as {
+        principalType: PrincipalType;
+        principalId: string;
+        capability: SystemCapability;
+      };
+
+      if (!(await callerHasManageCapability(req, principalType))) {
+        return res.status(403).json({ error: 'Insufficient permissions' });
+      }
+
+      const grant = await grantCapability({
+        principalType,
+        principalId,
+        capability,
+        grantedBy: resolveUser(req)?.userId,
+      });
+      return res.status(200).json({ grant });
+    } catch (error) {
+      logger.error('[adminGrants] assignGrant error:', error);
+      return res.status(500).json({ error: 'Failed to assign grant' });
+    }
+  }
+
+  async function revokeGrantHandler(req: ServerRequest, res: Response) {
+    try {
+      const bodyError = validateGrantBody(req.body as Record<string, unknown>);
+      if (bodyError) {
+        return res.status(400).json({ error: bodyError });
+      }
+
+      const { principalType, principalId, capability } = req.body as {
+        principalType: PrincipalType;
+        principalId: string;
+        capability: SystemCapability;
+      };
+
+      if (!(await callerHasManageCapability(req, principalType))) {
+        return res.status(403).json({ error: 'Insufficient permissions' });
+      }
+
+      await revokeCapability({ principalType, principalId, capability });
+      return res.status(200).json({ success: true });
+    } catch (error) {
+      logger.error('[adminGrants] revokeGrant error:', error);
+      return res.status(500).json({ error: 'Failed to revoke grant' });
+    }
+  }
+
+  return {
+    getEffectiveCapabilities: getEffectiveCapabilitiesHandler,
+    getPrincipalGrants: getPrincipalGrantsHandler,
+    assignGrant: assignGrantHandler,
+    revokeGrant: revokeGrantHandler,
+  };
+}

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -212,6 +212,18 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     }
   }
 
+  /**
+   * Returns the caller's effective capabilities: direct grants plus base-level
+   * implications (e.g. manage:roles → read:roles).
+   *
+   * Note: this endpoint does NOT expand parent capabilities into their
+   * section-level children (e.g. manage:configs does NOT expand into
+   * manage:configs:endpoints, manage:configs:models, etc.). Section-level
+   * capabilities are resolved dynamically by the authorization layer
+   * (hasCapabilityForPrincipals / getHeldCapabilities) at check time via
+   * getParentCapabilities. The admin UI should treat a base capability like
+   * manage:configs as implying authority over all its sections.
+   */
   async function getEffectiveCapabilitiesHandler(req: ServerRequest, res: Response) {
     try {
       const user = resolveUser(req);

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -1,6 +1,7 @@
 import { PrincipalType } from 'librechat-data-provider';
 import {
   logger,
+  isValidCapability,
   isValidObjectIdString,
   SystemCapabilities,
   expandImplications,
@@ -10,6 +11,7 @@ import type { Response } from 'express';
 import type { Types } from 'mongoose';
 import type { ResolvedPrincipal } from '~/types/principal';
 import type { ServerRequest } from '~/types/http';
+import { parsePagination } from './pagination';
 
 interface GrantRequestBody {
   principalType?: unknown;
@@ -18,7 +20,16 @@ interface GrantRequestBody {
 }
 
 export interface AdminGrantsDeps {
-  listAllGrants: (tenantId?: string) => Promise<ISystemGrant[]>;
+  listGrants: (options?: {
+    tenantId?: string;
+    principalTypes?: PrincipalType[];
+    limit?: number;
+    offset?: number;
+  }) => Promise<ISystemGrant[]>;
+  countGrants: (options?: {
+    tenantId?: string;
+    principalTypes?: PrincipalType[];
+  }) => Promise<number>;
   getCapabilitiesForPrincipal: (params: {
     principalType: PrincipalType;
     principalId: string | Types.ObjectId;
@@ -41,31 +52,35 @@ export interface AdminGrantsDeps {
     capability: SystemCapability;
     tenantId?: string;
   }) => Promise<void>;
-  getUserPrincipals: (params: { userId: string; role?: string | null }) => Promise<ResolvedPrincipal[]>;
+  getUserPrincipals: (params: {
+    userId: string;
+    role?: string | null;
+  }) => Promise<ResolvedPrincipal[]>;
   hasCapabilityForPrincipals: (params: {
     principals: ResolvedPrincipal[];
     capability: SystemCapability;
     tenantId?: string;
   }) => Promise<boolean>;
+  getCachedPrincipals?: (user: {
+    id: string;
+    role: string;
+    tenantId?: string;
+  }) => ResolvedPrincipal[] | undefined;
 }
 
-/**
- * Creates admin grant handlers with dependency injection for the /api/admin/grants routes.
- * All operations are currently platform-scoped (no tenantId threading).
- * Multi-tenant grant management will require threading req.user.tenantId through dep calls.
- */
+/** Creates admin grant handlers with dependency injection for the /api/admin/grants routes. */
 export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
   const {
-    listAllGrants,
+    listGrants,
+    countGrants,
     getCapabilitiesForPrincipal,
     getCapabilitiesForPrincipals,
     grantCapability,
     revokeCapability,
     getUserPrincipals,
     hasCapabilityForPrincipals,
+    getCachedPrincipals,
   } = deps;
-
-  const VALID_CAPABILITIES = new Set<string>(Object.values(SystemCapabilities));
 
   type GrantPrincipalType = PrincipalType.ROLE | PrincipalType.GROUP | PrincipalType.USER;
 
@@ -83,7 +98,9 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
 
   const VALID_PRINCIPAL_TYPES = new Set<string>(Object.keys(MANAGE_CAPABILITY_BY_TYPE));
 
-  function resolveUser(req: ServerRequest): { userId: string; role: string } | null {
+  function resolveUser(
+    req: ServerRequest,
+  ): { userId: string; role: string; tenantId?: string } | null {
     const user = req.user;
     if (!user) {
       return null;
@@ -92,7 +109,25 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     if (!userId || !user.role) {
       return null;
     }
-    return { userId, role: user.role };
+    return { userId, role: user.role, tenantId: user.tenantId };
+  }
+
+  async function resolvePrincipals(user: {
+    userId: string;
+    role: string;
+    tenantId?: string;
+  }): Promise<ResolvedPrincipal[]> {
+    if (getCachedPrincipals) {
+      const cached = getCachedPrincipals({
+        id: user.userId,
+        role: user.role,
+        tenantId: user.tenantId,
+      });
+      if (cached) {
+        return cached;
+      }
+    }
+    return getUserPrincipals(user);
   }
 
   function validatePrincipal(principalType: string, principalId: string): string | null {
@@ -120,32 +155,40 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     if (principalError) {
       return principalError;
     }
-    if (!capability || typeof capability !== 'string' || !VALID_CAPABILITIES.has(capability)) {
+    if (!capability || typeof capability !== 'string' || !isValidCapability(capability)) {
       return 'Invalid capability';
     }
     return null;
   }
 
-  async function listAllGrantsHandler(req: ServerRequest, res: Response) {
+  async function listGrantsHandler(req: ServerRequest, res: Response) {
     try {
       const user = resolveUser(req);
       if (!user) {
         return res.status(401).json({ error: 'Authentication required' });
       }
 
-      const principals = await getUserPrincipals(user);
-      const allowedTypes = new Set<string>();
-      for (const [type, cap] of Object.entries(READ_CAPABILITY_BY_TYPE)) {
-        if (await hasCapabilityForPrincipals({ principals, capability: cap })) {
-          allowedTypes.add(type);
-        }
-      }
+      const { tenantId } = user;
+      const principals = await resolvePrincipals(user);
+      const entries = Object.entries(READ_CAPABILITY_BY_TYPE) as [string, SystemCapability][];
 
-      const allGrants = await listAllGrants();
-      const grants = allGrants.filter((g) => allowedTypes.has(g.principalType));
-      return res.status(200).json({ grants });
+      const checks = await Promise.all(
+        entries.map(([, cap]) =>
+          hasCapabilityForPrincipals({ principals, capability: cap, tenantId }),
+        ),
+      );
+      const allowedTypes = entries
+        .filter((_, i) => checks[i])
+        .map(([type]) => type) as PrincipalType[];
+
+      const { limit, offset } = parsePagination(req.query as { limit?: string; offset?: string });
+      const [grants, total] = await Promise.all([
+        listGrants({ tenantId, principalTypes: allowedTypes, limit, offset }),
+        countGrants({ tenantId, principalTypes: allowedTypes }),
+      ]);
+      return res.status(200).json({ grants, total, limit, offset });
     } catch (error) {
-      logger.error('[adminGrants] listAllGrants error:', error);
+      logger.error('[adminGrants] listGrants error:', error);
       return res.status(500).json({ error: 'Failed to list grants' });
     }
   }
@@ -157,13 +200,17 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         return res.status(401).json({ error: 'Authentication required' });
       }
 
-      const principals = await getUserPrincipals(user);
+      const { tenantId } = user;
+      const principals = await resolvePrincipals(user);
       const filteredPrincipals = principals.filter(
         (p): p is ResolvedPrincipal & { principalId: string | Types.ObjectId } =>
           p.principalId != null,
       );
 
-      const grants = await getCapabilitiesForPrincipals({ principals: filteredPrincipals });
+      const grants = await getCapabilitiesForPrincipals({
+        principals: filteredPrincipals,
+        tenantId,
+      });
 
       const directCaps = new Set<string>();
       for (const grant of grants) {
@@ -194,12 +241,17 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         return res.status(401).json({ error: 'Authentication required' });
       }
 
+      const { tenantId } = user;
       const readCap = READ_CAPABILITY_BY_TYPE[principalType as GrantPrincipalType];
       if (!readCap) {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
-      const principals = await getUserPrincipals(user);
-      const allowed = await hasCapabilityForPrincipals({ principals, capability: readCap });
+      const principals = await resolvePrincipals(user);
+      const allowed = await hasCapabilityForPrincipals({
+        principals,
+        capability: readCap,
+        tenantId,
+      });
       if (!allowed) {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
@@ -207,6 +259,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       const grants = await getCapabilitiesForPrincipal({
         principalType: principalType as PrincipalType,
         principalId,
+        tenantId,
       });
       return res.status(200).json({ grants });
     } catch (error) {
@@ -233,17 +286,15 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         return res.status(401).json({ error: 'Authentication required' });
       }
 
-      const principals = await getUserPrincipals(caller);
+      const { tenantId } = caller;
+      const principals = await resolvePrincipals(caller);
 
       const manageCap = MANAGE_CAPABILITY_BY_TYPE[principalType];
-      if (
-        !manageCap ||
-        !(await hasCapabilityForPrincipals({ principals, capability: manageCap }))
-      ) {
+      if (!(await hasCapabilityForPrincipals({ principals, capability: manageCap, tenantId }))) {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
 
-      if (!(await hasCapabilityForPrincipals({ principals, capability }))) {
+      if (!(await hasCapabilityForPrincipals({ principals, capability, tenantId }))) {
         return res.status(403).json({ error: 'Cannot grant a capability you do not possess' });
       }
 
@@ -251,6 +302,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         principalType,
         principalId,
         capability,
+        tenantId,
         grantedBy: caller.userId,
       });
       if (!grant) {
@@ -270,17 +322,17 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
    */
   async function revokeGrantHandler(req: ServerRequest, res: Response) {
     try {
-      const { principalType, principalId, capability } = req.params as {
+      const { principalType, principalId } = req.params as {
         principalType: string;
         principalId: string;
-        capability: string;
       };
+      const capability = (req.query as { capability?: string }).capability;
 
       const principalError = validatePrincipal(principalType, principalId);
       if (principalError) {
         return res.status(400).json({ error: principalError });
       }
-      if (!capability || !VALID_CAPABILITIES.has(capability)) {
+      if (!capability || !isValidCapability(capability)) {
         return res.status(400).json({ error: 'Invalid capability' });
       }
 
@@ -289,12 +341,10 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         return res.status(401).json({ error: 'Authentication required' });
       }
 
-      const principals = await getUserPrincipals(caller);
+      const { tenantId } = caller;
+      const principals = await resolvePrincipals(caller);
       const manageCap = MANAGE_CAPABILITY_BY_TYPE[principalType as GrantPrincipalType];
-      if (
-        !manageCap ||
-        !(await hasCapabilityForPrincipals({ principals, capability: manageCap }))
-      ) {
+      if (!(await hasCapabilityForPrincipals({ principals, capability: manageCap, tenantId }))) {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
 
@@ -302,6 +352,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         principalType: principalType as PrincipalType,
         principalId,
         capability: capability as SystemCapability,
+        tenantId,
       });
       return res.status(200).json({ success: true });
     } catch (error) {
@@ -311,7 +362,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
   }
 
   return {
-    listAllGrants: listAllGrantsHandler,
+    listGrants: listGrantsHandler,
     getEffectiveCapabilities: getEffectiveCapabilitiesHandler,
     getPrincipalGrants: getPrincipalGrantsHandler,
     assignGrant: assignGrantHandler,

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -11,13 +11,6 @@ import type { Types } from 'mongoose';
 import type { ResolvedPrincipal } from '~/types/principal';
 import type { ServerRequest } from '~/types/http';
 
-/** Module-level: PrincipalType is from librechat-data-provider (never mocked by external tests). */
-const VALID_PRINCIPAL_TYPES = new Set<string>([
-  PrincipalType.ROLE,
-  PrincipalType.GROUP,
-  PrincipalType.USER,
-]);
-
 interface GrantRequestBody {
   principalType?: unknown;
   principalId?: unknown;
@@ -72,17 +65,21 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
 
   const VALID_CAPABILITIES = new Set<string>(Object.values(SystemCapabilities));
 
-  const MANAGE_CAPABILITY_BY_TYPE: Partial<Record<PrincipalType, SystemCapability>> = {
+  type GrantPrincipalType = PrincipalType.ROLE | PrincipalType.GROUP | PrincipalType.USER;
+
+  const MANAGE_CAPABILITY_BY_TYPE: Record<GrantPrincipalType, SystemCapability> = {
     [PrincipalType.ROLE]: SystemCapabilities.MANAGE_ROLES,
     [PrincipalType.GROUP]: SystemCapabilities.MANAGE_GROUPS,
     [PrincipalType.USER]: SystemCapabilities.MANAGE_USERS,
   };
 
-  const READ_CAPABILITY_BY_TYPE: Partial<Record<PrincipalType, SystemCapability>> = {
+  const READ_CAPABILITY_BY_TYPE: Record<GrantPrincipalType, SystemCapability> = {
     [PrincipalType.ROLE]: SystemCapabilities.READ_ROLES,
     [PrincipalType.GROUP]: SystemCapabilities.READ_GROUPS,
     [PrincipalType.USER]: SystemCapabilities.READ_USERS,
   };
+
+  const VALID_PRINCIPAL_TYPES = new Set<string>(Object.keys(MANAGE_CAPABILITY_BY_TYPE));
 
   function resolveUser(req: ServerRequest): { userId: string; role: string } | null {
     const user = req.user;

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -24,8 +24,14 @@ const MANAGE_CAPABILITY_BY_TYPE: Partial<Record<PrincipalType, SystemCapability>
   [PrincipalType.USER]: SystemCapabilities.MANAGE_USERS,
 };
 
-interface ResolvedPrincipal {
-  principalType: PrincipalType;
+const READ_CAPABILITY_BY_TYPE: Partial<Record<PrincipalType, SystemCapability>> = {
+  [PrincipalType.ROLE]: SystemCapabilities.READ_ROLES,
+  [PrincipalType.GROUP]: SystemCapabilities.READ_GROUPS,
+  [PrincipalType.USER]: SystemCapabilities.READ_USERS,
+};
+
+export interface ResolvedPrincipal {
+  principalType: string;
   principalId?: string | Types.ObjectId;
 }
 
@@ -48,7 +54,7 @@ export interface AdminGrantsDeps {
     capability: SystemCapability;
     tenantId?: string;
   }) => Promise<void>;
-  getUserPrincipals: (params: { userId: string; role: string }) => Promise<ResolvedPrincipal[]>;
+  getUserPrincipals: (params: { userId: string; role?: string | null }) => Promise<ResolvedPrincipal[]>;
   hasCapabilityForPrincipals: (params: {
     principals: ResolvedPrincipal[];
     capability: SystemCapability;
@@ -56,6 +62,7 @@ export interface AdminGrantsDeps {
   }) => Promise<boolean>;
 }
 
+/** Creates admin grant handlers with dependency injection for the /api/admin/grants routes. */
 export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
   const {
     getCapabilitiesForPrincipal,
@@ -70,48 +77,42 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     if (!user) {
       return null;
     }
-    const userId = user._id?.toString();
+    const userId = (user.id ?? user._id)?.toString();
     if (!userId || !user.role) {
       return null;
     }
     return { userId, role: user.role };
   }
 
-  function validateGrantBody(body: Record<string, unknown>): string | null {
-    const { principalType, principalId, capability } = body;
-    if (
-      !principalType ||
-      typeof principalType !== 'string' ||
-      !VALID_PRINCIPAL_TYPES.has(principalType)
-    ) {
+  function validatePrincipal(principalType: string, principalId: string): string | null {
+    if (!principalType || !VALID_PRINCIPAL_TYPES.has(principalType)) {
       return 'Invalid principal type';
     }
-    if (!principalId || typeof principalId !== 'string') {
+    if (!principalId) {
       return 'principalId is required';
     }
     if (principalType !== PrincipalType.ROLE && !isValidObjectIdString(principalId)) {
       return 'Invalid principalId format';
     }
+    return null;
+  }
+
+  function validateGrantBody(body: Record<string, unknown>): string | null {
+    const { principalType, principalId, capability } = body;
+    if (typeof principalType !== 'string') {
+      return 'Invalid principal type';
+    }
+    if (typeof principalId !== 'string') {
+      return 'principalId is required';
+    }
+    const principalError = validatePrincipal(principalType, principalId);
+    if (principalError) {
+      return principalError;
+    }
     if (!capability || typeof capability !== 'string' || !VALID_CAPABILITIES.has(capability)) {
       return 'Invalid capability';
     }
     return null;
-  }
-
-  async function callerHasManageCapability(
-    req: ServerRequest,
-    principalType: PrincipalType,
-  ): Promise<boolean> {
-    const user = resolveUser(req);
-    if (!user) {
-      return false;
-    }
-    const capability = MANAGE_CAPABILITY_BY_TYPE[principalType];
-    if (!capability) {
-      return false;
-    }
-    const principals = await getUserPrincipals(user);
-    return hasCapabilityForPrincipals({ principals, capability });
   }
 
   async function getEffectiveCapabilitiesHandler(req: ServerRequest, res: Response) {
@@ -122,6 +123,11 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       }
 
       const principals = await getUserPrincipals(user);
+      /**
+       * PUBLIC principals have no principalId and are intentionally excluded —
+       * the data layer (hasCapabilityForPrincipals) also filters them out.
+       * PUBLIC is not in VALID_PRINCIPAL_TYPES so it cannot be granted via this API.
+       */
       const grantArrays = await Promise.all(
         principals
           .filter(
@@ -130,7 +136,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
           )
           .map((p) =>
             getCapabilitiesForPrincipal({
-              principalType: p.principalType,
+              principalType: p.principalType as PrincipalType,
               principalId: p.principalId,
             }),
           ),
@@ -157,14 +163,23 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         principalId: string;
       };
 
-      if (!VALID_PRINCIPAL_TYPES.has(principalType)) {
-        return res.status(400).json({ error: 'Invalid principal type' });
+      const principalError = validatePrincipal(principalType, principalId);
+      if (principalError) {
+        return res.status(400).json({ error: principalError });
       }
-      if (!principalId) {
-        return res.status(400).json({ error: 'principalId is required' });
+
+      const user = resolveUser(req);
+      if (!user) {
+        return res.status(401).json({ error: 'Authentication required' });
       }
-      if (principalType !== PrincipalType.ROLE && !isValidObjectIdString(principalId)) {
-        return res.status(400).json({ error: 'Invalid principalId format' });
+
+      const readCap = READ_CAPABILITY_BY_TYPE[principalType as PrincipalType];
+      if (readCap) {
+        const principals = await getUserPrincipals(user);
+        const allowed = await hasCapabilityForPrincipals({ principals, capability: readCap });
+        if (!allowed) {
+          return res.status(403).json({ error: 'Insufficient permissions' });
+        }
       }
 
       const grants = await getCapabilitiesForPrincipal({
@@ -191,17 +206,35 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         capability: SystemCapability;
       };
 
-      if (!(await callerHasManageCapability(req, principalType))) {
+      const caller = resolveUser(req);
+      if (!caller) {
+        return res.status(401).json({ error: 'Authentication required' });
+      }
+
+      const principals = await getUserPrincipals(caller);
+
+      const manageCap = MANAGE_CAPABILITY_BY_TYPE[principalType];
+      if (
+        !manageCap ||
+        !(await hasCapabilityForPrincipals({ principals, capability: manageCap }))
+      ) {
         return res.status(403).json({ error: 'Insufficient permissions' });
+      }
+
+      if (!(await hasCapabilityForPrincipals({ principals, capability }))) {
+        return res.status(403).json({ error: 'Cannot grant a capability you do not possess' });
       }
 
       const grant = await grantCapability({
         principalType,
         principalId,
         capability,
-        grantedBy: resolveUser(req)?.userId,
+        grantedBy: caller.userId,
       });
-      return res.status(200).json({ grant });
+      if (!grant) {
+        return res.status(500).json({ error: 'Failed to create grant' });
+      }
+      return res.status(201).json({ grant });
     } catch (error) {
       logger.error('[adminGrants] assignGrant error:', error);
       return res.status(500).json({ error: 'Failed to assign grant' });
@@ -210,22 +243,39 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
 
   async function revokeGrantHandler(req: ServerRequest, res: Response) {
     try {
-      const bodyError = validateGrantBody(req.body as Record<string, unknown>);
-      if (bodyError) {
-        return res.status(400).json({ error: bodyError });
-      }
-
-      const { principalType, principalId, capability } = req.body as {
-        principalType: PrincipalType;
+      const { principalType, principalId, capability } = req.params as {
+        principalType: string;
         principalId: string;
-        capability: SystemCapability;
+        capability: string;
       };
 
-      if (!(await callerHasManageCapability(req, principalType))) {
+      const principalError = validatePrincipal(principalType, principalId);
+      if (principalError) {
+        return res.status(400).json({ error: principalError });
+      }
+      if (!capability || !VALID_CAPABILITIES.has(capability)) {
+        return res.status(400).json({ error: 'Invalid capability' });
+      }
+
+      const caller = resolveUser(req);
+      if (!caller) {
+        return res.status(401).json({ error: 'Authentication required' });
+      }
+
+      const principals = await getUserPrincipals(caller);
+      const manageCap = MANAGE_CAPABILITY_BY_TYPE[principalType as PrincipalType];
+      if (
+        !manageCap ||
+        !(await hasCapabilityForPrincipals({ principals, capability: manageCap }))
+      ) {
         return res.status(403).json({ error: 'Insufficient permissions' });
       }
 
-      await revokeCapability({ principalType, principalId, capability });
+      await revokeCapability({
+        principalType: principalType as PrincipalType,
+        principalId,
+        capability: capability as SystemCapability,
+      });
       return res.status(200).json({ success: true });
     } catch (error) {
       logger.error('[adminGrants] revokeGrant error:', error);

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -43,6 +43,10 @@ export interface AdminGrantsDeps {
     principalId: string | Types.ObjectId;
     tenantId?: string;
   }) => Promise<ISystemGrant[]>;
+  getCapabilitiesForPrincipals: (params: {
+    principals: Array<{ principalType: string; principalId: string | Types.ObjectId }>;
+    tenantId?: string;
+  }) => Promise<ISystemGrant[]>;
   grantCapability: (params: {
     principalType: PrincipalType;
     principalId: string | Types.ObjectId;
@@ -68,6 +72,7 @@ export interface AdminGrantsDeps {
 export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
   const {
     getCapabilitiesForPrincipal,
+    getCapabilitiesForPrincipals,
     grantCapability,
     revokeCapability,
     getUserPrincipals,
@@ -125,30 +130,16 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
       }
 
       const principals = await getUserPrincipals(user);
-      /**
-       * PUBLIC principals have no principalId and are intentionally excluded —
-       * the data layer (hasCapabilityForPrincipals) also filters them out.
-       * PUBLIC is not in VALID_PRINCIPAL_TYPES so it cannot be granted via this API.
-       */
-      const grantArrays = await Promise.all(
-        principals
-          .filter(
-            (p): p is ResolvedPrincipal & { principalId: string | Types.ObjectId } =>
-              p.principalId != null,
-          )
-          .map((p) =>
-            getCapabilitiesForPrincipal({
-              principalType: p.principalType as PrincipalType,
-              principalId: p.principalId,
-            }),
-          ),
+      const filteredPrincipals = principals.filter(
+        (p): p is ResolvedPrincipal & { principalId: string | Types.ObjectId } =>
+          p.principalId != null,
       );
 
+      const grants = await getCapabilitiesForPrincipals({ principals: filteredPrincipals });
+
       const directCaps = new Set<string>();
-      for (const grants of grantArrays) {
-        for (const grant of grants) {
-          directCaps.add(grant.capability);
-        }
+      for (const grant of grants) {
+        directCaps.add(grant.capability);
       }
 
       return res.status(200).json({ capabilities: expandImplications(Array.from(directCaps)) });

--- a/packages/api/src/admin/groups.spec.ts
+++ b/packages/api/src/admin/groups.spec.ts
@@ -809,11 +809,9 @@ describe('createAdminGroupsHandlers', () => {
         principalType: PrincipalType.GROUP,
         principalId: new Types.ObjectId(validId),
       });
-      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(
-        PrincipalType.GROUP,
-        validId,
-        undefined,
-      );
+      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.GROUP, validId, {
+        tenantId: undefined,
+      });
     });
 
     it('cleans up Config, AclEntry, and SystemGrant on group delete', async () => {
@@ -829,11 +827,9 @@ describe('createAdminGroupsHandlers', () => {
         principalType: PrincipalType.GROUP,
         principalId: new Types.ObjectId(validId),
       });
-      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(
-        PrincipalType.GROUP,
-        validId,
-        undefined,
-      );
+      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.GROUP, validId, {
+        tenantId: undefined,
+      });
     });
   });
 

--- a/packages/api/src/admin/groups.spec.ts
+++ b/packages/api/src/admin/groups.spec.ts
@@ -8,7 +8,7 @@ import { createAdminGroupsHandlers } from './groups';
 
 jest.mock('@librechat/data-schemas', () => ({
   ...jest.requireActual('@librechat/data-schemas'),
-  logger: { error: jest.fn(), warn: jest.fn() },
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
 }));
 
 describe('createAdminGroupsHandlers', () => {

--- a/packages/api/src/admin/groups.spec.ts
+++ b/packages/api/src/admin/groups.spec.ts
@@ -809,7 +809,11 @@ describe('createAdminGroupsHandlers', () => {
         principalType: PrincipalType.GROUP,
         principalId: new Types.ObjectId(validId),
       });
-      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.GROUP, validId);
+      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(
+        PrincipalType.GROUP,
+        validId,
+        undefined,
+      );
     });
 
     it('cleans up Config, AclEntry, and SystemGrant on group delete', async () => {
@@ -825,7 +829,11 @@ describe('createAdminGroupsHandlers', () => {
         principalType: PrincipalType.GROUP,
         principalId: new Types.ObjectId(validId),
       });
-      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.GROUP, validId);
+      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(
+        PrincipalType.GROUP,
+        validId,
+        undefined,
+      );
     });
   });
 

--- a/packages/api/src/admin/groups.ts
+++ b/packages/api/src/admin/groups.ts
@@ -85,7 +85,7 @@ export interface AdminGroupsDeps {
   deleteGrantsForPrincipal: (
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
-    tenantId?: string,
+    options?: { tenantId?: string },
   ) => Promise<void>;
 }
 
@@ -318,7 +318,7 @@ export function createAdminGroupsHandlers(deps: AdminGroupsDeps) {
           principalType: PrincipalType.GROUP,
           principalId: new Types.ObjectId(id),
         }),
-        deleteGrantsForPrincipal(PrincipalType.GROUP, id, tenantId),
+        deleteGrantsForPrincipal(PrincipalType.GROUP, id, { tenantId }),
       ]);
       for (const result of cleanupResults) {
         if (result.status === 'rejected') {

--- a/packages/api/src/admin/groups.ts
+++ b/packages/api/src/admin/groups.ts
@@ -85,6 +85,7 @@ export interface AdminGroupsDeps {
   deleteGrantsForPrincipal: (
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
+    tenantId?: string,
   ) => Promise<void>;
 }
 
@@ -310,13 +311,14 @@ export function createAdminGroupsHandlers(deps: AdminGroupsDeps) {
        * grantPermission stores group principalId as ObjectId, so we must
        * cast here. deleteConfig and deleteGrantsForPrincipal normalize internally.
        */
+      const tenantId = req.user?.tenantId;
       const cleanupResults = await Promise.allSettled([
         deleteConfig(PrincipalType.GROUP, id),
         deleteAclEntries({
           principalType: PrincipalType.GROUP,
           principalId: new Types.ObjectId(id),
         }),
-        deleteGrantsForPrincipal(PrincipalType.GROUP, id),
+        deleteGrantsForPrincipal(PrincipalType.GROUP, id, tenantId),
       ]);
       for (const result of cleanupResults) {
         if (result.status === 'rejected') {

--- a/packages/api/src/admin/index.ts
+++ b/packages/api/src/admin/index.ts
@@ -1,6 +1,8 @@
 export { createAdminConfigHandlers } from './config';
+export { createAdminGrantsHandlers } from './grants';
 export { createAdminGroupsHandlers } from './groups';
 export { createAdminRolesHandlers } from './roles';
 export type { AdminConfigDeps } from './config';
+export type { AdminGrantsDeps } from './grants';
 export type { AdminGroupsDeps } from './groups';
 export type { AdminRolesDeps } from './roles';

--- a/packages/api/src/admin/index.ts
+++ b/packages/api/src/admin/index.ts
@@ -3,6 +3,6 @@ export { createAdminGrantsHandlers } from './grants';
 export { createAdminGroupsHandlers } from './groups';
 export { createAdminRolesHandlers } from './roles';
 export type { AdminConfigDeps } from './config';
-export type { AdminGrantsDeps } from './grants';
+export type { AdminGrantsDeps, GrantPrincipalType } from './grants';
 export type { AdminGroupsDeps } from './groups';
 export type { AdminRolesDeps } from './roles';

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -970,6 +970,21 @@ describe('createAdminRolesHandlers', () => {
       expect(json).toHaveBeenCalledWith({ success: true });
     });
 
+    it('succeeds even when all cascade operations fail', async () => {
+      const deps = createDeps({
+        deleteConfig: jest.fn().mockRejectedValue(new Error('config cleanup failed')),
+        deleteAclEntries: jest.fn().mockRejectedValue(new Error('acl cleanup failed')),
+        deleteGrantsForPrincipal: jest.fn().mockRejectedValue(new Error('grant cleanup failed')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: 'editor' } });
+
+      await handlers.deleteRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ success: true });
+    });
+
     it('returns 403 for system role', async () => {
       const deps = createDeps();
       const handlers = createAdminRolesHandlers(deps);

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -40,12 +40,14 @@ function createReqRes(
     params?: Record<string, string>;
     query?: Record<string, string>;
     body?: Record<string, unknown>;
+    user?: { _id: Types.ObjectId; role: string; tenantId?: string };
   } = {},
 ) {
   const req = {
     params: overrides.params ?? {},
     query: overrides.query ?? {},
     body: overrides.body ?? {},
+    user: overrides.user,
   } as unknown as ServerRequest;
 
   const json = jest.fn();
@@ -941,7 +943,29 @@ describe('createAdminRolesHandlers', () => {
         principalType: PrincipalType.ROLE,
         principalId: 'editor',
       });
-      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.ROLE, 'editor');
+      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(
+        PrincipalType.ROLE,
+        'editor',
+        undefined,
+      );
+    });
+
+    it('passes tenantId to grant cleanup', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status } = createReqRes({
+        params: { name: 'editor' },
+        user: { _id: new Types.ObjectId(), role: 'admin', tenantId: 'tenant-1' },
+      });
+
+      await handlers.deleteRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(
+        PrincipalType.ROLE,
+        'editor',
+        'tenant-1',
+      );
     });
 
     it('does not clean up when role not found', async () => {

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -957,7 +957,7 @@ describe('createAdminRolesHandlers', () => {
       expect(deps.deleteGrantsForPrincipal).not.toHaveBeenCalled();
     });
 
-    it('succeeds even when cascade cleanup fails', async () => {
+    it('succeeds even when grant cleanup fails', async () => {
       const deps = createDeps({
         deleteGrantsForPrincipal: jest.fn().mockRejectedValue(new Error('cleanup failed')),
       });

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -1,5 +1,5 @@
 import { Types } from 'mongoose';
-import { SystemRoles } from 'librechat-data-provider';
+import { PrincipalType, SystemRoles } from 'librechat-data-provider';
 import type { IRole, IUser } from '@librechat/data-schemas';
 import type { Response } from 'express';
 import type { ServerRequest } from '~/types/http';
@@ -71,6 +71,7 @@ function createDeps(overrides: Partial<AdminRolesDeps> = {}): AdminRolesDeps {
     updateUsersRoleByIds: jest.fn().mockResolvedValue(undefined),
     listUsersByRole: jest.fn().mockResolvedValue([]),
     countUsersByRole: jest.fn().mockResolvedValue(0),
+    deleteGrantsForPrincipal: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -921,6 +922,41 @@ describe('createAdminRolesHandlers', () => {
       await handlers.deleteRole(req, res);
 
       expect(deps.deleteRoleByName).toHaveBeenCalledWith('editor');
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('cleans up grants after successful deletion', async () => {
+      const deps = createDeps();
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status } = createReqRes({ params: { name: 'editor' } });
+
+      await handlers.deleteRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.ROLE, 'editor');
+    });
+
+    it('does not clean up grants when role not found', async () => {
+      const deps = createDeps({ deleteRoleByName: jest.fn().mockResolvedValue(null) });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status } = createReqRes({ params: { name: 'nonexistent' } });
+
+      await handlers.deleteRole(req, res);
+
+      expect(status).toHaveBeenCalledWith(404);
+      expect(deps.deleteGrantsForPrincipal).not.toHaveBeenCalled();
+    });
+
+    it('succeeds even when grant cleanup fails', async () => {
+      const deps = createDeps({
+        deleteGrantsForPrincipal: jest.fn().mockRejectedValue(new Error('cleanup failed')),
+      });
+      const handlers = createAdminRolesHandlers(deps);
+      const { req, res, status, json } = createReqRes({ params: { name: 'editor' } });
+
+      await handlers.deleteRole(req, res);
+
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith({ success: true });
     });

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -10,7 +10,7 @@ const { RoleConflictError } = jest.requireActual('@librechat/data-schemas');
 
 jest.mock('@librechat/data-schemas', () => ({
   ...jest.requireActual('@librechat/data-schemas'),
-  logger: { error: jest.fn() },
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
 }));
 
 const validUserId = new Types.ObjectId().toString();

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -71,6 +71,8 @@ function createDeps(overrides: Partial<AdminRolesDeps> = {}): AdminRolesDeps {
     updateUsersRoleByIds: jest.fn().mockResolvedValue(undefined),
     listUsersByRole: jest.fn().mockResolvedValue([]),
     countUsersByRole: jest.fn().mockResolvedValue(0),
+    deleteConfig: jest.fn().mockResolvedValue(null),
+    deleteAclEntries: jest.fn().mockResolvedValue(undefined),
     deleteGrantsForPrincipal: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
@@ -934,10 +936,15 @@ describe('createAdminRolesHandlers', () => {
       await handlers.deleteRole(req, res);
 
       expect(status).toHaveBeenCalledWith(200);
+      expect(deps.deleteConfig).toHaveBeenCalledWith(PrincipalType.ROLE, 'editor');
+      expect(deps.deleteAclEntries).toHaveBeenCalledWith({
+        principalType: PrincipalType.ROLE,
+        principalId: 'editor',
+      });
       expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.ROLE, 'editor');
     });
 
-    it('does not clean up grants when role not found', async () => {
+    it('does not clean up when role not found', async () => {
       const deps = createDeps({ deleteRoleByName: jest.fn().mockResolvedValue(null) });
       const handlers = createAdminRolesHandlers(deps);
       const { req, res, status } = createReqRes({ params: { name: 'nonexistent' } });
@@ -945,10 +952,12 @@ describe('createAdminRolesHandlers', () => {
       await handlers.deleteRole(req, res);
 
       expect(status).toHaveBeenCalledWith(404);
+      expect(deps.deleteConfig).not.toHaveBeenCalled();
+      expect(deps.deleteAclEntries).not.toHaveBeenCalled();
       expect(deps.deleteGrantsForPrincipal).not.toHaveBeenCalled();
     });
 
-    it('succeeds even when grant cleanup fails', async () => {
+    it('succeeds even when cascade cleanup fails', async () => {
       const deps = createDeps({
         deleteGrantsForPrincipal: jest.fn().mockRejectedValue(new Error('cleanup failed')),
       });

--- a/packages/api/src/admin/roles.spec.ts
+++ b/packages/api/src/admin/roles.spec.ts
@@ -943,11 +943,9 @@ describe('createAdminRolesHandlers', () => {
         principalType: PrincipalType.ROLE,
         principalId: 'editor',
       });
-      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(
-        PrincipalType.ROLE,
-        'editor',
-        undefined,
-      );
+      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.ROLE, 'editor', {
+        tenantId: undefined,
+      });
     });
 
     it('passes tenantId to grant cleanup', async () => {
@@ -961,11 +959,9 @@ describe('createAdminRolesHandlers', () => {
       await handlers.deleteRole(req, res);
 
       expect(status).toHaveBeenCalledWith(200);
-      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(
-        PrincipalType.ROLE,
-        'editor',
-        'tenant-1',
-      );
+      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.ROLE, 'editor', {
+        tenantId: 'tenant-1',
+      });
     });
 
     it('does not clean up when role not found', async () => {

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -119,6 +119,7 @@ export interface AdminRolesDeps {
   deleteGrantsForPrincipal: (
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
+    tenantId?: string,
   ) => Promise<void>;
 }
 
@@ -386,10 +387,11 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(404).json({ error: 'Role not found' });
       }
 
+      const tenantId = req.user?.tenantId;
       const cleanupResults = await Promise.allSettled([
         deleteConfig(PrincipalType.ROLE, name),
         deleteAclEntries({ principalType: PrincipalType.ROLE, principalId: name }),
-        deleteGrantsForPrincipal(PrincipalType.ROLE, name),
+        deleteGrantsForPrincipal(PrincipalType.ROLE, name, tenantId),
       ]);
       for (const result of cleanupResults) {
         if (result.status === 'rejected') {

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -119,7 +119,7 @@ export interface AdminRolesDeps {
   deleteGrantsForPrincipal: (
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
-    tenantId?: string,
+    options?: { tenantId?: string },
   ) => Promise<void>;
 }
 
@@ -391,7 +391,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       const cleanupResults = await Promise.allSettled([
         deleteConfig(PrincipalType.ROLE, name),
         deleteAclEntries({ principalType: PrincipalType.ROLE, principalId: name }),
-        deleteGrantsForPrincipal(PrincipalType.ROLE, name, tenantId),
+        deleteGrantsForPrincipal(PrincipalType.ROLE, name, { tenantId }),
       ]);
       for (const result of cleanupResults) {
         if (result.status === 'rejected') {

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -1,6 +1,6 @@
 import { PrincipalType, SystemRoles } from 'librechat-data-provider';
 import { logger, isValidObjectIdString, RoleConflictError } from '@librechat/data-schemas';
-import type { IRole, IUser, AdminMember } from '@librechat/data-schemas';
+import type { IRole, IUser, IConfig, AdminMember } from '@librechat/data-schemas';
 import type { FilterQuery, Types } from 'mongoose';
 import type { Response } from 'express';
 import type { ServerRequest } from '~/types/http';
@@ -105,6 +105,14 @@ export interface AdminRolesDeps {
     options?: { limit?: number; offset?: number },
   ) => Promise<IUser[]>;
   countUsersByRole: (roleName: string) => Promise<number>;
+  deleteConfig: (
+    principalType: PrincipalType,
+    principalId: string | Types.ObjectId,
+  ) => Promise<IConfig | null>;
+  deleteAclEntries: (filter: {
+    principalType: PrincipalType;
+    principalId: string | Types.ObjectId;
+  }) => Promise<void>;
   deleteGrantsForPrincipal: (
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
@@ -127,6 +135,8 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
     updateUsersRoleByIds,
     listUsersByRole,
     countUsersByRole,
+    deleteConfig,
+    deleteAclEntries,
     deleteGrantsForPrincipal,
   } = deps;
 
@@ -373,10 +383,15 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(404).json({ error: 'Role not found' });
       }
 
-      try {
-        await deleteGrantsForPrincipal(PrincipalType.ROLE, name);
-      } catch (cleanupError) {
-        logger.error('[adminRoles] cascade cleanup failed for role:', name, cleanupError);
+      const cleanupResults = await Promise.allSettled([
+        deleteConfig(PrincipalType.ROLE, name),
+        deleteAclEntries({ principalType: PrincipalType.ROLE, principalId: name }),
+        deleteGrantsForPrincipal(PrincipalType.ROLE, name),
+      ]);
+      for (const result of cleanupResults) {
+        if (result.status === 'rejected') {
+          logger.error('[adminRoles] cascade cleanup failed for role:', name, result.reason);
+        }
       }
 
       return res.status(200).json({ success: true });

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -1,4 +1,4 @@
-import { SystemRoles } from 'librechat-data-provider';
+import { PrincipalType, SystemRoles } from 'librechat-data-provider';
 import { logger, isValidObjectIdString, RoleConflictError } from '@librechat/data-schemas';
 import type { IRole, IUser, AdminMember } from '@librechat/data-schemas';
 import type { FilterQuery, Types } from 'mongoose';
@@ -105,6 +105,10 @@ export interface AdminRolesDeps {
     options?: { limit?: number; offset?: number },
   ) => Promise<IUser[]>;
   countUsersByRole: (roleName: string) => Promise<number>;
+  deleteGrantsForPrincipal: (
+    principalType: PrincipalType,
+    principalId: string | Types.ObjectId,
+  ) => Promise<void>;
 }
 
 export function createAdminRolesHandlers(deps: AdminRolesDeps) {
@@ -123,6 +127,7 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
     updateUsersRoleByIds,
     listUsersByRole,
     countUsersByRole,
+    deleteGrantsForPrincipal,
   } = deps;
 
   async function listRolesHandler(req: ServerRequest, res: Response) {
@@ -367,6 +372,16 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
       if (!deleted) {
         return res.status(404).json({ error: 'Role not found' });
       }
+
+      const cleanupResults = await Promise.allSettled([
+        deleteGrantsForPrincipal(PrincipalType.ROLE, name),
+      ]);
+      for (const result of cleanupResults) {
+        if (result.status === 'rejected') {
+          logger.error('[adminRoles] cascade cleanup failed for role:', name, result.reason);
+        }
+      }
+
       return res.status(200).json({ success: true });
     } catch (error) {
       logger.error('[adminRoles] deleteRole error:', error);

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -105,14 +105,17 @@ export interface AdminRolesDeps {
     options?: { limit?: number; offset?: number },
   ) => Promise<IUser[]>;
   countUsersByRole: (roleName: string) => Promise<number>;
+  /** Removes the per-principal config override (keyed by type + name, not ObjectId). */
   deleteConfig: (
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
   ) => Promise<IConfig | null>;
+  /** Removes all ACL entries scoped to this principal. */
   deleteAclEntries: (filter: {
     principalType: PrincipalType;
     principalId: string | Types.ObjectId;
   }) => Promise<void>;
+  /** Removes all system capability grants held by this principal. */
   deleteGrantsForPrincipal: (
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,

--- a/packages/api/src/admin/roles.ts
+++ b/packages/api/src/admin/roles.ts
@@ -373,13 +373,10 @@ export function createAdminRolesHandlers(deps: AdminRolesDeps) {
         return res.status(404).json({ error: 'Role not found' });
       }
 
-      const cleanupResults = await Promise.allSettled([
-        deleteGrantsForPrincipal(PrincipalType.ROLE, name),
-      ]);
-      for (const result of cleanupResults) {
-        if (result.status === 'rejected') {
-          logger.error('[adminRoles] cascade cleanup failed for role:', name, result.reason);
-        }
+      try {
+        await deleteGrantsForPrincipal(PrincipalType.ROLE, name);
+      } catch (cleanupError) {
+        logger.error('[adminRoles] cascade cleanup failed for role:', name, cleanupError);
       }
 
       return res.status(200).json({ success: true });

--- a/packages/api/src/middleware/capabilities.ts
+++ b/packages/api/src/middleware/capabilities.ts
@@ -9,7 +9,7 @@ import {
 import type { SystemCapability, ConfigSection } from '@librechat/data-schemas';
 import type { NextFunction, Response } from 'express';
 import type { Types, ClientSession } from 'mongoose';
-import type { ResolvedPrincipal } from '~/admin/grants';
+import type { ResolvedPrincipal } from '~/types/principal';
 import type { ServerRequest } from '~/types/http';
 
 interface CapabilityDeps {

--- a/packages/api/src/middleware/capabilities.ts
+++ b/packages/api/src/middleware/capabilities.ts
@@ -6,16 +6,11 @@ import {
   SystemCapabilities,
   readConfigCapability,
 } from '@librechat/data-schemas';
-import type { PrincipalType } from 'librechat-data-provider';
 import type { SystemCapability, ConfigSection } from '@librechat/data-schemas';
 import type { NextFunction, Response } from 'express';
 import type { Types, ClientSession } from 'mongoose';
+import type { ResolvedPrincipal } from '~/admin/grants';
 import type { ServerRequest } from '~/types/http';
-
-interface ResolvedPrincipal {
-  principalType: PrincipalType;
-  principalId?: string | Types.ObjectId;
-}
 
 interface CapabilityDeps {
   getUserPrincipals: (

--- a/packages/api/src/middleware/capabilities.ts
+++ b/packages/api/src/middleware/capabilities.ts
@@ -50,6 +50,8 @@ export type HasConfigCapabilityFn = (
   verb?: 'manage' | 'read',
 ) => Promise<boolean>;
 
+export type GetCachedPrincipalsFn = (user: CapabilityUser) => ResolvedPrincipal[] | undefined;
+
 /**
  * Per-request store for caching resolved principals and capability check results.
  * When running inside an Express request (via `capabilityContextMiddleware`),
@@ -73,6 +75,20 @@ export function capabilityContextMiddleware(
     );
   }
   capabilityStore.run({ principals: new Map(), results: new Map() }, next);
+}
+
+/**
+ * Reads principals from the per-request ALS cache without side effects.
+ * Returns `undefined` when called outside a request context or before
+ * `requireCapability` has populated the cache for this user.
+ */
+export function getCachedPrincipals(user: CapabilityUser): ResolvedPrincipal[] | undefined {
+  const store = capabilityStore.getStore();
+  if (!store) {
+    return undefined;
+  }
+  const key = `${user.id}:${user.role}:${user.tenantId ?? ''}`;
+  return store.principals.get(key);
 }
 
 /**

--- a/packages/api/src/middleware/capabilities.ts
+++ b/packages/api/src/middleware/capabilities.ts
@@ -50,8 +50,6 @@ export type HasConfigCapabilityFn = (
   verb?: 'manage' | 'read',
 ) => Promise<boolean>;
 
-export type GetCachedPrincipalsFn = (user: CapabilityUser) => ResolvedPrincipal[] | undefined;
-
 /**
  * Per-request store for caching resolved principals and capability check results.
  * When running inside an Express request (via `capabilityContextMiddleware`),

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -14,3 +14,4 @@ export * from './prompts';
 export * from './run';
 export * from './tokens';
 export * from './stream';
+export * from './principal';

--- a/packages/api/src/types/principal.ts
+++ b/packages/api/src/types/principal.ts
@@ -1,0 +1,6 @@
+import type { Types } from 'mongoose';
+
+export interface ResolvedPrincipal {
+  principalType: string;
+  principalId?: string | Types.ObjectId;
+}

--- a/packages/api/src/types/principal.ts
+++ b/packages/api/src/types/principal.ts
@@ -1,6 +1,7 @@
+import type { PrincipalType } from 'librechat-data-provider';
 import type { Types } from 'mongoose';
 
 export interface ResolvedPrincipal {
-  principalType: string;
+  principalType: PrincipalType;
   principalId?: string | Types.ObjectId;
 }

--- a/packages/data-schemas/src/admin/capabilities.spec.ts
+++ b/packages/data-schemas/src/admin/capabilities.spec.ts
@@ -1,0 +1,38 @@
+import { SystemCapabilities, isValidCapability } from './capabilities';
+
+describe('isValidCapability', () => {
+  it.each(Object.values(SystemCapabilities))('accepts base capability: %s', (cap) => {
+    expect(isValidCapability(cap)).toBe(true);
+  });
+
+  it.each(['manage:configs:endpoints', 'read:configs:registration', 'manage:configs:speech'])(
+    'accepts section-level capability: %s',
+    (cap) => {
+      expect(isValidCapability(cap)).toBe(true);
+    },
+  );
+
+  it.each(['assign:configs:user', 'assign:configs:group', 'assign:configs:role'])(
+    'accepts assignment capability: %s',
+    (cap) => {
+      expect(isValidCapability(cap)).toBe(true);
+    },
+  );
+
+  it.each([
+    '',
+    'fake',
+    'god:mode',
+    'manage:configs:',
+    'manage:configs: spaces',
+    'manage:configs:a:b',
+    'delete:configs:endpoints',
+    'assign:configs:admin',
+    'assign:configs:',
+    'MANAGE:USERS',
+    'manage:users:extra',
+    'read:configs:end points',
+  ])('rejects invalid capability: "%s"', (cap) => {
+    expect(isValidCapability(cap)).toBe(false);
+  });
+});

--- a/packages/data-schemas/src/admin/capabilities.ts
+++ b/packages/data-schemas/src/admin/capabilities.ts
@@ -56,6 +56,24 @@ export const CapabilityImplications: Partial<Record<BaseSystemCapability, BaseSy
   };
 
 // ---------------------------------------------------------------------------
+// Capability validation
+// ---------------------------------------------------------------------------
+
+const baseCapabilitySet = new Set<string>(Object.values(SystemCapabilities));
+const sectionCapPattern = /^(?:manage|read):configs:\w+$/;
+const assignCapPattern = /^assign:configs:(?:user|group|role)$/;
+
+/**
+ * Runtime validator for the full `SystemCapability` union:
+ * base capabilities, section-level config capabilities, and config assignment capabilities.
+ */
+export function isValidCapability(value: string): boolean {
+  return (
+    baseCapabilitySet.has(value) || sectionCapPattern.test(value) || assignCapPattern.test(value)
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Capability utility functions
 // ---------------------------------------------------------------------------
 

--- a/packages/data-schemas/src/methods/systemGrant.spec.ts
+++ b/packages/data-schemas/src/methods/systemGrant.spec.ts
@@ -913,6 +913,139 @@ describe('systemGrant methods', () => {
     });
   });
 
+  describe('listGrants', () => {
+    beforeEach(async () => {
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.ACCESS_ADMIN,
+      });
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'editor',
+        capability: SystemCapabilities.READ_USERS,
+      });
+      await methods.grantCapability({
+        principalType: PrincipalType.GROUP,
+        principalId: new Types.ObjectId(),
+        capability: SystemCapabilities.READ_CONFIGS,
+      });
+    });
+
+    it('returns all platform-level grants when called without options', async () => {
+      const grants = await methods.listGrants();
+      expect(grants).toHaveLength(3);
+    });
+
+    it('respects limit parameter', async () => {
+      const grants = await methods.listGrants({ limit: 2 });
+      expect(grants).toHaveLength(2);
+    });
+
+    it('respects offset parameter', async () => {
+      const all = await methods.listGrants();
+      const page2 = await methods.listGrants({ offset: 2, limit: 10 });
+      expect(page2).toHaveLength(1);
+      expect(page2[0].capability).toBe(all[2].capability);
+    });
+
+    it('filters by principalTypes', async () => {
+      const grants = await methods.listGrants({
+        principalTypes: [PrincipalType.ROLE],
+      });
+      expect(grants).toHaveLength(2);
+      for (const g of grants) {
+        expect(g.principalType).toBe(PrincipalType.ROLE);
+      }
+    });
+
+    it('returns empty array for principalTypes with no grants', async () => {
+      const grants = await methods.listGrants({
+        principalTypes: [PrincipalType.USER],
+      });
+      expect(grants).toHaveLength(0);
+    });
+
+    it('excludes tenant-scoped grants when no tenantId provided', async () => {
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.MANAGE_USERS,
+        tenantId: 'tenant-1',
+      });
+
+      const grants = await methods.listGrants();
+      expect(grants.every((g) => !('tenantId' in g && g.tenantId))).toBe(true);
+    });
+
+    it('includes tenant and platform grants when tenantId provided', async () => {
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.MANAGE_USERS,
+        tenantId: 'tenant-1',
+      });
+
+      const grants = await methods.listGrants({ tenantId: 'tenant-1' });
+      expect(grants).toHaveLength(4);
+    });
+
+    it('sorts by principalType then capability', async () => {
+      const grants = await methods.listGrants();
+      for (let i = 1; i < grants.length; i++) {
+        const prev = `${grants[i - 1].principalType}:${grants[i - 1].capability}`;
+        const curr = `${grants[i].principalType}:${grants[i].capability}`;
+        expect(prev <= curr).toBe(true);
+      }
+    });
+  });
+
+  describe('countGrants', () => {
+    it('returns total count matching the filter', async () => {
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.ACCESS_ADMIN,
+      });
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'editor',
+        capability: SystemCapabilities.READ_USERS,
+      });
+      await methods.grantCapability({
+        principalType: PrincipalType.GROUP,
+        principalId: new Types.ObjectId(),
+        capability: SystemCapabilities.READ_CONFIGS,
+      });
+
+      const total = await methods.countGrants();
+      expect(total).toBe(3);
+    });
+
+    it('filters by principalTypes', async () => {
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.ACCESS_ADMIN,
+      });
+      await methods.grantCapability({
+        principalType: PrincipalType.GROUP,
+        principalId: new Types.ObjectId(),
+        capability: SystemCapabilities.READ_CONFIGS,
+      });
+
+      const count = await methods.countGrants({
+        principalTypes: [PrincipalType.ROLE],
+      });
+      expect(count).toBe(1);
+    });
+
+    it('returns 0 when no grants match', async () => {
+      const count = await methods.countGrants();
+      expect(count).toBe(0);
+    });
+  });
+
   describe('getCapabilitiesForPrincipals', () => {
     it('returns grants across multiple principals in a single query', async () => {
       const userId = new Types.ObjectId();
@@ -1030,6 +1163,39 @@ describe('systemGrant methods', () => {
       });
 
       expect(grants).toHaveLength(2);
+    });
+
+    it('filters out PUBLIC principals before querying', async () => {
+      const userId = new Types.ObjectId();
+      await SystemGrant.create({
+        principalType: PrincipalType.USER,
+        principalId: userId,
+        capability: SystemCapabilities.READ_USERS,
+      });
+
+      const grants = await methods.getCapabilitiesForPrincipals({
+        principals: [
+          { principalType: PrincipalType.PUBLIC },
+          { principalType: PrincipalType.USER, principalId: userId },
+        ],
+      });
+
+      expect(grants).toHaveLength(1);
+      expect(grants[0].capability).toBe(SystemCapabilities.READ_USERS);
+    });
+
+    it('returns empty array when all principals are PUBLIC', async () => {
+      await SystemGrant.create({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.ACCESS_ADMIN,
+      });
+
+      const grants = await methods.getCapabilitiesForPrincipals({
+        principals: [{ principalType: PrincipalType.PUBLIC }],
+      });
+
+      expect(grants).toEqual([]);
     });
   });
 });

--- a/packages/data-schemas/src/methods/systemGrant.spec.ts
+++ b/packages/data-schemas/src/methods/systemGrant.spec.ts
@@ -1198,4 +1198,102 @@ describe('systemGrant methods', () => {
       expect(grants).toEqual([]);
     });
   });
+
+  describe('getHeldCapabilities', () => {
+    const userId = new Types.ObjectId();
+
+    it('returns the subset of capabilities the principals hold', async () => {
+      await methods.grantCapability({
+        principalType: PrincipalType.USER,
+        principalId: userId,
+        capability: SystemCapabilities.READ_ROLES,
+      });
+
+      const held = await methods.getHeldCapabilities({
+        principals: [{ principalType: PrincipalType.USER, principalId: userId }],
+        capabilities: [
+          SystemCapabilities.READ_ROLES,
+          SystemCapabilities.READ_GROUPS,
+        ],
+      });
+
+      expect(held).toEqual(new Set([SystemCapabilities.READ_ROLES]));
+    });
+
+    it('returns empty set when no capabilities match', async () => {
+      const held = await methods.getHeldCapabilities({
+        principals: [{ principalType: PrincipalType.USER, principalId: new Types.ObjectId() }],
+        capabilities: [SystemCapabilities.MANAGE_ROLES],
+      });
+
+      expect(held.size).toBe(0);
+    });
+
+    it('returns empty set for empty principals', async () => {
+      const held = await methods.getHeldCapabilities({
+        principals: [],
+        capabilities: [SystemCapabilities.READ_ROLES],
+      });
+
+      expect(held.size).toBe(0);
+    });
+
+    it('returns empty set for empty capabilities', async () => {
+      const held = await methods.getHeldCapabilities({
+        principals: [{ principalType: PrincipalType.USER, principalId: userId }],
+        capabilities: [],
+      });
+
+      expect(held.size).toBe(0);
+    });
+
+    it('resolves implied capabilities via reverse implication map', async () => {
+      const implUser = new Types.ObjectId();
+      await methods.grantCapability({
+        principalType: PrincipalType.USER,
+        principalId: implUser,
+        capability: SystemCapabilities.MANAGE_ROLES,
+      });
+
+      const held = await methods.getHeldCapabilities({
+        principals: [{ principalType: PrincipalType.USER, principalId: implUser }],
+        capabilities: [SystemCapabilities.READ_ROLES, SystemCapabilities.MANAGE_GROUPS],
+      });
+
+      expect(held).toEqual(new Set([SystemCapabilities.READ_ROLES]));
+    });
+
+    it('filters out PUBLIC principals', async () => {
+      const held = await methods.getHeldCapabilities({
+        principals: [{ principalType: PrincipalType.PUBLIC, principalId: '' }],
+        capabilities: [SystemCapabilities.READ_ROLES],
+      });
+
+      expect(held.size).toBe(0);
+    });
+
+    it('respects tenant scoping', async () => {
+      const tenantUser = new Types.ObjectId();
+      await methods.grantCapability({
+        principalType: PrincipalType.USER,
+        principalId: tenantUser,
+        capability: SystemCapabilities.READ_ROLES,
+        tenantId: 'tenant-a',
+      });
+
+      const held = await methods.getHeldCapabilities({
+        principals: [{ principalType: PrincipalType.USER, principalId: tenantUser }],
+        capabilities: [SystemCapabilities.READ_ROLES],
+        tenantId: 'tenant-a',
+      });
+      expect(held).toEqual(new Set([SystemCapabilities.READ_ROLES]));
+
+      const heldOther = await methods.getHeldCapabilities({
+        principals: [{ principalType: PrincipalType.USER, principalId: tenantUser }],
+        capabilities: [SystemCapabilities.READ_ROLES],
+        tenantId: 'tenant-b',
+      });
+      expect(heldOther.size).toBe(0);
+    });
+  });
 });

--- a/packages/data-schemas/src/methods/systemGrant.spec.ts
+++ b/packages/data-schemas/src/methods/systemGrant.spec.ts
@@ -1175,7 +1175,7 @@ describe('systemGrant methods', () => {
 
       const grants = await methods.getCapabilitiesForPrincipals({
         principals: [
-          { principalType: PrincipalType.PUBLIC },
+          { principalType: PrincipalType.PUBLIC, principalId: '' },
           { principalType: PrincipalType.USER, principalId: userId },
         ],
       });
@@ -1192,7 +1192,7 @@ describe('systemGrant methods', () => {
       });
 
       const grants = await methods.getCapabilitiesForPrincipals({
-        principals: [{ principalType: PrincipalType.PUBLIC }],
+        principals: [{ principalType: PrincipalType.PUBLIC, principalId: '' }],
       });
 
       expect(grants).toEqual([]);

--- a/packages/data-schemas/src/methods/systemGrant.spec.ts
+++ b/packages/data-schemas/src/methods/systemGrant.spec.ts
@@ -1117,12 +1117,12 @@ describe('systemGrant methods', () => {
   describe('getCapabilitiesForPrincipals', () => {
     it('returns grants across multiple principals in a single query', async () => {
       const userId = new Types.ObjectId();
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.USER,
         principalId: userId,
         capability: SystemCapabilities.READ_USERS,
       });
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.ROLE,
         principalId: 'editor',
         capability: SystemCapabilities.READ_ROLES,
@@ -1141,7 +1141,7 @@ describe('systemGrant methods', () => {
     });
 
     it('returns empty array for empty principals list', async () => {
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.ROLE,
         principalId: 'admin',
         capability: SystemCapabilities.ACCESS_ADMIN,
@@ -1153,12 +1153,12 @@ describe('systemGrant methods', () => {
 
     it('returns only matching principals, not all grants', async () => {
       const userId = new Types.ObjectId();
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.USER,
         principalId: userId,
         capability: SystemCapabilities.READ_USERS,
       });
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.ROLE,
         principalId: 'unrelated',
         capability: SystemCapabilities.MANAGE_ROLES,
@@ -1173,12 +1173,12 @@ describe('systemGrant methods', () => {
     });
 
     it('returns multiple grants for the same principal', async () => {
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.ROLE,
         principalId: 'admin',
         capability: SystemCapabilities.ACCESS_ADMIN,
       });
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.ROLE,
         principalId: 'admin',
         capability: SystemCapabilities.MANAGE_ROLES,
@@ -1192,12 +1192,12 @@ describe('systemGrant methods', () => {
     });
 
     it('excludes tenant-scoped grants when no tenantId provided', async () => {
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.ROLE,
         principalId: 'admin',
         capability: SystemCapabilities.ACCESS_ADMIN,
       });
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.ROLE,
         principalId: 'admin',
         capability: SystemCapabilities.MANAGE_USERS,
@@ -1213,12 +1213,12 @@ describe('systemGrant methods', () => {
     });
 
     it('includes both platform and tenant grants when tenantId provided', async () => {
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.ROLE,
         principalId: 'admin',
         capability: SystemCapabilities.ACCESS_ADMIN,
       });
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.ROLE,
         principalId: 'admin',
         capability: SystemCapabilities.MANAGE_USERS,
@@ -1235,7 +1235,7 @@ describe('systemGrant methods', () => {
 
     it('filters out PUBLIC principals before querying', async () => {
       const userId = new Types.ObjectId();
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.USER,
         principalId: userId,
         capability: SystemCapabilities.READ_USERS,
@@ -1253,7 +1253,7 @@ describe('systemGrant methods', () => {
     });
 
     it('returns empty array when all principals are PUBLIC', async () => {
-      await SystemGrant.create({
+      await methods.grantCapability({
         principalType: PrincipalType.ROLE,
         principalId: 'admin',
         capability: SystemCapabilities.ACCESS_ADMIN,
@@ -1380,6 +1380,38 @@ describe('systemGrant methods', () => {
         capabilities: [SystemCapabilities.READ_ROLES],
       });
       expect(heldNoTenant.size).toBe(0);
+    });
+
+    it('resolves extended capability when principal holds the parent base capability', async () => {
+      const extUser = new Types.ObjectId();
+      await methods.grantCapability({
+        principalType: PrincipalType.USER,
+        principalId: extUser,
+        capability: SystemCapabilities.MANAGE_CONFIGS,
+      });
+
+      const held = await methods.getHeldCapabilities({
+        principals: [{ principalType: PrincipalType.USER, principalId: extUser }],
+        capabilities: ['manage:configs:endpoints' as SystemCapability],
+      });
+
+      expect(held).toEqual(new Set(['manage:configs:endpoints']));
+    });
+
+    it('does not resolve extended capability when principal holds a different verb parent', async () => {
+      const readOnlyUser = new Types.ObjectId();
+      await methods.grantCapability({
+        principalType: PrincipalType.USER,
+        principalId: readOnlyUser,
+        capability: SystemCapabilities.READ_CONFIGS,
+      });
+
+      const held = await methods.getHeldCapabilities({
+        principals: [{ principalType: PrincipalType.USER, principalId: readOnlyUser }],
+        capabilities: ['manage:configs:endpoints' as SystemCapability],
+      });
+
+      expect(held.size).toBe(0);
     });
   });
 });

--- a/packages/data-schemas/src/methods/systemGrant.spec.ts
+++ b/packages/data-schemas/src/methods/systemGrant.spec.ts
@@ -1263,6 +1263,21 @@ describe('systemGrant methods', () => {
       expect(held).toEqual(new Set([SystemCapabilities.READ_ROLES]));
     });
 
+    it('excludes principals with undefined principalId', async () => {
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.READ_ROLES,
+      });
+
+      const held = await methods.getHeldCapabilities({
+        principals: [{ principalType: PrincipalType.ROLE }],
+        capabilities: [SystemCapabilities.READ_ROLES],
+      });
+
+      expect(held.size).toBe(0);
+    });
+
     it('filters out PUBLIC principals', async () => {
       const held = await methods.getHeldCapabilities({
         principals: [{ principalType: PrincipalType.PUBLIC, principalId: '' }],
@@ -1294,6 +1309,12 @@ describe('systemGrant methods', () => {
         tenantId: 'tenant-b',
       });
       expect(heldOther.size).toBe(0);
+
+      const heldNoTenant = await methods.getHeldCapabilities({
+        principals: [{ principalType: PrincipalType.USER, principalId: tenantUser }],
+        capabilities: [SystemCapabilities.READ_ROLES],
+      });
+      expect(heldNoTenant.size).toBe(0);
     });
   });
 });

--- a/packages/data-schemas/src/methods/systemGrant.spec.ts
+++ b/packages/data-schemas/src/methods/systemGrant.spec.ts
@@ -830,6 +830,63 @@ describe('systemGrant methods', () => {
       expect(remainingA).toBe(0);
       expect(remainingB).toBe(1);
     });
+
+    it('with tenantId deletes only tenant-scoped grants, not platform-level grants', async () => {
+      // Platform-level grant (no tenantId)
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'editor',
+        capability: SystemCapabilities.READ_USERS,
+      });
+      // Tenant-scoped grant
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'editor',
+        capability: SystemCapabilities.READ_CONFIGS,
+        tenantId: 'tenant-1',
+      });
+      // Different tenant grant
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'editor',
+        capability: SystemCapabilities.READ_GROUPS,
+        tenantId: 'tenant-2',
+      });
+
+      await methods.deleteGrantsForPrincipal(PrincipalType.ROLE, 'editor', {
+        tenantId: 'tenant-1',
+      });
+
+      const remaining = await SystemGrant.find({
+        principalType: PrincipalType.ROLE,
+        principalId: 'editor',
+      }).lean();
+      const caps = remaining.map((g) => g.capability).sort();
+      // Platform-level and tenant-2 grants survive
+      expect(caps).toEqual([SystemCapabilities.READ_GROUPS, SystemCapabilities.READ_USERS]);
+    });
+
+    it('without tenantId deletes all grants across all tenants', async () => {
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'temp-role',
+        capability: SystemCapabilities.READ_USERS,
+      });
+      await methods.grantCapability({
+        principalType: PrincipalType.ROLE,
+        principalId: 'temp-role',
+        capability: SystemCapabilities.READ_CONFIGS,
+        tenantId: 'tenant-a',
+      });
+
+      await methods.deleteGrantsForPrincipal(PrincipalType.ROLE, 'temp-role');
+
+      const remaining = await SystemGrant.countDocuments({
+        principalType: PrincipalType.ROLE,
+        principalId: 'temp-role',
+      });
+      expect(remaining).toBe(0);
+    });
   });
 
   describe('schema validation', () => {

--- a/packages/data-schemas/src/methods/systemGrant.spec.ts
+++ b/packages/data-schemas/src/methods/systemGrant.spec.ts
@@ -912,4 +912,124 @@ describe('systemGrant methods', () => {
       expect(count).toBe(2);
     });
   });
+
+  describe('getCapabilitiesForPrincipals', () => {
+    it('returns grants across multiple principals in a single query', async () => {
+      const userId = new Types.ObjectId();
+      await SystemGrant.create({
+        principalType: PrincipalType.USER,
+        principalId: userId,
+        capability: SystemCapabilities.READ_USERS,
+      });
+      await SystemGrant.create({
+        principalType: PrincipalType.ROLE,
+        principalId: 'editor',
+        capability: SystemCapabilities.READ_ROLES,
+      });
+
+      const grants = await methods.getCapabilitiesForPrincipals({
+        principals: [
+          { principalType: PrincipalType.USER, principalId: userId },
+          { principalType: PrincipalType.ROLE, principalId: 'editor' },
+        ],
+      });
+
+      expect(grants).toHaveLength(2);
+      const caps = grants.map((g) => g.capability).sort();
+      expect(caps).toEqual([SystemCapabilities.READ_ROLES, SystemCapabilities.READ_USERS]);
+    });
+
+    it('returns empty array for empty principals list', async () => {
+      await SystemGrant.create({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.ACCESS_ADMIN,
+      });
+
+      const grants = await methods.getCapabilitiesForPrincipals({ principals: [] });
+      expect(grants).toEqual([]);
+    });
+
+    it('returns only matching principals, not all grants', async () => {
+      const userId = new Types.ObjectId();
+      await SystemGrant.create({
+        principalType: PrincipalType.USER,
+        principalId: userId,
+        capability: SystemCapabilities.READ_USERS,
+      });
+      await SystemGrant.create({
+        principalType: PrincipalType.ROLE,
+        principalId: 'unrelated',
+        capability: SystemCapabilities.MANAGE_ROLES,
+      });
+
+      const grants = await methods.getCapabilitiesForPrincipals({
+        principals: [{ principalType: PrincipalType.USER, principalId: userId }],
+      });
+
+      expect(grants).toHaveLength(1);
+      expect(grants[0].capability).toBe(SystemCapabilities.READ_USERS);
+    });
+
+    it('returns multiple grants for the same principal', async () => {
+      await SystemGrant.create({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.ACCESS_ADMIN,
+      });
+      await SystemGrant.create({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.MANAGE_ROLES,
+      });
+
+      const grants = await methods.getCapabilitiesForPrincipals({
+        principals: [{ principalType: PrincipalType.ROLE, principalId: 'admin' }],
+      });
+
+      expect(grants).toHaveLength(2);
+    });
+
+    it('excludes tenant-scoped grants when no tenantId provided', async () => {
+      await SystemGrant.create({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.ACCESS_ADMIN,
+      });
+      await SystemGrant.create({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.MANAGE_USERS,
+        tenantId: 'tenant-1',
+      });
+
+      const grants = await methods.getCapabilitiesForPrincipals({
+        principals: [{ principalType: PrincipalType.ROLE, principalId: 'admin' }],
+      });
+
+      expect(grants).toHaveLength(1);
+      expect(grants[0].capability).toBe(SystemCapabilities.ACCESS_ADMIN);
+    });
+
+    it('includes both platform and tenant grants when tenantId provided', async () => {
+      await SystemGrant.create({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.ACCESS_ADMIN,
+      });
+      await SystemGrant.create({
+        principalType: PrincipalType.ROLE,
+        principalId: 'admin',
+        capability: SystemCapabilities.MANAGE_USERS,
+        tenantId: 'tenant-1',
+      });
+
+      const grants = await methods.getCapabilitiesForPrincipals({
+        principals: [{ principalType: PrincipalType.ROLE, principalId: 'admin' }],
+        tenantId: 'tenant-1',
+      });
+
+      expect(grants).toHaveLength(2);
+    });
+  });
 });

--- a/packages/data-schemas/src/methods/systemGrant.spec.ts
+++ b/packages/data-schemas/src/methods/systemGrant.spec.ts
@@ -542,6 +542,74 @@ describe('systemGrant methods', () => {
       });
     });
 
+    describe('hierarchical config capabilities', () => {
+      it('manage:configs satisfies manage:configs:<section>', async () => {
+        const userId = new Types.ObjectId();
+        await methods.grantCapability({
+          principalType: PrincipalType.USER,
+          principalId: userId,
+          capability: SystemCapabilities.MANAGE_CONFIGS,
+        });
+
+        const result = await methods.hasCapabilityForPrincipals({
+          principals: [{ principalType: PrincipalType.USER, principalId: userId }],
+          capability: 'manage:configs:endpoints' as SystemCapability,
+        });
+        expect(result).toBe(true);
+      });
+
+      it('manage:configs satisfies read:configs:<section> transitively', async () => {
+        const userId = new Types.ObjectId();
+        await methods.grantCapability({
+          principalType: PrincipalType.USER,
+          principalId: userId,
+          capability: SystemCapabilities.MANAGE_CONFIGS,
+        });
+
+        const result = await methods.hasCapabilityForPrincipals({
+          principals: [{ principalType: PrincipalType.USER, principalId: userId }],
+          capability: 'read:configs:endpoints' as SystemCapability,
+        });
+        expect(result).toBe(true);
+      });
+
+      it('read:configs satisfies read:configs:<section> but NOT manage:configs:<section>', async () => {
+        const userId = new Types.ObjectId();
+        await methods.grantCapability({
+          principalType: PrincipalType.USER,
+          principalId: userId,
+          capability: SystemCapabilities.READ_CONFIGS,
+        });
+
+        const readResult = await methods.hasCapabilityForPrincipals({
+          principals: [{ principalType: PrincipalType.USER, principalId: userId }],
+          capability: 'read:configs:endpoints' as SystemCapability,
+        });
+        expect(readResult).toBe(true);
+
+        const manageResult = await methods.hasCapabilityForPrincipals({
+          principals: [{ principalType: PrincipalType.USER, principalId: userId }],
+          capability: 'manage:configs:endpoints' as SystemCapability,
+        });
+        expect(manageResult).toBe(false);
+      });
+
+      it('assign:configs satisfies assign:configs:<target>', async () => {
+        const userId = new Types.ObjectId();
+        await methods.grantCapability({
+          principalType: PrincipalType.USER,
+          principalId: userId,
+          capability: SystemCapabilities.ASSIGN_CONFIGS,
+        });
+
+        const result = await methods.hasCapabilityForPrincipals({
+          principals: [{ principalType: PrincipalType.USER, principalId: userId }],
+          capability: 'assign:configs:user' as SystemCapability,
+        });
+        expect(result).toBe(true);
+      });
+    });
+
     describe('tenant scoping', () => {
       it('tenant-scoped grant does not match platform-level query', async () => {
         const userId = new Types.ObjectId();
@@ -1211,10 +1279,7 @@ describe('systemGrant methods', () => {
 
       const held = await methods.getHeldCapabilities({
         principals: [{ principalType: PrincipalType.USER, principalId: userId }],
-        capabilities: [
-          SystemCapabilities.READ_ROLES,
-          SystemCapabilities.READ_GROUPS,
-        ],
+        capabilities: [SystemCapabilities.READ_ROLES, SystemCapabilities.READ_GROUPS],
       });
 
       expect(held).toEqual(new Set([SystemCapabilities.READ_ROLES]));

--- a/packages/data-schemas/src/methods/systemGrant.ts
+++ b/packages/data-schemas/src/methods/systemGrant.ts
@@ -194,13 +194,52 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     return await SystemGrant.find(filter).lean();
   }
 
-  async function listAllGrants(tenantId?: string): Promise<ISystemGrant[]> {
+  function buildTenantFilter(filter: Record<string, unknown>, tenantId?: string): void {
+    if (tenantId != null) {
+      filter.$or = [{ tenantId }, { tenantId: { $exists: false } }];
+    } else {
+      filter.tenantId = { $exists: false };
+    }
+  }
+
+  async function listGrants(options?: {
+    tenantId?: string;
+    principalTypes?: PrincipalType[];
+    limit?: number;
+    offset?: number;
+  }): Promise<ISystemGrant[]> {
     const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
-    const filter: Record<string, unknown> =
-      tenantId != null
-        ? { $or: [{ tenantId }, { tenantId: { $exists: false } }] }
-        : { tenantId: { $exists: false } };
-    return await SystemGrant.find(filter).lean();
+    const limit = options?.limit ?? 50;
+    const offset = options?.offset ?? 0;
+    const filter: Record<string, unknown> = {};
+
+    if (options?.principalTypes?.length) {
+      filter.principalType = { $in: options.principalTypes };
+    }
+
+    buildTenantFilter(filter, options?.tenantId);
+
+    return SystemGrant.find(filter)
+      .sort({ principalType: 1, capability: 1 })
+      .skip(offset)
+      .limit(limit)
+      .lean();
+  }
+
+  async function countGrants(options?: {
+    tenantId?: string;
+    principalTypes?: PrincipalType[];
+  }): Promise<number> {
+    const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
+    const filter: Record<string, unknown> = {};
+
+    if (options?.principalTypes?.length) {
+      filter.principalType = { $in: options.principalTypes };
+    }
+
+    buildTenantFilter(filter, options?.tenantId);
+
+    return SystemGrant.countDocuments(filter);
   }
 
   async function getCapabilitiesForPrincipals({
@@ -215,10 +254,16 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     }
 
     const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
-    const principalsQuery = principals.map((p) => ({
-      principalType: p.principalType,
-      principalId: normalizePrincipalId(p.principalId, p.principalType as PrincipalType),
-    }));
+    const principalsQuery = principals
+      .filter((p) => p.principalType !== PrincipalType.PUBLIC)
+      .map((p) => ({
+        principalType: p.principalType,
+        principalId: normalizePrincipalId(p.principalId, p.principalType as PrincipalType),
+      }));
+
+    if (!principalsQuery.length) {
+      return [];
+    }
 
     const filter: Record<string, unknown> = { $or: principalsQuery };
 
@@ -303,7 +348,8 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     seedSystemGrants,
     revokeCapability,
     hasCapabilityForPrincipals,
-    listAllGrants,
+    listGrants,
+    countGrants,
     getCapabilitiesForPrincipal,
     getCapabilitiesForPrincipals,
     deleteGrantsForPrincipal,

--- a/packages/data-schemas/src/methods/systemGrant.ts
+++ b/packages/data-schemas/src/methods/systemGrant.ts
@@ -72,8 +72,14 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
   }): Promise<boolean> {
     const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
     const principalsQuery = principals
-      .filter((p) => p.principalType !== PrincipalType.PUBLIC)
-      .map((p) => ({ principalType: p.principalType, principalId: p.principalId }));
+      .filter(
+        (p): p is typeof p & { principalId: string | Types.ObjectId } =>
+          p.principalType !== PrincipalType.PUBLIC && p.principalId != null,
+      )
+      .map((p) => ({
+        principalType: p.principalType,
+        principalId: normalizePrincipalId(p.principalId, p.principalType),
+      }));
 
     if (!principalsQuery.length) {
       return false;
@@ -281,7 +287,9 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     offset?: number;
   }): Promise<ISystemGrant[]> {
     const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
-    const limit = Math.max(1, options?.limit ?? 50);
+    const GRANTS_DEFAULT_LIMIT = 50;
+    const GRANTS_MAX_LIMIT = 200;
+    const limit = Math.min(GRANTS_MAX_LIMIT, Math.max(1, options?.limit ?? GRANTS_DEFAULT_LIMIT));
     const offset = options?.offset ?? 0;
     const filter: FilterQuery<ISystemGrant> = {
       ...(options?.principalTypes?.length && { principalType: { $in: options.principalTypes } }),
@@ -395,36 +403,27 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
    * Delete system grants for a principal.
    * Used for cascade cleanup when a principal (group, role) is deleted.
    *
-   * When `tenantId` is provided, only grants scoped to that tenant (plus
-   * platform-level grants without a tenantId) are removed. When omitted,
-   * ALL grants for the principal are removed regardless of tenant — this
-   * matches the current role-deletion path which is also tenant-unaware.
+   * When `tenantId` is provided, only grants scoped to **exactly** that
+   * tenant are removed — platform-level grants (no tenantId) are left
+   * intact so they continue to serve other tenants.
+   * When `tenantId` is omitted, ALL grants for the principal are removed
+   * regardless of tenant scope.
    */
   async function deleteGrantsForPrincipal(
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
-    sessionOrTenantId?: ClientSession | string,
-    maybeSession?: ClientSession,
+    options?: { tenantId?: string; session?: ClientSession },
   ): Promise<void> {
     const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
     const normalizedPrincipalId = normalizePrincipalId(principalId, principalType);
 
-    let tenantId: string | undefined;
-    let session: ClientSession | undefined;
-    if (typeof sessionOrTenantId === 'string') {
-      tenantId = sessionOrTenantId;
-      session = maybeSession;
-    } else {
-      session = sessionOrTenantId;
-    }
-
     const filter: FilterQuery<ISystemGrant> = {
       principalType,
       principalId: normalizedPrincipalId,
-      ...(tenantId != null && tenantCondition(tenantId)),
+      ...(options?.tenantId != null && { tenantId: options.tenantId }),
     };
-    const options = session ? { session } : {};
-    await SystemGrant.deleteMany(filter, options);
+    const queryOptions = options?.session ? { session: options.session } : {};
+    await SystemGrant.deleteMany(filter, queryOptions);
   }
 
   return {

--- a/packages/data-schemas/src/methods/systemGrant.ts
+++ b/packages/data-schemas/src/methods/systemGrant.ts
@@ -201,16 +201,15 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     principals: Array<{ principalType: string; principalId: string | Types.ObjectId }>;
     tenantId?: string;
   }): Promise<ISystemGrant[]> {
-    const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
+    if (!principals.length) {
+      return [];
+    }
 
+    const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
     const principalsQuery = principals.map((p) => ({
       principalType: p.principalType,
       principalId: normalizePrincipalId(p.principalId, p.principalType as PrincipalType),
     }));
-
-    if (!principalsQuery.length) {
-      return [];
-    }
 
     const filter: Record<string, unknown> = { $or: principalsQuery };
 

--- a/packages/data-schemas/src/methods/systemGrant.ts
+++ b/packages/data-schemas/src/methods/systemGrant.ts
@@ -80,23 +80,25 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
   }): Promise<Set<SystemCapability>> {
     const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
     const principalsQuery = principals
-      .filter((p) => p.principalType !== PrincipalType.PUBLIC)
-      .map((p) => ({ principalType: p.principalType, principalId: p.principalId }));
+      .filter(
+        (p): p is typeof p & { principalId: string | Types.ObjectId } =>
+          p.principalType !== PrincipalType.PUBLIC && p.principalId != null,
+      )
+      .map((p) => ({
+        principalType: p.principalType,
+        principalId: normalizePrincipalId(p.principalId, p.principalType as PrincipalType),
+      }));
 
     if (!principalsQuery.length || !capabilities.length) {
       return new Set();
     }
 
-    const allCaps = new Set<string>();
-    for (const cap of capabilities) {
-      allCaps.add(cap);
-      const implied = reverseImplications[cap as keyof typeof reverseImplications];
-      if (implied) {
-        for (const imp of implied) {
-          allCaps.add(imp);
-        }
-      }
-    }
+    const allCaps = new Set<string>([
+      ...capabilities,
+      ...capabilities.flatMap(
+        (cap) => reverseImplications[cap as keyof typeof reverseImplications] ?? [],
+      ),
+    ]);
 
     const docs = await SystemGrant.find(
       {

--- a/packages/data-schemas/src/methods/systemGrant.ts
+++ b/packages/data-schemas/src/methods/systemGrant.ts
@@ -1,5 +1,5 @@
 import { PrincipalType, SystemRoles } from 'librechat-data-provider';
-import type { Types, Model, ClientSession } from 'mongoose';
+import type { Types, Model, ClientSession, FilterQuery } from 'mongoose';
 import type { SystemCapability } from '~/types/admin';
 import type { ISystemGrant } from '~/types';
 import { SystemCapabilities, CapabilityImplications } from '~/admin/capabilities';
@@ -49,16 +49,11 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     const impliedBy = reverseImplications[capability as keyof typeof reverseImplications] ?? [];
     const capabilityQuery = impliedBy.length ? { $in: [capability, ...impliedBy] } : capability;
 
-    const query: Record<string, unknown> = {
+    const query: FilterQuery<ISystemGrant> = {
       $or: principalsQuery,
       capability: capabilityQuery,
+      ...tenantCondition(tenantId),
     };
-
-    if (tenantId != null) {
-      query.$and = [{ $or: [{ tenantId }, { tenantId: { $exists: false } }] }];
-    } else {
-      query.tenantId = { $exists: false };
-    }
 
     const doc = await SystemGrant.exists(query);
     return doc != null;
@@ -87,17 +82,12 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
 
     const normalizedPrincipalId = normalizePrincipalId(principalId, principalType);
 
-    const filter: Record<string, unknown> = {
+    const filter: FilterQuery<ISystemGrant> = {
       principalType,
       principalId: normalizedPrincipalId,
       capability,
+      tenantId: tenantId != null ? tenantId : { $exists: false },
     };
-
-    if (tenantId != null) {
-      filter.tenantId = tenantId;
-    } else {
-      filter.tenantId = { $exists: false };
-    }
 
     const update = {
       $set: {
@@ -149,17 +139,12 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
 
     const normalizedPrincipalId = normalizePrincipalId(principalId, principalType);
 
-    const filter: Record<string, unknown> = {
+    const filter: FilterQuery<ISystemGrant> = {
       principalType,
       principalId: normalizedPrincipalId,
       capability,
+      tenantId: tenantId != null ? tenantId : { $exists: false },
     };
-
-    if (tenantId != null) {
-      filter.tenantId = tenantId;
-    } else {
-      filter.tenantId = { $exists: false };
-    }
 
     const options = session ? { session } : {};
     await SystemGrant.deleteOne(filter, options);
@@ -180,26 +165,19 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
   }): Promise<ISystemGrant[]> {
     const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
 
-    const filter: Record<string, unknown> = {
+    const filter: FilterQuery<ISystemGrant> = {
       principalType,
       principalId: normalizePrincipalId(principalId, principalType),
+      ...tenantCondition(tenantId),
     };
-
-    if (tenantId != null) {
-      filter.$or = [{ tenantId }, { tenantId: { $exists: false } }];
-    } else {
-      filter.tenantId = { $exists: false };
-    }
 
     return await SystemGrant.find(filter).lean();
   }
 
-  function buildTenantFilter(filter: Record<string, unknown>, tenantId?: string): void {
-    if (tenantId != null) {
-      filter.$or = [{ tenantId }, { tenantId: { $exists: false } }];
-    } else {
-      filter.tenantId = { $exists: false };
-    }
+  function tenantCondition(tenantId?: string): FilterQuery<ISystemGrant> {
+    return tenantId != null
+      ? { $and: [{ $or: [{ tenantId }, { tenantId: { $exists: false } }] }] }
+      : { tenantId: { $exists: false } };
   }
 
   async function listGrants(options?: {
@@ -211,13 +189,10 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
     const limit = options?.limit ?? 50;
     const offset = options?.offset ?? 0;
-    const filter: Record<string, unknown> = {};
-
-    if (options?.principalTypes?.length) {
-      filter.principalType = { $in: options.principalTypes };
-    }
-
-    buildTenantFilter(filter, options?.tenantId);
+    const filter: FilterQuery<ISystemGrant> = {
+      ...(options?.principalTypes?.length && { principalType: { $in: options.principalTypes } }),
+      ...tenantCondition(options?.tenantId),
+    };
 
     return SystemGrant.find(filter)
       .sort({ principalType: 1, capability: 1 })
@@ -231,13 +206,10 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     principalTypes?: PrincipalType[];
   }): Promise<number> {
     const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
-    const filter: Record<string, unknown> = {};
-
-    if (options?.principalTypes?.length) {
-      filter.principalType = { $in: options.principalTypes };
-    }
-
-    buildTenantFilter(filter, options?.tenantId);
+    const filter: FilterQuery<ISystemGrant> = {
+      ...(options?.principalTypes?.length && { principalType: { $in: options.principalTypes } }),
+      ...tenantCondition(options?.tenantId),
+    };
 
     return SystemGrant.countDocuments(filter);
   }
@@ -265,13 +237,10 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
       return [];
     }
 
-    const filter: Record<string, unknown> = { $or: principalsQuery };
-
-    if (tenantId != null) {
-      filter.$and = [{ $or: [{ tenantId }, { tenantId: { $exists: false } }] }];
-    } else {
-      filter.tenantId = { $exists: false };
-    }
+    const filter: FilterQuery<ISystemGrant> = {
+      $or: principalsQuery,
+      ...tenantCondition(tenantId),
+    };
 
     return await SystemGrant.find(filter).lean();
   }

--- a/packages/data-schemas/src/methods/systemGrant.ts
+++ b/packages/data-schemas/src/methods/systemGrant.ts
@@ -19,6 +19,12 @@ for (const [broad, implied] of Object.entries(CapabilityImplications)) {
 }
 
 export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
+  function tenantCondition(tenantId?: string): FilterQuery<ISystemGrant> {
+    return tenantId != null
+      ? { $and: [{ $or: [{ tenantId }, { tenantId: { $exists: false } }] }] }
+      : { tenantId: { $exists: false } };
+  }
+
   /**
    * Check if any of the given principals holds a specific capability.
    * Follows the same principal-resolution pattern as AclEntry:
@@ -57,6 +63,64 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
 
     const doc = await SystemGrant.exists(query);
     return doc != null;
+  }
+
+  /**
+   * Returns the subset of `capabilities` that any of the given principals hold.
+   * Single DB round-trip — replaces N parallel `hasCapabilityForPrincipals` calls.
+   */
+  async function getHeldCapabilities({
+    principals,
+    capabilities,
+    tenantId,
+  }: {
+    principals: Array<{ principalType: PrincipalType; principalId?: string | Types.ObjectId }>;
+    capabilities: SystemCapability[];
+    tenantId?: string;
+  }): Promise<Set<SystemCapability>> {
+    const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
+    const principalsQuery = principals
+      .filter((p) => p.principalType !== PrincipalType.PUBLIC)
+      .map((p) => ({ principalType: p.principalType, principalId: p.principalId }));
+
+    if (!principalsQuery.length || !capabilities.length) {
+      return new Set();
+    }
+
+    const allCaps = new Set<string>();
+    for (const cap of capabilities) {
+      allCaps.add(cap);
+      const implied = reverseImplications[cap as keyof typeof reverseImplications];
+      if (implied) {
+        for (const imp of implied) {
+          allCaps.add(imp);
+        }
+      }
+    }
+
+    const docs = await SystemGrant.find(
+      {
+        $or: principalsQuery,
+        capability: { $in: [...allCaps] },
+        ...tenantCondition(tenantId),
+      },
+      { capability: 1, _id: 0 },
+    ).lean();
+
+    const held = new Set<string>(docs.map((d) => d.capability));
+    const result = new Set<SystemCapability>();
+    for (const cap of capabilities) {
+      if (held.has(cap)) {
+        result.add(cap);
+        continue;
+      }
+      const implied = reverseImplications[cap as keyof typeof reverseImplications];
+      if (implied?.some((imp) => held.has(imp))) {
+        result.add(cap);
+      }
+    }
+
+    return result;
   }
 
   /**
@@ -174,12 +238,6 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     return await SystemGrant.find(filter).lean();
   }
 
-  function tenantCondition(tenantId?: string): FilterQuery<ISystemGrant> {
-    return tenantId != null
-      ? { $and: [{ $or: [{ tenantId }, { tenantId: { $exists: false } }] }] }
-      : { tenantId: { $exists: false } };
-  }
-
   async function listGrants(options?: {
     tenantId?: string;
     principalTypes?: PrincipalType[];
@@ -187,7 +245,7 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     offset?: number;
   }): Promise<ISystemGrant[]> {
     const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
-    const limit = options?.limit ?? 50;
+    const limit = Math.max(1, options?.limit ?? 50);
     const offset = options?.offset ?? 0;
     const filter: FilterQuery<ISystemGrant> = {
       ...(options?.principalTypes?.length && { principalType: { $in: options.principalTypes } }),
@@ -317,6 +375,7 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     seedSystemGrants,
     revokeCapability,
     hasCapabilityForPrincipals,
+    getHeldCapabilities,
     listGrants,
     countGrants,
     getCapabilitiesForPrincipal,

--- a/packages/data-schemas/src/methods/systemGrant.ts
+++ b/packages/data-schemas/src/methods/systemGrant.ts
@@ -312,7 +312,7 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     principals,
     tenantId,
   }: {
-    principals: Array<{ principalType: string; principalId: string | Types.ObjectId }>;
+    principals: Array<{ principalType: PrincipalType; principalId: string | Types.ObjectId }>;
     tenantId?: string;
   }): Promise<ISystemGrant[]> {
     if (!principals.length) {
@@ -324,7 +324,7 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
       .filter((p) => p.principalType !== PrincipalType.PUBLIC)
       .map((p) => ({
         principalType: p.principalType,
-        principalId: normalizePrincipalId(p.principalId, p.principalType as PrincipalType),
+        principalId: normalizePrincipalId(p.principalId, p.principalType),
       }));
 
     if (!principalsQuery.length) {

--- a/packages/data-schemas/src/methods/systemGrant.ts
+++ b/packages/data-schemas/src/methods/systemGrant.ts
@@ -194,6 +194,35 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     return await SystemGrant.find(filter).lean();
   }
 
+  async function getCapabilitiesForPrincipals({
+    principals,
+    tenantId,
+  }: {
+    principals: Array<{ principalType: string; principalId: string | Types.ObjectId }>;
+    tenantId?: string;
+  }): Promise<ISystemGrant[]> {
+    const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
+
+    const principalsQuery = principals.map((p) => ({
+      principalType: p.principalType,
+      principalId: normalizePrincipalId(p.principalId, p.principalType as PrincipalType),
+    }));
+
+    if (!principalsQuery.length) {
+      return [];
+    }
+
+    const filter: Record<string, unknown> = { $or: principalsQuery };
+
+    if (tenantId != null) {
+      filter.$and = [{ $or: [{ tenantId }, { tenantId: { $exists: false } }] }];
+    } else {
+      filter.tenantId = { $exists: false };
+    }
+
+    return await SystemGrant.find(filter).lean();
+  }
+
   /**
    * Seed the ADMIN role with all system capabilities (no tenantId — single-instance mode).
    * Idempotent and concurrency-safe: uses bulkWrite with ordered:false so parallel
@@ -267,6 +296,7 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     revokeCapability,
     hasCapabilityForPrincipals,
     getCapabilitiesForPrincipal,
+    getCapabilitiesForPrincipals,
     deleteGrantsForPrincipal,
   };
 }

--- a/packages/data-schemas/src/methods/systemGrant.ts
+++ b/packages/data-schemas/src/methods/systemGrant.ts
@@ -18,6 +18,33 @@ for (const [broad, implied] of Object.entries(CapabilityImplications)) {
   }
 }
 
+const baseCapabilityValues = new Set<string>(Object.values(SystemCapabilities));
+
+/**
+ * For a section/assignment capability like `manage:configs:endpoints` or
+ * `assign:configs:user`, returns all base capabilities that subsume it:
+ * the direct parent (`manage:configs`) plus any that imply the parent
+ * via `reverseImplications` (`manage:configs` has no reverse, but
+ * `read:configs` is implied by `manage:configs`—so `read:configs:endpoints`
+ * is satisfied by holding `manage:configs`).
+ */
+function getParentCapabilities(capability: string): string[] {
+  const lastColon = capability.lastIndexOf(':');
+  if (lastColon === -1) {
+    return [];
+  }
+  const parent = capability.slice(0, lastColon);
+  if (!baseCapabilityValues.has(parent)) {
+    return [];
+  }
+  const parents = [parent];
+  const implied = reverseImplications[parent as keyof typeof reverseImplications];
+  if (implied) {
+    parents.push(...implied);
+  }
+  return parents;
+}
+
 export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
   function tenantCondition(tenantId?: string): FilterQuery<ISystemGrant> {
     return tenantId != null
@@ -53,7 +80,9 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     }
 
     const impliedBy = reverseImplications[capability as keyof typeof reverseImplications] ?? [];
-    const capabilityQuery = impliedBy.length ? { $in: [capability, ...impliedBy] } : capability;
+    const parents = getParentCapabilities(capability);
+    const allMatches = [capability, ...impliedBy, ...parents];
+    const capabilityQuery = allMatches.length > 1 ? { $in: allMatches } : capability;
 
     const query: FilterQuery<ISystemGrant> = {
       $or: principalsQuery,
@@ -98,6 +127,7 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
       ...capabilities.flatMap(
         (cap) => reverseImplications[cap as keyof typeof reverseImplications] ?? [],
       ),
+      ...capabilities.flatMap(getParentCapabilities),
     ]);
 
     const docs = await SystemGrant.find(
@@ -118,6 +148,10 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
       }
       const implied = reverseImplications[cap as keyof typeof reverseImplications];
       if (implied?.some((imp) => held.has(imp))) {
+        result.add(cap);
+        continue;
+      }
+      if (getParentCapabilities(cap).some((p) => held.has(p))) {
         result.add(cap);
       }
     }

--- a/packages/data-schemas/src/methods/systemGrant.ts
+++ b/packages/data-schemas/src/methods/systemGrant.ts
@@ -280,6 +280,9 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     return await SystemGrant.find(filter).lean();
   }
 
+  const GRANTS_DEFAULT_LIMIT = 50;
+  const GRANTS_MAX_LIMIT = 200;
+
   async function listGrants(options?: {
     tenantId?: string;
     principalTypes?: PrincipalType[];
@@ -287,8 +290,6 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     offset?: number;
   }): Promise<ISystemGrant[]> {
     const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
-    const GRANTS_DEFAULT_LIMIT = 50;
-    const GRANTS_MAX_LIMIT = 200;
     const limit = Math.min(GRANTS_MAX_LIMIT, Math.max(1, options?.limit ?? GRANTS_DEFAULT_LIMIT));
     const offset = options?.offset ?? 0;
     const filter: FilterQuery<ISystemGrant> = {

--- a/packages/data-schemas/src/methods/systemGrant.ts
+++ b/packages/data-schemas/src/methods/systemGrant.ts
@@ -392,18 +392,39 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
   }
 
   /**
-   * Delete all system grants for a principal.
+   * Delete system grants for a principal.
    * Used for cascade cleanup when a principal (group, role) is deleted.
+   *
+   * When `tenantId` is provided, only grants scoped to that tenant (plus
+   * platform-level grants without a tenantId) are removed. When omitted,
+   * ALL grants for the principal are removed regardless of tenant — this
+   * matches the current role-deletion path which is also tenant-unaware.
    */
   async function deleteGrantsForPrincipal(
     principalType: PrincipalType,
     principalId: string | Types.ObjectId,
-    session?: ClientSession,
+    sessionOrTenantId?: ClientSession | string,
+    maybeSession?: ClientSession,
   ): Promise<void> {
     const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
     const normalizedPrincipalId = normalizePrincipalId(principalId, principalType);
+
+    let tenantId: string | undefined;
+    let session: ClientSession | undefined;
+    if (typeof sessionOrTenantId === 'string') {
+      tenantId = sessionOrTenantId;
+      session = maybeSession;
+    } else {
+      session = sessionOrTenantId;
+    }
+
+    const filter: FilterQuery<ISystemGrant> = {
+      principalType,
+      principalId: normalizedPrincipalId,
+      ...(tenantId != null && tenantCondition(tenantId)),
+    };
     const options = session ? { session } : {};
-    await SystemGrant.deleteMany({ principalType, principalId: normalizedPrincipalId }, options);
+    await SystemGrant.deleteMany(filter, options);
   }
 
   return {

--- a/packages/data-schemas/src/methods/systemGrant.ts
+++ b/packages/data-schemas/src/methods/systemGrant.ts
@@ -194,6 +194,15 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     return await SystemGrant.find(filter).lean();
   }
 
+  async function listAllGrants(tenantId?: string): Promise<ISystemGrant[]> {
+    const SystemGrant = mongoose.models.SystemGrant as Model<ISystemGrant>;
+    const filter: Record<string, unknown> =
+      tenantId != null
+        ? { $or: [{ tenantId }, { tenantId: { $exists: false } }] }
+        : { tenantId: { $exists: false } };
+    return await SystemGrant.find(filter).lean();
+  }
+
   async function getCapabilitiesForPrincipals({
     principals,
     tenantId,
@@ -294,6 +303,7 @@ export function createSystemGrantMethods(mongoose: typeof import('mongoose')) {
     seedSystemGrants,
     revokeCapability,
     hasCapabilityForPrincipals,
+    listAllGrants,
     getCapabilitiesForPrincipal,
     getCapabilitiesForPrincipals,
     deleteGrantsForPrincipal,

--- a/packages/data-schemas/src/schema/systemGrant.ts
+++ b/packages/data-schemas/src/schema/systemGrant.ts
@@ -66,6 +66,6 @@ systemGrantSchema.index(
 );
 
 systemGrantSchema.index({ capability: 1, tenantId: 1 });
-systemGrantSchema.index({ principalType: 1, capability: 1 });
+systemGrantSchema.index({ principalType: 1, capability: 1, tenantId: 1 });
 
 export default systemGrantSchema;

--- a/packages/data-schemas/src/schema/systemGrant.ts
+++ b/packages/data-schemas/src/schema/systemGrant.ts
@@ -66,5 +66,6 @@ systemGrantSchema.index(
 );
 
 systemGrantSchema.index({ capability: 1, tenantId: 1 });
+systemGrantSchema.index({ principalType: 1, capability: 1 });
 
 export default systemGrantSchema;

--- a/packages/data-schemas/src/schema/systemGrant.ts
+++ b/packages/data-schemas/src/schema/systemGrant.ts
@@ -1,12 +1,7 @@
 import { Schema } from 'mongoose';
 import { PrincipalType } from 'librechat-data-provider';
-import { SystemCapabilities } from '~/admin/capabilities';
-import type { SystemCapability } from '~/types/admin';
+import { isValidCapability } from '~/admin/capabilities';
 import type { ISystemGrant } from '~/types';
-
-const baseCapabilities = new Set<SystemCapability>(Object.values(SystemCapabilities));
-const sectionCapPattern = /^(?:manage|read):configs:\w+$/;
-const assignCapPattern = /^assign:configs:(?:user|group|role)$/;
 
 const systemGrantSchema = new Schema<ISystemGrant>(
   {
@@ -23,8 +18,7 @@ const systemGrantSchema = new Schema<ISystemGrant>(
       type: String,
       required: true,
       validate: {
-        validator: (v: SystemCapability) =>
-          baseCapabilities.has(v) || sectionCapPattern.test(v) || assignCapPattern.test(v),
+        validator: isValidCapability,
         message: 'Invalid capability string: "{VALUE}"',
       },
     },


### PR DESCRIPTION
## Summary

This pull request introduces a new admin "grants" API for managing system capability grants for roles, groups, and users. It adds both backend handlers and API routes for granting, revoking, and querying capabilities, and integrates grant cleanup when roles are deleted. The changes also include test coverage for the new and updated functionality.

**New admin grants API:**

- Added a new `admin/grants` API route (`/api/admin/grants`) with endpoints to assign, revoke, and query capability grants for principals (roles, groups, users), including effective capabilities for the current user. [[1]](diffhunk://#diff-fa433d1b40cf186d06215bcdd5517c05ee38b5e6e2011c5806db5b893d4552b0R1-R27) [[2]](diffhunk://#diff-a7e858ecd8004b310ac59b25e999ad677fba3cd712ab7f7da4f0aa5bf8d28cf4R147) [[3]](diffhunk://#diff-0c38957435f76b24040fc4ef3e17e78bb12f18ff39b0bde9ca03a7685b14f19bR6) [[4]](diffhunk://#diff-0c38957435f76b24040fc4ef3e17e78bb12f18ff39b0bde9ca03a7685b14f19bR39)
- Implemented `createAdminGrantsHandlers` in `packages/api/src/admin/grants.ts` to handle grant assignment, revocation, and capability queries, with validation and permission checks. [[1]](diffhunk://#diff-c76765d8b379b913913fc5838613ee1cbcf88fef116ce7194bc6d5dac81798f8R1-R242) [[2]](diffhunk://#diff-cb68d9b9a6aedf94f91febfe7fbbd8a2c4907549d8df4e2498a64192d829937fR2-R6)

**Role deletion and grant cleanup:**

- Updated the admin roles handler to call `deleteGrantsForPrincipal` when a role is deleted, ensuring capability grants are cleaned up for that role; errors in cleanup are logged but do not block deletion. [[1]](diffhunk://#diff-074dfee7b518203f2b2f0c7f9f9a495efb092f5a8302033000c4c1290a2c0759R108-R111) [[2]](diffhunk://#diff-074dfee7b518203f2b2f0c7f9f9a495efb092f5a8302033000c4c1290a2c0759R130) [[3]](diffhunk://#diff-57ffcb0eecb2451ab5daaf9e57426482780805eede39895d96b553fe4b656501R29) [[4]](diffhunk://#diff-074dfee7b518203f2b2f0c7f9f9a495efb092f5a8302033000c4c1290a2c0759R375-R384) [[5]](diffhunk://#diff-074dfee7b518203f2b2f0c7f9f9a495efb092f5a8302033000c4c1290a2c0759L1-R1)

**Test updates:**

- Expanded tests for role deletion to cover grant cleanup, including cases where grant deletion fails or the role does not exist. [[1]](diffhunk://#diff-d993d8ef6a7c1406b76f1d5560077b8c03628d254c5b25cf56a751d3f2a178f1R74) [[2]](diffhunk://#diff-d993d8ef6a7c1406b76f1d5560077b8c03628d254c5b25cf56a751d3f2a178f1R929-R963) [[3]](diffhunk://#diff-d993d8ef6a7c1406b76f1d5560077b8c03628d254c5b25cf56a751d3f2a178f1L2-R2)

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

**Grants handler tests** (`grants.spec.ts` — 46 tests):

- `listAllGrants` — returns all grants, empty array, filters by caller's read permissions, 401 unauthenticated, 500 on error
- `getEffectiveCapabilities` — expanded capabilities for user, empty grants, single-batch principal query, skips principals without ID, deduplicates across principals, 401 unauthenticated, 500 on error
- `getPrincipalGrants` — role and group principals, 400 for invalid type / missing ID / non-ObjectId group ID, accepts string role ID, 401 unauthenticated, 403 when caller lacks READ capability, 500 on error
- `assignGrant` — successful 201, passes `grantedBy`, 400 for missing/invalid type/ID/capability/ObjectId, 401 unauthenticated, 403 when caller lacks manage capability, 403 privilege amplification (caller lacks the capability being granted), allows implied capability transitively, checks correct manage capability per principal type (MANAGE_ROLES/GROUPS/USERS), 500 when `grantCapability` returns null, 500 on error
- `revokeGrant` — successful 200, 400 for missing type/ID/invalid capability, 401 unauthenticated, 403 when caller lacks manage capability, 400 for invalid user ObjectId, 500 on error

**Roles handler grant cleanup tests** (`roles.spec.ts`):

- `deleteRole` — cleans up grants after successful deletion, succeeds even when cascade cleanup fails, succeeds even when all cascade operations fail


## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.
