### PR TITLE
fix: persist Gemini 3+ thoughtSignatures for multi-turn tool calling

### DIFF
--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -22,12 +22,16 @@ const { saveBase64Image } = require('~/server/services/Files/process');
 class ModelEndHandler {
   /**
    * @param {Array<UsageMetadata>} collectedUsage
+   * @param {string[]} [collectedSignatures] - Shared array for Gemini 3+ thoughtSignatures
+   * @param {Array} [contentParts] - Shared contentParts to attach signatures immediately
    */
-  constructor(collectedUsage) {
+  constructor(collectedUsage, collectedSignatures, contentParts) {
     if (!Array.isArray(collectedUsage)) {
       throw new Error('collectedUsage must be an array');
     }
     this.collectedUsage = collectedUsage;
+    this.collectedSignatures = collectedSignatures;
+    this.contentParts = contentParts;
   }
 
   finalize(errorMessage) {
@@ -68,6 +72,9 @@ class ModelEndHandler {
         });
       }
 
+      // Collect thoughtSignatures for Gemini 3+ and attach to tool_call contentParts
+      this._collectAndAttachSignatures(data);
+
       const usage = data?.output?.usage_metadata;
       if (!usage) {
         return this.finalize(errorMessage);
@@ -83,6 +90,48 @@ class ModelEndHandler {
     } catch (error) {
       logger.error('Error handling model end event:', error);
       return this.finalize(errorMessage);
+    }
+  }
+
+  /**
+   * Extract thoughtSignatures from model output and attach to tool_call contentParts.
+   * Required for Gemini 3+ with thinking enabled — signatures must persist through DB
+   * so that multi-turn tool calling works correctly.
+   * @param {ModelEndData | undefined} data
+   */
+  _collectAndAttachSignatures(data) {
+    if (!Array.isArray(this.collectedSignatures) || !data?.output?.additional_kwargs) {
+      return;
+    }
+    const ak = data.output.additional_kwargs;
+    const sigMap = ak.__gemini_function_call_thought_signatures__;
+    const sigArray = ak.signatures;
+
+    if (sigMap && typeof sigMap === 'object') {
+      for (const sig of Object.values(sigMap)) {
+        if (typeof sig === 'string' && sig !== '') {
+          this.collectedSignatures.push(sig);
+        }
+      }
+    } else if (Array.isArray(sigArray)) {
+      for (const sig of sigArray) {
+        if (typeof sig === 'string' && sig !== '' && !this.collectedSignatures.includes(sig)) {
+          this.collectedSignatures.push(sig);
+        }
+      }
+    }
+
+    // Attach to existing tool_call contentParts for DB persistence
+    if (this.collectedSignatures.length > 0 && Array.isArray(this.contentParts)) {
+      for (let i = 0; i < this.contentParts.length; i++) {
+        const part = this.contentParts[i];
+        if (part?.type === 'tool_call' && part?.tool_call && !part.tool_call.thoughtSignature) {
+          const sig = this.collectedSignatures.shift();
+          if (sig) {
+            part.tool_call.thoughtSignature = sig;
+          }
+        }
+      }
     }
   }
 }
@@ -139,6 +188,8 @@ function getDefaultHandlers({
   aggregateContent,
   toolEndCallback,
   collectedUsage,
+  collectedSignatures,
+  contentParts,
   streamId = null,
   toolExecuteOptions = null,
   summarizationOptions = null,
@@ -149,7 +200,7 @@ function getDefaultHandlers({
     );
   }
   const handlers = {
-    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage),
+    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage, collectedSignatures, contentParts),
     [GraphEvents.TOOL_END]: new ToolEndHandler(toolEndCallback, logger),
     [GraphEvents.ON_RUN_STEP]: {
       /**

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -770,6 +770,35 @@ class AgentClient extends BaseClient {
         tokenCounter,
       });
 
+      // Restore thoughtSignatures for Gemini 3+ multi-turn tool calling.
+      // Moves DB-persisted tool_call.thoughtSignature → additional_kwargs.signatures
+      // and adds placeholders for index alignment in fixThoughtSignatures.
+      for (const msg of initialMessages) {
+        if (msg._getType?.() !== 'ai') {
+          continue;
+        }
+        if (!msg.additional_kwargs) {
+          msg.additional_kwargs = {};
+        }
+        if (Array.isArray(msg.tool_calls)) {
+          const sigs = [];
+          for (const tc of msg.tool_calls) {
+            if (tc.thoughtSignature) {
+              sigs.push(tc.thoughtSignature);
+              delete tc.thoughtSignature;
+            }
+          }
+          if (sigs.length > 0) {
+            msg.additional_kwargs.signatures = sigs;
+            continue;
+          }
+        }
+        // Placeholder to maintain index alignment in fixThoughtSignatures
+        if (!msg.additional_kwargs.signatures?.length) {
+          msg.additional_kwargs.signatures = [''];
+        }
+      }
+
       /**
        * @param {BaseMessage[]} messages
        */

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -101,6 +101,8 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
 
   /** @type {Array<UsageMetadata>} */
   const collectedUsage = [];
+  /** @type {string[]} Collected thoughtSignatures for Gemini 3+ multi-turn tool calling */
+  const collectedSignatures = [];
   /** @type {ArtifactPromises} */
   const artifactPromises = [];
   const { contentParts, aggregateContent } = createContentAggregator();
@@ -154,6 +156,8 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
     aggregateContent,
     toolEndCallback,
     collectedUsage,
+    collectedSignatures,
+    contentParts,
     streamId,
   });
 


### PR DESCRIPTION
## Summary

Gemini 3+ models with thinking enabled generate a `thoughtSignature` for each tool call made during a thinking block. These signatures are required in subsequent turns for the API to accept the conversation history — without them, multi-turn tool calling fails with an API rejection.

This PR adds a save/restore pipeline to persist `thoughtSignature` values through MongoDB, enabling reliable multi-turn conversations with Gemini 3+ thinking + tool calling.

**Save path** (`callbacks.js`):
- Add `_collectAndAttachSignatures()` to `ModelEndHandler`
- Extract signatures from `additional_kwargs` (supports both `__gemini_function_call_thought_signatures__` Map format and `signatures` Array format)
- Attach to corresponding `tool_call` contentParts so they are persisted to DB

**Restore path** (`client.js`):
- On conversation reload, move `tool_call.thoughtSignature` back to `additional_kwargs.signatures` (the format Gemini expects)
- Add placeholder signatures (`['']`) for AI messages without tool calls to maintain index alignment in `fixThoughtSignatures`

**Wiring** (`initialize.js`):
- Create shared `collectedSignatures` array
- Pass `collectedSignatures` and `contentParts` to `getDefaultHandlers`

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Configure a Gemini 3+ model (e.g. `gemini-3.1-pro-preview`) with thinking enabled
2. Create an agent with a tool (e.g. `web_search`)
3. Send a message that triggers tool calling
4. Verify `thoughtSignature` is saved in MongoDB: `db.messages.findOne({"content.tool_call.thoughtSignature": {$exists: true}})`
5. Send a follow-up message in the same conversation — multi-turn should succeed without API rejection
6. Without this fix, step 5 fails because signatures are lost between turns

### **Test Configuration**:
- Model: gemini-3.1-pro-preview (thinking enabled)
- Endpoint: Agents
- Tools: web_search, MCP tools

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes
