### PR TITLE
🗺️ fix: Resolve Custom-Endpoint Providers for Summarization

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -836,6 +836,7 @@ class AgentClient extends BaseClient {
           requestBody: config.configurable.requestBody,
           user: createSafeUser(this.options.req?.user),
           summarizationConfig: appConfig?.summarization,
+          appConfig,
           tokenCounter,
         });
 

--- a/api/server/controllers/agents/openai.js
+++ b/api/server/controllers/agents/openai.js
@@ -477,6 +477,7 @@ const OpenAIChatCompletionController = async (req, res) => {
       initialSummary,
       runId: responseId,
       summarizationConfig,
+      appConfig,
       signal: abortController.signal,
       customHandlers: handlers,
       requestBody: {

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -492,6 +492,7 @@ const createResponse = async (req, res) => {
         initialSummary,
         runId: responseId,
         summarizationConfig,
+        appConfig,
         signal: abortController.signal,
         customHandlers: handlers,
         requestBody: {
@@ -655,6 +656,7 @@ const createResponse = async (req, res) => {
         initialSummary,
         runId: responseId,
         summarizationConfig,
+        appConfig,
         signal: abortController.signal,
         customHandlers: handlers,
         requestBody: {

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -492,7 +492,7 @@ const createResponse = async (req, res) => {
         initialSummary,
         runId: responseId,
         summarizationConfig,
-        appConfig,
+        appConfig: req.config,
         signal: abortController.signal,
         customHandlers: handlers,
         requestBody: {
@@ -656,7 +656,7 @@ const createResponse = async (req, res) => {
         initialSummary,
         runId: responseId,
         summarizationConfig,
-        appConfig,
+        appConfig: req.config,
         signal: abortController.signal,
         customHandlers: handlers,
         requestBody: {

--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -41,17 +41,6 @@ const { loadAgentTools, loadToolsForExecution } = require('~/server/services/Too
 const { findAccessibleResources } = require('~/server/services/PermissionService');
 const db = require('~/models');
 
-/** @type {import('@librechat/api').AppConfig | null} */
-let appConfig = null;
-
-/**
- * Set the app config for the controller
- * @param {import('@librechat/api').AppConfig} config
- */
-function setAppConfig(config) {
-  appConfig = config;
-}
-
 /**
  * Creates a tool loader function for the agent.
  * @param {AbortSignal} signal - The abort signal
@@ -333,7 +322,7 @@ const createResponse = async (req, res) => {
 
     // Build allowed providers set
     const allowedProviders = new Set(
-      appConfig?.endpoints?.[EModelEndpoint.agents]?.allowedProviders,
+      req.config?.endpoints?.[EModelEndpoint.agents]?.allowedProviders,
     );
 
     // Create tool loader
@@ -941,5 +930,4 @@ module.exports = {
   createResponse,
   getResponse,
   listModels,
-  setAppConfig,
 };

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -1,6 +1,6 @@
 import type { AppConfig } from '@librechat/data-schemas';
-import type { SummarizationConfig } from 'librechat-data-provider';
-import { EModelEndpoint } from 'librechat-data-provider';
+import type { SummarizationConfig, TEndpoint } from 'librechat-data-provider';
+import { EModelEndpoint, FileSources } from 'librechat-data-provider';
 import { createRun } from '~/agents/run';
 
 // Mock winston logger
@@ -82,14 +82,27 @@ async function callAndCapture(
 }
 
 /** Minimal AppConfig with a single custom endpoint for testing provider resolution. */
-function makeAppConfig(
-  customEndpoints: Array<{ name: string; baseURL: string; apiKey: string }>,
-): AppConfig {
+type TestCustomEndpoint = Partial<TEndpoint> & {
+  name: string;
+  baseURL: string;
+  apiKey: string;
+};
+
+/**
+ * Minimal AppConfig fixture for testing. Only `endpoints` is read by
+ * `resolveSummarizationProvider`; other required AppConfig fields are
+ * filled with empty/default values so the shape matches without needing
+ * `as unknown as AppConfig`.
+ */
+function makeAppConfig(customEndpoints: TestCustomEndpoint[]): AppConfig {
   return {
+    config: {},
+    fileStrategy: FileSources.local,
+    imageOutputType: 'png',
     endpoints: {
       [EModelEndpoint.custom]: customEndpoints,
     },
-  } as unknown as AppConfig;
+  };
 }
 
 beforeEach(() => {
@@ -413,22 +426,25 @@ describe('custom-endpoint provider resolution', () => {
 
   it('extracts ${ENV_VAR} references in custom endpoint credentials', async () => {
     process.env.TEST_OLLAMA_KEY = 'resolved-key-value';
-    const appConfig = makeAppConfig([
-      {
-        name: 'Ollama',
-        baseURL: 'http://localhost:11434/v1',
-        apiKey: '${TEST_OLLAMA_KEY}',
-      },
-    ]);
-    const agents = await callAndCapture({
-      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
-      appConfig,
-    });
+    try {
+      const appConfig = makeAppConfig([
+        {
+          name: 'Ollama',
+          baseURL: 'http://localhost:11434/v1',
+          apiKey: '${TEST_OLLAMA_KEY}',
+        },
+      ]);
+      const agents = await callAndCapture({
+        summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+        appConfig,
+      });
 
-    const config = agents[0].summarizationConfig as Record<string, unknown>;
-    const parameters = config.parameters as Record<string, unknown>;
-    expect(parameters.apiKey).toBe('resolved-key-value');
-    delete process.env.TEST_OLLAMA_KEY;
+      const config = agents[0].summarizationConfig as Record<string, unknown>;
+      const parameters = config.parameters as Record<string, unknown>;
+      expect(parameters.apiKey).toBe('resolved-key-value');
+    } finally {
+      delete process.env.TEST_OLLAMA_KEY;
+    }
   });
 
   it('keeps raw provider when apiKey is marked user_provided', async () => {
@@ -520,7 +536,7 @@ describe('custom-endpoint provider resolution', () => {
         baseURL: 'http://localhost:11434/v1',
         apiKey: 'ollama-key',
         headers: { 'X-Custom-Header': 'value-123' },
-      } as unknown as { name: string; baseURL: string; apiKey: string },
+      },
     ]);
     const agents = await callAndCapture({
       summarizationConfig: { provider: 'Ollama', model: 'llama3' },
@@ -546,7 +562,7 @@ describe('custom-endpoint provider resolution', () => {
         baseURL: 'http://localhost:11434/v1',
         apiKey: 'ollama-key',
         headers: { Authorization: 'Bearer ${TEST_PORTKEY_KEY}' },
-      } as unknown as { name: string; baseURL: string; apiKey: string },
+      },
     ]);
     await callAndCapture({
       summarizationConfig: { provider: 'Ollama', model: 'llama3' },
@@ -645,6 +661,42 @@ describe('custom-endpoint provider resolution', () => {
     expect((parameters.configuration as Record<string, unknown>).baseURL).toBe(
       'https://api.together.ai/v1',
     );
+  });
+
+  it('deep-merges user configuration with endpoint-resolved configuration', async () => {
+    /**
+     * User-supplied `parameters.configuration.defaultQuery` must merge with —
+     * not replace — the resolved `configuration` (baseURL, defaultHeaders).
+     */
+    const appConfig = makeAppConfig([
+      {
+        name: 'Ollama',
+        baseURL: 'http://localhost:11434/v1',
+        apiKey: 'ollama-key',
+        headers: { 'X-Required-Header': 'keep-me' },
+      },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: {
+        provider: 'Ollama',
+        model: 'llama3',
+        parameters: {
+          configuration: { defaultQuery: { 'api-version': '2024-06-01' } },
+        } as unknown as SummarizationConfig['parameters'],
+      },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    const parameters = config.parameters as Record<string, unknown>;
+    const configuration = parameters.configuration as Record<string, unknown>;
+    /** Endpoint defaults preserved... */
+    expect(configuration.baseURL).toBe('http://localhost:11434/v1');
+    expect((configuration.defaultHeaders as Record<string, string>)['X-Required-Header']).toBe(
+      'keep-me',
+    );
+    /** ...alongside the user's additions. */
+    expect(configuration.defaultQuery).toEqual({ 'api-version': '2024-06-01' });
   });
 
   it('user-supplied summarization.parameters override endpoint defaults', async () => {

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -431,7 +431,7 @@ describe('custom-endpoint provider resolution', () => {
     delete process.env.TEST_OLLAMA_KEY;
   });
 
-  it('skips override when apiKey is marked user_provided', async () => {
+  it('keeps raw provider when apiKey is marked user_provided', async () => {
     const appConfig = makeAppConfig([
       { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'user_provided' },
     ]);
@@ -441,14 +441,17 @@ describe('custom-endpoint provider resolution', () => {
     });
 
     const config = agents[0].summarizationConfig as Record<string, unknown>;
-    // Provider still remapped to the SDK-recognized name...
-    expect(config.provider).toBe('openAI');
-    // ...but credentials are not forwarded (async user lookup not supported here;
-    // SDK's self-summarize path will reuse the agent's clientOptions).
+    /**
+     * Keep the raw name so the SDK raises "Unsupported LLM provider: Ollama"
+     * rather than silently remapping to `openAI` and routing summaries to the
+     * default backend. (User-provided creds cannot be resolved here — the
+     * async DB lookup is out of scope for this synchronous code path.)
+     */
+    expect(config.provider).toBe('Ollama');
     expect(config.parameters).toBeUndefined();
   });
 
-  it('skips override when env var reference cannot be resolved', async () => {
+  it('keeps raw provider when env var reference cannot be resolved', async () => {
     delete process.env.UNSET_TEST_KEY;
     const appConfig = makeAppConfig([
       {
@@ -463,11 +466,11 @@ describe('custom-endpoint provider resolution', () => {
     });
 
     const config = agents[0].summarizationConfig as Record<string, unknown>;
-    expect(config.provider).toBe('openAI');
+    expect(config.provider).toBe('Ollama');
     expect(config.parameters).toBeUndefined();
   });
 
-  it('skips override when partial env var reference (prefix/suffix) stays unresolved', async () => {
+  it('keeps raw provider when partial env var reference (prefix/suffix) stays unresolved', async () => {
     delete process.env.UNSET_TEST_SEGMENT;
     const appConfig = makeAppConfig([
       {
@@ -482,7 +485,7 @@ describe('custom-endpoint provider resolution', () => {
     });
 
     const config = agents[0].summarizationConfig as Record<string, unknown>;
-    expect(config.provider).toBe('openAI');
+    expect(config.provider).toBe('Ollama');
     /** Even though the baseURL is a partial-match pattern, it must not be forwarded. */
     expect(config.parameters).toBeUndefined();
   });

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -89,6 +89,16 @@ type TestCustomEndpoint = Partial<TEndpoint> & {
 };
 
 /**
+ * Shape of summarization parameters used in tests. The LibreChat config
+ * schema restricts yaml `parameters` to primitive values, but the SDK
+ * passes any record through as-is — tests need the wider shape to exercise
+ * cross-endpoint `configuration` merging.
+ */
+type TestSummarizationParameters = Record<string, unknown> & {
+  configuration?: Record<string, unknown>;
+};
+
+/**
  * Minimal AppConfig fixture for testing. Only `endpoints` is read by
  * `resolveSummarizationProvider`; other required AppConfig fields are
  * filled with empty/default values so the shape matches without needing
@@ -676,20 +686,21 @@ describe('custom-endpoint provider resolution', () => {
         headers: { 'X-Required-Header': 'keep-me' },
       },
     ]);
+    const parameters: TestSummarizationParameters = {
+      configuration: { defaultQuery: { 'api-version': '2024-06-01' } },
+    };
     const agents = await callAndCapture({
       summarizationConfig: {
         provider: 'Ollama',
         model: 'llama3',
-        parameters: {
-          configuration: { defaultQuery: { 'api-version': '2024-06-01' } },
-        } as unknown as SummarizationConfig['parameters'],
+        parameters: parameters as SummarizationConfig['parameters'],
       },
       appConfig,
     });
 
     const config = agents[0].summarizationConfig as Record<string, unknown>;
-    const parameters = config.parameters as Record<string, unknown>;
-    const configuration = parameters.configuration as Record<string, unknown>;
+    const resolvedParameters = config.parameters as Record<string, unknown>;
+    const configuration = resolvedParameters.configuration as Record<string, unknown>;
     /** Endpoint defaults preserved... */
     expect(configuration.baseURL).toBe('http://localhost:11434/v1');
     expect((configuration.defaultHeaders as Record<string, string>)['X-Required-Header']).toBe(
@@ -697,6 +708,33 @@ describe('custom-endpoint provider resolution', () => {
     );
     /** ...alongside the user's additions. */
     expect(configuration.defaultQuery).toEqual({ 'api-version': '2024-06-01' });
+  });
+
+  it('user-supplied configuration.baseURL overrides resolved baseURL', async () => {
+    /**
+     * Deep-merge still lets user keys win on conflict — if a user explicitly
+     * sets `configuration.baseURL` in their summarization parameters, it
+     * must override the baseURL resolved from the endpoint config.
+     */
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },
+    ]);
+    const parameters: TestSummarizationParameters = {
+      configuration: { baseURL: 'https://user-override.example.com/v1' },
+    };
+    const agents = await callAndCapture({
+      summarizationConfig: {
+        provider: 'Ollama',
+        model: 'llama3',
+        parameters: parameters as SummarizationConfig['parameters'],
+      },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    const resolvedParameters = config.parameters as Record<string, unknown>;
+    const configuration = resolvedParameters.configuration as Record<string, unknown>;
+    expect(configuration.baseURL).toBe('https://user-override.example.com/v1');
   });
 
   it('user-supplied summarization.parameters override endpoint defaults', async () => {

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -337,7 +337,7 @@ describe('custom-endpoint provider resolution', () => {
     });
   });
 
-  it('is case-insensitive when matching custom endpoint names', async () => {
+  it('matches Ollama case-insensitively (via normalizeEndpointName)', async () => {
     const appConfig = makeAppConfig([
       { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },
     ]);
@@ -349,6 +349,30 @@ describe('custom-endpoint provider resolution', () => {
     const config = agents[0].summarizationConfig as Record<string, unknown>;
     expect(config.provider).toBe('openAI');
     expect((config.parameters as Record<string, unknown>).apiKey).toBe('ollama-key');
+  });
+
+  it('resolves non-Ollama endpoints on exact-case match', async () => {
+    const appConfig = makeAppConfig([
+      { name: 'Together', baseURL: 'https://api.together.ai/v1', apiKey: 'together-key' },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'Together', model: 'mixtral' },
+      appConfig,
+    });
+    expect((agents[0].summarizationConfig as Record<string, unknown>).provider).toBe('openAI');
+  });
+
+  it('does not match non-Ollama endpoints with different casing', async () => {
+    const appConfig = makeAppConfig([
+      { name: 'Together', baseURL: 'https://api.together.ai/v1', apiKey: 'together-key' },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'together', model: 'mixtral' },
+      appConfig,
+    });
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.provider).toBe('together');
+    expect(config.parameters).toBeUndefined();
   });
 
   it('leaves known SDK providers untouched', async () => {
@@ -440,6 +464,26 @@ describe('custom-endpoint provider resolution', () => {
 
     const config = agents[0].summarizationConfig as Record<string, unknown>;
     expect(config.provider).toBe('openAI');
+    expect(config.parameters).toBeUndefined();
+  });
+
+  it('skips override when partial env var reference (prefix/suffix) stays unresolved', async () => {
+    delete process.env.UNSET_TEST_SEGMENT;
+    const appConfig = makeAppConfig([
+      {
+        name: 'Ollama',
+        baseURL: 'https://${UNSET_TEST_SEGMENT}.example.com/v1',
+        apiKey: 'ollama-key',
+      },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.provider).toBe('openAI');
+    /** Even though the baseURL is a partial-match pattern, it must not be forwarded. */
     expect(config.parameters).toBeUndefined();
   });
 

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -1,4 +1,6 @@
+import type { AppConfig } from '@librechat/data-schemas';
 import type { SummarizationConfig } from 'librechat-data-provider';
+import { EModelEndpoint } from 'librechat-data-provider';
 import { createRun } from '~/agents/run';
 
 // Mock winston logger
@@ -57,6 +59,7 @@ async function callAndCapture(
     agents?: ReturnType<typeof makeAgent>[];
     summarizationConfig?: SummarizationConfig;
     initialSummary?: { text: string; tokenCount: number };
+    appConfig?: AppConfig;
   } = {},
 ) {
   const agents = opts.agents ?? [makeAgent()];
@@ -67,6 +70,7 @@ async function callAndCapture(
     signal,
     summarizationConfig: opts.summarizationConfig,
     initialSummary: opts.initialSummary,
+    appConfig: opts.appConfig,
     streaming: true,
     streamUsage: true,
   });
@@ -75,6 +79,17 @@ async function callAndCapture(
   expect(createMock).toHaveBeenCalledTimes(1);
   const callArgs = createMock.mock.calls[0][0];
   return callArgs.graphConfig.agents as Array<Record<string, unknown>>;
+}
+
+/** Minimal AppConfig with a single custom endpoint for testing provider resolution. */
+function makeAppConfig(
+  customEndpoints: Array<{ name: string; baseURL: string; apiKey: string }>,
+): AppConfig {
+  return {
+    endpoints: {
+      [EModelEndpoint.custom]: customEndpoints,
+    },
+  } as unknown as AppConfig;
 }
 
 beforeEach(() => {
@@ -295,5 +310,158 @@ describe('initialSummary passthrough', () => {
   it('undefined when not provided', async () => {
     const agents = await callAndCapture({});
     expect(agents[0].initialSummary).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 7: custom-endpoint provider resolution
+// ---------------------------------------------------------------------------
+describe('custom-endpoint provider resolution', () => {
+  it('remaps a custom endpoint name to openAI and injects baseURL/apiKey', async () => {
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.provider).toBe('openAI');
+    expect(config.model).toBe('llama3');
+
+    const parameters = config.parameters as Record<string, unknown>;
+    expect(parameters).toMatchObject({
+      configuration: { baseURL: 'http://localhost:11434/v1' },
+      apiKey: 'ollama-key',
+    });
+  });
+
+  it('is case-insensitive when matching custom endpoint names', async () => {
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'ollama', model: 'llama3' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.provider).toBe('openAI');
+    expect((config.parameters as Record<string, unknown>).apiKey).toBe('ollama-key');
+  });
+
+  it('leaves known SDK providers untouched', async () => {
+    const appConfig = makeAppConfig([]);
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'anthropic', model: 'claude' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.provider).toBe('anthropic');
+    expect(config.parameters).toBeUndefined();
+  });
+
+  it('preserves unknown provider names when appConfig is missing', async () => {
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.provider).toBe('Ollama');
+    expect(config.parameters).toBeUndefined();
+  });
+
+  it('leaves unrecognized names untouched when no matching custom endpoint exists', async () => {
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'nonexistent', model: 'foo' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.provider).toBe('nonexistent');
+    expect(config.parameters).toBeUndefined();
+  });
+
+  it('extracts ${ENV_VAR} references in custom endpoint credentials', async () => {
+    process.env.TEST_OLLAMA_KEY = 'resolved-key-value';
+    const appConfig = makeAppConfig([
+      {
+        name: 'Ollama',
+        baseURL: 'http://localhost:11434/v1',
+        apiKey: '${TEST_OLLAMA_KEY}',
+      },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    const parameters = config.parameters as Record<string, unknown>;
+    expect(parameters.apiKey).toBe('resolved-key-value');
+    delete process.env.TEST_OLLAMA_KEY;
+  });
+
+  it('skips override when apiKey is marked user_provided', async () => {
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'user_provided' },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    // Provider still remapped to the SDK-recognized name...
+    expect(config.provider).toBe('openAI');
+    // ...but credentials are not forwarded (async user lookup not supported here;
+    // SDK's self-summarize path will reuse the agent's clientOptions).
+    expect(config.parameters).toBeUndefined();
+  });
+
+  it('skips override when env var reference cannot be resolved', async () => {
+    delete process.env.UNSET_TEST_KEY;
+    const appConfig = makeAppConfig([
+      {
+        name: 'Ollama',
+        baseURL: 'http://localhost:11434/v1',
+        apiKey: '${UNSET_TEST_KEY}',
+      },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.provider).toBe('openAI');
+    expect(config.parameters).toBeUndefined();
+  });
+
+  it('merges overrides alongside user-supplied parameters', async () => {
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: {
+        provider: 'Ollama',
+        model: 'llama3',
+        parameters: { temperature: 0.2 },
+      },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    const parameters = config.parameters as Record<string, unknown>;
+    expect(parameters).toMatchObject({
+      temperature: 0.2,
+      configuration: { baseURL: 'http://localhost:11434/v1' },
+      apiKey: 'ollama-key',
+    });
   });
 });

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -534,6 +534,64 @@ describe('custom-endpoint provider resolution', () => {
     expect(defaultHeaders['X-Custom-Header']).toBe('value-123');
   });
 
+  it('runs custom-endpoint headers through resolveHeaders (not forwarded raw)', async () => {
+    const { resolveHeaders } = jest.requireMock('~/utils/env') as {
+      resolveHeaders: jest.Mock;
+    };
+    resolveHeaders.mockClear();
+
+    const appConfig = makeAppConfig([
+      {
+        name: 'Ollama',
+        baseURL: 'http://localhost:11434/v1',
+        apiKey: 'ollama-key',
+        headers: { Authorization: 'Bearer ${TEST_PORTKEY_KEY}' },
+      } as unknown as { name: string; baseURL: string; apiKey: string },
+    ]);
+    await callAndCapture({
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+      appConfig,
+    });
+
+    /**
+     * Templated header values must go through the same `resolveHeaders`
+     * pipeline the main agent flow uses, so `${VAR}`/`{{BODY_FIELD}}`
+     * references don't get forwarded verbatim to the summarization backend.
+     */
+    const call = resolveHeaders.mock.calls.find(
+      (args: unknown[]) =>
+        (args[0] as { headers?: Record<string, string> }).headers?.Authorization ===
+        'Bearer ${TEST_PORTKEY_KEY}',
+    );
+    expect(call).toBeDefined();
+  });
+
+  it('forwards PROXY env var into summarization client configuration', async () => {
+    const originalProxy = process.env.PROXY;
+    process.env.PROXY = 'http://proxy.internal:3128';
+    try {
+      const appConfig = makeAppConfig([
+        { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },
+      ]);
+      const agents = await callAndCapture({
+        summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+        appConfig,
+      });
+
+      const config = agents[0].summarizationConfig as Record<string, unknown>;
+      const parameters = config.parameters as Record<string, unknown>;
+      const configuration = parameters.configuration as Record<string, unknown>;
+      /** getOpenAIConfig wires proxy through to fetchOptions.dispatcher (undici ProxyAgent). */
+      expect(configuration.fetchOptions).toBeDefined();
+    } finally {
+      if (originalProxy === undefined) {
+        delete process.env.PROXY;
+      } else {
+        process.env.PROXY = originalProxy;
+      }
+    }
+  });
+
   it('skips overrides when summarization targets the same endpoint as the agent', async () => {
     /**
      * When summarization provider matches the agent's endpoint, we rely on

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -504,8 +504,47 @@ describe('custom-endpoint provider resolution', () => {
     const parameters = config.parameters as Record<string, unknown>;
     expect(parameters).toMatchObject({
       temperature: 0.2,
-      configuration: { baseURL: 'http://localhost:11434/v1' },
       apiKey: 'ollama-key',
     });
+    const configuration = parameters.configuration as Record<string, unknown>;
+    expect(configuration.baseURL).toBe('http://localhost:11434/v1');
+  });
+
+  it('forwards custom-endpoint headers as configuration.defaultHeaders', async () => {
+    const appConfig = makeAppConfig([
+      {
+        name: 'Ollama',
+        baseURL: 'http://localhost:11434/v1',
+        apiKey: 'ollama-key',
+        headers: { 'X-Custom-Header': 'value-123' },
+      } as unknown as { name: string; baseURL: string; apiKey: string },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    const parameters = config.parameters as Record<string, unknown>;
+    const configuration = parameters.configuration as Record<string, unknown>;
+    const defaultHeaders = configuration.defaultHeaders as Record<string, string>;
+    expect(defaultHeaders['X-Custom-Header']).toBe('value-123');
+  });
+
+  it('does not leak model/modelName from getOpenAIConfig defaults', async () => {
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.model).toBe('llama3');
+    const parameters = config.parameters as Record<string, unknown>;
+    /** Summarization.model must win — parameters must not carry a stale model/modelName. */
+    expect(parameters.model).toBeUndefined();
+    expect(parameters.modelName).toBeUndefined();
   });
 });

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -531,6 +531,61 @@ describe('custom-endpoint provider resolution', () => {
     expect(defaultHeaders['X-Custom-Header']).toBe('value-123');
   });
 
+  it('skips overrides when summarization targets the same endpoint as the agent', async () => {
+    /**
+     * When summarization provider matches the agent's endpoint, we rely on
+     * the SDK's self-summarize path (which reuses agentContext.clientOptions).
+     * Overriding here would shallow-replace the agent's resolved configuration
+     * (dynamic headers, proxy/fetch options) with yaml-only config.
+     */
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },
+    ]);
+    const agents = await callAndCapture({
+      agents: [makeAgent({ provider: 'openAI', endpoint: 'Ollama' })],
+      summarizationConfig: { provider: 'Ollama', model: 'llama3' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.provider).toBe('openAI');
+    /** No overrides injected — SDK will pull from agentContext.clientOptions. */
+    expect(config.parameters).toBeUndefined();
+  });
+
+  it('skips overrides when endpoints differ only by case for Ollama', async () => {
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },
+    ]);
+    const agents = await callAndCapture({
+      agents: [makeAgent({ provider: 'openAI', endpoint: 'Ollama' })],
+      summarizationConfig: { provider: 'ollama', model: 'llama3' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    expect(config.parameters).toBeUndefined();
+  });
+
+  it('applies overrides when summarization targets a different endpoint than the agent', async () => {
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },
+      { name: 'Together', baseURL: 'https://api.together.ai/v1', apiKey: 'together-key' },
+    ]);
+    const agents = await callAndCapture({
+      agents: [makeAgent({ provider: 'openAI', endpoint: 'Ollama' })],
+      summarizationConfig: { provider: 'Together', model: 'mixtral' },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    const parameters = config.parameters as Record<string, unknown>;
+    expect(parameters.apiKey).toBe('together-key');
+    expect((parameters.configuration as Record<string, unknown>).baseURL).toBe(
+      'https://api.together.ai/v1',
+    );
+  });
+
   it('does not leak model/modelName from getOpenAIConfig defaults', async () => {
     const appConfig = makeAppConfig([
       { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -647,6 +647,32 @@ describe('custom-endpoint provider resolution', () => {
     );
   });
 
+  it('user-supplied summarization.parameters override endpoint defaults', async () => {
+    /**
+     * `getOpenAIConfig` defaults `streaming: true`, but a user who sets
+     * `summarization.parameters.streaming: false` in their config has
+     * explicitly opted out; the user's setting must win over endpoint
+     * defaults injected from the custom endpoint config.
+     */
+    const appConfig = makeAppConfig([
+      { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },
+    ]);
+    const agents = await callAndCapture({
+      summarizationConfig: {
+        provider: 'Ollama',
+        model: 'llama3',
+        parameters: { streaming: false },
+      },
+      appConfig,
+    });
+
+    const config = agents[0].summarizationConfig as Record<string, unknown>;
+    const parameters = config.parameters as Record<string, unknown>;
+    expect(parameters.streaming).toBe(false);
+    /** Endpoint defaults still injected for the rest. */
+    expect(parameters.apiKey).toBe('ollama-key');
+  });
+
   it('does not leak model/modelName from getOpenAIConfig defaults', async () => {
     const appConfig = makeAppConfig([
       { name: 'Ollama', baseURL: 'http://localhost:11434/v1', apiKey: 'ollama-key' },

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -196,6 +196,17 @@ function hasUnresolvedPlaceholder(value: string): boolean {
   return UNRESOLVED_ENV_VAR_PLACEHOLDER.test(value);
 }
 
+/**
+ * Lightweight endpoint-name normalizer for comparing summarization-provider
+ * strings against the agent's endpoint. Mirrors `normalizeEndpointName` in
+ * `librechat-data-provider` (only Ollama is special-cased to be
+ * case-insensitive), so an agent on `"Ollama"` and summarization on `"ollama"`
+ * are treated as the same endpoint.
+ */
+function normalizedEndpointName(name: string): string {
+  return name.toLowerCase() === 'ollama' ? 'ollama' : name;
+}
+
 /** Client-option overrides for summarization models targeting custom endpoints. */
 type SummarizationClientOverrides = Record<string, unknown>;
 
@@ -300,9 +311,25 @@ function shapeSummarizationConfig(
   fallbackProvider: string,
   fallbackModel: string | undefined,
   appConfig: AppConfig | undefined,
+  agentEndpoint: string | undefined,
 ) {
   const rawProvider = config?.provider ?? fallbackProvider;
-  const { provider, clientOverrides } = resolveSummarizationProvider(rawProvider, appConfig);
+  /**
+   * When the summarization provider resolves to the same custom endpoint as
+   * the main agent, skip client-option overrides. The SDK's self-summarize
+   * path will reuse `agentContext.clientOptions` as-is, preserving any
+   * request-resolved dynamic headers, fetch/proxy options, and other state
+   * that `getOpenAIConfig` produced from raw yaml config does not capture.
+   */
+  const isSameEndpointAsAgent =
+    agentEndpoint != null &&
+    isNonEmptyString(rawProvider) &&
+    normalizedEndpointName(rawProvider) === normalizedEndpointName(agentEndpoint);
+
+  const { provider, clientOverrides } = isSameEndpointAsAgent
+    ? { provider: fallbackProvider, clientOverrides: undefined }
+    : resolveSummarizationProvider(rawProvider, appConfig);
+
   const model = config?.model ?? fallbackModel;
   const trigger =
     config?.trigger?.type && config?.trigger?.value
@@ -310,10 +337,11 @@ function shapeSummarizationConfig(
       : undefined;
 
   /**
-   * Custom-endpoint overrides (baseURL/apiKey) are merged into `parameters` so
-   * that the SDK's `buildSummarizationClientConfig` spreads them onto the
-   * summarization client options. This is required when summarization targets
-   * a different custom endpoint than the main agent.
+   * Custom-endpoint overrides are merged into `parameters` so the SDK's
+   * `buildSummarizationClientConfig` spreads them onto the summarization
+   * client options. Only applied when summarization targets a *different*
+   * custom endpoint than the main agent; the same-endpoint case leaves
+   * `parameters` untouched so `agentContext.clientOptions` wins.
    */
   const parameters =
     clientOverrides != null
@@ -438,6 +466,7 @@ export async function createRun({
       provider as string,
       selfModel,
       appConfig,
+      agent.endpoint ?? undefined,
     );
 
     const llmConfig: t.RunLLMConfig = Object.assign(

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1,5 +1,10 @@
 import { Run, Providers, Constants } from '@librechat/agents';
-import { KnownEndpoints, extractEnvVariable, providerEndpointMap } from 'librechat-data-provider';
+import {
+  KnownEndpoints,
+  extractEnvVariable,
+  providerEndpointMap,
+  normalizeEndpointName,
+} from 'librechat-data-provider';
 import type {
   SummarizationConfig as AgentSummarizationConfig,
   MultiAgentGraphConfig,
@@ -13,6 +18,7 @@ import type {
   IState,
   LCTool,
 } from '@librechat/agents';
+import { logger } from '@librechat/data-schemas';
 import type { Agent, SummarizationConfig } from 'librechat-data-provider';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { AppConfig, IUser } from '@librechat/data-schemas';
@@ -191,24 +197,43 @@ function isNonEmptyString(value: unknown): value is string {
 
 const UNRESOLVED_ENV_VAR_PLACEHOLDER = /\$\{[^}]+\}/;
 
-/** True if the string still contains a `${VAR}` placeholder after env extraction. */
 function hasUnresolvedPlaceholder(value: string): boolean {
   return UNRESOLVED_ENV_VAR_PLACEHOLDER.test(value);
 }
 
-/**
- * Lightweight endpoint-name normalizer for comparing summarization-provider
- * strings against the agent's endpoint. Mirrors `normalizeEndpointName` in
- * `librechat-data-provider` (only Ollama is special-cased to be
- * case-insensitive), so an agent on `"Ollama"` and summarization on `"ollama"`
- * are treated as the same endpoint.
- */
-function normalizedEndpointName(name: string): string {
-  return name.toLowerCase() === 'ollama' ? 'ollama' : name;
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
 }
 
-/** Client-option overrides for summarization models targeting custom endpoints. */
-type SummarizationClientOverrides = Record<string, unknown>;
+/**
+ * Merges user-supplied summarization parameters on top of endpoint-resolved
+ * overrides. User params win for top-level keys; `configuration` is
+ * deep-merged so user additions (e.g. `defaultQuery`) don't wipe out the
+ * resolved `baseURL`/`defaultHeaders`/`fetchOptions`.
+ */
+function mergeParameters(
+  overrides: SummarizationClientOverrides,
+  userParams: SummarizationConfig['parameters'],
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...overrides, ...(userParams ?? {}) };
+  const userConfiguration = (userParams as Record<string, unknown> | undefined)?.configuration;
+  if (isPlainObject(overrides.configuration) && isPlainObject(userConfiguration)) {
+    merged.configuration = { ...overrides.configuration, ...userConfiguration };
+  }
+  return merged;
+}
+
+/**
+ * Mirrors `getOpenAIConfig`'s `llmConfig` shape (plus its `configOptions`
+ * assigned to `configuration`). Index signature covers fields that the
+ * helper emits dynamically per provider variant.
+ */
+interface SummarizationClientOverrides {
+  apiKey?: string;
+  streaming?: boolean;
+  configuration?: t.OpenAIConfiguration;
+  [key: string]: unknown;
+}
 
 /**
  * Resolves a summarization provider string (which may be a custom-endpoint name
@@ -320,7 +345,11 @@ function resolveSummarizationProvider(
       provider: overrideProvider,
       clientOverrides,
     };
-  } catch {
+  } catch (error) {
+    logger.warn(
+      `[resolveSummarizationProvider] failed to resolve "${rawProvider}"; falling back to raw provider`,
+      error,
+    );
     return { provider: rawProvider };
   }
 }
@@ -345,7 +374,7 @@ function shapeSummarizationConfig(
   const isSameEndpointAsAgent =
     agentEndpoint != null &&
     isNonEmptyString(rawProvider) &&
-    normalizedEndpointName(rawProvider) === normalizedEndpointName(agentEndpoint);
+    normalizeEndpointName(rawProvider) === normalizeEndpointName(agentEndpoint);
 
   const { provider, clientOverrides } = isSameEndpointAsAgent
     ? { provider: fallbackProvider, clientOverrides: undefined }
@@ -367,14 +396,13 @@ function shapeSummarizationConfig(
    * Order matters: `clientOverrides` supplies endpoint defaults (baseURL,
    * apiKey, headers, transforms), then explicit user `summarization.parameters`
    * are spread on top so settings like `streaming: false` still win over
-   * `getOpenAIConfig`'s defaults.
+   * `getOpenAIConfig`'s defaults. `configuration` is deep-merged so a user
+   * adding e.g. `configuration.defaultQuery` keeps the resolved `baseURL`
+   * and `defaultHeaders` rather than replacing the whole object.
    */
   const parameters =
     clientOverrides != null
-      ? {
-          ...clientOverrides,
-          ...(config?.parameters ?? {}),
-        }
+      ? mergeParameters(clientOverrides, config?.parameters)
       : config?.parameters;
 
   return {

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -18,6 +18,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { AppConfig, IUser } from '@librechat/data-schemas';
 import type * as t from '~/types';
 import { getProviderConfig } from '~/endpoints/config/providers';
+import { getOpenAIConfig } from '~/endpoints/openai/config';
 import { resolveHeaders, createSafeUser } from '~/utils/env';
 import { isUserProvided } from '~/utils/common';
 
@@ -196,14 +197,11 @@ function hasUnresolvedPlaceholder(value: string): boolean {
 }
 
 /** Client-option overrides for summarization models targeting custom endpoints. */
-interface SummarizationClientOverrides {
-  configuration?: { baseURL: string };
-  apiKey?: string;
-}
+type SummarizationClientOverrides = Record<string, unknown>;
 
 /**
  * Resolves a summarization provider string (which may be a custom-endpoint name
- * like "Ollama") into the SDK-recognized provider and any baseURL/apiKey
+ * like "Ollama") into the SDK-recognized provider and any client-option
  * overrides required to talk to that endpoint.
  *
  * Without this step, a `summarization.provider: "Ollama"` entry in
@@ -254,12 +252,42 @@ function resolveSummarizationProvider(
     ) {
       return { provider: overrideProvider };
     }
+    /**
+     * Run the endpoint config through `getOpenAIConfig` so summarization
+     * inherits the same `headers`, `defaultQuery`, `addParams`/`dropParams`,
+     * and `customParams` transforms that `initializeCustom` applies for the
+     * main agent flow. Without this, summarization drops endpoint-specific
+     * behavior (e.g. Anthropic/Google param transforms, required headers)
+     * that the main agent relied on.
+     */
+    const { llmConfig, configOptions } = getOpenAIConfig(
+      apiKey,
+      {
+        reverseProxyUrl: baseURL,
+        headers: customEndpointConfig.headers,
+        addParams: customEndpointConfig.addParams,
+        dropParams: customEndpointConfig.dropParams,
+        customParams: customEndpointConfig.customParams,
+        directEndpoint: customEndpointConfig.directEndpoint,
+      },
+      rawProvider,
+    );
+    const clientOverrides: SummarizationClientOverrides = {
+      ...llmConfig,
+    };
+    if (configOptions) {
+      clientOverrides.configuration = configOptions;
+    }
+    /**
+     * `model`/`modelName` on `llmConfig` default to whatever `getOpenAIConfig`
+     * produces from empty modelOptions. Strip them so the user-supplied
+     * `summarization.model` wins.
+     */
+    delete clientOverrides.model;
+    delete clientOverrides.modelName;
     return {
       provider: overrideProvider,
-      clientOverrides: {
-        configuration: { baseURL },
-        apiKey,
-      },
+      clientOverrides,
     };
   } catch {
     return { provider: rawProvider };

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -222,6 +222,7 @@ type SummarizationClientOverrides = Record<string, unknown>;
 function resolveSummarizationProvider(
   rawProvider: string,
   appConfig: AppConfig | undefined,
+  headerContext: { user?: IUser; requestBody?: t.RequestBody },
 ): {
   provider: string;
   clientOverrides?: SummarizationClientOverrides;
@@ -267,18 +268,34 @@ function resolveSummarizationProvider(
       return { provider: rawProvider };
     }
     /**
+     * Resolve templated header values (e.g. `${PORTKEY_API_KEY}`,
+     * `{{LIBRECHAT_BODY_PARENTMESSAGEID}}`) before handing them to
+     * `getOpenAIConfig`, matching the agent main flow where `resolveHeaders`
+     * runs on `llmConfig.configuration.defaultHeaders`.
+     */
+    const resolvedHeaders =
+      customEndpointConfig.headers != null
+        ? resolveHeaders({
+            headers: customEndpointConfig.headers as Record<string, string>,
+            user: createSafeUser(headerContext.user),
+            body: headerContext.requestBody,
+          })
+        : undefined;
+    /**
      * Run the endpoint config through `getOpenAIConfig` so summarization
      * inherits the same `headers`, `defaultQuery`, `addParams`/`dropParams`,
      * and `customParams` transforms that `initializeCustom` applies for the
      * main agent flow. Without this, summarization drops endpoint-specific
      * behavior (e.g. Anthropic/Google param transforms, required headers)
-     * that the main agent relied on.
+     * that the main agent relied on. `proxy` is forwarded so outbound proxy
+     * dispatchers (`PROXY` env var) apply to cross-endpoint summarization.
      */
     const { llmConfig, configOptions } = getOpenAIConfig(
       apiKey,
       {
         reverseProxyUrl: baseURL,
-        headers: customEndpointConfig.headers,
+        proxy: process.env.PROXY ?? null,
+        headers: resolvedHeaders,
         addParams: customEndpointConfig.addParams,
         dropParams: customEndpointConfig.dropParams,
         customParams: customEndpointConfig.customParams,
@@ -315,6 +332,7 @@ function shapeSummarizationConfig(
   fallbackModel: string | undefined,
   appConfig: AppConfig | undefined,
   agentEndpoint: string | undefined,
+  headerContext: { user?: IUser; requestBody?: t.RequestBody },
 ) {
   const rawProvider = config?.provider ?? fallbackProvider;
   /**
@@ -331,7 +349,7 @@ function shapeSummarizationConfig(
 
   const { provider, clientOverrides } = isSameEndpointAsAgent
     ? { provider: fallbackProvider, clientOverrides: undefined }
-    : resolveSummarizationProvider(rawProvider, appConfig);
+    : resolveSummarizationProvider(rawProvider, appConfig, headerContext);
 
   const model = config?.model ?? fallbackModel;
   const trigger =
@@ -470,6 +488,7 @@ export async function createRun({
       selfModel,
       appConfig,
       agent.endpoint ?? undefined,
+      { user, requestBody },
     );
 
     const llmConfig: t.RunLLMConfig = Object.assign(

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1,10 +1,5 @@
 import { Run, Providers, Constants } from '@librechat/agents';
-import {
-  envVarRegex,
-  KnownEndpoints,
-  extractEnvVariable,
-  providerEndpointMap,
-} from 'librechat-data-provider';
+import { KnownEndpoints, extractEnvVariable, providerEndpointMap } from 'librechat-data-provider';
 import type {
   SummarizationConfig as AgentSummarizationConfig,
   MultiAgentGraphConfig,
@@ -193,6 +188,13 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+const UNRESOLVED_ENV_VAR_PLACEHOLDER = /\$\{[^}]+\}/;
+
+/** True if the string still contains a `${VAR}` placeholder after env extraction. */
+function hasUnresolvedPlaceholder(value: string): boolean {
+  return UNRESOLVED_ENV_VAR_PLACEHOLDER.test(value);
+}
+
 /** Client-option overrides for summarization models targeting custom endpoints. */
 interface SummarizationClientOverrides {
   configuration?: { baseURL: string };
@@ -238,7 +240,18 @@ function resolveSummarizationProvider(
     }
     const apiKey = extractEnvVariable(rawApiKey);
     const baseURL = extractEnvVariable(rawBaseURL);
-    if (!apiKey || !baseURL || apiKey.match(envVarRegex) || baseURL.match(envVarRegex)) {
+    /**
+     * `extractEnvVariable` leaves any unresolved `${VAR}` placeholder in place
+     * — including in the middle of a prefix/suffix string — when the env var
+     * is missing. Reject overrides whenever either value still contains any
+     * unresolved placeholder so the SDK doesn't receive a broken URL/key.
+     */
+    if (
+      !apiKey ||
+      !baseURL ||
+      hasUnresolvedPlaceholder(apiKey) ||
+      hasUnresolvedPlaceholder(baseURL)
+    ) {
       return { provider: overrideProvider };
     }
     return {

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -363,12 +363,17 @@ function shapeSummarizationConfig(
    * client options. Only applied when summarization targets a *different*
    * custom endpoint than the main agent; the same-endpoint case leaves
    * `parameters` untouched so `agentContext.clientOptions` wins.
+   *
+   * Order matters: `clientOverrides` supplies endpoint defaults (baseURL,
+   * apiKey, headers, transforms), then explicit user `summarization.parameters`
+   * are spread on top so settings like `streaming: false` still win over
+   * `getOpenAIConfig`'s defaults.
    */
   const parameters =
     clientOverrides != null
       ? {
-          ...(config?.parameters ?? {}),
           ...clientOverrides,
+          ...(config?.parameters ?? {}),
         }
       : config?.parameters;
 

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1,3 +1,4 @@
+import { logger } from '@librechat/data-schemas';
 import { Run, Providers, Constants } from '@librechat/agents';
 import {
   KnownEndpoints,
@@ -18,7 +19,6 @@ import type {
   IState,
   LCTool,
 } from '@librechat/agents';
-import { logger } from '@librechat/data-schemas';
 import type { Agent, SummarizationConfig } from 'librechat-data-provider';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { AppConfig, IUser } from '@librechat/data-schemas';

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -1,5 +1,10 @@
 import { Run, Providers, Constants } from '@librechat/agents';
-import { providerEndpointMap, KnownEndpoints } from 'librechat-data-provider';
+import {
+  envVarRegex,
+  KnownEndpoints,
+  extractEnvVariable,
+  providerEndpointMap,
+} from 'librechat-data-provider';
 import type {
   SummarizationConfig as AgentSummarizationConfig,
   MultiAgentGraphConfig,
@@ -15,9 +20,11 @@ import type {
 } from '@librechat/agents';
 import type { Agent, SummarizationConfig } from 'librechat-data-provider';
 import type { BaseMessage } from '@langchain/core/messages';
-import type { IUser } from '@librechat/data-schemas';
+import type { AppConfig, IUser } from '@librechat/data-schemas';
 import type * as t from '~/types';
+import { getProviderConfig } from '~/endpoints/config/providers';
 import { resolveHeaders, createSafeUser } from '~/utils/env';
+import { isUserProvided } from '~/utils/common';
 
 /** Expected shape of JSON tool search results */
 interface ToolSearchJsonResult {
@@ -186,18 +193,94 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+/** Client-option overrides for summarization models targeting custom endpoints. */
+interface SummarizationClientOverrides {
+  configuration?: { baseURL: string };
+  apiKey?: string;
+}
+
+/**
+ * Resolves a summarization provider string (which may be a custom-endpoint name
+ * like "Ollama") into the SDK-recognized provider and any baseURL/apiKey
+ * overrides required to talk to that endpoint.
+ *
+ * Without this step, a `summarization.provider: "Ollama"` entry in
+ * `librechat.yaml` flows verbatim to the agents SDK, which only knows a fixed
+ * set of provider names and throws "Unsupported LLM provider: Ollama".
+ */
+function resolveSummarizationProvider(
+  rawProvider: string,
+  appConfig: AppConfig | undefined,
+): {
+  provider: string;
+  clientOverrides?: SummarizationClientOverrides;
+} {
+  if (!appConfig || !isNonEmptyString(rawProvider)) {
+    return { provider: rawProvider };
+  }
+  try {
+    const { overrideProvider, customEndpointConfig } = getProviderConfig({
+      provider: rawProvider,
+      appConfig,
+    });
+    if (!customEndpointConfig) {
+      return { provider: overrideProvider };
+    }
+    const rawApiKey = customEndpointConfig.apiKey ?? '';
+    const rawBaseURL = customEndpointConfig.baseURL ?? '';
+    /**
+     * User-provided credentials require an async DB lookup and expiry checks
+     * that are out of scope here. Fall back to the remapped provider and let
+     * the SDK's self-summarize path reuse the agent's own client options.
+     */
+    if (isUserProvided(rawApiKey) || isUserProvided(rawBaseURL)) {
+      return { provider: overrideProvider };
+    }
+    const apiKey = extractEnvVariable(rawApiKey);
+    const baseURL = extractEnvVariable(rawBaseURL);
+    if (!apiKey || !baseURL || apiKey.match(envVarRegex) || baseURL.match(envVarRegex)) {
+      return { provider: overrideProvider };
+    }
+    return {
+      provider: overrideProvider,
+      clientOverrides: {
+        configuration: { baseURL },
+        apiKey,
+      },
+    };
+  } catch {
+    return { provider: rawProvider };
+  }
+}
+
 /** Shapes a SummarizationConfig into the format expected by AgentInputs. */
 function shapeSummarizationConfig(
   config: SummarizationConfig | undefined,
   fallbackProvider: string,
   fallbackModel: string | undefined,
+  appConfig: AppConfig | undefined,
 ) {
-  const provider = config?.provider ?? fallbackProvider;
+  const rawProvider = config?.provider ?? fallbackProvider;
+  const { provider, clientOverrides } = resolveSummarizationProvider(rawProvider, appConfig);
   const model = config?.model ?? fallbackModel;
   const trigger =
     config?.trigger?.type && config?.trigger?.value
       ? { type: config.trigger.type, value: config.trigger.value }
       : undefined;
+
+  /**
+   * Custom-endpoint overrides (baseURL/apiKey) are merged into `parameters` so
+   * that the SDK's `buildSummarizationClientConfig` spreads them onto the
+   * summarization client options. This is required when summarization targets
+   * a different custom endpoint than the main agent.
+   */
+  const parameters =
+    clientOverrides != null
+      ? {
+          ...(config?.parameters ?? {}),
+          ...clientOverrides,
+        }
+      : config?.parameters;
 
   return {
     enabled: config?.enabled !== false && isNonEmptyString(provider) && isNonEmptyString(model),
@@ -205,7 +288,7 @@ function shapeSummarizationConfig(
       trigger,
       provider,
       model,
-      parameters: config?.parameters,
+      parameters,
       prompt: config?.prompt,
       updatePrompt: config?.updatePrompt,
       reserveRatio: config?.reserveRatio,
@@ -260,6 +343,7 @@ export async function createRun({
   summarizationConfig,
   initialSummary,
   calibrationRatio,
+  appConfig,
   streaming = true,
   streamUsage = true,
 }: {
@@ -277,6 +361,11 @@ export async function createRun({
   initialSummary?: { text: string; tokenCount: number };
   /** Calibration ratio from previous run's contextMeta, seeds the pruner EMA */
   calibrationRatio?: number;
+  /**
+   * Resolved app config. Used to translate custom-endpoint provider names
+   * (e.g. "Ollama") in the summarization config to SDK-recognized providers.
+   */
+  appConfig?: AppConfig;
 } & Pick<RunConfig, 'tokenCounter' | 'customHandlers' | 'indexTokenCountMap'>): Promise<
   Run<IState>
 > {
@@ -307,6 +396,7 @@ export async function createRun({
       agent.summarization ?? summarizationConfig,
       provider as string,
       selfModel,
+      appConfig,
     );
 
     const llmConfig: t.RunLLMConfig = Object.assign(

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -241,19 +241,22 @@ function resolveSummarizationProvider(
     const rawBaseURL = customEndpointConfig.baseURL ?? '';
     /**
      * User-provided credentials require an async DB lookup and expiry checks
-     * that are out of scope here. Fall back to the remapped provider and let
-     * the SDK's self-summarize path reuse the agent's own client options.
+     * that are out of scope here. Keep the raw provider so the SDK surfaces
+     * a clear "Unsupported LLM provider" error rather than silently
+     * remapping to `openAI` and routing summaries to the default backend.
+     * Callers wanting user-provided summarization against a non-agent
+     * endpoint must hit the same endpoint as the agent (handled upstream).
      */
     if (isUserProvided(rawApiKey) || isUserProvided(rawBaseURL)) {
-      return { provider: overrideProvider };
+      return { provider: rawProvider };
     }
     const apiKey = extractEnvVariable(rawApiKey);
     const baseURL = extractEnvVariable(rawBaseURL);
     /**
      * `extractEnvVariable` leaves any unresolved `${VAR}` placeholder in place
      * — including in the middle of a prefix/suffix string — when the env var
-     * is missing. Reject overrides whenever either value still contains any
-     * unresolved placeholder so the SDK doesn't receive a broken URL/key.
+     * is missing. If the value is still broken, keep the raw provider so the
+     * SDK errors out loudly instead of forwarding a malformed URL/key.
      */
     if (
       !apiKey ||
@@ -261,7 +264,7 @@ function resolveSummarizationProvider(
       hasUnresolvedPlaceholder(apiKey) ||
       hasUnresolvedPlaceholder(baseURL)
     ) {
-      return { provider: overrideProvider };
+      return { provider: rawProvider };
     }
     /**
      * Run the endpoint config through `getOpenAIConfig` so summarization


### PR DESCRIPTION
## Summary

Fix for [Discussion #12614](https://github.com/danny-avila/LibreChat/discussions/12614): when `summarization.provider` in `librechat.yaml` is set to a custom-endpoint name (e.g. `Ollama`), the string was passed verbatim to the agents SDK, which only knows a fixed set of provider names and threw `Unsupported LLM provider: Ollama`.

Before shaping the summarization config for the SDK, the new `resolveSummarizationProvider` helper runs the provider through `getProviderConfig`:

- **Custom-endpoint labels** are remapped to the underlying SDK provider (e.g. `openAI`) and the endpoint's `baseURL`/`apiKey` are injected into `parameters` so the summarization model reaches the right backend — even when summarization targets a different custom endpoint than the main agent.
- **Known SDK providers** (`anthropic`, `openAI`, etc.) flow through unchanged.
- **Unknown names** with no matching endpoint flow through unchanged so the SDK can surface a clear error.
- **User-provided credentials** and **unresolved env-var references** are skipped rather than forwarded, letting the SDK's self-summarize path reuse the agent's own `clientOptions`.

The companion PR in the agents SDK ([agents#110](https://github.com/danny-avila/agents/pull/110)) wraps `initializeModel` in the existing try/catch so any remaining misconfigurations surface through `log('error', ...)` instead of bubbling up silently — also resolving [Discussion #12733](https://github.com/danny-avila/LibreChat/discussions/12733).

## Test plan
- [x] `npx jest packages/api/src/agents/__tests__/run-summarization.test.ts` — 26 tests pass (17 existing + 9 new).
- [x] New tests cover: custom-endpoint remap + baseURL/apiKey injection, case-insensitive matching, known-provider passthrough, missing-appConfig fallback, unknown-name passthrough, env-var extraction, user-provided skip, unresolved env-var skip, and parameter merge.
- [x] Full agents test suite: 396 pass, 2 pre-existing e2e failures unrelated to this change.
- [x] `tsc --noEmit` and `eslint` clean on modified files.