### PR TITLE
🏗️ chore: Set Up Docker Buildx for GitNexus Image GHA Cache Export

### DIFF
--- a/.github/workflows/gitnexus-deploy-do.yml
+++ b/.github/workflows/gitnexus-deploy-do.yml
@@ -111,6 +111,10 @@ jobs:
         id: tag
         run: echo "value=v${{ env.GITNEXUS_VERSION }}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         if: steps.changes.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary

I fixed the GitNexus Deploy Docker build failing on main with \`ERROR: Cache export is not supported for the docker driver\`.

- Add a \`docker/setup-buildx-action@v3\` step before the GHCR login so \`docker/build-push-action@v5\` has a builder that supports \`cache-to: type=gha\`
- Gated on the same condition as the build step so it only runs when an image rebuild is actually needed

### Root cause

The default Docker setup on GitHub's \`ubuntu-latest\` runners uses the classic \`docker\` driver, which can pull images and build them but cannot export build cache to external backends like GHA Actions cache. \`docker/build-push-action@v5\` with \`cache-to: type=gha,mode=max\` requires a driver that supports cache export — \`docker-container\` is the default when \`setup-buildx-action\` runs without arguments, so adding that one step is enough.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Merge
2. Manually dispatch \`GitNexus Deploy (DigitalOcean)\` from \`main\`
3. Verify the \`build-image\` job now succeeds, pushes to GHCR, and completes the \`deploy\` job