### PR TITLE
feat: Support built-in server-side tools for custom endpoints (xAI x_search, web_search)

### DIFF
--- a/packages/api/src/agents/__tests__/initialize.test.ts
+++ b/packages/api/src/agents/__tests__/initialize.test.ts
@@ -282,3 +282,126 @@ describe('initializeAgent — maxContextTokens', () => {
     expect(result.maxContextTokens).toBe(userValue);
   });
 });
+
+describe('initializeAgent — tool merging for custom providers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('merges built-in tools with agent tools for xAI provider', async () => {
+    const { agent, req, res, loadTools, db } = createMocks();
+    agent.provider = Providers.XAI;
+
+    const builtInTools = [{ type: 'web_search' }, { type: 'x_search' }];
+    const structuredTool = { name: 'file_search', description: 'search files' };
+
+    mockGetProviderConfig.mockReturnValue({
+      getOptions: jest.fn().mockResolvedValue({
+        llmConfig: { model: 'grok-3' },
+        tools: builtInTools,
+        endpointTokenConfig: undefined,
+      } satisfies InitializeResultBase),
+      overrideProvider: Providers.XAI,
+    });
+
+    loadTools.mockResolvedValue({
+      tools: [structuredTool],
+      toolContextMap: {},
+      userMCPAuthMap: undefined,
+      toolRegistry: undefined,
+      toolDefinitions: [],
+      hasDeferredTools: false,
+    });
+
+    const result = await initializeAgent(
+      {
+        req,
+        res,
+        agent,
+        loadTools,
+        endpointOption: { endpoint: EModelEndpoint.agents },
+        allowedProviders: new Set([Providers.XAI]),
+        isInitialAgent: true,
+      },
+      db,
+    );
+
+    expect(result.tools).toContainEqual(structuredTool);
+    expect(result.tools).toContainEqual({ type: 'web_search' });
+    expect(result.tools).toContainEqual({ type: 'x_search' });
+    expect(result.tools).toHaveLength(3);
+  });
+
+  it('uses only built-in tools when no agent tools exist for xAI', async () => {
+    const { agent, req, res, loadTools, db } = createMocks();
+    agent.provider = Providers.XAI;
+
+    const builtInTools = [{ type: 'x_search' }];
+
+    mockGetProviderConfig.mockReturnValue({
+      getOptions: jest.fn().mockResolvedValue({
+        llmConfig: { model: 'grok-3' },
+        tools: builtInTools,
+        endpointTokenConfig: undefined,
+      } satisfies InitializeResultBase),
+      overrideProvider: Providers.XAI,
+    });
+
+    const result = await initializeAgent(
+      {
+        req,
+        res,
+        agent,
+        loadTools,
+        endpointOption: { endpoint: EModelEndpoint.agents },
+        allowedProviders: new Set([Providers.XAI]),
+        isInitialAgent: true,
+      },
+      db,
+    );
+
+    expect(result.tools).toContainEqual({ type: 'x_search' });
+    expect(result.tools).toHaveLength(1);
+  });
+
+  it('still throws conflict error for Google provider', async () => {
+    const { agent, req, res, loadTools, db } = createMocks();
+    agent.provider = Providers.GOOGLE;
+
+    const builtInTools = [{ googleSearch: {} }];
+    const structuredTool = { name: 'file_search', description: 'search files' };
+
+    mockGetProviderConfig.mockReturnValue({
+      getOptions: jest.fn().mockResolvedValue({
+        llmConfig: { model: 'gemini-2.5-pro' },
+        tools: builtInTools,
+        endpointTokenConfig: undefined,
+      } satisfies InitializeResultBase),
+      overrideProvider: Providers.GOOGLE,
+    });
+
+    loadTools.mockResolvedValue({
+      tools: [structuredTool],
+      toolContextMap: {},
+      userMCPAuthMap: undefined,
+      toolRegistry: undefined,
+      toolDefinitions: [],
+      hasDeferredTools: false,
+    });
+
+    await expect(
+      initializeAgent(
+        {
+          req,
+          res,
+          agent,
+          loadTools,
+          endpointOption: { endpoint: EModelEndpoint.agents },
+          allowedProviders: new Set([Providers.GOOGLE]),
+          isInitialAgent: true,
+        },
+        db,
+      ),
+    ).rejects.toThrow('google_tool_conflict');
+  });
+});

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -374,9 +374,8 @@ export async function initializeAgent(
   ) {
     throw new Error(`{ "type": "${ErrorTypes.GOOGLE_TOOL_CONFLICT}"}`);
   } else if (
-    (agent.provider === Providers.OPENAI ||
-      agent.provider === Providers.AZURE ||
-      agent.provider === Providers.ANTHROPIC) &&
+    agent.provider !== Providers.GOOGLE &&
+    agent.provider !== Providers.VERTEXAI &&
     options.tools?.length &&
     structuredTools?.length
   ) {

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -759,3 +759,117 @@ describe('applyDefaultParams', () => {
     });
   });
 });
+
+describe('builtInTools via addParams', () => {
+  it('should inject built-in tools and enable Responses API', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      modelOptions: { model: 'grok-3' },
+      addParams: {
+        builtInTools: ['x_search'],
+      },
+    });
+
+    expect(result.llmConfig).toHaveProperty('useResponsesApi', true);
+    expect(result.tools).toContainEqual({ type: 'x_search' });
+    expect(result.tools).toHaveLength(1);
+  });
+
+  it('should inject multiple built-in tools', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      modelOptions: { model: 'grok-3' },
+      addParams: {
+        builtInTools: ['x_search', 'web_search', 'code_execution'],
+      },
+    });
+
+    expect(result.llmConfig).toHaveProperty('useResponsesApi', true);
+    expect(result.tools).toContainEqual({ type: 'x_search' });
+    expect(result.tools).toContainEqual({ type: 'web_search' });
+    expect(result.tools).toContainEqual({ type: 'code_execution' });
+    expect(result.tools).toHaveLength(3);
+  });
+
+  it('should avoid duplicate web_search when both web_search: true and builtInTools include it', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      modelOptions: {
+        model: 'grok-3',
+        web_search: true,
+      },
+      addParams: {
+        builtInTools: ['web_search', 'x_search'],
+      },
+    });
+
+    expect(result.llmConfig).toHaveProperty('useResponsesApi', true);
+    const webSearchTools = result.tools!.filter(
+      (t) => typeof t === 'object' && 'type' in t && t.type === 'web_search',
+    );
+    expect(webSearchTools).toHaveLength(1);
+    expect(result.tools).toContainEqual({ type: 'x_search' });
+  });
+
+  it('should not leak builtInTools into llmConfig or modelKwargs', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      modelOptions: { model: 'grok-3' },
+      addParams: {
+        builtInTools: ['x_search'],
+      },
+    });
+
+    expect(result.llmConfig).not.toHaveProperty('builtInTools');
+    expect(result.llmConfig.modelKwargs).toBeUndefined();
+  });
+
+  it('should filter out non-string values from builtInTools', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      modelOptions: { model: 'grok-3' },
+      addParams: {
+        builtInTools: ['x_search', 123, null, undefined, { type: 'bad' }],
+      },
+    });
+
+    expect(result.tools).toEqual([{ type: 'x_search' }]);
+  });
+
+  it('should support builtInTools via defaultParams', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      modelOptions: { model: 'grok-3' },
+      defaultParams: {
+        builtInTools: ['x_search'],
+      },
+    });
+
+    expect(result.llmConfig).toHaveProperty('useResponsesApi', true);
+    expect(result.tools).toContainEqual({ type: 'x_search' });
+  });
+
+  it('should allow addParams builtInTools to override defaultParams', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      modelOptions: { model: 'grok-3' },
+      defaultParams: {
+        builtInTools: ['web_search'],
+      },
+      addParams: {
+        builtInTools: ['x_search', 'code_execution'],
+      },
+    });
+
+    expect(result.tools).toContainEqual({ type: 'x_search' });
+    expect(result.tools).toContainEqual({ type: 'code_execution' });
+    expect(result.tools).not.toContainEqual({ type: 'web_search' });
+  });
+});

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -828,13 +828,13 @@ describe('builtInTools via addParams', () => {
     expect(result.llmConfig.modelKwargs).toBeUndefined();
   });
 
-  it('should filter out non-string values from builtInTools', () => {
+  it('should filter out non-string, empty, and duplicate values from builtInTools', () => {
     const result = getOpenAILLMConfig({
       apiKey: 'test-api-key',
       streaming: true,
       modelOptions: { model: 'grok-3' },
       addParams: {
-        builtInTools: ['x_search', 123, null, undefined, { type: 'bad' }],
+        builtInTools: ['x_search', 123, null, '', '  ', undefined, { type: 'bad' }, 'x_search', ' x_search '],
       },
     });
 
@@ -871,5 +871,106 @@ describe('builtInTools via addParams', () => {
     expect(result.tools).toContainEqual({ type: 'x_search' });
     expect(result.tools).toContainEqual({ type: 'code_execution' });
     expect(result.tools).not.toContainEqual({ type: 'web_search' });
+  });
+
+  it('should respect dropParams when builtInTools includes a dropped tool', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      modelOptions: { model: 'grok-3' },
+      addParams: {
+        builtInTools: ['web_search', 'x_search'],
+      },
+      dropParams: ['web_search'],
+    });
+
+    expect(result.tools).not.toContainEqual({ type: 'web_search' });
+    expect(result.tools).toContainEqual({ type: 'x_search' });
+    expect(result.tools).toHaveLength(1);
+  });
+
+  it('should skip non-web_search builtInTools for OpenRouter', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      useOpenRouter: true,
+      modelOptions: { model: 'grok-3' },
+      addParams: {
+        builtInTools: ['x_search'],
+      },
+    });
+
+    expect(result.tools).toEqual([]);
+    expect(result.llmConfig).not.toHaveProperty('useResponsesApi');
+  });
+
+  it('should translate builtInTools web_search to OpenRouter plugins format', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      useOpenRouter: true,
+      modelOptions: { model: 'grok-3' },
+      addParams: {
+        builtInTools: ['web_search', 'x_search'],
+      },
+    });
+
+    expect(result.llmConfig.modelKwargs).toHaveProperty('plugins', [{ id: 'web' }]);
+    expect(result.tools).toEqual([]);
+    expect(result.llmConfig).not.toHaveProperty('useResponsesApi');
+  });
+
+  it('should produce empty tools and no useResponsesApi when all builtInTools are dropped', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      modelOptions: { model: 'grok-3' },
+      addParams: {
+        builtInTools: ['web_search'],
+      },
+      dropParams: ['web_search'],
+    });
+
+    expect(result.tools).toEqual([]);
+    expect(result.llmConfig.useResponsesApi).toBeUndefined();
+  });
+
+  it('should disable all builtInTools via dropParams: ["builtInTools"]', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      modelOptions: { model: 'grok-3' },
+      addParams: {
+        builtInTools: ['x_search', 'web_search'],
+      },
+      dropParams: ['builtInTools'],
+    });
+
+    expect(result.tools).toEqual([]);
+    expect(result.llmConfig.useResponsesApi).toBeUndefined();
+  });
+
+  it('should use reasoning object format when builtInTools forces Responses API on OpenAI endpoint', () => {
+    const result = getOpenAILLMConfig({
+      apiKey: 'test-api-key',
+      streaming: true,
+      endpoint: EModelEndpoint.openAI,
+      modelOptions: {
+        model: 'gpt-4',
+        reasoning_effort: ReasoningEffort.high,
+        reasoning_summary: ReasoningSummary.concise,
+      },
+      addParams: {
+        builtInTools: ['web_search'],
+      },
+    });
+
+    expect(result.llmConfig).toHaveProperty('useResponsesApi', true);
+    expect(result.llmConfig).toHaveProperty('reasoning');
+    expect(result.llmConfig.reasoning).toEqual({
+      effort: ReasoningEffort.high,
+      summary: ReasoningSummary.concise,
+    });
+    expect(result.llmConfig).not.toHaveProperty('reasoning_effort');
   });
 });

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -181,6 +181,25 @@ export function getOpenAILLMConfig({
   let enableWebSearch = web_search;
   let builtInToolTypes: string[] = [];
 
+  const parseBuiltInTools = (value: unknown): string[] => {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const v of value) {
+      if (typeof v !== 'string') {
+        continue;
+      }
+      const trimmed = v.trim();
+      if (trimmed !== '' && !seen.has(trimmed)) {
+        seen.add(trimmed);
+        result.push(trimmed);
+      }
+    }
+    return result;
+  };
+
   /** Apply defaultParams first - only if fields are undefined */
   if (defaultParams && typeof defaultParams === 'object') {
     for (const [key, value] of Object.entries(defaultParams)) {
@@ -194,8 +213,8 @@ export function getOpenAILLMConfig({
 
       /** Handle builtInTools separately - provider-specific server-side tools */
       if (key === 'builtInTools') {
-        if (Array.isArray(value) && builtInToolTypes.length === 0) {
-          builtInToolTypes = value.filter((v): v is string => typeof v === 'string');
+        if (builtInToolTypes.length === 0) {
+          builtInToolTypes = parseBuiltInTools(value);
         }
         continue;
       }
@@ -225,9 +244,7 @@ export function getOpenAILLMConfig({
 
       /** Handle builtInTools - addParams overrides defaultParams */
       if (key === 'builtInTools') {
-        if (Array.isArray(value)) {
-          builtInToolTypes = value.filter((v): v is string => typeof v === 'string');
-        }
+        builtInToolTypes = parseBuiltInTools(value);
         continue;
       }
       if (knownOpenAIParams.has(key)) {
@@ -236,6 +253,28 @@ export function getOpenAILLMConfig({
         hasModelKwargs = true;
         modelKwargs[key] = value;
       }
+    }
+  }
+
+  /** Check if web_search or builtInTools should be disabled via dropParams */
+  if (dropParams && dropParams.includes('web_search')) {
+    enableWebSearch = false;
+  }
+  if (dropParams && dropParams.includes('builtInTools')) {
+    builtInToolTypes = [];
+  }
+
+  /**
+   * Pre-determine if builtInTools will force the Responses API, so reasoning params
+   * are serialized in the correct format. The actual tool injection happens later.
+   */
+  if (builtInToolTypes.length > 0 && !useOpenRouter) {
+    const droppedCheck = new Set(dropParams ?? []);
+    const hasNonDroppedTools = builtInToolTypes.some(
+      (t) => !droppedCheck.has(t) && !(t === 'web_search' && enableWebSearch),
+    );
+    if (hasNonDroppedTools) {
+      llmConfig.useResponsesApi = true;
     }
   }
 
@@ -276,9 +315,9 @@ export function getOpenAILLMConfig({
 
   const tools: BindToolsInput[] = [];
 
-  /** Check if web_search should be disabled via dropParams */
-  if (dropParams && dropParams.includes('web_search')) {
-    enableWebSearch = false;
+  /** For OpenRouter, translate builtInTools web_search into the plugins format */
+  if (useOpenRouter && !enableWebSearch && builtInToolTypes.includes('web_search')) {
+    enableWebSearch = true;
   }
 
   if (useOpenRouter && enableWebSearch) {
@@ -292,9 +331,12 @@ export function getOpenAILLMConfig({
   }
 
   /** Inject provider-specific built-in server-side tools (e.g., xAI x_search, code_execution) */
-  if (builtInToolTypes.length > 0) {
-    llmConfig.useResponsesApi = true;
+  if (builtInToolTypes.length > 0 && !useOpenRouter) {
+    const droppedTools = new Set(dropParams ?? []);
     for (const toolType of builtInToolTypes) {
+      if (droppedTools.has(toolType)) {
+        continue;
+      }
       if (toolType === 'web_search' && enableWebSearch) {
         continue;
       }

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -179,6 +179,7 @@ export function getOpenAILLMConfig({
   }
 
   let enableWebSearch = web_search;
+  let builtInToolTypes: string[] = [];
 
   /** Apply defaultParams first - only if fields are undefined */
   if (defaultParams && typeof defaultParams === 'object') {
@@ -187,6 +188,14 @@ export function getOpenAILLMConfig({
       if (key === 'web_search') {
         if (enableWebSearch === undefined && typeof value === 'boolean') {
           enableWebSearch = value;
+        }
+        continue;
+      }
+
+      /** Handle builtInTools separately - provider-specific server-side tools */
+      if (key === 'builtInTools') {
+        if (Array.isArray(value) && builtInToolTypes.length === 0) {
+          builtInToolTypes = value.filter((v): v is string => typeof v === 'string');
         }
         continue;
       }
@@ -210,6 +219,14 @@ export function getOpenAILLMConfig({
       if (key === 'web_search') {
         if (typeof value === 'boolean') {
           enableWebSearch = value;
+        }
+        continue;
+      }
+
+      /** Handle builtInTools - addParams overrides defaultParams */
+      if (key === 'builtInTools') {
+        if (Array.isArray(value)) {
+          builtInToolTypes = value.filter((v): v is string => typeof v === 'string');
         }
         continue;
       }
@@ -272,6 +289,17 @@ export function getOpenAILLMConfig({
     /** Standard OpenAI web search uses tools API */
     llmConfig.useResponsesApi = true;
     tools.push({ type: 'web_search' });
+  }
+
+  /** Inject provider-specific built-in server-side tools (e.g., xAI x_search, code_execution) */
+  if (builtInToolTypes.length > 0) {
+    llmConfig.useResponsesApi = true;
+    for (const toolType of builtInToolTypes) {
+      if (toolType === 'web_search' && enableWebSearch) {
+        continue;
+      }
+      tools.push({ type: toolType });
+    }
   }
 
   /**

--- a/packages/api/src/endpoints/openai/transform.ts
+++ b/packages/api/src/endpoints/openai/transform.ts
@@ -93,8 +93,8 @@ export function transformToOpenAIConfig({
 
   if (addParams && typeof addParams === 'object') {
     for (const [key, value] of Object.entries(addParams)) {
-      /** Skip web_search - it's handled separately as a tool */
-      if (key === 'web_search') {
+      /** Skip web_search and builtInTools - handled separately as tools */
+      if (key === 'web_search' || key === 'builtInTools') {
         continue;
       }
 
@@ -113,8 +113,8 @@ export function transformToOpenAIConfig({
 
   if (dropParams && Array.isArray(dropParams)) {
     dropParams.forEach((param) => {
-      /** Skip web_search - handled separately */
-      if (param === 'web_search') {
+      /** Skip web_search and builtInTools - handled separately */
+      if (param === 'web_search' || param === 'builtInTools') {
         return;
       }
 


### PR DESCRIPTION
## Summary

- **Fixes built-in tool merging for custom providers**: When an agent has both built-in Responses API tools (e.g., `web_search`) and structured agent tools (e.g., MCP tools, `file_search`), the merge logic in `initializeAgent()` previously only ran for OpenAI, Azure, and Anthropic providers. For xAI, DeepSeek, OpenRouter, and other custom providers, built-in tools were silently dropped. This PR fixes the condition to merge for all providers except Google/VertexAI (which have their own conflict semantics).

- **Adds `builtInTools` config for custom endpoints**: Custom endpoints can now inject provider-specific server-side tools via `addParams.builtInTools` in `librechat.yaml`. xAI supports `web_search`, `x_search`, and `code_execution` as built-in server-side tools passed to the Responses API. These are NOT client-side function-calling tools — they run server-side at the provider.

### Configuration Example

```yaml
endpoints:
  custom:
    - name: "xAI"
      apiKey: "${XAI_API_KEY}"
      baseURL: "https://api.x.ai/v1"
      models:
        default: ["grok-3", "grok-3-mini"]
      addParams:
        builtInTools:
          - web_search
          - x_search
```

### Changes

| File | Change |
|------|--------|
| `packages/api/src/agents/initialize.ts` | Fix tool merge condition to include all non-Google/VertexAI providers |
| `packages/api/src/endpoints/openai/llm.ts` | Intercept `builtInTools` in `addParams`/`defaultParams`, inject as `{ type: toolName }` |
| `packages/api/src/endpoints/openai/transform.ts` | Skip `builtInTools` in transform to prevent leaking into `modelKwargs` |
| `packages/api/src/endpoints/openai/llm.spec.ts` | 7 new tests for `builtInTools` functionality |
| `packages/api/src/agents/__tests__/initialize.test.ts` | 3 new tests for tool merging with custom providers |

### Edge Cases Handled

- `web_search: true` + `builtInTools: ["web_search", "x_search"]` → no duplicate `web_search`
- `builtInTools` via `defaultParams` vs `addParams` → `addParams` overrides
- Non-string values in `builtInTools` array → filtered out
- Google/VertexAI provider → still throws conflict error (unchanged behavior)
- No schema changes needed (`addParams` already accepts `z.record(z.any())`)

Closes #7499
Relates to #12365

## Test plan

- [x] All 196 existing `llm.spec` tests pass
- [x] All 8 `initialize.test` tests pass (5 existing + 3 new)
- [x] No new TypeScript errors in modified files
- [ ] Manual test with xAI `grok-4.20-multi-agent` model to verify `x_search` and `web_search` work as server-side tools
- [ ] Verify regular Grok models still work normally without `builtInTools`