### PR TITLE
🧹 fix: Disk Management for 10GB Droplet — PR Cap, Prune, Rsync-Then-Swap

### DIFF
--- a/.github/workflows/gitnexus-deploy.yml
+++ b/.github/workflows/gitnexus-deploy.yml
@@ -247,7 +247,17 @@ jobs:
               }
             }
 
-            for (const { pr, artifactName, fresh } of prMatches) {
+            // Cap PR indexes to the N most recent by artifact timestamp.
+            // Each index is ~130MB; on a 10GB disk 3 PRs + main + dev ≈
+            // 650MB, leaving room for the ~700MB Docker image and OS.
+            const MAX_PR_INDEXES = 3;
+            prMatches.sort(
+              (a, b) => new Date(b.fresh.created_at) - new Date(a.fresh.created_at),
+            );
+            const keptPrs = prMatches.slice(0, MAX_PR_INDEXES);
+            const evictedPrs = prMatches.slice(MAX_PR_INDEXES);
+
+            for (const { pr, artifactName, fresh } of keptPrs) {
               serve.push({
                 name: `LibreChat-pr-${pr.number}`,
                 artifactName,
@@ -255,7 +265,13 @@ jobs:
               });
               core.info(`PR #${pr.number}: run ${fresh.workflow_run.id} -> LibreChat-pr-${pr.number}`);
             }
-            core.info(`Resolved ${prMatches.length} PR indexes out of ${openPrs.length} open PRs`);
+            if (evictedPrs.length) {
+              core.info(
+                `Evicted ${evictedPrs.length} older PR indexes (cap=${MAX_PR_INDEXES}): ` +
+                  evictedPrs.map((e) => `#${e.pr.number}`).join(', '),
+              );
+            }
+            core.info(`Serving ${keptPrs.length}/${prMatches.length} PR indexes (${openPrs.length} open PRs total)`);
 
             if (!serve.length) {
               core.setFailed('No indexes to serve');
@@ -360,37 +376,21 @@ jobs:
             .do/gitnexus/Caddyfile \
             "$SSH_USER@$SSH_HOST:/opt/gitnexus/"
 
-      - name: Rsync indexes and prune stale ones
+      - name: Prune stale indexes then sync fresh ones
         env:
           SSH_USER: ${{ secrets.GITNEXUS_DO_USER }}
           SSH_HOST: ${{ secrets.GITNEXUS_DO_HOST }}
           ACTIVE_NAMES: ${{ steps.resolve.outputs.active_names }}
         run: |
           set -e
-          # Push every active index up
-          for dir in staging/*/; do
-            [ -d "$dir" ] || continue
-            name=$(basename "$dir")
-            echo "Syncing $name"
-            ssh -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" \
-              "mkdir -p /opt/gitnexus/indexes/$name"
-            rsync -az --delete -e "ssh -i ~/.ssh/deploy_key" \
-              "$dir" \
-              "$SSH_USER@$SSH_HOST:/opt/gitnexus/indexes/$name/"
-          done
-
-          # Prune any folders on the droplet that aren't in the active set.
-          # This cleans up closed PRs the cleanup workflow might have missed,
-          # and is safe because main/dev/PR-<N> are always present if active.
+          # ── Step 1: prune FIRST ────────────────────────────────
+          # Remove folders not in the active set BEFORE uploading new
+          # data. Frees disk on a 10GB droplet where headroom matters.
           echo "Pruning stale indexes (keeping: $ACTIVE_NAMES)"
           ssh -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" \
             ACTIVE_NAMES="$ACTIVE_NAMES" bash <<'REMOTE'
             set -e
             cd /opt/gitnexus/indexes || exit 0
-            # nullglob makes `for dir in */` expand to nothing when the
-            # directory is empty (first deploy), instead of the literal
-            # string "*/". Explicit no-op > relying on rm -f to silently
-            # tolerate a nonexistent file named "*".
             shopt -s nullglob
             IFS=',' read -ra ACTIVE <<< "$ACTIVE_NAMES"
             for dir in */; do
@@ -404,7 +404,41 @@ jobs:
                 rm -rf "$dir"
               fi
             done
+            echo "Disk after prune:"
+            df -h / | tail -1
           REMOTE
+
+          # ── Step 2: rsync-then-swap ────────────────────────────
+          # Upload to a .new temp dir, then rm old + mv .new into place
+          # only after rsync succeeds. If rsync fails, old index stays
+          # live and .new is cleaned up. main/dev failures abort the
+          # deploy; PR failures are soft-fail.
+          for dir in staging/*/; do
+            [ -d "$dir" ] || continue
+            name=$(basename "$dir")
+            echo "Syncing $name (rsync-then-swap)"
+            ssh -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" \
+              "mkdir -p /opt/gitnexus/indexes/${name}.new"
+            if rsync -az -e "ssh -i ~/.ssh/deploy_key" \
+              "$dir" \
+              "$SSH_USER@$SSH_HOST:/opt/gitnexus/indexes/${name}.new/"; then
+              ssh -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" \
+                "rm -rf /opt/gitnexus/indexes/$name && mv /opt/gitnexus/indexes/${name}.new /opt/gitnexus/indexes/$name"
+              echo "  $name swapped successfully"
+            else
+              ssh -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" \
+                "rm -rf /opt/gitnexus/indexes/${name}.new"
+              case "$name" in
+                LibreChat|LibreChat-dev)
+                  echo "::error::rsync failed for critical index $name — aborting deploy"
+                  exit 1
+                  ;;
+                *)
+                  echo "::warning::rsync failed for PR index $name — keeping previous index"
+                  ;;
+              esac
+            fi
+          done
 
       - name: Pull image, restart gitnexus, reload Caddy, wait for healthy
         env:
@@ -414,6 +448,23 @@ jobs:
           ssh -i ~/.ssh/deploy_key "$SSH_USER@$SSH_HOST" bash <<'REMOTE'
             set -e
             cd /opt/gitnexus
+
+            # Clean stale Docker layers before pulling. Each deploy
+            # leaves the previous image's layers as dangling; on a
+            # 10GB disk this fills up after ~10 deploys. Omit --volumes
+            # to preserve Caddy's TLS cert storage.
+            echo "Disk before docker cleanup:"
+            df -h / | tail -1
+            docker system prune -af 2>/dev/null || true
+            echo "Disk after docker cleanup:"
+            df -h / | tail -1
+
+            AVAIL_MB=$(df --output=avail -m / | tail -1 | tr -d ' ')
+            if [ "$AVAIL_MB" -lt 2048 ]; then
+              echo "::error::Disk critically low (${AVAIL_MB}MB free). Aborting deploy."
+              exit 1
+            fi
+
             docker compose pull gitnexus
             docker compose up -d --force-recreate gitnexus
 

--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -45,17 +45,16 @@ env:
 
 jobs:
   index:
-    # Allow push + dispatch unconditionally; filter native pull_request
-    # events to contributors only. The /gitnexus command workflow does
-    # its own contributor-commenter check before it dispatches this
-    # workflow, so workflow_dispatch is always trusted here — including
-    # the case where the commenter wants to index a non-contributor or
-    # fork PR (the command uses refs/pull/<N>/head so checkout resolves).
+    # Push + dispatch run unconditionally. Native pull_request events
+    # are restricted to PRs authored by danny-avila only — keeps
+    # automatic CI spend low on a repo with 200+ open PRs.
+    #
+    # Other contributors' PRs can still be indexed on demand:
+    #   - /gitnexus index    (PR comment command, contributor-gated)
+    #   - workflow_dispatch   (manual from Actions UI)
     if: |
       github.event_name != 'pull_request' ||
-      github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.author_association == 'COLLABORATOR'
+      github.event.pull_request.user.login == 'danny-avila'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:


### PR DESCRIPTION
## Summary

Re-application of disk management fixes from #12672 that were lost during merge. The 10GB droplet fills up from uncapped PR indexes (~130MB each × 10 PRs = 1.3GB) plus stale Docker layers, causing the deploy to fail with \`no space left on device\`.

- Cap PR indexes at 3 most recent in the resolve step — older PR folders get evicted by the prune step
- Prune stale indexes BEFORE syncing new data (was after) so freed disk is available for uploads
- Replace in-place \`rsync --delete\` with rsync-then-swap: upload to \`.new\` temp dir, \`rm -rf old && mv .new\` only after rsync succeeds. Main/dev rsync failures abort the deploy; PR failures soft-fail.
- Add \`docker system prune -af\` (no \`--volumes\`, preserves Caddy TLS) before every image pull, plus a 2GB free-space hard guard
- Restrict automatic PR indexing to \`danny-avila\` authored PRs only. Others can still use \`/gitnexus index\` command or manual dispatch.

**IMPORTANT: Please do not modify these workflow files during the merge. The previous PR's fixes were reverted by modifications before merge, which is why this re-application is needed.**

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. SSH into the droplet and clean up excess PR indexes first:
   \`\`\`bash
   cd /opt/gitnexus/indexes && ls -lt
   # Remove all PR indexes (deploy will re-sync the 3 newest)
   rm -rf LibreChat-pr-*
   df -h /
   \`\`\`
2. Merge this PR
3. Manually dispatch GitNexus Deploy from main
4. Verify deploy log shows: docker prune output, evicted PR count, rsync-then-swap per index, health check passes
5. \`curl /api/repos\` shows at most 5 entries (main + dev + 3 PRs)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings