### PR TITLE
🔏 fix: Prevent Browser Autofill From Silently Dropping MCP CustomUserVars on Save

### DIFF
--- a/client/src/components/MCP/CustomUserVarsSection.tsx
+++ b/client/src/components/MCP/CustomUserVarsSection.tsx
@@ -85,7 +85,17 @@ function AuthField({ name, config, hasValue, control, errors, autoFocus }: AuthF
         render={({ field }) => (
           <Input
             id={name}
-            type="text"
+            // Discourage browser password managers from autofilling these
+            // per-user credential fields. Matches the pattern used in
+            // `SidePanel/Builder/ActionsAuth.tsx` for the same reason.
+            // Critical because autofilled values are set via the DOM and
+            // do NOT fire React's synthetic onChange -- react-hook-form
+            // then sees an empty string and the user's typed credential
+            // is silently dropped on save.
+            type="new-password"
+            autoComplete="new-password"
+            data-lpignore="true"
+            data-1p-ignore="true"
             /* autoFocus is generally disabled due to the fact that it can disorient users,
              * but in this case, the required field would logically be immediately navigated to anyways, and the component's
              * functionality emulates that of a new modal opening, where users would expect focus to be shifted to the new content */

--- a/client/src/components/MCP/CustomUserVarsSection.tsx
+++ b/client/src/components/MCP/CustomUserVarsSection.tsx
@@ -85,13 +85,8 @@ function AuthField({ name, config, hasValue, control, errors, autoFocus }: AuthF
         render={({ field }) => (
           <Input
             id={name}
-            // Discourage browser password managers from autofilling these
-            // per-user credential fields. Matches the pattern used in
-            // `SidePanel/Builder/ActionsAuth.tsx` for the same reason.
-            // Critical because autofilled values are set via the DOM and
-            // do NOT fire React's synthetic onChange -- react-hook-form
-            // then sees an empty string and the user's typed credential
-            // is silently dropped on save.
+            // Prevent autofill: browser DOM mutations bypass React's synthetic
+            // onChange, silently emptying react-hook-form state on submit.
             type="new-password"
             autoComplete="new-password"
             data-lpignore="true"

--- a/client/src/components/MCP/__tests__/CustomUserVarsSection.test.tsx
+++ b/client/src/components/MCP/__tests__/CustomUserVarsSection.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import CustomUserVarsSection from '../CustomUserVarsSection';
+
+jest.mock('~/data-provider/Tools/queries', () => ({
+  useMCPAuthValuesQuery: () => ({ data: { authValueFlags: {} } }),
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+}));
+
+describe('CustomUserVarsSection', () => {
+  const fields = {
+    api_key: { title: 'My API Key', description: 'Your API key' },
+  };
+
+  it('renders autofill-prevention attributes on credential inputs', () => {
+    render(
+      <CustomUserVarsSection
+        serverName="test-server"
+        fields={fields}
+        onSave={jest.fn()}
+        onRevoke={jest.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText(/My API Key/);
+    expect(input).toHaveAttribute('autocomplete', 'new-password');
+    expect(input).toHaveAttribute('type', 'new-password');
+    expect(input).toHaveAttribute('data-lpignore', 'true');
+    expect(input).toHaveAttribute('data-1p-ignore', 'true');
+  });
+});


### PR DESCRIPTION
## Summary

The customUserVars form in `CustomUserVarsSection.tsx` renders each credential as a plain `<input type="text">` with no autofill guards. This causes two user-visible problems when configuring a remote MCP server's per-user credentials from the Settings UI:

1. **Password managers offer to save the values.** Chrome's built-in manager, 1Password, LastPass, and Bitwarden all detect the fields as credential-shaped and prompt to store them. That cuts against the point of the per-user model (each user's secrets stay in their own browser session and backend-encrypted, not cached in a password vault).

2. **More seriously: autofill silently empties the save.** When a password manager fills a field via DOM mutation, it does **not** fire React's synthetic `onChange`. `react-hook-form`'s `Controller` therefore never sees the value, form state stays `""`, and on submit the backend receives empty strings for every affected field. The user's typed credentials are silently dropped. Concretely this writes 16 encrypted-empty-string rows into `pluginauths`, every subsequent MCP tool call then fails with `"API key not set"`-style errors, and the UI shows an `"Unset"` pill next to fields the user is sure they filled in.

### The fix

Match the pattern already used in `client/src/components/SidePanel/Builder/ActionsAuth.tsx` for the analogous actions-credential input:

```tsx
type="new-password"
autoComplete="new-password"
```

plus the two vendor-specific ignore attributes:

```tsx
data-lpignore="true"     // LastPass
data-1p-ignore="true"    // 1Password
```

Modern browsers ignore `autocomplete="off"` for password-shaped fields, so the vendor attributes are the reliable defence for LastPass and 1Password (which have their own heuristics that ignore the standard attribute).

No behavioural change beyond preventing autofill: the input still accepts typed and pasted values, `react-hook-form` still collects them, and submit still writes to the backend. The difference is that the collected values actually reach the submit handler now.

Because `@librechat/client`'s `Input` forwards `{...props}` through to the native `<input>`, the new attributes flow through without a component change.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual verification in a local deployment:

1. Without this fix, with any password manager active (Chrome built-in is enough), configure a remote MCP server that has `customUserVars` defined. Fill in all fields via the Settings UI. Save.
2. Reopen the dialog. All fields show "Unset" despite being filled and saved.
3. Query `db.pluginauths` directly: every field has an identical short hex `value` (the encrypted form of an empty string). Any MCP tool call that needs one of those credentials fails server-side with an auth error.
4. Apply this patch.
5. Repeat the configuration. After save, the fields show "Set" and `db.pluginauths` has distinct encrypted values of meaningful length. Tool calls succeed.

### Test Configuration

- macOS 14, Chrome 138 with built-in password manager enabled
- LibreChat main at commit 7cf8b84
- Remote MCP server with 16 `customUserVars` defined in `librechat.yaml` (`mcpServers.<name>.customUserVars`)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code (a block comment above the new attributes explains the React-autofill interaction)
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.

*Notes on the unchecked items: the change is four new HTML attributes on one `<Input>`; I did not add a unit test because the behaviour is asserted at the DOM/browser-integration level (password-manager interaction is not exercised by the existing jest/vitest suites). Happy to add a snapshot test or similar if you'd like.*