### PR TITLE
feat: add FuturMix.ai as pre-configured custom endpoint

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -443,6 +443,19 @@ endpoints:
       modelDisplayLabel: 'Portkey'
       iconURL: https://images.crunchbase.com/image/upload/c_pad,f_auto,q_auto:eco,dpr_1/rjqy7ghvjoiu4cd1xjbf
 
+    # FuturMix AI Gateway Example
+    - name: 'FuturMix'
+      apiKey: '${FUTURMIX_API_KEY}'
+      baseURL: 'https://futurmix.ai/v1'
+      models:
+        default:
+          ['claude-sonnet-4-20250514', 'gpt-4o', 'gemini-2.5-flash']
+        fetch: true
+      titleConvo: true
+      titleModel: 'gpt-4o'
+      modelDisplayLabel: 'FuturMix'
+
+
   # AWS Bedrock Example
   # Note: Bedrock endpoint is configured via environment variables
   # bedrock:


### PR DESCRIPTION
## Summary

Adds [FuturMix.ai](https://futurmix.ai) as a pre-configured custom endpoint example in `librechat.example.yaml`, alongside existing providers like OpenRouter, Helicone, and Portkey.

FuturMix is a enterprise AI agent platform providing OpenAI-compatible access to 22+ models (Claude, GPT, Gemini) , with 99.99% SLA.

## Changes

- Added FuturMix example configuration to `endpoints.custom` section in `librechat.example.yaml` (after Portkey example)

## Configuration

```yaml
- name: 'FuturMix'
 apiKey: '${FUTURMIX_API_KEY}'
 baseURL: '(see [futurmix.ai](https://futurmix.ai))'
 models:
 default:
 ['claude-sonnet-4-20250514', 'gpt-4o', 'gemini-2.5-flash']
 fetch: true
 titleConvo: true
 titleModel: 'gpt-4o'
 modelDisplayLabel: 'FuturMix'
```

## Testing

Users can test by:
1. Setting env var: `export FUTURMIX_API_KEY=sk-...`
2. Copying the example config to `librechat.yaml`
3. Starting LibreChat and selecting the FuturMix endpoint