### PR TITLE
⚠️ fix: lock `axios` version to 1.13.5 in package.json

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -52,7 +52,7 @@
     "@node-saml/passport-saml": "^5.1.0",
     "@smithy/node-http-handler": "^4.4.5",
     "ai-tokenizer": "^1.0.6",
-    "axios": "^1.13.5",
+    "axios": "1.13.5",
     "bcryptjs": "^2.4.3",
     "compression": "^1.8.1",
     "connect-redis": "^8.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "@node-saml/passport-saml": "^5.1.0",
         "@smithy/node-http-handler": "^4.4.5",
         "ai-tokenizer": "^1.0.6",
-        "axios": "^1.13.5",
+        "axios": "1.13.5",
         "bcryptjs": "^2.4.3",
         "compression": "^1.8.1",
         "connect-redis": "^8.1.0",
@@ -43982,7 +43982,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@smithy/node-http-handler": "^4.4.5",
         "ai-tokenizer": "^1.0.6",
-        "axios": "^1.13.5",
+        "axios": "1.13.5",
         "connect-redis": "^8.1.0",
         "eventsource": "^3.0.2",
         "express": "^5.1.0",
@@ -45874,10 +45874,10 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.401",
+      "version": "0.8.405",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.13.5",
+        "axios": "1.13.5",
         "dayjs": "^1.11.13",
         "js-yaml": "^4.1.1",
         "zod": "^3.22.4"
@@ -45932,7 +45932,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.40",
+      "version": "0.0.47",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -100,7 +100,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@smithy/node-http-handler": "^4.4.5",
     "ai-tokenizer": "^1.0.6",
-    "axios": "^1.13.5",
+    "axios": "1.13.5",
     "connect-redis": "^8.1.0",
     "eventsource": "^3.0.2",
     "express": "^5.1.0",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://librechat.ai",
   "dependencies": {
-    "axios": "^1.13.5",
+    "axios": "1.13.5",
     "dayjs": "^1.11.13",
     "js-yaml": "^4.1.1",
     "zod": "^3.22.4"

--- a/packages/data-provider/react-query/package-lock.json
+++ b/packages/data-provider/react-query/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "librechat-data-provider/react-query",
       "dependencies": {
-        "axios": "^1.13.5"
+        "axios": "1.13.5"
       }
     },
     "node_modules/asynckit": {

--- a/packages/data-provider/react-query/package.json
+++ b/packages/data-provider/react-query/package.json
@@ -5,6 +5,6 @@
   "module": "./index.es.js",
   "types": "../dist/types/react-query/index.d.ts",
   "dependencies": {
-    "axios": "^1.13.5"
+    "axios": "1.13.5"
   }
 }


### PR DESCRIPTION
## Summary

The `axios` npm package was reported as compromised overnight. The affected versions are `axios@1.14.1` and `axios@0.30.4`.

The affected versions have been removed from npm, but vulnerable versions could exist in npm caches and other registries.

This PR locks `axios` down to `1.13.5` to prevent any accidental installation of compromised versions via cached registries or transitive dependency resolution.

See also:
https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan
https://github.com/axios/axios/issues/10604

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Run `npm install`, ensure that `axios` is fixed to `1.13.5` without the caret `^` symbol.

### **Test Configuration**:
Node v24.11.0, npm v11.12.1

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
