### PR TITLE
🎯 fix: Preserve Selected Artifact When Clicking Artifact Button

### DIFF
--- a/client/src/components/Artifacts/ArtifactButton.tsx
+++ b/client/src/components/Artifacts/ArtifactButton.tsx
@@ -63,16 +63,12 @@ const ArtifactButton = ({ artifact }: { artifact: Artifact | null }) => {
             return;
           }
 
-          resetCurrentArtifactId();
+          setCurrentArtifactId(artifact.id);
           setVisible(true);
 
           if (artifacts?.[artifact.id] == null) {
             setArtifacts(visibleArtifacts);
           }
-
-          setTimeout(() => {
-            setCurrentArtifactId(artifact.id);
-          }, 15);
         };
 
         const buttonClass = cn(

--- a/client/src/hooks/Artifacts/__tests__/useArtifacts.test.ts
+++ b/client/src/hooks/Artifacts/__tests__/useArtifacts.test.ts
@@ -372,6 +372,50 @@ describe('useArtifacts', () => {
     });
   });
 
+  describe('artifact selection preservation', () => {
+    it('should preserve selection when a new artifact is added', () => {
+      const artifact1 = createArtifact({ id: 'artifact-1', lastUpdateTime: 1000 });
+
+      (useRecoilValue as jest.Mock).mockReturnValue({ 'artifact-1': artifact1 });
+      (useRecoilState as jest.Mock).mockReturnValue(['artifact-1', mockSetCurrentArtifactId]);
+
+      const { rerender } = renderHook(() => useArtifacts());
+
+      mockSetCurrentArtifactId.mockClear();
+
+      /** Append a second artifact; mock still returns 'artifact-1' as current */
+      const artifact2 = createArtifact({ id: 'artifact-2', lastUpdateTime: 2000 });
+      (useRecoilValue as jest.Mock).mockReturnValue({
+        'artifact-1': artifact1,
+        'artifact-2': artifact2,
+      });
+
+      rerender();
+
+      expect(mockSetCurrentArtifactId).not.toHaveBeenCalled();
+    });
+
+    it('should keep selection null after an explicit reset', () => {
+      const artifact1 = createArtifact({ id: 'artifact-1', lastUpdateTime: 1000 });
+
+      /** First render: valid selection */
+      (useRecoilValue as jest.Mock).mockReturnValue({ 'artifact-1': artifact1 });
+      (useRecoilState as jest.Mock).mockReturnValue(['artifact-1', mockSetCurrentArtifactId]);
+
+      const { rerender } = renderHook(() => useArtifacts());
+
+      mockSetCurrentArtifactId.mockClear();
+
+      /** Rerender: currentArtifactId transitions to null (user closed the panel) */
+      (useRecoilState as jest.Mock).mockReturnValue([null, mockSetCurrentArtifactId]);
+
+      rerender();
+
+      /** Should NOT bounce back to 'artifact-1' */
+      expect(mockSetCurrentArtifactId).not.toHaveBeenCalled();
+    });
+  });
+
   describe('cleanup on unmount', () => {
     it('should reset artifacts when unmounting', () => {
       (useRecoilValue as jest.Mock).mockReturnValue({});

--- a/client/src/hooks/Artifacts/__tests__/useArtifacts.test.ts
+++ b/client/src/hooks/Artifacts/__tests__/useArtifacts.test.ts
@@ -395,6 +395,31 @@ describe('useArtifacts', () => {
       expect(mockSetCurrentArtifactId).not.toHaveBeenCalled();
     });
 
+    it('should advance to new artifact during streaming', () => {
+      const artifact1 = createArtifact({ id: 'artifact-1', lastUpdateTime: 1000, content: 'c1' });
+
+      (useRecoilValue as jest.Mock).mockReturnValue({ 'artifact-1': artifact1 });
+      (useRecoilState as jest.Mock).mockReturnValue(['artifact-1', mockSetCurrentArtifactId]);
+      (useArtifactsContext as jest.Mock).mockReturnValue({
+        ...defaultContext,
+        isSubmitting: true,
+        latestMessageId: 'msg-1',
+      });
+
+      const { rerender } = renderHook(() => useArtifacts());
+      mockSetCurrentArtifactId.mockClear();
+
+      const artifact2 = createArtifact({ id: 'artifact-2', lastUpdateTime: 2000, content: 'c2' });
+      (useRecoilValue as jest.Mock).mockReturnValue({
+        'artifact-1': artifact1,
+        'artifact-2': artifact2,
+      });
+
+      rerender();
+
+      expect(mockSetCurrentArtifactId).toHaveBeenCalledWith('artifact-2');
+    });
+
     it('should keep selection null after an explicit reset', () => {
       const artifact1 = createArtifact({ id: 'artifact-1', lastUpdateTime: 1000 });
 

--- a/client/src/hooks/Artifacts/useArtifacts.ts
+++ b/client/src/hooks/Artifacts/useArtifacts.ts
@@ -51,6 +51,8 @@ export default function useArtifacts() {
     };
   }, [conversationId, resetArtifacts, resetCurrentArtifactId]);
 
+  /** Read currentArtifactId in effects without subscribing as a dependency.
+   * Adding it to effect deps fires auto-select on every reset, breaking toggle-close. */
   const currentArtifactIdRef = useRef(currentArtifactId);
   currentArtifactIdRef.current = currentArtifactId;
 
@@ -86,14 +88,7 @@ export default function useArtifacts() {
       return;
     }
 
-    const userHasManualSelection =
-      currentArtifactId != null &&
-      currentArtifactId !== latestArtifactId &&
-      orderedArtifactIds.includes(currentArtifactId);
-
-    if (!userHasManualSelection) {
-      setCurrentArtifactId(latestArtifactId);
-    }
+    setCurrentArtifactId(latestArtifactId);
     lastContentRef.current = latestArtifact?.content ?? null;
 
     // Only switch to code tab if we haven't detected an enclosed artifact yet

--- a/client/src/hooks/Artifacts/useArtifacts.ts
+++ b/client/src/hooks/Artifacts/useArtifacts.ts
@@ -51,8 +51,10 @@ export default function useArtifacts() {
     };
   }, [conversationId, resetArtifacts, resetCurrentArtifactId]);
 
-  /** Read currentArtifactId in effects without subscribing as a dependency.
-   * Adding it to effect deps fires auto-select on every reset, breaking toggle-close. */
+  /**
+   * Read currentArtifactId in effects without subscribing as a dependency.
+   * Adding it to effect deps fires auto-select on every reset, breaking toggle-close.
+   */
   const currentArtifactIdRef = useRef(currentArtifactId);
   currentArtifactIdRef.current = currentArtifactId;
 

--- a/client/src/hooks/Artifacts/useArtifacts.ts
+++ b/client/src/hooks/Artifacts/useArtifacts.ts
@@ -51,16 +51,15 @@ export default function useArtifacts() {
     };
   }, [conversationId, resetArtifacts, resetCurrentArtifactId]);
 
+  const currentArtifactIdRef = useRef(currentArtifactId);
+  currentArtifactIdRef.current = currentArtifactId;
+
   useEffect(() => {
-    if (orderedArtifactIds.length === 0) {
-      return;
-    }
-    if (currentArtifactId != null && orderedArtifactIds.includes(currentArtifactId)) {
-      return;
-    }
-    const latestArtifactId = orderedArtifactIds[orderedArtifactIds.length - 1];
-    setCurrentArtifactId(latestArtifactId);
-  }, [currentArtifactId, setCurrentArtifactId, orderedArtifactIds]);
+    if (orderedArtifactIds.length === 0) return;
+    const currentId = currentArtifactIdRef.current;
+    if (currentId != null && orderedArtifactIds.includes(currentId)) return;
+    setCurrentArtifactId(orderedArtifactIds[orderedArtifactIds.length - 1]);
+  }, [orderedArtifactIds, setCurrentArtifactId]);
 
   /**
    * Manage artifact selection and code tab switching for non-enclosed artifacts
@@ -87,7 +86,14 @@ export default function useArtifacts() {
       return;
     }
 
-    setCurrentArtifactId(latestArtifactId);
+    const userHasManualSelection =
+      currentArtifactId != null &&
+      currentArtifactId !== latestArtifactId &&
+      orderedArtifactIds.includes(currentArtifactId);
+
+    if (!userHasManualSelection) {
+      setCurrentArtifactId(latestArtifactId);
+    }
     lastContentRef.current = latestArtifact?.content ?? null;
 
     // Only switch to code tab if we haven't detected an enclosed artifact yet

--- a/client/src/hooks/Artifacts/useArtifacts.ts
+++ b/client/src/hooks/Artifacts/useArtifacts.ts
@@ -52,11 +52,15 @@ export default function useArtifacts() {
   }, [conversationId, resetArtifacts, resetCurrentArtifactId]);
 
   useEffect(() => {
-    if (orderedArtifactIds.length > 0) {
-      const latestArtifactId = orderedArtifactIds[orderedArtifactIds.length - 1];
-      setCurrentArtifactId(latestArtifactId);
+    if (orderedArtifactIds.length === 0) {
+      return;
     }
-  }, [setCurrentArtifactId, orderedArtifactIds]);
+    if (currentArtifactId != null && orderedArtifactIds.includes(currentArtifactId)) {
+      return;
+    }
+    const latestArtifactId = orderedArtifactIds[orderedArtifactIds.length - 1];
+    setCurrentArtifactId(latestArtifactId);
+  }, [currentArtifactId, setCurrentArtifactId, orderedArtifactIds]);
 
   /**
    * Manage artifact selection and code tab switching for non-enclosed artifacts


### PR DESCRIPTION
## Summary

Clicking an artifact button in the conversation incorrectly resets the view to the latest artifact instead of opening the clicked one. This happens because:

1. `ArtifactButton` was calling `resetCurrentArtifactId()` and then relying on a `setTimeout` to set the correct ID 15ms later — a race condition with the `useArtifacts` effect.
2. The `useArtifacts` effect unconditionally overwrites `currentArtifactId` with the latest artifact whenever `orderedArtifactIds` changes, clobbering the user's selection.

This PR fixes both issues:

1. `ArtifactButton` now sets the artifact ID directly via `setCurrentArtifactId(artifact.id)` instead of the reset + `setTimeout` workaround.
2. The auto-select effect uses a `currentArtifactIdRef` to read the current selection without subscribing as a reactive dependency. This preserves valid user selections when new artifacts are added, while still falling back to the latest artifact when no valid selection exists. The ref pattern avoids a toggle-close regression that occurs when `currentArtifactId` is added directly to the effect's dependency array.
3. The streaming effect (effect #3) remains unchanged from base — it unconditionally tracks the latest artifact during active generation. A `userHasManualSelection` guard was explored but reverted because it cannot distinguish manual clicks from system auto-selection, which blocked auto-advancement to new artifacts during streaming.

Three new tests cover the behavioral contracts: selection preservation on new artifact, auto-advancement during streaming, and reset stability (no bounce-back after toggle-close).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Start a conversation and generate multiple artifacts.
2. Click on an earlier artifact button in the message stream.
3. Verify the side panel opens showing the clicked artifact, not the latest one.
4. Generate a new artifact — verify the panel auto-selects the new one.
5. Click a selected artifact to close the panel — verify it stays closed and the button deselects.
6. Switch conversations and return — verify the latest artifact is selected by default.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes