### PR TITLE
fix(mcp/oauth): prefer WWW-Authenticate resource_metadata hint over RFC 9728 path-aware discovery

### DIFF
--- a/packages/api/src/mcp/__tests__/handler.test.ts
+++ b/packages/api/src/mcp/__tests__/handler.test.ts
@@ -2153,4 +2153,124 @@ describe('MCPOAuthHandler - Configurable OAuth Metadata', () => {
       });
     });
   });
+
+  describe('WWW-Authenticate resource_metadata hint (RFC 9728 §5.1)', () => {
+    // Regression test for LibreChat#12761: the MCP SDK supports
+    // `opts.resourceMetadataUrl` to override RFC 9728 path-aware discovery
+    // with the URL advertised in the 401 `WWW-Authenticate` header.  The
+    // handler must probe the server for that hint and pass it through,
+    // otherwise LibreChat diverges from Claude / MCP Inspector / OpenAI /
+    // Copilot behaviour on servers whose path-aware and root well-known
+    // endpoints disagree.
+
+    const originalFetch = global.fetch;
+    const mockFetch = jest.fn() as unknown as jest.MockedFunction<typeof fetch>;
+
+    beforeEach(() => {
+      global.fetch = mockFetch;
+      mockFetch.mockReset();
+
+      mockDiscoverAuthorizationServerMetadata.mockResolvedValue({
+        issuer: 'https://mcp.example.com/',
+        authorization_endpoint: 'https://mcp.example.com/authorize',
+        token_endpoint: 'https://mcp.example.com/token',
+        registration_endpoint: 'https://mcp.example.com/register',
+        response_types_supported: ['code'],
+        grant_types_supported: ['authorization_code', 'refresh_token'],
+        code_challenge_methods_supported: ['S256'],
+        token_endpoint_auth_methods_supported: ['client_secret_basic'],
+      } as AuthorizationServerMetadata);
+
+      mockRegisterClient.mockResolvedValue({
+        client_id: 'dcr-client-id',
+        client_secret: 'dcr-client-secret',
+        redirect_uris: ['http://localhost:3080/api/mcp/test-server/oauth/callback'],
+      });
+
+      mockDiscoverOAuthProtectedResourceMetadata.mockResolvedValue({
+        resource: 'https://mcp.example.com/',
+        authorization_servers: ['https://mcp.example.com/'],
+      } as Awaited<ReturnType<typeof discoverOAuthProtectedResourceMetadata>>);
+    });
+
+    afterAll(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('passes resource_metadata hint from WWW-Authenticate to the SDK', async () => {
+      const hintUrl = 'https://mcp.example.com/.well-known/oauth-protected-resource';
+
+      // The MCP server 401-challenges the probe with the hint pointing at
+      // the root well-known URL — authoritative per RFC 9728.
+      mockFetch.mockResolvedValueOnce({
+        status: 401,
+        headers: new Headers({
+          'www-authenticate': `Bearer resource_metadata="${hintUrl}"`,
+        }),
+      } as Response);
+
+      await MCPOAuthHandler.initiateOAuthFlow(
+        mockServerName,
+        mockServerUrl,
+        mockUserId,
+        {},
+        undefined, // no pre-configured oauth block → discoverMetadata runs
+      );
+
+      // Must be called with the extracted hint — not empty opts.
+      expect(mockDiscoverOAuthProtectedResourceMetadata).toHaveBeenCalledWith(
+        mockServerUrl,
+        expect.objectContaining({
+          resourceMetadataUrl: expect.any(URL),
+        }),
+        expect.any(Function),
+      );
+      const opts = mockDiscoverOAuthProtectedResourceMetadata.mock.calls[0][1] as {
+        resourceMetadataUrl?: URL;
+      };
+      expect(opts.resourceMetadataUrl?.toString()).toBe(hintUrl);
+    });
+
+    it('falls back to path-aware discovery when no resource_metadata hint is present', async () => {
+      // 401 without resource_metadata — e.g. legacy server that only says "Bearer".
+      mockFetch.mockResolvedValueOnce({
+        status: 401,
+        headers: new Headers({ 'www-authenticate': 'Bearer' }),
+      } as Response);
+
+      await MCPOAuthHandler.initiateOAuthFlow(
+        mockServerName,
+        mockServerUrl,
+        mockUserId,
+        {},
+        undefined,
+      );
+
+      // SDK still called, but with empty opts — path-aware discovery wins.
+      expect(mockDiscoverOAuthProtectedResourceMetadata).toHaveBeenCalledWith(
+        mockServerUrl,
+        {},
+        expect.any(Function),
+      );
+    });
+
+    it('swallows probe failures and falls back to path-aware discovery', async () => {
+      // Probe errors out — the hint path must not break OAuth initiation.
+      mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+      await MCPOAuthHandler.initiateOAuthFlow(
+        mockServerName,
+        mockServerUrl,
+        mockUserId,
+        {},
+        undefined,
+      );
+
+      expect(mockDiscoverOAuthProtectedResourceMetadata).toHaveBeenCalledWith(
+        mockServerUrl,
+        {},
+        expect.any(Function),
+      );
+    });
+  });
 });

