### PR TITLE
🛂 fix: Respect `requiresOAuth` Config in User MCP Connections

### DIFF
--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -239,7 +239,7 @@ export class MCPConnectionFactory {
         );
         connection.emit('oauthFailed', new Error('Server does not use OAuth'));
       };
-      connection.once('oauthRequired', nonOAuthHandler);
+      connection.on('oauthRequired', nonOAuthHandler);
       cleanupOAuthHandlers = () => {
         connection.removeListener('oauthRequired', nonOAuthHandler);
       };

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -45,7 +45,7 @@ export class MCPConnectionFactory {
   /** Creates a new MCP connection with optional OAuth support */
   static async create(
     basic: t.BasicConnectionOptions,
-    oauth?: t.OAuthConnectionOptions,
+    oauth?: t.OAuthConnectionOptions | t.UserConnectionContext,
   ): Promise<MCPConnection> {
     const factory = new this(basic, oauth);
     return factory.createConnection();
@@ -232,6 +232,17 @@ export class MCPConnectionFactory {
     let cleanupOAuthHandlers: (() => void) | null = null;
     if (this.useOAuth) {
       cleanupOAuthHandlers = this.handleOAuthEvents(connection);
+    } else {
+      const nonOAuthHandler = () => {
+        logger.info(
+          `${this.logPrefix} Server does not use OAuth — treating 401/403 as auth failure, not OAuth`,
+        );
+        connection.emit('oauthFailed', new Error('Server does not use OAuth'));
+      };
+      connection.once('oauthRequired', nonOAuthHandler);
+      cleanupOAuthHandlers = () => {
+        connection.removeListener('oauthRequired', nonOAuthHandler);
+      };
     }
 
     try {

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -18,7 +18,7 @@ import { preProcessGraphTokens } from '~/utils/graph';
 import { formatToolContent } from './parsers';
 import { MCPConnection } from './connection';
 import { processMCPEnv } from '~/utils/env';
-import { isUserSourced } from './utils';
+import { isUserSourced, isOAuthServer } from './utils';
 
 /**
  * Centralized manager for MCP server connections and tool execution.
@@ -102,7 +102,7 @@ export class MCPManager extends UserConnectionManager {
       return { tools: null, oauthRequired: false, oauthUrl: null };
     }
 
-    const useOAuth = Boolean(serverConfig.requiresOAuth || serverConfig.oauthMetadata);
+    const useOAuth = isOAuthServer(serverConfig);
 
     const registry = MCPServersRegistry.getInstance();
     const useSSRFProtection = registry.shouldEnableSSRFProtection();

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -4,7 +4,7 @@ import type * as t from './types';
 import { MCPServersRegistry } from '~/mcp/registry/MCPServersRegistry';
 import { ConnectionsRepository } from '~/mcp/ConnectionsRepository';
 import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
-import { isUserSourced } from './utils';
+import { isUserSourced, isOAuthServer } from './utils';
 import { MCPConnection } from './connection';
 import { mcpConfig } from './mcpConfig';
 
@@ -35,14 +35,7 @@ export abstract class UserConnectionManager {
   }
 
   /** Gets or creates a connection for a specific user, coalescing concurrent attempts */
-  public async getUserConnection(
-    opts: {
-      serverName: string;
-      forceNew?: boolean;
-      /** Pre-resolved config for config-source servers not in YAML/DB */
-      serverConfig?: t.ParsedServerConfig;
-    } & Omit<t.OAuthConnectionOptions, 'useOAuth'>,
-  ): Promise<MCPConnection> {
+  public async getUserConnection(opts: t.UserMCPConnectionOptions): Promise<MCPConnection> {
     const { serverName, forceNew, user } = opts;
     const userId = user?.id;
     if (!userId) {
@@ -89,11 +82,7 @@ export abstract class UserConnectionManager {
       returnOnOAuth = false,
       connectionTimeout,
       serverConfig: providedConfig,
-    }: {
-      serverName: string;
-      forceNew?: boolean;
-      serverConfig?: t.ParsedServerConfig;
-    } & Omit<t.OAuthConnectionOptions, 'useOAuth'>,
+    }: t.UserMCPConnectionOptions,
     userId: string,
   ): Promise<MCPConnection> {
     if (await this.appConnections!.has(serverName)) {
@@ -169,13 +158,19 @@ export abstract class UserConnectionManager {
         allowedDomains: registry.getAllowedDomains(),
       };
 
-      const useOAuth = Boolean(config.requiresOAuth || config.oauthMetadata);
+      const useOAuth = isOAuthServer(config);
+      if (useOAuth && !flowManager) {
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          `[MCP][User: ${userId}] OAuth server "${serverName}" requires a flowManager`,
+        );
+      }
       const oauthOptions: t.OAuthConnectionOptions | t.UserConnectionContext = useOAuth
         ? {
             useOAuth: true as const,
             user,
             customUserVars,
-            flowManager: flowManager!,
+            flowManager: flowManager,
             tokenMethods,
             signal,
             oauthStart,

--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -161,28 +161,32 @@ export abstract class UserConnectionManager {
 
     try {
       const registry = MCPServersRegistry.getInstance();
-      connection = await MCPConnectionFactory.create(
-        {
-          serverConfig: config,
-          serverName: serverName,
-          dbSourced: isUserSourced(config),
-          useSSRFProtection: registry.shouldEnableSSRFProtection(),
-          allowedDomains: registry.getAllowedDomains(),
-        },
-        {
-          useOAuth: true,
-          user: user,
-          customUserVars: customUserVars,
-          flowManager: flowManager,
-          tokenMethods: tokenMethods,
-          signal: signal,
-          oauthStart: oauthStart,
-          oauthEnd: oauthEnd,
-          returnOnOAuth: returnOnOAuth,
-          requestBody: requestBody,
-          connectionTimeout: connectionTimeout,
-        },
-      );
+      const basic: t.BasicConnectionOptions = {
+        serverConfig: config,
+        serverName: serverName,
+        dbSourced: isUserSourced(config),
+        useSSRFProtection: registry.shouldEnableSSRFProtection(),
+        allowedDomains: registry.getAllowedDomains(),
+      };
+
+      const useOAuth = Boolean(config.requiresOAuth || config.oauthMetadata);
+      const oauthOptions: t.OAuthConnectionOptions | t.UserConnectionContext = useOAuth
+        ? {
+            useOAuth: true as const,
+            user,
+            customUserVars,
+            flowManager: flowManager!,
+            tokenMethods,
+            signal,
+            oauthStart,
+            oauthEnd,
+            returnOnOAuth,
+            requestBody,
+            connectionTimeout,
+          }
+        : { user, customUserVars, requestBody, connectionTimeout };
+
+      connection = await MCPConnectionFactory.create(basic, oauthOptions);
 
       if (!(await connection?.isConnected())) {
         throw new Error('Failed to establish connection after initialization attempt.');

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -103,22 +103,23 @@ describe('MCPConnectionFactory', () => {
 
       await MCPConnectionFactory.create(basicOptions);
 
-      expect(mockConnectionInstance.once).toHaveBeenCalledWith(
-        'oauthRequired',
-        expect.any(Function),
-      );
+      expect(mockConnectionInstance.on).toHaveBeenCalledWith('oauthRequired', expect.any(Function));
 
-      const onceCall = (mockConnectionInstance.once as jest.Mock).mock.calls.find(
+      const onCall = (mockConnectionInstance.on as jest.Mock).mock.calls.find(
         ([event]: [string]) => event === 'oauthRequired',
       );
-      expect(onceCall).toBeDefined();
 
-      const handler = onceCall![1] as () => void;
+      const handler = onCall![1] as () => void;
       handler();
 
       expect(mockConnectionInstance.emit).toHaveBeenCalledWith(
         'oauthFailed',
         expect.objectContaining({ message: 'Server does not use OAuth' }),
+      );
+
+      expect(mockConnectionInstance.removeListener).toHaveBeenCalledWith(
+        'oauthRequired',
+        expect.any(Function),
       );
     });
 

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -93,6 +93,35 @@ describe('MCPConnectionFactory', () => {
       expect(mockConnectionInstance.connect).toHaveBeenCalled();
     });
 
+    it('should register fallback oauthRequired handler for non-OAuth connections', async () => {
+      const basicOptions = {
+        serverName: 'test-server',
+        serverConfig: mockServerConfig,
+      };
+
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      await MCPConnectionFactory.create(basicOptions);
+
+      expect(mockConnectionInstance.once).toHaveBeenCalledWith(
+        'oauthRequired',
+        expect.any(Function),
+      );
+
+      const onceCall = (mockConnectionInstance.once as jest.Mock).mock.calls.find(
+        ([event]: [string]) => event === 'oauthRequired',
+      );
+      expect(onceCall).toBeDefined();
+
+      const handler = onceCall![1] as () => void;
+      handler();
+
+      expect(mockConnectionInstance.emit).toHaveBeenCalledWith(
+        'oauthFailed',
+        expect.objectContaining({ message: 'Server does not use OAuth' }),
+      );
+    });
+
     it('should create a connection with OAuth', async () => {
       const basicOptions = {
         serverName: 'test-server',

--- a/packages/api/src/mcp/__tests__/MCPManager.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPManager.test.ts
@@ -925,6 +925,44 @@ describe('MCPManager', () => {
       );
     });
 
+    it('should use isOAuthServer in discoverServerTools', async () => {
+      const mockUser = { id: 'user123', email: 'test@example.com' } as unknown as IUser;
+      const mockFlowManager = {
+        createFlow: jest.fn(),
+        getFlowState: jest.fn(),
+        deleteFlow: jest.fn(),
+      };
+
+      mockAppConnections({
+        get: jest.fn().mockResolvedValue(null),
+      });
+
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'http://private-mcp.svc:5446/mcp',
+        requiresOAuth: false,
+      });
+
+      (MCPConnectionFactory.discoverTools as jest.Mock).mockResolvedValue({
+        tools: mockTools,
+        connection: null,
+        oauthRequired: false,
+        oauthUrl: null,
+      });
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      await manager.discoverServerTools({
+        serverName,
+        user: mockUser,
+        flowManager: mockFlowManager as unknown as t.ToolDiscoveryOptions['flowManager'],
+      });
+
+      expect(MCPConnectionFactory.discoverTools).toHaveBeenCalledWith(
+        expect.objectContaining({ serverName }),
+        expect.not.objectContaining({ useOAuth: true }),
+      );
+    });
+
     it('should discover tools with OAuth when user and flowManager provided', async () => {
       const mockUser = { id: 'user123', email: 'test@example.com' } as unknown as IUser;
       const mockFlowManager = {
@@ -964,6 +1002,91 @@ describe('MCPManager', () => {
         expect.objectContaining({ serverName }),
         expect.objectContaining({ user: mockUser, useOAuth: true }),
       );
+    });
+  });
+
+  describe('getUserConnection - useOAuth derivation', () => {
+    const mockUser = { id: userId, email: 'test@example.com' } as unknown as IUser;
+    const mockFlowManager = {
+      createFlow: jest.fn(),
+      getFlowState: jest.fn(),
+      deleteFlow: jest.fn(),
+    };
+    const mockConnection = {
+      isConnected: jest.fn().mockResolvedValue(true),
+      isStale: jest.fn().mockReturnValue(false),
+      disconnect: jest.fn(),
+    } as unknown as MCPConnection;
+
+    it('should pass useOAuth: true for servers with requiresOAuth', async () => {
+      mockAppConnections({
+        has: jest.fn().mockResolvedValue(false),
+      });
+
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'sse',
+        url: 'https://oauth-mcp.example.com',
+        requiresOAuth: true,
+      });
+
+      (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(mockConnection);
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      await manager.getUserConnection({
+        serverName,
+        user: mockUser,
+        flowManager: mockFlowManager as unknown as t.UserMCPConnectionOptions['flowManager'],
+      });
+
+      expect(MCPConnectionFactory.create).toHaveBeenCalledWith(
+        expect.objectContaining({ serverName }),
+        expect.objectContaining({ useOAuth: true }),
+      );
+    });
+
+    it('should not pass useOAuth for servers with requiresOAuth: false', async () => {
+      mockAppConnections({
+        has: jest.fn().mockResolvedValue(false),
+      });
+
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'streamable-http',
+        url: 'http://private-mcp.svc:5446/mcp',
+        requiresOAuth: false,
+      });
+
+      (MCPConnectionFactory.create as jest.Mock).mockResolvedValue(mockConnection);
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      await manager.getUserConnection({
+        serverName,
+        user: mockUser,
+      });
+
+      expect(MCPConnectionFactory.create).toHaveBeenCalledWith(
+        expect.objectContaining({ serverName }),
+        expect.not.objectContaining({ useOAuth: true }),
+      );
+    });
+
+    it('should throw when OAuth server lacks flowManager', async () => {
+      mockAppConnections({
+        has: jest.fn().mockResolvedValue(false),
+      });
+
+      (mockRegistryInstance.getServerConfig as jest.Mock).mockResolvedValue({
+        type: 'sse',
+        url: 'https://oauth-mcp.example.com',
+        requiresOAuth: true,
+      });
+
+      const manager = await MCPManager.createInstance(newMCPServersConfig());
+      await expect(
+        manager.getUserConnection({
+          serverName,
+          user: mockUser,
+        }),
+      ).rejects.toThrow('requires a flowManager');
     });
   });
 });

--- a/packages/api/src/mcp/types/index.ts
+++ b/packages/api/src/mcp/types/index.ts
@@ -202,6 +202,19 @@ export interface OAuthConnectionOptions extends UserConnectionContext {
   returnOnOAuth?: boolean;
 }
 
+/** Options accepted by UserConnectionManager.getUserConnection — OAuth fields are optional. */
+export interface UserMCPConnectionOptions extends UserConnectionContext {
+  serverName: string;
+  forceNew?: boolean;
+  serverConfig?: ParsedServerConfig;
+  flowManager?: FlowStateManager<o.MCPOAuthTokens | null>;
+  tokenMethods?: TokenMethods;
+  signal?: AbortSignal;
+  oauthStart?: (authURL: string) => Promise<void>;
+  oauthEnd?: () => Promise<void>;
+  returnOnOAuth?: boolean;
+}
+
 export interface ToolDiscoveryOptions {
   serverName: string;
   user?: IUser;

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -3,6 +3,13 @@ import type { ParsedServerConfig } from '~/mcp/types';
 
 export const mcpToolPattern = new RegExp(`^.+${Constants.mcp_delimiter}.+$`);
 
+/** Whether a server requires OAuth (has `requiresOAuth` or `oauthMetadata`). */
+export function isOAuthServer(
+  config: Pick<ParsedServerConfig, 'requiresOAuth' | 'oauthMetadata'>,
+): boolean {
+  return Boolean(config.requiresOAuth || config.oauthMetadata);
+}
+
 /** Checks that `customUserVars` is present AND non-empty (guards against truthy `{}`) */
 export function hasCustomUserVars(config: Pick<ParsedServerConfig, 'customUserVars'>): boolean {
   return !!config.customUserVars && Object.keys(config.customUserVars).length > 0;


### PR DESCRIPTION
## Summary

Private MCP servers configured with `requiresOAuth: false` and OIDC token pass-through headers (`{{LIBRECHAT_OPENID_ACCESS_TOKEN}}`) were incorrectly triggering OAuth flows when the token expired (401 response). This happened because `UserConnectionManager` hardcoded `useOAuth: true` for all user connections, causing the OAuth machinery to intercept standard auth failures. The server would attempt OAuth client registration against a private endpoint with no OAuth support, resulting in a 404 and total connection failure.

- Derive `useOAuth` from `config.requiresOAuth` and `config.oauthMetadata` in `UserConnectionManager.createUserConnectionInternal()`, aligning with the conditional logic already used in `MCPManager.discoverServerTools()`.
- Extract `isOAuthServer()` utility into `utils.ts` as a single source of truth for the OAuth check, replacing duplicated `Boolean(config.requiresOAuth || config.oauthMetadata)` in both `MCPManager` and `UserConnectionManager`.
- Widen `MCPConnectionFactory.create()` signature to accept `UserConnectionContext` for non-OAuth user connections, since OAuth fields (flowManager, tokenMethods, etc.) are unnecessary when `useOAuth` is false.
- Register a fallback `oauthRequired` handler on non-OAuth connections using `connection.on` (not `once`) so it survives all three retry attempts in `connectTo()`, immediately emitting `oauthFailed` to prevent a 120-second timeout hang.
- Add `UserMCPConnectionOptions` type with optional OAuth-specific fields, so `getUserConnection` callers connecting to non-OAuth servers are not forced to supply `flowManager`/`tokenMethods`/`signal`.
- Add explicit early throw when an OAuth server is missing `flowManager`, replacing a silent `flowManager!` non-null assertion that would crash deep in `getOAuthTokens()` with no actionable context.
- Add test coverage verifying `useOAuth` derivation through `getUserConnection`, fallback handler behavior, listener cleanup, and the `flowManager` guard.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `MCPConnectionFactory` test suite (20 tests pass), including updated test for fallback handler using `connection.on`, cleanup verification, and removal of redundant assertion.
- Ran `MCPManager` test suite (30 tests pass, up from 26), including new tests for:
  - Non-OAuth `discoverServerTools` path (`requiresOAuth: false` → no `useOAuth: true`)
  - `getUserConnection` with `requiresOAuth: true` → passes `useOAuth: true` to factory
  - `getUserConnection` with `requiresOAuth: false` → does NOT pass `useOAuth: true`
  - OAuth server missing `flowManager` → throws early with descriptive message
- TypeScript compilation passes with no new errors.

### Verification steps:
1. Deploy updated LibreChat to dev.
2. Connect as a user to a private MCP server (e.g., `clickhouse-cloud` with `requiresOAuth: false`) — should connect without OAuth prompts using OIDC token headers.
3. Let the OIDC token expire — reconnection should propagate the auth error normally, NOT trigger OAuth client registration.
4. Verify OAuth-based MCP servers (with `requiresOAuth: true`) still complete OAuth flows correctly.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes