### PR TITLE
feat: made memory agent optional

### DIFF
--- a/api/server/controllers/agents/client.js
+++ b/api/server/controllers/agents/client.js
@@ -454,6 +454,8 @@ class AgentClient extends BaseClient {
       return;
     }
 
+    const userId = this.options.req.user.id + '';
+
     /** @type {Agent} */
     let prelimAgent;
     const allowedProviders = new Set(
@@ -483,7 +485,17 @@ class AgentClient extends BaseClient {
     }
 
     if (!prelimAgent) {
-      return;
+      this.processMemory = undefined;
+      try {
+        const { withoutKeys } = await db.getFormattedMemories({ userId });
+        return withoutKeys;
+      } catch (error) {
+        logger.error(
+          '[api/server/controllers/agents/client.js #useMemory] Error loading memories without memory agent',
+          error,
+        );
+        return;
+      }
     }
 
     const agent = await initializeAgent(
@@ -534,7 +546,6 @@ class AgentClient extends BaseClient {
       tokenLimit: memoryConfig.tokenLimit,
     };
 
-    const userId = this.options.req.user.id + '';
     const messageId = this.responseMessageId + '';
     const conversationId = this.conversationId + '';
     const streamId = this.options.req?._resumableStreamId || null;

--- a/api/server/controllers/agents/client.test.js
+++ b/api/server/controllers/agents/client.test.js
@@ -29,6 +29,7 @@ jest.mock('~/server/services/MCP', () => ({
 jest.mock('~/models', () => ({
   getAgent: jest.fn(),
   getRoleByName: jest.fn(),
+  getFormattedMemories: jest.fn(),
 }));
 
 // Mock getMCPManager
@@ -2099,6 +2100,7 @@ describe('AgentClient - titleConvo', () => {
     let mockLoadAgent;
     let mockInitializeAgent;
     let mockCreateMemoryProcessor;
+    let mockGetFormattedMemories;
 
     beforeEach(() => {
       jest.clearAllMocks();
@@ -2147,6 +2149,12 @@ describe('AgentClient - titleConvo', () => {
       mockLoadAgent = require('@librechat/api').loadAgent;
       mockInitializeAgent = require('@librechat/api').initializeAgent;
       mockCreateMemoryProcessor = require('@librechat/api').createMemoryProcessor;
+      mockGetFormattedMemories = require('~/models').getFormattedMemories;
+      mockGetFormattedMemories.mockResolvedValue({
+        withKeys: '',
+        withoutKeys: '',
+        totalTokens: 0,
+      });
     });
 
     it('should use current agent when memory config agent.id matches current agent id', async () => {
@@ -2211,12 +2219,18 @@ describe('AgentClient - titleConvo', () => {
       );
     });
 
-    it('should return early when prelimAgent is undefined (no valid memory agent config)', async () => {
+    it('should return existing memories without auto-processing when memory agent is not configured', async () => {
       mockReq.config.memory = {
-        agent: {},
+        disabled: false,
+        personalize: true,
       };
 
       mockCheckAccess.mockResolvedValue(true);
+      mockGetFormattedMemories.mockResolvedValue({
+        withKeys: 'food: likes pasta',
+        withoutKeys: 'likes pasta',
+        totalTokens: 3,
+      });
 
       client = new AgentClient(mockOptions);
       client.conversationId = 'convo-123';
@@ -2224,9 +2238,11 @@ describe('AgentClient - titleConvo', () => {
 
       const result = await client.useMemory();
 
-      expect(result).toBeUndefined();
+      expect(result).toBe('likes pasta');
+      expect(mockGetFormattedMemories).toHaveBeenCalledWith({ userId: 'user-123' });
       expect(mockInitializeAgent).not.toHaveBeenCalled();
       expect(mockCreateMemoryProcessor).not.toHaveBeenCalled();
+      expect(client.processMemory).toBeUndefined();
     });
 
     it('should create ephemeral agent when no id but model and provider are specified', async () => {

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -597,7 +597,8 @@ endpoints:
 #   # (optional) Enable personalization features (defaults to true if memory is configured)
 #   # When false, users will not see the Personalization tab in settings
 #   personalize: true
-#   # Memory agent configuration - either use an existing agent by ID or define inline
+#   # (optional) Memory agent configuration for automatic memory updates from chat messages
+#   # If omitted, users can still create, edit, and delete memories manually.
 #   agent:
 #     # Option 1: Use existing agent by ID
 #     id: "your-memory-agent-id"

--- a/packages/api/src/app/permissions.spec.ts
+++ b/packages/api/src/app/permissions.spec.ts
@@ -1693,7 +1693,7 @@ describe('updateInterfacePermissions - permissions', () => {
     });
   });
 
-  it('should re-enable memory permissions when valid memory config exists without disabled field', async () => {
+  it('should re-enable memory permissions when memory config exists without disabled field', async () => {
     // Mock existing memory permissions that are disabled
     mockGetRoleByName.mockResolvedValue({
       permissions: {
@@ -1709,11 +1709,6 @@ describe('updateInterfacePermissions - permissions', () => {
 
     const config = {
       memory: {
-        // No disabled field, but valid config
-        agent: {
-          id: 'test-agent-id',
-          provider: 'openai',
-        },
         personalize: false,
       } as unknown as TCustomConfig['memory'],
     };

--- a/packages/api/src/memory/config.ts
+++ b/packages/api/src/memory/config.ts
@@ -1,11 +1,6 @@
 import { memorySchema } from 'librechat-data-provider';
 import type { TCustomConfig, TMemoryConfig } from 'librechat-data-provider';
 
-const hasValidAgent = (agent: TMemoryConfig['agent']) =>
-  !!agent &&
-  (('id' in agent && !!agent.id) ||
-    ('provider' in agent && 'model' in agent && !!agent.provider && !!agent.model));
-
 const isDisabled = (config?: TMemoryConfig | TCustomConfig['memory']) =>
   !config || config.disabled === true;
 
@@ -13,16 +8,11 @@ export function loadMemoryConfig(config: TCustomConfig['memory']): TMemoryConfig
   if (!config) return undefined;
   if (isDisabled(config)) return config as TMemoryConfig;
 
-  if (!hasValidAgent(config.agent)) {
-    return { ...config, disabled: true } as TMemoryConfig;
-  }
-
   const charLimit = memorySchema.shape.charLimit.safeParse(config.charLimit).data ?? 10000;
 
   return { ...config, charLimit };
 }
 
 export function isMemoryEnabled(config: TMemoryConfig | undefined): boolean {
-  if (isDisabled(config)) return false;
-  return hasValidAgent(config!.agent);
+  return !isDisabled(config);
 }

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -24,7 +24,7 @@ export async function loadDefaultInterface({
 
   const memoryConfig = config?.memory;
   const memoryEnabled = isMemoryEnabled(memoryConfig);
-  /** Only disable memories if memory config is present but disabled/invalid */
+  /** Only disable memories if memory config is present and explicitly disabled */
   const shouldDisableMemories = memoryConfig && !memoryEnabled;
 
   const loadedInterface: AppConfig['interfaceConfig'] = removeNullishValues({

--- a/packages/data-schemas/src/app/memory.ts
+++ b/packages/data-schemas/src/app/memory.ts
@@ -1,11 +1,6 @@
 import { memorySchema } from 'librechat-data-provider';
 import type { TCustomConfig, TMemoryConfig } from 'librechat-data-provider';
 
-const hasValidAgent = (agent: TMemoryConfig['agent']) =>
-  !!agent &&
-  (('id' in agent && !!agent.id) ||
-    ('provider' in agent && 'model' in agent && !!agent.provider && !!agent.model));
-
 const isDisabled = (config?: TMemoryConfig | TCustomConfig['memory']) =>
   !config || config.disabled === true;
 
@@ -13,16 +8,11 @@ export function loadMemoryConfig(config: TCustomConfig['memory']): TMemoryConfig
   if (!config) return undefined;
   if (isDisabled(config)) return config as TMemoryConfig;
 
-  if (!hasValidAgent(config.agent)) {
-    return { ...config, disabled: true } as TMemoryConfig;
-  }
-
   const charLimit = memorySchema.shape.charLimit.safeParse(config.charLimit).data ?? 10000;
 
   return { ...config, charLimit };
 }
 
 export function isMemoryEnabled(config: TMemoryConfig | undefined): boolean {
-  if (isDisabled(config)) return false;
-  return hasValidAgent(config!.agent);
+  return !isDisabled(config);
 }


### PR DESCRIPTION
# Pull Request Template

⚠️ Before Submitting a PR, Please Review:
- Please ensure that you have thoroughly read and understood the [Contributing Docs](https://github.com/danny-avila/LibreChat/blob/main/.github/CONTRIBUTING.md) before submitting your Pull Request.

⚠️ Documentation Updates Notice:
- Kindly note that documentation updates are managed in this repository: [librechat.ai](https://github.com/LibreChat-AI/librechat.ai)

## Summary
- Updated memory config resolution so the `memory.agent` block is no longer treated as required for enabling memory.
- Kept memory enabled whenever `memory` is configured and not explicitly disabled.
- Updated agent chat memory flow so when no memory agent is configured, existing memories are still loaded and injected into context, while automatic memory extraction is skipped.
- Clarified `librechat.example.yaml` comments to document that `memory.agent` is optional and only needed for automatic memory updates.

### Code changes
- `packages/data-schemas/src/app/memory.ts`
  - Removed memory-agent validation as a hard requirement.
  - `loadMemoryConfig` now normalizes config (charLimit) without disabling memory when `agent` is absent.
  - `isMemoryEnabled` now checks only explicit disabled state.
- `packages/api/src/memory/config.ts`
  - Mirrored the same memory-enabled behavior change used by permissions logic.
- `packages/data-schemas/src/app/interface.ts`
  - Updated memory-disable comment to reflect explicit disable behavior.
- `api/server/controllers/agents/client.js`
  - In `useMemory()`, when no memory agent is configured:
    - stop auto-memory processing,
    - fetch and return existing formatted memories,
    - avoid initializing a memory agent.
- Tests
  - `api/server/controllers/agents/client.test.js`: added/updated coverage for no-agent memory behavior (manual memories available, no auto-processing setup).
  - `packages/api/src/app/permissions.spec.ts`: updated coverage to ensure memory permissions re-enable from config even without `memory.agent`.
- Docs/example
  - `librechat.example.yaml`: clarified `memory.agent` is optional and only for automatic memory updates.

### Why
This allows deployments to use the memory feature for manual reminders without requiring an AI memory agent configuration, while still supporting optional automated memory extraction when `memory.agent` is provided.

## Change Type

Please delete any irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Checklist

Please delete any irrelevant options.

- [X] My code adheres to this project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have made pertinent documentation changes
- [X] I have written tests demonstrating that my changes are effective or that my feature works
