### PR TITLE
📄 feat: Model-Aware Bedrock Document Size Validation

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1085,6 +1085,7 @@ class BaseClient {
         provider: this.options.agent?.provider ?? this.options.endpoint,
         endpoint: this.options.agent?.endpoint ?? this.options.endpoint,
         useResponsesApi: this.options.agent?.model_parameters?.useResponsesApi,
+        model: this.modelOptions?.model ?? this.model,
       },
       getStrategyFunctions,
     );

--- a/packages/api/src/files/encode/document.spec.ts
+++ b/packages/api/src/files/encode/document.spec.ts
@@ -88,11 +88,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
       updatedAt: new Date(),
     }) as unknown as IMongoFile;
 
-  const createMockDocFile = (
-    sizeInMB: number,
-    mimeType: string,
-    filename: string,
-  ): IMongoFile =>
+  const createMockDocFile = (sizeInMB: number, mimeType: string, filename: string): IMongoFile =>
     ({
       _id: new Types.ObjectId(),
       user: new Types.ObjectId(),
@@ -135,6 +131,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
         expect.any(Number),
         Providers.OPENAI,
         configuredLimit,
+        undefined,
       );
     });
 
@@ -162,6 +159,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
         expect.any(Buffer),
         expect.any(Number),
         Providers.OPENAI,
+        undefined,
         undefined,
       );
     });
@@ -195,6 +193,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
         expect.any(Buffer),
         expect.any(Number),
         Providers.OPENAI,
+        undefined,
         undefined,
       );
     });
@@ -235,6 +234,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
         expect.any(Number),
         Providers.ANTHROPIC,
         configuredLimit,
+        undefined,
       );
     });
 
@@ -274,6 +274,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
         expect.any(Number),
         Providers.GOOGLE,
         configuredLimit,
+        undefined,
       );
     });
 
@@ -313,6 +314,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
         expect.any(Buffer),
         expect.any(Number),
         Providers.OPENAI,
+        undefined,
         undefined,
       );
     });
@@ -407,6 +409,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
         expect.any(Number),
         Providers.OPENAI,
         mbToBytes(5),
+        undefined,
       );
     });
 
@@ -441,6 +444,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
         expect.any(Number),
         Providers.OPENAI,
         mbToBytes(50),
+        undefined,
       );
     });
 
@@ -480,6 +484,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
         expect.any(Number),
         Providers.OPENAI,
         mbToBytes(10),
+        undefined,
       );
       expect(mockedValidatePdf).toHaveBeenNthCalledWith(
         2,
@@ -487,6 +492,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
         expect.any(Number),
         Providers.OPENAI,
         mbToBytes(10),
+        undefined,
       );
     });
   });

--- a/packages/api/src/files/encode/document.spec.ts
+++ b/packages/api/src/files/encode/document.spec.ts
@@ -663,6 +663,36 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
       });
     });
 
+    it('should thread model to validateBedrockDocument when model is provided', async () => {
+      const req = createMockRequest() as ServerRequest;
+      const model = 'anthropic.claude-sonnet-4-20250514-v1:0';
+      const file = createMockDocFile(1, 'text/csv', 'data.csv');
+
+      const mockContent = Buffer.from('col1,col2\nval1,val2').toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: mockContent,
+        metadata: file,
+      });
+
+      mockedValidateBedrockDocument.mockResolvedValue({ isValid: true });
+
+      await encodeAndFormatDocuments(
+        req,
+        [file],
+        { provider: Providers.BEDROCK, model },
+        mockStrategyFunctions,
+      );
+
+      expect(mockedValidateBedrockDocument).toHaveBeenCalledWith(
+        expect.any(Number),
+        'text/csv',
+        expect.any(Buffer),
+        undefined,
+        model,
+      );
+    });
+
     it('should reject Bedrock document when validation fails', async () => {
       const req = createMockRequest() as ServerRequest;
       const file = createMockDocFile(5, 'text/csv', 'big.csv');

--- a/packages/api/src/files/encode/document.ts
+++ b/packages/api/src/files/encode/document.ts
@@ -29,10 +29,10 @@ import { getFileStream, getConfiguredFileSizeLimit } from './utils';
 export async function encodeAndFormatDocuments(
   req: ServerRequest,
   files: IMongoFile[],
-  params: { provider: Providers; endpoint?: string; useResponsesApi?: boolean },
+  params: { provider: Providers; endpoint?: string; useResponsesApi?: boolean; model?: string },
   getStrategyFunctions: (source: string) => StrategyFunctions,
 ): Promise<DocumentResult> {
-  const { provider, endpoint, useResponsesApi } = params;
+  const { provider, endpoint, useResponsesApi, model } = params;
   if (!files?.length) {
     return { documents: [], files: [] };
   }
@@ -94,6 +94,7 @@ export async function encodeAndFormatDocuments(
         mimeType,
         fileBuffer,
         configuredFileSizeLimit,
+        model,
       );
 
       if (!validation.isValid) {
@@ -122,6 +123,7 @@ export async function encodeAndFormatDocuments(
         pdfBuffer.length,
         provider,
         configuredFileSizeLimit,
+        model,
       );
 
       if (!validation.isValid) {

--- a/packages/api/src/files/validation.spec.ts
+++ b/packages/api/src/files/validation.spec.ts
@@ -212,9 +212,27 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
       expect(result.error).toBeUndefined();
     });
 
+    it('should exempt Claude 4+ PDFs via cross-region inference profile ID', async () => {
+      const pdfBuffer = createMockPdfBuffer(10);
+      const model = 'us.anthropic.claude-sonnet-4-20250514-v1:0';
+      const result = await validatePdf(pdfBuffer, pdfBuffer.length, provider, undefined, model);
+
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
     it('should exempt Nova PDFs from the 4.5MB limit', async () => {
       const pdfBuffer = createMockPdfBuffer(10);
       const model = 'amazon.nova-pro-v1:0';
+      const result = await validatePdf(pdfBuffer, pdfBuffer.length, provider, undefined, model);
+
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should exempt Nova PDFs via cross-region inference profile ID', async () => {
+      const pdfBuffer = createMockPdfBuffer(10);
+      const model = 'us.amazon.nova-pro-v1:0';
       const result = await validatePdf(pdfBuffer, pdfBuffer.length, provider, undefined, model);
 
       expect(result.isValid).toBe(true);

--- a/packages/api/src/files/validation.spec.ts
+++ b/packages/api/src/files/validation.spec.ts
@@ -173,13 +173,13 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
       expect(result.error).toContain('2.0MB');
     });
 
-    it('should allow configured limit higher than 4.5MB default', async () => {
+    it('should clamp to 4.5MB hard limit even when config is higher for non-exempt models', async () => {
       const configuredLimit = mbToBytes(512);
       const pdfBuffer = createMockPdfBuffer(5);
       const result = await validatePdf(pdfBuffer, pdfBuffer.length, provider, configuredLimit);
 
-      expect(result.isValid).toBe(true);
-      expect(result.error).toBeUndefined();
+      expect(result.isValid).toBe(false);
+      expect(result.error).toContain('4.5MB');
     });
 
     it('should reject PDFs with invalid header', async () => {
@@ -230,7 +230,7 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
       expect(result.error).toContain('4.5MB');
     });
 
-    it('should use 32MB as default limit for exempt Claude 4+ models', async () => {
+    it('should accept PDFs below 32MB for exempt Claude 4+ models', async () => {
       const pdfBuffer = createMockPdfBuffer(30);
       const model = 'anthropic.claude-opus-4-20250514-v1:0';
       const result = await validatePdf(pdfBuffer, pdfBuffer.length, provider, undefined, model);
@@ -245,6 +245,54 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
 
       expect(result.isValid).toBe(false);
       expect(result.error).toContain('32.0MB');
+    });
+
+    it('should respect configuredFileSizeLimit when lower than 32MB for exempt models', async () => {
+      const configuredLimit = mbToBytes(10);
+      const pdfBuffer = createMockPdfBuffer(15);
+      const model = 'anthropic.claude-sonnet-4-20250514-v1:0';
+      const result = await validatePdf(
+        pdfBuffer,
+        pdfBuffer.length,
+        provider,
+        configuredLimit,
+        model,
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toContain('10.0MB');
+    });
+
+    it('should allow configuredFileSizeLimit higher than 32MB for exempt models', async () => {
+      const configuredLimit = mbToBytes(50);
+      const pdfBuffer = createMockPdfBuffer(35);
+      const model = 'amazon.nova-pro-v1:0';
+      const result = await validatePdf(
+        pdfBuffer,
+        pdfBuffer.length,
+        provider,
+        configuredLimit,
+        model,
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should clamp to 4.5MB for non-exempt models even with high configuredFileSizeLimit', async () => {
+      const configuredLimit = mbToBytes(100);
+      const pdfBuffer = createMockPdfBuffer(5);
+      const model = 'anthropic.claude-3-5-sonnet-20241022-v2:0';
+      const result = await validatePdf(
+        pdfBuffer,
+        pdfBuffer.length,
+        provider,
+        configuredLimit,
+        model,
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toContain('4.5MB');
     });
   });
 
@@ -274,7 +322,7 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
       expect(result.error).toContain('4.5MB');
     });
 
-    it('should allow configured limit higher than 4.5MB for non-PDF', async () => {
+    it('should clamp to 4.5MB even when config is higher for non-exempt non-PDF', async () => {
       const fileSize = 5 * 1024 * 1024;
       const configuredLimit = mbToBytes(512);
       const result = await validateBedrockDocument(
@@ -284,8 +332,8 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
         configuredLimit,
       );
 
-      expect(result.isValid).toBe(true);
-      expect(result.error).toBeUndefined();
+      expect(result.isValid).toBe(false);
+      expect(result.error).toContain('4.5MB');
     });
 
     it('should use configured limit when lower than provider limit for non-PDF', async () => {

--- a/packages/api/src/files/validation.spec.ts
+++ b/packages/api/src/files/validation.spec.ts
@@ -173,13 +173,13 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
       expect(result.error).toContain('2.0MB');
     });
 
-    it('should clamp to 4.5MB hard limit even when config is higher for non-exempt models', async () => {
+    it('should allow configured limit higher than 4.5MB default', async () => {
       const configuredLimit = mbToBytes(512);
       const pdfBuffer = createMockPdfBuffer(5);
       const result = await validatePdf(pdfBuffer, pdfBuffer.length, provider, configuredLimit);
 
-      expect(result.isValid).toBe(false);
-      expect(result.error).toContain('4.5MB');
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
     });
 
     it('should reject PDFs with invalid header', async () => {
@@ -279,7 +279,7 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
       expect(result.error).toBeUndefined();
     });
 
-    it('should clamp to 4.5MB for non-exempt models even with high configuredFileSizeLimit', async () => {
+    it('should allow configuredFileSizeLimit higher than 4.5MB for non-exempt models', async () => {
       const configuredLimit = mbToBytes(100);
       const pdfBuffer = createMockPdfBuffer(5);
       const model = 'anthropic.claude-3-5-sonnet-20241022-v2:0';
@@ -291,8 +291,8 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
         model,
       );
 
-      expect(result.isValid).toBe(false);
-      expect(result.error).toContain('4.5MB');
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
     });
   });
 
@@ -322,7 +322,7 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
       expect(result.error).toContain('4.5MB');
     });
 
-    it('should clamp to 4.5MB even when config is higher for non-exempt non-PDF', async () => {
+    it('should allow configured limit higher than 4.5MB for non-PDF', async () => {
       const fileSize = 5 * 1024 * 1024;
       const configuredLimit = mbToBytes(512);
       const result = await validateBedrockDocument(
@@ -332,8 +332,8 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
         configuredLimit,
       );
 
-      expect(result.isValid).toBe(false);
-      expect(result.error).toContain('4.5MB');
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
     });
 
     it('should use configured limit when lower than provider limit for non-PDF', async () => {

--- a/packages/api/src/files/validation.spec.ts
+++ b/packages/api/src/files/validation.spec.ts
@@ -173,13 +173,13 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
       expect(result.error).toContain('2.0MB');
     });
 
-    it('should clamp to 4.5MB hard limit even when config is higher', async () => {
+    it('should allow configured limit higher than 4.5MB default', async () => {
       const configuredLimit = mbToBytes(512);
       const pdfBuffer = createMockPdfBuffer(5);
       const result = await validatePdf(pdfBuffer, pdfBuffer.length, provider, configuredLimit);
 
-      expect(result.isValid).toBe(false);
-      expect(result.error).toContain('4.5MB');
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
     });
 
     it('should reject PDFs with invalid header', async () => {
@@ -197,6 +197,54 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
 
       expect(result.isValid).toBe(false);
       expect(result.error).toContain('too small');
+    });
+  });
+
+  describe('validatePdf - Bedrock with model-specific exemptions', () => {
+    const provider = Providers.BEDROCK;
+
+    it('should exempt Claude 4+ PDFs from the 4.5MB limit', async () => {
+      const pdfBuffer = createMockPdfBuffer(10);
+      const model = 'anthropic.claude-sonnet-4-20250514-v1:0';
+      const result = await validatePdf(pdfBuffer, pdfBuffer.length, provider, undefined, model);
+
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should exempt Nova PDFs from the 4.5MB limit', async () => {
+      const pdfBuffer = createMockPdfBuffer(10);
+      const model = 'amazon.nova-pro-v1:0';
+      const result = await validatePdf(pdfBuffer, pdfBuffer.length, provider, undefined, model);
+
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should still enforce 4.5MB for non-exempt models without config override', async () => {
+      const pdfBuffer = createMockPdfBuffer(5);
+      const model = 'anthropic.claude-3-5-sonnet-20241022-v2:0';
+      const result = await validatePdf(pdfBuffer, pdfBuffer.length, provider, undefined, model);
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toContain('4.5MB');
+    });
+
+    it('should use 32MB as default limit for exempt Claude 4+ models', async () => {
+      const pdfBuffer = createMockPdfBuffer(30);
+      const model = 'anthropic.claude-opus-4-20250514-v1:0';
+      const result = await validatePdf(pdfBuffer, pdfBuffer.length, provider, undefined, model);
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should reject exempt model PDFs exceeding 32MB', async () => {
+      const pdfBuffer = createMockPdfBuffer(35);
+      const model = 'anthropic.claude-sonnet-4-20250514-v1:0';
+      const result = await validatePdf(pdfBuffer, pdfBuffer.length, provider, undefined, model);
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toContain('32.0MB');
     });
   });
 
@@ -218,7 +266,7 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
       expect(result.error).toBeUndefined();
     });
 
-    it('should reject non-PDF document exceeding 4.5MB hard limit', async () => {
+    it('should reject non-PDF document exceeding 4.5MB default limit', async () => {
       const fileSize = 5 * 1024 * 1024;
       const result = await validateBedrockDocument(fileSize, 'text/plain');
 
@@ -226,22 +274,52 @@ describe('PDF Validation with fileConfig.endpoints.*.fileSizeLimit', () => {
       expect(result.error).toContain('4.5MB');
     });
 
-    it('should clamp to 4.5MB even when config is higher for non-PDF', async () => {
+    it('should allow configured limit higher than 4.5MB for non-PDF', async () => {
       const fileSize = 5 * 1024 * 1024;
       const configuredLimit = mbToBytes(512);
-      const result = await validateBedrockDocument(fileSize, 'text/html', undefined, configuredLimit);
+      const result = await validateBedrockDocument(
+        fileSize,
+        'text/html',
+        undefined,
+        configuredLimit,
+      );
 
-      expect(result.isValid).toBe(false);
-      expect(result.error).toContain('4.5MB');
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
     });
 
     it('should use configured limit when lower than provider limit for non-PDF', async () => {
       const fileSize = 3 * 1024 * 1024;
       const configuredLimit = mbToBytes(2);
-      const result = await validateBedrockDocument(fileSize, 'text/markdown', undefined, configuredLimit);
+      const result = await validateBedrockDocument(
+        fileSize,
+        'text/markdown',
+        undefined,
+        configuredLimit,
+      );
 
       expect(result.isValid).toBe(false);
       expect(result.error).toContain('2.0MB');
+    });
+
+    it('should exempt Nova DOCX from 4.5MB limit', async () => {
+      const fileSize = 10 * 1024 * 1024;
+      const mimeType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+      const model = 'amazon.nova-pro-v1:0';
+      const result = await validateBedrockDocument(fileSize, mimeType, undefined, undefined, model);
+
+      expect(result.isValid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should NOT exempt Claude 4+ DOCX from 4.5MB limit (only PDF exempt)', async () => {
+      const fileSize = 5 * 1024 * 1024;
+      const mimeType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+      const model = 'anthropic.claude-sonnet-4-20250514-v1:0';
+      const result = await validateBedrockDocument(fileSize, mimeType, undefined, undefined, model);
+
+      expect(result.isValid).toBe(false);
+      expect(result.error).toContain('4.5MB');
     });
 
     it('should not run PDF header check on non-PDF types', async () => {

--- a/packages/api/src/files/validation.ts
+++ b/packages/api/src/files/validation.ts
@@ -31,13 +31,20 @@ export async function validatePdf(
   fileSize: number,
   provider: Providers,
   configuredFileSizeLimit?: number,
+  model?: string,
 ): Promise<PDFValidationResult> {
   if (provider === Providers.ANTHROPIC) {
     return validateAnthropicPdf(pdfBuffer, fileSize, configuredFileSizeLimit);
   }
 
   if (provider === Providers.BEDROCK) {
-    return validateBedrockDocument(fileSize, 'application/pdf', pdfBuffer, configuredFileSizeLimit);
+    return validateBedrockDocument(
+      fileSize,
+      'application/pdf',
+      pdfBuffer,
+      configuredFileSizeLimit,
+      model,
+    );
   }
 
   if (isOpenAILikeProvider(provider)) {
@@ -122,13 +129,46 @@ async function validateAnthropicPdf(
   }
 }
 
+/** Matches Bedrock Claude 4+ model identifiers (e.g. "anthropic.claude-sonnet-4-20250514-v1:0") */
+const isBedrockClaude4Plus = (model?: string): boolean =>
+  model != null &&
+  /anthropic\.claude-(?:[4-9](?:\.\d+)?(?:-\d+)?-(?:sonnet|opus|haiku)|(?:sonnet|opus|haiku)-[4-9])/.test(
+    model,
+  );
+
+/** Matches Bedrock Nova model identifiers (e.g. "amazon.nova-pro-v1:0") */
+const isBedrockNova = (model?: string): boolean => model != null && model.includes('amazon.nova');
+
+const pdfMimeType = 'application/pdf';
+const docxMimeType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
 /**
- * Validates a document against Bedrock's 4.5MB hard limit. PDF-specific header
- * checks run only when the MIME type is `application/pdf`.
+ * Returns true when the given model + MIME type combination is exempt from
+ * Bedrock's default 4.5 MB per-document limit.
+ *
+ * Per AWS docs (https://docs.aws.amazon.com/bedrock/latest/userguide/inference-api-restrictions.html):
+ * - Claude 4+: PDFs are exempt from the 4.5 MB limit
+ * - Nova: PDFs and DOCX are exempt from the 4.5 MB limit
+ */
+const isExemptFromBedrockDocLimit = (model?: string, mimeType?: string): boolean => {
+  if (mimeType === pdfMimeType) {
+    return isBedrockClaude4Plus(model) || isBedrockNova(model);
+  }
+  if (mimeType === docxMimeType) {
+    return isBedrockNova(model);
+  }
+  return false;
+};
+
+/**
+ * Validates a document against Bedrock size limits. The default limit is 4.5 MB,
+ * but Claude 4+ (PDF) and Nova (PDF/DOCX) models are exempt per AWS docs.
+ * When exempt, falls back to a 32 MB request-level limit as a reasonable upper bound.
  * @param fileSize - The file size in bytes
  * @param mimeType - The MIME type of the document
  * @param fileBuffer - The file buffer (used for PDF header validation)
  * @param configuredFileSizeLimit - Optional configured file size limit from fileConfig (in bytes)
+ * @param model - Optional Bedrock model identifier for model-specific limit exceptions
  * @returns Promise that resolves to validation result
  */
 export async function validateBedrockDocument(
@@ -136,14 +176,13 @@ export async function validateBedrockDocument(
   mimeType: string,
   fileBuffer?: Buffer,
   configuredFileSizeLimit?: number,
+  model?: string,
 ): Promise<ValidationResult> {
   try {
-    /** Bedrock enforces a hard 4.5MB per-document limit at the API level; config can only lower it */
-    const providerLimit = mbToBytes(4.5);
-    const effectiveLimit =
-      configuredFileSizeLimit != null
-        ? Math.min(configuredFileSizeLimit, providerLimit)
-        : providerLimit;
+    const exempt = isExemptFromBedrockDocLimit(model, mimeType);
+    /** Default 4.5 MB limit; exempt models fall back to 32 MB (Bedrock max request payload) */
+    const providerLimit = exempt ? mbToBytes(32) : mbToBytes(4.5);
+    const effectiveLimit = configuredFileSizeLimit ?? providerLimit;
 
     if (fileSize > effectiveLimit) {
       const limitMB = (effectiveLimit / (1024 * 1024)).toFixed(1);
@@ -153,7 +192,7 @@ export async function validateBedrockDocument(
       };
     }
 
-    if (mimeType === 'application/pdf' && fileBuffer) {
+    if (mimeType === pdfMimeType && fileBuffer) {
       if (fileBuffer.length < 5) {
         return {
           isValid: false,

--- a/packages/api/src/files/validation.ts
+++ b/packages/api/src/files/validation.ts
@@ -183,17 +183,9 @@ export async function validateBedrockDocument(
 ): Promise<ValidationResult> {
   try {
     const exempt = isExemptFromBedrockDocLimit(model, mimeType);
-    /** Default 4.5 MB limit; exempt models default to 32 MB (Bedrock max request payload) when unconfigured */
+    /** Default 4.5 MB; exempt models (Claude 4+ PDF, Nova PDF/DOCX) default to 32 MB when unconfigured */
     const providerLimit = exempt ? mbToBytes(32) : mbToBytes(4.5);
-    /**
-     * Exempt models: fileConfig can override the 32 MB default in either direction.
-     * Non-exempt models: fileConfig can only restrict below the hard 4.5 MB Bedrock API limit.
-     */
-    const effectiveLimit = exempt
-      ? (configuredFileSizeLimit ?? providerLimit)
-      : configuredFileSizeLimit != null
-        ? Math.min(configuredFileSizeLimit, providerLimit)
-        : providerLimit;
+    const effectiveLimit = configuredFileSizeLimit ?? providerLimit;
 
     if (fileSize > effectiveLimit) {
       const limitMB = (effectiveLimit / (1024 * 1024)).toFixed(1);

--- a/packages/api/src/files/validation.ts
+++ b/packages/api/src/files/validation.ts
@@ -130,17 +130,20 @@ async function validateAnthropicPdf(
 }
 
 /**
- * Matches Bedrock Claude 4+ model identifiers.
- * Pattern: anthropic.claude-{family}-{version≥4}-{date}-v{n}:{rev}
- * e.g. "anthropic.claude-sonnet-4-20250514-v1:0"
+ * Matches Bedrock Claude 4+ model identifiers, including cross-region inference profile IDs.
+ * Pattern: [region.]anthropic.claude-{family}-{version≥4}-{date}-v{n}:{rev}
+ * e.g. "anthropic.claude-sonnet-4-20250514-v1:0" or "us.anthropic.claude-sonnet-4-20250514-v1:0"
  */
-const BEDROCK_CLAUDE_4_PLUS_RE = /anthropic\.claude-(?:sonnet|opus|haiku)-[4-9]\d*-/;
+const BEDROCK_CLAUDE_4_PLUS_RE = /(?:^|\.)anthropic\.claude-(?:sonnet|opus|haiku)-[4-9]\d*-/;
 const isBedrockClaude4Plus = (model?: string): boolean =>
   model != null && BEDROCK_CLAUDE_4_PLUS_RE.test(model);
 
-/** Matches Bedrock Nova model identifiers (e.g. "amazon.nova-pro-v1:0") */
+/**
+ * Matches Bedrock Nova model identifiers, including cross-region inference profile IDs.
+ * e.g. "amazon.nova-pro-v1:0" or "us.amazon.nova-pro-v1:0"
+ */
 const isBedrockNova = (model?: string): boolean =>
-  model != null && model.startsWith('amazon.nova-');
+  model != null && /(?:^|\.)amazon\.nova-/.test(model);
 
 const pdfMimeType = 'application/pdf';
 const docxMimeType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';

--- a/packages/api/src/files/validation.ts
+++ b/packages/api/src/files/validation.ts
@@ -129,15 +129,18 @@ async function validateAnthropicPdf(
   }
 }
 
-/** Matches Bedrock Claude 4+ model identifiers (e.g. "anthropic.claude-sonnet-4-20250514-v1:0") */
+/**
+ * Matches Bedrock Claude 4+ model identifiers.
+ * Pattern: anthropic.claude-{family}-{version≥4}-{date}-v{n}:{rev}
+ * e.g. "anthropic.claude-sonnet-4-20250514-v1:0"
+ */
+const BEDROCK_CLAUDE_4_PLUS_RE = /anthropic\.claude-(?:sonnet|opus|haiku)-[4-9]\d*-/;
 const isBedrockClaude4Plus = (model?: string): boolean =>
-  model != null &&
-  /anthropic\.claude-(?:[4-9](?:\.\d+)?(?:-\d+)?-(?:sonnet|opus|haiku)|(?:sonnet|opus|haiku)-[4-9])/.test(
-    model,
-  );
+  model != null && BEDROCK_CLAUDE_4_PLUS_RE.test(model);
 
 /** Matches Bedrock Nova model identifiers (e.g. "amazon.nova-pro-v1:0") */
-const isBedrockNova = (model?: string): boolean => model != null && model.includes('amazon.nova');
+const isBedrockNova = (model?: string): boolean =>
+  model != null && model.startsWith('amazon.nova-');
 
 const pdfMimeType = 'application/pdf';
 const docxMimeType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
@@ -180,9 +183,17 @@ export async function validateBedrockDocument(
 ): Promise<ValidationResult> {
   try {
     const exempt = isExemptFromBedrockDocLimit(model, mimeType);
-    /** Default 4.5 MB limit; exempt models fall back to 32 MB (Bedrock max request payload) */
+    /** Default 4.5 MB limit; exempt models default to 32 MB (Bedrock max request payload) when unconfigured */
     const providerLimit = exempt ? mbToBytes(32) : mbToBytes(4.5);
-    const effectiveLimit = configuredFileSizeLimit ?? providerLimit;
+    /**
+     * Exempt models: fileConfig can override the 32 MB default in either direction.
+     * Non-exempt models: fileConfig can only restrict below the hard 4.5 MB Bedrock API limit.
+     */
+    const effectiveLimit = exempt
+      ? (configuredFileSizeLimit ?? providerLimit)
+      : configuredFileSizeLimit != null
+        ? Math.min(configuredFileSizeLimit, providerLimit)
+        : providerLimit;
 
     if (fileSize > effectiveLimit) {
       const limitMB = (effectiveLimit / (1024 * 1024)).toFixed(1);


### PR DESCRIPTION
## Summary

I removed the hard 4.5 MB clamp on Bedrock document uploads so that model-specific exceptions documented by AWS are respected. Previously, Bedrock was the only provider where `fileConfig` could not raise the size limit above the default — this change makes Bedrock consistent with every other provider.

- Add `model` parameter threading from `BaseClient.addDocuments()` through `encodeAndFormatDocuments` to `validateBedrockDocument`
- Introduce `isBedrockClaude4Plus()` and `isBedrockNova()` matchers to detect exempt model IDs
- Exempt Claude 4+ PDFs and Nova PDF/DOCX from the 4.5 MB default, using 32 MB (Bedrock max request payload) as the fallback limit
- Replace `Math.min(configuredFileSizeLimit, providerLimit)` with `configuredFileSizeLimit ?? providerLimit` so `fileConfig` can override in either direction, matching Anthropic/OpenAI/Google behavior
- Preserve the 4.5 MB default for non-exempt Bedrock models and document types
- Update validation and document encoding tests to cover model-specific exemptions and the new override behavior

**Ref:** [AWS Bedrock inference API restrictions](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-api-restrictions.html) — Claude 4+ PDFs and Nova PDF/DOCX are exceptions to the 4.5 MB per-document limit.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran the full validation and document encoding test suites (84 tests passing):

```
npx jest src/files/validation.spec.ts src/files/encode/document.spec.ts --no-coverage
```

Key test scenarios added:
- Claude 4+ model (`anthropic.claude-sonnet-4-20250514-v1:0`) accepts PDFs >4.5 MB up to 32 MB
- Nova model (`amazon.nova-pro-v1:0`) accepts PDFs and DOCX >4.5 MB
- Claude 4+ DOCX is **not** exempt (only PDF per AWS docs)
- Non-exempt models (e.g. Claude 3.5) still enforce the 4.5 MB default
- `fileConfig` can now raise **or** lower Bedrock limits (previously could only lower)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes