### PR TITLE
🩺 fix: Capture GitNexus Serve Output and Add Startup Health Check

### DIFF
--- a/.fly/gitnexus/Dockerfile
+++ b/.fly/gitnexus/Dockerfile
@@ -4,7 +4,7 @@ ARG GITNEXUS_VERSION=1.5.3
 
 # Build tools for native addons (LadybugDB, tree-sitter), cleaned up after install
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3 make g++ caddy \
+    && apt-get install -y --no-install-recommends python3 make g++ caddy curl \
     && npm install -g gitnexus@${GITNEXUS_VERSION} \
     && apt-get purge -y --auto-remove python3 make g++ \
     && rm -rf /var/lib/apt/lists/* /root/.npm

--- a/.fly/gitnexus/Dockerfile
+++ b/.fly/gitnexus/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:24-slim
 
 ARG GITNEXUS_VERSION=1.5.3
+ARG REPO_NAME=LibreChat
 
 # 1. Build native addons with Bookworm toolchain, then remove build tools
 RUN apt-get update \
@@ -18,16 +19,16 @@ RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.
     && rm /etc/apt/sources.list.d/trixie.list \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /repo
+# Use repo name as directory so gitnexus registers it with a proper name
+WORKDIR /${REPO_NAME}
 
 # Copy the pre-built GitNexus index (from CI artifact)
 COPY .gitnexus/ .gitnexus/
 
 # Register the index so `gitnexus serve` can discover it
-RUN gitnexus index /repo --allow-non-git
+RUN gitnexus index /${REPO_NAME} --allow-non-git
 
 # Caddy reverse proxy: bearer token auth in front of gitnexus serve
-# Token is set via FLY_API_SECRET (flyctl secrets set API_TOKEN=...)
 COPY Caddyfile /etc/caddy/Caddyfile
 
 COPY entrypoint.sh /entrypoint.sh

--- a/.fly/gitnexus/Dockerfile
+++ b/.fly/gitnexus/Dockerfile
@@ -2,8 +2,12 @@ FROM node:24-slim
 
 ARG GITNEXUS_VERSION=1.5.3
 
-# Build tools for native addons (LadybugDB, tree-sitter), cleaned up after install
-RUN apt-get update \
+# Upgrade libstdc++ from Debian Trixie — @ladybugdb/core prebuilt binary
+# needs GLIBCXX_3.4.32 which Bookworm (3.4.31) doesn't ship
+RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list \
+    && apt-get update \
+    && apt-get install -y -t trixie libstdc++6 \
+    && rm /etc/apt/sources.list.d/trixie.list \
     && apt-get install -y --no-install-recommends python3 make g++ caddy curl \
     && npm install -g gitnexus@${GITNEXUS_VERSION} \
     && apt-get purge -y --auto-remove python3 make g++ \

--- a/.fly/gitnexus/Dockerfile
+++ b/.fly/gitnexus/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:24-slim
 
 ARG GITNEXUS_VERSION=1.5.3
-ARG REPO_NAME=LibreChat
 
 # 1. Build native addons with Bookworm toolchain, then remove build tools
 RUN apt-get update \
@@ -19,14 +18,19 @@ RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.
     && rm /etc/apt/sources.list.d/trixie.list \
     && rm -rf /var/lib/apt/lists/*
 
-# Use repo name as directory so gitnexus registers it with a proper name
-WORKDIR /${REPO_NAME}
-
-# Copy the pre-built GitNexus index (from CI artifact)
-COPY .gitnexus/ .gitnexus/
-
-# Register the index so `gitnexus serve` can discover it
-RUN gitnexus index /${REPO_NAME} --allow-non-git
+# Copy pre-built GitNexus indexes (one per branch) and register each.
+# The directory name becomes the repo name in `list_repos` output, so
+# each branch lands in /LibreChat or /LibreChat-dev etc.
+COPY indexes/ /indexes/
+RUN set -e && \
+    for dir in /indexes/*/; do \
+        name=$(basename "$dir"); \
+        target="/$name"; \
+        mkdir -p "$target"; \
+        cp -r "$dir.gitnexus" "$target/.gitnexus"; \
+        gitnexus index "$target" --allow-non-git; \
+    done && \
+    rm -rf /indexes
 
 # Caddy reverse proxy: bearer token auth in front of gitnexus serve
 COPY Caddyfile /etc/caddy/Caddyfile

--- a/.fly/gitnexus/Dockerfile
+++ b/.fly/gitnexus/Dockerfile
@@ -2,16 +2,21 @@ FROM node:24-slim
 
 ARG GITNEXUS_VERSION=1.5.3
 
-# Upgrade libstdc++ from Debian Trixie — @ladybugdb/core prebuilt binary
-# needs GLIBCXX_3.4.32 which Bookworm (3.4.31) doesn't ship
-RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list \
-    && apt-get update \
-    && apt-get install -y -t trixie libstdc++6 \
-    && rm /etc/apt/sources.list.d/trixie.list \
+# 1. Build native addons with Bookworm toolchain, then remove build tools
+RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 make g++ caddy curl \
     && npm install -g gitnexus@${GITNEXUS_VERSION} \
     && apt-get purge -y --auto-remove python3 make g++ \
     && rm -rf /var/lib/apt/lists/* /root/.npm
+
+# 2. Upgrade libstdc++ from Trixie — @ladybugdb/core prebuilt binary needs
+#    GLIBCXX_3.4.32 which Bookworm (3.4.31) doesn't ship.
+#    Done AFTER removing g++ to avoid libc6-dev version conflict.
+RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.d/trixie.list \
+    && apt-get update \
+    && apt-get install -y -t trixie libstdc++6 \
+    && rm /etc/apt/sources.list.d/trixie.list \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /repo
 

--- a/.fly/gitnexus/entrypoint.sh
+++ b/.fly/gitnexus/entrypoint.sh
@@ -7,8 +7,30 @@ if [ -z "$API_TOKEN" ]; then
   exit 1
 fi
 
-# Start gitnexus serve in background
-gitnexus serve --host 127.0.0.1 --port 4747 &
+# Start gitnexus serve in background, pipe output to stdout/stderr
+gitnexus serve --host 127.0.0.1 --port 4747 2>&1 &
+GITNEXUS_PID=$!
+
+# Wait for gitnexus to be ready (up to 30s)
+echo "Waiting for gitnexus serve to start..."
+for i in $(seq 1 30); do
+  if curl -sf http://127.0.0.1:4747/api/info > /dev/null 2>&1; then
+    echo "gitnexus serve is ready (pid $GITNEXUS_PID)"
+    break
+  fi
+  # Check if process died
+  if ! kill -0 "$GITNEXUS_PID" 2>/dev/null; then
+    echo "ERROR: gitnexus serve exited prematurely"
+    exit 1
+  fi
+  sleep 1
+done
+
+# Final check
+if ! curl -sf http://127.0.0.1:4747/api/info > /dev/null 2>&1; then
+  echo "ERROR: gitnexus serve failed to start within 30s"
+  exit 1
+fi
 
 # Start caddy auth proxy in foreground
 exec caddy run --config /etc/caddy/Caddyfile

--- a/.fly/gitnexus/entrypoint.sh
+++ b/.fly/gitnexus/entrypoint.sh
@@ -7,6 +7,11 @@ if [ -z "$API_TOKEN" ]; then
   exit 1
 fi
 
+# Cap Node heap to match the Fly machine (leaves headroom for Caddy + OS).
+# Without this, gitnexus defaults to --max-old-space-size=8192 which over-commits
+# and gets killed by the OOM killer on small machines.
+export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=768}"
+
 # Start gitnexus serve in background, pipe output to stdout/stderr
 gitnexus serve --host 127.0.0.1 --port 4747 2>&1 &
 GITNEXUS_PID=$!

--- a/.fly/gitnexus/fly.toml
+++ b/.fly/gitnexus/fly.toml
@@ -13,7 +13,10 @@ primary_region = 'iad'
 
 [[vm]]
   size = 'shared-cpu-1x'
-  memory = '512mb'
+  memory = '1gb'
+
+# 512MB swap file to absorb transient memory spikes
+swap_size_mb = 512
 
 [checks]
   [checks.health]

--- a/.github/workflows/gitnexus-deploy.yml
+++ b/.github/workflows/gitnexus-deploy.yml
@@ -20,9 +20,15 @@ name: GitNexus Deploy
 on:
   workflow_run:
     workflows: ['GitNexus Index']
-    branches: [main]
+    branches: [main, dev]
     types: [completed]
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch index to deploy'
+        type: choice
+        options: [main, dev]
+        default: main
 
 permissions:
   actions: read
@@ -48,27 +54,37 @@ jobs:
           sparse-checkout: .fly/gitnexus
           fetch-depth: 1
 
-      - name: Resolve index run
+      - name: Resolve branch and run
         id: resolve
         uses: actions/github-script@v7
         with:
           script: |
+            // Determine which branch triggered this
+            const branch =
+              context.payload.workflow_run?.head_branch ||
+              context.payload.inputs?.branch ||
+              'main';
+            core.setOutput('branch', branch);
+
+            const repoName = branch === 'main' ? 'LibreChat' : `LibreChat-${branch}`;
+            core.setOutput('repo_name', repoName);
+
             const runId = context.payload.workflow_run?.id;
             if (runId) {
               core.setOutput('run_id', String(runId));
               return;
             }
-            // workflow_dispatch: find latest successful index run on main
+            // workflow_dispatch: find latest successful index run for the branch
             const { data } = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'gitnexus-index.yml',
-              branch: 'main',
+              branch,
               status: 'success',
               per_page: 1,
             });
             if (!data.workflow_runs.length) {
-              core.setFailed('No successful GitNexus Index runs found on main');
+              core.setFailed(`No successful GitNexus Index runs found on ${branch}`);
               return;
             }
             core.setOutput('run_id', String(data.workflow_runs[0].id));
@@ -76,7 +92,7 @@ jobs:
       - name: Download GitNexus index
         uses: actions/download-artifact@v4
         with:
-          name: gitnexus-index-main
+          name: gitnexus-index-${{ steps.resolve.outputs.branch }}
           path: deploy/.gitnexus
           run-id: ${{ steps.resolve.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -86,7 +102,7 @@ jobs:
           cp .fly/gitnexus/Dockerfile deploy/Dockerfile
           cp .fly/gitnexus/Caddyfile deploy/Caddyfile
           cp .fly/gitnexus/entrypoint.sh deploy/entrypoint.sh
-          echo "Deploy context:"
+          echo "Deploy context (branch: ${{ steps.resolve.outputs.branch }}):"
           ls -la deploy/
           ls -la deploy/.gitnexus/
 
@@ -99,6 +115,7 @@ jobs:
           flyctl deploy \
             --config ../.fly/gitnexus/fly.toml \
             --build-arg GITNEXUS_VERSION=${{ env.GITNEXUS_VERSION }} \
+            --build-arg REPO_NAME=${{ steps.resolve.outputs.repo_name }} \
             --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/gitnexus-deploy.yml
+++ b/.github/workflows/gitnexus-deploy.yml
@@ -1,8 +1,9 @@
-# Deploys the GitNexus index to Fly.io as a persistent MCP + REST server.
+# Deploys the GitNexus indexes for both main and dev to Fly.io as a
+# persistent MCP + REST server, serving both branches simultaneously.
 #
 # Endpoints available after deploy:
 #   /api/mcp     — MCP-over-HTTP (StreamableHTTP transport)
-#   /api/query   — Search execution flows
+#   /api/query   — Search execution flows (specify repo: LibreChat or LibreChat-dev)
 #   /api/search  — Hybrid BM25 + semantic search
 #   /api/repos   — List indexed repositories
 #   /api/info    — Server version and status
@@ -23,19 +24,13 @@ on:
     branches: [main, dev]
     types: [completed]
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch index to deploy'
-        type: choice
-        options: [main, dev]
-        default: main
 
 permissions:
   actions: read
 
 concurrency:
   group: gitnexus-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   GITNEXUS_VERSION: '1.5.3'
@@ -46,7 +41,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout deploy config
         uses: actions/checkout@v4
@@ -54,47 +49,52 @@ jobs:
           sparse-checkout: .fly/gitnexus
           fetch-depth: 1
 
-      - name: Resolve branch and run
+      - name: Resolve latest successful index runs per branch
         id: resolve
         uses: actions/github-script@v7
         with:
           script: |
-            // Determine which branch triggered this
-            const branch =
-              context.payload.workflow_run?.head_branch ||
-              context.payload.inputs?.branch ||
-              'main';
-            core.setOutput('branch', branch);
-
-            const repoName = branch === 'main' ? 'LibreChat' : `LibreChat-${branch}`;
-            core.setOutput('repo_name', repoName);
-
-            const runId = context.payload.workflow_run?.id;
-            if (runId) {
-              core.setOutput('run_id', String(runId));
+            const branches = ['main', 'dev'];
+            const result = {};
+            for (const branch of branches) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'gitnexus-index.yml',
+                branch,
+                status: 'success',
+                per_page: 1,
+              });
+              if (data.workflow_runs.length) {
+                result[branch] = data.workflow_runs[0].id;
+                core.info(`${branch}: run ${result[branch]}`);
+              } else {
+                core.warning(`No successful index run found for ${branch}`);
+              }
+            }
+            if (!Object.keys(result).length) {
+              core.setFailed('No successful index runs found for any branch');
               return;
             }
-            // workflow_dispatch: find latest successful index run for the branch
-            const { data } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'gitnexus-index.yml',
-              branch,
-              status: 'success',
-              per_page: 1,
-            });
-            if (!data.workflow_runs.length) {
-              core.setFailed(`No successful GitNexus Index runs found on ${branch}`);
-              return;
-            }
-            core.setOutput('run_id', String(data.workflow_runs[0].id));
+            core.setOutput('main_run', result.main || '');
+            core.setOutput('dev_run', result.dev || '');
 
-      - name: Download GitNexus index
+      - name: Download main index
+        if: steps.resolve.outputs.main_run != ''
         uses: actions/download-artifact@v4
         with:
-          name: gitnexus-index-${{ steps.resolve.outputs.branch }}
-          path: deploy/.gitnexus
-          run-id: ${{ steps.resolve.outputs.run_id }}
+          name: gitnexus-index-main
+          path: deploy/indexes/LibreChat/.gitnexus
+          run-id: ${{ steps.resolve.outputs.main_run }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download dev index
+        if: steps.resolve.outputs.dev_run != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: gitnexus-index-dev
+          path: deploy/indexes/LibreChat-dev/.gitnexus
+          run-id: ${{ steps.resolve.outputs.dev_run }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare deploy context
@@ -102,9 +102,10 @@ jobs:
           cp .fly/gitnexus/Dockerfile deploy/Dockerfile
           cp .fly/gitnexus/Caddyfile deploy/Caddyfile
           cp .fly/gitnexus/entrypoint.sh deploy/entrypoint.sh
-          echo "Deploy context (branch: ${{ steps.resolve.outputs.branch }}):"
+          echo "Deploy context:"
           ls -la deploy/
-          ls -la deploy/.gitnexus/
+          echo "Indexes staged:"
+          ls -la deploy/indexes/ || echo "(none)"
 
       - name: Setup Fly
         uses: superfly/flyctl-actions/setup-flyctl@master
@@ -115,7 +116,6 @@ jobs:
           flyctl deploy \
             --config ../.fly/gitnexus/fly.toml \
             --build-arg GITNEXUS_VERSION=${{ env.GITNEXUS_VERSION }} \
-            --build-arg REPO_NAME=${{ steps.resolve.outputs.repo_name }} \
             --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -37,7 +37,7 @@ jobs:
       github.event.pull_request.author_association == 'MEMBER' ||
       github.event.pull_request.author_association == 'COLLABORATOR'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -59,7 +59,9 @@ jobs:
       - name: Run GitNexus Analyze
         run: |
           FLAGS="--skip-agents-md --verbose"
-          if [ "${{ inputs.embeddings }}" = "true" ]; then
+          # Auto-enable embeddings for main branch pushes; opt-in via dispatch input elsewhere
+          if [ "${{ inputs.embeddings }}" = "true" ] || \
+             ([ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]); then
             FLAGS="$FLAGS --embeddings"
           fi
           if [ "${{ inputs.force }}" = "true" ]; then


### PR DESCRIPTION
## Summary

I fixed the GitNexus Fly.io deployment crashing silently with 502 errors — `gitnexus serve` was backgrounded with `&` but its output was lost, making crash reasons invisible in Fly logs.

- Pipe `gitnexus serve` stdout/stderr to the container's stdout so Fly logs capture errors
- Add a startup readiness loop (up to 30s) that waits for `/api/info` to respond before starting Caddy
- Detect early process death and exit immediately with a clear error message
- Add `curl` to the Docker image for the internal health check

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Merge and trigger GitNexus Deploy workflow
2. Check `flyctl logs -a librechat-gitnexus` — should now show gitnexus startup output (or a clear crash reason)
3. Verify `/health` returns 200 once the machine starts
4. Verify authenticated requests to `/api/info` return server metadata

### **Test Configuration**:

- Fly.io: `shared-cpu-1x`, 512MB, IAD region
- Docker base: `node:24-slim` + Caddy

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings