### PR TITLE
🩹 chore: Correct lbug-adapter Path for GitNexus Vector Extension Patch

### DIFF
--- a/.fly/gitnexus/Dockerfile
+++ b/.fly/gitnexus/Dockerfile
@@ -26,13 +26,16 @@ RUN echo "deb http://deb.debian.org/debian trixie main" > /etc/apt/sources.list.
 COPY install-extensions.js /tmp/install-extensions.js
 RUN node /tmp/install-extensions.js && rm -rf /tmp/install-extensions.js /tmp/lbug-ext-install
 
-# 4. Patch pool-adapter.js to also LOAD EXTENSION vector after FTS.
+# 4. Patch mcp/core/lbug-adapter.js to also LOAD EXTENSION vector after FTS.
 #    Upstream only loads FTS at serve time; without vector extension
 #    loaded, semantic search's CALL QUERY_VECTOR_INDEX fails silently.
-RUN POOL_ADAPTER=/usr/local/lib/node_modules/gitnexus/dist/core/lbug/pool-adapter.js \
-    && grep -q "LOAD EXTENSION fts" "$POOL_ADAPTER" \
-    && sed -i "s|await available\[0\]\.query('LOAD EXTENSION fts');|await available[0].query('LOAD EXTENSION fts'); try { await available[0].query('LOAD EXTENSION vector'); } catch (e) { /* vector extension may not be installed */ }|g" "$POOL_ADAPTER" \
-    && echo "pool-adapter.js patched to load vector extension"
+#    Note: the published npm package compiles the source pool-adapter.ts
+#    to dist/mcp/core/lbug-adapter.js (not a 'pool-adapter.js' file).
+RUN LBUG_ADAPTER=/usr/local/lib/node_modules/gitnexus/dist/mcp/core/lbug-adapter.js \
+    && grep -q "LOAD EXTENSION fts" "$LBUG_ADAPTER" \
+    && sed -i "s|await available\[0\]\.query('LOAD EXTENSION fts');|await available[0].query('LOAD EXTENSION fts'); try { await available[0].query('LOAD EXTENSION vector'); } catch (e) { /* vector extension may not be installed */ }|g" "$LBUG_ADAPTER" \
+    && grep -c "LOAD EXTENSION vector" "$LBUG_ADAPTER" \
+    && echo "lbug-adapter.js patched to load vector extension"
 
 # Copy pre-built GitNexus indexes (one per branch) and register each.
 # The directory name becomes the repo name in `list_repos` output, so


### PR DESCRIPTION
## Summary

I fixed the GitNexus Deploy Docker build failing with \`grep: /usr/local/lib/node_modules/gitnexus/dist/core/lbug/pool-adapter.js: No such file or directory\` after PR #12607.

- Point the sed patch at \`dist/mcp/core/lbug-adapter.js\` — the actual compiled output path in the published \`gitnexus@1.5.3\` npm package. The source file is \`pool-adapter.ts\` but the build process emits it under \`mcp/core/\` with the renamed basename.
- Add a \`grep -c "LOAD EXTENSION vector"\` verification step after the sed call so the build fails loudly if the replacement didn't land (instead of silently producing a broken image).

### Root cause

PR #12607 guessed the compiled path based on the TypeScript source layout. I inspected the actual published \`gitnexus-1.5.3.tgz\` tarball and confirmed the correct path is \`package/dist/mcp/core/lbug-adapter.js\`. Both \`LOAD EXTENSION fts\` call sites (lines 256 and 316) are in that file.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Merge and watch the GitNexus Deploy workflow run.
2. Verify the build log shows \`lbug-adapter.js patched to load vector extension\` and the \`grep -c\` returns a non-zero match count.
3. Once deployed, query the MCP server with an exact function name — should return results now that both FTS install and vector extension load are wired up correctly.

### **Test Configuration**:

- Fly.io: \`shared-cpu-1x\`, 1GB, IAD region
- GitNexus: \`1.5.3\`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings