### PR TITLE
⚡ perf: Separate Error Handling for Principal Resolution vs Config Overrides

### DIFF
--- a/packages/api/src/app/service.spec.ts
+++ b/packages/api/src/app/service.spec.ts
@@ -254,6 +254,18 @@ describe('createAppConfigService', () => {
       expect(config).toEqual(deps._baseConfig);
     });
 
+    it('falls back to base config on buildPrincipals error', async () => {
+      const deps = createDeps({
+        getUserPrincipals: jest.fn().mockRejectedValue(new Error('principal lookup failed')),
+      });
+      const { getAppConfig } = createAppConfigService(deps);
+
+      const config = await getAppConfig({ userId: 'uid1', role: 'USER' });
+
+      expect(deps.getApplicableConfigs).not.toHaveBeenCalled();
+      expect(config).toEqual(deps._baseConfig);
+    });
+
     it('falls back to base config on getApplicableConfigs error', async () => {
       const deps = createDeps({
         getApplicableConfigs: jest.fn().mockRejectedValue(new Error('DB down')),

--- a/packages/api/src/app/service.ts
+++ b/packages/api/src/app/service.ts
@@ -168,14 +168,20 @@ export function createAppConfigService(deps: AppConfigServiceDeps) {
       }
     }
 
+    let principals: Array<{ principalType: string; principalId?: string | Types.ObjectId }>;
     try {
-      const principals = await buildPrincipals(role, userId);
+      principals = await buildPrincipals(role, userId);
+    } catch (error) {
+      logger.error('[getAppConfig] Error building principals, falling back to base:', error);
+      return baseConfig;
+    }
 
-      if (principals.length === 0) {
-        await cache.set(cacheKey, baseConfig, overrideCacheTtl);
-        return baseConfig;
-      }
+    if (principals.length === 0) {
+      await cache.set(cacheKey, baseConfig, overrideCacheTtl);
+      return baseConfig;
+    }
 
+    try {
       const configs = await getApplicableConfigs(principals);
 
       if (configs.length === 0) {


### PR DESCRIPTION
## Summary

Separated the try/catch for `buildPrincipals` from `getApplicableConfigs` so each failure path has a distinct log message, making it clear whether the fallback to base config was due to a principal lookup failure or a config override query failure.

- Split the single try/catch into two: one around `buildPrincipals`, one around `getApplicableConfigs` and merge logic
- Log `[getAppConfig] Error building principals` for principal resolution failures, distinct from the existing `Error resolving config overrides` message
- Neither error path caches the base config, keeping both as intentional uncached fallbacks
- Add test verifying that `buildPrincipals` failure returns base config without calling `getApplicableConfigs`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran `npx jest service.spec --no-coverage` from `packages/api`. New test validates that when `getUserPrincipals` throws, the service falls back to base config and never calls `getApplicableConfigs`.

### **Test Configuration**:
- `npx jest service.spec --no-coverage` from `packages/api`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes