### PR TITLE
fix: OAuth Retry on 401 During MCP Tool Execution

### DIFF
--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -7,7 +7,7 @@ import type { FlowStateManager } from '~/flow/manager';
 import type * as t from './types';
 import { MCPTokenStorage, MCPOAuthHandler, ReauthenticationRequiredError } from '~/mcp/oauth';
 import { PENDING_STALE_MS, normalizeExpiresAt } from '~/flow/manager';
-import { sanitizeUrlForLogging } from './utils';
+import { isOAuthError, sanitizeUrlForLogging } from './utils';
 import { withTimeout } from '~/utils/promise';
 import { MCPConnection } from './connection';
 import { processMCPEnv } from '~/utils';
@@ -183,6 +183,44 @@ export class MCPConnectionFactory {
     }
 
     return null;
+  }
+
+  /**
+   * Handles OAuth flow for a tool call 401 retry.
+   * Creates a temporary factory instance and runs the existing handleOAuthRequired() flow,
+   * storing tokens on success.
+   */
+  static async handleToolCallOAuth(
+    basic: t.BasicConnectionOptions,
+    oauth: t.OAuthConnectionOptions,
+  ): Promise<MCPOAuthTokens | null> {
+    const factory = new this(basic, oauth);
+    const result = await factory.handleOAuthRequired();
+    if (!result?.tokens) {
+      return null;
+    }
+
+    if (oauth.tokenMethods?.createToken) {
+      try {
+        await MCPTokenStorage.storeTokens({
+          userId: oauth.user!.id,
+          serverName: basic.serverName,
+          tokens: result.tokens,
+          createToken: oauth.tokenMethods.createToken,
+          updateToken: oauth.tokenMethods.updateToken,
+          findToken: oauth.tokenMethods.findToken,
+          clientInfo: result.clientInfo,
+          metadata: result.metadata,
+        });
+      } catch (error) {
+        logger.error(
+          `[MCP][${basic.serverName}] Failed to store tokens after tool call OAuth`,
+          error,
+        );
+      }
+    }
+
+    return result.tokens;
   }
 
   protected constructor(
@@ -466,38 +504,8 @@ export class MCPConnectionFactory {
     }
   }
 
-  // Determines if an error indicates OAuth authentication is required
   private isOAuthError(error: unknown): boolean {
-    if (!error || typeof error !== 'object') {
-      return false;
-    }
-
-    // Check for error code
-    if ('code' in error) {
-      const code = (error as { code?: number }).code;
-      if (code === 401 || code === 403) {
-        return true;
-      }
-    }
-
-    // Check message for various auth error indicators
-    if ('message' in error && typeof error.message === 'string') {
-      const message = error.message.toLowerCase();
-      // Check for 401 status
-      if (message.includes('401') || message.includes('non-200 status code (401)')) {
-        return true;
-      }
-      // Check for invalid_token (OAuth servers return this for expired/revoked tokens)
-      if (message.includes('invalid_token')) {
-        return true;
-      }
-      // Check for authentication required
-      if (message.includes('authentication required') || message.includes('unauthorized')) {
-        return true;
-      }
-    }
-
-    return false;
+    return isOAuthError(error);
   }
 
   /** Manages OAuth flow initiation and completion */

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -17,6 +17,7 @@ import { MCPConnectionFactory } from './MCPConnectionFactory';
 import { preProcessGraphTokens } from '~/utils/graph';
 import { formatToolContent } from './parsers';
 import { MCPConnection } from './connection';
+import { isOAuthError } from './utils';
 import { processMCPEnv } from '~/utils/env';
 
 /**
@@ -241,11 +242,86 @@ Please follow these instructions when using tools from the respective MCP server
    * (if userId is provided) or an app-level connection. Updates the last activity timestamp
    * for user-specific connections upon successful call initiation.
    *
+   * On 401/auth errors, attempts OAuth flow and retries once with a fresh connection.
+   *
    * @param graphTokenResolver - Optional function to resolve Graph API tokens via OBO flow.
    *   When provided and the server config contains `{{LIBRECHAT_GRAPH_ACCESS_TOKEN}}` placeholders,
    *   they will be resolved to actual Graph API tokens before the tool call.
    */
-  async callTool({
+  async callTool(params: {
+    user?: IUser;
+    serverName: string;
+    toolName: string;
+    provider: t.Provider;
+    toolArguments?: Record<string, unknown>;
+    options?: RequestOptions;
+    requestBody?: RequestBody;
+    tokenMethods?: TokenMethods;
+    customUserVars?: Record<string, string>;
+    flowManager: FlowStateManager<MCPOAuthTokens | null>;
+    oauthStart?: (authURL: string) => Promise<void>;
+    oauthEnd?: () => Promise<void>;
+    graphTokenResolver?: GraphTokenResolver;
+  }): Promise<t.FormattedToolResponse> {
+    const { user, serverName, toolName, flowManager, oauthStart, tokenMethods, options } = params;
+    const userId = user?.id;
+    const logPrefix = userId ? `[MCP][User: ${userId}][${serverName}]` : `[MCP][${serverName}]`;
+
+    try {
+      return await this._doToolCall(params);
+    } catch (error) {
+      if (!isOAuthError(error) || !userId || !flowManager || !oauthStart) {
+        logger.error(`${logPrefix}[${toolName}] Tool call failed`, error);
+        throw error;
+      }
+
+      logger.info(`${logPrefix}[${toolName}] Got auth error during tool call, attempting OAuth`);
+
+      const serverConfig = await MCPServersRegistry.getInstance().getServerConfig(
+        serverName,
+        userId,
+      );
+      if (!serverConfig) {
+        logger.error(`${logPrefix}[${toolName}] Server config not found for OAuth retry`);
+        throw error;
+      }
+
+      const registry = MCPServersRegistry.getInstance();
+      const basic: t.BasicConnectionOptions = {
+        serverName,
+        serverConfig,
+        dbSourced: !!serverConfig.dbId,
+        useSSRFProtection: registry.shouldEnableSSRFProtection(),
+        allowedDomains: registry.getAllowedDomains(),
+      };
+
+      const tokens = await MCPConnectionFactory.handleToolCallOAuth(basic, {
+        useOAuth: true,
+        user,
+        flowManager,
+        tokenMethods,
+        oauthStart,
+        signal: options?.signal,
+      });
+
+      if (!tokens) {
+        logger.warn(`${logPrefix}[${toolName}] OAuth flow returned no tokens, throwing original`);
+        throw error;
+      }
+
+      await this.disconnectUserConnection(userId, serverName);
+      logger.info(`${logPrefix}[${toolName}] OAuth succeeded, retrying tool call`);
+
+      try {
+        return await this._doToolCall(params);
+      } catch (retryError) {
+        logger.error(`${logPrefix}[${toolName}] Tool call failed after OAuth retry`, retryError);
+        throw retryError;
+      }
+    }
+  }
+
+  private async _doToolCall({
     user,
     serverName,
     toolName,
@@ -274,81 +350,72 @@ Please follow these instructions when using tools from the respective MCP server
     oauthEnd?: () => Promise<void>;
     graphTokenResolver?: GraphTokenResolver;
   }): Promise<t.FormattedToolResponse> {
-    /** User-specific connection */
-    let connection: MCPConnection | undefined;
     const userId = user?.id;
     const logPrefix = userId ? `[MCP][User: ${userId}][${serverName}]` : `[MCP][${serverName}]`;
 
-    try {
-      if (userId && user) this.updateUserLastActivity(userId);
-
-      connection = await this.getConnection({
-        serverName,
-        user,
-        flowManager,
-        tokenMethods,
-        oauthStart,
-        oauthEnd,
-        signal: options?.signal,
-        customUserVars,
-        requestBody,
-      });
-
-      if (!(await connection.isConnected())) {
-        /** May happen if getUserConnection failed silently or app connection dropped */
-        throw new McpError(
-          ErrorCode.InternalError, // Use InternalError for connection issues
-          `${logPrefix} Connection is not active. Cannot execute tool ${toolName}.`,
-        );
-      }
-
-      const rawConfig = await MCPServersRegistry.getInstance().getServerConfig(serverName, userId);
-      const isDbSourced = !!rawConfig?.dbId;
-
-      /** Pre-process Graph token placeholders (async) before the synchronous processMCPEnv pass */
-      const graphProcessedConfig = isDbSourced
-        ? (rawConfig as t.MCPOptions)
-        : await preProcessGraphTokens(rawConfig as t.MCPOptions, {
-            user,
-            graphTokenResolver,
-            scopes: process.env.GRAPH_API_SCOPES,
-          });
-      const currentOptions = processMCPEnv({
-        user,
-        body: requestBody,
-        dbSourced: isDbSourced,
-        options: graphProcessedConfig,
-        customUserVars,
-      });
-      if ('headers' in currentOptions) {
-        connection.setRequestHeaders(currentOptions.headers || {});
-      }
-
-      const result = await connection.client.request(
-        {
-          method: 'tools/call',
-          params: {
-            name: toolName,
-            arguments: toolArguments,
-          },
-        },
-        CallToolResultSchema,
-        {
-          timeout: connection.timeout,
-          resetTimeoutOnProgress: true,
-          ...options,
-        },
-      );
-      if (userId) {
-        this.updateUserLastActivity(userId);
-      }
-      this.checkIdleConnections();
-      return formatToolContent(result as t.MCPToolCallResponse, provider);
-    } catch (error) {
-      // Log with context and re-throw or handle as needed
-      logger.error(`${logPrefix}[${toolName}] Tool call failed`, error);
-      // Rethrowing allows the caller (createMCPTool) to handle the final user message
-      throw error;
+    if (userId && user) {
+      this.updateUserLastActivity(userId);
     }
+
+    const connection = await this.getConnection({
+      serverName,
+      user,
+      flowManager,
+      tokenMethods,
+      oauthStart,
+      oauthEnd,
+      signal: options?.signal,
+      customUserVars,
+      requestBody,
+    });
+
+    if (!(await connection.isConnected())) {
+      throw new McpError(
+        ErrorCode.InternalError,
+        `${logPrefix} Connection is not active. Cannot execute tool ${toolName}.`,
+      );
+    }
+
+    const rawConfig = await MCPServersRegistry.getInstance().getServerConfig(serverName, userId);
+    const isDbSourced = !!rawConfig?.dbId;
+
+    const graphProcessedConfig = isDbSourced
+      ? (rawConfig as t.MCPOptions)
+      : await preProcessGraphTokens(rawConfig as t.MCPOptions, {
+          user,
+          graphTokenResolver,
+          scopes: process.env.GRAPH_API_SCOPES,
+        });
+    const currentOptions = processMCPEnv({
+      user,
+      body: requestBody,
+      dbSourced: isDbSourced,
+      options: graphProcessedConfig,
+      customUserVars,
+    });
+    if ('headers' in currentOptions) {
+      connection.setRequestHeaders(currentOptions.headers || {});
+    }
+
+    const result = await connection.client.request(
+      {
+        method: 'tools/call',
+        params: {
+          name: toolName,
+          arguments: toolArguments,
+        },
+      },
+      CallToolResultSchema,
+      {
+        timeout: connection.timeout,
+        resetTimeoutOnProgress: true,
+        ...options,
+      },
+    );
+    if (userId) {
+      this.updateUserLastActivity(userId);
+    }
+    this.checkIdleConnections();
+    return formatToolContent(result as t.MCPToolCallResponse, provider);
   }
 }

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -1,6 +1,8 @@
 import { logger } from '@librechat/data-schemas';
 import type { IUser } from '@librechat/data-schemas';
 import type { GraphTokenResolver } from '~/utils/graph';
+import type { FlowStateManager } from '~/flow/manager';
+import type { MCPOAuthTokens } from '~/mcp/oauth';
 import type * as t from '~/mcp/types';
 import { MCPServersInitializer } from '~/mcp/registry/MCPServersInitializer';
 import { MCPServerInspector } from '~/mcp/registry/MCPServerInspector';
@@ -964,6 +966,181 @@ describe('MCPManager', () => {
         expect.objectContaining({ serverName }),
         expect.objectContaining({ user: mockUser, useOAuth: true }),
       );
+    });
+  });
+
+  describe('callTool - OAuth retry on 401', () => {
+    const mockUser: Partial<IUser> = {
+      id: 'user-123',
+      provider: 'openid',
+      openidId: 'oidc-sub-456',
+    };
+
+    const mockFlowManager = {
+      getState: jest.fn(),
+      setState: jest.fn(),
+      clearState: jest.fn(),
+      createFlow: jest.fn(),
+      getFlowState: jest.fn(),
+      deleteFlow: jest.fn(),
+      initFlow: jest.fn(),
+    } as unknown as FlowStateManager<MCPOAuthTokens | null>;
+
+    const mockOauthStart = jest.fn().mockResolvedValue(undefined);
+
+    const toolCallParams = {
+      user: mockUser as IUser,
+      serverName,
+      toolName: 'test_tool',
+      provider: 'openai' as t.Provider,
+      flowManager: mockFlowManager,
+      oauthStart: mockOauthStart,
+    };
+
+    function createMockConnection(requestFn: jest.Mock) {
+      return {
+        isConnected: jest.fn().mockResolvedValue(true),
+        setRequestHeaders: jest.fn(),
+        timeout: 30000,
+        client: { request: requestFn },
+      } as unknown as MCPConnection;
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      (graphUtils.preProcessGraphTokens as jest.Mock).mockImplementation(
+        async (options) => options,
+      );
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'sse',
+        url: 'https://api.example.com',
+      });
+    });
+
+    it('should retry tool call after successful OAuth flow on 401', async () => {
+      const requestFn = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('Non-200 status code (401)'))
+        .mockResolvedValueOnce({
+          content: [{ type: 'text', text: 'Success after OAuth' }],
+          isError: false,
+        });
+
+      let callCount = 0;
+      mockAppConnections({
+        get: jest.fn().mockImplementation(() => {
+          callCount++;
+          return Promise.resolve(createMockConnection(requestFn));
+        }),
+      });
+
+      (MCPConnectionFactory.handleToolCallOAuth as jest.Mock) = jest
+        .fn()
+        .mockResolvedValue({ access_token: 'new-token' });
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      jest.spyOn(manager, 'disconnectUserConnection').mockResolvedValue(undefined);
+
+      const result = await manager.callTool(toolCallParams);
+
+      expect(result).toBeDefined();
+      expect(MCPConnectionFactory.handleToolCallOAuth).toHaveBeenCalledTimes(1);
+      expect(manager.disconnectUserConnection).toHaveBeenCalledWith(mockUser.id, serverName);
+      expect(requestFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should only retry once even if retry also returns 401', async () => {
+      const authError = new Error('Non-200 status code (401)');
+      const requestFn = jest.fn().mockRejectedValue(authError);
+
+      mockAppConnections({
+        get: jest.fn().mockResolvedValue(createMockConnection(requestFn)),
+      });
+
+      (MCPConnectionFactory.handleToolCallOAuth as jest.Mock) = jest
+        .fn()
+        .mockResolvedValue({ access_token: 'new-token' });
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      jest.spyOn(manager, 'disconnectUserConnection').mockResolvedValue(undefined);
+
+      await expect(manager.callTool(toolCallParams)).rejects.toThrow();
+      expect(MCPConnectionFactory.handleToolCallOAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw immediately without OAuth attempt when no flowManager', async () => {
+      const authError = new Error('Non-200 status code (401)');
+      const requestFn = jest.fn().mockRejectedValue(authError);
+
+      mockAppConnections({
+        get: jest.fn().mockResolvedValue(createMockConnection(requestFn)),
+      });
+
+      (MCPConnectionFactory.handleToolCallOAuth as jest.Mock) = jest.fn();
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+
+      await expect(
+        manager.callTool({
+          ...toolCallParams,
+          flowManager: undefined as unknown as FlowStateManager<MCPOAuthTokens | null>,
+        }),
+      ).rejects.toThrow('401');
+
+      expect(MCPConnectionFactory.handleToolCallOAuth).not.toHaveBeenCalled();
+    });
+
+    it('should throw immediately without OAuth attempt when no oauthStart', async () => {
+      const authError = new Error('Non-200 status code (401)');
+      const requestFn = jest.fn().mockRejectedValue(authError);
+
+      mockAppConnections({
+        get: jest.fn().mockResolvedValue(createMockConnection(requestFn)),
+      });
+
+      (MCPConnectionFactory.handleToolCallOAuth as jest.Mock) = jest.fn();
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+
+      await expect(
+        manager.callTool({
+          ...toolCallParams,
+          oauthStart: undefined,
+        }),
+      ).rejects.toThrow('401');
+
+      expect(MCPConnectionFactory.handleToolCallOAuth).not.toHaveBeenCalled();
+    });
+
+    it('should throw original error when OAuth flow returns no tokens', async () => {
+      const authError = new Error('Non-200 status code (401)');
+      const requestFn = jest.fn().mockRejectedValue(authError);
+
+      mockAppConnections({
+        get: jest.fn().mockResolvedValue(createMockConnection(requestFn)),
+      });
+
+      (MCPConnectionFactory.handleToolCallOAuth as jest.Mock) = jest.fn().mockResolvedValue(null);
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+
+      await expect(manager.callTool(toolCallParams)).rejects.toThrow('401');
+      expect(MCPConnectionFactory.handleToolCallOAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not attempt OAuth for non-auth errors', async () => {
+      const requestFn = jest.fn().mockRejectedValue(new Error('Connection timeout'));
+
+      mockAppConnections({
+        get: jest.fn().mockResolvedValue(createMockConnection(requestFn)),
+      });
+
+      (MCPConnectionFactory.handleToolCallOAuth as jest.Mock) = jest.fn();
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+
+      await expect(manager.callTool(toolCallParams)).rejects.toThrow('Connection timeout');
+      expect(MCPConnectionFactory.handleToolCallOAuth).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -1,5 +1,53 @@
-import { normalizeServerName, redactServerSecrets, redactAllServerSecrets } from '~/mcp/utils';
+import {
+  isOAuthError,
+  normalizeServerName,
+  redactServerSecrets,
+  redactAllServerSecrets,
+} from '~/mcp/utils';
 import type { ParsedServerConfig } from '~/mcp/types';
+
+describe('isOAuthError', () => {
+  it('should return true for error with code 401', () => {
+    expect(isOAuthError({ code: 401, message: 'Unauthorized' })).toBe(true);
+  });
+
+  it('should return true for error with code 403', () => {
+    expect(isOAuthError({ code: 403, message: 'Forbidden' })).toBe(true);
+  });
+
+  it('should return true for message containing 401', () => {
+    expect(isOAuthError(new Error('Non-200 status code (401)'))).toBe(true);
+  });
+
+  it('should return true for message containing invalid_token', () => {
+    expect(isOAuthError(new Error('invalid_token: token expired'))).toBe(true);
+  });
+
+  it('should return true for message containing invalid_grant', () => {
+    expect(isOAuthError(new Error('invalid_grant: refresh token revoked'))).toBe(true);
+  });
+
+  it('should return true for message containing authentication required', () => {
+    expect(isOAuthError(new Error('Authentication Required'))).toBe(true);
+  });
+
+  it('should return true for message containing unauthorized', () => {
+    expect(isOAuthError(new Error('Unauthorized access'))).toBe(true);
+  });
+
+  it('should return false for non-auth errors', () => {
+    expect(isOAuthError(new Error('Connection timeout'))).toBe(false);
+    expect(isOAuthError(new Error('Internal server error'))).toBe(false);
+    expect(isOAuthError({ code: 500, message: 'Server error' })).toBe(false);
+  });
+
+  it('should return false for null/undefined/non-object', () => {
+    expect(isOAuthError(null)).toBe(false);
+    expect(isOAuthError(undefined)).toBe(false);
+    expect(isOAuthError('string error')).toBe(false);
+    expect(isOAuthError(42)).toBe(false);
+  });
+});
 
 describe('normalizeServerName', () => {
   it('should not modify server names that already match the pattern', () => {

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -20,7 +20,7 @@ import type { MCPOAuthTokens } from './oauth/types';
 import type * as t from './types';
 import { createSSRFSafeUndiciConnect, resolveHostnameSSRF } from '~/auth';
 import { runOutsideTracing } from '~/utils/tracing';
-import { sanitizeUrlForLogging } from './utils';
+import { isOAuthError, sanitizeUrlForLogging } from './utils';
 import { withTimeout } from '~/utils/promise';
 import { mcpConfig } from './mcpConfig';
 
@@ -1233,40 +1233,7 @@ export class MCPConnection extends EventEmitter {
   }
 
   private isOAuthError(error: unknown): boolean {
-    if (!error || typeof error !== 'object') {
-      return false;
-    }
-
-    // Check for error code
-    if ('code' in error) {
-      const code = (error as { code?: number }).code;
-      if (code === 401 || code === 403) {
-        return true;
-      }
-    }
-
-    // Check message for various auth error indicators
-    if ('message' in error && typeof error.message === 'string') {
-      const message = error.message.toLowerCase();
-      // Check for 401 status
-      if (message.includes('401') || message.includes('non-200 status code (401)')) {
-        return true;
-      }
-      // Check for invalid_token (OAuth servers return this for expired/revoked tokens)
-      if (message.includes('invalid_token')) {
-        return true;
-      }
-      // Check for invalid_grant (OAuth servers return this for expired/revoked grants)
-      if (message.includes('invalid_grant')) {
-        return true;
-      }
-      // Check for authentication required
-      if (message.includes('authentication required') || message.includes('unauthorized')) {
-        return true;
-      }
-    }
-
-    return false;
+    return isOAuthError(error);
   }
 
   /**

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -111,6 +111,38 @@ export function sanitizeUrlForLogging(url: string | URL): string {
   }
 }
 
+/** Determines if an error indicates OAuth authentication is required */
+export function isOAuthError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  if ('code' in error) {
+    const code = (error as { code?: number }).code;
+    if (code === 401 || code === 403) {
+      return true;
+    }
+  }
+
+  if ('message' in error && typeof (error as { message?: unknown }).message === 'string') {
+    const message = ((error as { message: string }).message).toLowerCase();
+    if (message.includes('401') || message.includes('non-200 status code (401)')) {
+      return true;
+    }
+    if (message.includes('invalid_token')) {
+      return true;
+    }
+    if (message.includes('invalid_grant')) {
+      return true;
+    }
+    if (message.includes('authentication required') || message.includes('unauthorized')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Escapes special regex characters in a string so they are treated literally.
  * @param str - The string to escape


### PR DESCRIPTION
## Summary

MCP spec requires clients to handle 401 reactively at any point, including during `tools/call`. Previously, LibreChat only detected OAuth requirements during `connectClient()` (`initialize` + `tools/list`). If a server (e.g. Google MCP Toolbox) returned tools without auth but required auth for actual tool execution, the 401 was thrown as a plain error — no OAuth flow was triggered.

This PR adds OAuth catch-and-retry logic to `MCPManager.callTool` so that 401 errors during `tools/call` trigger the OAuth flow and retry once with a fresh connection.

- Extract shared `isOAuthError()` utility to `packages/api/src/mcp/utils.ts`, replacing duplicate implementations in `MCPConnection` and `MCPConnectionFactory`
- Add `MCPConnectionFactory.handleToolCallOAuth()` static method that wraps the existing OAuth flow for use outside the connection lifecycle
- Refactor `MCPManager.callTool` into `callTool` + `_doToolCall` so that 401/auth errors during `tools/call` trigger OAuth and retry once with a fresh connection

Closes #12415
Related: #9657

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Unit Tests
- `isOAuthError` utility: 9 test cases covering code 401/403, message patterns (`invalid_token`, `invalid_grant`, `authentication required`, `unauthorized`), non-auth errors, and null/undefined inputs
- OAuth retry in `MCPManager.callTool`: 6 test cases:
  - Retry succeeds after OAuth flow on 401
  - Only retries once even if retry also returns 401
  - Throws immediately without OAuth attempt when no `flowManager`
  - Throws immediately without OAuth attempt when no `oauthStart`
  - Throws original error when OAuth flow returns no tokens
  - Does not attempt OAuth for non-auth errors (e.g. timeout)

### Manual Verification
1. Configure an MCP server that allows `tools/list` without auth but requires auth for `tools/call`
2. Start a conversation and ask the LLM to use an MCP tool
3. Verify: OAuth popup appears, complete auth, tool call succeeds on retry

### **Test Configuration**:
- Node.js v20+
- Run: `cd packages/api && npx jest --no-coverage src/mcp/__tests__/utils.test.ts src/mcp/__tests__/MCPManager.test.ts`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
