### PR TITLE
🔑 fix: Auth-Aware Startup Config Caching for Fresh Sessions

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
@@ -2,8 +2,6 @@ import React, { useMemo } from 'react';
 import { TooltipAnchor } from '@librechat/client';
 import { getConfigDefaults } from 'librechat-data-provider';
 import type { ModelSelectorProps } from '~/common';
-
-const defaultInterface = getConfigDefaults().interface;
 import {
   renderModelSpecs,
   renderEndpoints,
@@ -16,6 +14,8 @@ import { getSelectedIcon, getDisplayValue } from './utils';
 import { CustomMenu as Menu } from './CustomMenu';
 import DialogManager from './DialogManager';
 import { useLocalize } from '~/hooks';
+
+const defaultInterface = getConfigDefaults().interface;
 
 function ModelSelectorContent() {
   const localize = useLocalize();

--- a/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelector.tsx
@@ -2,6 +2,8 @@ import React, { useMemo } from 'react';
 import { TooltipAnchor } from '@librechat/client';
 import { getConfigDefaults } from 'librechat-data-provider';
 import type { ModelSelectorProps } from '~/common';
+
+const defaultInterface = getConfigDefaults().interface;
 import {
   renderModelSpecs,
   renderEndpoints,
@@ -122,7 +124,7 @@ function ModelSelectorContent() {
 }
 
 export default function ModelSelector({ startupConfig }: ModelSelectorProps) {
-  const interfaceConfig = startupConfig?.interface ?? getConfigDefaults().interface;
+  const interfaceConfig = startupConfig?.interface ?? defaultInterface;
   const modelSpecs = startupConfig?.modelSpecs?.list ?? [];
 
   // Hide the selector when modelSelect is false and there are no model specs to show

--- a/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
+++ b/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
@@ -3,7 +3,7 @@ import { Import } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import { QueryKeys, TStartupConfig } from 'librechat-data-provider';
 import { Spinner, useToastContext, Label, Button } from '@librechat/client';
-import { useUploadConversationsMutation } from '~/data-provider';
+import { startupConfigKey, useUploadConversationsMutation } from '~/data-provider';
 import { NotificationSeverity } from '~/common';
 import { useLocalize } from '~/hooks';
 import { cn, logger } from '~/utils';
@@ -51,7 +51,7 @@ function ImportConversations() {
   const handleFileUpload = useCallback(
     async (file: File) => {
       try {
-        const startupConfig = queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]);
+        const startupConfig = queryClient.getQueryData<TStartupConfig>(startupConfigKey(true));
         const maxFileSize = startupConfig?.conversationImportMaxFileSize;
         if (maxFileSize && file.size > maxFileSize) {
           const size = (maxFileSize / (1024 * 1024)).toFixed(2);

--- a/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
+++ b/client/src/components/Nav/SettingsTabs/Data/ImportConversations.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback } from 'react';
 import { Import } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
-import { QueryKeys, TStartupConfig } from 'librechat-data-provider';
+import type { TStartupConfig } from 'librechat-data-provider';
 import { Spinner, useToastContext, Label, Button } from '@librechat/client';
 import { startupConfigKey, useUploadConversationsMutation } from '~/data-provider';
 import { NotificationSeverity } from '~/common';

--- a/client/src/data-provider/Auth/mutations.ts
+++ b/client/src/data-provider/Auth/mutations.ts
@@ -50,6 +50,10 @@ export const useLoginUserMutation = (
     onSuccess: (...args) => {
       options?.onSuccess?.(...args);
     },
+    onError: (...args) => {
+      setQueriesEnabled(true);
+      options?.onError?.(...args);
+    },
   });
 };
 

--- a/client/src/data-provider/Auth/mutations.ts
+++ b/client/src/data-provider/Auth/mutations.ts
@@ -40,13 +40,14 @@ export const useLoginUserMutation = (
     mutationFn: (payload: t.TLoginUser) => dataService.login(payload),
     ...(options || {}),
     onMutate: (vars) => {
+      setQueriesEnabled(false);
       resetDefaultPreset();
       clearStates();
       queryClient.removeQueries();
       options?.onMutate?.(vars);
     },
+    // Queries re-enabled in setUserContext (AuthContext) after setTokenHeader runs
     onSuccess: (...args) => {
-      setQueriesEnabled(true);
       options?.onSuccess?.(...args);
     },
   });

--- a/client/src/data-provider/Endpoints/queries.ts
+++ b/client/src/data-provider/Endpoints/queries.ts
@@ -23,12 +23,21 @@ export const useGetEndpointsQuery = <TData = t.TEndpointsConfig>(
   );
 };
 
+/**
+ * Auth-aware query key so unauthenticated (login page) and authenticated
+ * (chat page) configs are cached independently, preventing stale
+ * unauthenticated config from persisting after login.
+ */
+export const startupConfigKey = (isAuthenticated: boolean) =>
+  [QueryKeys.startupConfig, isAuthenticated] as const;
+
 export const useGetStartupConfig = (
   config?: UseQueryOptions<t.TStartupConfig>,
 ): QueryObserverResult<t.TStartupConfig> => {
   const queriesEnabled = useRecoilValue<boolean>(store.queriesEnabled);
+  const user = useRecoilValue<t.TUser | undefined>(store.user);
   return useQuery<t.TStartupConfig>(
-    [QueryKeys.startupConfig],
+    startupConfigKey(!!user),
     () => dataService.getStartupConfig(),
     {
       staleTime: Infinity,

--- a/client/src/hooks/AuthContext.tsx
+++ b/client/src/hooks/AuthContext.tsx
@@ -8,7 +8,7 @@ import {
   createContext,
 } from 'react';
 import { debounce } from 'lodash';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import {
   apiBaseUrl,
@@ -45,6 +45,7 @@ const AuthContextProvider = ({
   const [token, setToken] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | undefined>(undefined);
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
+  const setQueriesEnabled = useSetRecoilState<boolean>(store.queriesEnabled);
 
   const { data: userRole = null } = useGetRole(SystemRoles.USER, {
     enabled: !!(isAuthenticated && (user?.role ?? '')),
@@ -63,6 +64,9 @@ const AuthContextProvider = ({
         setToken(token);
         setTokenHeader(token);
         setIsAuthenticated(isAuthenticated);
+        if (isAuthenticated) {
+          setQueriesEnabled(true);
+        }
 
         const searchParams = new URLSearchParams(window.location.search);
         const postLoginRedirect = getPostLoginRedirect(searchParams);
@@ -81,7 +85,7 @@ const AuthContextProvider = ({
 
         navigate(finalRedirect, { replace: true });
       }, 50),
-    [navigate, setUser],
+    [navigate, setUser, setQueriesEnabled],
   );
   const doSetError = useTimeout({ callback: (error) => setError(error as string | undefined) });
 

--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -26,11 +26,11 @@ import type {
 } from 'librechat-data-provider';
 import type { SetterOrUpdater } from 'recoil';
 import type { TAskFunction, ExtendedFile } from '~/common';
-import { startupConfigKey } from '~/data-provider';
 import useSetFilesToDelete from '~/hooks/Files/useSetFilesToDelete';
 import useGetSender from '~/hooks/Conversations/useGetSender';
 import { logger, createDualMessageContent } from '~/utils';
 import store, { useGetEphemeralAgent } from '~/store';
+import { startupConfigKey } from '~/data-provider';
 import useUserKey from '~/hooks/Input/useUserKey';
 import { useAuthContext } from '~/hooks';
 

--- a/client/src/hooks/Chat/useChatFunctions.ts
+++ b/client/src/hooks/Chat/useChatFunctions.ts
@@ -26,6 +26,7 @@ import type {
 } from 'librechat-data-provider';
 import type { SetterOrUpdater } from 'recoil';
 import type { TAskFunction, ExtendedFile } from '~/common';
+import { startupConfigKey } from '~/data-provider';
 import useSetFilesToDelete from '~/hooks/Files/useSetFilesToDelete';
 import useGetSender from '~/hooks/Conversations/useGetSender';
 import { logger, createDualMessageContent } from '~/utils';
@@ -172,7 +173,7 @@ export default function useChatFunctions({
     }
 
     const endpointsConfig = queryClient.getQueryData<TEndpointsConfig>([QueryKeys.endpoints]);
-    const startupConfig = queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]);
+    const startupConfig = queryClient.getQueryData<TStartupConfig>(startupConfigKey(true));
     const endpointType = getEndpointField(endpointsConfig, endpoint, 'type');
     const iconURL = conversation?.iconURL;
     const defaultParamsEndpoint = getDefaultParamsEndpoint(endpointsConfig, endpoint);

--- a/client/src/hooks/Conversations/useNavigateToConvo.tsx
+++ b/client/src/hooks/Conversations/useNavigateToConvo.tsx
@@ -22,6 +22,7 @@ import {
   buildDefaultConvo,
   logger,
 } from '~/utils';
+import { startupConfigKey } from '~/data-provider';
 import { useApplyModelSpecEffects } from '~/hooks/Agents';
 import store from '~/store';
 
@@ -41,7 +42,7 @@ const useNavigateToConvo = (index = 0) => {
         return;
       }
 
-      const startupConfig = queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]);
+      const startupConfig = queryClient.getQueryData<TStartupConfig>(startupConfigKey(true));
       applyModelSpecEffects({
         startupConfig,
         specName: conversation?.spec,

--- a/client/src/hooks/Conversations/useNavigateToConvo.tsx
+++ b/client/src/hooks/Conversations/useNavigateToConvo.tsx
@@ -22,8 +22,8 @@ import {
   buildDefaultConvo,
   logger,
 } from '~/utils';
-import { startupConfigKey } from '~/data-provider';
 import { useApplyModelSpecEffects } from '~/hooks/Agents';
+import { startupConfigKey } from '~/data-provider';
 import store from '~/store';
 
 const useNavigateToConvo = (index = 0) => {

--- a/client/src/hooks/Endpoint/useEndpoints.ts
+++ b/client/src/hooks/Endpoint/useEndpoints.ts
@@ -5,8 +5,8 @@ import {
   alternateName,
   EModelEndpoint,
   PermissionTypes,
-  getConfigDefaults,
   getEndpointField,
+  getConfigDefaults,
 } from 'librechat-data-provider';
 import type {
   TEndpointsConfig,

--- a/client/src/hooks/Endpoint/useEndpoints.ts
+++ b/client/src/hooks/Endpoint/useEndpoints.ts
@@ -5,6 +5,7 @@ import {
   alternateName,
   EModelEndpoint,
   PermissionTypes,
+  getConfigDefaults,
   getEndpointField,
 } from 'librechat-data-provider';
 import type {
@@ -20,6 +21,8 @@ import { mapEndpoints, getIconKey } from '~/utils';
 import { useHasAccess } from '~/hooks';
 import { icons } from './Icons';
 
+const defaultInterface = getConfigDefaults().interface;
+
 export const useEndpoints = ({
   agents,
   assistantsMap,
@@ -33,7 +36,7 @@ export const useEndpoints = ({
 }) => {
   const modelsQuery = useGetModelsQuery();
   const { data: endpoints = [] } = useGetEndpointsQuery({ select: mapEndpoints });
-  const interfaceConfig = startupConfig?.interface ?? {};
+  const interfaceConfig = startupConfig?.interface ?? defaultInterface;
   const includedEndpoints = useMemo(
     () => new Set(startupConfig?.modelSpecs?.addedEndpoints ?? []),
     [startupConfig?.modelSpecs?.addedEndpoints],

--- a/client/src/hooks/Input/useQueryParams.spec.ts
+++ b/client/src/hooks/Input/useQueryParams.spec.ts
@@ -93,19 +93,23 @@ jest.mock('librechat-data-provider', () => {
   };
 });
 
-// Mock data-provider hooks
-jest.mock('~/data-provider', () => ({
-  useGetAgentByIdQuery: jest.fn(() => ({
-    data: null,
-    isLoading: false,
-    error: null,
-  })),
-  useListAgentsQuery: jest.fn(() => ({
-    data: null,
-    isLoading: false,
-    error: null,
-  })),
-}));
+// Mock data-provider hooks while preserving real exports like startupConfigKey
+jest.mock('~/data-provider', () => {
+  const actual = jest.requireActual<typeof import('~/data-provider')>('~/data-provider');
+  return {
+    ...actual,
+    useGetAgentByIdQuery: jest.fn(() => ({
+      data: null,
+      isLoading: false,
+      error: null,
+    })),
+    useListAgentsQuery: jest.fn(() => ({
+      data: null,
+      isLoading: false,
+      error: null,
+    })),
+  };
+});
 
 // Mock global window.history
 global.window = Object.create(window);

--- a/client/src/hooks/Input/useQueryParams.ts
+++ b/client/src/hooks/Input/useQueryParams.ts
@@ -3,6 +3,7 @@ import { useRecoilValue } from 'recoil';
 import { useSearchParams } from 'react-router-dom';
 import { QueryClient, useQueryClient } from '@tanstack/react-query';
 import { QueryKeys, EModelEndpoint, PermissionBits } from 'librechat-data-provider';
+import { startupConfigKey } from '~/data-provider';
 import type {
   AgentListResponse,
   TEndpointsConfig,
@@ -84,7 +85,7 @@ export default function useQueryParams({
       }
       let newPreset = removeUnavailableTools(_newPreset, availableTools);
       if (newPreset.spec != null && newPreset.spec !== '') {
-        const startupConfig = queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]);
+        const startupConfig = queryClient.getQueryData<TStartupConfig>(startupConfigKey(true));
         const modelSpecs = startupConfig?.modelSpecs?.list ?? [];
         const spec = modelSpecs.find((s) => s.name === newPreset.spec);
         if (!spec) {
@@ -258,7 +259,7 @@ export default function useQueryParams({
       if (!textAreaRef.current) {
         return;
       }
-      const startupConfig = queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]);
+      const startupConfig = queryClient.getQueryData<TStartupConfig>(startupConfigKey(true));
       if (!startupConfig) {
         return;
       }

--- a/client/src/hooks/Input/useQueryParams.ts
+++ b/client/src/hooks/Input/useQueryParams.ts
@@ -3,7 +3,6 @@ import { useRecoilValue } from 'recoil';
 import { useSearchParams } from 'react-router-dom';
 import { QueryClient, useQueryClient } from '@tanstack/react-query';
 import { QueryKeys, EModelEndpoint, PermissionBits } from 'librechat-data-provider';
-import { startupConfigKey } from '~/data-provider';
 import type {
   AgentListResponse,
   TEndpointsConfig,
@@ -20,8 +19,8 @@ import {
   logger,
 } from '~/utils';
 import { useAuthContext, useAgentsMap, useDefaultConvo, useSubmitMessage } from '~/hooks';
+import { startupConfigKey, useGetAgentByIdQuery } from '~/data-provider';
 import { useChatContext, useChatFormContext } from '~/Providers';
-import { useGetAgentByIdQuery } from '~/data-provider';
 import store from '~/store';
 
 const injectAgentIntoAgentsMap = (queryClient: QueryClient, agent: any) => {

--- a/client/src/hooks/SSE/useEventHandlers.ts
+++ b/client/src/hooks/SSE/useEventHandlers.ts
@@ -33,7 +33,7 @@ import {
   removeConvoFromAllQueries,
   findConversationInInfinite,
 } from '~/utils';
-import { queueTitleGeneration } from '~/data-provider/SSE/queries';
+import { startupConfigKey, queueTitleGeneration } from '~/data-provider';
 import useAttachmentHandler from '~/hooks/SSE/useAttachmentHandler';
 import useContentHandler from '~/hooks/SSE/useContentHandler';
 import useStepHandler from '~/hooks/SSE/useStepHandler';
@@ -406,7 +406,7 @@ export default function useEventHandlers({
           sourceId: submission.conversation?.conversationId,
           ephemeralAgent: submission.ephemeralAgent,
           specName: submission.conversation?.spec,
-          startupConfig: queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]),
+          startupConfig: queryClient.getQueryData<TStartupConfig>(startupConfigKey(true)),
         });
       }
 
@@ -588,7 +588,7 @@ export default function useEventHandlers({
               sourceId: submissionConvo.conversationId,
               ephemeralAgent: submission.ephemeralAgent,
               specName: submission.conversation?.spec,
-              startupConfig: queryClient.getQueryData<TStartupConfig>([QueryKeys.startupConfig]),
+              startupConfig: queryClient.getQueryData<TStartupConfig>(startupConfigKey(true)),
             });
           }
 


### PR DESCRIPTION
## Summary

I fixed an issue where the model selector was empty in fresh/incognito sessions. The root cause was a cache conflict: the login page fetches `/api/config` without auth (getting a limited response missing `interface.modelSelect`), and after login, `queryClient.removeQueries()` triggers a premature re-fetch from the still-mounted login page — again without auth — caching the limited config with `staleTime: Infinity`. The chat page then uses this stale unauthenticated config permanently.

- Include `!!user` in the startup config query key so unauthenticated (login page) and authenticated (chat page) configs are cached independently under separate keys, eliminating cross-contamination.
- Disable queries (`queriesEnabled = false`) during login `onMutate` before `queryClient.removeQueries()` to prevent the still-mounted login page from firing a premature unauthenticated re-fetch after the cache is cleared.
- Re-enable queries inside `setUserContext` immediately after `setTokenHeader(token)`, ensuring queries only fire once the auth header is ready.
- Remove `setQueriesEnabled(true)` from the login mutation's `onSuccess` since it ran before the token was set, creating a window for unauthenticated fetches.
- Fall back to `getConfigDefaults().interface` in `useEndpoints` (matching `ModelSelector`), ensuring `modelSelect` defaults to `true` during brief loading transitions rather than falling back to `{}`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Open an incognito/private browser window (or clear localStorage)
2. Navigate to the LibreChat instance and log in
3. Verify the model selector populates with all configured endpoints and models
4. Verify the Network tab shows exactly 2 `/api/config` requests (1 unauthenticated for the login page, 1 authenticated after login)
5. Test logout → re-login flow to confirm config refreshes correctly
6. Test normal (non-incognito) usage to confirm no regressions

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes