### PR TITLE
🔗 fix: Defer Auto-Submit on Agent Deeplinks Until Agent Query Resolves

### DIFF
--- a/client/src/hooks/Input/useQueryParams.spec.ts
+++ b/client/src/hooks/Input/useQueryParams.spec.ts
@@ -452,6 +452,100 @@ describe('useQueryParams', () => {
     expect(mockSubmitMessage).toHaveBeenCalled();
   });
 
+  it('should defer submission until the URL agent query resolves', () => {
+    const mockSetValue = jest.fn();
+    const mockHandleSubmit = jest.fn((callback) => () => callback({ text: 'test message' }));
+    const mockSubmitMessage = jest.fn();
+    const mockNewConversation = jest.fn();
+    const mockTextAreaRef = {
+      current: {
+        focus: jest.fn(),
+        setSelectionRange: jest.fn(),
+      } as unknown as HTMLTextAreaElement,
+    };
+
+    (useChatFormContext as jest.Mock).mockReturnValue({
+      setValue: mockSetValue,
+      getValues: jest.fn().mockReturnValue(''),
+      handleSubmit: mockHandleSubmit,
+    });
+
+    (useSubmitMessage as jest.Mock).mockReturnValue({
+      submitMessage: mockSubmitMessage,
+    });
+
+    const conversationWithAgent = { agent_id: 'agent_test_123', endpoint: 'agents' };
+    (useChatContext as jest.Mock).mockReturnValue({
+      conversation: conversationWithAgent,
+      newConversation: mockNewConversation,
+    });
+
+    (useQueryClient as jest.Mock).mockReturnValue({
+      getQueryData: jest.fn().mockImplementation((key) => {
+        const k = Array.isArray(key) ? key[0] : key;
+        if (k === 'startupConfig') {
+          return { modelSpecs: { list: [] } };
+        }
+        if (k === 'endpoints') {
+          return { agents: {} };
+        }
+        return null;
+      }),
+    });
+
+    const dataProvider = jest.requireMock('~/data-provider');
+    (dataProvider.useGetAgentByIdQuery as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+
+    const dataProviderMock = jest.requireMock('librechat-data-provider');
+    dataProviderMock.tQueryParamsSchema = {
+      shape: {
+        agent_id: { parse: jest.fn((value) => value) },
+        endpoint: { parse: jest.fn((value) => value) },
+      },
+    };
+
+    setUrlParams({
+      q: 'hello world',
+      submit: 'true',
+      agent_id: 'agent_test_123',
+    });
+
+    const { rerender } = renderHook(() => useQueryParams({ textAreaRef: mockTextAreaRef }));
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    // Should not submit while the agent query is still loading.
+    expect(mockSubmitMessage).not.toHaveBeenCalled();
+
+    // Timeout fires with the agent still unresolved → must stay deferred.
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    expect(mockSubmitMessage).not.toHaveBeenCalled();
+
+    // Agent resolves; the urlAgent-keyed effect should now fire the submission.
+    (dataProvider.useGetAgentByIdQuery as jest.Mock).mockReturnValue({
+      data: { id: 'agent_test_123', name: 'Test Agent' },
+      isLoading: false,
+      error: null,
+    });
+    rerender();
+
+    expect(mockSetValue).toHaveBeenCalledWith(
+      'text',
+      'hello world',
+      expect.objectContaining({ shouldValidate: true }),
+    );
+    expect(mockHandleSubmit).toHaveBeenCalled();
+    expect(mockSubmitMessage).toHaveBeenCalled();
+  });
+
   it('should mark as submitted when no submit parameter is present', () => {
     // Setup
     const mockSetValue = jest.fn();

--- a/client/src/hooks/Input/useQueryParams.ts
+++ b/client/src/hooks/Input/useQueryParams.ts
@@ -182,14 +182,26 @@ export default function useQueryParams({
   const conversationRef = useRef(conversation);
   conversationRef.current = conversation;
 
+  const urlAgentRef = useRef(urlAgent);
+  urlAgentRef.current = urlAgent;
+
   const areSettingsApplied = useCallback(() => {
     const convo = conversationRef.current;
     if (!validSettingsRef.current || !convo) {
       return false;
     }
 
-    for (const [key, value] of Object.entries(validSettingsRef.current)) {
+    const settings = validSettingsRef.current;
+    /** `endpoint` is derived from `agent_id` / `assistant_id` in `processValidSettings`;
+     *  skip the strict check to avoid false negatives when the conversation endpoint
+     *  is normalized differently than the URL-derived value. */
+    const hasDerivedEndpoint = Boolean(settings.agent_id) || Boolean(settings.assistant_id);
+
+    for (const [key, value] of Object.entries(settings)) {
       if (['presetOverride', 'iconURL', 'spec', 'modelLabel'].includes(key)) {
+        continue;
+      }
+      if (hasDerivedEndpoint && key === 'endpoint') {
         continue;
       }
 
@@ -299,6 +311,16 @@ export default function useQueryParams({
           // Set a timeout to handle the case where settings might never fully apply
           settingsTimeoutRef.current = setTimeout(() => {
             if (!submissionHandledRef.current && pendingSubmitRef.current) {
+              /** When `agent_id` is requested, defer instead of firing against an
+               *  unloaded agent; the `urlAgent`-keyed effect below will submit once
+               *  the agent query resolves. */
+              if (validSettingsRef.current?.agent_id && !urlAgentRef.current) {
+                logger.log(
+                  'conversation',
+                  'Agent not loaded before timeout, deferring submission',
+                );
+                return;
+              }
               logger.log(
                 'conversation',
                 'Settings application timeout, proceeding with submission',
@@ -363,6 +385,13 @@ export default function useQueryParams({
       return;
     }
 
+    /** When `agent_id` is present in the URL, wait for the agent query to resolve
+     *  before firing submission so the downstream `ask()` call binds against a
+     *  fully loaded agent. Re-runs when `urlAgent` transitions from null to loaded. */
+    if (validSettingsRef.current.agent_id && !urlAgent) {
+      return;
+    }
+
     if (areSettingsApplied()) {
       settingsAppliedRef.current = true;
 
@@ -376,7 +405,7 @@ export default function useQueryParams({
         processSubmission();
       }
     }
-  }, [conversation, processSubmission, areSettingsApplied]);
+  }, [conversation, urlAgent, processSubmission, areSettingsApplied]);
 
   const { isAuthenticated } = useAuthContext();
   const agentsMap = useAgentsMap({ isAuthenticated });

--- a/client/src/hooks/Input/useQueryParams.ts
+++ b/client/src/hooks/Input/useQueryParams.ts
@@ -315,10 +315,7 @@ export default function useQueryParams({
                *  unloaded agent; the `urlAgent`-keyed effect below will submit once
                *  the agent query resolves. */
               if (validSettingsRef.current?.agent_id && !urlAgentRef.current) {
-                logger.log(
-                  'conversation',
-                  'Agent not loaded before timeout, deferring submission',
-                );
+                logger.log('conversation', 'Agent not loaded before timeout, deferring submission');
                 return;
               }
               logger.log(


### PR DESCRIPTION
## Summary

When a URL includes both `agent_id` and `submit=true` (the shape produced by the agent Share button, e.g. `/c/new?agent_id=<id>&prompt=<text>&submit=true`), the deep-linked prompt is prefilled in the composer but never submitted.

### Root cause

`useQueryParams` takes the *deferred submission* branch whenever `hasSettings` is true. The deferred path:

1. Marks `pendingSubmitRef.current = true` and arms a 3 s fallback timeout.
2. Waits for the second effect (keyed on `conversation`) to observe that `areSettingsApplied()` returns true, then fires `processSubmission()`.

Two issues combine for agent deeplinks:

- `useGetAgentByIdQuery(urlAgentId)` is async; when the 3 s fallback fires before the agent resolves, `processSubmission` → `submitMessage` → `ask` runs against a conversation whose agent binding is not yet loaded, and the submit silently no-ops.
- `processValidSettings` injects `endpoint: 'agents'` alongside `agent_id`, and `areSettingsApplied()` strict-compares every setting field against `conversation`. Any divergence between the URL-derived endpoint and the normalized conversation endpoint keeps the check false, so the deterministic "settings applied" path never fires and we fall through to the fallback timeout described above.

### Fix

- Gate the `settings-applied` effect on `urlAgent` having resolved when `agent_id` is requested; add `urlAgent` to the effect's dep array so it re-runs when the agent query transitions from loading to loaded.
- Gate the fallback timeout on the same condition so a slow agent fetch does not force submission against an unready conversation; the `urlAgent`-keyed effect submits once the data arrives.
- Skip the strict `endpoint` equality check in `areSettingsApplied` when `agent_id` / `assistant_id` is present (endpoint is derived from them in `processValidSettings`).

## Test plan

- [x] Added a regression test: `useQueryParams` does not submit while `useGetAgentByIdQuery` is loading, remains deferred across the 3 s fallback, and submits once the agent data resolves.
- [x] Manual: open `/c/new?agent_id=<id>&prompt=<text>&submit=true` on a fresh session; the agent loads, the prompt submits without manual Enter.
- [x] Manual: open `/c/new?prompt=<text>&submit=true` (no agent) — still submits immediately against the active endpoint.
- [x] Manual: open `/c/new?model=gpt-4&prompt=<text>&submit=true` — still submits after the model settings apply (existing non-agent deferred path unchanged).