### PR TITLE
🗂️ fix: Allow Empty-Overrides Scope Creation in Admin Config

### DIFF
--- a/packages/api/src/admin/config.handler.spec.ts
+++ b/packages/api/src/admin/config.handler.spec.ts
@@ -535,6 +535,63 @@ describe('createAdminConfigHandlers', () => {
     });
   });
 
+  describe('upsertConfigOverrides — empty-overrides scope creation', () => {
+    it('creates config document when overrides is empty but priority is provided', async () => {
+      const upsertConfig = jest.fn().mockResolvedValue({
+        _id: 'c1',
+        principalType: 'role',
+        principalId: 'admin',
+        overrides: {},
+        configVersion: 1,
+      });
+      const { handlers } = createHandlers({ upsertConfig });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: {}, priority: 5 },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body).toHaveProperty('config');
+      expect(res.body?.config).toHaveProperty('_id', 'c1');
+      expect(upsertConfig).toHaveBeenCalledWith('role', 'admin', expect.anything(), {}, 5);
+    });
+
+    it('returns no-op message when overrides is empty and no priority is provided', async () => {
+      const upsertConfig = jest.fn();
+      const { handlers } = createHandlers({ upsertConfig });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: {} },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toHaveProperty('message', 'No actionable override sections provided');
+      expect(upsertConfig).not.toHaveBeenCalled();
+    });
+
+    it('skips per-section permission checks when overrides is empty with priority', async () => {
+      const hasConfigCapability = jest.fn().mockResolvedValue(true);
+      const { handlers } = createHandlers({ hasConfigCapability });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: {}, priority: 3 },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      // Should only be called once for the general manage check, not for any sections
+      expect(hasConfigCapability).toHaveBeenCalledTimes(1);
+      expect(hasConfigCapability).toHaveBeenCalledWith(expect.anything(), null, 'manage');
+    });
+  });
+
   // ── Invariant tests: rules that must hold across ALL handlers ──────
 
   const MUTATION_HANDLERS: Array<{

--- a/packages/api/src/admin/config.handler.spec.ts
+++ b/packages/api/src/admin/config.handler.spec.ts
@@ -560,7 +560,7 @@ describe('createAdminConfigHandlers', () => {
     });
 
     it('returns no-op message when overrides is empty and no priority is provided', async () => {
-      const upsertConfig = jest.fn();
+      const upsertConfig = jest.fn().mockResolvedValue(null);
       const { handlers } = createHandlers({ upsertConfig });
       const req = mockReq({
         params: { principalType: 'role', principalId: 'admin' },
@@ -575,7 +575,7 @@ describe('createAdminConfigHandlers', () => {
       expect(upsertConfig).not.toHaveBeenCalled();
     });
 
-    it('skips per-section permission checks when overrides is empty with priority', async () => {
+    it('calls general manage check exactly once when overrides is empty with priority', async () => {
       const hasConfigCapability = jest.fn().mockResolvedValue(true);
       const { handlers } = createHandlers({ hasConfigCapability });
       const req = mockReq({
@@ -586,9 +586,39 @@ describe('createAdminConfigHandlers', () => {
 
       await handlers.upsertConfigOverrides(req, res);
 
-      // Should only be called once for the general manage check, not for any sections
       expect(hasConfigCapability).toHaveBeenCalledTimes(1);
       expect(hasConfigCapability).toHaveBeenCalledWith(expect.anything(), null, 'manage');
+      expect(res.statusCode).toBe(201);
+      expect(res.body).toHaveProperty('config');
+    });
+
+    it('returns 403 for empty overrides with priority when user lacks MANAGE_CONFIGS', async () => {
+      const { handlers } = createHandlers({
+        hasConfigCapability: jest.fn().mockResolvedValue(false),
+      });
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: {}, priority: 5 },
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('returns 401 for empty overrides with priority when unauthenticated', async () => {
+      const { handlers } = createHandlers();
+      const req = mockReq({
+        params: { principalType: 'role', principalId: 'admin' },
+        body: { overrides: {}, priority: 5 },
+        user: undefined,
+      });
+      const res = mockRes();
+
+      await handlers.upsertConfigOverrides(req, res);
+
+      expect(res.statusCode).toBe(401);
     });
   });
 

--- a/packages/api/src/admin/config.ts
+++ b/packages/api/src/admin/config.ts
@@ -333,18 +333,20 @@ export function createAdminConfigHandlers(deps: AdminConfigDeps) {
 
       const overrideSections = Object.keys(filteredOverrides);
 
-      if (overrideSections.length === 0) {
+      if (overrideSections.length === 0 && priority == null) {
         return res.status(200).json({ message: 'No actionable override sections provided' });
       }
 
-      const allowed = await Promise.all(
-        overrideSections.map((s) => hasConfigCapability(user, s as ConfigSection, 'manage')),
-      );
-      const denied = overrideSections.find((_, i) => !allowed[i]);
-      if (denied) {
-        return res.status(403).json({
-          error: `Insufficient permissions for config section: ${denied}`,
-        });
+      if (overrideSections.length > 0) {
+        const allowed = await Promise.all(
+          overrideSections.map((s) => hasConfigCapability(user, s as ConfigSection, 'manage')),
+        );
+        const denied = overrideSections.find((_, i) => !allowed[i]);
+        if (denied) {
+          return res.status(403).json({
+            error: `Insufficient permissions for config section: ${denied}`,
+          });
+        }
       }
 
       const config = await upsertConfig(


### PR DESCRIPTION
## Summary

I fixed a bug in the `upsertConfigOverrides` handler where sending `{ overrides: {}, priority: N }` from the admin panel to create a blank scope would short-circuit and return `{ message: ... }` instead of creating the config document with `{ config: ... }`. This caused the admin panel to fail with an `_id` error since it expected the response to contain the created config.

- Adjust the early-return guard to only trigger when both overrides are empty **and** no priority is provided, allowing empty-overrides scope creation when a priority value is present.
- Scope per-section permission checks to only run when override sections are actually present, relying on the existing general `manage` capability check for empty-override requests.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Open the admin panel and attempt to create a new blank config scope (empty overrides with a priority value).
2. Verify the config document is created successfully and the admin panel does not throw an `_id` error.
3. Verify that sending `{ overrides: {} }` with no priority still returns the `"No actionable override sections provided"` message.
4. Verify that sending overrides with unauthorized sections still returns a 403 error.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings