### PR TITLE
🔎 fix: Specify Explicit Primary Key for Meilisearch Document Operations

### DIFF
--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -156,6 +156,46 @@ describe('Meilisearch Mongoose plugin', () => {
     );
   });
 
+  test('updating an indexed message calls updateDocuments with primaryKey: messageId', async () => {
+    const messageModel = createMessageModel(mongoose);
+    const msg = await messageModel.create({
+      messageId: new mongoose.Types.ObjectId().toString(),
+      conversationId: new mongoose.Types.ObjectId(),
+      user: new mongoose.Types.ObjectId(),
+      isCreatedByUser: true,
+    });
+    mockUpdateDocuments.mockClear();
+
+    msg._meiliIndex = true;
+    msg.text = 'Updated text';
+    await msg.save();
+
+    expect(mockUpdateDocuments).toHaveBeenCalledWith(
+      [expect.objectContaining({ messageId: expect.anything() })],
+      { primaryKey: 'messageId' },
+    );
+  });
+
+  test('deleteObjectFromMeili calls deleteDocument with messageId, not _id', async () => {
+    const messageModel = createMessageModel(mongoose);
+    const msgId = new mongoose.Types.ObjectId().toString();
+    const msg = await messageModel.create({
+      messageId: msgId,
+      conversationId: new mongoose.Types.ObjectId(),
+      user: new mongoose.Types.ObjectId(),
+      isCreatedByUser: true,
+    });
+    mockDeleteDocument.mockClear();
+
+    const typedMsg = msg as unknown as import('./mongoMeili').DocumentWithMeiliIndex;
+    await new Promise<void>((resolve, reject) => {
+      typedMsg.deleteObjectFromMeili!((err) => (err ? reject(err) : resolve()));
+    });
+
+    expect(mockDeleteDocument).toHaveBeenCalledWith(msgId);
+    expect(mockDeleteDocument).not.toHaveBeenCalledWith(String(msg._id));
+  });
+
   test('updateDocuments receives preprocessed data with primaryKey', async () => {
     const conversationModel = createConversationModel(mongoose);
     const conversationId = 'abc|def|ghi';

--- a/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.spec.ts
@@ -73,7 +73,10 @@ describe('Meilisearch Mongoose plugin', () => {
       title: 'Test Conversation',
       endpoint: EModelEndpoint.openAI,
     });
-    expect(mockAddDocuments).toHaveBeenCalled();
+    expect(mockAddDocuments).toHaveBeenCalledWith(
+      [expect.objectContaining({ conversationId: expect.anything() })],
+      { primaryKey: 'conversationId' },
+    );
   });
 
   test('saving conversation indexes with expiredAt=null w/ meilisearch', async () => {
@@ -105,7 +108,10 @@ describe('Meilisearch Mongoose plugin', () => {
       user: new mongoose.Types.ObjectId(),
       isCreatedByUser: true,
     });
-    expect(mockAddDocuments).toHaveBeenCalled();
+    expect(mockAddDocuments).toHaveBeenCalledWith(
+      [expect.objectContaining({ messageId: expect.anything() })],
+      { primaryKey: 'messageId' },
+    );
   });
 
   test('saving messages with expiredAt=null indexes w/ meilisearch', async () => {
@@ -128,6 +134,47 @@ describe('Meilisearch Mongoose plugin', () => {
       expiredAt: new Date(),
     });
     expect(mockAddDocuments).not.toHaveBeenCalled();
+  });
+
+  test('updating an indexed conversation calls updateDocuments with primaryKey', async () => {
+    const conversationModel = createConversationModel(mongoose);
+    const convo = await conversationModel.create({
+      conversationId: new mongoose.Types.ObjectId().toString(),
+      user: new mongoose.Types.ObjectId(),
+      title: 'Original Title',
+      endpoint: EModelEndpoint.openAI,
+    });
+    mockUpdateDocuments.mockClear();
+
+    convo._meiliIndex = true;
+    convo.title = 'Updated Title';
+    await convo.save();
+
+    expect(mockUpdateDocuments).toHaveBeenCalledWith(
+      [expect.objectContaining({ conversationId: expect.anything() })],
+      { primaryKey: 'conversationId' },
+    );
+  });
+
+  test('updateDocuments receives preprocessed data with primaryKey', async () => {
+    const conversationModel = createConversationModel(mongoose);
+    const conversationId = 'abc|def|ghi';
+    const convo = await conversationModel.create({
+      conversationId,
+      user: new mongoose.Types.ObjectId(),
+      title: 'Pipe Test',
+      endpoint: EModelEndpoint.openAI,
+    });
+    mockUpdateDocuments.mockClear();
+
+    convo._meiliIndex = true;
+    convo.title = 'Updated Pipe Test';
+    await convo.save();
+
+    expect(mockUpdateDocuments).toHaveBeenCalledWith(
+      [expect.objectContaining({ conversationId: 'abc--def--ghi' })],
+      { primaryKey: 'conversationId' },
+    );
   });
 
   test('sync w/ meili does not include TTL documents', async () => {
@@ -299,8 +346,10 @@ describe('Meilisearch Mongoose plugin', () => {
       // Run sync which should call processSyncBatch internally
       await conversationModel.syncWithMeili();
 
-      // Verify addDocumentsInBatches was called (new batch method)
-      expect(mockAddDocumentsInBatches).toHaveBeenCalled();
+      // Verify addDocumentsInBatches was called with explicit primaryKey
+      expect(mockAddDocumentsInBatches).toHaveBeenCalledWith(expect.any(Array), undefined, {
+        primaryKey: 'conversationId',
+      });
     });
 
     test('addObjectToMeili retries on failure', async () => {

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -94,7 +94,7 @@ const getSyncConfig = () => ({
  * Validates the required options for configuring the mongoMeili plugin.
  */
 const validateOptions = (options: Partial<MongoMeiliOptions>): void => {
-  const requiredKeys: (keyof MongoMeiliOptions)[] = ['host', 'apiKey', 'indexName'];
+  const requiredKeys: (keyof MongoMeiliOptions)[] = ['host', 'apiKey', 'indexName', 'primaryKey'];
   requiredKeys.forEach((key) => {
     if (!options[key]) {
       throw new Error(`Missing mongoMeili Option: ${key}`);
@@ -136,13 +136,14 @@ const processBatch = async <T>(
 const createMeiliMongooseModel = ({
   index,
   attributesToIndex,
+  primaryKey,
   syncOptions,
 }: {
   index: Index<MeiliIndexable>;
   attributesToIndex: string[];
+  primaryKey: string;
   syncOptions: { batchSize: number; delayMs: number };
 }) => {
-  const primaryKey = attributesToIndex[0];
   const syncConfig = { ...getSyncConfig(), ...syncOptions };
 
   class MeiliMongooseModel {
@@ -436,11 +437,10 @@ const createMeiliMongooseModel = ({
       }
 
       try {
-        const Model = this.constructor as Model<DocumentWithMeiliIndex>;
-        await Model.updateMany(
+        // eslint-disable-next-line no-restricted-syntax -- _meiliIndex is an internal bookkeeping flag, not tenant-scoped data
+        await this.collection.updateOne(
           { _id: this._id as Types.ObjectId },
           { $set: { _meiliIndex: true } },
-          { timestamps: false },
         );
       } catch (error) {
         logger.error('[addObjectToMeili] Error updating _meiliIndex field:', error);
@@ -458,9 +458,7 @@ const createMeiliMongooseModel = ({
       next: CallbackWithoutResultAndOptionalError,
     ): Promise<void> {
       try {
-        const object = _.omitBy(_.pick(this.toJSON(), attributesToIndex), (v, k) =>
-          k.startsWith('$'),
-        );
+        const object = this.preprocessObjectForIndex!();
         await index.updateDocuments([object], { primaryKey });
         next();
       } catch (error) {
@@ -479,7 +477,7 @@ const createMeiliMongooseModel = ({
       next: CallbackWithoutResultAndOptionalError,
     ): Promise<void> {
       try {
-        await index.deleteDocument(this._id as string);
+        await index.deleteDocument(String(this[primaryKey as keyof DocumentWithMeiliIndex]));
         next();
       } catch (error) {
         logger.error('[deleteObjectFromMeili] Error deleting document from Meili:', error);
@@ -645,7 +643,7 @@ export default function mongoMeili(schema: Schema, options: MongoMeiliOptions): 
     logger.debug(`[mongoMeili] Added 'user' field to ${indexName} index attributes`);
   }
 
-  schema.loadClass(createMeiliMongooseModel({ index, attributesToIndex, syncOptions }));
+  schema.loadClass(createMeiliMongooseModel({ index, attributesToIndex, primaryKey, syncOptions }));
 
   // Register Mongoose hooks
   schema.post('save', function (doc: DocumentWithMeiliIndex, next) {

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -255,7 +255,7 @@ const createMeiliMongooseModel = ({
 
       try {
         // Add documents to MeiliSearch
-        await index.addDocumentsInBatches(formattedDocs);
+        await index.addDocumentsInBatches(formattedDocs, undefined, { primaryKey });
 
         // Update MongoDB to mark documents as indexed.
         // { timestamps: false } prevents Mongoose from touching updatedAt, preserving
@@ -422,7 +422,7 @@ const createMeiliMongooseModel = ({
 
       while (retryCount < maxRetries) {
         try {
-          await index.addDocuments([object]);
+          await index.addDocuments([object], { primaryKey });
           break;
         } catch (error) {
           retryCount++;
@@ -436,9 +436,11 @@ const createMeiliMongooseModel = ({
       }
 
       try {
-        await this.collection.updateMany(
+        const Model = this.constructor as Model<DocumentWithMeiliIndex>;
+        await Model.updateMany(
           { _id: this._id as Types.ObjectId },
           { $set: { _meiliIndex: true } },
+          { timestamps: false },
         );
       } catch (error) {
         logger.error('[addObjectToMeili] Error updating _meiliIndex field:', error);
@@ -459,7 +461,7 @@ const createMeiliMongooseModel = ({
         const object = _.omitBy(_.pick(this.toJSON(), attributesToIndex), (v, k) =>
           k.startsWith('$'),
         );
-        await index.updateDocuments([object]);
+        await index.updateDocuments([object], { primaryKey });
         next();
       } catch (error) {
         logger.error('[updateObjectToMeili] Error updating document in Meili:', error);

--- a/packages/data-schemas/src/models/plugins/mongoMeili.ts
+++ b/packages/data-schemas/src/models/plugins/mongoMeili.ts
@@ -130,6 +130,7 @@ const processBatch = async <T>(
  * @param config - Configuration object.
  * @param config.index - The MeiliSearch index object.
  * @param config.attributesToIndex - List of attributes to index.
+ * @param config.primaryKey - The primary key field for MeiliSearch document operations.
  * @param config.syncOptions - Sync configuration options.
  * @returns A class definition that will be loaded into the Mongoose schema.
  */


### PR DESCRIPTION
## Summary

Fixed message search returning empty results on Meilisearch v1.0+ and resolved several pre-existing bugs in the `mongoMeili` Mongoose plugin discovered during review.

Meilisearch v1.0 tightened primary key inference: when a document contains multiple fields ending with `id`, it refuses to auto-infer and requires the primary key to be specified explicitly. The `messages` index contains both `conversationId` and `messageId`, causing every `addDocuments` / `addDocumentsInBatches` / `updateDocuments` call to silently fail with `index_primary_key_multiple_candidates_found`. Documents get marked as `_meiliIndex: true` in MongoDB but never actually reach Meilisearch, leaving message search empty while conversation search continues working.

- Pass `{ primaryKey }` to `index.addDocumentsInBatches()` in `processSyncBatch` (bulk sync path).
- Pass `{ primaryKey }` to `index.addDocuments()` in `addObjectToMeili` (per-save hook path).
- Pass `{ primaryKey }` to `index.updateDocuments()` in `updateObjectToMeili` (per-update hook path).
- Fix `deleteObjectFromMeili` using MongoDB `_id` instead of the Meilisearch primary key (`conversationId`/`messageId`), which caused post-remove cleanup to silently no-op and leave orphaned documents in the index.
- Pass `options.primaryKey` explicitly to the `createMeiliMongooseModel` factory function instead of deriving it from `attributesToIndex[0]` (schema field order), eliminating a fragile implicit contract.
- Fix `updateObjectToMeili` skipping `preprocessObjectForIndex()`, which meant updates bypassed `content` array-to-text conversion and `conversationId` pipe character escaping.
- Change `collection.updateMany` to `collection.updateOne` in `addObjectToMeili` since `_id` is unique.
- Add `primaryKey` to `validateOptions` required keys to fail fast if omitted.
- Strengthen test assertions to verify `{ primaryKey }` argument is passed to `addDocuments`, `addDocumentsInBatches`, and `updateDocuments`. Add tests for the update path including `preprocessObjectForIndex` pipe escaping.

Closes #12538

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

All 43 tests pass in the `mongoMeili.spec.ts` suite.

To verify the primary fix on a live deployment:
1. Deploy with Meilisearch v1.12+ (e.g., v1.35.1).
2. Clear the Meilisearch `messages` index (or start with a fresh volume).
3. Reset `_meiliIndex` flags in MongoDB: `db.messages.updateMany({}, { $set: { _meiliIndex: false } })`.
4. Restart LibreChat and confirm the sync completes.
5. Check Meilisearch tasks — `addDocuments` tasks should now succeed instead of failing with `index_primary_key_multiple_candidates_found`.
6. Verify message search returns results in the UI.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes