### PR TITLE
🛡️ chore: Bump `@xmldom/xmldom` to 0.8.13 via Root Override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21854,9 +21854,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
   },
   "overrides": {
     "@anthropic-ai/sdk": "0.73.0",
+    "@xmldom/xmldom": "^0.8.13",
     "@librechat/agents": {
       "@langchain/anthropic": {
         "@anthropic-ai/sdk": "0.73.0",


### PR DESCRIPTION
## Summary

I bumped `@xmldom/xmldom` from 0.8.12 to 0.8.13 across the tree by adding a single root-level `overrides` entry in `package.json`. This resolves Dependabot advisory #196 (uncontrolled recursion in XML serialization leading to DoS) with no breaking changes and no direct dependency bumps.

- Added `"@xmldom/xmldom": "^0.8.13"` to the `overrides` block in root `package.json`.
- Regenerated `package-lock.json` — a single `@xmldom/xmldom` node now resolves to 0.8.13.
- Left transitive parents untouched: `mammoth@1.11.0`, `@node-saml/node-saml@5.1.0`, `xml-crypto@6.1.2`, and `xml-encryption@3.1.0` all already declare `^0.8.x`, which accepts 0.8.13. No parent bumps needed.
- Confirmed deduplication: all four transitive usage sites now share the single 0.8.13 resolution (no duplicate installs).

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified via `npm ls @xmldom/xmldom` that every occurrence in both the `api` and `packages/api` subtrees — mammoth, node-saml, xml-crypto, and xml-encryption — resolves to 0.8.13 (deduped). Ran `npm audit` afterwards; the `@xmldom/xmldom` advisory is no longer listed. Performed a full `npm run reinstall` beforehand to establish a clean baseline, then `npm update @xmldom/xmldom` to force the lockfile to pick up the new override.

### **Test Configuration**:

- Node.js v20.19.2, npm 11.12.0
- Windows 11
- No runtime code paths changed; SAML auth and `.docx` file parsing (mammoth) exercise the affected library at runtime and should be smoke-tested before release.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes