### PR TITLE
fix: normalize MIME types in Azure OpenAI STT format validation (fixes #12632)

### DIFF
--- a/api/server/services/Files/Audio/STTService.js
+++ b/api/server/services/Files/Audio/STTService.js
@@ -238,7 +238,7 @@ class STTService {
     }
 
     const acceptedFormats = ['flac', 'mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'ogg', 'wav', 'webm'];
-    const fileFormat = audioFile.mimetype.split('/')[1];
+    const fileFormat = getFileExtensionFromMime(audioFile.mimetype);
     if (!acceptedFormats.includes(fileFormat)) {
       throw new Error(`The audio file format ${fileFormat} is not accepted`);
     }


### PR DESCRIPTION
## Background

When using Speech-to-Text with the Azure OpenAI provider, uploading `.m4a` audio files fails with `"The audio file format x-m4a is not accepted"`. The root cause is in `azureOpenAIProvider` where the MIME type is split on `/` and the raw subtype is checked against `acceptedFormats`. However, browsers commonly report `.m4a` files as `audio/x-m4a` (the `x-` vendor prefix form), so `split("/")` yields `x-m4a` which does not match `m4a`.

The same issue affects other vendor-prefixed MIME types like `audio/x-wav`, `audio/x-flac`, etc.

## Solution

Use the existing `getFileExtensionFromMime()` utility function (which already has a `MIME_TO_EXTENSION_MAP` that correctly normalizes `audio/x-m4a` → `m4a`, `audio/x-wav` → `wav`, etc.) instead of raw `mimetype.split("/")`.

## Changes

- `api/server/services/Files/Audio/STTService.js` — Changed `audioFile.mimetype.split("/")[1]` to `getFileExtensionFromMime(audioFile.mimetype)` in `azureOpenAIProvider`

## Verification

1. Configure Azure OpenAI as STT provider
2. Upload an `.m4a` audio file (browser sends `audio/x-m4a`)
3. Previously: `"The audio file format x-m4a is not accepted"`
4. Now: File is accepted and transcribed successfully
5. Also fixes `audio/x-wav`, `audio/x-flac`, and similar vendor-prefixed MIME types