### PR TITLE
🔎 fix: Install LadybugDB Extensions and Patch Vector Load for GitNexus Search

### DIFF
--- a/.fly/gitnexus/Dockerfile
+++ b/.fly/gitnexus/Dockerfile
@@ -18,6 +18,22 @@ RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.
     && rm /etc/apt/sources.list.d/trixie.list \
     && rm -rf /var/lib/apt/lists/*
 
+# 3. Pre-install LadybugDB FTS + vector extensions so the cache in
+#    ~/.kuzu/extension/ is baked into the image. Workaround for upstream
+#    bug: gitnexus serve's pool-adapter calls LOAD EXTENSION but never
+#    INSTALL, so without this step, query()'s BM25 + semantic search
+#    silently return empty.
+COPY install-extensions.js /tmp/install-extensions.js
+RUN node /tmp/install-extensions.js && rm -rf /tmp/install-extensions.js /tmp/lbug-ext-install
+
+# 4. Patch pool-adapter.js to also LOAD EXTENSION vector after FTS.
+#    Upstream only loads FTS at serve time; without vector extension
+#    loaded, semantic search's CALL QUERY_VECTOR_INDEX fails silently.
+RUN POOL_ADAPTER=/usr/local/lib/node_modules/gitnexus/dist/core/lbug/pool-adapter.js \
+    && grep -q "LOAD EXTENSION fts" "$POOL_ADAPTER" \
+    && sed -i "s|await available\[0\]\.query('LOAD EXTENSION fts');|await available[0].query('LOAD EXTENSION fts'); try { await available[0].query('LOAD EXTENSION vector'); } catch (e) { /* vector extension may not be installed */ }|g" "$POOL_ADAPTER" \
+    && echo "pool-adapter.js patched to load vector extension"
+
 # Copy pre-built GitNexus indexes (one per branch) and register each.
 # The directory name becomes the repo name in `list_repos` output, so
 # each branch lands in /LibreChat or /LibreChat-dev etc.

--- a/.fly/gitnexus/install-extensions.js
+++ b/.fly/gitnexus/install-extensions.js
@@ -1,0 +1,43 @@
+/**
+ * Pre-install LadybugDB extensions (FTS + vector) into the Docker image's
+ * extension cache (~/.kuzu/extension/). Without this, gitnexus serve's
+ * pool-adapter calls LOAD EXTENSION fts at runtime but fails silently
+ * because the extension was never installed, causing all BM25 and
+ * semantic queries via the query() tool to return empty.
+ *
+ * This is a workaround for an upstream GitNexus 1.5.3 bug:
+ * pool-adapter.ts loads extensions but never installs them, and the
+ * CI-produced .gitnexus/ artifact doesn't include the extension cache.
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+// @ladybugdb/core lives under the globally-installed gitnexus package
+const lbugPath = '/usr/local/lib/node_modules/gitnexus/node_modules/@ladybugdb/core';
+const lbug = require(lbugPath);
+
+const tmpDir = '/tmp/lbug-ext-install';
+fs.mkdirSync(tmpDir, { recursive: true });
+
+// Open a throwaway database to run INSTALL against. The extension cache
+// persists in ~/.kuzu/extension/ regardless of which database was used.
+const db = new lbug.Database(path.join(tmpDir, 'db'), 0, false, false);
+const conn = new lbug.Connection(db);
+
+(async () => {
+  try {
+    await conn.query('INSTALL fts');
+    console.log('FTS extension installed');
+  } catch (err) {
+    console.error('FTS install failed:', err.message);
+    process.exit(1);
+  }
+  try {
+    await conn.query('INSTALL vector');
+    console.log('Vector extension installed');
+  } catch (err) {
+    console.error('Vector install failed:', err.message);
+    process.exit(1);
+  }
+})();

--- a/.github/workflows/gitnexus-deploy.yml
+++ b/.github/workflows/gitnexus-deploy.yml
@@ -102,6 +102,7 @@ jobs:
           cp .fly/gitnexus/Dockerfile deploy/Dockerfile
           cp .fly/gitnexus/Caddyfile deploy/Caddyfile
           cp .fly/gitnexus/entrypoint.sh deploy/entrypoint.sh
+          cp .fly/gitnexus/install-extensions.js deploy/install-extensions.js
           echo "Deploy context:"
           ls -la deploy/
           echo "Indexes staged:"


### PR DESCRIPTION
## Summary

I fixed the GitNexus MCP server's \`query()\` tool silently returning empty results for every search — including exact function name matches — while \`context()\`, \`cypher()\`, and \`route_map()\` continued working. Traced this to two upstream bugs in GitNexus 1.5.3's \`pool-adapter.ts\` that combine to nullify both legs of hybrid search.

- Add \`install-extensions.js\` that runs \`INSTALL fts\` and \`INSTALL vector\` against a throwaway LadybugDB during Docker build, populating \`~/.kuzu/extension/\` with the cached extension binaries so runtime \`LOAD EXTENSION\` calls actually find something.
- Sed-patch the globally-installed \`pool-adapter.js\` to also \`LOAD EXTENSION vector\` alongside the existing \`LOAD EXTENSION fts\` call, wrapped in try/catch to match upstream's defensive pattern.
- Update the deploy workflow's prepare-context step to copy \`install-extensions.js\` into the build directory alongside the other Fly config files.

### Root cause

**Bug 1 — FTS extension never installed in serve mode.** \`pool-adapter.ts\` calls \`LOAD EXTENSION fts\` at pool init but never \`INSTALL fts\`. LadybugDB caches installed extensions per-user in \`~/.kuzu/extension/\`. During \`gitnexus analyze\` in CI, the extension gets installed and cached — but that cache lives on the CI runner's filesystem, not in the \`.gitnexus/\` artifact that gets uploaded. When the Fly container starts, \`~/.kuzu/extension/\` is empty, \`LOAD\` fails silently, and every FTS query returns empty. The upstream comment literally says *\"Extension may not be installed — FTS queries will fail gracefully\"*.

**Bug 2 — Vector extension never loaded in serve mode at all.** \`pool-adapter.ts\` only loads FTS. There is no \`LOAD EXTENSION vector\` anywhere in the serve path. \`LOAD EXTENSION VECTOR\` only exists in \`embedding-pipeline.ts\` which runs during analyze, not serve. So even when vector indexes exist in the database and embeddings are populated, every \`CALL QUERY_VECTOR_INDEX\` at serve time fails because the extension was never loaded on that connection.

**Combined effect.** \`query()\` uses hybrid search (BM25 + semantic) merged via reciprocal rank fusion. Both sources return empty → merged result empty → \`query()\` returns \`{processes: [], process_symbols: [], definitions: []}\`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Merge and verify the deploy workflow builds the new image successfully (the sed patch logs confirmation and the \`grep -q\` guard fails the build if the target line disappeared upstream).
2. Once deployed, hit the MCP \`query\` tool against \`librechat-gitnexus.fly.dev\` with an exact function name (e.g. \`loginController\`) and verify non-empty results.
3. Verify hybrid search ranking by querying a conceptual term (e.g. \`\"authentication flow\"\`) — semantic matches should now appear alongside keyword matches.
4. Check Fly logs for the \`pool-adapter.js patched\` message during build and no warnings about missing extensions at startup.

### **Test Configuration**:

- Fly.io: \`shared-cpu-1x\`, 1GB, IAD region (with 512MB swap)
- GitNexus: \`1.5.3\` via \`npm install -g\`
- LadybugDB: \`@ladybugdb/core\` bundled with gitnexus

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings