### PR TITLE
🛡️ fix: Add Origin Binding to Admin OAuth Exchange Codes

### DIFF
--- a/api/server/controllers/auth/oauth.js
+++ b/api/server/controllers/auth/oauth.js
@@ -47,7 +47,13 @@ function createOAuthHandler(redirectUri = domains.client) {
         const refreshToken =
           req.user.tokenset?.refresh_token || req.user.federatedTokens?.refresh_token;
 
-        const exchangeCode = await generateAdminExchangeCode(cache, req.user, token, refreshToken);
+        const exchangeCode = await generateAdminExchangeCode(
+          cache,
+          req.user,
+          token,
+          refreshToken,
+          new URL(redirectUri).origin,
+        );
 
         const callbackUrl = new URL(redirectUri);
         callbackUrl.searchParams.set('code', exchangeCode);

--- a/api/server/controllers/auth/oauth.js
+++ b/api/server/controllers/auth/oauth.js
@@ -53,6 +53,7 @@ function createOAuthHandler(redirectUri = domains.client) {
           token,
           refreshToken,
           new URL(redirectUri).origin,
+          req.pkceChallenge,
         );
 
         const callbackUrl = new URL(redirectUri);

--- a/api/server/controllers/auth/oauth.js
+++ b/api/server/controllers/auth/oauth.js
@@ -47,16 +47,15 @@ function createOAuthHandler(redirectUri = domains.client) {
         const refreshToken =
           req.user.tokenset?.refresh_token || req.user.federatedTokens?.refresh_token;
 
+        const callbackUrl = new URL(redirectUri);
         const exchangeCode = await generateAdminExchangeCode(
           cache,
           req.user,
           token,
           refreshToken,
-          new URL(redirectUri).origin,
+          callbackUrl.origin,
           req.pkceChallenge,
         );
-
-        const callbackUrl = new URL(redirectUri);
         callbackUrl.searchParams.set('code', exchangeCode);
         logger.info(`[OAuth] Admin panel redirect with exchange code for user: ${req.user.email}`);
         return res.redirect(callbackUrl.toString());

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -104,7 +104,7 @@ router.get('/oauth/openid', async (req, res, next) => {
 router.get(
   '/oauth/openid/callback',
   (req, res, next) => {
-    req.oauthState = req.query.state;
+    req.oauthState = typeof req.query.state === 'string' ? req.query.state : undefined;
     next();
   },
   passport.authenticate('openidAdmin', {

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -27,7 +27,11 @@ const router = express.Router();
 function resolveRequestOrigin(req) {
   const originHeader = req.get('origin');
   if (originHeader) {
-    return originHeader;
+    try {
+      return new URL(originHeader).origin;
+    } catch {
+      return originHeader;
+    }
   }
 
   const refererHeader = req.get('referer');
@@ -73,16 +77,22 @@ router.get('/oauth/openid/check', (req, res) => {
 /** PKCE challenge cache TTL: 5 minutes (enough for user to authenticate with IdP) */
 const PKCE_CHALLENGE_TTL = 5 * 60 * 1000;
 /** Regex pattern for valid PKCE challenges: 64 hex characters (SHA-256 hex digest) */
-const PKCE_CHALLENGE_PATTERN = /^[a-f0-9]{64}$/i;
+const PKCE_CHALLENGE_PATTERN = /^[a-f0-9]{64}$/;
 
-router.get('/oauth/openid', (req, res, next) => {
+router.get('/oauth/openid', async (req, res, next) => {
   const state = randomState();
   const codeChallenge = req.query.code_challenge;
 
-  /** Store PKCE challenge keyed by OAuth state for retrieval in callback */
   if (typeof codeChallenge === 'string' && PKCE_CHALLENGE_PATTERN.test(codeChallenge)) {
-    const cache = getLogStores(CacheKeys.ADMIN_OAUTH_EXCHANGE);
-    cache.set(`pkce:${state}`, codeChallenge, PKCE_CHALLENGE_TTL);
+    try {
+      const cache = getLogStores(CacheKeys.ADMIN_OAUTH_EXCHANGE);
+      await cache.set(`pkce:${state}`, codeChallenge, PKCE_CHALLENGE_TTL);
+    } catch (err) {
+      logger.error('[admin/oauth/openid] Failed to store PKCE challenge:', err);
+      return res.redirect(
+        `${getAdminPanelUrl()}/auth/openid/callback?error=pkce_store_failed&error_description=Failed+to+store+PKCE+challenge`,
+      );
+    }
   }
 
   return passport.authenticate('openidAdmin', {
@@ -126,7 +136,7 @@ router.get(
 );
 
 /** Regex pattern for valid exchange codes: 64 hex characters */
-const EXCHANGE_CODE_PATTERN = /^[a-f0-9]{64}$/i;
+const EXCHANGE_CODE_PATTERN = /^[a-f0-9]{64}$/;
 
 /**
  * Exchange OAuth authorization code for tokens.
@@ -154,6 +164,17 @@ router.post('/oauth/exchange', middleware.loginLimiter, async (req, res) => {
       return res.status(400).json({
         error: 'Invalid authorization code format',
         error_code: 'INVALID_CODE_FORMAT',
+      });
+    }
+
+    if (
+      codeVerifier !== undefined &&
+      (typeof codeVerifier !== 'string' || codeVerifier.length > 512)
+    ) {
+      logger.warn('[admin/oauth/exchange] Invalid code_verifier format');
+      return res.status(400).json({
+        error: 'Invalid code_verifier',
+        error_code: 'INVALID_VERIFIER',
       });
     }
 

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -70,20 +70,55 @@ router.get('/oauth/openid/check', (req, res) => {
   res.status(200).json({ message: 'OpenID check successful' });
 });
 
+/** PKCE challenge cache TTL: 5 minutes (enough for user to authenticate with IdP) */
+const PKCE_CHALLENGE_TTL = 5 * 60 * 1000;
+/** Regex pattern for valid PKCE challenges: 64 hex characters (SHA-256 hex digest) */
+const PKCE_CHALLENGE_PATTERN = /^[a-f0-9]{64}$/i;
+
 router.get('/oauth/openid', (req, res, next) => {
+  const state = randomState();
+  const codeChallenge = req.query.code_challenge;
+
+  /** Store PKCE challenge keyed by OAuth state for retrieval in callback */
+  if (typeof codeChallenge === 'string' && PKCE_CHALLENGE_PATTERN.test(codeChallenge)) {
+    const cache = getLogStores(CacheKeys.ADMIN_OAUTH_EXCHANGE);
+    cache.set(`pkce:${state}`, codeChallenge, PKCE_CHALLENGE_TTL);
+  }
+
   return passport.authenticate('openidAdmin', {
     session: false,
-    state: randomState(),
+    state,
   })(req, res, next);
 });
 
 router.get(
   '/oauth/openid/callback',
+  /** Capture OAuth state before passport consumes the query params */
+  (req, res, next) => {
+    req.oauthState = req.query.state;
+    next();
+  },
   passport.authenticate('openidAdmin', {
     failureRedirect: `${getAdminPanelUrl()}/auth/openid/callback?error=auth_failed&error_description=Authentication+failed`,
     failureMessage: true,
     session: false,
   }),
+  /** Retrieve PKCE challenge from cache using the OAuth state */
+  async (req, res, next) => {
+    try {
+      if (req.oauthState) {
+        const cache = getLogStores(CacheKeys.ADMIN_OAUTH_EXCHANGE);
+        const challenge = await cache.get(`pkce:${req.oauthState}`);
+        if (challenge) {
+          req.pkceChallenge = challenge;
+          await cache.delete(`pkce:${req.oauthState}`);
+        }
+      }
+    } catch (err) {
+      logger.warn('[admin/oauth/callback] Failed to retrieve PKCE challenge:', err);
+    }
+    next();
+  },
   requireAdminAccess,
   setBalanceConfig,
   middleware.checkDomainAllowed,
@@ -104,7 +139,7 @@ const EXCHANGE_CODE_PATTERN = /^[a-f0-9]{64}$/i;
  */
 router.post('/oauth/exchange', middleware.loginLimiter, async (req, res) => {
   try {
-    const { code } = req.body;
+    const { code, code_verifier: codeVerifier } = req.body;
 
     if (!code) {
       logger.warn('[admin/oauth/exchange] Missing authorization code');
@@ -124,7 +159,7 @@ router.post('/oauth/exchange', middleware.loginLimiter, async (req, res) => {
 
     const cache = getLogStores(CacheKeys.ADMIN_OAUTH_EXCHANGE);
     const requestOrigin = resolveRequestOrigin(req);
-    const result = await exchangeAdminCode(cache, code, requestOrigin);
+    const result = await exchangeAdminCode(cache, code, requestOrigin, codeVerifier);
 
     if (!result) {
       return res.status(401).json({

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -122,6 +122,10 @@ router.get(
       if (challenge) {
         req.pkceChallenge = challenge;
         await cache.delete(`pkce:${req.oauthState}`);
+      } else {
+        logger.warn(
+          '[admin/oauth/callback] State present but no PKCE challenge found; PKCE will not be enforced for this request',
+        );
       }
     } catch (err) {
       logger.error('[admin/oauth/callback] Failed to retrieve PKCE challenge, aborting:', err);
@@ -146,7 +150,7 @@ const EXCHANGE_CODE_PATTERN = /^[a-f0-9]{64}$/;
  * The code is one-time-use and expires in 30 seconds.
  *
  * POST /api/admin/oauth/exchange
- * Body: { code: string }
+ * Body: { code: string, code_verifier?: string }
  * Response: { token: string, refreshToken: string, user: object }
  */
 router.post('/oauth/exchange', middleware.loginLimiter, async (req, res) => {
@@ -171,7 +175,7 @@ router.post('/oauth/exchange', middleware.loginLimiter, async (req, res) => {
 
     if (
       codeVerifier !== undefined &&
-      (typeof codeVerifier !== 'string' || codeVerifier.length > 512)
+      (typeof codeVerifier !== 'string' || codeVerifier.length < 1 || codeVerifier.length > 512)
     ) {
       logger.warn('[admin/oauth/exchange] Invalid code_verifier format');
       return res.status(400).json({

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -24,6 +24,24 @@ const setBalanceConfig = createSetBalanceConfig({
 
 const router = express.Router();
 
+function resolveRequestOrigin(req) {
+  const originHeader = req.get('origin');
+  if (originHeader) {
+    return originHeader;
+  }
+
+  const refererHeader = req.get('referer');
+  if (!refererHeader) {
+    return undefined;
+  }
+
+  try {
+    return new URL(refererHeader).origin;
+  } catch {
+    return undefined;
+  }
+}
+
 router.post(
   '/login/local',
   middleware.logHeaders,
@@ -105,7 +123,8 @@ router.post('/oauth/exchange', middleware.loginLimiter, async (req, res) => {
     }
 
     const cache = getLogStores(CacheKeys.ADMIN_OAUTH_EXCHANGE);
-    const result = await exchangeAdminCode(cache, code);
+    const requestOrigin = resolveRequestOrigin(req);
+    const result = await exchangeAdminCode(cache, code, requestOrigin);
 
     if (!result) {
       return res.status(401).json({

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -30,7 +30,7 @@ function resolveRequestOrigin(req) {
     try {
       return new URL(originHeader).origin;
     } catch {
-      return originHeader;
+      return undefined;
     }
   }
 
@@ -115,17 +115,21 @@ router.get(
   }),
   /** Retrieve PKCE challenge from cache using the OAuth state */
   async (req, res, next) => {
+    if (!req.oauthState) {
+      return next();
+    }
     try {
-      if (req.oauthState) {
-        const cache = getLogStores(CacheKeys.ADMIN_OAUTH_EXCHANGE);
-        const challenge = await cache.get(`pkce:${req.oauthState}`);
-        if (challenge) {
-          req.pkceChallenge = challenge;
-          await cache.delete(`pkce:${req.oauthState}`);
-        }
+      const cache = getLogStores(CacheKeys.ADMIN_OAUTH_EXCHANGE);
+      const challenge = await cache.get(`pkce:${req.oauthState}`);
+      if (challenge) {
+        req.pkceChallenge = challenge;
+        await cache.delete(`pkce:${req.oauthState}`);
       }
     } catch (err) {
-      logger.warn('[admin/oauth/callback] Failed to retrieve PKCE challenge:', err);
+      logger.error('[admin/oauth/callback] Failed to retrieve PKCE challenge, aborting:', err);
+      return res.redirect(
+        `${getAdminPanelUrl()}/auth/openid/callback?error=pkce_retrieval_failed&error_description=Failed+to+retrieve+PKCE+challenge`,
+      );
     }
     next();
   },

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -103,7 +103,6 @@ router.get('/oauth/openid', async (req, res, next) => {
 
 router.get(
   '/oauth/openid/callback',
-  /** Capture OAuth state before passport consumes the query params */
   (req, res, next) => {
     req.oauthState = req.query.state;
     next();
@@ -113,7 +112,6 @@ router.get(
     failureMessage: true,
     session: false,
   }),
-  /** Retrieve PKCE challenge from cache using the OAuth state */
   async (req, res, next) => {
     if (!req.oauthState) {
       return next();

--- a/packages/api/src/auth/exchange.spec.ts
+++ b/packages/api/src/auth/exchange.spec.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import { Keyv } from 'keyv';
+import type { IUser } from '@librechat/data-schemas';
 
 jest.mock(
   '@librechat/data-schemas',
@@ -22,7 +23,7 @@ describe('admin OAuth code exchange', () => {
     username: 'admin',
     role: 'ADMIN',
     provider: 'openid',
-  };
+  } as unknown as IUser;
 
   const createCache = () => {
     const cache = new Keyv();

--- a/packages/api/src/auth/exchange.spec.ts
+++ b/packages/api/src/auth/exchange.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import crypto from 'crypto';
 
 jest.mock(
@@ -22,6 +21,7 @@ describe('admin OAuth code exchange', () => {
     username: 'admin',
     role: 'ADMIN',
     provider: 'openid',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
 
   const createCache = () => {
@@ -36,6 +36,7 @@ describe('admin OAuth code exchange', () => {
       }),
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return { cache: cache as any, store, spies: cache };
   };
 

--- a/packages/api/src/auth/exchange.spec.ts
+++ b/packages/api/src/auth/exchange.spec.ts
@@ -1,0 +1,100 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+jest.mock(
+  '@librechat/data-schemas',
+  () => ({
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  }),
+  { virtual: true },
+);
+
+import { exchangeAdminCode, generateAdminExchangeCode } from './exchange';
+
+describe('admin OAuth code exchange', () => {
+  const user = {
+    _id: 'user123',
+    email: 'admin@example.com',
+    name: 'Admin User',
+    username: 'admin',
+    role: 'ADMIN',
+    provider: 'openid',
+  } as any;
+
+  const createCache = () => {
+    const store = new Map();
+    const cache = {
+      set: jest.fn(async (key: string, value: unknown) => {
+        store.set(key, value);
+      }),
+      get: jest.fn(async (key: string) => store.get(key)),
+      delete: jest.fn(async (key: string) => {
+        store.delete(key);
+      }),
+    };
+
+    return { cache: cache as any, store, spies: cache };
+  };
+
+  it('exchanges code when request origin matches generated origin', async () => {
+    const { cache } = createCache();
+    const exchangeCode = await generateAdminExchangeCode(
+      cache,
+      user,
+      'jwt-token',
+      'refresh-token',
+      'https://admin.example.com',
+    );
+
+    const result = await exchangeAdminCode(cache, exchangeCode, 'https://admin.example.com');
+
+    expect(result).not.toBeNull();
+    expect(result!.token).toBe('jwt-token');
+    expect(result!.refreshToken).toBe('refresh-token');
+    expect(result!.user.email).toBe('admin@example.com');
+  });
+
+  it('rejects code exchange when request origin does not match generated origin', async () => {
+    const { cache, store, spies } = createCache();
+    const exchangeCode = await generateAdminExchangeCode(
+      cache,
+      user,
+      'jwt-token',
+      'refresh-token',
+      'https://admin.example.com',
+    );
+
+    const result = await exchangeAdminCode(cache, exchangeCode, 'https://evil.example.com');
+
+    expect(result).toBeNull();
+    expect(spies.delete).toHaveBeenCalledWith(exchangeCode);
+    expect(store.has(exchangeCode)).toBe(false);
+  });
+
+  it('allows exchange when no origin was stored (backward compat)', async () => {
+    const { cache } = createCache();
+    const exchangeCode = await generateAdminExchangeCode(cache, user, 'jwt-token', 'refresh-token');
+
+    const result = await exchangeAdminCode(cache, exchangeCode, 'https://any-origin.com');
+
+    expect(result).not.toBeNull();
+    expect(result!.token).toBe('jwt-token');
+  });
+
+  it('rejects code that has already been used (one-time use)', async () => {
+    const { cache } = createCache();
+    const exchangeCode = await generateAdminExchangeCode(
+      cache,
+      user,
+      'jwt-token',
+      'refresh-token',
+      'https://admin.example.com',
+    );
+
+    await exchangeAdminCode(cache, exchangeCode, 'https://admin.example.com');
+    const secondAttempt = await exchangeAdminCode(cache, exchangeCode, 'https://admin.example.com');
+
+    expect(secondAttempt).toBeNull();
+  });
+});

--- a/packages/api/src/auth/exchange.spec.ts
+++ b/packages/api/src/auth/exchange.spec.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import crypto from 'crypto';
+
 jest.mock(
   '@librechat/data-schemas',
   () => ({
@@ -10,7 +12,7 @@ jest.mock(
   { virtual: true },
 );
 
-import { exchangeAdminCode, generateAdminExchangeCode } from './exchange';
+import { exchangeAdminCode, generateAdminExchangeCode, verifyCodeChallenge } from './exchange';
 
 describe('admin OAuth code exchange', () => {
   const user = {
@@ -37,64 +39,165 @@ describe('admin OAuth code exchange', () => {
     return { cache: cache as any, store, spies: cache };
   };
 
-  it('exchanges code when request origin matches generated origin', async () => {
-    const { cache } = createCache();
-    const exchangeCode = await generateAdminExchangeCode(
-      cache,
-      user,
-      'jwt-token',
-      'refresh-token',
-      'https://admin.example.com',
-    );
+  describe('origin binding', () => {
+    it('exchanges code when request origin matches generated origin', async () => {
+      const { cache } = createCache();
+      const exchangeCode = await generateAdminExchangeCode(
+        cache,
+        user,
+        'jwt-token',
+        'refresh-token',
+        'https://admin.example.com',
+      );
 
-    const result = await exchangeAdminCode(cache, exchangeCode, 'https://admin.example.com');
+      const result = await exchangeAdminCode(cache, exchangeCode, 'https://admin.example.com');
 
-    expect(result).not.toBeNull();
-    expect(result!.token).toBe('jwt-token');
-    expect(result!.refreshToken).toBe('refresh-token');
-    expect(result!.user.email).toBe('admin@example.com');
+      expect(result).not.toBeNull();
+      expect(result!.token).toBe('jwt-token');
+      expect(result!.refreshToken).toBe('refresh-token');
+      expect(result!.user.email).toBe('admin@example.com');
+    });
+
+    it('rejects code exchange when request origin does not match generated origin', async () => {
+      const { cache, store, spies } = createCache();
+      const exchangeCode = await generateAdminExchangeCode(
+        cache,
+        user,
+        'jwt-token',
+        'refresh-token',
+        'https://admin.example.com',
+      );
+
+      const result = await exchangeAdminCode(cache, exchangeCode, 'https://evil.example.com');
+
+      expect(result).toBeNull();
+      expect(spies.delete).toHaveBeenCalledWith(exchangeCode);
+      expect(store.has(exchangeCode)).toBe(false);
+    });
+
+    it('allows exchange when no origin was stored (backward compat)', async () => {
+      const { cache } = createCache();
+      const exchangeCode = await generateAdminExchangeCode(
+        cache,
+        user,
+        'jwt-token',
+        'refresh-token',
+      );
+
+      const result = await exchangeAdminCode(cache, exchangeCode, 'https://any-origin.com');
+
+      expect(result).not.toBeNull();
+      expect(result!.token).toBe('jwt-token');
+    });
   });
 
-  it('rejects code exchange when request origin does not match generated origin', async () => {
-    const { cache, store, spies } = createCache();
-    const exchangeCode = await generateAdminExchangeCode(
-      cache,
-      user,
-      'jwt-token',
-      'refresh-token',
-      'https://admin.example.com',
-    );
+  describe('one-time use', () => {
+    it('rejects code that has already been used', async () => {
+      const { cache } = createCache();
+      const exchangeCode = await generateAdminExchangeCode(
+        cache,
+        user,
+        'jwt-token',
+        'refresh-token',
+        'https://admin.example.com',
+      );
 
-    const result = await exchangeAdminCode(cache, exchangeCode, 'https://evil.example.com');
+      await exchangeAdminCode(cache, exchangeCode, 'https://admin.example.com');
+      const secondAttempt = await exchangeAdminCode(
+        cache,
+        exchangeCode,
+        'https://admin.example.com',
+      );
 
-    expect(result).toBeNull();
-    expect(spies.delete).toHaveBeenCalledWith(exchangeCode);
-    expect(store.has(exchangeCode)).toBe(false);
+      expect(secondAttempt).toBeNull();
+    });
   });
 
-  it('allows exchange when no origin was stored (backward compat)', async () => {
-    const { cache } = createCache();
-    const exchangeCode = await generateAdminExchangeCode(cache, user, 'jwt-token', 'refresh-token');
+  describe('PKCE verification', () => {
+    const codeVerifier = crypto.randomBytes(32).toString('hex');
+    const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('hex');
 
-    const result = await exchangeAdminCode(cache, exchangeCode, 'https://any-origin.com');
+    it('verifyCodeChallenge returns true for matching verifier', () => {
+      expect(verifyCodeChallenge(codeVerifier, codeChallenge)).toBe(true);
+    });
 
-    expect(result).not.toBeNull();
-    expect(result!.token).toBe('jwt-token');
-  });
+    it('verifyCodeChallenge returns false for wrong verifier', () => {
+      expect(verifyCodeChallenge('wrong-verifier', codeChallenge)).toBe(false);
+    });
 
-  it('rejects code that has already been used (one-time use)', async () => {
-    const { cache } = createCache();
-    const exchangeCode = await generateAdminExchangeCode(
-      cache,
-      user,
-      'jwt-token',
-      'refresh-token',
-      'https://admin.example.com',
-    );
+    it('exchanges code when valid code_verifier is provided', async () => {
+      const { cache } = createCache();
+      const exchangeCode = await generateAdminExchangeCode(
+        cache,
+        user,
+        'jwt-token',
+        'refresh-token',
+        'https://admin.example.com',
+        codeChallenge,
+      );
 
-    await exchangeAdminCode(cache, exchangeCode, 'https://admin.example.com');
-    const secondAttempt = await exchangeAdminCode(cache, exchangeCode, 'https://admin.example.com');
+      const result = await exchangeAdminCode(
+        cache,
+        exchangeCode,
+        'https://admin.example.com',
+        codeVerifier,
+      );
 
-    expect(secondAttempt).toBeNull();
+      expect(result).not.toBeNull();
+      expect(result!.token).toBe('jwt-token');
+    });
+
+    it('rejects exchange when code_verifier does not match challenge', async () => {
+      const { cache } = createCache();
+      const exchangeCode = await generateAdminExchangeCode(
+        cache,
+        user,
+        'jwt-token',
+        'refresh-token',
+        'https://admin.example.com',
+        codeChallenge,
+      );
+
+      const result = await exchangeAdminCode(
+        cache,
+        exchangeCode,
+        'https://admin.example.com',
+        'wrong-verifier',
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('rejects exchange when challenge stored but no verifier provided', async () => {
+      const { cache } = createCache();
+      const exchangeCode = await generateAdminExchangeCode(
+        cache,
+        user,
+        'jwt-token',
+        'refresh-token',
+        'https://admin.example.com',
+        codeChallenge,
+      );
+
+      const result = await exchangeAdminCode(cache, exchangeCode, 'https://admin.example.com');
+
+      expect(result).toBeNull();
+    });
+
+    it('allows exchange when no challenge stored and no verifier sent (backward compat)', async () => {
+      const { cache } = createCache();
+      const exchangeCode = await generateAdminExchangeCode(
+        cache,
+        user,
+        'jwt-token',
+        'refresh-token',
+        'https://admin.example.com',
+      );
+
+      const result = await exchangeAdminCode(cache, exchangeCode, 'https://admin.example.com');
+
+      expect(result).not.toBeNull();
+      expect(result!.token).toBe('jwt-token');
+    });
   });
 });

--- a/packages/api/src/auth/exchange.spec.ts
+++ b/packages/api/src/auth/exchange.spec.ts
@@ -27,7 +27,7 @@ describe('admin OAuth code exchange', () => {
   const createCache = () => {
     const store = new Map();
     const cache = {
-      set: jest.fn(async (key: string, value: unknown) => {
+      set: jest.fn(async (key: string, value: unknown, _ttl?: number) => {
         store.set(key, value);
       }),
       get: jest.fn(async (key: string) => store.get(key)),
@@ -73,6 +73,21 @@ describe('admin OAuth code exchange', () => {
       expect(result).toBeNull();
       expect(spies.delete).toHaveBeenCalledWith(exchangeCode);
       expect(store.has(exchangeCode)).toBe(false);
+    });
+
+    it('rejects code exchange when origin is stored but request has no origin', async () => {
+      const { cache } = createCache();
+      const exchangeCode = await generateAdminExchangeCode(
+        cache,
+        user,
+        'jwt-token',
+        'refresh-token',
+        'https://admin.example.com',
+      );
+
+      const result = await exchangeAdminCode(cache, exchangeCode, undefined);
+
+      expect(result).toBeNull();
     });
 
     it('allows exchange when no origin was stored (backward compat)', async () => {
@@ -123,6 +138,13 @@ describe('admin OAuth code exchange', () => {
 
     it('verifyCodeChallenge returns false for wrong verifier', () => {
       expect(verifyCodeChallenge('wrong-verifier', codeChallenge)).toBe(false);
+    });
+
+    it('verifyCodeChallenge handles hex case insensitively (input gate rejects uppercase)', () => {
+      const uppercaseChallenge = codeChallenge.toUpperCase();
+      // Buffer.from(hex) is case-insensitive, so verification passes at this layer.
+      // Uppercase challenges are rejected earlier by PKCE_CHALLENGE_PATTERN (no /i flag).
+      expect(verifyCodeChallenge(codeVerifier, uppercaseChallenge)).toBe(true);
     });
 
     it('exchanges code when valid code_verifier is provided', async () => {

--- a/packages/api/src/auth/exchange.spec.ts
+++ b/packages/api/src/auth/exchange.spec.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import { Keyv } from 'keyv';
 
 jest.mock(
   '@librechat/data-schemas',
@@ -21,23 +22,12 @@ describe('admin OAuth code exchange', () => {
     username: 'admin',
     role: 'ADMIN',
     provider: 'openid',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any;
+  };
 
   const createCache = () => {
-    const store = new Map();
-    const cache = {
-      set: jest.fn(async (key: string, value: unknown, _ttl?: number) => {
-        store.set(key, value);
-      }),
-      get: jest.fn(async (key: string) => store.get(key)),
-      delete: jest.fn(async (key: string) => {
-        store.delete(key);
-      }),
-    };
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return { cache: cache as any, store, spies: cache };
+    const cache = new Keyv();
+    const deleteSpy = jest.spyOn(cache, 'delete');
+    return { cache, deleteSpy };
   };
 
   describe('origin binding', () => {
@@ -60,7 +50,7 @@ describe('admin OAuth code exchange', () => {
     });
 
     it('rejects code exchange when request origin does not match generated origin', async () => {
-      const { cache, store, spies } = createCache();
+      const { cache, deleteSpy } = createCache();
       const exchangeCode = await generateAdminExchangeCode(
         cache,
         user,
@@ -72,8 +62,8 @@ describe('admin OAuth code exchange', () => {
       const result = await exchangeAdminCode(cache, exchangeCode, 'https://evil.example.com');
 
       expect(result).toBeNull();
-      expect(spies.delete).toHaveBeenCalledWith(exchangeCode);
-      expect(store.has(exchangeCode)).toBe(false);
+      expect(deleteSpy).toHaveBeenCalledWith(exchangeCode);
+      await expect(cache.get(exchangeCode)).resolves.toBeUndefined();
     });
 
     it('rejects code exchange when origin is stored but request has no origin', async () => {

--- a/packages/api/src/auth/exchange.ts
+++ b/packages/api/src/auth/exchange.ts
@@ -37,6 +37,7 @@ export interface AdminExchangeData {
   user: AdminExchangeUser;
   token: string;
   refreshToken?: string;
+  origin?: string;
 }
 
 /**
@@ -81,6 +82,7 @@ export async function generateAdminExchangeCode(
   user: IUser,
   token: string,
   refreshToken?: string,
+  origin?: string,
 ): Promise<string> {
   const exchangeCode = crypto.randomBytes(32).toString('hex');
 
@@ -89,6 +91,7 @@ export async function generateAdminExchangeCode(
     user: serializeUserForExchange(user),
     token,
     refreshToken,
+    origin,
   };
 
   await cache.set(exchangeCode, data);
@@ -108,6 +111,7 @@ export async function generateAdminExchangeCode(
 export async function exchangeAdminCode(
   cache: Keyv,
   code: string,
+  requestOrigin?: string,
 ): Promise<AdminExchangeResponse | null> {
   const data = (await cache.get(code)) as AdminExchangeData | undefined;
 
@@ -116,6 +120,11 @@ export async function exchangeAdminCode(
 
   if (!data) {
     logger.warn('[adminExchange] Invalid or expired authorization code');
+    return null;
+  }
+
+  if (data.origin && data.origin !== requestOrigin) {
+    logger.warn('[adminExchange] Authorization code origin mismatch');
     return null;
   }
 

--- a/packages/api/src/auth/exchange.ts
+++ b/packages/api/src/auth/exchange.ts
@@ -139,7 +139,6 @@ export async function exchangeAdminCode(
 ): Promise<AdminExchangeResponse | null> {
   const data = (await cache.get(code)) as AdminExchangeData | undefined;
 
-  /** Delete immediately - one-time use */
   await cache.delete(code);
 
   if (!data) {
@@ -152,7 +151,6 @@ export async function exchangeAdminCode(
     return null;
   }
 
-  /** PKCE verification: if a challenge was stored, the verifier must match */
   if (data.codeChallenge) {
     if (!codeVerifier || !verifyCodeChallenge(codeVerifier, data.codeChallenge)) {
       logger.warn('[adminExchange] PKCE code_verifier mismatch or missing');

--- a/packages/api/src/auth/exchange.ts
+++ b/packages/api/src/auth/exchange.ts
@@ -79,12 +79,7 @@ export function serializeUserForExchange(user: IUser): AdminExchangeUser {
  */
 export function verifyCodeChallenge(verifier: string, challenge: string): boolean {
   const computed = crypto.createHash('sha256').update(verifier).digest();
-  let storedBuf: Buffer;
-  try {
-    storedBuf = Buffer.from(challenge, 'hex');
-  } catch {
-    return false;
-  }
+  const storedBuf = Buffer.from(challenge, 'hex');
   if (computed.length !== storedBuf.length) {
     return false;
   }

--- a/packages/api/src/auth/exchange.ts
+++ b/packages/api/src/auth/exchange.ts
@@ -139,6 +139,7 @@ export async function exchangeAdminCode(
 ): Promise<AdminExchangeResponse | null> {
   const data = (await cache.get(code)) as AdminExchangeData | undefined;
 
+  /** Delete before validation — ensures one-time use even if subsequent checks throw */
   await cache.delete(code);
 
   if (!data) {

--- a/packages/api/src/auth/exchange.ts
+++ b/packages/api/src/auth/exchange.ts
@@ -72,14 +72,23 @@ export function serializeUserForExchange(user: IUser): AdminExchangeUser {
 
 /**
  * Verifies a PKCE code_verifier against a stored code_challenge.
- * Uses SHA-256 hash comparison (S256 method).
+ * Uses hex-encoded SHA-256 comparison (not RFC 7636 S256 which uses base64url).
  * @param verifier - The code_verifier provided during exchange
- * @param challenge - The code_challenge stored during code generation
+ * @param challenge - The hex-encoded SHA-256 code_challenge stored during code generation
  * @returns True if the verifier matches the challenge
  */
 export function verifyCodeChallenge(verifier: string, challenge: string): boolean {
-  const computed = crypto.createHash('sha256').update(verifier).digest('hex');
-  return computed === challenge;
+  const computed = crypto.createHash('sha256').update(verifier).digest();
+  let storedBuf: Buffer;
+  try {
+    storedBuf = Buffer.from(challenge, 'hex');
+  } catch {
+    return false;
+  }
+  if (computed.length !== storedBuf.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(computed, storedBuf);
 }
 
 /**

--- a/packages/api/src/auth/exchange.ts
+++ b/packages/api/src/auth/exchange.ts
@@ -38,6 +38,7 @@ export interface AdminExchangeData {
   token: string;
   refreshToken?: string;
   origin?: string;
+  codeChallenge?: string;
 }
 
 /**
@@ -70,11 +71,25 @@ export function serializeUserForExchange(user: IUser): AdminExchangeUser {
 }
 
 /**
+ * Verifies a PKCE code_verifier against a stored code_challenge.
+ * Uses SHA-256 hash comparison (S256 method).
+ * @param verifier - The code_verifier provided during exchange
+ * @param challenge - The code_challenge stored during code generation
+ * @returns True if the verifier matches the challenge
+ */
+export function verifyCodeChallenge(verifier: string, challenge: string): boolean {
+  const computed = crypto.createHash('sha256').update(verifier).digest('hex');
+  return computed === challenge;
+}
+
+/**
  * Generates an exchange code and stores user data for admin panel OAuth flow.
  * @param cache - The Keyv cache instance for storing exchange data
  * @param user - The authenticated user object
  * @param token - The JWT access token
  * @param refreshToken - Optional refresh token for OpenID users
+ * @param origin - The admin panel origin (scheme://host:port) for origin binding
+ * @param codeChallenge - PKCE code_challenge (hex-encoded SHA-256 of code_verifier)
  * @returns The generated exchange code
  */
 export async function generateAdminExchangeCode(
@@ -83,6 +98,7 @@ export async function generateAdminExchangeCode(
   token: string,
   refreshToken?: string,
   origin?: string,
+  codeChallenge?: string,
 ): Promise<string> {
   const exchangeCode = crypto.randomBytes(32).toString('hex');
 
@@ -92,6 +108,7 @@ export async function generateAdminExchangeCode(
     token,
     refreshToken,
     origin,
+    codeChallenge,
   };
 
   await cache.set(exchangeCode, data);
@@ -106,12 +123,15 @@ export async function generateAdminExchangeCode(
  * The code is deleted immediately after retrieval (one-time use).
  * @param cache - The Keyv cache instance for retrieving exchange data
  * @param code - The authorization code to exchange
+ * @param requestOrigin - The origin of the requesting client for origin binding
+ * @param codeVerifier - PKCE code_verifier to verify against the stored code_challenge
  * @returns The exchange response with token, refreshToken, and user data, or null if invalid/expired
  */
 export async function exchangeAdminCode(
   cache: Keyv,
   code: string,
   requestOrigin?: string,
+  codeVerifier?: string,
 ): Promise<AdminExchangeResponse | null> {
   const data = (await cache.get(code)) as AdminExchangeData | undefined;
 
@@ -126,6 +146,14 @@ export async function exchangeAdminCode(
   if (data.origin && data.origin !== requestOrigin) {
     logger.warn('[adminExchange] Authorization code origin mismatch');
     return null;
+  }
+
+  /** PKCE verification: if a challenge was stored, the verifier must match */
+  if (data.codeChallenge) {
+    if (!codeVerifier || !verifyCodeChallenge(codeVerifier, data.codeChallenge)) {
+      logger.warn('[adminExchange] PKCE code_verifier mismatch or missing');
+      return null;
+    }
   }
 
   logger.info(`[adminExchange] Exchanged code for user: ${data.user?.email}`);


### PR DESCRIPTION
## Summary

Adds two layered security controls to the admin OAuth exchange code flow to mitigate a security finding where exchange codes acted as bearer secrets. If an exchange code leaked (via referrer headers, logs, or network interception) within its 30-second TTL, any party could redeem it for admin tokens since the `/api/admin/oauth/exchange` endpoint had no client binding.

### Layer 1: Origin Binding
- Store the admin panel's origin alongside the exchange code at generation time
- Validate the request origin (`Origin`/`Referer` headers) against the stored origin at redemption
- Origin binding is defense-in-depth for browser contexts; it is spoofable from non-browser HTTP clients

### Layer 2: PKCE Proof-of-Possession
- Accept an optional `code_challenge` (hex-encoded SHA-256) at OAuth initiation, stored in cache keyed by OAuth state
- Retrieve the challenge in the callback middleware and bind it to the exchange code
- At redemption, verify `sha256(code_verifier) === stored_challenge` using `crypto.timingSafeEqual`
- The `code_verifier` only exists in the admin panel's encrypted HttpOnly session cookie — it never appears in URLs, logs, or headers

**Important:** Origin binding alone provides weak protection. Full mitigation requires the companion admin panel PR which implements the client-side PKCE flow. Both layers are backward-compatible: codes generated without an origin or challenge are accepted, allowing independent deployment.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified origin match, mismatch, and undefined origin rejection
- Verified PKCE: valid verifier, wrong verifier, missing verifier, backward compat
- Verified one-time-use enforcement
- Verified hex case handling (uppercase rejected at input gate)
- Unit tests in `packages/api/src/auth/exchange.spec.ts` using real Keyv in-memory store with `jest.spyOn`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Any changes dependent on mine have been merged and published in downstream modules