### PR TITLE
fix: wrap SearchContent with MessagesViewContext provider

### DIFF
--- a/client/src/components/Chat/Messages/Content/SearchContent.tsx
+++ b/client/src/components/Chat/Messages/Content/SearchContent.tsx
@@ -9,12 +9,31 @@ import type {
   SearchResultData,
   TMessageContentParts,
 } from 'librechat-data-provider';
+import type { MessagesViewContextValue } from '~/Providers/MessagesViewContext';
+import { MessagesViewContext } from '~/Providers/MessagesViewContext';
 import { UnfinishedMessage } from './MessageContent';
 import { cn, mapAttachments } from '~/utils';
 import { SearchContext } from '~/Providers';
 import MarkdownLite from './MarkdownLite';
 import store from '~/store';
 import Part from './Part';
+
+const SEARCH_VIEW_DEFAULTS: MessagesViewContextValue = {
+  conversation: null,
+  conversationId: null,
+  isSubmitting: false,
+  abortScroll: false,
+  setAbortScroll: () => {},
+  ask: () => Promise.resolve(),
+  regenerate: () => {},
+  handleContinue: () => {},
+  index: 0,
+  latestMessageId: undefined,
+  latestMessageDepth: undefined,
+  setLatestMessage: () => {},
+  getMessages: () => [],
+  setMessages: () => {},
+};
 
 const SearchContent = ({
   message,
@@ -32,36 +51,38 @@ const SearchContent = ({
 
   if (Array.isArray(message.content) && message.content.length > 0) {
     return (
-      <SearchContext.Provider value={{ searchResults }}>
-        {message.content
-          .filter((part: TMessageContentParts | undefined) => part)
-          .map((part: TMessageContentParts | undefined, idx: number) => {
-            if (!part) {
-              return null;
-            }
+      <MessagesViewContext.Provider value={SEARCH_VIEW_DEFAULTS}>
+        <SearchContext.Provider value={{ searchResults }}>
+          {message.content
+            .filter((part: TMessageContentParts | undefined) => part)
+            .map((part: TMessageContentParts | undefined, idx: number) => {
+              if (!part) {
+                return null;
+              }
 
-            const toolCallId =
-              (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
-            const partAttachments = attachmentMap[toolCallId];
-            return (
-              <Part
-                key={`display-${messageId}-${idx}`}
-                showCursor={false}
-                isSubmitting={false}
-                isCreatedByUser={message.isCreatedByUser}
-                attachments={partAttachments}
-                part={part}
-              />
-            );
-          })}
-        {message.unfinished === true && (
-          <Suspense>
-            <DelayedRender delay={250}>
-              <UnfinishedMessage message={message} key={`unfinished-${messageId}`} />
-            </DelayedRender>
-          </Suspense>
-        )}
-      </SearchContext.Provider>
+              const toolCallId =
+                (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
+              const partAttachments = attachmentMap[toolCallId];
+              return (
+                <Part
+                  key={`display-${messageId}-${idx}`}
+                  showCursor={false}
+                  isSubmitting={false}
+                  isCreatedByUser={message.isCreatedByUser}
+                  attachments={partAttachments}
+                  part={part}
+                />
+              );
+            })}
+          {message.unfinished === true && (
+            <Suspense>
+              <DelayedRender delay={250}>
+                <UnfinishedMessage message={message} key={`unfinished-${messageId}`} />
+              </DelayedRender>
+            </Suspense>
+          )}
+        </SearchContext.Provider>
+      </MessagesViewContext.Provider>
     );
   }
 

--- a/client/src/components/Chat/Messages/Content/__tests__/SearchContent.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/SearchContent.test.tsx
@@ -24,9 +24,7 @@ jest.mock('../Part', () => ({
 
 jest.mock('../MarkdownLite', () => ({
   __esModule: true,
-  default: ({ content }: { content: string }) => (
-    <div data-testid="markdown-lite">{content}</div>
-  ),
+  default: ({ content }: { content: string }) => <div data-testid="markdown-lite">{content}</div>,
 }));
 
 jest.mock('../MessageContent', () => ({

--- a/client/src/components/Chat/Messages/Content/__tests__/SearchContent.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/SearchContent.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { ContentTypes } from 'librechat-data-provider';
+import { render, screen } from '@testing-library/react';
+import type { TMessage, TMessageContentParts } from 'librechat-data-provider';
+import SearchContent from '../SearchContent';
+
+jest.mock('~/store', () => {
+  const { atom } = jest.requireActual('recoil');
+  return {
+    __esModule: true,
+    default: {
+      enableUserMsgMarkdown: atom({ key: 'test-enableUserMsgMarkdown', default: true }),
+    },
+  };
+});
+
+jest.mock('../Part', () => ({
+  __esModule: true,
+  default: ({ part }: { part: TMessageContentParts }) => (
+    <div data-testid="part">{JSON.stringify(part)}</div>
+  ),
+}));
+
+jest.mock('../MarkdownLite', () => ({
+  __esModule: true,
+  default: ({ content }: { content: string }) => (
+    <div data-testid="markdown-lite">{content}</div>
+  ),
+}));
+
+jest.mock('../MessageContent', () => ({
+  UnfinishedMessage: () => <div data-testid="unfinished" />,
+}));
+
+jest.mock('~/utils', () => ({
+  cn: (...classes: (string | boolean | undefined)[]) => classes.filter(Boolean).join(' '),
+  mapAttachments: () => ({}),
+}));
+
+const renderSearchContent = (message: TMessage) =>
+  render(
+    <RecoilRoot>
+      <SearchContent message={message} />
+    </RecoilRoot>,
+  );
+
+describe('SearchContent', () => {
+  it('renders content array with tool_call parts without throwing', () => {
+    const message = {
+      messageId: 'msg-1',
+      isCreatedByUser: false,
+      content: [
+        {
+          [ContentTypes.TEXT]: { value: 'some text' },
+          type: ContentTypes.TEXT,
+        },
+        {
+          [ContentTypes.TOOL_CALL]: { id: 'call-1', name: 'search', args: '{}', output: 'ok' },
+          type: ContentTypes.TOOL_CALL,
+        },
+      ],
+    } as unknown as TMessage;
+
+    const { container } = renderSearchContent(message);
+
+    const parts = screen.getAllByTestId('part');
+    expect(parts).toHaveLength(2);
+    expect(container).toBeTruthy();
+  });
+
+  it('renders MarkdownLite for plain text messages without content array', () => {
+    const message = {
+      messageId: 'msg-2',
+      isCreatedByUser: true,
+      text: 'hello world',
+    } as unknown as TMessage;
+
+    renderSearchContent(message);
+
+    const markdown = screen.getByTestId('markdown-lite');
+    expect(markdown).toHaveTextContent('hello world');
+  });
+});


### PR DESCRIPTION
Fixes #12421

## Summary

Search route crashes when displaying messages with tool calls because `ToolCallInfo` (and similar components) call `useMessagesViewContext()`, but `SearchContent` doesn't have a `MessagesViewProvider` in its component tree. 

Added a `MessagesViewContext.Provider` wrapper inside `SearchContent` with no-op defaults. Search results are display-only so the interactive callbacks (ask, regenerate, etc.) aren't needed here.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Added `SearchContent.test.tsx` covering both the tool_call content path and the plain text fallback path
- Ran `cd client && npx jest SearchContent` -- 2/2 tests pass

### **Test Configuration**:

Node v22, macOS

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes