### PR TITLE
fix: set default maxRetries to 0 for OpenAI endpoint to prevent retry delays (fixes #12547)

### DIFF
--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -159,6 +159,10 @@ export function getOpenAILLMConfig({
     {
       streaming,
       model: modelOptions.model ?? '',
+      /** Default to 0 retries to avoid long delays from LangChain's
+       *  exponential backoff (up to ~2 min with default maxRetries=6).
+       *  Can be overridden via modelOptions or customParams.defaultParams. */
+      maxRetries: 0,
     },
     modelOptions,
   ) as Partial<t.OAIClientOptions> & Partial<t.OpenAIParameters> & Partial<AzureOpenAIInput>;


### PR DESCRIPTION
## Background

When an OpenAI-compatible API returns an error (e.g., 503), LangChain's AsyncCaller retries up to 6 times with exponential backoff, causing a ~2 minute delay before the user sees the error message. This happens because the default `maxRetries` in `@langchain/core` is 6.

While `@librechat/agents` already sets `maxRetries: 0` on the OpenAI SDK client itself, the outer LangChain layer still retries via `caller.call(...)`.

## Solution

Set `maxRetries: 0` as the default in the OpenAI LLM configuration. This disables the outer LangChain retry layer by default, so error responses are returned immediately to the user.

The value can still be overridden:
- Via `modelOptions.maxRetries` in conversation settings
- Via `customParams.defaultParams` with `{ key: "maxRetries", default: N }`

## Changes

- **`packages/api/src/endpoints/openai/llm.ts`**: Added `maxRetries: 0` to the default llmConfig object in `getOpenAILLMConfig()`. Since `Object.assign` is used, any explicit `maxRetries` value from `modelOptions` or `defaultParams` will override this default.

## Verification

1. Send a request that triggers a 503 error → error message should appear immediately (not after ~2 minutes)
2. Set `maxRetries: 2` in model options → verify retries still work as expected
3. Verify existing functionality is unchanged for normal (non-error) requests

Closes #12547