### PR TITLE
🗂️ feat: Sidebar Icon Toggle & New Chat History Switch

### DIFF
--- a/client/src/Providers/ActivePanelContext.tsx
+++ b/client/src/Providers/ActivePanelContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useMemo, useState, ReactNode } from 'react';
 
 const STORAGE_KEY = 'side:active-panel';
-const DEFAULT_PANEL = 'conversations';
+export const DEFAULT_PANEL = 'conversations';
 
 function getInitialActivePanel(): string {
   const saved = localStorage.getItem(STORAGE_KEY);

--- a/client/src/components/Nav/SettingsTabs/General/General.tsx
+++ b/client/src/components/Nav/SettingsTabs/General/General.tsx
@@ -29,6 +29,13 @@ const toggleSwitchConfigs = [
     hoverCardText: undefined,
     key: 'keepScreenAwake',
   },
+  {
+    stateAtom: store.newChatSwitchToHistory,
+    localizationKey: 'com_nav_new_chat_switch_to_history' as const,
+    switchId: 'newChatSwitchToHistory',
+    hoverCardText: undefined,
+    key: 'newChatSwitchToHistory',
+  },
 ];
 
 export const ThemeSelector = ({

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -6,7 +6,7 @@ import { QueryKeys } from 'librechat-data-provider';
 import { Skeleton, Sidebar, Button, TooltipAnchor } from '@librechat/client';
 import type { NavLink } from '~/common';
 import { CLOSE_SIDEBAR_ID } from '~/components/Chat/Menus/OpenSidebar';
-import { useActivePanel, resolveActivePanel } from '~/Providers';
+import { useActivePanel, resolveActivePanel, DEFAULT_PANEL } from '~/Providers';
 import { useLocalize, useNewConvo } from '~/hooks';
 import { clearMessagesCache, cn } from '~/utils';
 import store from '~/store';
@@ -29,7 +29,7 @@ const NewChatButton = memo(function NewChatButton() {
         queryClient.invalidateQueries([QueryKeys.messages]);
         newConversation();
         if (switchToHistory) {
-          setActive('conversations');
+          setActive(DEFAULT_PANEL);
         }
       }
     },

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -17,7 +17,9 @@ const NewChatButton = memo(function NewChatButton() {
   const localize = useLocalize();
   const queryClient = useQueryClient();
   const { newConversation } = useNewConvo();
+  const { setActive } = useActivePanel();
   const conversation = useRecoilValue(store.conversationByIndex(0));
+  const switchToHistory = useRecoilValue(store.newChatSwitchToHistory);
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -26,9 +28,12 @@ const NewChatButton = memo(function NewChatButton() {
         clearMessagesCache(queryClient, conversation?.conversationId);
         queryClient.invalidateQueries([QueryKeys.messages]);
         newConversation();
+        if (switchToHistory) {
+          setActive('conversations');
+        }
       }
     },
-    [queryClient, conversation?.conversationId, newConversation],
+    [queryClient, conversation?.conversationId, newConversation, switchToHistory, setActive],
   );
 
   return (
@@ -56,12 +61,14 @@ const NavIconButton = memo(function NavIconButton({
   expanded,
   setActive,
   onExpand,
+  onCollapse,
 }: {
   link: NavLink;
   isActive: boolean;
   expanded: boolean;
   setActive: (id: string) => void;
   onExpand?: () => void;
+  onCollapse?: () => void;
 }) {
   const localize = useLocalize();
 
@@ -71,6 +78,10 @@ const NavIconButton = memo(function NavIconButton({
         link.onClick(e);
         return;
       }
+      if (isActive && expanded) {
+        onCollapse?.();
+        return;
+      }
       if (!isActive) {
         setActive(link.id);
       }
@@ -78,7 +89,7 @@ const NavIconButton = memo(function NavIconButton({
         onExpand?.();
       }
     },
-    [link, isActive, setActive, expanded, onExpand],
+    [link, isActive, setActive, expanded, onExpand, onCollapse],
   );
 
   return (
@@ -153,6 +164,7 @@ function ExpandedPanel({
             expanded={expanded ?? true}
             setActive={setActive}
             onExpand={onExpand}
+            onCollapse={onCollapse}
           />
         ))}
       </div>

--- a/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
+++ b/client/src/components/UnifiedSidebar/ExpandedPanel.tsx
@@ -13,11 +13,14 @@ import store from '~/store';
 
 const AccountSettings = lazy(() => import('~/components/Nav/AccountSettings'));
 
-const NewChatButton = memo(function NewChatButton() {
+const NewChatButton = memo(function NewChatButton({
+  setActive,
+}: {
+  setActive: (id: string) => void;
+}) {
   const localize = useLocalize();
   const queryClient = useQueryClient();
   const { newConversation } = useNewConvo();
-  const { setActive } = useActivePanel();
   const conversation = useRecoilValue(store.conversationByIndex(0));
   const switchToHistory = useRecoilValue(store.newChatSwitchToHistory);
 
@@ -153,7 +156,7 @@ function ExpandedPanel({
           </Button>
         }
       />
-      <NewChatButton />
+      <NewChatButton setActive={setActive} />
       <div className="mx-2 border-b border-border-light" />
       <div className="flex flex-col gap-1 overflow-y-auto">
         {links.map((link) => (

--- a/client/src/components/UnifiedSidebar/__tests__/ExpandedPanel.spec.tsx
+++ b/client/src/components/UnifiedSidebar/__tests__/ExpandedPanel.spec.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RecoilRoot } from 'recoil';
+import '@testing-library/jest-dom/extend-expect';
 import { MessagesSquare, NotebookPen } from 'lucide-react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { MutableSnapshot } from 'recoil';
 import { ActivePanelProvider, DEFAULT_PANEL } from '~/Providers/ActivePanelContext';
 
 const mockNewConversation = jest.fn();
@@ -12,15 +13,16 @@ const mockClearMessagesCache = jest.fn();
 jest.mock('~/store', () => {
   const { atom } = jest.requireActual('recoil');
   let counter = 0;
+  const switchAtom = atom({
+    key: 'mock-newChatSwitchToHistory',
+    default: true,
+  });
   return {
     __esModule: true,
     default: {
       conversationByIndex: () =>
         atom({ key: `mock-conversationByIndex-${counter++}`, default: null }),
-      newChatSwitchToHistory: atom({
-        key: 'mock-newChatSwitchToHistory',
-        default: true,
-      }),
+      newChatSwitchToHistory: switchAtom,
     },
   };
 });
@@ -45,12 +47,13 @@ jest.mock('~/components/Nav/AccountSettings', () => ({
 }));
 
 import ExpandedPanel from '../ExpandedPanel';
+import store from '~/store';
 
 const createLinks = () => [
   {
     title: 'com_ui_chat_history' as const,
     icon: MessagesSquare,
-    id: 'conversations',
+    id: DEFAULT_PANEL,
   },
   {
     title: 'com_ui_prompts' as const,
@@ -66,11 +69,13 @@ function renderPanel({
   onCollapse = jest.fn(),
   onExpand = jest.fn(),
   initialPanel = DEFAULT_PANEL,
+  initializeState,
 }: {
   expanded?: boolean;
   onCollapse?: jest.Mock;
   onExpand?: jest.Mock;
   initialPanel?: string;
+  initializeState?: (snapshot: MutableSnapshot) => void;
 } = {}) {
   if (initialPanel !== DEFAULT_PANEL) {
     localStorage.setItem('side:active-panel', initialPanel);
@@ -78,7 +83,7 @@ function renderPanel({
 
   const result = render(
     <QueryClientProvider client={createQueryClient()}>
-      <RecoilRoot>
+      <RecoilRoot initializeState={initializeState}>
         <ActivePanelProvider>
           <ExpandedPanel
             links={createLinks()}
@@ -108,11 +113,12 @@ describe('ExpandedPanel', () => {
       expect(onCollapse).toHaveBeenCalledTimes(1);
     });
 
-    it('does not collapse when clicking an inactive icon while expanded', () => {
+    it('switches panel when clicking an inactive icon while expanded', () => {
       const { onCollapse } = renderPanel({ expanded: true });
       const inactiveButton = screen.getByRole('button', { name: 'com_ui_prompts' });
       fireEvent.click(inactiveButton);
       expect(onCollapse).not.toHaveBeenCalled();
+      expect(localStorage.getItem('side:active-panel')).toBe('prompts');
     });
 
     it('expands sidebar when clicking any icon while collapsed', () => {
@@ -127,11 +133,12 @@ describe('ExpandedPanel', () => {
       const inactiveButton = screen.getByRole('button', { name: 'com_ui_prompts' });
       fireEvent.click(inactiveButton);
       expect(onExpand).toHaveBeenCalledTimes(1);
+      expect(localStorage.getItem('side:active-panel')).toBe('prompts');
     });
   });
 
   describe('NewChatButton panel switch', () => {
-    it('switches to chat history panel on new chat click', () => {
+    it('switches to chat history panel on new chat click when setting is enabled', () => {
       renderPanel({ expanded: true, initialPanel: 'prompts' });
 
       const newChatLink = screen.getByTestId('new-chat-button');
@@ -141,13 +148,20 @@ describe('ExpandedPanel', () => {
       expect(localStorage.getItem('side:active-panel')).toBe(DEFAULT_PANEL);
     });
 
-    it('calls newConversation regardless of panel switch setting', () => {
-      renderPanel({ expanded: true });
+    it('does not switch panel on new chat click when setting is disabled', () => {
+      renderPanel({
+        expanded: true,
+        initialPanel: 'prompts',
+        initializeState: ({ set }: MutableSnapshot) => {
+          set(store.newChatSwitchToHistory, false);
+        },
+      });
 
       const newChatLink = screen.getByTestId('new-chat-button');
       fireEvent.click(newChatLink);
 
       expect(mockNewConversation).toHaveBeenCalledTimes(1);
+      expect(localStorage.getItem('side:active-panel')).toBe('prompts');
     });
   });
 });

--- a/client/src/components/UnifiedSidebar/__tests__/ExpandedPanel.spec.tsx
+++ b/client/src/components/UnifiedSidebar/__tests__/ExpandedPanel.spec.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RecoilRoot } from 'recoil';
+import { MessagesSquare, NotebookPen } from 'lucide-react';
+import { ActivePanelProvider, DEFAULT_PANEL } from '~/Providers/ActivePanelContext';
+
+const mockNewConversation = jest.fn();
+const mockClearMessagesCache = jest.fn();
+
+jest.mock('~/store', () => {
+  const { atom } = jest.requireActual('recoil');
+  let counter = 0;
+  return {
+    __esModule: true,
+    default: {
+      conversationByIndex: () =>
+        atom({ key: `mock-conversationByIndex-${counter++}`, default: null }),
+      newChatSwitchToHistory: atom({
+        key: 'mock-newChatSwitchToHistory',
+        default: true,
+      }),
+    },
+  };
+});
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+  useNewConvo: () => ({ newConversation: mockNewConversation }),
+}));
+
+jest.mock('~/utils', () => ({
+  clearMessagesCache: (...args: unknown[]) => mockClearMessagesCache(...args),
+  cn: (...classes: unknown[]) => classes.filter(Boolean).join(' '),
+}));
+
+jest.mock('~/components/Chat/Menus/OpenSidebar', () => ({
+  CLOSE_SIDEBAR_ID: 'close-sidebar',
+}));
+
+jest.mock('~/components/Nav/AccountSettings', () => ({
+  __esModule: true,
+  default: () => <div data-testid="account-settings" />,
+}));
+
+import ExpandedPanel from '../ExpandedPanel';
+
+const createLinks = () => [
+  {
+    title: 'com_ui_chat_history' as const,
+    icon: MessagesSquare,
+    id: 'conversations',
+  },
+  {
+    title: 'com_ui_prompts' as const,
+    icon: NotebookPen,
+    id: 'prompts',
+  },
+];
+
+const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+function renderPanel({
+  expanded = true,
+  onCollapse = jest.fn(),
+  onExpand = jest.fn(),
+  initialPanel = DEFAULT_PANEL,
+}: {
+  expanded?: boolean;
+  onCollapse?: jest.Mock;
+  onExpand?: jest.Mock;
+  initialPanel?: string;
+} = {}) {
+  if (initialPanel !== DEFAULT_PANEL) {
+    localStorage.setItem('side:active-panel', initialPanel);
+  }
+
+  const result = render(
+    <QueryClientProvider client={createQueryClient()}>
+      <RecoilRoot>
+        <ActivePanelProvider>
+          <ExpandedPanel
+            links={createLinks()}
+            expanded={expanded}
+            onCollapse={onCollapse}
+            onExpand={onExpand}
+          />
+        </ActivePanelProvider>
+      </RecoilRoot>
+    </QueryClientProvider>,
+  );
+
+  return { ...result, onCollapse, onExpand };
+}
+
+describe('ExpandedPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('NavIconButton collapse toggle', () => {
+    it('collapses sidebar when clicking the active icon while expanded', () => {
+      const { onCollapse } = renderPanel({ expanded: true });
+      const activeButton = screen.getByRole('button', { name: 'com_ui_chat_history' });
+      fireEvent.click(activeButton);
+      expect(onCollapse).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not collapse when clicking an inactive icon while expanded', () => {
+      const { onCollapse } = renderPanel({ expanded: true });
+      const inactiveButton = screen.getByRole('button', { name: 'com_ui_prompts' });
+      fireEvent.click(inactiveButton);
+      expect(onCollapse).not.toHaveBeenCalled();
+    });
+
+    it('expands sidebar when clicking any icon while collapsed', () => {
+      const { onExpand } = renderPanel({ expanded: false });
+      const activeButton = screen.getByRole('button', { name: 'com_ui_chat_history' });
+      fireEvent.click(activeButton);
+      expect(onExpand).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets active panel and expands when clicking an inactive icon while collapsed', () => {
+      const { onExpand } = renderPanel({ expanded: false });
+      const inactiveButton = screen.getByRole('button', { name: 'com_ui_prompts' });
+      fireEvent.click(inactiveButton);
+      expect(onExpand).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('NewChatButton panel switch', () => {
+    it('switches to chat history panel on new chat click', () => {
+      renderPanel({ expanded: true, initialPanel: 'prompts' });
+
+      const newChatLink = screen.getByTestId('new-chat-button');
+      fireEvent.click(newChatLink);
+
+      expect(mockNewConversation).toHaveBeenCalledTimes(1);
+      expect(localStorage.getItem('side:active-panel')).toBe(DEFAULT_PANEL);
+    });
+
+    it('calls newConversation regardless of panel switch setting', () => {
+      renderPanel({ expanded: true });
+
+      const newChatLink = screen.getByTestId('new-chat-button');
+      fireEvent.click(newChatLink);
+
+      expect(mockNewConversation).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -501,6 +501,7 @@
   "com_nav_info_show_thinking": "When enabled, the chat will display the thinking dropdowns open by default, allowing you to view the AI's reasoning in real-time. When disabled, the thinking dropdowns will remain closed by default for a cleaner and more streamlined interface",
   "com_nav_info_user_name_display": "When enabled, the username of the sender will be shown above each message you send. When disabled, you will only see \"You\" above your messages.",
   "com_nav_keep_screen_awake": "Keep screen awake during response generation",
+  "com_nav_new_chat_switch_to_history": "Switch to Chat History on new chat",
   "com_nav_lang_arabic": "العربية",
   "com_nav_lang_armenian": "Հայերեն",
   "com_nav_lang_auto": "Auto detect",

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -26,6 +26,7 @@ const localStorageAtoms = {
     true,
   ),
   keepScreenAwake: atomWithLocalStorage('keepScreenAwake', true),
+  newChatSwitchToHistory: atomWithLocalStorage('newChatSwitchToHistory', true),
 
   // Chat settings
   enterToSend: atomWithLocalStorage('enterToSend', true),


### PR DESCRIPTION
## Summary

I added two sidebar UX improvements: clicking an already-active sidebar icon now collapses the sidebar (matching VSCode behavior), and clicking the "New Chat" button optionally switches the active panel to Chat History. The latter is controlled by a new General Settings toggle that defaults to enabled.

- Add collapse behavior to `NavIconButton` when clicking the currently active sidebar icon while the sidebar is expanded, providing a familiar toggle interaction matching editors like VSCode.
- Introduce `onCollapse` prop to `NavIconButton` and wire it through `ExpandedPanel` to the parent collapse handler.
- Create `newChatSwitchToHistory` Recoil atom with localStorage persistence, defaulting to `true`.
- Update `NewChatButton` to switch the active panel to "conversations" (Chat History) after creating a new chat, gated by the new setting.
- Add "Switch to Chat History on new chat" toggle to the General Settings tab using the existing `toggleSwitchConfigs` pattern.
- Add `com_nav_new_chat_switch_to_history` localization key to the English translation file.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

1. **Toggle collapse on active icon**: Open the sidebar, ensure a panel (e.g., Chat History) is active. Click the same icon again — the sidebar should collapse. Click it once more — the sidebar should re-expand showing the same panel.
2. **Non-active icon behavior**: With the sidebar collapsed, click any panel icon — the sidebar should expand with that panel active. With the sidebar expanded, click a different panel icon — it should switch panels without collapsing.
3. **New Chat → Chat History**: Navigate to any panel (e.g., Agents, Prompts). Click the "New Chat" button (pencil icon). The active panel should switch to Chat History.
4. **Setting toggle**: Go to Settings → General → disable "Switch to Chat History on new chat." Click "New Chat" from a non-Chat History panel — the panel should remain unchanged. Re-enable the setting and verify the switch behavior returns.
5. **Persistence**: Toggle the setting, refresh the page, and confirm the preference persists.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings