### PR TITLE
🔒 fix: Exclude Unnecessary fields from Conversation `$unset`

### DIFF
--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -1,7 +1,7 @@
 import type { TEndpointsConfig } from './types';
 import { EModelEndpoint, isDocumentSupportedProvider } from './schemas';
 import { getEndpointFileConfig, mergeFileConfig } from './file-config';
-import { resolveEndpointType } from './config';
+import { resolveEndpointType, excludedKeys } from './config';
 
 const endpointsConfig: TEndpointsConfig = {
   [EModelEndpoint.openAI]: { userProvide: false, order: 0 },
@@ -12,6 +12,15 @@ const endpointsConfig: TEndpointsConfig = {
   'Some Endpoint': { type: EModelEndpoint.custom, userProvide: false, order: 9999 },
   Gemini: { type: EModelEndpoint.custom, userProvide: false, order: 9999 },
 };
+
+describe('excludedKeys', () => {
+  it.each(['_id', 'user', 'conversationId', '__v', 'tenantId'])(
+    'excludes system field "%s"',
+    (field) => {
+      expect(excludedKeys.has(field)).toBe(true);
+    },
+  );
+});
 
 describe('resolveEndpointType', () => {
   describe('non-agents endpoints', () => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -48,6 +48,7 @@ export const excludedKeys = new Set([
   'isArchived',
   'tags',
   'user',
+  'tenantId',
   '__v',
   '_id',
   'tools',


### PR DESCRIPTION
## Summary

- Adds `tenantId` to `excludedKeys` in `data-provider/config.ts` so `BaseClient.saveMessageToDatabase` won't include it in `$unset` when diffing against `endpointOptions`
- Fixes tenant isolation plugin throwing `assertNoTenantIdMutation` when `tenantId` is present on the conversation document but absent from `endpointOptions`

## Context

`BaseClient.js` ~L794 iterates all keys of the existing conversation document to build `unsetFields`. When tenant isolation stamps `tenantId` on the document, it becomes a candidate for `$unset` since `endpointOptions` never includes it. The tenant isolation plugin then rejects the update.

The downstream fix in `data-schemas` strips `tenantId` from `$unset` before `findOneAndUpdate`, but the proper fix is preventing it from entering `unsetFields` in the first place — same pattern used for `_id`, `user`, `conversationId`, and other system fields.

## Test plan

- [ ] Verify conversations save correctly with tenant isolation enabled
- [ ] Verify no regression in conversation field cleanup when switching endpoint options