### PR TITLE
deploy: Add golden path deployment script and project docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,132 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+LibreChat-FIPS is a fork of [LibreChat](https://github.com/danny-avila/LibreChat) (v0.8.1-rc2) customized for FIPS-compliant deployment on Red Hat OpenShift. It's an all-in-one AI chat platform supporting multiple model providers (OpenAI, Anthropic, Google, AWS Bedrock, custom/local endpoints) with agents, MCP servers, and multi-user auth.
+
+## Common Commands
+
+### Install & Build
+
+```bash
+npm ci                          # Install dependencies
+npm run build:packages          # Build shared packages (required order: data-provider -> data-schemas -> api -> client)
+npm run frontend                # Build all packages + Vite client bundle (production)
+```
+
+### Development Servers
+
+```bash
+npm run backend:dev             # API server with nodemon (port 3080)
+npm run frontend:dev            # Vite dev server with HMR
+```
+
+### Testing
+
+```bash
+npm run test:api                # Backend tests (jest --ci)
+npm run test:client             # Frontend tests (jest --ci)
+cd api && npx jest path/to/test.spec.js           # Single API test
+cd client && npx jest src/components/Foo.test.tsx  # Single client test
+
+# Package-level tests (with coverage)
+cd packages/data-provider && npm run test:ci
+cd packages/data-schemas && npm run test:ci
+cd packages/api && npm run test:ci
+
+# E2E
+npm run e2e                     # Playwright headless
+npm run e2e:headed              # With browser visible
+```
+
+### Lint & Format
+
+```bash
+npm run lint                    # ESLint (no fix)
+npm run lint:fix                # ESLint with auto-fix
+npm run format                  # Prettier --write
+cd client && npm run typecheck  # TypeScript type check (client only)
+```
+
+Pre-commit hooks run `lint-staged` automatically: prettier + eslint on JS/TS/JSX/TSX, prettier on JSON.
+
+### OpenShift Deployment
+
+```bash
+make deploy NAMESPACE=librechat-fips    # Deploy via Helm
+make status NAMESPACE=librechat-fips    # Show pods/services/routes
+make logs NAMESPACE=librechat-fips      # Follow app logs
+make update-config NAMESPACE=librechat-fips  # Push updated librechat.yaml ConfigMap + rollout
+make restart NAMESPACE=librechat-fips   # Rolling restart
+make url NAMESPACE=librechat-fips       # Print app URL
+make test-health NAMESPACE=librechat-fips
+```
+
+## Architecture
+
+### Monorepo Structure (npm workspaces)
+
+The project has four workspace members that must be built in dependency order:
+
+1. **`packages/data-provider`** (`librechat-data-provider`) - Shared API contract: endpoint URL builders, Axios request layer with JWT refresh, React Query hooks, TypeScript types/enums. Used by both client and API.
+2. **`packages/data-schemas`** (`@librechat/data-schemas`) - Mongoose schemas, model factories, Winston logger. Used by API-side code.
+3. **`packages/api`** (`@librechat/api`) - MCP system, agents engine (LangChain-based), caching layer, OAuth, crypto, tools. Used by the API server.
+4. **`packages/client`** (`@librechat/client`) - Shared React components, hooks, store, theming.
+
+### API Server (`api/`)
+
+- **Express.js** with Passport.js auth (JWT, OpenID, LDAP, SAML, social OAuth)
+- Entry: `api/server/index.js`
+- AI provider clients: `api/app/clients/` (OpenAIClient, AnthropicClient, GoogleClient, OllamaClient extending BaseClient)
+- Endpoint initialization: `api/server/services/Endpoints/` - each provider has an `initialize.js`
+- MongoDB via Mongoose; optional Redis for caching/rate-limiting
+- MeiliSearch for full-text search
+- Middleware stack in `api/server/middleware/` (auth, rate limiting, RBAC, request validation, ban checks)
+
+### Client (`client/`)
+
+- **React + Vite** SPA, being migrated from JS to TypeScript
+- Communicates with API via hooks from `packages/data-provider` (React Query)
+- AI streaming via SSE (Server-Sent Events)
+- Tailwind CSS for styling
+
+### Configuration
+
+- **`librechat.yaml`** - Primary app config: MCP servers, custom endpoints, memory, interface settings, rate limits, file storage strategy. Loaded at runtime, supports `CONFIG_PATH` env var override.
+- **`.env`** - Credentials and feature flags (see `.env.example` for full reference)
+- **`helm/librechat/`** - Helm chart with `values-openshift.yaml` for OpenShift deploys
+
+### MCP System (`packages/api/src/mcp/`)
+
+- `MCPManager` - singleton managing all server connections
+- `MCPServersRegistry` - registry of server configs from `librechat.yaml`
+- Supports `stdio` and `sse` transports
+- OAuth reconnection support
+- MCP servers configured under `mcpServers:` in `librechat.yaml`
+
+### Database
+
+- MongoDB + Mongoose exclusively
+- Schemas in `packages/data-schemas/src/schema/`
+- Connection in `api/db/connect.js`
+- Key models: User, Conversation, Message, Agent, File, Transaction, Session, Balance
+
+## Conventions
+
+- **Commit format**: Conventional commits (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `style:`, `test:`)
+- **Branch naming**: Slash-based (`fix/description`, `feat/description`, `new/feature/x`)
+- **File naming**: camelCase for JS/TS; PascalCase for React components (`.tsx`)
+- **Import order** (ESLint-enforced): npm packages -> TypeScript types -> local imports, each group sorted longest to shortest
+- **Frontend migration**: JS -> TypeScript is ongoing; new frontend code should be TypeScript
+- **Backend**: Remains JavaScript/Express.js
+
+## FIPS Compliance Notes
+
+This fork replaces non-FIPS algorithms:
+- **bcrypt -> PBKDF2-HMAC-SHA256** for password hashing
+- **HMAC-SHA1 -> HMAC-SHA256** for TOTP
+- Uses Red Hat UBI 9 / `nodejs-20` base image with FIPS-validated OpenSSL 3.0
+- Build with `Containerfile.fips` (on the `feat/fips-openshift-deployment` branch)
+- Breaking change: existing deployments with bcrypt passwords require reset on migration

--- a/README.md
+++ b/README.md
@@ -1,217 +1,119 @@
-<p align="center">
-  <a href="https://librechat.ai">
-    <img src="client/public/assets/logo.svg" height="256">
-  </a>
-  <h1 align="center">
-    <a href="https://librechat.ai">LibreChat</a>
-  </h1>
-</p>
+# LibreChat-FIPS
 
-<p align="center">
-  <a href="https://discord.librechat.ai"> 
-    <img
-      src="https://img.shields.io/discord/1086345563026489514?label=&logo=discord&style=for-the-badge&logoWidth=20&logoColor=white&labelColor=000000&color=blueviolet">
-  </a>
-  <a href="https://www.youtube.com/@LibreChat"> 
-    <img
-      src="https://img.shields.io/badge/YOUTUBE-red.svg?style=for-the-badge&logo=youtube&logoColor=white&labelColor=000000&logoWidth=20">
-  </a>
-  <a href="https://docs.librechat.ai"> 
-    <img
-      src="https://img.shields.io/badge/DOCS-blue.svg?style=for-the-badge&logo=read-the-docs&logoColor=white&labelColor=000000&logoWidth=20">
-  </a>
-  <a aria-label="Sponsors" href="https://github.com/sponsors/danny-avila">
-    <img
-      src="https://img.shields.io/badge/SPONSORS-brightgreen.svg?style=for-the-badge&logo=github-sponsors&logoColor=white&labelColor=000000&logoWidth=20">
-  </a>
-</p>
+Fork of [LibreChat](https://github.com/danny-avila/LibreChat) (v0.8.1-rc2) for deployment on Red Hat OpenShift, with optional FIPS compliance.
 
-<p align="center">
-<a href="https://railway.app/template/b5k2mn?referralCode=HI9hWz">
-  <img src="https://railway.app/button.svg" alt="Deploy on Railway" height="30">
-</a>
-<a href="https://zeabur.com/templates/0X2ZY8">
-  <img src="https://zeabur.com/button.svg" alt="Deploy on Zeabur" height="30"/>
-</a>
-<a href="https://template.cloud.sealos.io/deploy?templateName=librechat">
-  <img src="https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg" alt="Deploy on Sealos" height="30">
-</a>
-</p>
+Upstream docs: [docs.librechat.ai](https://docs.librechat.ai/)
 
-<p align="center">
-  <a href="https://www.librechat.ai/docs/translation">
-    <img 
-      src="https://img.shields.io/badge/dynamic/json.svg?style=for-the-badge&color=2096F3&label=locize&query=%24.translatedPercentage&url=https://api.locize.app/badgedata/4cb2598b-ed4d-469c-9b04-2ed531a8cb45&suffix=%+translated" 
-      alt="Translation Progress">
-  </a>
-</p>
+## Quick Start: Deploy to OpenShift
 
+### Prerequisites
 
-# ✨ Features
+- `oc` CLI, logged into your OpenShift cluster
+- `helm` CLI installed
+- `python3` with `bcrypt` (`pip install bcrypt`)
+- A `.env` file in the repo root with your API keys (see `.env.example`)
+- A `librechat.yaml` in the repo root with your MCP server URLs and endpoint config
 
-- 🖥️ **UI & Experience** inspired by ChatGPT with enhanced design and features
+### One-Command Deploy
 
-- 🤖 **AI Model Selection**:  
-  - Anthropic (Claude), AWS Bedrock, OpenAI, Azure OpenAI, Google, Vertex AI, OpenAI Responses API (incl. Azure)
-  - [Custom Endpoints](https://www.librechat.ai/docs/quick_start/custom_endpoints): Use any OpenAI-compatible API with LibreChat, no proxy required
-  - Compatible with [Local & Remote AI Providers](https://www.librechat.ai/docs/configuration/librechat_yaml/ai_endpoints):
-    - Ollama, groq, Cohere, Mistral AI, Apple MLX, koboldcpp, together.ai,
-    - OpenRouter, Helicone, Perplexity, ShuttleAI, Deepseek, Qwen, and more
+```bash
+./scripts/deploy-golden-path.sh \
+  --admin-email you@example.com \
+  --admin-name "Your Name" \
+  --agents-file agents-export.json \
+  --make-public
+```
 
-- 🔧 **[Code Interpreter API](https://www.librechat.ai/docs/features/code_interpreter)**: 
-  - Secure, Sandboxed Execution in Python, Node.js (JS/TS), Go, C/C++, Java, PHP, Rust, and Fortran
-  - Seamless File Handling: Upload, process, and download files directly
-  - No Privacy Concerns: Fully isolated and secure execution
+This will:
+1. Create the namespace, grant SCCs, create secrets and ConfigMap
+2. Helm install LibreChat + MongoDB + Meilisearch
+3. Create an ADMIN user with a generated password (printed once at the end)
+4. Import agents from the export file and make them publicly visible
+5. Verify health and print a summary
 
-- 🔦 **Agents & Tools Integration**:  
-  - **[LibreChat Agents](https://www.librechat.ai/docs/features/agents)**:
-    - No-Code Custom Assistants: Build specialized, AI-driven helpers
-    - Agent Marketplace: Discover and deploy community-built agents
-    - Collaborative Sharing: Share agents with specific users and groups
-    - Flexible & Extensible: Use MCP Servers, tools, file search, code execution, and more
-    - Compatible with Custom Endpoints, OpenAI, Azure, Anthropic, AWS Bedrock, Google, Vertex AI, Responses API, and more
-    - [Model Context Protocol (MCP) Support](https://modelcontextprotocol.io/clients#librechat) for Tools
+### Options
 
-- 🔍 **Web Search**:  
-  - Search the internet and retrieve relevant information to enhance your AI context
-  - Combines search providers, content scrapers, and result rerankers for optimal results
-  - **Customizable Jina Reranking**: Configure custom Jina API URLs for reranking services
-  - **[Learn More →](https://www.librechat.ai/docs/features/web_search)**
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--admin-email` | (required) | Email for the admin account |
+| `--admin-name` | email prefix | Display name |
+| `--namespace` | `librechat-fips` | OpenShift namespace |
+| `--agents-file` | (none) | Path to `agents-export.json` for import |
+| `--make-public` | off | Make imported agents visible to all users |
+| `--image-registry` | `ghcr.io` | Container image registry |
+| `--image-repo` | `danny-avila/librechat` | Container image repository |
+| `--image-tag` | Chart appVersion | Container image tag |
+| `--skip-user` | off | Skip admin user creation |
+| `--skip-agents` | off | Skip agent import |
+| `--dry-run` | off | Show what would be done |
 
-- 🪄 **Generative UI with Code Artifacts**:  
-  - [Code Artifacts](https://youtu.be/GfTj7O4gmd0?si=WJbdnemZpJzBrJo3) allow creation of React, HTML, and Mermaid diagrams directly in chat
+### Updating Configuration
 
-- 🎨 **Image Generation & Editing**
-  - Text-to-image and image-to-image with [GPT-Image-1](https://www.librechat.ai/docs/features/image_gen#1--openai-image-tools-recommended)
-  - Text-to-image with [DALL-E (3/2)](https://www.librechat.ai/docs/features/image_gen#2--dalle-legacy), [Stable Diffusion](https://www.librechat.ai/docs/features/image_gen#3--stable-diffusion-local), [Flux](https://www.librechat.ai/docs/features/image_gen#4--flux), or any [MCP server](https://www.librechat.ai/docs/features/image_gen#5--model-context-protocol-mcp)
-  - Produce stunning visuals from prompts or refine existing images with a single instruction
+After editing `librechat.yaml`:
 
-- 💾 **Presets & Context Management**:  
-  - Create, Save, & Share Custom Presets  
-  - Switch between AI Endpoints and Presets mid-chat
-  - Edit, Resubmit, and Continue Messages with Conversation branching  
-  - Create and share prompts with specific users and groups
-  - [Fork Messages & Conversations](https://www.librechat.ai/docs/features/fork) for Advanced Context control
+```bash
+./update-librechat-config.sh librechat-fips
+```
 
-- 💬 **Multimodal & File Interactions**:  
-  - Upload and analyze images with Claude 3, GPT-4.5, GPT-4o, o1, Llama-Vision, and Gemini 📸  
-  - Chat with Files using Custom Endpoints, OpenAI, Azure, Anthropic, AWS Bedrock, & Google 🗃️
+### Common Operations
 
-- 🌎 **Multilingual UI**:
-  - English, 中文 (简体), 中文 (繁體), العربية, Deutsch, Español, Français, Italiano
-  - Polski, Português (PT), Português (BR), Русский, 日本語, Svenska, 한국어, Tiếng Việt
-  - Türkçe, Nederlands, עברית, Català, Čeština, Dansk, Eesti, فارسی
-  - Suomi, Magyar, Հայերեն, Bahasa Indonesia, ქართული, Latviešu, ไทย, ئۇيغۇرچە
+```bash
+# Check status
+make status NAMESPACE=librechat-fips
 
-- 🧠 **Reasoning UI**:  
-  - Dynamic Reasoning UI for Chain-of-Thought/Reasoning AI models like DeepSeek-R1
+# Follow logs
+make logs NAMESPACE=librechat-fips
 
-- 🎨 **Customizable Interface**:  
-  - Customizable Dropdown & Interface that adapts to both power users and newcomers
+# Export agents (for migration to another cluster)
+make export-agents NAMESPACE=librechat-fips
 
-- 🗣️ **Speech & Audio**:  
-  - Chat hands-free with Speech-to-Text and Text-to-Speech  
-  - Automatically send and play Audio  
-  - Supports OpenAI, Azure OpenAI, and Elevenlabs
+# Import agents
+make import-agents NAMESPACE=librechat-fips EMAIL=you@example.com PUBLIC=true
 
-- 📥 **Import & Export Conversations**:  
-  - Import Conversations from LibreChat, ChatGPT, Chatbot UI  
-  - Export conversations as screenshots, markdown, text, json
+# Restart
+make restart NAMESPACE=librechat-fips
 
-- 🔍 **Search & Discovery**:  
-  - Search all messages/conversations
+# Tear down
+make undeploy NAMESPACE=librechat-fips
+```
 
-- 👥 **Multi-User & Secure Access**:
-  - Multi-User, Secure Authentication with OAuth2, LDAP, & Email Login Support
-  - Built-in Moderation, and Token spend tools
+## Configuration
 
-- ⚙️ **Configuration & Deployment**:  
-  - Configure Proxy, Reverse Proxy, Docker, & many Deployment options  
-  - Use completely local or deploy on the cloud
+### `.env`
 
-- 📖 **Open-Source & Community**:  
-  - Completely Open-Source & Built in Public  
-  - Community-driven development, support, and feedback
+Contains API keys and secrets (JWT, encryption keys, Meilisearch master key, provider API keys). See `.env.example` for the full list.
 
-[For a thorough review of our features, see our docs here](https://docs.librechat.ai/) 📚
+### `librechat.yaml`
 
-## 🪶 All-In-One AI Conversations with LibreChat
+Primary application config: MCP servers, custom AI endpoints, memory settings, interface options, rate limits. Mounted into the pod as a ConfigMap at `/app/librechat.yaml`.
 
-LibreChat brings together the future of assistant AIs with the revolutionary technology of OpenAI's ChatGPT. Celebrating the original styling, LibreChat gives you the ability to integrate multiple AI models. It also integrates and enhances original client features such as conversation and message search, prompt templates and plugins.
+### `helm/librechat/values-openshift.yaml`
 
-With LibreChat, you no longer need to opt for ChatGPT Plus and can instead use free or pay-per-call APIs. We welcome contributions, cloning, and forking to enhance the capabilities of this advanced chatbot platform.
+Helm values for OpenShift. The deploy script patches the cluster hostname and image settings automatically via `sed`, so the values file doesn't need manual cluster-specific edits.
 
-[![Watch the video](https://raw.githubusercontent.com/LibreChat-AI/librechat.ai/main/public/images/changelog/v0.7.6.gif)](https://www.youtube.com/watch?v=ilfwGQtJNlI)
+## FIPS Compliance
 
-Click on the thumbnail to open the video☝️
+For FIPS-enabled clusters, build with `Containerfile.fips` (on the `feat/fips-openshift-deployment` branch):
 
----
+- Red Hat UBI 9 / nodejs-20 base with FIPS-validated OpenSSL 3.0
+- bcrypt replaced with PBKDF2-HMAC-SHA256
+- HMAC-SHA1 replaced with HMAC-SHA256 for TOTP
 
-## 🌐 Resources
+Note: existing bcrypt password hashes are incompatible - users must reset passwords after migration.
 
-**GitHub Repo:**
-  - **RAG API:** [github.com/danny-avila/rag_api](https://github.com/danny-avila/rag_api)
-  - **Website:** [github.com/LibreChat-AI/librechat.ai](https://github.com/LibreChat-AI/librechat.ai)
+## Development
 
-**Other:**
-  - **Website:** [librechat.ai](https://librechat.ai)
-  - **Documentation:** [librechat.ai/docs](https://librechat.ai/docs)
-  - **Blog:** [librechat.ai/blog](https://librechat.ai/blog)
+```bash
+npm ci                    # Install dependencies
+npm run build:packages    # Build shared packages (required before running)
+npm run backend:dev       # API server with auto-reload (port 3080)
+npm run frontend:dev      # Vite dev server with HMR
+npm run test:api          # Backend tests
+npm run test:client       # Frontend tests
+npm run lint              # ESLint
+npm run format            # Prettier
+```
 
----
+## Upstream
 
-## 📝 Changelog
-
-Keep up with the latest updates by visiting the releases page and notes:
-- [Releases](https://github.com/danny-avila/LibreChat/releases)
-- [Changelog](https://www.librechat.ai/changelog) 
-
-**⚠️ Please consult the [changelog](https://www.librechat.ai/changelog) for breaking changes before updating.**
-
----
-
-## ⭐ Star History
-
-<p align="center">
-  <a href="https://star-history.com/#danny-avila/LibreChat&Date">
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=danny-avila/LibreChat&type=Date&theme=dark" onerror="this.src='https://api.star-history.com/svg?repos=danny-avila/LibreChat&type=Date'" />
-  </a>
-</p>
-<p align="center">
-  <a href="https://trendshift.io/repositories/4685" target="_blank" style="padding: 10px;">
-    <img src="https://trendshift.io/api/badge/repositories/4685" alt="danny-avila%2FLibreChat | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/>
-  </a>
-  <a href="https://runacap.com/ross-index/q1-24/" target="_blank" rel="noopener" style="margin-left: 20px;">
-    <img style="width: 260px; height: 56px" src="https://runacap.com/wp-content/uploads/2024/04/ROSS_badge_white_Q1_2024.svg" alt="ROSS Index - Fastest Growing Open-Source Startups in Q1 2024 | Runa Capital" width="260" height="56"/>
-  </a>
-</p>
-
----
-
-## ✨ Contributions
-
-Contributions, suggestions, bug reports and fixes are welcome!
-
-For new features, components, or extensions, please open an issue and discuss before sending a PR.
-
-If you'd like to help translate LibreChat into your language, we'd love your contribution! Improving our translations not only makes LibreChat more accessible to users around the world but also enhances the overall user experience. Please check out our [Translation Guide](https://www.librechat.ai/docs/translation).
-
----
-
-## 💖 This project exists in its current state thanks to all the people who contribute
-
-<a href="https://github.com/danny-avila/LibreChat/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=danny-avila/LibreChat" />
-</a>
-
----
-
-## 🎉 Special Thanks
-
-We thank [Locize](https://locize.com) for their translation management tools that support multiple languages in LibreChat.
-
-<p align="center">
-  <a href="https://locize.com" target="_blank" rel="noopener noreferrer">
-    <img src="https://github.com/user-attachments/assets/d6b70894-6064-475e-bb65-92a9e23e0077" alt="Locize Logo" height="50">
-  </a>
-</p>
+Based on [danny-avila/LibreChat](https://github.com/danny-avila/LibreChat). See upstream [changelog](https://www.librechat.ai/changelog) for release notes.

--- a/helm/librechat/values-openshift.yaml
+++ b/helm/librechat/values-openshift.yaml
@@ -1,0 +1,144 @@
+# OpenShift deployment values for LibreChat-FIPS
+# Cluster: cluster-n7pd5.n7pd5.sandbox5167.opentlc.com
+
+replicaCount: 1
+
+global:
+  librechat:
+    existingSecretName: "librechat-credentials-env"
+    existingSecretApiKey: OPENAI_API_KEY
+    env:
+      - name: OPENROUTER_KEY
+        valueFrom:
+          secretKeyRef:
+            name: librechat-credentials-env
+            key: OPENROUTER_KEY
+      - name: VLLM_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: librechat-credentials-env
+            key: VLLM_API_KEY
+      - name: VLLM_API_URL
+        valueFrom:
+          secretKeyRef:
+            name: librechat-credentials-env
+            key: VLLM_API_URL
+      - name: ANTHROPIC_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: librechat-credentials-env
+            key: ANTHROPIC_API_KEY
+      - name: OPENAI_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: librechat-credentials-env
+            key: OPENAI_API_KEY
+
+librechat:
+  configEnv:
+    # DEBUG settings
+    DEBUG_PLUGINS: "true"
+    # Feature flags
+    ALLOW_REGISTRATION: "true"
+    ALLOW_SOCIAL_LOGIN: "false"
+    ALLOW_UNVERIFIED_EMAIL_LOGIN: "true"
+    # MongoDB connection (uses Helm chart internal service)
+    MONGO_URI: "mongodb://librechat-mongodb:27017/LibreChat"
+    # Meilisearch connection
+    MEILI_HOST: "http://librechat-meilisearch:7700"
+    # Domain settings (will be set after route is created)
+    DOMAIN_SERVER: "https://librechat-librechat-fips.apps.cluster-n7pd5.n7pd5.sandbox5167.opentlc.com"
+    DOMAIN_CLIENT: "https://librechat-librechat-fips.apps.cluster-n7pd5.n7pd5.sandbox5167.opentlc.com"
+
+  existingSecretName: "librechat-credentials-env"
+
+  # Reference existing ConfigMap with librechat.yaml
+  existingConfigYaml: "librechat-config"
+
+  imageVolume:
+    enabled: true
+    size: 10Gi
+    accessModes: ReadWriteOnce
+
+# RAG API disabled for initial deployment
+librechat-rag-api:
+  enabled: false
+
+image:
+  repository: danny-avila/librechat
+  registry: ghcr.io
+  pullPolicy: IfNotPresent
+  tag: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+# OpenShift security context - with anyuid SCC, use chart defaults
+podSecurityContext:
+  fsGroup: 1000
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 3080
+  targetPort: 3080
+  containerPort: 3080
+  annotations: {}
+
+# Disable Ingress - use OpenShift Route instead
+ingress:
+  enabled: false
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 3080
+  initialDelaySeconds: 30
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 3080
+  initialDelaySeconds: 10
+  periodSeconds: 5
+
+# MongoDB configuration - with anyuid SCC, enable security contexts
+mongodb:
+  enabled: true
+  auth:
+    enabled: false
+  databases:
+    - LibreChat
+  image:
+    registry: docker.io
+    repository: bitnami/mongodb
+    tag: "latest"
+  persistence:
+    enabled: true
+    size: 8Gi
+
+# Meilisearch configuration - with anyuid SCC, use defaults
+meilisearch:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 5Gi
+    storageClass: ""
+  image:
+    tag: "v1.7.3"
+  auth:
+    existingMasterKeySecret: "librechat-credentials-env"

--- a/scripts/deploy-golden-path.sh
+++ b/scripts/deploy-golden-path.sh
@@ -1,0 +1,459 @@
+#!/bin/bash
+# deploy-golden-path.sh - Full LibreChat deployment to OpenShift
+#
+# Consolidates: namespace setup, SCC grants, secrets, configmap, helm deploy,
+# route creation, admin user creation, and agent import into a single
+# idempotent script.
+#
+# Usage:
+#   ./scripts/deploy-golden-path.sh --admin-email admin@example.com
+#   ./scripts/deploy-golden-path.sh --admin-email admin@example.com --agents-file agents-export.json --make-public
+#   ./scripts/deploy-golden-path.sh --dry-run --admin-email admin@example.com
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+START_TIME=$(date +%s)
+
+# -- Colors ------------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log()   { echo -e "${CYAN}[$(date +%H:%M:%S)]${NC} $*"; }
+ok()    { echo -e "${GREEN}  OK:${NC} $*"; }
+warn()  { echo -e "${YELLOW}  WARN:${NC} $*"; }
+err()   { echo -e "${RED}  ERROR:${NC} $*" >&2; }
+phase() { echo -e "\n${YELLOW}=== $* ===${NC}"; }
+
+# -- Defaults ----------------------------------------------------------------
+NAMESPACE="librechat-fips"
+ADMIN_EMAIL=""
+ADMIN_NAME=""
+AGENTS_FILE=""
+MAKE_PUBLIC=""
+IMAGE_REGISTRY="ghcr.io"
+IMAGE_REPO="danny-avila/librechat"
+IMAGE_TAG=""
+DRY_RUN=false
+SKIP_AGENTS=false
+SKIP_USER=false
+
+# -- Argument parsing --------------------------------------------------------
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Required:
+  --admin-email EMAIL       Email for the admin user
+
+Optional:
+  --namespace NS            OpenShift namespace (default: librechat-fips)
+  --admin-name NAME         Display name for admin (default: email prefix)
+  --agents-file PATH        Path to agents-export.json for import
+  --make-public             Make imported agents publicly visible
+  --image-registry REG      Container image registry (default: ghcr.io)
+  --image-repo REPO         Container image repository (default: danny-avila/librechat)
+  --image-tag TAG           Container image tag (default: Chart.appVersion)
+  --dry-run                 Show what would be done without making changes
+  --skip-agents             Skip agent import even if --agents-file is set
+  --skip-user               Skip admin user creation
+  -h, --help                Show this help
+EOF
+  exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace)      NAMESPACE="$2";       shift 2 ;;
+    --admin-email)    ADMIN_EMAIL="$2";     shift 2 ;;
+    --admin-name)     ADMIN_NAME="$2";      shift 2 ;;
+    --agents-file)    AGENTS_FILE="$2";     shift 2 ;;
+    --make-public)    MAKE_PUBLIC="--make-public"; shift ;;
+    --image-registry) IMAGE_REGISTRY="$2";  shift 2 ;;
+    --image-repo)     IMAGE_REPO="$2";      shift 2 ;;
+    --image-tag)      IMAGE_TAG="$2";       shift 2 ;;
+    --dry-run)        DRY_RUN=true;         shift ;;
+    --skip-agents)    SKIP_AGENTS=true;     shift ;;
+    --skip-user)      SKIP_USER=true;       shift ;;
+    -h|--help)        usage 0 ;;
+    *)                err "Unknown option: $1"; usage 1 ;;
+  esac
+done
+
+if [[ -z "$ADMIN_EMAIL" ]]; then
+  err "--admin-email is required"
+  usage 1
+fi
+
+ADMIN_NAME="${ADMIN_NAME:-${ADMIN_EMAIL%%@*}}"
+
+# -- Prerequisite checks ----------------------------------------------------
+phase "Checking prerequisites"
+
+for tool in oc helm python3; do
+  if ! command -v "$tool" &>/dev/null; then
+    err "$tool is not installed or not in PATH"
+    exit 1
+  fi
+done
+ok "CLI tools present (oc, helm, python3)"
+
+if ! oc whoami &>/dev/null; then
+  err "Not logged into an OpenShift cluster (run 'oc login' first)"
+  exit 1
+fi
+ok "Logged into OpenShift as $(oc whoami)"
+
+if [[ ! -f "$REPO_ROOT/.env" ]]; then
+  err ".env file not found at $REPO_ROOT/.env"
+  exit 1
+fi
+ok ".env file found"
+
+if [[ ! -f "$REPO_ROOT/librechat.yaml" ]]; then
+  err "librechat.yaml not found at $REPO_ROOT/librechat.yaml"
+  exit 1
+fi
+ok "librechat.yaml found"
+
+if [[ -n "$AGENTS_FILE" && ! -f "$AGENTS_FILE" ]]; then
+  err "Agents file not found: $AGENTS_FILE"
+  exit 1
+fi
+
+# Auto-detect cluster domain
+CLUSTER_DOMAIN="$(oc whoami --show-server | sed 's|https://api\.||' | sed 's|:6443||')"
+ROUTE_HOST="librechat-${NAMESPACE}.apps.${CLUSTER_DOMAIN}"
+
+log "Namespace:  $NAMESPACE"
+log "Cluster:    $CLUSTER_DOMAIN"
+log "Route host: $ROUTE_HOST"
+log "Image:      ${IMAGE_REGISTRY}/${IMAGE_REPO}:${IMAGE_TAG:-<chart-default>}"
+
+if $DRY_RUN; then
+  phase "DRY RUN - no changes will be made"
+  echo "Would: create namespace $NAMESPACE"
+  echo "Would: grant anyuid SCC to service accounts"
+  echo "Would: create secret librechat-credentials-env from .env"
+  echo "Would: create configmap librechat-config from librechat.yaml"
+  echo "Would: helm install/upgrade librechat"
+  echo "Would: create edge route -> librechat-librechat:3080"
+  $SKIP_USER  || echo "Would: create admin user $ADMIN_EMAIL"
+  if [[ -n "$AGENTS_FILE" ]] && ! $SKIP_AGENTS; then
+    echo "Would: import agents from $AGENTS_FILE"
+    [[ -n "$MAKE_PUBLIC" ]] && echo "Would: make agents public"
+  fi
+  exit 0
+fi
+
+# -- Phase 1: Deploy --------------------------------------------------------
+phase "Phase 1: Deploy"
+
+# 1. Namespace
+log "Creating namespace (if needed)..."
+if oc get namespace "$NAMESPACE" &>/dev/null; then
+  ok "Namespace $NAMESPACE already exists"
+else
+  oc new-project "$NAMESPACE" \
+    --display-name="LibreChat FIPS" \
+    --description="LibreChat with FIPS compliance"
+  ok "Created namespace $NAMESPACE"
+fi
+
+# 2. SCC grants
+log "Granting anyuid SCC to service accounts..."
+for sa in default librechat-librechat librechat-mongodb librechat-meilisearch; do
+  oc adm policy add-scc-to-user anyuid -z "$sa" -n "$NAMESPACE" 2>/dev/null || true
+done
+ok "SCC permissions granted"
+
+# 3. Credentials secret (delete + recreate for idempotency)
+log "Creating credentials secret..."
+# shellcheck disable=SC1091
+source "$REPO_ROOT/.env"
+oc delete secret librechat-credentials-env -n "$NAMESPACE" 2>/dev/null || true
+oc create secret generic librechat-credentials-env -n "$NAMESPACE" \
+  --from-literal=CREDS_KEY="${CREDS_KEY}" \
+  --from-literal=CREDS_IV="${CREDS_IV}" \
+  --from-literal=JWT_SECRET="${JWT_SECRET}" \
+  --from-literal=JWT_REFRESH_SECRET="${JWT_REFRESH_SECRET}" \
+  --from-literal=MEILI_MASTER_KEY="${MEILI_MASTER_KEY}" \
+  --from-literal=OPENROUTER_KEY="${OPENROUTER_KEY:-dummy}" \
+  --from-literal=VLLM_API_KEY="${VLLM_API_KEY:-dummy}" \
+  --from-literal=VLLM_API_URL="${VLLM_API_URL:-http://localhost}" \
+  --from-literal=ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-dummy}" \
+  --from-literal=OPENAI_API_KEY="${OPENAI_API_KEY:-dummy}"
+ok "Secret created"
+
+# 4. ConfigMap (delete + recreate for idempotency)
+log "Creating librechat-config ConfigMap..."
+oc delete configmap librechat-config -n "$NAMESPACE" 2>/dev/null || true
+oc create configmap librechat-config \
+  --from-file=librechat.yaml="$REPO_ROOT/librechat.yaml" -n "$NAMESPACE"
+ok "ConfigMap created"
+
+# 5. Prepare Helm values with patched domain and image settings
+log "Preparing Helm values..."
+TMP_VALUES=$(mktemp)
+trap 'rm -f "$TMP_VALUES"' EXIT
+
+sed \
+  -e "s|DOMAIN_SERVER:.*|DOMAIN_SERVER: \"https://${ROUTE_HOST}\"|g" \
+  -e "s|DOMAIN_CLIENT:.*|DOMAIN_CLIENT: \"https://${ROUTE_HOST}\"|g" \
+  -e "/^  registry:/s|registry:.*|registry: ${IMAGE_REGISTRY}|" \
+  -e "/^  repository:/s|repository:.*|repository: ${IMAGE_REPO}|" \
+  "$REPO_ROOT/helm/librechat/values-openshift.yaml" > "$TMP_VALUES"
+
+# Patch image tag only if explicitly provided
+if [[ -n "$IMAGE_TAG" ]]; then
+  sed -i.bak "/^  tag:/s|tag:.*|tag: \"${IMAGE_TAG}\"|" "$TMP_VALUES"
+  rm -f "${TMP_VALUES}.bak"
+fi
+ok "Values prepared"
+
+# 6. Helm install or upgrade
+log "Running helm install/upgrade..."
+if helm list -n "$NAMESPACE" 2>/dev/null | grep -q librechat; then
+  helm upgrade librechat "$REPO_ROOT/helm/librechat" \
+    -f "$TMP_VALUES" -n "$NAMESPACE" --timeout 10m
+  ok "Helm upgrade complete"
+else
+  helm install librechat "$REPO_ROOT/helm/librechat" \
+    -f "$TMP_VALUES" -n "$NAMESPACE" --timeout 10m
+  ok "Helm install complete"
+fi
+
+# 7. Route
+log "Creating route (if needed)..."
+if oc get route librechat -n "$NAMESPACE" &>/dev/null; then
+  ok "Route already exists"
+else
+  oc create route edge librechat \
+    --service=librechat-librechat --port=3080 -n "$NAMESPACE"
+  ok "Route created"
+fi
+
+# 8. Wait for rollout
+log "Waiting for deployment rollout (timeout 300s)..."
+if oc rollout status deployment/librechat-librechat \
+     -n "$NAMESPACE" --timeout=300s; then
+  ok "Deployment is ready"
+else
+  err "Deployment rollout timed out"
+  echo "  Check pods: oc get pods -n $NAMESPACE"
+  exit 1
+fi
+
+ROUTE_URL="$(oc get route librechat -n "$NAMESPACE" \
+  -o jsonpath='{.spec.host}' 2>/dev/null || echo "$ROUTE_HOST")"
+
+# -- Phase 2: Admin user ----------------------------------------------------
+GENERATED_PASSWORD=""
+
+if $SKIP_USER; then
+  phase "Phase 2: Admin user (SKIPPED)"
+else
+  phase "Phase 2: Admin user"
+
+  # Wait for MongoDB pod
+  log "Waiting for MongoDB pod..."
+  MONGO_POD=""
+  for i in $(seq 1 30); do
+    MONGO_POD=$(oc get pods -n "$NAMESPACE" \
+      -l app.kubernetes.io/name=mongodb \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [[ -n "$MONGO_POD" ]]; then
+      # Verify it's running
+      POD_STATUS=$(oc get pod "$MONGO_POD" -n "$NAMESPACE" \
+        -o jsonpath='{.status.phase}' 2>/dev/null || true)
+      [[ "$POD_STATUS" == "Running" ]] && break
+    fi
+    sleep 5
+  done
+
+  if [[ -z "$MONGO_POD" ]]; then
+    err "Could not find a running MongoDB pod after 150s"
+    exit 1
+  fi
+  ok "MongoDB pod: $MONGO_POD"
+
+  # Check if user already exists
+  log "Checking for existing user..."
+  EXISTING=$(oc exec "$MONGO_POD" -n "$NAMESPACE" -c mongodb -- \
+    mongosh --quiet --eval \
+    "JSON.stringify(db.users.findOne({email: '${ADMIN_EMAIL}'}))" \
+    LibreChat 2>/dev/null || echo "null")
+
+  if [[ "$EXISTING" != "null" && -n "$EXISTING" ]]; then
+    ok "User $ADMIN_EMAIL already exists, skipping creation"
+  else
+    log "Creating admin user $ADMIN_EMAIL..."
+    GENERATED_PASSWORD=$(python3 -c "import secrets; print(secrets.token_urlsafe(16))")
+
+    # Hash the password with bcrypt if available, otherwise warn
+    HASHED_PASSWORD=""
+    if python3 -c "import bcrypt" 2>/dev/null; then
+      HASHED_PASSWORD=$(python3 -c "
+import bcrypt
+print(bcrypt.hashpw(b'${GENERATED_PASSWORD}', bcrypt.gensalt(10)).decode())
+")
+    else
+      warn "bcrypt not installed locally; user will need to set password via UI"
+      warn "Install with: pip install bcrypt"
+      # Use a placeholder that will never match, forcing password reset
+      HASHED_PASSWORD='$2b$10$PLACEHOLDER_NO_LOGIN_SET_VIA_UI'
+    fi
+
+    NOW=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+    USERNAME="${ADMIN_EMAIL%%@*}"
+
+    oc exec "$MONGO_POD" -n "$NAMESPACE" -c mongodb -- \
+      mongosh --quiet --eval "
+        db.users.insertOne({
+          name: '${ADMIN_NAME}',
+          username: '${USERNAME}',
+          email: '${ADMIN_EMAIL}',
+          emailVerified: true,
+          password: '${HASHED_PASSWORD}',
+          avatar: null,
+          provider: 'local',
+          role: 'ADMIN',
+          plugins: [],
+          createdAt: ISODate('${NOW}'),
+          updatedAt: ISODate('${NOW}')
+        })
+      " LibreChat
+    ok "Admin user created"
+  fi
+fi
+
+# -- Phase 3: Agent import --------------------------------------------------
+if [[ -z "$AGENTS_FILE" ]] || $SKIP_AGENTS; then
+  phase "Phase 3: Agent import (SKIPPED)"
+else
+  phase "Phase 3: Agent import"
+
+  # Ensure we have the MongoDB pod name
+  if [[ -z "${MONGO_POD:-}" ]]; then
+    MONGO_POD=$(oc get pods -n "$NAMESPACE" \
+      -l app.kubernetes.io/name=mongodb \
+      -o jsonpath='{.items[0].metadata.name}')
+  fi
+
+  # Get the admin user's ObjectId for agent ownership
+  log "Looking up admin user ID..."
+  USER_ID=$(oc exec "$MONGO_POD" -n "$NAMESPACE" -c mongodb -- \
+    mongosh --quiet --eval \
+    "let u = db.users.findOne({email: '${ADMIN_EMAIL}'}); print(u ? u._id.toString() : '')" \
+    LibreChat 2>/dev/null || true)
+
+  if [[ -z "$USER_ID" ]]; then
+    err "Could not find user $ADMIN_EMAIL in MongoDB; cannot import agents"
+    exit 1
+  fi
+  ok "User ID: $USER_ID"
+
+  # Step 1: Run migrate-agents.py for standard-size agents
+  log "Importing agents via migrate-agents.py..."
+  python3 "$REPO_ROOT/scripts/migrate-agents.py" \
+    --agents "$AGENTS_FILE" \
+    --new-user-email "$ADMIN_EMAIL" \
+    --new-user-name "$ADMIN_NAME" \
+    $MAKE_PUBLIC \
+    --target-namespace "$NAMESPACE" || warn "Some agents may have failed (expected for large ones)"
+
+  # Step 2: Import large agents that exceeded command-line limits
+  log "Importing large agents via import-large-agent.py..."
+  AUTHOR_NAME_ARG="$ADMIN_NAME"
+  PUBLIC_FLAG=""
+  [[ -n "$MAKE_PUBLIC" ]] && PUBLIC_FLAG="--public"
+
+  python3 "$REPO_ROOT/scripts/import-large-agent.py" \
+    "$NAMESPACE" "$MONGO_POD" "$AGENTS_FILE" \
+    "$USER_ID" "$AUTHOR_NAME_ARG" $PUBLIC_FLAG || warn "Some large agents may have failed"
+
+  # Step 3: Backfill public ACL entries for agents that are missing them
+  if [[ -n "$MAKE_PUBLIC" ]]; then
+    log "Backfilling public ACL entries for agents without them..."
+    oc exec "$MONGO_POD" -n "$NAMESPACE" -c mongodb -- \
+      mongosh --quiet --eval "
+        const agents = db.agents.find({}, {_id: 1, id: 1, name: 1}).toArray();
+        let created = 0;
+        for (const agent of agents) {
+          const existing = db.aclentries.findOne({
+            resourceType: 'agent',
+            resourceId: agent._id,
+            principalType: 'public'
+          });
+          if (!existing) {
+            db.aclentries.insertOne({
+              principalType: 'public',
+              resourceType: 'agent',
+              resourceId: agent._id,
+              permBits: 1,
+              grantedBy: ObjectId('${USER_ID}'),
+              grantedAt: new Date(),
+              createdAt: new Date(),
+              updatedAt: new Date()
+            });
+            created++;
+            print('  Created ACL for: ' + agent.name);
+          }
+        }
+        print('Backfilled ' + created + ' ACL entries');
+      " LibreChat
+    ok "ACL backfill complete"
+  fi
+fi
+
+# -- Phase 4: Verify --------------------------------------------------------
+phase "Phase 4: Verify"
+
+# Health check
+log "Checking health endpoint..."
+HTTP_CODE=$(curl -sk -o /dev/null -w "%{http_code}" \
+  "https://${ROUTE_URL}/health" 2>/dev/null || echo "000")
+
+if [[ "$HTTP_CODE" == "200" ]]; then
+  ok "Health check passed (HTTP $HTTP_CODE)"
+else
+  warn "Health check returned HTTP $HTTP_CODE (app may still be starting)"
+fi
+
+# Count agents and ACL entries
+if [[ -n "${MONGO_POD:-}" ]]; then
+  AGENT_COUNT=$(oc exec "$MONGO_POD" -n "$NAMESPACE" -c mongodb -- \
+    mongosh --quiet --eval "db.agents.countDocuments()" LibreChat 2>/dev/null || echo "?")
+  ACL_COUNT=$(oc exec "$MONGO_POD" -n "$NAMESPACE" -c mongodb -- \
+    mongosh --quiet --eval "db.aclentries.countDocuments()" LibreChat 2>/dev/null || echo "?")
+  ok "Agents: $AGENT_COUNT, ACL entries: $ACL_COUNT"
+fi
+
+# -- Summary -----------------------------------------------------------------
+ELAPSED=$(( $(date +%s) - START_TIME ))
+
+phase "Deployment Summary"
+echo ""
+echo "  URL:         https://${ROUTE_URL}"
+echo "  Namespace:   $NAMESPACE"
+echo "  Admin email: $ADMIN_EMAIL"
+if [[ -n "$GENERATED_PASSWORD" ]]; then
+  echo ""
+  echo -e "  ${GREEN}Admin password: ${GENERATED_PASSWORD}${NC}"
+  echo "  (save this now -- it will not be shown again)"
+fi
+if [[ -n "${AGENT_COUNT:-}" ]]; then
+  echo "  Agents:      $AGENT_COUNT"
+  echo "  ACL entries: $ACL_COUNT"
+fi
+echo ""
+echo "  Completed in ${ELAPSED}s"
+echo ""
+echo "Useful commands:"
+echo "  oc get pods -n $NAMESPACE"
+echo "  oc logs -f deployment/librechat-librechat -n $NAMESPACE"
+echo "  ./update-librechat-config.sh $NAMESPACE"

--- a/scripts/import-large-agent.py
+++ b/scripts/import-large-agent.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Import large agents via file copy to pod.
+Handles agents that are too large for command-line mongosh.
+"""
+
+import json
+import subprocess
+import sys
+from datetime import datetime
+import tempfile
+import os
+
+
+def run_cmd(cmd):
+    """Run a shell command and return output."""
+    result = subprocess.run(cmd, capture_output=True, text=True, shell=isinstance(cmd, str))
+    if result.returncode != 0:
+        raise Exception(f"Command failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+def import_large_agent(namespace: str, pod_name: str, agent: dict, new_author_id: str,
+                       new_author_name: str, make_public: bool = False):
+    """Import a single large agent via file transfer."""
+
+    agent_name = agent.get("name", "Unknown")
+    agent_id = agent.get("id")
+    now = datetime.utcnow().isoformat() + "Z"
+
+    # Prepare the document
+    doc = {
+        "id": agent["id"],
+        "name": agent.get("name", ""),
+        "description": agent.get("description", ""),
+        "instructions": agent.get("instructions", ""),
+        "avatar": agent.get("avatar"),
+        "provider": agent.get("provider", ""),
+        "model": agent.get("model", ""),
+        "model_parameters": agent.get("model_parameters", {}),
+        "artifacts": agent.get("artifacts", ""),
+        "tools": agent.get("tools", []),
+        "tool_kwargs": agent.get("tool_kwargs", []),
+        "actions": agent.get("actions", []),
+        "author": {"$oid": new_author_id},
+        "authorName": new_author_name,
+        "agent_ids": [],
+        "edges": agent.get("edges", []),
+        "isCollaborative": agent.get("isCollaborative", False),
+        "conversation_starters": agent.get("conversation_starters", []),
+        "tool_resources": agent.get("tool_resources", {}),
+        "projectIds": [],
+        "versions": agent.get("versions", []),
+        "category": agent.get("category", "general"),
+        "is_promoted": agent.get("is_promoted", False),
+        "createdAt": {"$date": now},
+        "updatedAt": {"$date": now}
+    }
+
+    # Write to temp file
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump(doc, f)
+        temp_file = f.name
+
+    try:
+        # Copy file to pod
+        remote_path = f"/tmp/agent-{agent_id}.json"
+        run_cmd(["oc", "cp", temp_file, f"{pod_name}:{remote_path}", "-n", namespace, "-c", "mongodb"])
+
+        # Import using mongoimport
+        import_cmd = f"mongoimport --db LibreChat --collection agents --file {remote_path}"
+        run_cmd(["oc", "exec", pod_name, "-n", namespace, "-c", "mongodb", "--", "sh", "-c", import_cmd])
+
+        # Cleanup remote file
+        run_cmd(["oc", "exec", pod_name, "-n", namespace, "-c", "mongodb", "--", "rm", remote_path])
+
+        print(f"  Imported: {agent_name} ({agent_id})")
+
+        # Make public if requested
+        if make_public:
+            # Get the inserted document's _id
+            get_id_cmd = f'''mongosh --quiet --eval "JSON.stringify(db.agents.findOne({{id: '{agent_id}'}}, {{_id: 1}}))" LibreChat'''
+            result = run_cmd(["oc", "exec", pod_name, "-n", namespace, "-c", "mongodb", "--", "sh", "-c", get_id_cmd])
+
+            if result and result != "null":
+                result_data = json.loads(result)
+                raw_id = result_data.get("_id")
+                # Handle both {"$oid": "..."} dict format and plain string format
+                agent_oid = raw_id.get("$oid") if isinstance(raw_id, dict) else raw_id
+
+                if agent_oid:
+                    # Create public ACL entry
+                    acl_doc = {
+                        "principalType": "public",
+                        "resourceType": "agent",
+                        "resourceId": {"$oid": agent_oid},
+                        "permBits": 1,
+                        "grantedBy": {"$oid": new_author_id},
+                        "grantedAt": {"$date": now},
+                        "createdAt": {"$date": now},
+                        "updatedAt": {"$date": now}
+                    }
+
+                    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+                        json.dump(acl_doc, f)
+                        acl_file = f.name
+
+                    try:
+                        acl_remote = f"/tmp/acl-{agent_id}.json"
+                        run_cmd(["oc", "cp", acl_file, f"{pod_name}:{acl_remote}", "-n", namespace, "-c", "mongodb"])
+                        acl_import_cmd = f"mongoimport --db LibreChat --collection aclentries --file {acl_remote}"
+                        run_cmd(["oc", "exec", pod_name, "-n", namespace, "-c", "mongodb", "--", "sh", "-c", acl_import_cmd])
+                        run_cmd(["oc", "exec", pod_name, "-n", namespace, "-c", "mongodb", "--", "rm", acl_remote])
+                        print(f"    Made public: {agent_id}")
+                    finally:
+                        os.unlink(acl_file)
+
+        return True
+
+    finally:
+        os.unlink(temp_file)
+
+
+def main():
+    if len(sys.argv) < 5:
+        print("Usage: python3 import-large-agent.py <namespace> <pod> <agents.json> <author_id> [author_name] [--public]")
+        sys.exit(1)
+
+    namespace = sys.argv[1]
+    pod_name = sys.argv[2]
+    agents_file = sys.argv[3]
+    author_id = sys.argv[4]
+    author_name = sys.argv[5] if len(sys.argv) > 5 and not sys.argv[5].startswith("--") else "Admin"
+    make_public = "--public" in sys.argv
+
+    # Load agents
+    with open(agents_file) as f:
+        agents = json.load(f)
+
+    # Filter to failed agents (the ones with long instructions)
+    failed_names = [
+        "ServiceNow Chat",
+        "FBI - Crime Stats Chat",
+        "Public Health Researcher",
+        "FAA Agent",
+        "USAF - Findings Analyst"
+    ]
+
+    large_agents = [a for a in agents if a.get("name") in failed_names]
+
+    print(f"Found {len(large_agents)} large agents to import")
+
+    for agent in large_agents:
+        try:
+            import_large_agent(namespace, pod_name, agent, author_id, author_name, make_public)
+        except Exception as e:
+            print(f"  Error importing {agent.get('name')}: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate-agents.py
+++ b/scripts/migrate-agents.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+LibreChat Agent Migration Script
+
+Migrates agents from one LibreChat MongoDB instance to another,
+updating ownership and optionally making them publicly accessible.
+
+Usage:
+    # Export from source cluster (run this first)
+    oc exec <mongodb-pod> -n <namespace> -- mongosh --quiet \
+        --eval "JSON.stringify(db.agents.find().toArray())" LibreChat > agents-export.json
+    oc exec <mongodb-pod> -n <namespace> -- mongosh --quiet \
+        --eval "JSON.stringify(db.aclentries.find().toArray())" LibreChat > aclentries-export.json
+
+    # Then run migration against target cluster
+    python3 migrate-agents.py --agents agents-export.json \
+        --new-user-email admin@example.com \
+        --make-public \
+        --target-namespace librechat-fips
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from typing import Optional
+import uuid
+
+
+def generate_object_id() -> str:
+    """Generate a MongoDB-style ObjectId (24 hex chars)."""
+    import time
+    timestamp = int(time.time())
+    random_part = uuid.uuid4().hex[:16]
+    return f"{timestamp:08x}{random_part}"
+
+
+def run_mongosh(namespace: str, pod_name: str, command: str) -> str:
+    """Run a mongosh command in the target MongoDB pod."""
+    cmd = [
+        "oc", "exec", pod_name, "-n", namespace, "--",
+        "mongosh", "--quiet", "--eval", command, "LibreChat"
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise Exception(f"mongosh failed: {result.stderr}")
+    return result.stdout.strip()
+
+
+def get_mongodb_pod(namespace: str) -> str:
+    """Get the MongoDB pod name in the target namespace."""
+    cmd = ["oc", "get", "pods", "-n", namespace, "-l", "app.kubernetes.io/name=mongodb",
+           "-o", "jsonpath={.items[0].metadata.name}"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0 or not result.stdout.strip():
+        # Try alternate label
+        cmd = ["oc", "get", "pods", "-n", namespace,
+               "-o", "jsonpath={.items[?(@.metadata.name contains 'mongodb')].metadata.name}"]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0 or not result.stdout.strip():
+            raise Exception(f"Could not find MongoDB pod in namespace {namespace}")
+    return result.stdout.strip().split()[0]
+
+
+def get_or_create_user(namespace: str, pod_name: str, email: str, name: Optional[str] = None) -> dict:
+    """Get existing user by email or create a new admin user."""
+    # Check if user exists - use JSON.stringify for clean output
+    check_cmd = f'JSON.stringify(db.users.findOne({{email: "{email}"}}))'
+    result = run_mongosh(namespace, pod_name, check_cmd)
+
+    if result and result != "null":
+        user_data = json.loads(result)
+        print(f"Found existing user: {email}")
+        return user_data
+
+    # Create new user
+    user_id = generate_object_id()
+    username = email.split("@")[0]
+    display_name = name or username
+    now = datetime.utcnow().isoformat() + "Z"
+
+    create_cmd = f'''db.users.insertOne({{
+        _id: ObjectId("{user_id}"),
+        name: "{display_name}",
+        username: "{username}",
+        email: "{email}",
+        role: "ADMIN",
+        provider: "local",
+        createdAt: ISODate("{now}"),
+        updatedAt: ISODate("{now}")
+    }})'''
+
+    run_mongosh(namespace, pod_name, create_cmd)
+    print(f"Created new admin user: {email} with ID: {user_id}")
+
+    return {"_id": user_id, "email": email, "name": display_name}
+
+
+def import_agents(namespace: str, pod_name: str, agents: list, new_author_id: str,
+                  new_author_name: str, make_public: bool = False) -> dict:
+    """Import agents with updated ownership."""
+    results = {"imported": 0, "skipped": 0, "errors": []}
+
+    for agent in agents:
+        agent_id = agent.get("id")
+        agent_name = agent.get("name", "Unknown")
+
+        # Check if agent already exists
+        check_cmd = f'db.agents.findOne({{id: "{agent_id}"}})'
+        existing = run_mongosh(namespace, pod_name, check_cmd)
+
+        if existing and existing != "null":
+            print(f"  Skipping existing agent: {agent_name} ({agent_id})")
+            results["skipped"] += 1
+            continue
+
+        try:
+            # Prepare agent document for insertion
+            # Remove MongoDB-specific fields that will be regenerated
+            agent_copy = {k: v for k, v in agent.items() if k not in ["_id", "__v"]}
+
+            # Update ownership
+            agent_copy["author"] = f'ObjectId("{new_author_id}")'
+            agent_copy["authorName"] = new_author_name
+
+            # Clear project associations (they won't exist in new cluster)
+            agent_copy["projectIds"] = []
+
+            # Convert to mongosh-compatible format
+            now = datetime.utcnow().isoformat() + "Z"
+
+            # Handle arrays and nested objects - use json.dumps for safe escaping
+            tools_str = json.dumps(agent_copy.get("tools", []))
+            tool_kwargs_str = json.dumps(agent_copy.get("tool_kwargs", []))
+            actions_str = json.dumps(agent_copy.get("actions", []))
+            starters_str = json.dumps(agent_copy.get("conversation_starters", []))
+            versions_str = json.dumps(agent_copy.get("versions", []))
+            model_params_str = json.dumps(agent_copy.get("model_parameters", {}))
+            tool_resources_str = json.dumps(agent_copy.get("tool_resources", {}))
+            edges_str = json.dumps(agent_copy.get("edges", []))
+
+            # Handle string fields - use json.dumps for safe escaping
+            agent_id_str = agent_copy['id']
+            name_str = json.dumps(agent_copy.get('name', ''))
+            desc_str = json.dumps(agent_copy.get('description', ''))
+            instr_str = json.dumps(agent_copy.get('instructions', ''))
+            provider_str = agent_copy.get('provider', '')
+            model_str = agent_copy.get('model', '')
+            artifacts_str = agent_copy.get('artifacts', '')
+            category_str = agent_copy.get('category', 'general')
+
+            # Handle avatar
+            avatar = agent_copy.get("avatar")
+            avatar_str = json.dumps(avatar) if avatar else "null"
+
+            # Handle booleans
+            is_collab = str(agent_copy.get('isCollaborative', False)).lower()
+            is_promo = str(agent_copy.get('is_promoted', False)).lower()
+
+            insert_cmd = f'''db.agents.insertOne({{
+                id: "{agent_id_str}",
+                name: {name_str},
+                description: {desc_str},
+                instructions: {instr_str},
+                avatar: {avatar_str},
+                provider: "{provider_str}",
+                model: "{model_str}",
+                model_parameters: {model_params_str},
+                artifacts: "{artifacts_str}",
+                tools: {tools_str},
+                tool_kwargs: {tool_kwargs_str},
+                actions: {actions_str},
+                author: ObjectId("{new_author_id}"),
+                authorName: "{new_author_name}",
+                agent_ids: [],
+                edges: {edges_str},
+                isCollaborative: {is_collab},
+                conversation_starters: {starters_str},
+                tool_resources: {tool_resources_str},
+                projectIds: [],
+                versions: {versions_str},
+                category: "{category_str}",
+                is_promoted: {is_promo},
+                createdAt: ISODate("{now}"),
+                updatedAt: ISODate("{now}")
+            }})'''
+
+            run_mongosh(namespace, pod_name, insert_cmd)
+            print(f"  Imported: {agent_name} ({agent_id})")
+            results["imported"] += 1
+
+            # Make public if requested
+            if make_public:
+                create_public_acl(namespace, pod_name, agent_id, new_author_id)
+
+        except Exception as e:
+            print(f"  Error importing {agent_name}: {e}")
+            results["errors"].append({"agent": agent_name, "error": str(e)})
+
+    return results
+
+
+def create_public_acl(namespace: str, pod_name: str, agent_id: str, granted_by: str):
+    """Create a public ACL entry for an agent."""
+    now = datetime.utcnow().isoformat() + "Z"
+
+    # First get the agent's _id
+    get_id_cmd = f'db.agents.findOne({{id: "{agent_id}"}}, {{_id: 1}})'
+    result = run_mongosh(namespace, pod_name, get_id_cmd)
+
+    if not result or result == "null":
+        print(f"    Warning: Could not find agent {agent_id} for ACL creation")
+        return
+
+    # Parse the ObjectId from the result
+    # Result looks like: { _id: ObjectId('...') }
+    import re
+    match = re.search(r"ObjectId\(['\"]([^'\"]+)['\"]\)", result)
+    if not match:
+        print(f"    Warning: Could not parse agent _id from: {result}")
+        return
+
+    agent_object_id = match.group(1)
+
+    # Create public ACL entry with VIEW permission (permBits: 1)
+    acl_cmd = f'''db.aclentries.insertOne({{
+        principalType: "public",
+        resourceType: "agent",
+        resourceId: ObjectId("{agent_object_id}"),
+        permBits: 1,
+        grantedBy: ObjectId("{granted_by}"),
+        grantedAt: ISODate("{now}"),
+        createdAt: ISODate("{now}"),
+        updatedAt: ISODate("{now}")
+    }})'''
+
+    run_mongosh(namespace, pod_name, acl_cmd)
+    print(f"    Made public: {agent_id}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Migrate LibreChat agents between MongoDB instances"
+    )
+    parser.add_argument("--agents", required=True, help="Path to agents JSON export file")
+    parser.add_argument("--aclentries", help="Path to ACL entries JSON export file (optional)")
+    parser.add_argument("--new-user-email", required=True, help="Email for the new owner")
+    parser.add_argument("--new-user-name", help="Display name for new owner")
+    parser.add_argument("--make-public", action="store_true", help="Make all agents publicly viewable")
+    parser.add_argument("--target-namespace", default="librechat-fips", help="Target OpenShift namespace")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without making changes")
+
+    args = parser.parse_args()
+
+    # Load agents
+    print(f"Loading agents from {args.agents}...")
+    with open(args.agents, "r") as f:
+        agents = json.load(f)
+    print(f"Found {len(agents)} agents to migrate")
+
+    if args.dry_run:
+        print("\n=== DRY RUN MODE ===")
+        for agent in agents:
+            print(f"  Would import: {agent.get('name')} ({agent.get('id')})")
+            if args.make_public:
+                print(f"    Would make public")
+        return
+
+    # Get MongoDB pod
+    print(f"\nConnecting to MongoDB in namespace {args.target_namespace}...")
+    pod_name = get_mongodb_pod(args.target_namespace)
+    print(f"Found MongoDB pod: {pod_name}")
+
+    # Get or create user
+    print(f"\nSetting up owner user: {args.new_user_email}...")
+    user = get_or_create_user(
+        args.target_namespace,
+        pod_name,
+        args.new_user_email,
+        args.new_user_name
+    )
+
+    # Extract user ID (handle both string and dict formats)
+    if isinstance(user.get("_id"), dict):
+        user_id = user["_id"].get("$oid", str(user["_id"]))
+    else:
+        user_id = str(user["_id"]).replace("ObjectId('", "").replace("')", "")
+
+    user_name = user.get("name", args.new_user_email.split("@")[0])
+
+    # Import agents
+    print(f"\nImporting agents...")
+    results = import_agents(
+        args.target_namespace,
+        pod_name,
+        agents,
+        user_id,
+        user_name,
+        args.make_public
+    )
+
+    # Summary
+    print(f"\n=== Migration Complete ===")
+    print(f"Imported: {results['imported']}")
+    print(f"Skipped (already exist): {results['skipped']}")
+    if results['errors']:
+        print(f"Errors: {len(results['errors'])}")
+        for err in results['errors']:
+            print(f"  - {err['agent']}: {err['error']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `scripts/deploy-golden-path.sh` — single-command, idempotent deployment of LibreChat to OpenShift (namespace, Helm, admin user, agent import with public ACLs)
- Rewrite `README.md` to focus on this fork's deployment workflow, removing upstream marketing content
- Add `CLAUDE.md` for Claude Code project guidance
- Add `helm/librechat/values-openshift.yaml` and migration scripts (`migrate-agents.py`, `import-large-agent.py`) to main branch with bug fixes:
  - Fix mongosh output parsing (use `JSON.stringify` instead of fragile string replacement)
  - Fix `_id` extraction to handle plain string format from `JSON.stringify`

## Test plan

- [x] Deployed to `cluster-n7pd5` sandbox using this exact flow
- [x] 15 agents imported, all with public ACL entries
- [x] Health endpoint verified, admin login confirmed
- [x] MCP-backed agents tested and working
- [ ] Run `./scripts/deploy-golden-path.sh --dry-run` on a clean checkout to verify argument parsing