### PR TITLE
📝 docs: add `RAG_API_URL` to `.env.example`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -392,6 +392,7 @@ TTS_API_KEY=
 #==================================================#
 # More info: https://www.librechat.ai/docs/configuration/rag_api
 
+# RAG_API_URL=http://rag_api:8000
 # RAG_OPENAI_BASEURL=
 # RAG_OPENAI_API_KEY=
 # RAG_USE_FULL_CONTEXT=


### PR DESCRIPTION
### Summary

Adds the missing `RAG_API_URL` environment variable to `.env.example`, placed alongside existing `RAG_*` variables.

This variable is referenced in multiple runtime paths for file search, vector DB operations, and RAG health checks, but was not documented in the example environment file.

### Test plan

Grep-verified that `RAG_API_URL` is referenced in `api/` and `packages/api/` runtime code and had no entry in `.env.example`.

### Issue number

N/A — discovered during codebase review.

### Checks

- [ ] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [ ] I've run `make lint` and `make format`
- [ ] I've made sure tests pass