### PR TITLE
🎯 fix: Use Resolved Provider for Agent Token Lookup on Custom Endpoints

### DIFF
--- a/packages/api/src/agents/__tests__/initialize.test.ts
+++ b/packages/api/src/agents/__tests__/initialize.test.ts
@@ -1,7 +1,7 @@
 import { Providers } from '@librechat/agents';
 import { EModelEndpoint } from 'librechat-data-provider';
 import type { Agent } from 'librechat-data-provider';
-import type { ServerRequest, InitializeResultBase } from '~/types';
+import type { ServerRequest, InitializeResultBase, EndpointTokenConfig } from '~/types';
 import type { InitializeAgentDbMethods } from '../initialize';
 
 // Mock logger
@@ -147,7 +147,7 @@ describe('initializeAgent — custom provider token lookup', () => {
     customProvider?: string;
     model?: string;
     maxOutputTokens?: number;
-    endpointTokenConfig?: Record<string, number>;
+    endpointTokenConfig?: EndpointTokenConfig;
   }) {
     const {
       customProvider = 'EduGPT',
@@ -260,7 +260,9 @@ describe('initializeAgent — custom provider token lookup', () => {
   });
 
   it('uses endpointTokenConfig from the custom endpoint for unrecognized models', async () => {
-    const customTokenConfig = { 'my-custom-model-v1': 65536 };
+    const customTokenConfig: EndpointTokenConfig = {
+      'my-custom-model-v1': { context: 65536, prompt: 1, completion: 1 },
+    };
     const { agent, req, res, loadTools, db, customProvider } = createCustomProviderMocks({
       model: 'my-custom-model-v1',
       endpointTokenConfig: customTokenConfig,

--- a/packages/api/src/agents/__tests__/initialize.test.ts
+++ b/packages/api/src/agents/__tests__/initialize.test.ts
@@ -55,22 +55,44 @@ jest.mock('../resources', () => ({
 
 import { initializeAgent } from '../initialize';
 
+const realUtils = jest.requireActual<typeof import('~/utils')>('~/utils');
+
 /**
  * Creates minimal mock objects for initializeAgent tests.
+ *
+ * When `useRealTokenLookup` is true, `getModelMaxTokens` delegates to the real
+ * implementation so tests exercise the actual token-map resolution. Otherwise a
+ * controlled `modelDefault` is returned.
  */
 function createMocks(overrides?: {
+  provider?: string;
+  overrideProvider?: string;
+  model?: string;
   maxContextTokens?: number;
   modelDefault?: number;
   maxOutputTokens?: number;
+  endpointTokenConfig?: EndpointTokenConfig;
+  useRealTokenLookup?: boolean;
 }) {
-  const { maxContextTokens, modelDefault = 200000, maxOutputTokens = 4096 } = overrides ?? {};
+  const {
+    provider = Providers.OPENAI,
+    overrideProvider,
+    model = 'test-model',
+    maxContextTokens,
+    modelDefault = 200000,
+    maxOutputTokens = 4096,
+    endpointTokenConfig,
+    useRealTokenLookup = false,
+  } = overrides ?? {};
+
+  const resolvedOverrideProvider = overrideProvider ?? provider;
 
   const agent = {
     id: 'agent-1',
-    model: 'test-model',
-    provider: Providers.OPENAI,
+    model,
+    provider,
     tools: [],
-    model_parameters: { model: 'test-model' },
+    model_parameters: { model },
   } as unknown as Agent;
 
   const req = {
@@ -81,39 +103,28 @@ function createMocks(overrides?: {
   const res = {} as unknown as import('express').Response;
 
   const mockGetOptions = jest.fn().mockResolvedValue({
-    llmConfig: {
-      model: 'test-model',
-      maxTokens: maxOutputTokens,
-    },
-    endpointTokenConfig: undefined,
+    llmConfig: { model, maxTokens: maxOutputTokens },
+    endpointTokenConfig,
   } satisfies InitializeResultBase);
 
   mockGetProviderConfig.mockReturnValue({
     getOptions: mockGetOptions,
-    overrideProvider: Providers.OPENAI,
+    overrideProvider: resolvedOverrideProvider,
   });
 
-  // extractLibreChatParams returns maxContextTokens when provided in model_parameters
   mockExtractLibreChatParams.mockReturnValue({
     resendFiles: false,
     maxContextTokens,
-    modelOptions: { model: 'test-model' },
+    modelOptions: { model },
   });
 
-  // getModelMaxTokens returns the model's default context window
-  mockGetModelMaxTokens.mockReturnValue(modelDefault);
+  if (useRealTokenLookup) {
+    mockGetModelMaxTokens.mockImplementation(realUtils.getModelMaxTokens);
+  } else {
+    mockGetModelMaxTokens.mockReturnValue(modelDefault);
+  }
 
-  // Implement real optionalChainWithEmptyCheck behavior
-  mockOptionalChainWithEmptyCheck.mockImplementation(
-    (...values: (string | number | undefined)[]) => {
-      for (const v of values) {
-        if (v !== undefined && v !== null && v !== '') {
-          return v;
-        }
-      }
-      return values[values.length - 1];
-    },
-  );
+  mockOptionalChainWithEmptyCheck.mockImplementation(realUtils.optionalChainWithEmptyCheck);
 
   const loadTools = jest.fn().mockResolvedValue({
     tools: [],
@@ -137,82 +148,18 @@ function createMocks(overrides?: {
 }
 
 describe('initializeAgent — custom provider token lookup', () => {
-  const realUtils = jest.requireActual<typeof import('~/utils')>('~/utils');
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  function createCustomProviderMocks(overrides?: {
-    customProvider?: string;
-    model?: string;
-    maxOutputTokens?: number;
-    endpointTokenConfig?: EndpointTokenConfig;
-  }) {
-    const {
-      customProvider = 'EduGPT',
-      model = 'qwen3-235b-a22b',
-      maxOutputTokens = 4096,
-      endpointTokenConfig,
-    } = overrides ?? {};
-
-    const agent = {
-      id: 'agent-1',
-      model,
-      provider: customProvider,
-      tools: [],
-      model_parameters: { model },
-    } as unknown as Agent;
-
-    const req = {
-      user: { id: 'user-1' },
-      config: {},
-    } as unknown as ServerRequest;
-
-    const res = {} as unknown as import('express').Response;
-
-    const mockGetOptions = jest.fn().mockResolvedValue({
-      llmConfig: { model, maxTokens: maxOutputTokens },
-      endpointTokenConfig,
-    } satisfies InitializeResultBase);
-
-    mockGetProviderConfig.mockReturnValue({
-      getOptions: mockGetOptions,
-      overrideProvider: Providers.OPENAI,
-    });
-
-    mockExtractLibreChatParams.mockReturnValue({
-      resendFiles: false,
-      maxContextTokens: undefined,
-      modelOptions: { model },
-    });
-
-    mockGetModelMaxTokens.mockImplementation(realUtils.getModelMaxTokens);
-    mockOptionalChainWithEmptyCheck.mockImplementation(realUtils.optionalChainWithEmptyCheck);
-
-    const loadTools = jest.fn().mockResolvedValue({
-      tools: [],
-      toolContextMap: {},
-      userMCPAuthMap: undefined,
-      toolRegistry: undefined,
-      toolDefinitions: [],
-      hasDeferredTools: false,
-    });
-
-    const db: InitializeAgentDbMethods = {
-      getFiles: jest.fn().mockResolvedValue([]),
-      getConvoFiles: jest.fn().mockResolvedValue([]),
-      updateFilesUsage: jest.fn().mockResolvedValue([]),
-      getUserKey: jest.fn().mockResolvedValue('user-1'),
-      getUserKeyValues: jest.fn().mockResolvedValue([]),
-      getToolFilesByIds: jest.fn().mockResolvedValue([]),
-    };
-
-    return { agent, req, res, loadTools, db, customProvider };
-  }
-
   it('passes the resolved provider endpoint to getModelMaxTokens, not the custom name', async () => {
-    const { agent, req, res, loadTools, db, customProvider } = createCustomProviderMocks();
+    const customProvider = 'EduGPT';
+    const { agent, req, res, loadTools, db } = createMocks({
+      provider: customProvider,
+      overrideProvider: Providers.OPENAI,
+      model: 'qwen3-235b-a22b',
+      useRealTokenLookup: true,
+    });
 
     await initializeAgent(
       {
@@ -235,37 +182,17 @@ describe('initializeAgent — custom provider token lookup', () => {
     );
   });
 
-  it('uses the model real context window for a custom provider, not the 18000 fallback', async () => {
-    const { agent, req, res, loadTools, db, customProvider } = createCustomProviderMocks();
-
-    const result = await initializeAgent(
-      {
-        req,
-        res,
-        agent,
-        loadTools,
-        endpointOption: { endpoint: EModelEndpoint.agents },
-        allowedProviders: new Set([customProvider]),
-        isInitialAgent: true,
-      },
-      db,
-    );
-
-    // qwen3-235b-a22b has 40960 tokens in the openAI aggregate map.
-    // With the fix, the resolved provider maps to the correct token lookup.
-    // Without the fix, providerEndpointMap["EduGPT"] is undefined → 18000 fallback.
-    const realTokens = realUtils.getModelMaxTokens('qwen3-235b-a22b', EModelEndpoint.openAI);
-    expect(realTokens).toBe(40960);
-    expect(result.maxContextTokens).toBeGreaterThan(18000);
-  });
-
   it('uses endpointTokenConfig from the custom endpoint for unrecognized models', async () => {
+    const customProvider = 'EduGPT';
     const customTokenConfig: EndpointTokenConfig = {
       'my-custom-model-v1': { context: 65536, prompt: 1, completion: 1 },
     };
-    const { agent, req, res, loadTools, db, customProvider } = createCustomProviderMocks({
+    const { agent, req, res, loadTools, db } = createMocks({
+      provider: customProvider,
+      overrideProvider: Providers.OPENAI,
       model: 'my-custom-model-v1',
       endpointTokenConfig: customTokenConfig,
+      useRealTokenLookup: true,
     });
 
     const result = await initializeAgent(

--- a/packages/api/src/agents/__tests__/initialize.test.ts
+++ b/packages/api/src/agents/__tests__/initialize.test.ts
@@ -136,6 +136,160 @@ function createMocks(overrides?: {
   return { agent, req, res, loadTools, db };
 }
 
+describe('initializeAgent — custom provider token lookup', () => {
+  const realUtils = jest.requireActual<typeof import('~/utils')>('~/utils');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function createCustomProviderMocks(overrides?: {
+    customProvider?: string;
+    model?: string;
+    maxOutputTokens?: number;
+    endpointTokenConfig?: Record<string, number>;
+  }) {
+    const {
+      customProvider = 'EduGPT',
+      model = 'qwen3-235b-a22b',
+      maxOutputTokens = 4096,
+      endpointTokenConfig,
+    } = overrides ?? {};
+
+    const agent = {
+      id: 'agent-1',
+      model,
+      provider: customProvider,
+      tools: [],
+      model_parameters: { model },
+    } as unknown as Agent;
+
+    const req = {
+      user: { id: 'user-1' },
+      config: {},
+    } as unknown as ServerRequest;
+
+    const res = {} as unknown as import('express').Response;
+
+    const mockGetOptions = jest.fn().mockResolvedValue({
+      llmConfig: { model, maxTokens: maxOutputTokens },
+      endpointTokenConfig,
+    } satisfies InitializeResultBase);
+
+    mockGetProviderConfig.mockReturnValue({
+      getOptions: mockGetOptions,
+      overrideProvider: Providers.OPENAI,
+    });
+
+    mockExtractLibreChatParams.mockReturnValue({
+      resendFiles: false,
+      maxContextTokens: undefined,
+      modelOptions: { model },
+    });
+
+    mockGetModelMaxTokens.mockImplementation(realUtils.getModelMaxTokens);
+    mockOptionalChainWithEmptyCheck.mockImplementation(realUtils.optionalChainWithEmptyCheck);
+
+    const loadTools = jest.fn().mockResolvedValue({
+      tools: [],
+      toolContextMap: {},
+      userMCPAuthMap: undefined,
+      toolRegistry: undefined,
+      toolDefinitions: [],
+      hasDeferredTools: false,
+    });
+
+    const db: InitializeAgentDbMethods = {
+      getFiles: jest.fn().mockResolvedValue([]),
+      getConvoFiles: jest.fn().mockResolvedValue([]),
+      updateFilesUsage: jest.fn().mockResolvedValue([]),
+      getUserKey: jest.fn().mockResolvedValue('user-1'),
+      getUserKeyValues: jest.fn().mockResolvedValue([]),
+      getToolFilesByIds: jest.fn().mockResolvedValue([]),
+    };
+
+    return { agent, req, res, loadTools, db, customProvider };
+  }
+
+  it('passes the resolved provider endpoint to getModelMaxTokens, not the custom name', async () => {
+    const { agent, req, res, loadTools, db, customProvider } = createCustomProviderMocks();
+
+    await initializeAgent(
+      {
+        req,
+        res,
+        agent,
+        loadTools,
+        endpointOption: { endpoint: EModelEndpoint.agents },
+        allowedProviders: new Set([customProvider]),
+        isInitialAgent: true,
+      },
+      db,
+    );
+
+    // providerEndpointMap["openAI"] = "openAI" (valid), not providerEndpointMap["EduGPT"] = undefined
+    expect(mockGetModelMaxTokens).toHaveBeenCalledWith(
+      'qwen3-235b-a22b',
+      EModelEndpoint.openAI,
+      undefined,
+    );
+  });
+
+  it('uses the model real context window for a custom provider, not the 18000 fallback', async () => {
+    const { agent, req, res, loadTools, db, customProvider } = createCustomProviderMocks();
+
+    const result = await initializeAgent(
+      {
+        req,
+        res,
+        agent,
+        loadTools,
+        endpointOption: { endpoint: EModelEndpoint.agents },
+        allowedProviders: new Set([customProvider]),
+        isInitialAgent: true,
+      },
+      db,
+    );
+
+    // qwen3-235b-a22b has 40960 tokens in the openAI aggregate map.
+    // With the fix, the resolved provider maps to the correct token lookup.
+    // Without the fix, providerEndpointMap["EduGPT"] is undefined → 18000 fallback.
+    const realTokens = realUtils.getModelMaxTokens('qwen3-235b-a22b', EModelEndpoint.openAI);
+    expect(realTokens).toBe(40960);
+    expect(result.maxContextTokens).toBeGreaterThan(18000);
+  });
+
+  it('uses endpointTokenConfig from the custom endpoint for unrecognized models', async () => {
+    const customTokenConfig = { 'my-custom-model-v1': 65536 };
+    const { agent, req, res, loadTools, db, customProvider } = createCustomProviderMocks({
+      model: 'my-custom-model-v1',
+      endpointTokenConfig: customTokenConfig,
+    });
+
+    const result = await initializeAgent(
+      {
+        req,
+        res,
+        agent,
+        loadTools,
+        endpointOption: { endpoint: EModelEndpoint.agents },
+        allowedProviders: new Set([customProvider]),
+        isInitialAgent: true,
+      },
+      db,
+    );
+
+    expect(mockGetModelMaxTokens).toHaveBeenCalledWith(
+      'my-custom-model-v1',
+      EModelEndpoint.openAI,
+      customTokenConfig,
+    );
+
+    // endpointTokenConfig provides the model's real context (65536), not 18000
+    expect(result.maxContextTokens).toBeGreaterThan(18000);
+  });
+});
+
 describe('initializeAgent — maxContextTokens', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/api/src/agents/__tests__/initialize.test.ts
+++ b/packages/api/src/agents/__tests__/initialize.test.ts
@@ -60,9 +60,13 @@ const realUtils = jest.requireActual<typeof import('~/utils')>('~/utils');
 /**
  * Creates minimal mock objects for initializeAgent tests.
  *
- * When `useRealTokenLookup` is true, `getModelMaxTokens` delegates to the real
- * implementation so tests exercise the actual token-map resolution. Otherwise a
- * controlled `modelDefault` is returned.
+ * @param overrides.overrideProvider - Simulates the value returned by `getProviderConfig`.
+ *   Defaults to `provider` (native endpoint where no remapping occurs). Set to a different
+ *   value (e.g. `Providers.OPENAI`) alongside a custom `provider` to simulate a custom
+ *   endpoint whose provider is resolved to a built-in.
+ * @param overrides.useRealTokenLookup - When true, `getModelMaxTokens` delegates to the real
+ *   implementation so tests exercise actual token-map resolution. Otherwise a controlled
+ *   `modelDefault` is returned.
  */
 function createMocks(overrides?: {
   provider?: string;
@@ -124,6 +128,7 @@ function createMocks(overrides?: {
     mockGetModelMaxTokens.mockReturnValue(modelDefault);
   }
 
+  /** Real implementation: treats 0 as a valid (non-empty) value — load-bearing for the maxContextTokens=0 test */
   mockOptionalChainWithEmptyCheck.mockImplementation(realUtils.optionalChainWithEmptyCheck);
 
   const loadTools = jest.fn().mockResolvedValue({
@@ -148,14 +153,15 @@ function createMocks(overrides?: {
 }
 
 describe('initializeAgent — custom provider token lookup', () => {
+  const CUSTOM_PROVIDER = 'EduGPT';
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('passes the resolved provider endpoint to getModelMaxTokens, not the custom name', async () => {
-    const customProvider = 'EduGPT';
     const { agent, req, res, loadTools, db } = createMocks({
-      provider: customProvider,
+      provider: CUSTOM_PROVIDER,
       overrideProvider: Providers.OPENAI,
       model: 'qwen3-235b-a22b',
       useRealTokenLookup: true,
@@ -168,7 +174,7 @@ describe('initializeAgent — custom provider token lookup', () => {
         agent,
         loadTools,
         endpointOption: { endpoint: EModelEndpoint.agents },
-        allowedProviders: new Set([customProvider]),
+        allowedProviders: new Set([CUSTOM_PROVIDER]),
         isInitialAgent: true,
       },
       db,
@@ -183,12 +189,11 @@ describe('initializeAgent — custom provider token lookup', () => {
   });
 
   it('uses endpointTokenConfig from the custom endpoint for unrecognized models', async () => {
-    const customProvider = 'EduGPT';
     const customTokenConfig: EndpointTokenConfig = {
       'my-custom-model-v1': { context: 65536, prompt: 1, completion: 1 },
     };
     const { agent, req, res, loadTools, db } = createMocks({
-      provider: customProvider,
+      provider: CUSTOM_PROVIDER,
       overrideProvider: Providers.OPENAI,
       model: 'my-custom-model-v1',
       endpointTokenConfig: customTokenConfig,
@@ -202,7 +207,7 @@ describe('initializeAgent — custom provider token lookup', () => {
         agent,
         loadTools,
         endpointOption: { endpoint: EModelEndpoint.agents },
-        allowedProviders: new Set([customProvider]),
+        allowedProviders: new Set([CUSTOM_PROVIDER]),
         isInitialAgent: true,
       },
       db,
@@ -214,8 +219,9 @@ describe('initializeAgent — custom provider token lookup', () => {
       customTokenConfig,
     );
 
-    // endpointTokenConfig provides the model's real context (65536), not 18000
-    expect(result.maxContextTokens).toBeGreaterThan(18000);
+    // endpointTokenConfig.context=65536, maxOutputTokens=4096 (default)
+    // maxContextTokens = Math.max(1024, Math.round((65536 - 4096) * 0.95)) = 58368
+    expect(result.maxContextTokens).toBe(Math.round((65536 - 4096) * 0.95));
   });
 });
 

--- a/packages/api/src/agents/__tests__/initialize.test.ts
+++ b/packages/api/src/agents/__tests__/initialize.test.ts
@@ -128,7 +128,7 @@ function createMocks(overrides?: {
     mockGetModelMaxTokens.mockReturnValue(modelDefault);
   }
 
-  /** Real implementation: treats 0 as a valid (non-empty) value — load-bearing for the maxContextTokens=0 test */
+  // Real implementation: treats 0 as a valid (non-empty) value — load-bearing for the maxContextTokens=0 test
   mockOptionalChainWithEmptyCheck.mockImplementation(realUtils.optionalChainWithEmptyCheck);
 
   const loadTools = jest.fn().mockResolvedValue({
@@ -219,8 +219,9 @@ describe('initializeAgent — custom provider token lookup', () => {
       customTokenConfig,
     );
 
-    // endpointTokenConfig.context=65536, maxOutputTokens=4096 (default)
-    // maxContextTokens = Math.max(1024, Math.round((65536 - 4096) * 0.95)) = 58368
+    // Pipeline check: verifies endpointTokenConfig.context flows through the full
+    // optionalChainWithEmptyCheck → Math.max formula. The toHaveBeenCalledWith
+    // assertion above catches the actual provider-resolution regression.
     expect(result.maxContextTokens).toBe(Math.round((65536 - 4096) * 0.95));
   });
 });

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -354,7 +354,7 @@ export async function initializeAgent(
     maxContextTokens,
     getModelMaxTokens(
       tokensModel ?? '',
-      providerEndpointMap[provider as keyof typeof providerEndpointMap],
+      providerEndpointMap[overrideProvider as keyof typeof providerEndpointMap],
       options.endpointTokenConfig,
     ),
     18000,


### PR DESCRIPTION
## Summary

Fixed a bug where the agent initialization token lookup used the original custom provider name (e.g. `"EduGPT"`, `"ScalewayQwen"`) instead of the resolved `overrideProvider` (e.g. `"openai"`) when querying `providerEndpointMap`. Since this map only contains the 4 built-in providers (`openAI`, `bedrock`, `anthropic`, `azureOpenAI`), custom OpenAI-compatible providers resolved to `undefined`, relying on `getModelMaxTokens`'s JS default parameter to implicitly fall back to `openAI`. While this implicit fallback often produces the correct result for models in the aggregate token map, it breaks when a custom endpoint provides its own `endpointTokenConfig` that doesn't include the model, or if the default parameter signature ever changes. The fix ensures the resolved provider is always passed explicitly.

- Use `overrideProvider` instead of `provider` in the `providerEndpointMap` lookup at `packages/api/src/agents/initialize.ts:357`, so the resolved provider (e.g. `Providers.OPENAI`) maps to the correct endpoint for token lookups.
- Add 2 regression tests verifying the resolved endpoint is passed to `getModelMaxTokens` and that `endpointTokenConfig` from custom endpoints flows through correctly.
- Unify `createMocks` factory with `provider`, `overrideProvider`, and `useRealTokenLookup` parameters, eliminating a duplicate factory function.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran the full `packages/api/src/agents/__tests__/initialize.test.ts` suite (9 tests, all passing). Verified regression by temporarily reverting the one-line fix and confirming both new tests fail with the expected mismatch (`undefined` instead of `"openAI"` as the endpoint argument).

### New test cases:
- `passes the resolved provider endpoint to getModelMaxTokens, not the custom name` — Asserts `getModelMaxTokens` receives `EModelEndpoint.openAI` rather than `undefined`
- `uses endpointTokenConfig from the custom endpoint for unrecognized models` — Verifies custom `endpointTokenConfig` flows through with the correct resolved endpoint for models not in the built-in token map

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes