### PR TITLE
🔉 fix: Normalize audio MIME types in STT format validation

### DIFF
--- a/api/server/services/Files/Audio/STTService.js
+++ b/api/server/services/Files/Audio/STTService.js
@@ -238,11 +238,14 @@ class STTService {
     }
 
     const acceptedFormats = ['flac', 'mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'ogg', 'wav', 'webm'];
-    const mimePrefix = audioFile.mimetype.split('/')[0];
-    const rawFormat = audioFile.mimetype.split('/')[1];
+    const [mimePrefix, rawFormat = ''] = audioFile.mimetype.split('/');
     const isAudioMime = mimePrefix === 'audio' || mimePrefix === 'video';
-    const normalizedFormat = isAudioMime ? getFileExtensionFromMime(audioFile.mimetype) : null;
-    if (!acceptedFormats.includes(normalizedFormat) && !acceptedFormats.includes(rawFormat)) {
+    const isKnownMime = audioFile.mimetype in MIME_TO_EXTENSION_MAP;
+    const normalizedFormat = isKnownMime ? MIME_TO_EXTENSION_MAP[audioFile.mimetype] : null;
+    if (
+      !acceptedFormats.includes(normalizedFormat) &&
+      !(isAudioMime && acceptedFormats.includes(rawFormat))
+    ) {
       throw new Error(`The audio file format ${rawFormat} is not accepted`);
     }
 
@@ -380,4 +383,4 @@ async function speechToText(req, res) {
   await sttService.processSpeechToText(req, res);
 }
 
-module.exports = { STTService, speechToText, getFileExtensionFromMime };
+module.exports = { STTService, speechToText, getFileExtensionFromMime, MIME_TO_EXTENSION_MAP };

--- a/api/server/services/Files/Audio/STTService.js
+++ b/api/server/services/Files/Audio/STTService.js
@@ -238,9 +238,12 @@ class STTService {
     }
 
     const acceptedFormats = ['flac', 'mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'ogg', 'wav', 'webm'];
-    const fileFormat = audioFile.mimetype.split('/')[1];
-    if (!acceptedFormats.includes(fileFormat)) {
-      throw new Error(`The audio file format ${fileFormat} is not accepted`);
+    const mimePrefix = audioFile.mimetype.split('/')[0];
+    const rawFormat = audioFile.mimetype.split('/')[1];
+    const isAudioMime = mimePrefix === 'audio' || mimePrefix === 'video';
+    const normalizedFormat = isAudioMime ? getFileExtensionFromMime(audioFile.mimetype) : null;
+    if (!acceptedFormats.includes(normalizedFormat) && !acceptedFormats.includes(rawFormat)) {
+      throw new Error(`The audio file format ${rawFormat} is not accepted`);
     }
 
     const formData = new FormData();
@@ -377,4 +380,4 @@ async function speechToText(req, res) {
   await sttService.processSpeechToText(req, res);
 }
 
-module.exports = { STTService, speechToText };
+module.exports = { STTService, speechToText, getFileExtensionFromMime };

--- a/api/server/services/Files/Audio/STTService.spec.js
+++ b/api/server/services/Files/Audio/STTService.spec.js
@@ -10,7 +10,7 @@ jest.mock('librechat-data-provider', () => ({
 }));
 jest.mock('~/server/services/Config', () => ({ getAppConfig: jest.fn() }));
 
-const { getFileExtensionFromMime } = require('./STTService');
+const { getFileExtensionFromMime, MIME_TO_EXTENSION_MAP } = require('./STTService');
 
 describe('getFileExtensionFromMime', () => {
   it('should normalize audio/x-m4a to m4a', () => {
@@ -55,16 +55,21 @@ describe('STT audio format validation with MIME normalization', () => {
   const acceptedFormats = ['flac', 'mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'ogg', 'wav', 'webm'];
 
   /**
-   * Simulates the format validation logic in azureOpenAIProvider after the fix.
-   * Only normalizes audio/video MIME types to prevent non-audio types from
-   * matching via the webm default fallback in getFileExtensionFromMime().
+   * Mirrors the format validation logic in azureOpenAIProvider.
+   * Only uses MIME_TO_EXTENSION_MAP for normalization so unknown audio
+   * subtypes are not silently accepted via the webm default fallback.
+   * Raw subtype matching is gated on audio/video prefix to prevent
+   * non-audio types like text/webm from passing.
    */
   function isFormatAccepted(mimetype) {
-    const mimePrefix = mimetype.split('/')[0];
-    const rawFormat = mimetype.split('/')[1];
+    const [mimePrefix, rawFormat = ''] = mimetype.split('/');
     const isAudioMime = mimePrefix === 'audio' || mimePrefix === 'video';
-    const normalizedFormat = isAudioMime ? getFileExtensionFromMime(mimetype) : null;
-    return acceptedFormats.includes(normalizedFormat) || acceptedFormats.includes(rawFormat);
+    const isKnownMime = mimetype in MIME_TO_EXTENSION_MAP;
+    const normalizedFormat = isKnownMime ? MIME_TO_EXTENSION_MAP[mimetype] : null;
+    return (
+      acceptedFormats.includes(normalizedFormat) ||
+      (isAudioMime && acceptedFormats.includes(rawFormat))
+    );
   }
 
   it('should accept audio/x-m4a (browser MIME for .m4a files)', () => {
@@ -90,7 +95,18 @@ describe('STT audio format validation with MIME normalization', () => {
     expect(isFormatAccepted('audio/mpga')).toBe(true);
   });
 
-  it('should reject unsupported formats', () => {
+  it('should reject unknown audio subtypes', () => {
+    expect(isFormatAccepted('audio/aac')).toBe(false);
+    expect(isFormatAccepted('audio/somethingelse')).toBe(false);
+    expect(isFormatAccepted('video/unknown')).toBe(false);
+  });
+
+  it('should accept application/ogg (valid Ogg container MIME type in the map)', () => {
+    expect(isFormatAccepted('application/ogg')).toBe(true);
+  });
+
+  it('should reject non-audio types even if subtype matches an accepted format', () => {
+    expect(isFormatAccepted('text/webm')).toBe(false);
     expect(isFormatAccepted('text/plain')).toBe(false);
     expect(isFormatAccepted('application/json')).toBe(false);
   });

--- a/api/server/services/Files/Audio/STTService.spec.js
+++ b/api/server/services/Files/Audio/STTService.spec.js
@@ -1,0 +1,97 @@
+// Mock all external dependencies so we can test getFileExtensionFromMime in isolation
+jest.mock('axios');
+jest.mock('form-data');
+jest.mock('https-proxy-agent');
+jest.mock('@librechat/data-schemas', () => ({ logger: { warn: jest.fn(), error: jest.fn() } }));
+jest.mock('@librechat/api', () => ({ genAzureEndpoint: jest.fn(), logAxiosError: jest.fn() }));
+jest.mock('librechat-data-provider', () => ({
+  extractEnvVariable: jest.fn(),
+  STTProviders: {},
+}));
+jest.mock('~/server/services/Config', () => ({ getAppConfig: jest.fn() }));
+
+const { getFileExtensionFromMime } = require('./STTService');
+
+describe('getFileExtensionFromMime', () => {
+  it('should normalize audio/x-m4a to m4a', () => {
+    expect(getFileExtensionFromMime('audio/x-m4a')).toBe('m4a');
+  });
+
+  it('should normalize audio/mp4 to m4a', () => {
+    expect(getFileExtensionFromMime('audio/mp4')).toBe('m4a');
+  });
+
+  it('should normalize audio/x-wav to wav', () => {
+    expect(getFileExtensionFromMime('audio/x-wav')).toBe('wav');
+  });
+
+  it('should normalize audio/x-flac to flac', () => {
+    expect(getFileExtensionFromMime('audio/x-flac')).toBe('flac');
+  });
+
+  it('should normalize audio/mpeg to mp3', () => {
+    expect(getFileExtensionFromMime('audio/mpeg')).toBe('mp3');
+  });
+
+  it('should return webm for audio/webm', () => {
+    expect(getFileExtensionFromMime('audio/webm')).toBe('webm');
+  });
+
+  it('should return ogg for audio/ogg', () => {
+    expect(getFileExtensionFromMime('audio/ogg')).toBe('ogg');
+  });
+
+  it('should fall back to webm for unknown MIME types', () => {
+    expect(getFileExtensionFromMime('audio/somethingelse')).toBe('webm');
+  });
+
+  it('should return webm for null/undefined input', () => {
+    expect(getFileExtensionFromMime(null)).toBe('webm');
+    expect(getFileExtensionFromMime(undefined)).toBe('webm');
+  });
+});
+
+describe('STT audio format validation with MIME normalization', () => {
+  const acceptedFormats = ['flac', 'mp3', 'mp4', 'mpeg', 'mpga', 'm4a', 'ogg', 'wav', 'webm'];
+
+  /**
+   * Simulates the format validation logic in azureOpenAIProvider after the fix.
+   * Only normalizes audio/video MIME types to prevent non-audio types from
+   * matching via the webm default fallback in getFileExtensionFromMime().
+   */
+  function isFormatAccepted(mimetype) {
+    const mimePrefix = mimetype.split('/')[0];
+    const rawFormat = mimetype.split('/')[1];
+    const isAudioMime = mimePrefix === 'audio' || mimePrefix === 'video';
+    const normalizedFormat = isAudioMime ? getFileExtensionFromMime(mimetype) : null;
+    return acceptedFormats.includes(normalizedFormat) || acceptedFormats.includes(rawFormat);
+  }
+
+  it('should accept audio/x-m4a (browser MIME for .m4a files)', () => {
+    expect(isFormatAccepted('audio/x-m4a')).toBe(true);
+  });
+
+  it('should accept audio/x-wav', () => {
+    expect(isFormatAccepted('audio/x-wav')).toBe(true);
+  });
+
+  it('should accept audio/x-flac', () => {
+    expect(isFormatAccepted('audio/x-flac')).toBe(true);
+  });
+
+  it('should accept standard formats directly', () => {
+    expect(isFormatAccepted('audio/mpeg')).toBe(true);
+    expect(isFormatAccepted('audio/wav')).toBe(true);
+    expect(isFormatAccepted('audio/ogg')).toBe(true);
+    expect(isFormatAccepted('audio/webm')).toBe(true);
+    expect(isFormatAccepted('audio/flac')).toBe(true);
+    expect(isFormatAccepted('audio/mp3')).toBe(true);
+    expect(isFormatAccepted('audio/mp4')).toBe(true);
+    expect(isFormatAccepted('audio/mpga')).toBe(true);
+  });
+
+  it('should reject unsupported formats', () => {
+    expect(isFormatAccepted('text/plain')).toBe(false);
+    expect(isFormatAccepted('application/json')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Browsers commonly report audio files with non-standard MIME types (e.g. `audio/x-m4a` for `.m4a` files, `audio/x-wav`, `audio/x-flac`). The STT `azureOpenAIProvider` rejects these because the format validation only checks the raw MIME subtype against the accepted formats list.

This is the same class of bug as #12608 (`text/x-markdown` rejected in file uploads). The fix reuses the existing `MIME_TO_EXTENSION_MAP` — which already has the correct MIME-to-extension mapping — to normalize the format before validation. Unknown MIME types are correctly rejected instead of silently falling through to a `webm` default. Raw subtype fallback is gated on `audio/video` prefix to prevent non-audio types from bypassing validation.

Fixes #12632
Continues #12633

Credit to @jona7o for the original PR.

## Changes

- Use `MIME_TO_EXTENSION_MAP` directly for normalization instead of `getFileExtensionFromMime()` (which has a `webm` default fallback that would accept unknown audio subtypes)
- Gate raw subtype matching on `audio/video` prefix to reject types like `text/webm`
- Export `MIME_TO_EXTENSION_MAP` for test use
- Add negative tests for unknown audio subtypes and non-audio prefix bypass

## Test plan

- [x] 16 unit tests pass covering MIME normalization and format validation
- [x] Known non-standard MIME types (`audio/x-m4a`, `audio/x-wav`, `audio/x-flac`) accepted
- [x] Standard formats (`audio/mpeg`, `audio/wav`, etc.) accepted
- [x] Unknown audio subtypes (`audio/aac`, `audio/somethingelse`) rejected
- [x] Non-audio types with audio subtypes (`text/webm`) rejected
- [x] `application/ogg` (valid Ogg container in the MIME map) accepted