### PR TITLE
🎯 feat: Per-Agent Skill Selection in Builder and Runtime Scoping

### DIFF
--- a/api/server/controllers/agents/__tests__/openai.spec.js
+++ b/api/server/controllers/agents/__tests__/openai.spec.js
@@ -40,6 +40,7 @@ jest.mock('@librechat/api', () => ({
   }),
   createChunk: jest.fn().mockReturnValue({}),
   buildToolSet: jest.fn().mockReturnValue(new Set()),
+  scopeSkillIds: jest.fn().mockImplementation((ids) => ids),
   sendFinalChunk: jest.fn(),
   createSafeUser: jest.fn().mockReturnValue({ id: 'user-123' }),
   validateRequest: jest

--- a/api/server/controllers/agents/__tests__/responses.unit.spec.js
+++ b/api/server/controllers/agents/__tests__/responses.unit.spec.js
@@ -41,6 +41,7 @@ jest.mock('@librechat/api', () => ({
     processStream: jest.fn().mockResolvedValue(undefined),
   }),
   buildToolSet: jest.fn().mockReturnValue(new Set()),
+  scopeSkillIds: jest.fn().mockImplementation((ids) => ids),
   createSafeUser: jest.fn().mockReturnValue({ id: 'user-123' }),
   initializeAgent: jest.fn().mockResolvedValue({
     model: 'claude-3',

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -12,6 +12,7 @@ const {
   createRun,
   createChunk,
   buildToolSet,
+  scopeSkillIds,
   sendFinalChunk,
   createSafeUser,
   validateRequest,
@@ -217,10 +218,9 @@ const OpenAIChatCompletionController = async (req, res) => {
     };
 
     const enabledCapabilities = new Set(agentsEConfig?.capabilities);
-    const ephemeralAgent = req.body?.ephemeralAgent;
-    const skillsEnabled =
-      enabledCapabilities.has(AgentCapabilities.skills) && ephemeralAgent?.skills === true;
-    const accessibleSkillIds = skillsEnabled
+    const skillsCapabilityEnabled = enabledCapabilities.has(AgentCapabilities.skills);
+    const ephemeralSkillsToggle = req.body?.ephemeralAgent?.skills === true;
+    const accessibleSkillIds = skillsCapabilityEnabled
       ? await findAccessibleResources({
           userId: req.user.id,
           role: req.user.role,
@@ -241,7 +241,10 @@ const OpenAIChatCompletionController = async (req, res) => {
         endpointOption,
         allowedProviders,
         isInitialAgent: true,
-        accessibleSkillIds,
+        accessibleSkillIds: scopeSkillIds(
+          accessibleSkillIds,
+          ephemeralSkillsToggle ? undefined : agent.skills,
+        ),
         codeEnvAvailable: enabledCapabilities.has(AgentCapabilities.execute_code),
       },
       {

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -11,6 +11,7 @@ const {
 const {
   createRun,
   buildToolSet,
+  scopeSkillIds,
   createSafeUser,
   initializeAgent,
   getBalanceConfig,
@@ -357,10 +358,9 @@ const createResponse = async (req, res) => {
     const enabledCapabilities = new Set(
       appConfig?.endpoints?.[EModelEndpoint.agents]?.capabilities,
     );
-    const ephemeralAgent = req.body?.ephemeralAgent;
-    const skillsEnabled =
-      enabledCapabilities.has(AgentCapabilities.skills) && ephemeralAgent?.skills === true;
-    const accessibleSkillIds = skillsEnabled
+    const skillsCapabilityEnabled = enabledCapabilities.has(AgentCapabilities.skills);
+    const ephemeralSkillsToggle = req.body?.ephemeralAgent?.skills === true;
+    const accessibleSkillIds = skillsCapabilityEnabled
       ? await findAccessibleResources({
           userId: req.user.id,
           role: req.user.role,
@@ -381,7 +381,10 @@ const createResponse = async (req, res) => {
         endpointOption,
         allowedProviders,
         isInitialAgent: true,
-        accessibleSkillIds,
+        accessibleSkillIds: scopeSkillIds(
+          accessibleSkillIds,
+          ephemeralSkillsToggle ? undefined : agent.skills,
+        ),
         codeEnvAvailable: enabledCapabilities.has(AgentCapabilities.execute_code),
       },
       {

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -1,6 +1,7 @@
 const { logger } = require('@librechat/data-schemas');
 const { EnvVar, createContentAggregator } = require('@librechat/agents');
 const {
+  scopeSkillIds,
   initializeAgent,
   primeInvokedSkills,
   validateAgentModel,
@@ -111,11 +112,12 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
   const toolEndCallback = createToolEndCallback({ req, res, artifactPromises, streamId });
 
   /** Query accessible skill IDs once per run (shared across all agents).
-   *  Requires both admin capability AND per-conversation toggle (if ephemeral). */
+   *  Skills activate when the admin capability is enabled AND either:
+   *  - the per-conversation toggle is on (ephemeral), OR
+   *  - the agent has stored skills (scoped by scopeSkillIds later). */
   const enabledCapabilities = new Set(appConfig?.endpoints?.[EModelEndpoint.agents]?.capabilities);
-  const ephemeralSkillsToggle = req.body?.ephemeralAgent?.skills;
-  const skillsCapabilityEnabled =
-    enabledCapabilities.has(AgentCapabilities.skills) && ephemeralSkillsToggle === true;
+  const skillsCapabilityEnabled = enabledCapabilities.has(AgentCapabilities.skills);
+  const ephemeralSkillsToggle = req.body?.ephemeralAgent?.skills === true;
 
   const accessibleSkillIds = skillsCapabilityEnabled
     ? await findAccessibleResources({
@@ -240,7 +242,10 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
       endpointOption,
       allowedProviders,
       isInitialAgent: true,
-      accessibleSkillIds,
+      accessibleSkillIds: scopeSkillIds(
+        accessibleSkillIds,
+        ephemeralSkillsToggle ? undefined : primaryAgent.skills,
+      ),
       codeEnvAvailable: enabledCapabilities.has(AgentCapabilities.execute_code),
     },
     {
@@ -325,7 +330,10 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
         parentMessageId,
         endpointOption,
         allowedProviders,
-        accessibleSkillIds,
+        accessibleSkillIds: scopeSkillIds(
+          accessibleSkillIds,
+          ephemeralSkillsToggle ? undefined : agent.skills,
+        ),
       },
       {
         getFiles: db.getFiles,

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -490,7 +490,10 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
         primeInvokedSkills({
           req,
           payload,
-          accessibleSkillIds,
+          accessibleSkillIds: scopeSkillIds(
+            accessibleSkillIds,
+            ephemeralSkillsToggle ? undefined : primaryAgent.skills,
+          ),
           codeApiKey,
           loadAuthValues,
           ...getSkillToolDeps(),

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -485,30 +485,21 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
       modelLabel: endpointOption.model_parameters.modelLabel,
     });
 
-  /** Union scoped skill IDs across primary + all loaded handoff agents.
-   *  primeInvokedSkills processes the full conversation payload (including prior
-   *  handoff invocations), so it needs access to every skill any active agent
-   *  could legitimately invoke — not just the current primary agent's scope. */
-  const unionAccessibleSkillIds = () => {
-    const unionMap = new Map();
-    const addAll = (ids) => {
-      for (const oid of ids ?? []) {
-        unionMap.set(oid.toString(), oid);
-      }
-    };
-    addAll(primaryConfig.accessibleSkillIds);
-    for (const config of agentConfigs.values()) {
-      addAll(config.accessibleSkillIds);
-    }
-    return Array.from(unionMap.values());
-  };
-
+  /** primeInvokedSkills reconstructs bodies of skills invoked in prior turns so
+   *  formatAgentMessages can rebuild HumanMessages and re-prime code-env files.
+   *  Unlike catalog injection and runtime invocation (both scoped per-agent),
+   *  history priming must use the user's full ACL-accessible set: historical
+   *  skill calls can reference skills no longer in any active agent's scope
+   *  (agent.skills edited, ephemeral toggle flipped), and scoping those out
+   *  would drop prior skill context and break file references in follow-up
+   *  turns. The ACL check remains the security gate; handleSkillToolCall is
+   *  where per-agent scoping prevents NEW invocations. */
   const handlePrimeInvokedSkills = skillsCapabilityEnabled
     ? (payload) =>
         primeInvokedSkills({
           req,
           payload,
-          accessibleSkillIds: unionAccessibleSkillIds(),
+          accessibleSkillIds,
           codeApiKey,
           loadAuthValues,
           ...getSkillToolDeps(),

--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -485,15 +485,30 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
       modelLabel: endpointOption.model_parameters.modelLabel,
     });
 
+  /** Union scoped skill IDs across primary + all loaded handoff agents.
+   *  primeInvokedSkills processes the full conversation payload (including prior
+   *  handoff invocations), so it needs access to every skill any active agent
+   *  could legitimately invoke — not just the current primary agent's scope. */
+  const unionAccessibleSkillIds = () => {
+    const unionMap = new Map();
+    const addAll = (ids) => {
+      for (const oid of ids ?? []) {
+        unionMap.set(oid.toString(), oid);
+      }
+    };
+    addAll(primaryConfig.accessibleSkillIds);
+    for (const config of agentConfigs.values()) {
+      addAll(config.accessibleSkillIds);
+    }
+    return Array.from(unionMap.values());
+  };
+
   const handlePrimeInvokedSkills = skillsCapabilityEnabled
     ? (payload) =>
         primeInvokedSkills({
           req,
           payload,
-          accessibleSkillIds: scopeSkillIds(
-            accessibleSkillIds,
-            ephemeralSkillsToggle ? undefined : primaryAgent.skills,
-          ),
+          accessibleSkillIds: unionAccessibleSkillIds(),
           codeApiKey,
           loadAuthValues,
           ...getSkillToolDeps(),

--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -74,17 +74,25 @@ export default function AgentConfig() {
   const skills = useWatch({ control, name: 'skills' });
   const agent_id = useWatch({ control, name: 'id' });
 
+  const {
+    codeEnabled,
+    toolsEnabled,
+    contextEnabled,
+    actionsEnabled,
+    skillsEnabled,
+    artifactsEnabled,
+    webSearchEnabled,
+    fileSearchEnabled,
+  } = useAgentCapabilities(agentsConfig?.capabilities);
+
   const hasSkillsAccess = useHasAccess({
     permissionType: PermissionTypes.SKILLS,
     permission: Permissions.USE,
   });
-  const { data: skillsData } = useListSkillsQuery({ limit: 100 }, { enabled: false });
+  const showSkills = hasSkillsAccess && skillsEnabled;
+  const { data: skillsData } = useListSkillsQuery({ limit: 100 }, { enabled: showSkills });
   const skillsMap = useMemo(() => {
     const map = new Map<string, string>();
-    // Backend list response: `{ skills: TSkillSummary[]; ... }` (renamed
-    // from `.data` in the CRUD PR). This integration is gated behind
-    // `false &&` below so this map is currently unreachable — kept here
-    // so the section compiles for when agent-skills wiring lands.
     for (const skill of skillsData?.skills ?? []) {
       map.set(skill._id, skill.name);
     }
@@ -102,16 +110,6 @@ export default function AgentConfig() {
     });
     return newFileMap;
   }, [fileMap, agentFiles]);
-
-  const {
-    codeEnabled,
-    toolsEnabled,
-    contextEnabled,
-    actionsEnabled,
-    artifactsEnabled,
-    webSearchEnabled,
-    fileSearchEnabled,
-  } = useAgentCapabilities(agentsConfig?.capabilities);
 
   const context_files = useMemo(() => {
     if (typeof agent === 'string') {
@@ -340,8 +338,7 @@ export default function AgentConfig() {
           />
         )}
 
-        {/* WIP: Skills — remove `false &&` to re-enable */}
-        {false && hasSkillsAccess && (
+        {showSkills && (
           <div className="mb-4">
             <label className="text-token-text-primary mb-2 block text-sm font-medium">
               {localize('com_ui_skills')}
@@ -581,10 +578,7 @@ export default function AgentConfig() {
           endpoint={EModelEndpoint.agents}
         />
       )}
-      {/* WIP: Skills — remove `false &&` to re-enable */}
-      {false && hasSkillsAccess && (
-        <SkillSelectDialog isOpen={showSkillDialog} setIsOpen={setShowSkillDialog} />
-      )}
+      {showSkills && <SkillSelectDialog isOpen={showSkillDialog} setIsOpen={setShowSkillDialog} />}
     </>
   );
 }

--- a/client/src/components/SidePanel/Agents/AgentConfig.tsx
+++ b/client/src/components/SidePanel/Agents/AgentConfig.tsx
@@ -363,6 +363,7 @@ export default function AgentConfig() {
                           methods.setValue(
                             'skills',
                             current.filter((id) => id !== skillId),
+                            { shouldDirty: true },
                           );
                         }}
                         className="ml-2 flex-shrink-0 text-text-secondary transition-colors hover:text-text-primary"

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -75,6 +75,7 @@ export function composeAgentUpdatePayload(data: AgentForm, agent_id?: string | n
     category,
     support_contact,
     tool_options,
+    skills,
     avatar_action: avatarActionState,
   } = data;
 
@@ -101,6 +102,7 @@ export function composeAgentUpdatePayload(data: AgentForm, agent_id?: string | n
       category,
       support_contact,
       tool_options,
+      skills,
       ...(shouldResetAvatar ? { avatar: null } : {}),
     },
     provider,

--- a/client/src/components/SidePanel/Agents/AgentSelect.tsx
+++ b/client/src/components/SidePanel/Agents/AgentSelect.tsx
@@ -106,6 +106,15 @@ function AgentSelect({
           return;
         }
 
+        if (
+          name === 'skills' &&
+          Array.isArray(value) &&
+          value.every((item) => typeof item === 'string')
+        ) {
+          formValues[name] = value;
+          return;
+        }
+
         if (name === 'edges' && Array.isArray(value)) {
           formValues[name] = value;
           return;

--- a/packages/api/src/agents/__tests__/skills.test.ts
+++ b/packages/api/src/agents/__tests__/skills.test.ts
@@ -8,6 +8,8 @@ jest.mock('@librechat/agents', () => ({
   },
 }));
 
+import { Types } from 'mongoose';
+import { scopeSkillIds } from '../skills';
 import { extractInvokedSkillsFromPayload } from '../run';
 
 describe('extractInvokedSkillsFromPayload', () => {
@@ -179,5 +181,70 @@ describe('extractInvokedSkillsFromPayload', () => {
     const result = extractInvokedSkillsFromPayload(payload);
     expect(result.size).toBe(1);
     expect(result.has('pdf')).toBe(true);
+  });
+});
+
+describe('scopeSkillIds', () => {
+  const makeId = () => new Types.ObjectId();
+
+  it('returns the full set when agentSkills is undefined (not configured)', () => {
+    const a = makeId();
+    const b = makeId();
+    const accessible = [a, b];
+    expect(scopeSkillIds(accessible, undefined)).toBe(accessible);
+  });
+
+  it('returns the full set when agentSkills is null (not configured)', () => {
+    const a = makeId();
+    const b = makeId();
+    const accessible = [a, b];
+    expect(scopeSkillIds(accessible, null)).toBe(accessible);
+  });
+
+  it('returns [] when agentSkills is an empty array (explicit none)', () => {
+    const accessible = [makeId(), makeId()];
+    expect(scopeSkillIds(accessible, [])).toEqual([]);
+  });
+
+  it('returns intersection when agentSkills overlaps accessibleSkillIds', () => {
+    const a = makeId();
+    const b = makeId();
+    const c = makeId();
+    const accessible = [a, b, c];
+    const scoped = scopeSkillIds(accessible, [a.toString(), c.toString()]);
+    expect(scoped).toHaveLength(2);
+    expect(scoped.map((o) => o.toString())).toEqual([a.toString(), c.toString()]);
+  });
+
+  it('returns [] when agentSkills is disjoint from accessibleSkillIds', () => {
+    const a = makeId();
+    const b = makeId();
+    const accessible = [a, b];
+    const unrelated = makeId().toString();
+    expect(scopeSkillIds(accessible, [unrelated])).toEqual([]);
+  });
+
+  it('returns the full accessible set when agentSkills exactly matches it', () => {
+    const a = makeId();
+    const b = makeId();
+    const accessible = [a, b];
+    const scoped = scopeSkillIds(accessible, [a.toString(), b.toString()]);
+    expect(scoped).toHaveLength(2);
+    expect(scoped.map((o) => o.toString()).sort()).toEqual([a.toString(), b.toString()].sort());
+  });
+
+  it('filters out agentSkills entries that the user does not have ACL access to', () => {
+    const a = makeId();
+    const accessible = [a];
+    const notAccessible = makeId().toString();
+    const scoped = scopeSkillIds(accessible, [a.toString(), notAccessible]);
+    expect(scoped).toHaveLength(1);
+    expect(scoped[0].toString()).toBe(a.toString());
+  });
+
+  it('returns [] when accessibleSkillIds is empty regardless of agentSkills', () => {
+    expect(scopeSkillIds([], undefined)).toEqual([]);
+    expect(scopeSkillIds([], [])).toEqual([]);
+    expect(scopeSkillIds([], [new Types.ObjectId().toString()])).toEqual([]);
   });
 });

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -12,6 +12,23 @@ import type { InitializeAgentDbMethods } from './initialize';
 
 const SKILL_CATALOG_LIMIT = 100;
 
+/**
+ * Scopes user-accessible skill IDs to only those configured on the agent.
+ * When `agentSkills` is empty/undefined, all accessible skills are returned (full catalog).
+ * When `agentSkills` is a non-empty array of skill _id hex strings, only the intersection
+ * of accessible IDs and agent-configured IDs is returned.
+ */
+export function scopeSkillIds(
+  accessibleSkillIds: Types.ObjectId[],
+  agentSkills: string[] | undefined,
+): Types.ObjectId[] {
+  if (!agentSkills || agentSkills.length === 0) {
+    return accessibleSkillIds;
+  }
+  const agentSet = new Set(agentSkills);
+  return accessibleSkillIds.filter((oid) => agentSet.has(oid.toString()));
+}
+
 export interface InjectSkillCatalogParams {
   agent: Agent;
   toolDefinitions: LCTool[] | undefined;

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -14,16 +14,24 @@ const SKILL_CATALOG_LIMIT = 100;
 
 /**
  * Scopes user-accessible skill IDs to only those configured on the agent.
- * When `agentSkills` is empty/undefined, all accessible skills are returned (full catalog).
- * When `agentSkills` is a non-empty array of skill _id hex strings, only the intersection
- * of accessible IDs and agent-configured IDs is returned.
+ *
+ * Semantics (pinned by unit tests):
+ * - `undefined` / `null` → not configured, returns the full accessible catalog.
+ * - `[]` (empty array) → explicitly none, returns `[]`. A user who narrows their
+ *   agent to a subset and then removes all entries is explicitly opting out of
+ *   the full catalog fallback.
+ * - non-empty array of skill `_id` hex strings → intersection of accessible IDs
+ *   and agent-configured IDs.
  */
 export function scopeSkillIds(
   accessibleSkillIds: Types.ObjectId[],
-  agentSkills: string[] | undefined,
+  agentSkills: string[] | null | undefined,
 ): Types.ObjectId[] {
-  if (!agentSkills || agentSkills.length === 0) {
+  if (agentSkills == null) {
     return accessibleSkillIds;
+  }
+  if (agentSkills.length === 0) {
+    return [];
   }
   const agentSet = new Set(agentSkills);
   return accessibleSkillIds.filter((oid) => agentSet.has(oid.toString()));

--- a/packages/api/src/agents/validation.ts
+++ b/packages/api/src/agents/validation.ts
@@ -68,6 +68,7 @@ export const agentBaseSchema = z.object({
   avatar: agentAvatarSchema.nullable().optional(),
   model_parameters: z.record(z.unknown()).optional(),
   tools: z.array(z.string()).optional(),
+  skills: z.array(z.string()).optional(),
   /** @deprecated Use edges instead */
   agent_ids: z.array(z.string()).optional(),
   edges: z.array(graphEdgeSchema).optional(),

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -269,7 +269,11 @@ export const defaultAgentFormValues = {
     name: '',
     email: '',
   },
-  skills: [],
+  /** `undefined` = not configured, full catalog applies. `[]` = explicitly none.
+   *  Keeping this `undefined` ensures a brand-new agent (where the user never
+   *  interacted with the skills UI) does not accidentally persist "explicit none"
+   *  on first save — removeNullishValues strips the field server-side. */
+  skills: undefined as string[] | undefined,
 };
 
 export const ImageVisionTool: FunctionTool = {

--- a/packages/data-schemas/src/schema/agent.ts
+++ b/packages/data-schemas/src/schema/agent.ts
@@ -44,6 +44,10 @@ const agentSchema = new Schema<IAgent>(
       type: [String],
       default: undefined,
     },
+    skills: {
+      type: [String],
+      default: undefined,
+    },
     tool_kwargs: {
       type: [{ type: Schema.Types.Mixed }],
     },

--- a/packages/data-schemas/src/types/agent.ts
+++ b/packages/data-schemas/src/types/agent.ts
@@ -22,6 +22,7 @@ export interface IAgent extends Omit<Document, 'model'> {
   access_level?: number;
   recursion_limit?: number;
   tools?: string[];
+  skills?: string[];
   tool_kwargs?: Array<unknown>;
   actions?: string[];
   author: Types.ObjectId;


### PR DESCRIPTION
## Summary

I wired skills persistence on the Agent document and enabled per-agent skill selection in the agents builder panel, with runtime catalog scoping in both the main agents endpoint and the OpenAI/Responses API routes.

- Add `skills: [String]` to the Mongoose agent schema and `skills?: string[]` to the `IAgent` TypeScript interface, making skills a first-class persisted field on agents.
- Add `skills` validation to the Zod `agentBaseSchema`, flowing through to both create and update validation schemas.
- Include `skills` in `composeAgentUpdatePayload` so the client sends the configured skill IDs to the backend on agent create/update.
- Remove the `false &&` guard on the skills section in `AgentConfig`, gating it on `hasSkillsAccess && skillsEnabled` (permission + admin capability). Enable the `useListSkillsQuery` conditionally so the skill catalog loads only when the section is visible.
- Introduce `scopeSkillIds()` utility that intersects user-accessible skill ObjectIds with the agent's configured skill ID strings. When `agent.skills` is empty/undefined, all accessible skills pass through (full catalog as default).
- Update `initialize.js` to use `scopeSkillIds` when calling `initializeAgent` for both primary and handoff agents. The ephemeral chat toggle overrides per-agent scoping to provide the full catalog.
- Apply the same scoping logic in the Responses API controller (`responses.js`), ensuring skills are functional for agents accessed via the OpenAI/Responses routes.
- Decouple skill resolution from the ephemeral toggle: the admin skills capability flag now triggers accessible skill ID resolution independently, with the ephemeral toggle controlling only whether per-agent scoping applies.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

1. Enable the `skills` capability in admin settings.
2. Create a skill via the Skills UI.
3. Open the agents builder panel and verify the "Skills" section appears.
4. Add/remove skills from an agent via the skill selection dialog.
5. Save the agent and verify skills persist (reload the agent and confirm skills are still shown).
6. Chat with the agent and verify only the configured skills appear in the skill catalog (check `additional_instructions` in logs or observe tool behavior).
7. Toggle the ephemeral skills switch in chat and verify the full catalog is used regardless of per-agent configuration.
8. Test via the Responses API (`POST /v1/responses`) with an agent that has stored skills and verify scoped skill injection.
9. Test an agent with no configured skills and verify the full user catalog is used as the default.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes