### PR TITLE
📂 fix: Enable Hidden File Upload for GitNexus Index Artifact

### DIFF
--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -88,4 +88,5 @@ jobs:
               || github.ref_name
             }}
           path: .gitnexus/
+          include-hidden-files: true
           retention-days: 30


### PR DESCRIPTION
## Summary

I fixed the GitNexus Index CI workflow failing to upload the `.gitnexus/` artifact due to `upload-artifact@v4` silently skipping dotfiles by default.

- Add `include-hidden-files: true` to the artifact upload step in `gitnexus-index.yml`, scoped to the `.gitnexus/` path so only GitNexus index files are affected.
- Resolve the root cause of the deploy workflow failing with `Artifact not found for name: gitnexus-index-main` — the index was being built successfully but the upload produced zero artifacts because `.gitnexus` is a hidden directory.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Re-run the GitNexus Index workflow via `workflow_dispatch` on `main` and verify:
1. The `gitnexus-index-main` artifact appears in the workflow run's artifact list with `.gitnexus/` contents (`.gitnexus/meta.json`, `.gitnexus/lbug`)
2. The GitNexus Deploy workflow can successfully download the artifact in the subsequent `workflow_run` trigger

### **Test Configuration**:

- GitHub Actions runner: `ubuntu-latest`
- Node.js: 24
- `actions/upload-artifact@v4`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings