### PR TITLE
⚡ perf: Short-Circuit Config Override Resolution for Empty Principals

### DIFF
--- a/packages/api/src/app/service.spec.ts
+++ b/packages/api/src/app/service.spec.ts
@@ -201,14 +201,16 @@ describe('createAppConfigService', () => {
       const deps = createDeps({ getApplicableConfigs: mockGetConfigs });
       const { getAppConfig } = createAppConfigService(deps);
 
+      // No role/userId → empty principals → short-circuits without calling getApplicableConfigs
       await getAppConfig();
+      expect(mockGetConfigs).not.toHaveBeenCalled();
 
       mockGetConfigs.mockResolvedValueOnce([
         { priority: 10, overrides: { restricted: true }, isActive: true },
       ]);
       const config = await getAppConfig({ role: 'ADMIN' });
 
-      expect(mockGetConfigs).toHaveBeenCalledTimes(2);
+      expect(mockGetConfigs).toHaveBeenCalledTimes(1);
       expect((config as TestConfig).restricted).toBe(true);
     });
 
@@ -227,6 +229,29 @@ describe('createAppConfigService', () => {
 
       expect(mockGetConfigs).toHaveBeenCalledTimes(2);
       expect((config as TestConfig).x).toBe('admin-only');
+    });
+
+    it('skips getApplicableConfigs when buildPrincipals returns empty', async () => {
+      const deps = createDeps({
+        getUserPrincipals: jest.fn().mockResolvedValue([]),
+      });
+      const { getAppConfig } = createAppConfigService(deps);
+
+      const config = await getAppConfig({ userId: 'uid1', role: 'USER' });
+
+      expect(deps.getUserPrincipals).toHaveBeenCalledWith({ userId: 'uid1', role: 'USER' });
+      expect(deps.getApplicableConfigs).not.toHaveBeenCalled();
+      expect(config).toEqual(deps._baseConfig);
+    });
+
+    it('skips getApplicableConfigs when no role or userId is provided', async () => {
+      const deps = createDeps();
+      const { getAppConfig } = createAppConfigService(deps);
+
+      const config = await getAppConfig();
+
+      expect(deps.getApplicableConfigs).not.toHaveBeenCalled();
+      expect(config).toEqual(deps._baseConfig);
     });
 
     it('falls back to base config on getApplicableConfigs error', async () => {

--- a/packages/api/src/app/service.ts
+++ b/packages/api/src/app/service.ts
@@ -170,6 +170,12 @@ export function createAppConfigService(deps: AppConfigServiceDeps) {
 
     try {
       const principals = await buildPrincipals(role, userId);
+
+      if (principals.length === 0) {
+        await cache.set(cacheKey, baseConfig, overrideCacheTtl);
+        return baseConfig;
+      }
+
       const configs = await getApplicableConfigs(principals);
 
       if (configs.length === 0) {


### PR DESCRIPTION
## Summary

Added an early return in `getAppConfig` when `buildPrincipals` yields an empty array, skipping the unnecessary `getApplicableConfigs` DB query since there are no principals to match against.

- Short-circuit `getAppConfig` to return the base config immediately when no principals exist (no role or userId provided, or `getUserPrincipals` returns empty)
- Avoid an unnecessary async `getApplicableConfigs` call that would always return zero matches for an empty principal set
- Add two new test cases covering the short-circuit behavior for empty principals
- Update the "base-only empty result" test to reflect that the no-args path no longer invokes `getApplicableConfigs`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran the existing `service.spec.ts` test suite in `packages/api`. Two new tests validate:
1. When `getUserPrincipals` returns empty, `getApplicableConfigs` is never called and the base config is returned
2. When neither `role` nor `userId` is provided, `getApplicableConfigs` is skipped entirely

### **Test Configuration**:
- `npx jest service.spec --no-coverage` from `packages/api`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes