### PR TITLE
📩 fix: Restore Primary Action Button Visibility in Light Mode

### DIFF
--- a/client/src/components/Agents/AgentDetail.tsx
+++ b/client/src/components/Agents/AgentDetail.tsx
@@ -183,7 +183,12 @@ const AgentDetail: React.FC<AgentDetailProps> = ({ agent, isOpen, onClose }) => 
           >
             <Link className="h-4 w-4" aria-hidden="true" />
           </Button>
-          <Button className="w-full max-w-xs" onClick={handleStartChat} disabled={!agent}>
+          <Button
+            variant="submit"
+            className="w-full max-w-xs"
+            onClick={handleStartChat}
+            disabled={!agent}
+          >
             {localize('com_agents_start_chat')}
           </Button>
         </div>

--- a/client/src/components/Agents/AgentDetailContent.tsx
+++ b/client/src/components/Agents/AgentDetailContent.tsx
@@ -181,7 +181,12 @@ const AgentDetailContent: React.FC<AgentDetailContentProps> = ({ agent }) => {
         >
           <Link className="h-4 w-4" aria-hidden="true" />
         </Button>
-        <Button className="w-full max-w-xs" onClick={handleStartChat} disabled={!agent}>
+        <Button
+          variant="submit"
+          className="w-full max-w-xs"
+          onClick={handleStartChat}
+          disabled={!agent}
+        >
           {localize('com_agents_start_chat')}
         </Button>
       </div>

--- a/client/src/components/Sharing/GenericGrantAccessDialog.tsx
+++ b/client/src/components/Sharing/GenericGrantAccessDialog.tsx
@@ -401,6 +401,7 @@ export default function GenericGrantAccessDialog({
                 </Button>
               </OGDialogClose>
               <Button
+                variant="submit"
                 onClick={handleSave}
                 disabled={
                   updatePermissionsMutation.isLoading ||


### PR DESCRIPTION
## Summary

Fixes #12590.

The default `<Button>` variant (`bg-primary` + `text-primary-foreground`) renders invisible in light mode on three primary action buttons:

- Agent Marketplace detail modal — **Start Chat** (`AgentDetail.tsx`, `AgentDetailContent.tsx`)
- Grant Access dialog — **Save Changes** (`GenericGrantAccessDialog.tsx`)

The buttons are still clickable, but users cannot see them (the pin/copy-link icon buttons next to Start Chat use `variant="outline"` and are visible, which makes the missing primary action particularly confusing).

This PR switches those three affirmative-action buttons to `variant="submit"`, which already exists in `packages/client/src/components/Button.tsx` and uses the hardcoded `bg-surface-submit text-white` combination. The comment above the `submit` variant literally says:

```ts
// hardcoded text color because of WCAG contrast issues (text-white)
submit: 'bg-surface-submit text-white hover:bg-surface-submit-hover',
```

— so the variant was explicitly introduced to sidestep contrast problems with the default variant. These three buttons are semantically "submit / confirm" actions and should have been using it already.

**Scope:** This is an intentionally minimal, surgical fix. It does not try to solve the underlying cascade/token issue behind the default variant's light-mode rendering (which is hard to reproduce reliably from source inspection alone). Other default-variant `<Button>` instances in the app are not touched by this PR; they can be audited in a follow-up if needed.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Manual verification:

1. Check out this branch, `npm run reinstall && npm run build && npm run backend`
2. Open the app in light mode
3. **Agent Marketplace** → open any agent detail modal → the "Start Chat" button is now rendered as the green `submit` style with white text (previously invisible)
4. **Agent share dialog** → open Grant Access for any agent, make any permission change → the "Save Changes" button is now rendered with the same green `submit` style
5. Switch to dark mode and verify no visual regression (dark mode already rendered the default variant correctly; `submit` is also valid in dark mode — green on dark is fine)

### Test Configuration

- Node 22, latest `main`
- Chrome + Edge

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code (n/a — three-line variant change)
- [ ] I have made pertinent documentation changes (n/a)
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works (n/a — visual-only change; verified manually per the steps above)
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules (n/a)
- [ ] A pull request for updating the documentation has been submitted (n/a)
