### PR TITLE
🔐 feat: OIDC Bearer Token Authentication for Remote Agent API

### DIFF
--- a/api/server/controllers/AuthController.js
+++ b/api/server/controllers/AuthController.js
@@ -2,7 +2,7 @@ const cookies = require('cookie');
 const jwt = require('jsonwebtoken');
 const openIdClient = require('openid-client');
 const { logger } = require('@librechat/data-schemas');
-const { isEnabled, findOpenIDUser } = require('@librechat/api');
+const { isEnabled, findOpenIDUser, getOpenIdIssuer } = require('@librechat/api');
 const {
   requestPasswordReset,
   setOpenIDAuthTokens,
@@ -85,10 +85,12 @@ const refreshController = async (req, res) => {
         refreshParams,
       );
       const claims = tokenset.claims();
+      const openidIssuer = getOpenIdIssuer(claims, openIdConfig);
       const { user, error, migration } = await findOpenIDUser({
         findUser,
         email: getOpenIdEmail(claims),
         openidId: claims.sub,
+        openidIssuer,
         idOnTheSource: claims.oid,
         strategyName: 'refreshController',
       });
@@ -111,6 +113,7 @@ const refreshController = async (req, res) => {
         await updateUser(user._id.toString(), {
           provider: 'openid',
           openidId: claims.sub,
+          ...(openidIssuer ? { openidIssuer } : {}),
         });
         logger.info(
           `[refreshController] Updated user ${user.email} openidId (${reason}): ${user.openidId ?? 'null'} -> ${claims.sub}`,

--- a/api/server/controllers/AuthController.spec.js
+++ b/api/server/controllers/AuthController.spec.js
@@ -23,6 +23,7 @@ jest.mock('~/models', () => ({
 jest.mock('@librechat/api', () => ({
   isEnabled: jest.fn(),
   findOpenIDUser: jest.fn(),
+  getOpenIdIssuer: jest.fn(() => 'https://issuer.example.com'),
 }));
 
 const openIdClient = require('openid-client');
@@ -157,6 +158,7 @@ describe('refreshController – OpenID path', () => {
   };
 
   const baseClaims = {
+    iss: 'https://issuer.example.com',
     sub: 'oidc-sub-123',
     oid: 'oid-456',
     email: 'user@example.com',
@@ -204,7 +206,10 @@ describe('refreshController – OpenID path', () => {
 
     expect(getOpenIdEmail).toHaveBeenCalledWith(baseClaims);
     expect(findOpenIDUser).toHaveBeenCalledWith(
-      expect.objectContaining({ email: baseClaims.email }),
+      expect.objectContaining({
+        email: baseClaims.email,
+        openidIssuer: baseClaims.iss,
+      }),
     );
     expect(res.status).toHaveBeenCalledWith(200);
   });
@@ -225,7 +230,10 @@ describe('refreshController – OpenID path', () => {
 
     expect(getOpenIdEmail).toHaveBeenCalledWith(claimsWithUpn);
     expect(findOpenIDUser).toHaveBeenCalledWith(
-      expect.objectContaining({ email: 'user@corp.example.com' }),
+      expect.objectContaining({
+        email: 'user@corp.example.com',
+        openidIssuer: baseClaims.iss,
+      }),
     );
     expect(res.status).toHaveBeenCalledWith(200);
   });
@@ -236,7 +244,10 @@ describe('refreshController – OpenID path', () => {
     await refreshController(req, res);
 
     expect(findOpenIDUser).toHaveBeenCalledWith(
-      expect.objectContaining({ email: baseClaims.email }),
+      expect.objectContaining({
+        email: baseClaims.email,
+        openidIssuer: baseClaims.iss,
+      }),
     );
   });
 
@@ -267,7 +278,11 @@ describe('refreshController – OpenID path', () => {
 
     expect(updateUser).toHaveBeenCalledWith(
       'user-db-id',
-      expect.objectContaining({ provider: 'openid', openidId: baseClaims.sub }),
+      expect.objectContaining({
+        provider: 'openid',
+        openidId: baseClaims.sub,
+        openidIssuer: baseClaims.iss,
+      }),
     );
     expect(res.status).toHaveBeenCalledWith(200);
   });

--- a/api/server/routes/agents/middleware.js
+++ b/api/server/routes/agents/middleware.js
@@ -1,0 +1,39 @@
+const { PermissionTypes, Permissions } = require('librechat-data-provider');
+const {
+  generateCheckAccess,
+  createRequireApiKeyAuth,
+  createRemoteAgentAuth,
+  createCheckRemoteAgentAccess,
+} = require('@librechat/api');
+const { getEffectivePermissions } = require('~/server/services/PermissionService');
+const { getAppConfig } = require('~/server/services/Config');
+const db = require('~/models');
+
+const apiKeyMiddleware = createRequireApiKeyAuth({
+  validateAgentApiKey: db.validateAgentApiKey,
+  findUser: db.findUser,
+});
+
+const requireRemoteAgentAuth = createRemoteAgentAuth({
+  apiKeyMiddleware,
+  findUser: db.findUser,
+  updateUser: db.updateUser,
+  getAppConfig,
+});
+
+const checkRemoteAgentsFeature = generateCheckAccess({
+  permissionType: PermissionTypes.REMOTE_AGENTS,
+  permissions: [Permissions.USE],
+  getRoleByName: db.getRoleByName,
+});
+
+const checkAgentPermission = createCheckRemoteAgentAccess({
+  getAgent: db.getAgent,
+  getEffectivePermissions,
+});
+
+module.exports = {
+  checkAgentPermission,
+  requireRemoteAgentAuth,
+  checkRemoteAgentsFeature,
+};

--- a/api/server/routes/agents/middleware.js
+++ b/api/server/routes/agents/middleware.js
@@ -1,6 +1,7 @@
 const { PermissionTypes, Permissions } = require('librechat-data-provider');
 const {
   generateCheckAccess,
+  preAuthTenantMiddleware,
   createRequireApiKeyAuth,
   createRemoteAgentAuth,
   createCheckRemoteAgentAccess,
@@ -34,6 +35,7 @@ const checkAgentPermission = createCheckRemoteAgentAccess({
 
 module.exports = {
   checkAgentPermission,
+  preAuthTenantMiddleware,
   requireRemoteAgentAuth,
   checkRemoteAgentsFeature,
 };

--- a/api/server/routes/agents/openai.js
+++ b/api/server/routes/agents/openai.js
@@ -21,6 +21,7 @@ const { PermissionTypes, Permissions } = require('librechat-data-provider');
 const {
   generateCheckAccess,
   createRequireApiKeyAuth,
+  createRemoteAgentAuth,
   createCheckRemoteAgentAccess,
 } = require('@librechat/api');
 const {
@@ -29,14 +30,19 @@ const {
   GetModelController,
 } = require('~/server/controllers/agents/openai');
 const { getEffectivePermissions } = require('~/server/services/PermissionService');
+const { validateAgentApiKey, findUser } = require('~/models');
 const { configMiddleware } = require('~/server/middleware');
+const { getAppConfig } = require('~/server/services/Config');
 const db = require('~/models');
 
 const router = express.Router();
 
-const requireApiKeyAuth = createRequireApiKeyAuth({
-  validateAgentApiKey: db.validateAgentApiKey,
+const apiKeyMiddleware = createRequireApiKeyAuth({ validateAgentApiKey, findUser });
+
+const requireRemoteAgentAuth = createRemoteAgentAuth({
+  apiKeyMiddleware,
   findUser: db.findUser,
+  getAppConfig,
 });
 
 const checkRemoteAgentsFeature = generateCheckAccess({
@@ -50,7 +56,7 @@ const checkAgentPermission = createCheckRemoteAgentAccess({
   getEffectivePermissions,
 });
 
-router.use(requireApiKeyAuth);
+router.use(requireRemoteAgentAuth);
 router.use(configMiddleware);
 router.use(checkRemoteAgentsFeature);
 

--- a/api/server/routes/agents/openai.js
+++ b/api/server/routes/agents/openai.js
@@ -25,12 +25,14 @@ const {
 const { configMiddleware } = require('~/server/middleware');
 const {
   checkAgentPermission,
+  preAuthTenantMiddleware,
   requireRemoteAgentAuth,
   checkRemoteAgentsFeature,
 } = require('./middleware');
 
 const router = express.Router();
 
+router.use(preAuthTenantMiddleware);
 router.use(requireRemoteAgentAuth);
 router.use(configMiddleware);
 router.use(checkRemoteAgentsFeature);

--- a/api/server/routes/agents/openai.js
+++ b/api/server/routes/agents/openai.js
@@ -38,7 +38,7 @@ const router = express.Router();
 
 const apiKeyMiddleware = createRequireApiKeyAuth({
   validateAgentApiKey: db.validateAgentApiKey,
-  findUser: db.findUser
+  findUser: db.findUser,
 });
 
 const requireRemoteAgentAuth = createRemoteAgentAuth({

--- a/api/server/routes/agents/openai.js
+++ b/api/server/routes/agents/openai.js
@@ -30,18 +30,21 @@ const {
   GetModelController,
 } = require('~/server/controllers/agents/openai');
 const { getEffectivePermissions } = require('~/server/services/PermissionService');
-const { validateAgentApiKey, findUser } = require('~/models');
 const { configMiddleware } = require('~/server/middleware');
 const { getAppConfig } = require('~/server/services/Config');
 const db = require('~/models');
 
 const router = express.Router();
 
-const apiKeyMiddleware = createRequireApiKeyAuth({ validateAgentApiKey, findUser });
+const apiKeyMiddleware = createRequireApiKeyAuth({
+  validateAgentApiKey: db.validateAgentApiKey,
+  findUser: db.findUser
+});
 
 const requireRemoteAgentAuth = createRemoteAgentAuth({
   apiKeyMiddleware,
   findUser: db.findUser,
+  updateUser: db.updateUser,
   getAppConfig,
 });
 

--- a/api/server/routes/agents/openai.js
+++ b/api/server/routes/agents/openai.js
@@ -17,47 +17,19 @@
  *   }
  */
 const express = require('express');
-const { PermissionTypes, Permissions } = require('librechat-data-provider');
-const {
-  generateCheckAccess,
-  createRequireApiKeyAuth,
-  createRemoteAgentAuth,
-  createCheckRemoteAgentAccess,
-} = require('@librechat/api');
 const {
   OpenAIChatCompletionController,
   ListModelsController,
   GetModelController,
 } = require('~/server/controllers/agents/openai');
-const { getEffectivePermissions } = require('~/server/services/PermissionService');
 const { configMiddleware } = require('~/server/middleware');
-const { getAppConfig } = require('~/server/services/Config');
-const db = require('~/models');
+const {
+  checkAgentPermission,
+  requireRemoteAgentAuth,
+  checkRemoteAgentsFeature,
+} = require('./middleware');
 
 const router = express.Router();
-
-const apiKeyMiddleware = createRequireApiKeyAuth({
-  validateAgentApiKey: db.validateAgentApiKey,
-  findUser: db.findUser,
-});
-
-const requireRemoteAgentAuth = createRemoteAgentAuth({
-  apiKeyMiddleware,
-  findUser: db.findUser,
-  updateUser: db.updateUser,
-  getAppConfig,
-});
-
-const checkRemoteAgentsFeature = generateCheckAccess({
-  permissionType: PermissionTypes.REMOTE_AGENTS,
-  permissions: [Permissions.USE],
-  getRoleByName: db.getRoleByName,
-});
-
-const checkAgentPermission = createCheckRemoteAgentAccess({
-  getAgent: db.getAgent,
-  getEffectivePermissions,
-});
 
 router.use(requireRemoteAgentAuth);
 router.use(configMiddleware);

--- a/api/server/routes/agents/responses.js
+++ b/api/server/routes/agents/responses.js
@@ -24,6 +24,7 @@ const { PermissionTypes, Permissions } = require('librechat-data-provider');
 const {
   generateCheckAccess,
   createRequireApiKeyAuth,
+  createRemoteAgentAuth,
   createCheckRemoteAgentAccess,
 } = require('@librechat/api');
 const {
@@ -32,14 +33,19 @@ const {
   listModels,
 } = require('~/server/controllers/agents/responses');
 const { getEffectivePermissions } = require('~/server/services/PermissionService');
+const { validateAgentApiKey, findUser } = require('~/models');
 const { configMiddleware } = require('~/server/middleware');
+const { getAppConfig } = require('~/server/services/Config');
 const db = require('~/models');
 
 const router = express.Router();
 
-const requireApiKeyAuth = createRequireApiKeyAuth({
-  validateAgentApiKey: db.validateAgentApiKey,
+const apiKeyMiddleware = createRequireApiKeyAuth({ validateAgentApiKey, findUser });
+
+const requireRemoteAgentAuth = createRemoteAgentAuth({
+  apiKeyMiddleware,
   findUser: db.findUser,
+  getAppConfig,
 });
 
 const checkRemoteAgentsFeature = generateCheckAccess({
@@ -53,7 +59,7 @@ const checkAgentPermission = createCheckRemoteAgentAccess({
   getEffectivePermissions,
 });
 
-router.use(requireApiKeyAuth);
+router.use(requireRemoteAgentAuth);
 router.use(configMiddleware);
 router.use(checkRemoteAgentsFeature);
 

--- a/api/server/routes/agents/responses.js
+++ b/api/server/routes/agents/responses.js
@@ -28,12 +28,14 @@ const {
 const { configMiddleware } = require('~/server/middleware');
 const {
   checkAgentPermission,
+  preAuthTenantMiddleware,
   requireRemoteAgentAuth,
   checkRemoteAgentsFeature,
 } = require('./middleware');
 
 const router = express.Router();
 
+router.use(preAuthTenantMiddleware);
 router.use(requireRemoteAgentAuth);
 router.use(configMiddleware);
 router.use(checkRemoteAgentsFeature);

--- a/api/server/routes/agents/responses.js
+++ b/api/server/routes/agents/responses.js
@@ -41,7 +41,7 @@ const router = express.Router();
 
 const apiKeyMiddleware = createRequireApiKeyAuth({
   validateAgentApiKey: db.validateAgentApiKey,
-  findUser: db.findUser
+  findUser: db.findUser,
 });
 
 const requireRemoteAgentAuth = createRemoteAgentAuth({

--- a/api/server/routes/agents/responses.js
+++ b/api/server/routes/agents/responses.js
@@ -33,18 +33,21 @@ const {
   listModels,
 } = require('~/server/controllers/agents/responses');
 const { getEffectivePermissions } = require('~/server/services/PermissionService');
-const { validateAgentApiKey, findUser } = require('~/models');
 const { configMiddleware } = require('~/server/middleware');
 const { getAppConfig } = require('~/server/services/Config');
 const db = require('~/models');
 
 const router = express.Router();
 
-const apiKeyMiddleware = createRequireApiKeyAuth({ validateAgentApiKey, findUser });
+const apiKeyMiddleware = createRequireApiKeyAuth({
+  validateAgentApiKey: db.validateAgentApiKey,
+  findUser: db.findUser
+});
 
 const requireRemoteAgentAuth = createRemoteAgentAuth({
   apiKeyMiddleware,
   findUser: db.findUser,
+  updateUser: db.updateUser,
   getAppConfig,
 });
 

--- a/api/server/routes/agents/responses.js
+++ b/api/server/routes/agents/responses.js
@@ -20,47 +20,19 @@
  * @see https://openresponses.org/specification
  */
 const express = require('express');
-const { PermissionTypes, Permissions } = require('librechat-data-provider');
-const {
-  generateCheckAccess,
-  createRequireApiKeyAuth,
-  createRemoteAgentAuth,
-  createCheckRemoteAgentAccess,
-} = require('@librechat/api');
 const {
   createResponse,
   getResponse,
   listModels,
 } = require('~/server/controllers/agents/responses');
-const { getEffectivePermissions } = require('~/server/services/PermissionService');
 const { configMiddleware } = require('~/server/middleware');
-const { getAppConfig } = require('~/server/services/Config');
-const db = require('~/models');
+const {
+  checkAgentPermission,
+  requireRemoteAgentAuth,
+  checkRemoteAgentsFeature,
+} = require('./middleware');
 
 const router = express.Router();
-
-const apiKeyMiddleware = createRequireApiKeyAuth({
-  validateAgentApiKey: db.validateAgentApiKey,
-  findUser: db.findUser,
-});
-
-const requireRemoteAgentAuth = createRemoteAgentAuth({
-  apiKeyMiddleware,
-  findUser: db.findUser,
-  updateUser: db.updateUser,
-  getAppConfig,
-});
-
-const checkRemoteAgentsFeature = generateCheckAccess({
-  permissionType: PermissionTypes.REMOTE_AGENTS,
-  permissions: [Permissions.USE],
-  getRoleByName: db.getRoleByName,
-});
-
-const checkAgentPermission = createCheckRemoteAgentAccess({
-  getAgent: db.getAgent,
-  getEffectivePermissions,
-});
 
 router.use(requireRemoteAgentAuth);
 router.use(configMiddleware);

--- a/api/strategies/openIdJwtStrategy.js
+++ b/api/strategies/openIdJwtStrategy.js
@@ -3,9 +3,8 @@ const jwksRsa = require('jwks-rsa');
 const { logger } = require('@librechat/data-schemas');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const { SystemRoles } = require('librechat-data-provider');
-const { isEnabled, findOpenIDUser, math } = require('@librechat/api');
 const { Strategy: JwtStrategy, ExtractJwt } = require('passport-jwt');
-const { getOpenIdEmail } = require('./openidStrategy');
+const { isEnabled, findOpenIDUser, getOpenIdEmail, math } = require('@librechat/api');
 const { updateUser, findUser } = require('~/models');
 
 /**

--- a/api/strategies/openIdJwtStrategy.js
+++ b/api/strategies/openIdJwtStrategy.js
@@ -27,7 +27,9 @@ const { updateUser, findUser } = require('~/models');
  */
 const openIdJwtLogin = (openIdConfig) => {
   let jwksRsaOptions = {
-    cache: isEnabled(process.env.OPENID_JWKS_URL_CACHE_ENABLED) || true,
+    cache: process.env.OPENID_JWKS_URL_CACHE_ENABLED
+      ? isEnabled(process.env.OPENID_JWKS_URL_CACHE_ENABLED)
+      : true,
     cacheMaxAge: math(process.env.OPENID_JWKS_URL_CACHE_TIME, 60000),
     jwksUri: openIdConfig.serverMetadata().jwks_uri,
   };

--- a/api/strategies/openIdJwtStrategy.js
+++ b/api/strategies/openIdJwtStrategy.js
@@ -4,7 +4,13 @@ const { logger } = require('@librechat/data-schemas');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const { SystemRoles } = require('librechat-data-provider');
 const { Strategy: JwtStrategy, ExtractJwt } = require('passport-jwt');
-const { isEnabled, findOpenIDUser, getOpenIdEmail, math } = require('@librechat/api');
+const {
+  isEnabled,
+  findOpenIDUser,
+  getOpenIdEmail,
+  getOpenIdIssuer,
+  math,
+} = require('@librechat/api');
 const { updateUser, findUser } = require('~/models');
 
 /**
@@ -52,11 +58,13 @@ const openIdJwtLogin = (openIdConfig) => {
       try {
         const authHeader = req.headers.authorization;
         const rawToken = authHeader?.replace('Bearer ', '');
+        const openidIssuer = getOpenIdIssuer(payload, openIdConfig);
 
         const { user, error, migration } = await findOpenIDUser({
           findUser,
           email: payload ? getOpenIdEmail(payload) : undefined,
           openidId: payload?.sub,
+          openidIssuer,
           idOnTheSource: payload?.oid,
           strategyName: 'openIdJwtLogin',
         });
@@ -73,6 +81,9 @@ const openIdJwtLogin = (openIdConfig) => {
           if (migration) {
             updateData.provider = 'openid';
             updateData.openidId = payload?.sub;
+            if (openidIssuer) {
+              updateData.openidIssuer = openidIssuer;
+            }
           }
           if (!user.role) {
             user.role = SystemRoles.USER;

--- a/api/strategies/openIdJwtStrategy.spec.js
+++ b/api/strategies/openIdJwtStrategy.spec.js
@@ -23,6 +23,7 @@ jest.mock('@librechat/data-schemas', () => ({
 jest.mock('@librechat/api', () => ({
   isEnabled: jest.fn(() => false),
   findOpenIDUser: jest.fn(),
+  getOpenIdEmail: jest.requireActual('@librechat/api').getOpenIdEmail,
   math: jest.fn((val, fallback) => fallback),
 }));
 jest.mock('~/models', () => ({

--- a/api/strategies/openIdJwtStrategy.spec.js
+++ b/api/strategies/openIdJwtStrategy.spec.js
@@ -24,6 +24,7 @@ jest.mock('@librechat/api', () => ({
   isEnabled: jest.fn(() => false),
   findOpenIDUser: jest.fn(),
   getOpenIdEmail: jest.requireActual('@librechat/api').getOpenIdEmail,
+  getOpenIdIssuer: jest.fn(() => 'https://issuer.example.com'),
   math: jest.fn((val, fallback) => fallback),
 }));
 jest.mock('~/models', () => ({
@@ -48,7 +49,10 @@ const { findUser, updateUser } = require('~/models');
 
 // Helper: build a mock openIdConfig
 const mockOpenIdConfig = {
-  serverMetadata: () => ({ jwks_uri: 'https://example.com/.well-known/jwks.json' }),
+  serverMetadata: () => ({
+    issuer: 'https://issuer.example.com',
+    jwks_uri: 'https://example.com/.well-known/jwks.json',
+  }),
 };
 
 // Helper: invoke the captured verify callback
@@ -226,6 +230,7 @@ describe('openIdJwtStrategy – OPENID_EMAIL_CLAIM', () => {
       _id: 'user-id-1',
       provider: 'openid',
       openidId: payload.sub,
+      openidIssuer: 'https://issuer.example.com',
       email: payload.email,
       role: SystemRoles.USER,
     };
@@ -241,7 +246,9 @@ describe('openIdJwtStrategy – OPENID_EMAIL_CLAIM', () => {
 
     expect(findUser).toHaveBeenCalledWith(
       expect.objectContaining({
-        $or: expect.arrayContaining([{ openidId: payload.sub }]),
+        $or: expect.arrayContaining([
+          { openidId: payload.sub, openidIssuer: 'https://issuer.example.com' },
+        ]),
       }),
     );
   });
@@ -255,7 +262,9 @@ describe('openIdJwtStrategy – OPENID_EMAIL_CLAIM', () => {
 
     expect(findUser).toHaveBeenCalledTimes(2);
     expect(findUser.mock.calls[0][0]).toMatchObject({
-      $or: expect.arrayContaining([{ openidId: payload.sub }]),
+      $or: expect.arrayContaining([
+        { openidId: payload.sub, openidIssuer: 'https://issuer.example.com' },
+      ]),
     });
     expect(findUser.mock.calls[1][0]).toEqual({ email: 'test@corp.example.com' });
     expect(user).toBe(false);
@@ -368,7 +377,11 @@ describe('openIdJwtStrategy – OPENID_EMAIL_CLAIM', () => {
     expect(user).toBeTruthy();
     expect(updateUser).toHaveBeenCalledWith(
       'legacy-db-id',
-      expect.objectContaining({ provider: 'openid', openidId: payloadNoEmail.sub }),
+      expect.objectContaining({
+        provider: 'openid',
+        openidId: payloadNoEmail.sub,
+        openidIssuer: 'https://issuer.example.com',
+      }),
     );
   });
 });

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -14,6 +14,7 @@ const {
   safeStringify,
   findOpenIDUser,
   getOpenIdEmail,
+  getOpenIdIssuer,
   getBalanceConfig,
   isEmailDomainAllowed,
   resolveAppConfigForUser,
@@ -443,6 +444,7 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
   }
 
   const email = getOpenIdEmail(userinfo);
+  const openidIssuer = getOpenIdIssuer(claims, userinfo, openidConfig);
 
   const baseConfig = await getAppConfig({ baseOnly: true });
   if (!isEmailDomainAllowed(email, baseConfig?.registration?.allowedDomains)) {
@@ -456,6 +458,7 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
     findUser,
     email: email,
     openidId: claims.sub || userinfo.sub,
+    openidIssuer,
     idOnTheSource: claims.oid || userinfo.oid,
     strategyName: 'openidStrategy',
   });
@@ -561,6 +564,7 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
       emailVerified: userinfo.email_verified || false,
       name: fullName,
       idOnTheSource: userinfo.oid,
+      openidIssuer,
     };
 
     const balanceConfig = getBalanceConfig(appConfig);
@@ -568,6 +572,9 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
   } else {
     user.provider = 'openid';
     user.openidId = userinfo.sub;
+    if (openidIssuer) {
+      user.openidIssuer = openidIssuer;
+    }
     user.username = username;
     user.name = fullName;
     user.idOnTheSource = userinfo.oid;

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -13,6 +13,7 @@ const {
   logHeaders,
   safeStringify,
   findOpenIDUser,
+  getOpenIdEmail,
   getBalanceConfig,
   isEmailDomainAllowed,
   resolveAppConfigForUser,
@@ -266,34 +267,6 @@ function getFullName(userinfo) {
   }
 
   return userinfo.username || userinfo.email;
-}
-
-/**
- * Resolves the user identifier from OpenID claims.
- * Configurable via OPENID_EMAIL_CLAIM; defaults to: email -> preferred_username -> upn.
- *
- * @param {Object} userinfo - The user information object from OpenID Connect
- * @returns {string|undefined} The resolved identifier string
- */
-function getOpenIdEmail(userinfo) {
-  const claimKey = process.env.OPENID_EMAIL_CLAIM?.trim();
-  if (claimKey) {
-    const value = userinfo[claimKey];
-    if (typeof value === 'string' && value) {
-      return value;
-    }
-    if (value !== undefined && value !== null) {
-      logger.warn(
-        `[openidStrategy] OPENID_EMAIL_CLAIM="${claimKey}" resolved to a non-string value (type: ${typeof value}). Falling back to: email -> preferred_username -> upn.`,
-      );
-    } else {
-      logger.warn(
-        `[openidStrategy] OPENID_EMAIL_CLAIM="${claimKey}" not present in userinfo. Falling back to: email -> preferred_username -> upn.`,
-      );
-    }
-  }
-  const fallback = userinfo.email || userinfo.preferred_username || userinfo.upn;
-  return typeof fallback === 'string' ? fallback : undefined;
 }
 
 /**

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -444,7 +444,7 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
   }
 
   const email = getOpenIdEmail(userinfo);
-  const openidIssuer = getOpenIdIssuer(claims, userinfo, openidConfig);
+  const openidIssuer = getOpenIdIssuer(claims, openidConfig);
 
   const baseConfig = await getAppConfig({ baseOnly: true });
   if (!isEmailDomainAllowed(email, baseConfig?.registration?.allowedDomains)) {

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -3,7 +3,7 @@ const fetch = require('node-fetch');
 const jwtDecode = require('jsonwebtoken/decode');
 const { ErrorTypes } = require('librechat-data-provider');
 const { findUser, createUser, updateUser } = require('~/models');
-const { resolveAppConfigForUser } = require('@librechat/api');
+const { getOpenIdIssuer, resolveAppConfigForUser } = require('@librechat/api');
 const { getAppConfig } = require('~/server/services/Config');
 const { setupOpenId } = require('./openidStrategy');
 
@@ -27,6 +27,7 @@ jest.mock('@librechat/api', () => ({
   isEnabled: jest.fn(() => false),
   isEmailDomainAllowed: jest.fn(() => true),
   findOpenIDUser: jest.requireActual('@librechat/api').findOpenIDUser,
+  getOpenIdEmail: jest.requireActual('@librechat/api').getOpenIdEmail,
   getBalanceConfig: jest.fn(() => ({
     enabled: false,
   })),
@@ -203,6 +204,12 @@ describe('setupOpenId', () => {
 
     // Assert
     expect(user.username).toBe(userinfo.preferred_username);
+    expect(getOpenIdIssuer).toHaveBeenCalledTimes(1);
+    expect(getOpenIdIssuer.mock.calls[0]).toHaveLength(2);
+    expect(getOpenIdIssuer.mock.calls[0][0]).toEqual(userinfo);
+    expect(getOpenIdIssuer.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ issuer: 'https://fake-issuer.com' }),
+    );
     expect(createUser).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: 'openid',

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -30,6 +30,7 @@ jest.mock('@librechat/api', () => ({
   getBalanceConfig: jest.fn(() => ({
     enabled: false,
   })),
+  getOpenIdIssuer: jest.fn(() => 'https://fake-issuer.com'),
   resolveAppConfigForUser: jest.fn(async (_getAppConfig, _user) => ({})),
 }));
 jest.mock('~/models', () => ({
@@ -206,6 +207,7 @@ describe('setupOpenId', () => {
       expect.objectContaining({
         provider: 'openid',
         openidId: userinfo.sub,
+        openidIssuer: 'https://fake-issuer.com',
         username: userinfo.preferred_username,
         email: userinfo.email,
         name: `${userinfo.given_name} ${userinfo.family_name}`,
@@ -326,6 +328,7 @@ describe('setupOpenId', () => {
       expect.objectContaining({
         provider: 'openid',
         openidId: userinfo.sub,
+        openidIssuer: 'https://fake-issuer.com',
         username: userinfo.preferred_username,
         name: `${userinfo.given_name} ${userinfo.family_name}`,
       }),

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -112,6 +112,7 @@
     "ioredis": "^5.3.2",
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.0",
+    "jwks-rsa": "^3.2.0",
     "keyv": "^5.3.2",
     "keyv-file": "^5.1.2",
     "librechat-data-provider": "*",

--- a/packages/api/src/app/service.ts
+++ b/packages/api/src/app/service.ts
@@ -48,6 +48,15 @@ export interface AppConfigServiceDeps {
   overrideCacheTtl?: number;
 }
 
+export interface GetAppConfigOptions {
+  role?: string;
+  userId?: string;
+  tenantId?: string;
+  refresh?: boolean;
+  /** When true, return only the YAML-derived base config — no DB override queries. */
+  baseOnly?: boolean;
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 let _strictOverride: boolean | undefined;
@@ -140,16 +149,7 @@ export function createAppConfigService(deps: AppConfigServiceDeps) {
    * `role`, `userId`, and `tenantId` are ignored in this mode.
    * Use this for startup, auth strategies, and other pre-tenant code paths.
    */
-  async function getAppConfig(
-    options: {
-      role?: string;
-      userId?: string;
-      tenantId?: string;
-      refresh?: boolean;
-      /** When true, return only the YAML-derived base config — no DB override queries. */
-      baseOnly?: boolean;
-    } = {},
-  ): Promise<AppConfig> {
+  async function getAppConfig(options: GetAppConfigOptions = {}): Promise<AppConfig> {
     const { role, userId, tenantId, refresh, baseOnly } = options;
 
     const baseConfig = await ensureBaseConfig(refresh);

--- a/packages/api/src/auth/openid.spec.ts
+++ b/packages/api/src/auth/openid.spec.ts
@@ -18,12 +18,22 @@ jest.mock('@librechat/data-schemas', () => ({
 
 describe('findOpenIDUser', () => {
   let mockFindUser: jest.MockedFunction<UserMethods['findUser']>;
+  const originalOpenIdIssuer = process.env.OPENID_ISSUER;
 
   beforeEach(() => {
     mockFindUser = jest.fn();
+    delete process.env.OPENID_ISSUER;
     jest.clearAllMocks();
     (logger.warn as jest.Mock).mockClear();
     (logger.info as jest.Mock).mockClear();
+  });
+
+  afterAll(() => {
+    if (originalOpenIdIssuer == null) {
+      delete process.env.OPENID_ISSUER;
+      return;
+    }
+    process.env.OPENID_ISSUER = originalOpenIdIssuer;
   });
 
   describe('Primary condition searches', () => {
@@ -107,6 +117,73 @@ describe('findOpenIDUser', () => {
         user: mockUser,
         error: null,
         migration: false,
+      });
+    });
+
+    it('should bind primary lookup to issuer', async () => {
+      const mockUser: IUser = {
+        _id: newId(),
+        provider: 'openid',
+        openidId: 'openid_123',
+        openidIssuer: 'https://issuer.example.com',
+        email: 'user@example.com',
+        username: 'testuser',
+      } as IUser;
+
+      mockFindUser.mockResolvedValueOnce(mockUser);
+
+      const result = await findOpenIDUser({
+        openidId: 'openid_123',
+        openidIssuer: 'https://issuer.example.com/',
+        findUser: mockFindUser,
+        email: 'user@example.com',
+      });
+
+      expect(mockFindUser).toHaveBeenCalledWith({
+        $or: [{ openidId: 'openid_123', openidIssuer: 'https://issuer.example.com' }],
+      });
+      expect(result).toEqual({
+        user: mockUser,
+        error: null,
+        migration: false,
+      });
+    });
+
+    it('should allow legacy issuer-less lookup only for the configured OpenID login issuer', async () => {
+      process.env.OPENID_ISSUER = 'https://issuer.example.com/';
+      const mockUser: IUser = {
+        _id: newId(),
+        provider: 'openid',
+        openidId: 'openid_123',
+        email: 'user@example.com',
+        username: 'testuser',
+      } as IUser;
+
+      mockFindUser.mockResolvedValueOnce(mockUser);
+
+      const result = await findOpenIDUser({
+        openidId: 'openid_123',
+        openidIssuer: 'https://issuer.example.com',
+        findUser: mockFindUser,
+      });
+
+      expect(mockFindUser).toHaveBeenCalledWith({
+        $or: [
+          { openidId: 'openid_123', openidIssuer: 'https://issuer.example.com' },
+          {
+            openidId: 'openid_123',
+            $or: [
+              { openidIssuer: { $exists: false } },
+              { openidIssuer: null },
+              { openidIssuer: '' },
+            ],
+          },
+        ],
+      });
+      expect(result).toEqual({
+        user: { ...mockUser, openidIssuer: 'https://issuer.example.com' },
+        error: null,
+        migration: true,
       });
     });
   });
@@ -252,6 +329,58 @@ describe('findOpenIDUser', () => {
         migration: false,
       });
     });
+
+    it('should reject email fallback when stored openidIssuer does not match token issuer', async () => {
+      const mockUser: IUser = {
+        _id: newId(),
+        provider: 'openid',
+        openidId: 'openid_123',
+        openidIssuer: 'https://issuer-a.example.com',
+        email: 'user@example.com',
+        username: 'testuser',
+      } as IUser;
+
+      mockFindUser.mockResolvedValueOnce(null).mockResolvedValueOnce(mockUser);
+
+      const result = await findOpenIDUser({
+        openidId: 'openid_123',
+        openidIssuer: 'https://issuer-b.example.com',
+        findUser: mockFindUser,
+        email: 'user@example.com',
+      });
+
+      expect(result).toEqual({
+        user: null,
+        error: ErrorTypes.AUTH_FAILED,
+        migration: false,
+      });
+    });
+
+    it('should reject legacy email fallback when token issuer is not the configured OpenID login issuer', async () => {
+      process.env.OPENID_ISSUER = 'https://issuer-a.example.com';
+      const mockUser: IUser = {
+        _id: newId(),
+        provider: 'openid',
+        openidId: 'openid_123',
+        email: 'user@example.com',
+        username: 'testuser',
+      } as IUser;
+
+      mockFindUser.mockResolvedValueOnce(null).mockResolvedValueOnce(mockUser);
+
+      const result = await findOpenIDUser({
+        openidId: 'openid_123',
+        openidIssuer: 'https://issuer-b.example.com',
+        findUser: mockFindUser,
+        email: 'user@example.com',
+      });
+
+      expect(result).toEqual({
+        user: null,
+        error: ErrorTypes.AUTH_FAILED,
+        migration: false,
+      });
+    });
   });
 
   describe('User migration scenarios', () => {
@@ -278,6 +407,34 @@ describe('findOpenIDUser', () => {
           ...mockUser,
           provider: 'openid',
           openidId: 'openid_123',
+        },
+        error: null,
+        migration: true,
+      });
+    });
+
+    it('should persist issuer when migrating a user by email', async () => {
+      const mockUser: IUser = {
+        _id: newId(),
+        email: 'user@example.com',
+        username: 'testuser',
+      } as IUser;
+
+      mockFindUser.mockResolvedValueOnce(null).mockResolvedValueOnce(mockUser);
+
+      const result = await findOpenIDUser({
+        openidId: 'openid_123',
+        openidIssuer: 'https://issuer.example.com',
+        findUser: mockFindUser,
+        email: 'user@example.com',
+      });
+
+      expect(result).toEqual({
+        user: {
+          ...mockUser,
+          provider: 'openid',
+          openidId: 'openid_123',
+          openidIssuer: 'https://issuer.example.com',
         },
         error: null,
         migration: true,

--- a/packages/api/src/auth/openid.spec.ts
+++ b/packages/api/src/auth/openid.spec.ts
@@ -1,8 +1,8 @@
 import { Types } from 'mongoose';
-import { ErrorTypes } from 'librechat-data-provider';
 import { logger } from '@librechat/data-schemas';
+import { ErrorTypes } from 'librechat-data-provider';
 import type { IUser, UserMethods } from '@librechat/data-schemas';
-import { findOpenIDUser } from './openid';
+import { findOpenIDUser, getOpenIdEmail } from './openid';
 
 function newId() {
   return new Types.ObjectId();
@@ -476,5 +476,65 @@ describe('findOpenIDUser', () => {
         migration: false,
       });
     });
+  });
+});
+
+describe('getOpenIdEmail', () => {
+  const originalEmailClaim = process.env.OPENID_EMAIL_CLAIM;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.OPENID_EMAIL_CLAIM;
+  });
+
+  afterAll(() => {
+    if (originalEmailClaim == null) {
+      delete process.env.OPENID_EMAIL_CLAIM;
+      return;
+    }
+    process.env.OPENID_EMAIL_CLAIM = originalEmailClaim;
+  });
+
+  it('uses the default claim order', () => {
+    expect(
+      getOpenIdEmail({
+        email: 'user@example.com',
+        preferred_username: 'preferred@example.com',
+        upn: 'upn@example.com',
+      }),
+    ).toBe('user@example.com');
+  });
+
+  it('uses OPENID_EMAIL_CLAIM when present', () => {
+    process.env.OPENID_EMAIL_CLAIM = 'custom_identifier';
+
+    expect(
+      getOpenIdEmail({
+        email: 'user@example.com',
+        custom_identifier: 'agent@corp.example.com',
+      }),
+    ).toBe('agent@corp.example.com');
+  });
+
+  it('falls back with a warning when OPENID_EMAIL_CLAIM is missing', () => {
+    process.env.OPENID_EMAIL_CLAIM = 'missing_identifier';
+
+    expect(getOpenIdEmail({ email: 'user@example.com' }, 'remoteAgentAuth')).toBe(
+      'user@example.com',
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('OPENID_EMAIL_CLAIM="missing_identifier" not present in userinfo'),
+    );
+  });
+
+  it('falls back with a warning when OPENID_EMAIL_CLAIM is not a string', () => {
+    process.env.OPENID_EMAIL_CLAIM = 'groups';
+
+    expect(getOpenIdEmail({ email: 'user@example.com', groups: ['a'] })).toBe('user@example.com');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'OPENID_EMAIL_CLAIM="groups" resolved to a non-string value (type: object)',
+      ),
+    );
   });
 });

--- a/packages/api/src/auth/openid.spec.ts
+++ b/packages/api/src/auth/openid.spec.ts
@@ -2,7 +2,7 @@ import { Types } from 'mongoose';
 import { logger } from '@librechat/data-schemas';
 import { ErrorTypes } from 'librechat-data-provider';
 import type { IUser, UserMethods } from '@librechat/data-schemas';
-import { findOpenIDUser, getOpenIdEmail } from './openid';
+import { findOpenIDUser, getOpenIdEmail, normalizeOpenIdIssuer } from './openid';
 
 function newId() {
   return new Types.ObjectId();
@@ -15,6 +15,20 @@ jest.mock('@librechat/data-schemas', () => ({
     info: jest.fn(),
   },
 }));
+
+describe('normalizeOpenIdIssuer', () => {
+  it('normalizes blank, trailing-slash, and discovery-document issuers', () => {
+    expect(normalizeOpenIdIssuer('')).toBeUndefined();
+    expect(normalizeOpenIdIssuer('   ')).toBeUndefined();
+    expect(normalizeOpenIdIssuer('https://issuer.example.com/')).toBe('https://issuer.example.com');
+    expect(
+      normalizeOpenIdIssuer('https://issuer.example.com/.well-known/openid-configuration/'),
+    ).toBe('https://issuer.example.com');
+    expect(
+      normalizeOpenIdIssuer('https://issuer.example.com/realm/.well-known/openid-configuration'),
+    ).toBe('https://issuer.example.com/realm');
+  });
+});
 
 describe('findOpenIDUser', () => {
   let mockFindUser: jest.MockedFunction<UserMethods['findUser']>;
@@ -151,6 +165,44 @@ describe('findOpenIDUser', () => {
 
     it('should allow legacy issuer-less lookup only for the configured OpenID login issuer', async () => {
       process.env.OPENID_ISSUER = 'https://issuer.example.com/';
+      const mockUser: IUser = {
+        _id: newId(),
+        provider: 'openid',
+        openidId: 'openid_123',
+        email: 'user@example.com',
+        username: 'testuser',
+      } as IUser;
+
+      mockFindUser.mockResolvedValueOnce(mockUser);
+
+      const result = await findOpenIDUser({
+        openidId: 'openid_123',
+        openidIssuer: 'https://issuer.example.com',
+        findUser: mockFindUser,
+      });
+
+      expect(mockFindUser).toHaveBeenCalledWith({
+        $or: [
+          { openidId: 'openid_123', openidIssuer: 'https://issuer.example.com' },
+          {
+            openidId: 'openid_123',
+            $or: [
+              { openidIssuer: { $exists: false } },
+              { openidIssuer: null },
+              { openidIssuer: '' },
+            ],
+          },
+        ],
+      });
+      expect(result).toEqual({
+        user: { ...mockUser, openidIssuer: 'https://issuer.example.com' },
+        error: null,
+        migration: true,
+      });
+    });
+
+    it('should allow legacy issuer-less lookup when login issuer is a discovery document URL', async () => {
+      process.env.OPENID_ISSUER = 'https://issuer.example.com/.well-known/openid-configuration';
       const mockUser: IUser = {
         _id: newId(),
         provider: 'openid',

--- a/packages/api/src/auth/openid.spec.ts
+++ b/packages/api/src/auth/openid.spec.ts
@@ -2,7 +2,7 @@ import { Types } from 'mongoose';
 import { logger } from '@librechat/data-schemas';
 import { ErrorTypes } from 'librechat-data-provider';
 import type { IUser, UserMethods } from '@librechat/data-schemas';
-import { findOpenIDUser, getOpenIdEmail, normalizeOpenIdIssuer } from './openid';
+import { findOpenIDUser, getOpenIdEmail, getOpenIdIssuer, normalizeOpenIdIssuer } from './openid';
 
 function newId() {
   return new Types.ObjectId();
@@ -30,9 +30,38 @@ describe('normalizeOpenIdIssuer', () => {
   });
 });
 
+describe('getOpenIdIssuer', () => {
+  const originalOpenIdIssuer = process.env.OPENID_ISSUER;
+
+  afterEach(() => {
+    if (originalOpenIdIssuer == null) {
+      delete process.env.OPENID_ISSUER;
+      return;
+    }
+
+    process.env.OPENID_ISSUER = originalOpenIdIssuer;
+  });
+
+  it('prefers token issuer and falls back to metadata and env issuer', () => {
+    process.env.OPENID_ISSUER = 'https://env.example.com/.well-known/openid-configuration';
+
+    expect(
+      getOpenIdIssuer(
+        { iss: 'https://token.example.com/' },
+        { serverMetadata: () => ({ issuer: 'https://metadata.example.com' }) },
+      ),
+    ).toBe('https://token.example.com');
+    expect(
+      getOpenIdIssuer({}, { serverMetadata: () => ({ issuer: 'https://metadata.example.com/' }) }),
+    ).toBe('https://metadata.example.com');
+    expect(getOpenIdIssuer({})).toBe('https://env.example.com');
+  });
+});
+
 describe('findOpenIDUser', () => {
   let mockFindUser: jest.MockedFunction<UserMethods['findUser']>;
   const originalOpenIdIssuer = process.env.OPENID_ISSUER;
+  const issuer = 'https://issuer.example.com';
 
   beforeEach(() => {
     mockFindUser = jest.fn();
@@ -56,6 +85,7 @@ describe('findOpenIDUser', () => {
         _id: newId(),
         provider: 'openid',
         openidId: 'openid_123',
+        openidIssuer: issuer,
         email: 'user@example.com',
         username: 'testuser',
       } as IUser;
@@ -64,12 +94,13 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         email: 'user@example.com',
       });
 
       expect(mockFindUser).toHaveBeenCalledWith({
-        $or: [{ openidId: 'openid_123' }],
+        $or: [{ openidId: 'openid_123', openidIssuer: issuer }],
       });
       expect(result).toEqual({
         user: mockUser,
@@ -91,12 +122,16 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         idOnTheSource: 'source_123',
       });
 
       expect(mockFindUser).toHaveBeenCalledWith({
-        $or: [{ openidId: 'openid_123' }, { idOnTheSource: 'source_123' }],
+        $or: [
+          { openidId: 'openid_123', openidIssuer: issuer },
+          { idOnTheSource: 'source_123', openidIssuer: issuer },
+        ],
       });
       expect(result).toEqual({
         user: mockUser,
@@ -111,6 +146,7 @@ describe('findOpenIDUser', () => {
         provider: 'openid',
         openidId: 'openid_123',
         idOnTheSource: 'source_123',
+        openidIssuer: issuer,
         email: 'user@example.com',
         username: 'testuser',
       } as IUser;
@@ -119,13 +155,17 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         idOnTheSource: 'source_123',
         email: 'user@example.com',
       });
 
       expect(mockFindUser).toHaveBeenCalledWith({
-        $or: [{ openidId: 'openid_123' }, { idOnTheSource: 'source_123' }],
+        $or: [
+          { openidId: 'openid_123', openidIssuer: issuer },
+          { idOnTheSource: 'source_123', openidIssuer: issuer },
+        ],
       });
       expect(result).toEqual({
         user: mockUser,
@@ -238,6 +278,25 @@ describe('findOpenIDUser', () => {
         migration: true,
       });
     });
+
+    it('should skip primary ID lookup when issuer context is missing', async () => {
+      mockFindUser.mockResolvedValueOnce(null);
+
+      const result = await findOpenIDUser({
+        openidId: 'openid_123',
+        idOnTheSource: 'source_123',
+        findUser: mockFindUser,
+        email: 'user@example.com',
+      });
+
+      expect(mockFindUser).toHaveBeenCalledTimes(1);
+      expect(mockFindUser).toHaveBeenCalledWith({ email: 'user@example.com' });
+      expect(result).toEqual({
+        user: null,
+        error: null,
+        migration: false,
+      });
+    });
   });
 
   describe('Email-based searches', () => {
@@ -246,6 +305,7 @@ describe('findOpenIDUser', () => {
         _id: newId(),
         provider: 'openid',
         openidId: 'openid_123',
+        openidIssuer: issuer,
         email: 'user@example.com',
         username: 'testuser',
       } as IUser;
@@ -254,12 +314,13 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         email: 'user@example.com',
       });
 
       expect(mockFindUser).toHaveBeenNthCalledWith(1, {
-        $or: [{ openidId: 'openid_123' }],
+        $or: [{ openidId: 'openid_123', openidIssuer: issuer }],
       });
       expect(mockFindUser).toHaveBeenNthCalledWith(2, { email: 'user@example.com' });
       expect(result).toEqual({
@@ -276,6 +337,7 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         email: 'user@example.com',
       });
@@ -293,12 +355,13 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
       });
 
       expect(mockFindUser).toHaveBeenCalledTimes(1);
       expect(mockFindUser).toHaveBeenCalledWith({
-        $or: [{ openidId: 'openid_123' }],
+        $or: [{ openidId: 'openid_123', openidIssuer: issuer }],
       });
       expect(result).toEqual({
         user: null,
@@ -323,6 +386,7 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         email: 'user@example.com',
       });
@@ -347,6 +411,7 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         email: 'user@example.com',
       });
@@ -363,6 +428,7 @@ describe('findOpenIDUser', () => {
         _id: newId(),
         provider: 'openid',
         openidId: 'openid_123',
+        openidIssuer: issuer,
         email: 'user@example.com',
         username: 'testuser',
       } as IUser;
@@ -371,6 +437,7 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         email: 'user@example.com',
       });
@@ -450,6 +517,7 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         email: 'user@example.com',
       });
@@ -459,6 +527,7 @@ describe('findOpenIDUser', () => {
           ...mockUser,
           provider: 'openid',
           openidId: 'openid_123',
+          openidIssuer: issuer,
         },
         error: null,
         migration: true,
@@ -506,6 +575,7 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         email: 'user@example.com',
       });
@@ -530,6 +600,7 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         email: 'user@example.com',
       });
@@ -597,12 +668,13 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         idOnTheSource: '',
       });
 
       expect(mockFindUser).toHaveBeenCalledWith({
-        $or: [{ openidId: 'openid_123' }],
+        $or: [{ openidId: 'openid_123', openidIssuer: issuer }],
       });
       expect(result).toEqual({
         user: null,
@@ -629,6 +701,7 @@ describe('findOpenIDUser', () => {
         _id: newId(),
         provider: 'openid',
         openidId: 'openid_123',
+        openidIssuer: issuer,
         email: 'user@example.com',
         username: 'testuser',
       } as IUser;
@@ -637,6 +710,7 @@ describe('findOpenIDUser', () => {
 
       const result = await findOpenIDUser({
         openidId: 'openid_123',
+        openidIssuer: issuer,
         findUser: mockFindUser,
         email: 'User@Example.COM',
       });
@@ -655,6 +729,7 @@ describe('findOpenIDUser', () => {
       await expect(
         findOpenIDUser({
           openidId: 'openid_123',
+          openidIssuer: issuer,
           findUser: mockFindUser,
         }),
       ).rejects.toThrow('Database error');

--- a/packages/api/src/auth/openid.spec.ts
+++ b/packages/api/src/auth/openid.spec.ts
@@ -789,6 +789,10 @@ describe('getOpenIdEmail', () => {
     ).toBe('user@example.com');
   });
 
+  it('returns undefined when default claims are absent', () => {
+    expect(getOpenIdEmail({})).toBeUndefined();
+  });
+
   it('skips empty fallback claims', () => {
     expect(
       getOpenIdEmail({

--- a/packages/api/src/auth/openid.spec.ts
+++ b/packages/api/src/auth/openid.spec.ts
@@ -505,6 +505,16 @@ describe('getOpenIdEmail', () => {
     ).toBe('user@example.com');
   });
 
+  it('skips empty fallback claims', () => {
+    expect(
+      getOpenIdEmail({
+        email: '',
+        preferred_username: 'preferred@example.com',
+        upn: 'upn@example.com',
+      }),
+    ).toBe('preferred@example.com');
+  });
+
   it('uses OPENID_EMAIL_CLAIM when present', () => {
     process.env.OPENID_EMAIL_CLAIM = 'custom_identifier';
 

--- a/packages/api/src/auth/openid.ts
+++ b/packages/api/src/auth/openid.ts
@@ -12,9 +12,13 @@ export type OpenIdEmailClaims = {
 
 type OpenIdLookupField = 'openidId' | 'idOnTheSource';
 
+const OPENID_DISCOVERY_PATH = '/.well-known/openid-configuration';
+
 export function normalizeOpenIdIssuer(issuer: string | undefined): string | undefined {
   const normalized = issuer?.trim().replace(/\/+$/, '');
-  return normalized || undefined;
+  if (!normalized) return undefined;
+  if (!normalized.endsWith(OPENID_DISCOVERY_PATH)) return normalized;
+  return normalized.slice(0, -OPENID_DISCOVERY_PATH.length) || undefined;
 }
 
 function getStringClaim(claims: OpenIdEmailClaims, claim: string): string | undefined {

--- a/packages/api/src/auth/openid.ts
+++ b/packages/api/src/auth/openid.ts
@@ -17,6 +17,7 @@ export type OpenIdIssuerSource = {
 };
 
 type OpenIdLookupField = 'openidId' | 'idOnTheSource';
+type OpenIdUserResolution = { user: IUser | null; error: string | null; migration: boolean };
 
 const OPENID_DISCOVERY_PATH = '/.well-known/openid-configuration';
 
@@ -84,6 +85,33 @@ function isUserIssuerAllowed(user: IUser, openidIssuer: string | undefined): boo
   return isLegacyOpenIdIssuer(openidIssuer);
 }
 
+function resolveIssuerBoundUser(
+  user: IUser | null,
+  normalizedIssuer: string | undefined,
+  strategyName: string,
+  context: string,
+): OpenIdUserResolution | null {
+  if (!user?.openidId) return null;
+
+  if (!isUserIssuerAllowed(user, normalizedIssuer)) {
+    logger.warn(
+      `[${strategyName}] Rejected ${context} for ${user.email}: stored openidIssuer does not match token issuer`,
+    );
+    return { user: null, error: ErrorTypes.AUTH_FAILED, migration: false };
+  }
+
+  if (normalizedIssuer && !normalizeOpenIdIssuer(user.openidIssuer)) {
+    user.openidIssuer = normalizedIssuer;
+    return { user, error: null, migration: true };
+  }
+
+  return null;
+}
+
+/**
+ * Resolves the OpenID user identifier claim, honoring OPENID_EMAIL_CLAIM before
+ * email/preferred_username/upn fallbacks.
+ */
 export function getOpenIdEmail(
   claims: OpenIdEmailClaims | null | undefined,
   strategyName = 'openidStrategy',
@@ -130,7 +158,7 @@ export async function findOpenIDUser({
   openidIssuer?: string;
   idOnTheSource?: string;
   strategyName?: string;
-}): Promise<{ user: IUser | null; error: string | null; migration: boolean }> {
+}): Promise<OpenIdUserResolution> {
   const normalizedIssuer = normalizeOpenIdIssuer(openidIssuer);
   const primaryConditions = [
     ...getIssuerBoundConditions('openidId', openidId, normalizedIssuer),
@@ -142,17 +170,13 @@ export async function findOpenIDUser({
     user = await findUser({ $or: primaryConditions });
   }
 
-  if (user?.openidId && !isUserIssuerAllowed(user, normalizedIssuer)) {
-    logger.warn(
-      `[${strategyName}] Rejected OpenID lookup for ${user.email}: stored openidIssuer does not match token issuer`,
-    );
-    return { user: null, error: ErrorTypes.AUTH_FAILED, migration: false };
-  }
-
-  if (user?.openidId && normalizedIssuer && !normalizeOpenIdIssuer(user.openidIssuer)) {
-    user.openidIssuer = normalizedIssuer;
-    return { user, error: null, migration: true };
-  }
+  const primaryIssuerResolution = resolveIssuerBoundUser(
+    user,
+    normalizedIssuer,
+    strategyName,
+    'OpenID lookup',
+  );
+  if (primaryIssuerResolution) return primaryIssuerResolution;
 
   if (!user && email) {
     user = await findUser({ email });
@@ -175,17 +199,13 @@ export async function findOpenIDUser({
       return { user: null, error: ErrorTypes.AUTH_FAILED, migration: false };
     }
 
-    if (user?.openidId && !isUserIssuerAllowed(user, normalizedIssuer)) {
-      logger.warn(
-        `[${strategyName}] Rejected email fallback for ${user.email}: stored openidIssuer does not match token issuer`,
-      );
-      return { user: null, error: ErrorTypes.AUTH_FAILED, migration: false };
-    }
-
-    if (user?.openidId && normalizedIssuer && !normalizeOpenIdIssuer(user.openidIssuer)) {
-      user.openidIssuer = normalizedIssuer;
-      return { user, error: null, migration: true };
-    }
+    const emailIssuerResolution = resolveIssuerBoundUser(
+      user,
+      normalizedIssuer,
+      strategyName,
+      'email fallback',
+    );
+    if (emailIssuerResolution) return emailIssuerResolution;
 
     if (user && !user.openidId) {
       logger.info(

--- a/packages/api/src/auth/openid.ts
+++ b/packages/api/src/auth/openid.ts
@@ -1,6 +1,7 @@
 import { logger } from '@librechat/data-schemas';
 import { ErrorTypes } from 'librechat-data-provider';
 import type { IUser, UserMethods } from '@librechat/data-schemas';
+import type { FilterQuery } from 'mongoose';
 
 export type OpenIdEmailClaims = {
   email?: unknown;
@@ -9,9 +10,50 @@ export type OpenIdEmailClaims = {
   [claim: string]: unknown;
 };
 
+type OpenIdLookupField = 'openidId' | 'idOnTheSource';
+
+export function normalizeOpenIdIssuer(issuer: string | undefined): string | undefined {
+  const normalized = issuer?.trim().replace(/\/+$/, '');
+  return normalized || undefined;
+}
+
 function getStringClaim(claims: OpenIdEmailClaims, claim: string): string | undefined {
   const value = claims[claim];
   return typeof value === 'string' && value ? value : undefined;
+}
+
+function isLegacyOpenIdIssuer(openidIssuer: string | undefined): boolean {
+  const loginIssuer = normalizeOpenIdIssuer(process.env.OPENID_ISSUER);
+  return openidIssuer != null && loginIssuer != null && openidIssuer === loginIssuer;
+}
+
+function getIssuerBoundConditions(
+  field: OpenIdLookupField,
+  value: string | undefined,
+  openidIssuer: string | undefined,
+): FilterQuery<IUser>[] {
+  if (!value || typeof value !== 'string') return [];
+  if (!openidIssuer) return [{ [field]: value }];
+
+  const conditions: FilterQuery<IUser>[] = [{ [field]: value, openidIssuer }];
+
+  if (isLegacyOpenIdIssuer(openidIssuer)) {
+    conditions.push({
+      [field]: value,
+      $or: [{ openidIssuer: { $exists: false } }, { openidIssuer: null }, { openidIssuer: '' }],
+    });
+  }
+
+  return conditions;
+}
+
+function isUserIssuerAllowed(user: IUser, openidIssuer: string | undefined): boolean {
+  if (!openidIssuer) return true;
+
+  const userIssuer = normalizeOpenIdIssuer(user.openidIssuer);
+  if (userIssuer) return userIssuer === openidIssuer;
+
+  return isLegacyOpenIdIssuer(openidIssuer);
 }
 
 export function getOpenIdEmail(
@@ -50,29 +92,40 @@ export async function findOpenIDUser({
   openidId,
   findUser,
   email,
+  openidIssuer,
   idOnTheSource,
   strategyName = 'openid',
 }: {
   openidId: string;
   findUser: UserMethods['findUser'];
   email?: string;
+  openidIssuer?: string;
   idOnTheSource?: string;
   strategyName?: string;
 }): Promise<{ user: IUser | null; error: string | null; migration: boolean }> {
-  const primaryConditions = [];
-
-  if (openidId && typeof openidId === 'string') {
-    primaryConditions.push({ openidId });
-  }
-
-  if (idOnTheSource && typeof idOnTheSource === 'string') {
-    primaryConditions.push({ idOnTheSource });
-  }
+  const normalizedIssuer = normalizeOpenIdIssuer(openidIssuer);
+  const primaryConditions = [
+    ...getIssuerBoundConditions('openidId', openidId, normalizedIssuer),
+    ...getIssuerBoundConditions('idOnTheSource', idOnTheSource, normalizedIssuer),
+  ];
 
   let user = null;
   if (primaryConditions.length > 0) {
     user = await findUser({ $or: primaryConditions });
   }
+
+  if (user?.openidId && !isUserIssuerAllowed(user, normalizedIssuer)) {
+    logger.warn(
+      `[${strategyName}] Rejected OpenID lookup for ${user.email}: stored openidIssuer does not match token issuer`,
+    );
+    return { user: null, error: ErrorTypes.AUTH_FAILED, migration: false };
+  }
+
+  if (user?.openidId && normalizedIssuer && !normalizeOpenIdIssuer(user.openidIssuer)) {
+    user.openidIssuer = normalizedIssuer;
+    return { user, error: null, migration: true };
+  }
+
   if (!user && email) {
     user = await findUser({ email });
     logger.warn(
@@ -94,12 +147,25 @@ export async function findOpenIDUser({
       return { user: null, error: ErrorTypes.AUTH_FAILED, migration: false };
     }
 
+    if (user?.openidId && !isUserIssuerAllowed(user, normalizedIssuer)) {
+      logger.warn(
+        `[${strategyName}] Rejected email fallback for ${user.email}: stored openidIssuer does not match token issuer`,
+      );
+      return { user: null, error: ErrorTypes.AUTH_FAILED, migration: false };
+    }
+
+    if (user?.openidId && normalizedIssuer && !normalizeOpenIdIssuer(user.openidIssuer)) {
+      user.openidIssuer = normalizedIssuer;
+      return { user, error: null, migration: true };
+    }
+
     if (user && !user.openidId) {
       logger.info(
         `[${strategyName}] Preparing user ${user.email} for migration to OpenID with sub: ${openidId}`,
       );
       user.provider = 'openid';
       user.openidId = openidId;
+      if (normalizedIssuer) user.openidIssuer = normalizedIssuer;
       return { user, error: null, migration: true };
     }
   }

--- a/packages/api/src/auth/openid.ts
+++ b/packages/api/src/auth/openid.ts
@@ -2,6 +2,46 @@ import { logger } from '@librechat/data-schemas';
 import { ErrorTypes } from 'librechat-data-provider';
 import type { IUser, UserMethods } from '@librechat/data-schemas';
 
+export type OpenIdEmailClaims = {
+  email?: unknown;
+  preferred_username?: unknown;
+  upn?: unknown;
+  [claim: string]: unknown;
+};
+
+function getStringClaim(claims: OpenIdEmailClaims, claim: string): string | undefined {
+  const value = claims[claim];
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function getOpenIdEmail(
+  claims: OpenIdEmailClaims | null | undefined,
+  strategyName = 'openidStrategy',
+): string | undefined {
+  if (claims == null) return undefined;
+
+  const claimKey = process.env.OPENID_EMAIL_CLAIM?.trim();
+  if (claimKey) {
+    const value = claims[claimKey];
+    if (typeof value === 'string' && value) return value;
+    if (value != null) {
+      logger.warn(
+        `[${strategyName}] OPENID_EMAIL_CLAIM="${claimKey}" resolved to a non-string value (type: ${typeof value}). Falling back to: email -> preferred_username -> upn.`,
+      );
+    } else {
+      logger.warn(
+        `[${strategyName}] OPENID_EMAIL_CLAIM="${claimKey}" not present in userinfo. Falling back to: email -> preferred_username -> upn.`,
+      );
+    }
+  }
+
+  return (
+    getStringClaim(claims, 'email') ??
+    getStringClaim(claims, 'preferred_username') ??
+    getStringClaim(claims, 'upn')
+  );
+}
+
 /**
  * Finds or migrates a user for OpenID authentication
  * @returns user object (with migration fields if needed), error message, and whether migration is needed

--- a/packages/api/src/auth/openid.ts
+++ b/packages/api/src/auth/openid.ts
@@ -11,7 +11,7 @@ export type OpenIdEmailClaims = {
 
 function getStringClaim(claims: OpenIdEmailClaims, claim: string): string | undefined {
   const value = claims[claim];
-  return typeof value === 'string' ? value : undefined;
+  return typeof value === 'string' && value ? value : undefined;
 }
 
 export function getOpenIdEmail(

--- a/packages/api/src/auth/openid.ts
+++ b/packages/api/src/auth/openid.ts
@@ -10,6 +10,12 @@ export type OpenIdEmailClaims = {
   [claim: string]: unknown;
 };
 
+export type OpenIdIssuerSource = {
+  iss?: string;
+  issuer?: string;
+  serverMetadata?: () => { issuer?: string } | undefined;
+};
+
 type OpenIdLookupField = 'openidId' | 'idOnTheSource';
 
 const OPENID_DISCOVERY_PATH = '/.well-known/openid-configuration';
@@ -21,9 +27,27 @@ export function normalizeOpenIdIssuer(issuer: string | undefined): string | unde
   return normalized.slice(0, -OPENID_DISCOVERY_PATH.length) || undefined;
 }
 
+function getIssuerFromSource(source: OpenIdIssuerSource | null | undefined): string | undefined {
+  if (source == null) return undefined;
+
+  const issuer = source.iss || source.serverMetadata?.()?.issuer || source.issuer;
+  return normalizeOpenIdIssuer(issuer);
+}
+
 function getStringClaim(claims: OpenIdEmailClaims, claim: string): string | undefined {
   const value = claims[claim];
   return typeof value === 'string' && value ? value : undefined;
+}
+
+export function getOpenIdIssuer(
+  ...sources: Array<OpenIdIssuerSource | null | undefined>
+): string | undefined {
+  for (const source of sources) {
+    const issuer = getIssuerFromSource(source);
+    if (issuer) return issuer;
+  }
+
+  return normalizeOpenIdIssuer(process.env.OPENID_ISSUER);
 }
 
 function isLegacyOpenIdIssuer(openidIssuer: string | undefined): boolean {
@@ -37,7 +61,7 @@ function getIssuerBoundConditions(
   openidIssuer: string | undefined,
 ): FilterQuery<IUser>[] {
   if (!value || typeof value !== 'string') return [];
-  if (!openidIssuer) return [{ [field]: value }];
+  if (!openidIssuer) return [];
 
   const conditions: FilterQuery<IUser>[] = [{ [field]: value, openidIssuer }];
 

--- a/packages/api/src/middleware/balance.spec.ts
+++ b/packages/api/src/middleware/balance.spec.ts
@@ -39,7 +39,6 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await mongoose.connection.dropDatabase();
-  await Balance.syncIndexes();
   jest.clearAllMocks();
   jest.restoreAllMocks();
 });

--- a/packages/api/src/middleware/balance.spec.ts
+++ b/packages/api/src/middleware/balance.spec.ts
@@ -39,6 +39,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await mongoose.connection.dropDatabase();
+  await Balance.syncIndexes();
   jest.clearAllMocks();
   jest.restoreAllMocks();
 });

--- a/packages/api/src/middleware/balance.ts
+++ b/packages/api/src/middleware/balance.ts
@@ -21,6 +21,27 @@ export interface BalanceMiddlewareOptions {
   upsertBalanceFields: (userId: string, fields: IBalanceUpdate) => Promise<IBalance | null>;
 }
 
+const balanceUpdateLocks = new Map<string, Promise<void>>();
+
+async function runBalanceUpdate(userId: string, task: () => Promise<void>): Promise<void> {
+  const previous = balanceUpdateLocks.get(userId) ?? Promise.resolve();
+  const current = previous.catch(() => undefined).then(task);
+  const tail = current.then(
+    () => undefined,
+    () => undefined,
+  );
+
+  balanceUpdateLocks.set(userId, tail);
+
+  try {
+    await current;
+  } finally {
+    if (balanceUpdateLocks.get(userId) === tail) {
+      balanceUpdateLocks.delete(userId);
+    }
+  }
+}
+
 /**
  * Build an object containing fields that need updating
  * @param config - The balance configuration
@@ -112,14 +133,16 @@ export function createSetBalanceConfig({
         return next();
       }
       const userId = typeof user._id === 'string' ? user._id : user._id.toString();
-      const userBalanceRecord = await findBalanceByUser(userId);
-      const updateFields = buildUpdateFields(balanceConfig, userBalanceRecord, userId);
+      await runBalanceUpdate(userId, async () => {
+        const userBalanceRecord = await findBalanceByUser(userId);
+        const updateFields = buildUpdateFields(balanceConfig, userBalanceRecord, userId);
 
-      if (Object.keys(updateFields).length === 0) {
-        return next();
-      }
+        if (Object.keys(updateFields).length === 0) {
+          return;
+        }
 
-      await upsertBalanceFields(userId, updateFields);
+        await upsertBalanceFields(userId, updateFields);
+      });
 
       next();
     } catch (error) {

--- a/packages/api/src/middleware/index.ts
+++ b/packages/api/src/middleware/index.ts
@@ -9,3 +9,4 @@ export { tenantContextMiddleware } from './tenant';
 export { preAuthTenantMiddleware } from './preAuthTenant';
 export * from './concurrency';
 export * from './checkBalance';
+export * from './remoteAgentAuth';

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -1,0 +1,457 @@
+import type { Request, Response } from 'express';
+import type { AppConfig, IUser } from '@librechat/data-schemas';
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('~/utils', () => ({
+  isEnabled: jest.fn(() => false),
+  math: jest.fn(() => 60000),
+}));
+
+const mockGetSigningKey = jest.fn();
+const mockGetKeys = jest.fn();
+
+jest.mock('jwks-rsa', () =>
+  jest.fn(() => ({ getSigningKey: mockGetSigningKey, getKeys: mockGetKeys })),
+);
+
+jest.mock('jsonwebtoken', () => ({
+  decode: jest.fn(),
+  verify: jest.fn(),
+}));
+
+jest.mock('../auth/openid', () => ({
+  findOpenIDUser: jest.fn(),
+}));
+
+import jwt from 'jsonwebtoken';
+import { logger } from '@librechat/data-schemas';
+import { findOpenIDUser } from '../auth/openid';
+import { createRemoteAgentAuth } from './remoteAgentAuth';
+
+const fetchMock = jest.fn();
+
+beforeAll(() => {
+  (global as unknown as Record<string, unknown>).fetch = fetchMock;
+});
+
+const FAKE_TOKEN = 'header.payload.signature';
+const BASE_ISSUER = 'https://auth.example.com/realms/test';
+const BASE_JWKS_URI = `${BASE_ISSUER}/protocol/openid-connect/certs`;
+
+type SigningKeyCallback = (err: Error | null, key?: { getPublicKey: () => string }) => void;
+type JwtVerifyCallback = (err: Error | null, payload?: object) => void;
+
+const mockUser = { _id: 'uid123', id: 'uid123', email: 'agent@test.com' };
+
+function makeRes() {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  return { res: { status, json } as unknown as Response, status, json };
+}
+
+function makeReq(headers: Record<string, string> = {}): Partial<Request> {
+  return { headers };
+}
+
+function makeConfig(oidcOverrides?: object, apiKeyOverrides?: object): AppConfig {
+  return {
+    endpoints: {
+      agents: {
+        remoteApi: {
+          auth: {
+            oidc: {
+              enabled: true,
+              issuer: BASE_ISSUER,
+              jwksUri: BASE_JWKS_URI,
+              ...oidcOverrides,
+            },
+            apiKey: { enabled: true, ...apiKeyOverrides },
+          },
+        },
+      },
+    },
+  } as unknown as AppConfig;
+}
+
+function makeDeps(appConfig: AppConfig | null = makeConfig()) {
+  return {
+    findUser: jest.fn(),
+    getAppConfig: jest.fn().mockResolvedValue(appConfig),
+    apiKeyMiddleware: jest.fn((_req: unknown, _res: unknown, next: () => void) => next()),
+  };
+}
+
+function setupOidcMocks(payload: object, kid = 'test-kid') {
+  (jwt.decode as jest.Mock).mockReturnValue({ header: { kid }, payload });
+  mockGetSigningKey.mockImplementation((_k: string, cb: SigningKeyCallback) =>
+    cb(null, { getPublicKey: () => 'public-key' }),
+  );
+  (jwt.verify as jest.Mock).mockImplementation(
+    (_t: string, _k: string, _o: object, cb: JwtVerifyCallback) => cb(null, payload),
+  );
+}
+
+describe('createRemoteAgentAuth', () => {
+  let mockNext: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchMock.mockReset();
+    mockNext = jest.fn();
+  });
+
+  describe('when OIDC is not enabled', () => {
+    it('falls back to apiKeyMiddleware when getAppConfig returns null', async () => {
+      const deps = makeDeps(null);
+      const mw = createRemoteAgentAuth(deps);
+      const req = makeReq();
+      const { res } = makeRes();
+
+      await mw(req as Request, res, mockNext);
+
+      expect(deps.apiKeyMiddleware).toHaveBeenCalledWith(req, res, mockNext);
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('falls back to apiKeyMiddleware when oidc.enabled is false', async () => {
+      const deps = makeDeps(makeConfig({ enabled: false }));
+      await createRemoteAgentAuth(deps)(makeReq() as Request, makeRes().res, mockNext);
+      expect(deps.apiKeyMiddleware).toHaveBeenCalled();
+    });
+
+    it('falls back to apiKeyMiddleware when remoteApi auth is absent', async () => {
+      const deps = makeDeps({ endpoints: { agents: {} } } as unknown as AppConfig);
+      await createRemoteAgentAuth(deps)(makeReq() as Request, makeRes().res, mockNext);
+      expect(deps.apiKeyMiddleware).toHaveBeenCalled();
+    });
+  });
+
+  describe('when OIDC enabled but no Bearer token', () => {
+    it('falls back to apiKeyMiddleware when apiKey is enabled', async () => {
+      const deps = makeDeps(makeConfig({}, { enabled: true }));
+      const { res } = makeRes();
+
+      await createRemoteAgentAuth(deps)(makeReq() as Request, res, mockNext);
+
+      expect(deps.apiKeyMiddleware).toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('returns 401 when apiKey is disabled and no token present', async () => {
+      const deps = makeDeps(makeConfig({}, { enabled: false }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(makeReq() as Request, res, mockNext);
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Bearer token required' });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when OIDC verification succeeds', () => {
+    beforeEach(() => {
+      (findOpenIDUser as jest.Mock).mockResolvedValue({ user: { ...mockUser }, error: null });
+    });
+
+    it('sets req.user and calls next()', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com', exp: 9999999999 });
+      const deps = makeDeps();
+      const req = makeReq({ authorization: `Bearer ${FAKE_TOKEN}` });
+      const { res } = makeRes();
+
+      await createRemoteAgentAuth(deps)(req as Request, res, mockNext);
+
+      expect(req.user).toMatchObject({ id: 'uid123', email: 'agent@test.com' });
+      expect(mockNext).toHaveBeenCalledWith();
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
+    });
+
+    it('attaches federatedTokens with access_token and expires_at', async () => {
+      const exp = 1234567890;
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com', exp });
+      const deps = makeDeps();
+      const req = makeReq({ authorization: `Bearer ${FAKE_TOKEN}` });
+
+      await createRemoteAgentAuth(deps)(req as Request, makeRes().res, mockNext);
+
+      expect((req.user as IUser).federatedTokens).toEqual({
+        access_token: FAKE_TOKEN,
+        expires_at: exp,
+      });
+    });
+
+    it('falls back to apiKeyMiddleware when user is not found and apiKey is enabled', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
+      (findOpenIDUser as jest.Mock).mockResolvedValue({ user: null, error: null });
+
+      const deps = makeDeps(makeConfig({}, { enabled: true }));
+      const { res } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(deps.apiKeyMiddleware).toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('no matching LibreChat user'),
+      );
+    });
+
+    it('returns 401 when user is not found and apiKey is disabled', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
+      (findOpenIDUser as jest.Mock).mockResolvedValue({ user: null, error: null });
+
+      const deps = makeDeps(makeConfig({}, { enabled: false }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when OIDC verification fails', () => {
+    beforeEach(() => {
+      (jwt.decode as jest.Mock).mockReturnValue({ header: { kid: 'kid' }, payload: {} });
+      mockGetSigningKey.mockImplementation((_k: string, cb: SigningKeyCallback) =>
+        cb(new Error('Signing key not found')),
+      );
+    });
+
+    it('falls back to apiKeyMiddleware when apiKey is enabled', async () => {
+      const deps = makeDeps(makeConfig({}, { enabled: true }));
+      const { res } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(deps.apiKeyMiddleware).toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('OIDC verification failed'),
+        expect.any(Error),
+      );
+    });
+
+    it('returns 401 when apiKey is disabled', async () => {
+      const deps = makeDeps(makeConfig({}, { enabled: false }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    });
+
+    it('returns 401 when JWT cannot be decoded', async () => {
+      (jwt.decode as jest.Mock).mockReturnValue(null);
+      const deps = makeDeps(makeConfig({}, { enabled: false }));
+      const { res, status } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: 'Bearer not.a.jwt' }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+    });
+  });
+
+  describe('unexpected errors', () => {
+    it('returns 500 when getAppConfig throws', async () => {
+      const deps = {
+        ...makeDeps(),
+        getAppConfig: jest.fn().mockRejectedValue(new Error('DB down')),
+      };
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(makeReq() as Request, res, mockNext);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Internal server error' });
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Unexpected error'),
+        expect.any(Error),
+      );
+    });
+
+    it('returns 401 when findOpenIDUser throws and apiKey is disabled', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
+      (findOpenIDUser as jest.Mock).mockRejectedValue(new Error('DB error'));
+
+      const deps = makeDeps(makeConfig({}, { enabled: false }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    });
+  });
+
+  describe('JWKS URI resolution', () => {
+    beforeEach(() => {
+      setupOidcMocks({ sub: 'sub1', email: 'a@b.com' });
+      (findOpenIDUser as jest.Mock).mockResolvedValue({ user: { ...mockUser }, error: null });
+    });
+
+    it('uses jwksUri from config and skips discovery', async () => {
+      const deps = makeDeps(
+        makeConfig({
+          jwksUri: 'https://explicit-1.example.com/jwks',
+          issuer: 'https://issuer-explicit-1.example.com',
+        }),
+      );
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('uses OPENID_JWKS_URL env var and skips discovery', async () => {
+      process.env.OPENID_JWKS_URL = 'https://env.example.com/jwks';
+      const deps = makeDeps(
+        makeConfig({ jwksUri: undefined, issuer: 'https://issuer-env-1.example.com' }),
+      );
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalled();
+
+      delete process.env.OPENID_JWKS_URL;
+    });
+
+    it('fetches discovery document when jwksUri and env var are absent', async () => {
+      delete process.env.OPENID_JWKS_URL;
+      const issuer = 'https://issuer-discovery-1.example.com';
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ jwks_uri: `${issuer}/protocol/openid-connect/certs` }),
+      });
+
+      const deps = makeDeps(makeConfig({ jwksUri: undefined, issuer }));
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(`${issuer}/.well-known/openid-configuration`);
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('returns 401 when discovery returns non-ok response', async () => {
+      delete process.env.OPENID_JWKS_URL;
+      fetchMock.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+
+      const deps = makeDeps(
+        makeConfig(
+          { jwksUri: undefined, issuer: 'https://issuer-discovery-fail-1.example.com' },
+          { enabled: false },
+        ),
+      );
+      const { res, status } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+    });
+
+    it('returns 401 when discovery response is missing jwks_uri field', async () => {
+      delete process.env.OPENID_JWKS_URL;
+      fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+
+      const deps = makeDeps(
+        makeConfig(
+          { jwksUri: undefined, issuer: 'https://issuer-missing-jwks-1.example.com' },
+          { enabled: false },
+        ),
+      );
+      const { res, status } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+    });
+  });
+
+  describe('email claim resolution', () => {
+    async function captureEmailArg(claims: object): Promise<string | undefined> {
+      setupOidcMocks(claims);
+      (findOpenIDUser as jest.Mock).mockResolvedValue({ user: { ...mockUser }, error: null });
+
+      const deps = makeDeps();
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      return (findOpenIDUser as jest.Mock).mock.calls[0][0].email;
+    }
+
+    it('uses email claim', async () => {
+      expect(await captureEmailArg({ sub: 's1', email: 'user@example.com' })).toBe(
+        'user@example.com',
+      );
+    });
+
+    it('falls back to preferred_username when email is absent', async () => {
+      expect(await captureEmailArg({ sub: 's2', preferred_username: 'agent-user' })).toBe(
+        'agent-user',
+      );
+    });
+
+    it('falls back to upn when email and preferred_username are absent', async () => {
+      expect(await captureEmailArg({ sub: 's3', upn: 'upn@corp.com' })).toBe('upn@corp.com');
+    });
+  });
+});

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -904,6 +904,33 @@ describe('createRemoteAgentAuth', () => {
       expect(mockNext).toHaveBeenCalled();
     });
 
+    it('normalizes discovery document issuer URL only when fetching discovery metadata', async () => {
+      const issuer = 'https://issuer-discovery-url.example.com/.well-known/openid-configuration';
+      const normalizedIssuer = 'https://issuer-discovery-url.example.com';
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ jwks_uri: `${normalizedIssuer}/protocol/openid-connect/certs` }),
+      });
+
+      const deps = makeDeps(makeConfig({ jwksUri: undefined, issuer }));
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${normalizedIssuer}/.well-known/openid-configuration`,
+        expect.objectContaining({ signal: expect.any(Object) }),
+      );
+      expect((jwt.verify as jest.Mock).mock.calls[0][2]).toEqual(
+        expect.objectContaining({ issuer }),
+      );
+      expect(mockNext).toHaveBeenCalled();
+    });
+
     it('rejects insecure JWKS URIs returned by discovery', async () => {
       const issuer = 'https://issuer-discovery-insecure.example.com';
 

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -73,7 +73,15 @@ type AgentAuthConfig = NonNullable<NonNullable<TAgentsEndpoint['remoteApi']>['au
 type OidcConfig = NonNullable<AgentAuthConfig['oidc']>;
 type ApiKeyConfig = NonNullable<AgentAuthConfig['apiKey']>;
 type JwtVerifyCallback = (err: Error | null, payload?: JwtPayload) => void;
-type FindUserCondition = Pick<Partial<IUser>, '_id' | 'email' | 'openidId' | 'idOnTheSource'>;
+type FindUserValue = IUser['_id'] | string | null | { $exists: boolean };
+type FindUserCondition = {
+  _id?: FindUserValue;
+  email?: FindUserValue;
+  openidId?: FindUserValue;
+  openidIssuer?: FindUserValue;
+  idOnTheSource?: FindUserValue;
+  $or?: FindUserCondition[];
+};
 type FindUserQuery = FindUserCondition & { $or?: FindUserCondition[] };
 
 const mockUser = { _id: 'uid123', id: 'uid123', email: 'agent@test.com' };
@@ -144,15 +152,37 @@ function makeUser(overrides: Partial<IUser> = {}): IUser {
     role: 'user',
     provider: 'openid',
     openidId: 'sub123',
+    openidIssuer: BASE_ISSUER,
     ...overrides,
   } as IUser;
 }
 
+function matchesValue(value: FindUserValue | undefined, condition: FindUserValue): boolean {
+  if (condition && typeof condition === 'object' && '$exists' in condition) {
+    return condition.$exists ? value != null : value == null;
+  }
+  return value === condition;
+}
+
 function matchesCondition(user: IUser, condition: FindUserCondition): boolean {
-  if (condition._id != null && user._id !== condition._id) return false;
-  if (condition.email != null && user.email !== condition.email) return false;
-  if (condition.openidId != null && user.openidId !== condition.openidId) return false;
-  if (condition.idOnTheSource != null && user.idOnTheSource !== condition.idOnTheSource) {
+  if (condition.$or && !condition.$or.some((nested) => matchesCondition(user, nested))) {
+    return false;
+  }
+  if (condition._id !== undefined && !matchesValue(user._id, condition._id)) return false;
+  if (condition.email !== undefined && !matchesValue(user.email, condition.email)) return false;
+  if (condition.openidId !== undefined && !matchesValue(user.openidId, condition.openidId)) {
+    return false;
+  }
+  if (
+    condition.openidIssuer !== undefined &&
+    !matchesValue(user.openidIssuer, condition.openidIssuer)
+  ) {
+    return false;
+  }
+  if (
+    condition.idOnTheSource !== undefined &&
+    !matchesValue(user.idOnTheSource, condition.idOnTheSource)
+  ) {
     return false;
   }
   return true;
@@ -517,6 +547,30 @@ describe('createRemoteAgentAuth', () => {
       expect(status).toHaveBeenCalledWith(401);
       expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
       expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('does not resolve a colliding legacy openidId from a different issuer', async () => {
+      const issuer = 'https://issuer-b.example.com';
+      setupOidcMocks({ sub: 'shared-sub', email: 'attacker@example.com' });
+
+      const deps = makeDeps(makeConfig({ issuer }, { enabled: false }));
+      deps.findUser = makeFindUser(
+        makeUser({
+          email: 'victim@example.com',
+          openidId: 'shared-sub',
+          openidIssuer: undefined,
+        }),
+      );
+      const req = makeReq({ authorization: `Bearer ${FAKE_TOKEN}` });
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(req as Request, res, mockNext);
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(req.user).toBeUndefined();
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
     });
 
     it('returns 401 without user lookup when sub claim is missing', async () => {
@@ -1130,7 +1184,11 @@ describe('createRemoteAgentAuth', () => {
 
       expect(mockUpdateUser).toHaveBeenCalledWith(
         mockUser.id,
-        expect.objectContaining({ provider: 'openid', openidId: 'sub-new' }),
+        expect.objectContaining({
+          provider: 'openid',
+          openidId: 'sub-new',
+          openidIssuer: BASE_ISSUER,
+        }),
       );
       expect(mockNext).toHaveBeenCalled();
     });

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -5,7 +5,6 @@ import type { Request, Response } from 'express';
 import type { RequestInit } from 'undici';
 
 jest.mock('@librechat/data-schemas', () => ({
-  getTenantId: jest.fn(),
   logger: {
     info: jest.fn(),
     warn: jest.fn(),
@@ -44,14 +43,13 @@ jest.mock('../auth/openid', () => {
 import jwt from 'jsonwebtoken';
 import jwksRsa from 'jwks-rsa';
 import { ProxyAgent, fetch as undiciFetch } from 'undici';
-import { logger, getTenantId } from '@librechat/data-schemas';
+import { logger } from '@librechat/data-schemas';
 import { clearRemoteAgentAuthCache, createRemoteAgentAuth } from './remoteAgentAuth';
 import { findOpenIDUser } from '../auth/openid';
 import { math } from '~/utils';
 
 const mockFetch = undiciFetch as jest.Mock;
 const mockProxyAgent = ProxyAgent as unknown as jest.Mock;
-const mockGetTenantId = getTenantId as jest.Mock;
 const mockMath = math as jest.Mock;
 const realFindOpenIDUser =
   jest.requireActual<typeof import('../auth/openid')>('../auth/openid').findOpenIDUser;
@@ -193,8 +191,6 @@ describe('createRemoteAgentAuth', () => {
     deleteEnvKeys();
     clearRemoteAgentAuthCache();
     mockFetch.mockReset();
-    mockGetTenantId.mockReset();
-    mockGetTenantId.mockReturnValue(undefined);
     mockMath.mockReturnValue(60000);
     mockFindOpenIDUser.mockImplementation(realFindOpenIDUser);
     mockNext = jest.fn();
@@ -240,11 +236,21 @@ describe('createRemoteAgentAuth', () => {
       expect(deps.apiKeyMiddleware).toHaveBeenCalled();
     });
 
-    it('loads config with pre-auth tenant context when present', async () => {
-      mockGetTenantId.mockReturnValue('tenant-a');
+    it('loads base config before authentication when only pre-auth tenant context exists', async () => {
       const deps = makeDeps(makeConfig({ enabled: false }));
 
       await createRemoteAgentAuth(deps)(makeReq() as Request, makeRes().res, mockNext);
+
+      expect(deps.getAppConfig).toHaveBeenCalledWith({ baseOnly: true });
+      expect(deps.apiKeyMiddleware).toHaveBeenCalled();
+    });
+
+    it('loads tenant config when an authenticated user is already present', async () => {
+      const deps = makeDeps(makeConfig({ enabled: false }));
+      const req = makeReq();
+      req.user = makeUser({ tenantId: 'tenant-a' });
+
+      await createRemoteAgentAuth(deps)(req as Request, makeRes().res, mockNext);
 
       expect(deps.getAppConfig).toHaveBeenCalledWith({ tenantId: 'tenant-a' });
       expect(deps.apiKeyMiddleware).toHaveBeenCalled();
@@ -317,6 +323,23 @@ describe('createRemoteAgentAuth', () => {
       expect(req.user).toMatchObject({ id: 'uid123', email: 'agent@test.com' });
       expect(mockNext).toHaveBeenCalledWith();
       expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
+    });
+
+    it('accepts case-insensitive Bearer auth scheme', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
+      const deps = makeDeps();
+      const req = makeReq({ authorization: `bearer ${FAKE_TOKEN}` });
+
+      await createRemoteAgentAuth(deps)(req as Request, makeRes().res, mockNext);
+
+      expect(jwt.verify).toHaveBeenCalledWith(
+        FAKE_TOKEN,
+        'public-key',
+        expect.any(Object),
+        expect.any(Function),
+      );
+      expect(req.user).toMatchObject({ id: 'uid123', email: 'agent@test.com' });
+      expect(mockNext).toHaveBeenCalledWith();
     });
 
     it('allows RSA, RSA-PSS, and ECDSA signing algorithms', async () => {

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -400,6 +400,94 @@ describe('createRemoteAgentAuth', () => {
       expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
     });
 
+    it('re-evaluates OIDC auth config after resolving the user tenant', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com', scope: 'remote_agent' });
+      const deps = makeDeps();
+      deps.findUser = makeFindUser(makeUser({ tenantId: 'tenant-strict' }));
+      deps.getAppConfig.mockImplementation(async (options) =>
+        options?.tenantId === 'tenant-strict'
+          ? makeConfig({ audience: 'tenant-audience', scope: 'remote_agent' }, { enabled: false })
+          : makeConfig({ audience: undefined, scope: undefined }, { enabled: true }),
+      );
+      const req = makeReq({ authorization: `Bearer ${FAKE_TOKEN}` });
+
+      await createRemoteAgentAuth(deps)(req as Request, makeRes().res, mockNext);
+
+      expect(deps.getAppConfig).toHaveBeenNthCalledWith(1, { baseOnly: true });
+      expect(deps.getAppConfig).toHaveBeenNthCalledWith(2, { tenantId: 'tenant-strict' });
+      expect(jwt.verify).toHaveBeenCalledTimes(2);
+      expect((jwt.verify as jest.Mock).mock.calls[1][2]).toEqual(
+        expect.objectContaining({ audience: 'tenant-audience' }),
+      );
+      expect(req.user).toMatchObject({ id: 'uid123', tenantId: 'tenant-strict' });
+      expect(mockNext).toHaveBeenCalledWith();
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
+    });
+
+    it('rejects OIDC auth when the resolved user tenant requires a missing scope', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com', scope: 'openid profile' });
+      const deps = makeDeps();
+      deps.findUser = makeFindUser(
+        makeUser({
+          tenantId: 'tenant-strict',
+          provider: undefined,
+          openidId: undefined,
+          openidIssuer: undefined,
+        }),
+      );
+      deps.getAppConfig.mockImplementation(async (options) =>
+        options?.tenantId === 'tenant-strict'
+          ? makeConfig({ scope: 'remote_agent' }, { enabled: false })
+          : makeConfig({ scope: undefined }, { enabled: true }),
+      );
+      const req = makeReq({ authorization: `Bearer ${FAKE_TOKEN}` });
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(req as Request, res, mockNext);
+
+      expect(deps.getAppConfig).toHaveBeenNthCalledWith(1, { baseOnly: true });
+      expect(deps.getAppConfig).toHaveBeenNthCalledWith(2, { tenantId: 'tenant-strict' });
+      expect(jwt.verify).toHaveBeenCalledTimes(2);
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(req.user).toBeUndefined();
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
+      expect(deps.updateUser).not.toHaveBeenCalled();
+    });
+
+    it('rejects OIDC auth when the resolved user tenant disables OIDC', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
+      const deps = makeDeps();
+      deps.findUser = makeFindUser(
+        makeUser({
+          tenantId: 'tenant-api-key-only',
+          provider: undefined,
+          openidId: undefined,
+          openidIssuer: undefined,
+        }),
+      );
+      deps.getAppConfig.mockImplementation(async (options) =>
+        options?.tenantId === 'tenant-api-key-only'
+          ? makeConfig({ enabled: false }, { enabled: true })
+          : makeConfig({}, { enabled: true }),
+      );
+      const req = makeReq({ authorization: `Bearer ${FAKE_TOKEN}` });
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(req as Request, res, mockNext);
+
+      expect(deps.getAppConfig).toHaveBeenNthCalledWith(1, { baseOnly: true });
+      expect(deps.getAppConfig).toHaveBeenNthCalledWith(2, { tenantId: 'tenant-api-key-only' });
+      expect(jwt.verify).toHaveBeenCalledTimes(1);
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(req.user).toBeUndefined();
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
+      expect(deps.updateUser).not.toHaveBeenCalled();
+    });
+
     it('allows exact and normalized configured issuers when verifying JWTs', async () => {
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
       const issuer = `${BASE_ISSUER}/`;

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -376,6 +376,25 @@ describe('createRemoteAgentAuth', () => {
       expect(mockNext).not.toHaveBeenCalled();
     });
 
+    it('returns 401 without user lookup when sub claim is missing', async () => {
+      setupOidcMocks({ email: 'agent@test.com' });
+
+      const deps = makeDeps(makeConfig({}, { enabled: true }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(findOpenIDUser).not.toHaveBeenCalled();
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
     it('returns 401 without API key fallback when OpenID user resolution is rejected', async () => {
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
       (findOpenIDUser as jest.Mock).mockResolvedValue({

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -378,9 +378,10 @@ describe('createRemoteAgentAuth', () => {
       expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
     });
 
-    it('normalizes trailing slash issuer before verifying JWTs', async () => {
+    it('preserves exact configured issuer when verifying JWTs', async () => {
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
-      const deps = makeDeps(makeConfig({ issuer: `${BASE_ISSUER}/` }));
+      const issuer = `${BASE_ISSUER}/`;
+      const deps = makeDeps(makeConfig({ issuer }));
 
       await createRemoteAgentAuth(deps)(
         makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
@@ -389,7 +390,7 @@ describe('createRemoteAgentAuth', () => {
       );
 
       expect((jwt.verify as jest.Mock).mock.calls[0][2]).toEqual(
-        expect.objectContaining({ issuer: BASE_ISSUER }),
+        expect.objectContaining({ issuer }),
       );
       expect(mockNext).toHaveBeenCalledWith();
     });

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -276,8 +276,8 @@ describe('createRemoteAgentAuth', () => {
           ? makeConfig({ enabled: true }, { enabled: false })
           : makeConfig({ enabled: false }, { enabled: true }),
       );
-      deps.apiKeyMiddleware.mockImplementation((req: Request, _res: Response, next) => {
-        req.user = makeUser({ tenantId: 'tenant-oidc-only' });
+      deps.apiKeyMiddleware.mockImplementation((req: unknown, _res: unknown, next) => {
+        (req as Request).user = makeUser({ tenantId: 'tenant-oidc-only' });
         next();
       });
       const { res, status, json } = makeRes();

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -378,6 +378,22 @@ describe('createRemoteAgentAuth', () => {
       expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
     });
 
+    it('normalizes trailing slash issuer before verifying JWTs', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
+      const deps = makeDeps(makeConfig({ issuer: `${BASE_ISSUER}/` }));
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect((jwt.verify as jest.Mock).mock.calls[0][2]).toEqual(
+        expect.objectContaining({ issuer: BASE_ISSUER }),
+      );
+      expect(mockNext).toHaveBeenCalledWith();
+    });
+
     it('accepts case-insensitive Bearer auth scheme', async () => {
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
       const deps = makeDeps();

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -560,8 +560,9 @@ describe('createRemoteAgentAuth', () => {
       );
 
       expect(deps.apiKeyMiddleware).toHaveBeenCalled();
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('OIDC verification failed'),
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('trying API key auth'),
         expect.any(Error),
       );
     });
@@ -578,6 +579,10 @@ describe('createRemoteAgentAuth', () => {
 
       expect(status).toHaveBeenCalledWith(401);
       expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('OIDC verification failed'),
+        expect.any(Error),
+      );
     });
 
     it('returns 401 when JWT cannot be decoded', async () => {

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -169,7 +169,7 @@ function makeFindUser(...users: IUser[]): jest.MockedFunction<UserMethods['findU
   }) as jest.MockedFunction<UserMethods['findUser']>;
 }
 
-function makeDeps(appConfig: AppConfig | null = makeConfig()) {
+function makeDeps(appConfig: AppConfig = makeConfig()) {
   return {
     findUser: makeFindUser(makeUser()),
     updateUser: jest.fn(),
@@ -212,18 +212,6 @@ describe('createRemoteAgentAuth', () => {
   });
 
   describe('when OIDC is not enabled', () => {
-    it('falls back to apiKeyMiddleware when getAppConfig returns null', async () => {
-      const deps = makeDeps(null);
-      const mw = createRemoteAgentAuth(deps);
-      const req = makeReq();
-      const { res } = makeRes();
-
-      await mw(req as Request, res, mockNext);
-
-      expect(deps.apiKeyMiddleware).toHaveBeenCalledWith(req, res, mockNext);
-      expect(mockNext).toHaveBeenCalled();
-    });
-
     it('returns 401 when oidc.enabled is false and apiKey is disabled', async () => {
       const deps = makeDeps(makeConfig({ enabled: false }, { enabled: false }));
       const { res, status, json } = makeRes();
@@ -377,6 +365,23 @@ describe('createRemoteAgentAuth', () => {
       expect(mockNext).toHaveBeenCalledWith();
     });
 
+    it('trims trailing whitespace from Bearer tokens', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
+      const deps = makeDeps();
+      const req = makeReq({ authorization: `Bearer ${FAKE_TOKEN}   ` });
+
+      await createRemoteAgentAuth(deps)(req as Request, makeRes().res, mockNext);
+
+      expect(jwt.verify).toHaveBeenCalledWith(
+        FAKE_TOKEN,
+        'public-key',
+        expect.any(Object),
+        expect.any(Function),
+      );
+      expect(req.user).toMatchObject({ id: 'uid123', email: 'agent@test.com' });
+      expect(mockNext).toHaveBeenCalledWith();
+    });
+
     it('allows RSA, RSA-PSS, and ECDSA signing algorithms', async () => {
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
       const deps = makeDeps();
@@ -462,6 +467,18 @@ describe('createRemoteAgentAuth', () => {
       expect((req.user as IUser).federatedTokens).toEqual({
         access_token: FAKE_TOKEN,
         expires_at: exp,
+      });
+    });
+
+    it('omits federatedTokens expires_at when exp is absent', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
+      const deps = makeDeps();
+      const req = makeReq({ authorization: `Bearer ${FAKE_TOKEN}` });
+
+      await createRemoteAgentAuth(deps)(req as Request, makeRes().res, mockNext);
+
+      expect((req.user as IUser).federatedTokens).toEqual({
+        access_token: FAKE_TOKEN,
       });
     });
 

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -499,4 +499,62 @@ describe('createRemoteAgentAuth', () => {
       expect(mockUpdateUser).not.toHaveBeenCalled();
     });
   });
+
+  describe('scope validation', () => {
+    it('returns 401 when required scope is missing from token', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com', scope: 'openid profile' });
+
+      const deps = makeDeps(makeConfig({ scope: 'remote_agent' }, { enabled: false }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+    });
+
+    it('passes when required scope is present in token', async () => {
+      setupOidcMocks({
+        sub: 'sub123',
+        email: 'agent@test.com',
+        scope: 'openid profile remote_agent',
+      });
+      (findOpenIDUser as jest.Mock).mockResolvedValue({
+        user: { ...mockUser },
+        error: null,
+        migration: false,
+      });
+
+      const deps = makeDeps(makeConfig({ scope: 'remote_agent' }));
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('passes when scope is not configured (backward compat)', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' }); // no scope claim at all
+      (findOpenIDUser as jest.Mock).mockResolvedValue({
+        user: { ...mockUser },
+        error: null,
+        migration: false,
+      });
+
+      const deps = makeDeps(makeConfig({ scope: undefined }));
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -45,7 +45,7 @@ import jwksRsa from 'jwks-rsa';
 import { ProxyAgent, fetch as undiciFetch } from 'undici';
 import { logger } from '@librechat/data-schemas';
 import { clearRemoteAgentAuthCache, createRemoteAgentAuth } from './remoteAgentAuth';
-import { findOpenIDUser } from '../auth/openid';
+import { findOpenIDUser, getOpenIdEmail } from '../auth/openid';
 import { math } from '~/utils';
 
 const mockFetch = undiciFetch as jest.Mock;
@@ -58,6 +58,7 @@ const FAKE_TOKEN = 'header.payload.signature';
 const BASE_ISSUER = 'https://auth.example.com/realms/test';
 const BASE_JWKS_URI = `${BASE_ISSUER}/protocol/openid-connect/certs`;
 const ENV_KEYS = [
+  'OPENID_EMAIL_CLAIM',
   'OPENID_JWKS_URL',
   'OPENID_JWKS_URL_CACHE_ENABLED',
   'OPENID_JWKS_URL_CACHE_TIME',
@@ -75,6 +76,7 @@ const mockUser = { _id: 'uid123', id: 'uid123', email: 'agent@test.com' };
 const originalEnv = ENV_KEYS.reduce<Record<(typeof ENV_KEYS)[number], string | undefined>>(
   (env, key) => ({ ...env, [key]: process.env[key] }),
   {
+    OPENID_EMAIL_CLAIM: undefined,
     OPENID_JWKS_URL: undefined,
     OPENID_JWKS_URL_CACHE_ENABLED: undefined,
     OPENID_JWKS_URL_CACHE_TIME: undefined,
@@ -917,7 +919,7 @@ describe('createRemoteAgentAuth', () => {
       const deps = makeDeps();
       deps.findUser
         .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(makeUser({ email: getExpectedEmail(claims), openidId: claims.sub }));
+        .mockResolvedValueOnce(makeUser({ email: getOpenIdEmail(claims), openidId: claims.sub }));
       await createRemoteAgentAuth(deps)(
         makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
         makeRes().res,
@@ -925,14 +927,6 @@ describe('createRemoteAgentAuth', () => {
       );
 
       return (deps.findUser.mock.calls[1]?.[0] as { email?: string } | undefined)?.email;
-    }
-
-    function getExpectedEmail(claims: JwtPayload): string | undefined {
-      return (
-        (claims['email'] as string | undefined) ??
-        (claims['preferred_username'] as string | undefined) ??
-        (claims['upn'] as string | undefined)
-      );
     }
 
     it('uses email claim', async () => {
@@ -949,6 +943,18 @@ describe('createRemoteAgentAuth', () => {
 
     it('falls back to upn when email and preferred_username are absent', async () => {
       expect(await captureEmailArg({ sub: 's3', upn: 'upn@corp.com' })).toBe('upn@corp.com');
+    });
+
+    it('uses OPENID_EMAIL_CLAIM when configured', async () => {
+      process.env.OPENID_EMAIL_CLAIM = 'custom_identifier';
+
+      expect(
+        await captureEmailArg({
+          sub: 's4',
+          email: 'user@example.com',
+          custom_identifier: 'agent@corp.example.com',
+        }),
+      ).toBe('agent@corp.example.com');
     });
   });
 

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -269,6 +269,28 @@ describe('createRemoteAgentAuth', () => {
       expect(deps.apiKeyMiddleware).toHaveBeenCalled();
     });
 
+    it('rejects API key auth when the resolved user tenant disables API keys', async () => {
+      const deps = makeDeps(makeConfig({ enabled: false }, { enabled: true }));
+      deps.getAppConfig.mockImplementation(async (options) =>
+        options?.tenantId === 'tenant-oidc-only'
+          ? makeConfig({ enabled: true }, { enabled: false })
+          : makeConfig({ enabled: false }, { enabled: true }),
+      );
+      deps.apiKeyMiddleware.mockImplementation((req: Request, _res: Response, next) => {
+        req.user = makeUser({ tenantId: 'tenant-oidc-only' });
+        next();
+      });
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(makeReq() as Request, res, mockNext);
+
+      expect(deps.getAppConfig).toHaveBeenNthCalledWith(1, { baseOnly: true });
+      expect(deps.getAppConfig).toHaveBeenNthCalledWith(2, { tenantId: 'tenant-oidc-only' });
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
     it('loads tenant config from pre-auth tenant context before authentication', async () => {
       const deps = makeDeps(makeConfig({ enabled: false }));
 

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -4,14 +4,18 @@ import type { JwtPayload, VerifyOptions } from 'jsonwebtoken';
 import type { Request, Response } from 'express';
 import type { RequestInit } from 'undici';
 
-jest.mock('@librechat/data-schemas', () => ({
-  logger: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    debug: jest.fn(),
-  },
-}));
+jest.mock('@librechat/data-schemas', () => {
+  const actual = jest.requireActual('@librechat/data-schemas');
+  return {
+    ...actual,
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+});
 
 jest.mock('~/utils', () => ({
   isEnabled: jest.fn(() => false),
@@ -43,7 +47,7 @@ jest.mock('../auth/openid', () => {
 import jwt from 'jsonwebtoken';
 import jwksRsa from 'jwks-rsa';
 import { ProxyAgent, fetch as undiciFetch } from 'undici';
-import { logger } from '@librechat/data-schemas';
+import { logger, tenantStorage } from '@librechat/data-schemas';
 import { clearRemoteAgentAuthCache, createRemoteAgentAuth } from './remoteAgentAuth';
 import { findOpenIDUser, getOpenIdEmail } from '../auth/openid';
 import { math } from '~/utils';
@@ -238,13 +242,42 @@ describe('createRemoteAgentAuth', () => {
       expect(deps.apiKeyMiddleware).toHaveBeenCalled();
     });
 
-    it('loads base config before authentication when only pre-auth tenant context exists', async () => {
+    it('loads base config before authentication when tenant context is absent', async () => {
       const deps = makeDeps(makeConfig({ enabled: false }));
 
       await createRemoteAgentAuth(deps)(makeReq() as Request, makeRes().res, mockNext);
 
       expect(deps.getAppConfig).toHaveBeenCalledWith({ baseOnly: true });
       expect(deps.apiKeyMiddleware).toHaveBeenCalled();
+    });
+
+    it('loads tenant config from pre-auth tenant context before authentication', async () => {
+      const deps = makeDeps(makeConfig({ enabled: false }));
+
+      await tenantStorage.run({ tenantId: 'tenant-preauth' }, async () => {
+        await createRemoteAgentAuth(deps)(makeReq() as Request, makeRes().res, mockNext);
+      });
+
+      expect(deps.getAppConfig).toHaveBeenCalledWith({ tenantId: 'tenant-preauth' });
+      expect(deps.apiKeyMiddleware).toHaveBeenCalled();
+    });
+
+    it('enforces tenant auth policy from pre-auth tenant context', async () => {
+      const deps = makeDeps(makeConfig({ enabled: false }));
+      deps.getAppConfig.mockImplementation(async (options) =>
+        options?.tenantId === 'tenant-oidc-only'
+          ? makeConfig({ enabled: false }, { enabled: false })
+          : makeConfig({ enabled: false }, { enabled: true }),
+      );
+      const { res, status } = makeRes();
+
+      await tenantStorage.run({ tenantId: 'tenant-oidc-only' }, async () => {
+        await createRemoteAgentAuth(deps)(makeReq() as Request, res, mockNext);
+      });
+
+      expect(deps.getAppConfig).toHaveBeenCalledWith({ tenantId: 'tenant-oidc-only' });
+      expect(status).toHaveBeenCalledWith(401);
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
     });
 
     it('loads tenant config when an authenticated user is already present', async () => {

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -122,6 +122,18 @@ describe('createRemoteAgentAuth', () => {
       expect(mockNext).toHaveBeenCalled();
     });
 
+    it('returns 401 when oidc.enabled is false and apiKey is disabled', async () => {
+      const deps = makeDeps(makeConfig({ enabled: false }, { enabled: false }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(makeReq() as Request, res, mockNext);
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Authentication required' });
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled(); // ← this is the key assertion
+    });
+
     it('falls back to apiKeyMiddleware when oidc.enabled is false', async () => {
       const deps = makeDeps(makeConfig({ enabled: false }));
       await createRemoteAgentAuth(deps)(makeReq() as Request, makeRes().res, mockNext);
@@ -132,6 +144,20 @@ describe('createRemoteAgentAuth', () => {
       const deps = makeDeps({ endpoints: { agents: {} } } as unknown as AppConfig);
       await createRemoteAgentAuth(deps)(makeReq() as Request, makeRes().res, mockNext);
       expect(deps.apiKeyMiddleware).toHaveBeenCalled();
+    });
+
+    it('returns 401 when remoteApi auth is absent and apiKey is disabled', async () => {
+      const config = {
+        endpoints: { agents: { remoteApi: { auth: { apiKey: { enabled: false } } } } },
+      } as unknown as AppConfig;
+      const deps = makeDeps(config);
+      const { res, status } = makeRes();
+
+      await createRemoteAgentAuth(deps)(makeReq() as Request, res, mockNext);
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -1,4 +1,4 @@
-import type { AppConfig, IUser } from '@librechat/data-schemas';
+import type { AppConfig, IUser, UserMethods } from '@librechat/data-schemas';
 import type { TAgentsEndpoint } from 'librechat-data-provider';
 import type { JwtPayload, VerifyOptions } from 'jsonwebtoken';
 import type { Request, Response } from 'express';
@@ -36,9 +36,10 @@ jest.mock('jsonwebtoken', () => ({
   verify: jest.fn(),
 }));
 
-jest.mock('../auth/openid', () => ({
-  findOpenIDUser: jest.fn(),
-}));
+jest.mock('../auth/openid', () => {
+  const actual = jest.requireActual('../auth/openid') as typeof import('../auth/openid');
+  return { ...actual, findOpenIDUser: jest.fn(actual.findOpenIDUser) };
+});
 
 import jwt from 'jsonwebtoken';
 import jwksRsa from 'jwks-rsa';
@@ -50,6 +51,9 @@ import { findOpenIDUser } from '../auth/openid';
 const mockFetch = undiciFetch as jest.Mock;
 const mockProxyAgent = ProxyAgent as unknown as jest.Mock;
 const mockGetTenantId = getTenantId as jest.Mock;
+const realFindOpenIDUser =
+  jest.requireActual<typeof import('../auth/openid')>('../auth/openid').findOpenIDUser;
+const mockFindOpenIDUser = findOpenIDUser as jest.MockedFunction<typeof findOpenIDUser>;
 const FAKE_TOKEN = 'header.payload.signature';
 const BASE_ISSUER = 'https://auth.example.com/realms/test';
 const BASE_JWKS_URI = `${BASE_ISSUER}/protocol/openid-connect/certs`;
@@ -64,6 +68,8 @@ type AgentAuthConfig = NonNullable<NonNullable<TAgentsEndpoint['remoteApi']>['au
 type OidcConfig = NonNullable<AgentAuthConfig['oidc']>;
 type ApiKeyConfig = NonNullable<AgentAuthConfig['apiKey']>;
 type JwtVerifyCallback = (err: Error | null, payload?: JwtPayload) => void;
+type FindUserCondition = Pick<Partial<IUser>, '_id' | 'email' | 'openidId' | 'idOnTheSource'>;
+type FindUserQuery = FindUserCondition & { $or?: FindUserCondition[] };
 
 const mockUser = { _id: 'uid123', id: 'uid123', email: 'agent@test.com' };
 const originalEnv = ENV_KEYS.reduce<Record<(typeof ENV_KEYS)[number], string | undefined>>(
@@ -126,9 +132,40 @@ function makeConfig(
   } as unknown as AppConfig;
 }
 
+function makeUser(overrides: Partial<IUser> = {}): IUser {
+  return {
+    ...mockUser,
+    role: 'user',
+    provider: 'openid',
+    openidId: 'sub123',
+    ...overrides,
+  } as IUser;
+}
+
+function matchesCondition(user: IUser, condition: FindUserCondition): boolean {
+  if (condition._id != null && user._id !== condition._id) return false;
+  if (condition.email != null && user.email !== condition.email) return false;
+  if (condition.openidId != null && user.openidId !== condition.openidId) return false;
+  if (condition.idOnTheSource != null && user.idOnTheSource !== condition.idOnTheSource) {
+    return false;
+  }
+  return true;
+}
+
+function makeFindUser(...users: IUser[]): jest.MockedFunction<UserMethods['findUser']> {
+  return jest.fn(async (query) => {
+    const userQuery = query as FindUserQuery;
+    const conditions = userQuery.$or ?? [userQuery];
+    return (
+      users.find((user) => conditions.some((condition) => matchesCondition(user, condition))) ??
+      null
+    );
+  }) as jest.MockedFunction<UserMethods['findUser']>;
+}
+
 function makeDeps(appConfig: AppConfig | null = makeConfig()) {
   return {
-    findUser: jest.fn(),
+    findUser: makeFindUser(makeUser()),
     updateUser: jest.fn(),
     getAppConfig: jest.fn().mockResolvedValue(appConfig),
     apiKeyMiddleware: jest.fn((_req: unknown, _res: unknown, next: () => void) => next()),
@@ -156,6 +193,7 @@ describe('createRemoteAgentAuth', () => {
     mockFetch.mockReset();
     mockGetTenantId.mockReset();
     mockGetTenantId.mockReturnValue(undefined);
+    mockFindOpenIDUser.mockImplementation(realFindOpenIDUser);
     mockNext = jest.fn();
   });
 
@@ -265,10 +303,6 @@ describe('createRemoteAgentAuth', () => {
   });
 
   describe('when OIDC verification succeeds', () => {
-    beforeEach(() => {
-      (findOpenIDUser as jest.Mock).mockResolvedValue({ user: { ...mockUser }, error: null });
-    });
-
     it('sets req.user and calls next()', async () => {
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com', exp: 9999999999 });
       const deps = makeDeps();
@@ -305,6 +339,23 @@ describe('createRemoteAgentAuth', () => {
             'ES384',
             'ES512',
           ]),
+        }),
+      );
+    });
+
+    it('does not allow HMAC signing algorithms', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
+      const deps = makeDeps();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect((jwt.verify as jest.Mock).mock.calls[0][2]).toEqual(
+        expect.objectContaining({
+          algorithms: expect.not.arrayContaining(['HS256', 'HS384', 'HS512']),
         }),
       );
     });
@@ -355,9 +406,9 @@ describe('createRemoteAgentAuth', () => {
 
     it('falls back to apiKeyMiddleware when user is not found and apiKey is enabled', async () => {
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
-      (findOpenIDUser as jest.Mock).mockResolvedValue({ user: null, error: null });
 
       const deps = makeDeps(makeConfig({}, { enabled: true }));
+      deps.findUser.mockResolvedValue(null);
       const { res } = makeRes();
 
       await createRemoteAgentAuth(deps)(
@@ -374,9 +425,9 @@ describe('createRemoteAgentAuth', () => {
 
     it('returns 401 when user is not found and apiKey is disabled', async () => {
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
-      (findOpenIDUser as jest.Mock).mockResolvedValue({ user: null, error: null });
 
       const deps = makeDeps(makeConfig({}, { enabled: false }));
+      deps.findUser.mockResolvedValue(null);
       const { res, status, json } = makeRes();
 
       await createRemoteAgentAuth(deps)(
@@ -411,13 +462,11 @@ describe('createRemoteAgentAuth', () => {
 
     it('returns 401 without API key fallback when OpenID user resolution is rejected', async () => {
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
-      (findOpenIDUser as jest.Mock).mockResolvedValue({
-        user: null,
-        error: 'AUTH_FAILED',
-        migration: false,
-      });
 
       const deps = makeDeps(makeConfig({}, { enabled: true }));
+      deps.findUser
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(makeUser({ provider: 'google', openidId: undefined }));
       const { res, status, json } = makeRes();
 
       await createRemoteAgentAuth(deps)(
@@ -483,6 +532,36 @@ describe('createRemoteAgentAuth', () => {
 
       expect(status).toHaveBeenCalledWith(401);
     });
+
+    it('returns 401 when verifier rejects a HMAC-signed token', async () => {
+      const payload = { sub: 'sub123', email: 'agent@test.com' };
+      setupOidcMocks(payload);
+      (jwt.decode as jest.Mock).mockReturnValue({
+        header: { alg: 'HS256', kid: 'test-kid' },
+        payload,
+      });
+      (jwt.verify as jest.Mock).mockImplementation(
+        (_t: string, _k: string, options: VerifyOptions, cb: JwtVerifyCallback) => {
+          expect(options.algorithms).toEqual(
+            expect.not.arrayContaining(['HS256', 'HS384', 'HS512']),
+          );
+          cb(new Error('invalid algorithm'));
+        },
+      );
+
+      const deps = makeDeps(makeConfig({}, { enabled: false }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
   });
 
   describe('unexpected errors', () => {
@@ -505,7 +584,7 @@ describe('createRemoteAgentAuth', () => {
 
     it('returns 500 when findOpenIDUser throws', async () => {
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
-      (findOpenIDUser as jest.Mock).mockRejectedValue(new Error('DB error'));
+      mockFindOpenIDUser.mockRejectedValue(new Error('DB error'));
 
       const deps = makeDeps(makeConfig({}, { enabled: true }));
       const { res, status, json } = makeRes();
@@ -524,8 +603,7 @@ describe('createRemoteAgentAuth', () => {
 
   describe('JWKS URI resolution', () => {
     beforeEach(() => {
-      setupOidcMocks({ sub: 'sub1', email: 'a@b.com' });
-      (findOpenIDUser as jest.Mock).mockResolvedValue({ user: { ...mockUser }, error: null });
+      setupOidcMocks({ sub: 'sub123', email: 'a@b.com' });
     });
 
     it('uses jwksUri from config and skips discovery', async () => {
@@ -661,6 +739,33 @@ describe('createRemoteAgentAuth', () => {
       expect(jwksRsa).toHaveBeenCalledTimes(2);
     });
 
+    it('evicts the oldest JWKS client entry when the cache exceeds its limit', async () => {
+      const runRequest = async (index: number) => {
+        const deps = makeDeps(
+          makeConfig({
+            jwksUri: `https://cache-${index}.example.com/jwks`,
+            issuer: `https://issuer-cache-${index}.example.com`,
+          }),
+        );
+
+        await createRemoteAgentAuth(deps)(
+          makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+          makeRes().res,
+          mockNext,
+        );
+      };
+
+      for (let i = 0; i < 101; i++) {
+        await runRequest(i);
+      }
+      await runRequest(0);
+
+      expect(jwksRsa).toHaveBeenCalledTimes(102);
+      expect(jwksRsa).toHaveBeenLastCalledWith(
+        expect.objectContaining({ jwksUri: 'https://cache-0.example.com/jwks' }),
+      );
+    });
+
     it('aborts discovery when the timeout expires', async () => {
       jest.useFakeTimers();
 
@@ -740,16 +845,26 @@ describe('createRemoteAgentAuth', () => {
   describe('email claim resolution', () => {
     async function captureEmailArg(claims: JwtPayload): Promise<string | undefined> {
       setupOidcMocks(claims);
-      (findOpenIDUser as jest.Mock).mockResolvedValue({ user: { ...mockUser }, error: null });
 
       const deps = makeDeps();
+      deps.findUser
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(makeUser({ email: getExpectedEmail(claims), openidId: claims.sub }));
       await createRemoteAgentAuth(deps)(
         makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
         makeRes().res,
         mockNext,
       );
 
-      return (findOpenIDUser as jest.Mock).mock.calls[0][0].email;
+      return (deps.findUser.mock.calls[1]?.[0] as { email?: string } | undefined)?.email;
+    }
+
+    function getExpectedEmail(claims: JwtPayload): string | undefined {
+      return (
+        (claims['email'] as string | undefined) ??
+        (claims['preferred_username'] as string | undefined) ??
+        (claims['upn'] as string | undefined)
+      );
     }
 
     it('uses email claim', async () => {
@@ -773,13 +888,16 @@ describe('createRemoteAgentAuth', () => {
     it('persists openidId binding when migration is needed', async () => {
       const mockUpdateUser = jest.fn().mockResolvedValue(undefined);
       setupOidcMocks({ sub: 'sub-new', email: 'existing@test.com' });
-      (findOpenIDUser as jest.Mock).mockResolvedValue({
-        user: { ...mockUser, openidId: undefined, role: 'user' },
-        error: null,
-        migration: true,
-      });
 
       const deps = { ...makeDeps(), updateUser: mockUpdateUser };
+      deps.findUser.mockResolvedValueOnce(null).mockResolvedValueOnce(
+        makeUser({
+          email: 'existing@test.com',
+          openidId: undefined,
+          provider: undefined,
+          role: 'user',
+        }),
+      );
       await createRemoteAgentAuth(deps)(
         makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
         makeRes().res,
@@ -796,13 +914,16 @@ describe('createRemoteAgentAuth', () => {
     it('returns 500 when migration update fails', async () => {
       const mockUpdateUser = jest.fn().mockRejectedValue(new Error('DB write failed'));
       setupOidcMocks({ sub: 'sub-new', email: 'existing@test.com' });
-      (findOpenIDUser as jest.Mock).mockResolvedValue({
-        user: { ...mockUser, openidId: undefined, role: 'user' },
-        error: null,
-        migration: true,
-      });
 
       const deps = { ...makeDeps(makeConfig({}, { enabled: true })), updateUser: mockUpdateUser };
+      deps.findUser.mockResolvedValueOnce(null).mockResolvedValueOnce(
+        makeUser({
+          email: 'existing@test.com',
+          openidId: undefined,
+          provider: undefined,
+          role: 'user',
+        }),
+      );
       const { res, status, json } = makeRes();
 
       await createRemoteAgentAuth(deps)(
@@ -820,11 +941,6 @@ describe('createRemoteAgentAuth', () => {
     it('does not call updateUser when migration is false and role exists', async () => {
       const mockUpdateUser = jest.fn();
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
-      (findOpenIDUser as jest.Mock).mockResolvedValue({
-        user: { ...mockUser, role: 'user' },
-        error: null,
-        migration: false,
-      });
 
       const deps = { ...makeDeps(), updateUser: mockUpdateUser };
       await createRemoteAgentAuth(deps)(
@@ -854,16 +970,29 @@ describe('createRemoteAgentAuth', () => {
       expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
     });
 
+    it('does not fall back to apiKeyMiddleware when a verified token is missing scope', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com', scope: 'openid profile' });
+
+      const deps = makeDeps(makeConfig({ scope: 'remote_agent' }, { enabled: true }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
     it('passes when required scope is present in token', async () => {
       setupOidcMocks({
         sub: 'sub123',
         email: 'agent@test.com',
         scope: 'openid profile remote_agent',
-      });
-      (findOpenIDUser as jest.Mock).mockResolvedValue({
-        user: { ...mockUser },
-        error: null,
-        migration: false,
       });
 
       const deps = makeDeps(makeConfig({ scope: 'remote_agent' }));
@@ -876,13 +1005,63 @@ describe('createRemoteAgentAuth', () => {
       expect(mockNext).toHaveBeenCalled();
     });
 
-    it('passes when scope is not configured (backward compat)', async () => {
-      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' }); // no scope claim at all
-      (findOpenIDUser as jest.Mock).mockResolvedValue({
-        user: { ...mockUser },
-        error: null,
-        migration: false,
+    it('passes when scp is an array containing the required scope', async () => {
+      setupOidcMocks({
+        sub: 'sub123',
+        email: 'agent@test.com',
+        scp: ['openid', 'remote_agent'],
       });
+
+      const deps = makeDeps(makeConfig({ scope: 'remote_agent' }));
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('passes when all configured scopes are present', async () => {
+      setupOidcMocks({
+        sub: 'sub123',
+        email: 'agent@test.com',
+        scp: ['openid', 'remote_agent', 'admin'],
+      });
+
+      const deps = makeDeps(makeConfig({ scope: 'remote_agent admin' }));
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('returns 401 when any configured scope is missing', async () => {
+      setupOidcMocks({
+        sub: 'sub123',
+        email: 'agent@test.com',
+        scp: ['openid', 'remote_agent'],
+      });
+
+      const deps = makeDeps(makeConfig({ scope: 'remote_agent admin' }, { enabled: false }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('passes when scope is not configured (backward compat)', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
 
       const deps = makeDeps(makeConfig({ scope: undefined }));
       await createRemoteAgentAuth(deps)(

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -5,6 +5,7 @@ import type { Request, Response } from 'express';
 import type { RequestInit } from 'undici';
 
 jest.mock('@librechat/data-schemas', () => ({
+  getTenantId: jest.fn(),
   logger: {
     info: jest.fn(),
     warn: jest.fn(),
@@ -41,13 +42,14 @@ jest.mock('../auth/openid', () => ({
 
 import jwt from 'jsonwebtoken';
 import jwksRsa from 'jwks-rsa';
-import { logger } from '@librechat/data-schemas';
 import { ProxyAgent, fetch as undiciFetch } from 'undici';
+import { logger, getTenantId } from '@librechat/data-schemas';
 import { clearRemoteAgentAuthCache, createRemoteAgentAuth } from './remoteAgentAuth';
 import { findOpenIDUser } from '../auth/openid';
 
 const mockFetch = undiciFetch as jest.Mock;
 const mockProxyAgent = ProxyAgent as unknown as jest.Mock;
+const mockGetTenantId = getTenantId as jest.Mock;
 const FAKE_TOKEN = 'header.payload.signature';
 const BASE_ISSUER = 'https://auth.example.com/realms/test';
 const BASE_JWKS_URI = `${BASE_ISSUER}/protocol/openid-connect/certs`;
@@ -152,6 +154,8 @@ describe('createRemoteAgentAuth', () => {
     deleteEnvKeys();
     clearRemoteAgentAuthCache();
     mockFetch.mockReset();
+    mockGetTenantId.mockReset();
+    mockGetTenantId.mockReturnValue(undefined);
     mockNext = jest.fn();
   });
 
@@ -192,6 +196,16 @@ describe('createRemoteAgentAuth', () => {
     it('falls back to apiKeyMiddleware when oidc.enabled is false', async () => {
       const deps = makeDeps(makeConfig({ enabled: false }));
       await createRemoteAgentAuth(deps)(makeReq() as Request, makeRes().res, mockNext);
+      expect(deps.apiKeyMiddleware).toHaveBeenCalled();
+    });
+
+    it('loads config with pre-auth tenant context when present', async () => {
+      mockGetTenantId.mockReturnValue('tenant-a');
+      const deps = makeDeps(makeConfig({ enabled: false }));
+
+      await createRemoteAgentAuth(deps)(makeReq() as Request, makeRes().res, mockNext);
+
+      expect(deps.getAppConfig).toHaveBeenCalledWith({ tenantId: 'tenant-a' });
       expect(deps.apiKeyMiddleware).toHaveBeenCalled();
     });
 

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -400,7 +400,7 @@ describe('createRemoteAgentAuth', () => {
       expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
     });
 
-    it('preserves exact configured issuer when verifying JWTs', async () => {
+    it('allows exact and normalized configured issuers when verifying JWTs', async () => {
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
       const issuer = `${BASE_ISSUER}/`;
       const deps = makeDeps(makeConfig({ issuer }));
@@ -412,7 +412,7 @@ describe('createRemoteAgentAuth', () => {
       );
 
       expect((jwt.verify as jest.Mock).mock.calls[0][2]).toEqual(
-        expect.objectContaining({ issuer }),
+        expect.objectContaining({ issuer: [issuer, BASE_ISSUER] }),
       );
       expect(mockNext).toHaveBeenCalledWith();
     });
@@ -904,7 +904,7 @@ describe('createRemoteAgentAuth', () => {
       expect(mockNext).toHaveBeenCalled();
     });
 
-    it('normalizes discovery document issuer URL only when fetching discovery metadata', async () => {
+    it('normalizes discovery document issuer URL for discovery and issuer validation', async () => {
       const issuer = 'https://issuer-discovery-url.example.com/.well-known/openid-configuration';
       const normalizedIssuer = 'https://issuer-discovery-url.example.com';
 
@@ -926,7 +926,7 @@ describe('createRemoteAgentAuth', () => {
         expect.objectContaining({ signal: expect.any(Object) }),
       );
       expect((jwt.verify as jest.Mock).mock.calls[0][2]).toEqual(
-        expect.objectContaining({ issuer }),
+        expect.objectContaining({ issuer: [issuer, normalizedIssuer] }),
       );
       expect(mockNext).toHaveBeenCalled();
     });

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -1,7 +1,8 @@
-import type { JwtPayload, VerifyOptions } from 'jsonwebtoken';
 import type { AppConfig, IUser } from '@librechat/data-schemas';
 import type { TAgentsEndpoint } from 'librechat-data-provider';
+import type { JwtPayload, VerifyOptions } from 'jsonwebtoken';
 import type { Request, Response } from 'express';
+import type { RequestInit } from 'undici';
 
 jest.mock('@librechat/data-schemas', () => ({
   logger: {
@@ -625,6 +626,41 @@ describe('createRemoteAgentAuth', () => {
       );
 
       expect(jwksRsa).toHaveBeenCalledTimes(2);
+    });
+
+    it('aborts discovery when the timeout expires', async () => {
+      jest.useFakeTimers();
+
+      try {
+        mockFetch.mockImplementation(
+          (_url: string, init?: RequestInit) =>
+            new Promise((_resolve, reject) => {
+              init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+            }),
+        );
+
+        const deps = makeDeps(
+          makeConfig(
+            { jwksUri: undefined, issuer: 'https://issuer-discovery-timeout.example.com' },
+            { enabled: false },
+          ),
+        );
+        const { res, status } = makeRes();
+        const request = createRemoteAgentAuth(deps)(
+          makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+          res,
+          mockNext,
+        );
+
+        await Promise.resolve();
+        jest.advanceTimersByTime(10000);
+        await request;
+
+        expect(status).toHaveBeenCalledWith(401);
+        expect(mockNext).not.toHaveBeenCalled();
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('returns 401 when discovery returns non-ok response', async () => {

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -47,10 +47,12 @@ import { ProxyAgent, fetch as undiciFetch } from 'undici';
 import { logger, getTenantId } from '@librechat/data-schemas';
 import { clearRemoteAgentAuthCache, createRemoteAgentAuth } from './remoteAgentAuth';
 import { findOpenIDUser } from '../auth/openid';
+import { math } from '~/utils';
 
 const mockFetch = undiciFetch as jest.Mock;
 const mockProxyAgent = ProxyAgent as unknown as jest.Mock;
 const mockGetTenantId = getTenantId as jest.Mock;
+const mockMath = math as jest.Mock;
 const realFindOpenIDUser =
   jest.requireActual<typeof import('../auth/openid')>('../auth/openid').findOpenIDUser;
 const mockFindOpenIDUser = findOpenIDUser as jest.MockedFunction<typeof findOpenIDUser>;
@@ -193,6 +195,7 @@ describe('createRemoteAgentAuth', () => {
     mockFetch.mockReset();
     mockGetTenantId.mockReset();
     mockGetTenantId.mockReturnValue(undefined);
+    mockMath.mockReturnValue(60000);
     mockFindOpenIDUser.mockImplementation(realFindOpenIDUser);
     mockNext = jest.fn();
   });
@@ -541,10 +544,7 @@ describe('createRemoteAgentAuth', () => {
         payload,
       });
       (jwt.verify as jest.Mock).mockImplementation(
-        (_t: string, _k: string, options: VerifyOptions, cb: JwtVerifyCallback) => {
-          expect(options.algorithms).toEqual(
-            expect.not.arrayContaining(['HS256', 'HS384', 'HS512']),
-          );
+        (_t: string, _k: string, _options: VerifyOptions, cb: JwtVerifyCallback) => {
           cb(new Error('invalid algorithm'));
         },
       );
@@ -560,6 +560,11 @@ describe('createRemoteAgentAuth', () => {
 
       expect(status).toHaveBeenCalledWith(401);
       expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect((jwt.verify as jest.Mock).mock.calls[0][2]).toEqual(
+        expect.objectContaining({
+          algorithms: expect.not.arrayContaining(['HS256', 'HS384', 'HS512']),
+        }),
+      );
       expect(mockNext).not.toHaveBeenCalled();
     });
   });
@@ -764,6 +769,46 @@ describe('createRemoteAgentAuth', () => {
       expect(jwksRsa).toHaveBeenLastCalledWith(
         expect.objectContaining({ jwksUri: 'https://cache-0.example.com/jwks' }),
       );
+    });
+
+    it('prunes expired JWKS client entries before evicting valid entries', async () => {
+      const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(0);
+      const runRequest = async (key: string) => {
+        const deps = makeDeps(
+          makeConfig({
+            jwksUri: `https://cache-prune-${key}.example.com/jwks`,
+            issuer: `https://issuer-cache-prune-${key}.example.com`,
+          }),
+        );
+
+        await createRemoteAgentAuth(deps)(
+          makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+          makeRes().res,
+          mockNext,
+        );
+      };
+
+      try {
+        mockMath.mockReturnValue(120000);
+        await runRequest('keeper');
+
+        mockMath.mockReturnValue(1000);
+        for (let i = 0; i < 99; i++) {
+          await runRequest(`expired-${i}`);
+        }
+
+        nowSpy.mockReturnValue(2000);
+        mockMath.mockReturnValue(60000);
+        await runRequest('new');
+
+        expect(jwksRsa).toHaveBeenCalledTimes(101);
+
+        await runRequest('keeper');
+
+        expect(jwksRsa).toHaveBeenCalledTimes(101);
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
 
     it('aborts discovery when the timeout expires', async () => {
@@ -1047,6 +1092,27 @@ describe('createRemoteAgentAuth', () => {
       });
 
       const deps = makeDeps(makeConfig({ scope: 'remote_agent admin' }, { enabled: false }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('treats comma-separated configured scopes as one invalid scope token', async () => {
+      setupOidcMocks({
+        sub: 'sub123',
+        email: 'agent@test.com',
+        scope: 'remote_agent admin',
+      });
+
+      const deps = makeDeps(makeConfig({ scope: 'remote_agent,admin' }, { enabled: false }));
       const { res, status, json } = makeRes();
 
       await createRemoteAgentAuth(deps)(

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -708,6 +708,69 @@ describe('createRemoteAgentAuth', () => {
       expect(mockNext).toHaveBeenCalled();
     });
 
+    it('rejects insecure OPENID_JWKS_URL values outside localhost', async () => {
+      process.env.OPENID_JWKS_URL = 'http://env.example.com/jwks';
+      const deps = makeDeps(
+        makeConfig(
+          { jwksUri: undefined, issuer: 'https://issuer-env-insecure.example.com' },
+          { enabled: false },
+        ),
+      );
+      const { res, status } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(jwksRsa).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('rejects insecure issuer values outside localhost before JWKS resolution', async () => {
+      process.env.OPENID_JWKS_URL = 'https://env.example.com/jwks';
+      const deps = makeDeps(
+        makeConfig(
+          { jwksUri: undefined, issuer: 'http://issuer-env-insecure.example.com' },
+          { enabled: false },
+        ),
+      );
+      const { res, status } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(jwksRsa).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('allows localhost HTTP OPENID_JWKS_URL values for development', async () => {
+      process.env.OPENID_JWKS_URL = 'http://localhost:8080/jwks';
+      const deps = makeDeps(
+        makeConfig({ jwksUri: undefined, issuer: 'http://localhost:8080/realms/test' }),
+      );
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(jwksRsa).toHaveBeenCalledWith(
+        expect.objectContaining({ jwksUri: 'http://localhost:8080/jwks' }),
+      );
+      expect(mockNext).toHaveBeenCalled();
+    });
+
     it('fetches discovery document when jwksUri and env var are absent', async () => {
       const issuer = 'https://issuer-discovery-1.example.com';
 
@@ -729,6 +792,28 @@ describe('createRemoteAgentAuth', () => {
         expect.objectContaining({ signal: expect.any(Object) }),
       );
       expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('rejects insecure JWKS URIs returned by discovery', async () => {
+      const issuer = 'https://issuer-discovery-insecure.example.com';
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ jwks_uri: 'http://issuer-discovery-insecure.example.com/jwks' }),
+      });
+
+      const deps = makeDeps(makeConfig({ jwksUri: undefined, issuer }, { enabled: false }));
+      const { res, status } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(jwksRsa).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
     });
 
     it('uses a proxy agent for discovery when PROXY is set', async () => {

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -84,6 +84,7 @@ function makeConfig(oidcOverrides?: object, apiKeyOverrides?: object): AppConfig
 function makeDeps(appConfig: AppConfig | null = makeConfig()) {
   return {
     findUser: jest.fn(),
+    updateUser: jest.fn(),
     getAppConfig: jest.fn().mockResolvedValue(appConfig),
     apiKeyMiddleware: jest.fn((_req: unknown, _res: unknown, next: () => void) => next()),
   };
@@ -454,4 +455,48 @@ describe('createRemoteAgentAuth', () => {
       expect(await captureEmailArg({ sub: 's3', upn: 'upn@corp.com' })).toBe('upn@corp.com');
     });
   });
+
+  describe('update user and migration scenarios', () => {
+    it('persists openidId binding when migration is needed', async () => {
+      const mockUpdateUser = jest.fn().mockResolvedValue(undefined);
+      setupOidcMocks({ sub: 'sub-new', email: 'existing@test.com' });
+      (findOpenIDUser as jest.Mock).mockResolvedValue({
+        user: { ...mockUser, openidId: undefined, role: 'user' },
+        error: null,
+        migration: true,
+      });
+
+      const deps = { ...makeDeps(), updateUser: mockUpdateUser };
+      await createRemoteAgentAuth(deps as any)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(mockUpdateUser).toHaveBeenCalledWith(
+        mockUser.id,
+        expect.objectContaining({ provider: 'openid', openidId: 'sub-new' }),
+      );
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('does not call updateUser when migration is false and role exists', async () => {
+      const mockUpdateUser = jest.fn();
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
+      (findOpenIDUser as jest.Mock).mockResolvedValue({
+        user: { ...mockUser, role: 'user' },
+        error: null,
+        migration: false,
+      });
+
+      const deps = { ...makeDeps(), updateUser: mockUpdateUser };
+      await createRemoteAgentAuth(deps as any)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(mockUpdateUser).not.toHaveBeenCalled();
+    });
+  })
 });

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -467,7 +467,7 @@ describe('createRemoteAgentAuth', () => {
       });
 
       const deps = { ...makeDeps(), updateUser: mockUpdateUser };
-      await createRemoteAgentAuth(deps as any)(
+      await createRemoteAgentAuth(deps)(
         makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
         makeRes().res,
         mockNext,
@@ -490,7 +490,7 @@ describe('createRemoteAgentAuth', () => {
       });
 
       const deps = { ...makeDeps(), updateUser: mockUpdateUser };
-      await createRemoteAgentAuth(deps as any)(
+      await createRemoteAgentAuth(deps)(
         makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
         makeRes().res,
         mockNext,
@@ -498,5 +498,5 @@ describe('createRemoteAgentAuth', () => {
 
       expect(mockUpdateUser).not.toHaveBeenCalled();
     });
-  })
+  });
 });

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -941,6 +941,16 @@ describe('createRemoteAgentAuth', () => {
       );
     });
 
+    it('falls back to preferred_username when email is empty', async () => {
+      expect(
+        await captureEmailArg({
+          sub: 's2-empty',
+          email: '',
+          preferred_username: 'agent-user',
+        }),
+      ).toBe('agent-user');
+    });
+
     it('falls back to upn when email and preferred_username are absent', async () => {
       expect(await captureEmailArg({ sub: 's3', upn: 'upn@corp.com' })).toBe('upn@corp.com');
     });

--- a/packages/api/src/middleware/remoteAgentAuth.spec.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.spec.ts
@@ -1,5 +1,7 @@
-import type { Request, Response } from 'express';
+import type { JwtPayload, VerifyOptions } from 'jsonwebtoken';
 import type { AppConfig, IUser } from '@librechat/data-schemas';
+import type { TAgentsEndpoint } from 'librechat-data-provider';
+import type { Request, Response } from 'express';
 
 jest.mock('@librechat/data-schemas', () => ({
   logger: {
@@ -16,11 +18,16 @@ jest.mock('~/utils', () => ({
 }));
 
 const mockGetSigningKey = jest.fn();
-const mockGetKeys = jest.fn();
+const mockGetSigningKeys = jest.fn();
 
 jest.mock('jwks-rsa', () =>
-  jest.fn(() => ({ getSigningKey: mockGetSigningKey, getKeys: mockGetKeys })),
+  jest.fn(() => ({ getSigningKey: mockGetSigningKey, getSigningKeys: mockGetSigningKeys })),
 );
+
+jest.mock('undici', () => ({
+  fetch: jest.fn(),
+  ProxyAgent: jest.fn((proxy: string) => ({ proxy })),
+}));
 
 jest.mock('jsonwebtoken', () => ({
   decode: jest.fn(),
@@ -32,24 +39,56 @@ jest.mock('../auth/openid', () => ({
 }));
 
 import jwt from 'jsonwebtoken';
+import jwksRsa from 'jwks-rsa';
 import { logger } from '@librechat/data-schemas';
+import { ProxyAgent, fetch as undiciFetch } from 'undici';
+import { clearRemoteAgentAuthCache, createRemoteAgentAuth } from './remoteAgentAuth';
 import { findOpenIDUser } from '../auth/openid';
-import { createRemoteAgentAuth } from './remoteAgentAuth';
 
-const fetchMock = jest.fn();
-
-beforeAll(() => {
-  (global as unknown as Record<string, unknown>).fetch = fetchMock;
-});
-
+const mockFetch = undiciFetch as jest.Mock;
+const mockProxyAgent = ProxyAgent as unknown as jest.Mock;
 const FAKE_TOKEN = 'header.payload.signature';
 const BASE_ISSUER = 'https://auth.example.com/realms/test';
 const BASE_JWKS_URI = `${BASE_ISSUER}/protocol/openid-connect/certs`;
+const ENV_KEYS = [
+  'OPENID_JWKS_URL',
+  'OPENID_JWKS_URL_CACHE_ENABLED',
+  'OPENID_JWKS_URL_CACHE_TIME',
+  'PROXY',
+] as const;
 
-type SigningKeyCallback = (err: Error | null, key?: { getPublicKey: () => string }) => void;
-type JwtVerifyCallback = (err: Error | null, payload?: object) => void;
+type AgentAuthConfig = NonNullable<NonNullable<TAgentsEndpoint['remoteApi']>['auth']>;
+type OidcConfig = NonNullable<AgentAuthConfig['oidc']>;
+type ApiKeyConfig = NonNullable<AgentAuthConfig['apiKey']>;
+type JwtVerifyCallback = (err: Error | null, payload?: JwtPayload) => void;
 
 const mockUser = { _id: 'uid123', id: 'uid123', email: 'agent@test.com' };
+const originalEnv = ENV_KEYS.reduce<Record<(typeof ENV_KEYS)[number], string | undefined>>(
+  (env, key) => ({ ...env, [key]: process.env[key] }),
+  {
+    OPENID_JWKS_URL: undefined,
+    OPENID_JWKS_URL_CACHE_ENABLED: undefined,
+    OPENID_JWKS_URL_CACHE_TIME: undefined,
+    PROXY: undefined,
+  },
+);
+
+function deleteEnvKeys() {
+  ENV_KEYS.forEach((key) => {
+    delete process.env[key];
+  });
+}
+
+function restoreOriginalEnv() {
+  ENV_KEYS.forEach((key) => {
+    const value = originalEnv[key];
+    if (value == null) {
+      delete process.env[key];
+      return;
+    }
+    process.env[key] = value;
+  });
+}
 
 function makeRes() {
   const json = jest.fn();
@@ -61,7 +100,10 @@ function makeReq(headers: Record<string, string> = {}): Partial<Request> {
   return { headers };
 }
 
-function makeConfig(oidcOverrides?: object, apiKeyOverrides?: object): AppConfig {
+function makeConfig(
+  oidcOverrides?: Partial<OidcConfig>,
+  apiKeyOverrides?: Partial<ApiKeyConfig>,
+): AppConfig {
   return {
     endpoints: {
       agents: {
@@ -90,13 +132,14 @@ function makeDeps(appConfig: AppConfig | null = makeConfig()) {
   };
 }
 
-function setupOidcMocks(payload: object, kid = 'test-kid') {
-  (jwt.decode as jest.Mock).mockReturnValue({ header: { kid }, payload });
-  mockGetSigningKey.mockImplementation((_k: string, cb: SigningKeyCallback) =>
-    cb(null, { getPublicKey: () => 'public-key' }),
-  );
+function setupOidcMocks(payload: JwtPayload, kid: string | null = 'test-kid') {
+  (jwt.decode as jest.Mock).mockReturnValue({ header: kid == null ? {} : { kid }, payload });
+  mockGetSigningKey.mockResolvedValue({ getPublicKey: () => 'public-key' });
+  mockGetSigningKeys.mockResolvedValue([
+    { kid: kid ?? 'test-kid', getPublicKey: () => 'public-key' },
+  ]);
   (jwt.verify as jest.Mock).mockImplementation(
-    (_t: string, _k: string, _o: object, cb: JwtVerifyCallback) => cb(null, payload),
+    (_t: string, _k: string, _o: VerifyOptions, cb: JwtVerifyCallback) => cb(null, payload),
   );
 }
 
@@ -105,8 +148,19 @@ describe('createRemoteAgentAuth', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    fetchMock.mockReset();
+    deleteEnvKeys();
+    clearRemoteAgentAuthCache();
+    mockFetch.mockReset();
     mockNext = jest.fn();
+  });
+
+  afterEach(() => {
+    deleteEnvKeys();
+    clearRemoteAgentAuthCache();
+  });
+
+  afterAll(() => {
+    restoreOriginalEnv();
   });
 
   describe('when OIDC is not enabled', () => {
@@ -131,7 +185,7 @@ describe('createRemoteAgentAuth', () => {
       expect(status).toHaveBeenCalledWith(401);
       expect(json).toHaveBeenCalledWith({ error: 'Authentication required' });
       expect(mockNext).not.toHaveBeenCalled();
-      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled(); // ← this is the key assertion
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
     });
 
     it('falls back to apiKeyMiddleware when oidc.enabled is false', async () => {
@@ -182,6 +236,17 @@ describe('createRemoteAgentAuth', () => {
       expect(json).toHaveBeenCalledWith({ error: 'Bearer token required' });
       expect(mockNext).not.toHaveBeenCalled();
     });
+
+    it('returns 500 when OIDC is enabled without an issuer', async () => {
+      const deps = makeDeps(makeConfig({ issuer: undefined }, { enabled: false }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(makeReq() as Request, res, mockNext);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Internal server error' });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
   });
 
   describe('when OIDC verification succeeds', () => {
@@ -200,6 +265,63 @@ describe('createRemoteAgentAuth', () => {
       expect(req.user).toMatchObject({ id: 'uid123', email: 'agent@test.com' });
       expect(mockNext).toHaveBeenCalledWith();
       expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
+    });
+
+    it('allows RSA, RSA-PSS, and ECDSA signing algorithms', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
+      const deps = makeDeps();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect((jwt.verify as jest.Mock).mock.calls[0][2]).toEqual(
+        expect.objectContaining({
+          algorithms: expect.arrayContaining([
+            'RS256',
+            'RS384',
+            'RS512',
+            'PS256',
+            'PS384',
+            'PS512',
+            'ES256',
+            'ES384',
+            'ES512',
+          ]),
+        }),
+      );
+    });
+
+    it('tries signing keys until a token without kid verifies', async () => {
+      const payload = { sub: 'sub123', email: 'agent@test.com' };
+      setupOidcMocks(payload, null);
+      mockGetSigningKeys.mockResolvedValue([
+        { kid: 'first-kid', getPublicKey: () => 'first-public-key' },
+        { kid: 'second-kid', getPublicKey: () => 'second-public-key' },
+      ]);
+      (jwt.verify as jest.Mock).mockImplementation(
+        (_t: string, key: string, _o: VerifyOptions, cb: JwtVerifyCallback) => {
+          if (key === 'first-public-key') {
+            cb(new Error('invalid signature'));
+            return;
+          }
+          cb(null, payload);
+        },
+      );
+
+      const deps = makeDeps();
+      const req = makeReq({ authorization: `Bearer ${FAKE_TOKEN}` });
+
+      await createRemoteAgentAuth(deps)(req as Request, makeRes().res, mockNext);
+
+      expect(mockGetSigningKey).not.toHaveBeenCalled();
+      expect(jwt.verify).toHaveBeenCalledTimes(2);
+      expect((jwt.verify as jest.Mock).mock.calls[0][1]).toBe('first-public-key');
+      expect((jwt.verify as jest.Mock).mock.calls[1][1]).toBe('second-public-key');
+      expect(req.user).toMatchObject({ id: 'uid123', email: 'agent@test.com' });
+      expect(mockNext).toHaveBeenCalledWith();
     });
 
     it('attaches federatedTokens with access_token and expires_at', async () => {
@@ -252,14 +374,35 @@ describe('createRemoteAgentAuth', () => {
       expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
       expect(mockNext).not.toHaveBeenCalled();
     });
+
+    it('returns 401 without API key fallback when OpenID user resolution is rejected', async () => {
+      setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
+      (findOpenIDUser as jest.Mock).mockResolvedValue({
+        user: null,
+        error: 'AUTH_FAILED',
+        migration: false,
+      });
+
+      const deps = makeDeps(makeConfig({}, { enabled: true }));
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(401);
+      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+    });
   });
 
   describe('when OIDC verification fails', () => {
     beforeEach(() => {
       (jwt.decode as jest.Mock).mockReturnValue({ header: { kid: 'kid' }, payload: {} });
-      mockGetSigningKey.mockImplementation((_k: string, cb: SigningKeyCallback) =>
-        cb(new Error('Signing key not found')),
-      );
+      mockGetSigningKey.mockRejectedValue(new Error('Signing key not found'));
     });
 
     it('falls back to apiKeyMiddleware when apiKey is enabled', async () => {
@@ -326,11 +469,11 @@ describe('createRemoteAgentAuth', () => {
       );
     });
 
-    it('returns 401 when findOpenIDUser throws and apiKey is disabled', async () => {
+    it('returns 500 when findOpenIDUser throws', async () => {
       setupOidcMocks({ sub: 'sub123', email: 'agent@test.com' });
       (findOpenIDUser as jest.Mock).mockRejectedValue(new Error('DB error'));
 
-      const deps = makeDeps(makeConfig({}, { enabled: false }));
+      const deps = makeDeps(makeConfig({}, { enabled: true }));
       const { res, status, json } = makeRes();
 
       await createRemoteAgentAuth(deps)(
@@ -339,8 +482,9 @@ describe('createRemoteAgentAuth', () => {
         mockNext,
       );
 
-      expect(status).toHaveBeenCalledWith(401);
-      expect(json).toHaveBeenCalledWith({ error: 'Unauthorized' });
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Internal server error' });
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
     });
   });
 
@@ -364,7 +508,7 @@ describe('createRemoteAgentAuth', () => {
         mockNext,
       );
 
-      expect(fetchMock).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
       expect(mockNext).toHaveBeenCalled();
     });
 
@@ -380,17 +524,14 @@ describe('createRemoteAgentAuth', () => {
         mockNext,
       );
 
-      expect(fetchMock).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
       expect(mockNext).toHaveBeenCalled();
-
-      delete process.env.OPENID_JWKS_URL;
     });
 
     it('fetches discovery document when jwksUri and env var are absent', async () => {
-      delete process.env.OPENID_JWKS_URL;
       const issuer = 'https://issuer-discovery-1.example.com';
 
-      fetchMock.mockResolvedValue({
+      mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({ jwks_uri: `${issuer}/protocol/openid-connect/certs` }),
       });
@@ -403,13 +544,91 @@ describe('createRemoteAgentAuth', () => {
         mockNext,
       );
 
-      expect(fetchMock).toHaveBeenCalledWith(`${issuer}/.well-known/openid-configuration`);
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${issuer}/.well-known/openid-configuration`,
+        expect.objectContaining({ signal: expect.any(Object) }),
+      );
       expect(mockNext).toHaveBeenCalled();
     });
 
+    it('uses a proxy agent for discovery when PROXY is set', async () => {
+      process.env.PROXY = 'http://proxy.example.com';
+      const issuer = 'https://issuer-proxy.example.com';
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ jwks_uri: `${issuer}/protocol/openid-connect/certs` }),
+      });
+
+      const deps = makeDeps(makeConfig({ jwksUri: undefined, issuer }));
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(mockProxyAgent).toHaveBeenCalledWith('http://proxy.example.com');
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${issuer}/.well-known/openid-configuration`,
+        expect.objectContaining({ dispatcher: { proxy: 'http://proxy.example.com' } }),
+      );
+    });
+
+    it('caches JWKS clients by resolved URI', async () => {
+      process.env.OPENID_JWKS_URL = 'https://env-one.example.com/jwks';
+      const deps = makeDeps(
+        makeConfig({ jwksUri: undefined, issuer: 'https://issuer-env-cache.example.com' }),
+      );
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      process.env.OPENID_JWKS_URL = 'https://env-two.example.com/jwks';
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(jwksRsa).toHaveBeenCalledWith(
+        expect.objectContaining({ jwksUri: 'https://env-one.example.com/jwks' }),
+      );
+      expect(jwksRsa).toHaveBeenCalledWith(
+        expect.objectContaining({ jwksUri: 'https://env-two.example.com/jwks' }),
+      );
+    });
+
+    it('honors disabled JWKS caching', async () => {
+      process.env.OPENID_JWKS_URL_CACHE_ENABLED = 'false';
+      const deps = makeDeps(
+        makeConfig({
+          jwksUri: 'https://cache-disabled.example.com/jwks',
+          issuer: 'https://issuer-cache-disabled.example.com',
+        }),
+      );
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        makeRes().res,
+        mockNext,
+      );
+
+      expect(jwksRsa).toHaveBeenCalledTimes(2);
+    });
+
     it('returns 401 when discovery returns non-ok response', async () => {
-      delete process.env.OPENID_JWKS_URL;
-      fetchMock.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+      mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
 
       const deps = makeDeps(
         makeConfig(
@@ -429,8 +648,7 @@ describe('createRemoteAgentAuth', () => {
     });
 
     it('returns 401 when discovery response is missing jwks_uri field', async () => {
-      delete process.env.OPENID_JWKS_URL;
-      fetchMock.mockResolvedValue({ ok: true, json: async () => ({}) });
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
 
       const deps = makeDeps(
         makeConfig(
@@ -451,7 +669,7 @@ describe('createRemoteAgentAuth', () => {
   });
 
   describe('email claim resolution', () => {
-    async function captureEmailArg(claims: object): Promise<string | undefined> {
+    async function captureEmailArg(claims: JwtPayload): Promise<string | undefined> {
       setupOidcMocks(claims);
       (findOpenIDUser as jest.Mock).mockResolvedValue({ user: { ...mockUser }, error: null });
 
@@ -504,6 +722,30 @@ describe('createRemoteAgentAuth', () => {
         expect.objectContaining({ provider: 'openid', openidId: 'sub-new' }),
       );
       expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('returns 500 when migration update fails', async () => {
+      const mockUpdateUser = jest.fn().mockRejectedValue(new Error('DB write failed'));
+      setupOidcMocks({ sub: 'sub-new', email: 'existing@test.com' });
+      (findOpenIDUser as jest.Mock).mockResolvedValue({
+        user: { ...mockUser, openidId: undefined, role: 'user' },
+        error: null,
+        migration: true,
+      });
+
+      const deps = { ...makeDeps(makeConfig({}, { enabled: true })), updateUser: mockUpdateUser };
+      const { res, status, json } = makeRes();
+
+      await createRemoteAgentAuth(deps)(
+        makeReq({ authorization: `Bearer ${FAKE_TOKEN}` }) as Request,
+        res,
+        mockNext,
+      );
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith({ error: 'Internal server error' });
+      expect(deps.apiKeyMiddleware).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
     });
 
     it('does not call updateUser when migration is false and role exists', async () => {

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -1,0 +1,228 @@
+import jwt from 'jsonwebtoken';
+import jwksRsa from 'jwks-rsa';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { logger } from '@librechat/data-schemas';
+import type { RequestHandler, Request, Response, NextFunction } from 'express';
+import type { JwtPayload } from 'jsonwebtoken';
+import type { AppConfig, IUser, UserMethods } from '@librechat/data-schemas';
+import type { TAgentsEndpoint } from 'librechat-data-provider';
+import { isEnabled, math } from '~/utils';
+import { findOpenIDUser } from '../auth/openid';
+
+export interface RemoteAgentAuthDeps {
+  apiKeyMiddleware: RequestHandler;
+  findUser: UserMethods['findUser'];
+  getAppConfig: () => Promise<AppConfig | null>;
+}
+
+type OidcConfig = NonNullable<
+  NonNullable<NonNullable<TAgentsEndpoint['remoteApi']>['auth']>['oidc']
+>;
+
+const jwksClientCache = new Map<string, Promise<jwksRsa.JwksClient>>();
+
+function extractBearer(authHeader: string | undefined): string | null {
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  return authHeader.slice(7);
+}
+
+function getEmail(payload: JwtPayload): string | undefined {
+  return (
+    (payload['email'] as string | undefined) ??
+    (payload['preferred_username'] as string | undefined) ??
+    (payload['upn'] as string | undefined)
+  );
+}
+
+async function resolveJwksUri(oidcConfig: OidcConfig): Promise<string> {
+  if (oidcConfig.jwksUri) return oidcConfig.jwksUri;
+  if (process.env.OPENID_JWKS_URL) return process.env.OPENID_JWKS_URL;
+
+  const issuer = oidcConfig.issuer.replace(/\/$/, '');
+  const discoveryUrl = `${issuer}/.well-known/openid-configuration`;
+
+  const res = await fetch(discoveryUrl);
+  if (!res.ok) throw new Error(`OIDC discovery failed: ${res.status} ${res.statusText}`);
+
+  const meta = (await res.json()) as { jwks_uri?: string };
+  if (!meta.jwks_uri) throw new Error('OIDC discovery response missing jwks_uri');
+
+  return meta.jwks_uri;
+}
+
+function buildJwksClient(uri: string): jwksRsa.JwksClient {
+  const options: jwksRsa.Options = {
+    cache: isEnabled(process.env.OPENID_JWKS_URL_CACHE_ENABLED) || true,
+    cacheMaxAge: math(process.env.OPENID_JWKS_URL_CACHE_TIME, 60000),
+    jwksUri: uri,
+  };
+
+  if (process.env.PROXY) {
+    options.requestAgent = new HttpsProxyAgent(process.env.PROXY);
+  }
+
+  return jwksRsa(options);
+}
+
+async function getJwksClient(oidcConfig: OidcConfig): Promise<jwksRsa.JwksClient> {
+  const cacheKey = oidcConfig.jwksUri ?? oidcConfig.issuer;
+
+  const cached = jwksClientCache.get(cacheKey);
+  if (cached != null) return cached;
+
+  const promise = resolveJwksUri(oidcConfig)
+    .then((uri) => {
+      return buildJwksClient(uri);
+    })
+    .catch((err) => {
+      jwksClientCache.delete(cacheKey); // не кэшируем ошибку
+      throw err;
+    });
+
+  jwksClientCache.set(cacheKey, promise);
+  return promise;
+}
+
+function verifyOidcBearer(token: string, oidcConfig: OidcConfig): Promise<JwtPayload> {
+  return new Promise((resolve, reject) => {
+    const decoded = jwt.decode(token, { complete: true });
+    if (decoded == null) return reject(new Error('Invalid JWT: cannot decode'));
+
+    const kid = decoded.header?.kid as string | undefined;
+
+    getJwksClient(oidcConfig)
+      .then((client) => {
+        const fetchKey = (callback: (key: jwksRsa.SigningKey) => void) => {
+          if (kid != null) {
+            client.getSigningKey(kid, (err, key) => {
+              if (err != null || key == null)
+                return reject(err ?? new Error('No signing key for kid'));
+              callback(key);
+            });
+          } else {
+            client
+              .getKeys()
+              .then((keys: unknown) => {
+                const jwkKeys = keys as Array<{ kid: string }>;
+                if (jwkKeys.length === 0) return reject(new Error('No keys in JWKS'));
+                client.getSigningKey(jwkKeys[0].kid, (keyErr, key) => {
+                  if (keyErr != null || key == null)
+                    return reject(keyErr ?? new Error('No signing key'));
+                  callback(key);
+                });
+              })
+              .catch((err: unknown) => reject(err));
+          }
+        };
+
+        fetchKey((signingKey) => {
+          jwt.verify(
+            token,
+            signingKey.getPublicKey(),
+            {
+              algorithms: ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512'],
+              ...(oidcConfig.issuer ? { issuer: oidcConfig.issuer } : {}),
+              ...(oidcConfig.audience ? { audience: oidcConfig.audience } : {}),
+            },
+            (err, payload) => {
+              if (err != null || payload == null) {
+                return reject(err ?? new Error('Empty payload'));
+              }
+              resolve(payload as JwtPayload);
+            },
+          );
+        });
+      })
+      .catch(reject);
+  });
+}
+
+async function resolveUser(
+  token: string,
+  payload: JwtPayload,
+  findUser: UserMethods['findUser'],
+): Promise<IUser | null> {
+  const { user, error } = await findOpenIDUser({
+    findUser,
+    email: getEmail(payload),
+    openidId: payload.sub ?? '',
+    idOnTheSource: payload['oid'] as string | undefined,
+    strategyName: 'remoteAgentAuth',
+  });
+
+  if (error != null || user == null) return null;
+
+  user.id = String(user._id);
+  user.federatedTokens = { access_token: token, expires_at: payload.exp };
+  return user;
+}
+
+/**
+ * Factory for Remote Agent API auth middleware.
+ *
+ * Validates Bearer tokens against configured OIDC issuer via JWKS,
+ * falling back to API key auth when enabled. Stateless — no session dependency.
+ *
+ * ```yaml
+ * endpoints:
+ *   agents:
+ *     remoteApi:
+ *       auth:
+ *         apiKey:
+ *           enabled: false
+ *         oidc:
+ *           enabled: true
+ *           issuer: <issuer>
+ *           jwksUri: <jwksUri>
+ *           audience: <audience>
+ * ```
+ */
+export function createRemoteAgentAuth({
+  apiKeyMiddleware,
+  findUser,
+  getAppConfig,
+}: RemoteAgentAuthDeps): RequestHandler {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const config = await getAppConfig();
+      const authConfig = config?.endpoints?.agents?.remoteApi?.auth;
+
+      if (authConfig?.oidc?.enabled !== true) {
+        return apiKeyMiddleware(req, res, next);
+      }
+
+      const token = extractBearer(req.headers.authorization);
+      const apiKeyEnabled = authConfig.apiKey?.enabled !== false;
+
+      if (token == null) {
+        if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
+        res.status(401).json({ error: 'Bearer token required' });
+        return;
+      }
+
+      try {
+        const payload = await verifyOidcBearer(token, authConfig.oidc);
+        const user = await resolveUser(token, payload, findUser);
+
+        if (user == null) {
+          logger.warn('[remoteAgentAuth] OIDC token valid but no matching LibreChat user');
+          if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
+          res.status(401).json({ error: 'Unauthorized' });
+          return;
+        }
+
+        req.user = user;
+        return next();
+      } catch (oidcErr) {
+        logger.error('[remoteAgentAuth] OIDC verification failed:', oidcErr);
+        if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+    } catch (err) {
+      logger.error('[remoteAgentAuth] Unexpected error', err);
+      res.status(500).json({ error: 'Internal server error' });
+      return;
+    }
+  };
+}

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -17,7 +17,7 @@ export interface RemoteAgentAuthDeps {
   apiKeyMiddleware: RequestHandler;
   findUser: UserMethods['findUser'];
   updateUser: UserMethods['updateUser'];
-  getAppConfig: (options?: GetAppConfigOptions) => Promise<AppConfig | null>;
+  getAppConfig: (options?: GetAppConfigOptions) => Promise<AppConfig>;
 }
 
 type OidcConfig = NonNullable<
@@ -84,7 +84,7 @@ function setCacheEntry<T>(
 }
 
 function extractBearer(authHeader: string | undefined): string | null {
-  const match = authHeader?.match(/^Bearer\s+(.+)$/i);
+  const match = authHeader?.match(/^Bearer\s+(\S+)\s*$/i);
   return match?.[1] ?? null;
 }
 
@@ -229,7 +229,7 @@ function getVerifyOptions(oidcConfig: EnabledOidcConfig): VerifyOptions {
   };
 }
 
-function getConfigOptions(req: Request): GetAppConfigOptions | undefined {
+function getConfigOptions(req: Request): GetAppConfigOptions {
   const user = req.user as { tenantId?: string } | undefined;
   const tenantId = user?.tenantId ?? getTenantId();
 
@@ -325,7 +325,10 @@ async function resolveUser(
     await updateUser(user.id, updateData);
   }
 
-  user.federatedTokens = { access_token: token, expires_at: payload.exp };
+  user.federatedTokens = {
+    access_token: token,
+    ...(payload.exp != null ? { expires_at: payload.exp } : {}),
+  };
   return { status: 'resolved', user };
 }
 
@@ -359,7 +362,7 @@ export function createRemoteAgentAuth({
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       const config = await getAppConfig(getConfigOptions(req));
-      const authConfig = config?.endpoints?.agents?.remoteApi?.auth;
+      const authConfig = config.endpoints?.agents?.remoteApi?.auth;
       const apiKeyEnabled = authConfig?.apiKey?.enabled !== false;
 
       if (authConfig?.oidc?.enabled !== true) {

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -1,14 +1,16 @@
 import jwt from 'jsonwebtoken';
 import jwksRsa from 'jwks-rsa';
-import { HttpsProxyAgent } from 'https-proxy-agent';
 import { logger } from '@librechat/data-schemas';
-import type { RequestHandler, Request, Response, NextFunction } from 'express';
-import type { JwtPayload } from 'jsonwebtoken';
-import type { AppConfig, IUser, UserMethods } from '@librechat/data-schemas';
-import type { TAgentsEndpoint } from 'librechat-data-provider';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import { SystemRoles } from 'librechat-data-provider';
-import { isEnabled, math } from '~/utils';
+import { ProxyAgent, fetch as undiciFetch } from 'undici';
+import type { RequestHandler, Request, Response, NextFunction } from 'express';
+import type { AppConfig, IUser, UserMethods } from '@librechat/data-schemas';
+import type { Algorithm, JwtPayload, VerifyOptions } from 'jsonwebtoken';
+import type { TAgentsEndpoint } from 'librechat-data-provider';
+import type { RequestInit } from 'undici';
 import { findOpenIDUser } from '../auth/openid';
+import { isEnabled, math } from '~/utils';
 
 export interface RemoteAgentAuthDeps {
   apiKeyMiddleware: RequestHandler;
@@ -21,7 +23,39 @@ type OidcConfig = NonNullable<
   NonNullable<NonNullable<TAgentsEndpoint['remoteApi']>['auth']>['oidc']
 >;
 
-const jwksClientCache = new Map<string, Promise<jwksRsa.JwksClient>>();
+type EnabledOidcConfig = OidcConfig & { issuer: string };
+type JwksCacheOptions = {
+  enabled: boolean;
+  maxAge: number;
+};
+type CacheEntry<T> = {
+  expiresAt: number;
+  promise: Promise<T>;
+};
+type UserResolution =
+  | { status: 'resolved'; user: IUser }
+  | { status: 'missing' }
+  | { status: 'rejected'; error: string };
+
+const OIDC_DISCOVERY_TIMEOUT_MS = 10000;
+const JWT_ALGORITHMS: Algorithm[] = [
+  'RS256',
+  'RS384',
+  'RS512',
+  'PS256',
+  'PS384',
+  'PS512',
+  'ES256',
+  'ES384',
+  'ES512',
+];
+const jwksUriCache = new Map<string, CacheEntry<string>>();
+const jwksClientCache = new Map<string, CacheEntry<jwksRsa.JwksClient>>();
+
+export function clearRemoteAgentAuthCache(): void {
+  jwksUriCache.clear();
+  jwksClientCache.clear();
+}
 
 function extractBearer(authHeader: string | undefined): string | null {
   if (!authHeader?.startsWith('Bearer ')) return null;
@@ -36,28 +70,74 @@ function getEmail(payload: JwtPayload): string | undefined {
   );
 }
 
-async function resolveJwksUri(oidcConfig: OidcConfig): Promise<string> {
+function getJwksCacheOptions(): JwksCacheOptions {
+  return {
+    enabled: process.env.OPENID_JWKS_URL_CACHE_ENABLED
+      ? isEnabled(process.env.OPENID_JWKS_URL_CACHE_ENABLED)
+      : true,
+    maxAge: Math.max(math(process.env.OPENID_JWKS_URL_CACHE_TIME, 60000), 0),
+  };
+}
+
+function buildDiscoveryOptions(controller: AbortController): RequestInit {
+  const options: RequestInit = { signal: controller.signal };
+
+  if (process.env.PROXY) {
+    options.dispatcher = new ProxyAgent(process.env.PROXY);
+  }
+
+  return options;
+}
+
+async function discoverJwksUri(issuer: string): Promise<string> {
+  const normalizedIssuer = issuer.replace(/\/$/, '');
+  const discoveryUrl = `${normalizedIssuer}/.well-known/openid-configuration`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), OIDC_DISCOVERY_TIMEOUT_MS);
+
+  try {
+    const res = await undiciFetch(discoveryUrl, buildDiscoveryOptions(controller));
+    if (!res.ok) throw new Error(`OIDC discovery failed: ${res.status} ${res.statusText}`);
+
+    const meta = (await res.json()) as { jwks_uri?: string };
+    if (!meta.jwks_uri) throw new Error('OIDC discovery response missing jwks_uri');
+
+    return meta.jwks_uri;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function resolveJwksUri(
+  oidcConfig: EnabledOidcConfig,
+  cacheOptions: JwksCacheOptions,
+): Promise<string> {
   if (oidcConfig.jwksUri) return oidcConfig.jwksUri;
   if (process.env.OPENID_JWKS_URL) return process.env.OPENID_JWKS_URL;
 
-  const issuer = oidcConfig.issuer.replace(/\/$/, '');
-  const discoveryUrl = `${issuer}/.well-known/openid-configuration`;
+  if (!cacheOptions.enabled) return discoverJwksUri(oidcConfig.issuer);
 
-  const res = await fetch(discoveryUrl);
-  if (!res.ok) throw new Error(`OIDC discovery failed: ${res.status} ${res.statusText}`);
+  const cacheKey = oidcConfig.issuer;
+  const cached = jwksUriCache.get(cacheKey);
+  if (cached != null && cached.expiresAt > Date.now()) return cached.promise;
+  if (cached != null) jwksUriCache.delete(cacheKey);
 
-  const meta = (await res.json()) as { jwks_uri?: string };
-  if (!meta.jwks_uri) throw new Error('OIDC discovery response missing jwks_uri');
+  const promise = discoverJwksUri(oidcConfig.issuer).catch((err) => {
+    jwksUriCache.delete(cacheKey);
+    throw err;
+  });
 
-  return meta.jwks_uri;
+  jwksUriCache.set(cacheKey, {
+    promise,
+    expiresAt: Date.now() + cacheOptions.maxAge,
+  });
+  return promise;
 }
 
-function buildJwksClient(uri: string): jwksRsa.JwksClient {
+function buildJwksClient(uri: string, cacheOptions: JwksCacheOptions): jwksRsa.JwksClient {
   const options: jwksRsa.Options = {
-    cache: process.env.OPENID_JWKS_URL_CACHE_ENABLED
-      ? isEnabled(process.env.OPENID_JWKS_URL_CACHE_ENABLED)
-      : true,
-    cacheMaxAge: math(process.env.OPENID_JWKS_URL_CACHE_TIME, 60000),
+    cache: cacheOptions.enabled,
+    cacheMaxAge: cacheOptions.maxAge,
     jwksUri: uri,
   };
 
@@ -68,79 +148,84 @@ function buildJwksClient(uri: string): jwksRsa.JwksClient {
   return jwksRsa(options);
 }
 
-async function getJwksClient(oidcConfig: OidcConfig): Promise<jwksRsa.JwksClient> {
-  const cacheKey = oidcConfig.jwksUri ?? oidcConfig.issuer;
+async function getJwksClient(oidcConfig: EnabledOidcConfig): Promise<jwksRsa.JwksClient> {
+  const cacheOptions = getJwksCacheOptions();
+  const uri = await resolveJwksUri(oidcConfig, cacheOptions);
 
+  if (!cacheOptions.enabled) return buildJwksClient(uri, cacheOptions);
+
+  const cacheKey = uri;
   const cached = jwksClientCache.get(cacheKey);
-  if (cached != null) return cached;
+  if (cached != null && cached.expiresAt > Date.now()) return cached.promise;
+  if (cached != null) jwksClientCache.delete(cacheKey);
 
-  const promise = resolveJwksUri(oidcConfig)
-    .then((uri) => {
-      return buildJwksClient(uri);
-    })
+  const promise = Promise.resolve()
+    .then(() => buildJwksClient(uri, cacheOptions))
     .catch((err) => {
-      jwksClientCache.delete(cacheKey); // не кэшируем ошибку
+      jwksClientCache.delete(cacheKey);
       throw err;
     });
 
-  jwksClientCache.set(cacheKey, promise);
+  jwksClientCache.set(cacheKey, {
+    promise,
+    expiresAt: Date.now() + cacheOptions.maxAge,
+  });
   return promise;
 }
 
-function verifyOidcBearer(token: string, oidcConfig: OidcConfig): Promise<JwtPayload> {
+function getVerifyOptions(oidcConfig: EnabledOidcConfig): VerifyOptions {
+  return {
+    algorithms: JWT_ALGORITHMS,
+    issuer: oidcConfig.issuer,
+    ...(oidcConfig.audience ? { audience: oidcConfig.audience } : {}),
+  };
+}
+
+function verifyJwt(
+  token: string,
+  signingKey: jwksRsa.SigningKey,
+  oidcConfig: EnabledOidcConfig,
+): Promise<JwtPayload> {
   return new Promise((resolve, reject) => {
-    const decoded = jwt.decode(token, { complete: true });
-    if (decoded == null) return reject(new Error('Invalid JWT: cannot decode'));
-
-    const kid = decoded.header?.kid as string | undefined;
-
-    getJwksClient(oidcConfig)
-      .then((client) => {
-        const fetchKey = (callback: (key: jwksRsa.SigningKey) => void) => {
-          if (kid != null) {
-            client.getSigningKey(kid, (err, key) => {
-              if (err != null || key == null)
-                return reject(err ?? new Error('No signing key for kid'));
-              callback(key);
-            });
-          } else {
-            client
-              .getKeys()
-              .then((keys: unknown) => {
-                const jwkKeys = keys as Array<{ kid: string; use?: string }>;
-                if (jwkKeys.length === 0) return reject(new Error('No keys in JWKS'));
-                const signingKeys = jwkKeys.filter((k) => !k.use || k.use === 'sig');
-                const keyToUse = signingKeys[0] ?? jwkKeys[0];
-                client.getSigningKey(keyToUse.kid, (keyErr, key) => {
-                  if (keyErr != null || key == null)
-                    return reject(keyErr ?? new Error('No signing key'));
-                  callback(key);
-                });
-              })
-              .catch((err: unknown) => reject(err));
-          }
-        };
-
-        fetchKey((signingKey) => {
-          jwt.verify(
-            token,
-            signingKey.getPublicKey(),
-            {
-              algorithms: ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512'],
-              ...(oidcConfig.issuer ? { issuer: oidcConfig.issuer } : {}),
-              ...(oidcConfig.audience ? { audience: oidcConfig.audience } : {}),
-            },
-            (err, payload) => {
-              if (err != null || payload == null) {
-                return reject(err ?? new Error('Empty payload'));
-              }
-              resolve(payload as JwtPayload);
-            },
-          );
-        });
-      })
-      .catch(reject);
+    jwt.verify(token, signingKey.getPublicKey(), getVerifyOptions(oidcConfig), (err, payload) => {
+      if (err != null || payload == null) return reject(err ?? new Error('Empty payload'));
+      if (typeof payload === 'string') return reject(new Error('Invalid JWT payload'));
+      resolve(payload);
+    });
   });
+}
+
+async function verifyWithSigningKeys(
+  token: string,
+  signingKeys: jwksRsa.SigningKey[],
+  oidcConfig: EnabledOidcConfig,
+): Promise<JwtPayload> {
+  let lastError: Error | null = null;
+
+  for (const signingKey of signingKeys) {
+    try {
+      return await verifyJwt(token, signingKey, oidcConfig);
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  throw lastError ?? new Error('No signing keys in JWKS');
+}
+
+async function verifyOidcBearer(token: string, oidcConfig: EnabledOidcConfig): Promise<JwtPayload> {
+  const decoded = jwt.decode(token, { complete: true });
+  if (decoded == null || typeof decoded === 'string') throw new Error('Invalid JWT: cannot decode');
+
+  const kid = typeof decoded.header?.kid === 'string' ? decoded.header.kid : undefined;
+  const client = await getJwksClient(oidcConfig);
+
+  if (kid != null) {
+    const signingKey = await client.getSigningKey(kid);
+    return verifyJwt(token, signingKey, oidcConfig);
+  }
+
+  return verifyWithSigningKeys(token, await client.getSigningKeys(), oidcConfig);
 }
 
 async function resolveUser(
@@ -148,7 +233,7 @@ async function resolveUser(
   payload: JwtPayload,
   findUser: UserMethods['findUser'],
   updateUser: UserMethods['updateUser'],
-): Promise<IUser | null> {
+): Promise<UserResolution> {
   const { user, error, migration } = await findOpenIDUser({
     findUser,
     email: getEmail(payload),
@@ -157,7 +242,8 @@ async function resolveUser(
     strategyName: 'remoteAgentAuth',
   });
 
-  if (error != null || user == null) return null;
+  if (error != null) return { status: 'rejected', error };
+  if (user == null) return { status: 'missing' };
 
   user.id = String(user._id);
 
@@ -178,7 +264,7 @@ async function resolveUser(
   }
 
   user.federatedTokens = { access_token: token, expires_at: payload.exp };
-  return user;
+  return { status: 'resolved', user };
 }
 
 /**
@@ -220,6 +306,17 @@ export function createRemoteAgentAuth({
         return;
       }
 
+      if (!authConfig.oidc.issuer) {
+        logger.error('[remoteAgentAuth] OIDC issuer is required when OIDC auth is enabled');
+        res.status(500).json({ error: 'Internal server error' });
+        return;
+      }
+
+      const oidcConfig: EnabledOidcConfig = {
+        ...authConfig.oidc,
+        issuer: authConfig.oidc.issuer,
+      };
+
       const token = extractBearer(req.headers.authorization);
       if (token == null) {
         if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
@@ -227,39 +324,46 @@ export function createRemoteAgentAuth({
         return;
       }
 
-      try {
-        const payload = await verifyOidcBearer(token, authConfig.oidc);
+      let payload: JwtPayload;
 
-        if (authConfig.oidc.scope != null) {
+      try {
+        payload = await verifyOidcBearer(token, oidcConfig);
+        if (oidcConfig.scope != null) {
           const rawScope = payload['scp'] ?? payload['scope'];
           const tokenScopes: string[] = Array.isArray(rawScope)
             ? rawScope
             : ((rawScope as string | undefined)?.split(' ') ?? []);
-          if (!tokenScopes.includes(authConfig.oidc.scope)) {
-            logger.warn(`[remoteAgentAuth] Token missing required scope: ${authConfig.oidc.scope}`);
+          if (!tokenScopes.includes(oidcConfig.scope)) {
+            logger.warn(`[remoteAgentAuth] Token missing required scope: ${oidcConfig.scope}`);
             if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
             res.status(401).json({ error: 'Unauthorized' });
             return;
           }
         }
-
-        const user = await resolveUser(token, payload, findUser, updateUser);
-
-        if (user == null) {
-          logger.warn('[remoteAgentAuth] OIDC token valid but no matching LibreChat user');
-          if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
-          res.status(401).json({ error: 'Unauthorized' });
-          return;
-        }
-
-        req.user = user;
-        return next();
       } catch (oidcErr) {
         logger.error('[remoteAgentAuth] OIDC verification failed:', oidcErr);
         if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
         res.status(401).json({ error: 'Unauthorized' });
         return;
       }
+
+      const userResolution = await resolveUser(token, payload, findUser, updateUser);
+
+      if (userResolution.status === 'rejected') {
+        logger.warn(`[remoteAgentAuth] OpenID user rejected: ${userResolution.error}`);
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      if (userResolution.status === 'missing') {
+        logger.warn('[remoteAgentAuth] OIDC token valid but no matching LibreChat user');
+        if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      req.user = userResolution.user;
+      return next();
     } catch (err) {
       logger.error('[remoteAgentAuth] Unexpected error', err);
       res.status(500).json({ error: 'Internal server error' });

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -237,6 +237,53 @@ function getConfigOptions(req: Request): GetAppConfigOptions {
   return { baseOnly: true };
 }
 
+function getRemoteAuthConfig(config: AppConfig): AgentAuthConfig | undefined {
+  return config.endpoints?.agents?.remoteApi?.auth;
+}
+
+function isApiKeyEnabled(config: AppConfig): boolean {
+  return getRemoteAuthConfig(config)?.apiKey?.enabled !== false;
+}
+
+async function enforceApiKeyTenantPolicy(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  getAppConfig: RemoteAgentAuthDeps['getAppConfig'],
+): Promise<void> {
+  const config = await getAppConfig(getConfigOptions(req));
+
+  if (!isApiKeyEnabled(config)) {
+    logger.warn('[remoteAgentAuth] API key rejected by resolved tenant auth policy');
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  next();
+}
+
+async function runApiKeyAuth(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  apiKeyMiddleware: RequestHandler,
+  getAppConfig: RemoteAgentAuthDeps['getAppConfig'],
+): Promise<void> {
+  let postAuth: Promise<void> | undefined;
+
+  const wrappedNext: NextFunction = (err?: unknown) => {
+    if (err != null) {
+      next(err);
+      return;
+    }
+
+    postAuth = enforceApiKeyTenantPolicy(req, res, next, getAppConfig);
+  };
+
+  await Promise.resolve(apiKeyMiddleware(req, res, wrappedNext));
+  if (postAuth) await postAuth;
+}
+
 function verifyJwt(
   token: string,
   signingKey: jwksRsa.SigningKey,
@@ -365,11 +412,14 @@ export function createRemoteAgentAuth({
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       const config = await getAppConfig(getConfigOptions(req));
-      const authConfig = config.endpoints?.agents?.remoteApi?.auth;
-      const apiKeyEnabled = authConfig?.apiKey?.enabled !== false;
+      const authConfig = getRemoteAuthConfig(config);
+      const apiKeyEnabled = isApiKeyEnabled(config);
 
       if (authConfig?.oidc?.enabled !== true) {
-        if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
+        if (apiKeyEnabled) {
+          await runApiKeyAuth(req, res, next, apiKeyMiddleware, getAppConfig);
+          return;
+        }
         res.status(401).json({ error: 'Authentication required' });
         return;
       }
@@ -387,7 +437,10 @@ export function createRemoteAgentAuth({
 
       const token = extractBearer(req.headers.authorization);
       if (token == null) {
-        if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
+        if (apiKeyEnabled) {
+          await runApiKeyAuth(req, res, next, apiKeyMiddleware, getAppConfig);
+          return;
+        }
         res.status(401).json({ error: 'Bearer token required' });
         return;
       }
@@ -404,7 +457,8 @@ export function createRemoteAgentAuth({
       } catch (oidcErr) {
         if (apiKeyEnabled) {
           logger.debug('[remoteAgentAuth] OIDC verification failed; trying API key auth:', oidcErr);
-          return apiKeyMiddleware(req, res, next);
+          await runApiKeyAuth(req, res, next, apiKeyMiddleware, getAppConfig);
+          return;
         }
         logger.error('[remoteAgentAuth] OIDC verification failed:', oidcErr);
         res.status(401).json({ error: 'Unauthorized' });
@@ -421,7 +475,10 @@ export function createRemoteAgentAuth({
 
       if (userResolution.status === 'missing') {
         logger.warn('[remoteAgentAuth] OIDC token valid but no matching LibreChat user');
-        if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
+        if (apiKeyEnabled) {
+          await runApiKeyAuth(req, res, next, apiKeyMiddleware, getAppConfig);
+          return;
+        }
         res.status(401).json({ error: 'Unauthorized' });
         return;
       }

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -159,12 +159,15 @@ async function getJwksClient(oidcConfig: EnabledOidcConfig): Promise<jwksRsa.Jwk
   if (cached != null && cached.expiresAt > Date.now()) return cached.promise;
   if (cached != null) jwksClientCache.delete(cacheKey);
 
-  const promise = Promise.resolve()
-    .then(() => buildJwksClient(uri, cacheOptions))
-    .catch((err) => {
-      jwksClientCache.delete(cacheKey);
-      throw err;
-    });
+  let client: jwksRsa.JwksClient;
+  try {
+    client = buildJwksClient(uri, cacheOptions);
+  } catch (err) {
+    jwksClientCache.delete(cacheKey);
+    throw err;
+  }
+
+  const promise = Promise.resolve(client);
 
   jwksClientCache.set(cacheKey, {
     promise,

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -10,7 +10,7 @@ import type { Algorithm, JwtPayload, VerifyOptions } from 'jsonwebtoken';
 import type { TAgentsEndpoint } from 'librechat-data-provider';
 import type { RequestInit } from 'undici';
 import type { GetAppConfigOptions } from '../app/service';
-import { findOpenIDUser, getOpenIdEmail } from '../auth/openid';
+import { findOpenIDUser, getOpenIdEmail, normalizeOpenIdIssuer } from '../auth/openid';
 import { isEnabled, math } from '~/utils';
 
 export interface RemoteAgentAuthDeps {
@@ -289,6 +289,7 @@ async function verifyOidcBearer(token: string, oidcConfig: EnabledOidcConfig): P
 async function resolveUser(
   token: string,
   payload: JwtPayload,
+  oidcConfig: EnabledOidcConfig,
   findUser: UserMethods['findUser'],
   updateUser: UserMethods['updateUser'],
 ): Promise<UserResolution> {
@@ -300,6 +301,7 @@ async function resolveUser(
     findUser,
     email: getOpenIdEmail(payload, 'remoteAgentAuth'),
     openidId: payload.sub,
+    openidIssuer: oidcConfig.issuer,
     idOnTheSource: payload['oid'] as string | undefined,
     strategyName: 'remoteAgentAuth',
   });
@@ -314,6 +316,7 @@ async function resolveUser(
   if (migration) {
     updateData.provider = 'openid';
     updateData.openidId = payload.sub;
+    updateData.openidIssuer = normalizeOpenIdIssuer(oidcConfig.issuer);
   }
 
   if (!user.role) {
@@ -408,7 +411,7 @@ export function createRemoteAgentAuth({
         return;
       }
 
-      const userResolution = await resolveUser(token, payload, findUser, updateUser);
+      const userResolution = await resolveUser(token, payload, oidcConfig, findUser, updateUser);
 
       if (userResolution.status === 'rejected') {
         logger.warn(`[remoteAgentAuth] OpenID user rejected: ${userResolution.error}`);

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -1,9 +1,9 @@
 import jwt from 'jsonwebtoken';
 import jwksRsa from 'jwks-rsa';
-import { logger } from '@librechat/data-schemas';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { SystemRoles } from 'librechat-data-provider';
 import { ProxyAgent, fetch as undiciFetch } from 'undici';
+import { logger, getTenantId } from '@librechat/data-schemas';
 import type { RequestHandler, Request, Response, NextFunction } from 'express';
 import type { AppConfig, IUser, UserMethods } from '@librechat/data-schemas';
 import type { Algorithm, JwtPayload, VerifyOptions } from 'jsonwebtoken';
@@ -16,8 +16,16 @@ export interface RemoteAgentAuthDeps {
   apiKeyMiddleware: RequestHandler;
   findUser: UserMethods['findUser'];
   updateUser: UserMethods['updateUser'];
-  getAppConfig: () => Promise<AppConfig | null>;
+  getAppConfig: (options?: GetAppConfigOptions) => Promise<AppConfig | null>;
 }
+
+type GetAppConfigOptions = {
+  role?: string;
+  userId?: string;
+  tenantId?: string;
+  refresh?: boolean;
+  baseOnly?: boolean;
+};
 
 type OidcConfig = NonNullable<
   NonNullable<NonNullable<TAgentsEndpoint['remoteApi']>['auth']>['oidc']
@@ -184,6 +192,14 @@ function getVerifyOptions(oidcConfig: EnabledOidcConfig): VerifyOptions {
   };
 }
 
+function getConfigOptions(req: Request): GetAppConfigOptions | undefined {
+  const user = req.user as { tenantId?: string } | undefined;
+  const tenantId = user?.tenantId ?? getTenantId();
+
+  if (!tenantId) return undefined;
+  return { tenantId };
+}
+
 function verifyJwt(
   token: string,
   signingKey: jwksRsa.SigningKey,
@@ -303,7 +319,7 @@ export function createRemoteAgentAuth({
 }: RemoteAgentAuthDeps): RequestHandler {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const config = await getAppConfig();
+      const config = await getAppConfig(getConfigOptions(req));
       const authConfig = config?.endpoints?.agents?.remoteApi?.auth;
       const apiKeyEnabled = authConfig?.apiKey?.enabled !== false;
 

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -36,7 +36,7 @@ type CacheEntry<T> = {
 };
 type ScopeClaim = string | string[] | undefined;
 type UserResolution =
-  | { status: 'resolved'; user: IUser }
+  | { status: 'resolved'; user: IUser; updateData: Partial<IUser> }
   | { status: 'missing' }
   | { status: 'rejected'; error: string };
 
@@ -246,8 +246,29 @@ function getConfigOptions(req: Request): GetAppConfigOptions {
   return { baseOnly: true };
 }
 
+function getUserConfigOptions(user: IUser): GetAppConfigOptions {
+  if (user.tenantId) return { tenantId: user.tenantId };
+  return { baseOnly: true };
+}
+
+function isResolvedUserConfigScope(initialOptions: GetAppConfigOptions, user: IUser): boolean {
+  const userOptions = getUserConfigOptions(user);
+  return (
+    initialOptions.tenantId === userOptions.tenantId &&
+    initialOptions.baseOnly === userOptions.baseOnly
+  );
+}
+
 function getRemoteAuthConfig(config: AppConfig): AgentAuthConfig | undefined {
   return config.endpoints?.agents?.remoteApi?.auth;
+}
+
+function getEnabledOidcConfig(
+  authConfig: AgentAuthConfig | undefined,
+): EnabledOidcConfig | undefined {
+  if (authConfig?.oidc?.enabled !== true) return undefined;
+  if (!authConfig.oidc.issuer) throw new Error('OIDC issuer is required when OIDC auth is enabled');
+  return { ...authConfig.oidc, issuer: authConfig.oidc.issuer };
 }
 
 function isApiKeyEnabled(config: AppConfig): boolean {
@@ -291,6 +312,34 @@ async function runApiKeyAuth(
 
   await Promise.resolve(apiKeyMiddleware(req, res, wrappedNext));
   if (postAuth) await postAuth;
+}
+
+async function enforceOidcTenantPolicy(
+  token: string,
+  user: IUser,
+  initialOptions: GetAppConfigOptions,
+  getAppConfig: RemoteAgentAuthDeps['getAppConfig'],
+): Promise<boolean> {
+  if (isResolvedUserConfigScope(initialOptions, user)) return true;
+
+  const config = await getAppConfig(getUserConfigOptions(user));
+  const oidcConfig = getEnabledOidcConfig(getRemoteAuthConfig(config));
+  if (!oidcConfig) {
+    logger.warn('[remoteAgentAuth] OIDC rejected by resolved tenant auth policy');
+    return false;
+  }
+
+  try {
+    const payload = await verifyOidcBearer(token, oidcConfig);
+    if (hasRequiredScopes(oidcConfig.scope, payload)) return true;
+    logger.warn(
+      `[remoteAgentAuth] Token missing resolved tenant required scope: ${oidcConfig.scope}`,
+    );
+  } catch (err) {
+    logger.warn('[remoteAgentAuth] OIDC token rejected by resolved tenant auth policy:', err);
+  }
+
+  return false;
 }
 
 function verifyJwt(
@@ -347,7 +396,6 @@ async function resolveUser(
   payload: JwtPayload,
   oidcConfig: EnabledOidcConfig,
   findUser: UserMethods['findUser'],
-  updateUser: UserMethods['updateUser'],
 ): Promise<UserResolution> {
   if (typeof payload.sub !== 'string' || payload.sub.trim() === '') {
     return { status: 'rejected', error: 'missing_sub_claim' };
@@ -380,15 +428,11 @@ async function resolveUser(
     updateData.role = SystemRoles.USER;
   }
 
-  if (Object.keys(updateData).length > 0) {
-    await updateUser(user.id, updateData);
-  }
-
   user.federatedTokens = {
     access_token: token,
     ...(payload.exp != null ? { expires_at: payload.exp } : {}),
   };
-  return { status: 'resolved', user };
+  return { status: 'resolved', user, updateData };
 }
 
 /**
@@ -420,7 +464,8 @@ export function createRemoteAgentAuth({
 }: RemoteAgentAuthDeps): RequestHandler {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const config = await getAppConfig(getConfigOptions(req));
+      const initialConfigOptions = getConfigOptions(req);
+      const config = await getAppConfig(initialConfigOptions);
       const authConfig = getRemoteAuthConfig(config);
       const apiKeyEnabled = isApiKeyEnabled(config);
 
@@ -439,10 +484,8 @@ export function createRemoteAgentAuth({
         return;
       }
 
-      const oidcConfig: EnabledOidcConfig = {
-        ...authConfig.oidc,
-        issuer: authConfig.oidc.issuer,
-      };
+      const oidcConfig = getEnabledOidcConfig(authConfig);
+      if (!oidcConfig) throw new Error('OIDC issuer is required when OIDC auth is enabled');
 
       const token = extractBearer(req.headers.authorization);
       if (token == null) {
@@ -474,7 +517,7 @@ export function createRemoteAgentAuth({
         return;
       }
 
-      const userResolution = await resolveUser(token, payload, oidcConfig, findUser, updateUser);
+      const userResolution = await resolveUser(token, payload, oidcConfig, findUser);
 
       if (userResolution.status === 'rejected') {
         logger.warn(`[remoteAgentAuth] OpenID user rejected: ${userResolution.error}`);
@@ -490,6 +533,22 @@ export function createRemoteAgentAuth({
         }
         res.status(401).json({ error: 'Unauthorized' });
         return;
+      }
+
+      if (
+        !(await enforceOidcTenantPolicy(
+          token,
+          userResolution.user,
+          initialConfigOptions,
+          getAppConfig,
+        ))
+      ) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      if (Object.keys(userResolution.updateData).length > 0) {
+        await updateUser(userResolution.user.id, userResolution.updateData);
       }
 
       req.user = userResolution.user;

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -225,9 +225,15 @@ async function getJwksClient(oidcConfig: EnabledOidcConfig): Promise<jwksRsa.Jwk
 }
 
 function getVerifyOptions(oidcConfig: EnabledOidcConfig): VerifyOptions {
+  const normalizedIssuer = normalizeOpenIdIssuer(oidcConfig.issuer);
+  const issuer =
+    normalizedIssuer && normalizedIssuer !== oidcConfig.issuer
+      ? [oidcConfig.issuer, normalizedIssuer]
+      : oidcConfig.issuer;
+
   return {
     algorithms: JWT_ALGORITHMS,
-    issuer: oidcConfig.issuer,
+    issuer,
     ...(oidcConfig.audience ? { audience: oidcConfig.audience } : {}),
   };
 }

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -1,9 +1,9 @@
 import jwt from 'jsonwebtoken';
 import jwksRsa from 'jwks-rsa';
-import { logger } from '@librechat/data-schemas';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { SystemRoles } from 'librechat-data-provider';
 import { ProxyAgent, fetch as undiciFetch } from 'undici';
+import { getTenantId, logger } from '@librechat/data-schemas';
 import type { RequestHandler, Request, Response, NextFunction } from 'express';
 import type { AppConfig, IUser, UserMethods } from '@librechat/data-schemas';
 import type { Algorithm, JwtPayload, VerifyOptions } from 'jsonwebtoken';
@@ -224,8 +224,9 @@ function getVerifyOptions(oidcConfig: EnabledOidcConfig): VerifyOptions {
 
 function getConfigOptions(req: Request): GetAppConfigOptions | undefined {
   const user = req.user as { tenantId?: string } | undefined;
+  const tenantId = user?.tenantId ?? getTenantId();
 
-  if (user?.tenantId) return { tenantId: user.tenantId };
+  if (tenantId) return { tenantId };
   return { baseOnly: true };
 }
 

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -97,10 +97,7 @@ function getEmail(payload: JwtPayload): string | undefined {
 }
 
 function splitScopes(scopes: string): string[] {
-  return scopes
-    .trim()
-    .split(/[\s,]+/)
-    .filter(Boolean);
+  return scopes.trim().split(/\s+/).filter(Boolean);
 }
 
 function getTokenScopes(scopeClaim: ScopeClaim): string[] {

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -54,7 +54,9 @@ async function resolveJwksUri(oidcConfig: OidcConfig): Promise<string> {
 
 function buildJwksClient(uri: string): jwksRsa.JwksClient {
   const options: jwksRsa.Options = {
-    cache: isEnabled(process.env.OPENID_JWKS_URL_CACHE_ENABLED) || true,
+    cache: process.env.OPENID_JWKS_URL_CACHE_ENABLED
+      ? isEnabled(process.env.OPENID_JWKS_URL_CACHE_ENABLED)
+      : true,
     cacheMaxAge: math(process.env.OPENID_JWKS_URL_CACHE_TIME, 60000),
     jwksUri: uri,
   };
@@ -208,14 +210,15 @@ export function createRemoteAgentAuth({
     try {
       const config = await getAppConfig();
       const authConfig = config?.endpoints?.agents?.remoteApi?.auth;
+      const apiKeyEnabled = authConfig?.apiKey?.enabled !== false;
 
       if (authConfig?.oidc?.enabled !== true) {
-        return apiKeyMiddleware(req, res, next);
+        if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
+        res.status(401).json({ error: 'Authentication required' });
+        return;
       }
 
       const token = extractBearer(req.headers.authorization);
-      const apiKeyEnabled = authConfig.apiKey?.enabled !== false;
-
       if (token == null) {
         if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
         res.status(401).json({ error: 'Bearer token required' });

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -24,6 +24,7 @@ type OidcConfig = NonNullable<
   NonNullable<NonNullable<TAgentsEndpoint['remoteApi']>['auth']>['oidc']
 >;
 
+type AgentAuthConfig = NonNullable<NonNullable<TAgentsEndpoint['remoteApi']>['auth']>;
 type EnabledOidcConfig = OidcConfig & { issuer: string };
 type JwksCacheOptions = {
   enabled: boolean;

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -1,9 +1,9 @@
 import jwt from 'jsonwebtoken';
 import jwksRsa from 'jwks-rsa';
 import { HttpsProxyAgent } from 'https-proxy-agent';
-import { SystemRoles } from 'librechat-data-provider';
 import { ProxyAgent, fetch as undiciFetch } from 'undici';
 import { getTenantId, logger } from '@librechat/data-schemas';
+import { SystemRoles, isRemoteOidcUrlAllowed } from 'librechat-data-provider';
 import type { RequestHandler, Request, Response, NextFunction } from 'express';
 import type { AppConfig, IUser, UserMethods } from '@librechat/data-schemas';
 import type { Algorithm, JwtPayload, VerifyOptions } from 'jsonwebtoken';
@@ -127,8 +127,13 @@ function buildDiscoveryOptions(controller: AbortController): RequestInit {
   return options;
 }
 
+function ensureRemoteOidcUrlAllowed(value: string, label: string): string {
+  if (isRemoteOidcUrlAllowed(value)) return value;
+  throw new Error(`${label} must use https:// unless targeting localhost`);
+}
+
 async function discoverJwksUri(issuer: string): Promise<string> {
-  const normalizedIssuer = issuer.replace(/\/$/, '');
+  const normalizedIssuer = ensureRemoteOidcUrlAllowed(issuer, 'OIDC issuer').replace(/\/$/, '');
   const discoveryUrl = `${normalizedIssuer}/.well-known/openid-configuration`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), OIDC_DISCOVERY_TIMEOUT_MS);
@@ -140,7 +145,7 @@ async function discoverJwksUri(issuer: string): Promise<string> {
     const meta = (await res.json()) as { jwks_uri?: string };
     if (!meta.jwks_uri) throw new Error('OIDC discovery response missing jwks_uri');
 
-    return meta.jwks_uri;
+    return ensureRemoteOidcUrlAllowed(meta.jwks_uri, 'OIDC JWKS URI');
   } finally {
     clearTimeout(timeout);
   }
@@ -150,8 +155,10 @@ async function resolveJwksUri(
   oidcConfig: EnabledOidcConfig,
   cacheOptions: JwksCacheOptions,
 ): Promise<string> {
-  if (oidcConfig.jwksUri) return oidcConfig.jwksUri;
-  if (process.env.OPENID_JWKS_URL) return process.env.OPENID_JWKS_URL;
+  if (oidcConfig.jwksUri) return ensureRemoteOidcUrlAllowed(oidcConfig.jwksUri, 'OIDC JWKS URI');
+  if (process.env.OPENID_JWKS_URL) {
+    return ensureRemoteOidcUrlAllowed(process.env.OPENID_JWKS_URL, 'OIDC JWKS URI');
+  }
 
   if (!cacheOptions.enabled) return discoverJwksUri(oidcConfig.issuer);
 
@@ -263,6 +270,8 @@ async function verifyWithSigningKeys(
 }
 
 async function verifyOidcBearer(token: string, oidcConfig: EnabledOidcConfig): Promise<JwtPayload> {
+  ensureRemoteOidcUrlAllowed(oidcConfig.issuer, 'OIDC issuer');
+
   const decoded = jwt.decode(token, { complete: true });
   if (decoded == null || typeof decoded === 'string') throw new Error('Invalid JWT: cannot decode');
 

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -107,9 +107,11 @@ function verifyOidcBearer(token: string, oidcConfig: OidcConfig): Promise<JwtPay
             client
               .getKeys()
               .then((keys: unknown) => {
-                const jwkKeys = keys as Array<{ kid: string }>;
+                const jwkKeys = keys as Array<{ kid: string; use?: string }>;
                 if (jwkKeys.length === 0) return reject(new Error('No keys in JWKS'));
-                client.getSigningKey(jwkKeys[0].kid, (keyErr, key) => {
+                const signingKeys = jwkKeys.filter((k) => !k.use || k.use === 'sig');
+                const keyToUse = signingKeys[0] ?? jwkKeys[0];
+                client.getSigningKey(keyToUse.kid, (keyErr, key) => {
                   if (keyErr != null || key == null)
                     return reject(keyErr ?? new Error('No signing key'));
                   callback(key);

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -159,7 +159,7 @@ async function resolveUser(
 
   const updateData: Partial<IUser> = {};
 
-  if (migration) {
+  if (migration && payload.sub != null) {
     updateData.provider = 'openid';
     updateData.openidId = payload.sub;
   }
@@ -195,6 +195,7 @@ async function resolveUser(
  *           issuer: <issuer>
  *           jwksUri: <jwksUri>
  *           audience: <audience>
+ *           scope: <scope>
  * ```
  */
 export function createRemoteAgentAuth({
@@ -223,6 +224,20 @@ export function createRemoteAgentAuth({
 
       try {
         const payload = await verifyOidcBearer(token, authConfig.oidc);
+
+        if (authConfig.oidc.scope != null) {
+          const rawScope = payload['scp'] ?? payload['scope'];
+          const tokenScopes: string[] = Array.isArray(rawScope)
+            ? rawScope
+            : ((rawScope as string | undefined)?.split(' ') ?? []);
+          if (!tokenScopes.includes(authConfig.oidc.scope)) {
+            logger.warn(`[remoteAgentAuth] Token missing required scope: ${authConfig.oidc.scope}`);
+            if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
+            res.status(401).json({ error: 'Unauthorized' });
+            return;
+          }
+        }
+
         const user = await resolveUser(token, payload, findUser, updateUser);
 
         if (user == null) {

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -224,7 +224,7 @@ async function getJwksClient(oidcConfig: EnabledOidcConfig): Promise<jwksRsa.Jwk
 function getVerifyOptions(oidcConfig: EnabledOidcConfig): VerifyOptions {
   return {
     algorithms: JWT_ALGORITHMS,
-    issuer: normalizeOpenIdIssuer(oidcConfig.issuer) ?? oidcConfig.issuer,
+    issuer: oidcConfig.issuer,
     ...(oidcConfig.audience ? { audience: oidcConfig.audience } : {}),
   };
 }

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -237,10 +237,14 @@ async function resolveUser(
   findUser: UserMethods['findUser'],
   updateUser: UserMethods['updateUser'],
 ): Promise<UserResolution> {
+  if (typeof payload.sub !== 'string' || payload.sub.trim() === '') {
+    return { status: 'rejected', error: 'missing_sub_claim' };
+  }
+
   const { user, error, migration } = await findOpenIDUser({
     findUser,
     email: getEmail(payload),
-    openidId: payload.sub ?? '',
+    openidId: payload.sub,
     idOnTheSource: payload['oid'] as string | undefined,
     strategyName: 'remoteAgentAuth',
   });

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -387,8 +387,11 @@ export function createRemoteAgentAuth({
           return;
         }
       } catch (oidcErr) {
+        if (apiKeyEnabled) {
+          logger.debug('[remoteAgentAuth] OIDC verification failed; trying API key auth:', oidcErr);
+          return apiKeyMiddleware(req, res, next);
+        }
         logger.error('[remoteAgentAuth] OIDC verification failed:', oidcErr);
-        if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
         res.status(401).json({ error: 'Unauthorized' });
         return;
       }

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -1,9 +1,9 @@
 import jwt from 'jsonwebtoken';
 import jwksRsa from 'jwks-rsa';
+import { logger } from '@librechat/data-schemas';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { SystemRoles } from 'librechat-data-provider';
 import { ProxyAgent, fetch as undiciFetch } from 'undici';
-import { logger, getTenantId } from '@librechat/data-schemas';
 import type { RequestHandler, Request, Response, NextFunction } from 'express';
 import type { AppConfig, IUser, UserMethods } from '@librechat/data-schemas';
 import type { Algorithm, JwtPayload, VerifyOptions } from 'jsonwebtoken';
@@ -84,8 +84,8 @@ function setCacheEntry<T>(
 }
 
 function extractBearer(authHeader: string | undefined): string | null {
-  if (!authHeader?.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
+  const match = authHeader?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1] ?? null;
 }
 
 function getEmail(payload: JwtPayload): string | undefined {
@@ -232,10 +232,9 @@ function getVerifyOptions(oidcConfig: EnabledOidcConfig): VerifyOptions {
 
 function getConfigOptions(req: Request): GetAppConfigOptions | undefined {
   const user = req.user as { tenantId?: string } | undefined;
-  const tenantId = user?.tenantId ?? getTenantId();
 
-  if (!tenantId) return undefined;
-  return { tenantId };
+  if (user?.tenantId) return { tenantId: user.tenantId };
+  return { baseOnly: true };
 }
 
 function verifyJwt(

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -10,7 +10,7 @@ import type { Algorithm, JwtPayload, VerifyOptions } from 'jsonwebtoken';
 import type { TAgentsEndpoint } from 'librechat-data-provider';
 import type { RequestInit } from 'undici';
 import type { GetAppConfigOptions } from '../app/service';
-import { findOpenIDUser } from '../auth/openid';
+import { findOpenIDUser, getOpenIdEmail } from '../auth/openid';
 import { isEnabled, math } from '~/utils';
 
 export interface RemoteAgentAuthDeps {
@@ -86,14 +86,6 @@ function setCacheEntry<T>(
 function extractBearer(authHeader: string | undefined): string | null {
   const match = authHeader?.match(/^Bearer\s+(.+)$/i);
   return match?.[1] ?? null;
-}
-
-function getEmail(payload: JwtPayload): string | undefined {
-  return (
-    (payload['email'] as string | undefined) ??
-    (payload['preferred_username'] as string | undefined) ??
-    (payload['upn'] as string | undefined)
-  );
 }
 
 function splitScopes(scopes: string): string[] {
@@ -296,7 +288,7 @@ async function resolveUser(
 
   const { user, error, migration } = await findOpenIDUser({
     findUser,
-    email: getEmail(payload),
+    email: getOpenIdEmail(payload, 'remoteAgentAuth'),
     openidId: payload.sub,
     idOnTheSource: payload['oid'] as string | undefined,
     strategyName: 'remoteAgentAuth',

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -134,7 +134,9 @@ function ensureRemoteOidcUrlAllowed(value: string, label: string): string {
 }
 
 async function discoverJwksUri(issuer: string): Promise<string> {
-  const normalizedIssuer = ensureRemoteOidcUrlAllowed(issuer, 'OIDC issuer').replace(/\/$/, '');
+  const normalizedIssuer = normalizeOpenIdIssuer(ensureRemoteOidcUrlAllowed(issuer, 'OIDC issuer'));
+  if (!normalizedIssuer) throw new Error('OIDC issuer is required');
+
   const discoveryUrl = `${normalizedIssuer}/.well-known/openid-configuration`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), OIDC_DISCOVERY_TIMEOUT_MS);

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -224,7 +224,7 @@ async function getJwksClient(oidcConfig: EnabledOidcConfig): Promise<jwksRsa.Jwk
 function getVerifyOptions(oidcConfig: EnabledOidcConfig): VerifyOptions {
   return {
     algorithms: JWT_ALGORITHMS,
-    issuer: oidcConfig.issuer,
+    issuer: normalizeOpenIdIssuer(oidcConfig.issuer) ?? oidcConfig.issuer,
     ...(oidcConfig.audience ? { audience: oidcConfig.audience } : {}),
   };
 }

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -6,12 +6,14 @@ import type { RequestHandler, Request, Response, NextFunction } from 'express';
 import type { JwtPayload } from 'jsonwebtoken';
 import type { AppConfig, IUser, UserMethods } from '@librechat/data-schemas';
 import type { TAgentsEndpoint } from 'librechat-data-provider';
+import { SystemRoles } from 'librechat-data-provider';
 import { isEnabled, math } from '~/utils';
 import { findOpenIDUser } from '../auth/openid';
 
 export interface RemoteAgentAuthDeps {
   apiKeyMiddleware: RequestHandler;
   findUser: UserMethods['findUser'];
+  updateUser: UserMethods['updateUser'];
   getAppConfig: () => Promise<AppConfig | null>;
 }
 
@@ -141,8 +143,9 @@ async function resolveUser(
   token: string,
   payload: JwtPayload,
   findUser: UserMethods['findUser'],
+  updateUser: UserMethods['updateUser'],
 ): Promise<IUser | null> {
-  const { user, error } = await findOpenIDUser({
+  const { user, error, migration } = await findOpenIDUser({
     findUser,
     email: getEmail(payload),
     openidId: payload.sub ?? '',
@@ -153,6 +156,23 @@ async function resolveUser(
   if (error != null || user == null) return null;
 
   user.id = String(user._id);
+
+  const updateData: Partial<IUser> = {};
+
+  if (migration) {
+    updateData.provider = 'openid';
+    updateData.openidId = payload.sub;
+  }
+
+  if (!user.role) {
+    user.role = SystemRoles.USER;
+    updateData.role = SystemRoles.USER;
+  }
+
+  if (Object.keys(updateData).length > 0) {
+    await updateUser(user.id, updateData);
+  }
+
   user.federatedTokens = { access_token: token, expires_at: payload.exp };
   return user;
 }
@@ -180,6 +200,7 @@ async function resolveUser(
 export function createRemoteAgentAuth({
   apiKeyMiddleware,
   findUser,
+  updateUser,
   getAppConfig,
 }: RemoteAgentAuthDeps): RequestHandler {
   return async (req: Request, res: Response, next: NextFunction) => {
@@ -202,7 +223,7 @@ export function createRemoteAgentAuth({
 
       try {
         const payload = await verifyOidcBearer(token, authConfig.oidc);
-        const user = await resolveUser(token, payload, findUser);
+        const user = await resolveUser(token, payload, findUser, updateUser);
 
         if (user == null) {
           logger.warn('[remoteAgentAuth] OIDC token valid but no matching LibreChat user');

--- a/packages/api/src/middleware/remoteAgentAuth.ts
+++ b/packages/api/src/middleware/remoteAgentAuth.ts
@@ -9,6 +9,7 @@ import type { AppConfig, IUser, UserMethods } from '@librechat/data-schemas';
 import type { Algorithm, JwtPayload, VerifyOptions } from 'jsonwebtoken';
 import type { TAgentsEndpoint } from 'librechat-data-provider';
 import type { RequestInit } from 'undici';
+import type { GetAppConfigOptions } from '../app/service';
 import { findOpenIDUser } from '../auth/openid';
 import { isEnabled, math } from '~/utils';
 
@@ -18,14 +19,6 @@ export interface RemoteAgentAuthDeps {
   updateUser: UserMethods['updateUser'];
   getAppConfig: (options?: GetAppConfigOptions) => Promise<AppConfig | null>;
 }
-
-type GetAppConfigOptions = {
-  role?: string;
-  userId?: string;
-  tenantId?: string;
-  refresh?: boolean;
-  baseOnly?: boolean;
-};
 
 type OidcConfig = NonNullable<
   NonNullable<NonNullable<TAgentsEndpoint['remoteApi']>['auth']>['oidc']
@@ -40,12 +33,14 @@ type CacheEntry<T> = {
   expiresAt: number;
   promise: Promise<T>;
 };
+type ScopeClaim = string | string[] | undefined;
 type UserResolution =
   | { status: 'resolved'; user: IUser }
   | { status: 'missing' }
   | { status: 'rejected'; error: string };
 
 const OIDC_DISCOVERY_TIMEOUT_MS = 10000;
+const MAX_JWKS_CACHE_ENTRIES = 100;
 const JWT_ALGORITHMS: Algorithm[] = [
   'RS256',
   'RS384',
@@ -65,6 +60,29 @@ export function clearRemoteAgentAuthCache(): void {
   jwksClientCache.clear();
 }
 
+function pruneExpiredEntries<T>(cache: Map<string, CacheEntry<T>>): void {
+  const now = Date.now();
+  for (const [key, entry] of cache) {
+    if (entry.expiresAt <= now) cache.delete(key);
+  }
+}
+
+function setCacheEntry<T>(
+  cache: Map<string, CacheEntry<T>>,
+  key: string,
+  entry: CacheEntry<T>,
+): void {
+  pruneExpiredEntries(cache);
+
+  while (cache.size >= MAX_JWKS_CACHE_ENTRIES) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey == null) break;
+    cache.delete(oldestKey);
+  }
+
+  cache.set(key, entry);
+}
+
 function extractBearer(authHeader: string | undefined): string | null {
   if (!authHeader?.startsWith('Bearer ')) return null;
   return authHeader.slice(7);
@@ -76,6 +94,29 @@ function getEmail(payload: JwtPayload): string | undefined {
     (payload['preferred_username'] as string | undefined) ??
     (payload['upn'] as string | undefined)
   );
+}
+
+function splitScopes(scopes: string): string[] {
+  return scopes
+    .trim()
+    .split(/[\s,]+/)
+    .filter(Boolean);
+}
+
+function getTokenScopes(scopeClaim: ScopeClaim): string[] {
+  if (Array.isArray(scopeClaim)) return scopeClaim.flatMap(splitScopes);
+  return scopeClaim ? splitScopes(scopeClaim) : [];
+}
+
+function hasRequiredScopes(requiredScope: string | undefined, payload: JwtPayload): boolean {
+  if (!requiredScope) return true;
+
+  const requiredScopes = splitScopes(requiredScope);
+  if (requiredScopes.length === 0) return true;
+
+  const rawScope = (payload['scp'] ?? payload['scope']) as ScopeClaim;
+  const tokenScopes = getTokenScopes(rawScope);
+  return requiredScopes.every((scope) => tokenScopes.includes(scope));
 }
 
 function getJwksCacheOptions(): JwksCacheOptions {
@@ -135,7 +176,7 @@ async function resolveJwksUri(
     throw err;
   });
 
-  jwksUriCache.set(cacheKey, {
+  setCacheEntry(jwksUriCache, cacheKey, {
     promise,
     expiresAt: Date.now() + cacheOptions.maxAge,
   });
@@ -177,7 +218,7 @@ async function getJwksClient(oidcConfig: EnabledOidcConfig): Promise<jwksRsa.Jwk
 
   const promise = Promise.resolve(client);
 
-  jwksClientCache.set(cacheKey, {
+  setCacheEntry(jwksClientCache, cacheKey, {
     promise,
     expiresAt: Date.now() + cacheOptions.maxAge,
   });
@@ -272,7 +313,7 @@ async function resolveUser(
 
   const updateData: Partial<IUser> = {};
 
-  if (migration && payload.sub != null) {
+  if (migration) {
     updateData.provider = 'openid';
     updateData.openidId = payload.sub;
   }
@@ -351,17 +392,10 @@ export function createRemoteAgentAuth({
 
       try {
         payload = await verifyOidcBearer(token, oidcConfig);
-        if (oidcConfig.scope != null) {
-          const rawScope = payload['scp'] ?? payload['scope'];
-          const tokenScopes: string[] = Array.isArray(rawScope)
-            ? rawScope
-            : ((rawScope as string | undefined)?.split(' ') ?? []);
-          if (!tokenScopes.includes(oidcConfig.scope)) {
-            logger.warn(`[remoteAgentAuth] Token missing required scope: ${oidcConfig.scope}`);
-            if (apiKeyEnabled) return apiKeyMiddleware(req, res, next);
-            res.status(401).json({ error: 'Unauthorized' });
-            return;
-          }
+        if (!hasRequiredScopes(oidcConfig.scope, payload)) {
+          logger.warn(`[remoteAgentAuth] Token missing required scope: ${oidcConfig.scope}`);
+          res.status(401).json({ error: 'Unauthorized' });
+          return;
         }
       } catch (oidcErr) {
         logger.error('[remoteAgentAuth] OIDC verification failed:', oidcErr);

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -352,6 +352,45 @@ describe('agentsEndpointSchema', () => {
       expect(result.data).not.toHaveProperty('baseURL');
     }
   });
+
+  it('allows explicitly disabled remote OIDC auth without issuer', () => {
+    const result = agentsEndpointSchema.safeParse({
+      remoteApi: {
+        auth: {
+          oidc: {
+            enabled: false,
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('requires a valid issuer when remote OIDC auth is enabled', () => {
+    const missingIssuer = agentsEndpointSchema.safeParse({
+      remoteApi: {
+        auth: {
+          oidc: {
+            enabled: true,
+          },
+        },
+      },
+    });
+    const invalidIssuer = agentsEndpointSchema.safeParse({
+      remoteApi: {
+        auth: {
+          oidc: {
+            enabled: true,
+            issuer: 'my-realm',
+          },
+        },
+      },
+    });
+
+    expect(missingIssuer.success).toBe(false);
+    expect(invalidIssuer.success).toBe(false);
+  });
 });
 
 describe('azureEndpointSchema', () => {

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -391,6 +391,49 @@ describe('agentsEndpointSchema', () => {
     expect(missingIssuer.success).toBe(false);
     expect(invalidIssuer.success).toBe(false);
   });
+
+  it('requires HTTPS remote OIDC issuer and JWKS URLs outside localhost', () => {
+    const insecureIssuer = agentsEndpointSchema.safeParse({
+      remoteApi: {
+        auth: {
+          oidc: {
+            enabled: true,
+            issuer: 'http://auth.example.com',
+          },
+        },
+      },
+    });
+    const insecureJwksUri = agentsEndpointSchema.safeParse({
+      remoteApi: {
+        auth: {
+          oidc: {
+            enabled: true,
+            issuer: 'https://auth.example.com',
+            jwksUri: 'http://auth.example.com/jwks',
+          },
+        },
+      },
+    });
+
+    expect(insecureIssuer.success).toBe(false);
+    expect(insecureJwksUri.success).toBe(false);
+  });
+
+  it('allows localhost HTTP remote OIDC URLs for development', () => {
+    const result = agentsEndpointSchema.safeParse({
+      remoteApi: {
+        auth: {
+          oidc: {
+            enabled: true,
+            issuer: 'http://localhost:8080/realms/test',
+            jwksUri: 'http://127.0.0.1:8080/realms/test/protocol/openid-connect/certs',
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
 });
 
 describe('azureEndpointSchema', () => {

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -434,6 +434,22 @@ describe('agentsEndpointSchema', () => {
 
     expect(result.success).toBe(true);
   });
+
+  it('requires space-separated remote OIDC scopes', () => {
+    const result = agentsEndpointSchema.safeParse({
+      remoteApi: {
+        auth: {
+          oidc: {
+            enabled: true,
+            issuer: 'https://auth.example.com',
+            scope: 'remote_agent,admin',
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('azureEndpointSchema', () => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -323,12 +323,32 @@ export const defaultAgentCapabilities = [
   AgentCapabilities.ocr,
 ];
 
+const LOCAL_REMOTE_OIDC_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+export function isRemoteOidcUrlAllowed(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol === 'https:') return true;
+    if (url.protocol !== 'http:') return false;
+
+    const hostname = url.hostname.toLowerCase();
+    return LOCAL_REMOTE_OIDC_HOSTS.has(hostname) || hostname.endsWith('.localhost');
+  } catch {
+    return false;
+  }
+}
+
+const remoteApiOidcUrlSchema = z
+  .string()
+  .url()
+  .refine(isRemoteOidcUrlAllowed, { message: 'must use https:// unless targeting localhost' });
+
 const remoteApiOidcSchema = z
   .object({
     enabled: z.boolean().default(false),
-    issuer: z.string().url().optional(),
+    issuer: remoteApiOidcUrlSchema.optional(),
     audience: z.string().optional(),
-    jwksUri: z.string().url().optional(),
+    jwksUri: remoteApiOidcUrlSchema.optional(),
     scope: z.string().optional(),
   })
   .superRefine((oidc, ctx) => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -335,6 +335,7 @@ const remoteApiAuthSchema = z.object({
       issuer: z.string(),
       audience: z.string().optional(),
       jwksUri: z.string().optional(),
+      scope: z.string().optional(),
     })
     .optional(),
 });

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -323,6 +323,26 @@ export const defaultAgentCapabilities = [
   AgentCapabilities.ocr,
 ];
 
+const remoteApiAuthSchema = z.object({
+  apiKey: z
+    .object({
+      enabled: z.boolean().default(true),
+    })
+    .optional(),
+  oidc: z
+    .object({
+      enabled: z.boolean().default(false),
+      issuer: z.string(),
+      audience: z.string().optional(),
+      jwksUri: z.string().optional(),
+    })
+    .optional(),
+});
+
+const remoteApiSchema = z.object({
+  auth: remoteApiAuthSchema.optional(),
+});
+
 export const agentsEndpointSchema = baseEndpointSchema
   .omit({ baseURL: true })
   .merge(
@@ -339,6 +359,7 @@ export const agentsEndpointSchema = baseEndpointSchema
         .array(z.nativeEnum(AgentCapabilities))
         .optional()
         .default(defaultAgentCapabilities),
+      remoteApi: remoteApiSchema.optional(),
     }),
   )
   .default({

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -323,21 +323,31 @@ export const defaultAgentCapabilities = [
   AgentCapabilities.ocr,
 ];
 
+const remoteApiOidcSchema = z
+  .object({
+    enabled: z.boolean().default(false),
+    issuer: z.string().url().optional(),
+    audience: z.string().optional(),
+    jwksUri: z.string().url().optional(),
+    scope: z.string().optional(),
+  })
+  .superRefine((oidc, ctx) => {
+    if (oidc.enabled === true && !oidc.issuer) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['issuer'],
+        message: 'issuer is required when OIDC auth is enabled',
+      });
+    }
+  });
+
 const remoteApiAuthSchema = z.object({
   apiKey: z
     .object({
       enabled: z.boolean().default(true),
     })
     .optional(),
-  oidc: z
-    .object({
-      enabled: z.boolean().default(false),
-      issuer: z.string(),
-      audience: z.string().optional(),
-      jwksUri: z.string().optional(),
-      scope: z.string().optional(),
-    })
-    .optional(),
+  oidc: remoteApiOidcSchema.optional(),
 });
 
 const remoteApiSchema = z.object({

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -343,13 +343,17 @@ const remoteApiOidcUrlSchema = z
   .url()
   .refine(isRemoteOidcUrlAllowed, { message: 'must use https:// unless targeting localhost' });
 
+const remoteApiOidcScopeSchema = z.string().refine((scope) => !scope.includes(','), {
+  message: 'scopes must be space-separated',
+});
+
 const remoteApiOidcSchema = z
   .object({
     enabled: z.boolean().default(false),
     issuer: remoteApiOidcUrlSchema.optional(),
     audience: z.string().optional(),
     jwksUri: remoteApiOidcUrlSchema.optional(),
-    scope: z.string().optional(),
+    scope: remoteApiOidcScopeSchema.optional(),
   })
   .superRefine((oidc, ctx) => {
     if (oidc.enabled === true && !oidc.issuer) {

--- a/packages/data-schemas/src/methods/user.methods.spec.ts
+++ b/packages/data-schemas/src/methods/user.methods.spec.ts
@@ -37,6 +37,37 @@ beforeEach(async () => {
   await mongoose.connection.dropDatabase();
 });
 
+describe('User schema indexes', () => {
+  test('should allow the same OpenID subject from different issuers', async () => {
+    await User.syncIndexes();
+
+    await User.create({
+      email: 'issuer-a@example.com',
+      provider: 'openid',
+      openidId: 'shared-sub',
+      openidIssuer: 'https://issuer-a.example.com',
+    });
+
+    await expect(
+      User.create({
+        email: 'issuer-b@example.com',
+        provider: 'openid',
+        openidId: 'shared-sub',
+        openidIssuer: 'https://issuer-b.example.com',
+      }),
+    ).resolves.toBeTruthy();
+
+    await expect(
+      User.create({
+        email: 'issuer-a-duplicate@example.com',
+        provider: 'openid',
+        openidId: 'shared-sub',
+        openidIssuer: 'https://issuer-a.example.com',
+      }),
+    ).rejects.toThrow(/duplicate key/);
+  });
+});
+
 describe('User Methods - Database Tests', () => {
   describe('findUser', () => {
     test('should find user by exact email', async () => {

--- a/packages/data-schemas/src/migrations/tenantIndexes.spec.ts
+++ b/packages/data-schemas/src/migrations/tenantIndexes.spec.ts
@@ -22,7 +22,7 @@ afterAll(async () => {
 });
 
 describe('dropSupersededTenantIndexes', () => {
-  describe('with pre-existing single-field unique indexes (simulates upgrade)', () => {
+  describe('with pre-existing superseded unique indexes (simulates upgrade)', () => {
     beforeAll(async () => {
       const db = mongoose.connection.db!;
 
@@ -35,6 +35,10 @@ describe('dropSupersededTenantIndexes', () => {
         { unique: true, sparse: true, name: 'facebookId_1' },
       );
       await users.createIndex({ openidId: 1 }, { unique: true, sparse: true, name: 'openidId_1' });
+      await users.createIndex(
+        { openidId: 1, tenantId: 1 },
+        { unique: true, name: 'openidId_1_tenantId_1' },
+      );
       await users.createIndex({ samlId: 1 }, { unique: true, sparse: true, name: 'samlId_1' });
       await users.createIndex({ ldapId: 1 }, { unique: true, sparse: true, name: 'ldapId_1' });
       await users.createIndex({ githubId: 1 }, { unique: true, sparse: true, name: 'githubId_1' });
@@ -139,6 +143,7 @@ describe('dropSupersededTenantIndexes', () => {
       expect(indexNames).not.toContain('email_1');
       expect(indexNames).not.toContain('googleId_1');
       expect(indexNames).not.toContain('openidId_1');
+      expect(indexNames).not.toContain('openidId_1_tenantId_1');
       expect(indexNames).toContain('_id_');
     });
 
@@ -290,11 +295,12 @@ describe('dropSupersededTenantIndexes', () => {
       }
     });
 
-    it('users collection lists all 9 OAuth ID indexes plus email', () => {
-      expect(SUPERSEDED_INDEXES.users).toHaveLength(9);
+    it('users collection lists all superseded OAuth and email indexes', () => {
+      expect(SUPERSEDED_INDEXES.users).toHaveLength(10);
       expect(SUPERSEDED_INDEXES.users).toContain('email_1');
       expect(SUPERSEDED_INDEXES.users).toContain('googleId_1');
       expect(SUPERSEDED_INDEXES.users).toContain('openidId_1');
+      expect(SUPERSEDED_INDEXES.users).toContain('openidId_1_tenantId_1');
     });
   });
 });

--- a/packages/data-schemas/src/migrations/tenantIndexes.ts
+++ b/packages/data-schemas/src/migrations/tenantIndexes.ts
@@ -17,6 +17,7 @@ const SUPERSEDED_INDEXES: Record<string, string[]> = {
     'googleId_1',
     'facebookId_1',
     'openidId_1',
+    'openidId_1_tenantId_1',
     'samlId_1',
     'ldapId_1',
     'githubId_1',

--- a/packages/data-schemas/src/schema/balance.ts
+++ b/packages/data-schemas/src/schema/balance.ts
@@ -5,7 +5,7 @@ const balanceSchema = new Schema<t.IBalance>({
   user: {
     type: Schema.Types.ObjectId,
     ref: 'User',
-    unique: true,
+    index: true,
     required: true,
   },
   // 1000 tokenCredits = 1 mill ($0.001 USD)

--- a/packages/data-schemas/src/schema/balance.ts
+++ b/packages/data-schemas/src/schema/balance.ts
@@ -5,7 +5,7 @@ const balanceSchema = new Schema<t.IBalance>({
   user: {
     type: Schema.Types.ObjectId,
     ref: 'User',
-    index: true,
+    unique: true,
     required: true,
   },
   // 1000 tokenCredits = 1 mill ($0.001 USD)

--- a/packages/data-schemas/src/schema/user.ts
+++ b/packages/data-schemas/src/schema/user.ts
@@ -181,6 +181,14 @@ const oAuthIdFields = [
 ] as const;
 
 for (const field of oAuthIdFields) {
+  if (field === 'openidId') {
+    userSchema.index(
+      { openidId: 1, openidIssuer: 1, tenantId: 1 },
+      { unique: true, partialFilterExpression: { openidId: { $exists: true } } },
+    );
+    continue;
+  }
+
   userSchema.index(
     { [field]: 1, tenantId: 1 },
     { unique: true, partialFilterExpression: { [field]: { $exists: true } } },

--- a/packages/data-schemas/src/schema/user.ts
+++ b/packages/data-schemas/src/schema/user.ts
@@ -74,6 +74,9 @@ const userSchema = new Schema<IUser>(
     openidId: {
       type: String,
     },
+    openidIssuer: {
+      type: String,
+    },
     samlId: {
       type: String,
     },

--- a/packages/data-schemas/src/types/user.ts
+++ b/packages/data-schemas/src/types/user.ts
@@ -21,6 +21,7 @@ export interface IUser extends Document {
   discordId?: string;
   appleId?: string;
   plugins?: string[];
+  openidIssuer?: string;
   twoFactorEnabled?: boolean;
   totpSecret?: string;
   backupCodes?: Array<{


### PR DESCRIPTION
## Summary

Adds OIDC Bearer token authentication support for the Remote Agent API (`endpoints.agents.remoteApi`). Previously only API key auth was supported. The new middleware validates Bearer tokens against a configured OIDC issuer via JWKS, with a fallback to API key auth when enabled.

Closes #11733, closes #11640

### How it works

1. Reads `endpoints.agents.remoteApi.auth` from `AppConfig`
2. If `oidc.enabled: true` attempts to verify the Bearer token via JWKS
3. JWKS URI is resolved in priority order:
   - Explicit `jwksUri` in `librechat.yaml`
   - `OPENID_JWKS_URL` env var
   - Auto-discovery via `{issuer}/.well-known/openid-configuration`
4. On success resolves the LibreChat user via `findOpenIDUser` and attaches it to `req.user`
5. On any failure falls back to `apiKeyMiddleware` if `apiKey.enabled !== false`, otherwise returns `401`

### Config example

```yaml
endpoints:
  agents:
    remoteApi:
      auth:
        apiKey:
          enabled: false
        oidc:
          enabled: true
          issuer: https://auth.example.com/realms/myrealm
          # jwksUri is optional — resolved via discovery if omitted
          audience: my-client-id
```

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

Tested interaction flow through `/agents/v1` endpoint with OIDC Keycloak instance.

Also unit tests are written.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted: https://github.com/LibreChat-AI/librechat.ai/pull/544