### PR TITLE
🗣️ fix: Prevent `@librechat/client` useLocalize from Overwriting Host App Language State

### DIFF
--- a/packages/client/src/hooks/useLocalize.ts
+++ b/packages/client/src/hooks/useLocalize.ts
@@ -1,21 +1,11 @@
-import { useEffect } from 'react';
 import { TOptions } from 'i18next';
-import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { resources } from '~/locales/i18n';
-import { langAtom } from '~/store';
 
 export type TranslationKeys = keyof typeof resources.en.translation;
 
 export default function useLocalize() {
-  const lang = useAtomValue(langAtom);
-  const { t, i18n } = useTranslation();
-
-  useEffect(() => {
-    if (i18n.language !== lang) {
-      i18n.changeLanguage(lang);
-    }
-  }, [lang, i18n]);
+  const { t } = useTranslation();
 
   return (phraseKey: TranslationKeys, options?: TOptions) => t(phraseKey, options);
 }

--- a/packages/client/src/hooks/useLocalize.ts
+++ b/packages/client/src/hooks/useLocalize.ts
@@ -1,11 +1,16 @@
+import { useCallback } from 'react';
 import { TOptions } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { resources } from '~/locales/i18n';
 
 export type TranslationKeys = keyof typeof resources.en.translation;
 
+/** Language lifecycle is managed by the host app — do not add i18n.changeLanguage() calls here. */
 export default function useLocalize() {
   const { t } = useTranslation();
 
-  return (phraseKey: TranslationKeys, options?: TOptions) => t(phraseKey, options);
+  return useCallback(
+    (phraseKey: TranslationKeys, options?: TOptions) => t(phraseKey, options),
+    [t],
+  );
 }

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -1,7 +1,6 @@
 import { atom } from 'jotai';
 import { NotificationSeverity } from '~/common';
 
-export const langAtom = atom<string>('en');
 export const chatDirectionAtom = atom<string>('ltr');
 export const fontSizeAtom = atom<string>('text-base');
 


### PR DESCRIPTION
## Summary

`langAtom` is hardcoded to `en` in  `packages/client/src/store.ts` 
in comparison with the main app's `client/src/hooks/useLocalize.ts` which reads from real sources  in `client/src/store/language.ts`

Both hooks call `i18n.changeLanguage()` on the **same** i18next singleton. When the packages/client hook fires first with `'en'`, it overwrites the language before the main app hook can correct it.

---
(look at value of i18nextLng in localstorage)

https://github.com/user-attachments/assets/f87c8a65-ad1d-4822-8b9c-56aa93b4ef05


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## How the bug plays out

1. User visits `/d/new` with language set to e.g., `fr`
2. Opens settings dialog, which imports components from `@librechat/client` (e.g., `Button`, `Input`, `Select`)
3. Some of these components use `useLocalize` from `packages/client/src/hooks/useLocalize.ts`
4. That hook reads `langAtom` → `'en'` (hardcoded default)
5. Since `i18n.language` (detected as `fr`) !== `'en'`, it calls `i18n.changeLanguage('en')`
6. This writes `i18nextLng = 'en'` to localStorage. the user sees the flicker to English(not very visible in the dialog case but can be worse when you are fetching data and have to wait for the result)
7. The main app's(client/) `useLocalize` (from `client/src/hooks/useLocalize.ts`) reads the Recoil atom (`fr`) and calls `i18n.changeLanguage('fr')` fixing it back since no data is fetched it happens fast.
8. On second visit, `i18nextLng` is already `fr` from step 7, so `i18n.language` matches `langAtom`... wait, no, `langAtom` is still `'en'`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code

## Proposed fix
It removes the language overwrite from `packages/client/src/hooks/useLocalize.ts` hook and only read it.

Alt fix: initialize `langAtom` from actual language sources.

> Note: If there is any reason for keeping it as it is, please let me know.