### PR TITLE
🔐 chore: Skills Permissions Housekeeping, Reachable Admin Dialog + Defaults Tests

### DIFF
--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -378,7 +378,6 @@ const createResponse = async (req, res) => {
       getSkillByName: db.getSkillByName,
     };
 
-    const appConfig = req.config;
     const enabledCapabilities = new Set(
       appConfig?.endpoints?.[EModelEndpoint.agents]?.capabilities,
     );

--- a/client/src/components/Skills/sidebar/SkillsAccordion.tsx
+++ b/client/src/components/Skills/sidebar/SkillsAccordion.tsx
@@ -1,7 +1,7 @@
 import { SystemRoles } from 'librechat-data-provider';
 import { AdminSettings } from '~/components/Skills/buttons';
-import { useAuthContext } from '~/hooks';
 import SkillsSidePanel from './SkillsSidePanel';
+import { useAuthContext } from '~/hooks';
 
 export default function SkillsAccordion() {
   const { user } = useAuthContext();

--- a/client/src/components/Skills/sidebar/SkillsAccordion.tsx
+++ b/client/src/components/Skills/sidebar/SkillsAccordion.tsx
@@ -1,9 +1,18 @@
+import { SystemRoles } from 'librechat-data-provider';
+import { AdminSettings } from '~/components/Skills/buttons';
+import { useAuthContext } from '~/hooks';
 import SkillsSidePanel from './SkillsSidePanel';
 
 export default function SkillsAccordion() {
+  const { user } = useAuthContext();
   return (
     <div className="flex h-auto w-full flex-col">
       <SkillsSidePanel className="h-auto border-r-0" />
+      {user?.role === SystemRoles.ADMIN && (
+        <div className="flex w-full items-center justify-end px-4 pb-2">
+          <AdminSettings />
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/api/src/endpoints/config/endpoints.spec.ts
+++ b/packages/api/src/endpoints/config/endpoints.spec.ts
@@ -237,4 +237,10 @@ describe('createEndpointsConfigService', () => {
       expect(result).toBe(true);
     });
   });
+
+  describe('defaultAgentCapabilities', () => {
+    it('includes AgentCapabilities.skills so skills are enabled by default', () => {
+      expect(defaultAgentCapabilities).toContain(AgentCapabilities.skills);
+    });
+  });
 });

--- a/packages/api/src/endpoints/config/endpoints.spec.ts
+++ b/packages/api/src/endpoints/config/endpoints.spec.ts
@@ -237,10 +237,10 @@ describe('createEndpointsConfigService', () => {
       expect(result).toBe(true);
     });
   });
+});
 
-  describe('defaultAgentCapabilities', () => {
-    it('includes AgentCapabilities.skills so skills are enabled by default', () => {
-      expect(defaultAgentCapabilities).toContain(AgentCapabilities.skills);
-    });
+describe('defaultAgentCapabilities', () => {
+  it('includes AgentCapabilities.skills so skills are enabled by default', () => {
+    expect(defaultAgentCapabilities).toContain(AgentCapabilities.skills);
   });
 });

--- a/packages/data-provider/src/roles.spec.ts
+++ b/packages/data-provider/src/roles.spec.ts
@@ -130,4 +130,30 @@ describe('roleDefaults', () => {
       }
     });
   });
+
+  describe('SKILLS permission defaults', () => {
+    it('grants ADMIN all four skill permissions by default', () => {
+      const adminSkills = roleDefaults[SystemRoles.ADMIN].permissions[
+        PermissionTypes.SKILLS
+      ] as Record<string, boolean>;
+      expect(adminSkills).toEqual({
+        [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.SHARE]: true,
+        [Permissions.SHARE_PUBLIC]: true,
+      });
+    });
+
+    it('grants USER USE+CREATE but no sharing by default', () => {
+      const userSkills = roleDefaults[SystemRoles.USER].permissions[
+        PermissionTypes.SKILLS
+      ] as Record<string, boolean>;
+      expect(userSkills).toEqual({
+        [Permissions.USE]: true,
+        [Permissions.CREATE]: true,
+        [Permissions.SHARE]: false,
+        [Permissions.SHARE_PUBLIC]: false,
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Phase 9 housekeeping pass. Skills was already gated on `PermissionTypes.SKILLS` (seeded from `interface.skills`) and `AgentCapabilities.skills` everywhere it matters, but three smaller parity gaps with Prompts/Memory/MCP remained:

- **Admin settings dialog was unreachable.** The skills admin settings dialog (`components/Skills/buttons/AdminSettings.tsx`) existed but its only mount lived in `FilterSkills.tsx`, which is never rendered anywhere in the UI. Admins had no route to the role-permissions editor for skills. Mounted it in `SkillsAccordion` gated on `SystemRoles.ADMIN`, matching the `PromptsAccordion` pattern.
- **No regression lock on Skills permission defaults.** `roles.spec.ts` asserted structural completeness but not the specific shape — a future refactor could silently flip ADMIN's `USE/CREATE/SHARE/SHARE_PUBLIC` to `false` or drop SKILLS from USER defaults without failing a test. Added explicit Skills assertions for both roles.
- **No lock on `AgentCapabilities.skills` being in `defaultAgentCapabilities`.** A future `defaultAgentCapabilities` edit could silently drop skills. Added an assertion in `endpoints.spec.ts`.

## Non-gaps confirmed by the audit

- **Frontend UI gating.** Skills UI already respects `interface.skills: false` in the yaml — that field seeds `PermissionTypes.SKILLS.USE` at startup (see `packages/api/src/app/permissions.ts:48-49`). When set to `false`, `useHasAccess` returns `false` and the entire sidebar, route, and chat-input affordance disappear. Same pattern as `interface.prompts` / `interface.memories`. No separate `interfaceConfig?.skills` check is needed (Prompts/Memories don't have one either).
- **Backend capability gating.** `enabledCapabilities.has(AgentCapabilities.skills)` is already checked at every skill-invocation site — `initialize.js:122`, `openai.js:254`, `responses.js:385` (the last one was tightened in #12760). When the capability is off, `accessibleSkillIds = []` and no catalog injection, manual priming, or always-apply priming runs. Existing tests at `accessibleSkillIds: []` (see `packages/api/src/agents/__tests__/initialize.test.ts:552`) cover this path.
- **Role defaults.** ADMIN already has `{ USE, CREATE, SHARE, SHARE_PUBLIC } = true` and USER has `{ USE: true, CREATE: true, SHARE: false, SHARE_PUBLIC: false }` — now locked in by explicit tests.
- **`AdminSettings` component parity.** The component itself mirrors `Prompts/AdminSettings.tsx` structurally (same `AdminSettingsDialog` wrapper, same mutation hook shape, same permissions array). Only the mounting was missing.

## Test plan

- [x] `cd packages/data-provider && npx jest src/roles.spec.ts` passes (6/6, including 2 new Skills-specific cases).
- [x] `cd packages/api && npx jest src/endpoints/config/endpoints.spec.ts` passes (12/12, including 1 new `defaultAgentCapabilities` case).
- [x] `cd packages/data-provider && npx jest` — full package suite passes (982 tests).
- [x] `npx prettier --check` and `npx eslint` on touched files — clean.
- [x] Spot-checked in reader that `SkillsAccordion` renders admin dialog only when `user.role === ADMIN`.

## Base branch

Targets `feat/agent-skills` (not `dev`) per the umbrella PR flow.