### PR TITLE
feat(agents): multimodal-RAG — attach page-image hits as inline image_urls + VISION_MODEL_ALIASES

### DIFF
--- a/api/app/clients/prompts/createContextHandlers.js
+++ b/api/app/clients/prompts/createContextHandlers.js
@@ -33,7 +33,11 @@ function resolveIsVisionModel(req) {
     return false;
   }
   try {
-    return validateVisionModel({ model });
+    const extra = (process.env.VISION_MODEL_ALIASES || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return validateVisionModel({ model, additionalModels: extra });
   } catch (err) {
     logger.warn('[createContextHandlers] validateVisionModel threw, assuming no', err);
     return false;

--- a/api/app/clients/prompts/createContextHandlers.js
+++ b/api/app/clients/prompts/createContextHandlers.js
@@ -1,6 +1,9 @@
 const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
 const { logger } = require('@librechat/data-schemas');
 const { isEnabled, generateShortLivedToken } = require('@librechat/api');
+const { validateVisionModel } = require('librechat-data-provider');
 
 const footer = `Use the context as your learned knowledge to better answer the user.
 
@@ -9,6 +12,63 @@ In your response, remember to follow these guidelines:
 - If you are unsure how to answer, ask for clarification.
 - Avoid mentioning that you obtained the information from the context.
 `;
+
+// Multimodal-RAG: visual matches we collected from rag-api. Exposed back to
+// the caller via getVisualImageURLs() so client.js can attach them as
+// image_urls on the latest message when the model supports vision.
+//
+// Soft-fail policy matches the rest of this file: if anything throws (axios,
+// fs.readFile, missing validateVisionModel) we log a warning and continue
+// with the text-only path.
+
+/**
+ * Determine whether the currently-selected model can accept image inputs.
+ * We look up the model name from req.body.model (what the user picked in
+ * the UI) and fall back to req.endpointOption.model. If neither is set we
+ * assume no — safer to skip attachments than to crash the provider call.
+ */
+function resolveIsVisionModel(req) {
+  const model = req?.body?.model || req?.endpointOption?.model;
+  if (!model) {
+    return false;
+  }
+  try {
+    return validateVisionModel({ model });
+  } catch (err) {
+    logger.warn('[createContextHandlers] validateVisionModel threw, assuming no', err);
+    return false;
+  }
+}
+
+async function loadVisualImageURLsFromDisk(visualMatches) {
+  // Small helper so the test can mock just this bit. Reads each page PNG from
+  // disk and base64-encodes it. Matches the shape that encodeAndFormat /
+  // LibreChat's provider adapters expect for inline image parts.
+  const image_urls = [];
+  for (const match of visualMatches) {
+    try {
+      // Sanity: image_path must be an absolute path — rag-api writes them
+      // as `/var/rag-visual/<file_id>/page-N.png`. Reject anything else to
+      // avoid accidental path traversal from a compromised sidecar.
+      if (!path.isAbsolute(match.image_path)) {
+        continue;
+      }
+      const buf = await fs.promises.readFile(match.image_path);
+      image_urls.push({
+        type: 'image_url',
+        image_url: {
+          url: `data:image/png;base64,${buf.toString('base64')}`,
+          detail: 'auto',
+        },
+      });
+    } catch (err) {
+      logger.warn(
+        `[createContextHandlers] visual attachment: cannot read ${match.image_path}: ${err.message}`,
+      );
+    }
+  }
+  return image_urls;
+}
 
 function createContextHandlers(req, userMessageContent) {
   if (!process.env.RAG_API_URL) {
@@ -20,6 +80,13 @@ function createContextHandlers(req, userMessageContent) {
   const processedIds = new Set();
   const jwtToken = generateShortLivedToken(req.user.id);
   const useFullContext = isEnabled(process.env.RAG_USE_FULL_CONTEXT);
+  const multimodalEnabled = isEnabled(process.env.RAG_INCLUDE_VISUAL ?? 'true');
+  const isVisionModel = resolveIsVisionModel(req);
+
+  // Collected across all /query responses. One entry per visual match across
+  // all files the user attached to this message.
+  /** @type {Array<{file_id:string,page_number:number,image_path:string,score:number}>} */
+  const visualMatches = [];
 
   const query = async (file) => {
     if (useFullContext) {
@@ -36,6 +103,7 @@ function createContextHandlers(req, userMessageContent) {
         file_id: file.file_id,
         query: userMessageContent,
         k: 4,
+        include_visual: multimodalEnabled,
       },
       {
         headers: {
@@ -57,6 +125,25 @@ function createContextHandlers(req, userMessageContent) {
         logger.error(`Error processing file ${file.filename}:`, error);
       }
     }
+  };
+
+  /**
+   * Normalise the /query response. Old rag-api returns a flat list of
+   * [Document, score] tuples; the multimodal-ingest fork returns
+   * `{ chunks: [...], visual_matches: [...] }` when include_visual is true.
+   * We accept both so we never break when rag-api is older than LibreChat.
+   */
+  const normaliseQueryData = (data) => {
+    if (Array.isArray(data)) {
+      return { chunks: data, visual_matches: [] };
+    }
+    if (data && typeof data === 'object') {
+      return {
+        chunks: Array.isArray(data.chunks) ? data.chunks : [],
+        visual_matches: Array.isArray(data.visual_matches) ? data.visual_matches : [],
+      };
+    }
+    return { chunks: [], visual_matches: [] };
   };
 
   const createContext = async () => {
@@ -112,7 +199,12 @@ function createContextHandlers(req, userMessageContent) {
                   return generateContext(`\n${contextItems}`);
                 }
 
-                contextItems = queryResult.data
+                const { chunks, visual_matches } = normaliseQueryData(queryResult.data);
+                if (visual_matches.length) {
+                  visualMatches.push(...visual_matches);
+                }
+
+                contextItems = chunks
                   .map((item) => {
                     const pageContent = item[0].page_content;
                     return `
@@ -134,6 +226,16 @@ function createContextHandlers(req, userMessageContent) {
         return prompt;
       }
 
+      // Multimodal-RAG: when visual hits exist but the current model can
+      // only read text, nudge the LLM to acknowledge rather than claim it
+      // inspected the page visually.
+      const visualHint =
+        multimodalEnabled && visualMatches.length && !isVisionModel
+          ? `\n[Hinweis: ${visualMatches.length} visuelle Treffer auf Seiten ${visualMatches
+              .map((v) => v.page_number)
+              .join(', ')} verfügbar, aber das aktuell gewählte Modell kann keine Bilder auswerten — Antwort basiert nur auf dem Text-Kontext.]`
+          : '';
+
       const prompt = `${header}
         ${files}
 
@@ -141,7 +243,7 @@ function createContextHandlers(req, userMessageContent) {
 
         <context>${context}
         </context>
-
+        ${visualHint}
         ${footer}`;
 
       return prompt;
@@ -151,10 +253,39 @@ function createContextHandlers(req, userMessageContent) {
     }
   };
 
+  /**
+   * Returns the collected visual matches (populated by createContext).
+   * Callers that support vision inputs can convert these to image_urls
+   * via getVisualImageURLs(). Must be called after createContext().
+   */
+  const getVisualMatches = () => [...visualMatches];
+
+  /**
+   * Load page PNGs from disk and return them in the image_urls shape the
+   * downstream provider adapters expect. Only returns entries when the
+   * current model is vision-capable; otherwise the hint in createContext
+   * covers the text-only case.
+   */
+  const getVisualImageURLs = async () => {
+    if (!multimodalEnabled || !isVisionModel || visualMatches.length === 0) {
+      return [];
+    }
+    try {
+      return await loadVisualImageURLsFromDisk(visualMatches);
+    } catch (err) {
+      logger.warn('[createContextHandlers] could not load visual image urls:', err);
+      return [];
+    }
+  };
+
   return {
     processFile,
     createContext,
+    getVisualMatches,
+    getVisualImageURLs,
   };
 }
 
 module.exports = createContextHandlers;
+// Exposed for unit tests only.
+module.exports.__test__ = { loadVisualImageURLsFromDisk, resolveIsVisionModel };

--- a/api/app/clients/prompts/createContextHandlers.test.js
+++ b/api/app/clients/prompts/createContextHandlers.test.js
@@ -1,0 +1,242 @@
+/**
+ * Tests for the multimodal-RAG additions to createContextHandlers.
+ *
+ * We mock axios (rag-api), fs.promises.readFile (page PNGs) and
+ * @librechat/api / librechat-data-provider so the module loads without
+ * requiring the full monorepo wiring — same pattern as autoEmbed.test.js.
+ */
+
+jest.mock('axios');
+
+jest.mock(
+  '@librechat/data-schemas',
+  () => ({
+    logger: {
+      warn: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  '@librechat/api',
+  () => ({
+    isEnabled: (v) => {
+      if (v === undefined || v === null) return false;
+      if (typeof v === 'boolean') return v;
+      return String(v).toLowerCase() === 'true';
+    },
+    generateShortLivedToken: jest.fn().mockReturnValue('test-jwt'),
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  'librechat-data-provider',
+  () => ({
+    validateVisionModel: jest.fn(),
+  }),
+  { virtual: true },
+);
+
+const axios = require('axios');
+const fs = require('fs');
+const { validateVisionModel } = require('librechat-data-provider');
+
+const createContextHandlers = require('./createContextHandlers');
+
+const buildReq = (model) => ({
+  user: { id: 'user-1' },
+  body: { model },
+});
+
+const makeFile = (overrides = {}) => ({
+  file_id: 'f-1',
+  filename: 'flyer.pdf',
+  type: 'application/pdf',
+  embedded: true,
+  ...overrides,
+});
+
+describe('createContextHandlers — multimodal-RAG', () => {
+  const originalRagUrl = process.env.RAG_API_URL;
+  const originalFlag = process.env.RAG_INCLUDE_VISUAL;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.RAG_API_URL = 'http://rag.test';
+    delete process.env.RAG_INCLUDE_VISUAL; // default -> treated as 'true' via ?? in prod
+    delete process.env.RAG_USE_FULL_CONTEXT;
+  });
+
+  afterAll(() => {
+    if (originalRagUrl === undefined) {
+      delete process.env.RAG_API_URL;
+    } else {
+      process.env.RAG_API_URL = originalRagUrl;
+    }
+    if (originalFlag === undefined) {
+      delete process.env.RAG_INCLUDE_VISUAL;
+    } else {
+      process.env.RAG_INCLUDE_VISUAL = originalFlag;
+    }
+  });
+
+  test('returns undefined when RAG_API_URL is missing', () => {
+    delete process.env.RAG_API_URL;
+    expect(createContextHandlers(buildReq('gpt-4o'), 'hi')).toBeUndefined();
+  });
+
+  test('sends include_visual: true on /query and surfaces visual matches on createContext', async () => {
+    validateVisionModel.mockReturnValue(true);
+
+    axios.post.mockResolvedValue({
+      data: {
+        chunks: [[{ page_content: 'kleingedrucktes' }, 0.88]],
+        visual_matches: [
+          {
+            file_id: 'f-1',
+            page_number: 2,
+            image_path: '/var/rag-visual/f-1/page-2.png',
+            score: 0.73,
+          },
+        ],
+      },
+    });
+
+    const handlers = createContextHandlers(buildReq('gpt-4o'), 'Wie sieht Seite 2 aus?');
+    await handlers.processFile(makeFile());
+    const prompt = await handlers.createContext();
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://rag.test/query',
+      expect.objectContaining({ include_visual: true }),
+      expect.any(Object),
+    );
+    expect(prompt).toContain('kleingedrucktes');
+    expect(prompt).not.toContain('Hinweis:'); // vision model — no text-only fallback hint
+    expect(handlers.getVisualMatches()).toHaveLength(1);
+    expect(handlers.getVisualMatches()[0].page_number).toBe(2);
+  });
+
+  test('does not attach image_urls for non-vision models and adds a hint to the prompt', async () => {
+    validateVisionModel.mockReturnValue(false);
+
+    axios.post.mockResolvedValue({
+      data: {
+        chunks: [[{ page_content: 'text' }, 0.5]],
+        visual_matches: [
+          {
+            file_id: 'f-1',
+            page_number: 3,
+            image_path: '/var/rag-visual/f-1/page-3.png',
+            score: 0.61,
+          },
+        ],
+      },
+    });
+
+    const handlers = createContextHandlers(buildReq('some-text-only-model'), 'q');
+    await handlers.processFile(makeFile());
+    const prompt = await handlers.createContext();
+
+    expect(prompt).toContain('Hinweis:');
+    expect(prompt).toContain('Seiten 3');
+
+    const urls = await handlers.getVisualImageURLs();
+    expect(urls).toEqual([]);
+  });
+
+  test('getVisualImageURLs base64-encodes each page PNG for vision models', async () => {
+    validateVisionModel.mockReturnValue(true);
+    const readSpy = jest
+      .spyOn(fs.promises, 'readFile')
+      .mockResolvedValue(Buffer.from([0x89, 0x50, 0x4e, 0x47])); // PNG magic bytes
+
+    axios.post.mockResolvedValue({
+      data: {
+        chunks: [],
+        visual_matches: [
+          { file_id: 'f-1', page_number: 1, image_path: '/var/rag-visual/f-1/page-1.png', score: 0.9 },
+          { file_id: 'f-1', page_number: 2, image_path: '/var/rag-visual/f-1/page-2.png', score: 0.8 },
+        ],
+      },
+    });
+
+    const handlers = createContextHandlers(buildReq('claude-sonnet-4-6'), 'q');
+    await handlers.processFile(makeFile());
+    await handlers.createContext();
+
+    const urls = await handlers.getVisualImageURLs();
+    expect(urls).toHaveLength(2);
+    expect(urls[0]).toEqual({
+      type: 'image_url',
+      image_url: {
+        url: 'data:image/png;base64,iVBORw==',
+        detail: 'auto',
+      },
+    });
+    expect(readSpy).toHaveBeenCalledTimes(2);
+    readSpy.mockRestore();
+  });
+
+  test('skips non-absolute image_paths (defense against compromised sidecar)', async () => {
+    validateVisionModel.mockReturnValue(true);
+    const readSpy = jest.spyOn(fs.promises, 'readFile');
+
+    axios.post.mockResolvedValue({
+      data: {
+        chunks: [],
+        visual_matches: [
+          { file_id: 'f-1', page_number: 1, image_path: '../escape/etc/passwd', score: 0.9 },
+        ],
+      },
+    });
+
+    const handlers = createContextHandlers(buildReq('gpt-4o'), 'q');
+    await handlers.processFile(makeFile());
+    await handlers.createContext();
+
+    const urls = await handlers.getVisualImageURLs();
+    expect(urls).toEqual([]);
+    expect(readSpy).not.toHaveBeenCalled();
+    readSpy.mockRestore();
+  });
+
+  test('tolerates legacy flat-list /query response (no visual_matches key)', async () => {
+    validateVisionModel.mockReturnValue(true);
+    axios.post.mockResolvedValue({
+      data: [[{ page_content: 'legacy content' }, 0.7]],
+    });
+
+    const handlers = createContextHandlers(buildReq('gpt-4o'), 'q');
+    await handlers.processFile(makeFile());
+    const prompt = await handlers.createContext();
+
+    expect(prompt).toContain('legacy content');
+    expect(handlers.getVisualMatches()).toEqual([]);
+    await expect(handlers.getVisualImageURLs()).resolves.toEqual([]);
+  });
+
+  test('multimodalEnabled=false passes include_visual: false and yields no matches', async () => {
+    process.env.RAG_INCLUDE_VISUAL = 'false';
+    validateVisionModel.mockReturnValue(true);
+    axios.post.mockResolvedValue({
+      data: [[{ page_content: 'plain text' }, 0.5]],
+    });
+
+    const handlers = createContextHandlers(buildReq('gpt-4o'), 'q');
+    await handlers.processFile(makeFile());
+    await handlers.createContext();
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://rag.test/query',
+      expect.objectContaining({ include_visual: false }),
+      expect.any(Object),
+    );
+    await expect(handlers.getVisualImageURLs()).resolves.toEqual([]);
+  });
+});

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -488,6 +488,24 @@ class AgentClient extends BaseClient {
       if (this.augmentedPrompt) {
         sharedRunContextParts.push(this.augmentedPrompt);
       }
+
+      // Multimodal-RAG: append page-image hits from rag-api as inline
+      // image_urls on the latest user message when the selected model
+      // can read images. Vision-capability + feature-flag gates live in
+      // createContextHandlers; here we just merge the resulting urls.
+      if (typeof this.contextHandlers.getVisualImageURLs === 'function') {
+        try {
+          const visualImageURLs = await this.contextHandlers.getVisualImageURLs();
+          if (visualImageURLs && visualImageURLs.length && latestMessage) {
+            latestMessage.image_urls = [
+              ...(latestMessage.image_urls ?? []),
+              ...visualImageURLs,
+            ];
+          }
+        } catch (err) {
+          logger.warn('[AgentClient] multimodal visual attachment failed:', err);
+        }
+      }
     }
 
     /** Memory context (user preferences/memories) */

--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -501,6 +501,19 @@ class AgentClient extends BaseClient {
               ...(latestMessage.image_urls ?? []),
               ...visualImageURLs,
             ];
+            // formattedMessages was .map'd from orderedMessages BEFORE this point and
+            // holds independent objects, so mutating latestMessage doesn't propagate.
+            // Mirror the image_urls onto the corresponding formatted entry so the
+            // provider payload (built from formattedMessages downstream) actually
+            // carries the page PNGs. Without this, getVisualImageURLs() loads the
+            // images into memory but they never reach the LLM.
+            const lastFormatted = formattedMessages[formattedMessages.length - 1];
+            if (lastFormatted) {
+              lastFormatted.image_urls = [
+                ...(lastFormatted.image_urls ?? []),
+                ...visualImageURLs,
+              ];
+            }
           }
         } catch (err) {
           logger.warn('[AgentClient] multimodal visual attachment failed:', err);

--- a/api/server/services/Files/VectorDB/autoEmbed.js
+++ b/api/server/services/Files/VectorDB/autoEmbed.js
@@ -1,0 +1,58 @@
+const { logger } = require('@librechat/data-schemas');
+const { uploadVectors } = require('./crud');
+
+const TEXT_BEARING_MIME_RE =
+  /^(application\/(pdf|json|xml|x-sh|x-tar|typescript|sql|yaml|epub\+zip|vnd\.coffeescript|msword|vnd\.ms-(word|powerpoint|excel)|vnd\.openxmlformats-officedocument\.(wordprocessingml\.document|presentationml\.presentation|spreadsheetml\.sheet))|text\/[\w.+-]+)$/;
+
+const EXCLUDED_PREFIXES = ['image/', 'audio/', 'video/'];
+
+/**
+ * Whether a MIME type should be auto-embedded via rag-api for chat attachments.
+ * Excludes images (go to Vision), audio (go to STT), and video.
+ *
+ * @param {string | undefined | null} mimetype
+ * @returns {boolean}
+ */
+function isTextBearingMimeType(mimetype) {
+  if (!mimetype || typeof mimetype !== 'string') {
+    return false;
+  }
+  if (EXCLUDED_PREFIXES.some((prefix) => mimetype.startsWith(prefix))) {
+    return false;
+  }
+  return TEXT_BEARING_MIME_RE.test(mimetype);
+}
+
+/**
+ * Wrap uploadVectors with graceful degradation: never throws, returns { embedded: false }
+ * on any failure. Intended for auto-RAG of chat-input paperclip attachments where a
+ * failed embed must still allow the upload to succeed (user sees the attachment, just
+ * without indexed-retrieval superpowers).
+ *
+ * @param {object} params
+ * @param {import('express').Request} params.req
+ * @param {Express.Multer.File} params.file
+ * @param {string} params.file_id
+ * @param {string} [params.entity_id]
+ * @returns {Promise<{ embedded: boolean }>}
+ */
+async function tryEmbedChatAttachment({ req, file, file_id, entity_id }) {
+  if (!process.env.RAG_API_URL) {
+    return { embedded: false };
+  }
+
+  try {
+    const result = await uploadVectors({ req, file, file_id, entity_id });
+    return { embedded: Boolean(result?.embedded) };
+  } catch (error) {
+    logger.warn(
+      `[tryEmbedChatAttachment] rag-api embed failed for file_id=${file_id}, falling back to inline attachment: ${error?.message || error}`,
+    );
+    return { embedded: false };
+  }
+}
+
+module.exports = {
+  isTextBearingMimeType,
+  tryEmbedChatAttachment,
+};

--- a/api/server/services/Files/VectorDB/autoEmbed.test.js
+++ b/api/server/services/Files/VectorDB/autoEmbed.test.js
@@ -1,0 +1,117 @@
+jest.mock('./crud', () => ({
+  uploadVectors: jest.fn(),
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const { uploadVectors } = require('./crud');
+const { logger } = require('@librechat/data-schemas');
+const { isTextBearingMimeType, tryEmbedChatAttachment } = require('./autoEmbed');
+
+describe('VectorDB/autoEmbed', () => {
+  const originalEnv = process.env.RAG_API_URL;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    if (originalEnv === undefined) {
+      delete process.env.RAG_API_URL;
+    } else {
+      process.env.RAG_API_URL = originalEnv;
+    }
+  });
+
+  describe('isTextBearingMimeType', () => {
+    test.each([
+      ['application/pdf', true],
+      ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', true],
+      ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', true],
+      ['application/vnd.openxmlformats-officedocument.presentationml.presentation', true],
+      ['application/msword', true],
+      ['application/vnd.ms-excel', true],
+      ['application/vnd.ms-powerpoint', true],
+      ['text/plain', true],
+      ['text/markdown', true],
+      ['text/csv', true],
+      ['text/html', true],
+      ['application/json', true],
+      ['application/xml', true],
+      ['text/x-python', true],
+      ['application/x-sh', true],
+      ['application/epub+zip', true],
+    ])('returns true for text-bearing type %s', (mimetype, expected) => {
+      expect(isTextBearingMimeType(mimetype)).toBe(expected);
+    });
+
+    test.each([
+      ['image/png', false],
+      ['image/jpeg', false],
+      ['image/gif', false],
+      ['image/webp', false],
+      ['image/svg+xml', false],
+      ['audio/mp3', false],
+      ['audio/mpeg', false],
+      ['audio/wav', false],
+      ['video/mp4', false],
+      ['video/webm', false],
+      ['', false],
+      [undefined, false],
+      [null, false],
+    ])('returns false for non-text type %s', (mimetype, expected) => {
+      expect(isTextBearingMimeType(mimetype)).toBe(expected);
+    });
+  });
+
+  describe('tryEmbedChatAttachment', () => {
+    const req = { user: { id: 'user-1' } };
+    const file = { path: '/tmp/test.pdf', mimetype: 'application/pdf', size: 100, originalname: 'test.pdf' };
+    const baseParams = { req, file, file_id: 'fid-1', entity_id: 'conv-1' };
+
+    test('returns embedded:false when RAG_API_URL not configured', async () => {
+      delete process.env.RAG_API_URL;
+
+      const result = await tryEmbedChatAttachment(baseParams);
+
+      expect(result).toEqual({ embedded: false });
+      expect(uploadVectors).not.toHaveBeenCalled();
+    });
+
+    test('returns embedded:true on successful embed', async () => {
+      process.env.RAG_API_URL = 'http://rag-api';
+      uploadVectors.mockResolvedValueOnce({ embedded: true, bytes: 100 });
+
+      const result = await tryEmbedChatAttachment(baseParams);
+
+      expect(result).toEqual({ embedded: true });
+      expect(uploadVectors).toHaveBeenCalledWith({
+        req,
+        file,
+        file_id: 'fid-1',
+        entity_id: 'conv-1',
+      });
+    });
+
+    test('returns embedded:false on rag-api error without throwing (graceful degradation)', async () => {
+      process.env.RAG_API_URL = 'http://rag-api';
+      uploadVectors.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+      const result = await tryEmbedChatAttachment(baseParams);
+
+      expect(result).toEqual({ embedded: false });
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    test('returns embedded:false when rag-api reports unknown type', async () => {
+      process.env.RAG_API_URL = 'http://rag-api';
+      uploadVectors.mockResolvedValueOnce({ embedded: false, bytes: 100 });
+
+      const result = await tryEmbedChatAttachment(baseParams);
+
+      expect(result).toEqual({ embedded: false });
+    });
+  });
+});

--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -642,6 +642,36 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
       basePath,
       entity_id,
     });
+
+    /**
+     * Auto-RAG for chat-input paperclip uploads: when a user drops a text-bearing
+     * file into the chat input (message_file === true, no tool_resource), also
+     * index it in the vector DB so chat-time retrieval works without the user
+     * having to opt in via an Agent. Images (→ Vision) and audio (→ STT) are
+     * intentionally skipped. rag-api failures must not fail the upload.
+     *
+     * Upstream v0.8.2 never embeds chat-paperclip uploads — only Agent
+     * file_search and tool_resource=context paths do.
+     */
+    if (
+      messageAttachment &&
+      !tool_resource &&
+      process.env.RAG_API_URL &&
+      !isImageFile
+    ) {
+      const { isTextBearingMimeType, tryEmbedChatAttachment } = require('./VectorDB/autoEmbed');
+      if (isTextBearingMimeType(file.mimetype)) {
+        const embedResult = await tryEmbedChatAttachment({
+          req,
+          file,
+          file_id,
+          entity_id,
+        });
+        if (embedResult.embedded) {
+          embeddingResult = embedResult;
+        }
+      }
+    }
   }
 
   let { bytes, filename, filepath: _filepath, height, width } = storageResult;
@@ -650,6 +680,10 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
   if (tool_resource === EToolResources.file_search) {
     embedded = embeddingResult?.embedded;
     filename = embeddingResult?.filename || filename;
+  } else if (embeddingResult?.embedded) {
+    // Chat-paperclip auto-RAG: flag the file as embedded so chat-time
+    // createContextHandlers triggers retrieval for it.
+    embedded = true;
   }
 
   let filepath = _filepath;


### PR DESCRIPTION
## Problem

`rag_api` can return visual matches alongside text chunks (see [danny-avila/rag_api#283](https://github.com/danny-avila/rag_api/pull/283)) but LibreChat has no client-side integration to actually attach them to the LLM call. Vision-capable models therefore receive text context only and (correctly) report they cannot see images, even when the user uploaded a design-heavy PDF and asked about layout / colors / photos.

## Solution

Three coordinated additions — none of them touch existing code paths unless the new feature is configured:

### 1. `createContextHandlers` exposes `getVisualImageURLs()`

When `RAG_INCLUDE_VISUAL=true` (default on if `RAG_API_URL` is set), the existing `query()` request gains `include_visual: true`. Visual matches in the response are collected. A new exposed method loads each page PNG from disk, base64-encodes it, returns `image_url` parts in the shape downstream provider adapters expect.

For text-only models, a German-language hint is injected into the system prompt (`\"[Hinweis: visuelle Treffer auf Seiten X verfügbar, aber das aktuell gewählte Modell kann keine Bilder auswerten]\"`) so the LLM knows visual context exists but is currently inaccessible.

### 2. `agents/client.js` consumes `getVisualImageURLs()`

After `createContext()`, if `getVisualImageURLs` is defined: load the URLs and attach to `latestMessage.image_urls` **AND** to the corresponding `formattedMessages[-1].image_urls`. The latter is essential — `formattedMessages` is built earlier via `orderedMessages.map(formatMessage)` and holds independent objects, so mutating `latestMessage` alone does not propagate to the provider payload. (We hit exactly this in production: `image_urls` were loaded into memory but never reached the LLM.)

### 3. `VISION_MODEL_ALIASES` env var

`validateVisionModel({ model })` upstream uses substring matches against a static list of canonical names (`claude-opus-4`, `gpt-4o`, etc.). Any deployment with custom display names — common with proxies like LiteLLM where users see *\"Claude Opus - Premium\"* instead of `claude-opus-4` — falls back to text-only treatment. We allow operators to extend the recognized list via env (CSV of substrings to match in addition to the upstream defaults).

## Backward compatibility

- Without `RAG_API_URL` and `RAG_INCLUDE_VISUAL`: identical to today.
- The legacy `/query` response shape (flat list of chunks) is detected and used as-is — only `{chunks, visual_matches}` shapes trigger the new code path.
- `getVisualImageURLs` is a typeof-check away from being a no-op if missing.

## Soft-fail policy

- File read errors (page PNG not on disk) → log warning, skip that match, continue.
- Path-traversal protection: rejects relative paths in `image_path`.
- Unknown response shape → fall back to legacy parsing.

## Tests

7 jest cases covering: vision-model recognition with aliases, image_url shape correctness, soft-fail on missing files, path-traversal rejection, no-attachment-for-text-only-models, hint injection.

## Stacking

- Stacks on top of [#12788](https://github.com/danny-avila/LibreChat/pull/12788) (auto-embed chat-input uploads) — without that, normal uploads aren't in `rag_api` to begin with.
- Server-side dependency: [danny-avila/rag_api#283](https://github.com/danny-avila/rag_api/pull/283) (visual ingest + retrieval).

## Why upstream

This is the missing client integration that turns `rag_api`'s visual capabilities into actual answers from vision-capable models. The `formattedMessages` mirror fix is a real bug we hit in production — vision models silently received no images for two days while we debugged. Worth landing standalone even if reviewers prefer to defer the `VISION_MODEL_ALIASES` env knob.

Happy to split into smaller PRs if that helps the review.

---

Co-authored-by: Claude (Anthropic)