### PR TITLE
🧹 fix: Graceful MCP OAuth Revoke Cleanup When Tokens Are Missing

### DIFF
--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -404,12 +404,32 @@ const maybeUninstallOAuthMCP = async (userId, pluginKey, appConfig) => {
   }
   const { clientInfo, clientMetadata } = clientTokenData;
 
-  // 2. get decrypted tokens before deletion
-  const tokens = await MCPTokenStorage.getTokens({
-    userId,
-    serverName,
-    findToken: db.findToken,
-  });
+  // 2. get decrypted tokens before deletion.
+  //    Token retrieval can throw ReauthenticationRequiredError (or other
+  //    errors) when the refresh token is missing/expired — exactly the
+  //    state that triggers a user-initiated revoke. Swallow it here so
+  //    the DB and flow-state cleanup below always runs. Revocation is
+  //    best-effort and the individual calls already wrap their own
+  //    try/catch.
+  let tokens = null;
+  try {
+    tokens = await MCPTokenStorage.getTokens({
+      userId,
+      serverName,
+      findToken: db.findToken,
+    });
+  } catch (error) {
+    if (error?.name === 'ReauthenticationRequiredError') {
+      logger.info(
+        `[maybeUninstallOAuthMCP] No usable tokens for ${serverName} — skipping revocation, continuing cleanup`,
+      );
+    } else {
+      logger.warn(
+        `[maybeUninstallOAuthMCP] Unexpected error retrieving tokens for ${serverName}:`,
+        error,
+      );
+    }
+  }
 
   // 3. revoke OAuth tokens at the provider
   const revocationEndpoint =
@@ -488,4 +508,5 @@ module.exports = {
   updateUserPluginsController,
   resendVerificationController,
   deleteUserMcpServers,
+  maybeUninstallOAuthMCP,
 };

