### PR TITLE
fix: skip OpenAI model fetch if using user-provided key

### DIFF
--- a/packages/api/src/endpoints/models.spec.ts
+++ b/packages/api/src/endpoints/models.spec.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { Time, EModelEndpoint, defaultModels } from 'librechat-data-provider';
+import { Time, EModelEndpoint, defaultModels, AuthType } from 'librechat-data-provider';
 import {
   fetchModels,
   splitAndTrim,
@@ -209,6 +209,17 @@ describe('getOpenAIModels', () => {
 
   it('returns default models when no environment configurations are provided (and fetch fails)', async () => {
     const models = await getOpenAIModels({ user: 'user456' });
+    expect(models).toContain('gpt-4');
+  });
+
+  it('returns default models when OpenAI API key is user provided', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { data: [{ id: 'should-not-appear' }] } });
+    process.env.OPENAI_API_KEY = AuthType.USER_PROVIDED;
+
+    const models = await getOpenAIModels({ user: 'user456' });
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(models).not.toContain('should-not-appear');
     expect(models).toContain('gpt-4');
   });
 

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -310,7 +310,7 @@ export async function getOpenAIModels(opts: GetOpenAIModelsOptions = {}): Promis
     return splitAndTrim(process.env[key]);
   }
 
-  if (opts.userProvidedOpenAI) {
+  if (isUserProvided(process.env.OPENAI_API_KEY)) {
     return models;
   }
 


### PR DESCRIPTION
## Summary

There was a check present (via `opts.userProvidedOpenAI`), but it wasn't working because `loadDefaultModels()` doesn't provide that parameter. As a result, the server would repeatedly try to request models from OpenAI and get 401 errors in return.

We now check the env var directly, which matches how `getAnthropicModels()` works.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I added a unit test to verify that it works (and ensure that the unit test isn't accidentally testing the wrong part of the code, too).

I also ran the server after the change to make sure the aforementioned 401 errors are gone.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
