### PR TITLE
🪆 fix: Allow Nested `addParams` in Config Schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ helm/**/.values.yaml
 
 # AI Assistants
 /.claude/
+/.codex/
 /.cursor/
 /.copilot/
 /.aider/

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -202,9 +202,6 @@ describe('endpointSchema deprecated fields', () => {
       only: ['z-ai'],
       quantizations: ['int4'],
     },
-    web_search: {
-      enabled: true,
-    },
   };
 
   it('silently strips deprecated summarize field', () => {
@@ -255,6 +252,43 @@ describe('endpointSchema deprecated fields', () => {
       },
     });
     expect(result.success).toBe(true);
+  });
+
+  it('rejects non-boolean web_search objects in addParams', () => {
+    const result = endpointSchema.safeParse({
+      ...validEndpoint,
+      addParams: {
+        provider: {
+          only: ['z-ai'],
+        },
+        web_search: {
+          enabled: true,
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects configSchema entries with non-boolean web_search objects in custom addParams', () => {
+    const result = configSchema.safeParse({
+      version: '1.0.0',
+      endpoints: {
+        custom: [
+          {
+            ...validEndpoint,
+            addParams: {
+              provider: {
+                only: ['z-ai'],
+              },
+              web_search: {
+                enabled: true,
+              },
+            },
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
   });
 });
 
@@ -311,5 +345,26 @@ describe('azureEndpointSchema', () => {
         },
       });
     }
+  });
+
+  it('rejects non-boolean web_search objects in azure addParams', () => {
+    const result = azureEndpointSchema.safeParse({
+      groups: [
+        {
+          group: 'test-group',
+          apiKey: 'test-key',
+          models: { 'gpt-4': true },
+          addParams: {
+            provider: {
+              only: ['z-ai'],
+            },
+            web_search: {
+              enabled: true,
+            },
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -1,9 +1,9 @@
 import {
-  configSchema,
-  endpointSchema,
   paramDefinitionSchema,
   agentsEndpointSchema,
   azureEndpointSchema,
+  endpointSchema,
+  configSchema,
 } from '../src/config';
 import { tModelSpecPresetSchema, EModelEndpoint } from '../src/schemas';
 
@@ -197,12 +197,6 @@ describe('endpointSchema deprecated fields', () => {
     baseURL: 'https://api.example.com',
     models: { default: ['model-1'] },
   };
-  const nestedAddParams = {
-    provider: {
-      only: ['z-ai'],
-      quantizations: ['int4'],
-    },
-  };
 
   it('silently strips deprecated summarize field', () => {
     const result = endpointSchema.safeParse({
@@ -227,6 +221,21 @@ describe('endpointSchema deprecated fields', () => {
       expect(result.data).not.toHaveProperty('customOrder');
     }
   });
+});
+
+describe('endpointSchema addParams validation', () => {
+  const validEndpoint = {
+    name: 'CustomEndpoint',
+    apiKey: 'test-key',
+    baseURL: 'https://api.example.com',
+    models: { default: ['model-1'] },
+  };
+  const nestedAddParams = {
+    provider: {
+      only: ['z-ai'],
+      quantizations: ['int4'],
+    },
+  };
 
   it('accepts nested addParams objects and arrays', () => {
     const result = endpointSchema.safeParse({
@@ -249,6 +258,31 @@ describe('endpointSchema deprecated fields', () => {
             addParams: nestedAddParams,
           },
         ],
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts boolean web_search in addParams', () => {
+    const result = endpointSchema.safeParse({
+      ...validEndpoint,
+      addParams: {
+        provider: {
+          only: ['z-ai'],
+        },
+        web_search: true,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts scalar addParams values', () => {
+    const result = endpointSchema.safeParse({
+      ...validEndpoint,
+      addParams: {
+        model: 'custom-model',
+        retries: 2,
+        metadata: null,
       },
     });
     expect(result.success).toBe(true);
@@ -345,6 +379,25 @@ describe('azureEndpointSchema', () => {
         },
       });
     }
+  });
+
+  it('accepts boolean web_search in azure addParams', () => {
+    const result = azureEndpointSchema.safeParse({
+      groups: [
+        {
+          group: 'test-group',
+          apiKey: 'test-key',
+          models: { 'gpt-4': true },
+          addParams: {
+            provider: {
+              only: ['z-ai'],
+            },
+            web_search: false,
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
   });
 
   it('rejects non-boolean web_search objects in azure addParams', () => {

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -1,4 +1,5 @@
 import {
+  configSchema,
   endpointSchema,
   paramDefinitionSchema,
   agentsEndpointSchema,
@@ -196,6 +197,15 @@ describe('endpointSchema deprecated fields', () => {
     baseURL: 'https://api.example.com',
     models: { default: ['model-1'] },
   };
+  const nestedAddParams = {
+    provider: {
+      only: ['z-ai'],
+      quantizations: ['int4'],
+    },
+    web_search: {
+      enabled: true,
+    },
+  };
 
   it('silently strips deprecated summarize field', () => {
     const result = endpointSchema.safeParse({
@@ -219,6 +229,32 @@ describe('endpointSchema deprecated fields', () => {
     if (result.success) {
       expect(result.data).not.toHaveProperty('customOrder');
     }
+  });
+
+  it('accepts nested addParams objects and arrays', () => {
+    const result = endpointSchema.safeParse({
+      ...validEndpoint,
+      addParams: nestedAddParams,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.addParams).toEqual(nestedAddParams);
+    }
+  });
+
+  it('keeps configSchema validation intact with nested custom addParams', () => {
+    const result = configSchema.safeParse({
+      version: '1.0.0',
+      endpoints: {
+        custom: [
+          {
+            ...validEndpoint,
+            addParams: nestedAddParams,
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(true);
   });
 });
 
@@ -249,6 +285,31 @@ describe('azureEndpointSchema', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data).not.toHaveProperty('plugins');
+    }
+  });
+
+  it('accepts nested addParams in azure groups', () => {
+    const result = azureEndpointSchema.safeParse({
+      groups: [
+        {
+          group: 'test-group',
+          apiKey: 'test-key',
+          models: { 'gpt-4': true },
+          addParams: {
+            provider: {
+              only: ['z-ai'],
+            },
+          },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.groups[0].addParams).toEqual({
+        provider: {
+          only: ['z-ai'],
+        },
+      });
     }
   });
 });

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -115,9 +115,7 @@ export const modelConfigSchema = z
 
 export type TAzureModelConfig = z.infer<typeof modelConfigSchema>;
 
-type ParamValue = string | number | boolean | null | ParamValue[] | { [key: string]: ParamValue };
-
-const paramValueSchema: z.ZodType<ParamValue> = z.lazy(() =>
+const paramValueSchema: z.ZodType<unknown> = z.lazy(() =>
   z.union([
     z.string(),
     z.number(),
@@ -128,13 +126,27 @@ const paramValueSchema: z.ZodType<ParamValue> = z.lazy(() =>
   ]),
 );
 
+const addParamsSchema: z.ZodType<Record<string, unknown>> = z
+  .record(z.string(), paramValueSchema)
+  .superRefine((params, ctx) => {
+    if (params.web_search === undefined || typeof params.web_search === 'boolean') {
+      return;
+    }
+
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['web_search'],
+      message: '`web_search` must be a boolean in addParams',
+    });
+  });
+
 export const azureBaseSchema = z.object({
   apiKey: z.string(),
   serverless: z.boolean().optional(),
   instanceName: z.string().optional(),
   deploymentName: z.string().optional(),
   assistants: z.boolean().optional(),
-  addParams: z.record(z.string(), paramValueSchema).optional(),
+  addParams: addParamsSchema.optional(),
   dropParams: z.array(z.string()).optional(),
   version: z.string().optional(),
   baseURL: z.string().optional(),
@@ -374,7 +386,7 @@ export const endpointSchema = baseEndpointSchema.merge(
     iconURL: z.string().optional(),
     modelDisplayLabel: z.string().optional(),
     headers: z.record(z.string()).optional(),
-    addParams: z.record(z.string(), paramValueSchema).optional(),
+    addParams: addParamsSchema.optional(),
     dropParams: z.array(z.string()).optional(),
     customParams: z
       .object({

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -126,6 +126,7 @@ const paramValueSchema: z.ZodType<unknown> = z.lazy(() =>
   ]),
 );
 
+/** Validates addParams while keeping web_search aligned with current runtime boolean handling. */
 const addParamsSchema: z.ZodType<Record<string, unknown>> = z
   .record(z.string(), paramValueSchema)
   .superRefine((params, ctx) => {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -115,13 +115,26 @@ export const modelConfigSchema = z
 
 export type TAzureModelConfig = z.infer<typeof modelConfigSchema>;
 
+type ParamValue = string | number | boolean | null | ParamValue[] | { [key: string]: ParamValue };
+
+const paramValueSchema: z.ZodType<ParamValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(paramValueSchema),
+    z.record(z.string(), paramValueSchema),
+  ]),
+);
+
 export const azureBaseSchema = z.object({
   apiKey: z.string(),
   serverless: z.boolean().optional(),
   instanceName: z.string().optional(),
   deploymentName: z.string().optional(),
   assistants: z.boolean().optional(),
-  addParams: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(),
+  addParams: z.record(z.string(), paramValueSchema).optional(),
   dropParams: z.array(z.string()).optional(),
   version: z.string().optional(),
   baseURL: z.string().optional(),
@@ -361,7 +374,7 @@ export const endpointSchema = baseEndpointSchema.merge(
     iconURL: z.string().optional(),
     modelDisplayLabel: z.string().optional(),
     headers: z.record(z.string()).optional(),
-    addParams: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(),
+    addParams: z.record(z.string(), paramValueSchema).optional(),
     dropParams: z.array(z.string()).optional(),
     customParams: z
       .object({


### PR DESCRIPTION
## Summary

Closes #12521.

This fixes a config-schema regression that rejected nested `addParams` values for custom and Azure endpoints.

Root cause:
- `addParams` validation was narrowed to scalar-only values in `packages/data-provider/src/config.ts`
- runtime handling already supports nested objects and arrays, so valid configs could fail full `librechat.yaml` validation

What changed:
- replaced the scalar-only `addParams` schema with a recursive JSON-like schema
- applied it to both `endpointSchema` and `azureBaseSchema`
- aligned `addParams.web_search` validation with current runtime behavior by requiring a boolean value
- added regression coverage for nested provider-style `addParams` plus edge cases where object-valued `web_search` should be rejected in custom and Azure configs

## Change Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

- `cd packages/data-provider && npx jest specs/config-schemas.spec.ts --runInBand`
- TypeScript diagnostics checked for:
  - `packages/data-provider/src/config.ts`
  - `packages/data-provider/specs/config-schemas.spec.ts`
  - `packages/data-schemas/src/methods/config.ts`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.