### PR TITLE
🧩 style: Agent Side Panel Layout and Consistency Fixes

### DIFF
--- a/client/src/components/Chat/Messages/Content/MarkdownComponents.tsx
+++ b/client/src/components/Chat/Messages/Content/MarkdownComponents.tsx
@@ -17,6 +17,16 @@ type TCodeProps = {
   children: React.ReactNode;
 };
 
+const isSingleLineCode = (children: React.ReactNode): boolean => {
+  if (typeof children === 'string') {
+    return !children.includes('\n');
+  }
+  if (Array.isArray(children)) {
+    return children.every((child) => typeof child === 'string' && !child.includes('\n'));
+  }
+  return false;
+};
+
 export const code: React.ElementType = memo(function MarkdownCode({
   className,
   children,
@@ -29,7 +39,7 @@ export const code: React.ElementType = memo(function MarkdownCode({
   const lang = match && match[1];
   const isMath = lang === 'math';
   const isMermaid = lang === 'mermaid';
-  const isSingleLine = typeof children === 'string' && children.split('\n').length === 1;
+  const isSingleLine = isSingleLineCode(children);
 
   const { getNextIndex, resetCounter } = useCodeBlockContext();
   const blockIndex = useRef(getNextIndex(isMath || isMermaid || isSingleLine)).current;
@@ -78,7 +88,7 @@ export const codeNoExecution: React.ElementType = memo(function MarkdownCodeNoEx
   } else if (lang === 'mermaid') {
     const content = typeof children === 'string' ? children : String(children);
     return <Mermaid>{content}</Mermaid>;
-  } else if (typeof children === 'string' && children.split('\n').length === 1) {
+  } else if (isSingleLineCode(children)) {
     return (
       <code onDoubleClick={handleDoubleClick} className={className}>
         {children}

--- a/client/src/components/Prompts/editor/Markdown.tsx
+++ b/client/src/components/Prompts/editor/Markdown.tsx
@@ -44,6 +44,9 @@ const processChildren = (children: React.ReactNode): React.ReactNode => {
 
   if (React.isValidElement(children)) {
     const element = children as React.ReactElement<{ children?: React.ReactNode }>;
+    if (typeof element.type !== 'string' || element.type === 'code') {
+      return children;
+    }
     if (element.props.children) {
       return React.cloneElement(element, {
         ...element.props,

--- a/client/src/components/SidePanel/Agents/ActionsInput.tsx
+++ b/client/src/components/SidePanel/Agents/ActionsInput.tsx
@@ -270,11 +270,11 @@ export default function ActionsInput({
           />
         </div>
       </div>
-      <div className="flex items-center justify-end">
+      <div className="mt-auto flex items-center justify-end pt-2">
         <button
           disabled={!functions || !functions.length}
           onClick={saveAction}
-          className="focus:shadow-outline mt-1 flex min-w-[100px] items-center justify-center rounded bg-green-500 px-4 py-2 font-semibold text-white hover:bg-green-400 focus:border-green-500 focus:outline-none focus:ring-0 disabled:bg-green-400"
+          className="focus:shadow-outline flex min-w-[100px] items-center justify-center rounded bg-green-500 px-4 py-2 font-semibold text-white hover:bg-green-400 focus:border-green-500 focus:outline-none focus:ring-0 disabled:bg-green-400"
           type="button"
         >
           {getButtonContent()}

--- a/client/src/components/SidePanel/Agents/ActionsInput.tsx
+++ b/client/src/components/SidePanel/Agents/ActionsInput.tsx
@@ -202,7 +202,7 @@ export default function ActionsInput({
 
   return (
     <>
-      <div className="">
+      <div className="flex min-h-0 flex-1 flex-col">
         <div className="mb-1 flex flex-wrap items-center justify-between gap-4">
           <label
             htmlFor="schemaInput"
@@ -210,31 +210,17 @@ export default function ActionsInput({
           >
             {localize('com_ui_schema')}
           </label>
-          {/* TODO: Implement examples functionality
-          <div className="flex items-center gap-2">
-            <select
-              onChange={(e) => logger.log('actions', 'selecting example action', e.target.value)}
-              className="border-token-border-medium h-8 min-w-[100px] rounded-lg border bg-transparent px-2 py-0 text-sm"
-            >
-              <option value="label">{localize('com_ui_examples')}</option>
-              <option value="0">Weather (JSON)</option>
-              <option value="1">Pet Store (YAML)</option>
-              <option value="2">Blank Template</option>
-            </select>
-          </div>
-          */}
         </div>
-        <div className="border-token-border-medium bg-token-surface-primary hover:border-token-border-hover mb-4 w-full overflow-hidden rounded-lg border ring-0">
-          <div className="relative">
+        <div className="border-token-border-medium bg-token-surface-primary hover:border-token-border-hover mb-4 flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border ring-0">
+          <div className="relative flex min-h-0 flex-1 flex-col">
             <textarea
               id="schemaInput"
               value={inputValue}
               onChange={handleInputChange}
               spellCheck="false"
               placeholder={localize('com_ui_enter_openapi_schema')}
-              className="text-token-text-primary block h-96 w-full bg-transparent p-2 font-mono text-xs outline-none focus:ring-1 focus:ring-border-light"
+              className="text-token-text-primary block min-h-[12rem] flex-1 resize-y bg-transparent p-2 font-mono text-xs outline-none focus:ring-1 focus:ring-border-light"
             />
-            {/* TODO: format input button */}
           </div>
           {validationResult && validationResult.message !== 'OpenAPI spec is valid.' && (
             <div className="border-token-border-light border-t p-2 text-red-500">

--- a/client/src/components/SidePanel/Agents/ActionsPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ActionsPanel.tsx
@@ -86,7 +86,7 @@ export default function ActionsPanel() {
     <FormProvider {...methods}>
       <form className="h-full grow overflow-hidden">
         <div className="h-full overflow-auto px-2 pb-12 text-sm">
-          <div className="relative flex flex-col items-center px-16 py-6 text-center">
+          <div className="relative flex flex-col items-center px-16 pt-2 text-center">
             <div className="absolute left-0 top-6">
               <button
                 type="button"

--- a/client/src/components/SidePanel/Agents/ActionsPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ActionsPanel.tsx
@@ -85,76 +85,81 @@ export default function ActionsPanel() {
   return (
     <FormProvider {...methods}>
       <form className="h-full grow overflow-hidden">
-        <div className="h-full overflow-auto px-2 pb-12 text-sm">
-          <div className="relative flex flex-col items-center px-16 pt-2 text-center">
-            <div className="absolute left-0 top-6">
-              <button
-                type="button"
-                className="btn btn-neutral relative"
-                onClick={() => {
-                  setActivePanel(Panel.builder);
-                  setAction(undefined);
-                }}
-              >
-                <div className="flex w-full items-center justify-center gap-2">
-                  <ChevronLeft />
+        <div className="h-full overflow-auto px-2 text-sm">
+          <div className="flex min-h-full flex-col pb-3">
+            <div>
+              <div className="relative flex flex-col items-center px-16 pt-2 text-center">
+                <div className="absolute left-0 top-6">
+                  <button
+                    type="button"
+                    className="btn btn-neutral relative"
+                    onClick={() => {
+                      setActivePanel(Panel.builder);
+                      setAction(undefined);
+                    }}
+                  >
+                    <div className="flex w-full items-center justify-center gap-2">
+                      <ChevronLeft />
+                    </div>
+                  </button>
                 </div>
-              </button>
-            </div>
 
-            {!!action && (
-              <OGDialog>
-                <OGDialogTrigger asChild>
-                  <div className="absolute right-0 top-6">
-                    <button
-                      type="button"
-                      disabled={isEphemeralAgent(agent_id) || !action.action_id}
-                      className="btn btn-neutral border-token-border-light relative h-9 rounded-lg font-medium"
-                    >
-                      <TrashIcon className="text-red-500" />
-                    </button>
-                  </div>
-                </OGDialogTrigger>
-                <OGDialogTemplate
-                  showCloseButton={false}
-                  title={localize('com_ui_delete_action')}
-                  className="max-w-[450px]"
-                  main={
-                    <Label className="text-left text-sm font-medium">
-                      {localize('com_ui_delete_action_confirm')}
-                    </Label>
-                  }
-                  selection={{
-                    selectHandler: () => {
-                      if (isEphemeralAgent(agent_id)) {
-                        return showToast({
-                          message: localize('com_agents_no_agent_id_error'),
-                          status: 'error',
-                        });
+                {!!action && (
+                  <OGDialog>
+                    <OGDialogTrigger asChild>
+                      <div className="absolute right-0 top-6">
+                        <button
+                          type="button"
+                          disabled={isEphemeralAgent(agent_id) || !action.action_id}
+                          className="btn btn-neutral border-token-border-light relative h-9 rounded-lg font-medium"
+                        >
+                          <TrashIcon className="text-red-500" />
+                        </button>
+                      </div>
+                    </OGDialogTrigger>
+                    <OGDialogTemplate
+                      showCloseButton={false}
+                      title={localize('com_ui_delete_action')}
+                      className="max-w-[450px]"
+                      main={
+                        <Label className="text-left text-sm font-medium">
+                          {localize('com_ui_delete_action_confirm')}
+                        </Label>
                       }
-                      deleteAgentAction.mutate({
-                        action_id: action.action_id,
-                        agent_id: agent_id || '',
-                      });
-                    },
-                    selectClasses:
-                      'bg-red-700 dark:bg-red-600 hover:bg-red-800 dark:hover:bg-red-800 transition-color duration-200 text-white',
-                    selectText: localize('com_ui_delete'),
-                  }}
-                />
-              </OGDialog>
-            )}
+                      selection={{
+                        selectHandler: () => {
+                          if (isEphemeralAgent(agent_id)) {
+                            return showToast({
+                              message: localize('com_agents_no_agent_id_error'),
+                              status: 'error',
+                            });
+                          }
+                          deleteAgentAction.mutate({
+                            action_id: action.action_id,
+                            agent_id: agent_id || '',
+                          });
+                        },
+                        selectClasses:
+                          'bg-red-700 dark:bg-red-600 hover:bg-red-800 dark:hover:bg-red-800 transition-color duration-200 text-white',
+                        selectText: localize('com_ui_delete'),
+                      }}
+                    />
+                  </OGDialog>
+                )}
 
-            <div className="text-xl font-medium">{(action ? 'Edit' : 'Add') + ' ' + 'actions'}</div>
-            <div className="text-xs text-text-secondary">
-              {localize('com_assistants_actions_info')}
+                <div className="text-xl font-medium">
+                  {(action ? 'Edit' : 'Add') + ' ' + 'actions'}
+                </div>
+                <div className="text-xs text-text-secondary">
+                  {localize('com_assistants_actions_info')}
+                </div>
+              </div>
+              <ActionsAuth />
             </div>
-            {/* <div className="text-sm text-text-secondary">
-            <a href="https://help.openai.com/en/articles/8554397-creating-a-gpt" target="_blank" rel="noreferrer" className="font-medium">Learn more.</a>
-          </div> */}
+            <div className="flex flex-1 flex-col">
+              <ActionsInput action={action} agent_id={agent_id} setAction={setAction} />
+            </div>
           </div>
-          <ActionsAuth />
-          <ActionsInput action={action} agent_id={agent_id} setAction={setAction} />
         </div>
       </form>
     </FormProvider>

--- a/client/src/components/SidePanel/Agents/Advanced/AdvancedPanel.tsx
+++ b/client/src/components/SidePanel/Agents/Advanced/AdvancedPanel.tsx
@@ -23,8 +23,8 @@ export default function AdvancedPanel() {
   );
 
   return (
-    <div className="scrollbar-gutter-stable h-full min-h-[40vh] overflow-auto pb-12 text-sm">
-      <div className="advanced-panel relative flex flex-col items-center px-16 py-4 text-center">
+    <div className="mb-1 flex w-full flex-col gap-2 text-sm">
+      <div className="advanced-panel relative flex flex-col items-center px-16 pt-2 text-center">
         <div className="absolute left-0 top-4">
           <button
             type="button"
@@ -41,7 +41,7 @@ export default function AdvancedPanel() {
         </div>
         <div className="mb-2 mt-2 text-xl font-medium">{localize('com_ui_advanced_settings')}</div>
       </div>
-      <div className="flex flex-col gap-4 px-2">
+      <div className="flex flex-col gap-4 px-2 pb-2">
         <MaxAgentSteps />
         <Controller
           name="edges"

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -480,71 +480,70 @@ export default function AgentPanel() {
     <FormProvider {...methods}>
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="scrollbar-gutter-stable h-auto w-full flex-shrink-0 px-3 pb-3"
+        className="scrollbar-gutter-stable flex flex-1 flex-col px-3 pb-3"
         aria-label="Agent configuration form"
       >
-        <div className="flex w-full flex-wrap gap-2">
-          <div className="w-full">
-            <AgentSelect
-              createMutation={create}
-              agentQuery={agentQuery}
-              setCurrentAgentId={setCurrentAgentId}
-              // The following is required to force re-render the component when the form's agent ID changes
-              // Also maintains ComboBox Focus for Accessibility
-              selectedAgentId={agentQuery.isInitialLoading ? null : (current_agent_id ?? null)}
-            />
+        <div className="flex-1">
+          <div className="flex w-full flex-wrap gap-2">
+            <div className="w-full">
+              <AgentSelect
+                createMutation={create}
+                agentQuery={agentQuery}
+                setCurrentAgentId={setCurrentAgentId}
+                selectedAgentId={agentQuery.isInitialLoading ? null : (current_agent_id ?? null)}
+              />
+            </div>
+            {agent_id && (
+              <div className="flex w-full gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full justify-center"
+                  onClick={() => {
+                    reset(getDefaultAgentFormValues());
+                    setCurrentAgentId(undefined);
+                  }}
+                  disabled={agentQuery.isInitialLoading}
+                  aria-label={localize('com_ui_create_new_agent')}
+                >
+                  <Plus className="mr-1 h-4 w-4" aria-hidden="true" />
+                  {localize('com_ui_create_new_agent')}
+                </Button>
+                <Button
+                  variant="submit"
+                  disabled={isEphemeralAgent(agent_id) || agentQuery.isInitialLoading}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    handleSelectAgent();
+                  }}
+                  aria-label={localize('com_ui_select_agent')}
+                >
+                  {localize('com_ui_select')}
+                </Button>
+              </div>
+            )}
           </div>
-          {/* Create + Select Button */}
-          {agent_id && (
-            <div className="flex w-full gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                className="w-full justify-center"
-                onClick={() => {
-                  reset(getDefaultAgentFormValues());
-                  setCurrentAgentId(undefined);
-                }}
-                disabled={agentQuery.isInitialLoading}
-                aria-label={localize('com_ui_create_new_agent')}
-              >
-                <Plus className="mr-1 h-4 w-4" aria-hidden="true" />
-                {localize('com_ui_create_new_agent')}
-              </Button>
-              <Button
-                variant="submit"
-                disabled={isEphemeralAgent(agent_id) || agentQuery.isInitialLoading}
-                onClick={(e) => {
-                  e.preventDefault();
-                  handleSelectAgent();
-                }}
-                aria-label={localize('com_ui_select_agent')}
-              >
-                {localize('com_ui_select')}
-              </Button>
+          {agentQuery.isInitialLoading && <AgentPanelSkeleton />}
+          {!canEditAgent && !agentQuery.isInitialLoading && (
+            <div className="flex h-[30vh] w-full items-center justify-center">
+              <div className="text-center">
+                <h2 className="text-token-text-primary m-2 text-xl font-semibold">
+                  {localize('com_agents_not_available')}
+                </h2>
+                <p className="text-token-text-secondary">{localize('com_agents_no_access')}</p>
+              </div>
             </div>
           )}
+          {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.model && (
+            <ModelPanel models={models} providers={providers} setActivePanel={setActivePanel} />
+          )}
+          {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.builder && (
+            <AgentConfig />
+          )}
+          {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.advanced && (
+            <AdvancedPanel />
+          )}
         </div>
-        {agentQuery.isInitialLoading && <AgentPanelSkeleton />}
-        {!canEditAgent && !agentQuery.isInitialLoading && (
-          <div className="flex h-[30vh] w-full items-center justify-center">
-            <div className="text-center">
-              <h2 className="text-token-text-primary m-2 text-xl font-semibold">
-                {localize('com_agents_not_available')}
-              </h2>
-              <p className="text-token-text-secondary">{localize('com_agents_no_access')}</p>
-            </div>
-          </div>
-        )}
-        {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.model && (
-          <ModelPanel models={models} providers={providers} setActivePanel={setActivePanel} />
-        )}
-        {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.builder && (
-          <AgentConfig />
-        )}
-        {canEditAgent && !agentQuery.isInitialLoading && activePanel === Panel.advanced && (
-          <AdvancedPanel />
-        )}
         {canEditAgent && !agentQuery.isInitialLoading && (
           <AgentFooter
             createMutation={create}

--- a/client/src/components/SidePanel/Agents/MCPTool.tsx
+++ b/client/src/components/SidePanel/Agents/MCPTool.tsx
@@ -102,7 +102,7 @@ export default function MCPTool({ serverInfo }: { serverInfo?: MCPServerInfo }) 
       <Accordion type="single" value={accordionValue} onValueChange={setAccordionValue} collapsible>
         <AccordionItem value={currentServerName} className="group relative w-full border-none">
           <div
-            className="relative flex w-full items-center gap-1 rounded-lg p-1 hover:bg-surface-primary-alt"
+            className="relative flex w-full items-center gap-1 rounded-lg p-1 text-sm hover:bg-surface-primary-alt"
             onMouseEnter={() => setIsHovering(true)}
             onMouseLeave={() => setIsHovering(false)}
             onFocus={() => setIsFocused(true)}

--- a/client/src/components/SidePanel/Agents/ModelPanel.tsx
+++ b/client/src/components/SidePanel/Agents/ModelPanel.tsx
@@ -97,8 +97,8 @@ export default function ModelPanel({
   };
 
   return (
-    <div className="mb-1 flex h-full min-h-[50vh] w-full flex-col gap-2 text-sm">
-      <div className="model-panel relative flex flex-col items-center px-16 py-4 text-center">
+    <div className="mb-1 flex w-full flex-col gap-2 text-sm">
+      <div className="model-panel relative flex flex-col items-center px-16 pt-2 text-center">
         <div className="absolute left-0 top-4">
           <button
             type="button"

--- a/packages/client/src/components/Dropdown.tsx
+++ b/packages/client/src/components/Dropdown.tsx
@@ -102,7 +102,7 @@ const Dropdown: React.FC<DropdownProps> = ({
         portal={portal}
         store={selectProps}
         className={cn(
-          'popover-ui z-40',
+          'popover-ui z-40 text-sm',
           sizeClasses,
           className,
           'max-h-[80vh] overflow-y-auto',


### PR DESCRIPTION
## Summary

I fixed layout and styling inconsistencies across the Agent side panel, improved markdown code block detection to handle edge cases, and cleaned up dead code.

- Refactored `AgentPanel` form layout from `h-auto flex-shrink-0` to `flex flex-1 flex-col`, wrapping panel content in a `flex-1` container so the footer stays anchored at the bottom regardless of content height.
- Restructured `ActionsPanel` to use a `min-h-full flex-col` inner wrapper, separating the header/auth section from the `ActionsInput` so the schema textarea and save button fill remaining vertical space naturally.
- Updated `ActionsInput` to use flex-based sizing (`flex-1 min-h-0`) instead of the fixed `h-96` textarea height, making the schema input resizable (`resize-y`) with a `min-h-[12rem]` floor and pinning the save button to the bottom with `mt-auto`.
- Removed stale commented-out TODO blocks (example actions dropdown, format input button, "Learn more" link) from `ActionsInput` and `ActionsPanel`.
- Reduced vertical padding in `ModelPanel`, `AdvancedPanel`, and `ActionsPanel` headers from `py-4`/`py-6` to `pt-2` for tighter, more consistent spacing across all sub-panels.
- Removed the hardcoded `min-h-[50vh]` from `ModelPanel` and `min-h-[40vh]`/`scrollbar-gutter-stable` from `AdvancedPanel`, letting both panels size naturally within the parent flex container.
- Added `text-sm` to the `Dropdown` popover and `MCPTool` accordion row to match the font size used elsewhere in the side panel.
- Extracted an `isSingleLineCode` utility in `MarkdownComponents` that correctly handles `children` passed as an array of strings (not just a single string), fixing false negatives in single-line code detection for both `code` and `codeNoExecution` components.
- Added an early return guard in the prompt editor's `processChildren` to skip cloning of non-HTML-string elements and `code` elements, preventing unintended re-processing of React component nodes.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

- Opened the Agent builder side panel and verified the form layout fills available height with the footer pinned at the bottom across all sub-panels (Builder, Model, Advanced).
- Navigated to the Actions panel, confirmed the schema textarea grows to fill available space, is resizable, and the save button remains anchored below.
- Verified `Dropdown` popovers and `MCPTool` accordion items render with consistent `text-sm` font sizing.
- Tested inline code rendering in chat messages with both single-string and array-of-strings children to confirm `isSingleLineCode` correctly distinguishes single-line from multi-line code blocks.
- Confirmed the prompt editor renders markdown with inline code without errors or unexpected re-processing of component nodes.

### **Test Configuration**:

- Browser: Chrome (latest)
- Screen sizes: default and narrow side panel widths

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings