### PR TITLE
📑 fix: Alias Mimetype `text/x-markdown` to `text/markdown`

### DIFF
--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -19,6 +19,10 @@ describe('inferMimeType', () => {
     expect(inferMimeType('test.py', 'text/x-python-script')).toBe('text/x-python');
   });
 
+  it('should normalize text/x-markdown to text/markdown', () => {
+    expect(inferMimeType('test.md', 'text/x-markdown')).toBe('text/markdown');
+  });
+
   it('should return a type that matches textMimeTypes after normalization', () => {
     const normalized = inferMimeType('test.py', 'text/x-python-script');
     expect(textMimeTypes.test(normalized)).toBe(true);
@@ -45,8 +49,17 @@ describe('inferMimeType', () => {
     expect(baseFileConfig.checkType(normalized)).toBe(true);
   });
 
+  it('should produce a type accepted by checkType after normalizing text/x-markdown', () => {
+    const normalized = inferMimeType('test.md', 'text/x-markdown');
+    expect(baseFileConfig.checkType(normalized)).toBe(true);
+  });
+
   it('should reject raw text/x-python-script without normalization', () => {
     expect(baseFileConfig.checkType('text/x-python-script')).toBe(false);
+  });
+
+  it('should reject raw text/x-markdown without normalization', () => {
+    expect(baseFileConfig.checkType('text/x-markdown')).toBe(false);
   });
 });
 

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -362,6 +362,7 @@ export const imageTypeMapping: { [key: string]: string } = {
 /** Normalizes non-standard MIME types that browsers may report to their canonical forms */
 export const mimeTypeAliases: Readonly<Record<string, string>> = {
   'text/x-python-script': 'text/x-python',
+  'text/x-markdown': 'text/markdown',
 };
 
 /**


### PR DESCRIPTION
## Summary

text/x-markdown is a deprecated version of a markdown mimetype, but we're seeing that sometimes users still send this mimetype. This change allows these files to be uploaded as text/markdown.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I added unit tests to verify that the `inferMimeType()` function will work correctly with `text/x-markdown`.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes