### PR TITLE
chore: add gemma-4 context sizes to tokens.ts

### DIFF
--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -97,6 +97,8 @@ const googleModels = {
   'gemma-2': 32768,
   'gemma-3': 32768,
   'gemma-3-27b': 131072,
+  'gemma-4': 262144,
+  'gemma-4-e': 131072,
   gemini: 30720, // -2048 from max
   'gemini-pro-vision': 12288,
   'gemini-1.5': 1000000,


### PR DESCRIPTION
## Summary

Adds Gemma-4 model variants to the context-window lookup table in tokens.ts.

Without these entries, any Gemma-4 model name (e.g. google/gemma-4-e2b) falls through to the shorter gemma key, which maps to only 8,196 tokens.

This also caused MCP tool call results that had more than a few thousand chars to get truncated, unless maxToolResultChars was manually configured.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified that google/gemma-4-e2b now uses the correct context size by default.
Confirmed that a ~20k character MCP tool result is no longer truncated without setting maxToolResultChars.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
