### PR TITLE
🔼 refactor: Improve UX for Command Popovers

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -83,10 +83,8 @@ const ChatForm = memo(function ChatForm({
   const [badges, setBadges] = useRecoilState(store.chatBadges);
   const [isEditingBadges, setIsEditingBadges] = useRecoilState(store.isEditingBadges);
   const [showStopButton, setShowStopButton] = useRecoilState(store.showStopButtonByIndex(index));
-  const [showPlusPopover, setShowPlusPopover] = useRecoilState(store.showPlusPopoverFamily(index));
-  const [showMentionPopover, setShowMentionPopover] = useRecoilState(
-    store.showMentionPopoverFamily(index),
-  );
+  const plusPopoverAtom = useMemo(() => store.showPlusPopoverFamily(index), [index]);
+  const mentionPopoverAtom = useMemo(() => store.showMentionPopoverFamily(index), [index]);
 
   const { requiresKey } = useRequiresKey();
   const methods = useChatFormContext();
@@ -158,8 +156,6 @@ const ChatForm = memo(function ChatForm({
   const handleKeyUp = useHandleKeyUp({
     index,
     textAreaRef,
-    setShowPlusPopover,
-    setShowMentionPopover,
   });
   const {
     isNotAppendable,
@@ -242,23 +238,21 @@ const ChatForm = memo(function ChatForm({
     >
       <div className="relative flex h-full flex-1 items-stretch md:flex-col">
         <div className={cn('flex w-full items-center', isRTL && 'flex-row-reverse')}>
-          {showPlusPopover && !isAssistantsEndpoint(endpoint) && (
-            <Mention
-              setShowMentionPopover={setShowPlusPopover}
-              newConversation={generateConversation}
-              textAreaRef={textAreaRef}
-              commandChar="+"
-              placeholder="com_ui_add_model_preset"
-              includeAssistants={false}
-            />
-          )}
-          {showMentionPopover && (
-            <Mention
-              setShowMentionPopover={setShowMentionPopover}
-              newConversation={newConversation}
-              textAreaRef={textAreaRef}
-            />
-          )}
+          <Mention
+            index={index}
+            popoverAtom={plusPopoverAtom}
+            newConversation={generateConversation}
+            textAreaRef={textAreaRef}
+            commandChar="+"
+            placeholder="com_ui_add_model_preset"
+            includeAssistants={false}
+          />
+          <Mention
+            index={index}
+            popoverAtom={mentionPopoverAtom}
+            newConversation={newConversation}
+            textAreaRef={textAreaRef}
+          />
           <PromptsCommand index={index} textAreaRef={textAreaRef} submitPrompt={submitPrompt} />
           <div
             onClick={handleContainerClick}

--- a/client/src/components/Chat/Input/Mention.tsx
+++ b/client/src/components/Chat/Input/Mention.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useRef, useEffect, useCallback } from 'react';
+import { memo, useState, useRef, useEffect } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { AutoSizer, List } from 'react-virtualized';
 import { Spinner, useCombobox } from '@librechat/client';
@@ -6,6 +6,7 @@ import { EModelEndpoint } from 'librechat-data-provider';
 import type { RecoilState } from 'recoil';
 import type { MentionOption, ConvoGenerator } from '~/common';
 import { useGetConversation, useLocalize, TranslationKeys } from '~/hooks';
+import useInitPopoverInput from '~/hooks/Input/useInitPopoverInput';
 import useSelectMention from '~/hooks/Input/useSelectMention';
 import { useAssistantsMapContext } from '~/Providers';
 import useMentions from '~/hooks/Input/useMentions';
@@ -25,14 +26,13 @@ type MentionProps = {
 };
 
 function MentionContent({
-  index: _index,
   popoverAtom,
   newConversation,
   textAreaRef,
   commandChar = '@',
   placeholder = 'com_ui_mention',
   includeAssistants = true,
-}: MentionProps) {
+}: Omit<MentionProps, 'index'>) {
   const localize = useLocalize();
   const getConversation = useGetConversation(0);
   const assistantsMap = useAssistantsMapContext();
@@ -66,30 +66,13 @@ function MentionContent({
     options: inputOptions,
   });
 
-  const initInputRef = useCallback(
-    (node: HTMLInputElement | null) => {
-      inputRef.current = node;
-      if (!node) {
-        return;
-      }
-      node.focus();
-      setOpen(true);
-      const textarea = textAreaRef.current;
-      if (!textarea) {
-        return;
-      }
-      const text = textarea.value;
-      if (text.length > 0 && text[0] === commandChar) {
-        if (text.length > 1) {
-          setSearchValue(text.slice(1));
-        }
-        textarea.value = '';
-        textarea.setSelectionRange(0, 0);
-        textarea.dispatchEvent(new Event('input', { bubbles: true }));
-      }
-    },
-    [textAreaRef, commandChar, setSearchValue, setOpen],
-  );
+  const initInputRef = useInitPopoverInput({
+    inputRef,
+    textAreaRef,
+    commandChar,
+    setSearchValue,
+    setOpen,
+  });
 
   const handleSelect = (mention?: MentionOption) => {
     if (!mention) {
@@ -262,6 +245,7 @@ function MentionContent({
 }
 
 const MentionPopoverContainer = memo(function MentionPopoverContainer({
+  index: _index,
   popoverAtom,
   ...rest
 }: MentionProps) {

--- a/client/src/components/Chat/Input/Mention.tsx
+++ b/client/src/components/Chat/Input/Mention.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
-import { useCombobox } from '@librechat/client';
 import { AutoSizer, List } from 'react-virtualized';
+import { Spinner, useCombobox } from '@librechat/client';
 import { EModelEndpoint } from 'librechat-data-provider';
 import type { MentionOption, ConvoGenerator } from '~/common';
 import type { SetterOrUpdater } from 'recoil';
@@ -34,6 +34,7 @@ export default function Mention({
   const {
     options,
     presets,
+    isLoading,
     modelSpecs,
     agentsList,
     modelsConfig,
@@ -197,7 +198,22 @@ export default function Mention({
             }
           }}
           onChange={(e) => setSearchValue(e.target.value)}
-          onFocus={() => setOpen(true)}
+          onFocus={() => {
+            setOpen(true);
+            const textarea = textAreaRef.current;
+            if (!textarea) {
+              return;
+            }
+            const text = textarea.value;
+            if (text.length > 0 && text[0] === commandChar) {
+              if (text.length > 1) {
+                setSearchValue(text.slice(1));
+              }
+              textarea.value = '';
+              textarea.setSelectionRange(0, 0);
+              textarea.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+          }}
           onBlur={() => {
             timeoutRef.current = setTimeout(() => {
               setOpen(false);
@@ -205,7 +221,12 @@ export default function Mention({
             }, 150);
           }}
         />
-        {open && (
+        {open && isLoading && matches.length === 0 && (
+          <div className="flex h-32 items-center justify-center text-text-primary">
+            <Spinner />
+          </div>
+        )}
+        {open && matches.length > 0 && (
           <div className="max-h-40">
             <AutoSizer disableHeight>
               {({ width }) => (

--- a/client/src/components/Chat/Input/Mention.tsx
+++ b/client/src/components/Chat/Input/Mention.tsx
@@ -1,9 +1,10 @@
-import { useState, useRef, useEffect } from 'react';
+import { memo, useState, useRef, useEffect, useCallback } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { AutoSizer, List } from 'react-virtualized';
 import { Spinner, useCombobox } from '@librechat/client';
 import { EModelEndpoint } from 'librechat-data-provider';
+import type { RecoilState } from 'recoil';
 import type { MentionOption, ConvoGenerator } from '~/common';
-import type { SetterOrUpdater } from 'recoil';
 import { useGetConversation, useLocalize, TranslationKeys } from '~/hooks';
 import useSelectMention from '~/hooks/Input/useSelectMention';
 import { useAssistantsMapContext } from '~/Providers';
@@ -13,24 +14,29 @@ import MentionItem from './MentionItem';
 
 const ROW_HEIGHT = 44;
 
-export default function Mention({
-  setShowMentionPopover,
-  newConversation,
-  textAreaRef,
-  commandChar = '@',
-  placeholder = 'com_ui_mention',
-  includeAssistants = true,
-}: {
-  setShowMentionPopover: SetterOrUpdater<boolean>;
+type MentionProps = {
+  index: number;
+  popoverAtom: RecoilState<boolean>;
   newConversation: ConvoGenerator;
   textAreaRef: React.MutableRefObject<HTMLTextAreaElement | null>;
   commandChar?: string;
   placeholder?: TranslationKeys;
   includeAssistants?: boolean;
-}) {
+};
+
+function MentionContent({
+  index: _index,
+  popoverAtom,
+  newConversation,
+  textAreaRef,
+  commandChar = '@',
+  placeholder = 'com_ui_mention',
+  includeAssistants = true,
+}: MentionProps) {
   const localize = useLocalize();
   const getConversation = useGetConversation(0);
   const assistantsMap = useAssistantsMapContext();
+  const setShowPopover = useSetRecoilState(popoverAtom);
   const {
     options,
     presets,
@@ -60,6 +66,31 @@ export default function Mention({
     options: inputOptions,
   });
 
+  const initInputRef = useCallback(
+    (node: HTMLInputElement | null) => {
+      inputRef.current = node;
+      if (!node) {
+        return;
+      }
+      node.focus();
+      setOpen(true);
+      const textarea = textAreaRef.current;
+      if (!textarea) {
+        return;
+      }
+      const text = textarea.value;
+      if (text.length > 0 && text[0] === commandChar) {
+        if (text.length > 1) {
+          setSearchValue(text.slice(1));
+        }
+        textarea.value = '';
+        textarea.setSelectionRange(0, 0);
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    },
+    [textAreaRef, commandChar, setSearchValue, setOpen],
+  );
+
   const handleSelect = (mention?: MentionOption) => {
     if (!mention) {
       return;
@@ -68,7 +99,7 @@ export default function Mention({
     const defaultSelect = () => {
       setSearchValue('');
       setOpen(false);
-      setShowMentionPopover(false);
+      setShowPopover(false);
       onSelectMention?.(mention);
 
       if (textAreaRef.current) {
@@ -165,10 +196,7 @@ export default function Mention({
     <div className="absolute bottom-28 z-10 w-full space-y-2">
       <div className="popover border-token-border-light rounded-2xl border bg-white p-2 shadow-lg dark:bg-gray-700">
         <input
-          // The user expects focus to transition to the input field when the popover is opened
-          // eslint-disable-next-line jsx-a11y/no-autofocus
-          autoFocus
-          ref={inputRef}
+          ref={initInputRef}
           placeholder={localize(placeholder)}
           className="mb-1 w-full border-0 bg-white p-2 text-sm focus:outline-none dark:bg-gray-700 dark:text-gray-200"
           autoComplete="off"
@@ -176,7 +204,7 @@ export default function Mention({
           onKeyDown={(e) => {
             if (e.key === 'Escape') {
               setOpen(false);
-              setShowMentionPopover(false);
+              setShowPopover(false);
               textAreaRef.current?.focus();
             }
             if (e.key === 'ArrowDown') {
@@ -193,31 +221,16 @@ export default function Mention({
               handleSelect(matches[activeIndex] as MentionOption);
             } else if (e.key === 'Backspace' && searchValue === '') {
               setOpen(false);
-              setShowMentionPopover(false);
+              setShowPopover(false);
               textAreaRef.current?.focus();
             }
           }}
           onChange={(e) => setSearchValue(e.target.value)}
-          onFocus={() => {
-            setOpen(true);
-            const textarea = textAreaRef.current;
-            if (!textarea) {
-              return;
-            }
-            const text = textarea.value;
-            if (text.length > 0 && text[0] === commandChar) {
-              if (text.length > 1) {
-                setSearchValue(text.slice(1));
-              }
-              textarea.value = '';
-              textarea.setSelectionRange(0, 0);
-              textarea.dispatchEvent(new Event('input', { bubbles: true }));
-            }
-          }}
+          onFocus={() => setOpen(true)}
           onBlur={() => {
             timeoutRef.current = setTimeout(() => {
               setOpen(false);
-              setShowMentionPopover(false);
+              setShowPopover(false);
             }, 150);
           }}
         />
@@ -247,3 +260,16 @@ export default function Mention({
     </div>
   );
 }
+
+const MentionPopoverContainer = memo(function MentionPopoverContainer({
+  popoverAtom,
+  ...rest
+}: MentionProps) {
+  const show = useRecoilValue(popoverAtom);
+  if (!show) {
+    return null;
+  }
+  return <MentionContent popoverAtom={popoverAtom} {...rest} />;
+});
+
+export default MentionPopoverContainer;

--- a/client/src/components/Chat/Input/PromptsCommand.tsx
+++ b/client/src/components/Chat/Input/PromptsCommand.tsx
@@ -4,6 +4,7 @@ import { Spinner, useCombobox } from '@librechat/client';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import type { TPromptGroup } from 'librechat-data-provider';
 import type { PromptOption } from '~/common';
+import useInitPopoverInput from '~/hooks/Input/useInitPopoverInput';
 import { removeCharIfLast, detectVariables } from '~/utils';
 import { useRecordPromptUsage } from '~/data-provider';
 import { VariableDialog } from '~/components/Prompts';
@@ -81,30 +82,13 @@ function PromptsCommand({
     options: prompts ?? [],
   });
 
-  const initInputRef = useCallback(
-    (node: HTMLInputElement | null) => {
-      inputRef.current = node;
-      if (!node) {
-        return;
-      }
-      node.focus();
-      setOpen(true);
-      const textarea = textAreaRef.current;
-      if (!textarea) {
-        return;
-      }
-      const text = textarea.value;
-      if (text.length > 0 && text[0] === commandChar) {
-        if (text.length > 1) {
-          setSearchValue(text.slice(1));
-        }
-        textarea.value = '';
-        textarea.setSelectionRange(0, 0);
-        textarea.dispatchEvent(new Event('input', { bubbles: true }));
-      }
-    },
-    [textAreaRef, setSearchValue, setOpen],
-  );
+  const initInputRef = useInitPopoverInput({
+    inputRef,
+    textAreaRef,
+    commandChar,
+    setSearchValue,
+    setOpen,
+  });
 
   const handleSelect = useCallback(
     (mention?: PromptOption, e?: React.KeyboardEvent<HTMLInputElement>) => {

--- a/client/src/components/Chat/Input/PromptsCommand.tsx
+++ b/client/src/components/Chat/Input/PromptsCommand.tsx
@@ -81,6 +81,31 @@ function PromptsCommand({
     options: prompts ?? [],
   });
 
+  const initInputRef = useCallback(
+    (node: HTMLInputElement | null) => {
+      inputRef.current = node;
+      if (!node) {
+        return;
+      }
+      node.focus();
+      setOpen(true);
+      const textarea = textAreaRef.current;
+      if (!textarea) {
+        return;
+      }
+      const text = textarea.value;
+      if (text.length > 0 && text[0] === commandChar) {
+        if (text.length > 1) {
+          setSearchValue(text.slice(1));
+        }
+        textarea.value = '';
+        textarea.setSelectionRange(0, 0);
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    },
+    [textAreaRef, setSearchValue, setOpen],
+  );
+
   const handleSelect = useCallback(
     (mention?: PromptOption, e?: React.KeyboardEvent<HTMLInputElement>) => {
       if (!mention) {
@@ -193,10 +218,7 @@ function PromptsCommand({
       <div className="absolute bottom-28 z-10 w-full space-y-2">
         <div className="popover border-token-border-light rounded-2xl border bg-surface-tertiary-alt p-2 shadow-lg">
           <input
-            // The user expects focus to transition to the input field when the popover is opened
-            // eslint-disable-next-line jsx-a11y/no-autofocus
-            autoFocus
-            ref={inputRef}
+            ref={initInputRef}
             placeholder={localize('com_ui_command_usage_placeholder')}
             className="mb-1 w-full border-0 bg-surface-tertiary-alt p-2 text-sm focus:outline-none dark:text-gray-200"
             autoComplete="off"
@@ -223,22 +245,7 @@ function PromptsCommand({
               }
             }}
             onChange={(e) => setSearchValue(e.target.value)}
-            onFocus={() => {
-              setOpen(true);
-              const textarea = textAreaRef.current;
-              if (!textarea) {
-                return;
-              }
-              const text = textarea.value;
-              if (text.length > 0 && text[0] === commandChar) {
-                if (text.length > 1) {
-                  setSearchValue(text.slice(1));
-                }
-                textarea.value = '';
-                textarea.setSelectionRange(0, 0);
-                textarea.dispatchEvent(new Event('input', { bubbles: true }));
-              }
-            }}
+            onFocus={() => setOpen(true)}
             onBlur={() => {
               timeoutRef.current = setTimeout(() => {
                 setOpen(false);

--- a/client/src/components/Chat/Input/PromptsCommand.tsx
+++ b/client/src/components/Chat/Input/PromptsCommand.tsx
@@ -223,7 +223,22 @@ function PromptsCommand({
               }
             }}
             onChange={(e) => setSearchValue(e.target.value)}
-            onFocus={() => setOpen(true)}
+            onFocus={() => {
+              setOpen(true);
+              const textarea = textAreaRef.current;
+              if (!textarea) {
+                return;
+              }
+              const text = textarea.value;
+              if (text.length > 0 && text[0] === commandChar) {
+                if (text.length > 1) {
+                  setSearchValue(text.slice(1));
+                }
+                textarea.value = '';
+                textarea.setSelectionRange(0, 0);
+                textarea.dispatchEvent(new Event('input', { bubbles: true }));
+              }
+            }}
             onBlur={() => {
               timeoutRef.current = setTimeout(() => {
                 setOpen(false);
@@ -231,38 +246,28 @@ function PromptsCommand({
               }, 150);
             }}
           />
-          <div className="max-h-40 overflow-y-auto">
-            {(() => {
-              if (isLoading && open) {
-                return (
-                  <div className="flex h-32 items-center justify-center text-text-primary">
-                    <Spinner />
-                  </div>
-                );
-              }
-
-              if (!isLoading && open) {
-                return (
-                  <div className="max-h-40">
-                    <AutoSizer disableHeight>
-                      {({ width }) => (
-                        <List
-                          width={width}
-                          overscanRowCount={5}
-                          rowHeight={ROW_HEIGHT}
-                          rowCount={matches.length}
-                          rowRenderer={rowRenderer}
-                          scrollToIndex={activeIndex}
-                          height={Math.min(matches.length * ROW_HEIGHT, 160)}
-                        />
-                      )}
-                    </AutoSizer>
-                  </div>
-                );
-              }
-              return null;
-            })()}
-          </div>
+          {open && isLoading && matches.length === 0 && (
+            <div className="flex h-32 items-center justify-center text-text-primary">
+              <Spinner />
+            </div>
+          )}
+          {open && matches.length > 0 && (
+            <div className="max-h-40">
+              <AutoSizer disableHeight>
+                {({ width }) => (
+                  <List
+                    width={width}
+                    overscanRowCount={5}
+                    rowHeight={ROW_HEIGHT}
+                    rowCount={matches.length}
+                    rowRenderer={rowRenderer}
+                    scrollToIndex={activeIndex}
+                    height={Math.min(matches.length * ROW_HEIGHT, 160)}
+                  />
+                )}
+              </AutoSizer>
+            </div>
+          )}
         </div>
       </div>
     </PopoverContainer>

--- a/client/src/hooks/Input/useHandleKeyUp.spec.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.spec.ts
@@ -1,6 +1,9 @@
+const mockSetShowMentionPopover = jest.fn();
+const mockSetShowPlusPopover = jest.fn();
 const mockSetShowPromptsPopover = jest.fn();
 const mockHasPromptsAccess = { current: true };
 const mockHasMultiConvoAccess = { current: true };
+const mockEndpoint = { current: 'openAI' as string | null };
 const mockCommandToggles = { at: true, plus: true, slash: true };
 
 jest.mock('recoil', () => ({
@@ -8,6 +11,9 @@ jest.mock('recoil', () => ({
   useRecoilValue: jest.fn((atom) => {
     if (atom === 'latestMessageFamily-0') {
       return null;
+    }
+    if (atom === 'conversationEndpointByIndex-0') {
+      return mockEndpoint.current;
     }
     if (atom === 'atCommand') {
       return mockCommandToggles.at;
@@ -20,13 +26,25 @@ jest.mock('recoil', () => ({
     }
     return undefined;
   }),
-  useSetRecoilState: jest.fn(() => mockSetShowPromptsPopover),
+  useSetRecoilState: jest.fn((atom: string) => {
+    if (atom === 'showMentionPopoverFamily-0') {
+      return mockSetShowMentionPopover;
+    }
+    if (atom === 'showPlusPopoverFamily-0') {
+      return mockSetShowPlusPopover;
+    }
+    if (atom === 'showPromptsPopoverFamily-0') {
+      return mockSetShowPromptsPopover;
+    }
+    return jest.fn();
+  }),
 }));
 
 jest.mock('~/store', () => ({
   showPromptsPopoverFamily: (idx: number) => `showPromptsPopoverFamily-${idx}`,
   showMentionPopoverFamily: (idx: number) => `showMentionPopoverFamily-${idx}`,
   showPlusPopoverFamily: (idx: number) => `showPlusPopoverFamily-${idx}`,
+  conversationEndpointByIndex: (idx: number) => `conversationEndpointByIndex-${idx}`,
   latestMessageFamily: (idx: number) => `latestMessageFamily-${idx}`,
   atCommand: 'atCommand',
   plusCommand: 'plusCommand',
@@ -66,22 +84,17 @@ const renderUseHandleKeyUp = (
   textAreaRef: React.RefObject<HTMLTextAreaElement>,
   overrides?: { index?: number },
 ) => {
-  const setShowMentionPopover = jest.fn();
-  const setShowPlusPopover = jest.fn();
-
   const { result } = renderHook(() =>
     useHandleKeyUp({
       index: overrides?.index ?? 0,
       textAreaRef,
-      setShowPlusPopover,
-      setShowMentionPopover,
     }),
   );
 
   return {
     handleKeyUp: result.current,
-    setShowMentionPopover,
-    setShowPlusPopover,
+    setShowMentionPopover: mockSetShowMentionPopover,
+    setShowPlusPopover: mockSetShowPlusPopover,
     setShowPromptsPopover: mockSetShowPromptsPopover,
   };
 };
@@ -90,6 +103,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockHasPromptsAccess.current = true;
   mockHasMultiConvoAccess.current = true;
+  mockEndpoint.current = 'openAI';
   mockCommandToggles.at = true;
   mockCommandToggles.plus = true;
   mockCommandToggles.slash = true;

--- a/client/src/hooks/Input/useHandleKeyUp.spec.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.spec.ts
@@ -12,7 +12,7 @@ jest.mock('recoil', () => ({
     if (atom === 'latestMessageFamily-0') {
       return null;
     }
-    if (atom === 'conversationEndpointByIndex-0') {
+    if (atom === 'effectiveEndpointByIndex-0') {
       return mockEndpoint.current;
     }
     if (atom === 'atCommand') {
@@ -44,7 +44,7 @@ jest.mock('~/store', () => ({
   showPromptsPopoverFamily: (idx: number) => `showPromptsPopoverFamily-${idx}`,
   showMentionPopoverFamily: (idx: number) => `showMentionPopoverFamily-${idx}`,
   showPlusPopoverFamily: (idx: number) => `showPlusPopoverFamily-${idx}`,
-  conversationEndpointByIndex: (idx: number) => `conversationEndpointByIndex-${idx}`,
+  effectiveEndpointByIndex: (idx: number) => `effectiveEndpointByIndex-${idx}`,
   latestMessageFamily: (idx: number) => `latestMessageFamily-${idx}`,
   atCommand: 'atCommand',
   plusCommand: 'plusCommand',
@@ -177,7 +177,7 @@ describe('useHandleKeyUp', () => {
     });
   });
 
-  describe('navigation within short command text — should NOT retrigger', () => {
+  describe('navigation keys — should never trigger', () => {
     it('does NOT trigger when cursor is mid-text after ArrowLeft', () => {
       const ref = makeTextAreaRef('/abc', 2);
       const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
@@ -194,6 +194,42 @@ describe('useHandleKeyUp', () => {
       act(() => handleKeyUp(makeKeyEvent('Delete')));
 
       expect(setShowMentionPopover).not.toHaveBeenCalled();
+    });
+
+    it('does NOT trigger when ArrowRight lands at end of short command text', () => {
+      const ref = makeTextAreaRef('/ab', 3);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('ArrowRight')));
+
+      expect(setShowPromptsPopover).not.toHaveBeenCalled();
+    });
+
+    it('does NOT trigger when Home key is pressed on command text', () => {
+      const ref = makeTextAreaRef('/abc', 0);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('Home')));
+
+      expect(setShowPromptsPopover).not.toHaveBeenCalled();
+    });
+
+    it('does NOT trigger when End key lands at end of short command text', () => {
+      const ref = makeTextAreaRef('+ab', 3);
+      const { handleKeyUp, setShowPlusPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('End')));
+
+      expect(setShowPlusPopover).not.toHaveBeenCalled();
+    });
+
+    it('does NOT trigger when ArrowUp is pressed on non-empty command text', () => {
+      const ref = makeTextAreaRef('/ab', 3);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('ArrowUp')));
+
+      expect(setShowPromptsPopover).not.toHaveBeenCalled();
     });
   });
 
@@ -250,7 +286,18 @@ describe('useHandleKeyUp', () => {
   });
 
   describe('invalid keys', () => {
-    it.each(['Escape', 'Backspace', 'Enter'])('does NOT trigger on %s key', (key) => {
+    it.each([
+      'Escape',
+      'Backspace',
+      'Enter',
+      'ArrowUp',
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowDown',
+      'Home',
+      'End',
+      'Delete',
+    ])('does NOT trigger on %s key', (key) => {
       const ref = makeTextAreaRef('/', 1);
       const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
 
@@ -322,6 +369,48 @@ describe('useHandleKeyUp', () => {
       act(() => handleKeyUp(makeKeyEvent('@')));
 
       expect(setShowMentionPopover).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('endpoint gating', () => {
+    it('does NOT trigger + command on assistants endpoint', () => {
+      mockEndpoint.current = 'assistants';
+      const ref = makeTextAreaRef('+', 1);
+      const { handleKeyUp, setShowPlusPopover } = renderUseHandleKeyUp(ref);
+      setShowPlusPopover.mockClear();
+
+      act(() => handleKeyUp(makeKeyEvent('+')));
+
+      expect(setShowPlusPopover).not.toHaveBeenCalledWith(true);
+    });
+
+    it('does NOT trigger + command on azureAssistants endpoint', () => {
+      mockEndpoint.current = 'azureAssistants';
+      const ref = makeTextAreaRef('+', 1);
+      const { handleKeyUp, setShowPlusPopover } = renderUseHandleKeyUp(ref);
+      setShowPlusPopover.mockClear();
+
+      act(() => handleKeyUp(makeKeyEvent('+')));
+
+      expect(setShowPlusPopover).not.toHaveBeenCalledWith(true);
+    });
+
+    it('resets + popover when endpoint switches to assistants', () => {
+      mockEndpoint.current = 'assistants';
+      const ref = makeTextAreaRef('', 0);
+      const { setShowPlusPopover } = renderUseHandleKeyUp(ref);
+
+      expect(setShowPlusPopover).toHaveBeenCalledWith(false);
+    });
+
+    it('triggers + command on non-assistants endpoint', () => {
+      mockEndpoint.current = 'openAI';
+      const ref = makeTextAreaRef('+', 1);
+      const { handleKeyUp, setShowPlusPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('+')));
+
+      expect(setShowPlusPopover).toHaveBeenCalledWith(true);
     });
   });
 });

--- a/client/src/hooks/Input/useHandleKeyUp.spec.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.spec.ts
@@ -163,6 +163,26 @@ describe('useHandleKeyUp', () => {
     });
   });
 
+  describe('navigation within short command text — should NOT retrigger', () => {
+    it('does NOT trigger when cursor is mid-text after ArrowLeft', () => {
+      const ref = makeTextAreaRef('/abc', 2);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('ArrowLeft')));
+
+      expect(setShowPromptsPopover).not.toHaveBeenCalled();
+    });
+
+    it('does NOT trigger when cursor is mid-text after Delete', () => {
+      const ref = makeTextAreaRef('@bo', 2);
+      const { handleKeyUp, setShowMentionPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('Delete')));
+
+      expect(setShowMentionPopover).not.toHaveBeenCalled();
+    });
+  });
+
   describe('paste protection — long text starting with command char', () => {
     it('does NOT trigger for pasted "/api/v1/users"', () => {
       const ref = makeTextAreaRef('/api/v1/users', 13);

--- a/client/src/hooks/Input/useHandleKeyUp.spec.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.spec.ts
@@ -1,0 +1,293 @@
+const mockSetShowPromptsPopover = jest.fn();
+const mockHasPromptsAccess = { current: true };
+const mockHasMultiConvoAccess = { current: true };
+const mockCommandToggles = { at: true, plus: true, slash: true };
+
+jest.mock('recoil', () => ({
+  ...jest.requireActual('recoil'),
+  useRecoilValue: jest.fn((atom) => {
+    if (atom === 'latestMessageFamily-0') {
+      return null;
+    }
+    if (atom === 'atCommand') {
+      return mockCommandToggles.at;
+    }
+    if (atom === 'plusCommand') {
+      return mockCommandToggles.plus;
+    }
+    if (atom === 'slashCommand') {
+      return mockCommandToggles.slash;
+    }
+    return undefined;
+  }),
+  useSetRecoilState: jest.fn(() => mockSetShowPromptsPopover),
+}));
+
+jest.mock('~/store', () => ({
+  showPromptsPopoverFamily: (idx: number) => `showPromptsPopoverFamily-${idx}`,
+  showMentionPopoverFamily: (idx: number) => `showMentionPopoverFamily-${idx}`,
+  showPlusPopoverFamily: (idx: number) => `showPlusPopoverFamily-${idx}`,
+  latestMessageFamily: (idx: number) => `latestMessageFamily-${idx}`,
+  atCommand: 'atCommand',
+  plusCommand: 'plusCommand',
+  slashCommand: 'slashCommand',
+}));
+
+jest.mock('~/hooks/Roles/useHasAccess', () =>
+  jest.fn(({ permissionType }: { permissionType: string }) => {
+    if (permissionType === 'PROMPTS') {
+      return mockHasPromptsAccess.current;
+    }
+    if (permissionType === 'MULTI_CONVO') {
+      return mockHasMultiConvoAccess.current;
+    }
+    return false;
+  }),
+);
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import useHandleKeyUp from './useHandleKeyUp';
+
+const makeTextAreaRef = (value = '', selectionStart?: number) => {
+  const ref = {
+    current: {
+      value,
+      selectionStart: selectionStart ?? value.length,
+    },
+  } as unknown as React.RefObject<HTMLTextAreaElement>;
+  return ref;
+};
+
+const makeKeyEvent = (key: string) =>
+  ({ key, preventDefault: jest.fn() }) as unknown as React.KeyboardEvent<HTMLTextAreaElement>;
+
+const renderUseHandleKeyUp = (
+  textAreaRef: React.RefObject<HTMLTextAreaElement>,
+  overrides?: { index?: number },
+) => {
+  const setShowMentionPopover = jest.fn();
+  const setShowPlusPopover = jest.fn();
+
+  const { result } = renderHook(() =>
+    useHandleKeyUp({
+      index: overrides?.index ?? 0,
+      textAreaRef,
+      setShowPlusPopover,
+      setShowMentionPopover,
+    }),
+  );
+
+  return {
+    handleKeyUp: result.current,
+    setShowMentionPopover,
+    setShowPlusPopover,
+    setShowPromptsPopover: mockSetShowPromptsPopover,
+  };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockHasPromptsAccess.current = true;
+  mockHasMultiConvoAccess.current = true;
+  mockCommandToggles.at = true;
+  mockCommandToggles.plus = true;
+  mockCommandToggles.slash = true;
+});
+
+describe('useHandleKeyUp', () => {
+  describe('command triggering — normal typing speed (cursor at position 1)', () => {
+    it('triggers slash command for "/" at position 1', () => {
+      const ref = makeTextAreaRef('/', 1);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('/')));
+
+      expect(setShowPromptsPopover).toHaveBeenCalledWith(true);
+    });
+
+    it('triggers @ mention for "@" at position 1', () => {
+      const ref = makeTextAreaRef('@', 1);
+      const { handleKeyUp, setShowMentionPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('@')));
+
+      expect(setShowMentionPopover).toHaveBeenCalledWith(true);
+    });
+
+    it('triggers + command for "+" at position 1', () => {
+      const ref = makeTextAreaRef('+', 1);
+      const { handleKeyUp, setShowPlusPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('+')));
+
+      expect(setShowPlusPopover).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('fast typing — cursor past position 1 but text is short', () => {
+    it('triggers slash command for "/sc" (fast typed)', () => {
+      const ref = makeTextAreaRef('/sc', 3);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('c')));
+
+      expect(setShowPromptsPopover).toHaveBeenCalledWith(true);
+    });
+
+    it('triggers @ mention for "@bo" (fast typed)', () => {
+      const ref = makeTextAreaRef('@bo', 3);
+      const { handleKeyUp, setShowMentionPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('o')));
+
+      expect(setShowMentionPopover).toHaveBeenCalledWith(true);
+    });
+
+    it('triggers for text up to MAX_COMMAND_TRIGGER_LENGTH (5 chars)', () => {
+      const ref = makeTextAreaRef('/abcd', 5);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('d')));
+
+      expect(setShowPromptsPopover).toHaveBeenCalledWith(true);
+    });
+
+    it('does NOT trigger for text exceeding MAX_COMMAND_TRIGGER_LENGTH', () => {
+      const ref = makeTextAreaRef('/abcde', 6);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('e')));
+
+      expect(setShowPromptsPopover).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('paste protection — long text starting with command char', () => {
+    it('does NOT trigger for pasted "/api/v1/users"', () => {
+      const ref = makeTextAreaRef('/api/v1/users', 13);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('v')));
+
+      expect(setShowPromptsPopover).not.toHaveBeenCalled();
+    });
+
+    it('does NOT trigger for pasted "@username mentioned in a long message"', () => {
+      const ref = makeTextAreaRef('@username mentioned in a long message', 37);
+      const { handleKeyUp, setShowMentionPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('v')));
+
+      expect(setShowMentionPopover).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('non-command text', () => {
+    it('does NOT trigger when text does not start with a command char', () => {
+      const ref = makeTextAreaRef('hello', 5);
+      const { handleKeyUp, setShowPromptsPopover, setShowMentionPopover, setShowPlusPopover } =
+        renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('o')));
+
+      expect(setShowPromptsPopover).not.toHaveBeenCalled();
+      expect(setShowMentionPopover).not.toHaveBeenCalled();
+      expect(setShowPlusPopover).not.toHaveBeenCalled();
+    });
+
+    it('does NOT trigger when text is empty', () => {
+      const ref = makeTextAreaRef('', 0);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('a')));
+
+      expect(setShowPromptsPopover).not.toHaveBeenCalled();
+    });
+
+    it('does NOT trigger for command char in the middle of text', () => {
+      const ref = makeTextAreaRef('hello /world', 12);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('d')));
+
+      expect(setShowPromptsPopover).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('invalid keys', () => {
+    it.each(['Escape', 'Backspace', 'Enter'])('does NOT trigger on %s key', (key) => {
+      const ref = makeTextAreaRef('/', 1);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent(key)));
+
+      expect(setShowPromptsPopover).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('command toggles', () => {
+    it('does NOT trigger slash command when slashCommand toggle is disabled', () => {
+      mockCommandToggles.slash = false;
+      const ref = makeTextAreaRef('/', 1);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('/')));
+
+      expect(setShowPromptsPopover).not.toHaveBeenCalled();
+    });
+
+    it('does NOT trigger @ mention when atCommand toggle is disabled', () => {
+      mockCommandToggles.at = false;
+      const ref = makeTextAreaRef('@', 1);
+      const { handleKeyUp, setShowMentionPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('@')));
+
+      expect(setShowMentionPopover).not.toHaveBeenCalled();
+    });
+
+    it('does NOT trigger + command when plusCommand toggle is disabled', () => {
+      mockCommandToggles.plus = false;
+      const ref = makeTextAreaRef('+', 1);
+      const { handleKeyUp, setShowPlusPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('+')));
+
+      expect(setShowPlusPopover).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('permission gating', () => {
+    it('does NOT trigger slash command without PROMPTS access', () => {
+      mockHasPromptsAccess.current = false;
+      const ref = makeTextAreaRef('/', 1);
+      const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('/')));
+
+      expect(setShowPromptsPopover).not.toHaveBeenCalled();
+    });
+
+    it('does NOT trigger + command without MULTI_CONVO access', () => {
+      mockHasMultiConvoAccess.current = false;
+      const ref = makeTextAreaRef('+', 1);
+      const { handleKeyUp, setShowPlusPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('+')));
+
+      expect(setShowPlusPopover).not.toHaveBeenCalled();
+    });
+
+    it('triggers @ mention regardless of other permissions', () => {
+      mockHasPromptsAccess.current = false;
+      mockHasMultiConvoAccess.current = false;
+      const ref = makeTextAreaRef('@', 1);
+      const { handleKeyUp, setShowMentionPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('@')));
+
+      expect(setShowMentionPopover).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/client/src/hooks/Input/useHandleKeyUp.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.ts
@@ -13,8 +13,13 @@ const invalidKeys = {
 };
 
 /**
- * Utility function to determine if a command should trigger.
+ * Determines if a command popover should trigger.
+ * Uses `startPos === 1` for normal typing speed (cursor right after the command char)
+ * and a short text-length fallback for fast typists whose keyup fires after the cursor
+ * has already moved past position 1. The length cap prevents false triggers from
+ * pasted content that happens to start with a command character.
  */
+const MAX_COMMAND_TRIGGER_LENGTH = 5;
 const shouldTriggerCommand = (
   textAreaRef: React.RefObject<HTMLTextAreaElement>,
   commandChar: string,
@@ -29,7 +34,7 @@ const shouldTriggerCommand = (
     return false;
   }
 
-  return startPos === 1;
+  return startPos === 1 || text.length <= MAX_COMMAND_TRIGGER_LENGTH;
 };
 
 /**

--- a/client/src/hooks/Input/useHandleKeyUp.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
-import { PermissionTypes, Permissions } from 'librechat-data-provider';
-import type { SetterOrUpdater } from 'recoil';
+import { PermissionTypes, Permissions, isAssistantsEndpoint } from 'librechat-data-provider';
 import useHasAccess from '~/hooks/Roles/useHasAccess';
 import store from '~/store';
 
@@ -43,13 +42,9 @@ const shouldTriggerCommand = (
 const useHandleKeyUp = ({
   index,
   textAreaRef,
-  setShowPlusPopover,
-  setShowMentionPopover,
 }: {
   index: number;
   textAreaRef: React.RefObject<HTMLTextAreaElement>;
-  setShowPlusPopover: SetterOrUpdater<boolean>;
-  setShowMentionPopover: SetterOrUpdater<boolean>;
 }) => {
   const hasPromptsAccess = useHasAccess({
     permissionType: PermissionTypes.PROMPTS,
@@ -60,9 +55,11 @@ const useHandleKeyUp = ({
     permission: Permissions.USE,
   });
   const latestMessage = useRecoilValue(store.latestMessageFamily(index));
+  const endpoint = useRecoilValue(store.conversationEndpointByIndex(index));
+  const setShowMentionPopover = useSetRecoilState(store.showMentionPopoverFamily(index));
+  const setShowPlusPopover = useSetRecoilState(store.showPlusPopoverFamily(index));
   const setShowPromptsPopover = useSetRecoilState(store.showPromptsPopoverFamily(index));
 
-  // Get the current state of command toggles
   const atCommandEnabled = useRecoilValue(store.atCommand);
   const plusCommandEnabled = useRecoilValue(store.plusCommand);
   const slashCommandEnabled = useRecoilValue(store.slashCommand);
@@ -74,13 +71,13 @@ const useHandleKeyUp = ({
   }, [textAreaRef, setShowMentionPopover, atCommandEnabled]);
 
   const handlePlusCommand = useCallback(() => {
-    if (!hasMultiConvoAccess || !plusCommandEnabled) {
+    if (!hasMultiConvoAccess || !plusCommandEnabled || isAssistantsEndpoint(endpoint)) {
       return;
     }
     if (shouldTriggerCommand(textAreaRef, '+')) {
       setShowPlusPopover(true);
     }
-  }, [textAreaRef, setShowPlusPopover, plusCommandEnabled, hasMultiConvoAccess]);
+  }, [textAreaRef, setShowPlusPopover, plusCommandEnabled, hasMultiConvoAccess, endpoint]);
 
   const handlePromptsCommand = useCallback(() => {
     if (!hasPromptsAccess || !slashCommandEnabled) {

--- a/client/src/hooks/Input/useHandleKeyUp.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.ts
@@ -1,14 +1,21 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { PermissionTypes, Permissions, isAssistantsEndpoint } from 'librechat-data-provider';
 import useHasAccess from '~/hooks/Roles/useHasAccess';
 import store from '~/store';
 
-/** Event Keys that shouldn't trigger a command */
+/** Event keys that shouldn't trigger a command */
 const invalidKeys = {
   Escape: true,
   Backspace: true,
   Enter: true,
+  ArrowUp: true,
+  ArrowLeft: true,
+  ArrowRight: true,
+  ArrowDown: true,
+  Home: true,
+  End: true,
+  Delete: true,
 };
 
 /**
@@ -55,7 +62,7 @@ const useHandleKeyUp = ({
     permission: Permissions.USE,
   });
   const latestMessage = useRecoilValue(store.latestMessageFamily(index));
-  const endpoint = useRecoilValue(store.conversationEndpointByIndex(index));
+  const endpoint = useRecoilValue(store.effectiveEndpointByIndex(index));
   const setShowMentionPopover = useSetRecoilState(store.showMentionPopoverFamily(index));
   const setShowPlusPopover = useSetRecoilState(store.showPlusPopoverFamily(index));
   const setShowPromptsPopover = useSetRecoilState(store.showPromptsPopoverFamily(index));
@@ -63,6 +70,12 @@ const useHandleKeyUp = ({
   const atCommandEnabled = useRecoilValue(store.atCommand);
   const plusCommandEnabled = useRecoilValue(store.plusCommand);
   const slashCommandEnabled = useRecoilValue(store.slashCommand);
+
+  useEffect(() => {
+    if (isAssistantsEndpoint(endpoint)) {
+      setShowPlusPopover(false);
+    }
+  }, [endpoint, setShowPlusPopover]);
 
   const handleAtCommand = useCallback(() => {
     if (atCommandEnabled && shouldTriggerCommand(textAreaRef, '@')) {

--- a/client/src/hooks/Input/useHandleKeyUp.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.ts
@@ -34,7 +34,7 @@ const shouldTriggerCommand = (
     return false;
   }
 
-  return startPos === 1 || text.length <= MAX_COMMAND_TRIGGER_LENGTH;
+  return startPos === 1 || (startPos === text.length && text.length <= MAX_COMMAND_TRIGGER_LENGTH);
 };
 
 /**

--- a/client/src/hooks/Input/useInitPopoverInput.ts
+++ b/client/src/hooks/Input/useInitPopoverInput.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+
+/** Creates a callback ref that focuses the popover input, transfers the command text as a search prefix, and clears the textarea. */
+const useInitPopoverInput = ({
+  inputRef,
+  textAreaRef,
+  commandChar,
+  setSearchValue,
+  setOpen,
+}: {
+  inputRef: React.MutableRefObject<HTMLInputElement | null>;
+  textAreaRef: React.MutableRefObject<HTMLTextAreaElement | null>;
+  commandChar: string;
+  setSearchValue: (value: string) => void;
+  setOpen: (value: boolean) => void;
+}) =>
+  useCallback(
+    (node: HTMLInputElement | null) => {
+      inputRef.current = node;
+      if (!node) {
+        return;
+      }
+      node.focus();
+      setOpen(true);
+      const textarea = textAreaRef.current;
+      if (!textarea) {
+        return;
+      }
+      const text = textarea.value;
+      if (text.length > 0 && text[0] === commandChar) {
+        if (text.length > 1) {
+          setSearchValue(text.slice(1));
+        }
+        textarea.value = '';
+        textarea.setSelectionRange(0, 0);
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    },
+    [inputRef, textAreaRef, commandChar, setSearchValue, setOpen],
+  );
+
+export default useInitPopoverInput;

--- a/client/src/hooks/Input/useMentions.ts
+++ b/client/src/hooks/Input/useMentions.ts
@@ -82,10 +82,11 @@ export default function useMentions({
     () => startupConfig?.interface ?? defaultInterface,
     [startupConfig?.interface],
   );
+  const agentQueryEnabled = hasAgentAccess && interfaceConfig.modelSelect === true;
   const { data: agentsList = null, isLoading: isLoadingAgents } = useListAgentsQuery(
     { requiredPermission: PermissionBits.VIEW },
     {
-      enabled: hasAgentAccess && interfaceConfig.modelSelect === true,
+      enabled: agentQueryEnabled,
       select: (res) => {
         const { data } = res;
         return data.map(({ id, name, avatar }) => ({
@@ -257,7 +258,7 @@ export default function useMentions({
     isLoadingModels ||
     isLoadingStartup ||
     isLoadingEndpoints ||
-    isLoadingAgents;
+    (agentQueryEnabled && isLoadingAgents);
 
   return {
     options,

--- a/client/src/hooks/Input/useMentions.ts
+++ b/client/src/hooks/Input/useMentions.ts
@@ -64,10 +64,10 @@ export default function useMentions({
   });
 
   const agentsMap = useAgentsMapContext();
-  const { data: presets } = useGetPresetsQuery();
-  const { data: modelsConfig } = useGetModelsQuery();
-  const { data: startupConfig } = useGetStartupConfig();
-  const { data: endpointsConfig } = useGetEndpointsQuery();
+  const { data: presets, isLoading: isLoadingPresets } = useGetPresetsQuery();
+  const { data: modelsConfig, isLoading: isLoadingModels } = useGetModelsQuery();
+  const { data: startupConfig, isLoading: isLoadingStartup } = useGetStartupConfig();
+  const { data: endpointsConfig, isLoading: isLoadingEndpoints } = useGetEndpointsQuery();
   const { data: endpoints = [] } = useGetEndpointsQuery({
     select: mapEndpoints,
   });
@@ -82,7 +82,7 @@ export default function useMentions({
     () => startupConfig?.interface ?? defaultInterface,
     [startupConfig?.interface],
   );
-  const { data: agentsList = null } = useListAgentsQuery(
+  const { data: agentsList = null, isLoading: isLoadingAgents } = useListAgentsQuery(
     { requiredPermission: PermissionBits.VIEW },
     {
       enabled: hasAgentAccess && interfaceConfig.modelSelect === true,
@@ -252,9 +252,17 @@ export default function useMentions({
     interfaceConfig.modelSelect,
   ]);
 
+  const isLoading =
+    isLoadingPresets ||
+    isLoadingModels ||
+    isLoadingStartup ||
+    isLoadingEndpoints ||
+    isLoadingAgents;
+
   return {
     options,
     presets,
+    isLoading,
     modelSpecs,
     agentsList,
     modelsConfig,

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -172,6 +172,17 @@ const conversationEndpointByIndex = selectorFamily<EModelEndpoint | null, string
       get(conversationByIndex(index))?.endpoint ?? null,
 });
 
+/** Returns `endpointType ?? endpoint`, matching the effective endpoint used for feature gating. */
+const effectiveEndpointByIndex = selectorFamily<EModelEndpoint | null, string | number>({
+  key: 'effectiveEndpointByIndex',
+  get:
+    (index: string | number) =>
+    ({ get }) => {
+      const convo = get(conversationByIndex(index));
+      return convo?.endpointType ?? convo?.endpoint ?? null;
+    },
+});
+
 const conversationModelByIndex = selectorFamily<string | null, string | number>({
   key: 'conversationModelByIndex',
   get:
@@ -466,6 +477,7 @@ export default {
   allConversationsSelector,
   conversationIdByIndex,
   conversationEndpointByIndex,
+  effectiveEndpointByIndex,
   conversationModelByIndex,
   conversationSpecByIndex,
   conversationAgentIdByIndex,


### PR DESCRIPTION
## Summary

Fixes several UX issues with the `@`, `+`, and `/` command popovers in the chat input:

1. **`@`/`+` command text not clearing from textarea** — When the mention popover opened, the command character stayed visible in the textarea (unlike `/` which cleared correctly). Root cause: `ChatForm` subscribed to the mention popover atoms via `useRecoilState`, causing it to re-render when the popover opened, which interfered with the textarea clearing logic. The `/` command avoided this because `PromptsCommand` managed its popover state internally.

2. **Perpetual loading spinner for mentions** — `useMentions` included `isLoadingAgents` unconditionally in its aggregate `isLoading` flag, but the agents query is often disabled (no agent access / model select off). With React Query v4, disabled queries without cache stay in loading status, causing a permanent spinner.

3. **Overly broad command trigger fallback** — The fast-typing fallback in `shouldTriggerCommand` would re-trigger the popover on navigation keys (ArrowLeft, Delete) within short command text, since it only checked text length without verifying cursor position.

## Changes

### Architecture: Align Mention with PromptsCommand pattern
- **`Mention.tsx`** — Wrapped in a `MentionPopoverContainer` (memoized) that reads its popover atom internally via `useRecoilValue` and conditionally renders the content. Uses `useSetRecoilState` (write-only) to close itself. Replaces the old `setShowMentionPopover` prop with `popoverAtom`.
- **`ChatForm.tsx`** — Removed `useRecoilState` subscriptions for `showMentionPopoverFamily` and `showPlusPopoverFamily`. ChatForm no longer re-renders when these popover states change. Both `<Mention>` components are rendered unconditionally — they manage their own visibility internally.
- **`useHandleKeyUp.ts`** — All three popover setters (`@`, `+`, `/`) now use `useSetRecoilState` internally. Removed setter props from the hook parameters, fully decoupling it from ChatForm. Moved the `isAssistantsEndpoint` guard (previously in ChatForm's render) into the `+` command handler.

### Bug fixes
- **`useMentions.ts`** — Exposed aggregate `isLoading` from all data queries. Gated `isLoadingAgents` behind `agentQueryEnabled` so a disabled query can't cause perpetual loading.
- **`useHandleKeyUp.ts`** — `shouldTriggerCommand` fallback now requires `startPos === text.length` (cursor at end) in addition to the length cap, preventing spurious triggers during text navigation.

### UX improvements
- **`Mention.tsx` / `PromptsCommand.tsx`** — Replaced `autoFocus` with a callback ref (`initInputRef`) that focuses the input, transfers command text as a search prefix, and clears the textarea in one synchronous pass. Shows a loading spinner when data is still fetching and no matches exist yet.

## Test plan
- [x] `useHandleKeyUp` unit tests (37 tests) — covers command triggering, fast typing, navigation keys, paste protection, toggles, permission gating, and endpoint gating
- [ ] Manual: type `@` → popover opens, textarea clears, command char is gone
- [ ] Manual: type `+` → same behavior (not on assistants endpoints)
- [ ] Manual: type `/` → same behavior (unchanged)
- [ ] Manual: verify loading spinner appears briefly when mention data is fetching
- [ ] Manual: user without agent access sees no perpetual spinner