### PR TITLE
feat: add admin-configurable theme palette to interface config

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { RecoilRoot } from 'recoil';
 import { DndProvider } from 'react-dnd';
 import { RouterProvider } from 'react-router-dom';
@@ -8,11 +8,27 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Toast, ThemeProvider, ToastProvider } from '@librechat/client';
 import { QueryClient, QueryClientProvider, QueryCache } from '@tanstack/react-query';
 import { ScreenshotProvider, useApiErrorBoundary } from './hooks';
+import { useGetStartupConfig } from '~/data-provider';
 import WakeLockManager from '~/components/System/WakeLockManager';
 import { getThemeFromEnv } from './utils/getThemeFromEnv';
 import { initializeFontSize } from '~/store/fontSize';
 import { LiveAnnouncer } from '~/a11y';
 import { router } from './routes';
+
+const PaletteThemeProvider = ({ envTheme, children }) => {
+  const { data: startupConfig } = useGetStartupConfig();
+  const palette = useMemo(() => startupConfig?.interface?.theme?.palette, [startupConfig]);
+  return (
+    <ThemeProvider
+      palette={palette}
+      // Only pass initialTheme and themeRGB if environment theme exists
+      // This allows localStorage values to persist when no env theme is set
+      {...(envTheme && { initialTheme: 'system', themeRGB: envTheme })}
+    >
+      {children}
+    </ThemeProvider>
+  );
+};
 
 const App = () => {
   const { setError } = useApiErrorBoundary();
@@ -48,16 +64,13 @@ const App = () => {
     <QueryClientProvider client={queryClient}>
       <RecoilRoot>
         <LiveAnnouncer>
-          <ThemeProvider
-            // Only pass initialTheme and themeRGB if environment theme exists
-            // This allows localStorage values to persist when no env theme is set
-            {...(envTheme && { initialTheme: 'system', themeRGB: envTheme })}
-          >
+          <PaletteThemeProvider envTheme={envTheme}>
             {/* The ThemeProvider will automatically:
                 1. Apply dark/light mode classes
                 2. Apply custom theme colors if envTheme is provided
-                3. Otherwise use stored theme preferences from localStorage
-                4. Fall back to default theme colors if nothing is stored */}
+                3. Apply admin-configured palette colors if palette is provided
+                4. Otherwise use stored theme preferences from localStorage
+                5. Fall back to default theme colors if nothing is stored */}
             <RadixToast.Provider>
               <ToastProvider>
                 <DndProvider backend={HTML5Backend}>
@@ -69,7 +82,7 @@ const App = () => {
                 </DndProvider>
               </ToastProvider>
             </RadixToast.Provider>
-          </ThemeProvider>
+          </PaletteThemeProvider>
         </LiveAnnouncer>
       </RecoilRoot>
     </QueryClientProvider>

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -132,6 +132,25 @@ interface:
   # Temporary chat retention period in hours (default: 720, min: 1, max: 8760)
   # temporaryChatRetention: 1
 
+  # Custom color palette (RGB values: "R G B", each 0-255) overrides default theme colors
+  # See packages/client/src/theme/utils/applyTheme.ts for all available keys.
+  # theme:
+  #   palette:
+  #     light:
+  #       presentation: "240 253 244"
+  #       surface-primary: "240 253 244"
+  #       surface-primary-alt: "209 250 229"
+  #       surface-secondary: "220 252 231"
+  #       text-primary: "20 83 45"
+  #       text-secondary: "22 101 52"
+  #     dark:
+  #       presentation: "20 83 45"
+  #       surface-primary: "20 83 45"
+  #       surface-primary-alt: "6 78 59"
+  #       surface-secondary: "22 101 52"
+  #       text-primary: "220 252 231"
+  #       text-secondary: "187 247 208"
+
 # Example Cloudflare turnstile (optional)
 #turnstile:
 #  siteKey: "your-site-key-here"

--- a/packages/client/src/theme/context/ThemeProvider.spec.tsx
+++ b/packages/client/src/theme/context/ThemeProvider.spec.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { ThemeProvider, useTheme } from './ThemeProvider';
+import type { ThemePalette } from './ThemeProvider';
+
+jest.mock('../utils/applyTheme', () => jest.fn());
+
+function ThemeConsumer({ onTheme }: { onTheme: (ctx: ReturnType<typeof useTheme>) => void }) {
+  const ctx = useTheme();
+  React.useEffect(() => {
+    onTheme(ctx);
+  });
+  return null;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.className = '';
+  document.documentElement.style.cssText = '';
+});
+
+describe('palette prop', () => {
+  const palette: ThemePalette = {
+    light: { 'surface-primary': '255 255 255', 'text-primary': '0 0 0' },
+    dark: { 'surface-primary': '30 30 30', 'text-primary': '220 220 220' },
+  };
+
+  it('applies light palette colors when theme is light', () => {
+    let captured: ReturnType<typeof useTheme> | undefined;
+    render(
+      <ThemeProvider initialTheme="light" palette={palette}>
+        <ThemeConsumer onTheme={(ctx) => (captured = ctx)} />
+      </ThemeProvider>,
+    );
+
+    expect(captured?.themeRGB).toEqual(
+      expect.objectContaining({
+        'rgb-surface-primary': '255 255 255',
+        'rgb-text-primary': '0 0 0',
+      }),
+    );
+  });
+
+  it('applies dark palette colors when theme is dark', () => {
+    let captured: ReturnType<typeof useTheme> | undefined;
+    render(
+      <ThemeProvider initialTheme="dark" palette={palette}>
+        <ThemeConsumer onTheme={(ctx) => (captured = ctx)} />
+      </ThemeProvider>,
+    );
+
+    expect(captured?.themeRGB).toEqual(
+      expect.objectContaining({
+        'rgb-surface-primary': '30 30 30',
+        'rgb-text-primary': '220 220 220',
+      }),
+    );
+  });
+
+  it('prefixes palette keys with rgb-', () => {
+    let captured: ReturnType<typeof useTheme> | undefined;
+    render(
+      <ThemeProvider initialTheme="light" palette={palette}>
+        <ThemeConsumer onTheme={(ctx) => (captured = ctx)} />
+      </ThemeProvider>,
+    );
+
+    const keys = Object.keys(captured?.themeRGB ?? {});
+    expect(keys.every((k) => k.startsWith('rgb-'))).toBe(true);
+  });
+
+  it('does not set themeRGB when palette is undefined', () => {
+    let captured: ReturnType<typeof useTheme> | undefined;
+    render(
+      <ThemeProvider initialTheme="light">
+        <ThemeConsumer onTheme={(ctx) => (captured = ctx)} />
+      </ThemeProvider>,
+    );
+
+    expect(captured?.themeRGB).toBeUndefined();
+  });
+
+  it('does not set themeRGB when current mode has no palette entry', () => {
+    const darkOnly: ThemePalette = {
+      dark: { 'surface-primary': '30 30 30' },
+    };
+    let captured: ReturnType<typeof useTheme> | undefined;
+    render(
+      <ThemeProvider initialTheme="light" palette={darkOnly}>
+        <ThemeConsumer onTheme={(ctx) => (captured = ctx)} />
+      </ThemeProvider>,
+    );
+
+    expect(captured?.themeRGB).toBeUndefined();
+  });
+
+  it('registers a media query listener for system theme and cleans up on unmount', () => {
+    const addSpy = jest.fn();
+    const removeSpy = jest.fn();
+    (window.matchMedia as jest.Mock).mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: addSpy,
+      removeEventListener: removeSpy,
+      dispatchEvent: jest.fn(),
+    }));
+
+    const { unmount } = render(
+      <ThemeProvider initialTheme="system" palette={palette}>
+        <div />
+      </ThemeProvider>,
+    );
+
+    const paletteCalls = addSpy.mock.calls.filter(([event]: [string]) => event === 'change');
+    expect(paletteCalls.length).toBeGreaterThanOrEqual(1);
+
+    unmount();
+    const removeCallCount = removeSpy.mock.calls.filter(
+      ([event]: [string]) => event === 'change',
+    ).length;
+    expect(removeCallCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('switches palette colors when theme changes from light to dark', () => {
+    let captured: ReturnType<typeof useTheme> | undefined;
+    render(
+      <ThemeProvider initialTheme="light" palette={palette}>
+        <ThemeConsumer onTheme={(ctx) => (captured = ctx)} />
+      </ThemeProvider>,
+    );
+
+    expect(captured?.themeRGB).toEqual(
+      expect.objectContaining({ 'rgb-surface-primary': '255 255 255' }),
+    );
+
+    act(() => captured?.setTheme('dark'));
+
+    expect(captured?.themeRGB).toEqual(
+      expect.objectContaining({ 'rgb-surface-primary': '30 30 30' }),
+    );
+  });
+});

--- a/packages/client/src/theme/context/ThemeProvider.tsx
+++ b/packages/client/src/theme/context/ThemeProvider.tsx
@@ -25,11 +25,17 @@ export const ThemeContext = createContext<ThemeContextType>({
   resetTheme: () => undefined,
 });
 
+export type ThemePalette = {
+  light?: Record<string, string>;
+  dark?: Record<string, string>;
+};
+
 export interface ThemeProviderProps {
   children: React.ReactNode;
   themeRGB?: IThemeRGB;
   themeName?: string;
   initialTheme?: string;
+  palette?: ThemePalette;
 }
 
 /**
@@ -115,6 +121,7 @@ export function ThemeProvider({
   themeRGB: propThemeRGB,
   themeName: propThemeName,
   initialTheme,
+  palette,
 }: ThemeProviderProps) {
   const [theme, setThemeState] = useState<string>(getInitialTheme);
   const [themeRGB, setThemeRGBState] = useState<IThemeRGB | undefined>(getInitialThemeColors);
@@ -208,6 +215,31 @@ export function ThemeProvider({
     mediaQuery.addEventListener('change', handleChange);
     return () => mediaQuery.removeEventListener('change', handleChange);
   }, [theme, applyThemeMode]);
+
+  // Apply admin-configured color palette for the current mode
+  useEffect(() => {
+    if (!palette) {
+      return;
+    }
+    const apply = () => {
+      const colors = palette[isDark(theme) ? 'dark' : 'light'];
+      if (!colors) {
+        return;
+      }
+      const mapped: Record<string, string> = {};
+      for (const key of Object.keys(colors)) {
+        mapped[`rgb-${key}`] = colors[key];
+      }
+      setThemeRGB(mapped as IThemeRGB);
+    };
+    apply();
+    if (theme !== 'system') {
+      return;
+    }
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    mq.addEventListener('change', apply);
+    return () => mq.removeEventListener('change', apply);
+  }, [palette, theme, setThemeRGB]);
 
   // Apply dynamic color theme
   useEffect(() => {

--- a/packages/client/src/theme/index.ts
+++ b/packages/client/src/theme/index.ts
@@ -3,6 +3,7 @@ export * from './types';
 
 // Export ThemeProvider, ThemeContext, useTheme hook, and isDark
 export { ThemeProvider, ThemeContext, useTheme, isDark } from './context/ThemeProvider';
+export type { ThemePalette } from './context/ThemeProvider';
 
 // Export utility functions
 export { default as applyTheme } from './utils/applyTheme';

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -8,6 +8,7 @@ import { fileConfigSchema } from './file-config';
 import { apiBaseUrl } from './api-endpoints';
 import { FileSources } from './types/files';
 import { MCPServersSchema } from './mcp';
+import { themeSchema } from './theme';
 
 export const defaultSocialLogins = ['google', 'facebook', 'openid', 'github', 'discord', 'saml'];
 
@@ -744,6 +745,7 @@ export const interfaceSchema = z
         public: z.boolean().optional(),
       })
       .optional(),
+    theme: themeSchema.optional(),
   })
   .default({
     modelSelect: true,

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -3,6 +3,7 @@ export * from './azure';
 export * from './bedrock';
 export * from './config';
 export * from './file-config';
+export * from './theme';
 /* messages  */
 export * from './messages';
 /* artifacts  */

--- a/packages/data-provider/src/theme.spec.ts
+++ b/packages/data-provider/src/theme.spec.ts
@@ -1,0 +1,56 @@
+import { themeSchema, rgbColorSchema } from './theme';
+
+describe('rgbColorSchema', () => {
+  it('accepts valid RGB string', () => {
+    expect(rgbColorSchema.parse('128 64 255')).toBe('128 64 255');
+  });
+
+  it('rejects out-of-range component', () => {
+    expect(() => rgbColorSchema.parse('256 0 0')).toThrow();
+  });
+
+  it('rejects empty string', () => {
+    expect(() => rgbColorSchema.parse('')).toThrow();
+  });
+
+  it('rejects hex format', () => {
+    expect(() => rgbColorSchema.parse('#ff00aa')).toThrow();
+  });
+
+  it('rejects non-numeric values', () => {
+    expect(() => rgbColorSchema.parse('not-a-color')).toThrow();
+  });
+});
+
+describe('themeSchema', () => {
+  it('accepts full light and dark palettes', () => {
+    const input = {
+      palette: {
+        light: { 'surface-primary': '255 255 255', 'text-primary': '26 26 46' },
+        dark: { 'surface-primary': '26 26 46', 'text-secondary': '176 176 192' },
+      },
+    };
+    expect(themeSchema.parse(input)).toEqual(input);
+  });
+
+  it('accepts partial palette with only light', () => {
+    const result = themeSchema.parse({ palette: { light: { 'surface-primary': '200 200 200' } } });
+    expect(result.palette?.light).toEqual({ 'surface-primary': '200 200 200' });
+    expect(result.palette?.dark).toBeUndefined();
+  });
+
+  it('accepts partial palette with only dark', () => {
+    const result = themeSchema.parse({ palette: { dark: { 'border-light': '45 45 74' } } });
+    expect(result.palette?.dark).toEqual({ 'border-light': '45 45 74' });
+    expect(result.palette?.light).toBeUndefined();
+  });
+
+  it('rejects invalid RGB in nested palette', () => {
+    const input = { palette: { light: { 'surface-primary': '999 0 0' } } };
+    expect(() => themeSchema.parse(input)).toThrow(/Must be an RGB color/);
+  });
+
+  it('rejects undefined (optionality applied at usage site)', () => {
+    expect(() => themeSchema.parse(undefined)).toThrow();
+  });
+});

--- a/packages/data-provider/src/theme.ts
+++ b/packages/data-provider/src/theme.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+const RGB_REGEX = /^(\d{1,3}) (\d{1,3}) (\d{1,3})$/;
+
+function isValidRGB(value: string): boolean {
+  const match = value.match(RGB_REGEX);
+  if (!match) {
+    return false;
+  }
+  return (
+    parseInt(match[1], 10) <= 255 && parseInt(match[2], 10) <= 255 && parseInt(match[3], 10) <= 255
+  );
+}
+
+export const rgbColorSchema = z.string().refine(isValidRGB, {
+  message: 'Must be an RGB color like "26 26 46" (three space-separated integers 0-255)',
+});
+
+export const paletteSchema = z.record(z.string(), rgbColorSchema);
+
+export const themeSchema = z.object({
+  palette: z
+    .object({
+      light: paletteSchema.optional(),
+      dark: paletteSchema.optional(),
+    })
+    .optional(),
+});

--- a/packages/data-schemas/src/app/interface.spec.ts
+++ b/packages/data-schemas/src/app/interface.spec.ts
@@ -1,0 +1,34 @@
+import { loadDefaultInterface } from './interface';
+import type { TConfigDefaults, TCustomConfig } from 'librechat-data-provider';
+
+describe('loadDefaultInterface theme pass-through', () => {
+  const minimalDefaults = { interface: {} } as TConfigDefaults;
+
+  it('includes theme in output when present in config', async () => {
+    const theme = {
+      palette: {
+        light: { 'surface-primary': '255 255 255' },
+        dark: { 'surface-primary': '26 26 46' },
+      },
+    };
+    const config: Partial<TCustomConfig> = {
+      interface: { theme },
+    };
+
+    const result = await loadDefaultInterface({ config, configDefaults: minimalDefaults });
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty('theme');
+    expect(result!.theme).toEqual(theme);
+  });
+
+  it('omits theme from output when absent from config', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {},
+    };
+
+    const result = await loadDefaultInterface({ config, configDefaults: minimalDefaults });
+
+    expect(result).not.toHaveProperty('theme');
+  });
+});

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -53,6 +53,7 @@ export async function loadDefaultInterface({
     peoplePicker: interfaceConfig?.peoplePicker,
     marketplace: interfaceConfig?.marketplace,
     remoteAgents: interfaceConfig?.remoteAgents,
+    theme: interfaceConfig?.theme,
   });
 
   return loadedInterface;


### PR DESCRIPTION
## Summary

Closes: https://github.com/danny-avila/LibreChat/issues/5389

Adds admin-configurable theme color palettes to the interface section of librechat.yaml. Admins can define custom RGB color overrides for light and dark modes, which are validated at config load time and applied at runtime via the existing ThemeProvider. Allows deployments to brand the UI with custom colors without forking the frontend.

- packages/data-provider: New theme.ts module with rgbColorSchema, paletteSchema, and themeSchema (Zod validation). Added theme field to interfaceSchema in config.ts. Re-exported from barrel index.
- packages/data-schemas: loadDefaultInterface passes theme through to the app config.
- packages/client: ThemeProvider accepts a palette prop, maps palette keys to rgb- prefixed CSS variables per light/dark mode, and listens for system theme changes.
- App.jsx: New PaletteThemeProvider wrapper reads startupConfig.interface.theme.palette and passes it to ThemeProvider.
- librechat.example.yaml: Documented example with commented-out palette config.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Translation update

## Testing

1. Add a theme.palette block to librechat.yaml under interface: with valid RGB values (e.g., surface-primary: "240 253 244").
2. Start the app — verify custom colors apply for the configured mode (light/dark).
3. Switch between light/dark — verify the correct palette is applied per mode.
4. Omit theme entirely — verify default theme behavior is unchanged.
5. Use an invalid RGB value (e.g., "999 0 0") — verify config validation rejects it on startup.
6. Run unit tests:
- cd packages/data-provider && npx jest theme.spec.ts
- cd packages/data-schemas && npx jest interface.spec.ts
- cd packages/client && npx jest ThemeProvider.spec.tsx

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [X] My changes do not introduce new warnings
- [X] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
- [X] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
