### PR TITLE
fix: Emit tool args and results on Agents API

### DIFF
--- a/api/server/controllers/agents/responses.js
+++ b/api/server/controllers/agents/responses.js
@@ -548,6 +548,10 @@ const createResponse = async (req, res) => {
         toolEndCallback,
       };
 
+      // Attachment side-effects run alongside the Responses-API tool-end
+      // emitters; both must fire on every tool end.
+      const toolEndHandler = new ToolEndHandler(toolEndCallback, logger);
+
       // Combine handlers
       const handlers = {
         on_message_delta: responsesHandlers.on_message_delta,
@@ -564,8 +568,13 @@ const createResponse = async (req, res) => {
             }
           },
         },
-        on_tool_end: new ToolEndHandler(toolEndCallback, logger),
-        on_run_step_completed: { handle: () => {} },
+        on_tool_end: {
+          handle: async (event, data, metadata, graph) => {
+            await toolEndHandler.handle(event, data, metadata, graph);
+            responsesHandlers.on_tool_end.handle(event, data);
+          },
+        },
+        on_run_step_completed: responsesHandlers.on_run_step_completed,
         on_chain_stream: { handle: () => {} },
         on_chain_end: { handle: () => {} },
         on_agent_update: { handle: () => {} },
@@ -716,6 +725,10 @@ const createResponse = async (req, res) => {
         toolEndCallback,
       };
 
+      // Attachment side-effects run alongside the aggregator's on_tool_end,
+      // which records tool outputs for `buildAggregatedResponse`.
+      const toolEndHandler = new ToolEndHandler(toolEndCallback, logger);
+
       const handlers = {
         on_message_delta: aggregatorHandlers.on_message_delta,
         on_reasoning_delta: aggregatorHandlers.on_reasoning_delta,
@@ -731,8 +744,13 @@ const createResponse = async (req, res) => {
             }
           },
         },
-        on_tool_end: new ToolEndHandler(toolEndCallback, logger),
-        on_run_step_completed: { handle: () => {} },
+        on_tool_end: {
+          handle: async (event, data, metadata, graph) => {
+            await toolEndHandler.handle(event, data, metadata, graph);
+            aggregatorHandlers.on_tool_end.handle(event, data);
+          },
+        },
+        on_run_step_completed: aggregatorHandlers.on_run_step_completed,
         on_chain_stream: { handle: () => {} },
         on_chain_end: { handle: () => {} },
         on_agent_update: { handle: () => {} },

--- a/packages/api/src/agents/responses/__tests__/service.test.ts
+++ b/packages/api/src/agents/responses/__tests__/service.test.ts
@@ -1,5 +1,47 @@
-import { convertInputToMessages } from '../service';
-import type { InputItem } from '../types';
+import type { Response as ServerResponse } from 'express';
+import {
+  convertInputToMessages,
+  createAggregatorEventHandlers,
+  createResponseAggregator,
+  createResponseContext,
+  createResponsesEventHandlers,
+} from '../service';
+import { createResponseTracker } from '../handlers';
+import type { InputItem, ResponseRequest } from '../types';
+
+function createMockStreamConfig() {
+  const writes: string[] = [];
+  const res = {
+    write: (chunk: string): boolean => {
+      writes.push(chunk);
+      return true;
+    },
+  } as unknown as ServerResponse;
+  const tracker = createResponseTracker();
+  const request: ResponseRequest = { model: 'test-model', input: '' };
+  const context = createResponseContext(request, 'resp_test');
+  return { writes, config: { res, context, tracker } };
+}
+
+function eventTypes(writes: string[]): string[] {
+  const types: string[] = [];
+  for (const chunk of writes) {
+    if (chunk.startsWith('event: ')) {
+      types.push(chunk.slice('event: '.length).trim());
+    }
+  }
+  return types;
+}
+
+function dataPayloads(writes: string[]): string[] {
+  const payloads: string[] = [];
+  for (const chunk of writes) {
+    if (chunk.startsWith('data: ') && !chunk.startsWith('data: [DONE]')) {
+      payloads.push(chunk);
+    }
+  }
+  return payloads;
+}
 
 describe('convertInputToMessages', () => {
   // ── String input shorthand ─────────────────────────────────────────
@@ -329,5 +371,245 @@ describe('convertInputToMessages', () => {
       { role: 'assistant', content: [{ type: 'text', text: '2+2 is 4.' }] },
       { role: 'user', content: [{ type: 'text', text: 'And 3+3?' }] },
     ]);
+  });
+});
+
+describe('createResponsesEventHandlers — tool call lifecycle', () => {
+  it('emits arguments.done, function_call item.done, and function_call_output on on_run_step_completed', () => {
+    const { writes, config } = createMockStreamConfig();
+    const { handlers } = createResponsesEventHandlers(config);
+
+    handlers.on_run_step.handle('on_run_step', {
+      stepDetails: { type: 'tool_calls', tool_calls: [{ id: 'call_1', name: 'tool_a' }] },
+    });
+    handlers.on_run_step_delta.handle('on_run_step_delta', {
+      delta: { type: 'tool_calls', tool_calls: [{ index: 0, args: '{"x":1}' }] },
+    });
+    handlers.on_run_step_completed.handle('on_run_step_completed', {
+      result: {
+        id: 'step_1',
+        index: 0,
+        type: 'tool_call',
+        tool_call: { id: 'call_1', name: 'tool_a', args: '{"x":1}', output: 'RESULT', progress: 1 },
+      },
+    });
+
+    expect(eventTypes(writes)).toEqual([
+      'response.output_item.added',
+      'response.function_call_arguments.delta',
+      'response.function_call_arguments.done',
+      'response.output_item.done',
+      'response.output_item.added',
+      'response.output_item.done',
+    ]);
+
+    const payloads = dataPayloads(writes);
+    const argumentsDone = payloads.find((p) => p.includes('function_call_arguments.done'));
+    expect(argumentsDone).toContain('"call_id":"call_1"');
+    expect(argumentsDone).toContain('"arguments":"{\\"x\\":1}"');
+
+    const fcoAdded = payloads.find(
+      (p) => p.includes('output_item.added') && p.includes('function_call_output'),
+    );
+    expect(fcoAdded).toContain('"call_id":"call_1"');
+    expect(fcoAdded).toContain('"output":"RESULT"');
+  });
+
+  it('routes deltas to per-step call_ids across sequential multi-step tool calls', () => {
+    const { writes, config } = createMockStreamConfig();
+    const { handlers } = createResponsesEventHandlers(config);
+
+    handlers.on_run_step.handle('on_run_step', {
+      stepDetails: { type: 'tool_calls', tool_calls: [{ id: 'call_A', name: 'tool_a' }] },
+    });
+    handlers.on_run_step_delta.handle('on_run_step_delta', {
+      delta: { type: 'tool_calls', tool_calls: [{ index: 0, args: 'ARGS_A' }] },
+    });
+    handlers.on_run_step_completed.handle('on_run_step_completed', {
+      result: {
+        id: 'step_A',
+        index: 0,
+        type: 'tool_call',
+        tool_call: { id: 'call_A', output: 'R_A' },
+      },
+    });
+
+    handlers.on_run_step.handle('on_run_step', {
+      stepDetails: { type: 'tool_calls', tool_calls: [{ id: 'call_B', name: 'tool_b' }] },
+    });
+    handlers.on_run_step_delta.handle('on_run_step_delta', {
+      delta: { type: 'tool_calls', tool_calls: [{ index: 0, args: 'ARGS_B' }] },
+    });
+    handlers.on_run_step_completed.handle('on_run_step_completed', {
+      result: {
+        id: 'step_B',
+        index: 1,
+        type: 'tool_call',
+        tool_call: { id: 'call_B', output: 'R_B' },
+      },
+    });
+
+    const payloads = dataPayloads(writes);
+
+    const deltaA = payloads.find(
+      (p) => p.includes('function_call_arguments.delta') && p.includes('ARGS_A'),
+    );
+    expect(deltaA).toContain('"call_id":"call_A"');
+
+    const deltaB = payloads.find(
+      (p) => p.includes('function_call_arguments.delta') && p.includes('ARGS_B'),
+    );
+    expect(deltaB).toBeDefined();
+    expect(deltaB).toContain('"call_id":"call_B"');
+    expect(deltaB).not.toContain('"call_id":"call_A"');
+
+    const argsDoneA = payloads.find(
+      (p) => p.includes('function_call_arguments.done') && p.includes('"call_id":"call_A"'),
+    );
+    expect(argsDoneA).toContain('"arguments":"ARGS_A"');
+
+    const argsDoneB = payloads.find(
+      (p) => p.includes('function_call_arguments.done') && p.includes('"call_id":"call_B"'),
+    );
+    expect(argsDoneB).toContain('"arguments":"ARGS_B"');
+  });
+
+  it('uses delta.tool_calls[].id when provided, overriding index lookup', () => {
+    const { writes, config } = createMockStreamConfig();
+    const { handlers } = createResponsesEventHandlers(config);
+
+    handlers.on_run_step.handle('on_run_step', {
+      stepDetails: {
+        type: 'tool_calls',
+        tool_calls: [
+          { id: 'call_A', name: 'tool_a' },
+          { id: 'call_B', name: 'tool_b' },
+        ],
+      },
+    });
+
+    handlers.on_run_step_delta.handle('on_run_step_delta', {
+      delta: { type: 'tool_calls', tool_calls: [{ id: 'call_B', index: 99, args: 'XYZ' }] },
+    });
+
+    const delta = dataPayloads(writes).find((p) => p.includes('function_call_arguments.delta'));
+    expect(delta).toContain('"call_id":"call_B"');
+    expect(delta).toContain('"delta":"XYZ"');
+  });
+
+  it('tops up arguments from on_run_step_completed when no deltas streamed', () => {
+    const { writes, config } = createMockStreamConfig();
+    const { handlers } = createResponsesEventHandlers(config);
+
+    handlers.on_run_step.handle('on_run_step', {
+      stepDetails: { type: 'tool_calls', tool_calls: [{ id: 'call_1', name: 'tool_a' }] },
+    });
+    // No on_run_step_delta fires — some providers send args whole.
+    handlers.on_run_step_completed.handle('on_run_step_completed', {
+      result: {
+        id: 'step_1',
+        type: 'tool_call',
+        tool_call: { id: 'call_1', args: '{"x":1}', output: 'RESULT' },
+      },
+    });
+
+    const payloads = dataPayloads(writes);
+    const argsDone = payloads.find((p) => p.includes('function_call_arguments.done'));
+    expect(argsDone).toContain('"arguments":"{\\"x\\":1}"');
+
+    // A synthesized delta carries the full args so streaming clients stay in sync.
+    const delta = payloads.find((p) => p.includes('function_call_arguments.delta'));
+    expect(delta).toContain('"delta":"{\\"x\\":1}"');
+  });
+
+  it('accepts object-shaped args on on_run_step_completed and stringifies them', () => {
+    const { writes, config } = createMockStreamConfig();
+    const { handlers } = createResponsesEventHandlers(config);
+
+    handlers.on_run_step.handle('on_run_step', {
+      stepDetails: { type: 'tool_calls', tool_calls: [{ id: 'call_1', name: 'tool_a' }] },
+    });
+    handlers.on_run_step_completed.handle('on_run_step_completed', {
+      result: {
+        id: 'step_1',
+        type: 'tool_call',
+        tool_call: { id: 'call_1', args: { x: 1 }, output: 'R' },
+      },
+    });
+
+    const argsDone = dataPayloads(writes).find((p) => p.includes('function_call_arguments.done'));
+    expect(argsDone).toContain('"arguments":"{\\"x\\":1}"');
+  });
+
+  it('is idempotent across on_run_step_completed and on_tool_end for the same call_id', () => {
+    const { writes, config } = createMockStreamConfig();
+    const { handlers } = createResponsesEventHandlers(config);
+
+    handlers.on_run_step.handle('on_run_step', {
+      stepDetails: { type: 'tool_calls', tool_calls: [{ id: 'call_1', name: 'tool_a' }] },
+    });
+    handlers.on_run_step_completed.handle('on_run_step_completed', {
+      result: { id: 'step_1', type: 'tool_call', tool_call: { id: 'call_1', output: 'R' } },
+    });
+
+    const countBefore = writes.length;
+
+    handlers.on_tool_end.handle('on_tool_end', {
+      output: { tool_call_id: 'call_1', content: 'R-again' },
+    });
+    expect(writes.length).toBe(countBefore);
+
+    handlers.on_run_step_completed.handle('on_run_step_completed', {
+      result: { id: 'step_x', type: 'tool_call', tool_call: { id: 'call_unknown', output: 'R' } },
+    });
+    expect(writes.length).toBe(countBefore);
+  });
+});
+
+describe('createAggregatorEventHandlers — tool call lifecycle', () => {
+  it('records tool output on on_run_step_completed (primary) and on_tool_end (web_search)', () => {
+    const aggregator = createResponseAggregator();
+    const handlers = createAggregatorEventHandlers(aggregator);
+
+    handlers.on_run_step.handle('on_run_step', {
+      stepDetails: { type: 'tool_calls', tool_calls: [{ id: 'call_1', name: 'tool_a' }] },
+    });
+    handlers.on_run_step_delta.handle('on_run_step_delta', {
+      delta: { type: 'tool_calls', tool_calls: [{ index: 0, args: '{"a":1}' }] },
+    });
+    handlers.on_run_step_completed.handle('on_run_step_completed', {
+      result: { id: 'step_1', type: 'tool_call', tool_call: { id: 'call_1', output: 'RESULT' } },
+    });
+
+    expect(aggregator.toolOutputs.get('call_1')).toBe('RESULT');
+    expect(aggregator.toolCalls.get('call_1')?.arguments).toBe('{"a":1}');
+
+    // on_tool_end also populates (for web_search).
+    handlers.on_tool_end.handle('on_tool_end', {
+      output: { tool_call_id: 'call_2', content: 'WEB' },
+    });
+    expect(aggregator.toolOutputs.get('call_2')).toBe('WEB');
+  });
+
+  it('attributes multi-step deltas to the correct call_id', () => {
+    const aggregator = createResponseAggregator();
+    const handlers = createAggregatorEventHandlers(aggregator);
+
+    handlers.on_run_step.handle('on_run_step', {
+      stepDetails: { type: 'tool_calls', tool_calls: [{ id: 'call_A', name: 'tool_a' }] },
+    });
+    handlers.on_run_step_delta.handle('on_run_step_delta', {
+      delta: { type: 'tool_calls', tool_calls: [{ index: 0, args: 'ARGS_A' }] },
+    });
+
+    handlers.on_run_step.handle('on_run_step', {
+      stepDetails: { type: 'tool_calls', tool_calls: [{ id: 'call_B', name: 'tool_b' }] },
+    });
+    handlers.on_run_step_delta.handle('on_run_step_delta', {
+      delta: { type: 'tool_calls', tool_calls: [{ index: 0, args: 'ARGS_B' }] },
+    });
+
+    expect(aggregator.toolCalls.get('call_A')?.arguments).toBe('ARGS_A');
+    expect(aggregator.toolCalls.get('call_B')?.arguments).toBe('ARGS_B');
   });
 });

--- a/packages/api/src/agents/responses/__tests__/service.test.ts
+++ b/packages/api/src/agents/responses/__tests__/service.test.ts
@@ -612,4 +612,21 @@ describe('createAggregatorEventHandlers — tool call lifecycle', () => {
     expect(aggregator.toolCalls.get('call_A')?.arguments).toBe('ARGS_A');
     expect(aggregator.toolCalls.get('call_B')?.arguments).toBe('ARGS_B');
   });
+
+  it('preserves on_run_step_completed output when on_tool_end also fires for the same call', () => {
+    const aggregator = createResponseAggregator();
+    const handlers = createAggregatorEventHandlers(aggregator);
+
+    handlers.on_run_step.handle('on_run_step', {
+      stepDetails: { type: 'tool_calls', tool_calls: [{ id: 'call_1', name: 'tool_a' }] },
+    });
+    handlers.on_run_step_completed.handle('on_run_step_completed', {
+      result: { id: 'step_1', type: 'tool_call', tool_call: { id: 'call_1', output: 'CANONICAL' } },
+    });
+    handlers.on_tool_end.handle('on_tool_end', {
+      output: { tool_call_id: 'call_1', content: 'DIVERGENT' },
+    });
+
+    expect(aggregator.toolOutputs.get('call_1')).toBe('CANONICAL');
+  });
 });

--- a/packages/api/src/agents/responses/service.ts
+++ b/packages/api/src/agents/responses/service.ts
@@ -327,6 +327,7 @@ interface StreamState {
   reasoningContentStarted: boolean;
   activeToolCalls: Set<string>;
   completedToolCalls: Set<string>;
+  currentStepToolCallIds: string[];
 }
 
 /**
@@ -344,6 +345,7 @@ export function createResponsesEventHandlers(config: StreamHandlerConfig): {
     reasoningContentStarted: false,
     activeToolCalls: new Set(),
     completedToolCalls: new Set(),
+    currentStepToolCallIds: [],
   };
 
   /**
@@ -386,6 +388,41 @@ export function createResponsesEventHandlers(config: StreamHandlerConfig): {
       emitReasoningContentPartAdded(config);
       state.reasoningContentStarted = true;
     }
+  };
+
+  /**
+   * Complete a tool call once — idempotent via `completedToolCalls`. Called
+   * from both `on_run_step_completed` (primary) and `on_tool_end` (fallback
+   * for provider-side tools). When streaming deltas didn't cover the full
+   * argument string, `finalArgs` tops up the accumulator so the `.done` event
+   * and `response.completed.output` carry the complete arguments.
+   */
+  const completeToolCall = (
+    callId: string | undefined,
+    output: string,
+    finalArgs?: string,
+  ): void => {
+    if (!callId || !state.activeToolCalls.has(callId) || state.completedToolCalls.has(callId)) {
+      return;
+    }
+    state.completedToolCalls.add(callId);
+    if (finalArgs != null) {
+      const accumulated = config.tracker.accumulatedArguments.get(callId) ?? '';
+      if (finalArgs !== accumulated) {
+        if (finalArgs.startsWith(accumulated)) {
+          emitFunctionCallArgumentsDelta(config, callId, finalArgs.slice(accumulated.length));
+        } else {
+          const item = config.tracker.functionCalls.get(callId);
+          if (item) {
+            config.tracker.accumulatedArguments.set(callId, finalArgs);
+            item.arguments = finalArgs;
+          }
+        }
+      }
+    }
+    emitFunctionCallArgumentsDone(config, callId);
+    emitFunctionCallItemDone(config, callId);
+    emitFunctionCallOutputItem(config, callId, output);
   };
 
   /**
@@ -475,14 +512,21 @@ export function createResponsesEventHandlers(config: StreamHandlerConfig): {
           // Close any open message/reasoning before tool calls
           closeOpenStreams();
 
+          state.currentStepToolCallIds = [];
+
           for (const tc of stepDetails.tool_calls) {
             const callId = tc.id ?? '';
             const name = tc.name ?? '';
 
-            if (callId && !state.activeToolCalls.has(callId)) {
+            if (!callId) {
+              continue;
+            }
+
+            if (!state.activeToolCalls.has(callId)) {
               state.activeToolCalls.add(callId);
               emitFunctionCallItemAdded(config, callId, name);
             }
+            state.currentStepToolCallIds.push(callId);
           }
         }
       },
@@ -494,7 +538,10 @@ export function createResponsesEventHandlers(config: StreamHandlerConfig): {
     on_run_step_delta: {
       handle: (_event: string, data: unknown): void => {
         const deltaData = data as {
-          delta?: { type: string; tool_calls?: Array<{ index?: number; args?: string }> };
+          delta?: {
+            type: string;
+            tool_calls?: Array<{ index?: number; id?: string; args?: string }>;
+          };
         };
         const delta = deltaData?.delta;
 
@@ -505,9 +552,7 @@ export function createResponsesEventHandlers(config: StreamHandlerConfig): {
               continue;
             }
 
-            // Find the call_id for this tool call by index
-            const toolCallsArray = Array.from(state.activeToolCalls);
-            const callId = toolCallsArray[tc.index ?? 0];
+            const callId = tc.id ?? state.currentStepToolCallIds[tc.index ?? 0];
 
             if (callId) {
               emitFunctionCallArgumentsDelta(config, callId, args);
@@ -518,24 +563,47 @@ export function createResponsesEventHandlers(config: StreamHandlerConfig): {
     },
 
     /**
-     * Handle tool end (tool execution complete)
+     * Handle run step completed — the primary tool-completion path. Dispatched
+     * by @librechat/agents' ToolNode for every tool call with the full output.
+     */
+    on_run_step_completed: {
+      handle: (_event: string, data: unknown): void => {
+        const stepData = data as {
+          result?: {
+            type?: string;
+            tool_call?: {
+              id?: string;
+              args?: string | Record<string, unknown>;
+              output?: string;
+            };
+          };
+        };
+        const result = stepData?.result;
+        if (result?.type !== 'tool_call' || !result.tool_call) {
+          return;
+        }
+        const { id, args, output } = result.tool_call;
+        let finalArgs: string | undefined;
+        if (args != null) {
+          finalArgs = typeof args === 'string' ? args : JSON.stringify(args);
+        }
+        completeToolCall(id, output ?? '', finalArgs);
+      },
+    },
+
+    /**
+     * Tool execution complete. A no-op for standard tool calls (completion
+     * already emitted via `on_run_step_completed`); the active path is for
+     * provider-side tools (e.g. web_search) whose results arrive here as a
+     * LangChain ToolMessage under `output`, not under `result.tool_call`.
      */
     on_tool_end: {
       handle: (_event: string, data: unknown): void => {
-        const toolData = data as { tool_call_id?: string; output?: string };
-        const callId = toolData?.tool_call_id;
-        const output = toolData?.output ?? '';
-
-        if (callId && state.activeToolCalls.has(callId) && !state.completedToolCalls.has(callId)) {
-          state.completedToolCalls.add(callId);
-
-          // Complete the function call item
-          emitFunctionCallArgumentsDone(config, callId);
-          emitFunctionCallItemDone(config, callId);
-
-          // Emit the function call output (internal tool result)
-          emitFunctionCallOutputItem(config, callId, output);
-        }
+        const toolData = data as {
+          output?: { tool_call_id?: string; name?: string; content?: string };
+        };
+        const toolOutput = toolData?.output;
+        completeToolCall(toolOutput?.tool_call_id, toolOutput?.content ?? '');
       },
     },
 
@@ -757,6 +825,7 @@ export function createAggregatorEventHandlers(aggregator: ResponseAggregator): R
   }
 > {
   const activeToolCalls = new Set<string>();
+  let currentStepToolCallIds: string[] = [];
 
   return {
     on_message_delta: {
@@ -800,14 +869,20 @@ export function createAggregatorEventHandlers(aggregator: ResponseAggregator): R
         const stepDetails = stepData?.stepDetails;
 
         if (stepDetails?.type === 'tool_calls' && stepDetails.tool_calls) {
+          currentStepToolCallIds = [];
           for (const tc of stepDetails.tool_calls) {
             const callId = tc.id ?? '';
             const name = tc.name ?? '';
 
-            if (callId && !activeToolCalls.has(callId)) {
+            if (!callId) {
+              continue;
+            }
+
+            if (!activeToolCalls.has(callId)) {
               activeToolCalls.add(callId);
               aggregator.toolCalls.set(callId, { id: callId, name, arguments: '' });
             }
+            currentStepToolCallIds.push(callId);
           }
         }
       },
@@ -816,7 +891,10 @@ export function createAggregatorEventHandlers(aggregator: ResponseAggregator): R
     on_run_step_delta: {
       handle: (_event: string, data: unknown): void => {
         const deltaData = data as {
-          delta?: { type: string; tool_calls?: Array<{ index?: number; args?: string }> };
+          delta?: {
+            type: string;
+            tool_calls?: Array<{ index?: number; id?: string; args?: string }>;
+          };
         };
         const delta = deltaData?.delta;
 
@@ -827,8 +905,7 @@ export function createAggregatorEventHandlers(aggregator: ResponseAggregator): R
               continue;
             }
 
-            const toolCallsArray = Array.from(activeToolCalls);
-            const callId = toolCallsArray[tc.index ?? 0];
+            const callId = tc.id ?? currentStepToolCallIds[tc.index ?? 0];
 
             if (callId) {
               const existing = aggregator.toolCalls.get(callId);
@@ -841,14 +918,42 @@ export function createAggregatorEventHandlers(aggregator: ResponseAggregator): R
       },
     },
 
+    on_run_step_completed: {
+      handle: (_event: string, data: unknown): void => {
+        const stepData = data as {
+          result?: {
+            type?: string;
+            tool_call?: {
+              id?: string;
+              args?: string | Record<string, unknown>;
+              output?: string;
+            };
+          };
+        };
+        const result = stepData?.result;
+        if (result?.type !== 'tool_call' || !result.tool_call?.id) {
+          return;
+        }
+        const { id, args, output } = result.tool_call;
+        aggregator.toolOutputs.set(id, output ?? '');
+        const existing = aggregator.toolCalls.get(id);
+        if (existing && !existing.arguments && args != null) {
+          existing.arguments = typeof args === 'string' ? args : JSON.stringify(args);
+        }
+      },
+    },
+
     on_tool_end: {
       handle: (_event: string, data: unknown): void => {
-        const toolData = data as { tool_call_id?: string; output?: string };
-        const callId = toolData?.tool_call_id;
-        const output = toolData?.output ?? '';
+        const toolData = data as {
+          output?: { tool_call_id?: string; name?: string; content?: string };
+        };
+        const toolOutput = toolData?.output;
+        const callId = toolOutput?.tool_call_id;
+        const content = toolOutput?.content ?? '';
 
         if (callId) {
-          aggregator.toolOutputs.set(callId, output);
+          aggregator.toolOutputs.set(callId, content);
         }
       },
     },

--- a/packages/api/src/agents/responses/service.ts
+++ b/packages/api/src/agents/responses/service.ts
@@ -952,7 +952,7 @@ export function createAggregatorEventHandlers(aggregator: ResponseAggregator): R
         const callId = toolOutput?.tool_call_id;
         const content = toolOutput?.content ?? '';
 
-        if (callId) {
+        if (callId && !aggregator.toolOutputs.has(callId)) {
           aggregator.toolOutputs.set(callId, content);
         }
       },


### PR DESCRIPTION
  On the Agents API, tool-call arguments and tool-call outputs were not being emitted in the Responses format (streaming or non-streaming). Clients saw tool-use items added but no arguments, no `function_call_arguments.done`, and no `function_call_output`, so tool usage was invisible downstream.

  Two underlying issues:

  1. **Wrong completion event.** `on_tool_end` was treated as the source of truth for tool completion, and `on_run_step_completed` was stubbed to `() => {}`. In current `@librechat/agents`, `ToolNode` dispatches `ON_RUN_STEP_COMPLETED` directly with the full tool output — that is the primary completion event. `on_tool_end` is only the primary path for provider-side tools (e.g. web_search) that don't flow through `ToolNode`.

  2. **Wrong payload shape on `on_tool_end`.** The handler read `{ tool_call_id, output }` from the top level of the event data, but the event actually carries a LangChain `ToolMessage` under `output` (`output.tool_call_id`, `output.content`). So even when the event did fire, the read was a silent miss.

  A smaller related bug: `on_run_step_delta` resolved the call_id for a
  delta via `Array.from(activeToolCalls)[index]`, which mixes up IDs across
  sequential tool-call steps because `activeToolCalls` is cumulative.

  ## Solution

  - Wire `on_run_step_completed` as the primary tool-completion path in both the streaming handler and the non-streaming aggregator. It emits `function_call_arguments.done`, `output_item.done` for the function_call item, and the `function_call_output` item.
  - Fix `on_tool_end` to read the `ToolMessage` shape under `output`, and keep it as a secondary path (idempotent via `completedToolCalls`) so provider-side tools still complete.
  - Extract a shared `completeToolCall` helper so both paths emit exactly once per call_id.
  - When args arrive whole on `on_run_step_completed` (no streaming deltas), top up the accumulator and synthesize a `function_call_arguments.delta` for the missing suffix so streaming clients and `response.completed.output` stay in sync.
  - Track per-step tool-call IDs so `on_run_step_delta` routes deltas to the correct call across sequential steps; also honour a delta-supplied `tool_calls[].id` when present.
  - In the Express controller, wrap `on_tool_end` to run the existing `ToolEndHandler` (attachment side-effects) alongside the Responses emitter, so neither is dropped.

  ## Tests

  Added `createResponsesEventHandlers` and `createAggregatorEventHandlers`
  lifecycle tests in `packages/api/src/agents/responses/__tests__/service.test.ts`
  covering: delta streaming, per-step call_id routing, delta-supplied ids,
  args-without-deltas top-up, object-shaped args, and idempotency between
  `on_run_step_completed` and `on_tool_end`.

# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary

Please provide a brief summary of your changes and the related issue. Include any motivation and context that is relevant to your changes. If there are any dependencies necessary for your changes, please list them here.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manually tested, and a couple passes of Claude.

### **Test Configuration**:

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
