### PR TITLE
Fix agent file unlink when file record is already deleted (manually from the DB)

### DIFF
--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -166,18 +166,6 @@ router.delete('/', async (req, res) => {
       }
     }
 
-    if (nonOwnedFiles.length === 0) {
-      await processDeleteRequest({ req, files: ownedFiles });
-      logger.debug(
-        `[/files] Files deleted successfully: ${ownedFiles
-          .filter((f) => f.file_id)
-          .map((f) => f.file_id)
-          .join(', ')}`,
-      );
-      res.status(200).json({ message: 'Files deleted successfully' });
-      return;
-    }
-
     let authorizedFiles = [...ownedFiles];
     let unauthorizedFiles = [];
 

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -430,5 +430,74 @@ describe('File Routes - Delete with Agent Access', () => {
       expect(response.body.unauthorizedFiles).toContain(fileId);
       expect(processDeleteRequest).not.toHaveBeenCalled();
     });
+
+    it('should cleanup/unlink agent resources even if the files doesnt exist in the db', async () => {
+      const agentFileId = uuidv4();
+      await createFile({
+        user: otherUserId,
+        file_id: agentFileId,
+        filename: 'agent-file.txt',
+        filepath: '/uploads/agent-file.txt',
+        bytes: 500,
+        type: 'text/plain',
+      });
+
+      const agent = await createAgent({
+        id: uuidv4(),
+        name: 'Test Agent',
+        provider: 'openai',
+        model: 'gpt-4',
+        author: otherUserId,
+        tool_resources: {
+          file_search: {
+            file_ids: [agentFileId],
+          },
+        },
+      });
+
+      // First delete (from file dialog, no agent context): actually remove the file from the db immediatly
+      processDeleteRequest.mockImplementationOnce(async ({ files }) => {
+        await File.deleteMany({ file_id: { $in: files.map((f) => f.file_id) } });
+      });
+
+      const firstResponse = await request(app)
+        .delete('/files')
+        .send({
+          files: [
+            {
+              file_id: agentFileId,
+              filepath: '/uploads/agent-file.txt',
+            },
+          ],
+        });
+
+      expect(firstResponse.status).toBe(200);
+      expect(firstResponse.body.message).toBe('Files deleted successfully');
+
+      const fileAfterDelete = await File.findOne({ file_id: agentFileId });
+      expect(fileAfterDelete).toBeNull();
+
+      // Second delete (from agent panel) should unlink from agent even though the file is gone
+      const secondResponse = await request(app)
+        .delete('/files')
+        .send({
+          agent_id: agent.id,
+          tool_resource: 'file_search',
+          files: [
+            {
+              file_id: agentFileId,
+              filepath: '/uploads/agent-file.txt',
+            },
+          ],
+        });
+
+      expect(secondResponse.status).toBe(200);
+      expect(secondResponse.body.message).toBe('File associations removed successfully from agent');
+      expect(processDeleteRequest).toHaveBeenCalledTimes(2);
+
+      const unlinkCall = processDeleteRequest.mock.calls[1][0];
+      expect(unlinkCall.files).toHaveLength(1);
+      expect(unlinkCall.files[0].file_id).toBe(agentFileId);
+    });
   });
 });


### PR DESCRIPTION
## Summary

when deleting an orphaned file (file exists in agent's tool_resources but not in the database) from the agent panel, the DELETE /api/files endpoint returns success but the agent's reference is not cleaned up. The file reappears in the UI.

Note: pr [#12781](https://github.com/danny-avila/LibreChat/pull/12781) adds a proper agent context cleanup so the above problem wont happen in the future.

### Why this pr then?
The problem still persists for already orphaned/stale files in the agent tool_resources or deleting a file directly from the DB. There is no way to clean it up unless doing it manually in the DB.


### Root Cause: 
In `api/server/routes/files/files.js`, the orphan cleanup logic is unreachable when dbFiles is empty because the function returns early.

With this change by removing a file from the context via agent panel, it properly runs the cleanup process.


## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing/Reproduction
1. Create an agent with a file in its context
2. Delete the file record directly from MongoDB (simulating orphan): db.files.deleteOne({ file_id: "the-file-id" })
3. Open the agent panel. the orphaned file should still appear
4. Click delete on the orphaned file
5. Verify:
   - DELETE request returns success
   - File disappears from UI
   - Agent document no longer contains the file_id in tool_resources.context.file_ids
   - Refreshing the page confirms the file is gone


## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
