### PR TITLE
🏖️ fix: Sandpack ExternalResources for Static HTML Artifact Previews

### DIFF
--- a/client/src/components/Artifacts/ArtifactPreview.tsx
+++ b/client/src/components/Artifacts/ArtifactPreview.tsx
@@ -39,12 +39,15 @@ export const ArtifactPreview = memo(function ({
     };
   }, [currentCode, files, fileKey]);
 
-  const options: typeof sharedOptions = useMemo(() => {
+  const options: SandpackProviderProps['options'] = useMemo(() => {
+    const baseOptions = template === 'static' ? {} : sharedOptions;
+
     if (!startupConfig) {
-      return sharedOptions;
+      return baseOptions;
     }
+
     return {
-      ...sharedOptions,
+      ...baseOptions,
       bundlerURL: template === 'static' ? startupConfig.staticBundlerURL : startupConfig.bundlerURL,
     };
   }, [startupConfig, template]);

--- a/client/src/components/Artifacts/ArtifactPreview.tsx
+++ b/client/src/components/Artifacts/ArtifactPreview.tsx
@@ -6,7 +6,7 @@ import type {
 } from '@codesandbox/sandpack-react/unstyled';
 import type { TStartupConfig } from 'librechat-data-provider';
 import type { ArtifactFiles } from '~/common';
-import { sharedFiles, sharedOptions } from '~/utils/artifacts';
+import { sharedFiles, buildSandpackOptions } from '~/utils/artifacts';
 
 export const ArtifactPreview = memo(function ({
   files,
@@ -39,18 +39,10 @@ export const ArtifactPreview = memo(function ({
     };
   }, [currentCode, files, fileKey]);
 
-  const options: SandpackProviderProps['options'] = useMemo(() => {
-    const baseOptions = template === 'static' ? {} : sharedOptions;
-
-    if (!startupConfig) {
-      return baseOptions;
-    }
-
-    return {
-      ...baseOptions,
-      bundlerURL: template === 'static' ? startupConfig.staticBundlerURL : startupConfig.bundlerURL,
-    };
-  }, [startupConfig, template]);
+  const options: SandpackProviderProps['options'] = useMemo(
+    () => buildSandpackOptions(template, startupConfig),
+    [startupConfig, template],
+  );
 
   if (Object.keys(artifactFiles).length === 0) {
     return null;

--- a/client/src/utils/__tests__/artifacts.test.ts
+++ b/client/src/utils/__tests__/artifacts.test.ts
@@ -1,14 +1,16 @@
 import { buildSandpackOptions } from '../artifacts';
 
+const TAILWIND_CDN = 'https://cdn.tailwindcss.com/3.4.17#tailwind.js';
+
 describe('buildSandpackOptions', () => {
-  it('omits externalResources for static template', () => {
+  it('includes externalResources with .js fragment hint for static template', () => {
     const options = buildSandpackOptions('static');
-    expect(options?.externalResources).toEqual([]);
+    expect(options?.externalResources).toEqual([TAILWIND_CDN]);
   });
 
   it('includes externalResources for react-ts template', () => {
     const options = buildSandpackOptions('react-ts');
-    expect(options?.externalResources).toEqual(['https://cdn.tailwindcss.com/3.4.17']);
+    expect(options?.externalResources).toEqual([TAILWIND_CDN]);
   });
 
   it('uses staticBundlerURL when template is static and config is provided', () => {
@@ -17,7 +19,7 @@ describe('buildSandpackOptions', () => {
     >[1];
     const options = buildSandpackOptions('static', config);
     expect(options?.bundlerURL).toBe('https://static.example.com');
-    expect(options?.externalResources).toEqual([]);
+    expect(options?.externalResources).toEqual([TAILWIND_CDN]);
   });
 
   it('uses bundlerURL when template is react-ts and config is provided', () => {
@@ -26,7 +28,7 @@ describe('buildSandpackOptions', () => {
     >[1];
     const options = buildSandpackOptions('react-ts', config);
     expect(options?.bundlerURL).toBe('https://bundler.example.com');
-    expect(options?.externalResources).toEqual(['https://cdn.tailwindcss.com/3.4.17']);
+    expect(options?.externalResources).toEqual([TAILWIND_CDN]);
   });
 
   it('returns base options without bundlerURL when no config is provided', () => {

--- a/client/src/utils/__tests__/artifacts.test.ts
+++ b/client/src/utils/__tests__/artifacts.test.ts
@@ -1,4 +1,4 @@
-import { buildSandpackOptions, sharedOptions } from '../artifacts';
+import { buildSandpackOptions } from '../artifacts';
 
 describe('buildSandpackOptions', () => {
   it('omits externalResources for static template', () => {
@@ -8,7 +8,7 @@ describe('buildSandpackOptions', () => {
 
   it('includes externalResources for react-ts template', () => {
     const options = buildSandpackOptions('react-ts');
-    expect(options?.externalResources).toEqual(sharedOptions?.externalResources);
+    expect(options?.externalResources).toEqual(['https://cdn.tailwindcss.com/3.4.17']);
   });
 
   it('uses staticBundlerURL when template is static and config is provided', () => {
@@ -26,7 +26,7 @@ describe('buildSandpackOptions', () => {
     >[1];
     const options = buildSandpackOptions('react-ts', config);
     expect(options?.bundlerURL).toBe('https://bundler.example.com');
-    expect(options?.externalResources).toEqual(sharedOptions?.externalResources);
+    expect(options?.externalResources).toEqual(['https://cdn.tailwindcss.com/3.4.17']);
   });
 
   it('returns base options without bundlerURL when no config is provided', () => {

--- a/client/src/utils/__tests__/artifacts.test.ts
+++ b/client/src/utils/__tests__/artifacts.test.ts
@@ -1,0 +1,36 @@
+import { buildSandpackOptions, sharedOptions } from '../artifacts';
+
+describe('buildSandpackOptions', () => {
+  it('omits externalResources for static template', () => {
+    const options = buildSandpackOptions('static');
+    expect(options?.externalResources).toEqual([]);
+  });
+
+  it('includes externalResources for react-ts template', () => {
+    const options = buildSandpackOptions('react-ts');
+    expect(options?.externalResources).toEqual(sharedOptions?.externalResources);
+  });
+
+  it('uses staticBundlerURL when template is static and config is provided', () => {
+    const config = { staticBundlerURL: 'https://static.example.com' } as Parameters<
+      typeof buildSandpackOptions
+    >[1];
+    const options = buildSandpackOptions('static', config);
+    expect(options?.bundlerURL).toBe('https://static.example.com');
+    expect(options?.externalResources).toEqual([]);
+  });
+
+  it('uses bundlerURL when template is react-ts and config is provided', () => {
+    const config = { bundlerURL: 'https://bundler.example.com' } as Parameters<
+      typeof buildSandpackOptions
+    >[1];
+    const options = buildSandpackOptions('react-ts', config);
+    expect(options?.bundlerURL).toBe('https://bundler.example.com');
+    expect(options?.externalResources).toEqual(sharedOptions?.externalResources);
+  });
+
+  it('returns base options without bundlerURL when no config is provided', () => {
+    const options = buildSandpackOptions('react-ts');
+    expect(options?.bundlerURL).toBeUndefined();
+  });
+});

--- a/client/src/utils/artifacts.ts
+++ b/client/src/utils/artifacts.ts
@@ -1,10 +1,10 @@
 import dedent from 'dedent';
 import { shadcnComponents } from 'librechat-data-provider';
-import type { TStartupConfig } from 'librechat-data-provider';
 import type {
   SandpackProviderProps,
   SandpackPredefinedTemplate,
 } from '@codesandbox/sandpack-react';
+import type { TStartupConfig } from 'librechat-data-provider';
 
 const artifactFilename = {
   'application/vnd.react': 'App.tsx',

--- a/client/src/utils/artifacts.ts
+++ b/client/src/utils/artifacts.ts
@@ -1,5 +1,6 @@
 import dedent from 'dedent';
 import { shadcnComponents } from 'librechat-data-provider';
+import type { TStartupConfig } from 'librechat-data-provider';
 import type {
   SandpackProviderProps,
   SandpackPredefinedTemplate,
@@ -141,6 +142,25 @@ export function getProps(type: string): Partial<SandpackProviderProps> {
 export const sharedOptions: SandpackProviderProps['options'] = {
   externalResources: ['https://cdn.tailwindcss.com/3.4.17'],
 };
+
+/** Static template loads Tailwind via `<script>` in sharedFiles index.html;
+ * externalResources causes "Unable to determine file type" since the CDN URL has no extension. */
+export function buildSandpackOptions(
+  template: SandpackProviderProps['template'],
+  startupConfig?: TStartupConfig,
+): SandpackProviderProps['options'] {
+  const baseOptions: SandpackProviderProps['options'] =
+    template === 'static' ? { ...sharedOptions, externalResources: [] } : sharedOptions;
+
+  if (!startupConfig) {
+    return baseOptions;
+  }
+
+  return {
+    ...baseOptions,
+    bundlerURL: template === 'static' ? startupConfig.staticBundlerURL : startupConfig.bundlerURL,
+  };
+}
 
 export const sharedFiles = {
   '/lib/utils.ts': shadcnComponents.utils,

--- a/client/src/utils/artifacts.ts
+++ b/client/src/utils/artifacts.ts
@@ -139,25 +139,25 @@ export function getProps(type: string): Partial<SandpackProviderProps> {
   };
 }
 
+/** Fragment hint lets Sandpack's static-template regex detect `.js` from the URL;
+ * without it, the versioned CDN path (`/3.4.17`) has no recognised extension and
+ * `injectExternalResources` throws "Unable to determine file type". */
+const TAILWIND_CDN = 'https://cdn.tailwindcss.com/3.4.17#tailwind.js';
+
 export const sharedOptions: SandpackProviderProps['options'] = {
-  externalResources: ['https://cdn.tailwindcss.com/3.4.17'],
+  externalResources: [TAILWIND_CDN],
 };
 
-/** Static template loads Tailwind via `<script>` in sharedFiles index.html;
- * externalResources causes "Unable to determine file type" since the CDN URL has no extension. */
 export function buildSandpackOptions(
   template: SandpackProviderProps['template'],
   startupConfig?: TStartupConfig,
 ): SandpackProviderProps['options'] {
-  const baseOptions: SandpackProviderProps['options'] =
-    template === 'static' ? { ...sharedOptions, externalResources: [] } : sharedOptions;
-
   if (!startupConfig) {
-    return baseOptions;
+    return sharedOptions;
   }
 
   return {
-    ...baseOptions,
+    ...sharedOptions,
     bundlerURL: template === 'static' ? startupConfig.staticBundlerURL : startupConfig.bundlerURL,
   };
 }


### PR DESCRIPTION
## Summary

Fixes #12507

Sandpack's `static` template detects external resource type by matching the last file extension in the URL. The versioned Tailwind CDN path (`https://cdn.tailwindcss.com/3.4.17`) matches `.17` instead of `.js`, causing `injectExternalResources` to throw `"Unable to determine file type"`. Because the throw occurs inside the injection pipeline's `try/catch`, it also aborts all subsequent runtime injections (console hook, refresh listener).

- Appended a `#tailwind.js` URL fragment hint so Sandpack's regex matches `.js`. Fragments are not sent to the server, so the CDN response is unchanged.
- Extracted the options computation into a pure `buildSandpackOptions` helper in `artifacts.ts` for testability.
- Added unit tests covering all template/config combinations for the new helper.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Create an HTML artifact using a prompt that generates a `text/html` artifact with Tailwind classes (without an explicit Tailwind `<script>` tag in the content).
2. Open the browser console and confirm no `Runtime injection failed` error appears.
3. Verify the HTML artifact renders with Tailwind styles applied.
4. Create a React artifact and confirm Tailwind styles still work.
5. Run `cd client && npx jest --no-coverage artifacts.test.ts` — all tests pass.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes