### PR TITLE
fix: clear stale client registration on invalid_client during token refresh

### DIFF
--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -264,6 +264,7 @@ export class MCPConnectionFactory {
             findToken: this.tokenMethods!.findToken!,
             createToken: this.tokenMethods!.createToken,
             updateToken: this.tokenMethods!.updateToken,
+            deleteTokens: this.tokenMethods!.deleteTokens,
             refreshTokens: this.createRefreshTokensFunction(),
           });
         },

--- a/packages/api/src/mcp/oauth/tokens.ts
+++ b/packages/api/src/mcp/oauth/tokens.ts
@@ -5,10 +5,12 @@ import type { MCPOAuthTokens, ExtendedOAuthTokens, OAuthMetadata } from './types
 import { isSystemUserId } from '~/mcp/enum';
 
 export class ReauthenticationRequiredError extends Error {
-  constructor(serverName: string, reason: 'expired' | 'missing') {
-    super(
-      `Re-authentication required for "${serverName}": access token ${reason} and no refresh token available`,
-    );
+  constructor(serverName: string, reason: 'expired' | 'missing' | 'invalid_client') {
+    const detail =
+      reason === 'invalid_client'
+        ? 'stored client registration is no longer valid'
+        : `access token ${reason} and no refresh token available`;
+    super(`Re-authentication required for "${serverName}": ${detail}`);
     this.name = 'ReauthenticationRequiredError';
   }
 }
@@ -47,6 +49,7 @@ interface GetTokensParams {
   ) => Promise<MCPOAuthTokens>;
   createToken?: TokenMethods['createToken'];
   updateToken?: TokenMethods['updateToken'];
+  deleteTokens?: TokenMethods['deleteTokens'];
 }
 
 export class MCPTokenStorage {
@@ -254,6 +257,7 @@ export class MCPTokenStorage {
     findToken,
     createToken,
     updateToken,
+    deleteTokens,
     refreshTokens,
   }: GetTokensParams): Promise<MCPOAuthTokens | null> {
     const logPrefix = this.getLogPrefix(userId, serverName);
@@ -389,6 +393,19 @@ export class MCPTokenStorage {
             logger.info(
               `${logPrefix} Server does not support refresh tokens for this client. New authentication required.`,
             );
+          }
+          if (errorMessage.includes('invalid_client') && deleteTokens) {
+            logger.info(
+              `${logPrefix} Client registration rejected during token refresh, clearing stale registration`,
+            );
+            await MCPTokenStorage.deleteClientRegistration({
+              userId,
+              serverName,
+              deleteTokens,
+            }).catch((err) => {
+              logger.warn(`${logPrefix} Failed to clear stale client registration`, err);
+            });
+            throw new ReauthenticationRequiredError(serverName, 'invalid_client');
           }
           return null;
         }


### PR DESCRIPTION
## Summary

- When a token refresh fails with `invalid_client`, clear the stale DCR client registration from the database and throw `ReauthenticationRequiredError` to trigger a fresh OAuth flow
- The existing error handler only checked for `unauthorized_client`, leaving stale `invalid_client` registrations cached permanently
- Passes `deleteTokens` from `MCPConnectionFactory` to `getTokens()` so the cleanup has access to the token deletion method

## Context

We observed this in production with MCP servers that use Dynamic Client Registration (RFC 7591). DCR client registrations stored in Redis became invalid, but LibreChat's token refresh handler didn't recognize `invalid_client` as a recoverable error. Users were permanently stuck — every token refresh attempt reused the same stale `client_id` and failed with:

```
Token refresh failed: 401 Unauthorized - {"error":"invalid_client","error_description":"Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method)."}
```

The `clearStaleClientIfRejected` logic in `MCPConnectionFactory` (added in #12563) doesn't catch this case because `getTokens()` returns `null` on refresh failure rather than throwing, so the error never propagates to the factory's handler.

## Changes

- `tokens.ts`: Detect `invalid_client` in the refresh error handler, call `deleteClientRegistration()`, and throw `ReauthenticationRequiredError` with new `'invalid_client'` reason
- `tokens.ts`: Add `deleteTokens` to `GetTokensParams` interface
- `MCPConnectionFactory.ts`: Pass `deleteTokens` to `getTokens()` call

## Test plan

Tested against MCP servers with DCR:

1. Connected to GitHub MCP successfully, confirming a valid DCR client registration was stored
2. Corrupted the stored `client_id` to a bogus UUID directly in the database to simulate a stale registration
3. Deleted the stored access token to force a token refresh using the corrupted client_id
4. Reinitialized GitHub MCP — LibreChat attempted to refresh with the corrupted client_id, received `invalid_client`, cleared the stale registration, and automatically completed a fresh DCR registration
5. Verified the stored `client_id` was replaced with a new valid UUID and the connection was working