### PR TITLE
💲 feat: Manual Skill Invocation via $ Command Popover (UI only)

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -26,6 +26,7 @@ import AttachFileChat from './Files/AttachFileChat';
 import FileFormChat from './Files/FileFormChat';
 import { cn, removeFocusRings } from '~/utils';
 import TextareaHeader from './TextareaHeader';
+import SkillsCommand from './SkillsCommand';
 import PromptsCommand from './PromptsCommand';
 import AudioRecorder from './AudioRecorder';
 import CollapseChat from './CollapseChat';
@@ -254,6 +255,7 @@ const ChatForm = memo(function ChatForm({
             textAreaRef={textAreaRef}
           />
           <PromptsCommand index={index} textAreaRef={textAreaRef} submitPrompt={submitPrompt} />
+          <SkillsCommand index={index} textAreaRef={textAreaRef} conversationId={conversationId} />
           <div
             onClick={handleContainerClick}
             className={cn(

--- a/client/src/components/Chat/Input/MentionItem.tsx
+++ b/client/src/components/Chat/Input/MentionItem.tsx
@@ -6,7 +6,7 @@ export interface MentionItemProps {
   name: string;
   onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
   index: number;
-  type?: 'prompt' | 'mention' | 'add-convo';
+  type?: 'prompt' | 'mention' | 'add-convo' | 'skill';
   icon?: React.ReactNode;
   isActive?: boolean;
   description?: string;

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useRef, useEffect, useMemo, useCallback } from 'react';
-import { useRecoilValue, useSetRecoilState, useRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { AutoSizer, List } from 'react-virtualized';
 import { Spinner, useCombobox } from '@librechat/client';
 import { InvocationMode } from 'librechat-data-provider';
@@ -16,16 +16,17 @@ import store from '~/store';
 
 const commandChar = '$';
 const ROW_HEIGHT = 44;
+const skillIcon = <ScrollText className="icon-md text-cyan-500" />;
 
 /**
- * Skills with `invocationMode === 'auto'` are model-triggered only and should
- * NOT appear in the user-facing `$` command popover.
- * `manual` (user-only) and `both` (either) are shown.
- * Default (undefined/auto) is shown for backward compatibility during phase 1.
+ * Determines whether a skill should appear in the `$` command popover.
+ * `manual` and `both` are user-invocable. `auto` is model-only and hidden.
+ * Skills without an explicit mode (undefined) default to visible for
+ * backward compatibility until the backend persists `invocationMode`.
  */
-function isUserInvocable(skill: TSkillSummary): boolean {
+export function isUserInvocable(skill: TSkillSummary): boolean {
   const mode = skill.invocationMode;
-  if (mode == null || mode === InvocationMode.auto || mode === InvocationMode.both) {
+  if (mode == null || mode === InvocationMode.both) {
     return true;
   }
   return mode === InvocationMode.manual;
@@ -42,11 +43,9 @@ function SkillsCommandContent({
 }) {
   const localize = useLocalize();
   const setShowSkillsPopover = useSetRecoilState(store.showSkillsPopoverFamily(index));
-  const [ephemeralAgent, setEphemeralAgent] = useRecoilState(
-    ephemeralAgentByConvoId(conversationId),
-  );
+  const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(conversationId));
 
-  const { data, isLoading } = useListSkillsQuery({ limit: 100 });
+  const { data, isLoading, isError } = useListSkillsQuery({ limit: 100 });
 
   const skillOptions: MentionOption[] = useMemo(() => {
     if (!data?.skills) {
@@ -59,7 +58,7 @@ function SkillsCommandContent({
           value: skill.name,
           description: skill.description,
           type: 'skill',
-          icon: <ScrollText className="icon-md text-cyan-500" />,
+          icon: skillIcon,
         });
       }
       return acc;
@@ -97,12 +96,12 @@ function SkillsCommandContent({
         removeCharIfLast(textAreaRef.current, commandChar);
       }
 
-      if (!ephemeralAgent?.skills) {
-        setEphemeralAgent((prev) => ({
-          ...(prev || {}),
-          skills: true,
-        }));
-      }
+      setEphemeralAgent((prev) => {
+        if (prev?.skills) {
+          return prev;
+        }
+        return { ...(prev || {}), skills: true };
+      });
 
       const textarea = textAreaRef.current;
       if (textarea) {
@@ -119,7 +118,7 @@ function SkillsCommandContent({
         textarea.setSelectionRange(insertion.length, insertion.length);
       }
     },
-    [setSearchValue, setOpen, setShowSkillsPopover, textAreaRef, ephemeralAgent, setEphemeralAgent],
+    [setSearchValue, setOpen, setShowSkillsPopover, textAreaRef, setEphemeralAgent],
   );
 
   useEffect(() => {
@@ -188,13 +187,17 @@ function SkillsCommandContent({
               textAreaRef.current?.focus();
             }
             if (e.key === 'ArrowDown') {
+              if (matches.length === 0) {
+                return;
+              }
               setActiveIndex((prevIndex) => (prevIndex + 1) % matches.length);
             } else if (e.key === 'ArrowUp') {
+              if (matches.length === 0) {
+                return;
+              }
               setActiveIndex((prevIndex) => (prevIndex - 1 + matches.length) % matches.length);
             } else if (e.key === 'Enter' || e.key === 'Tab') {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-              }
+              e.preventDefault();
               handleSelect(matches[activeIndex] as MentionOption | undefined);
             } else if (e.key === 'Backspace' && searchValue === '') {
               setOpen(false);
@@ -214,6 +217,16 @@ function SkillsCommandContent({
         {open && isLoading && matches.length === 0 && (
           <div className="flex h-32 items-center justify-center text-text-primary">
             <Spinner />
+          </div>
+        )}
+        {open && isError && (
+          <div className="p-4 text-center text-sm text-text-secondary">
+            {localize('com_ui_skills_load_error')}
+          </div>
+        )}
+        {open && !isLoading && !isError && matches.length === 0 && (
+          <div className="p-4 text-center text-sm text-text-secondary">
+            {localize('com_ui_skills_empty')}
           </div>
         )}
         {open && matches.length > 0 && (

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -7,7 +7,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import type { TSkillSummary } from 'librechat-data-provider';
 import type { MentionOption } from '~/common';
 import useInitPopoverInput from '~/hooks/Input/useInitPopoverInput';
-import { useListSkillsQuery } from '~/data-provider';
+import { useSkillsInfiniteQuery } from '~/data-provider';
 import { ephemeralAgentByConvoId } from '~/store';
 import { removeCharIfLast } from '~/utils';
 import MentionItem from './MentionItem';
@@ -45,25 +45,36 @@ function SkillsCommandContent({
   const setShowSkillsPopover = useSetRecoilState(store.showSkillsPopoverFamily(index));
   const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(conversationId));
 
-  const { data, isLoading, isError } = useListSkillsQuery({ limit: 100 });
+  const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useSkillsInfiniteQuery({ limit: 50 });
+
+  /* Auto-fetch all pages so client-side search covers the full catalog,
+     not just the first page. The skills API is server-side capped. */
+  useEffect(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const skillOptions: MentionOption[] = useMemo(() => {
-    if (!data?.skills) {
+    if (!data?.pages) {
       return [];
     }
-    return data.skills.reduce<MentionOption[]>((acc, skill) => {
-      if (isUserInvocable(skill)) {
-        acc.push({
-          label: skill.displayTitle ?? skill.name,
-          value: skill.name,
-          description: skill.description,
-          type: 'skill',
-          icon: skillIcon,
-        });
+    return data.pages.reduce<MentionOption[]>((acc, page) => {
+      for (const skill of page.skills) {
+        if (isUserInvocable(skill)) {
+          acc.push({
+            label: skill.displayTitle ?? skill.name,
+            value: skill.name,
+            description: skill.description,
+            type: 'skill',
+            icon: skillIcon,
+          });
+        }
       }
       return acc;
     }, []);
-  }, [data?.skills]);
+  }, [data?.pages]);
 
   const [activeIndex, setActiveIndex] = useState(0);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -225,7 +236,7 @@ function SkillsCommandContent({
             }, 150);
           }}
         />
-        {open && isLoading && matches.length === 0 && (
+        {open && (isLoading || isFetchingNextPage) && matches.length === 0 && (
           <div className="flex h-32 items-center justify-center text-text-primary">
             <Spinner />
           </div>
@@ -235,7 +246,7 @@ function SkillsCommandContent({
             {localize('com_ui_skills_load_error')}
           </div>
         )}
-        {open && !isLoading && !isError && matches.length === 0 && (
+        {open && !isLoading && !isFetchingNextPage && !isError && matches.length === 0 && (
           <div className="p-4 text-center text-sm text-text-secondary">
             {localize(searchValue ? 'com_ui_no_skills_found' : 'com_ui_skills_empty')}
           </div>

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -214,6 +214,9 @@ function SkillsCommandContent({
               setActiveIndex((prevIndex) => (prevIndex - 1 + matches.length) % matches.length);
             } else if (e.key === 'Enter' || e.key === 'Tab') {
               if (matches.length === 0) {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                }
                 setOpen(false);
                 setShowSkillsPopover(false);
                 textAreaRef.current?.focus();

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -1,0 +1,259 @@
+import { memo, useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { useRecoilValue, useSetRecoilState, useRecoilState } from 'recoil';
+import { AutoSizer, List } from 'react-virtualized';
+import { Spinner, useCombobox } from '@librechat/client';
+import { InvocationMode } from 'librechat-data-provider';
+import { ScrollText } from 'lucide-react';
+import type { TSkillSummary } from 'librechat-data-provider';
+import type { MentionOption } from '~/common';
+import useInitPopoverInput from '~/hooks/Input/useInitPopoverInput';
+import { useListSkillsQuery } from '~/data-provider';
+import { ephemeralAgentByConvoId } from '~/store';
+import { removeCharIfLast } from '~/utils';
+import MentionItem from './MentionItem';
+import { useLocalize } from '~/hooks';
+import store from '~/store';
+
+const commandChar = '$';
+const ROW_HEIGHT = 44;
+
+/**
+ * Skills with `invocationMode === 'auto'` are model-triggered only and should
+ * NOT appear in the user-facing `$` command popover.
+ * `manual` (user-only) and `both` (either) are shown.
+ * Default (undefined/auto) is shown for backward compatibility during phase 1.
+ */
+function isUserInvocable(skill: TSkillSummary): boolean {
+  const mode = skill.invocationMode;
+  if (mode == null || mode === InvocationMode.auto || mode === InvocationMode.both) {
+    return true;
+  }
+  return mode === InvocationMode.manual;
+}
+
+function SkillsCommandContent({
+  index,
+  textAreaRef,
+  conversationId,
+}: {
+  index: number;
+  textAreaRef: React.MutableRefObject<HTMLTextAreaElement | null>;
+  conversationId: string;
+}) {
+  const localize = useLocalize();
+  const setShowSkillsPopover = useSetRecoilState(store.showSkillsPopoverFamily(index));
+  const [ephemeralAgent, setEphemeralAgent] = useRecoilState(
+    ephemeralAgentByConvoId(conversationId),
+  );
+
+  const { data, isLoading } = useListSkillsQuery({ limit: 100 });
+
+  const skillOptions: MentionOption[] = useMemo(() => {
+    if (!data?.skills) {
+      return [];
+    }
+    return data.skills.reduce<MentionOption[]>((acc, skill) => {
+      if (isUserInvocable(skill)) {
+        acc.push({
+          label: skill.displayTitle ?? skill.name,
+          value: skill.name,
+          description: skill.description,
+          type: 'skill',
+          icon: <ScrollText className="icon-md text-cyan-500" />,
+        });
+      }
+      return acc;
+    }, []);
+  }, [data?.skills]);
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const { open, setOpen, searchValue, setSearchValue, matches } = useCombobox({
+    value: '',
+    options: skillOptions,
+  });
+
+  const initInputRef = useInitPopoverInput({
+    inputRef,
+    textAreaRef,
+    commandChar,
+    setSearchValue,
+    setOpen,
+  });
+
+  const handleSelect = useCallback(
+    (mention?: MentionOption) => {
+      if (!mention) {
+        return;
+      }
+
+      setSearchValue('');
+      setOpen(false);
+      setShowSkillsPopover(false);
+
+      if (textAreaRef.current) {
+        removeCharIfLast(textAreaRef.current, commandChar);
+      }
+
+      if (!ephemeralAgent?.skills) {
+        setEphemeralAgent((prev) => ({
+          ...(prev || {}),
+          skills: true,
+        }));
+      }
+
+      const textarea = textAreaRef.current;
+      if (textarea) {
+        const insertion = `$${mention.value} `;
+        const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+          HTMLTextAreaElement.prototype,
+          'value',
+        )?.set;
+        if (nativeInputValueSetter) {
+          nativeInputValueSetter.call(textarea, insertion);
+          textarea.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        textarea.focus();
+        textarea.setSelectionRange(insertion.length, insertion.length);
+      }
+    },
+    [setSearchValue, setOpen, setShowSkillsPopover, textAreaRef, ephemeralAgent, setEphemeralAgent],
+  );
+
+  useEffect(() => {
+    if (!open) {
+      setActiveIndex(0);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const el = document.getElementById(`skill-item-${activeIndex}`);
+    el?.scrollIntoView({ behavior: 'instant', block: 'nearest' });
+  }, [activeIndex]);
+
+  const rowRenderer = ({
+    index,
+    key,
+    style,
+  }: {
+    index: number;
+    key: string;
+    style: React.CSSProperties;
+  }) => {
+    const mention = matches[index] as MentionOption;
+    return (
+      <MentionItem
+        index={index}
+        type="skill"
+        key={key}
+        style={style}
+        onClick={() => {
+          if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+          }
+          timeoutRef.current = null;
+          handleSelect(mention);
+        }}
+        name={mention.label ?? ''}
+        icon={mention.icon}
+        description={mention.description}
+        isActive={index === activeIndex}
+      />
+    );
+  };
+
+  return (
+    <div className="absolute bottom-28 z-10 w-full space-y-2">
+      <div className="popover border-token-border-light rounded-2xl border bg-surface-tertiary-alt p-2 shadow-lg">
+        <input
+          ref={initInputRef}
+          placeholder={localize('com_ui_skills_command_placeholder')}
+          className="mb-1 w-full border-0 bg-surface-tertiary-alt p-2 text-sm focus:outline-none dark:text-gray-200"
+          autoComplete="off"
+          value={searchValue}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              setOpen(false);
+              setShowSkillsPopover(false);
+              textAreaRef.current?.focus();
+            }
+            if (e.key === 'ArrowDown') {
+              setActiveIndex((prevIndex) => (prevIndex + 1) % matches.length);
+            } else if (e.key === 'ArrowUp') {
+              setActiveIndex((prevIndex) => (prevIndex - 1 + matches.length) % matches.length);
+            } else if (e.key === 'Enter' || e.key === 'Tab') {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+              }
+              handleSelect(matches[activeIndex] as MentionOption | undefined);
+            } else if (e.key === 'Backspace' && searchValue === '') {
+              setOpen(false);
+              setShowSkillsPopover(false);
+              textAreaRef.current?.focus();
+            }
+          }}
+          onChange={(e) => setSearchValue(e.target.value)}
+          onFocus={() => setOpen(true)}
+          onBlur={() => {
+            timeoutRef.current = setTimeout(() => {
+              setOpen(false);
+              setShowSkillsPopover(false);
+            }, 150);
+          }}
+        />
+        {open && isLoading && matches.length === 0 && (
+          <div className="flex h-32 items-center justify-center text-text-primary">
+            <Spinner />
+          </div>
+        )}
+        {open && matches.length > 0 && (
+          <div className="max-h-40">
+            <AutoSizer disableHeight>
+              {({ width }) => (
+                <List
+                  width={width}
+                  overscanRowCount={5}
+                  rowHeight={ROW_HEIGHT}
+                  rowCount={matches.length}
+                  rowRenderer={rowRenderer}
+                  scrollToIndex={activeIndex}
+                  height={Math.min(matches.length * ROW_HEIGHT, 160)}
+                />
+              )}
+            </AutoSizer>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const SkillsCommand = memo(function SkillsCommand({
+  index,
+  textAreaRef,
+  conversationId,
+}: {
+  index: number;
+  textAreaRef: React.MutableRefObject<HTMLTextAreaElement | null>;
+  conversationId: string;
+}) {
+  const show = useRecoilValue(store.showSkillsPopoverFamily(index));
+  if (!show) {
+    return null;
+  }
+  return (
+    <SkillsCommandContent index={index} textAreaRef={textAreaRef} conversationId={conversationId} />
+  );
+});
+
+export default SkillsCommand;

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -1,9 +1,9 @@
 import { memo, useState, useRef, useEffect, useMemo, useCallback } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { ScrollText } from 'lucide-react';
 import { AutoSizer, List } from 'react-virtualized';
 import { Spinner, useCombobox } from '@librechat/client';
 import { InvocationMode } from 'librechat-data-provider';
-import { ScrollText } from 'lucide-react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import type { TSkillSummary } from 'librechat-data-provider';
 import type { MentionOption } from '~/common';
 import useInitPopoverInput from '~/hooks/Input/useInitPopoverInput';
@@ -128,6 +128,10 @@ function SkillsCommandContent({
   }, [open]);
 
   useEffect(() => {
+    setActiveIndex((prev) => Math.min(prev, Math.max(matches.length - 1, 0)));
+  }, [matches.length]);
+
+  useEffect(() => {
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
@@ -185,6 +189,7 @@ function SkillsCommandContent({
               setOpen(false);
               setShowSkillsPopover(false);
               textAreaRef.current?.focus();
+              return;
             }
             if (e.key === 'ArrowDown') {
               if (matches.length === 0) {
@@ -226,7 +231,7 @@ function SkillsCommandContent({
         )}
         {open && !isLoading && !isError && matches.length === 0 && (
           <div className="p-4 text-center text-sm text-text-secondary">
-            {localize('com_ui_skills_empty')}
+            {localize(searchValue ? 'com_ui_no_skills_found' : 'com_ui_skills_empty')}
           </div>
         )}
         {open && matches.length > 0 && (

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -44,6 +44,9 @@ function SkillsCommandContent({
   const localize = useLocalize();
   const setShowSkillsPopover = useSetRecoilState(store.showSkillsPopoverFamily(index));
   const setEphemeralAgent = useSetRecoilState(ephemeralAgentByConvoId(conversationId));
+  const setPendingManualSkills = useSetRecoilState(
+    store.pendingManualSkillsByConvoId(conversationId),
+  );
 
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSkillsInfiniteQuery({ limit: 50 });
@@ -128,6 +131,16 @@ function SkillsCommandContent({
         return { ...(prev || {}), skills: true };
       });
 
+      /* Structured channel for manual skill invocations. The follow-up PR
+         will read this in the submit pipeline and prime the corresponding
+         SKILL.md as a meta user message before the LLM turn, mirroring
+         Claude Code's `/skill` deterministic injection. The textual
+         `$skill-name ` insertion below remains as user-visible confirmation
+         and is treated as cosmetic by that future pipeline. */
+      setPendingManualSkills((prev) =>
+        prev.includes(mention.value) ? prev : [...prev, mention.value],
+      );
+
       const textarea = textAreaRef.current;
       if (textarea) {
         const insertion = `$${mention.value} `;
@@ -143,7 +156,14 @@ function SkillsCommandContent({
         textarea.setSelectionRange(insertion.length, insertion.length);
       }
     },
-    [setSearchValue, setOpen, setShowSkillsPopover, textAreaRef, setEphemeralAgent],
+    [
+      setSearchValue,
+      setOpen,
+      setShowSkillsPopover,
+      textAreaRef,
+      setEphemeralAgent,
+      setPendingManualSkills,
+    ],
   );
 
   useEffect(() => {

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -202,6 +202,12 @@ function SkillsCommandContent({
               }
               setActiveIndex((prevIndex) => (prevIndex - 1 + matches.length) % matches.length);
             } else if (e.key === 'Enter' || e.key === 'Tab') {
+              if (matches.length === 0) {
+                setOpen(false);
+                setShowSkillsPopover(false);
+                textAreaRef.current?.focus();
+                return;
+              }
               e.preventDefault();
               handleSelect(matches[activeIndex] as MentionOption | undefined);
             } else if (e.key === 'Backspace' && searchValue === '') {

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -48,13 +48,27 @@ function SkillsCommandContent({
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSkillsInfiniteQuery({ limit: 50 });
 
+  /* Sticky circuit breaker: once any page request fails, stop auto-fetching
+     for the lifetime of the popover so a transient API error does not turn
+     into an unbounded retry loop (isError can flip back to false on the
+     next attempt, which would otherwise re-arm the auto-fetch effect). */
+  const paginationBlockedRef = useRef(false);
+  useEffect(() => {
+    if (isError) {
+      paginationBlockedRef.current = true;
+    }
+  }, [isError]);
+
   /* Auto-fetch all pages so client-side search covers the full catalog,
      not just the first page. The skills API is server-side capped. */
   useEffect(() => {
+    if (paginationBlockedRef.current || isError) {
+      return;
+    }
     if (hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
     }
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [hasNextPage, isFetchingNextPage, isError, fetchNextPage]);
 
   const skillOptions: MentionOption[] = useMemo(() => {
     if (!data?.pages) {

--- a/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
@@ -1,0 +1,187 @@
+/**
+ * Locks in the selection-flow contract that the follow-up `manualSkills`
+ * PR has to honor: when a user picks a skill in the `$` popover the
+ * component must (a) push the skill name onto the per-conversation
+ * `pendingManualSkillsByConvoId` atom, (b) flip `ephemeralAgent.skills`
+ * to true, and (c) insert `$skill-name ` into the textarea.
+ */
+import React from 'react';
+import { act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+
+const CONVO_ID = 'convo-1';
+
+const mockSetShowSkillsPopover = jest.fn();
+const mockSetEphemeralAgent = jest.fn();
+const mockSetPendingManualSkills = jest.fn();
+const mockShowSkillsPopover = { current: true };
+
+jest.mock('recoil', () => {
+  const actual = jest.requireActual('recoil');
+  return {
+    ...actual,
+    useRecoilValue: jest.fn((atom: unknown) => {
+      if (atom === 'show-skills-popover') {
+        return mockShowSkillsPopover.current;
+      }
+      return undefined;
+    }),
+    useRecoilState: jest.fn(() => [null, jest.fn()]),
+    useSetRecoilState: jest.fn((atom: unknown) => {
+      if (atom === 'show-skills-popover') {
+        return mockSetShowSkillsPopover;
+      }
+      if (atom === 'ephemeral-agent') {
+        return mockSetEphemeralAgent;
+      }
+      if (atom === 'pending-manual-skills') {
+        return mockSetPendingManualSkills;
+      }
+      return jest.fn();
+    }),
+  };
+});
+
+jest.mock('~/store', () => ({
+  __esModule: true,
+  default: {
+    showSkillsPopoverFamily: () => 'show-skills-popover',
+    pendingManualSkillsByConvoId: () => 'pending-manual-skills',
+  },
+  ephemeralAgentByConvoId: () => 'ephemeral-agent',
+  pendingManualSkillsByConvoId: () => 'pending-manual-skills',
+}));
+
+const mockUseSkillsInfiniteQuery = jest.fn();
+jest.mock('~/data-provider', () => ({
+  useSkillsInfiniteQuery: () => mockUseSkillsInfiniteQuery(),
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+}));
+
+jest.mock('@librechat/client', () => {
+  const actual = jest.requireActual('@librechat/client');
+  return {
+    ...actual,
+    Spinner: () => null,
+  };
+});
+
+/* react-virtualized renders nothing in jsdom without measured size; replace
+   AutoSizer + List with a flat ul so row clicks are exercised normally. */
+jest.mock('react-virtualized', () => ({
+  ...jest.requireActual('react-virtualized'),
+  AutoSizer: ({ children }: { children: (size: { width: number }) => React.ReactNode }) =>
+    children({ width: 320 }),
+  List: ({
+    rowCount,
+    rowRenderer,
+  }: {
+    rowCount: number;
+    rowRenderer: (args: {
+      index: number;
+      key: string;
+      style: React.CSSProperties;
+    }) => React.ReactNode;
+  }) => {
+    const rows: React.ReactNode[] = [];
+    for (let i = 0; i < rowCount; i++) {
+      rows.push(rowRenderer({ index: i, key: `row-${i}`, style: {} }));
+    }
+    return <ul data-testid="skills-list">{rows}</ul>;
+  },
+}));
+
+import SkillsCommand from '../SkillsCommand';
+
+const makeTextarea = (initial = '$') => {
+  const textarea = document.createElement('textarea');
+  textarea.value = initial;
+  document.body.appendChild(textarea);
+  return { current: textarea } as React.MutableRefObject<HTMLTextAreaElement | null>;
+};
+
+const skillsResponse = {
+  pages: [
+    {
+      skills: [
+        {
+          _id: '1',
+          name: 'brand-guidelines',
+          displayTitle: 'Brand Guidelines',
+          description: 'Apply brand styling',
+          author: 'u',
+          authorName: 'U',
+          version: 1,
+          source: 'inline',
+          fileCount: 0,
+          createdAt: '',
+          updatedAt: '',
+        },
+      ],
+      has_more: false,
+      after: null,
+    },
+  ],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  document.body.innerHTML = '';
+  mockShowSkillsPopover.current = true;
+  mockUseSkillsInfiniteQuery.mockReturnValue({
+    data: skillsResponse,
+    isLoading: false,
+    isError: false,
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  });
+});
+
+describe('SkillsCommand', () => {
+  it('renders nothing when the popover atom is false', () => {
+    mockShowSkillsPopover.current = false;
+    const textAreaRef = makeTextarea();
+    const { container } = render(
+      <SkillsCommand index={0} textAreaRef={textAreaRef} conversationId={CONVO_ID} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('selecting a skill pushes to pendingManualSkillsByConvoId, flips ephemeralAgent.skills, inserts $name into textarea, and closes the popover', async () => {
+    const user = userEvent.setup();
+    const textAreaRef = makeTextarea('$');
+    render(<SkillsCommand index={0} textAreaRef={textAreaRef} conversationId={CONVO_ID} />);
+
+    const skillButton = await screen.findByRole('button', { name: /Brand Guidelines/i });
+    await act(async () => {
+      await user.click(skillButton);
+    });
+
+    /* Structured channel: the skill name is pushed into the per-convo atom,
+       which is the contract the follow-up PR depends on. */
+    expect(mockSetPendingManualSkills).toHaveBeenCalledTimes(1);
+    const updater = mockSetPendingManualSkills.mock.calls[0][0] as (prev: string[]) => string[];
+    expect(updater([])).toEqual(['brand-guidelines']);
+    expect(updater(['brand-guidelines'])).toEqual(['brand-guidelines']);
+
+    /* Ephemeral agent gets skills enabled so the badge lights up and the
+       backend includes the skill catalog. */
+    expect(mockSetEphemeralAgent).toHaveBeenCalledTimes(1);
+    const agentUpdater = mockSetEphemeralAgent.mock.calls[0][0] as (
+      prev: { skills?: boolean } | null,
+    ) => { skills?: boolean };
+    expect(agentUpdater(null)).toEqual({ skills: true });
+    expect(agentUpdater({ skills: true })).toEqual({ skills: true });
+
+    /* Cosmetic textarea insertion remains in place for user feedback. */
+    expect(textAreaRef.current?.value).toBe('$brand-guidelines ');
+
+    /* Popover dismisses on selection. */
+    expect(mockSetShowSkillsPopover).toHaveBeenCalledWith(false);
+  });
+});

--- a/client/src/hooks/Config/useClearStates.ts
+++ b/client/src/hooks/Config/useClearStates.ts
@@ -33,6 +33,7 @@ export default function useClearStates() {
           reset(store.showPlusPopoverFamily(key));
           reset(store.showPromptsPopoverFamily(key));
           reset(store.showSkillsPopoverFamily(key));
+          reset(store.pendingManualSkillsByConvoId(key.toString()));
           reset(store.activePromptByIndex(key));
           reset(store.globalAudioURLFamily(key));
           reset(store.globalAudioFetchingFamily(key));

--- a/client/src/hooks/Config/useClearStates.ts
+++ b/client/src/hooks/Config/useClearStates.ts
@@ -32,6 +32,7 @@ export default function useClearStates() {
           reset(store.showMentionPopoverFamily(key));
           reset(store.showPlusPopoverFamily(key));
           reset(store.showPromptsPopoverFamily(key));
+          reset(store.showSkillsPopoverFamily(key));
           reset(store.activePromptByIndex(key));
           reset(store.globalAudioURLFamily(key));
           reset(store.globalAudioFetchingFamily(key));

--- a/client/src/hooks/Input/useHandleKeyUp.spec.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.spec.ts
@@ -192,6 +192,15 @@ describe('useHandleKeyUp', () => {
       expect(setShowPromptsPopover).toHaveBeenCalledWith(true);
     });
 
+    it('triggers $ skill command for "$sk" (fast typed)', () => {
+      const ref = makeTextAreaRef('$sk', 3);
+      const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('k')));
+
+      expect(setShowSkillsPopover).toHaveBeenCalledWith(true);
+    });
+
     it('does NOT trigger for text exceeding MAX_COMMAND_TRIGGER_LENGTH', () => {
       const ref = makeTextAreaRef('/abcde', 6);
       const { handleKeyUp, setShowPromptsPopover } = renderUseHandleKeyUp(ref);

--- a/client/src/hooks/Input/useHandleKeyUp.spec.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.spec.ts
@@ -277,6 +277,24 @@ describe('useHandleKeyUp', () => {
       expect(setShowPromptsPopover).not.toHaveBeenCalled();
     });
 
+    it('does NOT trigger $ skill command for currency-like "$100"', () => {
+      const ref = makeTextAreaRef('$100', 4);
+      const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('0')));
+
+      expect(setShowSkillsPopover).not.toHaveBeenCalled();
+    });
+
+    it('does NOT trigger $ skill command for currency-like "$5.99"', () => {
+      const ref = makeTextAreaRef('$5.99', 5);
+      const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('9')));
+
+      expect(setShowSkillsPopover).not.toHaveBeenCalled();
+    });
+
     it('does NOT trigger for pasted "@username mentioned in a long message"', () => {
       const ref = makeTextAreaRef('@username mentioned in a long message', 37);
       const { handleKeyUp, setShowMentionPopover } = renderUseHandleKeyUp(ref);

--- a/client/src/hooks/Input/useHandleKeyUp.spec.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.spec.ts
@@ -154,20 +154,11 @@ describe('useHandleKeyUp', () => {
       expect(setShowPlusPopover).toHaveBeenCalledWith(true);
     });
 
-    it('does NOT trigger $ skill command for bare "$" (defers to next keystroke)', () => {
+    it('triggers $ skill command for "$" at position 1', () => {
       const ref = makeTextAreaRef('$', 1);
       const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
 
       act(() => handleKeyUp(makeKeyEvent('$')));
-
-      expect(setShowSkillsPopover).not.toHaveBeenCalled();
-    });
-
-    it('triggers $ skill command for "$a" once a letter follows', () => {
-      const ref = makeTextAreaRef('$a', 2);
-      const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
-
-      act(() => handleKeyUp(makeKeyEvent('a')));
 
       expect(setShowSkillsPopover).toHaveBeenCalledWith(true);
     });
@@ -284,24 +275,6 @@ describe('useHandleKeyUp', () => {
       act(() => handleKeyUp(makeKeyEvent('v')));
 
       expect(setShowPromptsPopover).not.toHaveBeenCalled();
-    });
-
-    it('does NOT trigger $ skill command for currency-like "$100"', () => {
-      const ref = makeTextAreaRef('$100', 4);
-      const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
-
-      act(() => handleKeyUp(makeKeyEvent('0')));
-
-      expect(setShowSkillsPopover).not.toHaveBeenCalled();
-    });
-
-    it('does NOT trigger $ skill command for currency-like "$5.99"', () => {
-      const ref = makeTextAreaRef('$5.99', 5);
-      const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
-
-      act(() => handleKeyUp(makeKeyEvent('9')));
-
-      expect(setShowSkillsPopover).not.toHaveBeenCalled();
     });
 
     it('does NOT trigger for pasted "@username mentioned in a long message"', () => {

--- a/client/src/hooks/Input/useHandleKeyUp.spec.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.spec.ts
@@ -466,5 +466,25 @@ describe('useHandleKeyUp', () => {
 
       expect(setShowPlusPopover).toHaveBeenCalledWith(true);
     });
+
+    it('does NOT trigger $ skill command on assistants endpoint', () => {
+      mockEndpoint.current = 'assistants';
+      const ref = makeTextAreaRef('$', 1);
+      const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('$')));
+
+      expect(setShowSkillsPopover).not.toHaveBeenCalledWith(true);
+    });
+
+    it('does NOT trigger $ skill command on azureAssistants endpoint', () => {
+      mockEndpoint.current = 'azureAssistants';
+      const ref = makeTextAreaRef('$', 1);
+      const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('$')));
+
+      expect(setShowSkillsPopover).not.toHaveBeenCalledWith(true);
+    });
   });
 });

--- a/client/src/hooks/Input/useHandleKeyUp.spec.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.spec.ts
@@ -486,5 +486,13 @@ describe('useHandleKeyUp', () => {
 
       expect(setShowSkillsPopover).not.toHaveBeenCalledWith(true);
     });
+
+    it('resets $ skills popover when endpoint switches to assistants', () => {
+      mockEndpoint.current = 'assistants';
+      const ref = makeTextAreaRef('', 0);
+      const { setShowSkillsPopover } = renderUseHandleKeyUp(ref);
+
+      expect(setShowSkillsPopover).toHaveBeenCalledWith(false);
+    });
   });
 });

--- a/client/src/hooks/Input/useHandleKeyUp.spec.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.spec.ts
@@ -1,10 +1,12 @@
 const mockSetShowMentionPopover = jest.fn();
 const mockSetShowPlusPopover = jest.fn();
 const mockSetShowPromptsPopover = jest.fn();
+const mockSetShowSkillsPopover = jest.fn();
 const mockHasPromptsAccess = { current: true };
 const mockHasMultiConvoAccess = { current: true };
+const mockHasSkillsAccess = { current: true };
 const mockEndpoint = { current: 'openAI' as string | null };
-const mockCommandToggles = { at: true, plus: true, slash: true };
+const mockCommandToggles = { at: true, plus: true, slash: true, dollar: true };
 
 jest.mock('recoil', () => ({
   ...jest.requireActual('recoil'),
@@ -24,6 +26,9 @@ jest.mock('recoil', () => ({
     if (atom === 'slashCommand') {
       return mockCommandToggles.slash;
     }
+    if (atom === 'dollarCommand') {
+      return mockCommandToggles.dollar;
+    }
     return undefined;
   }),
   useSetRecoilState: jest.fn((atom: string) => {
@@ -36,6 +41,9 @@ jest.mock('recoil', () => ({
     if (atom === 'showPromptsPopoverFamily-0') {
       return mockSetShowPromptsPopover;
     }
+    if (atom === 'showSkillsPopoverFamily-0') {
+      return mockSetShowSkillsPopover;
+    }
     return jest.fn();
   }),
 }));
@@ -44,11 +52,13 @@ jest.mock('~/store', () => ({
   showPromptsPopoverFamily: (idx: number) => `showPromptsPopoverFamily-${idx}`,
   showMentionPopoverFamily: (idx: number) => `showMentionPopoverFamily-${idx}`,
   showPlusPopoverFamily: (idx: number) => `showPlusPopoverFamily-${idx}`,
+  showSkillsPopoverFamily: (idx: number) => `showSkillsPopoverFamily-${idx}`,
   effectiveEndpointByIndex: (idx: number) => `effectiveEndpointByIndex-${idx}`,
   latestMessageFamily: (idx: number) => `latestMessageFamily-${idx}`,
   atCommand: 'atCommand',
   plusCommand: 'plusCommand',
   slashCommand: 'slashCommand',
+  dollarCommand: 'dollarCommand',
 }));
 
 jest.mock('~/hooks/Roles/useHasAccess', () =>
@@ -58,6 +68,9 @@ jest.mock('~/hooks/Roles/useHasAccess', () =>
     }
     if (permissionType === 'MULTI_CONVO') {
       return mockHasMultiConvoAccess.current;
+    }
+    if (permissionType === 'SKILLS') {
+      return mockHasSkillsAccess.current;
     }
     return false;
   }),
@@ -96,6 +109,7 @@ const renderUseHandleKeyUp = (
     setShowMentionPopover: mockSetShowMentionPopover,
     setShowPlusPopover: mockSetShowPlusPopover,
     setShowPromptsPopover: mockSetShowPromptsPopover,
+    setShowSkillsPopover: mockSetShowSkillsPopover,
   };
 };
 
@@ -103,10 +117,12 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockHasPromptsAccess.current = true;
   mockHasMultiConvoAccess.current = true;
+  mockHasSkillsAccess.current = true;
   mockEndpoint.current = 'openAI';
   mockCommandToggles.at = true;
   mockCommandToggles.plus = true;
   mockCommandToggles.slash = true;
+  mockCommandToggles.dollar = true;
 });
 
 describe('useHandleKeyUp', () => {
@@ -136,6 +152,15 @@ describe('useHandleKeyUp', () => {
       act(() => handleKeyUp(makeKeyEvent('+')));
 
       expect(setShowPlusPopover).toHaveBeenCalledWith(true);
+    });
+
+    it('triggers $ skill command for "$" at position 1', () => {
+      const ref = makeTextAreaRef('$', 1);
+      const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('$')));
+
+      expect(setShowSkillsPopover).toHaveBeenCalledWith(true);
     });
   });
 
@@ -337,6 +362,16 @@ describe('useHandleKeyUp', () => {
 
       expect(setShowPlusPopover).not.toHaveBeenCalled();
     });
+
+    it('does NOT trigger $ skill command when dollarCommand toggle is disabled', () => {
+      mockCommandToggles.dollar = false;
+      const ref = makeTextAreaRef('$', 1);
+      const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('$')));
+
+      expect(setShowSkillsPopover).not.toHaveBeenCalled();
+    });
   });
 
   describe('permission gating', () => {
@@ -369,6 +404,16 @@ describe('useHandleKeyUp', () => {
       act(() => handleKeyUp(makeKeyEvent('@')));
 
       expect(setShowMentionPopover).toHaveBeenCalledWith(true);
+    });
+
+    it('does NOT trigger $ skill command without SKILLS access', () => {
+      mockHasSkillsAccess.current = false;
+      const ref = makeTextAreaRef('$', 1);
+      const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('$')));
+
+      expect(setShowSkillsPopover).not.toHaveBeenCalled();
     });
   });
 

--- a/client/src/hooks/Input/useHandleKeyUp.spec.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.spec.ts
@@ -154,11 +154,20 @@ describe('useHandleKeyUp', () => {
       expect(setShowPlusPopover).toHaveBeenCalledWith(true);
     });
 
-    it('triggers $ skill command for "$" at position 1', () => {
+    it('does NOT trigger $ skill command for bare "$" (defers to next keystroke)', () => {
       const ref = makeTextAreaRef('$', 1);
       const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
 
       act(() => handleKeyUp(makeKeyEvent('$')));
+
+      expect(setShowSkillsPopover).not.toHaveBeenCalled();
+    });
+
+    it('triggers $ skill command for "$a" once a letter follows', () => {
+      const ref = makeTextAreaRef('$a', 2);
+      const { handleKeyUp, setShowSkillsPopover } = renderUseHandleKeyUp(ref);
+
+      act(() => handleKeyUp(makeKeyEvent('a')));
 
       expect(setShowSkillsPopover).toHaveBeenCalledWith(true);
     });

--- a/client/src/hooks/Input/useHandleKeyUp.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.ts
@@ -80,8 +80,9 @@ const useHandleKeyUp = ({
   useEffect(() => {
     if (isAssistantsEndpoint(endpoint)) {
       setShowPlusPopover(false);
+      setShowSkillsPopover(false);
     }
-  }, [endpoint, setShowPlusPopover]);
+  }, [endpoint, setShowPlusPopover, setShowSkillsPopover]);
 
   const handleAtCommand = useCallback(() => {
     if (atCommandEnabled && shouldTriggerCommand(textAreaRef, '@')) {

--- a/client/src/hooks/Input/useHandleKeyUp.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.ts
@@ -115,12 +115,13 @@ const useHandleKeyUp = ({
     if (!shouldTriggerCommand(textAreaRef, '$')) {
       return;
     }
-    /* Avoid hijacking currency input: bare `$` is a valid browse trigger,
-       but `$100`, `$5.99`, etc. should pass through unchanged. Only open
-       the popover when the character after `$` looks like a skill
-       identifier (lowercase ASCII letter). */
+    /* Avoid hijacking currency input. Bare `$` could be the start of
+       `$100`, so defer opening until a follow-up keystroke confirms a
+       skill-like prefix (lowercase ASCII letter immediately after `$`).
+       This means `$100`, `$5.99`, `$EUR` never open the popover, while
+       `$a`, `$skill`, `$my-skill` do. */
     const text = textAreaRef.current?.value ?? '';
-    if (text.length > 1 && !/^[a-z]/.test(text.slice(1))) {
+    if (text.length < 2 || !/^[a-z]/.test(text[1])) {
       return;
     }
     setShowSkillsPopover(true);

--- a/client/src/hooks/Input/useHandleKeyUp.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.ts
@@ -112,19 +112,9 @@ const useHandleKeyUp = ({
     if (!hasSkillsAccess || !dollarCommandEnabled || isAssistantsEndpoint(endpoint)) {
       return;
     }
-    if (!shouldTriggerCommand(textAreaRef, '$')) {
-      return;
+    if (shouldTriggerCommand(textAreaRef, '$')) {
+      setShowSkillsPopover(true);
     }
-    /* Avoid hijacking currency input. Bare `$` could be the start of
-       `$100`, so defer opening until a follow-up keystroke confirms a
-       skill-like prefix (lowercase ASCII letter immediately after `$`).
-       This means `$100`, `$5.99`, `$EUR` never open the popover, while
-       `$a`, `$skill`, `$my-skill` do. */
-    const text = textAreaRef.current?.value ?? '';
-    if (text.length < 2 || !/^[a-z]/.test(text[1])) {
-      return;
-    }
-    setShowSkillsPopover(true);
   }, [textAreaRef, hasSkillsAccess, setShowSkillsPopover, dollarCommandEnabled, endpoint]);
 
   const commandHandlers = useMemo(

--- a/client/src/hooks/Input/useHandleKeyUp.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.ts
@@ -108,13 +108,13 @@ const useHandleKeyUp = ({
   }, [textAreaRef, hasPromptsAccess, setShowPromptsPopover, slashCommandEnabled]);
 
   const handleSkillsCommand = useCallback(() => {
-    if (!hasSkillsAccess || !dollarCommandEnabled) {
+    if (!hasSkillsAccess || !dollarCommandEnabled || isAssistantsEndpoint(endpoint)) {
       return;
     }
     if (shouldTriggerCommand(textAreaRef, '$')) {
       setShowSkillsPopover(true);
     }
-  }, [textAreaRef, hasSkillsAccess, setShowSkillsPopover, dollarCommandEnabled]);
+  }, [textAreaRef, hasSkillsAccess, setShowSkillsPopover, dollarCommandEnabled, endpoint]);
 
   const commandHandlers = useMemo(
     () => ({

--- a/client/src/hooks/Input/useHandleKeyUp.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.ts
@@ -112,9 +112,18 @@ const useHandleKeyUp = ({
     if (!hasSkillsAccess || !dollarCommandEnabled || isAssistantsEndpoint(endpoint)) {
       return;
     }
-    if (shouldTriggerCommand(textAreaRef, '$')) {
-      setShowSkillsPopover(true);
+    if (!shouldTriggerCommand(textAreaRef, '$')) {
+      return;
     }
+    /* Avoid hijacking currency input: bare `$` is a valid browse trigger,
+       but `$100`, `$5.99`, etc. should pass through unchanged. Only open
+       the popover when the character after `$` looks like a skill
+       identifier (lowercase ASCII letter). */
+    const text = textAreaRef.current?.value ?? '';
+    if (text.length > 1 && !/^[a-z]/.test(text.slice(1))) {
+      return;
+    }
+    setShowSkillsPopover(true);
   }, [textAreaRef, hasSkillsAccess, setShowSkillsPopover, dollarCommandEnabled, endpoint]);
 
   const commandHandlers = useMemo(

--- a/client/src/hooks/Input/useHandleKeyUp.ts
+++ b/client/src/hooks/Input/useHandleKeyUp.ts
@@ -61,15 +61,21 @@ const useHandleKeyUp = ({
     permissionType: PermissionTypes.MULTI_CONVO,
     permission: Permissions.USE,
   });
+  const hasSkillsAccess = useHasAccess({
+    permissionType: PermissionTypes.SKILLS,
+    permission: Permissions.USE,
+  });
   const latestMessage = useRecoilValue(store.latestMessageFamily(index));
   const endpoint = useRecoilValue(store.effectiveEndpointByIndex(index));
   const setShowMentionPopover = useSetRecoilState(store.showMentionPopoverFamily(index));
   const setShowPlusPopover = useSetRecoilState(store.showPlusPopoverFamily(index));
   const setShowPromptsPopover = useSetRecoilState(store.showPromptsPopoverFamily(index));
+  const setShowSkillsPopover = useSetRecoilState(store.showSkillsPopoverFamily(index));
 
   const atCommandEnabled = useRecoilValue(store.atCommand);
   const plusCommandEnabled = useRecoilValue(store.plusCommand);
   const slashCommandEnabled = useRecoilValue(store.slashCommand);
+  const dollarCommandEnabled = useRecoilValue(store.dollarCommand);
 
   useEffect(() => {
     if (isAssistantsEndpoint(endpoint)) {
@@ -101,13 +107,23 @@ const useHandleKeyUp = ({
     }
   }, [textAreaRef, hasPromptsAccess, setShowPromptsPopover, slashCommandEnabled]);
 
+  const handleSkillsCommand = useCallback(() => {
+    if (!hasSkillsAccess || !dollarCommandEnabled) {
+      return;
+    }
+    if (shouldTriggerCommand(textAreaRef, '$')) {
+      setShowSkillsPopover(true);
+    }
+  }, [textAreaRef, hasSkillsAccess, setShowSkillsPopover, dollarCommandEnabled]);
+
   const commandHandlers = useMemo(
     () => ({
       '@': handleAtCommand,
       '+': handlePlusCommand,
       '/': handlePromptsCommand,
+      $: handleSkillsCommand,
     }),
-    [handleAtCommand, handlePlusCommand, handlePromptsCommand],
+    [handleAtCommand, handlePlusCommand, handlePromptsCommand, handleSkillsCommand],
   );
 
   const handleUpArrow = useCallback(

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1517,6 +1517,7 @@
   "com_ui_skills_allow_use": "Allow using Skills",
   "com_ui_skills_command_placeholder": "Select a Skill by name",
   "com_ui_skills_empty": "No skills yet",
+  "com_ui_skills_load_error": "Failed to load skills",
   "com_ui_sr_public_skill": "Public skill",
   "com_ui_special": "special",
   "com_ui_special_var_current_date": "Current Date",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1515,6 +1515,7 @@
   "com_ui_skills_allow_share": "Allow sharing Skills",
   "com_ui_skills_allow_share_public": "Allow sharing Skills publicly",
   "com_ui_skills_allow_use": "Allow using Skills",
+  "com_ui_skills_command_placeholder": "Select a Skill by name",
   "com_ui_skills_empty": "No skills yet",
   "com_ui_sr_public_skill": "Public skill",
   "com_ui_special": "special",

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -300,6 +300,11 @@ const showPromptsPopoverFamily = atomFamily<boolean, string | number | null>({
   default: false,
 });
 
+const showSkillsPopoverFamily = atomFamily<boolean, string | number | null>({
+  key: 'showSkillsPopoverByIndex',
+  default: false,
+});
+
 const globalAudioURLFamily = atomFamily<string | null, string | number | null>({
   key: 'globalAudioURLByIndex',
   default: null,
@@ -497,5 +502,6 @@ export default {
   useClearSubmissionState,
   useClearLatestMessages,
   showPromptsPopoverFamily,
+  showSkillsPopoverFamily,
   updateConversationSelector,
 };

--- a/client/src/store/families.ts
+++ b/client/src/store/families.ts
@@ -305,6 +305,21 @@ const showSkillsPopoverFamily = atomFamily<boolean, string | number | null>({
   default: false,
 });
 
+/**
+ * Per-conversation queue of skill names the user invoked manually via the
+ * `$` popover for the next submission. Acts as the structured channel
+ * paired with the cosmetic `$skill-name ` text inserted into the textarea.
+ *
+ * Phase 1: only the writer (SkillsCommand) is wired; the submit pipeline
+ * does not yet read or clear this atom. The follow-up PR will read this
+ * at `ask()` time, attach to the payload, and reset to `[]`. Until then
+ * the backend continues to receive only the textual `$name` reference.
+ */
+const pendingManualSkillsByConvoId = atomFamily<string[], string>({
+  key: 'pendingManualSkillsByConvoId',
+  default: [],
+});
+
 const globalAudioURLFamily = atomFamily<string | null, string | number | null>({
   key: 'globalAudioURLByIndex',
   default: null,
@@ -503,5 +518,6 @@ export default {
   useClearLatestMessages,
   showPromptsPopoverFamily,
   showSkillsPopoverFamily,
+  pendingManualSkillsByConvoId,
   updateConversationSelector,
 };

--- a/client/src/store/settings.ts
+++ b/client/src/store/settings.ts
@@ -50,6 +50,7 @@ const localStorageAtoms = {
   atCommand: atomWithLocalStorage('atCommand', true),
   plusCommand: atomWithLocalStorage('plusCommand', true),
   slashCommand: atomWithLocalStorage('slashCommand', true),
+  dollarCommand: atomWithLocalStorage('dollarCommand', true),
 
   // Speech settings
   conversationMode: atomWithLocalStorage('conversationMode', false),


### PR DESCRIPTION
## Summary

I added a `$` command trigger in the chat textarea that opens a searchable popover for manually invoking skills. This mirrors the existing `@` (mentions), `/` (prompts), and `+` (multi-convo) command patterns. Selecting a skill from the popover inserts `$skill-name` into the message text and auto-enables the skills badge on the ephemeral agent, ensuring the backend injects the skill catalog even if the user had not toggled skills on beforehand.

- Created `SkillsCommand.tsx` as a new popover component that fetches accessible skills via `useListSkillsQuery`, filters by `invocationMode` to exclude model-only skills, and renders a virtualized list with fuzzy search using the shared `useCombobox` hook.
- Registered `$` as a command trigger character in `useHandleKeyUp`, gated behind `PermissionTypes.SKILLS` access checks and a `dollarCommand` localStorage toggle (matching the existing `atCommand`/`slashCommand`/`plusCommand` pattern).
- Added `showSkillsPopoverFamily` Recoil atomFamily to manage per-conversation popover visibility state, and included it in the `useClearStates` reset loop.
- Extended `MentionItem` type union to accept `'skill'` as a valid popover item type.
- Wired `SkillsCommand` into `ChatForm` alongside the existing mention and prompt popovers, passing `conversationId` so the component can read/write the ephemeral agent atom directly.
- On skill selection, set `skills: true` on the conversation's ephemeral agent to activate the skills badge and signal the backend to inject the skill catalog into the agent's instructions.
- Inserted `$skill-name ` (with trailing space) into the textarea after selection so the user can see which skill was invoked and continue composing their message.
- Respected `invocationMode` from `TSkillSummary` to control popover visibility: `auto`/`both`/undefined are shown, `manual` is shown (user-only), and future model-only modes will be hidden. This lays groundwork for the frontmatter-based `user-invocable` and `disable-model-invocation` fields from the Claude Code skill spec.
- Added `com_ui_skills_command_placeholder` localization key for the popover search input.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

1. Create at least one skill via the Skills UI.
2. In the chat textarea, type `$` as the first character.
3. Verify the skills popover appears with a searchable list of available skills.
4. Type part of a skill name to confirm fuzzy filtering works.
5. Select a skill via Enter, Tab, or click and verify:
   - The popover closes.
   - `$skill-name ` is inserted into the textarea.
   - The skills badge in the badge row activates (turns cyan).
6. Submit the message and verify the agent receives the skill catalog in its instructions.
7. Press Escape or Backspace on empty search to confirm the popover dismisses cleanly.
8. Verify the popover does not appear for users without `PermissionTypes.SKILLS` access.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes