### PR TITLE
💰 fix: Lazy-Initialize Balance Record at Check Time for Admin Panel Overrides

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -523,6 +523,8 @@ class BaseClient {
           getMultiplier: db.getMultiplier,
           findBalanceByUser: db.findBalanceByUser,
           createAutoRefillTransaction: db.createAutoRefillTransaction,
+          balanceConfig,
+          upsertBalanceFields: db.upsertBalanceFields,
         },
       );
     }

--- a/api/server/controllers/assistants/chatV1.js
+++ b/api/server/controllers/assistants/chatV1.js
@@ -40,6 +40,7 @@ const { sendResponse } = require('~/server/middleware/error');
 const {
   createAutoRefillTransaction,
   findBalanceByUser,
+  upsertBalanceFields,
   getTransactions,
   getMultiplier,
   getConvo,
@@ -296,7 +297,14 @@ const chatV1 = async (req, res) => {
             amount: promptTokens,
           },
         },
-        { findBalanceByUser, getMultiplier, createAutoRefillTransaction, logViolation },
+        {
+          findBalanceByUser,
+          getMultiplier,
+          createAutoRefillTransaction,
+          logViolation,
+          balanceConfig,
+          upsertBalanceFields,
+        },
       );
     };
 

--- a/api/server/controllers/assistants/chatV2.js
+++ b/api/server/controllers/assistants/chatV2.js
@@ -37,6 +37,7 @@ const {
   getMultiplier,
   getTransactions,
   findBalanceByUser,
+  upsertBalanceFields,
   createAutoRefillTransaction,
 } = require('~/models');
 const { logViolation, getLogStores } = require('~/cache');
@@ -169,7 +170,14 @@ const chatV2 = async (req, res) => {
             amount: promptTokens,
           },
         },
-        { findBalanceByUser, getMultiplier, createAutoRefillTransaction, logViolation },
+        {
+          findBalanceByUser,
+          getMultiplier,
+          createAutoRefillTransaction,
+          logViolation,
+          balanceConfig,
+          upsertBalanceFields,
+        },
       );
     };
 

--- a/packages/api/src/middleware/checkBalance.spec.ts
+++ b/packages/api/src/middleware/checkBalance.spec.ts
@@ -1,7 +1,7 @@
 import { ViolationTypes } from 'librechat-data-provider';
 import type { Response } from 'express';
-import type { ServerRequest } from '~/types/http';
 import type { CheckBalanceDeps } from './checkBalance';
+import type { ServerRequest } from '~/types/http';
 import { checkBalance } from './checkBalance';
 
 jest.mock('@librechat/data-schemas', () => ({
@@ -236,6 +236,13 @@ describe('checkBalance', () => {
         user: 'user-1',
         tokenCredits: 0,
       });
+      expect(deps.logViolation).toHaveBeenCalledWith(
+        req,
+        res,
+        ViolationTypes.TOKEN_BALANCE,
+        expect.objectContaining({ balance: 0, tokenCost: 100 }),
+        0,
+      );
     });
 
     it('should fall back to balance: 0 when upsertBalanceFields rejects', async () => {

--- a/packages/api/src/middleware/checkBalance.spec.ts
+++ b/packages/api/src/middleware/checkBalance.spec.ts
@@ -1,0 +1,162 @@
+import { ViolationTypes } from 'librechat-data-provider';
+import type { CheckBalanceDeps } from './checkBalance';
+import { checkBalance } from './checkBalance';
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: {
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('checkBalance', () => {
+  const createMockDeps = (overrides: Partial<CheckBalanceDeps> = {}): CheckBalanceDeps => ({
+    findBalanceByUser: jest.fn().mockResolvedValue({ tokenCredits: 1000 }),
+    getMultiplier: jest.fn().mockReturnValue(1),
+    createAutoRefillTransaction: jest.fn(),
+    logViolation: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  });
+
+  const createMockReqRes = () => ({
+    req: { user: { id: 'user-1' } } as unknown as Parameters<typeof checkBalance>[0]['req'],
+    res: {} as unknown as Parameters<typeof checkBalance>[0]['res'],
+  });
+
+  const baseTxData = {
+    user: 'user-1',
+    tokenType: 'prompt',
+    amount: 100,
+    endpoint: 'openAI',
+    model: 'gpt-4',
+  };
+
+  it('should return true when user has sufficient balance', async () => {
+    const deps = createMockDeps();
+    const { req, res } = createMockReqRes();
+
+    const result = await checkBalance({ req, res, txData: baseTxData }, deps);
+    expect(result).toBe(true);
+  });
+
+  it('should throw when user has insufficient balance', async () => {
+    const deps = createMockDeps({
+      findBalanceByUser: jest.fn().mockResolvedValue({ tokenCredits: 10 }),
+      getMultiplier: jest.fn().mockReturnValue(1),
+    });
+    const { req, res } = createMockReqRes();
+
+    await expect(
+      checkBalance({ req, res, txData: { ...baseTxData, amount: 100 } }, deps),
+    ).rejects.toThrow();
+
+    expect(deps.logViolation).toHaveBeenCalledWith(
+      req,
+      res,
+      ViolationTypes.TOKEN_BALANCE,
+      expect.objectContaining({ balance: 10, tokenCost: 100 }),
+      0,
+    );
+  });
+
+  describe('lazy balance initialization', () => {
+    it('should create balance record when no record exists and startBalance is configured', async () => {
+      const upsertBalanceFields = jest.fn().mockResolvedValue({});
+      const deps = createMockDeps({
+        findBalanceByUser: jest.fn().mockResolvedValue(null),
+        balanceConfig: { startBalance: 5000 },
+        upsertBalanceFields,
+      });
+      const { req, res } = createMockReqRes();
+
+      const result = await checkBalance({ req, res, txData: baseTxData }, deps);
+
+      expect(result).toBe(true);
+      expect(upsertBalanceFields).toHaveBeenCalledWith('user-1', {
+        user: 'user-1',
+        tokenCredits: 5000,
+      });
+    });
+
+    it('should throw when lazy-initialized balance is less than token cost', async () => {
+      const upsertBalanceFields = jest.fn().mockResolvedValue({});
+      const deps = createMockDeps({
+        findBalanceByUser: jest.fn().mockResolvedValue(null),
+        getMultiplier: jest.fn().mockReturnValue(1),
+        balanceConfig: { startBalance: 50 },
+        upsertBalanceFields,
+      });
+      const { req, res } = createMockReqRes();
+
+      await expect(
+        checkBalance({ req, res, txData: { ...baseTxData, amount: 100 } }, deps),
+      ).rejects.toThrow();
+
+      expect(upsertBalanceFields).toHaveBeenCalledWith('user-1', {
+        user: 'user-1',
+        tokenCredits: 50,
+      });
+    });
+
+    it('should return canSpend: false when no record and no balanceConfig', async () => {
+      const deps = createMockDeps({
+        findBalanceByUser: jest.fn().mockResolvedValue(null),
+      });
+      const { req, res } = createMockReqRes();
+
+      await expect(checkBalance({ req, res, txData: baseTxData }, deps)).rejects.toThrow();
+      expect(deps.logViolation).toHaveBeenCalledWith(
+        req,
+        res,
+        ViolationTypes.TOKEN_BALANCE,
+        expect.objectContaining({ balance: 0 }),
+        0,
+      );
+    });
+
+    it('should return canSpend: false when no record and startBalance is undefined', async () => {
+      const deps = createMockDeps({
+        findBalanceByUser: jest.fn().mockResolvedValue(null),
+        balanceConfig: {},
+        upsertBalanceFields: jest.fn(),
+      });
+      const { req, res } = createMockReqRes();
+
+      await expect(checkBalance({ req, res, txData: baseTxData }, deps)).rejects.toThrow();
+      expect(deps.upsertBalanceFields).not.toHaveBeenCalled();
+    });
+
+    it('should not lazy-init when upsertBalanceFields is not provided', async () => {
+      const deps = createMockDeps({
+        findBalanceByUser: jest.fn().mockResolvedValue(null),
+        balanceConfig: { startBalance: 5000 },
+        // upsertBalanceFields not provided
+      });
+      const { req, res } = createMockReqRes();
+
+      await expect(checkBalance({ req, res, txData: baseTxData }, deps)).rejects.toThrow();
+    });
+
+    it('should handle startBalance of 0', async () => {
+      const upsertBalanceFields = jest.fn().mockResolvedValue({});
+      const deps = createMockDeps({
+        findBalanceByUser: jest.fn().mockResolvedValue(null),
+        getMultiplier: jest.fn().mockReturnValue(1),
+        balanceConfig: { startBalance: 0 },
+        upsertBalanceFields,
+      });
+      const { req, res } = createMockReqRes();
+
+      await expect(
+        checkBalance({ req, res, txData: { ...baseTxData, amount: 100 } }, deps),
+      ).rejects.toThrow();
+
+      // startBalance: 0 is != null, so lazy init should still occur
+      expect(upsertBalanceFields).toHaveBeenCalledWith('user-1', {
+        user: 'user-1',
+        tokenCredits: 0,
+      });
+    });
+  });
+});

--- a/packages/api/src/middleware/checkBalance.spec.ts
+++ b/packages/api/src/middleware/checkBalance.spec.ts
@@ -62,7 +62,7 @@ describe('checkBalance', () => {
 
   describe('lazy balance initialization', () => {
     it('should create balance record when no record exists and startBalance is configured', async () => {
-      const upsertBalanceFields = jest.fn().mockResolvedValue({});
+      const upsertBalanceFields = jest.fn().mockResolvedValue({ tokenCredits: 5000 });
       const deps = createMockDeps({
         findBalanceByUser: jest.fn().mockResolvedValue(null),
         balanceConfig: { startBalance: 5000 },
@@ -79,8 +79,39 @@ describe('checkBalance', () => {
       });
     });
 
-    it('should throw when lazy-initialized balance is less than token cost', async () => {
-      const upsertBalanceFields = jest.fn().mockResolvedValue({});
+    it('should include auto-refill fields when configured', async () => {
+      const upsertBalanceFields = jest.fn().mockResolvedValue({ tokenCredits: 5000 });
+      const deps = createMockDeps({
+        findBalanceByUser: jest.fn().mockResolvedValue(null),
+        balanceConfig: {
+          startBalance: 5000,
+          autoRefillEnabled: true,
+          refillIntervalValue: 1,
+          refillIntervalUnit: 'days',
+          refillAmount: 1000,
+        },
+        upsertBalanceFields,
+      });
+      const { req, res } = createMockReqRes();
+
+      await checkBalance({ req, res, txData: baseTxData }, deps);
+
+      expect(upsertBalanceFields).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          user: 'user-1',
+          tokenCredits: 5000,
+          autoRefillEnabled: true,
+          refillIntervalValue: 1,
+          refillIntervalUnit: 'days',
+          refillAmount: 1000,
+          lastRefill: expect.any(Date),
+        }),
+      );
+    });
+
+    it('should throw a TOKEN_BALANCE violation when lazy-initialized balance is less than token cost', async () => {
+      const upsertBalanceFields = jest.fn().mockResolvedValue({ tokenCredits: 50 });
       const deps = createMockDeps({
         findBalanceByUser: jest.fn().mockResolvedValue(null),
         getMultiplier: jest.fn().mockReturnValue(1),
@@ -99,7 +130,31 @@ describe('checkBalance', () => {
       });
     });
 
-    it('should return canSpend: false when no record and no balanceConfig', async () => {
+    it('should use the DB-returned balance instead of the raw config constant', async () => {
+      const upsertBalanceFields = jest.fn().mockResolvedValue({ tokenCredits: 3000 });
+      const deps = createMockDeps({
+        findBalanceByUser: jest.fn().mockResolvedValue(null),
+        getMultiplier: jest.fn().mockReturnValue(1),
+        balanceConfig: { startBalance: 5000 },
+        upsertBalanceFields,
+      });
+      const { req, res } = createMockReqRes();
+
+      // DB returned 3000 (not 5000), so 3000 < 4000 should throw
+      await expect(
+        checkBalance({ req, res, txData: { ...baseTxData, amount: 4000 } }, deps),
+      ).rejects.toThrow();
+
+      expect(deps.logViolation).toHaveBeenCalledWith(
+        req,
+        res,
+        ViolationTypes.TOKEN_BALANCE,
+        expect.objectContaining({ balance: 3000, tokenCost: 4000 }),
+        0,
+      );
+    });
+
+    it('should throw a TOKEN_BALANCE violation when no record and no balanceConfig', async () => {
       const deps = createMockDeps({
         findBalanceByUser: jest.fn().mockResolvedValue(null),
       });
@@ -115,7 +170,7 @@ describe('checkBalance', () => {
       );
     });
 
-    it('should return canSpend: false when no record and startBalance is undefined', async () => {
+    it('should throw a TOKEN_BALANCE violation when no record and startBalance is undefined', async () => {
       const deps = createMockDeps({
         findBalanceByUser: jest.fn().mockResolvedValue(null),
         balanceConfig: {},
@@ -125,21 +180,34 @@ describe('checkBalance', () => {
 
       await expect(checkBalance({ req, res, txData: baseTxData }, deps)).rejects.toThrow();
       expect(deps.upsertBalanceFields).not.toHaveBeenCalled();
+      expect(deps.logViolation).toHaveBeenCalledWith(
+        req,
+        res,
+        ViolationTypes.TOKEN_BALANCE,
+        expect.objectContaining({ balance: 0 }),
+        0,
+      );
     });
 
-    it('should not lazy-init when upsertBalanceFields is not provided', async () => {
+    it('should throw a TOKEN_BALANCE violation when upsertBalanceFields is not provided', async () => {
       const deps = createMockDeps({
         findBalanceByUser: jest.fn().mockResolvedValue(null),
         balanceConfig: { startBalance: 5000 },
-        // upsertBalanceFields not provided
       });
       const { req, res } = createMockReqRes();
 
       await expect(checkBalance({ req, res, txData: baseTxData }, deps)).rejects.toThrow();
+      expect(deps.logViolation).toHaveBeenCalledWith(
+        req,
+        res,
+        ViolationTypes.TOKEN_BALANCE,
+        expect.objectContaining({ balance: 0 }),
+        0,
+      );
     });
 
     it('should handle startBalance of 0', async () => {
-      const upsertBalanceFields = jest.fn().mockResolvedValue({});
+      const upsertBalanceFields = jest.fn().mockResolvedValue({ tokenCredits: 0 });
       const deps = createMockDeps({
         findBalanceByUser: jest.fn().mockResolvedValue(null),
         getMultiplier: jest.fn().mockReturnValue(1),
@@ -152,11 +220,29 @@ describe('checkBalance', () => {
         checkBalance({ req, res, txData: { ...baseTxData, amount: 100 } }, deps),
       ).rejects.toThrow();
 
-      // startBalance: 0 is != null, so lazy init should still occur
       expect(upsertBalanceFields).toHaveBeenCalledWith('user-1', {
         user: 'user-1',
         tokenCredits: 0,
       });
+    });
+
+    it('should fall back to balance: 0 when upsertBalanceFields rejects', async () => {
+      const upsertBalanceFields = jest.fn().mockRejectedValue(new Error('DB unavailable'));
+      const deps = createMockDeps({
+        findBalanceByUser: jest.fn().mockResolvedValue(null),
+        balanceConfig: { startBalance: 5000 },
+        upsertBalanceFields,
+      });
+      const { req, res } = createMockReqRes();
+
+      await expect(checkBalance({ req, res, txData: baseTxData }, deps)).rejects.toThrow();
+      expect(deps.logViolation).toHaveBeenCalledWith(
+        req,
+        res,
+        ViolationTypes.TOKEN_BALANCE,
+        expect.objectContaining({ balance: 0 }),
+        0,
+      );
     });
   });
 });

--- a/packages/api/src/middleware/checkBalance.spec.ts
+++ b/packages/api/src/middleware/checkBalance.spec.ts
@@ -1,4 +1,6 @@
 import { ViolationTypes } from 'librechat-data-provider';
+import type { Response } from 'express';
+import type { ServerRequest } from '~/types/http';
 import type { CheckBalanceDeps } from './checkBalance';
 import { checkBalance } from './checkBalance';
 
@@ -19,10 +21,8 @@ describe('checkBalance', () => {
     ...overrides,
   });
 
-  const createMockReqRes = () => ({
-    req: { user: { id: 'user-1' } } as unknown as Parameters<typeof checkBalance>[0]['req'],
-    res: {} as unknown as Parameters<typeof checkBalance>[0]['res'],
-  });
+  const req = { user: { id: 'user-1' } } as ServerRequest;
+  const res = {} as Response;
 
   const baseTxData = {
     user: 'user-1',
@@ -34,7 +34,6 @@ describe('checkBalance', () => {
 
   it('should return true when user has sufficient balance', async () => {
     const deps = createMockDeps();
-    const { req, res } = createMockReqRes();
 
     const result = await checkBalance({ req, res, txData: baseTxData }, deps);
     expect(result).toBe(true);
@@ -45,7 +44,6 @@ describe('checkBalance', () => {
       findBalanceByUser: jest.fn().mockResolvedValue({ tokenCredits: 10 }),
       getMultiplier: jest.fn().mockReturnValue(1),
     });
-    const { req, res } = createMockReqRes();
 
     await expect(
       checkBalance({ req, res, txData: { ...baseTxData, amount: 100 } }, deps),
@@ -68,7 +66,6 @@ describe('checkBalance', () => {
         balanceConfig: { startBalance: 5000 },
         upsertBalanceFields,
       });
-      const { req, res } = createMockReqRes();
 
       const result = await checkBalance({ req, res, txData: baseTxData }, deps);
 
@@ -92,7 +89,6 @@ describe('checkBalance', () => {
         },
         upsertBalanceFields,
       });
-      const { req, res } = createMockReqRes();
 
       await checkBalance({ req, res, txData: baseTxData }, deps);
 
@@ -117,7 +113,6 @@ describe('checkBalance', () => {
         balanceConfig: { startBalance: 5000, autoRefillEnabled: true },
         upsertBalanceFields,
       });
-      const { req, res } = createMockReqRes();
 
       await checkBalance({ req, res, txData: baseTxData }, deps);
 
@@ -135,7 +130,6 @@ describe('checkBalance', () => {
         balanceConfig: { startBalance: 50 },
         upsertBalanceFields,
       });
-      const { req, res } = createMockReqRes();
 
       await expect(
         checkBalance({ req, res, txData: { ...baseTxData, amount: 100 } }, deps),
@@ -162,7 +156,6 @@ describe('checkBalance', () => {
         balanceConfig: { startBalance: 5000 },
         upsertBalanceFields,
       });
-      const { req, res } = createMockReqRes();
 
       await expect(
         checkBalance({ req, res, txData: { ...baseTxData, amount: 4000 } }, deps),
@@ -181,7 +174,6 @@ describe('checkBalance', () => {
       const deps = createMockDeps({
         findBalanceByUser: jest.fn().mockResolvedValue(null),
       });
-      const { req, res } = createMockReqRes();
 
       await expect(checkBalance({ req, res, txData: baseTxData }, deps)).rejects.toThrow();
       expect(deps.logViolation).toHaveBeenCalledWith(
@@ -199,7 +191,6 @@ describe('checkBalance', () => {
         balanceConfig: {},
         upsertBalanceFields: jest.fn(),
       });
-      const { req, res } = createMockReqRes();
 
       await expect(checkBalance({ req, res, txData: baseTxData }, deps)).rejects.toThrow();
       expect(deps.upsertBalanceFields).not.toHaveBeenCalled();
@@ -217,7 +208,6 @@ describe('checkBalance', () => {
         findBalanceByUser: jest.fn().mockResolvedValue(null),
         balanceConfig: { startBalance: 5000 },
       });
-      const { req, res } = createMockReqRes();
 
       await expect(checkBalance({ req, res, txData: baseTxData }, deps)).rejects.toThrow();
       expect(deps.logViolation).toHaveBeenCalledWith(
@@ -237,7 +227,6 @@ describe('checkBalance', () => {
         balanceConfig: { startBalance: 0 },
         upsertBalanceFields,
       });
-      const { req, res } = createMockReqRes();
 
       await expect(
         checkBalance({ req, res, txData: { ...baseTxData, amount: 100 } }, deps),
@@ -256,7 +245,6 @@ describe('checkBalance', () => {
         balanceConfig: { startBalance: 5000 },
         upsertBalanceFields,
       });
-      const { req, res } = createMockReqRes();
 
       await expect(checkBalance({ req, res, txData: baseTxData }, deps)).rejects.toThrow();
       expect(deps.logViolation).toHaveBeenCalledWith(

--- a/packages/api/src/middleware/checkBalance.spec.ts
+++ b/packages/api/src/middleware/checkBalance.spec.ts
@@ -110,6 +110,23 @@ describe('checkBalance', () => {
       );
     });
 
+    it('should not include auto-refill fields when config is partial', async () => {
+      const upsertBalanceFields = jest.fn().mockResolvedValue({ tokenCredits: 5000 });
+      const deps = createMockDeps({
+        findBalanceByUser: jest.fn().mockResolvedValue(null),
+        balanceConfig: { startBalance: 5000, autoRefillEnabled: true },
+        upsertBalanceFields,
+      });
+      const { req, res } = createMockReqRes();
+
+      await checkBalance({ req, res, txData: baseTxData }, deps);
+
+      expect(upsertBalanceFields).toHaveBeenCalledWith('user-1', {
+        user: 'user-1',
+        tokenCredits: 5000,
+      });
+    });
+
     it('should throw a TOKEN_BALANCE violation when lazy-initialized balance is less than token cost', async () => {
       const upsertBalanceFields = jest.fn().mockResolvedValue({ tokenCredits: 50 });
       const deps = createMockDeps({
@@ -128,9 +145,16 @@ describe('checkBalance', () => {
         user: 'user-1',
         tokenCredits: 50,
       });
+      expect(deps.logViolation).toHaveBeenCalledWith(
+        req,
+        res,
+        ViolationTypes.TOKEN_BALANCE,
+        expect.objectContaining({ balance: 50, tokenCost: 100 }),
+        0,
+      );
     });
 
-    it('should use the DB-returned balance instead of the raw config constant', async () => {
+    it('should use DB-returned tokenCredits over raw startBalance config constant', async () => {
       const upsertBalanceFields = jest.fn().mockResolvedValue({ tokenCredits: 3000 });
       const deps = createMockDeps({
         findBalanceByUser: jest.fn().mockResolvedValue(null),
@@ -140,7 +164,6 @@ describe('checkBalance', () => {
       });
       const { req, res } = createMockReqRes();
 
-      // DB returned 3000 (not 5000), so 3000 < 4000 should throw
       await expect(
         checkBalance({ req, res, txData: { ...baseTxData, amount: 4000 } }, deps),
       ).rejects.toThrow();

--- a/packages/api/src/middleware/checkBalance.ts
+++ b/packages/api/src/middleware/checkBalance.ts
@@ -1,8 +1,8 @@
 import { logger } from '@librechat/data-schemas';
 import { ViolationTypes } from 'librechat-data-provider';
 import type { BalanceConfig, IBalanceUpdate } from '@librechat/data-schemas';
-import type { ServerRequest } from '~/types/http';
 import type { Response } from 'express';
+import type { ServerRequest } from '~/types/http';
 
 type TimeUnit = 'seconds' | 'minutes' | 'hours' | 'days' | 'weeks' | 'months';
 

--- a/packages/api/src/middleware/checkBalance.ts
+++ b/packages/api/src/middleware/checkBalance.ts
@@ -1,5 +1,6 @@
 import { logger } from '@librechat/data-schemas';
 import { ViolationTypes } from 'librechat-data-provider';
+import type { BalanceConfig, IBalanceUpdate } from '@librechat/data-schemas';
 import type { ServerRequest } from '~/types/http';
 import type { Response } from 'express';
 
@@ -38,10 +39,10 @@ export interface CheckBalanceDeps {
     errorMessage: Record<string, unknown>,
     score: number,
   ) => Promise<void>;
-  /** Optional: balance config for lazy initialization when no record exists */
-  balanceConfig?: { startBalance?: number };
-  /** Optional: upsert function for lazy initialization when no record exists */
-  upsertBalanceFields?: (userId: string, fields: Record<string, unknown>) => Promise<unknown>;
+  /** Balance config for lazy initialization when no record exists */
+  balanceConfig?: BalanceConfig;
+  /** Upsert function for lazy initialization when no record exists */
+  upsertBalanceFields?: (userId: string, fields: IBalanceUpdate) => Promise<BalanceRecord | null>;
 }
 
 function addIntervalToDate(date: Date, value: number, unit: TimeUnit): Date {
@@ -93,12 +94,31 @@ async function checkBalanceRecord(
         user,
         startBalance: deps.balanceConfig.startBalance,
       });
-      await deps.upsertBalanceFields(user, {
-        user,
-        tokenCredits: deps.balanceConfig.startBalance,
-      });
-      const balance = deps.balanceConfig.startBalance;
-      return { canSpend: balance >= tokenCost, balance, tokenCost };
+      try {
+        const fields: IBalanceUpdate = {
+          user,
+          tokenCredits: deps.balanceConfig.startBalance,
+        };
+        const config = deps.balanceConfig;
+        if (
+          config.autoRefillEnabled &&
+          config.refillIntervalValue != null &&
+          config.refillIntervalUnit != null &&
+          config.refillAmount != null
+        ) {
+          fields.autoRefillEnabled = config.autoRefillEnabled;
+          fields.refillIntervalValue = config.refillIntervalValue;
+          fields.refillIntervalUnit = config.refillIntervalUnit;
+          fields.refillAmount = config.refillAmount;
+          fields.lastRefill = new Date();
+        }
+        const created = await deps.upsertBalanceFields(user, fields);
+        const balance = created?.tokenCredits ?? deps.balanceConfig.startBalance;
+        return { canSpend: balance >= tokenCost, balance, tokenCost };
+      } catch (error) {
+        logger.error('[Balance.check] Failed to lazy-initialize balance record', { user, error });
+        return { canSpend: false, balance: 0, tokenCost };
+      }
     }
     logger.debug('[Balance.check] No balance record found for user', { user });
     return { canSpend: false, balance: 0, tokenCost };

--- a/packages/api/src/middleware/checkBalance.ts
+++ b/packages/api/src/middleware/checkBalance.ts
@@ -38,6 +38,10 @@ export interface CheckBalanceDeps {
     errorMessage: Record<string, unknown>,
     score: number,
   ) => Promise<void>;
+  /** Optional: balance config for lazy initialization when no record exists */
+  balanceConfig?: { startBalance?: number };
+  /** Optional: upsert function for lazy initialization when no record exists */
+  upsertBalanceFields?: (userId: string, fields: Record<string, unknown>) => Promise<unknown>;
 }
 
 function addIntervalToDate(date: Date, value: number, unit: TimeUnit): Date {
@@ -84,6 +88,18 @@ async function checkBalanceRecord(
 
   const record = await deps.findBalanceByUser(user);
   if (!record) {
+    if (deps.balanceConfig?.startBalance != null && deps.upsertBalanceFields) {
+      logger.debug('[Balance.check] Lazy-initializing balance record for user', {
+        user,
+        startBalance: deps.balanceConfig.startBalance,
+      });
+      await deps.upsertBalanceFields(user, {
+        user,
+        tokenCredits: deps.balanceConfig.startBalance,
+      });
+      const balance = deps.balanceConfig.startBalance;
+      return { canSpend: balance >= tokenCost, balance, tokenCost };
+    }
     logger.debug('[Balance.check] No balance record found for user', { user });
     return { canSpend: false, balance: 0, tokenCost };
   }


### PR DESCRIPTION
## Summary

I fixed a bug where users see a `balance: 0` error when balance is configured via admin panel DB overrides instead of YAML. The root cause is that balance initialization only happens during login/authentication middleware, so users with active sessions never get a balance record created — and `checkBalanceRecord` treats a missing record as `balance: 0`.

- Add optional `balanceConfig` and `upsertBalanceFields` dependencies to the `CheckBalanceDeps` interface for lazy initialization support.
- Modify `checkBalanceRecord` in `checkBalance.ts` to lazily create a balance record with `startBalance` credits when no record exists, instead of immediately returning `canSpend: false`.
- Pass `balanceConfig` and `upsertBalanceFields` from `BaseClient.js`, `chatV1.js`, and `chatV2.js` callers so the lazy init path is available at all balance check sites.
- Add `upsertBalanceFields` to the destructured imports from `~/models` in `chatV1.js` and `chatV2.js`.
- Add 8 unit tests covering lazy init scenarios: successful init, insufficient startBalance, missing config, undefined startBalance, missing upsert dep, and startBalance of 0.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Run the new test suite:

```bash
cd packages/api && npx jest src/middleware/checkBalance.spec.ts --no-coverage
```

All 8 tests pass, covering:
1. Normal balance check with sufficient/insufficient funds
2. Lazy init when no record + startBalance configured → creates record, returns canSpend
3. Lazy init when startBalance < tokenCost → creates record, throws violation
4. No lazy init when balanceConfig is absent → returns balance: 0 (old behavior)
5. No lazy init when startBalance is undefined → returns balance: 0
6. No lazy init when upsertBalanceFields dep is missing → returns balance: 0
7. Lazy init with startBalance: 0 → creates record with 0 credits

To reproduce the original bug:
1. Enable balance via admin panel DB override (not YAML) with a startBalance
2. Use a user with an active session who has never logged in since the override
3. Attempt to chat → previously saw `token_balance` error, now lazily initializes

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes