### PR TITLE
🔊 fix: Preserve Log Metadata on Console for Warn/Error Levels

### DIFF
--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -215,4 +215,18 @@ describe('debugTraverse', () => {
     const out = runFormatter(buildInfo('debug', { someField: 'not-sensitive' }));
     expect(out).toContain('not-sensitive');
   });
+
+  it('prefers structured metadata over a consumed printf arg in SPLAT[0]', () => {
+    const info = {
+      level: 'warn',
+      message: 'failed for tenant-7',
+      timestamp: 'ts',
+      provider: 'openai',
+      [SPLAT_SYMBOL]: ['tenant-7', { provider: 'openai' }],
+    };
+    const out = runFormatter(info);
+    expect(out).toContain('openai');
+    const tenantMatches = out.match(/tenant-7/g) ?? [];
+    expect(tenantMatches.length).toBeLessThanOrEqual(1);
+  });
 });

--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -1,0 +1,83 @@
+const { formatConsoleMeta } = jest.requireActual('../parsers');
+
+describe('formatConsoleMeta', () => {
+  it('returns empty string when there is no user metadata', () => {
+    expect(
+      formatConsoleMeta({
+        level: 'error',
+        message: 'oops',
+        timestamp: '2026-04-18 02:25:22',
+      }),
+    ).toBe('');
+  });
+
+  it('serializes user-supplied metadata keys', () => {
+    const meta = formatConsoleMeta({
+      level: 'error',
+      message: '[agents:summarize] Summarization LLM call failed',
+      timestamp: '2026-04-18 02:25:22',
+      provider: 'azureOpenAI',
+      model: 'gpt-5.4-mini',
+      messagesToRefineCount: 42,
+    });
+
+    expect(meta).toContain('"provider":"azureOpenAI"');
+    expect(meta).toContain('"model":"gpt-5.4-mini"');
+    expect(meta).toContain('"messagesToRefineCount":42');
+  });
+
+  it('ignores reserved winston keys and underscore-prefixed internals', () => {
+    const meta = formatConsoleMeta({
+      level: 'error',
+      message: 'boom',
+      timestamp: 'ts',
+      splat: [1, 2],
+      _internal: 'skip',
+      userField: 'keep',
+    });
+
+    expect(meta).toBe('{"userField":"keep"}');
+  });
+
+  it('drops empty, null, undefined, function, and symbol values', () => {
+    const meta = formatConsoleMeta({
+      level: 'warn',
+      message: 'noise',
+      timestamp: 'ts',
+      empty: '',
+      nullish: null,
+      undef: undefined,
+      fn: () => 1,
+      sym: Symbol('x'),
+      kept: 'yes',
+    });
+
+    expect(meta).toBe('{"kept":"yes"}');
+  });
+
+  it('truncates very long string values to avoid console spam', () => {
+    const longString = 'x'.repeat(5000);
+    const meta = formatConsoleMeta({
+      level: 'error',
+      message: 'long',
+      timestamp: 'ts',
+      errorStack: longString,
+    });
+
+    expect(meta.length).toBeLessThan(longString.length);
+    expect(meta).toContain('...');
+  });
+
+  it('gracefully handles circular objects', () => {
+    const circular = {};
+    circular.self = circular;
+    const meta = formatConsoleMeta({
+      level: 'error',
+      message: 'circular',
+      timestamp: 'ts',
+      circular,
+    });
+
+    expect(meta).toBe('');
+  });
+});

--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -229,4 +229,29 @@ describe('debugTraverse', () => {
     const tenantMatches = out.match(/tenant-7/g) ?? [];
     expect(tenantMatches.length).toBeLessThanOrEqual(1);
   });
+
+  it('does not duplicate a consumed %s arg when there is no structured metadata', () => {
+    const info = {
+      level: 'warn',
+      message: 'failed for tenant-7',
+      timestamp: 'ts',
+      [SPLAT_SYMBOL]: ['tenant-7'],
+    };
+    const out = runFormatter(info);
+    const tenantMatches = out.match(/tenant-7/g) ?? [];
+    expect(tenantMatches.length).toBe(1);
+  });
+
+  it('still surfaces array metadata in SPLAT[0] when no object is extracted', () => {
+    const info = {
+      level: 'debug',
+      message: 'list',
+      timestamp: 'ts',
+      [SPLAT_SYMBOL]: [['alpha', 'beta', 'gamma']],
+    };
+    const out = runFormatter(info);
+    expect(out).toContain('alpha');
+    expect(out).toContain('beta');
+    expect(out).toContain('gamma');
+  });
 });

--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -43,6 +43,20 @@ describe('formatConsoleMeta', () => {
     expect(meta).toBe('{"userField":"keep"}');
   });
 