--- a/packages/api/src/mcp/oauth/detectOAuth.test.ts
+++ b/packages/api/src/mcp/oauth/detectOAuth.test.ts
@@ -196,6 +196,54 @@ describe('detectOAuthRequirement', () => {
       });
     });
 
+    it('should prefer the WWW-Authenticate resource_metadata hint over RFC 9728 path-aware discovery', async () => {
+      // Regression test for LibreChat#12761: some MCP servers serve valid
+      // but divergent metadata at /.well-known/oauth-protected-resource
+      // (root) vs /.well-known/oauth-protected-resource/<path> (path-aware).
+      // The 401 `resource_metadata=` hint is authoritative per RFC 9728 §5.1
+      // and MUST be preferred, matching Claude / MCP Inspector / OpenAI /
+      // Copilot behaviour.
+      const hintUrl = 'https://mcp.example.com/.well-known/oauth-protected-resource';
+      const correctAuthServer = 'https://mcp.example.com/';
+      const staleAuthServer = 'https://legacy-as.example.com/realms/stale';
+
+      // SDK path-aware discovery returns STALE metadata (should be ignored).
+      mockDiscoverOAuthProtectedResourceMetadata.mockResolvedValue({
+        resource: 'https://mcp.example.com',
+        authorization_servers: [staleAuthServer],
+      } as Awaited<ReturnType<typeof discoverOAuthProtectedResourceMetadata>>);
+
+      mockFetch
+        // HEAD probe — 401 with the hint pointing at the (correct) root URL
+        .mockResolvedValueOnce({
+          status: 401,
+          headers: new Headers({
+            'www-authenticate': `Bearer resource_metadata="${hintUrl}"`,
+          }),
+        } as Response)
+        // Hint fetch — returns the correct metadata
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            resource: correctAuthServer,
+            authorization_servers: [correctAuthServer],
+          }),
+        } as Response);
+
+      const result = await detectOAuthRequirement('https://mcp.example.com/v1');
+
+      expect(result.requiresOAuth).toBe(true);
+      expect(result.method).toBe('401-challenge-metadata');
+      // The hint wins — the stale path-aware AS must NOT appear.
+      expect(result.metadata).toEqual({
+        resource: correctAuthServer,
+        authorization_servers: [correctAuthServer],
+      });
+      expect(
+        (result.metadata as { authorization_servers?: unknown[] })?.authorization_servers,
+      ).not.toContain(staleAuthServer);
+    });
+
     it('should fall back to Bearer detection if metadata fetch fails', async () => {
       const metadataUrl = 'https://auth.example.com/.well-known/oauth-protected-resource';
 

--- a/packages/api/src/mcp/oauth/detectOAuth.ts
+++ b/packages/api/src/mcp/oauth/detectOAuth.ts
@@ -26,11 +26,20 @@ export interface OAuthDetectionResult {
  * @returns Promise<OAuthDetectionResult> - OAuth requirement details
  */
 export async function detectOAuthRequirement(serverUrl: string): Promise<OAuthDetectionResult> {
-  const protectedResourceResult = await checkProtectedResourceMetadata(serverUrl);
-  if (protectedResourceResult) return protectedResourceResult;
-
+  /**
+   * RFC 9728 §5.1: prefer the `resource_metadata=` URL from the 401
+   * `WWW-Authenticate` challenge over RFC 9728 path-aware `.well-known`
+   * discovery.  Path-aware discovery can return valid-but-wrong metadata in
+   * split deployments where the root and path-aware well-known endpoints are
+   * served by different processes.  The 401 hint is always authoritative.
+   * Matches behaviour of Claude Desktop, OpenAI tooling, Microsoft Copilot
+   * Studio, and the MCP Inspector.
+   */
   const challengeResult = await check401ChallengeMetadata(serverUrl);
   if (challengeResult) return challengeResult;
+
+  const protectedResourceResult = await checkProtectedResourceMetadata(serverUrl);
+  if (protectedResourceResult) return protectedResourceResult;
 
   const fallbackResult = await checkAuthErrorFallback(serverUrl);
   if (fallbackResult) return fallbackResult;

--- a/packages/api/src/mcp/oauth/handler.ts
+++ b/packages/api/src/mcp/oauth/handler.ts
@@ -120,6 +120,37 @@ export class MCPOAuthHandler {
   }
 
   /**
+   * Probe the MCP server for a `WWW-Authenticate: Bearer ..., resource_metadata="<url>"`
+   * challenge (RFC 9728 §5.1).  The hint is authoritative when present and should be
+   * preferred over RFC 9728 path-aware discovery, which can return valid-but-wrong
+   * metadata in split deployments where the root and `/<mcp-path>` well-known
+   * endpoints are served by different processes.
+   *
+   * Returns the parsed URL when the server advertises one, or `undefined` when
+   * the probe fails / returns no hint (in which case the caller falls back to
+   * path-aware discovery).
+   */
+  private static async probeResourceMetadataHint(
+    serverUrl: string,
+    fetchFn: FetchLike,
+  ): Promise<URL | undefined> {
+    try {
+      const response = await fetchFn(serverUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      if (response.status !== 401) return undefined;
+      const wwwAuth = response.headers.get('www-authenticate');
+      const match = wwwAuth?.match(/resource_metadata="([^"]+)"/);
+      if (!match?.[1]) return undefined;
+      return new URL(match[1]);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
    * Discovers OAuth metadata from the server
    */
   private static async discoverMetadata(
@@ -140,12 +171,34 @@ export class MCPOAuthHandler {
 
     const fetchFn = this.createOAuthFetch(oauthHeaders);
 
+    /**
+     * RFC 9728 §5.1: if the MCP server advertises `resource_metadata=<url>` in
+     * the 401 `WWW-Authenticate` header, that URL is the authoritative
+     * protected-resource metadata source.  Use it directly instead of the
+     * SDK's path-aware discovery (which can return valid-but-wrong data when
+     * the path-aware and root well-known endpoints are served by different
+     * processes — e.g. an MCP app behind a gateway with its own hardcoded AS
+     * config, or a server that changed its OAuth story without invalidating
+     * CDN caches).  Matches behaviour of Claude Desktop, OpenAI tooling,
+     * Microsoft Copilot Studio, and the MCP Inspector.
+     */
+    const hintUrl = await this.probeResourceMetadataHint(serverUrl, fetchFn);
+    if (hintUrl) {
+      logger.debug(
+        `[MCPOAuth] Using WWW-Authenticate resource_metadata hint: ${sanitizeUrlForLogging(hintUrl.toString())}`,
+      );
+    }
+
     try {
       // Try to discover resource metadata first
       logger.debug(
         `[MCPOAuth] Attempting to discover protected resource metadata from ${serverUrl}`,
       );
-      resourceMetadata = await discoverOAuthProtectedResourceMetadata(serverUrl, {}, fetchFn);
+      resourceMetadata = await discoverOAuthProtectedResourceMetadata(
+        serverUrl,
+        hintUrl ? { resourceMetadataUrl: hintUrl } : {},
+        fetchFn,
+      );
 
       if (resourceMetadata?.authorization_servers?.length) {
         const discoveredAuthServer = resourceMetadata.authorization_servers[0];


### PR DESCRIPTION
## Summary

fixes #12761.

librechat calls `discoverOAuthProtectedResourceMetadata(serverUrl, {}, fetchFn)` with empty opts, so the MCP SDK falls through to RFC 9728 path-aware discovery (`/.well-known/oauth-protected-resource/<path>`) and never tries the URL advertised in the 401 `WWW-Authenticate: Bearer resource_metadata="<url>"` header.

per RFC 9728 §5.1 that hint is authoritative when present. in split deployments where the root and path-aware well-known endpoints are served by different processes (e.g. an MCP app behind a gateway with its own hardcoded AS config, or a server that evolved its auth story without invalidating CDN caches), path-aware discovery can return valid-but-wrong metadata pointing at a stale / defunct authorization server. every other mainstream MCP client (claude desktop, openai tooling, microsoft copilot studio, the MCP inspector) prefers the hint and therefore works against these servers. librechat currently doesn't.

the MCP typescript SDK already supports this via `opts.resourceMetadataUrl` and uses it correctly in its own `authInternal` code path. this change just plumbs the hint through from librechat.

## Changes

### `packages/api/src/mcp/oauth/handler.ts`

- new private helper `probeResourceMetadataHint(serverUrl, fetchFn)`. POSTs to the MCP URL, parses `resource_metadata="<url>"` out of the 401 `WWW-Authenticate` response, returns the parsed URL or `undefined`.
- `discoverMetadata` now runs the probe, logs the outcome, and passes `{ resourceMetadataUrl: hintUrl }` to `discoverOAuthProtectedResourceMetadata` when a hint is available. when the probe fails or the hint is absent, behaviour is byte-for-byte identical to before (empty opts, path-aware discovery).

### `packages/api/src/mcp/oauth/detectOAuth.ts`

- reorders `detectOAuthRequirement` to check the 401 challenge before RFC 9728 path-aware protected-resource discovery, matching RFC 9728 §5.1 precedence.
- existing tests that mock the SDK to reject keep passing unchanged.

### Tests

- `packages/api/src/mcp/__tests__/handler.test.ts`: 3 new tests under a new `WWW-Authenticate resource_metadata hint (RFC 9728 §5.1)` describe block:
  - `passes resource_metadata hint from WWW-Authenticate to the SDK`, asserts the extracted URL lands in `opts.resourceMetadataUrl`.
  - `falls back to path-aware discovery when no resource_metadata hint is present`.
  - `swallows probe failures and falls back to path-aware discovery`.
- `packages/api/src/mcp/oauth/detectOAuth.test.ts`: 1 new regression test, `should prefer the WWW-Authenticate resource_metadata hint over RFC 9728 path-aware discovery`, mocks both sources and asserts the hint-based metadata wins.

```
$ npm --prefix packages/api run test:ci -- --testPathPatterns='src/mcp/oauth/detectOAuth.test.ts|src/mcp/__tests__/handler.test.ts' --no-coverage
Test Suites: 2 passed, 2 total
Tests:       71 passed, 71 total
```

## Change Type

- [x] bug fix (non-breaking change which fixes an issue)

## Verified end-to-end

hot-patched the compiled `packages/api/dist/index.js` of a running `latest` librechat container (`v0.8.5-rc1`) against a real MCP server whose path-aware metadata diverges from the root. before the patch: OAuth flow dies with `Failed to initiate OAuth flow HTTP 404` hitting a dead AS. after the patch: DCR succeeds at the correct AS, browser popup auto-approves, tokens land in mongo, tool list populates. matches claude desktop behaviour with the same server and identical `mcpServers:` YAML (`type`, `url`, `timeout`, no `oauth:` block needed).

## Checklist

- [x] my code adheres to this project's style guidelines
- [x] i have performed a self-review of my own code
- [x] i have commented in any complex areas of my code
- [x] my changes do not introduce new warnings
- [x] i have written tests demonstrating that my changes are effective
- [x] local unit tests pass with my changes (71 tests across 2 files)
