### PR TITLE
🔑 fix: Clear Stale Client Registration on `invalid_client` During OAuth Token Refresh

### DIFF
--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -7,7 +7,7 @@ import type { FlowStateManager } from '~/flow/manager';
 import type * as t from './types';
 import { MCPTokenStorage, MCPOAuthHandler, ReauthenticationRequiredError } from '~/mcp/oauth';
 import { PENDING_STALE_MS, normalizeExpiresAt } from '~/flow/manager';
-import { sanitizeUrlForLogging } from './utils';
+import { sanitizeUrlForLogging, isClientRejectionMessage } from './utils';
 import { withTimeout } from '~/utils/promise';
 import { MCPConnection } from './connection';
 import { processMCPEnv } from '~/utils';
@@ -504,14 +504,7 @@ export class MCPConnectionFactory {
       return false;
     }
     if ('message' in error && typeof error.message === 'string') {
-      const msg = error.message.toLowerCase();
-      return (
-        msg.includes('invalid_client') ||
-        msg.includes('unauthorized_client') ||
-        msg.includes('client_id mismatch') ||
-        msg.includes('client not found') ||
-        msg.includes('unknown client')
-      );
+      return isClientRejectionMessage(error.message);
     }
     return false;
   }

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -264,6 +264,7 @@ export class MCPConnectionFactory {
             findToken: this.tokenMethods!.findToken!,
             createToken: this.tokenMethods!.createToken,
             updateToken: this.tokenMethods!.updateToken,
+            deleteTokens: this.tokenMethods!.deleteTokens,
             refreshTokens: this.createRefreshTokensFunction(),
           });
         },

--- a/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
@@ -511,6 +511,204 @@ describe('MCPTokenStorage', () => {
         expect.stringContaining('does not support refresh tokens'),
       );
     });
+
+    it('should delete client registration and refresh token on invalid_client when deleteTokens provided', async () => {
+      await store.createToken({
+        userId: 'u1',
+        type: 'mcp_oauth',
+        identifier: 'mcp:srv1',
+        token: 'enc:expired-token',
+        expiresIn: -1,
+      });
+      await store.createToken({
+        userId: 'u1',
+        type: 'mcp_oauth_refresh',
+        identifier: 'mcp:srv1:refresh',
+        token: 'enc:rt',
+        expiresIn: 86400,
+      });
+      await store.createToken({
+        userId: 'u1',
+        type: 'mcp_oauth_client',
+        identifier: 'mcp:srv1:client',
+        token: 'enc:{"client_id":"cid"}',
+        expiresIn: 86400,
+      });
+
+      const refreshTokens = jest.fn().mockRejectedValue(new Error('invalid_client'));
+
+      await expect(
+        MCPTokenStorage.getTokens({
+          userId: 'u1',
+          serverName: 'srv1',
+          findToken: store.findToken,
+          createToken: store.createToken,
+          deleteTokens: store.deleteTokens,
+          refreshTokens,
+        }),
+      ).rejects.toThrow(ReauthenticationRequiredError);
+
+      const clientReg = await store.findToken({
+        userId: 'u1',
+        type: 'mcp_oauth_client',
+        identifier: 'mcp:srv1:client',
+      });
+      expect(clientReg).toBeNull();
+
+      const refreshToken = await store.findToken({
+        userId: 'u1',
+        type: 'mcp_oauth_refresh',
+        identifier: 'mcp:srv1:refresh',
+      });
+      expect(refreshToken).toBeNull();
+    });
+
+    it('should return null and log warning on invalid_client when deleteTokens not provided', async () => {
+      const { logger } = await import('@librechat/data-schemas');
+
+      await store.createToken({
+        userId: 'u1',
+        type: 'mcp_oauth',
+        identifier: 'mcp:srv1',
+        token: 'enc:expired-token',
+        expiresIn: -1,
+      });
+      await store.createToken({
+        userId: 'u1',
+        type: 'mcp_oauth_refresh',
+        identifier: 'mcp:srv1:refresh',
+        token: 'enc:rt',
+        expiresIn: 86400,
+      });
+
+      const refreshTokens = jest.fn().mockRejectedValue(new Error('invalid_client'));
+
+      const result = await MCPTokenStorage.getTokens({
+        userId: 'u1',
+        serverName: 'srv1',
+        findToken: store.findToken,
+        createToken: store.createToken,
+        refreshTokens,
+      });
+
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('deleteTokens not available'),
+      );
+    });
+
+    it('should handle client_not_found and other vendor-specific rejection patterns', async () => {
+      await store.createToken({
+        userId: 'u1',
+        type: 'mcp_oauth',
+        identifier: 'mcp:srv1',
+        token: 'enc:expired-token',
+        expiresIn: -1,
+      });
+      await store.createToken({
+        userId: 'u1',
+        type: 'mcp_oauth_refresh',
+        identifier: 'mcp:srv1:refresh',
+        token: 'enc:rt',
+        expiresIn: 86400,
+      });
+      await store.createToken({
+        userId: 'u1',
+        type: 'mcp_oauth_client',
+        identifier: 'mcp:srv1:client',
+        token: 'enc:{"client_id":"cid"}',
+        expiresIn: 86400,
+      });
+
+      const refreshTokens = jest.fn().mockRejectedValue(new Error('client not found'));
+
+      await expect(
+        MCPTokenStorage.getTokens({
+          userId: 'u1',
+          serverName: 'srv1',
+          findToken: store.findToken,
+          createToken: store.createToken,
+          deleteTokens: store.deleteTokens,
+          refreshTokens,
+        }),
+      ).rejects.toThrow(ReauthenticationRequiredError);
+
+      expect(
+        await store.findToken({
+          userId: 'u1',
+          type: 'mcp_oauth_client',
+          identifier: 'mcp:srv1:client',
+        }),
+      ).toBeNull();
+      expect(
+        await store.findToken({
+          userId: 'u1',
+          type: 'mcp_oauth_refresh',
+          identifier: 'mcp:srv1:refresh',
+        }),
+      ).toBeNull();
+    });
+
+    it('should handle case-insensitive error messages for client rejection', async () => {
+      await store.createToken({
+        userId: 'u1',
+        type: 'mcp_oauth',
+        identifier: 'mcp:srv1',
+        token: 'enc:expired-token',
+        expiresIn: -1,
+      });
+      await store.createToken({
+        userId: 'u1',
+        type: 'mcp_oauth_refresh',
+        identifier: 'mcp:srv1:refresh',
+        token: 'enc:rt',
+        expiresIn: 86400,
+      });
+
+      const refreshTokens = jest.fn().mockRejectedValue(new Error('INVALID_CLIENT'));
+
+      await expect(
+        MCPTokenStorage.getTokens({
+          userId: 'u1',
+          serverName: 'srv1',
+          findToken: store.findToken,
+          createToken: store.createToken,
+          deleteTokens: store.deleteTokens,
+          refreshTokens,
+        }),
+      ).rejects.toThrow(ReauthenticationRequiredError);
+    });
+
+    it('should still throw ReauthenticationRequiredError when deleteClientRegistration fails', async () => {
+      await store.createToken({
+        userId: 'u1',
+        type: 'mcp_oauth',
+        identifier: 'mcp:srv1',
+        token: 'enc:expired-token',
+        expiresIn: -1,
+      });
+      await store.createToken({
+        userId: 'u1',
+        type: 'mcp_oauth_refresh',
+        identifier: 'mcp:srv1:refresh',
+        token: 'enc:rt',
+        expiresIn: 86400,
+      });
+
+      const refreshTokens = jest.fn().mockRejectedValue(new Error('invalid_client'));
+      const failingDeleteTokens = jest.fn().mockRejectedValue(new Error('DB connection lost'));
+
+      await expect(
+        MCPTokenStorage.getTokens({
+          userId: 'u1',
+          serverName: 'srv1',
+          findToken: store.findToken,
+          createToken: store.createToken,
+          deleteTokens: failingDeleteTokens,
+          refreshTokens,
+        }),
+      ).rejects.toThrow(ReauthenticationRequiredError);
+    });
   });
 
   describe('storeTokens + getTokens round-trip', () => {

--- a/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPOAuthTokenStorage.test.ts
@@ -546,7 +546,12 @@ describe('MCPTokenStorage', () => {
           deleteTokens: store.deleteTokens,
           refreshTokens,
         }),
-      ).rejects.toThrow(ReauthenticationRequiredError);
+      ).rejects.toThrow(
+        expect.objectContaining({
+          name: 'ReauthenticationRequiredError',
+          message: expect.stringContaining('stored client registration is no longer valid'),
+        }),
+      );
 
       const clientReg = await store.findToken({
         userId: 'u1',

--- a/packages/api/src/mcp/__tests__/utils.test.ts
+++ b/packages/api/src/mcp/__tests__/utils.test.ts
@@ -3,6 +3,8 @@ import {
   normalizeServerName,
   redactAllServerSecrets,
   redactServerSecrets,
+  isInvalidClientMessage,
+  isClientRejectionMessage,
   isUserSourced,
 } from '~/mcp/utils';
 import type { ParsedServerConfig } from '~/mcp/types';
@@ -272,6 +274,44 @@ describe('redactAllServerSecrets', () => {
     expect(redacted['server-b'].oauth?.client_secret).toBeUndefined();
     expect(redacted['server-b'].oauth?.client_id).toBe('cid-b');
     expect((redacted['server-c'] as Record<string, unknown>).command).toBeUndefined();
+  });
+});
+
+describe('isInvalidClientMessage', () => {
+  it.each(['invalid_client', 'client_id mismatch', 'client not found', 'unknown client'])(
+    'should detect "%s"',
+    (pattern) => {
+      expect(isInvalidClientMessage(`OAuth error: ${pattern}`)).toBe(true);
+    },
+  );
+
+  it('should be case-insensitive', () => {
+    expect(isInvalidClientMessage('INVALID_CLIENT')).toBe(true);
+    expect(isInvalidClientMessage('Client Not Found')).toBe(true);
+  });
+
+  it('should not match unauthorized_client', () => {
+    expect(isInvalidClientMessage('unauthorized_client')).toBe(false);
+  });
+
+  it('should return false for unrelated messages', () => {
+    expect(isInvalidClientMessage('connection timeout')).toBe(false);
+    expect(isInvalidClientMessage('')).toBe(false);
+  });
+});
+
+describe('isClientRejectionMessage', () => {
+  it('should match all isInvalidClientMessage patterns', () => {
+    expect(isClientRejectionMessage('invalid_client')).toBe(true);
+    expect(isClientRejectionMessage('client not found')).toBe(true);
+  });
+
+  it('should also match unauthorized_client', () => {
+    expect(isClientRejectionMessage('unauthorized_client')).toBe(true);
+  });
+
+  it('should return false for unrelated messages', () => {
+    expect(isClientRejectionMessage('server error')).toBe(false);
   });
 });
 

--- a/packages/api/src/mcp/oauth/tokens.ts
+++ b/packages/api/src/mcp/oauth/tokens.ts
@@ -5,10 +5,12 @@ import type { MCPOAuthTokens, ExtendedOAuthTokens, OAuthMetadata } from './types
 import { isSystemUserId } from '~/mcp/enum';
 
 export class ReauthenticationRequiredError extends Error {
-  constructor(serverName: string, reason: 'expired' | 'missing') {
-    super(
-      `Re-authentication required for "${serverName}": access token ${reason} and no refresh token available`,
-    );
+  constructor(serverName: string, reason: 'expired' | 'missing' | 'invalid_client') {
+    const detail =
+      reason === 'invalid_client'
+        ? 'stored client registration is no longer valid'
+        : `access token ${reason} and no refresh token available`;
+    super(`Re-authentication required for "${serverName}": ${detail}`);
     this.name = 'ReauthenticationRequiredError';
   }
 }
@@ -47,6 +49,7 @@ interface GetTokensParams {
   ) => Promise<MCPOAuthTokens>;
   createToken?: TokenMethods['createToken'];
   updateToken?: TokenMethods['updateToken'];
+  deleteTokens?: TokenMethods['deleteTokens'];
 }
 
 export class MCPTokenStorage {
@@ -254,6 +257,7 @@ export class MCPTokenStorage {
     findToken,
     createToken,
     updateToken,
+    deleteTokens,
     refreshTokens,
   }: GetTokensParams): Promise<MCPOAuthTokens | null> {
     const logPrefix = this.getLogPrefix(userId, serverName);
@@ -389,6 +393,19 @@ export class MCPTokenStorage {
             logger.info(
               `${logPrefix} Server does not support refresh tokens for this client. New authentication required.`,
             );
+          }
+          if (errorMessage.includes('invalid_client') && deleteTokens) {
+            logger.info(
+              `${logPrefix} Client registration rejected during token refresh, clearing stale registration`,
+            );
+            await MCPTokenStorage.deleteClientRegistration({
+              userId,
+              serverName,
+              deleteTokens,
+            }).catch((err) => {
+              logger.warn(`${logPrefix} Failed to clear stale client registration`, err);
+            });
+            throw new ReauthenticationRequiredError(serverName, 'invalid_client');
           }
           return null;
         }

--- a/packages/api/src/mcp/oauth/tokens.ts
+++ b/packages/api/src/mcp/oauth/tokens.ts
@@ -389,23 +389,41 @@ export class MCPTokenStorage {
           // Check if it's an unauthorized_client error (refresh not supported)
           const errorMessage =
             refreshError instanceof Error ? refreshError.message : String(refreshError);
-          if (errorMessage.includes('unauthorized_client')) {
+          const lowerMessage = errorMessage.toLowerCase();
+          if (lowerMessage.includes('unauthorized_client')) {
             logger.info(
               `${logPrefix} Server does not support refresh tokens for this client. New authentication required.`,
             );
-          }
-          if (errorMessage.includes('invalid_client') && deleteTokens) {
-            logger.info(
-              `${logPrefix} Client registration rejected during token refresh, clearing stale registration`,
+          } else if (
+            lowerMessage.includes('invalid_client') ||
+            lowerMessage.includes('client_id mismatch') ||
+            lowerMessage.includes('client not found') ||
+            lowerMessage.includes('unknown client')
+          ) {
+            if (deleteTokens) {
+              logger.info(
+                `${logPrefix} Client registration rejected during token refresh, attempting to clear stale registration and refresh token`,
+              );
+              const staleIdentifier = `mcp:${serverName}`;
+              await Promise.allSettled([
+                MCPTokenStorage.deleteClientRegistration({ userId, serverName, deleteTokens }),
+                deleteTokens({
+                  userId,
+                  type: 'mcp_oauth_refresh',
+                  identifier: `${staleIdentifier}:refresh`,
+                }),
+              ]).then((results) => {
+                for (const r of results) {
+                  if (r.status === 'rejected') {
+                    logger.warn(`${logPrefix} Failed to clear stale token data`, r.reason);
+                  }
+                }
+              });
+              throw new ReauthenticationRequiredError(serverName, 'invalid_client');
+            }
+            logger.warn(
+              `${logPrefix} Client registration rejected during token refresh but deleteTokens not available — stale registration cannot be cleared`,
             );
-            await MCPTokenStorage.deleteClientRegistration({
-              userId,
-              serverName,
-              deleteTokens,
-            }).catch((err) => {
-              logger.warn(`${logPrefix} Failed to clear stale client registration`, err);
-            });
-            throw new ReauthenticationRequiredError(serverName, 'invalid_client');
           }
           return null;
         }

--- a/packages/api/src/mcp/oauth/tokens.ts
+++ b/packages/api/src/mcp/oauth/tokens.ts
@@ -2,6 +2,7 @@ import { logger, encryptV2, decryptV2 } from '@librechat/data-schemas';
 import type { OAuthTokens, OAuthClientInformation } from '@modelcontextprotocol/sdk/shared/auth.js';
 import type { TokenMethods, IToken } from '@librechat/data-schemas';
 import type { MCPOAuthTokens, ExtendedOAuthTokens, OAuthMetadata } from './types';
+import { isInvalidClientMessage } from '~/mcp/utils';
 import { isSystemUserId } from '~/mcp/enum';
 
 export class ReauthenticationRequiredError extends Error {
@@ -49,6 +50,7 @@ interface GetTokensParams {
   ) => Promise<MCPOAuthTokens>;
   createToken?: TokenMethods['createToken'];
   updateToken?: TokenMethods['updateToken'];
+  /** Enables cleanup of stale client registration and refresh token on invalid_client errors during refresh. */
   deleteTokens?: TokenMethods['deleteTokens'];
 }
 
@@ -389,36 +391,28 @@ export class MCPTokenStorage {
           // Check if it's an unauthorized_client error (refresh not supported)
           const errorMessage =
             refreshError instanceof Error ? refreshError.message : String(refreshError);
-          const lowerMessage = errorMessage.toLowerCase();
-          if (lowerMessage.includes('unauthorized_client')) {
+          if (errorMessage.toLowerCase().includes('unauthorized_client')) {
             logger.info(
               `${logPrefix} Server does not support refresh tokens for this client. New authentication required.`,
             );
-          } else if (
-            lowerMessage.includes('invalid_client') ||
-            lowerMessage.includes('client_id mismatch') ||
-            lowerMessage.includes('client not found') ||
-            lowerMessage.includes('unknown client')
-          ) {
+          } else if (isInvalidClientMessage(errorMessage)) {
             if (deleteTokens) {
               logger.info(
                 `${logPrefix} Client registration rejected during token refresh, attempting to clear stale registration and refresh token`,
               );
-              const staleIdentifier = `mcp:${serverName}`;
-              await Promise.allSettled([
+              const results = await Promise.allSettled([
                 MCPTokenStorage.deleteClientRegistration({ userId, serverName, deleteTokens }),
                 deleteTokens({
                   userId,
                   type: 'mcp_oauth_refresh',
-                  identifier: `${staleIdentifier}:refresh`,
+                  identifier: `${identifier}:refresh`,
                 }),
-              ]).then((results) => {
-                for (const r of results) {
-                  if (r.status === 'rejected') {
-                    logger.warn(`${logPrefix} Failed to clear stale token data`, r.reason);
-                  }
+              ]);
+              for (const r of results) {
+                if (r.status === 'rejected') {
+                  logger.warn(`${logPrefix} Failed to clear stale token data`, r.reason);
                 }
-              });
+              }
               throw new ReauthenticationRequiredError(serverName, 'invalid_client');
             }
             logger.warn(

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -125,6 +125,21 @@ export function buildOAuthToolCallName(serverName: string): string {
 }
 
 /**
+ * Checks whether a message string indicates the OAuth client registration was rejected.
+ * Covers RFC 6749 §5.2 standard codes and known vendor-specific patterns.
+ */
+export function isClientRejectionMessage(message: string): boolean {
+  const msg = message.toLowerCase();
+  return (
+    msg.includes('invalid_client') ||
+    msg.includes('unauthorized_client') ||
+    msg.includes('client_id mismatch') ||
+    msg.includes('client not found') ||
+    msg.includes('unknown client')
+  );
+}
+
+/**
  * Sanitizes a URL by removing query parameters to prevent credential leakage in logs.
  * @param url - The URL to sanitize (string or URL object)
  * @returns The sanitized URL string without query parameters

--- a/packages/api/src/mcp/utils.ts
+++ b/packages/api/src/mcp/utils.ts
@@ -124,19 +124,26 @@ export function buildOAuthToolCallName(serverName: string): string {
   return `${oauthPrefix}${normalizeServerName(serverName)}`;
 }
 
+const INVALID_CLIENT_PATTERNS = [
+  'invalid_client',
+  'client_id mismatch',
+  'client not found',
+  'unknown client',
+] as const;
+
+/** Checks whether a message indicates the stored client registration is invalid/stale. */
+export function isInvalidClientMessage(message: string): boolean {
+  const msg = message.toLowerCase();
+  return INVALID_CLIENT_PATTERNS.some((p) => msg.includes(p));
+}
+
 /**
- * Checks whether a message string indicates the OAuth client registration was rejected.
- * Covers RFC 6749 §5.2 standard codes and known vendor-specific patterns.
+ * Checks whether a message indicates the OAuth client registration was rejected.
+ * Superset of `isInvalidClientMessage`: also matches `unauthorized_client`
+ * (grant-type refusal), which has different recovery semantics.
  */
 export function isClientRejectionMessage(message: string): boolean {
-  const msg = message.toLowerCase();
-  return (
-    msg.includes('invalid_client') ||
-    msg.includes('unauthorized_client') ||
-    msg.includes('client_id mismatch') ||
-    msg.includes('client not found') ||
-    msg.includes('unknown client')
-  );
+  return isInvalidClientMessage(message) || message.toLowerCase().includes('unauthorized_client');
 }
 
 /**


### PR DESCRIPTION


### Summary

I fixed a bug where MCP servers using Dynamic Client Registration (RFC 7591) would leave users permanently stuck when a stored `client_id` became invalid. The token refresh handler only recognized `unauthorized_client` as a recoverable error, so `invalid_client` rejections caused every retry to silently return `null` and reuse the same stale registration in an infinite loop.

- Detect `invalid_client` in the `getTokens()` refresh error handler, call `deleteClientRegistration()` to clear the stale DCR entry, and throw `ReauthenticationRequiredError` with a new `'invalid_client'` reason to trigger a fresh OAuth flow.
- Add `deleteTokens` to the `GetTokensParams` interface so the cleanup has access to the token deletion method inside the storage layer.
- Pass `deleteTokens` from `MCPConnectionFactory.getOAuthTokens()` into the `MCPTokenStorage.getTokens()` call.
- Extend the `ReauthenticationRequiredError` constructor's `reason` union type to accept `'invalid_client'`, with a distinct human-readable detail message for this case.

The existing `clearStaleClientIfRejected` logic in `MCPConnectionFactory` (added in #11925) does not catch this case because `getTokens()` returns `null` on refresh failure rather than throwing, so the error never propagates to the factory's handler.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Tested against MCP servers with Dynamic Client Registration:

1. Connected to GitHub MCP successfully, confirming a valid DCR client registration was stored.
2. Corrupted the stored `client_id` to a bogus UUID directly in the database to simulate a stale registration.
3. Deleted the stored access token to force a token refresh using the corrupted `client_id`.
4. Reinitialized GitHub MCP. LibreChat attempted to refresh with the corrupted `client_id`, received `invalid_client`, cleared the stale registration, and automatically completed a fresh DCR registration.
5. Verified the stored `client_id` was replaced with a new valid UUID and the connection was working.

Recommend adding unit tests for `MCPTokenStorage.getTokens()` covering:
- `invalid_client` during refresh with `deleteTokens` present: verify `deleteClientRegistration` is called and `ReauthenticationRequiredError` is thrown.
- `invalid_client` during refresh with `deleteTokens` absent: verify `return null` behavior.
- `deleteClientRegistration` failure: verify the `.catch` path does not block the rethrow.
- The `'invalid_client'` reason variant produces the correct error message.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes