### PR TITLE
fix: Normalize audio MIME types in STT format validation

### DIFF
--- a/api/server/services/Files/Audio/STTService.js
+++ b/api/server/services/Files/Audio/STTService.js
@@ -238,9 +238,12 @@ class STTService {
     }
 
     const acceptedFormats = ['flac', 'mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'ogg', 'wav', 'webm'];
-    const fileFormat = audioFile.mimetype.split('/')[1];
-    if (!acceptedFormats.includes(fileFormat)) {
-      throw new Error(`The audio file format ${fileFormat} is not accepted`);
+    const mimePrefix = audioFile.mimetype.split('/')[0];
+    const rawFormat = audioFile.mimetype.split('/')[1];
+    const isAudioMime = mimePrefix === 'audio' || mimePrefix === 'video';
+    const normalizedFormat = isAudioMime ? getFileExtensionFromMime(audioFile.mimetype) : null;
+    if (!acceptedFormats.includes(normalizedFormat) && !acceptedFormats.includes(rawFormat)) {
+      throw new Error(`The audio file format ${rawFormat} is not accepted`);
     }
 
     const formData = new FormData();
@@ -377,4 +380,4 @@ async function speechToText(req, res) {
   await sttService.processSpeechToText(req, res);
 }
 
-module.exports = { STTService, speechToText };
+module.exports = { STTService, speechToText, getFileExtensionFromMime };

--- a/api/server/services/Files/Audio/STTService.spec.js
+++ b/api/server/services/Files/Audio/STTService.spec.js
@@ -1,0 +1,97 @@
+// Mock all external dependencies so we can test getFileExtensionFromMime in isolation
+jest.mock('axios');
+jest.mock('form-data');
+jest.mock('https-proxy-agent');
+jest.mock('@librechat/data-schemas', () => ({ logger: { warn: jest.fn(), error: jest.fn() } }));
+jest.mock('@librechat/api', () => ({ genAzureEndpoint: jest.fn(), logAxiosError: jest.fn() }));
+jest.mock('librechat-data-provider', () => ({
+  extractEnvVariable: jest.fn(),
+  STTProviders: {},
+}));
+jest.mock('~/server/services/Config', () => ({ getAppConfig: jest.fn() }));
+
+const { getFileExtensionFromMime } = require('./STTService');
+
+describe('getFileExtensionFromMime', () => {
+  it('should normalize audio/x-m4a to m4a', () => {
+    expect(getFileExtensionFromMime('audio/x-m4a')).toBe('m4a');
+  });
+
+  it('should normalize audio/mp4 to m4a', () => {
+    expect(getFileExtensionFromMime('audio/mp4')).toBe('m4a');
+  });
+
+  it('should normalize audio/x-wav to wav', () => {
+    expect(getFileExtensionFromMime('audio/x-wav')).toBe('wav');
+  });
+
+  it('should normalize audio/x-flac to flac', () => {
+    expect(getFileExtensionFromMime('audio/x-flac')).toBe('flac');
+  });
+
+  it('should normalize audio/mpeg to mp3', () => {
+    expect(getFileExtensionFromMime('audio/mpeg')).toBe('mp3');
+  });
+
+  it('should return webm for audio/webm', () => {
+    expect(getFileExtensionFromMime('audio/webm')).toBe('webm');
+  });
+
+  it('should return ogg for audio/ogg', () => {
+    expect(getFileExtensionFromMime('audio/ogg')).toBe('ogg');
+  });
+
+  it('should fall back to webm for unknown MIME types', () => {
+    expect(getFileExtensionFromMime('audio/somethingelse')).toBe('webm');
+  });
+
+  it('should return webm for null/undefined input', () => {
+    expect(getFileExtensionFromMime(null)).toBe('webm');
+    expect(getFileExtensionFromMime(undefined)).toBe('webm');
+  });
+});
+
+describe('STT audio format validation with MIME normalization', () => {
+  const acceptedFormats = ['flac', 'mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'ogg', 'wav', 'webm'];
+
+  /**
+   * Simulates the format validation logic in azureOpenAIProvider after the fix.
+   * Only normalizes audio/video MIME types to prevent non-audio types from
+   * matching via the webm default fallback in getFileExtensionFromMime().
+   */
+  function isFormatAccepted(mimetype) {
+    const mimePrefix = mimetype.split('/')[0];
+    const rawFormat = mimetype.split('/')[1];
+    const isAudioMime = mimePrefix === 'audio' || mimePrefix === 'video';
+    const normalizedFormat = isAudioMime ? getFileExtensionFromMime(mimetype) : null;
+    return acceptedFormats.includes(normalizedFormat) || acceptedFormats.includes(rawFormat);
+  }
+
+  it('should accept audio/x-m4a (browser MIME for .m4a files)', () => {
+    expect(isFormatAccepted('audio/x-m4a')).toBe(true);
+  });
+
+  it('should accept audio/x-wav', () => {
+    expect(isFormatAccepted('audio/x-wav')).toBe(true);
+  });
+
+  it('should accept audio/x-flac', () => {
+    expect(isFormatAccepted('audio/x-flac')).toBe(true);
+  });
+
+  it('should accept standard formats directly', () => {
+    expect(isFormatAccepted('audio/mpeg')).toBe(true);
+    expect(isFormatAccepted('audio/wav')).toBe(true);
+    expect(isFormatAccepted('audio/ogg')).toBe(true);
+    expect(isFormatAccepted('audio/webm')).toBe(true);
+    expect(isFormatAccepted('audio/flac')).toBe(true);
+    expect(isFormatAccepted('audio/mp3')).toBe(true);
+    expect(isFormatAccepted('audio/mp4')).toBe(true);
+    expect(isFormatAccepted('audio/mpga')).toBe(true);
+  });
+
+  it('should reject unsupported formats', () => {
+    expect(isFormatAccepted('text/plain')).toBe(false);
+    expect(isFormatAccepted('application/json')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Browsers commonly report audio files with non-standard MIME types (e.g. `audio/x-m4a` for `.m4a` files, `audio/x-wav`, `audio/x-flac`). The STT `azureOpenAIProvider` rejects these because the format validation only checks the raw MIME subtype against the accepted formats list.

This is the same class of bug as #12608 (`text/x-markdown` rejected in file uploads). The fix reuses the existing `getFileExtensionFromMime()` function — which already has the correct MIME-to-extension mapping — to normalize the format before validation. A raw subtype fallback is kept for forward compatibility. Non-audio MIME prefixes are excluded from normalization to prevent false positives via the `webm` default fallback.

Fixes #12632

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added 14 unit tests in `STTService.spec.js`:
- 9 tests for `getFileExtensionFromMime()` covering all MIME normalizations, unknown types, and null/undefined input
- 5 integration-style tests simulating the format validation logic: accepting `audio/x-m4a`, `audio/x-wav`, `audio/x-flac`, all standard formats, and rejecting non-audio types (`text/plain`, `application/json`)

All existing API tests continue to pass (`npm run test:api` from `api/` directory).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes