### PR TITLE
Implement proactive OAuth flow for connections without tokens

### DIFF
--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -221,12 +221,15 @@ export class MCPConnectionFactory {
   /** Creates the base MCP connection with OAuth tokens */
   protected async createConnection(): Promise<MCPConnection> {
     const oauthTokens = this.useOAuth ? await this.getOAuthTokens() : null;
+    const requiresOAuth = (this.serverConfig as t.ParsedServerConfig).requiresOAuth === true;
 
-    /** True when OAuth is required but no stored tokens exist yet.
-     *  Some servers (e.g. BigQuery MCP) accept anonymous connections and never
-     *  return a 401 during initialize/tools/list, so we cannot rely on the server
-     *  to emit the oauthRequired event — we must trigger the flow proactively. */
-    const needsProactiveOAuth = this.useOAuth && !oauthTokens;
+    /** Only trigger proactive OAuth when the server explicitly requires it AND no stored
+     *  tokens exist. Some servers (e.g. BigQuery MCP) accept anonymous connections and
+     *  never return a 401 during initialize/tools/list, so we cannot rely on the server
+     *  to emit the oauthRequired event — we must trigger the flow proactively.
+     *  We gate on `requiresOAuth` (not just `useOAuth`) because user connections always
+     *  pass `useOAuth: true` even for servers that don't need OAuth. */
+    const needsProactiveOAuth = this.useOAuth && requiresOAuth && !oauthTokens;
 
     const connection = new MCPConnection({
       serverName: this.serverName,
@@ -243,15 +246,26 @@ export class MCPConnectionFactory {
 
     try {
       if (needsProactiveOAuth) {
+        const serverUrl = (this.serverConfig as t.ParsedServerConfig).url;
+        if (!serverUrl) {
+          throw new Error(`${this.logPrefix} OAuth required but server URL is missing from config`);
+        }
+
         logger.info(
           `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting`,
         );
-        const serverUrl =
-          (this.serverConfig as t.SSEOptions | t.StreamableHTTPOptions).url ?? '';
 
         await new Promise<void>((resolve, reject) => {
-          connection.once('oauthHandled', resolve);
-          connection.once('oauthFailed', (err: Error) => reject(err));
+          const handleSuccess = () => {
+            connection.off('oauthFailed', handleFailure);
+            resolve();
+          };
+          const handleFailure = (err: Error) => {
+            connection.off('oauthHandled', handleSuccess);
+            reject(err);
+          };
+          connection.once('oauthHandled', handleSuccess);
+          connection.once('oauthFailed', handleFailure);
           connection.emit('oauthRequired', {
             serverUrl,
             serverName: this.serverName,
@@ -259,8 +273,6 @@ export class MCPConnectionFactory {
           });
         });
 
-        // OAuth completed successfully — connection now has tokens set by handleOAuthEvents.
-        // Proceed to establish the actual MCP connection.
         await this.attemptToConnect(connection);
       } else {
         await this.attemptToConnect(connection);

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -251,27 +251,32 @@ export class MCPConnectionFactory {
           throw new Error(`${this.logPrefix} OAuth required but server URL is missing from config`);
         }
 
+        const oauthTimeout = this.connectionTimeout ?? this.serverConfig.initTimeout ?? 30000;
         logger.info(
-          `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting`,
+          `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting (timeout: ${oauthTimeout}ms)`,
         );
 
-        await new Promise<void>((resolve, reject) => {
-          const handleSuccess = () => {
-            connection.off('oauthFailed', handleFailure);
-            resolve();
-          };
-          const handleFailure = (err: Error) => {
-            connection.off('oauthHandled', handleSuccess);
-            reject(err);
-          };
-          connection.once('oauthHandled', handleSuccess);
-          connection.once('oauthFailed', handleFailure);
-          connection.emit('oauthRequired', {
-            serverUrl,
-            serverName: this.serverName,
-            userId: this.userId,
-          });
-        });
+        await withTimeout(
+          new Promise<void>((resolve, reject) => {
+            const handleSuccess = () => {
+              connection.off('oauthFailed', handleFailure);
+              resolve();
+            };
+            const handleFailure = (err: Error) => {
+              connection.off('oauthHandled', handleSuccess);
+              reject(err);
+            };
+            connection.once('oauthHandled', handleSuccess);
+            connection.once('oauthFailed', handleFailure);
+            connection.emit('oauthRequired', {
+              serverUrl,
+              serverName: this.serverName,
+              userId: this.userId,
+            });
+          }),
+          oauthTimeout,
+          `Proactive OAuth flow timeout after ${oauthTimeout}ms`,
+        );
 
         await this.attemptToConnect(connection);
       } else {

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -221,6 +221,13 @@ export class MCPConnectionFactory {
   /** Creates the base MCP connection with OAuth tokens */
   protected async createConnection(): Promise<MCPConnection> {
     const oauthTokens = this.useOAuth ? await this.getOAuthTokens() : null;
+
+    /** True when OAuth is required but no stored tokens exist yet.
+     *  Some servers (e.g. BigQuery MCP) accept anonymous connections and never
+     *  return a 401 during initialize/tools/list, so we cannot rely on the server
+     *  to emit the oauthRequired event — we must trigger the flow proactively. */
+    const needsProactiveOAuth = this.useOAuth && !oauthTokens;
+
     const connection = new MCPConnection({
       serverName: this.serverName,
       serverConfig: this.serverConfig,
@@ -235,7 +242,30 @@ export class MCPConnectionFactory {
     }
 
     try {
-      await this.attemptToConnect(connection);
+      if (needsProactiveOAuth) {
+        logger.info(
+          `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting`,
+        );
+        const serverUrl =
+          (this.serverConfig as t.SSEOptions | t.StreamableHTTPOptions).url ?? '';
+
+        await new Promise<void>((resolve, reject) => {
+          connection.once('oauthHandled', resolve);
+          connection.once('oauthFailed', (err: Error) => reject(err));
+          connection.emit('oauthRequired', {
+            serverUrl,
+            serverName: this.serverName,
+            userId: this.userId,
+          });
+        });
+
+        // OAuth completed successfully — connection now has tokens set by handleOAuthEvents.
+        // Proceed to establish the actual MCP connection.
+        await this.attemptToConnect(connection);
+      } else {
+        await this.attemptToConnect(connection);
+      }
+
       if (cleanupOAuthHandlers) {
         cleanupOAuthHandlers();
       }

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -225,6 +225,13 @@ export class MCPConnectionFactory {
   /** Creates the base MCP connection with OAuth tokens */
   protected async createConnection(): Promise<MCPConnection> {
     const oauthTokens = this.useOAuth ? await this.getOAuthTokens() : null;
+
+    /** True when OAuth is required but no stored tokens exist yet.
+     *  Some servers (e.g. BigQuery MCP) accept anonymous connections and never
+     *  return a 401 during initialize/tools/list, so we cannot rely on the server
+     *  to emit the oauthRequired event — we must trigger the flow proactively. */
+    const needsProactiveOAuth = this.useOAuth && !oauthTokens;
+
     const connection = new MCPConnection({
       serverName: this.serverName,
       serverConfig: this.serverConfig,
@@ -240,7 +247,30 @@ export class MCPConnectionFactory {
     }
 
     try {
-      await this.attemptToConnect(connection);
+      if (needsProactiveOAuth) {
+        logger.info(
+          `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting`,
+        );
+        const serverUrl =
+          (this.serverConfig as t.SSEOptions | t.StreamableHTTPOptions).url ?? '';
+
+        await new Promise<void>((resolve, reject) => {
+          connection.once('oauthHandled', resolve);
+          connection.once('oauthFailed', (err: Error) => reject(err));
+          connection.emit('oauthRequired', {
+            serverUrl,
+            serverName: this.serverName,
+            userId: this.userId,
+          });
+        });
+
+        // OAuth completed successfully — connection now has tokens set by handleOAuthEvents.
+        // Proceed to establish the actual MCP connection.
+        await this.attemptToConnect(connection);
+      } else {
+        await this.attemptToConnect(connection);
+      }
+
       if (cleanupOAuthHandlers) {
         cleanupOAuthHandlers();
       }

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -256,27 +256,32 @@ export class MCPConnectionFactory {
           throw new Error(`${this.logPrefix} OAuth required but server URL is missing from config`);
         }
 
+        const oauthTimeout = this.connectionTimeout ?? this.serverConfig.initTimeout ?? 30000;
         logger.info(
-          `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting`,
+          `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting (timeout: ${oauthTimeout}ms)`,
         );
 
-        await new Promise<void>((resolve, reject) => {
-          const handleSuccess = () => {
-            connection.off('oauthFailed', handleFailure);
-            resolve();
-          };
-          const handleFailure = (err: Error) => {
-            connection.off('oauthHandled', handleSuccess);
-            reject(err);
-          };
-          connection.once('oauthHandled', handleSuccess);
-          connection.once('oauthFailed', handleFailure);
-          connection.emit('oauthRequired', {
-            serverUrl,
-            serverName: this.serverName,
-            userId: this.userId,
-          });
-        });
+        await withTimeout(
+          new Promise<void>((resolve, reject) => {
+            const handleSuccess = () => {
+              connection.off('oauthFailed', handleFailure);
+              resolve();
+            };
+            const handleFailure = (err: Error) => {
+              connection.off('oauthHandled', handleSuccess);
+              reject(err);
+            };
+            connection.once('oauthHandled', handleSuccess);
+            connection.once('oauthFailed', handleFailure);
+            connection.emit('oauthRequired', {
+              serverUrl,
+              serverName: this.serverName,
+              userId: this.userId,
+            });
+          }),
+          oauthTimeout,
+          `Proactive OAuth flow timeout after ${oauthTimeout}ms`,
+        );
 
         await this.attemptToConnect(connection);
       } else {

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -225,12 +225,15 @@ export class MCPConnectionFactory {
   /** Creates the base MCP connection with OAuth tokens */
   protected async createConnection(): Promise<MCPConnection> {
     const oauthTokens = this.useOAuth ? await this.getOAuthTokens() : null;
+    const requiresOAuth = (this.serverConfig as t.ParsedServerConfig).requiresOAuth === true;
 
-    /** True when OAuth is required but no stored tokens exist yet.
-     *  Some servers (e.g. BigQuery MCP) accept anonymous connections and never
-     *  return a 401 during initialize/tools/list, so we cannot rely on the server
-     *  to emit the oauthRequired event — we must trigger the flow proactively. */
-    const needsProactiveOAuth = this.useOAuth && !oauthTokens;
+    /** Only trigger proactive OAuth when the server explicitly requires it AND no stored
+     *  tokens exist. Some servers (e.g. BigQuery MCP) accept anonymous connections and
+     *  never return a 401 during initialize/tools/list, so we cannot rely on the server
+     *  to emit the oauthRequired event — we must trigger the flow proactively.
+     *  We gate on `requiresOAuth` (not just `useOAuth`) because user connections always
+     *  pass `useOAuth: true` even for servers that don't need OAuth. */
+    const needsProactiveOAuth = this.useOAuth && requiresOAuth && !oauthTokens;
 
     const connection = new MCPConnection({
       serverName: this.serverName,
@@ -248,15 +251,26 @@ export class MCPConnectionFactory {
 
     try {
       if (needsProactiveOAuth) {
+        const serverUrl = (this.serverConfig as t.ParsedServerConfig).url;
+        if (!serverUrl) {
+          throw new Error(`${this.logPrefix} OAuth required but server URL is missing from config`);
+        }
+
         logger.info(
           `${this.logPrefix} No stored tokens — proactively triggering OAuth flow before connecting`,
         );
-        const serverUrl =
-          (this.serverConfig as t.SSEOptions | t.StreamableHTTPOptions).url ?? '';
 
         await new Promise<void>((resolve, reject) => {
-          connection.once('oauthHandled', resolve);
-          connection.once('oauthFailed', (err: Error) => reject(err));
+          const handleSuccess = () => {
+            connection.off('oauthFailed', handleFailure);
+            resolve();
+          };
+          const handleFailure = (err: Error) => {
+            connection.off('oauthHandled', handleSuccess);
+            reject(err);
+          };
+          connection.once('oauthHandled', handleSuccess);
+          connection.once('oauthFailed', handleFailure);
           connection.emit('oauthRequired', {
             serverUrl,
             serverName: this.serverName,
@@ -264,8 +278,6 @@ export class MCPConnectionFactory {
           });
         });
 
-        // OAuth completed successfully — connection now has tokens set by handleOAuthEvents.
-        // Proceed to establish the actual MCP connection.
         await this.attemptToConnect(connection);
       } else {
         await this.attemptToConnect(connection);

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -1002,4 +1002,272 @@ describe('MCPConnectionFactory', () => {
       expect(mockLogger.debug).toHaveBeenCalled();
     });
   });
+
+  describe('proactive OAuth flow', () => {
+    const makeOAuthServerConfig = (): t.MCPOptions =>
+      ({
+        type: 'streamable-http' as const,
+        url: 'https://bigquery.googleapis.com/mcp',
+        initTimeout: 5000,
+        requiresOAuth: true,
+      }) as unknown as t.MCPOptions;
+
+    const makeOAuthOptions = () => ({
+      useOAuth: true as const,
+      user: mockUser,
+      flowManager: mockFlowManager,
+      tokenMethods: {
+        findToken: jest.fn(),
+        createToken: jest.fn(),
+        updateToken: jest.fn(),
+        deleteTokens: jest.fn(),
+      },
+    });
+
+    /**
+     * Wires mock EventEmitter so `emit('oauthRequired', ...)` dispatches to
+     * the handler registered via `on('oauthRequired', ...)`, and
+     * `emit('oauthHandled')` / `emit('oauthFailed', err)` dispatch to the
+     * matching `once(...)` handler registered on the connection.
+     */
+    function wireEventHandlers(instance: jest.Mocked<MCPConnection>) {
+      const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+
+      const key = (event: string | symbol): string =>
+        typeof event === 'symbol' ? event.toString() : event;
+
+      instance.on.mockImplementation(
+        (event: string | symbol, handler: (...args: unknown[]) => void) => {
+          (handlers[key(event)] ??= []).push(handler);
+          return instance;
+        },
+      );
+
+      instance.once.mockImplementation(
+        (event: string | symbol, handler: (...args: unknown[]) => void) => {
+          (handlers[key(event)] ??= []).push(handler);
+          return instance;
+        },
+      );
+
+      instance.off.mockImplementation(
+        (event: string | symbol, handler: (...args: unknown[]) => void) => {
+          const list = handlers[key(event)];
+          if (list) {
+            const idx = list.indexOf(handler);
+            if (idx !== -1) list.splice(idx, 1);
+          }
+          return instance;
+        },
+      );
+
+      instance.removeListener.mockImplementation(
+        (event: string | symbol, handler: (...args: unknown[]) => void) => {
+          const list = handlers[key(event)];
+          if (list) {
+            const idx = list.indexOf(handler);
+            if (idx !== -1) list.splice(idx, 1);
+          }
+          return instance;
+        },
+      );
+
+      instance.emit.mockImplementation((event: string | symbol, ...args: unknown[]) => {
+        const list = handlers[key(event)];
+        if (list) {
+          for (const fn of [...list]) fn(...args);
+        }
+        return true;
+      });
+
+      return handlers;
+    }
+
+    it('should trigger proactive OAuth when requiresOAuth and no tokens', async () => {
+      const serverConfig = makeOAuthServerConfig();
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockRejectedValue(new Error('no tokens'));
+
+      const mockTokens: MCPOAuthTokens = {
+        access_token: 'bq-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+      };
+
+      const mockFlowData = {
+        authorizationUrl: 'https://accounts.google.com/o/oauth2/auth?state=xyz',
+        flowId: 'flow-bq',
+        flowMetadata: {
+          serverName: 'bigquery',
+          userId: 'user123',
+          serverUrl: 'https://bigquery.googleapis.com/mcp',
+          state: 'state-xyz',
+          clientInfo: { client_id: 'bq-client' },
+        },
+      };
+
+      mockMCPOAuthHandler.generateFlowId.mockReturnValue('flow-bq');
+      mockMCPOAuthHandler.initiateOAuthFlow.mockResolvedValue(mockFlowData);
+      mockFlowManager.getFlowState.mockResolvedValue(null);
+      mockFlowManager.createFlow.mockResolvedValue(mockTokens);
+
+      wireEventHandlers(mockConnectionInstance);
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      const connection = await MCPConnectionFactory.create(
+        { serverName: 'bigquery', serverConfig },
+        oauthOptions,
+      );
+
+      expect(connection).toBe(mockConnectionInstance);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('proactively triggering OAuth flow'),
+      );
+      expect(mockConnectionInstance.setOAuthTokens).toHaveBeenCalledWith(mockTokens);
+      expect(mockConnectionInstance.connect).toHaveBeenCalled();
+    });
+
+    it('should NOT trigger proactive OAuth when useOAuth is true but requiresOAuth is absent', async () => {
+      const serverConfig = {
+        command: 'node',
+        args: ['server.js'],
+        initTimeout: 5000,
+      } as t.MCPOptions;
+
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockRejectedValue(new Error('no tokens'));
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      const connection = await MCPConnectionFactory.create(
+        { serverName: 'test-server', serverConfig },
+        oauthOptions,
+      );
+
+      expect(connection).toBe(mockConnectionInstance);
+      expect(mockLogger.info).not.toHaveBeenCalledWith(
+        expect.stringContaining('proactively triggering OAuth flow'),
+      );
+    });
+
+    it('should skip proactive OAuth when tokens already exist', async () => {
+      const serverConfig = makeOAuthServerConfig();
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      const existingTokens: MCPOAuthTokens = {
+        access_token: 'existing-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+      };
+      mockFlowManager.createFlowWithHandler.mockResolvedValue(existingTokens);
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      const connection = await MCPConnectionFactory.create(
+        { serverName: 'bigquery', serverConfig },
+        oauthOptions,
+      );
+
+      expect(connection).toBe(mockConnectionInstance);
+      expect(mockLogger.info).not.toHaveBeenCalledWith(
+        expect.stringContaining('proactively triggering OAuth flow'),
+      );
+    });
+
+    it('should reject when proactive OAuth flow fails', async () => {
+      const serverConfig = makeOAuthServerConfig();
+      const oauthOptions = {
+        ...makeOAuthOptions(),
+        returnOnOAuth: true,
+        oauthStart: jest.fn(),
+      };
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockRejectedValue(new Error('no tokens'));
+
+      const mockFlowData = {
+        authorizationUrl: 'https://accounts.google.com/o/oauth2/auth',
+        flowId: 'flow-bq',
+        flowMetadata: {
+          serverName: 'bigquery',
+          userId: 'user123',
+          serverUrl: 'https://bigquery.googleapis.com/mcp',
+          state: 'state-xyz',
+        },
+      };
+
+      mockMCPOAuthHandler.generateFlowId.mockReturnValue('flow-bq');
+      mockMCPOAuthHandler.initiateOAuthFlow.mockResolvedValue(mockFlowData);
+      mockFlowManager.getFlowState.mockResolvedValue(null);
+      mockFlowManager.createFlow.mockReturnValue(new Promise(() => {}));
+
+      wireEventHandlers(mockConnectionInstance);
+      mockConnectionInstance.isConnected.mockResolvedValue(false);
+
+      await expect(
+        MCPConnectionFactory.create({ serverName: 'bigquery', serverConfig }, oauthOptions),
+      ).rejects.toThrow('OAuth flow initiated - return early');
+    });
+
+    it('should throw when requiresOAuth is true but url is missing', async () => {
+      const serverConfig = {
+        type: 'streamable-http' as const,
+        initTimeout: 5000,
+        requiresOAuth: true,
+      } as unknown as t.MCPOptions;
+
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockRejectedValue(new Error('no tokens'));
+
+      wireEventHandlers(mockConnectionInstance);
+      mockConnectionInstance.isConnected.mockResolvedValue(false);
+
+      await expect(
+        MCPConnectionFactory.create({ serverName: 'no-url', serverConfig }, oauthOptions),
+      ).rejects.toThrow('server URL is missing');
+    });
+
+    it('should clean up cross-listeners when oauthHandled fires', async () => {
+      const serverConfig = makeOAuthServerConfig();
+      const oauthOptions = makeOAuthOptions();
+
+      mockProcessMCPEnv.mockReturnValue(serverConfig);
+      mockFlowManager.createFlowWithHandler.mockRejectedValue(new Error('no tokens'));
+
+      const mockTokens: MCPOAuthTokens = {
+        access_token: 'cleanup-token',
+        token_type: 'Bearer',
+        obtained_at: Date.now(),
+      };
+
+      mockMCPOAuthHandler.generateFlowId.mockReturnValue('flow-cleanup');
+      mockMCPOAuthHandler.initiateOAuthFlow.mockResolvedValue({
+        authorizationUrl: 'https://auth.example.com',
+        flowId: 'flow-cleanup',
+        flowMetadata: {
+          serverName: 'bigquery',
+          userId: 'user123',
+          serverUrl: 'https://bigquery.googleapis.com/mcp',
+          state: 'state-cleanup',
+          clientInfo: { client_id: 'client-cleanup' },
+        },
+      });
+      mockFlowManager.getFlowState.mockResolvedValue(null);
+      mockFlowManager.createFlow.mockResolvedValue(mockTokens);
+
+      const handlers = wireEventHandlers(mockConnectionInstance);
+      mockConnectionInstance.isConnected.mockResolvedValue(true);
+
+      await MCPConnectionFactory.create({ serverName: 'bigquery', serverConfig }, oauthOptions);
+
+      // After oauthHandled resolved, the oauthFailed listener should have been removed
+      const failedListeners = handlers['oauthFailed'] ?? [];
+      expect(failedListeners.length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

**Problem:** MCP servers configured with `requiresOAuth: true` that accept unauthenticated connections during the MCP handshake (`initialize` + `tools/list`) would silently connect without triggering the OAuth flow. This affects servers like Google BigQuery MCP, which permit anonymous connections but reject unauthenticated `tools/call` requests.

The root cause: the OAuth flow was only triggered reactively — when `connectClient()` received a `401` from the server. Since these servers never return `401` during the connection handshake, the `oauthRequired` event was never emitted, tokens were never obtained, and all subsequent tool calls failed with an authentication error.

**Fix:** In `MCPConnectionFactory.createConnection()`, when `requiresOAuth` is explicitly `true` on the server config and no stored tokens exist, the OAuth flow is now triggered **proactively** before `attemptToConnect()` is called. The factory emits `oauthRequired` directly on the connection and awaits either `oauthHandled` (tokens obtained, proceed to connect) or `oauthFailed` (return early to caller with auth URL). This reuses the existing `handleOAuthEvents` machinery with no changes to the OAuth handler itself.

The proactive path is gated on `serverConfig.requiresOAuth === true` (not just `useOAuth`) so it only triggers for servers that explicitly require OAuth — user connections that pass `useOAuth: true` for non-OAuth servers are unaffected. The `serverUrl` is read from `ParsedServerConfig.url` (transport-agnostic) and fails fast if absent.

Fixes: MCP OAuth flow not triggered for servers that allow anonymous `initialize`/`tools/list` but require auth for tool execution.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

**Prerequisite config (`librechat.yaml`):**
```yaml
mcpServers:
  bigquery:
    type: streamable-http
    requiresOAuth: true
    initTimeout: 30000
    timeout: 300000
    url: "https://bigquery.googleapis.com/mcp"
    oauth:
      client_id: "YOUR_CLIENT_ID"
      client_secret: "YOUR_CLIENT_SECRET"
      authorization_url: "https://accounts.google.com/o/oauth2/auth"
      token_url: "https://oauth2.googleapis.com/token"
      redirect_uri: "http://localhost:3080/api/mcp/bigquery/oauth/callback"
      scope: "https://www.googleapis.com/auth/bigquery.readonly"
```

**Steps to reproduce the bug (before fix):**
1. Configure BigQuery MCP as above and start LibreChat.
2. Open the MCP panel in the UI and click Connect for BigQuery.
3. Observe: server turns green (connected), `oauthRequired: false` in logs — no OAuth prompt shown.
4. Ask the model to call any BigQuery tool → fails with `OAuth authentication required`.

**Steps to verify the fix:**
1. Apply the change, rebuild, and start LibreChat with the same config.
2. Click Connect for BigQuery in the UI.
3. Observe: OAuth browser redirect is issued immediately — log shows `No stored tokens — proactively triggering OAuth flow before connecting`.
4. Complete the Google OAuth consent flow.
5. Confirm BigQuery tools execute successfully with the authenticated session.

### **Test Configuration**:
- LibreChat `main` branch + patch applied
- MCP server: Google BigQuery MCP (`https://bigquery.googleapis.com/mcp`) via `streamable-http`
- OAuth provider: Google (`accounts.google.com`)
- Scope tested: `https://www.googleapis.com/auth/bigquery.readonly`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes