### PR TITLE
📂 fix: Respect `supportedMimeTypes` Config in File Picker Accept Filter

### DIFF
--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useMemo } from 'react';
+import React, { useRef, useState, useMemo, useCallback } from 'react';
 import { useRecoilState } from 'recoil';
 import * as Ariakit from '@ariakit/react';
 import {
@@ -111,29 +111,35 @@ const AttachFileMenu = ({
     ephemeralAgent,
   );
 
-  const handleUploadClick = (fileType?: FileUploadType) => {
-    if (!inputRef.current) {
-      return;
-    }
-    inputRef.current.value = '';
-    if (fileType !== undefined && isPermissiveMimeConfig(endpointFileConfig?.supportedMimeTypes)) {
+  const handleUploadClick = useCallback(
+    (fileType?: FileUploadType) => {
+      if (!inputRef.current) {
+        return;
+      }
+      inputRef.current.value = '';
+      if (
+        fileType !== undefined &&
+        isPermissiveMimeConfig(endpointFileConfig?.supportedMimeTypes)
+      ) {
+        inputRef.current.accept = '';
+      } else if (fileType === 'image') {
+        inputRef.current.accept = 'image/*,.heif,.heic';
+      } else if (fileType === 'document') {
+        inputRef.current.accept = '.pdf,application/pdf';
+      } else if (fileType === 'image_document') {
+        inputRef.current.accept = 'image/*,.heif,.heic,.pdf,application/pdf';
+      } else if (fileType === 'image_document_extended') {
+        inputRef.current.accept = `image/*,.heif,.heic,${bedrockDocumentExtensions}`;
+      } else if (fileType === 'image_document_video_audio') {
+        inputRef.current.accept = 'image/*,.heif,.heic,.pdf,application/pdf,video/*,audio/*';
+      } else {
+        inputRef.current.accept = '';
+      }
+      inputRef.current.click();
       inputRef.current.accept = '';
-    } else if (fileType === 'image') {
-      inputRef.current.accept = 'image/*,.heif,.heic';
-    } else if (fileType === 'document') {
-      inputRef.current.accept = '.pdf,application/pdf';
-    } else if (fileType === 'image_document') {
-      inputRef.current.accept = 'image/*,.heif,.heic,.pdf,application/pdf';
-    } else if (fileType === 'image_document_extended') {
-      inputRef.current.accept = `image/*,.heif,.heic,${bedrockDocumentExtensions}`;
-    } else if (fileType === 'image_document_video_audio') {
-      inputRef.current.accept = 'image/*,.heif,.heic,.pdf,application/pdf,video/*,audio/*';
-    } else {
-      inputRef.current.accept = '';
-    }
-    inputRef.current.click();
-    inputRef.current.accept = '';
-  };
+    },
+    [endpointFileConfig?.supportedMimeTypes],
+  );
 
   const dropdownItems = useMemo(() => {
     const createMenuItems = (onAction: (fileType?: FileUploadType) => void) => {
@@ -250,7 +256,7 @@ const AttachFileMenu = ({
     endpointType,
     capabilities,
     useResponsesApi,
-    endpointFileConfig,
+    handleUploadClick,
     setToolResource,
     setEphemeralAgent,
     sharePointEnabled,

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -116,7 +116,7 @@ const AttachFileMenu = ({
       return;
     }
     inputRef.current.value = '';
-    if (fileType != null && isPermissiveMimeConfig(endpointFileConfig?.supportedMimeTypes)) {
+    if (fileType !== undefined && isPermissiveMimeConfig(endpointFileConfig?.supportedMimeTypes)) {
       inputRef.current.accept = '';
     } else if (fileType === 'image') {
       inputRef.current.accept = 'image/*,.heif,.heic';
@@ -250,6 +250,7 @@ const AttachFileMenu = ({
     endpointType,
     capabilities,
     useResponsesApi,
+    endpointFileConfig,
     setToolResource,
     setEphemeralAgent,
     sharePointEnabled,

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -19,6 +19,7 @@ import {
   Providers,
   EToolResources,
   EModelEndpoint,
+  isPermissiveMimeConfig,
   defaultAgentCapabilities,
   bedrockDocumentExtensions,
   isDocumentSupportedProvider,
@@ -115,7 +116,9 @@ const AttachFileMenu = ({
       return;
     }
     inputRef.current.value = '';
-    if (fileType === 'image') {
+    if (fileType != null && isPermissiveMimeConfig(endpointFileConfig?.supportedMimeTypes)) {
+      inputRef.current.accept = '';
+    } else if (fileType === 'image') {
       inputRef.current.accept = 'image/*,.heif,.heic';
     } else if (fileType === 'document') {
       inputRef.current.accept = '.pdf,application/pdf';

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -1,6 +1,8 @@
 import type { FileConfig } from './types/files';
 import {
   fileConfig as baseFileConfig,
+  isPermissiveMimeConfig,
+  convertStringsToRegex,
   documentParserMimeTypes,
   getEndpointFileConfig,
   applicationMimeTypes,
@@ -1244,5 +1246,56 @@ describe('getEndpointFileConfig', () => {
       expect(result.totalSizeLimit).toBe(0);
       expect(result.supportedMimeTypes).toEqual([]);
     });
+  });
+});
+
+describe('isPermissiveMimeConfig', () => {
+  it('returns true for wildcard .* pattern', () => {
+    expect(isPermissiveMimeConfig([/.*/])).toBe(true);
+  });
+
+  it('returns true for .+ pattern', () => {
+    expect(isPermissiveMimeConfig([/.+/])).toBe(true);
+  });
+
+  it('returns true for anchored ^.*$ pattern', () => {
+    expect(isPermissiveMimeConfig([/^.*$/])).toBe(true);
+  });
+
+  it('returns true for anchored ^.+$ pattern', () => {
+    expect(isPermissiveMimeConfig([/^.+$/])).toBe(true);
+  });
+
+  it('returns true when at least one pattern is permissive', () => {
+    expect(isPermissiveMimeConfig([/^image\/.*$/, /.*/])).toBe(true);
+  });
+
+  it('returns false for image-only patterns', () => {
+    expect(isPermissiveMimeConfig([/^image\/(jpeg|png)$/])).toBe(false);
+  });
+
+  it('returns false for category patterns', () => {
+    expect(isPermissiveMimeConfig([/^image\/.*$/, /^text\/.*$/])).toBe(false);
+  });
+
+  it('returns false for specific MIME type patterns', () => {
+    expect(isPermissiveMimeConfig([/^application\/pdf$/])).toBe(false);
+  });
+
+  it('returns false for default supportedMimeTypes', () => {
+    expect(isPermissiveMimeConfig(supportedMimeTypes)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isPermissiveMimeConfig(undefined)).toBe(false);
+  });
+
+  it('returns false for empty array', () => {
+    expect(isPermissiveMimeConfig([])).toBe(false);
+  });
+
+  it('returns true for regex produced by convertStringsToRegex with .*', () => {
+    const converted = convertStringsToRegex(['.*']);
+    expect(isPermissiveMimeConfig(converted)).toBe(true);
   });
 });

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -1282,6 +1282,14 @@ describe('isPermissiveMimeConfig', () => {
     expect(isPermissiveMimeConfig([/^application\/pdf$/])).toBe(false);
   });
 
+  it('returns false for broad application category pattern', () => {
+    expect(isPermissiveMimeConfig([/^application\/.*$/])).toBe(false);
+  });
+
+  it('returns false for multi-category pattern', () => {
+    expect(isPermissiveMimeConfig([/^(application|text)\/.*$/])).toBe(false);
+  });
+
   it('returns false for default supportedMimeTypes', () => {
     expect(isPermissiveMimeConfig(supportedMimeTypes)).toBe(false);
   });

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -497,6 +497,13 @@ export const convertStringsToRegex = (patterns: string[]): RegExp[] =>
     return acc;
   }, []);
 
+export const isPermissiveMimeConfig = (types?: RegExp[]): boolean => {
+  if (!types || types.length === 0) {
+    return false;
+  }
+  return types.some((regex) => regex.test('application/x-librechat-any'));
+};
+
 /**
  * Gets the appropriate endpoint file configuration with standardized lookup logic.
  *

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -497,11 +497,12 @@ export const convertStringsToRegex = (patterns: string[]): RegExp[] =>
     return acc;
   }, []);
 
+/** Detects whether the given MIME type patterns accept all file types (e.g., `.*` or `.+`). */
 export const isPermissiveMimeConfig = (types?: RegExp[]): boolean => {
   if (!types || types.length === 0) {
     return false;
   }
-  return types.some((regex) => regex.test('application/x-librechat-any'));
+  return types.some((regex) => regex.test('x-librechat/x-probe'));
 };
 
 /**


### PR DESCRIPTION
## Summary

The browser file picker's `accept` attribute was hardcoded by provider identity in `AttachFileMenu.tsx`, ignoring the endpoint's `supportedMimeTypes` from `fileConfig`. PR #12508 fixed the backend routing so custom MIME types are processed correctly, but the frontend file picker dialog still showed a restrictive filter — confusing users who configured permissive types like `supportedMimeTypes: ['.*']`.

- Add `isPermissiveMimeConfig` utility in `packages/data-provider/src/file-config.ts` that detects wildcard patterns by testing a synthetic MIME type (`application/x-librechat-any`) against the endpoint's `supportedMimeTypes` RegExp array
- Insert a new first branch in `handleUploadClick` that sets the file input `accept` to `''` (unrestricted) when the endpoint's MIME config is permissive, short-circuiting the hardcoded provider-based strings
- Retain existing provider-specific accept filters for non-permissive configs, preserving the current UX for default setups
- Add 12 unit tests covering wildcard patterns (`/.*/`, `/.+/`, `/^.*$/`, `/^.+$/`), mixed arrays, category patterns, specific MIME types, defaults, edge cases, and the end-to-end `convertStringsToRegex` → `isPermissiveMimeConfig` path

Closes #12589

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Configure `fileConfig.endpoints.custom.supportedMimeTypes: ['.*']` in `librechat.yaml`
2. Start a chat with a custom endpoint
3. Click paperclip → **Upload to Provider**
4. Verify the file picker dialog shows all files (no restrictive filter)
5. Without the config override, verify the file picker still shows the original provider-specific filter (images/PDFs)
6. Run `cd packages/data-provider && npx jest file-config --verbose` — all 113 tests pass

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes