### PR TITLE
📎 fix: Route Unrecognized File Types via supportedMimeTypes Config

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1164,9 +1164,10 @@ class BaseClient {
 
     if (!this._mergedFileConfig && this.options.req?.config?.fileConfig) {
       this._mergedFileConfig = mergeFileConfig(this.options.req.config.fileConfig);
+      const endpoint = this.options.agent?.endpoint ?? this.options.endpoint;
       this._endpointFileConfig = getEndpointFileConfig({
         fileConfig: this._mergedFileConfig,
-        endpoint: provider,
+        endpoint,
         endpointType: this.options.endpointType,
       });
     }

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1162,16 +1162,17 @@ class BaseClient {
     const provider = this.options.agent?.provider ?? this.options.endpoint;
     const isBedrock = provider === EModelEndpoint.bedrock;
 
-    const mergedFileConfig = this.options.req?.config?.fileConfig
-      ? mergeFileConfig(this.options.req.config.fileConfig)
-      : null;
-    const endpointFileConfig = mergedFileConfig
-      ? getEndpointFileConfig({
-          fileConfig: mergedFileConfig,
-          endpoint: provider,
-          endpointType: this.options.endpointType,
-        })
-      : null;
+    if (!this._mergedFileConfig && this.options.req?.config?.fileConfig) {
+      this._mergedFileConfig = mergeFileConfig(this.options.req.config.fileConfig);
+      this._endpointFileConfig = getEndpointFileConfig({
+        fileConfig: this._mergedFileConfig,
+        endpoint: provider,
+        endpointType: this.options.endpointType,
+      });
+    }
+
+    const mergedFileConfig = this._mergedFileConfig ?? null;
+    const endpointFileConfig = this._endpointFileConfig ?? null;
 
     for (const file of attachments) {
       /** @type {FileSources} */
@@ -1200,6 +1201,7 @@ class BaseClient {
         categorizedAttachments.audios.push(file);
         allFiles.push(file);
       } else if (
+        file.type &&
         mergedFileConfig &&
         endpointFileConfig?.supportedMimeTypes &&
         mergedFileConfig.checkType(file.type, endpointFileConfig.supportedMimeTypes)

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1203,7 +1203,6 @@ class BaseClient {
         categorizedAttachments.audios.push(file);
         allFiles.push(file);
       } else if (
-        !isBedrock &&
         file.type &&
         this._mergedFileConfig &&
         this._endpointFileConfig?.supportedMimeTypes &&

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -1203,6 +1203,7 @@ class BaseClient {
         categorizedAttachments.audios.push(file);
         allFiles.push(file);
       } else if (
+        !isBedrock &&
         file.type &&
         this._mergedFileConfig &&
         this._endpointFileConfig?.supportedMimeTypes &&

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -73,6 +73,10 @@ class BaseClient {
     this.currentMessages = [];
     /** @type {import('librechat-data-provider').VisionModes | undefined} */
     this.visionMode;
+    /** @type {import('librechat-data-provider').FileConfig | undefined} */
+    this._mergedFileConfig;
+    /** @type {import('librechat-data-provider').EndpointFileConfig | undefined} */
+    this._endpointFileConfig;
   }
 
   setOptions() {
@@ -1172,9 +1176,6 @@ class BaseClient {
       });
     }
 
-    const mergedFileConfig = this._mergedFileConfig ?? null;
-    const endpointFileConfig = this._endpointFileConfig ?? null;
-
     for (const file of attachments) {
       /** @type {FileSources} */
       const source = file.source ?? FileSources.local;
@@ -1203,9 +1204,9 @@ class BaseClient {
         allFiles.push(file);
       } else if (
         file.type &&
-        mergedFileConfig &&
-        endpointFileConfig?.supportedMimeTypes &&
-        mergedFileConfig.checkType(file.type, endpointFileConfig.supportedMimeTypes)
+        this._mergedFileConfig &&
+        this._endpointFileConfig?.supportedMimeTypes &&
+        this._mergedFileConfig.checkType(file.type, this._endpointFileConfig.supportedMimeTypes)
       ) {
         categorizedAttachments.documents.push(file);
         allFiles.push(file);

--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -17,11 +17,13 @@ const {
   ContentTypes,
   excludedKeys,
   EModelEndpoint,
+  mergeFileConfig,
   isParamEndpoint,
   isAgentsEndpoint,
   isEphemeralAgentId,
   supportsBalanceCheck,
   isBedrockDocumentType,
+  getEndpointFileConfig,
 } = require('librechat-data-provider');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { logViolation } = require('~/cache');
@@ -1160,6 +1162,17 @@ class BaseClient {
     const provider = this.options.agent?.provider ?? this.options.endpoint;
     const isBedrock = provider === EModelEndpoint.bedrock;
 
+    const mergedFileConfig = this.options.req?.config?.fileConfig
+      ? mergeFileConfig(this.options.req.config.fileConfig)
+      : null;
+    const endpointFileConfig = mergedFileConfig
+      ? getEndpointFileConfig({
+          fileConfig: mergedFileConfig,
+          endpoint: provider,
+          endpointType: this.options.endpointType,
+        })
+      : null;
+
     for (const file of attachments) {
       /** @type {FileSources} */
       const source = file.source ?? FileSources.local;
@@ -1185,6 +1198,13 @@ class BaseClient {
         allFiles.push(file);
       } else if (file.type.startsWith('audio/')) {
         categorizedAttachments.audios.push(file);
+        allFiles.push(file);
+      } else if (
+        mergedFileConfig &&
+        endpointFileConfig?.supportedMimeTypes &&
+        mergedFileConfig.checkType(file.type, endpointFileConfig.supportedMimeTypes)
+      ) {
+        categorizedAttachments.documents.push(file);
         allFiles.push(file);
       }
     }

--- a/packages/api/src/files/encode/document.spec.ts
+++ b/packages/api/src/files/encode/document.spec.ts
@@ -747,4 +747,246 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
       });
     });
   });
+
+  describe('Generic document encoding path', () => {
+    it('should format text/plain for Anthropic with citations enabled', async () => {
+      const req = createMockRequest(30) as ServerRequest;
+      const file = createMockDocFile(1, 'text/plain', 'notes.txt');
+
+      const mockContent = Buffer.from('plain text content').toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: mockContent,
+        metadata: file,
+      });
+
+      const result = await encodeAndFormatDocuments(
+        req,
+        [file],
+        { provider: Providers.ANTHROPIC },
+        mockStrategyFunctions,
+      );
+
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]).toMatchObject({
+        type: 'document',
+        source: {
+          type: 'base64',
+          media_type: 'text/plain',
+          data: mockContent,
+        },
+        citations: { enabled: true },
+        context: 'File: "notes.txt"',
+      });
+      expect(result.files).toHaveLength(1);
+    });
+
+    it('should format text/html for Anthropic with citations enabled', async () => {
+      const req = createMockRequest(30) as ServerRequest;
+      const file = createMockDocFile(1, 'text/html', 'page.html');
+
+      const mockContent = Buffer.from('<html>content</html>').toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: mockContent,
+        metadata: file,
+      });
+
+      const result = await encodeAndFormatDocuments(
+        req,
+        [file],
+        { provider: Providers.ANTHROPIC },
+        mockStrategyFunctions,
+      );
+
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]).toMatchObject({
+        type: 'document',
+        source: { type: 'base64', media_type: 'text/html', data: mockContent },
+        citations: { enabled: true },
+      });
+    });
+
+    it('should format application/json for Anthropic without citations', async () => {
+      const req = createMockRequest(30) as ServerRequest;
+      const file = createMockDocFile(1, 'application/json', 'data.json');
+
+      const mockContent = Buffer.from('{"key":"value"}').toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: mockContent,
+        metadata: file,
+      });
+
+      const result = await encodeAndFormatDocuments(
+        req,
+        [file],
+        { provider: Providers.ANTHROPIC },
+        mockStrategyFunctions,
+      );
+
+      expect(result.documents).toHaveLength(1);
+      const doc = result.documents[0] as { citations?: unknown };
+      expect(doc).not.toHaveProperty('citations');
+    });
+
+    it('should format text/csv for OpenAI responses API', async () => {
+      const req = createMockRequest(15) as ServerRequest;
+      const file = createMockDocFile(1, 'text/csv', 'data.csv');
+
+      const mockContent = Buffer.from('a,b\n1,2').toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: mockContent,
+        metadata: file,
+      });
+
+      const result = await encodeAndFormatDocuments(
+        req,
+        [file],
+        { provider: Providers.OPENAI, useResponsesApi: true },
+        mockStrategyFunctions,
+      );
+
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]).toMatchObject({
+        type: 'input_file',
+        filename: 'data.csv',
+        file_data: `data:text/csv;base64,${mockContent}`,
+      });
+      expect(result.files).toHaveLength(1);
+    });
+
+    it('should format XLSX for Google/VertexAI as media block', async () => {
+      const req = createMockRequest(25) as ServerRequest;
+      const mimeType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+      const file = createMockDocFile(2, mimeType, 'report.xlsx');
+
+      const mockContent = Buffer.from('xlsx-binary').toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: mockContent,
+        metadata: file,
+      });
+
+      const result = await encodeAndFormatDocuments(
+        req,
+        [file],
+        { provider: Providers.GOOGLE },
+        mockStrategyFunctions,
+      );
+
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]).toMatchObject({
+        type: 'media',
+        mimeType,
+        data: mockContent,
+      });
+      expect(result.files).toHaveLength(1);
+    });
+
+    it('should format text/plain for standard OpenAI-like provider as file block', async () => {
+      const req = createMockRequest(15) as ServerRequest;
+      const file = createMockDocFile(1, 'text/plain', 'readme.txt');
+
+      const mockContent = Buffer.from('readme content').toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: mockContent,
+        metadata: file,
+      });
+
+      const result = await encodeAndFormatDocuments(
+        req,
+        [file],
+        { provider: Providers.OPENAI },
+        mockStrategyFunctions,
+      );
+
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]).toMatchObject({
+        type: 'file',
+        file: {
+          filename: 'readme.txt',
+          file_data: `data:text/plain;base64,${mockContent}`,
+        },
+      });
+      expect(result.files).toHaveLength(1);
+    });
+
+    it('should skip non-Bedrock-document types for Bedrock provider', async () => {
+      const req = createMockRequest() as ServerRequest;
+      const file = createMockDocFile(1, 'application/zip', 'archive.zip');
+
+      const mockContent = Buffer.from('zip-content').toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: mockContent,
+        metadata: file,
+      });
+
+      const result = await encodeAndFormatDocuments(
+        req,
+        [file],
+        { provider: Providers.BEDROCK },
+        mockStrategyFunctions,
+      );
+
+      expect(result.documents).toHaveLength(0);
+      expect(result.files).toHaveLength(0);
+    });
+
+    it('should throw when generic file exceeds configured size limit', async () => {
+      const req = {
+        config: {
+          fileConfig: {
+            endpoints: {
+              [Providers.ANTHROPIC]: {
+                fileSizeLimit: 1,
+              },
+            },
+          },
+        },
+      } as unknown as ServerRequest;
+      const file = createMockDocFile(2, 'text/plain', 'large.txt');
+
+      const largeContent = Buffer.alloc(2 * 1024 * 1024).toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: largeContent,
+        metadata: file,
+      });
+
+      await expect(
+        encodeAndFormatDocuments(
+          req,
+          [file],
+          { provider: Providers.ANTHROPIC },
+          mockStrategyFunctions,
+        ),
+      ).rejects.toThrow('File size');
+    });
+
+    it('should not push metadata when provider has no handler', async () => {
+      const req = createMockRequest(15) as ServerRequest;
+      const file = createMockDocFile(1, 'text/plain', 'test.txt');
+
+      const mockContent = Buffer.from('content').toString('base64');
+      mockedGetFileStream.mockResolvedValue({
+        file,
+        content: mockContent,
+        metadata: file,
+      });
+
+      const result = await encodeAndFormatDocuments(
+        req,
+        [file],
+        { provider: Providers.AZURE as Providers },
+        mockStrategyFunctions,
+      );
+
+      expect(result.documents).toHaveLength(0);
+      expect(result.files).toHaveLength(0);
+    });
+  });
 });

