### PR TITLE
🧜‍♂️ fix: Preserve Mermaid `foreignObject` HTML in Sanitized SVG

### DIFF
--- a/client/src/hooks/Mermaid/useMermaid.ts
+++ b/client/src/hooks/Mermaid/useMermaid.ts
@@ -1,10 +1,9 @@
 import { useContext, useMemo, useState } from 'react';
 import useSWR from 'swr';
 import { Md5 } from 'ts-md5';
-import DOMPurify from 'dompurify';
 import { ThemeContext, isDark } from '@librechat/client';
 import type { MermaidConfig } from 'mermaid';
-import { inlineFlowchartConfig } from '~/utils/mermaid';
+import { inlineFlowchartConfig, sanitizeMermaidSvg } from '~/utils/mermaid';
 
 // Constants
 const MD5_LENGTH_THRESHOLD = 10_000;
@@ -131,20 +130,7 @@ export const useMermaid = ({
       // Render to SVG
       const { svg } = await mermaidInstance.render(diagramId, content);
 
-      // Sanitize SVG output with DOMPurify for additional security
-      const purify = DOMPurify();
-      const sanitizedSvg = purify.sanitize(svg, {
-        USE_PROFILES: { svg: true, svgFilters: true },
-        // Allow additional elements used by mermaid for text rendering
-        ADD_TAGS: ['foreignObject', 'use', 'switch'],
-        ADD_ATTR: [
-          'dominant-baseline',
-          'text-anchor',
-          'requiredFeatures',
-          'systemLanguage',
-          'xmlns:xlink',
-        ],
-      });
+      const sanitizedSvg = sanitizeMermaidSvg(svg);
 
       // Store as last valid content
       setValidContent(sanitizedSvg);

--- a/client/src/utils/__tests__/mermaid.test.ts
+++ b/client/src/utils/__tests__/mermaid.test.ts
@@ -1,5 +1,6 @@
 import {
   fixSubgraphTitleContrast,
+  sanitizeMermaidSvg,
   artifactFlowchartConfig,
   inlineFlowchartConfig,
   getMermaidFiles,
@@ -167,6 +168,89 @@ describe('mermaid config', () => {
       const style = svg.querySelector('text')!.getAttribute('style')!;
       expect(style).not.toContain(';;');
       expect(style).toContain('fill: #1a1a1a');
+    });
+  });
+
+  describe('sanitizeMermaidSvg', () => {
+    const wrap = (inner: string) => `<svg xmlns="http://www.w3.org/2000/svg">${inner}</svg>`;
+
+    it('produces valid XML parseable as image/svg+xml', () => {
+      const svg = wrap('<rect width="10" height="10"/>');
+      const result = sanitizeMermaidSvg(svg);
+      const doc = new DOMParser().parseFromString(result, 'image/svg+xml');
+      expect(doc.querySelector('parsererror')).toBeNull();
+    });
+
+    it('preserves foreignObject and its HTML children', () => {
+      const svg = wrap(
+        '<foreignObject width="100" height="50"><div xmlns="http://www.w3.org/1999/xhtml"><p>Hello</p></div></foreignObject>',
+      );
+      const result = sanitizeMermaidSvg(svg);
+      expect(result).toContain('<foreignObject');
+      expect(result).toContain('<p>Hello</p>');
+    });
+
+    it('serializes <br> as self-closing <br /> for XML compatibility', () => {
+      const svg = wrap(
+        '<foreignObject width="100" height="50"><div xmlns="http://www.w3.org/1999/xhtml"><p>Line1<br/>Line2</p></div></foreignObject>',
+      );
+      const result = sanitizeMermaidSvg(svg);
+      expect(result).toMatch(/<br\s*\/>/);
+      expect(result).not.toMatch(/<br\s*>/);
+    });
+
+    it('retains xmlns="http://www.w3.org/2000/svg" on the root svg element', () => {
+      const svg = wrap('<rect width="10" height="10"/>');
+      const result = sanitizeMermaidSvg(svg);
+      expect(result).toContain('xmlns="http://www.w3.org/2000/svg"');
+    });
+
+    it('strips script tags from SVG', () => {
+      const svg = wrap('<script>alert("xss")</script><rect width="10" height="10"/>');
+      const result = sanitizeMermaidSvg(svg);
+      expect(result).not.toContain('<script');
+      expect(result).not.toContain('alert');
+    });
+
+    it('strips event handler attributes', () => {
+      const svg = wrap('<rect width="10" height="10" onclick="alert(1)"/>');
+      const result = sanitizeMermaidSvg(svg);
+      expect(result).not.toContain('onclick');
+    });
+
+    it('strips script tags inside foreignObject HTML', () => {
+      const svg = wrap(
+        '<foreignObject width="100" height="50"><div xmlns="http://www.w3.org/1999/xhtml"><script>alert("xss")</script><p>Safe</p></div></foreignObject>',
+      );
+      const result = sanitizeMermaidSvg(svg);
+      expect(result).not.toContain('<script');
+      expect(result).toContain('Safe');
+    });
+
+    it('strips javascript: URLs in foreignObject HTML', () => {
+      const svg = wrap(
+        '<foreignObject width="100" height="50"><div xmlns="http://www.w3.org/1999/xhtml"><a href="javascript:alert(1)">click</a></div></foreignObject>',
+      );
+      const result = sanitizeMermaidSvg(svg);
+      expect(result).not.toContain('javascript:');
+    });
+
+    it('preserves mermaid-specific attributes on SVG elements', () => {
+      const svg = wrap('<text dominant-baseline="middle" text-anchor="start">label</text>');
+      const result = sanitizeMermaidSvg(svg);
+      expect(result).toContain('dominant-baseline');
+      expect(result).toContain('text-anchor');
+    });
+
+    it('preserves styled span and class names inside foreignObject', () => {
+      const svg = wrap(
+        '<foreignObject width="150" height="48"><div xmlns="http://www.w3.org/1999/xhtml" style="display: table-cell;"><span class="nodeLabel"><p>Node text<br/>second line</p></span></div></foreignObject>',
+      );
+      const result = sanitizeMermaidSvg(svg);
+      expect(result).toContain('nodeLabel');
+      expect(result).toContain('Node text');
+      expect(result).toContain('second line');
+      expect(result).toMatch(/<br\s*\/>/);
     });
   });
 });

--- a/client/src/utils/mermaid.ts
+++ b/client/src/utils/mermaid.ts
@@ -1,4 +1,5 @@
 import dedent from 'dedent';
+import DOMPurify from 'dompurify';
 
 interface MermaidButtonStyles {
   bg: string;
@@ -484,3 +485,21 @@ root.render(<App />);
     'mermaid.css': mermaidCSS,
   };
 };
+
+/** Sanitize mermaid SVG and serialize as XML, preserving foreignObject HTML (cure53/DOMPurify#1002). */
+export const sanitizeMermaidSvg = (svg: string): string =>
+  new XMLSerializer().serializeToString(
+    DOMPurify().sanitize(svg, {
+      USE_PROFILES: { svg: true, svgFilters: true, html: true },
+      ADD_TAGS: ['foreignObject', 'use', 'switch'],
+      ADD_ATTR: [
+        'dominant-baseline',
+        'text-anchor',
+        'requiredFeatures',
+        'systemLanguage',
+        'xmlns:xlink',
+      ],
+      HTML_INTEGRATION_POINTS: { foreignobject: true },
+      RETURN_DOM_FRAGMENT: true,
+    }),
+  );


### PR DESCRIPTION
## Summary

This change fixes Mermaid inline rendering so sanitized SVGs keep HTML content inside foreignObject, which preserves multi-line labels and `<br />` line breaks in the browser while keeping DOMPurify in place. The sanitizer was moved into a dedicated helper in client/src/utils/mermaid.ts, and client/src/hooks/Mermaid/useMermaid.ts now routes rendered SVGs through that helper instead of using the previous inline sanitize call.

The new helper uses DOMPurify with SVG, SVG filter, and HTML profiles enabled, allows Mermaid’s required SVG tags and attributes, and returns a DOM fragment that is serialized back to XML so foreignObject HTML survives and `<br />` stays XML-safe for blob-based `<img>` rendering. Regression coverage was added in client/src/utils/tests/mermaid.test.ts for the browser issue we hit: preserving foreignObject children, keeping self-closing `<br />`, retaining required SVG attributes, and continuing to strip unsafe scripts, event handlers, and javascript: URLs.

## Change Type

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

Example Mermaid Code:

```mermaid
graph LR
    A[CN Branch CAMs] --> B[Zero Trust Architecture]
    A --> C[JADC2 Interoperability]
    A --> D[AI-Ready Infrastructure]
    A --> E[Cloud-Native Systems]
    A --> F[Cyber Resilience CDO]
    A --> G[Rapid Deployment]
    A --> H[Cost-Effectiveness]
    A --> I[Warfighter-Centric Design]
    A --> J[Supply Chain Security]
    A --> K[Small Business Teaming]
    B --> L[DoD ZTA Strategy 2.0
March 2026]
    C --> M[ABMS BAA
Open Architecture]
    D --> N[DoD AI Strategy
Jan 2026]
    E --> O[DAF Network of Future
Sep 2025]
    F --> P[Great Power Competition
China/Russia]
    G --> Q[DevSecOps 2.0
Software Acceleration]
    H --> R[DoD IT Budget
Efficiency Mandate]
    I --> S[Williams Leadership Vision
Dec 2025]
    J --> T[AFLCMC SCRM Network]
    K --> U[AFLCMC SBO
OTA/BAA/SBIR]
    style A fill:#e1f5ff
    style B fill:#fff4e1
    style C fill:#fff4e1
    style D fill:#fff4e1
    style E fill:#fff4e1
    style F fill:#fff4e1
    style G fill:#fff4e1
    style H fill:#fff4e1
    style I fill:#fff4e1
    style J fill:#fff4e1
    style K fill:#fff4e1
```

Before Fix:
<img width="562" height="720" alt="Screenshot 2026-04-24 at 11 09 38 PM" src="https://github.com/user-attachments/assets/9a2db154-49c3-49a5-a5ed-699a60a49d16" />

After Fix:
<img width="611" height="725" alt="Screenshot 2026-04-24 at 11 08 03 PM" src="https://github.com/user-attachments/assets/7e292667-1e34-4f13-a30b-0c4cdf8d6fb6" />

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented in any complex areas of my code
- [X] My changes do not introduce new warnings
- [X] I have written tests demonstrating that my changes are effective or that my feature works
- [X] Local unit tests pass with my changes
