### PR TITLE
🧬 fix: Merge Custom Endpoints by Name Instead of Replacing Entire Array

### DIFF
--- a/packages/data-schemas/src/app/resolution.spec.ts
+++ b/packages/data-schemas/src/app/resolution.spec.ts
@@ -50,10 +50,81 @@ describe('mergeConfigOverrides', () => {
     expect(reg.custom).toBe('yes');
   });
 
-  it('replaces arrays instead of concatenating', () => {
+  it('replaces plain arrays (no merge key) instead of concatenating', () => {
     const configs = [fakeConfig({ endpoints: ['anthropic', 'google'] }, 10)];
     const result = mergeConfigOverrides(baseConfig, configs) as unknown as Record<string, unknown>;
     expect(result.endpoints).toEqual(['anthropic', 'google']);
+  });
+
+  it('merges endpoints.custom arrays by name instead of replacing', () => {
+    const base = {
+      endpoints: {
+        custom: [
+          { name: 'yaml-only', baseURL: 'https://yaml-only.com', apiKey: 'key1' },
+          {
+            name: 'shared',
+            baseURL: 'https://original.com',
+            apiKey: 'key2',
+            models: { default: ['m1'] },
+          },
+        ],
+      },
+    } as unknown as AppConfig;
+
+    const configs = [
+      fakeConfig(
+        {
+          endpoints: {
+            custom: [
+              { name: 'shared', baseURL: 'https://overridden.com' },
+              { name: 'db-only', baseURL: 'https://db-only.com', apiKey: 'key3' },
+            ],
+          },
+        },
+        10,
+      ),
+    ];
+
+    const result = mergeConfigOverrides(base, configs) as unknown as Record<string, unknown>;
+    const endpoints = result.endpoints as Record<string, unknown>;
+    const custom = endpoints.custom as Array<Record<string, unknown>>;
+
+    expect(custom).toHaveLength(3);
+    // YAML-only item preserved
+    expect(custom[0]).toEqual({
+      name: 'yaml-only',
+      baseURL: 'https://yaml-only.com',
+      apiKey: 'key1',
+    });
+    // Shared item deep-merged: baseURL overridden, apiKey + models preserved from base
+    expect(custom[1]).toEqual({
+      name: 'shared',
+      baseURL: 'https://overridden.com',
+      apiKey: 'key2',
+      models: { default: ['m1'] },
+    });
+    // DB-only item appended
+    expect(custom[2]).toEqual({ name: 'db-only', baseURL: 'https://db-only.com', apiKey: 'key3' });
+  });
+
+  it('preserves all YAML custom endpoints when DB override is empty', () => {
+    const base = {
+      endpoints: {
+        custom: [
+          { name: 'ep1', baseURL: 'https://ep1.com' },
+          { name: 'ep2', baseURL: 'https://ep2.com' },
+        ],
+      },
+    } as unknown as AppConfig;
+
+    const configs = [fakeConfig({ endpoints: { custom: [] } }, 10)];
+    const result = mergeConfigOverrides(base, configs) as unknown as Record<string, unknown>;
+    const endpoints = result.endpoints as Record<string, unknown>;
+    const custom = endpoints.custom as Array<Record<string, unknown>>;
+
+    expect(custom).toHaveLength(2);
+    expect(custom[0].name).toBe('ep1');
+    expect(custom[1].name).toBe('ep2');
   });
 
   it('does not mutate the base config', () => {

--- a/packages/data-schemas/src/app/resolution.spec.ts
+++ b/packages/data-schemas/src/app/resolution.spec.ts
@@ -153,7 +153,26 @@ describe('mergeConfigOverrides', () => {
 
     expect(custom).toHaveLength(1);
     expect(custom[0].name).toBe('dup');
+    // last-write-wins: Map.set overwrites on duplicate keys
     expect(custom[0].baseURL).toBe('https://second.com');
+  });
+
+  it('silently drops source items without a name field', () => {
+    const base = {
+      endpoints: { custom: [{ name: 'ep1', baseURL: 'https://ep1.com' }] },
+    } as unknown as AppConfig;
+
+    const configs = [
+      fakeConfig({ endpoints: { custom: [{ baseURL: 'https://nameless.com' }] } }, 10),
+    ];
+
+    const result = mergeConfigOverrides(base, configs) as unknown as Record<string, unknown>;
+    const custom = (result.endpoints as Record<string, unknown>).custom as Array<
+      Record<string, unknown>
+    >;
+
+    expect(custom).toHaveLength(1);
+    expect(custom[0].name).toBe('ep1');
   });
 
   it('does not mutate base custom endpoint items', () => {

--- a/packages/data-schemas/src/app/resolution.spec.ts
+++ b/packages/data-schemas/src/app/resolution.spec.ts
@@ -175,6 +175,25 @@ describe('mergeConfigOverrides', () => {
     expect(custom[0].name).toBe('ep1');
   });
 
+  it('preserves base items without a name field', () => {
+    const base = {
+      endpoints: { custom: [{ baseURL: 'https://ep1.com' }] },
+    } as unknown as AppConfig;
+
+    const configs = [
+      fakeConfig({ endpoints: { custom: [{ name: 'db-only', baseURL: 'https://db.com' }] } }, 10),
+    ];
+
+    const result = mergeConfigOverrides(base, configs) as unknown as Record<string, unknown>;
+    const custom = (result.endpoints as Record<string, unknown>).custom as Array<
+      Record<string, unknown>
+    >;
+
+    expect(custom).toHaveLength(2);
+    expect(custom[0].baseURL).toBe('https://ep1.com');
+    expect(custom[1].name).toBe('db-only');
+  });
+
   it('does not mutate base custom endpoint items', () => {
     const base = {
       endpoints: { custom: [{ name: 'ep1', baseURL: 'https://ep1.com' }] },

--- a/packages/data-schemas/src/app/resolution.spec.ts
+++ b/packages/data-schemas/src/app/resolution.spec.ts
@@ -127,6 +127,72 @@ describe('mergeConfigOverrides', () => {
     expect(custom[1].name).toBe('ep2');
   });
 
+  it('deduplicates when source contains repeated endpoint names', () => {
+    const base = {
+      endpoints: { custom: [] },
+    } as unknown as AppConfig;
+
+    const configs = [
+      fakeConfig(
+        {
+          endpoints: {
+            custom: [
+              { name: 'dup', baseURL: 'https://first.com' },
+              { name: 'dup', baseURL: 'https://second.com' },
+            ],
+          },
+        },
+        10,
+      ),
+    ];
+
+    const result = mergeConfigOverrides(base, configs) as unknown as Record<string, unknown>;
+    const custom = (result.endpoints as Record<string, unknown>).custom as Array<
+      Record<string, unknown>
+    >;
+
+    expect(custom).toHaveLength(1);
+    expect(custom[0].name).toBe('dup');
+    expect(custom[0].baseURL).toBe('https://second.com');
+  });
+
+  it('does not mutate base custom endpoint items', () => {
+    const base = {
+      endpoints: { custom: [{ name: 'ep1', baseURL: 'https://ep1.com' }] },
+    } as unknown as AppConfig;
+
+    const configs = [fakeConfig({ endpoints: { custom: [] } }, 10)];
+    const result = mergeConfigOverrides(base, configs) as unknown as Record<string, unknown>;
+    const custom = (result.endpoints as Record<string, unknown>).custom as Array<
+      Record<string, unknown>
+    >;
+
+    custom[0].baseURL = 'https://mutated.com';
+    const original = (base as unknown as Record<string, unknown>).endpoints as Record<
+      string,
+      unknown
+    >;
+    expect((original.custom as Array<Record<string, unknown>>)[0].baseURL).toBe('https://ep1.com');
+  });
+
+  it('respects priority for custom endpoint merges — higher priority wins', () => {
+    const base = {
+      endpoints: { custom: [{ name: 'shared', baseURL: 'https://yaml.com' }] },
+    } as unknown as AppConfig;
+
+    const configs = [
+      fakeConfig({ endpoints: { custom: [{ name: 'shared', baseURL: 'https://low.com' }] } }, 10),
+      fakeConfig({ endpoints: { custom: [{ name: 'shared', baseURL: 'https://high.com' }] } }, 100),
+    ];
+
+    const result = mergeConfigOverrides(base, configs) as unknown as Record<string, unknown>;
+    const custom = (result.endpoints as Record<string, unknown>).custom as Array<
+      Record<string, unknown>
+    >;
+
+    expect(custom[0].baseURL).toBe('https://high.com');
+  });
+
   it('does not mutate the base config', () => {
     const original = JSON.parse(JSON.stringify(baseConfig));
     const configs = [fakeConfig({ interface: { modelSelect: false } }, 10)];

--- a/packages/data-schemas/src/app/resolution.ts
+++ b/packages/data-schemas/src/app/resolution.ts
@@ -43,12 +43,12 @@ function mergeArrayByKey(
   depth: number,
   path: string,
 ): AnyObject[] {
-  // Items without a key field value are skipped — they have no stable
-  // identity and cannot be matched to a base item or safely appended.
   const sourceByKey = new Map<unknown, AnyObject>();
   for (const item of source) {
     if (item != null && typeof item === 'object') {
       const key = item[keyField];
+      // Source items without a key value are skipped: no stable identity
+      // for matching or appending. (Keyless target items are preserved as-is below.)
       if (key != null) {
         sourceByKey.set(key, item);
       }

--- a/packages/data-schemas/src/app/resolution.ts
+++ b/packages/data-schemas/src/app/resolution.ts
@@ -43,6 +43,8 @@ function mergeArrayByKey(
   depth: number,
   path: string,
 ): AnyObject[] {
+  // Items without a key field value are skipped — they have no stable
+  // identity and cannot be matched to a base item or safely appended.
   const sourceByKey = new Map<unknown, AnyObject>();
   for (const item of source) {
     if (item != null && typeof item === 'object') {
@@ -56,6 +58,9 @@ function mergeArrayByKey(
   const result: AnyObject[] = [];
   const seen = new Set<unknown>();
 
+  // Pass the array container path (not a per-element path) so item
+  // properties build paths like 'endpoints.custom.baseURL' for any
+  // nested ARRAY_MERGE_KEYS lookups.
   for (const item of target) {
     if (item != null && typeof item === 'object') {
       const key = item[keyField];

--- a/packages/data-schemas/src/app/resolution.ts
+++ b/packages/data-schemas/src/app/resolution.ts
@@ -8,6 +8,16 @@ const MAX_MERGE_DEPTH = 10;
 const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 /**
+ * Paths within the config tree where arrays of objects should be merged by
+ * a key field rather than replaced wholesale. `deepMerge` matches items by
+ * the given key, deep-merges matching pairs, preserves unmatched base items,
+ * and appends new override-only items.
+ */
+const ARRAY_MERGE_KEYS: Record<string, string> = {
+  'endpoints.custom': 'name',
+};
+
+/**
  * Maps YAML-level override keys (TCustomConfig) to their AppConfig equivalents.
  * Overrides are stored with YAML keys but merged into the already-processed AppConfig
  * where some fields have been renamed by AppService.
@@ -23,12 +33,59 @@ const OVERRIDE_KEY_MAP: Partial<Record<keyof TCustomConfig, keyof AppConfig>> = 
   turnstile: 'turnstileConfig',
 };
 
-function deepMerge<T extends AnyObject>(target: T, source: AnyObject, depth = 0): T {
+function mergeArrayByKey(
+  target: AnyObject[],
+  source: AnyObject[],
+  keyField: string,
+  depth: number,
+  path: string,
+): AnyObject[] {
+  const sourceByKey = new Map<unknown, AnyObject>();
+  const sourceOrder: unknown[] = [];
+  for (const item of source) {
+    if (item != null && typeof item === 'object') {
+      const key = item[keyField];
+      if (key != null) {
+        sourceByKey.set(key, item);
+        sourceOrder.push(key);
+      }
+    }
+  }
+
+  const result: AnyObject[] = [];
+  const seen = new Set<unknown>();
+
+  for (const item of target) {
+    if (item != null && typeof item === 'object') {
+      const key = item[keyField];
+      const override = key != null ? sourceByKey.get(key) : undefined;
+      if (override) {
+        result.push(deepMerge(item, override, depth + 1, path));
+        seen.add(key);
+      } else {
+        result.push(item);
+      }
+    } else {
+      result.push(item);
+    }
+  }
+
+  for (const key of sourceOrder) {
+    if (!seen.has(key)) {
+      result.push(sourceByKey.get(key)!);
+    }
+  }
+
+  return result;
+}
+
+function deepMerge<T extends AnyObject>(target: T, source: AnyObject, depth = 0, path = ''): T {
   const result = { ...target } as AnyObject;
   for (const key of Object.keys(source)) {
     if (UNSAFE_KEYS.has(key)) {
       continue;
     }
+    const currentPath = path ? `${path}.${key}` : key;
     const sourceVal = source[key];
     const targetVal = result[key];
     if (
@@ -40,7 +97,25 @@ function deepMerge<T extends AnyObject>(target: T, source: AnyObject, depth = 0)
       typeof targetVal === 'object' &&
       !Array.isArray(targetVal)
     ) {
-      result[key] = deepMerge(targetVal as AnyObject, sourceVal as AnyObject, depth + 1);
+      result[key] = deepMerge(
+        targetVal as AnyObject,
+        sourceVal as AnyObject,
+        depth + 1,
+        currentPath,
+      );
+    } else if (
+      depth < MAX_MERGE_DEPTH &&
+      Array.isArray(sourceVal) &&
+      Array.isArray(targetVal) &&
+      ARRAY_MERGE_KEYS[currentPath]
+    ) {
+      result[key] = mergeArrayByKey(
+        targetVal as AnyObject[],
+        sourceVal as AnyObject[],
+        ARRAY_MERGE_KEYS[currentPath],
+        depth,
+        currentPath,
+      );
     } else {
       result[key] = sourceVal;
     }

--- a/packages/data-schemas/src/app/resolution.ts
+++ b/packages/data-schemas/src/app/resolution.ts
@@ -12,6 +12,9 @@ const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
  * a key field rather than replaced wholesale. `deepMerge` matches items by
  * the given key, deep-merges matching pairs, preserves unmatched base items,
  * and appends new override-only items.
+ *
+ * Paths use AppConfig key names (post-OVERRIDE_KEY_MAP remapping),
+ * not YAML-level key names. E.g. use `interfaceConfig.x`, not `interface.x`.
  */
 const ARRAY_MERGE_KEYS: Record<string, string> = {
   'endpoints.custom': 'name',
@@ -41,13 +44,11 @@ function mergeArrayByKey(
   path: string,
 ): AnyObject[] {
   const sourceByKey = new Map<unknown, AnyObject>();
-  const sourceOrder: unknown[] = [];
   for (const item of source) {
     if (item != null && typeof item === 'object') {
       const key = item[keyField];
       if (key != null) {
         sourceByKey.set(key, item);
-        sourceOrder.push(key);
       }
     }
   }
@@ -63,16 +64,16 @@ function mergeArrayByKey(
         result.push(deepMerge(item, override, depth + 1, path));
         seen.add(key);
       } else {
-        result.push(item);
+        result.push({ ...item });
       }
     } else {
       result.push(item);
     }
   }
 
-  for (const key of sourceOrder) {
+  for (const key of sourceByKey.keys()) {
     if (!seen.has(key)) {
-      result.push(sourceByKey.get(key)!);
+      result.push(deepMerge({} as AnyObject, sourceByKey.get(key)!, depth + 1, path));
     }
   }
 


### PR DESCRIPTION
## Summary

I fixed a bug where the DB base config's `endpoints.custom` array was wholesale-replacing the YAML-derived array during config resolution. Once an admin saved any change through the admin panel, the DB override captured the entire `endpoints.custom` array, and from that point on any new endpoints added to the YAML were silently ignored — the DB copy always won. The merge layer was supposed to be additive, not a complete replacement.

- Add an `ARRAY_MERGE_KEYS` path map to `deepMerge` that identifies array fields which should be merged by a key field (e.g., `endpoints.custom` merges by `name`) instead of replaced.
- Introduce `mergeArrayByKey` helper that preserves base (YAML) items not present in the override, deep-merges matching items (same `name`), and appends override-only items.
- Extend `deepMerge` to track the current object path during recursion so it can detect when it reaches a keyed-array path and delegate to `mergeArrayByKey`.
- Preserve existing behavior for non-keyed arrays (e.g., the top-level enabled-endpoints list) — they still get replaced as before.
- Add tests covering the merge-by-name behavior: YAML-only endpoints preserved, shared endpoints deep-merged, DB-only endpoints appended, and empty override array preserving all YAML endpoints.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Configure custom endpoints in `librechat.yaml` (e.g., `endpoint-a`, `endpoint-b`).
2. Open the admin panel and modify any config field that touches the DB base config — confirm the custom endpoints list is saved to the DB override.
3. Add a new custom endpoint (`endpoint-c`) to `librechat.yaml`.
4. Reload the app config — verify `endpoint-c` now appears alongside the existing endpoints instead of being silently dropped.
5. Modify `endpoint-a` via the admin panel (e.g., change `baseURL`) — verify the DB change takes effect while `endpoint-b` and `endpoint-c` retain their YAML values.
6. Run `cd packages/data-schemas && npx jest resolution` — confirm the new merge-by-name tests pass.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes