### PR TITLE
🪆 feat: Compose Agent Scope and Active-State Filters in $ Popover

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -255,7 +255,12 @@ const ChatForm = memo(function ChatForm({
             textAreaRef={textAreaRef}
           />
           <PromptsCommand index={index} textAreaRef={textAreaRef} submitPrompt={submitPrompt} />
-          <SkillsCommand index={index} textAreaRef={textAreaRef} conversationId={conversationId} />
+          <SkillsCommand
+            index={index}
+            textAreaRef={textAreaRef}
+            conversationId={conversationId}
+            agentId={conversation?.agent_id}
+          />
           <div
             onClick={handleContainerClick}
             className={cn(

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -7,8 +7,8 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import type { TSkillSummary } from 'librechat-data-provider';
 import type { MentionOption } from '~/common';
 import useInitPopoverInput from '~/hooks/Input/useInitPopoverInput';
-import { useChatContext, useAgentsMapContext } from '~/Providers';
 import { useLocalize, useSkillActiveState } from '~/hooks';
+import { useAgentsMapContext } from '~/Providers';
 import { useSkillsInfiniteQuery } from '~/data-provider';
 import { ephemeralAgentByConvoId } from '~/store';
 import { removeCharIfLast } from '~/utils';
@@ -82,10 +82,12 @@ function SkillsCommandContent({
   index,
   textAreaRef,
   conversationId,
+  agentId,
 }: {
   index: number;
   textAreaRef: React.MutableRefObject<HTMLTextAreaElement | null>;
   conversationId: string;
+  agentId?: string | null;
 }) {
   const localize = useLocalize();
   const setShowSkillsPopover = useSetRecoilState(store.showSkillsPopoverFamily(index));
@@ -94,7 +96,6 @@ function SkillsCommandContent({
     store.pendingManualSkillsByConvoId(conversationId),
   );
 
-  const { conversation } = useChatContext();
   const agentsMap = useAgentsMapContext();
   const { isActive } = useSkillActiveState();
 
@@ -103,14 +104,15 @@ function SkillsCommandContent({
      configured array (including `[]`) → pass through as-is so the filter can
      enforce explicit opt-out. Returning `undefined` until the agent is loaded
      keeps the popover populated instead of flashing empty during hydration;
-     the backend still enforces the agent scope at runtime regardless. */
+     the backend still enforces the agent scope at runtime regardless.
+     `agentId` is threaded in as a prop so this component stays memoizable
+     and skips re-renders on unrelated conversation-shape changes. */
   const agentSkillIds = useMemo<string[] | null | undefined>(() => {
-    const agentId = conversation?.agent_id;
     if (!agentId) {
       return undefined;
     }
     return agentsMap?.[agentId]?.skills;
-  }, [conversation?.agent_id, agentsMap]);
+  }, [agentId, agentsMap]);
 
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSkillsInfiniteQuery({ limit: 50 });
@@ -382,17 +384,24 @@ const SkillsCommand = memo(function SkillsCommand({
   index,
   textAreaRef,
   conversationId,
+  agentId,
 }: {
   index: number;
   textAreaRef: React.MutableRefObject<HTMLTextAreaElement | null>;
   conversationId: string;
+  agentId?: string | null;
 }) {
   const show = useRecoilValue(store.showSkillsPopoverFamily(index));
   if (!show) {
     return null;
   }
   return (
-    <SkillsCommandContent index={index} textAreaRef={textAreaRef} conversationId={conversationId} />
+    <SkillsCommandContent
+      index={index}
+      textAreaRef={textAreaRef}
+      conversationId={conversationId}
+      agentId={agentId}
+    />
   );
 });
 

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -105,8 +105,12 @@ function SkillsCommandContent({
      → intersection. Ephemeral agent ids (null/undefined/placeholder strings
      that don't begin with `agent_`) are unscoped — they correspond to
      conversations without a persisted agent and are intentionally absent
-     from the agents map. Fails closed for "map not hydrated" and "persisted
-     agent missing from map" — scope unknown, don't leak the full catalog.
+     from the agents map. While the map is still hydrating we pass through
+     (undefined → full catalog): the backend enforces scope at turn time, so
+     there's no security benefit to flashing an empty popover, and the map
+     typically lands well before the first open. Once the map is authoritative
+     but the agent isn't in it (deleted, or VIEW revoked mid-session), we fail
+     closed — scope is unresolvable and the full catalog would be misleading.
      `agentId` is threaded in as a prop so this component stays memoizable
      and skips re-renders on unrelated conversation-shape changes. */
   const agentSkillIds = useMemo<string[] | null | undefined>(() => {
@@ -114,7 +118,7 @@ function SkillsCommandContent({
       return undefined;
     }
     if (!agentsMap) {
-      return [];
+      return undefined;
     }
     const agent = agentsMap[agentId as string];
     if (!agent) {

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -10,6 +10,7 @@ import useInitPopoverInput from '~/hooks/Input/useInitPopoverInput';
 import { useLocalize, useSkillActiveState } from '~/hooks';
 import { useAgentsMapContext } from '~/Providers';
 import { useSkillsInfiniteQuery } from '~/data-provider';
+import { isEphemeralAgent } from '~/common';
 import { ephemeralAgentByConvoId } from '~/store';
 import { removeCharIfLast } from '~/utils';
 import MentionItem from './MentionItem';
@@ -101,20 +102,21 @@ function SkillsCommandContent({
 
   /* Resolve the per-agent skill scope. Mirrors backend `scopeSkillIds` for
      the happy path: no `skills` field → no scope, `[]` → opt-out, non-empty
-     → intersection. Fails closed for both "map not hydrated" and "agent not
-     in map" — if we cannot confirm the agent's scope we must not leak the
-     full ACL catalog, since the backend will reject any picked skill that
-     the agent was not configured to allow.
+     → intersection. Ephemeral agent ids (null/undefined/placeholder strings
+     that don't begin with `agent_`) are unscoped — they correspond to
+     conversations without a persisted agent and are intentionally absent
+     from the agents map. Fails closed for "map not hydrated" and "persisted
+     agent missing from map" — scope unknown, don't leak the full catalog.
      `agentId` is threaded in as a prop so this component stays memoizable
      and skips re-renders on unrelated conversation-shape changes. */
   const agentSkillIds = useMemo<string[] | null | undefined>(() => {
-    if (!agentId) {
+    if (isEphemeralAgent(agentId)) {
       return undefined;
     }
     if (!agentsMap) {
       return [];
     }
-    const agent = agentsMap[agentId];
+    const agent = agentsMap[agentId as string];
     if (!agent) {
       return [];
     }

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -7,11 +7,12 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import type { TSkillSummary } from 'librechat-data-provider';
 import type { MentionOption } from '~/common';
 import useInitPopoverInput from '~/hooks/Input/useInitPopoverInput';
+import { useChatContext, useAgentsMapContext } from '~/Providers';
+import { useLocalize, useSkillActiveState } from '~/hooks';
 import { useSkillsInfiniteQuery } from '~/data-provider';
 import { ephemeralAgentByConvoId } from '~/store';
 import { removeCharIfLast } from '~/utils';
 import MentionItem from './MentionItem';
-import { useLocalize } from '~/hooks';
 import store from '~/store';
 
 const commandChar = '$';
@@ -32,6 +33,51 @@ export function isUserInvocable(skill: TSkillSummary): boolean {
   return mode === InvocationMode.manual;
 }
 
+/**
+ * Filters the skills list down to what should appear in the `$` popover.
+ * Composes three rules, short-circuiting on the cheapest check first:
+ *
+ * 1. Agent scope — mirrors backend `scopeSkillIds` semantics:
+ *    - `null` / `undefined` → no scope filter (ephemeral convo, or agent
+ *      without a `skills` field configured).
+ *    - `[]` → explicit opt-out, nothing passes.
+ *    - non-empty → intersection with the agent's configured skill ids.
+ * 2. Active state — per-user ownership-aware toggle.
+ * 3. Invocation mode — `manual` / `both` / undefined are visible; `auto`
+ *    is model-only and hidden.
+ *
+ * Pure function; exported so tests can exercise the filter in isolation
+ * without rendering the component.
+ */
+export function filterSkillsForPopover(
+  skills: TSkillSummary[],
+  ctx: {
+    agentSkillIds: string[] | null | undefined;
+    isActive: (skill: Pick<TSkillSummary, '_id' | 'author'>) => boolean;
+  },
+): TSkillSummary[] {
+  const { agentSkillIds, isActive } = ctx;
+  if (agentSkillIds != null && agentSkillIds.length === 0) {
+    return [];
+  }
+  const agentSet =
+    agentSkillIds != null && agentSkillIds.length > 0 ? new Set(agentSkillIds) : null;
+  const result: TSkillSummary[] = [];
+  for (const skill of skills) {
+    if (agentSet && !agentSet.has(skill._id)) {
+      continue;
+    }
+    if (!isActive(skill)) {
+      continue;
+    }
+    if (!isUserInvocable(skill)) {
+      continue;
+    }
+    result.push(skill);
+  }
+  return result;
+}
+
 function SkillsCommandContent({
   index,
   textAreaRef,
@@ -47,6 +93,24 @@ function SkillsCommandContent({
   const setPendingManualSkills = useSetRecoilState(
     store.pendingManualSkillsByConvoId(conversationId),
   );
+
+  const { conversation } = useChatContext();
+  const agentsMap = useAgentsMapContext();
+  const { isActive } = useSkillActiveState();
+
+  /* Resolve the per-agent skill scope. Mirrors backend `scopeSkillIds`:
+     ephemeral convo or agent without a `skills` field → undefined (no scope);
+     configured array (including `[]`) → pass through as-is so the filter can
+     enforce explicit opt-out. Returning `undefined` until the agent is loaded
+     keeps the popover populated instead of flashing empty during hydration;
+     the backend still enforces the agent scope at runtime regardless. */
+  const agentSkillIds = useMemo<string[] | null | undefined>(() => {
+    const agentId = conversation?.agent_id;
+    if (!agentId) {
+      return undefined;
+    }
+    return agentsMap?.[agentId]?.skills;
+  }, [conversation?.agent_id, agentsMap]);
 
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSkillsInfiniteQuery({ limit: 50 });
@@ -77,21 +141,25 @@ function SkillsCommandContent({
     if (!data?.pages) {
       return [];
     }
-    return data.pages.reduce<MentionOption[]>((acc, page) => {
+    const allSkills: TSkillSummary[] = [];
+    for (const page of data.pages) {
       for (const skill of page.skills) {
-        if (isUserInvocable(skill)) {
-          acc.push({
-            label: skill.displayTitle ?? skill.name,
-            value: skill.name,
-            description: skill.description,
-            type: 'skill',
-            icon: skillIcon,
-          });
-        }
+        allSkills.push(skill);
       }
-      return acc;
-    }, []);
-  }, [data?.pages]);
+    }
+    const filtered = filterSkillsForPopover(allSkills, { agentSkillIds, isActive });
+    const options: MentionOption[] = [];
+    for (const skill of filtered) {
+      options.push({
+        label: skill.displayTitle ?? skill.name,
+        value: skill.name,
+        description: skill.description,
+        type: 'skill',
+        icon: skillIcon,
+      });
+    }
+    return options;
+  }, [data?.pages, agentSkillIds, isActive]);
 
   const [activeIndex, setActiveIndex] = useState(0);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -114,13 +114,13 @@ function SkillsCommandContent({
      `agentId` is threaded in as a prop so this component stays memoizable
      and skips re-renders on unrelated conversation-shape changes. */
   const agentSkillIds = useMemo<string[] | null | undefined>(() => {
-    if (isEphemeralAgent(agentId)) {
+    if (!agentId || isEphemeralAgent(agentId)) {
       return undefined;
     }
     if (!agentsMap) {
       return undefined;
     }
-    const agent = agentsMap[agentId as string];
+    const agent = agentsMap[agentId];
     if (!agent) {
       return [];
     }

--- a/client/src/components/Chat/Input/SkillsCommand.tsx
+++ b/client/src/components/Chat/Input/SkillsCommand.tsx
@@ -99,19 +99,26 @@ function SkillsCommandContent({
   const agentsMap = useAgentsMapContext();
   const { isActive } = useSkillActiveState();
 
-  /* Resolve the per-agent skill scope. Mirrors backend `scopeSkillIds`:
-     ephemeral convo or agent without a `skills` field → undefined (no scope);
-     configured array (including `[]`) → pass through as-is so the filter can
-     enforce explicit opt-out. Returning `undefined` until the agent is loaded
-     keeps the popover populated instead of flashing empty during hydration;
-     the backend still enforces the agent scope at runtime regardless.
+  /* Resolve the per-agent skill scope. Mirrors backend `scopeSkillIds` for
+     the happy path: no `skills` field → no scope, `[]` → opt-out, non-empty
+     → intersection. Fails closed for both "map not hydrated" and "agent not
+     in map" — if we cannot confirm the agent's scope we must not leak the
+     full ACL catalog, since the backend will reject any picked skill that
+     the agent was not configured to allow.
      `agentId` is threaded in as a prop so this component stays memoizable
      and skips re-renders on unrelated conversation-shape changes. */
   const agentSkillIds = useMemo<string[] | null | undefined>(() => {
     if (!agentId) {
       return undefined;
     }
-    return agentsMap?.[agentId]?.skills;
+    if (!agentsMap) {
+      return [];
+    }
+    const agent = agentsMap[agentId];
+    if (!agent) {
+      return [];
+    }
+    return agent.skills;
   }, [agentId, agentsMap]);
 
   const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =

--- a/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
@@ -65,15 +65,13 @@ jest.mock('~/data-provider', () => ({
   useSkillsInfiniteQuery: () => mockUseSkillsInfiniteQuery(),
 }));
 
-/* Phase 2: the popover must consult useChatContext() for the current
-   conversation's agent_id and useAgentsMapContext() for its `skills`
-   config, then intersect that with the ACL catalog. The test harness
-   swaps these in so individual cases can configure ephemeral vs.
-   agent-scoped behavior without standing up real providers. */
-const mockUseChatContext = jest.fn();
+/* Phase 2: the popover reads agent skill config via useAgentsMapContext
+   and the agent id is threaded down as a prop from ChatForm (so the
+   component stays memoizable across unrelated convo-shape changes). The
+   test harness swaps the agents map in so cases can configure ephemeral
+   vs. agent-scoped behavior without standing up a real provider. */
 const mockUseAgentsMapContext = jest.fn();
 jest.mock('~/Providers', () => ({
-  useChatContext: () => mockUseChatContext(),
   useAgentsMapContext: () => mockUseAgentsMapContext(),
 }));
 
@@ -175,9 +173,9 @@ beforeEach(() => {
     hasNextPage: false,
     isFetchingNextPage: false,
   });
-  /* Defaults: ephemeral conversation (no agent) and every skill active.
-     Individual tests override these to exercise the Phase 2 filter. */
-  mockUseChatContext.mockReturnValue({ conversation: { conversationId: CONVO_ID } });
+  /* Defaults: empty agents map and every skill active. Individual tests
+     override these and pass `agentId` as a prop to exercise the Phase 2
+     filter composition. */
   mockUseAgentsMapContext.mockReturnValue({});
   mockIsActive.mockReturnValue(true);
 });
@@ -234,15 +232,19 @@ describe('SkillsCommand', () => {
       hasNextPage: false,
       isFetchingNextPage: false,
     });
-    mockUseChatContext.mockReturnValue({
-      conversation: { conversationId: CONVO_ID, agent_id: 'agent-1' },
-    });
     mockUseAgentsMapContext.mockReturnValue({
       'agent-1': { id: 'agent-1', skills: ['2'] },
     });
 
     const textAreaRef = makeTextarea('$');
-    render(<SkillsCommand index={0} textAreaRef={textAreaRef} conversationId={CONVO_ID} />);
+    render(
+      <SkillsCommand
+        index={0}
+        textAreaRef={textAreaRef}
+        conversationId={CONVO_ID}
+        agentId="agent-1"
+      />,
+    );
 
     /* Only the skill whose _id is in agent.skills should appear. */
     expect(screen.queryByRole('button', { name: /Brand Guidelines/i })).toBeNull();
@@ -258,15 +260,19 @@ describe('SkillsCommand', () => {
       hasNextPage: false,
       isFetchingNextPage: false,
     });
-    mockUseChatContext.mockReturnValue({
-      conversation: { conversationId: CONVO_ID, agent_id: 'agent-1' },
-    });
     mockUseAgentsMapContext.mockReturnValue({
       'agent-1': { id: 'agent-1', skills: [] },
     });
 
     const textAreaRef = makeTextarea('$');
-    render(<SkillsCommand index={0} textAreaRef={textAreaRef} conversationId={CONVO_ID} />);
+    render(
+      <SkillsCommand
+        index={0}
+        textAreaRef={textAreaRef}
+        conversationId={CONVO_ID}
+        agentId="agent-1"
+      />,
+    );
 
     expect(screen.queryByRole('button', { name: /Brand Guidelines/i })).toBeNull();
     expect(screen.queryByRole('button', { name: /Style Guide/i })).toBeNull();
@@ -281,15 +287,19 @@ describe('SkillsCommand', () => {
       hasNextPage: false,
       isFetchingNextPage: false,
     });
-    mockUseChatContext.mockReturnValue({
-      conversation: { conversationId: CONVO_ID, agent_id: 'agent-1' },
-    });
     mockUseAgentsMapContext.mockReturnValue({
       'agent-1': { id: 'agent-1' },
     });
 
     const textAreaRef = makeTextarea('$');
-    render(<SkillsCommand index={0} textAreaRef={textAreaRef} conversationId={CONVO_ID} />);
+    render(
+      <SkillsCommand
+        index={0}
+        textAreaRef={textAreaRef}
+        conversationId={CONVO_ID}
+        agentId="agent-1"
+      />,
+    );
 
     expect(await screen.findByRole('button', { name: /Brand Guidelines/i })).toBeInTheDocument();
     expect(await screen.findByRole('button', { name: /Style Guide/i })).toBeInTheDocument();

--- a/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
@@ -332,7 +332,7 @@ describe('SkillsCommand', () => {
     expect(await screen.findByRole('button', { name: /Style Guide/i })).toBeInTheDocument();
   });
 
-  it('fails closed (empty list) when the agents map is not yet hydrated', () => {
+  it('shows the full ACL catalog while the agents map is hydrating (backend still gates the turn)', async () => {
     mockUseSkillsInfiniteQuery.mockReturnValue({
       data: twoSkillsResponse,
       isLoading: false,
@@ -353,10 +353,11 @@ describe('SkillsCommand', () => {
       />,
     );
 
-    /* Scope unknown → do not leak the full ACL catalog (backend would
-       reject anything picked here anyway). */
-    expect(screen.queryByRole('button', { name: /Brand Guidelines/i })).toBeNull();
-    expect(screen.queryByRole('button', { name: /Style Guide/i })).toBeNull();
+    /* Hydration race: map not yet loaded. Pass through to full catalog —
+       the backend scopes at turn time and blanking the popover during
+       sub-second hydration is worse UX for no security benefit. */
+    expect(await screen.findByRole('button', { name: /Brand Guidelines/i })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /Style Guide/i })).toBeInTheDocument();
   });
 
   it('fails closed when the agent id is set but missing from the agents map', () => {

--- a/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
@@ -305,6 +305,58 @@ describe('SkillsCommand', () => {
     expect(await screen.findByRole('button', { name: /Style Guide/i })).toBeInTheDocument();
   });
 
+  it('fails closed (empty list) when the agents map is not yet hydrated', () => {
+    mockUseSkillsInfiniteQuery.mockReturnValue({
+      data: twoSkillsResponse,
+      isLoading: false,
+      isError: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseAgentsMapContext.mockReturnValue(undefined);
+
+    const textAreaRef = makeTextarea('$');
+    render(
+      <SkillsCommand
+        index={0}
+        textAreaRef={textAreaRef}
+        conversationId={CONVO_ID}
+        agentId="agent-1"
+      />,
+    );
+
+    /* Scope unknown → do not leak the full ACL catalog (backend would
+       reject anything picked here anyway). */
+    expect(screen.queryByRole('button', { name: /Brand Guidelines/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Style Guide/i })).toBeNull();
+  });
+
+  it('fails closed when the agent id is set but missing from the agents map', () => {
+    mockUseSkillsInfiniteQuery.mockReturnValue({
+      data: twoSkillsResponse,
+      isLoading: false,
+      isError: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseAgentsMapContext.mockReturnValue({});
+
+    const textAreaRef = makeTextarea('$');
+    render(
+      <SkillsCommand
+        index={0}
+        textAreaRef={textAreaRef}
+        conversationId={CONVO_ID}
+        agentId="agent-1"
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /Brand Guidelines/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Style Guide/i })).toBeNull();
+  });
+
   it('hides inactive skills from the popover', () => {
     mockUseSkillsInfiniteQuery.mockReturnValue({
       data: twoSkillsResponse,

--- a/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
@@ -4,11 +4,18 @@
  * component must (a) push the skill name onto the per-conversation
  * `pendingManualSkillsByConvoId` atom, (b) flip `ephemeralAgent.skills`
  * to true, and (c) insert `$skill-name ` into the textarea.
+ *
+ * Also covers the Phase 2 filter composition: per-agent skill scope
+ * intersects with the ACL catalog, and per-user active-state toggles
+ * hide inactive entries from the popover (backend still enforces both
+ * at runtime regardless).
  */
 import React from 'react';
 import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
+import { InvocationMode } from 'librechat-data-provider';
+import type { TSkillSummary } from 'librechat-data-provider';
 
 const CONVO_ID = 'convo-1';
 
@@ -58,8 +65,22 @@ jest.mock('~/data-provider', () => ({
   useSkillsInfiniteQuery: () => mockUseSkillsInfiniteQuery(),
 }));
 
+/* Phase 2: the popover must consult useChatContext() for the current
+   conversation's agent_id and useAgentsMapContext() for its `skills`
+   config, then intersect that with the ACL catalog. The test harness
+   swaps these in so individual cases can configure ephemeral vs.
+   agent-scoped behavior without standing up real providers. */
+const mockUseChatContext = jest.fn();
+const mockUseAgentsMapContext = jest.fn();
+jest.mock('~/Providers', () => ({
+  useChatContext: () => mockUseChatContext(),
+  useAgentsMapContext: () => mockUseAgentsMapContext(),
+}));
+
+const mockIsActive = jest.fn();
 jest.mock('~/hooks', () => ({
   useLocalize: () => (key: string) => key,
+  useSkillActiveState: () => ({ isActive: mockIsActive }),
 }));
 
 jest.mock('@librechat/client', () => {
@@ -95,7 +116,7 @@ jest.mock('react-virtualized', () => ({
   },
 }));
 
-import SkillsCommand from '../SkillsCommand';
+import SkillsCommand, { filterSkillsForPopover } from '../SkillsCommand';
 
 const makeTextarea = (initial = '$') => {
   const textarea = document.createElement('textarea');
@@ -104,23 +125,37 @@ const makeTextarea = (initial = '$') => {
   return { current: textarea } as React.MutableRefObject<HTMLTextAreaElement | null>;
 };
 
+const makeSkill = (overrides: Partial<TSkillSummary>): TSkillSummary => ({
+  _id: '1',
+  name: 'brand-guidelines',
+  displayTitle: 'Brand Guidelines',
+  description: 'Apply brand styling',
+  author: 'u',
+  authorName: 'U',
+  version: 1,
+  source: 'inline',
+  fileCount: 0,
+  createdAt: '',
+  updatedAt: '',
+  ...overrides,
+});
+
 const skillsResponse = {
   pages: [
     {
+      skills: [makeSkill({})],
+      has_more: false,
+      after: null,
+    },
+  ],
+};
+
+const twoSkillsResponse = {
+  pages: [
+    {
       skills: [
-        {
-          _id: '1',
-          name: 'brand-guidelines',
-          displayTitle: 'Brand Guidelines',
-          description: 'Apply brand styling',
-          author: 'u',
-          authorName: 'U',
-          version: 1,
-          source: 'inline',
-          fileCount: 0,
-          createdAt: '',
-          updatedAt: '',
-        },
+        makeSkill({ _id: '1', name: 'brand-guidelines', displayTitle: 'Brand Guidelines' }),
+        makeSkill({ _id: '2', name: 'style-guide', displayTitle: 'Style Guide' }),
       ],
       has_more: false,
       after: null,
@@ -140,6 +175,11 @@ beforeEach(() => {
     hasNextPage: false,
     isFetchingNextPage: false,
   });
+  /* Defaults: ephemeral conversation (no agent) and every skill active.
+     Individual tests override these to exercise the Phase 2 filter. */
+  mockUseChatContext.mockReturnValue({ conversation: { conversationId: CONVO_ID } });
+  mockUseAgentsMapContext.mockReturnValue({});
+  mockIsActive.mockReturnValue(true);
 });
 
 describe('SkillsCommand', () => {
@@ -183,5 +223,153 @@ describe('SkillsCommand', () => {
 
     /* Popover dismisses on selection. */
     expect(mockSetShowSkillsPopover).toHaveBeenCalledWith(false);
+  });
+
+  it('narrows the list to the agent-configured scope when agent.skills is set', async () => {
+    mockUseSkillsInfiniteQuery.mockReturnValue({
+      data: twoSkillsResponse,
+      isLoading: false,
+      isError: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseChatContext.mockReturnValue({
+      conversation: { conversationId: CONVO_ID, agent_id: 'agent-1' },
+    });
+    mockUseAgentsMapContext.mockReturnValue({
+      'agent-1': { id: 'agent-1', skills: ['2'] },
+    });
+
+    const textAreaRef = makeTextarea('$');
+    render(<SkillsCommand index={0} textAreaRef={textAreaRef} conversationId={CONVO_ID} />);
+
+    /* Only the skill whose _id is in agent.skills should appear. */
+    expect(screen.queryByRole('button', { name: /Brand Guidelines/i })).toBeNull();
+    expect(await screen.findByRole('button', { name: /Style Guide/i })).toBeInTheDocument();
+  });
+
+  it('shows nothing when the agent has an empty skills array (explicit opt-out)', () => {
+    mockUseSkillsInfiniteQuery.mockReturnValue({
+      data: twoSkillsResponse,
+      isLoading: false,
+      isError: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseChatContext.mockReturnValue({
+      conversation: { conversationId: CONVO_ID, agent_id: 'agent-1' },
+    });
+    mockUseAgentsMapContext.mockReturnValue({
+      'agent-1': { id: 'agent-1', skills: [] },
+    });
+
+    const textAreaRef = makeTextarea('$');
+    render(<SkillsCommand index={0} textAreaRef={textAreaRef} conversationId={CONVO_ID} />);
+
+    expect(screen.queryByRole('button', { name: /Brand Guidelines/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Style Guide/i })).toBeNull();
+  });
+
+  it('shows the full ACL catalog when the agent has no skills field configured', async () => {
+    mockUseSkillsInfiniteQuery.mockReturnValue({
+      data: twoSkillsResponse,
+      isLoading: false,
+      isError: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseChatContext.mockReturnValue({
+      conversation: { conversationId: CONVO_ID, agent_id: 'agent-1' },
+    });
+    mockUseAgentsMapContext.mockReturnValue({
+      'agent-1': { id: 'agent-1' },
+    });
+
+    const textAreaRef = makeTextarea('$');
+    render(<SkillsCommand index={0} textAreaRef={textAreaRef} conversationId={CONVO_ID} />);
+
+    expect(await screen.findByRole('button', { name: /Brand Guidelines/i })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /Style Guide/i })).toBeInTheDocument();
+  });
+
+  it('hides inactive skills from the popover', () => {
+    mockUseSkillsInfiniteQuery.mockReturnValue({
+      data: twoSkillsResponse,
+      isLoading: false,
+      isError: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockIsActive.mockImplementation((skill: { _id: string }) => skill._id !== '1');
+
+    const textAreaRef = makeTextarea('$');
+    render(<SkillsCommand index={0} textAreaRef={textAreaRef} conversationId={CONVO_ID} />);
+
+    expect(screen.queryByRole('button', { name: /Brand Guidelines/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /Style Guide/i })).toBeInTheDocument();
+  });
+});
+
+describe('filterSkillsForPopover', () => {
+  const active = () => true;
+  const inactive = () => false;
+  const s1 = makeSkill({ _id: '1', name: 'a' });
+  const s2 = makeSkill({ _id: '2', name: 'b' });
+  const s3 = makeSkill({ _id: '3', name: 'c', invocationMode: InvocationMode.auto });
+
+  it('passes everything through when agentSkillIds is undefined', () => {
+    const out = filterSkillsForPopover([s1, s2], { agentSkillIds: undefined, isActive: active });
+    expect(out.map((s) => s._id)).toEqual(['1', '2']);
+  });
+
+  it('passes everything through when agentSkillIds is null', () => {
+    const out = filterSkillsForPopover([s1, s2], { agentSkillIds: null, isActive: active });
+    expect(out.map((s) => s._id)).toEqual(['1', '2']);
+  });
+
+  it('returns empty when agentSkillIds is []', () => {
+    const out = filterSkillsForPopover([s1, s2], { agentSkillIds: [], isActive: active });
+    expect(out).toEqual([]);
+  });
+
+  it('intersects with a non-empty agentSkillIds', () => {
+    const out = filterSkillsForPopover([s1, s2], { agentSkillIds: ['2'], isActive: active });
+    expect(out.map((s) => s._id)).toEqual(['2']);
+  });
+
+  it('excludes inactive skills', () => {
+    const isActive = (skill: { _id: string }) => skill._id !== '1';
+    const out = filterSkillsForPopover([s1, s2], { agentSkillIds: null, isActive });
+    expect(out.map((s) => s._id)).toEqual(['2']);
+  });
+
+  it('excludes auto-only skills via isUserInvocable', () => {
+    const out = filterSkillsForPopover([s1, s3], { agentSkillIds: null, isActive: active });
+    expect(out.map((s) => s._id)).toEqual(['1']);
+  });
+
+  it('still empty when agent scope is [] even if everything is active and invocable', () => {
+    const out = filterSkillsForPopover([s1, s2, s3], { agentSkillIds: [], isActive: active });
+    expect(out).toEqual([]);
+  });
+
+  it('layers all three filters (agent scope ∩ active ∩ invocable)', () => {
+    const isActive = (skill: { _id: string }) => skill._id !== '2';
+    const out = filterSkillsForPopover([s1, s2, s3], {
+      agentSkillIds: ['1', '2', '3'],
+      isActive,
+    });
+    /* s1 passes (active, manual-by-default, scoped), s2 drops (inactive),
+       s3 drops (auto-only invocation mode). */
+    expect(out.map((s) => s._id)).toEqual(['1']);
+  });
+
+  it('drops everything when isActive returns false for all inputs', () => {
+    const out = filterSkillsForPopover([s1, s2], { agentSkillIds: null, isActive: inactive });
+    expect(out).toEqual([]);
   });
 });

--- a/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
+++ b/client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
@@ -233,7 +233,7 @@ describe('SkillsCommand', () => {
       isFetchingNextPage: false,
     });
     mockUseAgentsMapContext.mockReturnValue({
-      'agent-1': { id: 'agent-1', skills: ['2'] },
+      agent_1: { id: 'agent_1', skills: ['2'] },
     });
 
     const textAreaRef = makeTextarea('$');
@@ -242,7 +242,7 @@ describe('SkillsCommand', () => {
         index={0}
         textAreaRef={textAreaRef}
         conversationId={CONVO_ID}
-        agentId="agent-1"
+        agentId="agent_1"
       />,
     );
 
@@ -261,7 +261,7 @@ describe('SkillsCommand', () => {
       isFetchingNextPage: false,
     });
     mockUseAgentsMapContext.mockReturnValue({
-      'agent-1': { id: 'agent-1', skills: [] },
+      agent_1: { id: 'agent_1', skills: [] },
     });
 
     const textAreaRef = makeTextarea('$');
@@ -270,7 +270,7 @@ describe('SkillsCommand', () => {
         index={0}
         textAreaRef={textAreaRef}
         conversationId={CONVO_ID}
-        agentId="agent-1"
+        agentId="agent_1"
       />,
     );
 
@@ -288,7 +288,7 @@ describe('SkillsCommand', () => {
       isFetchingNextPage: false,
     });
     mockUseAgentsMapContext.mockReturnValue({
-      'agent-1': { id: 'agent-1' },
+      agent_1: { id: 'agent_1' },
     });
 
     const textAreaRef = makeTextarea('$');
@@ -297,10 +297,37 @@ describe('SkillsCommand', () => {
         index={0}
         textAreaRef={textAreaRef}
         conversationId={CONVO_ID}
-        agentId="agent-1"
+        agentId="agent_1"
       />,
     );
 
+    expect(await screen.findByRole('button', { name: /Brand Guidelines/i })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /Style Guide/i })).toBeInTheDocument();
+  });
+
+  it('treats an ephemeral agent id as unscoped and shows the full ACL catalog', async () => {
+    mockUseSkillsInfiniteQuery.mockReturnValue({
+      data: twoSkillsResponse,
+      isLoading: false,
+      isError: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+    mockUseAgentsMapContext.mockReturnValue({});
+
+    const textAreaRef = makeTextarea('$');
+    render(
+      <SkillsCommand
+        index={0}
+        textAreaRef={textAreaRef}
+        conversationId={CONVO_ID}
+        agentId="ephemeral"
+      />,
+    );
+
+    /* `ephemeral` doesn't start with `agent_`, so it's an ephemeral id;
+       scope filter should be skipped and the full catalog displayed. */
     expect(await screen.findByRole('button', { name: /Brand Guidelines/i })).toBeInTheDocument();
     expect(await screen.findByRole('button', { name: /Style Guide/i })).toBeInTheDocument();
   });
@@ -322,7 +349,7 @@ describe('SkillsCommand', () => {
         index={0}
         textAreaRef={textAreaRef}
         conversationId={CONVO_ID}
-        agentId="agent-1"
+        agentId="agent_1"
       />,
     );
 
@@ -349,7 +376,7 @@ describe('SkillsCommand', () => {
         index={0}
         textAreaRef={textAreaRef}
         conversationId={CONVO_ID}
-        agentId="agent-1"
+        agentId="agent_1"
       />,
     );
 

--- a/packages/data-schemas/src/methods/agent.spec.ts
+++ b/packages/data-schemas/src/methods/agent.spec.ts
@@ -3229,6 +3229,33 @@ describe('Support Contact Field', () => {
       expect(result.data[0].name).toBe('Agent A1');
     });
 
+    test('should include the skills field in the list projection', async () => {
+      // Frontend popover scoping relies on `agent.skills` being present in
+      // list results so it can narrow the `$` catalog without refetching the
+      // full agent document. Locks in that projection contract.
+      const targetSkillIds = [
+        new mongoose.Types.ObjectId().toString(),
+        new mongoose.Types.ObjectId().toString(),
+      ];
+      const scopedAgent = await createAgent({
+        id: `agent_${uuidv4().slice(0, 12)}`,
+        name: 'Scoped Agent',
+        description: 'Agent with configured skill scope',
+        provider: 'openai',
+        model: 'gpt-4',
+        author: userA,
+        skills: targetSkillIds,
+      });
+
+      const result = await getListAgentsByAccess({
+        accessibleIds: [scopedAgent._id] as mongoose.Types.ObjectId[],
+        otherParams: {},
+      });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].skills).toEqual(targetSkillIds);
+    });
+
     test('should return multiple accessible agents when provided', async () => {
       // Give User B access to two of User A's agents
       const accessibleIds = [agentA1._id, agentA3._id] as mongoose.Types.ObjectId[];

--- a/packages/data-schemas/src/methods/agent.ts
+++ b/packages/data-schemas/src/methods/agent.ts
@@ -665,6 +665,9 @@ export function createAgentMethods(mongoose: typeof import('mongoose'), deps: Ag
       category: 1,
       support_contact: 1,
       is_promoted: 1,
+      /* Needed so the client can scope the `$` skill popover to each agent's
+         configured catalog without refetching the full agent document. */
+      skills: 1,
     }).sort({ updatedAt: -1, _id: 1 });
 
     if (isPaginated && normalizedLimit) {


### PR DESCRIPTION
## Summary

I composed per-agent skill scope and per-user active-state filters into the `$` command popover so the visible list mirrors what will actually be available at turn time. Backend still enforces both filters at runtime; this PR is the UX mirror.

- Added a pure, exported `filterSkillsForPopover` helper in [SkillsCommand.tsx](client/src/components/Chat/Input/SkillsCommand.tsx) that layers three rules short-circuiting on the cheapest check first: agent scope → active state → `isUserInvocable`.
- Resolved per-agent scope from `conversation.agent_id` via `useAgentsMapContext`, mirroring backend `scopeSkillIds` semantics exactly (`undefined`/`null` → no scope, `[]` → empty, non-empty → intersection).
- Surfaced `agent.skills` in the `getListAgentsByAccess` projection in [packages/data-schemas/src/methods/agent.ts](packages/data-schemas/src/methods/agent.ts) so the map actually carries the field; Phase 1 added the column but never updated this projection. Locked in with a new backend test.
- Treated ephemeral agent ids (anything that doesn't start with `agent_`, including the `ephemeral` placeholder carried after switching off the agents endpoint) as unscoped via the existing `isEphemeralAgent` helper — same as conversations without an agent id.
- Split the unresolved-scope handling: while the agents map is still hydrating, pass through (the map typically lands before the first `$` open and backend enforces anyway); once the map is authoritative but the agent is missing (deleted or VIEW revoked mid-session), fail closed so the catalog doesn't mislead.
- Threaded `agentId` in as a prop from `ChatForm` so `SkillsCommand` stays `React.memo`-friendly and skips re-renders on unrelated conversation-shape changes.
- Wired per-user active state through `useSkillActiveState().isActive` without reimplementing ownership-aware precedence.
- Extended [SkillsCommand.spec.tsx](client/src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx) with six rendering cases (narrow scope, `[]` opt-out, no-scope pass-through, ephemeral id, hydration pass-through, authoritative-missing fail-closed, inactive hiding) plus nine isolated unit tests on the pure helper covering the agent-scope ∩ active ∩ invocable matrix.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Exercised the filter composition end-to-end via the existing jest harness for `SkillsCommand` and directly on the exported helper. Reviewers can reproduce locally:

```bash
cd client && npx jest src/components/Chat/Input/__tests__/SkillsCommand.spec.tsx
cd packages/data-schemas && npx jest src/methods/agent.spec.ts -t "getListAgentsByAccess"
```

Manual UX verification to run against a local build:

1. Create two skills where you are the author; share one and toggle it inactive via the side panel. Confirm the inactive one disappears from the `$` popover.
2. In the agent builder, restrict an agent to a single skill and open a conversation with that agent. Type `$` and confirm only the configured skill appears.
3. Clear the agent's `skills` selection (empty array) and confirm the popover shows nothing in that conversation.
4. Switch to an ephemeral conversation (no agent selected or the `ephemeral` placeholder) and confirm the popover shows every ACL-accessible, active, user-invocable skill.
5. With a restricted agent selected, hard-refresh and open `$` before the agents list query settles. Confirm the popover shows the full catalog during the race rather than flashing empty; once the map lands the scope tightens to the configured subset.

### **Test Configuration**:

- Node v20.19.0+
- Branch base: `feat/agent-skills` (latest post-Phase-1 merges)
- 18/18 `SkillsCommand` tests pass; 10/10 `getListAgentsByAccess` tests pass; all 112 `Chat/Input` tests pass; `tsc --noEmit` clean on touched files; ESLint clean.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes