### PR TITLE
🚧 feat: Support Guardrail Config Option `streamProcessingMode`

### DIFF
--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -123,6 +123,7 @@ describe('initializeBedrock', () => {
         guardrailIdentifier: 'test-guardrail-id',
         guardrailVersion: '1',
         trace: 'enabled' as const,
+        streamProcessingMode: 'async',
       };
 
       const params = createMockParams({

--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -129,6 +129,7 @@ describe('initializeBedrock', () => {
         guardrailIdentifier: 'test-guardrail-id',
         guardrailVersion: '1',
         trace: 'enabled' as const,
+        streamProcessingMode: 'async',
       };
 
       const params = createMockParams({

--- a/packages/api/src/types/bedrock.ts
+++ b/packages/api/src/types/bedrock.ts
@@ -19,6 +19,8 @@ export interface GuardrailConfiguration {
   guardrailVersion: string;
   /** The trace behavior for the guardrail */
   trace?: 'enabled' | 'disabled' | 'enabled_full';
+  /** The processing mode for guardrail; 'sync' is the default guardrail behavior if unset */
+  streamProcessingMode?: 'sync' | 'async';
 }
 
 /**


### PR DESCRIPTION
## Summary

`streamProcessingMode` affects how guardrail processes the stream from the model. If it's in "sync" mode, it chunks up the response and processes them before returning them to the user. If it's in "async" mode, it both processes the chunk & sends it to the user at the same time, allowing for smoother streaming (at the cost of guardrail only reacting *after* offending content starts to stream, in some cases).

Related documentation change here: https://github.com/LibreChat-AI/librechat.ai/pull/564

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (here: https://github.com/LibreChat-AI/librechat.ai/pull/564)

## Testing

I added `streamProcessingMode` to an existing test to make sure it's processed by the guardrail configuration code.

I also verified that setting it to `async` in my librechat.yaml would result in a faster streaming response from Bedrock.

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] A pull request for updating the documentation has been submitted (here: https://github.com/LibreChat-AI/librechat.ai/pull/564)