+  it('drops numeric-index-like keys (splat artifacts from primitive args)', () => {
+    const meta = formatConsoleMeta({
+      level: 'warn',
+      message: 'Unhandled step:',
+      timestamp: 'ts',
+      0: 'f',
+      1: 'o',
+      2: 'o',
+      realField: 'real',
+    });
+
+    expect(meta).toBe('{"realField":"real"}');
+  });
+
   it('drops empty, null, undefined, function, and symbol values', () => {
     const meta = formatConsoleMeta({
       level: 'warn',

--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -88,17 +88,21 @@ describe('formatConsoleMeta', () => {
     expect(meta).toContain('...');
   });
 
-  it('gracefully handles circular objects', () => {
+  it('preserves non-circular fields when one value is circular', () => {
     const circular = {};
     circular.self = circular;
     const meta = formatConsoleMeta({
       level: 'error',
       message: 'circular',
       timestamp: 'ts',
+      provider: 'openai',
+      model: 'gpt-5.4-mini',
       circular,
     });
 
-    expect(meta).toBe('');
+    expect(meta).toContain('"provider":"openai"');
+    expect(meta).toContain('"model":"gpt-5.4-mini"');
+    expect(meta).toContain('[Circular]');
   });
 
   it('redacts sensitive patterns inside string metadata values', () => {

--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -256,6 +256,23 @@ describe('debugTraverse', () => {
     expect(tenantMatches.length).toBe(1);
   });
 
+  it('omits numeric splat-artifact keys from the traversed output', () => {
+    const info = {
+      level: 'error',
+      message: 'boom',
+      timestamp: 'ts',
+      0: 'x',
+      1: 'y',
+      realField: 'keep',
+      [SPLAT_SYMBOL]: [{ realField: 'keep' }],
+    };
+    const out = runFormatter(info);
+    expect(out).toContain('realField');
+    expect(out).toContain('keep');
+    expect(out).not.toMatch(/^\s*0:/m);
+    expect(out).not.toMatch(/^\s*1:/m);
+  });
+
   it('surfaces unconsumed primitive SPLAT[0] (no %s in message) for debug level', () => {
     const info = {
       level: 'debug',

--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -1,6 +1,7 @@
 jest.unmock('winston');
 
-const { formatConsoleMeta, redactMessage, debugTraverse } = jest.requireActual('../parsers');
+const { formatConsoleMeta, redactMessage, redactFormat, debugTraverse } =
+  jest.requireActual('../parsers');
 const SPLAT_SYMBOL = Symbol.for('splat');
 
 describe('formatConsoleMeta', () => {
@@ -150,6 +151,28 @@ describe('redactMessage', () => {
   it('still redacts standalone sk- keys at word boundaries', () => {
     expect(redactMessage('token: sk-abc123def')).toBe('token: sk-[REDACTED]');
     expect(redactMessage('"sk-abc123def"')).toBe('"sk-[REDACTED]"');
+  });
+});
+
+describe('redactFormat', () => {
+  const runFormat = (info) => redactFormat().transform(info) || info;
+
+  it('redacts info.message for error level before any colorize step runs', () => {
+    const info = runFormat({ level: 'error', message: 'Bearer secretvalue' });
+    expect(info.message).toBe('Bearer [REDACTED]');
+  });
+
+  it('redacts info.message for warn level too (avoids ANSI boundary issues later)', () => {
+    const info = runFormat({ level: 'warn', message: 'apiKey=sk-abc123def' });
+    expect(info.message).toContain('sk-[REDACTED]');
+  });
+
+  it('leaves info.message untouched for info and debug levels', () => {
+    const infoInfo = runFormat({ level: 'info', message: 'Bearer looksSensitive' });
+    expect(infoInfo.message).toBe('Bearer looksSensitive');
+
+    const infoDebug = runFormat({ level: 'debug', message: 'Bearer looksSensitive' });
+    expect(infoDebug.message).toBe('Bearer looksSensitive');
   });
 });
 

--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -136,6 +136,21 @@ describe('redactMessage', () => {
     expect(redactMessage('')).toBe('');
     expect(redactMessage(undefined)).toBe('');
   });
+
+  it('does not redact ordinary words that contain "sk-" inside them', () => {
+    expect(redactMessage('task-runner failed')).toBe('task-runner failed');
+    expect(redactMessage('mask-value computed')).toBe('mask-value computed');
+    expect(redactMessage('desk-lamp is on')).toBe('desk-lamp is on');
+  });
+
+  it('does not redact words that contain "key=" inside them', () => {
+    expect(redactMessage('monkey=10 bananas')).toBe('monkey=10 bananas');
+  });
+
+  it('still redacts standalone sk- keys at word boundaries', () => {
+    expect(redactMessage('token: sk-abc123def')).toBe('token: sk-[REDACTED]');
+    expect(redactMessage('"sk-abc123def"')).toBe('"sk-[REDACTED]"');
+  });
 });
 
 describe('debugTraverse', () => {

--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -105,6 +105,59 @@ describe('formatConsoleMeta', () => {
     expect(meta).toContain('[Circular]');
   });
 
+  it('falls back to per-field serialization when a value toJSON throws', () => {
+    const meta = formatConsoleMeta({
+      level: 'error',
+      message: 'crash',
+      timestamp: 'ts',
+      provider: 'azure',
+      model: 'gpt-5.4-mini',
+      broken: {
+        toJSON() {
+          throw new Error('nope');
+        },
+      },
+    });
+
+    expect(meta).toContain('"provider":"azure"');
+    expect(meta).toContain('"model":"gpt-5.4-mini"');
+    expect(meta).toContain('[Unserializable]');
+  });
+
+  it('redacts sensitive strings nested inside metadata objects', () => {
+    const meta = formatConsoleMeta({
+      level: 'error',
+      message: 'nested leak',
+      timestamp: 'ts',
+      config: {
+        headers: {
+          authorization: 'Bearer eyJhbGciOi.nestedTokenValue',
+        },
+        query: 'https://example.com/?key=AIzaNested',
+      },
+      openaiKey: 'sk-outerKey123',
+    });
+
+    expect(meta).not.toContain('eyJhbGciOi.nestedTokenValue');
+    expect(meta).not.toContain('AIzaNested');
+    expect(meta).not.toContain('sk-outerKey123');
+    expect(meta).toContain('Bearer [REDACTED]');
+    expect(meta).toContain('key=[REDACTED]');
+    expect(meta).toContain('sk-[REDACTED]');
+  });
+
+  it('redacts the Azure-style mixed-case Api-Key header', () => {
+    const meta = formatConsoleMeta({
+      level: 'error',
+      message: 'azure call',
+      timestamp: 'ts',
+      headers: 'Api-Key: 0123456789abcdef',
+    });
+
+    expect(meta).not.toContain('0123456789abcdef');
+    expect(meta).toContain('Api-Key: [REDACTED]');
+  });
+
   it('redacts sensitive patterns inside string metadata values', () => {
     const meta = formatConsoleMeta({
       level: 'error',

--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -256,6 +256,17 @@ describe('debugTraverse', () => {
     expect(tenantMatches.length).toBe(1);
   });
 
+  it('surfaces unconsumed primitive SPLAT[0] (no %s in message) for debug level', () => {
+    const info = {
+      level: 'debug',
+      message: 'prefix:',
+      timestamp: 'ts',
+      [SPLAT_SYMBOL]: ['detailValueXYZ'],
+    };
+    const out = runFormatter(info);
+    expect(out).toContain('detailValueXYZ');
+  });
+
   it('still surfaces array metadata in SPLAT[0] when no object is extracted', () => {
     const info = {
       level: 'debug',

--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -30,17 +30,19 @@ describe('formatConsoleMeta', () => {
     expect(meta).toContain('"messagesToRefineCount":42');
   });
 
-  it('ignores reserved winston keys and underscore-prefixed internals', () => {
+  it('ignores reserved winston keys but preserves legitimate fields like _id', () => {
     const meta = formatConsoleMeta({
       level: 'error',
       message: 'boom',
       timestamp: 'ts',
       splat: [1, 2],
-      _internal: 'skip',
+      _id: '507f191e810c19729de860ea',
       userField: 'keep',
     });
 
-    expect(meta).toBe('{"userField":"keep"}');
+    expect(meta).toContain('"_id":"507f191e810c19729de860ea"');
+    expect(meta).toContain('"userField":"keep"');
+    expect(meta).not.toContain('"splat"');
   });
 
   it('drops numeric-index-like keys (splat artifacts from primitive args)', () => {

--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -1,4 +1,7 @@
-const { formatConsoleMeta, redactMessage } = jest.requireActual('../parsers');
+jest.unmock('winston');
+
+const { formatConsoleMeta, redactMessage, debugTraverse } = jest.requireActual('../parsers');
+const SPLAT_SYMBOL = Symbol.for('splat');
 
 describe('formatConsoleMeta', () => {
   it('returns empty string when there is no user metadata', () => {
@@ -132,5 +135,46 @@ describe('redactMessage', () => {
   it('returns empty string for falsy input', () => {
     expect(redactMessage('')).toBe('');
     expect(redactMessage(undefined)).toBe('');
+  });
+});
+
+describe('debugTraverse', () => {
+  const runFormatter = (info) => {
+    const transformed = debugTraverse.transform(info);
+    const MESSAGE = Symbol.for('message');
+    if (transformed && typeof transformed === 'object') {
+      return transformed[MESSAGE] ?? String(transformed);
+    }
+    return String(transformed);
+  };
+
+  const buildInfo = (level, meta) => {
+    const info = {
+      level,
+      message: 'test',
+      timestamp: 'ts',
+      ...meta,
+    };
+    info[SPLAT_SYMBOL] = [meta];
+    return info;
+  };
+
+  it('redacts sensitive strings in metadata for error level', () => {
+    const out = runFormatter(buildInfo('error', { auth: 'Bearer eyJabc123', openai: 'sk-abc123' }));
+    expect(out).not.toContain('eyJabc123');
+    expect(out).not.toContain('sk-abc123');
+    expect(out).toContain('Bearer [REDACTED]');
+    expect(out).toContain('sk-[REDACTED]');
+  });
+
+  it('redacts sensitive strings in metadata for warn level', () => {
+    const out = runFormatter(buildInfo('warn', { header: 'Bearer supersecrettoken' }));
+    expect(out).not.toContain('supersecrettoken');
+    expect(out).toContain('Bearer [REDACTED]');
+  });
+
+  it('preserves debug-level metadata unmodified (existing behavior)', () => {
+    const out = runFormatter(buildInfo('debug', { someField: 'not-sensitive' }));
+    expect(out).toContain('not-sensitive');
   });
 });

--- a/api/config/__tests__/parsers.spec.js
+++ b/api/config/__tests__/parsers.spec.js
@@ -1,4 +1,4 @@
-const { formatConsoleMeta } = jest.requireActual('../parsers');
+const { formatConsoleMeta, redactMessage } = jest.requireActual('../parsers');
 
 describe('formatConsoleMeta', () => {
   it('returns empty string when there is no user metadata', () => {
@@ -79,5 +79,58 @@ describe('formatConsoleMeta', () => {
     });
 
     expect(meta).toBe('');
+  });
+
+  it('redacts sensitive patterns inside string metadata values', () => {
+    const meta = formatConsoleMeta({
+      level: 'error',
+      message: 'leak test',
+      timestamp: 'ts',
+      openaiKey: 'sk-abc123def456',
+      auth: 'Bearer eyJhbGciOi...tokenvalue',
+      google: 'https://example.com/?key=AIzaSyXX',
+    });
+
+    expect(meta).not.toContain('sk-abc123def456');
+    expect(meta).not.toContain('eyJhbGciOi...tokenvalue');
+    expect(meta).not.toContain('AIzaSyXX');
+    expect(meta).toContain('sk-[REDACTED]');
+    expect(meta).toContain('Bearer [REDACTED]');
+    expect(meta).toContain('key=[REDACTED]');
+  });
+
+  it('redacts multiple occurrences of the same pattern in one value', () => {
+    const meta = formatConsoleMeta({
+      level: 'error',
+      message: 'two keys',
+      timestamp: 'ts',
+      combined: 'first sk-aaa and then sk-bbb',
+    });
+
+    expect(meta).not.toContain('sk-aaa');
+    expect(meta).not.toContain('sk-bbb');
+    expect(meta.match(/sk-\[REDACTED\]/g)?.length).toBe(2);
+  });
+});
+
+describe('redactMessage', () => {
+  it('redacts sk- keys that are not at line start (inside JSON-like text)', () => {
+    const input = '{"apiKey":"sk-abc123"}';
+    expect(redactMessage(input)).toBe('{"apiKey":"sk-[REDACTED]"}');
+  });
+
+  it('redacts all sk- occurrences in a single pass', () => {
+    const input = 'sk-one sk-two sk-three';
+    expect(redactMessage(input)).toBe('sk-[REDACTED] sk-[REDACTED] sk-[REDACTED]');
+  });
+
+  it('trims redacted output when trimLength is provided', () => {
+    const input = 'Bearer supersecretvalue';
+    expect(redactMessage(input, 10)).toBe('Bearer [RE...');
+  });
+
+  it('returns empty string for falsy input', () => {
+    expect(redactMessage('')).toBe('');
+    expect(redactMessage(undefined)).toBe('');
   });
 });

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -147,18 +147,54 @@ function formatConsoleMeta(info) {
   if (!meta) {
     return '';
   }
-  try {
-    return JSON.stringify(meta, (_key, value) => {
-      if (typeof value !== 'string') {
-        return value;
-      }
+  const seen = new WeakSet();
+  const replacer = (_key, value) => {
+    if (typeof value === 'string') {
       const safe = redactMessage(value);
       return safe.length > CONSOLE_JSON_STRING_LENGTH
         ? `${safe.substring(0, CONSOLE_JSON_STRING_LENGTH)}...`
         : safe;
-    });
+    }
+    if (value !== null && typeof value === 'object') {
+      if (seen.has(value)) {
+        return '[Circular]';
+      }
+      seen.add(value);
+    }
+    return value;
+  };
+
+  try {
+    return JSON.stringify(meta, replacer);
   } catch {
-    return '';
+    /*
+     * Fall back to per-field serialization: a single unserializable field
+     * shouldn't drop every other scalar in the trailer. Scalars are emitted
+     * as-is; values that still fail serialization are replaced with a
+     * placeholder so `provider`, `model`, etc. continue to surface.
+     */
+    const parts = [];
+    for (const key of Object.keys(meta)) {
+      const perFieldSeen = new WeakSet();
+      const perFieldReplacer = (k, value) => {
+        if (typeof value === 'string') {
+          return replacer(k, value);
+        }
+        if (value !== null && typeof value === 'object') {
+          if (perFieldSeen.has(value)) {
+            return '[Circular]';
+          }
+          perFieldSeen.add(value);
+        }
+        return value;
+      };
+      try {
+        parts.push(`${JSON.stringify(key)}:${JSON.stringify(meta[key], perFieldReplacer)}`);
+      } catch {
+        parts.push(`${JSON.stringify(key)}:"[Unserializable]"`);
+      }
+    }
+    return parts.length > 0 ? `{${parts.join(',')}}` : '';
   }
 }
 

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -8,25 +8,11 @@ const CONSOLE_JSON_STRING_LENGTH = parseInt(process.env.CONSOLE_JSON_STRING_LENG
 const DEBUG_MESSAGE_LENGTH = parseInt(process.env.DEBUG_MESSAGE_LENGTH) || 150;
 
 const sensitiveKeys = [
-  /^(sk-)[^\s]+/, // OpenAI API key pattern
-  /(Bearer )[^\s]+/, // Header: Bearer token pattern
-  /(api-key:? )[^\s]+/, // Header: API key pattern
-  /(key=)[^\s]+/, // URL query param: sensitive key pattern (Google)
+  /(sk-)[^\s"']+/g, // OpenAI API key pattern (also catches keys embedded in JSON/quoted strings)
+  /(Bearer )[^\s"']+/g, // Header: Bearer token pattern
+  /(api-key:? )[^\s"']+/g, // Header: API key pattern
+  /(key=)[^\s"']+/g, // URL query param: sensitive key pattern (Google)
 ];
-
-/**
- * Determines if a given value string is sensitive and returns matching regex patterns.
- *
- * @param {string} valueStr - The value string to check.
- * @returns {Array<RegExp>} An array of regex patterns that match the value string.
- */
-function getMatchingSensitivePatterns(valueStr) {
-  if (valueStr) {
-    // Filter and return all regex patterns that match the value string
-    return sensitiveKeys.filter((regex) => regex.test(valueStr));
-  }
-  return [];
-}
 
 /**
  * Redacts sensitive information from a console message and trims it to a specified length if provided.
@@ -39,16 +25,16 @@ function redactMessage(str, trimLength) {
     return '';
   }
 
-  const patterns = getMatchingSensitivePatterns(str);
-  patterns.forEach((pattern) => {
-    str = str.replace(pattern, '$1[REDACTED]');
-  });
-
-  if (trimLength !== undefined && str.length > trimLength) {
-    return `${str.substring(0, trimLength)}...`;
+  let redacted = str;
+  for (const pattern of sensitiveKeys) {
+    redacted = redacted.replace(pattern, '$1[REDACTED]');
   }
 
-  return str;
+  if (trimLength !== undefined && redacted.length > trimLength) {
+    return `${redacted.substring(0, trimLength)}...`;
+  }
+
+  return redacted;
 }
 
 /**
@@ -141,10 +127,13 @@ function formatConsoleMeta(info) {
   }
   try {
     return JSON.stringify(meta, (_key, value) => {
-      if (typeof value === 'string' && value.length > CONSOLE_JSON_STRING_LENGTH) {
-        return `${value.substring(0, CONSOLE_JSON_STRING_LENGTH)}...`;
+      if (typeof value !== 'string') {
+        return value;
       }
-      return value;
+      const safe = redactMessage(value);
+      return safe.length > CONSOLE_JSON_STRING_LENGTH
+        ? `${safe.substring(0, CONSOLE_JSON_STRING_LENGTH)}...`
+        : safe;
     });
   } catch {
     return '';

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -198,17 +198,32 @@ const debugTraverse = winston.format.printf(({ level, message, timestamp, ...met
 
     /*
      * Prefer the structured metadata object (which winston merges into info)
-     * over `SPLAT_SYMBOL[0]`. The first splat entry may be a *consumed*
-     * printf arg — e.g. `logger.warn('failed for %s', tenant)` leaves
-     * `tenant` in `SPLAT[0]` after interpolation, and appending it again
-     * would emit `failed for tenant tenant`. Only fall back to the splat
-     * entry when it's a non-primitive (array or plain object); a string
-     * or number there is almost certainly a consumed %s/%d arg.
+     * over `SPLAT_SYMBOL[0]`. For primitive splat values, skip only if the
+     * value already appears in the interpolated message (i.e. `%s`/`%d`
+     * consumed it) — `logger.warn('failed for %s', tenant)` leaves `tenant`
+     * in `SPLAT[0]` after interpolation and would otherwise be appended a
+     * second time. Unconsumed primitives like
+     * `logger.debug('prefix:', detail)` still surface.
      */
     const extracted = extractMetaObject(metadata);
     const splatFirst = metadata[SPLAT_SYMBOL]?.[0];
-    const splatUsable =
-      Array.isArray(splatFirst) || (splatFirst != null && typeof splatFirst === 'object');
+    const splatUsable = (() => {
+      if (splatFirst == null) {
+        return false;
+      }
+      if (Array.isArray(splatFirst) || typeof splatFirst === 'object') {
+        return true;
+      }
+      if (
+        typeof splatFirst === 'string' ||
+        typeof splatFirst === 'number' ||
+        typeof splatFirst === 'boolean'
+      ) {
+        const splatStr = String(splatFirst);
+        return splatStr !== '' && !message.includes(splatStr);
+      }
+      return false;
+    })();
     const debugValue = extracted ?? (splatUsable ? splatFirst : undefined);
 
     if (!debugValue) {

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -241,7 +241,13 @@ const debugTraverse = winston.format.printf(({ level, message, timestamp, ...met
 
     msg += '\n{';
 
-    const copy = klona(metadata);
+    /*
+     * Traverse the filtered metadata (`debugValue`), not the raw `metadata`
+     * object. `extractMetaObject` strips reserved keys, underscore-prefixed
+     * internals, and numeric-string splat artifacts — re-reading from raw
+     * `metadata` here would put those artifacts back into the output.
+     */
+    const copy = klona(debugValue);
     traverse(copy).forEach(function (value) {
       if (typeof this?.key === 'symbol') {
         return;

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -8,10 +8,13 @@ const CONSOLE_JSON_STRING_LENGTH = parseInt(process.env.CONSOLE_JSON_STRING_LENG
 const DEBUG_MESSAGE_LENGTH = parseInt(process.env.DEBUG_MESSAGE_LENGTH) || 150;
 
 const sensitiveKeys = [
-  /(sk-)[^\s"']+/g, // OpenAI API key pattern (also catches keys embedded in JSON/quoted strings)
-  /(Bearer )[^\s"']+/g, // Header: Bearer token pattern
-  /(api-key:? )[^\s"']+/g, // Header: API key pattern
-  /(key=)[^\s"']+/g, // URL query param: sensitive key pattern (Google)
+  // OpenAI API key: `sk-` at a word boundary, followed by the documented
+  // charset for keys. `\b` keeps `task-runner`, `mask-value`, etc. from
+  // being mis-redacted.
+  /\b(sk-)[a-zA-Z0-9_-]+/g,
+  /\b(Bearer )[^\s"']+/g, // Header: Bearer token pattern
+  /\b(api-key:? )[^\s"']+/g, // Header: API key pattern
+  /\b(key=)[^\s"'&]+/g, // URL query param: sensitive key pattern (Google)
 ];
 
 /**

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -13,9 +13,11 @@ const sensitiveKeys = [
   // being mis-redacted.
   /\b(sk-)[a-zA-Z0-9_-]+/g,
   /\b(Bearer )[^\s"']+/g, // Header: Bearer token pattern
-  /\b(api-key:? )[^\s"']+/g, // Header: API key pattern
+  /\b(api-key:? )[^\s"']+/gi, // Header: API key pattern (case-insensitive; covers `Api-Key:`, `API-KEY:`)
   /\b(key=)[^\s"'&]+/g, // URL query param: sensitive key pattern (Google)
 ];
+
+const NUMERIC_KEY_RE = /^\d+$/;
 
 /**
  * Redacts sensitive information from a console message and trims it to a specified length if provided.
@@ -95,8 +97,14 @@ const condenseArray = (item) => {
 const RESERVED_LOG_KEYS = new Set(['level', 'message', 'timestamp', 'splat']);
 
 /**
- * Extracts user-supplied metadata from a winston info object, filtering out
- * reserved keys, internal underscore-prefixed keys, and non-serializable values.
+ * Extracts user-supplied metadata from a winston info object. Filters out:
+ * - Reserved winston keys (`level`, `message`, `timestamp`, `splat`).
+ * - Numeric-string keys (`"0"`, `"1"`, ...) that `format.splat()` can
+ *   synthesize when a primitive is passed as an extra log argument.
+ * - Values that are undefined, null, empty strings, functions, or symbols.
+ *
+ * Underscore-prefixed keys are intentionally preserved so legitimate
+ * fields like MongoDB `_id` survive.
  *
  * @param {Record<string, unknown>} source - The object to extract metadata from.
  * @returns {Record<string, unknown> | undefined} - The extracted metadata, or undefined if empty.
@@ -110,16 +118,7 @@ function extractMetaObject(source) {
     if (RESERVED_LOG_KEYS.has(key)) {
       continue;
     }
-    /*
-     * Skip numeric-index-like keys. When a caller passes a primitive as
-     * the second argument to `logger.warn/error`, `format.splat()` can
-     * leave character-index keys ("0", "1", ...) on `info`. Those are
-     * synthetic splat artifacts, not real metadata.
-     *
-     * Note: we intentionally do NOT filter keys starting with `_`, since
-     * legitimate fields like MongoDB `_id` use that prefix.
-     */
-    if (/^\d+$/.test(key)) {
+    if (NUMERIC_KEY_RE.test(key)) {
       continue;
     }
     const value = source[key];
@@ -199,11 +198,16 @@ function formatConsoleMeta(info) {
 }
 
 /**
- * Formats log messages for debugging purposes.
- * - Truncates long strings within log messages.
- * - Condenses arrays by truncating long strings and objects as strings within array items.
- * - Redacts sensitive information from log messages if the log level is 'error'.
- * - Converts log information object to a formatted string.
+ * Formats log messages for file and debug-console transports. Three paths:
+ * - `warn` / `error`: append a compact single-line JSON metadata trailer
+ *   (via `formatConsoleMeta`) and pass the full line through `redactMessage`
+ *   so sensitive patterns are scrubbed.
+ * - `debug`: perform the detailed multi-line object traversal of
+ *   `SPLAT_SYMBOL[0]`, with long-string truncation and array condensation.
+ *   Redaction on this path is not applied here (debug-file consumers
+ *   historically accept raw detail).
+ * - Other levels: return the truncated `"<timestamp> <level>: <message>"`
+ *   line with no metadata.
  *
  * @param {Object} options - The options for formatting log messages.
  * @param {string} options.level - The log level.

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -41,15 +41,22 @@ function redactMessage(str, trimLength) {
 }
 
 /**
- * Redacts sensitive information from log messages if the log level is 'error'.
+ * Redacts sensitive information from log messages when the log level is
+ * `error` or `warn`. Runs on the raw `info.message` before any colorize /
+ * splat transforms so the sensitive-token regexes don't have to contend
+ * with ANSI escape sequences (whose trailing `m` would otherwise defeat
+ * `\b` anchors).
+ *
  * Note: Intentionally mutates the object.
  * @param {Object} info - The log information object.
  * @returns {Object} - The modified log information object.
  */
 const redactFormat = winston.format((info) => {
-  if (info.level === 'error') {
-    info.message = redactMessage(info.message);
-    if (info[MESSAGE_SYMBOL]) {
+  if (info.level === 'error' || info.level === 'warn') {
+    if (typeof info.message === 'string') {
+      info.message = redactMessage(info.message);
+    }
+    if (typeof info[MESSAGE_SYMBOL] === 'string') {
       info[MESSAGE_SYMBOL] = redactMessage(info[MESSAGE_SYMBOL]);
     }
   }

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -186,7 +186,17 @@ const debugTraverse = winston.format.printf(({ level, message, timestamp, ...met
       return finalize(msg);
     }
 
-    const debugValue = metadata[SPLAT_SYMBOL]?.[0] ?? extractMetaObject(metadata);
+    /*
+     * Prefer the structured metadata object (which winston merges into info)
+     * over `SPLAT_SYMBOL[0]`. The first splat entry may be a *consumed*
+     * printf arg — e.g. `logger.warn('failed for %s', tenant, { provider })`
+     * leaves `tenant` in `SPLAT[0]` after interpolation, which would then
+     * be appended again to the line instead of surfacing the real metadata
+     * object `{ provider }`.
+     */
+    const extracted = extractMetaObject(metadata);
+    const splatFirst = metadata[SPLAT_SYMBOL]?.[0];
+    const debugValue = extracted ?? splatFirst;
 
     if (!debugValue) {
       return finalize(msg);

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -189,14 +189,17 @@ const debugTraverse = winston.format.printf(({ level, message, timestamp, ...met
     /*
      * Prefer the structured metadata object (which winston merges into info)
      * over `SPLAT_SYMBOL[0]`. The first splat entry may be a *consumed*
-     * printf arg — e.g. `logger.warn('failed for %s', tenant, { provider })`
-     * leaves `tenant` in `SPLAT[0]` after interpolation, which would then
-     * be appended again to the line instead of surfacing the real metadata
-     * object `{ provider }`.
+     * printf arg — e.g. `logger.warn('failed for %s', tenant)` leaves
+     * `tenant` in `SPLAT[0]` after interpolation, and appending it again
+     * would emit `failed for tenant tenant`. Only fall back to the splat
+     * entry when it's a non-primitive (array or plain object); a string
+     * or number there is almost certainly a consumed %s/%d arg.
      */
     const extracted = extractMetaObject(metadata);
     const splatFirst = metadata[SPLAT_SYMBOL]?.[0];
-    const debugValue = extracted ?? splatFirst;
+    const splatUsable =
+      Array.isArray(splatFirst) || (splatFirst != null && typeof splatFirst === 'object');
+    const debugValue = extracted ?? (splatUsable ? splatFirst : undefined);
 
     if (!debugValue) {
       return finalize(msg);

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -107,15 +107,17 @@ function extractMetaObject(source) {
   }
   const meta = {};
   for (const key of Object.keys(source)) {
-    if (RESERVED_LOG_KEYS.has(key) || key.startsWith('_')) {
+    if (RESERVED_LOG_KEYS.has(key)) {
       continue;
     }
     /*
      * Skip numeric-index-like keys. When a caller passes a primitive as
      * the second argument to `logger.warn/error`, `format.splat()` can
      * leave character-index keys ("0", "1", ...) on `info`. Those are
-     * synthetic splat artifacts, not real metadata, and would otherwise
-     * produce noisy output now that warn/error share this path.
+     * synthetic splat artifacts, not real metadata.
+     *
+     * Note: we intentionally do NOT filter keys starting with `_`, since
+     * legitimate fields like MongoDB `_id` use that prefix.
      */
     if (/^\d+$/.test(key)) {
       continue;
@@ -186,68 +188,48 @@ const debugTraverse = winston.format.printf(({ level, message, timestamp, ...met
   let msg = `${timestamp} ${level}: ${truncateLongStrings(message?.trim(), DEBUG_MESSAGE_LENGTH)}`;
   const levelStr = typeof level === 'string' ? level : String(level);
   const isErrorOrWarn = levelStr.includes('error') || levelStr.includes('warn');
-  const finalize = (text) => (isErrorOrWarn ? redactMessage(text) : text);
+
+  /*
+   * Warn/error follow a simpler code path: append a single-line JSON
+   * metadata trailer (same shape as the console formatter) and pass the
+   * result through `redactMessage`. The complex object-traversal below is
+   * kept for debug level only, where detailed multi-line output is the
+   * intended behavior and its splat/interpolation interactions were
+   * already tolerated.
+   */
+  if (isErrorOrWarn) {
+    const trailer = formatConsoleMeta(metadata);
+    const line = trailer ? `${msg} ${trailer}` : msg;
+    return redactMessage(line);
+  }
+
   try {
-    if (level !== 'debug' && !isErrorOrWarn) {
-      return finalize(msg);
+    if (level !== 'debug') {
+      return msg;
     }
 
     if (!metadata) {
-      return finalize(msg);
+      return msg;
     }
 
-    /*
-     * Prefer the structured metadata object (which winston merges into info)
-     * over `SPLAT_SYMBOL[0]`. For primitive splat values, skip only if the
-     * value already appears in the interpolated message (i.e. `%s`/`%d`
-     * consumed it) — `logger.warn('failed for %s', tenant)` leaves `tenant`
-     * in `SPLAT[0]` after interpolation and would otherwise be appended a
-     * second time. Unconsumed primitives like
-     * `logger.debug('prefix:', detail)` still surface.
-     */
-    const extracted = extractMetaObject(metadata);
-    const splatFirst = metadata[SPLAT_SYMBOL]?.[0];
-    const splatUsable = (() => {
-      if (splatFirst == null) {
-        return false;
-      }
-      if (Array.isArray(splatFirst) || typeof splatFirst === 'object') {
-        return true;
-      }
-      if (
-        typeof splatFirst === 'string' ||
-        typeof splatFirst === 'number' ||
-        typeof splatFirst === 'boolean'
-      ) {
-        const splatStr = String(splatFirst);
-        return splatStr !== '' && !message.includes(splatStr);
-      }
-      return false;
-    })();
-    const debugValue = extracted ?? (splatUsable ? splatFirst : undefined);
+    const debugValue = metadata[SPLAT_SYMBOL]?.[0];
 
     if (!debugValue) {
-      return finalize(msg);
+      return msg;
     }
 
     if (debugValue && Array.isArray(debugValue)) {
       msg += `\n${JSON.stringify(debugValue.map(condenseArray))}`;
-      return finalize(msg);
+      return msg;
     }
 
     if (typeof debugValue !== 'object') {
-      return finalize((msg += ` ${debugValue}`));
+      return (msg += ` ${debugValue}`);
     }
 
     msg += '\n{';
 
-    /*
-     * Traverse the filtered metadata (`debugValue`), not the raw `metadata`
-     * object. `extractMetaObject` strips reserved keys, underscore-prefixed
-     * internals, and numeric-string splat artifacts — re-reading from raw
-     * `metadata` here would put those artifacts back into the output.
-     */
-    const copy = klona(debugValue);
+    const copy = klona(metadata);
     traverse(copy).forEach(function (value) {
       if (typeof this?.key === 'symbol') {
         return;
@@ -283,9 +265,9 @@ const debugTraverse = winston.format.printf(({ level, message, timestamp, ...met
     });
 
     msg += '\n}';
-    return finalize(msg);
+    return msg;
   } catch (e) {
-    return finalize((msg += `\n[LOGGER PARSING ERROR] ${e.message}`));
+    return (msg += `\n[LOGGER PARSING ERROR] ${e.message}`);
   }
 });
 

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -110,6 +110,16 @@ function extractMetaObject(source) {
     if (RESERVED_LOG_KEYS.has(key) || key.startsWith('_')) {
       continue;
     }
+    /*
+     * Skip numeric-index-like keys. When a caller passes a primitive as
+     * the second argument to `logger.warn/error`, `format.splat()` can
+     * leave character-index keys ("0", "1", ...) on `info`. Those are
+     * synthetic splat artifacts, not real metadata, and would otherwise
+     * produce noisy output now that warn/error share this path.
+     */
+    if (/^\d+$/.test(key)) {
+      continue;
+    }
     const value = source[key];
     if (value === undefined || value === null || value === '') {
       continue;

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -96,6 +96,61 @@ const condenseArray = (item) => {
   return item;
 };
 
+const RESERVED_LOG_KEYS = new Set(['level', 'message', 'timestamp', 'splat']);
+
+/**
+ * Extracts user-supplied metadata from a winston info object, filtering out
+ * reserved keys, internal underscore-prefixed keys, and non-serializable values.
+ *
+ * @param {Record<string, unknown>} source - The object to extract metadata from.
+ * @returns {Record<string, unknown> | undefined} - The extracted metadata, or undefined if empty.
+ */
+function extractMetaObject(source) {
+  if (source == null || typeof source !== 'object') {
+    return undefined;
+  }
+  const meta = {};
+  for (const key of Object.keys(source)) {
+    if (RESERVED_LOG_KEYS.has(key) || key.startsWith('_')) {
+      continue;
+    }
+    const value = source[key];
+    if (value === undefined || value === null || value === '') {
+      continue;
+    }
+    if (typeof value === 'function' || typeof value === 'symbol') {
+      continue;
+    }
+    meta[key] = value;
+  }
+  return Object.keys(meta).length > 0 ? meta : undefined;
+}
+
+/**
+ * Formats the metadata portion of a winston info object as a compact
+ * single-line JSON trailer, suitable for appending to the console message.
+ * Returns an empty string when there is no meaningful metadata.
+ *
+ * @param {Record<string, unknown>} info - The winston info object.
+ * @returns {string} - The serialized metadata, or an empty string.
+ */
+function formatConsoleMeta(info) {
+  const meta = extractMetaObject(info);
+  if (!meta) {
+    return '';
+  }
+  try {
+    return JSON.stringify(meta, (_key, value) => {
+      if (typeof value === 'string' && value.length > CONSOLE_JSON_STRING_LENGTH) {
+        return `${value.substring(0, CONSOLE_JSON_STRING_LENGTH)}...`;
+      }
+      return value;
+    });
+  } catch {
+    return '';
+  }
+}
+
 /**
  * Formats log messages for debugging purposes.
  * - Truncates long strings within log messages.
@@ -121,7 +176,9 @@ const debugTraverse = winston.format.printf(({ level, message, timestamp, ...met
 
   let msg = `${timestamp} ${level}: ${truncateLongStrings(message?.trim(), DEBUG_MESSAGE_LENGTH)}`;
   try {
-    if (level !== 'debug') {
+    const levelStr = typeof level === 'string' ? level : String(level);
+    const isErrorOrWarn = levelStr.includes('error') || levelStr.includes('warn');
+    if (level !== 'debug' && !isErrorOrWarn) {
       return msg;
     }
 
@@ -129,7 +186,7 @@ const debugTraverse = winston.format.printf(({ level, message, timestamp, ...met
       return msg;
     }
 
-    const debugValue = metadata[SPLAT_SYMBOL]?.[0];
+    const debugValue = metadata[SPLAT_SYMBOL]?.[0] ?? extractMetaObject(metadata);
 
     if (!debugValue) {
       return msg;
@@ -229,4 +286,5 @@ module.exports = {
   redactMessage,
   debugTraverse,
   jsonTruncateFormat,
+  formatConsoleMeta,
 };

--- a/api/config/parsers.js
+++ b/api/config/parsers.js
@@ -164,30 +164,31 @@ const debugTraverse = winston.format.printf(({ level, message, timestamp, ...met
   }
 
   let msg = `${timestamp} ${level}: ${truncateLongStrings(message?.trim(), DEBUG_MESSAGE_LENGTH)}`;
+  const levelStr = typeof level === 'string' ? level : String(level);
+  const isErrorOrWarn = levelStr.includes('error') || levelStr.includes('warn');
+  const finalize = (text) => (isErrorOrWarn ? redactMessage(text) : text);
   try {
-    const levelStr = typeof level === 'string' ? level : String(level);
-    const isErrorOrWarn = levelStr.includes('error') || levelStr.includes('warn');
     if (level !== 'debug' && !isErrorOrWarn) {
-      return msg;
+      return finalize(msg);
     }
 
     if (!metadata) {
-      return msg;
+      return finalize(msg);
     }
 
     const debugValue = metadata[SPLAT_SYMBOL]?.[0] ?? extractMetaObject(metadata);
 
     if (!debugValue) {
-      return msg;
+      return finalize(msg);
     }
 
     if (debugValue && Array.isArray(debugValue)) {
       msg += `\n${JSON.stringify(debugValue.map(condenseArray))}`;
-      return msg;
+      return finalize(msg);
     }
 
     if (typeof debugValue !== 'object') {
-      return (msg += ` ${debugValue}`);
+      return finalize((msg += ` ${debugValue}`));
     }
 
     msg += '\n{';
@@ -228,9 +229,9 @@ const debugTraverse = winston.format.printf(({ level, message, timestamp, ...met
     });
 
     msg += '\n}';
-    return msg;
+    return finalize(msg);
   } catch (e) {
-    return (msg += `\n[LOGGER PARSING ERROR] ${e.message}`);
+    return finalize((msg += `\n[LOGGER PARSING ERROR] ${e.message}`));
   }
 });
 

--- a/api/config/winston.js
+++ b/api/config/winston.js
@@ -128,7 +128,7 @@ const consoleFormat = winston.format.combine(
       }
     }
 
-    if (isError) {
+    if (isError || isWarn) {
       return redactMessage(line);
     }
 

--- a/api/config/winston.js
+++ b/api/config/winston.js
@@ -2,7 +2,13 @@ const path = require('path');
 const fs = require('fs');
 const winston = require('winston');
 require('winston-daily-rotate-file');
-const { redactFormat, redactMessage, debugTraverse, jsonTruncateFormat } = require('./parsers');
+const {
+  redactFormat,
+  redactMessage,
+  debugTraverse,
+  jsonTruncateFormat,
+  formatConsoleMeta,
+} = require('./parsers');
 
 /**
  * Determine the log directory.
@@ -110,12 +116,23 @@ const consoleFormat = winston.format.combine(
   winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
   // redactErrors(),
   winston.format.printf((info) => {
-    const message = `${info.timestamp} ${info.level}: ${info.message}`;
-    if (info.level.includes('error')) {
-      return redactMessage(message);
+    const base = `${info.timestamp} ${info.level}: ${info.message}`;
+    const isError = info.level.includes('error');
+    const isWarn = info.level.includes('warn');
+
+    let line = base;
+    if (isError || isWarn) {
+      const metaTrailer = formatConsoleMeta(info);
+      if (metaTrailer) {
+        line = `${base} ${metaTrailer}`;
+      }
     }
 
-    return message;
+    if (isError) {
+      return redactMessage(line);
+    }
+
+    return line;
   }),
 );
 

--- a/api/config/winston.js
+++ b/api/config/winston.js
@@ -117,22 +117,15 @@ const consoleFormat = winston.format.combine(
   // redactErrors(),
   winston.format.printf((info) => {
     const base = `${info.timestamp} ${info.level}: ${info.message}`;
-    const isError = info.level.includes('error');
-    const isWarn = info.level.includes('warn');
+    const isErrorOrWarn = info.level.includes('error') || info.level.includes('warn');
 
-    let line = base;
-    if (isError || isWarn) {
+    if (isErrorOrWarn) {
       const metaTrailer = formatConsoleMeta(info);
-      if (metaTrailer) {
-        line = `${base} ${metaTrailer}`;
-      }
-    }
-
-    if (isError || isWarn) {
+      const line = metaTrailer ? `${base} ${metaTrailer}` : base;
       return redactMessage(line);
     }
 
-    return line;
+    return base;
   }),
 );
 

--- a/api/test/__mocks__/logger.js
+++ b/api/test/__mocks__/logger.js
@@ -56,5 +56,6 @@ jest.mock('~/config/parsers', () => {
     redactMessage: jest.fn(),
     redactFormat: jest.fn(),
     debugTraverse: jest.fn(),
+    formatConsoleMeta: jest.fn(() => ''),
   };
 });


### PR DESCRIPTION
## Summary

Resolves [Discussion #12733](https://github.com/danny-avila/LibreChat/discussions/12733) (and makes Discussions [#12614](https://github.com/danny-avila/LibreChat/discussions/12614), Issue [#12721](https://github.com/danny-avila/LibreChat/issues/12721) diagnosable).

The default console formatter discarded every structured metadata key on the winston `info` object — only `CONSOLE_JSON=true` preserved it. That meant failures emitted by the agents SDK (e.g. `Summarization LLM call failed`) reached stdout without provider, model, or underlying error attached, leaving users unable to diagnose the root cause.

### Before

```
info:  [agents:graph] Summarization triggered
error: [agents:summarize] Summarization LLM call failed
warn:  [agents:summarize] Summarization failed, falling back to metadata stub
info:  [agents:summarize] Summary persisted
```

### After

```
info:  [agents:graph] Summarization triggered
error: [agents:summarize] Summarization LLM call failed {"provider":"azureOpenAI","model":"gpt-5.4-mini","errorName":"NotFoundError","status":404,"messagesToRefineCount":18}
warn:  [agents:summarize] Summarization failed, falling back to metadata stub {"provider":"azureOpenAI","model":"gpt-5.4-mini",...}
info:  [agents:summarize] Summary persisted
```

### Changes

- `api/config/parsers.js`
  - New `formatConsoleMeta` helper serializes non-reserved metadata as a compact JSON trailer, with per-value string truncation (reusing `CONSOLE_JSON_STRING_LENGTH`) and safe handling of circular references.
  - `debugTraverse`'s debug-only gate relaxed so warn/error messages routed through the debug formatter also surface their metadata.
- `api/config/winston.js`
  - Default `consoleFormat` now appends `formatConsoleMeta(info)` on warn/error lines. Info/debug behavior is unchanged. Redaction on error is preserved.
- `api/test/__mocks__/logger.js` — add a `formatConsoleMeta` stub so tests that mock `~/config/parsers` keep working.
- `api/config/__tests__/parsers.spec.js` — new unit tests for `formatConsoleMeta` (6 tests, all pass).

## Pairs with

- Agents SDK PR: https://github.com/danny-avila/agents/pull/109 (folds provider/model/status into the summarization error message string so the info is visible even on formatters that drop metadata).

## Test plan

- [x] `npx jest config/__tests__/parsers.spec.js` — 6/6 pass.
- [x] Backwards compatibility: empty-metadata warn/error lines render exactly as before (no trailing ` `).
- [ ] Manual: run LibreChat with a deliberately wrong Azure deployment name for summarization; confirm error line now shows provider/model/status inline.
- [ ] Regression: confirm the summary success path still logs concisely (no metadata appended).
- [ ] Manual: set `CONSOLE_JSON=true` and confirm structured output is unchanged.