### PR TITLE
fix: initiate OAuth flow during tool discovery for servers requiring pre-auth

### DIFF
--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -81,17 +81,31 @@ export class MCPConnectionFactory {
       useSSRFProtection: this.useSSRFProtection,
     });
 
-    const oauthHandler = () => {
-      logger.info(
-        `${this.logPrefix} [Discovery] OAuth required; skipping URL generation in discovery mode`,
-      );
-      oauthRequired = true;
-      connection.emit('oauthFailed', new Error('OAuth required during tool discovery'));
-    };
-
-    // Register unconditionally: non-OAuth servers that return 401 also emit 'oauthRequired',
-    // and without this listener, connectClient()'s oauthHandledPromise hangs for 30s+.
-    connection.once('oauthRequired', oauthHandler);
+    let cleanupOAuthHandlers: (() => void) | undefined;
+    if (this.useOAuth) {
+      // Delegate to the real OAuth handler that initiates the flow and
+      // presents the authorization URL to the user. This is required for
+      // servers that need authentication before tool discovery (e.g.
+      // Cloudflare MCP Portal).
+      cleanupOAuthHandlers = this.handleOAuthEvents(connection);
+      connection.once('oauthRequired', () => {
+        logger.info(
+          `${this.logPrefix} [Discovery] OAuth required; delegating to handleOAuthEvents`,
+        );
+        oauthRequired = true;
+      });
+    } else {
+      // Non-OAuth servers: fail fast to prevent connectClient()'s
+      // oauthHandledPromise from hanging for 30s+.
+      const oauthHandler = () => {
+        logger.info(
+          `${this.logPrefix} [Discovery] OAuth required; skipping (non-OAuth server)`,
+        );
+        oauthRequired = true;
+        connection.emit('oauthFailed', new Error('OAuth required during tool discovery'));
+      };
+      connection.once('oauthRequired', oauthHandler);
+    }
 
     try {
       const connectTimeout = this.connectionTimeout ?? this.serverConfig.initTimeout ?? 30000;
@@ -103,7 +117,7 @@ export class MCPConnectionFactory {
 
       if (await connection.isConnected()) {
         const tools = await connection.fetchTools();
-        connection.removeListener('oauthRequired', oauthHandler);
+        cleanupOAuthHandlers?.();
         return { tools, connection, oauthRequired: false, oauthUrl: null };
       }
     } catch {
@@ -115,7 +129,7 @@ export class MCPConnectionFactory {
 
     try {
       const tools = await this.attemptUnauthenticatedToolListing();
-      connection.removeListener('oauthRequired', oauthHandler);
+      cleanupOAuthHandlers?.();
       if (tools && tools.length > 0) {
         logger.info(
           `${this.logPrefix} [Discovery] Successfully discovered ${tools.length} tools without auth`,
@@ -133,7 +147,7 @@ export class MCPConnectionFactory {
       logger.debug(`${this.logPrefix} [Discovery] Unauthenticated tool listing failed:`, listError);
     }
 
-    connection.removeListener('oauthRequired', oauthHandler);
+    cleanupOAuthHandlers?.();
 
     try {
       await connection.disconnect();


### PR DESCRIPTION
## Summary

Fixes MCP servers that require OAuth authentication **before** tool discovery (e.g. Cloudflare MCP Portal).

## Problem

When an MCP server returns 401 on the initial POST to `/mcp`, `discoverToolsInternal()` uses a stub `oauthHandler` that immediately emits `oauthFailed`, killing the connection. It never calls `handleOAuthEvents()` which would actually initiate the OAuth flow.

The comment in the code states *"Per MCP spec, tool listing should be possible without authentication"* — however, this is not true for all servers. The [MCP Authorization spec](https://modelcontextprotocol.io/specification/draft/basic/authorization) defines a reactive 401→OAuth pattern where the client should initiate the OAuth flow when receiving 401.

Servers like the [Cloudflare MCP Portal](https://developers.cloudflare.com/cloudflare-one/access-controls/ai-controls/mcp-portals/) require authentication before any interaction, including tool discovery.

## Fix

When `useOAuth` is true, delegate to `handleOAuthEvents()` instead of using the stub handler. The `handleOAuthEvents()` method already handles the full OAuth flow correctly and is used by `createConnection()` for tool execution — it just needs to also be used during discovery.

Non-OAuth servers retain the existing fast-fail behavior (no change).

## Changes

- `packages/api/src/mcp/MCPConnectionFactory.ts`: Replace stub OAuth handler in `discoverToolsInternal()` with `handleOAuthEvents()` delegation when `useOAuth` is true

## Test plan

- [x] Tested with Cloudflare MCP Portal (Streamable HTTP + OAuth 2.1 + PKCE)
- [ ] Existing non-OAuth MCP servers should continue to work (fast-fail behavior unchanged)
- [ ] OAuth servers that allow unauthenticated tool listing should still work (fallback path)

Related: #9657