### PR TITLE
🪜 chore: Plumb `allowedTools` through `resolveManualSkills`

### DIFF
--- a/packages/api/src/agents/__tests__/skills.test.ts
+++ b/packages/api/src/agents/__tests__/skills.test.ts
@@ -604,6 +604,7 @@ describe('resolveManualSkills', () => {
     name: string;
     body: string;
     author: Types.ObjectId;
+    allowedTools?: string[];
   };
 
   const buildGetSkillByName =
@@ -647,6 +648,45 @@ describe('resolveManualSkills', () => {
       userId,
     });
     expect(result).toEqual([{ name: 'my-skill', body: 'MY SKILL BODY' }]);
+  });
+
+  it('passes allowedTools through when the skill doc carries the field', async () => {
+    const owned: SkillDoc = {
+      ...mkSkill('with-tools', userOid, 'body'),
+      allowedTools: ['execute_code', 'read_file'],
+    };
+    const result = await resolveManualSkills({
+      names: ['with-tools'],
+      getSkillByName: buildGetSkillByName({ 'with-tools': owned }),
+      accessibleSkillIds: [owned._id],
+      userId,
+    });
+    expect(result).toEqual([
+      { name: 'with-tools', body: 'body', allowedTools: ['execute_code', 'read_file'] },
+    ]);
+  });
+
+  it('omits allowedTools when the skill doc does not declare it', async () => {
+    const owned = mkSkill('no-tools', userOid, 'body');
+    const [resolved] = await resolveManualSkills({
+      names: ['no-tools'],
+      getSkillByName: buildGetSkillByName({ 'no-tools': owned }),
+      accessibleSkillIds: [owned._id],
+      userId,
+    });
+    expect(resolved).toEqual({ name: 'no-tools', body: 'body' });
+    expect(resolved).not.toHaveProperty('allowedTools');
+  });
+
+  it('preserves an empty allowedTools array (distinguishes "declared none" from "undeclared")', async () => {
+    const owned: SkillDoc = { ...mkSkill('empty-tools', userOid, 'body'), allowedTools: [] };
+    const [resolved] = await resolveManualSkills({
+      names: ['empty-tools'],
+      getSkillByName: buildGetSkillByName({ 'empty-tools': owned }),
+      accessibleSkillIds: [owned._id],
+      userId,
+    });
+    expect(resolved).toEqual({ name: 'empty-tools', body: 'body', allowedTools: [] });
   });
 
   it('silently skips names with no backing skill (typo / ACL miss) without failing the batch', async () => {

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -204,7 +204,7 @@ export interface InitializeAgentDbMethods extends EndpointDbMethods {
     /**
      * Skill-declared tool allowlist, forwarded verbatim from the skill doc.
      * Surfaced so the resolver can carry it onto `ResolvedManualSkill` for
-     * future runtime enforcement (Phase 6) without a second round-trip.
+     * future runtime enforcement without a second round-trip.
      */
     allowedTools?: string[];
   } | null>;

--- a/packages/api/src/agents/initialize.ts
+++ b/packages/api/src/agents/initialize.ts
@@ -201,6 +201,12 @@ export interface InitializeAgentDbMethods extends EndpointDbMethods {
     name: string;
     body: string;
     author: import('mongoose').Types.ObjectId;
+    /**
+     * Skill-declared tool allowlist, forwarded verbatim from the skill doc.
+     * Surfaced so the resolver can carry it onto `ResolvedManualSkill` for
+     * future runtime enforcement (Phase 6) without a second round-trip.
+     */
+    allowedTools?: string[];
   } | null>;
 }
 

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -318,8 +318,8 @@ export interface ResolveManualSkillsParams {
     author: Types.ObjectId | string;
     /**
      * Skill-declared tool allowlist, forwarded verbatim from the skill doc.
-     * Surfaced on `ResolvedManualSkill` so future runtime enforcement (Phase 6)
-     * can union it into the agent's effective tool set for the turn without
+     * Surfaced on `ResolvedManualSkill` so future runtime enforcement can
+     * union it into the agent's effective tool set for the turn without
      * re-fetching the document. Populated by the DB method when available.
      */
     allowedTools?: string[];
@@ -340,8 +340,8 @@ export interface ResolvedManualSkill {
   /**
    * Skill-declared tool allowlist passed through from the skill doc. Present
    * only when the skill author declared `allowed-tools` in frontmatter.
-   * Currently populated but not consumed — Phase 6 will union these into the
-   * agent's effective tool set for the turn.
+   * Currently populated but not consumed — future runtime enforcement will
+   * union these into the agent's effective tool set for the turn.
    */
   allowedTools?: string[];
 }

--- a/packages/api/src/agents/skills.ts
+++ b/packages/api/src/agents/skills.ts
@@ -316,6 +316,13 @@ export interface ResolveManualSkillsParams {
     name: string;
     body: string;
     author: Types.ObjectId | string;
+    /**
+     * Skill-declared tool allowlist, forwarded verbatim from the skill doc.
+     * Surfaced on `ResolvedManualSkill` so future runtime enforcement (Phase 6)
+     * can union it into the agent's effective tool set for the turn without
+     * re-fetching the document. Populated by the DB method when available.
+     */
+    allowedTools?: string[];
   } | null>;
   /** ACL-accessible skill IDs for this user (already scoped by `scopeSkillIds`). */
   accessibleSkillIds: Types.ObjectId[];
@@ -330,6 +337,13 @@ export interface ResolveManualSkillsParams {
 export interface ResolvedManualSkill {
   name: string;
   body: string;
+  /**
+   * Skill-declared tool allowlist passed through from the skill doc. Present
+   * only when the skill author declared `allowed-tools` in frontmatter.
+   * Currently populated but not consumed — Phase 6 will union these into the
+   * agent's effective tool set for the turn.
+   */
+  allowedTools?: string[];
 }
 
 /**
@@ -414,7 +428,11 @@ export async function resolveManualSkills(
           logger.warn(`[resolveManualSkills] Skill "${name}" is inactive for this user — skipping`);
           return null;
         }
-        return { name: skill.name, body: skill.body };
+        const resolved: ResolvedManualSkill = { name: skill.name, body: skill.body };
+        if (skill.allowedTools !== undefined) {
+          resolved.allowedTools = skill.allowedTools;
+        }
+        return resolved;
       } catch (err) {
         logger.warn(
           `[resolveManualSkills] Failed to resolve skill "${name}":`,


### PR DESCRIPTION
## Summary

Tiny shape-only precursor shared by Phase 5 (`always-apply` frontmatter) and Phase 6 (frontmatter runtime enforcement). Lands first to eliminate the type-shape race between the two phases so they can proceed in parallel.

- Adds `allowedTools?: string[]` to `ResolvedManualSkill`.
- Widens the `getSkillByName` return type in `ResolveManualSkillsParams` and `InitializeAgentDbMethods` to carry the same field.
- `resolveManualSkills` forwards `skill.allowedTools` verbatim when present; absent otherwise.

**No runtime behavior change.** The field is populated from the skill doc but not yet consumed by any downstream code path. Phase 6 will union the per-skill allowlist into the agent's effective tool set for the turn; Phase 5's `ResolvedAlwaysApplySkill` will mirror this exact shape.

Scoped intentionally small:
- Three files, 65 additions, one deletion.
- No schema change — Phase 6 owns the structured column (`skill.allowedTools`) and the frontmatter importer mapping.
- No changes to `injectManualSkillPrimes`, call sites in `initialize.ts`, or JS controllers — downstream consumers only read `name` and `body`.

## Why a precursor

From the umbrella rollout plan: Phase 5 and Phase 6 both need `ResolvedManualSkill.allowedTools` in their resolver pipeline. Landing the shape here means neither phase has to own the interface addition, and merge conflicts between their branches stay textual.

## Test plan

- [x] `resolveManualSkills` forwards `allowedTools` when the skill doc declares it.
- [x] `resolveManualSkills` omits `allowedTools` when the field is absent (no spurious key on the resolved object).
- [x] `resolveManualSkills` preserves an empty `allowedTools: []` array (distinguishes "explicitly declared none" from "undeclared" for Phase 6 semantics).
- [x] All 78 existing `skills.test.ts` tests pass unchanged.
- [x] All 14 existing `initialize.test.ts` tests pass unchanged.
- [x] `tsc --noEmit` clean.
- [x] ESLint clean on the three changed files.

## Base branch

Targets `feat/agent-skills` (umbrella PR #12625), not `dev`.