### PR TITLE
feat: Add serviceAccountName support to pod spec

### DIFF
--- a/helm/librechat-rag-api/templates/rag-deployment.yaml
+++ b/helm/librechat-rag-api/templates/rag-deployment.yaml
@@ -26,6 +26,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "rag.serviceAccountName" . }}
+      {{- end }}
       {{- if kindIs "bool" .Values.enableServiceLinks }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}
       {{- end }}

--- a/helm/librechat-rag-api/templates/serviceaccount.yaml
+++ b/helm/librechat-rag-api/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "rag.serviceAccountName" . }}
+  labels:
+    {{- include "rag.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/librechat-rag-api/values.yaml
+++ b/helm/librechat-rag-api/values.yaml
@@ -37,6 +37,12 @@ imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: ''
 
+serviceAccount:
+  create: false
+  automount: true
+  annotations: {}
+  name: ''
+
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION
## Summary

Adds serviceAccount configuration to the librechat-rag-api Helm subchart, matching the pattern already used by the parent librechat chart. This enables use cases that require pod-level identity.

## Change Type

New feature (non-breaking change which adds functionality)

## Testing

All commands use helm template against the chart directory.

1. **Default — no serviceAccount configured**

   ```bash
   helm template my-release ./helm/librechat-rag-api \
     --show-only templates/rag-deployment.yaml \
     --set global.librechat.existingSecretName=dummy | grep "serviceAccountName"
   ```

   Expected: no output (serviceAccountName line is omitted).

2. **Existing SA by name only**

   ```bash
   helm template my-release ./helm/librechat-rag-api \
     --show-only templates/rag-deployment.yaml \
     --set serviceAccount.name=my-sa \
     --set global.librechat.existingSecretName=dummy | grep "serviceAccountName"
   ```

   Expected: `serviceAccountName: my-sa`

3. **Create SA with auto-generated name**

   Deployment:

   ```bash
   helm template my-release ./helm/librechat-rag-api \
     --show-only templates/rag-deployment.yaml \
     --set serviceAccount.create=true \
     --set global.librechat.existingSecretName=dummy | grep "serviceAccountName"
   ```

   Expected: `serviceAccountName: my-release-librechat-rag-api`

   ServiceAccount resource:

   ```bash
   helm template my-release ./helm/librechat-rag-api \
     --show-only templates/serviceaccount.yaml \
     --set serviceAccount.create=true \
     --set global.librechat.existingSecretName=dummy
   ```

   Expected: renders a ServiceAccount named `my-release-librechat-rag-api`.

4. **Create SA with explicit name**

   ```bash
   helm template my-release ./helm/librechat-rag-api \
     --show-only templates/rag-deployment.yaml \
     --set serviceAccount.create=true \
     --set serviceAccount.name=my-sa \
     --set global.librechat.existingSecretName=dummy | grep "serviceAccountName"
   ```

   Expected: `serviceAccountName: my-sa`

5. **Annotations**

   ```bash
   helm template my-release ./helm/librechat-rag-api \
     --show-only templates/serviceaccount.yaml \
     --set serviceAccount.create=true \
     --set "serviceAccount.annotations.example\.com/role=my-role" \
     --set global.librechat.existingSecretName=dummy
   ```

   Expected: renders `annotations:` block with `example.com/role: my-role`.

6. **Automount disabled**

   ```bash
   helm template my-release ./helm/librechat-rag-api \
     --show-only templates/serviceaccount.yaml \
     --set serviceAccount.create=true \
     --set serviceAccount.automount=false \
     --set global.librechat.existingSecretName=dummy | grep "automountServiceAccountToken"
   ```

   Expected: `automountServiceAccountToken: false`

7. **No SA created, no name — serviceaccount.yaml not rendered**

   ```bash
   helm template my-release ./helm/librechat-rag-api \
     --show-only templates/serviceaccount.yaml \
     --set global.librechat.existingSecretName=dummy
   ```

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
