### PR TITLE
feat: add branding capability and disableProviderUpload per-endpoint config

### DIFF
--- a/api/server/routes/__tests__/config.spec.js
+++ b/api/server/routes/__tests__/config.spec.js
@@ -16,8 +16,15 @@ jest.mock('~/server/middleware/roles/capabilities', () => ({
 
 const mockGetTenantId = jest.fn(() => undefined);
 jest.mock('@librechat/data-schemas', () => ({
-  ...jest.requireActual('@librechat/data-schemas'),
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+  },
   getTenantId: (...args) => mockGetTenantId(...args),
+  SystemCapabilities: {
+    ACCESS_ADMIN: 'ACCESS_ADMIN',
+  },
 }));
 
 const request = require('supertest');
@@ -43,6 +50,10 @@ const baseAppConfig = {
     privacyPolicy: { externalUrl: 'https://example.com/privacy' },
     termsOfService: { externalUrl: 'https://example.com/tos' },
     modelSelect: true,
+  },
+  brandingConfig: {
+    authLogo: '/assets/auth-logo.svg',
+    ui: { hideProviderUploadForEndpoints: ['openAI'] },
   },
   turnstileConfig: { siteKey: 'test-key' },
   modelSpecs: { list: [{ name: 'test-spec' }] },
@@ -148,6 +159,15 @@ describe('GET /api/config', () => {
 
       expect(response.body.socialLogins).toEqual(['google', 'github']);
       expect(response.body.turnstile).toEqual({ siteKey: 'test-key' });
+    });
+
+    it('should include branding from base config', async () => {
+      mockGetAppConfig.mockResolvedValue(baseAppConfig);
+      const app = createApp(null);
+
+      const response = await request(app).get('/api/config');
+
+      expect(response.body.branding).toEqual(baseAppConfig.brandingConfig);
     });
 
     it('should include only privacyPolicy and termsOfService from interface config', async () => {
@@ -276,6 +296,15 @@ describe('GET /api/config', () => {
       const response = await request(app).get('/api/config');
 
       expect(response.body.interface).toEqual(baseAppConfig.interfaceConfig);
+    });
+
+    it('should include branding config for authenticated users', async () => {
+      mockGetAppConfig.mockResolvedValue(baseAppConfig);
+      const app = createApp(mockUser);
+
+      const response = await request(app).get('/api/config');
+
+      expect(response.body.branding).toEqual(baseAppConfig.brandingConfig);
     });
 
     it('should include authenticated-only env var fields', async () => {

--- a/api/server/routes/config.js
+++ b/api/server/routes/config.js
@@ -129,6 +129,7 @@ router.get('/', async function (req, res) {
         ...sharedPayload,
         socialLogins: baseConfig?.registration?.socialLogins ?? defaultSocialLogins,
         turnstile: baseConfig?.turnstileConfig,
+        branding: baseConfig?.brandingConfig,
       };
 
       const interfaceConfig = baseConfig?.interfaceConfig;
@@ -159,6 +160,7 @@ router.get('/', async function (req, res) {
       socialLogins: appConfig?.registration?.socialLogins ?? defaultSocialLogins,
       interface: appConfig?.interfaceConfig,
       turnstile: appConfig?.turnstileConfig,
+      branding: appConfig?.brandingConfig,
       modelSpecs: appConfig?.modelSpecs,
       balance: balanceConfig,
       bundlerURL: process.env.SANDPACK_BUNDLER_URL,

--- a/client/src/components/Auth/AuthLayout.tsx
+++ b/client/src/components/Auth/AuthLayout.tsx
@@ -25,6 +25,8 @@ function AuthLayout({
   error: TranslationKeys | null;
 }) {
   const localize = useLocalize();
+  const authLogo =
+    startupConfig?.branding?.authLogo ?? startupConfig?.branding?.appLogo ?? 'assets/logo.svg';
 
   const hasStartupConfigError = startupConfigError !== null && startupConfigError !== undefined;
   const DisplayError = () => {
@@ -62,7 +64,7 @@ function AuthLayout({
       <BlinkAnimation active={isFetching}>
         <div className="mt-6 h-10 w-full bg-cover">
           <img
-            src="assets/logo.svg"
+            src={authLogo}
             className="h-full w-full object-contain"
             alt={localize('com_ui_logo', { 0: startupConfig?.appTitle ?? 'LibreChat' })}
           />

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -61,6 +61,8 @@ interface AttachFileMenuProps {
   conversation: TConversation | null;
 }
 
+const normalizeEndpointName = (value?: string | null) => value?.trim().toLowerCase();
+
 const AttachFileMenu = ({
   agentId,
   endpoint,
@@ -97,6 +99,7 @@ const AttachFileMenu = ({
   const { agentsConfig } = useGetAgentsConfig();
   const { data: startupConfig } = useGetStartupConfig();
   const sharePointEnabled = startupConfig?.sharePointFilePickerEnabled;
+  const hiddenProviderUploads = startupConfig?.branding?.ui?.hideProviderUploadForEndpoints ?? [];
 
   const [isSharePointDialogOpen, setIsSharePointDialogOpen] = useState(false);
 
@@ -154,12 +157,19 @@ const AttachFileMenu = ({
 
       const isAzureWithResponsesApi =
         currentProvider === EModelEndpoint.azureOpenAI && useResponsesApi;
+      const normalizedProvider = normalizeEndpointName(currentProvider);
+      const normalizedEndpointType = normalizeEndpointName(endpointType);
+      const hideProviderUpload = hiddenProviderUploads.some((entry) => {
+        const normalizedEntry = normalizeEndpointName(entry);
+        return normalizedEntry === normalizedProvider || normalizedEntry === normalizedEndpointType;
+      });
+      const canUploadToProvider =
+        !hideProviderUpload &&
+        (isDocumentSupportedProvider(endpointType) ||
+          isDocumentSupportedProvider(currentProvider) ||
+          isAzureWithResponsesApi);
 
-      if (
-        isDocumentSupportedProvider(endpointType) ||
-        isDocumentSupportedProvider(currentProvider) ||
-        isAzureWithResponsesApi
-      ) {
+      if (canUploadToProvider) {
         items.push({
           label: localize('com_ui_upload_provider'),
           onClick: () => {
@@ -260,6 +270,7 @@ const AttachFileMenu = ({
     setToolResource,
     setEphemeralAgent,
     sharePointEnabled,
+    hiddenProviderUploads,
     codeAllowedByAgent,
     fileSearchAllowedByAgent,
     setIsSharePointDialogOpen,

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -99,7 +99,7 @@ const AttachFileMenu = ({
   const { agentsConfig } = useGetAgentsConfig();
   const { data: startupConfig } = useGetStartupConfig();
   const sharePointEnabled = startupConfig?.sharePointFilePickerEnabled;
-  const hiddenProviderUploads = startupConfig?.branding?.ui?.hideProviderUploadForEndpoints ?? [];
+  const hiddenProviderUploads = startupConfig?.interface?.hideProviderUploadForEndpoints ?? [];
 
   const [isSharePointDialogOpen, setIsSharePointDialogOpen] = useState(false);
 

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -61,7 +61,6 @@ interface AttachFileMenuProps {
   conversation: TConversation | null;
 }
 
-const normalizeEndpointName = (value?: string | null) => value?.trim().toLowerCase();
 
 const AttachFileMenu = ({
   agentId,
@@ -99,7 +98,6 @@ const AttachFileMenu = ({
   const { agentsConfig } = useGetAgentsConfig();
   const { data: startupConfig } = useGetStartupConfig();
   const sharePointEnabled = startupConfig?.sharePointFilePickerEnabled;
-  const hiddenProviderUploads = startupConfig?.interface?.hideProviderUploadForEndpoints ?? [];
 
   const [isSharePointDialogOpen, setIsSharePointDialogOpen] = useState(false);
 
@@ -157,14 +155,8 @@ const AttachFileMenu = ({
 
       const isAzureWithResponsesApi =
         currentProvider === EModelEndpoint.azureOpenAI && useResponsesApi;
-      const normalizedProvider = normalizeEndpointName(currentProvider);
-      const normalizedEndpointType = normalizeEndpointName(endpointType);
-      const hideProviderUpload = hiddenProviderUploads.some((entry) => {
-        const normalizedEntry = normalizeEndpointName(entry);
-        return normalizedEntry === normalizedProvider || normalizedEntry === normalizedEndpointType;
-      });
       const canUploadToProvider =
-        !hideProviderUpload &&
+        !endpointFileConfig?.disableProviderUpload &&
         (isDocumentSupportedProvider(endpointType) ||
           isDocumentSupportedProvider(currentProvider) ||
           isAzureWithResponsesApi);
@@ -270,7 +262,7 @@ const AttachFileMenu = ({
     setToolResource,
     setEphemeralAgent,
     sharePointEnabled,
-    hiddenProviderUploads,
+    endpointFileConfig,
     codeAllowedByAgent,
     fileSearchAllowedByAgent,
     setIsSharePointDialogOpen,

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
@@ -114,10 +114,8 @@ function setupMocks(overrides: { provider?: string } = {}) {
   mockUseGetStartupConfig.mockReturnValue({
     data: {
       sharePointFilePickerEnabled: false,
-      branding: {
-        ui: {
-          hideProviderUploadForEndpoints: [],
-        },
+      interface: {
+        hideProviderUploadForEndpoints: [],
       },
     },
   });
@@ -211,7 +209,7 @@ describe('AttachFileMenu', () => {
       expect(screen.getByText('Upload Image')).toBeInTheDocument();
     });
 
-    it('hides "Upload to Provider" when branding disables it for the current provider', () => {
+    it('hides "Upload to Provider" when interface config disables it for the current provider', () => {
       setupMocks({ provider: EModelEndpoint.openAI });
       mockUseAgentCapabilities.mockReturnValue({
         contextEnabled: true,
@@ -221,10 +219,8 @@ describe('AttachFileMenu', () => {
       mockUseGetStartupConfig.mockReturnValue({
         data: {
           sharePointFilePickerEnabled: false,
-          branding: {
-            ui: {
-              hideProviderUploadForEndpoints: [EModelEndpoint.openAI],
-            },
+          interface: {
+            hideProviderUploadForEndpoints: [EModelEndpoint.openAI],
           },
         },
       });

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
@@ -27,35 +27,40 @@ jest.mock('~/components/SharePoint', () => ({
   SharePointPickerDialog: () => null,
 }));
 
-jest.mock('@librechat/client', () => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const R = require('react');
-  return {
-    FileUpload: (props) => R.createElement('div', { 'data-testid': 'file-upload' }, props.children),
-    TooltipAnchor: (props) => props.render,
-    DropdownPopup: (props) =>
-      R.createElement(
-        'div',
-        null,
-        R.createElement('div', { onClick: () => props.setIsOpen(!props.isOpen) }, props.trigger),
-        props.isOpen &&
-          R.createElement(
-            'div',
-            { 'data-testid': 'dropdown-menu' },
-            props.items.map((item, idx) =>
-              R.createElement(
-                'button',
-                { key: idx, onClick: item.onClick, 'data-testid': `menu-item-${idx}` },
-                item.label,
+jest.mock(
+  '@librechat/client',
+  () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const R = require('react');
+    return {
+      FileUpload: (props) =>
+        R.createElement('div', { 'data-testid': 'file-upload' }, props.children),
+      TooltipAnchor: (props) => props.render,
+      DropdownPopup: (props) =>
+        R.createElement(
+          'div',
+          null,
+          R.createElement('div', { onClick: () => props.setIsOpen(!props.isOpen) }, props.trigger),
+          props.isOpen &&
+            R.createElement(
+              'div',
+              { 'data-testid': 'dropdown-menu' },
+              props.items.map((item, idx) =>
+                R.createElement(
+                  'button',
+                  { key: idx, onClick: item.onClick, 'data-testid': `menu-item-${idx}` },
+                  item.label,
+                ),
               ),
             ),
-          ),
-      ),
-    AttachmentIcon: () => R.createElement('span', { 'data-testid': 'attachment-icon' }),
-    SharePointIcon: () => R.createElement('span', { 'data-testid': 'sharepoint-icon' }),
-    useToastContext: () => ({ showToast: jest.fn() }),
-  };
-});
+        ),
+      AttachmentIcon: () => R.createElement('span', { 'data-testid': 'attachment-icon' }),
+      SharePointIcon: () => R.createElement('span', { 'data-testid': 'sharepoint-icon' }),
+      useToastContext: () => ({ showToast: jest.fn() }),
+    };
+  },
+  { virtual: true },
+);
 
 jest.mock('@ariakit/react', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -106,7 +111,16 @@ function setupMocks(overrides: { provider?: string } = {}) {
   };
   mockUseSharePointFileHandling.mockReturnValue(sharePointReturnValue);
   mockUseSharePointFileHandlingNoChatContext.mockReturnValue(sharePointReturnValue);
-  mockUseGetStartupConfig.mockReturnValue({ data: { sharePointFilePickerEnabled: false } });
+  mockUseGetStartupConfig.mockReturnValue({
+    data: {
+      sharePointFilePickerEnabled: false,
+      branding: {
+        ui: {
+          hideProviderUploadForEndpoints: [],
+        },
+      },
+    },
+  });
   mockUseAgentToolPermissions.mockReturnValue({
     fileSearchAllowedByAgent: false,
     codeAllowedByAgent: false,
@@ -195,6 +209,29 @@ describe('AttachFileMenu', () => {
       renderMenu({ endpointType: EModelEndpoint.azureOpenAI, useResponsesApi: false });
       openMenu();
       expect(screen.getByText('Upload Image')).toBeInTheDocument();
+    });
+
+    it('hides "Upload to Provider" when branding disables it for the current provider', () => {
+      setupMocks({ provider: EModelEndpoint.openAI });
+      mockUseAgentCapabilities.mockReturnValue({
+        contextEnabled: true,
+        fileSearchEnabled: false,
+        codeEnabled: false,
+      });
+      mockUseGetStartupConfig.mockReturnValue({
+        data: {
+          sharePointFilePickerEnabled: false,
+          branding: {
+            ui: {
+              hideProviderUploadForEndpoints: [EModelEndpoint.openAI],
+            },
+          },
+        },
+      });
+      renderMenu({ endpointType: EModelEndpoint.openAI });
+      openMenu();
+      expect(screen.queryByText('Upload to Provider')).not.toBeInTheDocument();
+      expect(screen.getByText('Upload as Text')).toBeInTheDocument();
     });
   });
 

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
@@ -114,9 +114,6 @@ function setupMocks(overrides: { provider?: string } = {}) {
   mockUseGetStartupConfig.mockReturnValue({
     data: {
       sharePointFilePickerEnabled: false,
-      interface: {
-        hideProviderUploadForEndpoints: [],
-      },
     },
   });
   mockUseAgentToolPermissions.mockReturnValue({
@@ -209,22 +206,17 @@ describe('AttachFileMenu', () => {
       expect(screen.getByText('Upload Image')).toBeInTheDocument();
     });
 
-    it('hides "Upload to Provider" when interface config disables it for the current provider', () => {
+    it('hides "Upload to Provider" when endpointFileConfig.disableProviderUpload is true', () => {
       setupMocks({ provider: EModelEndpoint.openAI });
       mockUseAgentCapabilities.mockReturnValue({
         contextEnabled: true,
         fileSearchEnabled: false,
         codeEnabled: false,
       });
-      mockUseGetStartupConfig.mockReturnValue({
-        data: {
-          sharePointFilePickerEnabled: false,
-          interface: {
-            hideProviderUploadForEndpoints: [EModelEndpoint.openAI],
-          },
-        },
+      renderMenu({
+        endpointType: EModelEndpoint.openAI,
+        endpointFileConfig: { disableProviderUpload: true },
       });
-      renderMenu({ endpointType: EModelEndpoint.openAI });
       openMenu();
       expect(screen.queryByText('Upload to Provider')).not.toBeInTheDocument();
       expect(screen.getByText('Upload as Text')).toBeInTheDocument();

--- a/client/src/hooks/Config/useAppStartup.ts
+++ b/client/src/hooks/Config/useAppStartup.ts
@@ -3,11 +3,22 @@ import { useRecoilState } from 'recoil';
 import TagManager from 'react-gtm-module';
 import { LocalStorageKeys, PermissionTypes, Permissions } from 'librechat-data-provider';
 import type { TStartupConfig, TUser } from 'librechat-data-provider';
+import { isDark, useTheme } from '@librechat/client';
 import { useMCPToolsQuery, useMCPServersQuery } from '~/data-provider';
 import { cleanupTimestampedStorage } from '~/utils/timestamps';
 import useSpeechSettingsInit from './useSpeechSettingsInit';
 import { useHasAccess } from '~/hooks';
 import store from '~/store';
+
+function setHeadTag(selector: string, attribute: string, value?: string) {
+  if (!value) {
+    return;
+  }
+  const element = document.head.querySelector(selector);
+  if (element) {
+    element.setAttribute(attribute, value);
+  }
+}
 
 export default function useAppStartup({
   startupConfig,
@@ -17,6 +28,7 @@ export default function useAppStartup({
   user?: TUser;
 }) {
   const [defaultPreset, setDefaultPreset] = useRecoilState(store.defaultPreset);
+  const { theme, setThemeRGB } = useTheme();
   const canUseMcp = useHasAccess({
     permissionType: PermissionTypes.MCP_SERVERS,
     permission: Permissions.USE,
@@ -43,13 +55,47 @@ export default function useAppStartup({
 
   /** Set the app title */
   useEffect(() => {
-    const appTitle = startupConfig?.appTitle ?? '';
+    const appTitle = startupConfig?.branding?.meta?.title ?? startupConfig?.appTitle ?? '';
     if (!appTitle) {
       return;
     }
     document.title = appTitle;
     localStorage.setItem(LocalStorageKeys.APP_TITLE, appTitle);
-  }, [startupConfig]);
+  }, [startupConfig?.appTitle, startupConfig?.branding?.meta?.title]);
+
+  /** Apply runtime branding metadata */
+  useEffect(() => {
+    const branding = startupConfig?.branding;
+    if (!branding) {
+      return;
+    }
+
+    setHeadTag('link[rel="icon"]', 'href', branding.favicon);
+    setHeadTag('meta[name="description"]', 'content', branding.meta?.description);
+    setHeadTag('meta[name="theme-color"]', 'content', branding.meta?.themeColor);
+  }, [
+    startupConfig?.branding,
+    startupConfig?.branding?.favicon,
+    startupConfig?.branding?.meta?.description,
+    startupConfig?.branding?.meta?.themeColor,
+  ]);
+
+  /** Apply tenant theme tokens through the existing ThemeProvider path */
+  useEffect(() => {
+    const themeConfig = startupConfig?.branding?.theme;
+    if (!themeConfig) {
+      return;
+    }
+
+    const palette = isDark(theme)
+      ? (themeConfig.dark ?? themeConfig.light)
+      : (themeConfig.light ?? themeConfig.dark);
+    if (!palette) {
+      return;
+    }
+
+    setThemeRGB(palette);
+  }, [setThemeRGB, startupConfig?.branding?.theme, theme]);
 
   /** Set the default spec's preset as default */
   useEffect(() => {

--- a/docs/plans/Whitelabling Capability Plan.md
+++ b/docs/plans/Whitelabling Capability Plan.md
@@ -4,278 +4,333 @@
 
 This plan covers only the **LibreChat fork** work required to add reusable white-label capabilities to LibreChat.
 
-This is **Phase 1** of the larger Umniah rollout and should be executed **before** the infra repo plan.
+This is the capability layer that tenant-specific rollouts, such as Umniah, should build on later.
 
-The broader program is:
-
-1. Phase 1: implement tenant-agnostic white-label capabilities in this fork
-2. Phase 2: configure and deploy those capabilities for Umniah in the infra repo on `umniah.ai.shqear.online`
+The goal is not to hardcode a tenant into the fork. The goal is to expose white-label extension points in a way that follows the patterns already established in this codebase.
 
 ---
 
-## Summary
+## Core Design Principle
 
-Use this fork as the source for generic white-label features that can later be configured for Umniah or any other tenant.
+White-label customization in this repo should be split into **two distinct mechanisms**, because the code already splits the product that way:
 
-The fork work should:
+1. **Runtime app configuration**
+   This is for in-app behavior and branding that can be resolved after the server starts and sent through startup config.
 
-- keep LibreChat’s supported config-driven customization where it already exists
-- patch source only where the product still hardcodes branding or unsupported UI behavior
-- produce a buildable LibreChat source tree with reusable white-label capabilities for infra to configure during deployment
+2. **Build-time shell branding**
+   This is for browser shell and static asset identity that must exist before `/api/config` is fetched.
 
-The output of this repo is not a tenant-branded app hardcoded for one customer. It is a reusable application variant that exposes the branding and behavior extension points infra needs.
+The plan must follow the architecture already present in the repo:
 
----
+- `custom config` -> `AppConfig` resolution -> `/api/config` -> frontend startup usage
+- Vite/env/public-assets for static shell identity and boot-time branding
+- ThemeProvider for dynamic color theme injection
 
-## Investigated Code Paths
+This means white-label capability should **not** be implemented as:
 
-The required customization points are already clear from the source:
-
-- [`client/src/components/Auth/AuthLayout.tsx`](/Users/shqear/workspace/LibreChat/client/src/components/Auth/AuthLayout.tsx)
-  - auth page logo is hardcoded as `assets/logo.svg`
-- [`client/index.html`](/Users/shqear/workspace/LibreChat/client/index.html)
-  - static title, description, browser theme color, favicon links are hardcoded
-- [`client/vite.config.ts`](/Users/shqear/workspace/LibreChat/client/vite.config.ts)
-  - PWA manifest identity and icons are hardcoded
-- [`client/src/style.css`](/Users/shqear/workspace/LibreChat/client/src/style.css)
-  - product-wide color tokens are defined here
-- [`client/src/components/Chat/Input/Files/AttachFileMenu.tsx`](/Users/shqear/workspace/LibreChat/client/src/components/Chat/Input/Files/AttachFileMenu.tsx)
-  - `Upload to Provider`, `Upload as Text`, and `File Search` menu items are explicitly built here
-- [`api/server/routes/config.js`](/Users/shqear/workspace/LibreChat/api/server/routes/config.js)
-  - startup config payload is assembled here
-- [`packages/data-provider/src/config.ts`](/Users/shqear/workspace/LibreChat/packages/data-provider/src/config.ts)
-  - startup config schema/types live here
-
-Also confirmed:
-
-- `APP_TITLE` is already supported through startup config
-- `interface.customWelcome` is already supported
-- `privacyPolicy`, `termsOfService`, and `customFooter` are already supported
-- `modelSpecs.iconURL`, labels, descriptions, grouping, and defaults are already supported
-
-So those do **not** need source-level reinvention.
+- tenant-specific hardcoding in components
+- a one-off `style.css` rewrite per customer
+- a separate parallel config mechanism unrelated to `getAppConfig`
 
 ---
 
-## Implementation Changes
+## What Is Already Supported
 
-### 1. Extend startup config for generic UI overrides
-
-Add a formal startup-config section for frontend behavior that is not currently configurable.
-
-Add a field like:
-
-```ts
-uiOverrides?: {
-  hideProviderUploadForEndpoints?: string[];
-}
-```
-
-Plumb it through:
-
-- [`packages/data-provider/src/config.ts`](/Users/shqear/workspace/LibreChat/packages/data-provider/src/config.ts)
-- [`api/server/routes/config.js`](/Users/shqear/workspace/LibreChat/api/server/routes/config.js)
-
-This should be a real part of `TStartupConfig`, not a local-only constant.
-
-### 2. Keep supported branding in runtime config
-
-Continue using supported runtime config for:
+These capabilities already exist and should remain runtime-config driven:
 
 - `APP_TITLE`
 - `interface.customWelcome`
-- `customFooter`
 - `privacyPolicy`
 - `termsOfService`
-- model labels/descriptions/defaults
-- model `iconURL`
-- auth and registration behavior
+- `customFooter`
+- `modelSpecs` labels, descriptions, defaults, grouping, and `iconURL`
+- auth and registration toggles
 
-This avoids unnecessary fork drift and keeps the white-label maintainable.
+Confirmed code paths:
 
-The fork should remain secret-free:
+- [`api/server/routes/config.js`](/Users/shqear/workspace/LibreChat/api/server/routes/config.js)
+- [`packages/data-provider/src/config.ts`](/Users/shqear/workspace/LibreChat/packages/data-provider/src/config.ts)
+- [`packages/api/src/app/service.ts`](/Users/shqear/workspace/LibreChat/packages/api/src/app/service.ts)
+- [`packages/data-schemas/src/app/resolution.ts`](/Users/shqear/workspace/LibreChat/packages/data-schemas/src/app/resolution.ts)
+- [`client/src/hooks/Config/useAppStartup.ts`](/Users/shqear/workspace/LibreChat/client/src/hooks/Config/useAppStartup.ts)
+- [`client/src/routes/Layouts/Startup.tsx`](/Users/shqear/workspace/LibreChat/client/src/routes/Layouts/Startup.tsx)
 
-- do not commit production secrets in this repo
-- do not introduce tenant-specific `UMNIAH_*` parsing in application code unless there is a strong reason
-- expect infra to provide standard LibreChat runtime env names such as `APP_TITLE`, `DOMAIN_CLIENT`, `DOMAIN_SERVER`, and OAuth settings
+These should not be reimplemented through source patching unless there is a concrete gap.
 
-Tenant isolation belongs in infra. The fork should stay as close as possible to normal LibreChat runtime expectations.
+---
 
-### 3. Replace hardcoded static assets with configurable branding assets
+## What Is Still Hardcoded
 
-Add a generic white-label asset mechanism under [`client/public/assets`](/Users/shqear/workspace/LibreChat/client/public/assets) and/or through runtime-configurable asset references.
+These areas are not cleanly exposed through existing runtime config today:
 
-The fork should support a full branded asset set such as:
+- auth logo
+  - [`client/src/components/Auth/AuthLayout.tsx`](/Users/shqear/workspace/LibreChat/client/src/components/Auth/AuthLayout.tsx)
+- HTML shell title, description, theme color, favicon tags
+  - [`client/index.html`](/Users/shqear/workspace/LibreChat/client/index.html)
+- PWA manifest identity and icons
+  - [`client/vite.config.ts`](/Users/shqear/workspace/LibreChat/client/vite.config.ts)
+- attachment menu behavior for `Upload to Provider`
+  - [`client/src/components/Chat/Input/Files/AttachFileMenu.tsx`](/Users/shqear/workspace/LibreChat/client/src/components/Chat/Input/Files/AttachFileMenu.tsx)
 
-- `logo.svg`
-- `favicon-16x16.png`
-- `favicon-32x32.png`
-- `apple-touch-icon-180x180.png`
-- `icon-192x192.png`
-- `maskable-icon.png`
+These are the correct targets for new capability work.
 
-These should be treated as white-label inputs, not as Umniah-only files baked permanently into the fork.
+---
 
-For the Umniah rollout specifically, the infra/execution work will source the initial branding inputs from:
+## Proper Capability Model
 
-- official Umniah branding from `umniah.com`
-- current palette signal from site investigation:
-  - `#323E48`
-  - `#CE0037`
-  - white and neutral grays
-- current logo source discovered from the official site:
-  - `https://www.umniah.com/storage/umnia-beyon-2.png`
+### 1. Add a formal `branding` config block
 
-If a proper SVG/brand kit becomes available, it should replace the temporary web-fetched source material.
+Do not keep expanding startup config with unrelated top-level fields like ad hoc `uiOverrides`.
 
-The fork requirement is to support branded assets cleanly. The Umniah-specific asset acquisition strategy is:
+Instead, add a real white-label block to custom config, then resolve it the same way the project already resolves `interface`, `mcpServers`, and `turnstile`.
 
-- fetch the current public Umniah logo and favicon-compatible source material from official Umniah web properties
-- treat `umniah.com` as the source of truth, with Logodix used only as a visual reference and not as the authoritative asset source
-- generate the initial app asset set from those web-fetched inputs
+Proposed shape at the custom-config level:
 
-The fork should make these deliverables possible:
+```ts
+branding?: {
+  appLogo?: string;
+  authLogo?: string;
+  favicon?: string;
+  theme?: {
+    light?: IThemeRGB;
+    dark?: IThemeRGB;
+  };
+  ui?: {
+    hideProviderUploadForEndpoints?: string[];
+  };
+  meta?: {
+    title?: string;
+    description?: string;
+    themeColor?: string;
+    pwaName?: string;
+    pwaShortName?: string;
+    pwaBackgroundColor?: string;
+    pwaThemeColor?: string;
+  };
+}
+```
 
-- `client/public/assets/logo.svg`
-- `client/public/assets/favicon-16x16.png`
-- `client/public/assets/favicon-32x32.png`
-- `client/public/assets/apple-touch-icon-180x180.png`
-- `client/public/assets/icon-192x192.png`
-- `client/public/assets/maskable-icon.png`
+This should be modeled as part of `TCustomConfig`, then resolved into `brandingConfig` on `AppConfig`, following the existing resolution pattern.
 
-The plan assumes the execution work for Umniah will fetch the latest usable public assets from the web, then normalize them into the required LibreChat asset formats before commit or packaging.
+Why this is the correct approach:
 
-### 4. Patch auth and shell branding to use configurable white-label identity
+- it fits `getAppConfig`
+- it fits DB overrides and tenant-specific merges
+- it gives infra a standard config contract
+- it keeps tenant data out of source code
 
-Update:
+### 2. Resolve branding through the existing app-config pipeline
 
-- [`client/src/components/Auth/AuthLayout.tsx`](/Users/shqear/workspace/LibreChat/client/src/components/Auth/AuthLayout.tsx)
-  - ensure auth uses a configurable logo source
-  - keep alt text based on runtime `appTitle`
+The project standard is:
+
+- load custom config
+- process it into `AppConfig`
+- merge override records
+- expose safe frontend fields in `/api/config`
+
+White-label capability should follow that exact pattern.
+
+Concretely:
+
+- extend `TCustomConfig` in [`packages/data-provider/src/config.ts`](/Users/shqear/workspace/LibreChat/packages/data-provider/src/config.ts)
+- extend `AppConfig` in [`packages/data-schemas/src/types/app.ts`](/Users/shqear/workspace/LibreChat/packages/data-schemas/src/types/app.ts)
+- add config-key remapping only if needed in [`packages/data-schemas/src/app/resolution.ts`](/Users/shqear/workspace/LibreChat/packages/data-schemas/src/app/resolution.ts)
+- ensure branding survives `mergeConfigOverrides` in [`packages/data-schemas/src/app/resolution.ts`](/Users/shqear/workspace/LibreChat/packages/data-schemas/src/app/resolution.ts)
+- expose a frontend-safe subset in [`api/server/routes/config.js`](/Users/shqear/workspace/LibreChat/api/server/routes/config.js)
+
+This is the realistic, standards-aligned path.
+
+---
+
+## Runtime Customization Strategy
+
+These capabilities should be controlled through startup config and not hardcoded in source.
+
+### A. In-app branding
+
+Use startup config for:
+
+- app title
+- welcome copy
+- footer content
+- privacy/terms links
+- model labels/descriptions/icons
+- auth behavior
+
+This is already aligned with the project.
+
+### B. UI behavior overrides
+
+Use branding UI config for things like:
+
+- hiding `Upload to Provider` on selected endpoints
+
+Implementation target:
+
+- [`client/src/components/Chat/Input/Files/AttachFileMenu.tsx`](/Users/shqear/workspace/LibreChat/client/src/components/Chat/Input/Files/AttachFileMenu.tsx)
+
+Required behavior:
+
+- if `startupConfig.branding.ui.hideProviderUploadForEndpoints` contains the current endpoint
+- then omit `com_ui_upload_provider`
+- while preserving:
+  - `com_ui_upload_ocr_text`
+  - `com_ui_upload_file_search`
+  - other valid menu items
+
+This should be driven from startup config because the component already reads startup config and that is consistent with the project’s frontend pattern.
+
+### C. Runtime theme colors
+
+Do not make `style.css` itself the tenant customization API.
+
+The repo already has a dynamic theme pipeline:
+
+- [`client/src/App.jsx`](/Users/shqear/workspace/LibreChat/client/src/App.jsx)
+- [`client/src/utils/getThemeFromEnv.js`](/Users/shqear/workspace/LibreChat/client/src/utils/getThemeFromEnv.js)
+- [`packages/client/src/theme/context/ThemeProvider.tsx`](/Users/shqear/workspace/LibreChat/packages/client/src/theme/context/ThemeProvider.tsx)
+- [`packages/client/src/theme/types/index.ts`](/Users/shqear/workspace/LibreChat/packages/client/src/theme/types/index.ts)
+
+The realistic white-label approach is:
+
+- keep `client/src/style.css` as the default fallback theme
+- support tenant theme colors via `branding.theme`
+- feed resolved theme colors into the frontend through startup config or a boot-time config bridge
+- use `ThemeProvider` to apply the tenant palette
+
+If the tenant palette must be available before login or before user state loads, use the same boot-time path consistently for all tenants rather than rewriting CSS per tenant.
+
+`style.css` should only be patched where the default token model is missing values, not as the main tenant-customization interface.
+
+---
+
+## Build-Time Customization Strategy
+
+Some branding must exist before the app fetches startup config. Those capabilities should be treated as **build-time shell branding**.
+
+### A. Static assets
+
+Use `client/public/assets` as the stable asset contract for:
+
+- logo
+- favicons
+- apple touch icon
+- PWA icons
+
+This is already how the app references these assets.
+
+Capability requirement:
+
+- make the app able to consume tenant-provided assets cleanly
+- do not hardcode Umniah-specific asset names into component logic
+
+### B. HTML shell metadata
+
+These belong to build-time inputs, not startup config:
+
+- HTML title fallback
+- meta description
+- browser `theme-color`
+- favicon tag paths
+
+Implementation targets:
+
 - [`client/index.html`](/Users/shqear/workspace/LibreChat/client/index.html)
-  - replace hardcoded title/description/theme-color defaults with configurable branding inputs
-  - point icon links at configurable branded assets
 - [`client/vite.config.ts`](/Users/shqear/workspace/LibreChat/client/vite.config.ts)
-  - support configurable PWA `name`
-  - support configurable `short_name`
-  - support configurable `theme_color`
-  - support configurable `background_color`
-  - point manifest icons at branded assets
 
-This covers:
+The white-label capability should make these values tenant-configurable at build time.
 
-- auth branding
-- browser tab identity
-- favicon identity
-- installed-app identity
+### C. Auth/app logos
 
-### 5. Patch theme tokens to support tenant branding
+`AuthLayout.tsx` currently points directly to `assets/logo.svg`.
 
-Update [`client/src/style.css`](/Users/shqear/workspace/LibreChat/client/src/style.css) so tenant branding colors can be represented at the token layer.
+The realistic capability is:
 
-Focus on:
+- keep the component simple
+- make the logo path come from resolved branding config when available
+- otherwise fall back to the default asset path
 
-- `--text-*`
-- `--surface-*`
-- `--header-*`
-- `--border-*`
-- `--ring-primary`
-- `--primary`
-- any remaining product accent tokens that currently assume LibreChat defaults
+This lets the capability follow the same runtime-config pattern while still using static assets.
 
-This is the correct place to apply white-label color treatment because the existing UI already consumes these variables broadly. The fork should expose the mechanism; infra chooses the actual tenant palette.
+---
 
-### 6. Hide `Upload to Provider` through generic endpoint-level UI controls
+## Concrete Implementation Work
 
-Patch [`client/src/components/Chat/Input/Files/AttachFileMenu.tsx`](/Users/shqear/workspace/LibreChat/client/src/components/Chat/Input/Files/AttachFileMenu.tsx) so that:
+### 1. Config and types
 
-- if the current endpoint is listed in `startupConfig.uiOverrides.hideProviderUploadForEndpoints`
-- the `com_ui_upload_provider` menu item is omitted
-- `Upload as Text` and `File Search` remain available when their capabilities are enabled
+Add `branding` to the config schema and app config pipeline:
 
-This must be driven from startup config, not from an inline hardcoded `if (endpoint === 'LiteLLM')` branch.
+- [`packages/data-provider/src/config.ts`](/Users/shqear/workspace/LibreChat/packages/data-provider/src/config.ts)
+- [`packages/data-schemas/src/types/app.ts`](/Users/shqear/workspace/LibreChat/packages/data-schemas/src/types/app.ts)
+- app config resolution layer
+- startup payload types
 
-### 7. Keep model presentation config-driven
+### 2. Startup payload
 
-Do not patch model menus just to rename or decorate models.
+Expose a frontend-safe branding subset from:
 
-Use `modelSpecs` for:
+- [`api/server/routes/config.js`](/Users/shqear/workspace/LibreChat/api/server/routes/config.js)
 
-- labels
-- descriptions
-- default spec
-- grouping
-- `iconURL`
+Do not expose unnecessary server-only values.
 
-This is already supported and should remain data-driven.
+### 3. Frontend runtime wiring
+
+Update the frontend to consume `startupConfig.branding` for:
+
+- auth logo path
+- UI visibility overrides
+- optional runtime theme payload
+
+### 4. Theme integration
+
+Unify white-label theming with the existing `ThemeProvider` system instead of treating `style.css` as the tenant API.
+
+If needed, extend the current theme env loader pattern into a startup-config-based theme loader so both build and runtime branding models can coexist cleanly.
+
+### 5. Shell identity
+
+Add build-time branding inputs for:
+
+- `index.html`
+- PWA manifest config in `vite.config.ts`
+- public assets
 
 ---
 
 ## Validation
 
+### Automated
+
 Add or extend tests for:
 
-- startup config schema includes `uiOverrides`
-- startup payload includes `uiOverrides` when configured
-- attachment menu omits provider upload when the override is active
-- text/file-search upload options still work under the override
-- branded assets are referenced by auth shell, HTML shell, and PWA manifest
-- app title still derives correctly from startup config
+- config schema accepts `branding`
+- resolved app config includes branding
+- startup payload includes branding subset
+- attachment menu hides provider upload when configured
+- auth branding path resolution works
+- theme payload shape matches `ThemeProvider` expectations
 
-Manual verification in the fork build:
+### Manual
 
-- auth screen shows the configured tenant logo
-- browser tab and favicon reflect configured tenant identity
-- theme reflects configured tenant branding
-- `Upload to Provider` is hidden for the intended endpoint
-- `Upload as Text` remains visible
+Verify a branded build shows:
 
-## Fork Handoff Checklist
-
-Before infra work starts, this fork must have all of the following complete:
-
-- generic branding asset support implemented
-- auth branding extension points implemented
-- HTML shell branding extension points implemented
-- PWA manifest branding extension points implemented
-- theme token branding extension points implemented
-- startup config extension for `uiOverrides.hideProviderUploadForEndpoints` implemented
-- attachment menu behavior patched and verified
-- local build/test verification completed for the affected areas
-- a pinned fork branch, tag, or commit selected for infra deployment
+- branded auth logo
+- branded browser title and favicon
+- branded PWA metadata
+- branded in-app color palette
+- hidden `Upload to Provider` where configured
+- preserved `Upload as Text` and `File Search`
 
 ---
 
-## Build Handoff to Infra
+## Output of Phase 1
 
-This fork is not required to publish a Docker image before rollout.
+This fork should produce:
 
-The deployment contract is:
+- a reusable white-label capability model
+- a config-driven runtime branding path
+- a build-time shell-branding path
+- no tenant-specific source hardcoding
+- a clean contract that infra can use for Umniah or any other tenant later
 
-- this repo carries the source patches and assets for the Umniah variant
-- this repo should remain tenant-agnostic and expose reusable branding capabilities rather than hardcoding one tenant
-- infra builds that source during deployment on the VPS
-- infra owns the `UMNIAH_*` env namespace and maps it into standard LibreChat runtime envs at compose level
-- the infra compose setup should follow the same build-on-deploy pattern previously used in this repo for LibreChat, with a pinned repo/ref instead of a floating upstream image
-
-That means the fork work must stay compatible with a deterministic Docker build from source, but image publication is not part of Phase 1.
-
-## Output of This Repo
-
-This repo should produce:
-
-- a buildable LibreChat source tree with generic white-label capabilities
-- the source patches required to support tenant-level white-labeling in infra
-- any new startup config fields required by the customized frontend
-- a clear repo/ref contract for infra to build during deploy
-
-That output becomes the input artifact for the infra repo plan.
-
----
-
-## Decision Summary
-
-- Execute this fork plan first.
-- Use runtime config where LibreChat already supports customization.
-- Patch source only where branding or behavior is hardcoded.
-- Keep the fork tenant-agnostic; Umniah-specific values belong in infra/runtime configuration.
+The fork should remain tenant-agnostic. The tenant selection, asset sourcing, env wiring, and deployment isolation belong in infra.

--- a/docs/plans/Whitelabling Capability Plan.md
+++ b/docs/plans/Whitelabling Capability Plan.md
@@ -1,0 +1,281 @@
+# White-Label Capability Plan for the LibreChat Fork
+
+## Purpose
+
+This plan covers only the **LibreChat fork** work required to add reusable white-label capabilities to LibreChat.
+
+This is **Phase 1** of the larger Umniah rollout and should be executed **before** the infra repo plan.
+
+The broader program is:
+
+1. Phase 1: implement tenant-agnostic white-label capabilities in this fork
+2. Phase 2: configure and deploy those capabilities for Umniah in the infra repo on `umniah.ai.shqear.online`
+
+---
+
+## Summary
+
+Use this fork as the source for generic white-label features that can later be configured for Umniah or any other tenant.
+
+The fork work should:
+
+- keep LibreChat’s supported config-driven customization where it already exists
+- patch source only where the product still hardcodes branding or unsupported UI behavior
+- produce a buildable LibreChat source tree with reusable white-label capabilities for infra to configure during deployment
+
+The output of this repo is not a tenant-branded app hardcoded for one customer. It is a reusable application variant that exposes the branding and behavior extension points infra needs.
+
+---
+
+## Investigated Code Paths
+
+The required customization points are already clear from the source:
+
+- [`client/src/components/Auth/AuthLayout.tsx`](/Users/shqear/workspace/LibreChat/client/src/components/Auth/AuthLayout.tsx)
+  - auth page logo is hardcoded as `assets/logo.svg`
+- [`client/index.html`](/Users/shqear/workspace/LibreChat/client/index.html)
+  - static title, description, browser theme color, favicon links are hardcoded
+- [`client/vite.config.ts`](/Users/shqear/workspace/LibreChat/client/vite.config.ts)
+  - PWA manifest identity and icons are hardcoded
+- [`client/src/style.css`](/Users/shqear/workspace/LibreChat/client/src/style.css)
+  - product-wide color tokens are defined here
+- [`client/src/components/Chat/Input/Files/AttachFileMenu.tsx`](/Users/shqear/workspace/LibreChat/client/src/components/Chat/Input/Files/AttachFileMenu.tsx)
+  - `Upload to Provider`, `Upload as Text`, and `File Search` menu items are explicitly built here
+- [`api/server/routes/config.js`](/Users/shqear/workspace/LibreChat/api/server/routes/config.js)
+  - startup config payload is assembled here
+- [`packages/data-provider/src/config.ts`](/Users/shqear/workspace/LibreChat/packages/data-provider/src/config.ts)
+  - startup config schema/types live here
+
+Also confirmed:
+
+- `APP_TITLE` is already supported through startup config
+- `interface.customWelcome` is already supported
+- `privacyPolicy`, `termsOfService`, and `customFooter` are already supported
+- `modelSpecs.iconURL`, labels, descriptions, grouping, and defaults are already supported
+
+So those do **not** need source-level reinvention.
+
+---
+
+## Implementation Changes
+
+### 1. Extend startup config for generic UI overrides
+
+Add a formal startup-config section for frontend behavior that is not currently configurable.
+
+Add a field like:
+
+```ts
+uiOverrides?: {
+  hideProviderUploadForEndpoints?: string[];
+}
+```
+
+Plumb it through:
+
+- [`packages/data-provider/src/config.ts`](/Users/shqear/workspace/LibreChat/packages/data-provider/src/config.ts)
+- [`api/server/routes/config.js`](/Users/shqear/workspace/LibreChat/api/server/routes/config.js)
+
+This should be a real part of `TStartupConfig`, not a local-only constant.
+
+### 2. Keep supported branding in runtime config
+
+Continue using supported runtime config for:
+
+- `APP_TITLE`
+- `interface.customWelcome`
+- `customFooter`
+- `privacyPolicy`
+- `termsOfService`
+- model labels/descriptions/defaults
+- model `iconURL`
+- auth and registration behavior
+
+This avoids unnecessary fork drift and keeps the white-label maintainable.
+
+The fork should remain secret-free:
+
+- do not commit production secrets in this repo
+- do not introduce tenant-specific `UMNIAH_*` parsing in application code unless there is a strong reason
+- expect infra to provide standard LibreChat runtime env names such as `APP_TITLE`, `DOMAIN_CLIENT`, `DOMAIN_SERVER`, and OAuth settings
+
+Tenant isolation belongs in infra. The fork should stay as close as possible to normal LibreChat runtime expectations.
+
+### 3. Replace hardcoded static assets with configurable branding assets
+
+Add a generic white-label asset mechanism under [`client/public/assets`](/Users/shqear/workspace/LibreChat/client/public/assets) and/or through runtime-configurable asset references.
+
+The fork should support a full branded asset set such as:
+
+- `logo.svg`
+- `favicon-16x16.png`
+- `favicon-32x32.png`
+- `apple-touch-icon-180x180.png`
+- `icon-192x192.png`
+- `maskable-icon.png`
+
+These should be treated as white-label inputs, not as Umniah-only files baked permanently into the fork.
+
+For the Umniah rollout specifically, the infra/execution work will source the initial branding inputs from:
+
+- official Umniah branding from `umniah.com`
+- current palette signal from site investigation:
+  - `#323E48`
+  - `#CE0037`
+  - white and neutral grays
+- current logo source discovered from the official site:
+  - `https://www.umniah.com/storage/umnia-beyon-2.png`
+
+If a proper SVG/brand kit becomes available, it should replace the temporary web-fetched source material.
+
+The fork requirement is to support branded assets cleanly. The Umniah-specific asset acquisition strategy is:
+
+- fetch the current public Umniah logo and favicon-compatible source material from official Umniah web properties
+- treat `umniah.com` as the source of truth, with Logodix used only as a visual reference and not as the authoritative asset source
+- generate the initial app asset set from those web-fetched inputs
+
+The fork should make these deliverables possible:
+
+- `client/public/assets/logo.svg`
+- `client/public/assets/favicon-16x16.png`
+- `client/public/assets/favicon-32x32.png`
+- `client/public/assets/apple-touch-icon-180x180.png`
+- `client/public/assets/icon-192x192.png`
+- `client/public/assets/maskable-icon.png`
+
+The plan assumes the execution work for Umniah will fetch the latest usable public assets from the web, then normalize them into the required LibreChat asset formats before commit or packaging.
+
+### 4. Patch auth and shell branding to use configurable white-label identity
+
+Update:
+
+- [`client/src/components/Auth/AuthLayout.tsx`](/Users/shqear/workspace/LibreChat/client/src/components/Auth/AuthLayout.tsx)
+  - ensure auth uses a configurable logo source
+  - keep alt text based on runtime `appTitle`
+- [`client/index.html`](/Users/shqear/workspace/LibreChat/client/index.html)
+  - replace hardcoded title/description/theme-color defaults with configurable branding inputs
+  - point icon links at configurable branded assets
+- [`client/vite.config.ts`](/Users/shqear/workspace/LibreChat/client/vite.config.ts)
+  - support configurable PWA `name`
+  - support configurable `short_name`
+  - support configurable `theme_color`
+  - support configurable `background_color`
+  - point manifest icons at branded assets
+
+This covers:
+
+- auth branding
+- browser tab identity
+- favicon identity
+- installed-app identity
+
+### 5. Patch theme tokens to support tenant branding
+
+Update [`client/src/style.css`](/Users/shqear/workspace/LibreChat/client/src/style.css) so tenant branding colors can be represented at the token layer.
+
+Focus on:
+
+- `--text-*`
+- `--surface-*`
+- `--header-*`
+- `--border-*`
+- `--ring-primary`
+- `--primary`
+- any remaining product accent tokens that currently assume LibreChat defaults
+
+This is the correct place to apply white-label color treatment because the existing UI already consumes these variables broadly. The fork should expose the mechanism; infra chooses the actual tenant palette.
+
+### 6. Hide `Upload to Provider` through generic endpoint-level UI controls
+
+Patch [`client/src/components/Chat/Input/Files/AttachFileMenu.tsx`](/Users/shqear/workspace/LibreChat/client/src/components/Chat/Input/Files/AttachFileMenu.tsx) so that:
+
+- if the current endpoint is listed in `startupConfig.uiOverrides.hideProviderUploadForEndpoints`
+- the `com_ui_upload_provider` menu item is omitted
+- `Upload as Text` and `File Search` remain available when their capabilities are enabled
+
+This must be driven from startup config, not from an inline hardcoded `if (endpoint === 'LiteLLM')` branch.
+
+### 7. Keep model presentation config-driven
+
+Do not patch model menus just to rename or decorate models.
+
+Use `modelSpecs` for:
+
+- labels
+- descriptions
+- default spec
+- grouping
+- `iconURL`
+
+This is already supported and should remain data-driven.
+
+---
+
+## Validation
+
+Add or extend tests for:
+
+- startup config schema includes `uiOverrides`
+- startup payload includes `uiOverrides` when configured
+- attachment menu omits provider upload when the override is active
+- text/file-search upload options still work under the override
+- branded assets are referenced by auth shell, HTML shell, and PWA manifest
+- app title still derives correctly from startup config
+
+Manual verification in the fork build:
+
+- auth screen shows the configured tenant logo
+- browser tab and favicon reflect configured tenant identity
+- theme reflects configured tenant branding
+- `Upload to Provider` is hidden for the intended endpoint
+- `Upload as Text` remains visible
+
+## Fork Handoff Checklist
+
+Before infra work starts, this fork must have all of the following complete:
+
+- generic branding asset support implemented
+- auth branding extension points implemented
+- HTML shell branding extension points implemented
+- PWA manifest branding extension points implemented
+- theme token branding extension points implemented
+- startup config extension for `uiOverrides.hideProviderUploadForEndpoints` implemented
+- attachment menu behavior patched and verified
+- local build/test verification completed for the affected areas
+- a pinned fork branch, tag, or commit selected for infra deployment
+
+---
+
+## Build Handoff to Infra
+
+This fork is not required to publish a Docker image before rollout.
+
+The deployment contract is:
+
+- this repo carries the source patches and assets for the Umniah variant
+- this repo should remain tenant-agnostic and expose reusable branding capabilities rather than hardcoding one tenant
+- infra builds that source during deployment on the VPS
+- infra owns the `UMNIAH_*` env namespace and maps it into standard LibreChat runtime envs at compose level
+- the infra compose setup should follow the same build-on-deploy pattern previously used in this repo for LibreChat, with a pinned repo/ref instead of a floating upstream image
+
+That means the fork work must stay compatible with a deterministic Docker build from source, but image publication is not part of Phase 1.
+
+## Output of This Repo
+
+This repo should produce:
+
+- a buildable LibreChat source tree with generic white-label capabilities
+- the source patches required to support tenant-level white-labeling in infra
+- any new startup config fields required by the customized frontend
+- a clear repo/ref contract for infra to build during deploy
+
+That output becomes the input artifact for the infra repo plan.
+
+---
+
+## Decision Summary
+
+- Execute this fork plan first.
+- Use runtime config where LibreChat already supports customization.
+- Patch source only where branding or behavior is hardcoded.
+- Keep the fork tenant-agnostic; Umniah-specific values belong in infra/runtime configuration.

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -744,7 +744,6 @@ export const interfaceSchema = z
         public: z.boolean().optional(),
       })
       .optional(),
-    hideProviderUploadForEndpoints: z.array(z.string()).optional(),
   })
   .default({
     modelSelect: true,

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -812,11 +812,46 @@ export const turnstileSchema = z.object({
 
 export type TTurnstileConfig = z.infer<typeof turnstileSchema>;
 
+export const brandingThemeSchema = z.record(z.string(), z.string()).optional();
+
+export const brandingSchema = z
+  .object({
+    appLogo: z.string().optional(),
+    authLogo: z.string().optional(),
+    favicon: z.string().optional(),
+    meta: z
+      .object({
+        title: z.string().optional(),
+        description: z.string().optional(),
+        themeColor: z.string().optional(),
+        pwaName: z.string().optional(),
+        pwaShortName: z.string().optional(),
+        pwaBackgroundColor: z.string().optional(),
+        pwaThemeColor: z.string().optional(),
+      })
+      .optional(),
+    theme: z
+      .object({
+        light: brandingThemeSchema,
+        dark: brandingThemeSchema,
+      })
+      .optional(),
+    ui: z
+      .object({
+        hideProviderUploadForEndpoints: z.array(z.string()).optional(),
+      })
+      .optional(),
+  })
+  .optional();
+
+export type TBrandingConfig = z.infer<typeof brandingSchema>;
+
 export type TStartupConfig = {
   appTitle: string;
   socialLogins?: string[];
   interface?: TInterfaceConfig;
   turnstile?: TTurnstileConfig;
+  branding?: TBrandingConfig;
   balance?: TBalanceConfig;
   transactions?: TTransactionsConfig;
   discordLoginEnabled: boolean;
@@ -1069,6 +1104,7 @@ export const configSchema = z.object({
     .optional(),
   interface: interfaceSchema,
   turnstile: turnstileSchema.optional(),
+  branding: brandingSchema,
   fileStrategy: fileStorageSchema.default(FileSources.local),
   fileStrategies: fileStrategiesSchema,
   actions: z

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -744,6 +744,7 @@ export const interfaceSchema = z
         public: z.boolean().optional(),
       })
       .optional(),
+    hideProviderUploadForEndpoints: z.array(z.string()).optional(),
   })
   .default({
     modelSelect: true,
@@ -834,11 +835,6 @@ export const brandingSchema = z
       .object({
         light: brandingThemeSchema,
         dark: brandingThemeSchema,
-      })
-      .optional(),
-    ui: z
-      .object({
-        hideProviderUploadForEndpoints: z.array(z.string()).optional(),
       })
       .optional(),
   })

--- a/packages/data-provider/src/file-config.spec.ts
+++ b/packages/data-provider/src/file-config.spec.ts
@@ -1246,6 +1246,64 @@ describe('getEndpointFileConfig', () => {
       expect(result.totalSizeLimit).toBe(0);
       expect(result.supportedMimeTypes).toEqual([]);
     });
+
+    it('should propagate disableProviderUpload from endpoint config', () => {
+      const dynamicConfig = {
+        endpoints: {
+          litellm: {
+            disableProviderUpload: true,
+          },
+        },
+      };
+
+      const merged = mergeFileConfig(dynamicConfig);
+      const result = getEndpointFileConfig({
+        fileConfig: merged,
+        endpoint: 'litellm',
+        endpointType: EModelEndpoint.custom,
+      });
+
+      expect(result.disableProviderUpload).toBe(true);
+    });
+
+    it('should propagate disableProviderUpload from user default when not set on endpoint', () => {
+      const dynamicConfig = {
+        endpoints: {
+          default: {
+            disableProviderUpload: true,
+          },
+        },
+      };
+
+      const merged = mergeFileConfig(dynamicConfig);
+      const result = getEndpointFileConfig({
+        fileConfig: merged,
+        endpoint: EModelEndpoint.google,
+      });
+
+      expect(result.disableProviderUpload).toBe(true);
+    });
+
+    it('endpoint-level disableProviderUpload overrides default', () => {
+      const dynamicConfig = {
+        endpoints: {
+          default: {
+            disableProviderUpload: true,
+          },
+          [EModelEndpoint.openAI]: {
+            disableProviderUpload: false,
+          },
+        },
+      };
+
+      const merged = mergeFileConfig(dynamicConfig);
+      const result = getEndpointFileConfig({
+        fileConfig: merged,
+        endpoint: EModelEndpoint.openAI,
+      });
+
+      expect(result.disableProviderUpload).toBe(false);
+    });
   });
 });
 

--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -450,6 +450,7 @@ export const endpointFileConfigSchema = z.object({
   fileSizeLimit: z.number().min(0).optional(),
   totalSizeLimit: z.number().min(0).optional(),
   supportedMimeTypes: supportedMimeTypesSchema.optional(),
+  disableProviderUpload: z.boolean().optional(),
 });
 
 export const fileConfigSchema = z.object({
@@ -534,6 +535,7 @@ function mergeWithDefault(
     fileSizeLimit: endpointConfig.fileSizeLimit ?? defaultConfig.fileSizeLimit,
     totalSizeLimit: endpointConfig.totalSizeLimit ?? defaultConfig.totalSizeLimit,
     supportedMimeTypes: endpointConfig.supportedMimeTypes ?? defaultMimeTypes,
+    disableProviderUpload: endpointConfig.disableProviderUpload ?? defaultConfig.disableProviderUpload,
   };
 }
 
@@ -746,6 +748,10 @@ export function mergeFileConfig(dynamic: z.infer<typeof fileConfigSchema> | unde
 
     if (dynamicEndpoint.disabled !== undefined) {
       mergedEndpoint.disabled = dynamicEndpoint.disabled;
+    }
+
+    if (dynamicEndpoint.disableProviderUpload !== undefined) {
+      mergedEndpoint.disableProviderUpload = dynamicEndpoint.disableProviderUpload;
     }
 
     if (dynamicEndpoint.supportedMimeTypes) {

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -42,6 +42,7 @@ export type EndpointFileConfig = {
   fileSizeLimit?: number;
   totalSizeLimit?: number;
   supportedMimeTypes?: RegExp[];
+  disableProviderUpload?: boolean;
 };
 
 export type FileConfig = {

--- a/packages/data-schemas/src/app/resolution.spec.ts
+++ b/packages/data-schemas/src/app/resolution.spec.ts
@@ -39,6 +39,29 @@ describe('mergeConfigOverrides', () => {
     expect(iface.parameters).toBe(true);
   });
 
+  it('remaps branding overrides into brandingConfig', () => {
+    const configs = [
+      fakeConfig(
+        {
+          branding: {
+            authLogo: '/auth-logo.svg',
+            ui: {
+              hideProviderUploadForEndpoints: ['openAI'],
+            },
+          },
+        },
+        10,
+      ),
+    ];
+    const result = mergeConfigOverrides(baseConfig, configs) as unknown as Record<string, unknown>;
+    expect(result.brandingConfig).toEqual({
+      authLogo: '/auth-logo.svg',
+      ui: {
+        hideProviderUploadForEndpoints: ['openAI'],
+      },
+    });
+  });
+
   it('sorts by priority — higher priority wins', () => {
     const configs = [
       fakeConfig({ registration: { enabled: false } }, 100),

--- a/packages/data-schemas/src/app/resolution.ts
+++ b/packages/data-schemas/src/app/resolution.ts
@@ -34,6 +34,7 @@ const OVERRIDE_KEY_MAP: Partial<Record<keyof TCustomConfig, keyof AppConfig>> = 
   mcpServers: 'mcpConfig',
   interface: 'interfaceConfig',
   turnstile: 'turnstileConfig',
+  branding: 'brandingConfig',
 };
 
 function mergeArrayByKey(

--- a/packages/data-schemas/src/app/service.ts
+++ b/packages/data-schemas/src/app/service.ts
@@ -90,6 +90,7 @@ export const AppService = async (params?: {
   const registration = config.registration ?? configDefaults.registration;
   const interfaceConfig = await loadDefaultInterface({ config, configDefaults });
   const turnstileConfig = loadTurnstileConfig(config, configDefaults);
+  const brandingConfig = config.branding;
   const speech = config.speech;
 
   const defaultConfig = {
@@ -112,6 +113,7 @@ export const AppService = async (params?: {
     imageOutputType,
     interfaceConfig,
     turnstileConfig,
+    brandingConfig,
     mcpConfig: mcpServersConfig,
     fileStrategies: config.fileStrategies,
   };

--- a/packages/data-schemas/src/types/app.ts
+++ b/packages/data-schemas/src/types/app.ts
@@ -79,6 +79,8 @@ export interface AppConfig {
   interfaceConfig?: TCustomConfig['interface'];
   /** Turnstile configuration */
   turnstileConfig?: Partial<TCustomConfig['turnstile']>;
+  /** Branding configuration */
+  brandingConfig?: TCustomConfig['branding'];
   /** Balance configuration */
   balance?: Partial<TCustomConfig['balance']>;
   /** Transactions configuration */


### PR DESCRIPTION
## Summary

- **White-label branding config block** (`branding`) added to `librechat.yaml` with support for custom logos, favicon, meta description, and theme color tokens (light/dark RGB palettes)
- **Runtime branding application** via `useAppStartup` hook: injects favicon, meta, and CSS theme variables at startup from the `branding` config
- **`disableProviderUpload` per-endpoint field** in `fileConfig.endpoints`

## Changes

### `packages/data-provider`
- Added `brandingSchema` / `TBrandingConfig` to `config.ts` with fields: `appLogo`, `authLogo`, `favicon`, `meta` (title, description), `theme` (light/dark palette maps)
- Added `branding?: TBrandingConfig` to `TStartupConfig`
- Added `disableProviderUpload?: boolean` to `EndpointFileConfig` type (`types/files.ts`)
- Added `disableProviderUpload` to `endpointFileConfigSchema` and propagated through `mergeWithDefault` and `mergeFileConfig` (`file-config.ts`)
- Tests: new `disableProviderUpload` propagation tests in `file-config.spec.ts`

### `packages/data-schemas`
- Added `brandingConfig?: TCustomConfig['branding']` to `AppConfig`
- Added `branding → brandingConfig` remap in `resolution.ts`
- Included `brandingConfig` in `service.ts` default config

### `api/server/routes/config.js`
- Forwarded `branding` to both unauthenticated and authenticated config payloads

### `client`
- `AuthLayout.tsx`: reads `branding.authLogo` / `branding.appLogo` with fallback
- `useAppStartup.ts`: applies favicon, meta, and theme tokens at runtime from startup config
- `AttachFileMenu.tsx`: replaced `hiddenProviderUploads` string-matching with direct `endpointFileConfig?.disableProviderUpload` read; removed `normalizeEndpointName` helper
- `AttachFileMenu.spec.tsx`: updated test to use `endpointFileConfig: { disableProviderUpload: true }` prop

## Config shape

```yaml
# Branding
branding:
  appLogo: "https://cdn.example.com/logo.svg"
  authLogo: "https://cdn.example.com/auth-logo.svg"
  favicon: "https://cdn.example.com/favicon.ico"
  meta:
    title: "My AI Assistant"
    description: "Powered by LibreChat"
  theme:
    light:
      primary: "210 100% 40%"
      background: "0 0% 100%"
    dark:
      primary: "210 100% 60%"
      background: "222 20% 10%"

# Per-endpoint provider upload control
fileConfig:
  endpoints:
    litellm:
      disableProviderUpload: true
    custom:
      disableProviderUpload: true
```

## Test plan

- [ ] Run `cd packages/data-provider && npx jest file-config` — `disableProviderUpload` merge tests pass
- [ ] Run `cd client && npx jest AttachFileMenu` — rewritten test passes
- [ ] Set `branding` block in `librechat.yaml` and confirm logos/favicon/theme apply at startup
- [ ] Set `disableProviderUpload: true` on an endpoint and confirm "Upload to Provider" is hidden while "Upload as Text" remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)