--- a/packages/api/src/files/encode/document.spec.ts
+++ b/packages/api/src/files/encode/document.spec.ts
@@ -56,13 +56,16 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
   });
 
   /** Helper to create a mock request with file config */
-  const createMockRequest = (fileSizeLimit?: number): Partial<AppConfig> => ({
+  const createMockRequest = (
+    fileSizeLimit?: number,
+    provider: string = Providers.OPENAI,
+  ): Partial<AppConfig> => ({
     config:
       fileSizeLimit !== undefined
         ? {
             fileConfig: {
               endpoints: {
-                [Providers.OPENAI]: {
+                [provider]: {
                   fileSizeLimit,
                 },
               },
@@ -826,8 +829,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
       );
 
       expect(result.documents).toHaveLength(1);
-      const doc = result.documents[0] as { citations?: unknown };
-      expect(doc).not.toHaveProperty('citations');
+      expect(result.documents[0]).not.toHaveProperty('citations');
     });
 
     it('should format text/csv for OpenAI responses API', async () => {
@@ -937,17 +939,7 @@ describe('encodeAndFormatDocuments - fileConfig integration', () => {
     });
 
     it('should throw when generic file exceeds configured size limit', async () => {
-      const req = {
-        config: {
-          fileConfig: {
-            endpoints: {
-              [Providers.ANTHROPIC]: {
-                fileSizeLimit: 1,
-              },
-            },
-          },
-        },
-      } as unknown as ServerRequest;
+      const req = createMockRequest(1, Providers.ANTHROPIC) as ServerRequest;
       const file = createMockDocFile(2, 'text/plain', 'large.txt');
 
       const largeContent = Buffer.alloc(2 * 1024 * 1024).toString('base64');

--- a/packages/api/src/files/encode/document.ts
+++ b/packages/api/src/files/encode/document.ts
@@ -43,25 +43,8 @@ export async function encodeAndFormatDocuments(
   const isBedrock = provider === Providers.BEDROCK;
   const isDocSupported = isDocumentSupportedProvider(provider);
 
-  const documentFiles = files.filter((file) => {
-    if (isBedrock && isBedrockDocumentType(file.type)) {
-      return true;
-    }
-    return file.type === 'application/pdf' || file.type?.startsWith('application/');
-  });
-
-  if (!documentFiles.length) {
-    return result;
-  }
-
   const results = await Promise.allSettled(
-    documentFiles.map((file) => {
-      const isProcessable = isBedrock
-        ? isBedrockDocumentType(file.type)
-        : file.type === 'application/pdf' && isDocSupported;
-      if (!isProcessable) {
-        return Promise.resolve(null);
-      }
+    files.map((file) => {
       return getFileStream(req, file, encodingMethods, getStrategyFunctions);
     }),
   );
@@ -164,6 +147,44 @@ export async function encodeAndFormatDocuments(
           file: {
             filename: file.filename,
             file_data: `data:application/pdf;base64,${content}`,
+          },
+        });
+      }
+      result.files.push(metadata);
+    } else if (isDocSupported) {
+      if (provider === Providers.ANTHROPIC) {
+        const document: AnthropicDocumentBlock = {
+          type: 'document',
+          source: {
+            type: 'base64',
+            media_type: mimeType,
+            data: content,
+          },
+        };
+
+        if (file.filename) {
+          document.context = `File: "${file.filename}"`;
+        }
+
+        result.documents.push(document);
+      } else if (useResponsesApi) {
+        result.documents.push({
+          type: 'input_file',
+          filename: file.filename,
+          file_data: `data:${mimeType};base64,${content}`,
+        });
+      } else if (provider === Providers.GOOGLE || provider === Providers.VERTEXAI) {
+        result.documents.push({
+          type: 'media',
+          mimeType,
+          data: content,
+        });
+      } else if (isOpenAILikeProvider(provider) && provider != Providers.AZURE) {
+        result.documents.push({
+          type: 'file',
+          file: {
+            filename: file.filename,
+            file_data: `data:${mimeType};base64,${content}`,
           },
         });
       }

--- a/packages/api/src/files/encode/document.ts
+++ b/packages/api/src/files/encode/document.ts
@@ -55,7 +55,7 @@ function formatDocumentBlock(
     return document;
   }
 
-  const resolvedFilename = filename || 'document';
+  const resolvedFilename = filename ?? 'document';
 
   if (useResponsesApi) {
     return {
@@ -121,6 +121,8 @@ export async function encodeAndFormatDocuments(
     return result;
   }
 
+  const configuredFileSizeLimit = getConfiguredFileSizeLimit(req, { provider, endpoint });
+
   const results = await Promise.allSettled(
     processableFiles.map((file) => {
       return getFileStream(req, file, encodingMethods, getStrategyFunctions);
@@ -143,7 +145,6 @@ export async function encodeAndFormatDocuments(
       continue;
     }
 
-    const configuredFileSizeLimit = getConfiguredFileSizeLimit(req, { provider, endpoint });
     const mimeType = file.type ?? '';
 
     if (isBedrock && isBedrockDocumentType(mimeType)) {
@@ -203,10 +204,11 @@ export async function encodeAndFormatDocuments(
         result.files.push(metadata);
       }
     } else if (isDocSupported && !isBedrock) {
-      const fileBuffer = Buffer.from(content, 'base64');
-      if (configuredFileSizeLimit && fileBuffer.length > configuredFileSizeLimit) {
+      const paddingChars = content.endsWith('==') ? 2 : content.endsWith('=') ? 1 : 0;
+      const decodedByteCount = Math.floor((content.length * 3) / 4) - paddingChars;
+      if (configuredFileSizeLimit && decodedByteCount > configuredFileSizeLimit) {
         throw new Error(
-          `File size (${(fileBuffer.length / 1024 / 1024).toFixed(1)}MB) exceeds the configured limit for ${provider}`,
+          `File size (~${(decodedByteCount / 1024 / 1024).toFixed(1)}MB) exceeds the configured limit for ${provider}`,
         );
       }
 

--- a/packages/api/src/files/encode/document.ts
+++ b/packages/api/src/files/encode/document.ts
@@ -113,6 +113,10 @@ export async function encodeAndFormatDocuments(
   const isBedrock = provider === Providers.BEDROCK;
   const isDocSupported = isDocumentSupportedProvider(provider);
 
+  if (!isDocSupported && !isBedrock) {
+    return result;
+  }
+
   const processableFiles = isBedrock
     ? files.filter((file) => isBedrockDocumentType(file.type))
     : files;

--- a/packages/api/src/files/encode/document.ts
+++ b/packages/api/src/files/encode/document.ts
@@ -7,6 +7,7 @@ import {
 } from 'librechat-data-provider';
 import type { IMongoFile } from '@librechat/data-schemas';
 import type {
+  DocumentBlock,
   AnthropicDocumentBlock,
   StrategyFunctions,
   DocumentResult,
@@ -15,16 +16,83 @@ import type {
 import { validatePdf, validateBedrockDocument } from '~/files/validation';
 import { getFileStream, getConfiguredFileSizeLimit } from './utils';
 
+const ANTHROPIC_CITATION_TYPES = new Set([
+  'application/pdf',
+  'text/plain',
+  'text/html',
+  'text/markdown',
+]);
+
 /**
- * Processes and encodes document files for various providers
- * @param req - Express request object
- * @param files - Array of file objects to process
- * @param params - Object containing provider, endpoint, and other options
- * @param params.provider - The provider name
- * @param params.endpoint - Optional endpoint name for file config lookup
- * @param params.useResponsesApi - Whether to use responses API format
- * @param getStrategyFunctions - Function to get strategy functions
- * @returns Promise that resolves to documents and file metadata
+ * Formats a base64-encoded document into the appropriate provider-specific block.
+ * Returns `null` when the provider has no matching handler.
+ */
+function formatDocumentBlock(
+  provider: Providers,
+  mimeType: string,
+  content: string,
+  filename: string | undefined,
+  useResponsesApi: boolean | undefined,
+): DocumentBlock | null {
+  if (provider === Providers.ANTHROPIC) {
+    const document: AnthropicDocumentBlock = {
+      type: 'document',
+      source: {
+        type: 'base64',
+        media_type: mimeType,
+        data: content,
+      },
+    };
+
+    if (ANTHROPIC_CITATION_TYPES.has(mimeType)) {
+      document.citations = { enabled: true };
+    }
+
+    if (filename) {
+      document.context = `File: "${filename}"`;
+    }
+
+    return document;
+  }
+
+  if (useResponsesApi) {
+    return {
+      type: 'input_file',
+      filename,
+      file_data: `data:${mimeType};base64,${content}`,
+    };
+  }
+
+  if (provider === Providers.GOOGLE || provider === Providers.VERTEXAI) {
+    return {
+      type: 'media',
+      mimeType,
+      data: content,
+    };
+  }
+
+  if (isOpenAILikeProvider(provider) && provider !== Providers.AZURE) {
+    return {
+      type: 'file',
+      file: {
+        filename,
+        file_data: `data:${mimeType};base64,${content}`,
+      },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Encodes and formats document files for various providers.
+ *
+ * Callers are responsible for pre-filtering `files` to types the endpoint accepts
+ * (e.g., via `supportedMimeTypes` in `processAttachments`). This function processes
+ * every file it receives and dispatches to the appropriate provider format:
+ * - **Bedrock**: Only encodes types in `bedrockDocumentFormats`; all others are skipped.
+ * - **PDF**: Validated via `validatePdf` before encoding.
+ * - **Generic types**: Encoded with a provider-specific size check.
  */
 export async function encodeAndFormatDocuments(
   req: ServerRequest,
@@ -113,82 +181,36 @@ export async function encodeAndFormatDocuments(
         throw new Error(`PDF validation failed: ${validation.error}`);
       }
 
-      if (provider === Providers.ANTHROPIC) {
-        const document: AnthropicDocumentBlock = {
-          type: 'document',
-          source: {
-            type: 'base64',
-            media_type: 'application/pdf',
-            data: content,
-          },
-          citations: { enabled: true },
-        };
-
-        if (file.filename) {
-          document.context = `File: "${file.filename}"`;
-        }
-
-        result.documents.push(document);
-      } else if (useResponsesApi) {
-        result.documents.push({
-          type: 'input_file',
-          filename: file.filename,
-          file_data: `data:application/pdf;base64,${content}`,
-        });
-      } else if (provider === Providers.GOOGLE || provider === Providers.VERTEXAI) {
-        result.documents.push({
-          type: 'media',
-          mimeType: 'application/pdf',
-          data: content,
-        });
-      } else if (isOpenAILikeProvider(provider) && provider != Providers.AZURE) {
-        result.documents.push({
-          type: 'file',
-          file: {
-            filename: file.filename,
-            file_data: `data:application/pdf;base64,${content}`,
-          },
-        });
+      const block = formatDocumentBlock(
+        provider,
+        mimeType,
+        content,
+        file.filename,
+        useResponsesApi,
+      );
+      if (block) {
+        result.documents.push(block);
+        result.files.push(metadata);
       }
-      result.files.push(metadata);
-    } else if (isDocSupported) {
-      if (provider === Providers.ANTHROPIC) {
-        const document: AnthropicDocumentBlock = {
-          type: 'document',
-          source: {
-            type: 'base64',
-            media_type: mimeType,
-            data: content,
-          },
-        };
-
-        if (file.filename) {
-          document.context = `File: "${file.filename}"`;
-        }
-
-        result.documents.push(document);
-      } else if (useResponsesApi) {
-        result.documents.push({
-          type: 'input_file',
-          filename: file.filename,
-          file_data: `data:${mimeType};base64,${content}`,
-        });
-      } else if (provider === Providers.GOOGLE || provider === Providers.VERTEXAI) {
-        result.documents.push({
-          type: 'media',
-          mimeType,
-          data: content,
-        });
-      } else if (isOpenAILikeProvider(provider) && provider != Providers.AZURE) {
-        result.documents.push({
-          type: 'file',
-          file: {
-            filename: file.filename,
-            file_data: `data:${mimeType};base64,${content}`,
-          },
-        });
+    } else if (isDocSupported && !isBedrock) {
+      const fileBuffer = Buffer.from(content, 'base64');
+      if (configuredFileSizeLimit && fileBuffer.length > configuredFileSizeLimit) {
+        throw new Error(
+          `File size (${(fileBuffer.length / 1024 / 1024).toFixed(1)}MB) exceeds the configured limit for ${provider}`,
+        );
       }
-      result.files.push(metadata);
+
+      const block = formatDocumentBlock(
+        provider,
+        mimeType,
+        content,
+        file.filename,
+        useResponsesApi,
+      );
+      if (block) {
+        result.documents.push(block);
+        result.files.push(metadata);
+      }
     }
   }
 

--- a/packages/api/src/files/encode/document.ts
+++ b/packages/api/src/files/encode/document.ts
@@ -113,8 +113,16 @@ export async function encodeAndFormatDocuments(
   const isBedrock = provider === Providers.BEDROCK;
   const isDocSupported = isDocumentSupportedProvider(provider);
 
+  const processableFiles = isBedrock
+    ? files.filter((file) => isBedrockDocumentType(file.type))
+    : files;
+
+  if (!processableFiles.length) {
+    return result;
+  }
+
   const results = await Promise.allSettled(
-    files.map((file) => {
+    processableFiles.map((file) => {
       return getFileStream(req, file, encodingMethods, getStrategyFunctions);
     }),
   );

--- a/packages/api/src/files/encode/document.ts
+++ b/packages/api/src/files/encode/document.ts
@@ -55,10 +55,12 @@ function formatDocumentBlock(
     return document;
   }
 
+  const resolvedFilename = filename || 'document';
+
   if (useResponsesApi) {
     return {
       type: 'input_file',
-      filename,
+      filename: resolvedFilename,
       file_data: `data:${mimeType};base64,${content}`,
     };
   }
@@ -75,7 +77,7 @@ function formatDocumentBlock(
     return {
       type: 'file',
       file: {
-        filename,
+        filename: resolvedFilename,
         file_data: `data:${mimeType};base64,${content}`,
       },
     };

--- a/packages/api/src/files/encode/processAttachments.spec.ts
+++ b/packages/api/src/files/encode/processAttachments.spec.ts
@@ -44,7 +44,7 @@ function categorizeFile(
     file.type &&
     mergedFileConfig &&
     endpointFileConfig?.supportedMimeTypes &&
-    mergedFileConfig.checkType(file.type, endpointFileConfig.supportedMimeTypes)
+    mergedFileConfig.checkType?.(file.type, endpointFileConfig.supportedMimeTypes)
   ) {
     return 'documents';
   }

--- a/packages/api/src/files/encode/processAttachments.spec.ts
+++ b/packages/api/src/files/encode/processAttachments.spec.ts
@@ -41,6 +41,7 @@ function categorizeFile(
   } else if (file.type?.startsWith('audio/')) {
     return 'audios';
   } else if (
+    !isBedrock &&
     file.type &&
     mergedFileConfig &&
     endpointFileConfig?.supportedMimeTypes &&
@@ -126,6 +127,11 @@ describe('processAttachments — supportedMimeTypes routing logic', () => {
   it('should route Bedrock document types through documents for Bedrock provider', () => {
     const { merged, epConfig } = resolveConfig(['.*']);
     expect(categorizeFile({ type: 'text/csv' }, true, merged, epConfig)).toBe('documents');
+  });
+
+  it('should skip non-Bedrock-document types for Bedrock even with permissive config', () => {
+    const { merged, epConfig } = resolveConfig(['.*']);
+    expect(categorizeFile({ type: 'application/zip' }, true, merged, epConfig)).toBe('skipped');
   });
 
   it('should route xlsx to documents with matching config', () => {

--- a/packages/api/src/files/encode/processAttachments.spec.ts
+++ b/packages/api/src/files/encode/processAttachments.spec.ts
@@ -1,0 +1,153 @@
+import {
+  FileSources,
+  mergeFileConfig,
+  EModelEndpoint,
+  getEndpointFileConfig,
+  isBedrockDocumentType,
+} from 'librechat-data-provider';
+import type { FileConfig, EndpointFileConfig } from 'librechat-data-provider';
+
+/**
+ * Mirrors the categorization logic from BaseClient.processAttachments.
+ * Extracted here for testability since the /api workspace test setup is broken.
+ */
+function categorizeFile(
+  file: {
+    type?: string | null;
+    source?: string;
+    embedded?: boolean;
+    metadata?: { fileIdentifier?: string };
+  },
+  isBedrock: boolean,
+  mergedFileConfig: FileConfig | undefined,
+  endpointFileConfig: EndpointFileConfig | undefined,
+): 'images' | 'documents' | 'videos' | 'audios' | 'skipped' {
+  const source = file.source ?? FileSources.local;
+  if (source === FileSources.text) {
+    return 'skipped';
+  }
+  if (file.embedded === true || file.metadata?.fileIdentifier != null) {
+    return 'skipped';
+  }
+
+  if (file.type?.startsWith('image/')) {
+    return 'images';
+  } else if (file.type === 'application/pdf') {
+    return 'documents';
+  } else if (isBedrock && file.type && isBedrockDocumentType(file.type)) {
+    return 'documents';
+  } else if (file.type?.startsWith('video/')) {
+    return 'videos';
+  } else if (file.type?.startsWith('audio/')) {
+    return 'audios';
+  } else if (
+    file.type &&
+    mergedFileConfig &&
+    endpointFileConfig?.supportedMimeTypes &&
+    mergedFileConfig.checkType(file.type, endpointFileConfig.supportedMimeTypes)
+  ) {
+    return 'documents';
+  }
+
+  return 'skipped';
+}
+
+describe('processAttachments — supportedMimeTypes routing logic', () => {
+  const endpoint = EModelEndpoint.openAI;
+
+  function resolveConfig(mimePatterns: string[]) {
+    const merged = mergeFileConfig({
+      endpoints: {
+        [endpoint]: { supportedMimeTypes: mimePatterns },
+      },
+    });
+    const epConfig = getEndpointFileConfig({
+      fileConfig: merged,
+      endpoint,
+    });
+    return { merged, epConfig };
+  }
+
+  it('should route text/csv to documents when supportedMimeTypes includes it', () => {
+    const { merged, epConfig } = resolveConfig(['text/csv']);
+    const result = categorizeFile({ type: 'text/csv' }, false, merged, epConfig);
+    expect(result).toBe('documents');
+  });
+
+  it('should route text/plain to documents when supportedMimeTypes uses wildcard', () => {
+    const { merged, epConfig } = resolveConfig(['.*']);
+    const result = categorizeFile({ type: 'text/plain' }, false, merged, epConfig);
+    expect(result).toBe('documents');
+  });
+
+  it('should skip application/zip when supportedMimeTypes only allows text types', () => {
+    const { merged, epConfig } = resolveConfig(['text/csv', 'text/plain']);
+    const result = categorizeFile({ type: 'application/zip' }, false, merged, epConfig);
+    expect(result).toBe('skipped');
+  });
+
+  it('should skip files when no fileConfig is provided', () => {
+    const result = categorizeFile({ type: 'text/csv' }, false, undefined, undefined);
+    expect(result).toBe('skipped');
+  });
+
+  it('should skip files with null type even with permissive config', () => {
+    const { merged, epConfig } = resolveConfig(['.*']);
+    const result = categorizeFile({ type: null }, false, merged, epConfig);
+    expect(result).toBe('skipped');
+  });
+
+  it('should skip files with undefined type even with permissive config', () => {
+    const { merged, epConfig } = resolveConfig(['.*']);
+    const result = categorizeFile({ type: undefined }, false, merged, epConfig);
+    expect(result).toBe('skipped');
+  });
+
+  it('should still route image types through images category (not documents)', () => {
+    const { merged, epConfig } = resolveConfig(['.*']);
+    expect(categorizeFile({ type: 'image/png' }, false, merged, epConfig)).toBe('images');
+  });
+
+  it('should still route PDF through documents (dedicated branch)', () => {
+    const { merged, epConfig } = resolveConfig(['.*']);
+    expect(categorizeFile({ type: 'application/pdf' }, false, merged, epConfig)).toBe('documents');
+  });
+
+  it('should still route video types through videos category', () => {
+    const { merged, epConfig } = resolveConfig(['.*']);
+    expect(categorizeFile({ type: 'video/mp4' }, false, merged, epConfig)).toBe('videos');
+  });
+
+  it('should still route audio types through audios category', () => {
+    const { merged, epConfig } = resolveConfig(['.*']);
+    expect(categorizeFile({ type: 'audio/mp3' }, false, merged, epConfig)).toBe('audios');
+  });
+
+  it('should route Bedrock document types through documents for Bedrock provider', () => {
+    const { merged, epConfig } = resolveConfig(['.*']);
+    expect(categorizeFile({ type: 'text/csv' }, true, merged, epConfig)).toBe('documents');
+  });
+
+  it('should route xlsx to documents with matching config', () => {
+    const xlsxType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    const { merged, epConfig } = resolveConfig([xlsxType]);
+    expect(categorizeFile({ type: xlsxType }, false, merged, epConfig)).toBe('documents');
+  });
+
+  it('should skip text source files regardless of config', () => {
+    const { merged, epConfig } = resolveConfig(['.*']);
+    const result = categorizeFile(
+      { type: 'text/csv', source: FileSources.text },
+      false,
+      merged,
+      epConfig,
+    );
+    expect(result).toBe('skipped');
+  });
+
+  it('should skip embedded files regardless of config', () => {
+    const { merged, epConfig } = resolveConfig(['.*']);
+    const result = categorizeFile({ type: 'text/csv', embedded: true }, false, merged, epConfig);
+    expect(result).toBe('skipped');
+  });
+});

--- a/packages/api/src/files/encode/processAttachments.spec.ts
+++ b/packages/api/src/files/encode/processAttachments.spec.ts
@@ -41,7 +41,6 @@ function categorizeFile(
   } else if (file.type?.startsWith('audio/')) {
     return 'audios';
   } else if (
-    !isBedrock &&
     file.type &&
     mergedFileConfig &&
     endpointFileConfig?.supportedMimeTypes &&
@@ -129,9 +128,9 @@ describe('processAttachments — supportedMimeTypes routing logic', () => {
     expect(categorizeFile({ type: 'text/csv' }, true, merged, epConfig)).toBe('documents');
   });
 
-  it('should skip non-Bedrock-document types for Bedrock even with permissive config', () => {
+  it('should route non-Bedrock-document types for Bedrock when config allows them', () => {
     const { merged, epConfig } = resolveConfig(['.*']);
-    expect(categorizeFile({ type: 'application/zip' }, true, merged, epConfig)).toBe('skipped');
+    expect(categorizeFile({ type: 'application/zip' }, true, merged, epConfig)).toBe('documents');
   });
 
   it('should route xlsx to documents with matching config', () => {


### PR DESCRIPTION
## Summary

I fixed a silent failure where files with mime types not matching the hardcoded categories (image, PDF, video, audio) were dropped in `BaseClient.processAttachments`, never reaching the provider. The upload succeeded and the file appeared in the UI, but was never included in the API request.

- Resolve the endpoint's `supportedMimeTypes` config from `fileConfig` inside `processAttachments` and check unrecognized file types against it before routing to the documents pipeline.
- Guard `file.type` against null/undefined before calling `checkType` to prevent coercion to string `'null'`/`'undefined'` with permissive patterns like `'.*'`.
- Cache `_mergedFileConfig` and `_endpointFileConfig` on the instance so `addPreviousAttachments` doesn't recompute per historical message.
- Use `agent.endpoint` (not `agent.provider`) for the `getEndpointFileConfig` lookup, matching the pattern in `addDocuments` and ensuring custom endpoint MIME configs are resolved correctly for agent runs.
- Extract `formatDocumentBlock` helper to eliminate ~30 lines of duplicate provider-dispatch code between the PDF and generic encoding paths.
- Add size validation in the generic encoding path using a base64 length formula (O(1), no heap allocation) against `configuredFileSizeLimit`.
- Hoist `configuredFileSizeLimit` above the per-file loop to avoid recomputing `mergeFileConfig` on every iteration.
- Pre-filter Bedrock files before fetching streams to avoid downloading unsupported types that would be discarded.
- Guard Bedrock from the generic encoding path — non-`bedrockDocumentFormats` types are now skipped instead of silently tracking metadata with no document sent.
- Only push metadata to `result.files` when a document block was actually created, preventing silent inconsistent state.
- Enable Anthropic citations for `text/plain`, `text/html`, `text/markdown` (supported by Anthropic's document API).
- Fix `!=` to `!==` for `Providers.AZURE` comparison; use `??` instead of `||` for filename fallback.
- Add JSDoc `@type` annotations for `_mergedFileConfig` and `_endpointFileConfig` in the constructor.

Closes #12482

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Configure a custom endpoint in `librechat.yaml` with broad `supportedMimeTypes`:
   ```yaml
   fileConfig:
     endpoints:
       custom:
         supportedMimeTypes:
           - '.*'
   ```
2. Upload a non-standard file type (e.g., `.xlsx`, `.csv`, `.txt`) to a conversation using that endpoint.
3. Verify the file is encoded and included in the provider API request (previously silently dropped).
4. Verify standard file types (images, PDFs, video, audio) continue routing through their dedicated pipelines.
5. Verify that without `supportedMimeTypes` config matching the file type, unrecognized types are still skipped.
6. Run `cd packages/api && npx jest document processAttachments` — 63 tests pass (40 existing + 9 encoding + 14 routing).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes