### PR TITLE
🔐 fix: Restore Tenant Context in MCP OAuth Callback

### DIFF
--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -1866,6 +1866,18 @@ describe('MCP Routes', () => {
   });
 
   describe('GET /:serverName/oauth/callback - Tenant Context', () => {
+    beforeEach(() => {
+      const { getTenantId, tenantStorage } = require('@librechat/data-schemas');
+      const { MCPOAuthHandler, MCPTokenStorage } = require('@librechat/api');
+      getTenantId.mockReset();
+      tenantStorage.run.mockReset();
+      tenantStorage.run.mockImplementation((store, fn) => fn());
+      MCPOAuthHandler.resolveStateToFlowId.mockReset();
+      MCPOAuthHandler.getFlowState.mockReset();
+      MCPOAuthHandler.completeOAuthFlow.mockReset();
+      MCPTokenStorage.storeTokens.mockReset();
+    });
+
     it('should wrap callback body in tenantStorage.run when flowState has tenantId and no current context', async () => {
       const { getTenantId, tenantStorage } = require('@librechat/data-schemas');
       const { MCPOAuthHandler, MCPTokenStorage } = require('@librechat/api');
@@ -1911,7 +1923,6 @@ describe('MCP Routes', () => {
       const csrfToken = generateTestCsrfToken(flowId);
 
       getTenantId.mockReturnValue(undefined);
-      tenantStorage.run.mockClear();
 
       MCPOAuthHandler.resolveStateToFlowId.mockResolvedValue(flowId);
       MCPOAuthHandler.getFlowState.mockResolvedValue({

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -60,6 +60,9 @@ jest.mock('@librechat/api', () => {
 
 jest.mock('@librechat/data-schemas', () => ({
   getTenantId: jest.fn(),
+  tenantStorage: {
+    run: jest.fn((store, fn) => fn()),
+  },
   logger: {
     debug: jest.fn(),
     info: jest.fn(),
@@ -1859,6 +1862,77 @@ describe('MCP Routes', () => {
       const basePath = getBasePath();
 
       expect(response.headers.location).toContain(`${basePath}/oauth/success`);
+    });
+  });
+
+  describe('GET /:serverName/oauth/callback - Tenant Context', () => {
+    it('should wrap callback body in tenantStorage.run when flowState has tenantId and no current context', async () => {
+      const { getTenantId, tenantStorage } = require('@librechat/data-schemas');
+      const { MCPOAuthHandler, MCPTokenStorage } = require('@librechat/api');
+      const flowId = 'user123:test-server';
+      const csrfToken = generateTestCsrfToken(flowId);
+
+      getTenantId.mockReturnValue(undefined);
+
+      MCPOAuthHandler.resolveStateToFlowId.mockResolvedValue(flowId);
+      MCPOAuthHandler.getFlowState.mockResolvedValue({
+        serverName: 'test-server',
+        userId: 'user123',
+        tenantId: 'tenant-abc',
+        metadata: {},
+        clientInfo: {},
+        codeVerifier: 'test-verifier',
+      });
+      MCPOAuthHandler.completeOAuthFlow.mockResolvedValue({
+        access_token: 'token',
+        token_type: 'bearer',
+      });
+      MCPTokenStorage.storeTokens.mockResolvedValue();
+
+      const response = await request(app)
+        .get(`/api/mcp/test-server/oauth/callback?code=test-code&state=${flowId}`)
+        .set('Cookie', [`oauth_csrf=${csrfToken}`])
+        .expect(302);
+
+      expect(tenantStorage.run).toHaveBeenCalledWith(
+        { tenantId: 'tenant-abc' },
+        expect.any(Function),
+      );
+      expect(MCPTokenStorage.storeTokens).toHaveBeenCalled();
+
+      const basePath = getBasePath();
+      expect(response.headers.location).toContain(`${basePath}/oauth/success`);
+    });
+
+    it('should not call tenantStorage.run when flowState has no tenantId', async () => {
+      const { getTenantId, tenantStorage } = require('@librechat/data-schemas');
+      const { MCPOAuthHandler, MCPTokenStorage } = require('@librechat/api');
+      const flowId = 'user123:test-server';
+      const csrfToken = generateTestCsrfToken(flowId);
+
+      getTenantId.mockReturnValue(undefined);
+      tenantStorage.run.mockClear();
+
+      MCPOAuthHandler.resolveStateToFlowId.mockResolvedValue(flowId);
+      MCPOAuthHandler.getFlowState.mockResolvedValue({
+        serverName: 'test-server',
+        userId: 'user123',
+        metadata: {},
+        clientInfo: {},
+        codeVerifier: 'test-verifier',
+      });
+      MCPOAuthHandler.completeOAuthFlow.mockResolvedValue({
+        access_token: 'token',
+        token_type: 'bearer',
+      });
+      MCPTokenStorage.storeTokens.mockResolvedValue();
+
+      await request(app)
+        .get(`/api/mcp/test-server/oauth/callback?code=test-code&state=${flowId}`)
+        .set('Cookie', [`oauth_csrf=${csrfToken}`])
+        .expect(302);
+
+      expect(tenantStorage.run).not.toHaveBeenCalled();
     });
   });
 

--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -1,5 +1,5 @@
 const { Router } = require('express');
-const { logger, getTenantId } = require('@librechat/data-schemas');
+const { logger, getTenantId, tenantStorage } = require('@librechat/data-schemas');
 const {
   CacheKeys,
   Constants,
@@ -267,101 +267,121 @@ router.get('/:serverName/oauth/callback', async (req, res) => {
         { serverName, flowId },
       );
     }
-    const oauthHeaders =
-      flowState.oauthHeaders ?? (await getOAuthHeaders(serverName, flowState.userId));
-    const tokens = await MCPOAuthHandler.completeOAuthFlow(flowId, code, flowManager, oauthHeaders);
-    logger.info('[MCP OAuth] OAuth flow completed, tokens received in callback route');
-
-    /** Persist tokens immediately so reconnection uses fresh credentials */
-    if (flowState?.userId && tokens) {
-      try {
-        await MCPTokenStorage.storeTokens({
-          userId: flowState.userId,
-          serverName,
-          tokens,
-          createToken: db.createToken,
-          updateToken: db.updateToken,
-          findToken: db.findToken,
-          clientInfo: flowState.clientInfo,
-          metadata: flowState.metadata,
-        });
-        logger.debug('[MCP OAuth] Stored OAuth tokens prior to reconnection', {
-          serverName,
-          userId: flowState.userId,
-        });
-      } catch (error) {
-        logger.error('[MCP OAuth] Failed to store OAuth tokens after callback', error);
-        throw error;
+    /**
+     * Restore tenant context for the callback body. The callback is a cross-origin
+     * redirect from the OAuth provider, so SameSite=Strict cookies (including the
+     * JWT) are not sent. The tenantId was stored in the flow metadata at initiation
+     * time when the user was authenticated.
+     */
+    const runWithTenant = async (fn) => {
+      const flowTenantId = flowState.tenantId;
+      if (flowTenantId && !getTenantId()) {
+        return tenantStorage.run({ tenantId: flowTenantId }, fn);
       }
+      return fn();
+    };
 
-      /**
-       * Clear any cached `mcp_get_tokens` flow result so subsequent lookups
-       * re-fetch the freshly stored credentials instead of returning stale nulls.
-       */
-      if (typeof flowManager?.deleteFlow === 'function') {
+    await runWithTenant(async () => {
+      const oauthHeaders =
+        flowState.oauthHeaders ?? (await getOAuthHeaders(serverName, flowState.userId));
+      const tokens = await MCPOAuthHandler.completeOAuthFlow(
+        flowId,
+        code,
+        flowManager,
+        oauthHeaders,
+      );
+      logger.info('[MCP OAuth] OAuth flow completed, tokens received in callback route');
+
+      /** Persist tokens immediately so reconnection uses fresh credentials */
+      if (flowState?.userId && tokens) {
         try {
-          await flowManager.deleteFlow(flowId, 'mcp_get_tokens');
+          await MCPTokenStorage.storeTokens({
+            userId: flowState.userId,
+            serverName,
+            tokens,
+            createToken: db.createToken,
+            updateToken: db.updateToken,
+            findToken: db.findToken,
+            clientInfo: flowState.clientInfo,
+            metadata: flowState.metadata,
+          });
+          logger.debug('[MCP OAuth] Stored OAuth tokens prior to reconnection', {
+            serverName,
+            userId: flowState.userId,
+          });
         } catch (error) {
-          logger.warn('[MCP OAuth] Failed to clear cached token flow state', error);
+          logger.error('[MCP OAuth] Failed to store OAuth tokens after callback', error);
+          throw error;
+        }
+
+        /**
+         * Clear any cached `mcp_get_tokens` flow result so subsequent lookups
+         * re-fetch the freshly stored credentials instead of returning stale nulls.
+         */
+        if (typeof flowManager?.deleteFlow === 'function') {
+          try {
+            await flowManager.deleteFlow(flowId, 'mcp_get_tokens');
+          } catch (error) {
+            logger.warn('[MCP OAuth] Failed to clear cached token flow state', error);
+          }
         }
       }
-    }
 
-    try {
-      const mcpManager = getMCPManager(flowState.userId);
-      logger.debug(`[MCP OAuth] Attempting to reconnect ${serverName} with new OAuth tokens`);
+      try {
+        const mcpManager = getMCPManager(flowState.userId);
+        logger.debug(`[MCP OAuth] Attempting to reconnect ${serverName} with new OAuth tokens`);
 
-      if (flowState.userId !== 'system') {
-        const user = { id: flowState.userId };
+        if (flowState.userId !== 'system') {
+          const user = { id: flowState.userId };
 
-        const userConnection = await mcpManager.getUserConnection({
-          user,
-          serverName,
-          flowManager,
-          tokenMethods: {
-            findToken: db.findToken,
-            updateToken: db.updateToken,
-            createToken: db.createToken,
-            deleteTokens: db.deleteTokens,
-          },
-        });
+          const userConnection = await mcpManager.getUserConnection({
+            user,
+            serverName,
+            flowManager,
+            tokenMethods: {
+              findToken: db.findToken,
+              updateToken: db.updateToken,
+              createToken: db.createToken,
+              deleteTokens: db.deleteTokens,
+            },
+          });
 
-        logger.info(
-          `[MCP OAuth] Successfully reconnected ${serverName} for user ${flowState.userId}`,
-        );
+          logger.info(
+            `[MCP OAuth] Successfully reconnected ${serverName} for user ${flowState.userId}`,
+          );
 
-        // clear any reconnection attempts
-        const oauthReconnectionManager = getOAuthReconnectionManager();
-        oauthReconnectionManager.clearReconnection(flowState.userId, serverName);
+          const oauthReconnectionManager = getOAuthReconnectionManager();
+          oauthReconnectionManager.clearReconnection(flowState.userId, serverName);
 
-        const tools = await userConnection.fetchTools();
-        await updateMCPServerTools({
-          userId: flowState.userId,
-          serverName,
-          tools,
-        });
-      } else {
-        logger.debug(`[MCP OAuth] System-level OAuth completed for ${serverName}`);
-      }
-    } catch (error) {
-      logger.warn(
-        `[MCP OAuth] Failed to reconnect ${serverName} after OAuth, but tokens are saved:`,
-        error,
-      );
-    }
-
-    /** ID of the flow that the tool/connection is waiting for */
-    const toolFlowId = flowState.metadata?.toolFlowId;
-    if (toolFlowId) {
-      logger.debug('[MCP OAuth] Completing tool flow', { toolFlowId });
-      const completed = await flowManager.completeFlow(toolFlowId, 'mcp_oauth', tokens);
-      if (!completed) {
+          const tools = await userConnection.fetchTools();
+          await updateMCPServerTools({
+            userId: flowState.userId,
+            serverName,
+            tools,
+          });
+        } else {
+          logger.debug(`[MCP OAuth] System-level OAuth completed for ${serverName}`);
+        }
+      } catch (error) {
         logger.warn(
-          '[MCP OAuth] Tool flow state not found during completion — waiter will time out',
-          { toolFlowId },
+          `[MCP OAuth] Failed to reconnect ${serverName} after OAuth, but tokens are saved:`,
+          error,
         );
       }
-    }
+
+      /** ID of the flow that the tool/connection is waiting for */
+      const toolFlowId = flowState.metadata?.toolFlowId;
+      if (toolFlowId) {
+        logger.debug('[MCP OAuth] Completing tool flow', { toolFlowId });
+        const completed = await flowManager.completeFlow(toolFlowId, 'mcp_oauth', tokens);
+        if (!completed) {
+          logger.warn(
+            '[MCP OAuth] Tool flow state not found during completion — waiter will time out',
+            { toolFlowId },
+          );
+        }
+      }
+    }); /* end runWithTenant */
 
     /** Redirect to success page with flowId and serverName */
     const redirectUrl = `${basePath}/oauth/success?serverName=${encodeURIComponent(serverName)}`;

--- a/packages/api/src/mcp/MCPConnectionFactory.ts
+++ b/packages/api/src/mcp/MCPConnectionFactory.ts
@@ -1,4 +1,4 @@
-import { logger } from '@librechat/data-schemas';
+import { logger, getTenantId } from '@librechat/data-schemas';
 import type { OAuthClientInformation } from '@modelcontextprotocol/sdk/shared/auth.js';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { TokenMethods } from '@librechat/data-schemas';
@@ -366,7 +366,7 @@ export class MCPConnectionFactory {
           }
 
           // Store flow state BEFORE redirecting so the callback can find it
-          const metadataWithUrl = { ...flowMetadata, authorizationUrl };
+          const metadataWithUrl = { ...flowMetadata, authorizationUrl, tenantId: getTenantId() };
           await this.flowManager!.initFlow(newFlowId, 'mcp_oauth', metadataWithUrl);
           await MCPOAuthHandler.storeStateMapping(flowMetadata.state, newFlowId, this.flowManager!);
 
@@ -670,7 +670,7 @@ export class MCPConnectionFactory {
       reusedStoredClient = flowMetadata.reusedStoredClient === true;
 
       // Store flow state BEFORE redirecting so the callback can find it
-      const metadataWithUrl = { ...flowMetadata, authorizationUrl };
+      const metadataWithUrl = { ...flowMetadata, authorizationUrl, tenantId: getTenantId() };
       await this.flowManager.initFlow(newFlowId, 'mcp_oauth', metadataWithUrl);
       await MCPOAuthHandler.storeStateMapping(flowMetadata.state, newFlowId, this.flowManager);
 

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -18,6 +18,7 @@ jest.mock('@librechat/data-schemas', () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
+  getTenantId: jest.fn(),
 }));
 
 const mockLogger = logger as jest.Mocked<typeof logger>;

--- a/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts
@@ -242,6 +242,9 @@ describe('MCPConnectionFactory', () => {
         },
       };
 
+      const { getTenantId } = require('@librechat/data-schemas');
+      (getTenantId as jest.Mock).mockReturnValue('test-tenant');
+
       mockMCPOAuthHandler.initiateOAuthFlow.mockResolvedValue(mockFlowData);
       // createFlow runs as a background monitor — simulate it staying pending
       mockFlowManager.createFlow.mockReturnValue(new Promise(() => {}));
@@ -279,7 +282,7 @@ describe('MCPConnectionFactory', () => {
       expect(mockFlowManager.initFlow).toHaveBeenCalledWith(
         'flow123',
         'mcp_oauth',
-        expect.objectContaining(mockFlowData.flowMetadata),
+        expect.objectContaining({ ...mockFlowData.flowMetadata, tenantId: 'test-tenant' }),
       );
       const initCallOrder = mockFlowManager.initFlow.mock.invocationCallOrder[0];
       const oauthStartCallOrder = (oauthOptions.oauthStart as jest.Mock).mock

--- a/packages/api/src/mcp/oauth/types.ts
+++ b/packages/api/src/mcp/oauth/types.ts
@@ -93,6 +93,8 @@ export interface MCPOAuthFlowMetadata extends FlowMetadata {
   oauthHeaders?: Record<string, string>;
   /** True when the flow reused a stored client registration from a prior successful OAuth flow */
   reusedStoredClient?: boolean;
+  /** Tenant context captured at flow initiation for callback replay (SameSite cookies unavailable on cross-origin redirects) */
+  tenantId?: string;
 }
 
 export interface MCPOAuthTokens extends OAuthTokens {


### PR DESCRIPTION
## Summary

The MCP OAuth callback route (`GET /api/mcp/:serverName/oauth/callback`) is a cross-origin redirect from the OAuth provider. `SameSite=Strict` cookies (including the JWT) are not sent by the browser on cross-origin redirects, so the callback runs without tenant context. With `TENANT_ISOLATION_STRICT=true`, all DB writes fail with:

```
[TenantIsolation] Query attempted without tenant context in strict mode
```

This blocks all remote MCP server OAuth flows (Slack, Linear, Notion, Langfuse, etc.) in multi-tenant deployments.

The fix stores `tenantId` in the flow metadata at OAuth initiation time (when the user is authenticated and tenant context exists), then restores it via `tenantStorage.run` in the callback, wrapping the entire post-validation body. In single-tenant deployments, `tenantId` is `undefined` in the flow state, so `runWithTenant` is a no-op, so no behavior change.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- `packages/api/src/mcp/oauth/types.ts` - add `tenantId?: string` to `MCPOAuthFlowMetadata`
- `packages/api/src/mcp/MCPConnectionFactory.ts` - inject `tenantId: getTenantId()` into flow metadata at both OAuth initiation paths
- `api/server/routes/mcp.js` - read `flowState.tenantId` in the callback, wrap post-validation body in `runWithTenant` using `tenantStorage.run`
- `api/server/routes/__tests__/mcp.spec.js` - add `tenantStorage` to mock, add two tests: positive tenant context restoration and no-op when `tenantId` is absent
- `packages/api/src/mcp/__tests__/MCPConnectionFactory.test.ts` - add `getTenantId` to `@librechat/data-schemas` mock

## Testing

- Tested locally with `TENANT_ISOLATION_STRICT=true` 
- Linear MCP server OAuth flow completes, tokens stored, server connects
- Non-strict mode: `runWithTenant` is a no-op (no regressions for single-tenant deployments)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes