### PR TITLE
🎯 fix: MCP Tool Misclassification from Action Delimiter Collision

### DIFF
--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -1238,8 +1238,11 @@ async function loadToolsForExecution({
     ? [...new Set([...requestedNonSpecialToolNames, ...ptcOrchestratedToolNames])]
     : requestedNonSpecialToolNames;
 
-  const actionToolNames = allToolNamesToLoad.filter((name) => isActionTool(name));
-  const regularToolNames = allToolNamesToLoad.filter((name) => !isActionTool(name));
+  const actionToolNames = [];
+  const regularToolNames = [];
+  for (const name of allToolNamesToLoad) {
+    (isActionTool(name) ? actionToolNames : regularToolNames).push(name);
+  }
 
   if (regularToolNames.length > 0) {
     const includesWebSearch = regularToolNames.includes(Tools.web_search);

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -31,6 +31,7 @@ const {
   imageGenTools,
   EModelEndpoint,
   EToolResources,
+  isActionTool,
   actionDelimiter,
   ImageVisionTool,
   openapiToFunction,
@@ -490,7 +491,7 @@ async function loadToolDefinitionsWrapper({ req, res, agent, streamId = null, to
     if (tool === Tools.web_search) {
       return checkCapability(AgentCapabilities.web_search);
     }
-    if (tool.includes(actionDelimiter)) {
+    if (isActionTool(tool)) {
       return actionsEnabled;
     }
     if (!areToolsEnabled) {
@@ -871,7 +872,7 @@ async function loadAgentTools({
     } else if (tool === Tools.web_search) {
       includesWebSearch = checkCapability(AgentCapabilities.web_search);
       return includesWebSearch;
-    } else if (tool.includes(actionDelimiter)) {
+    } else if (isActionTool(tool)) {
       return actionsEnabled;
     } else if (!areToolsEnabled) {
       return false;
@@ -978,7 +979,7 @@ async function loadAgentTools({
 
   agentTools.push(...additionalTools);
 
-  const hasActionTools = _agentTools.some((t) => t.includes(actionDelimiter));
+  const hasActionTools = _agentTools.some((t) => isActionTool(t));
   if (!hasActionTools) {
     return {
       toolRegistry,
@@ -1237,8 +1238,8 @@ async function loadToolsForExecution({
     ? [...new Set([...requestedNonSpecialToolNames, ...ptcOrchestratedToolNames])]
     : requestedNonSpecialToolNames;
 
-  const actionToolNames = allToolNamesToLoad.filter((name) => name.includes(actionDelimiter));
-  const regularToolNames = allToolNamesToLoad.filter((name) => !name.includes(actionDelimiter));
+  const actionToolNames = allToolNamesToLoad.filter((name) => isActionTool(name));
+  const regularToolNames = allToolNamesToLoad.filter((name) => !isActionTool(name));
 
   if (regularToolNames.length > 0) {
     const includesWebSearch = regularToolNames.includes(Tools.web_search);

--- a/api/server/services/__tests__/ToolService.spec.js
+++ b/api/server/services/__tests__/ToolService.spec.js
@@ -2,6 +2,7 @@ const {
   Tools,
   Constants,
   EModelEndpoint,
+  isActionTool,
   actionDelimiter,
   AgentCapabilities,
   defaultAgentCapabilities,
@@ -143,6 +144,24 @@ describe('ToolService - Action Capability Gating', () => {
     });
   });
 
+  describe('isActionTool — cross-delimiter collision guard', () => {
+    it('should identify real action tools', () => {
+      expect(isActionTool(`get_weather${actionDelimiter}api_example_com`)).toBe(true);
+      expect(isActionTool(`fetch_data${actionDelimiter}my---domain---com`)).toBe(true);
+    });
+
+    it('should reject MCP tools whose name ends with _action', () => {
+      expect(isActionTool(`get_action${Constants.mcp_delimiter}myserver`)).toBe(false);
+      expect(isActionTool(`fetch_action${Constants.mcp_delimiter}server_name`)).toBe(false);
+      expect(isActionTool(`retrieve_action${Constants.mcp_delimiter}srv`)).toBe(false);
+    });
+
+    it('should reject tools without the action delimiter', () => {
+      expect(isActionTool('calculator')).toBe(false);
+      expect(isActionTool(`web_search${Constants.mcp_delimiter}myserver`)).toBe(false);
+    });
+  });
+
   describe('loadAgentTools (definitionsOnly=true) — action tool filtering', () => {
     const actionToolName = `get_weather${actionDelimiter}api_example_com`;
     const regularTool = 'calculator';
@@ -181,6 +200,25 @@ describe('ToolService - Action Capability Gating', () => {
       const [callArgs] = mockLoadToolDefinitions.mock.calls[0];
       expect(callArgs.tools).toContain(regularTool);
       expect(callArgs.tools).toContain(actionToolName);
+    });
+
+    it('should not filter MCP tools whose name contains _action (cross-delimiter collision)', async () => {
+      const mcpToolWithAction = `get_action${Constants.mcp_delimiter}myserver`;
+      const capabilities = [AgentCapabilities.tools];
+      const req = createMockReq(capabilities);
+      mockGetEndpointsConfig.mockResolvedValue(createEndpointsConfig(capabilities));
+
+      await loadAgentTools({
+        req,
+        res: {},
+        agent: { id: 'agent_123', tools: [regularTool, mcpToolWithAction] },
+        definitionsOnly: true,
+      });
+
+      expect(mockLoadToolDefinitions).toHaveBeenCalledTimes(1);
+      const [callArgs] = mockLoadToolDefinitions.mock.calls[0];
+      expect(callArgs.tools).toContain(mcpToolWithAction);
+      expect(callArgs.tools).toContain(regularTool);
     });
 
     it('should return actionsEnabled in the result', async () => {

--- a/api/server/services/__tests__/ToolService.spec.js
+++ b/api/server/services/__tests__/ToolService.spec.js
@@ -150,6 +150,11 @@ describe('ToolService - Action Capability Gating', () => {
       expect(isActionTool(`fetch_data${actionDelimiter}my---domain---com`)).toBe(true);
     });
 
+    it('should identify action tools whose operationId contains _mcp_', () => {
+      expect(isActionTool(`sync_mcp_state${actionDelimiter}api---example---com`)).toBe(true);
+      expect(isActionTool(`get_mcp_config${actionDelimiter}internal---api---com`)).toBe(true);
+    });
+
     it('should reject MCP tools whose name ends with _action', () => {
       expect(isActionTool(`get_action${Constants.mcp_delimiter}myserver`)).toBe(false);
       expect(isActionTool(`fetch_action${Constants.mcp_delimiter}server_name`)).toBe(false);

--- a/api/server/services/__tests__/ToolService.spec.js
+++ b/api/server/services/__tests__/ToolService.spec.js
@@ -156,6 +156,11 @@ describe('ToolService - Action Capability Gating', () => {
       expect(isActionTool(`retrieve_action${Constants.mcp_delimiter}srv`)).toBe(false);
     });
 
+    it('should reject MCP tools with _action_ in the middle of their name', () => {
+      expect(isActionTool(`get_action_data${Constants.mcp_delimiter}myserver`)).toBe(false);
+      expect(isActionTool(`create_action_item${Constants.mcp_delimiter}server`)).toBe(false);
+    });
+
     it('should reject tools without the action delimiter', () => {
       expect(isActionTool('calculator')).toBe(false);
       expect(isActionTool(`web_search${Constants.mcp_delimiter}myserver`)).toBe(false);

--- a/api/server/services/__tests__/ToolService.spec.js
+++ b/api/server/services/__tests__/ToolService.spec.js
@@ -170,6 +170,14 @@ describe('ToolService - Action Capability Gating', () => {
       expect(isActionTool('calculator')).toBe(false);
       expect(isActionTool(`web_search${Constants.mcp_delimiter}myserver`)).toBe(false);
     });
+
+    it('known limitation: non-RFC domain with _mcp_ substring yields false negative', () => {
+      // RFC 952/1123 prohibit underscores in hostnames, so this is not expected in practice.
+      // Encoded domain `api_mcp_internal_com` places `_mcp_` after `_action_`, which
+      // the guard interprets as the MCP suffix.
+      const edgeCaseTool = `getData${actionDelimiter}api_mcp_internal_com`;
+      expect(isActionTool(edgeCaseTool)).toBe(false);
+    });
   });
 
   describe('loadAgentTools (definitionsOnly=true) — action tool filtering', () => {

--- a/client/src/components/Chat/Messages/Content/ToolOutput/ToolIcon.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolOutput/ToolIcon.tsx
@@ -1,4 +1,4 @@
-import { Constants, actionDelimiter } from 'librechat-data-provider';
+import { Constants, isActionTool } from 'librechat-data-provider';
 import { Terminal, Globe, ImageIcon, ArrowRightLeft, FileSearch, Zap, Wrench } from 'lucide-react';
 import { cn } from '~/utils';
 
@@ -48,7 +48,7 @@ export function getToolIconType(name: string): ToolIconType {
   if (name.startsWith(Constants.LC_TRANSFER_TO_)) {
     return 'agent_handoff';
   }
-  if (name.includes(actionDelimiter)) {
+  if (isActionTool(name)) {
     return 'action';
   }
   return 'generic';

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolIcon.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolIcon.test.tsx
@@ -12,6 +12,12 @@ describe('getToolIconType - ACTN-01: Action delimiter detection', () => {
     expect(getToolIconType(toolName)).toBe('mcp');
   });
 
+  it('returns "mcp" not "action" for MCP tool whose name ends with _action (cross-delimiter collision)', () => {
+    const toolName = `get_action${Constants.mcp_delimiter}myserver`;
+    expect(getToolIconType(toolName)).not.toBe('action');
+    expect(getToolIconType(toolName)).toBe('mcp');
+  });
+
   it('returns "generic" for plain tool name without delimiters', () => {
     expect(getToolIconType('some_plain_tool')).toBe('generic');
   });

--- a/client/src/components/SidePanel/Builder/AssistantPanel.tsx
+++ b/client/src/components/SidePanel/Builder/AssistantPanel.tsx
@@ -5,7 +5,7 @@ import { useForm, FormProvider, Controller, useWatch } from 'react-hook-form';
 import {
   Tools,
   Capabilities,
-  actionDelimiter,
+  isActionTool,
   ImageVisionTool,
   defaultAssistantFormValues,
 } from 'librechat-data-provider';
@@ -139,7 +139,7 @@ export default function AssistantPanel({
 
   const onSubmit = (data: AssistantForm) => {
     const tools: Array<FunctionTool | string> = [...functions].map((functionName) => {
-      if (!functionName.includes(actionDelimiter)) {
+      if (!isActionTool(functionName)) {
         return functionName;
       } else {
         const assistant = assistantMap?.[endpoint]?.[assistant_id];

--- a/packages/api/src/tools/definitions.spec.ts
+++ b/packages/api/src/tools/definitions.spec.ts
@@ -119,6 +119,39 @@ describe('definitions.ts', () => {
         expect(actionDef?.parameters).toBeUndefined();
       });
 
+      it('should not classify MCP tools with _action in name as action tools', async () => {
+        const mockGetActionToolDefinitions = jest.fn();
+        const mcpTool = 'get_action_mcp_myserver';
+
+        mockGetOrFetchMCPServerTools.mockResolvedValue({
+          tools: [
+            {
+              name: 'get_action',
+              description: 'Gets an action',
+              inputSchema: { type: 'object', properties: {} },
+            },
+          ],
+        });
+
+        const params: LoadToolDefinitionsParams = {
+          userId: 'user-123',
+          agentId: 'agent-123',
+          tools: [mcpTool],
+        };
+
+        const deps: LoadToolDefinitionsDeps = {
+          getOrFetchMCPServerTools: mockGetOrFetchMCPServerTools,
+          isBuiltInTool: mockIsBuiltInTool,
+          loadAuthValues: mockLoadAuthValues,
+          getActionToolDefinitions: mockGetActionToolDefinitions,
+        };
+
+        await loadToolDefinitions(params, deps);
+
+        expect(mockGetActionToolDefinitions).not.toHaveBeenCalled();
+        expect(mockGetOrFetchMCPServerTools).toHaveBeenCalled();
+      });
+
       it('should not call getActionToolDefinitions when no action tools present', async () => {
         const mockGetActionToolDefinitions = jest.fn();
         mockIsBuiltInTool.mockReturnValue(true);

--- a/packages/api/src/tools/definitions.ts
+++ b/packages/api/src/tools/definitions.ts
@@ -5,7 +5,7 @@
  * @module packages/api/src/tools/definitions
  */
 
-import { Constants, isActionTool, actionDelimiter } from 'librechat-data-provider';
+import { Constants, isActionTool } from 'librechat-data-provider';
 import type { AgentToolOptions } from 'librechat-data-provider';
 import type { LCToolRegistry, JsonSchemaType, LCTool, GenericTool } from '@librechat/agents';
 import type { ToolDefinition } from './classification';

--- a/packages/api/src/tools/definitions.ts
+++ b/packages/api/src/tools/definitions.ts
@@ -5,7 +5,7 @@
  * @module packages/api/src/tools/definitions
  */
 
-import { Constants, actionDelimiter } from 'librechat-data-provider';
+import { Constants, isActionTool, actionDelimiter } from 'librechat-data-provider';
 import type { AgentToolOptions } from 'librechat-data-provider';
 import type { LCToolRegistry, JsonSchemaType, LCTool, GenericTool } from '@librechat/agents';
 import type { ToolDefinition } from './classification';
@@ -99,7 +99,7 @@ export async function loadToolDefinitions(
   const mcpAllPattern = `${Constants.mcp_all}${Constants.mcp_delimiter}`;
 
   for (const toolName of tools) {
-    if (toolName.includes(actionDelimiter)) {
+    if (isActionTool(toolName)) {
       actionToolNames.push(toolName);
       continue;
     }

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -583,6 +583,20 @@ export type TContentData = StreamContentData & {
 
 export const actionDelimiter = '_action_';
 export const actionDomainSeparator = '---';
+
+/**
+ * Checks whether a tool name is an OpenAPI action tool.
+ * Guards against cross-delimiter collision where an MCP tool name ending in
+ * `_action` joined with `_mcp_<server>` produces a false `_action_` substring.
+ */
+export function isActionTool(toolName: string): boolean {
+  if (!toolName.includes(actionDelimiter)) {
+    return false;
+  }
+  const idx = toolName.indexOf(actionDelimiter);
+  const afterDelimiter = toolName.slice(idx + actionDelimiter.length);
+  return !afterDelimiter.startsWith('mcp_');
+}
 export const hostImageIdSuffix = '_host_copy';
 export const hostImageNamePrefix = 'host_copy_';
 

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -583,20 +583,18 @@ export type TContentData = StreamContentData & {
 
 export const actionDelimiter = '_action_';
 export const actionDomainSeparator = '---';
+/** Mirrors `Constants.mcp_delimiter`; duplicated here to avoid a circular import from `config.ts`. */
+const mcpDelimiter = '_mcp_';
 
 /**
  * Checks whether a tool name is an OpenAPI action tool.
- * Guards against cross-delimiter collision where an MCP tool name ending in
+ * Guards against cross-delimiter collision where an MCP tool name containing
  * `_action` joined with `_mcp_<server>` produces a false `_action_` substring.
  */
 export function isActionTool(toolName: string): boolean {
-  if (!toolName.includes(actionDelimiter)) {
-    return false;
-  }
-  const idx = toolName.indexOf(actionDelimiter);
-  const afterDelimiter = toolName.slice(idx + actionDelimiter.length);
-  return !afterDelimiter.startsWith('mcp_');
+  return toolName.includes(actionDelimiter) && !toolName.includes(mcpDelimiter);
 }
+
 export const hostImageIdSuffix = '_host_copy';
 export const hostImageNamePrefix = 'host_copy_';
 

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -590,9 +590,16 @@ const mcpDelimiter = '_mcp_';
  * Checks whether a tool name is an OpenAPI action tool.
  * Guards against cross-delimiter collision where an MCP tool name containing
  * `_action` joined with `_mcp_<server>` produces a false `_action_` substring.
+ * Only rejects when `_mcp_` appears after `_action_` (the MCP suffix position);
+ * `_mcp_` before `_action_` is part of the operationId and is valid.
  */
 export function isActionTool(toolName: string): boolean {
-  return toolName.includes(actionDelimiter) && !toolName.includes(mcpDelimiter);
+  const actionIdx = toolName.indexOf(actionDelimiter);
+  if (actionIdx < 0) {
+    return false;
+  }
+  const mcpIdx = toolName.indexOf(mcpDelimiter);
+  return mcpIdx < 0 || mcpIdx < actionIdx;
 }
 
 export const hostImageIdSuffix = '_host_copy';

--- a/packages/data-provider/src/types/assistants.ts
+++ b/packages/data-provider/src/types/assistants.ts
@@ -588,10 +588,20 @@ const mcpDelimiter = '_mcp_';
 
 /**
  * Checks whether a tool name is an OpenAPI action tool.
- * Guards against cross-delimiter collision where an MCP tool name containing
- * `_action` joined with `_mcp_<server>` produces a false `_action_` substring.
- * Only rejects when `_mcp_` appears after `_action_` (the MCP suffix position);
- * `_mcp_` before `_action_` is part of the operationId and is valid.
+ *
+ * Action format: `operationId_action_normalizedDomain`
+ * MCP format:    `toolName_mcp_serverName`
+ *
+ * Cross-delimiter collision: an MCP tool like `get_action_mcp_srv` contains
+ * `_action_` as a false positive. Guarded by checking whether `_mcp_` appears
+ * after `_action_`. In the collision case the `_mcp_` suffix always follows
+ * `_action_`; in a valid action tool whose operationId contains `_mcp_`, the
+ * `_mcp_` precedes `_action_`.
+ *
+ * Theoretical limitation: a non-RFC-compliant domain containing literal
+ * underscores that form `_mcp_` (e.g. `api_mcp_internal.com`) would produce
+ * a false negative. RFC 952/1123 prohibit underscores in hostnames, so this
+ * is not expected in practice.
  */
 export function isActionTool(toolName: string): boolean {
   const actionIdx = toolName.indexOf(actionDelimiter);


### PR DESCRIPTION
## Summary

Closes #12494

I fixed a bug where MCP tools with `_action` in their name are silently misclassified as OpenAPI action tools and filtered out based on `actionsEnabled`, making them invisible to models with no error or warning.

- Add `isActionTool()` guard in `packages/data-provider` that uses delimiter position to distinguish MCP tools from action tools: only reject when `_mcp_` appears *after* `_action_` (the MCP suffix position). `_mcp_` appearing *before* `_action_` is part of the operationId and remains valid (e.g. `sync_mcp_state_action_api---example---com`).
- Replace all `includes(actionDelimiter)` classification checks with `isActionTool()` across `ToolService.js`, `definitions.ts`, `ToolIcon.tsx`, and `AssistantPanel.tsx`.
- Leave `actionDelimiter` string-manipulation uses (tool name construction and parsing) unchanged since those operate on confirmed action tools.
- Remove dead `actionDelimiter` import from `definitions.ts`.
- Replace double-filter with single-pass partition in `loadToolsForExecution` for the action/regular tool split.
- Add test coverage for cross-delimiter collision scenarios including end-of-name, mid-name, and operationId-containing-mcp patterns in `ToolService.spec.js`, `definitions.spec.ts`, and `ToolIcon.test.tsx`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified with unit tests across three test suites (34 + 21 + 5 = 60 tests passing):

1. `isActionTool('get_action_mcp_myserver')` → `false` — end-of-name collision rejected.
2. `isActionTool('get_action_data_mcp_myserver')` → `false` — mid-name collision rejected.
3. `isActionTool('sync_mcp_state_action_api---example---com')` → `true` — action tool with `_mcp_` in operationId preserved.
4. `isActionTool('get_weather_action_api_example_com')` → `true` — standard action tools detected.
5. `loadAgentTools` with `definitionsOnly=true` preserves MCP tools containing `_action` when `actionsEnabled` is disabled.
6. `getToolIconType` returns `'mcp'` not `'action'` for MCP tools whose name ends with `_action`.
7. `loadToolDefinitions` routes MCP tools with `_action` in their name to the MCP path, not the action tool path.

To reproduce the original bug manually:
1. Create an MCP server with a tool named `get_action` (or any name containing `_action`).
2. Assign it to an agent.
3. Verify the tool is now available to the model in chat (previously it was silently dropped).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes