### PR TITLE
fix: add Qwen3.5 model context window tokens

### DIFF
--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -255,6 +255,9 @@ const qwenModels = {
   'qwen3-32b': 40960,
   'qwen3-235b-a22b': 40960,
   'qwen3-8b': 128000,
+  // Qwen3.5 models (262K native context)
+  'qwen3.5': 262144,
+  'qwen3.5-397b': 262144,
   'qwen3-vl-235b-a22b': 131072,
   'qwen3-vl-8b-thinking': 256000,
   'qwen3-max': 256000,


### PR DESCRIPTION
## Summary

- Add `qwen3.5` (262,144) and `qwen3.5-397b` (262,144) entries to the `qwenModels` token map

## Problem

Qwen3.5 models (e.g. `Qwen/Qwen3.5-397B-A17B-FP8`) have a **262,144 token** native context window, but were falling back to the generic `qwen3` entry (**40,960 tokens**) via `findMatchingPattern` fuzzy name matching.

This caused the agent graph's `pruneMessages` (in `@librechat/agents`) to aggressively drop messages — including the user query, assistant `tool_calls`, and tool results — when tool output exceeded the undersized token budget (~36K tokens after the 0.9x scaling formula), leading to the model receiving **only the system message** and producing broken or empty responses.

### Symptoms observed
- Small tool outputs worked fine (~54KB / ~13K tokens fit within 36,864 budget)
- Large tool outputs (~144KB / ~36K tokens) caused the entire conversation to be pruned
- Model responded without context, ignoring tool results or producing "No user query found" errors
- Same scenario worked correctly with Anthropic (which has its own token map entry)
- Direct vLLM API calls with the same large payload worked correctly

## Test plan
- [x] Verified `Qwen/Qwen3.5-397B-A17B-FP8` now resolves to 262,144 tokens instead of 40,960
- [x] Tested with large tool output (~144KB) — all messages preserved, model responds correctly
- [x] Tested with small tool output — still works as before
