### PR TITLE
🖼️ fix: Hide Duplicate Image Placeholder During Image Generation

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
@@ -238,13 +238,15 @@ export default function OpenAIImageGen({
                 height={dimensions.height}
               />
             )}
-            <Image
-              altText={filename}
-              imagePath={filepath ?? ''}
-              width={Number(dimensions.width?.split('px')[0])}
-              height={Number(dimensions.height?.split('px')[0])}
-              args={parsedArgs}
-            />
+            {filepath && (
+              <Image
+                altText={filename}
+                imagePath={filepath}
+                width={Number(dimensions.width?.split('px')[0])}
+                height={Number(dimensions.height?.split('px')[0])}
+                args={parsedArgs}
+              />
+            )}
           </div>
         </div>
       )}

--- a/client/src/components/Chat/Messages/Content/__tests__/OpenAIImageGen.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/OpenAIImageGen.test.tsx
@@ -62,13 +62,13 @@ describe('OpenAIImageGen', () => {
     jest.useRealTimers();
   });
 
-  describe('image preloading', () => {
-    it('keeps Image mounted during generation (progress < 1)', () => {
+  describe('image visibility', () => {
+    it('hides Image during generation when no filepath exists', () => {
       render(<OpenAIImageGen {...defaultProps} initialProgress={0.5} />);
-      expect(screen.getByTestId('image-component')).toBeInTheDocument();
+      expect(screen.queryByTestId('image-component')).not.toBeInTheDocument();
     });
 
-    it('shows Image when progress >= 1', () => {
+    it('shows Image when filepath is available', () => {
       render(
         <OpenAIImageGen
           {...defaultProps}
@@ -127,7 +127,7 @@ describe('OpenAIImageGen', () => {
 
     it('handles invalid JSON args gracefully', () => {
       render(<OpenAIImageGen {...defaultProps} args="invalid json" />);
-      expect(screen.getByTestId('image-component')).toBeInTheDocument();
+      expect(screen.getByTestId('progress-text')).toBeInTheDocument();
     });
 
     it('handles object args', () => {
@@ -137,7 +137,7 @@ describe('OpenAIImageGen', () => {
           args={{ prompt: 'a dog', quality: 'low', size: '512x512' }}
         />,
       );
-      expect(screen.getByTestId('image-component')).toBeInTheDocument();
+      expect(screen.getByTestId('progress-text')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary

I fixed a visual bug where a duplicate image placeholder (skeleton) was rendered below the PixelCard canvas animation during image generation. The `Image` component was always mounted regardless of whether a `filepath` existed, causing an empty skeleton to appear beneath the generation animation. Now the `Image` component only renders when `filepath` is available, so the PixelCard animation serves as the sole visual indicator during generation.

- Conditionally render the `Image` component only when `filepath` is truthy in the `OpenAIImageGen` component
- Remove the `?? ''` fallback for `imagePath` since the component no longer renders without a valid path
- Preserve existing behavior for user-attached images, which always have a filepath

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Trigger an image generation request through an agent-style tool (e.g., GPT-Image-1)
2. Verify only the PixelCard canvas animation displays during generation — no duplicate skeleton placeholder below it
3. Verify the final generated image renders correctly once generation completes
4. Verify user-attached images still display with their skeleton loading state as expected

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings