### PR TITLE
👀 fix: Agents shared with Viewer role not visible in model selector

### DIFF
--- a/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
@@ -1,10 +1,14 @@
 import debounce from 'lodash/debounce';
 import React, { createContext, useContext, useState, useMemo, useCallback } from 'react';
-import { EModelEndpoint, isAgentsEndpoint, isAssistantsEndpoint } from 'librechat-data-provider';
+import {
+  EModelEndpoint,
+  PermissionBits,
+  isAgentsEndpoint,
+  isAssistantsEndpoint,
+} from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { Endpoint, SelectedValues } from '~/common';
 import {
-  useAgentDefaultPermissionLevel,
   useSelectorEffects,
   useKeyDialog,
   useEndpoints,
@@ -81,9 +85,8 @@ export function ModelSelectorProvider({ children, startupConfig }: ModelSelector
     });
   }, [startupConfig, agentsMap]);
 
-  const permissionLevel = useAgentDefaultPermissionLevel();
   const { data: agents = null } = useListAgentsQuery(
-    { requiredPermission: permissionLevel },
+    { requiredPermission: PermissionBits.VIEW },
     {
       select: (data) => data?.data,
     },

--- a/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
+++ b/client/src/components/Chat/Menus/Endpoints/ModelSelectorContext.tsx
@@ -8,12 +8,7 @@ import {
 } from 'librechat-data-provider';
 import type * as t from 'librechat-data-provider';
 import type { Endpoint, SelectedValues } from '~/common';
-import {
-  useSelectorEffects,
-  useKeyDialog,
-  useEndpoints,
-  useLocalize,
-} from '~/hooks';
+import { useSelectorEffects, useKeyDialog, useEndpoints, useLocalize } from '~/hooks';
 import { useAgentsMapContext, useAssistantsMapContext, useLiveAnnouncer } from '~/Providers';
 import { useGetEndpointsQuery, useListAgentsQuery } from '~/data-provider';
 import { useModelSelectorChatContext } from './ModelSelectorChatContext';

--- a/client/src/hooks/Agents/__tests__/useAgentDefaultPermissionLevel.spec.ts
+++ b/client/src/hooks/Agents/__tests__/useAgentDefaultPermissionLevel.spec.ts
@@ -1,12 +1,12 @@
 import { renderHook } from '@testing-library/react';
 import { PermissionBits } from 'librechat-data-provider';
-import useAgentDefaultPermissionLevel from '../useAgentDefaultPermissionLevel';
 
 jest.mock('~/hooks/Roles', () => ({
   useHasAccess: jest.fn(),
 }));
 
 import { useHasAccess } from '~/hooks/Roles';
+import useAgentDefaultPermissionLevel from '../useAgentDefaultPermissionLevel';
 const mockUseHasAccess = useHasAccess as jest.Mock;
 
 describe('useAgentDefaultPermissionLevel', () => {

--- a/client/src/hooks/Agents/__tests__/useAgentDefaultPermissionLevel.spec.ts
+++ b/client/src/hooks/Agents/__tests__/useAgentDefaultPermissionLevel.spec.ts
@@ -1,0 +1,24 @@
+import { renderHook } from '@testing-library/react';
+import { PermissionBits } from 'librechat-data-provider';
+import useAgentDefaultPermissionLevel from '../useAgentDefaultPermissionLevel';
+
+jest.mock('~/hooks/Roles', () => ({
+  useHasAccess: jest.fn(),
+}));
+
+import { useHasAccess } from '~/hooks/Roles';
+const mockUseHasAccess = useHasAccess as jest.Mock;
+
+describe('useAgentDefaultPermissionLevel', () => {
+  it('should return EDIT permission when marketplace access is enabled', () => {
+    mockUseHasAccess.mockReturnValue(true);
+    const { result } = renderHook(() => useAgentDefaultPermissionLevel());
+    expect(result.current).toBe(PermissionBits.EDIT);
+  });
+
+  it('should return VIEW permission when marketplace access is disabled', () => {
+    mockUseHasAccess.mockReturnValue(false);
+    const { result } = renderHook(() => useAgentDefaultPermissionLevel());
+    expect(result.current).toBe(PermissionBits.VIEW);
+  });
+});


### PR DESCRIPTION
## Summary
`ModelSelectorContext.tsx` (the chat agent/model selector) used `useAgentDefaultPermissionLevel()` which returns `PermissionBits.EDIT` (2) when marketplace is active. The agent listing query then uses `$bitsAllSet: 2` on ACL entries. The Viewer role (`agent_viewer`) only grants `permBits: 1` (VIEW), so viewer-shared agents were filtered out of the chat selector for any user with marketplace access (typically ADMINs).

  Other components that list agents for browsing (`useAgentsMap`, `useMentions`) already correctly use `PermissionBits.VIEW` and were not affected.

  - Change `ModelSelectorContext.tsx` to use `PermissionBits.VIEW` directly for its agent listing query, matching the pattern used by `useAgentsMap` and `useMentions`.
  - `AgentSelect.tsx` (the builder panel) still uses `useAgentDefaultPermissionLevel()` with EDIT, which is correct — it should only show agents the user can modify.
  - Add unit tests for `useAgentDefaultPermissionLevel` hook.

## Testing
- Reproduced on fresh upstream install (commit `6ecd1b510`): created two agents shared publicly — one with Viewer role (`permBits: 1`), one with Editor role (`permBits: 3`). Non-owner ADMIN user could only see the Editor-shared agent via `GET /api/agents/?requiredPermission=2`.
- Verified fix: with `requiredPermission=1` (VIEW), both agents appear in the listing.
- Added unit tests for `useAgentDefaultPermissionLevel` verifying it returns EDIT when marketplace is active and VIEW when it is not.

## Verification Steps

1. Log in as User A (ADMIN), create an agent, share it publicly with "Viewer" role.
2. Log in as User C (ADMIN, non-owner) — the shared agent should now appear in the chat model/agent selector dropdown.
3. Open the agent builder panel — the viewer-shared agent should NOT appear there (only agents the user can edit).
4. Verify agents shared with Editor role still appear in both the chat selector and builder panel.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

Fixes #12529 