### PR TITLE
💬 feat: Serialize GitNexus Deploys and Post Completion Comments on PR Commands

### DIFF
--- a/.github/workflows/gitnexus-deploy.yml
+++ b/.github/workflows/gitnexus-deploy.yml
@@ -1,4 +1,4 @@
-# Deploys GitNexus indexes to a DigitalOcean droplet via SSH + rsync.
+# Deploys GitNexus indexes to a droplet via SSH + rsync.
 #
 # Architecture:
 #   GitHub Actions (deploy)
@@ -49,26 +49,39 @@
 #   GITNEXUS_DO_KNOWN_HOST  — output of `ssh-keyscan -H <host>` pinning the
 #                             droplet's host keys (prevents MITM/TOFU risk)
 
-name: GitNexus Deploy (DigitalOcean)
+name: GitNexus Deploy
 
 on:
   workflow_run:
     workflows: ['GitNexus Index']
     types: [completed]
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Optional PR number to post completion comment on (set by bot-triggered dispatches from gitnexus-index.yml)'
+        type: string
+        default: ''
 
 permissions:
   actions: read
   contents: read
-  pull-requests: read
+  pull-requests: write # post completion comments on served PR indexes
 
-# Per-ref concurrency: rapid pushes to the same branch/PR coalesce, but
-# deploys targeting different refs can still run in parallel. Safe because
-# each deploy only rsync's its own folder; final step always reflects the
-# latest state for all refs discovered at resolve time.
+# Global serialization. Earlier versions used per-ref concurrency with
+# cancel-in-progress so rapid pushes to the same ref coalesced but deploys
+# targeting different refs ran in parallel. That had a data race: the
+# prune-stale-indexes step computes its active_names up front, so if
+# deploy A is rsyncing /opt/gitnexus/indexes/LibreChat-pr-12580 while
+# deploy B (started slightly later with a different ref) prunes, B can
+# rm -rf a folder A is still uploading into.
+#
+# All deploys now queue behind a single group. cancel-in-progress is
+# false so a running rsync/docker-compose restart never gets killed
+# mid-operation (which would leave the droplet in a partial state).
+# The 20-minute job timeout bounds total queue depth.
 concurrency:
-  group: gitnexus-deploy-do-${{ github.event.workflow_run.head_branch || github.ref }}
-  cancel-in-progress: true
+  group: gitnexus-deploy
+  cancel-in-progress: false
 
 env:
   GITNEXUS_VERSION: '1.5.3'
@@ -145,7 +158,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      pull-requests: read
+      pull-requests: write # post deploy-complete comments on served PR indexes
     steps:
       - name: Checkout deploy config
         uses: actions/checkout@v4
@@ -449,6 +462,70 @@ jobs:
             echo "--- GitNexus logs (last 30 lines) ---"
             docker compose logs --tail 30 gitnexus || true
           REMOTE
+
+      # When the deploy was triggered by a PR command path, post a
+      # terminal status comment on that one PR only. Two sub-cases:
+      #
+      #   1. workflow_run trigger: the PR's native auto-index run fired
+      #      workflow_run, so github.event.workflow_run.id is the trigger.
+      #      Find the matching PR via the matrix entry whose runId matches.
+      #
+      #   2. workflow_dispatch trigger with inputs.pr_number set: the
+      #      index workflow's bot-fallback path dispatched us directly
+      #      because workflow_run is suppressed for GITHUB_TOKEN triggers.
+      #      Use inputs.pr_number as the comment target.
+      #
+      # Broadcast-commenting on every active PR would be noise — only the
+      # PR that asked for a fresh index gets a reply.
+      - name: Comment on PR — deploy complete
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          MATRIX: ${{ steps.resolve.outputs.matrix }}
+          TRIGGER_RUN_ID: ${{ github.event.workflow_run.id }}
+          DISPATCH_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          DEPLOY_STATUS: ${{ job.status }}
+        with:
+          script: |
+            let prNum = null;
+
+            // Case 1: dispatched directly with pr_number (bot-fallback path)
+            if (process.env.DISPATCH_PR_NUMBER && process.env.DISPATCH_PR_NUMBER !== '') {
+              prNum = parseInt(process.env.DISPATCH_PR_NUMBER, 10);
+            }
+            // Case 2: workflow_run trigger from a PR index run
+            else if (context.eventName === 'workflow_run') {
+              const matrix = JSON.parse(process.env.MATRIX || '[]');
+              const triggerRunId = Number(process.env.TRIGGER_RUN_ID);
+              const match = matrix.find(
+                (m) => m.runId === triggerRunId && m.name.startsWith('LibreChat-pr-'),
+              );
+              if (match) {
+                prNum = parseInt(match.name.replace('LibreChat-pr-', ''), 10);
+              }
+            }
+
+            if (!prNum) {
+              core.info('No PR to comment on (trigger was not a PR-scoped index); skipping.');
+              return;
+            }
+
+            const deployUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const ok = process.env.DEPLOY_STATUS === 'success';
+            const body = [
+              `### GitNexus: ${ok ? '🚀 deployed' : '❌ deploy failed'}`,
+              '',
+              ok
+                ? `The \`LibreChat-pr-${prNum}\` index is now live on the MCP server.`
+                : `The deploy failed — the previous index (if any) continues to be served.`,
+              `[Deploy run](${deployUrl})`,
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNum,
+              body,
+            });
 
       - name: Cleanup SSH key
         if: always()

--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -31,7 +31,8 @@ on:
 
 permissions:
   contents: read
-  actions: write # needed to dispatch gitnexus-deploy-do.yml on bot-triggered runs
+  actions: write # dispatch gitnexus-deploy.yml on bot-triggered runs
+  pull-requests: write # post completion comments for /gitnexus command runs
 
 concurrency:
   # When triggered by the /gitnexus command, group by PR number so rapid
@@ -168,10 +169,48 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            core.info('Triggering actor is github-actions[bot]; workflow_run would not fire. Dispatching gitnexus-deploy-do.yml manually.');
+            core.info('Triggering actor is github-actions[bot]; workflow_run would not fire. Dispatching gitnexus-deploy.yml manually.');
+            // Pass pr_number through so the deploy workflow knows which
+            // PR to post its completion comment on (for /gitnexus
+            // command runs this will be set; for other bot dispatches
+            // it's empty and the deploy step falls back to matrix match).
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: 'gitnexus-deploy-do.yml',
+              workflow_id: 'gitnexus-deploy.yml',
               ref: 'main',
+              inputs: {
+                pr_number: '${{ inputs.pr_number }}',
+              },
+            });
+
+      # Reply on the PR when the /gitnexus command path runs so the
+      # requester knows the index step finished. This only fires when
+      # inputs.pr_number is set (command-triggered) AND the rest of the
+      # job succeeded. A separate comment posts from the deploy workflow
+      # when the live server has the fresh index.
+      - name: Comment on PR — index complete
+        if: always() && inputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const outcome = '${{ job.status }}' === 'success' ? '✅ indexed' : '❌ index failed';
+            const prNum = parseInt('${{ inputs.pr_number }}', 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const embeddingsFlag = '${{ inputs.embeddings }}' === 'true' ? 'with embeddings' : 'graph-only';
+            const body = [
+              `### GitNexus: ${outcome}`,
+              ``,
+              `PR #${prNum} was indexed ${embeddingsFlag}.`,
+              `[Index run](${runUrl})`,
+              '',
+              '${{ job.status }}' === 'success'
+                ? '⏳ Waiting for deploy to serve the fresh index…'
+                : '_Index run failed — the previous index (if any) continues to be served._',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNum,
+              body,
             });


### PR DESCRIPTION
## Summary

I tightened the GitNexus CI/CD loop with three related changes: global deploy serialization to fix a data race, PR completion comments on the `/gitnexus index` path, and a workflow rename to drop the `DigitalOcean` suffix now that it's visual noise.

- Replace the per-ref concurrency group with a single global `gitnexus-deploy` group and set `cancel-in-progress: false`. Previous setup let deploys targeting different refs run in parallel, which raced the prune-stale-indexes step against in-flight rsyncs and could \`rm -rf\` a folder that another deploy was still uploading into.
- Add a "index complete" comment step in `gitnexus-index.yml` that fires only when `inputs.pr_number` is set. Posts ✅/❌ with a link to the run and a note about whether embeddings were generated.
- Add a "deploy complete" comment step in `gitnexus-deploy.yml` that handles both `workflow_run` triggers (recovers the PR number from the matrix entry whose `runId` matches the triggering run) and `workflow_dispatch` triggers (uses a new `inputs.pr_number` passed through by the index workflow's bot-fallback path).
- Plumb `inputs.pr_number` through the bot-fallback dispatch in `gitnexus-index.yml` so the deploy workflow knows where to comment for command-triggered runs where GitHub suppresses `workflow_run`.
- Rename `gitnexus-deploy-do.yml` → `gitnexus-deploy.yml` and update the workflow `name:` field to `GitNexus Deploy`. Concurrency group and all cross-references updated in lock-step. The \`.do/gitnexus/\` directory stays since the underlying target is still DO-specific (Caddy + compose + droplet), but the workflow itself doesn't advertise the platform.
- Promote `pull-requests: read` → `pull-requests: write` on the deploy job so the comment step can post.

### Concurrency race example

Before:
1. User pushes to main → deploy A starts, concurrency group `gitnexus-deploy-do-main`
2. Contributor comments `/gitnexus index` on PR 12580 → deploy B starts 30s later, concurrency group `gitnexus-deploy-do-main` (dispatched from main) — **but wait, the old form used workflow_run.head_branch which would be 'main' for both** — so actually this case cancelled correctly. The real race:
3. User pushes to main → deploy A starts, group `gitnexus-deploy-do-main`
4. User pushes to dev → deploy B starts, group `gitnexus-deploy-do-dev` — **both run in parallel**
5. Deploy A rsyncs \`LibreChat-pr-12580\` (which is still in its active set)
6. Deploy B computes its active_names BEFORE A's rsync finishes, sees 12580 folder exists on droplet but maybe not in B's matrix if B resolved slightly earlier
7. B's prune step \`rm -rf\`s the 12580 folder while A is still writing into it

Global serialization eliminates this entirely. Deploys are short (~1-2 min without image rebuild), so queue depth is bounded and the serialization cost is modest.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (internal workflow references)

## Testing

1. Merge and dispatch the deploy manually from main — verify it uses the new concurrency group and completes normally.
2. Comment `/gitnexus index` on an open contributor PR.
3. Verify:
   - Rocket emoji reaction lands within a few seconds (existing behavior)
   - \`GitNexus Index\` completes and posts a "index complete" comment on the PR
   - \`GitNexus Deploy\` fires (via the bot-fallback dispatch) and posts a "deploy complete" comment on the same PR
4. Trigger two deploys in quick succession (e.g. push to main, then comment \`/gitnexus index\` on a PR). Verify they queue instead of running in parallel — the second run's UI should show "Waiting for gitnexus-deploy concurrency group".
5. Verify the workflow still appears in the Actions sidebar under its new name "GitNexus Deploy".

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings