### PR TITLE
📅 feat: Support `text/calendar` (iCalendar) in Code Outputs

### DIFF
--- a/packages/data-provider/src/file-config.ts
+++ b/packages/data-provider/src/file-config.ts
@@ -45,6 +45,7 @@ export const fullMimeTypesList = [
   'text/x-tex',
   'text/plain',
   'text/css',
+  'text/calendar',
   'text/vtt',
   'image/jpeg',
   'text/javascript',
@@ -109,6 +110,7 @@ export const codeInterpreterMimeTypesList = [
   'text/x-tex',
   'text/plain',
   'text/css',
+  'text/calendar',
   'image/jpeg',
   'text/javascript',
   'image/gif',
@@ -180,7 +182,7 @@ export const excelMimeTypes =
   /^application\/(vnd\.ms-excel|msexcel|x-msexcel|x-ms-excel|x-excel|x-dos_ms_excel|xls|x-xls|vnd\.openxmlformats-officedocument\.spreadsheetml\.sheet)$/;
 
 export const textMimeTypes =
-  /^(text\/(x-c|x-csharp|tab-separated-values|x-c\+\+|x-h|x-java|html|markdown|x-php|x-python|x-script\.python|x-ruby|x-tex|plain|css|vtt|javascript|csv|xml))$/;
+  /^(text\/(x-c|x-csharp|tab-separated-values|x-c\+\+|x-h|x-java|html|markdown|x-php|x-python|x-script\.python|x-ruby|x-tex|plain|css|vtt|javascript|csv|xml|calendar))$/;
 
 export const applicationMimeTypes =
   /^(application\/(epub\+zip|csv|json|msword|pdf|x-tar|x-sh|typescript|sql|yaml|x-parquet|vnd\.apache\.parquet|vnd\.coffeescript|vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation|spreadsheetml\.sheet)|vnd\.oasis\.opendocument\.(text|spreadsheet|presentation|graphics)|xml|zip))$/;
@@ -351,6 +353,10 @@ export const codeTypeMapping: { [key: string]: string } = {
   ods: 'application/vnd.oasis.opendocument.spreadsheet', // .ods - OpenDocument Spreadsheet
   odp: 'application/vnd.oasis.opendocument.presentation', // .odp - OpenDocument Presentation
   odg: 'application/vnd.oasis.opendocument.graphics', // .odg - OpenDocument Graphics
+  ics: 'text/calendar', // .ics - iCalendar
+  ical: 'text/calendar', // .ical - iCalendar
+  ifb: 'text/calendar', // .ifb - iCalendar free/busy
+  icalendar: 'text/calendar', // .icalendar - iCalendar
 };
 
 /** Maps image extensions to MIME types for formats browsers may not recognize */


### PR DESCRIPTION
## Summary

The code interpreter can produce iCalendar files (`.ics`), but they're currently rejected by the MIME allowlists and not mapped in `codeTypeMapping`, so they never surface as downloadable attachments. This PR registers `text/calendar` across `fullMimeTypesList`, `codeInterpreterMimeTypesList`, and the `textMimeTypes` regex, and maps `.ics` / `.ical` / `.ifb` / `.icalendar` in `codeTypeMapping`.

Single-file change: `packages/data-provider/src/file-config.ts`.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

### Test Configuration

- Code interpreter enabled; asked the model to emit an `.ics` file.

Before the change, the file was dropped by the MIME allowlist and never surfaced. After the change, the `.ics` file is accepted as a valid code-interpreter output, is rendered as a downloadable attachment, and opens correctly in standard calendar clients.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings