### PR TITLE
🗨️ fix: Restore ModelSpec Preset Greeting (and iconURL Fallback)

### DIFF
--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -160,10 +160,8 @@ describe('tModelSpecPresetSchema', () => {
     }
   });
 
-  it('strips frontend-only fields', () => {
+  it('strips client-managed and preset-override fields', () => {
     const result = tModelSpecPresetSchema.safeParse({
-      greeting: 'Hello!',
-      iconURL: 'https://example.com/icon.png',
       spec: 'some-spec',
       presetOverride: { model: 'other' },
       model: 'gpt-4o',
@@ -171,10 +169,22 @@ describe('tModelSpecPresetSchema', () => {
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data).not.toHaveProperty('greeting');
-      expect(result.data).not.toHaveProperty('iconURL');
       expect(result.data).not.toHaveProperty('spec');
       expect(result.data).not.toHaveProperty('presetOverride');
+    }
+  });
+
+  it('preserves admin-configurable display fields (greeting, iconURL)', () => {
+    const result = tModelSpecPresetSchema.safeParse({
+      greeting: 'Hello!',
+      iconURL: 'https://example.com/icon.png',
+      model: 'gpt-4o',
+      endpoint: EModelEndpoint.openAI,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveProperty('greeting', 'Hello!');
+      expect(result.data).toHaveProperty('iconURL', 'https://example.com/icon.png');
     }
   });
 

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -955,7 +955,13 @@ export const tQueryParamsSchema = tConversationSchema
     }),
   );
 
-/** Narrowed preset schema for use in model specs — omits system/DB/deprecated fields */
+/** Narrowed preset schema for use in model specs — omits system/DB/deprecated fields.
+ *
+ * `greeting` and `iconURL` are admin-configurable display fields on a model spec's
+ * preset (landing greeting, preset-level icon fallback) and must be preserved.
+ * `spec` is set by the client from `modelSpec.name` via `getModelSpecPreset` and is
+ * omitted to avoid duplicate configuration surface.
+ */
 export const tModelSpecPresetSchema = tPresetSchema.omit({
   conversationId: true,
   presetId: true,
@@ -972,8 +978,6 @@ export const tModelSpecPresetSchema = tPresetSchema.omit({
   resendImages: true,
   chatGptLabel: true,
   presetOverride: true,
-  greeting: true,
-  iconURL: true,
   spec: true,
 });
 


### PR DESCRIPTION
## Summary

- The narrowed `tModelSpecPresetSchema` introduced in #12452 omitted `greeting` and `iconURL`, so `configSchema.strict().safeParse(customConfig)` silently stripped these admin-configured fields from `modelSpecs.list[].preset` before the startup config reached the client. The landing greeting rendered nothing, and the `preset.iconURL` fallback in `getModelSpecIconURL` was dead.
- Un-omit `greeting` and `iconURL`; keep `spec` and `presetOverride` omitted since those are genuinely client-managed.
- Flip the associated schema test from asserting these fields are stripped to asserting they're preserved.

Fixes #12803

## Test plan

- [x] `npx jest packages/data-provider/specs/config-schemas.spec.ts` — 61/61 pass, including the new greeting/iconURL preservation case
- [x] Full data-provider suite: 984 tests pass
- [ ] Reproduce manually with the `modelSpecs` config from #12803 and confirm the greeting renders on the landing page