### PR TITLE
📦 chore: Update `@librechat/agents`to v3.1.68

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.67",
+    "@librechat/agents": "^3.1.68",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.67",
+        "@librechat/agents": "^3.1.68",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11913,9 +11913,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.67",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.67.tgz",
-      "integrity": "sha512-c2RJ/k0zLYRvlf6bFHdhuF2ahECFg5Osj/bskGoT/5+wcZjO9zvCAPxxZAkB+3tXPzhxAqPm7LEvXmKnd5RNOA==",
+      "version": "3.1.68",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.68.tgz",
+      "integrity": "sha512-lTfyPJkgOHdUFauIAcjt+DnJyTq6ApJWlX2UOqXJtLXmLilLBMl1fx0wb8PnwspB+8sEOm/8gte319wu2cRATw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -44194,7 +44194,7 @@
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
         "@langchain/core": "^0.3.80",
-        "@librechat/agents": "^3.1.67",
+        "@librechat/agents": "^3.1.68",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@smithy/node-http-handler": "^4.4.5",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "build:client-package": "cd packages/client && npm run build",
     "build:packages": "npm run build:data-provider && npm run build:data-schemas && npm run build:api && npm run build:client-package",
     "build": "npx turbo run build",
+    "build:safe": "npx turbo run build --no-daemon",
     "frontend": "npm run build:data-provider && npm run build:data-schemas && npm run build:api && npm run build:client-package && cd client && npm run build",
     "frontend:ci": "npm run build:data-provider && npm run build:client-package && cd client && npm run build:ci",
     "frontend:dev": "cd client && npm run dev",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -95,7 +95,7 @@
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
     "@langchain/core": "^0.3.80",
-    "@librechat/agents": "^3.1.67",
+    "@librechat/agents": "^3.1.68",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@smithy/node-http-handler": "^4.4.5",


### PR DESCRIPTION
- Bumped the version of @librechat/agents from 3.1.67 to 3.1.68 in multiple package.json files to ensure consistency and access to the latest features and fixes.
- Updated package-lock.json to reflect the new version and maintain dependency integrity.