### PR TITLE
🔁 fix: Pass recursionLimit to OpenAI-Compatible Agents API Endpoint

### DIFF
--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -68,6 +68,7 @@ jest.mock('@librechat/api', () => ({
     toolCalls: new Map(),
     usage: { promptTokens: 100, completionTokens: 50, reasoningTokens: 0 },
   }),
+  resolveRecursionLimit: jest.fn().mockReturnValue(50),
   createToolExecuteHandler: jest.fn().mockReturnValue({ handle: jest.fn() }),
   isChatCompletionValidationFailure: jest.fn().mockReturnValue(false),
 }));
@@ -284,6 +285,39 @@ describe('OpenAIChatCompletionController', () => {
           model: 'gpt-4',
         }),
       );
+    });
+  });
+
+  describe('recursionLimit resolution', () => {
+    it('should pass resolveRecursionLimit result to processStream config', async () => {
+      const { createRun, resolveRecursionLimit } = require('@librechat/api');
+      resolveRecursionLimit.mockReturnValue(75);
+
+      await OpenAIChatCompletionController(req, res);
+
+      const mockProcessStream = createRun.mock.results[0].value.processStream;
+      expect(mockProcessStream).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ recursionLimit: 75 }),
+        expect.anything(),
+      );
+    });
+
+    it('should call resolveRecursionLimit with agentsEConfig and agent', async () => {
+      const { resolveRecursionLimit } = require('@librechat/api');
+      const { getAgent } = require('~/models');
+      const mockAgent = { id: 'agent-123', name: 'Test', recursion_limit: 200 };
+      getAgent.mockResolvedValueOnce(mockAgent);
+
+      req.config = {
+        endpoints: {
+          agents: { recursionLimit: 100, maxRecursionLimit: 150, allowedProviders: [] },
+        },
+      };
+
+      await OpenAIChatCompletionController(req, res);
+
+      expect(resolveRecursionLimit).toHaveBeenCalledWith(req.config.endpoints.agents, mockAgent);
     });
   });
 });

--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -3,6 +3,7 @@
  * Tests that recordCollectedUsage is called correctly for token spending
  */
 
+const mockProcessStream = jest.fn().mockResolvedValue(undefined);
 const mockSpendTokens = jest.fn().mockResolvedValue({});
 const mockSpendStructuredTokens = jest.fn().mockResolvedValue({});
 const mockRecordCollectedUsage = jest
@@ -35,7 +36,7 @@ jest.mock('@librechat/agents', () => ({
 jest.mock('@librechat/api', () => ({
   writeSSE: jest.fn(),
   createRun: jest.fn().mockResolvedValue({
-    processStream: jest.fn().mockResolvedValue(undefined),
+    processStream: mockProcessStream,
   }),
   createChunk: jest.fn().mockReturnValue({}),
   buildToolSet: jest.fn().mockReturnValue(new Set()),
@@ -290,12 +291,11 @@ describe('OpenAIChatCompletionController', () => {
 
   describe('recursionLimit resolution', () => {
     it('should pass resolveRecursionLimit result to processStream config', async () => {
-      const { createRun, resolveRecursionLimit } = require('@librechat/api');
+      const { resolveRecursionLimit } = require('@librechat/api');
       resolveRecursionLimit.mockReturnValue(75);
 
       await OpenAIChatCompletionController(req, res);
 
-      const mockProcessStream = createRun.mock.results[0].value.processStream;
       expect(mockProcessStream).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ recursionLimit: 75 }),

--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -292,7 +292,7 @@ describe('OpenAIChatCompletionController', () => {
   describe('recursionLimit resolution', () => {
     it('should pass resolveRecursionLimit result to processStream config', async () => {
       const { resolveRecursionLimit } = require('@librechat/api');
-      resolveRecursionLimit.mockReturnValue(75);
+      resolveRecursionLimit.mockReturnValueOnce(75);
 
       await OpenAIChatCompletionController(req, res);
 

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -21,6 +21,7 @@ const {
   recordCollectedUsage,
   GenerationJobManager,
   getTransactionsConfig,
+  resolveRecursionLimit,
   createMemoryProcessor,
   loadAgent: loadAgentFn,
   createMultiAgentMapper,
@@ -733,7 +734,7 @@ class AgentClient extends BaseClient {
           },
           user: createSafeUser(this.options.req.user),
         },
-        recursionLimit: agentsEConfig?.recursionLimit ?? 50,
+        recursionLimit: resolveRecursionLimit(agentsEConfig, this.options.agent),
         signal: abortController.signal,
         streamMode: 'values',
         version: 'v2',
@@ -779,17 +780,6 @@ class AgentClient extends BaseClient {
         // - Agents without incoming edges become start nodes and run in parallel automatically
         if (this.agentConfigs && this.agentConfigs.size > 0) {
           agents.push(...this.agentConfigs.values());
-        }
-
-        if (agents[0].recursion_limit && typeof agents[0].recursion_limit === 'number') {
-          config.recursionLimit = agents[0].recursion_limit;
-        }
-
-        if (
-          agentsEConfig?.maxRecursionLimit &&
-          config.recursionLimit > agentsEConfig?.maxRecursionLimit
-        ) {
-          config.recursionLimit = agentsEConfig?.maxRecursionLimit;
         }
 
         // TODO: needs to be added as part of AgentContext initialization

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -492,6 +492,17 @@ const OpenAIChatCompletionController = async (req, res) => {
     }
 
     // Process the stream
+    const agentsEConfig = appConfig?.endpoints?.[EModelEndpoint.agents];
+    let recursionLimit = agentsEConfig?.recursionLimit ?? 50;
+
+    if (agent.recursion_limit && typeof agent.recursion_limit === 'number') {
+      recursionLimit = agent.recursion_limit;
+    }
+
+    if (agentsEConfig?.maxRecursionLimit && recursionLimit > agentsEConfig.maxRecursionLimit) {
+      recursionLimit = agentsEConfig.maxRecursionLimit;
+    }
+
     const config = {
       runName: 'AgentRun',
       configurable: {
@@ -504,6 +515,7 @@ const OpenAIChatCompletionController = async (req, res) => {
         },
         ...(userMCPAuthMap != null && { userMCPAuthMap }),
       },
+      recursionLimit,
       signal: abortController.signal,
       streamMode: 'values',
       version: 'v2',

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -15,6 +15,7 @@ const {
   createErrorResponse,
   recordCollectedUsage,
   getTransactionsConfig,
+  resolveRecursionLimit,
   createToolExecuteHandler,
   buildNonStreamingResponse,
   createOpenAIStreamTracker,
@@ -194,10 +195,8 @@ const OpenAIChatCompletionController = async (req, res) => {
     const conversationId = request.conversation_id ?? nanoid();
     const parentMessageId = request.parent_message_id ?? null;
 
-    // Build allowed providers set
-    const allowedProviders = new Set(
-      appConfig?.endpoints?.[EModelEndpoint.agents]?.allowedProviders,
-    );
+    const agentsEConfig = appConfig?.endpoints?.[EModelEndpoint.agents];
+    const allowedProviders = new Set(agentsEConfig?.allowedProviders);
 
     // Create tool loader
     const loadTools = createToolLoader(abortController.signal);
@@ -491,18 +490,6 @@ const OpenAIChatCompletionController = async (req, res) => {
       throw new Error('Failed to create agent run');
     }
 
-    // Process the stream
-    const agentsEConfig = appConfig?.endpoints?.[EModelEndpoint.agents];
-    let recursionLimit = agentsEConfig?.recursionLimit ?? 50;
-
-    if (agent.recursion_limit && typeof agent.recursion_limit === 'number') {
-      recursionLimit = agent.recursion_limit;
-    }
-
-    if (agentsEConfig?.maxRecursionLimit && recursionLimit > agentsEConfig.maxRecursionLimit) {
-      recursionLimit = agentsEConfig.maxRecursionLimit;
-    }
-
     const config = {
       runName: 'AgentRun',
       configurable: {
@@ -515,7 +502,7 @@ const OpenAIChatCompletionController = async (req, res) => {
         },
         ...(userMCPAuthMap != null && { userMCPAuthMap }),
       },
-      recursionLimit,
+      recursionLimit: resolveRecursionLimit(agentsEConfig, agent),
       signal: abortController.signal,
       streamMode: 'values',
       version: 'v2',

--- a/packages/api/src/agents/config.spec.ts
+++ b/packages/api/src/agents/config.spec.ts
@@ -1,0 +1,52 @@
+import type { TAgentsEndpoint } from 'librechat-data-provider';
+import { resolveRecursionLimit } from './config';
+
+describe('resolveRecursionLimit', () => {
+  it('returns default 50 when no config or agent provided', () => {
+    expect(resolveRecursionLimit(undefined, undefined)).toBe(50);
+  });
+
+  it('returns default 50 when config has no recursionLimit', () => {
+    expect(resolveRecursionLimit({} as TAgentsEndpoint, {})).toBe(50);
+  });
+
+  it('uses yaml recursionLimit when set', () => {
+    const config = { recursionLimit: 100 } as TAgentsEndpoint;
+    expect(resolveRecursionLimit(config, {})).toBe(100);
+  });
+
+  it('overrides with agent.recursion_limit when set', () => {
+    const config = { recursionLimit: 100 } as TAgentsEndpoint;
+    expect(resolveRecursionLimit(config, { recursion_limit: 200 })).toBe(200);
+  });
+
+  it('caps at maxRecursionLimit', () => {
+    const config = { recursionLimit: 100, maxRecursionLimit: 150 } as TAgentsEndpoint;
+    expect(resolveRecursionLimit(config, { recursion_limit: 200 })).toBe(150);
+  });
+
+  it('caps yaml default at maxRecursionLimit', () => {
+    const config = { recursionLimit: 200, maxRecursionLimit: 100 } as TAgentsEndpoint;
+    expect(resolveRecursionLimit(config, {})).toBe(100);
+  });
+
+  it('ignores agent.recursion_limit of 0', () => {
+    const config = { recursionLimit: 100 } as TAgentsEndpoint;
+    expect(resolveRecursionLimit(config, { recursion_limit: 0 })).toBe(100);
+  });
+
+  it('ignores negative agent.recursion_limit', () => {
+    const config = { recursionLimit: 100 } as TAgentsEndpoint;
+    expect(resolveRecursionLimit(config, { recursion_limit: -5 })).toBe(100);
+  });
+
+  it('ignores maxRecursionLimit of 0', () => {
+    const config = { recursionLimit: 100, maxRecursionLimit: 0 } as TAgentsEndpoint;
+    expect(resolveRecursionLimit(config, { recursion_limit: 200 })).toBe(200);
+  });
+
+  it('does not cap when recursionLimit is within maxRecursionLimit', () => {
+    const config = { recursionLimit: 50, maxRecursionLimit: 200 } as TAgentsEndpoint;
+    expect(resolveRecursionLimit(config, { recursion_limit: 150 })).toBe(150);
+  });
+});

--- a/packages/api/src/agents/config.spec.ts
+++ b/packages/api/src/agents/config.spec.ts
@@ -49,4 +49,14 @@ describe('resolveRecursionLimit', () => {
     const config = { recursionLimit: 50, maxRecursionLimit: 200 } as TAgentsEndpoint;
     expect(resolveRecursionLimit(config, { recursion_limit: 150 })).toBe(150);
   });
+
+  it('allows agent to override downward below yaml default', () => {
+    const config = { recursionLimit: 100 } as TAgentsEndpoint;
+    expect(resolveRecursionLimit(config, { recursion_limit: 30 })).toBe(30);
+  });
+
+  it('does not cap when agent.recursion_limit equals maxRecursionLimit', () => {
+    const config = { recursionLimit: 50, maxRecursionLimit: 150 } as TAgentsEndpoint;
+    expect(resolveRecursionLimit(config, { recursion_limit: 150 })).toBe(150);
+  });
 });

--- a/packages/api/src/agents/config.ts
+++ b/packages/api/src/agents/config.ts
@@ -1,0 +1,30 @@
+import type { TAgentsEndpoint } from 'librechat-data-provider';
+
+const DEFAULT_RECURSION_LIMIT = 50;
+
+/**
+ * Resolves the effective recursion limit for an agent run via a 3-step cascade:
+ * 1. YAML endpoint config default (falls back to 50)
+ * 2. Per-agent DB override (if set and positive)
+ * 3. Global max cap from YAML (if set and positive)
+ */
+export function resolveRecursionLimit(
+  agentsEConfig: TAgentsEndpoint | undefined,
+  agent: { recursion_limit?: number } | undefined,
+): number {
+  let limit = agentsEConfig?.recursionLimit ?? DEFAULT_RECURSION_LIMIT;
+
+  if (typeof agent?.recursion_limit === 'number' && agent.recursion_limit > 0) {
+    limit = agent.recursion_limit;
+  }
+
+  if (
+    typeof agentsEConfig?.maxRecursionLimit === 'number' &&
+    agentsEConfig.maxRecursionLimit > 0 &&
+    limit > agentsEConfig.maxRecursionLimit
+  ) {
+    limit = agentsEConfig.maxRecursionLimit;
+  }
+
+  return limit;
+}

--- a/packages/api/src/agents/index.ts
+++ b/packages/api/src/agents/index.ts
@@ -1,6 +1,7 @@
 export * from './avatars';
 export * from './chain';
 export * from './client';
+export * from './config';
 export * from './context';
 export * from './edges';
 export * from './handlers';


### PR DESCRIPTION
## Summary

Resolves #12476

The OpenAI-compatible Agents API endpoint (`openai.js`) never passed `recursionLimit` to LangGraph's `processStream()`, so all API-based agent calls were silently capped at LangGraph's default of 25 steps (~8 tool calls). The UI path (`client.js`) had the correct logic but it was duplicated inline.

- Extracted a shared `resolveRecursionLimit()` utility in `@librechat/api` (`packages/api/src/agents/config.ts`) that implements the 3-step cascade: yaml config default (fallback 50) → per-agent DB override → global max cap
- Fixed falsy-guard edge cases where `recursion_limit=0` or `maxRecursionLimit=0` would silently misbehave, by using explicit `typeof` + positive-number checks instead of truthiness
- Updated `openai.js` to call the shared utility, hoisted `agentsEConfig` to avoid a duplicate property walk for `allowedProviders`
- Updated `client.js` to replace the inline cascade with the shared utility call
- Added unit tests covering all cascade branches and edge cases (default, yaml override, agent override, max cap, zero/negative values)
- Added integration test assertions in `openai.spec.js` verifying `processStream` receives the resolved `recursionLimit`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Since this affects the OpenAI-compatible API endpoint for agents, testing should be done via programmatic API calls:

1. Configure an agent with a task requiring more than ~8 tool calls (which exceeds LangGraph's default 25-step limit)
2. Call the agent via the OpenAI-compatible API (`/v1/chat/completions` with an agent model)
3. Verify the agent completes all tool calls instead of silently stopping at the default cap
4. Test with a custom `recursion_limit` set on the agent in the database and verify it is respected
5. Test with `maxRecursionLimit` set in yaml config and verify the cap is enforced

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes