### PR TITLE
💰 fix: Load app config in `set-balance` script to respect balance settings

### DIFF
--- a/config/set-balance.js
+++ b/config/set-balance.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const { getBalanceConfig } = require('@librechat/api');
 const { User, Balance } = require('@librechat/data-schemas').createModels(mongoose);
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
+const { getAppConfig } = require('~/server/services/Config');
 const { askQuestion, silentExit } = require('./helpers');
 const connect = require('./connect');
 
@@ -31,7 +32,8 @@ const connect = require('./connect');
     // console.purple(`[DEBUG] Args Length: ${process.argv.length}`);
   }
 
-  const balanceConfig = getBalanceConfig();
+  const appConfig = await getAppConfig();
+  const balanceConfig = getBalanceConfig(appConfig);
   if (!balanceConfig?.enabled) {
     console.red('Error: Balance is not enabled. Use librechat.yaml to enable it');
     silentExit(1);


### PR DESCRIPTION
## Summary

The `npm run set-balance` command always errored with `Error: Balance is not enabled. Use librechat.yaml to enable it` even when balance was correctly configured in `librechat.yaml`.

Root cause: `config/set-balance.js` called `getBalanceConfig()` without the app config argument, so it couldn't read balance settings. The sibling `config/add-balance.js` script already does this correctly by loading the app config first and passing it in.

This PR aligns `set-balance.js` with `add-balance.js`:
- Imports `getAppConfig` from `~/server/services/Config`
- Awaits `getAppConfig()` before checking balance config
- Passes the resolved `appConfig` into `getBalanceConfig(appConfig)`

Fixes #12413 and #12412

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified against a locally built Docker image:

1. Build the image locally from this branch.
2. Configure balance in `librechat.yaml`:
   ```yaml
   balance:
     enabled: true
     startBalance: 50000
   ```
3. Run `npm run set-balance <email> <amount>` inside the container.
4. Before the fix: the script exits with `Error: Balance is not enabled. Use librechat.yaml to enable it`.
5. After the fix: the script proceeds, locates the user, updates the balance via `Balance.findOneAndUpdate`, and prints `Balance set successfully!` along with the new balance.
6. Verified behavior parity with `npm run add-balance`, which was already working correctly with the same config loading pattern.

### **Test Configuration**:

- Locally built Docker image from this branch
- Node.js v20.19.0
- MongoDB (local)
- `librechat.yaml` with `balance.enabled: true`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes