### PR TITLE
fix: pass Anthropic endpoint yaml addParams, dropParams, defaultParams to getLLMConfig

### DIFF
--- a/packages/api/src/endpoints/anthropic/initialize.ts
+++ b/packages/api/src/endpoints/anthropic/initialize.ts
@@ -80,7 +80,12 @@ export async function initializeAnthropic({
   const anthropicConfig = appConfig?.endpoints?.[EModelEndpoint.anthropic];
   const allConfig = appConfig?.endpoints?.all;
 
-  const result = getLLMConfig(credentials, clientOptions);
+  const result = getLLMConfig(credentials, {
+    ...clientOptions,
+    ...(anthropicConfig?.addParams != null && { addParams: anthropicConfig.addParams }),
+    ...(anthropicConfig?.dropParams != null && { dropParams: anthropicConfig.dropParams }),
+    ...(anthropicConfig?.defaultParams != null && { defaultParams: anthropicConfig.defaultParams }),
+  });
 
   if (anthropicConfig?.streamRate) {
     (result.llmConfig as Record<string, unknown>)._lc_stream_delay = anthropicConfig.streamRate;

--- a/packages/api/src/endpoints/anthropic/llm.spec.ts
+++ b/packages/api/src/endpoints/anthropic/llm.spec.ts
@@ -1535,6 +1535,17 @@ describe('getLLMConfig', () => {
           }
         });
       });
+
+      it('should omit native web_search tool when dropParams includes web_search', () => {
+        const result = getLLMConfig('test-key', {
+          modelOptions: {
+            model: 'claude-3-opus',
+            web_search: true,
+          },
+          dropParams: ['web_search'],
+        });
+        expect(result.tools).toEqual([]);
+      });
     });
 
     describe('Parameter Precedence and Override Logic', () => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -454,6 +454,12 @@ export const anthropicEndpointSchema = baseEndpointSchema.merge(
     vertex: vertexAISchema.optional(),
     /** Optional: List of available models */
     models: z.array(z.string()).optional(),
+    /** Additional parameters passed to getLLMConfig (same pattern as custom endpoints) */
+    addParams: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(),
+    /** Parameters excluded from the Anthropic client; e.g. web_search when using LibreChat search tools */
+    dropParams: z.array(z.string()).optional(),
+    /** Default parameters applied when model options omit a value */
+    defaultParams: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(),
   }),
 );
 


### PR DESCRIPTION
⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

tl;dr 
This PR adds support for optional `addParams`, `dropParams`, and `defaultParams` on `endpoints.anthropic` in the config schema and passes those fields from `initializeAnthropic` into `getLLMConfig`, matching the pattern used for custom endpoints.

Longer: 
`initializeAnthropic` did not forward optional endpoint-level `addParams`, `dropParams`, or `defaultParams` into `getLLMConfig`. This made Anthropic endpoint YAML less consistent with other endpoint config patterns and prevented valid overrides such as `dropParams: [web_search]` from taking effect. In practice, this could cause conflicts when Anthropic native web_search and external search tooling were both present, resulting in `400 tools: Tool names must be unique`.

This PR adds schema support for those optional keys on `endpoints.anthropic` and forwards them into `getLLMConfig`. Default behavior is unchanged unless these fields are configured.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

From repo root, with Node per [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md):

1. `npm ci`
2. `npm run build`
3. `cd packages/api && npx jest src/endpoints/anthropic/llm.spec.ts --coverage=false`
4. `npx eslint packages/api/src/endpoints/anthropic/initialize.ts packages/data-provider/src/config.ts` (from repo root)

New coverage: `llm.spec.ts` asserts that with `web_search: true` and `dropParams: ['web_search']`, native web_search tools are omitted (`tools` empty).

### **Test Configuration**

Local dev; no extra env required for this Jest file. (On Windows, root `npm run lint` may fail on the ESLint glob; targeted ESLint on the paths above was used.)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes