### PR TITLE
fix: retry OIDC discovery on transient failure

### DIFF
--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -772,9 +772,19 @@ const setupOpenIdAdmin = (openidConfig) => {
 };
 
 /**
+ * Sleep for the specified number of milliseconds.
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
  * Sets up the OpenID strategy for authentication.
  * This function configures the OpenID client, handles proxy settings,
  * and defines the OpenID strategy for Passport.js.
+ *
+ * Retries the OIDC discovery call on failure with exponential backoff to handle
+ * transient network errors or IdP unavailability during startup.
  *
  * @async
  * @function setupOpenId
@@ -782,39 +792,77 @@ const setupOpenIdAdmin = (openidConfig) => {
  * @throws {Error} If an error occurs during the setup process.
  */
 async function setupOpenId() {
+  const shouldGenerateNonce = isEnabled(process.env.OPENID_GENERATE_NONCE);
+
+  /** @type {ClientMetadata} */
+  const clientMetadata = {
+    client_id: process.env.OPENID_CLIENT_ID,
+    client_secret: process.env.OPENID_CLIENT_SECRET,
+  };
+
+  if (shouldGenerateNonce) {
+    clientMetadata.response_types = ['code'];
+    clientMetadata.grant_types = ['authorization_code'];
+    clientMetadata.token_endpoint_auth_method = 'client_secret_post';
+  }
+
+  const envRetries = process.env.OPENID_DISCOVERY_RETRIES;
+  const maxRetries = envRetries === undefined || envRetries === ''
+    ? 3
+    : Math.max(0, parseInt(envRetries, 10) || 0);
+
+  // Validate issuer URL before retrying — invalid URLs are configuration errors, not transient failures
+  let issuerUrl;
   try {
-    const shouldGenerateNonce = isEnabled(process.env.OPENID_GENERATE_NONCE);
+    issuerUrl = new URL(process.env.OPENID_ISSUER);
+  } catch (err) {
+    logger.error('[openidStrategy] Invalid OPENID_ISSUER URL:', err.message);
+    return null;
+  }
 
-    /** @type {ClientMetadata} */
-    const clientMetadata = {
-      client_id: process.env.OPENID_CLIENT_ID,
-      client_secret: process.env.OPENID_CLIENT_SECRET,
-    };
-
-    if (shouldGenerateNonce) {
-      clientMetadata.response_types = ['code'];
-      clientMetadata.grant_types = ['authorization_code'];
-      clientMetadata.token_endpoint_auth_method = 'client_secret_post';
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      /** @type {Configuration} */
+      openidConfig = await client.discovery(
+        issuerUrl,
+        process.env.OPENID_CLIENT_ID,
+        clientMetadata,
+        undefined,
+        {
+          [client.customFetch]: customFetch,
+        },
+      );
+      break;
+    } catch (err) {
+      if (attempt < maxRetries) {
+        const delay = 2000 * Math.pow(2, attempt);
+        logger.warn(
+          `[openidStrategy] Discovery failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms: ${err.message || err}`,
+        );
+        await sleep(delay);
+      } else {
+        logger.error(
+          `[openidStrategy] Discovery failed after ${maxRetries + 1} attempts`,
+          err,
+        );
+        return null;
+      }
     }
+  }
 
-    /** @type {Configuration} */
-    openidConfig = await client.discovery(
-      new URL(process.env.OPENID_ISSUER),
-      process.env.OPENID_CLIENT_ID,
-      clientMetadata,
-      undefined,
-      {
-        [client.customFetch]: customFetch,
-      },
-    );
+  if (!openidConfig) {
+    logger.error('[openidStrategy] Discovery produced no configuration');
+    return null;
+  }
 
-    logger.info(`[openidStrategy] OpenID authentication configuration`, {
-      generateNonce: shouldGenerateNonce,
-      reason: shouldGenerateNonce
-        ? 'OPENID_GENERATE_NONCE=true - Will generate nonce and use explicit metadata for federated providers'
-        : 'OPENID_GENERATE_NONCE=false - Standard flow without explicit nonce or metadata',
-    });
+  logger.info(`[openidStrategy] OpenID authentication configuration`, {
+    generateNonce: shouldGenerateNonce,
+    reason: shouldGenerateNonce
+      ? 'OPENID_GENERATE_NONCE=true - Will generate nonce and use explicit metadata for federated providers'
+      : 'OPENID_GENERATE_NONCE=false - Standard flow without explicit nonce or metadata',
+  });
 
+  try {
     const openidLogin = new CustomOpenIDStrategy(
       {
         config: openidConfig,
@@ -829,7 +877,7 @@ async function setupOpenId() {
     setupOpenIdAdmin(openidConfig);
     return openidConfig;
   } catch (err) {
-    logger.error('[openidStrategy]', err);
+    logger.error('[openidStrategy] Strategy registration failed', err);
     return null;
   }
 }

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -6,6 +6,7 @@ const client = require('openid-client');
 const jwtDecode = require('jsonwebtoken/decode');
 const { HttpsProxyAgent } = require('https-proxy-agent');
 const { hashToken, logger } = require('@librechat/data-schemas');
+const { sleep } = require('@librechat/agents');
 const { Strategy: OpenIDStrategy } = require('openid-client/passport');
 const { CacheKeys, ErrorTypes, SystemRoles } = require('librechat-data-provider');
 const {
@@ -772,13 +773,6 @@ const setupOpenIdAdmin = (openidConfig) => {
 };
 
 /**
- * Sleep for the specified number of milliseconds.
- * @param {number} ms
- * @returns {Promise<void>}
- */
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-/**
  * Sets up the OpenID strategy for authentication.
  * This function configures the OpenID client, handles proxy settings,
  * and defines the OpenID strategy for Passport.js.
@@ -807,9 +801,8 @@ async function setupOpenId() {
   }
 
   const envRetries = process.env.OPENID_DISCOVERY_RETRIES;
-  const maxRetries = envRetries === undefined || envRetries === ''
-    ? 3
-    : Math.max(0, parseInt(envRetries, 10) || 0);
+  const maxRetries =
+    envRetries === undefined || envRetries === '' ? 3 : Math.max(0, parseInt(envRetries, 10) || 0);
 
   // Validate issuer URL before retrying — invalid URLs are configuration errors, not transient failures
   let issuerUrl;
@@ -841,10 +834,7 @@ async function setupOpenId() {
         );
         await sleep(delay);
       } else {
-        logger.error(
-          `[openidStrategy] Discovery failed after ${maxRetries + 1} attempts`,
-          err,
-        );
+        logger.error(`[openidStrategy] Discovery failed after ${maxRetries + 1} attempts`, err);
         return null;
       }
     }

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -1870,4 +1870,97 @@ describe('setupOpenId', () => {
       expect(details).toEqual({ message: 'Email domain not allowed' });
     });
   });
+
+  describe('setupOpenId discovery retry', () => {
+    let discovery;
+
+    beforeAll(() => {
+      discovery = require('openid-client').discovery;
+    });
+
+    afterEach(() => {
+      // Restore the default mock so the parent beforeEach setupOpenId() call succeeds for sibling tests
+      discovery.mockResolvedValue({
+        clientId: 'fake_client_id',
+        clientSecret: 'fake_client_secret',
+        issuer: 'https://fake-issuer.com',
+      });
+      delete process.env.OPENID_DISCOVERY_RETRIES;
+    });
+
+    it('should retry discovery on transient failure and succeed', async () => {
+      discovery.mockClear();
+      discovery
+        .mockRejectedValueOnce(new Error('transient network error'))
+        .mockRejectedValueOnce(new Error('connection refused'))
+        .mockResolvedValueOnce({
+          clientId: 'fake_client_id',
+          clientSecret: 'fake_client_secret',
+          issuer: 'https://fake-issuer.com',
+        });
+
+      process.env.OPENID_DISCOVERY_RETRIES = '3';
+
+      const result = await setupOpenId();
+
+      expect(result).not.toBeNull();
+      expect(discovery).toHaveBeenCalledTimes(3);
+      const { logger } = require('@librechat/data-schemas');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Discovery failed (attempt 1/4)'),
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Discovery failed (attempt 2/4)'),
+      );
+    });
+
+    it('should return null after exhausting retries', async () => {
+      discovery.mockClear();
+      discovery.mockRejectedValue(new Error('persistent failure'));
+
+      process.env.OPENID_DISCOVERY_RETRIES = '2';
+
+      const result = await setupOpenId();
+
+      expect(result).toBeNull();
+      expect(discovery).toHaveBeenCalledTimes(3);
+      const { logger } = require('@librechat/data-schemas');
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Discovery failed after 3 attempts'),
+        expect.any(Error),
+      );
+    });
+
+    it('should respect OPENID_DISCOVERY_RETRIES=0 (no retry)', async () => {
+      discovery.mockClear();
+      discovery.mockRejectedValue(new Error('one-shot failure'));
+
+      process.env.OPENID_DISCOVERY_RETRIES = '0';
+
+      const result = await setupOpenId();
+
+      expect(result).toBeNull();
+      expect(discovery).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fail fast on invalid OPENID_ISSUER URL', async () => {
+      discovery.mockClear();
+      process.env.OPENID_ISSUER = 'not-a-url';
+      process.env.OPENID_DISCOVERY_RETRIES = '3';
+
+      const result = await setupOpenId();
+
+      expect(result).toBeNull();
+      expect(discovery).not.toHaveBeenCalled();
+      const { logger } = require('@librechat/data-schemas');
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid OPENID_ISSUER URL'),
+        expect.any(String),
+      );
+
+      // Restore issuer for other tests
+      process.env.OPENID_ISSUER = 'https://fake-issuer.com';
+      delete process.env.OPENID_DISCOVERY_RETRIES;
+    });
+  });
 });


### PR DESCRIPTION
## Summary

When `client.discovery()` fails during startup (transient network error, IdP unavailable, temporary HTTP 5xx), the `openid` passport strategy is never registered. The server continues running — port listening, healthchecks passing — but all OIDC login attempts permanently fail with:

```
error: ErrorController => error Unknown authentication strategy "openid"
```

Users see "An unknown error occurred." with no actionable information. A container restart is the only fix.

## Root Cause

`setupOpenId()` in `api/strategies/openidStrategy.js` calls `client.discovery()` exactly once. If it throws, the catch logs the error and returns `null`. The passport strategy is never registered. There is no retry and no health signal.

## Changes

- **Retry with exponential backoff** (2s, 4s, 8s by default) around `client.discovery()`. Configurable via `OPENID_DISCOVERY_RETRIES` env var (default 3, set to 0 to disable).
- **Fail fast on malformed `OPENID_ISSUER`** — invalid URLs are configuration errors, not transient failures. Validated before the retry loop.
- **Separate error messages** for discovery failure vs strategy registration failure.
- **4 test cases**: transient failure recovery, exhausted retries, zero-retry mode, invalid URL fail-fast.

## Backward Compatibility

`setupOpenId()` still returns `Configuration | null`. The caller in `socialLogins.js` already handles the `null` case. No contract change.

Related: #671, #1263, #5895, PR #9064