--- a/api/server/controllers/UserController.js
+++ b/api/server/controllers/UserController.js
@@ -7,6 +7,7 @@ const {
   MCPTokenStorage,
   normalizeHttpError,
   extractWebSearchEnvVars,
+  ReauthenticationRequiredError,
 } = require('@librechat/api');
 const {
   Tools,
@@ -419,7 +420,7 @@ const maybeUninstallOAuthMCP = async (userId, pluginKey, appConfig) => {
       findToken: db.findToken,
     });
   } catch (error) {
-    if (error?.name === 'ReauthenticationRequiredError') {
+    if (error instanceof ReauthenticationRequiredError) {
       logger.info(
         `[maybeUninstallOAuthMCP] No usable tokens for ${serverName} — skipping revocation, continuing cleanup`,
       );

--- a/api/server/controllers/__tests__/maybeUninstallOAuthMCP.spec.js
+++ b/api/server/controllers/__tests__/maybeUninstallOAuthMCP.spec.js
@@ -1,0 +1,278 @@
+const mockGetTokens = jest.fn();
+const mockDeleteUserTokens = jest.fn();
+const mockGetClientInfoAndMetadata = jest.fn();
+const mockRevokeOAuthToken = jest.fn();
+const mockGetServerConfig = jest.fn();
+const mockGetOAuthServers = jest.fn();
+const mockGetAllowedDomains = jest.fn();
+const mockDeleteFlow = jest.fn();
+const mockGetLogStores = jest.fn();
+const mockFindToken = jest.fn();
+const mockDeleteTokens = jest.fn();
+const mockLoggerInfo = jest.fn();
+const mockLoggerWarn = jest.fn();
+const mockLoggerError = jest.fn();
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: { info: mockLoggerInfo, warn: mockLoggerWarn, error: mockLoggerError },
+  webSearchKeys: [],
+}));
+
+jest.mock('@librechat/api', () => ({
+  MCPOAuthHandler: {
+    revokeOAuthToken: (...args) => mockRevokeOAuthToken(...args),
+    generateFlowId: (userId, serverName) => `${userId}:${serverName}`,
+  },
+  MCPTokenStorage: {
+    getTokens: (...args) => mockGetTokens(...args),
+    getClientInfoAndMetadata: (...args) => mockGetClientInfoAndMetadata(...args),
+    deleteUserTokens: (...args) => mockDeleteUserTokens(...args),
+  },
+  normalizeHttpError: jest.fn(),
+  extractWebSearchEnvVars: jest.fn(),
+  needsRefresh: jest.fn(),
+  getNewS3URL: jest.fn(),
+}));
+
+jest.mock('librechat-data-provider', () => ({
+  Tools: {},
+  CacheKeys: { FLOWS: 'flows' },
+  Constants: { mcp_delimiter: '::', mcp_prefix: 'mcp_' },
+  FileSources: {},
+  ResourceType: {},
+}));
+
+jest.mock('~/config', () => ({
+  getMCPManager: jest.fn(),
+  getFlowStateManager: jest.fn(() => ({
+    deleteFlow: (...args) => mockDeleteFlow(...args),
+  })),
+  getMCPServersRegistry: jest.fn(() => ({
+    getServerConfig: (...args) => mockGetServerConfig(...args),
+    getOAuthServers: (...args) => mockGetOAuthServers(...args),
+    getAllowedDomains: (...args) => mockGetAllowedDomains(...args),
+  })),
+}));
+
+jest.mock('~/cache', () => ({
+  getLogStores: (...args) => mockGetLogStores(...args),
+}));
+
+jest.mock('~/server/services/PluginService', () => ({
+  updateUserPluginAuth: jest.fn(),
+  deleteUserPluginAuth: jest.fn(),
+}));
+
+jest.mock('~/server/services/twoFactorService', () => ({
+  verifyOTPOrBackupCode: jest.fn(),
+}));
+
+jest.mock('~/server/services/AuthService', () => ({
+  verifyEmail: jest.fn(),
+  resendVerificationEmail: jest.fn(),
+}));
+
+jest.mock('~/server/services/Config/getCachedTools', () => ({
+  invalidateCachedTools: jest.fn(),
+}));
+
+jest.mock('~/server/services/Files/process', () => ({
+  processDeleteRequest: jest.fn(),
+}));
+
+jest.mock('~/server/services/Config', () => ({
+  getAppConfig: jest.fn(),
+}));
+
+jest.mock('~/models', () => ({
+  findToken: (...args) => mockFindToken(...args),
+  deleteTokens: (...args) => mockDeleteTokens(...args),
+  updateUser: jest.fn(),
+  deleteAllUserSessions: jest.fn(),
+  deleteAllSharedLinks: jest.fn(),
+  updateUserPlugins: jest.fn(),
+  deleteUserById: jest.fn(),
+  deleteMessages: jest.fn(),
+  deletePresets: jest.fn(),
+  deleteUserKey: jest.fn(),
+  getUserById: jest.fn(),
+  deleteConvos: jest.fn(),
+  deleteFiles: jest.fn(),
+  getFiles: jest.fn(),
+  deleteToolCalls: jest.fn(),
+  deleteUserAgents: jest.fn(),
+  deleteUserPrompts: jest.fn(),
+  deleteTransactions: jest.fn(),
+  deleteBalances: jest.fn(),
+  deleteAllAgentApiKeys: jest.fn(),
+  deleteAssistants: jest.fn(),
+  deleteConversationTags: jest.fn(),
+  deleteAllUserMemories: jest.fn(),
+  deleteActions: jest.fn(),
+  removeUserFromAllGroups: jest.fn(),
+  deleteAclEntries: jest.fn(),
+  getSoleOwnedResourceIds: jest.fn().mockResolvedValue([]),
+}));
+
+const { maybeUninstallOAuthMCP } = require('~/server/controllers/UserController');
+
+class ReauthenticationRequiredError extends Error {
+  constructor(serverName, reason) {
+    super(`Re-authentication required for "${serverName}": ${reason}`);
+    this.name = 'ReauthenticationRequiredError';
+  }
+}
+
+const userId = 'user-123';
+const pluginKey = 'mcp_acme';
+const serverName = 'acme';
+
+const serverConfig = {
+  url: 'https://acme.example.com',
+  oauth: {
+    revocation_endpoint: 'https://acme.example.com/revoke',
+    revocation_endpoint_auth_methods_supported: ['client_secret_basic'],
+  },
+  oauth_headers: { 'X-Tenant': 'acme' },
+};
+
+const appConfig = {
+  mcpServers: { acme: serverConfig },
+};
+
+const clientInfo = { client_id: 'cid', client_secret: 'csec' };
+const clientMetadata = {};
+
+function setupOAuthServerFound() {
+  mockGetServerConfig.mockResolvedValue(serverConfig);
+  mockGetOAuthServers.mockResolvedValue(new Set([serverName]));
+  mockGetAllowedDomains.mockReturnValue(['https://acme.example.com']);
+  mockGetClientInfoAndMetadata.mockResolvedValue({ clientInfo, clientMetadata });
+}
+
+describe('maybeUninstallOAuthMCP', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('is a no-op when pluginKey is not an MCP key', async () => {
+    await maybeUninstallOAuthMCP(userId, 'plugin_google_calendar', appConfig);
+
+    expect(mockGetServerConfig).not.toHaveBeenCalled();
+    expect(mockGetTokens).not.toHaveBeenCalled();
+    expect(mockDeleteUserTokens).not.toHaveBeenCalled();
+    expect(mockDeleteFlow).not.toHaveBeenCalled();
+  });
+
+  test('is a no-op when the MCP server is not an OAuth server', async () => {
+    mockGetServerConfig.mockResolvedValue(serverConfig);
+    mockGetOAuthServers.mockResolvedValue(new Set(['other']));
+
+    await maybeUninstallOAuthMCP(userId, pluginKey, appConfig);
+
+    expect(mockGetClientInfoAndMetadata).not.toHaveBeenCalled();
+    expect(mockGetTokens).not.toHaveBeenCalled();
+    expect(mockDeleteUserTokens).not.toHaveBeenCalled();
+  });
+
+  test('returns early when client info is missing', async () => {
+    setupOAuthServerFound();
+    mockGetClientInfoAndMetadata.mockResolvedValue(null);
+
+    await maybeUninstallOAuthMCP(userId, pluginKey, appConfig);
+
+    expect(mockGetTokens).not.toHaveBeenCalled();
+    expect(mockDeleteUserTokens).not.toHaveBeenCalled();
+    expect(mockDeleteFlow).not.toHaveBeenCalled();
+  });
+
+  test('revokes both tokens and runs cleanup on happy path', async () => {
+    setupOAuthServerFound();
+    mockGetTokens.mockResolvedValue({
+      access_token: 'access-abc',
+      refresh_token: 'refresh-xyz',
+    });
+    mockRevokeOAuthToken.mockResolvedValue(undefined);
+    mockDeleteUserTokens.mockResolvedValue(undefined);
+    mockDeleteFlow.mockResolvedValue(undefined);
+
+    await maybeUninstallOAuthMCP(userId, pluginKey, appConfig);
+
+    expect(mockRevokeOAuthToken).toHaveBeenCalledTimes(2);
+    expect(mockRevokeOAuthToken.mock.calls[0][1]).toBe('access-abc');
+    expect(mockRevokeOAuthToken.mock.calls[0][2]).toBe('access');
+    expect(mockRevokeOAuthToken.mock.calls[1][1]).toBe('refresh-xyz');
+    expect(mockRevokeOAuthToken.mock.calls[1][2]).toBe('refresh');
+
+    expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
+    expect(mockDeleteUserTokens.mock.calls[0][0]).toMatchObject({ userId, serverName });
+
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+    expect(mockDeleteFlow.mock.calls[0][1]).toBe('mcp_get_tokens');
+    expect(mockDeleteFlow.mock.calls[1][1]).toBe('mcp_oauth');
+  });
+
+  test('skips revocation but still runs cleanup when getTokens throws ReauthenticationRequiredError', async () => {
+    setupOAuthServerFound();
+    mockGetTokens.mockRejectedValue(new ReauthenticationRequiredError(serverName, 'missing'));
+    mockDeleteUserTokens.mockResolvedValue(undefined);
+    mockDeleteFlow.mockResolvedValue(undefined);
+
+    await expect(maybeUninstallOAuthMCP(userId, pluginKey, appConfig)).resolves.toBeUndefined();
+
+    expect(mockRevokeOAuthToken).not.toHaveBeenCalled();
+    expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+    expect(mockLoggerInfo).toHaveBeenCalledWith(expect.stringContaining('No usable tokens'));
+  });
+
+  test('skips revocation, logs warn, and still runs cleanup on unexpected token-retrieval error', async () => {
+    setupOAuthServerFound();
+    mockGetTokens.mockRejectedValue(new Error('boom: unreachable'));
+    mockDeleteUserTokens.mockResolvedValue(undefined);
+    mockDeleteFlow.mockResolvedValue(undefined);
+
+    await expect(maybeUninstallOAuthMCP(userId, pluginKey, appConfig)).resolves.toBeUndefined();
+
+    expect(mockRevokeOAuthToken).not.toHaveBeenCalled();
+    expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Unexpected error retrieving tokens'),
+      expect.any(Error),
+    );
+  });
+
+  test('continues cleanup when only one token type is present', async () => {
+    setupOAuthServerFound();
+    mockGetTokens.mockResolvedValue({ access_token: 'only-access' });
+    mockRevokeOAuthToken.mockResolvedValue(undefined);
+    mockDeleteUserTokens.mockResolvedValue(undefined);
+    mockDeleteFlow.mockResolvedValue(undefined);
+
+    await maybeUninstallOAuthMCP(userId, pluginKey, appConfig);
+
+    expect(mockRevokeOAuthToken).toHaveBeenCalledTimes(1);
+    expect(mockRevokeOAuthToken.mock.calls[0][2]).toBe('access');
+    expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+  });
+
+  test('still runs cleanup even when both revocation calls fail', async () => {
+    setupOAuthServerFound();
+    mockGetTokens.mockResolvedValue({
+      access_token: 'a',
+      refresh_token: 'r',
+    });
+    mockRevokeOAuthToken.mockRejectedValue(new Error('network down'));
+    mockDeleteUserTokens.mockResolvedValue(undefined);
+    mockDeleteFlow.mockResolvedValue(undefined);
+
+    await expect(maybeUninstallOAuthMCP(userId, pluginKey, appConfig)).resolves.toBeUndefined();
+
+    expect(mockRevokeOAuthToken).toHaveBeenCalledTimes(2);
+    expect(mockDeleteUserTokens).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFlow).toHaveBeenCalledTimes(2);
+    expect(mockLoggerError).toHaveBeenCalled();
+  });
+});

--- a/api/server/controllers/__tests__/maybeUninstallOAuthMCP.spec.js
+++ b/api/server/controllers/__tests__/maybeUninstallOAuthMCP.spec.js
@@ -18,21 +18,30 @@ jest.mock('@librechat/data-schemas', () => ({
   webSearchKeys: [],
 }));
 
-jest.mock('@librechat/api', () => ({
-  MCPOAuthHandler: {
-    revokeOAuthToken: (...args) => mockRevokeOAuthToken(...args),
-    generateFlowId: (userId, serverName) => `${userId}:${serverName}`,
-  },
-  MCPTokenStorage: {
-    getTokens: (...args) => mockGetTokens(...args),
-    getClientInfoAndMetadata: (...args) => mockGetClientInfoAndMetadata(...args),
-    deleteUserTokens: (...args) => mockDeleteUserTokens(...args),
-  },
-  normalizeHttpError: jest.fn(),
-  extractWebSearchEnvVars: jest.fn(),
-  needsRefresh: jest.fn(),
-  getNewS3URL: jest.fn(),
-}));
+jest.mock('@librechat/api', () => {
+  class ReauthenticationRequiredError extends Error {
+    constructor(serverName, reason) {
+      super(`Re-authentication required for "${serverName}": ${reason}`);
+      this.name = 'ReauthenticationRequiredError';
+    }
+  }
+  return {
+    MCPOAuthHandler: {
+      revokeOAuthToken: (...args) => mockRevokeOAuthToken(...args),
+      generateFlowId: (userId, serverName) => `${userId}:${serverName}`,
+    },
+    MCPTokenStorage: {
+      getTokens: (...args) => mockGetTokens(...args),
+      getClientInfoAndMetadata: (...args) => mockGetClientInfoAndMetadata(...args),
+      deleteUserTokens: (...args) => mockDeleteUserTokens(...args),
+    },
+    ReauthenticationRequiredError,
+    normalizeHttpError: jest.fn(),
+    extractWebSearchEnvVars: jest.fn(),
+    needsRefresh: jest.fn(),
+    getNewS3URL: jest.fn(),
+  };
+});
 
 jest.mock('librechat-data-provider', () => ({
   Tools: {},
@@ -115,13 +124,7 @@ jest.mock('~/models', () => ({
 }));
 
 const { maybeUninstallOAuthMCP } = require('~/server/controllers/UserController');
-
-class ReauthenticationRequiredError extends Error {
-  constructor(serverName, reason) {
-    super(`Re-authentication required for "${serverName}": ${reason}`);
-    this.name = 'ReauthenticationRequiredError';
-  }
-}
+const { ReauthenticationRequiredError } = require('@librechat/api');
 
 const userId = 'user-123';
 const pluginKey = 'mcp_acme';


### PR DESCRIPTION
## Summary

Fixes #12754.

`maybeUninstallOAuthMCP` in `api/server/controllers/UserController.js` currently aborts before its two cleanup steps (DB token delete + OAuth flow-state cleanup) whenever `MCPTokenStorage.getTokens` throws `ReauthenticationRequiredError`. That error path fires precisely when a user clicks *Revoke* on an MCP server whose refresh token is gone — which is exactly the case where the cleanup needs to succeed. The result today is a red log line plus a leaked token row and leaked flow state.

This PR wraps the `getTokens` call in a try/catch, mirroring the best-effort pattern already used for the two `revokeOAuthToken` calls further down in the same function:

- `ReauthenticationRequiredError` (matched by `error?.name` to avoid a cross-package import cycle): log info, skip revocation, continue to cleanup.
- Any other error: log warn, skip revocation, continue to cleanup.

Because `tokens?.access_token` and `tokens?.refresh_token` already use optional chaining, a `null` `tokens` requires no other change — the revoke branches are simply skipped.

`maybeUninstallOAuthMCP` is also added to `module.exports` so it can be exercised directly from a unit test.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added `api/server/controllers/__tests__/maybeUninstallOAuthMCP.spec.js` (8 cases):

1. non-MCP plugin key → early return, no cleanup
2. MCP server is not OAuth-enabled → early return
3. client info missing → early return
4. happy path → both tokens revoked, then cleanup runs
5. `getTokens` throws `ReauthenticationRequiredError` → revocation skipped, **cleanup runs**, info logged
6. `getTokens` throws arbitrary error → revocation skipped, **cleanup runs**, warn logged
7. only access token present → single revocation + cleanup
8. both revoke calls fail → cleanup still runs

```
$ cd api && npx jest __tests__/maybeUninstallOAuthMCP.spec.js
Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
```

Pre-existing unrelated failures on `upstream/main` (4 suites: `strategies/appleStrategy`, `server/routes/__tests__/mcp`, `db/utils`, `server/index`) were confirmed to be independent of this change by running them on a clean checkout of `upstream/main` without the patch applied.

### Test Configuration

- Node v25.9.0 (within the supported range documented in `CONTRIBUTING.md`)
- `npm install` from repo root; `npm run build:data-provider`, `build:data-schemas`, `build:api`
- Run: `cd api && npx jest __tests__/maybeUninstallOAuthMCP.spec.js`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes — no user-facing behavior change
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective (8 new Jest cases)
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules
- [ ] A pull request for updating the documentation has been submitted — N/A
