### PR TITLE
📝 fix: Preserve Raw Markdown Formatting on Upload as Text

### DIFF
--- a/packages/api/src/files/text.spec.ts
+++ b/packages/api/src/files/text.spec.ts
@@ -304,10 +304,14 @@ describe('text', () => {
     it.each([
       { mimetype: 'text/markdown', originalname: 'notes.md' },
       { mimetype: 'text/x-markdown', originalname: 'notes.md' },
+      { mimetype: 'text/md', originalname: 'notes' },
       { mimetype: 'application/markdown', originalname: 'notes.md' },
       { mimetype: 'application/x-markdown', originalname: 'notes.md' },
       { mimetype: 'application/octet-stream', originalname: 'README.md' },
       { mimetype: 'application/octet-stream', originalname: 'GUIDE.MARKDOWN' },
+      { mimetype: 'text/markdown; charset=utf-8', originalname: 'notes' },
+      { mimetype: 'TEXT/MARKDOWN', originalname: 'notes' },
+      { mimetype: '  text/markdown ; charset=UTF-8  ', originalname: 'notes' },
     ])(
       'should short-circuit to native parsing for markdown file (%o)',
       async ({ mimetype, originalname }) => {

--- a/packages/api/src/files/text.spec.ts
+++ b/packages/api/src/files/text.spec.ts
@@ -313,6 +313,7 @@ describe('text', () => {
       { mimetype: 'application/octet-stream', originalname: 'post.mdown' },
       { mimetype: 'application/octet-stream', originalname: 'post.mkdn' },
       { mimetype: 'application/octet-stream', originalname: 'post.mkd' },
+      { mimetype: 'application/octet-stream', originalname: 'docs.mdwn' },
       { mimetype: 'text/markdown; charset=utf-8', originalname: 'notes' },
       { mimetype: 'TEXT/MARKDOWN', originalname: 'notes' },
       { mimetype: '  text/markdown ; charset=UTF-8  ', originalname: 'notes' },

--- a/packages/api/src/files/text.spec.ts
+++ b/packages/api/src/files/text.spec.ts
@@ -307,11 +307,16 @@ describe('text', () => {
       { mimetype: 'text/md', originalname: 'notes' },
       { mimetype: 'application/markdown', originalname: 'notes.md' },
       { mimetype: 'application/x-markdown', originalname: 'notes.md' },
+      { mimetype: 'text/plain', originalname: 'notes.md' },
       { mimetype: 'application/octet-stream', originalname: 'README.md' },
       { mimetype: 'application/octet-stream', originalname: 'GUIDE.MARKDOWN' },
+      { mimetype: 'application/octet-stream', originalname: 'post.mdown' },
+      { mimetype: 'application/octet-stream', originalname: 'post.mkdn' },
+      { mimetype: 'application/octet-stream', originalname: 'post.mkd' },
       { mimetype: 'text/markdown; charset=utf-8', originalname: 'notes' },
       { mimetype: 'TEXT/MARKDOWN', originalname: 'notes' },
       { mimetype: '  text/markdown ; charset=UTF-8  ', originalname: 'notes' },
+      { mimetype: '', originalname: 'notes.md' },
     ])(
       'should short-circuit to native parsing for markdown file (%o)',
       async ({ mimetype, originalname }) => {
@@ -332,6 +337,9 @@ describe('text', () => {
 
         expect(mockedAxios.get).not.toHaveBeenCalled();
         expect(mockedAxios.post).not.toHaveBeenCalled();
+        expect(mockedReadFileAsString).toHaveBeenCalledWith('/tmp/test.txt', {
+          fileSize: 100,
+        });
         expect(result).toEqual({
           text: mockText,
           bytes: mockBytes,

--- a/packages/api/src/files/text.spec.ts
+++ b/packages/api/src/files/text.spec.ts
@@ -300,5 +300,60 @@ describe('text', () => {
         source: FileSources.text,
       });
     });
+
+    it.each([
+      { mimetype: 'text/markdown', originalname: 'notes.md' },
+      { mimetype: 'text/x-markdown', originalname: 'notes.md' },
+      { mimetype: 'application/markdown', originalname: 'notes.md' },
+      { mimetype: 'application/x-markdown', originalname: 'notes.md' },
+      { mimetype: 'application/octet-stream', originalname: 'README.md' },
+      { mimetype: 'application/octet-stream', originalname: 'GUIDE.MARKDOWN' },
+    ])(
+      'should short-circuit to native parsing for markdown file (%o)',
+      async ({ mimetype, originalname }) => {
+        process.env.RAG_API_URL = 'http://rag-api.test';
+        const mockText = '# Heading\n\n**bold** text';
+        const mockBytes = Buffer.byteLength(mockText, 'utf8');
+
+        mockedReadFileAsString.mockResolvedValue({
+          content: mockText,
+          bytes: mockBytes,
+        });
+
+        const result = await parseText({
+          req: mockReq,
+          file: { ...mockFile, mimetype, originalname },
+          file_id: mockFileId,
+        });
+
+        expect(mockedAxios.get).not.toHaveBeenCalled();
+        expect(mockedAxios.post).not.toHaveBeenCalled();
+        expect(result).toEqual({
+          text: mockText,
+          bytes: mockBytes,
+          source: FileSources.text,
+        });
+      },
+    );
+
+    it('should still call the RAG API for non-markdown text files', async () => {
+      process.env.RAG_API_URL = 'http://rag-api.test';
+      const mockText = 'plain text content';
+
+      mockedAxios.get.mockResolvedValue({ status: 200, statusText: 'OK' });
+      mockedAxios.post.mockResolvedValue({ data: { text: mockText } });
+
+      await parseText({
+        req: mockReq,
+        file: mockFile,
+        file_id: mockFileId,
+      });
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://rag-api.test/text',
+        expect.any(Object),
+        expect.objectContaining({ timeout: 300000 }),
+      );
+    });
   });
 });

--- a/packages/api/src/files/text.ts
+++ b/packages/api/src/files/text.ts
@@ -10,12 +10,22 @@ import { generateShortLivedToken } from '~/crypto/jwt';
 const MARKDOWN_MIME_TYPES = new Set([
   'text/markdown',
   'text/x-markdown',
+  'text/md',
   'application/markdown',
   'application/x-markdown',
 ]);
 
+function normalizeMimeType(mimetype: string | undefined): string {
+  if (!mimetype) {
+    return '';
+  }
+  const semi = mimetype.indexOf(';');
+  const base = semi === -1 ? mimetype : mimetype.slice(0, semi);
+  return base.trim().toLowerCase();
+}
+
 function isMarkdownFile(file: Express.Multer.File): boolean {
-  if (file.mimetype && MARKDOWN_MIME_TYPES.has(file.mimetype)) {
+  if (MARKDOWN_MIME_TYPES.has(normalizeMimeType(file.mimetype))) {
     return true;
   }
   const name = file.originalname?.toLowerCase() ?? '';

--- a/packages/api/src/files/text.ts
+++ b/packages/api/src/files/text.ts
@@ -15,7 +15,9 @@ const MARKDOWN_MIME_TYPES = new Set([
   'application/x-markdown',
 ]);
 
-function normalizeMimeType(mimetype: string | undefined): string {
+const MARKDOWN_EXTENSIONS_RE = /\.(md|markdown|mdown|mkdn|mkd|mdwn)$/i;
+
+function normalizeMimeType(mimetype: string): string {
   if (!mimetype) {
     return '';
   }
@@ -28,8 +30,7 @@ function isMarkdownFile(file: Express.Multer.File): boolean {
   if (MARKDOWN_MIME_TYPES.has(normalizeMimeType(file.mimetype))) {
     return true;
   }
-  const name = file.originalname?.toLowerCase() ?? '';
-  return name.endsWith('.md') || name.endsWith('.markdown');
+  return MARKDOWN_EXTENSIONS_RE.test(file.originalname ?? '');
 }
 
 /**
@@ -56,7 +57,7 @@ export async function parseText({
 
   if (isMarkdownFile(file)) {
     logger.debug(
-      '[parseText] Markdown file detected, using native parsing to preserve raw formatting',
+      `[parseText] Markdown file detected (${file.originalname}, ${file.mimetype}), using native parsing to preserve raw formatting`,
     );
     return parseTextNative(file);
   }

--- a/packages/api/src/files/text.ts
+++ b/packages/api/src/files/text.ts
@@ -7,6 +7,21 @@ import type { ServerRequest } from '~/types';
 import { logAxiosError, readFileAsString } from '~/utils';
 import { generateShortLivedToken } from '~/crypto/jwt';
 
+const MARKDOWN_MIME_TYPES = new Set([
+  'text/markdown',
+  'text/x-markdown',
+  'application/markdown',
+  'application/x-markdown',
+]);
+
+function isMarkdownFile(file: Express.Multer.File): boolean {
+  if (file.mimetype && MARKDOWN_MIME_TYPES.has(file.mimetype)) {
+    return true;
+  }
+  const name = file.originalname?.toLowerCase() ?? '';
+  return name.endsWith('.md') || name.endsWith('.markdown');
+}
+
 /**
  * Attempts to parse text using RAG API, falls back to native text parsing
  * @param params - The parameters object
@@ -26,6 +41,13 @@ export async function parseText({
 }): Promise<{ text: string; bytes: number; source: string }> {
   if (!process.env.RAG_API_URL) {
     logger.debug('[parseText] RAG_API_URL not defined, falling back to native text parsing');
+    return parseTextNative(file);
+  }
+
+  if (isMarkdownFile(file)) {
+    logger.debug(
+      '[parseText] Markdown file detected, using native parsing to preserve raw formatting',
+    );
     return parseTextNative(file);
   }
 


### PR DESCRIPTION
## Summary

Fixes #12731.

When `RAG_API_URL` is set, uploading a `.md` file via **Upload as Text** sent the file to the RAG API `/text` endpoint, which routes Markdown through `UnstructuredMarkdownLoader` and strips formatting (`#`, `**`, lists, blockquotes). A `.txt` file with identical bytes round-tripped verbatim, so two byte-identical uploads produced very different extracted text depending only on the file extension.

This PR adds a short-circuit in `parseText`: if the file is Markdown (by MIME type or `.md` / `.markdown` extension) it skips the RAG API call and reads the file verbatim via `parseTextNative`. This is the defensive fix on the LibreChat side — a matching loader fix in `danny-avila/rag_api` covers the server path as well.

The embedding path (`/embed`, used by file_search/RAG) is untouched and continues to use the semantic markdown loader so vector search quality is unchanged.

## Changes

- `packages/api/src/files/text.ts`: add `isMarkdownFile()` helper and short-circuit in `parseText`
- `packages/api/src/files/text.spec.ts`: cover each markdown MIME type, `.md` / `.MARKDOWN` by extension alone, and regression-check that non-markdown still hits the RAG API

## Test plan

- [x] `npx jest src/files/text.spec.ts` — 15/15 pass
- [ ] Manual: with `RAG_API_URL` set, upload a `.md` file with headings/bold/lists via **Upload as Text**; verify raw markdown reaches the model
- [ ] Manual: upload a `.txt` with identical content; behavior should match
- [ ] Manual regression: file_search (RAG) against a `.md` still uses the semantic loader on the RAG API side (unchanged)