### PR TITLE
fix: agent builder file upload ignores fileConfig when config hasn't loaded

### DIFF
--- a/client/src/hooks/Files/useFileHandling.ts
+++ b/client/src/hooks/Files/useFileHandling.ts
@@ -275,23 +275,28 @@ const useFileHandlingCore = (params: UseFileHandling | undefined, fileState: Fil
   const handleFiles = async (_files: FileList | File[], _toolResource?: string) => {
     abortControllerRef.current = new AbortController();
     const fileList = Array.from(_files);
-    /* Validate files */
+    /* Validate files — skip client-side validation when fileConfig hasn't loaded yet;
+       server-side validation will still enforce limits */
     let filesAreValid: boolean;
     try {
-      const endpointFileConfig = getEndpointFileConfig({
-        endpoint,
-        fileConfig,
-        endpointType,
-      });
+      if (fileConfig != null) {
+        const endpointFileConfig = getEndpointFileConfig({
+          endpoint,
+          fileConfig,
+          endpointType,
+        });
 
-      filesAreValid = validateFiles({
-        files,
-        fileList,
-        setError,
-        fileConfig,
-        endpointFileConfig,
-        toolResource: _toolResource,
-      });
+        filesAreValid = validateFiles({
+          files,
+          fileList,
+          setError,
+          fileConfig,
+          endpointFileConfig,
+          toolResource: _toolResource,
+        });
+      } else {
+        filesAreValid = true;
+      }
     } catch (error) {
       console.error('file validation error', error);
       setError('com_error_files_validation');


### PR DESCRIPTION
## Summary

Fixes agent builder file upload enforcing hardcoded `fileLimit: 10` instead of respecting the user's `librechat.yaml` configuration.

## Root Cause

In `client/src/hooks/Files/useFileHandling.ts`, the `useGetFileConfig` React Query hook defaults to `null` before the query resolves:

```ts
const { data: fileConfig = null } = useGetFileConfig({ ... });
```

When `handleFiles` is called and `fileConfig` is still `null`, `getEndpointFileConfig()` hits the early return:

```ts
if (!mergedFileConfig?.endpoints) {
    return fileConfig.endpoints.default; // hardcoded fileLimit: 10
}
```

This ignores the user's configured `fileConfig.endpoints.agents.fileLimit` (e.g., 50).

## Fix

Skip client-side file validation when `fileConfig` is null. Server-side validation still enforces limits.

## Test plan

- [ ] Set `fileConfig.endpoints.agents.fileLimit: 50` in `librechat.yaml`, upload > 10 files to agent File Search — should succeed

Fixes #11515

🤖 Generated with [Claude Code](https://claude.com/claude-code)