### PR TITLE
🛡️ fix: Restrict System Grants to Role Principals

### DIFF
--- a/api/server/routes/admin/groups.js
+++ b/api/server/routes/admin/groups.js
@@ -24,7 +24,6 @@ const handlers = createAdminGroupsHandlers({
   findUsers: db.findUsers,
   deleteConfig: db.deleteConfig,
   deleteAclEntries: db.deleteAclEntries,
-  deleteGrantsForPrincipal: db.deleteGrantsForPrincipal,
 });
 
 router.use(requireJwtAuth, requireAdminAccess);

--- a/api/server/routes/admin/users.js
+++ b/api/server/routes/admin/users.js
@@ -17,7 +17,6 @@ const handlers = createAdminUsersHandlers({
   deleteUserById: db.deleteUserById,
   deleteConfig: db.deleteConfig,
   deleteAclEntries: db.deleteAclEntries,
-  deleteGrantsForPrincipal: db.deleteGrantsForPrincipal,
 });
 
 router.use(requireJwtAuth, requireAdminAccess);

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -456,10 +456,8 @@ describe('createAdminGrantsHandlers', () => {
       expect(json).toHaveBeenCalledWith({ grants });
     });
 
-    it('returns grants for a group principal', async () => {
-      const deps = createDeps({
-        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
-      });
+    it('returns 400 for group principal type', async () => {
+      const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
         params: { principalType: PrincipalType.GROUP, principalId: validObjectId },
@@ -467,15 +465,12 @@ describe('createAdminGrantsHandlers', () => {
 
       await handlers.getPrincipalGrants(req, res);
 
-      expect(status).toHaveBeenCalledWith(200);
-      expect(json).toHaveBeenCalledWith({ grants: [] });
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principal type' });
     });
 
-    it('returns grants for a user principal', async () => {
-      const grants = [mockGrant({ principalType: PrincipalType.USER, principalId: validObjectId })];
-      const deps = createDeps({
-        getCapabilitiesForPrincipal: jest.fn().mockResolvedValue(grants),
-      });
+    it('returns 400 for user principal type', async () => {
+      const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
         params: { principalType: PrincipalType.USER, principalId: validObjectId },
@@ -483,17 +478,8 @@ describe('createAdminGrantsHandlers', () => {
 
       await handlers.getPrincipalGrants(req, res);
 
-      expect(deps.hasCapabilityForPrincipals).toHaveBeenCalledWith(
-        expect.objectContaining({ capability: SystemCapabilities.READ_USERS }),
-      );
-      expect(deps.getCapabilitiesForPrincipal).toHaveBeenCalledWith(
-        expect.objectContaining({
-          principalType: PrincipalType.USER,
-          principalId: validObjectId,
-        }),
-      );
-      expect(status).toHaveBeenCalledWith(200);
-      expect(json).toHaveBeenCalledWith({ grants });
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principal type' });
     });
 
     it('passes tenantId to dep calls', async () => {
@@ -542,33 +528,7 @@ describe('createAdminGrantsHandlers', () => {
       expect(json).toHaveBeenCalledWith({ error: 'Principal ID is required' });
     });
 
-    it('returns 400 for non-ObjectId group principalId', async () => {
-      const deps = createDeps();
-      const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({
-        params: { principalType: PrincipalType.GROUP, principalId: 'not-an-objectid' },
-      });
-
-      await handlers.getPrincipalGrants(req, res);
-
-      expect(status).toHaveBeenCalledWith(400);
-      expect(json).toHaveBeenCalledWith({ error: 'Invalid principalId format' });
-    });
-
-    it('returns 400 for non-ObjectId user principalId', async () => {
-      const deps = createDeps();
-      const handlers = createAdminGrantsHandlers(deps);
-      const { req, res, status, json } = createReqRes({
-        params: { principalType: PrincipalType.USER, principalId: 'not-an-objectid' },
-      });
-
-      await handlers.getPrincipalGrants(req, res);
-
-      expect(status).toHaveBeenCalledWith(400);
-      expect(json).toHaveBeenCalledWith({ error: 'Invalid principalId format' });
-    });
-
-    it('accepts string principalId for role type without ObjectId validation', async () => {
+    it('accepts string principalId for role type', async () => {
       const deps = createDeps({
         getCapabilitiesForPrincipal: jest.fn().mockResolvedValue([]),
       });
@@ -792,13 +752,13 @@ describe('createAdminGrantsHandlers', () => {
       expect(json).toHaveBeenCalledWith({ error: 'Invalid capability' });
     });
 
-    it('returns 400 for invalid ObjectId on group principalId', async () => {
+    it('returns 400 for group principal type', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
         body: {
           principalType: PrincipalType.GROUP,
-          principalId: 'not-an-objectid',
+          principalId: validObjectId,
           capability: SystemCapabilities.READ_USERS,
         },
       });
@@ -806,7 +766,7 @@ describe('createAdminGrantsHandlers', () => {
       await handlers.assignGrant(req, res);
 
       expect(status).toHaveBeenCalledWith(400);
-      expect(json).toHaveBeenCalledWith({ error: 'Invalid principalId format' });
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principal type' });
     });
 
     it('returns 401 when user is not authenticated', async () => {
@@ -899,16 +859,10 @@ describe('createAdminGrantsHandlers', () => {
       );
     });
 
-    it('checks MANAGE_GROUPS for group principal type', async () => {
-      const deps = createDeps({
-        getHeldCapabilities: jest
-          .fn()
-          .mockResolvedValue(
-            new Set([SystemCapabilities.MANAGE_GROUPS, SystemCapabilities.READ_USERS]),
-          ),
-      });
+    it('rejects group principal type before checking capabilities', async () => {
+      const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res } = createReqRes({
+      const { req, res, status, json } = createReqRes({
         body: {
           principalType: PrincipalType.GROUP,
           principalId: validObjectId,
@@ -918,23 +872,15 @@ describe('createAdminGrantsHandlers', () => {
 
       await handlers.assignGrant(req, res);
 
-      expect(deps.getHeldCapabilities).toHaveBeenCalledWith(
-        expect.objectContaining({
-          capabilities: expect.arrayContaining([SystemCapabilities.MANAGE_GROUPS]),
-        }),
-      );
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principal type' });
+      expect(deps.getHeldCapabilities).not.toHaveBeenCalled();
     });
 
-    it('checks MANAGE_USERS for user principal type', async () => {
-      const deps = createDeps({
-        getHeldCapabilities: jest
-          .fn()
-          .mockResolvedValue(
-            new Set([SystemCapabilities.MANAGE_USERS, SystemCapabilities.READ_USERS]),
-          ),
-      });
+    it('rejects user principal type before checking capabilities', async () => {
+      const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
-      const { req, res } = createReqRes({
+      const { req, res, status, json } = createReqRes({
         body: {
           principalType: PrincipalType.USER,
           principalId: validObjectId,
@@ -944,11 +890,9 @@ describe('createAdminGrantsHandlers', () => {
 
       await handlers.assignGrant(req, res);
 
-      expect(deps.getHeldCapabilities).toHaveBeenCalledWith(
-        expect.objectContaining({
-          capabilities: expect.arrayContaining([SystemCapabilities.MANAGE_USERS]),
-        }),
-      );
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principal type' });
+      expect(deps.getHeldCapabilities).not.toHaveBeenCalled();
     });
 
     it('returns 400 when role does not exist', async () => {
@@ -1174,13 +1118,13 @@ describe('createAdminGrantsHandlers', () => {
       expect(deps.revokeCapability).not.toHaveBeenCalled();
     });
 
-    it('returns 400 for invalid user ObjectId', async () => {
+    it('returns 400 for user principal type', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);
       const { req, res, status, json } = createReqRes({
         params: {
           principalType: PrincipalType.USER,
-          principalId: 'bad-id',
+          principalId: validObjectId,
           capability: SystemCapabilities.READ_USERS,
         },
       });
@@ -1188,7 +1132,7 @@ describe('createAdminGrantsHandlers', () => {
       await handlers.revokeGrant(req, res);
 
       expect(status).toHaveBeenCalledWith(400);
-      expect(json).toHaveBeenCalledWith({ error: 'Invalid principalId format' });
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principal type' });
     });
 
     it('returns 500 on unexpected error', async () => {

--- a/packages/api/src/admin/grants.spec.ts
+++ b/packages/api/src/admin/grants.spec.ts
@@ -1118,6 +1118,23 @@ describe('createAdminGrantsHandlers', () => {
       expect(deps.revokeCapability).not.toHaveBeenCalled();
     });
 
+    it('returns 400 for group principal type', async () => {
+      const deps = createDeps();
+      const handlers = createAdminGrantsHandlers(deps);
+      const { req, res, status, json } = createReqRes({
+        params: {
+          principalType: PrincipalType.GROUP,
+          principalId: validObjectId,
+          capability: SystemCapabilities.READ_USERS,
+        },
+      });
+
+      await handlers.revokeGrant(req, res);
+
+      expect(status).toHaveBeenCalledWith(400);
+      expect(json).toHaveBeenCalledWith({ error: 'Invalid principal type' });
+    });
+
     it('returns 400 for user principal type', async () => {
       const deps = createDeps();
       const handlers = createAdminGrantsHandlers(deps);

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -74,6 +74,7 @@ export interface AdminGrantsDeps {
   checkRoleExists?: (roleId: string) => Promise<boolean>;
 }
 
+/** Currently ROLE-only; Record/Set structure preserved for future principal-type expansion. */
 export type GrantPrincipalType = PrincipalType.ROLE;
 
 /** Creates admin grant handlers with dependency injection for the /api/admin/grants routes. */
@@ -327,6 +328,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         return res.status(403).json({ error: 'Cannot grant a capability you do not possess' });
       }
 
+      /** Reject grants targeting non-existent roles when the dep is provided. */
       if (checkRoleExists) {
         const exists = await checkRoleExists(principalId);
         if (!exists) {

--- a/packages/api/src/admin/grants.ts
+++ b/packages/api/src/admin/grants.ts
@@ -2,7 +2,6 @@ import { PrincipalType } from 'librechat-data-provider';
 import {
   logger,
   isValidCapability,
-  isValidObjectIdString,
   SystemCapabilities,
   expandImplications,
 } from '@librechat/data-schemas';
@@ -75,7 +74,7 @@ export interface AdminGrantsDeps {
   checkRoleExists?: (roleId: string) => Promise<boolean>;
 }
 
-export type GrantPrincipalType = PrincipalType.ROLE | PrincipalType.GROUP | PrincipalType.USER;
+export type GrantPrincipalType = PrincipalType.ROLE;
 
 /** Creates admin grant handlers with dependency injection for the /api/admin/grants routes. */
 export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
@@ -95,14 +94,10 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
 
   const MANAGE_CAPABILITY_BY_TYPE: Record<GrantPrincipalType, SystemCapability> = {
     [PrincipalType.ROLE]: SystemCapabilities.MANAGE_ROLES,
-    [PrincipalType.GROUP]: SystemCapabilities.MANAGE_GROUPS,
-    [PrincipalType.USER]: SystemCapabilities.MANAGE_USERS,
   };
 
   const READ_CAPABILITY_BY_TYPE: Record<GrantPrincipalType, SystemCapability> = {
     [PrincipalType.ROLE]: SystemCapabilities.READ_ROLES,
-    [PrincipalType.GROUP]: SystemCapabilities.READ_GROUPS,
-    [PrincipalType.USER]: SystemCapabilities.READ_USERS,
   };
 
   const VALID_PRINCIPAL_TYPES = new Set(
@@ -147,9 +142,6 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
     }
     if (!principalId) {
       return 'Principal ID is required';
-    }
-    if (principalType !== PrincipalType.ROLE && !isValidObjectIdString(principalId)) {
-      return 'Invalid principalId format';
     }
     return null;
   }
@@ -335,14 +327,7 @@ export function createAdminGrantsHandlers(deps: AdminGrantsDeps) {
         return res.status(403).json({ error: 'Cannot grant a capability you do not possess' });
       }
 
-      /*
-       * Role existence is validated when checkRoleExists is provided.
-       * GROUP and USER principals are ObjectId-validated by validatePrincipal
-       * but not existence-checked — orphan grants for deleted principals are
-       * accepted as a trade-off. Cascade cleanup on group/user deletion
-       * (deleteGrantsForPrincipal) handles the removal path.
-       */
-      if (principalType === PrincipalType.ROLE && checkRoleExists) {
+      if (checkRoleExists) {
         const exists = await checkRoleExists(principalId);
         if (!exists) {
           return res.status(400).json({ error: 'Role not found' });

--- a/packages/api/src/admin/groups.spec.ts
+++ b/packages/api/src/admin/groups.spec.ts
@@ -76,7 +76,6 @@ describe('createAdminGroupsHandlers', () => {
       findUsers: jest.fn().mockResolvedValue([]),
       deleteConfig: jest.fn().mockResolvedValue(null),
       deleteAclEntries: jest.fn().mockResolvedValue({ deletedCount: 0 }),
-      deleteGrantsForPrincipal: jest.fn().mockResolvedValue(undefined),
       ...overrides,
     };
   }
@@ -809,12 +808,9 @@ describe('createAdminGroupsHandlers', () => {
         principalType: PrincipalType.GROUP,
         principalId: new Types.ObjectId(validId),
       });
-      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.GROUP, validId, {
-        tenantId: undefined,
-      });
     });
 
-    it('cleans up Config, AclEntry, and SystemGrant on group delete', async () => {
+    it('cleans up Config and AclEntry on group delete', async () => {
       const deps = createDeps({ deleteGroup: jest.fn().mockResolvedValue(mockGroup()) });
       const handlers = createAdminGroupsHandlers(deps);
       const { req, res, status } = createReqRes({ params: { id: validId } });
@@ -826,9 +822,6 @@ describe('createAdminGroupsHandlers', () => {
       expect(deps.deleteAclEntries).toHaveBeenCalledWith({
         principalType: PrincipalType.GROUP,
         principalId: new Types.ObjectId(validId),
-      });
-      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.GROUP, validId, {
-        tenantId: undefined,
       });
     });
   });

--- a/packages/api/src/admin/groups.ts
+++ b/packages/api/src/admin/groups.ts
@@ -82,11 +82,6 @@ export interface AdminGroupsDeps {
     principalType: PrincipalType;
     principalId: string | Types.ObjectId;
   }) => Promise<DeleteResult>;
-  deleteGrantsForPrincipal: (
-    principalType: PrincipalType,
-    principalId: string | Types.ObjectId,
-    options?: { tenantId?: string },
-  ) => Promise<void>;
 }
 
 export function createAdminGroupsHandlers(deps: AdminGroupsDeps) {
@@ -103,7 +98,6 @@ export function createAdminGroupsHandlers(deps: AdminGroupsDeps) {
     findUsers,
     deleteConfig,
     deleteAclEntries,
-    deleteGrantsForPrincipal,
   } = deps;
 
   async function listGroupsHandler(req: ServerRequest, res: Response) {
@@ -309,16 +303,14 @@ export function createAdminGroupsHandlers(deps: AdminGroupsDeps) {
       /**
        * deleteAclEntries is a raw deleteMany wrapper with no type casting.
        * grantPermission stores group principalId as ObjectId, so we must
-       * cast here. deleteConfig and deleteGrantsForPrincipal normalize internally.
+       * cast here. deleteConfig normalizes internally.
        */
-      const tenantId = req.user?.tenantId;
       const cleanupResults = await Promise.allSettled([
         deleteConfig(PrincipalType.GROUP, id),
         deleteAclEntries({
           principalType: PrincipalType.GROUP,
           principalId: new Types.ObjectId(id),
         }),
-        deleteGrantsForPrincipal(PrincipalType.GROUP, id, { tenantId }),
       ]);
       for (const result of cleanupResults) {
         if (result.status === 'rejected') {

--- a/packages/api/src/admin/users.spec.ts
+++ b/packages/api/src/admin/users.spec.ts
@@ -58,7 +58,6 @@ function createDeps(overrides: Partial<AdminUsersDeps> = {}): AdminUsersDeps {
       .mockResolvedValue({ deletedCount: 1, message: 'User was deleted successfully.' }),
     deleteConfig: jest.fn().mockResolvedValue(null),
     deleteAclEntries: jest.fn().mockResolvedValue(undefined),
-    deleteGrantsForPrincipal: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -417,7 +416,7 @@ describe('createAdminUsersHandlers', () => {
       expect(deps.countUsers).not.toHaveBeenCalled();
     });
 
-    it('cascades cleanup of Config, AclEntries, and SystemGrants', async () => {
+    it('cascades cleanup of Config and AclEntries', async () => {
       const result: UserDeleteResult = {
         deletedCount: 1,
         message: 'User was deleted successfully.',
@@ -433,24 +432,6 @@ describe('createAdminUsersHandlers', () => {
       expect(deps.deleteAclEntries).toHaveBeenCalledWith({
         principalType: PrincipalType.USER,
         principalId: expect.any(Types.ObjectId),
-      });
-      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.USER, validUserId, {
-        tenantId: undefined,
-      });
-    });
-
-    it('scopes grant cleanup to the caller tenantId', async () => {
-      const deps = createDeps();
-      const handlers = createAdminUsersHandlers(deps);
-      const { req, res } = createReqRes({
-        params: { id: validUserId },
-        user: { _id: new Types.ObjectId(), role: 'admin', tenantId: 'tenant-xyz' },
-      });
-
-      await handlers.deleteUser(req, res);
-
-      expect(deps.deleteGrantsForPrincipal).toHaveBeenCalledWith(PrincipalType.USER, validUserId, {
-        tenantId: 'tenant-xyz',
       });
     });
 
@@ -483,7 +464,6 @@ describe('createAdminUsersHandlers', () => {
       expect(status).toHaveBeenCalledWith(404);
       expect(deps.deleteConfig).not.toHaveBeenCalled();
       expect(deps.deleteAclEntries).not.toHaveBeenCalled();
-      expect(deps.deleteGrantsForPrincipal).not.toHaveBeenCalled();
     });
 
     it('returns 400 for invalid ObjectId', async () => {

--- a/packages/api/src/admin/users.ts
+++ b/packages/api/src/admin/users.ts
@@ -28,7 +28,7 @@ export interface AdminUsersDeps {
    * Thin data-layer delete — removes the User document only.
    * Full cascade of user-owned resources (conversations, messages, files, tokens, etc.)
    * is handled by `UserController.deleteUserController` in the self-delete flow.
-   * This admin endpoint currently cascades Config, AclEntries, and SystemGrants.
+   * This admin endpoint currently cascades Config and AclEntries.
    * A future iteration should consolidate the full cascade into a shared service function.
    */
   deleteUserById: (userId: string) => Promise<UserDeleteResult>;
@@ -40,22 +40,10 @@ export interface AdminUsersDeps {
     principalType: PrincipalType;
     principalId: string | Types.ObjectId;
   }) => Promise<void>;
-  deleteGrantsForPrincipal: (
-    principalType: PrincipalType,
-    principalId: string | Types.ObjectId,
-    options?: { tenantId?: string },
-  ) => Promise<void>;
 }
 
 export function createAdminUsersHandlers(deps: AdminUsersDeps) {
-  const {
-    findUsers,
-    countUsers,
-    deleteUserById,
-    deleteConfig,
-    deleteAclEntries,
-    deleteGrantsForPrincipal,
-  } = deps;
+  const { findUsers, countUsers, deleteUserById, deleteConfig, deleteAclEntries } = deps;
 
   async function listUsersHandler(req: ServerRequest, res: Response) {
     try {
@@ -171,11 +159,9 @@ export function createAdminUsersHandlers(deps: AdminUsersDeps) {
       }
 
       const objectId = new Types.ObjectId(id);
-      const tenantId = req.user?.tenantId;
       const cleanupResults = await Promise.allSettled([
         deleteConfig(PrincipalType.USER, id),
         deleteAclEntries({ principalType: PrincipalType.USER, principalId: objectId }),
-        deleteGrantsForPrincipal(PrincipalType.USER, id, { tenantId }),
       ]);
       for (const r of cleanupResults) {
         if (r.status === 'rejected') {


### PR DESCRIPTION
## Summary

This pull request removes support for granting or revoking system capabilities to users and groups via the admin grants API, restricting grant management to roles only. As a result, related code paths, dependencies, and tests for user/group grants have been removed or updated accordingly. Cleanup on user or group deletion now only affects configs and ACL entries, not system grants.

**Grant management changes:**

* The admin grants API (`createAdminGrantsHandlers` in `grants.ts`) now only allows grants to `ROLE` principal types; all logic and type definitions for `USER` and `GROUP` principals have been removed. Attempts to use user or group principal types now return a 400 error with `Invalid principal type`. [[1]](diffhunk://#diff-c76765d8b379b913913fc5838613ee1cbcf88fef116ce7194bc6d5dac81798f8L78-R77) [[2]](diffhunk://#diff-c76765d8b379b913913fc5838613ee1cbcf88fef116ce7194bc6d5dac81798f8L98-L105) [[3]](diffhunk://#diff-c76765d8b379b913913fc5838613ee1cbcf88fef116ce7194bc6d5dac81798f8L151-L153) [[4]](diffhunk://#diff-43679779b9f802b4f60dce2d1a5a26232482552f8379b2eeccebea626d45f38aL459-R482) [[5]](diffhunk://#diff-43679779b9f802b4f60dce2d1a5a26232482552f8379b2eeccebea626d45f38aL795-R769) [[6]](diffhunk://#diff-43679779b9f802b4f60dce2d1a5a26232482552f8379b2eeccebea626d45f38aL902-R865) [[7]](diffhunk://#diff-43679779b9f802b4f60dce2d1a5a26232482552f8379b2eeccebea626d45f38aL921-R883) [[8]](diffhunk://#diff-43679779b9f802b4f60dce2d1a5a26232482552f8379b2eeccebea626d45f38aL947-R895) [[9]](diffhunk://#diff-43679779b9f802b4f60dce2d1a5a26232482552f8379b2eeccebea626d45f38aL1177-R1135)

**Dependency and handler cleanup:**

* The `deleteGrantsForPrincipal` dependency has been removed from admin group and user handlers, their interfaces, and related route registration. Cleanup on deletion now only covers configs and ACL entries. [[1]](diffhunk://#diff-3e7b4d1fb3f1f6be98ea3c3ca6b27b0e6572ad4a668a09d37115b8038a20940fL85-L89) [[2]](diffhunk://#diff-3e7b4d1fb3f1f6be98ea3c3ca6b27b0e6572ad4a668a09d37115b8038a20940fL106) [[3]](diffhunk://#diff-3e7b4d1fb3f1f6be98ea3c3ca6b27b0e6572ad4a668a09d37115b8038a20940fL312-L321) [[4]](diffhunk://#diff-4bd51b475cc19321bc65e3f8728deca190aa2335d6530c7fe3b3d027ad76e7efL27) [[5]](diffhunk://#diff-0ac1be9a91262f5dd3fb0eaa31018c2a5015e151370fbd7a11dcabc7ac724d9fL20) [[6]](diffhunk://#diff-2f11a7757e97d8ce5d5f3688b0b26bea09a7c183e2604559f8491e5173c80da9L61) [[7]](diffhunk://#diff-f58a14a34d49eb8ed4eb8e2c70cbf431756805894b181d1ba223633573bf06c8L79) [[8]](diffhunk://#diff-9f07f4883f5d63c605fde9896bc614f5fa980bce61b9330fb2c6fb24a7502146L31-R31)


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Testing

* Tests for user/group grant assignment, revocation, and cleanup have been removed or updated to reflect the new restriction to roles only. Tests now expect 400 errors for user/group principal types and no longer check for grant cleanup on user/group deletion. [[1]](diffhunk://#diff-43679779b9f802b4f60dce2d1a5a26232482552f8379b2eeccebea626d45f38aL545-R531) [[2]](diffhunk://#diff-f58a14a34d49eb8ed4eb8e2c70cbf431756805894b181d1ba223633573bf06c8L812-R813) [[3]](diffhunk://#diff-f58a14a34d49eb8ed4eb8e2c70cbf431756805894b181d1ba223633573bf06c8L830-L832) [[4]](diffhunk://#diff-2f11a7757e97d8ce5d5f3688b0b26bea09a7c183e2604559f8491e5173c80da9L420-R419) [[5]](diffhunk://#diff-2f11a7757e97d8ce5d5f3688b0b26bea09a7c183e2604559f8491e5173c80da9L437-L454) [[6]](diffhunk://#diff-2f11a7757e97d8ce5d5f3688b0b26bea09a7c183e2604559f8491e5173c80da9L486)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] A pull request for updating the documentation has been submitted.