### PR TITLE
📄 feat: Auto-render Text-Based Code Execution Artifacts Inline

### DIFF
--- a/api/server/services/Files/Code/__tests__/process-traversal.spec.js
+++ b/api/server/services/Files/Code/__tests__/process-traversal.spec.js
@@ -23,6 +23,8 @@ jest.mock('@librechat/api', () => {
     getBasePath: jest.fn(() => ''),
     sanitizeFilename: mockSanitizeFilename,
     createAxiosInstance: jest.fn(() => mockAxios),
+    classifyCodeArtifact: jest.fn(() => 'other'),
+    extractCodeArtifactText: jest.fn(async () => null),
     codeServerHttpAgent: new http.Agent({ keepAlive: false }),
     codeServerHttpsAgent: new https.Agent({ keepAlive: false }),
   };

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -243,7 +243,11 @@ const processCodeOutput = async ({
       context: FileContext.execute_code,
       usage: isUpdate ? (claimed.usage ?? 0) + 1 : 1,
       createdAt: isUpdate ? claimed.createdAt : formattedDate,
-      ...(text != null ? { text } : {}),
+      // Always set `text` explicitly (string or null) so that an update which
+      // produces a binary or oversized artifact clears any previously cached
+      // text — `createFile` uses findOneAndUpdate with $set semantics, which
+      // would otherwise leave a stale value behind.
+      text: text ?? null,
     };
 
     await createFile(file, true);

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -7,8 +7,10 @@ const {
   logAxiosError,
   sanitizeFilename,
   createAxiosInstance,
+  classifyCodeArtifact,
   codeServerHttpAgent,
   codeServerHttpsAgent,
+  extractCodeArtifactText,
 } = require('@librechat/api');
 const {
   Tools,
@@ -222,6 +224,9 @@ const processCodeOutput = async ({
       basePath: 'uploads',
     });
 
+    const category = classifyCodeArtifact(name, mimeType);
+    const text = await extractCodeArtifactText(buffer, name, mimeType, category);
+
     const file = {
       file_id,
       filepath,
@@ -238,6 +243,7 @@ const processCodeOutput = async ({
       context: FileContext.execute_code,
       usage: isUpdate ? (claimed.usage ?? 0) + 1 : 1,
       createdAt: isUpdate ? claimed.createdAt : formattedDate,
+      ...(text != null ? { text } : {}),
     };
 
     await createFile(file, true);

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -224,8 +224,8 @@ const processCodeOutput = async ({
       basePath: 'uploads',
     });
 
-    const category = classifyCodeArtifact(name, mimeType);
-    const text = await extractCodeArtifactText(buffer, name, mimeType, category);
+    const category = classifyCodeArtifact(safeName, mimeType);
+    const text = await extractCodeArtifactText(buffer, safeName, mimeType, category);
 
     const file = {
       file_id,

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -41,6 +41,8 @@ const mockAxios = jest.fn();
 mockAxios.post = jest.fn();
 mockAxios.isAxiosError = jest.fn(() => false);
 
+const mockClassifyCodeArtifact = jest.fn(() => 'other');
+const mockExtractCodeArtifactText = jest.fn(async () => null);
 jest.mock('@librechat/api', () => {
   const http = require('http');
   const https = require('https');
@@ -49,6 +51,8 @@ jest.mock('@librechat/api', () => {
     getBasePath: jest.fn(() => ''),
     sanitizeFilename: jest.fn((name) => name),
     createAxiosInstance: jest.fn(() => mockAxios),
+    classifyCodeArtifact: (...args) => mockClassifyCodeArtifact(...args),
+    extractCodeArtifactText: (...args) => mockExtractCodeArtifactText(...args),
     codeServerHttpAgent: new http.Agent({ keepAlive: false }),
     codeServerHttpsAgent: new https.Agent({ keepAlive: false }),
   };
@@ -280,6 +284,56 @@ describe('Code Process', () => {
         const result = await processCodeOutput({ ...baseParams, name: 'unknown.xyz' });
 
         expect(result.type).toBe('application/octet-stream');
+      });
+    });
+
+    describe('inline text extraction', () => {
+      it('should populate text on the file when extractor returns content', async () => {
+        const buffer = Buffer.from('hello world\n', 'utf-8');
+        mockAxios.mockResolvedValue({ data: buffer });
+        determineFileType.mockResolvedValue({ mime: 'text/plain' });
+        mockClassifyCodeArtifact.mockReturnValueOnce('utf8-text');
+        mockExtractCodeArtifactText.mockResolvedValueOnce('hello world\n');
+
+        const result = await processCodeOutput({ ...baseParams, name: 'note.txt' });
+
+        expect(mockClassifyCodeArtifact).toHaveBeenCalledWith('note.txt', 'text/plain');
+        expect(mockExtractCodeArtifactText).toHaveBeenCalledWith(
+          buffer,
+          'note.txt',
+          'text/plain',
+          'utf8-text',
+        );
+        expect(result.text).toBe('hello world\n');
+        expect(createFile).toHaveBeenCalledWith(
+          expect.objectContaining({ text: 'hello world\n' }),
+          true,
+        );
+      });
+
+      it('should omit text when extractor returns null', async () => {
+        const buffer = Buffer.alloc(100);
+        mockAxios.mockResolvedValue({ data: buffer });
+        determineFileType.mockResolvedValue({ mime: 'application/octet-stream' });
+        mockClassifyCodeArtifact.mockReturnValueOnce('other');
+        mockExtractCodeArtifactText.mockResolvedValueOnce(null);
+
+        const result = await processCodeOutput({ ...baseParams, name: 'archive.zip' });
+
+        expect(result).not.toHaveProperty('text');
+        const createCall = createFile.mock.calls[0][0];
+        expect(createCall).not.toHaveProperty('text');
+      });
+
+      it('should not invoke text extraction for image files', async () => {
+        const imageBuffer = Buffer.alloc(500);
+        mockAxios.mockResolvedValue({ data: imageBuffer });
+        convertImage.mockResolvedValue({ filepath: '/uploads/x.webp', bytes: 400 });
+
+        await processCodeOutput({ ...baseParams, name: 'chart.png' });
+
+        expect(mockClassifyCodeArtifact).not.toHaveBeenCalled();
+        expect(mockExtractCodeArtifactText).not.toHaveBeenCalled();
       });
     });
 

--- a/api/server/services/Files/Code/process.spec.js
+++ b/api/server/services/Files/Code/process.spec.js
@@ -311,7 +311,7 @@ describe('Code Process', () => {
         );
       });
 
-      it('should omit text when extractor returns null', async () => {
+      it('should set text to null when extractor returns null so updates clear stale values', async () => {
         const buffer = Buffer.alloc(100);
         mockAxios.mockResolvedValue({ data: buffer });
         determineFileType.mockResolvedValue({ mime: 'application/octet-stream' });
@@ -320,9 +320,31 @@ describe('Code Process', () => {
 
         const result = await processCodeOutput({ ...baseParams, name: 'archive.zip' });
 
-        expect(result).not.toHaveProperty('text');
+        expect(result.text).toBeNull();
         const createCall = createFile.mock.calls[0][0];
-        expect(createCall).not.toHaveProperty('text');
+        expect(createCall.text).toBeNull();
+      });
+
+      it('should overwrite a previously-stored text value when re-emitting a now-binary file', async () => {
+        // Same filename + conversationId already has a stored text value;
+        // claimCodeFile returns the existing record (isUpdate path).
+        mockClaimCodeFile.mockResolvedValueOnce({
+          file_id: 'existing-id',
+          filename: 'output.bin',
+          usage: 1,
+          createdAt: '2024-01-01T00:00:00.000Z',
+        });
+        const binaryBuffer = Buffer.from([0x00, 0xff, 0x00, 0xff]);
+        mockAxios.mockResolvedValue({ data: binaryBuffer });
+        determineFileType.mockResolvedValue({ mime: 'application/octet-stream' });
+        mockClassifyCodeArtifact.mockReturnValueOnce('other');
+        mockExtractCodeArtifactText.mockResolvedValueOnce(null);
+
+        await processCodeOutput({ ...baseParams, name: 'output.bin' });
+
+        // null (not omitted) so $set clears any prior `text` value.
+        const createCall = createFile.mock.calls[0][0];
+        expect(createCall).toHaveProperty('text', null);
       });
 
       it('should not invoke text extraction for image files', async () => {

--- a/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
@@ -3,8 +3,12 @@ import { imageExtRegex, Tools } from 'librechat-data-provider';
 import type { TAttachment, TFile, TAttachmentMetadata } from 'librechat-data-provider';
 import FileContainer from '~/components/Chat/Input/Files/FileContainer';
 import Image from '~/components/Chat/Messages/Content/Image';
+import { useLocalize } from '~/hooks';
 import { useAttachmentLink } from './LogLink';
 import { cn } from '~/utils';
+
+const COLLAPSED_MAX_HEIGHT = 320;
+const COLLAPSE_THRESHOLD = 800;
 
 const FileAttachment = memo(({ attachment }: { attachment: Partial<TAttachment> }) => {
   const [isVisible, setIsVisible] = useState(false);
@@ -50,6 +54,70 @@ const FileAttachment = memo(({ attachment }: { attachment: Partial<TAttachment> 
   );
 });
 
+const TextAttachment = memo(({ attachment }: { attachment: Partial<TAttachment> }) => {
+  const localize = useLocalize();
+  const [isVisible, setIsVisible] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const file = attachment as TFile & TAttachmentMetadata;
+  const { handleDownload } = useAttachmentLink({
+    href: attachment.filepath ?? '',
+    filename: attachment.filename ?? '',
+    file_id: file.file_id,
+    user: file.user,
+    source: file.source,
+  });
+  const extension = attachment.filename?.split('.').pop();
+  const text = file.text ?? '';
+  const canCollapse = text.length > COLLAPSE_THRESHOLD;
+
+  useEffect(() => {
+    const timer = setTimeout(() => setIsVisible(true), 50);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div
+      className={cn(
+        'text-attachment-container flex w-full flex-col gap-1.5',
+        'transition-all duration-300 ease-out',
+        isVisible ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0',
+      )}
+      style={{
+        transformOrigin: 'center top',
+        willChange: 'opacity, transform',
+        WebkitFontSmoothing: 'subpixel-antialiased',
+      }}
+    >
+      {attachment.filepath && (
+        <FileContainer
+          file={attachment}
+          onClick={handleDownload}
+          overrideType={extension}
+          containerClassName="max-w-fit"
+          buttonClassName="bg-surface-secondary hover:cursor-pointer hover:bg-surface-hover active:bg-surface-secondary focus:bg-surface-hover hover:border-border-heavy active:border-border-heavy"
+        />
+      )}
+      <div className="rounded-lg bg-surface-secondary p-4">
+        <pre
+          className="overflow-auto whitespace-pre-wrap break-words font-mono text-sm leading-6 text-text-primary"
+          style={canCollapse && !expanded ? { maxHeight: COLLAPSED_MAX_HEIGHT } : undefined}
+        >
+          {text}
+        </pre>
+        {canCollapse && (
+          <button
+            type="button"
+            onClick={() => setExpanded((prev) => !prev)}
+            className="mt-2 text-xs text-text-secondary transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-heavy"
+          >
+            {expanded ? localize('com_ui_collapse') : localize('com_ui_show_all')}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+});
+
 const ImageAttachment = memo(({ attachment }: { attachment: TAttachment }) => {
   const [isLoaded, setIsLoaded] = useState(false);
   const { width, height, filepath = null } = attachment as TFile & TAttachmentMetadata;
@@ -84,6 +152,21 @@ const ImageAttachment = memo(({ attachment }: { attachment: TAttachment }) => {
   );
 });
 
+const isImageAttachment = (attachment: TAttachment): boolean => {
+  if (!attachment.filename) {
+    return false;
+  }
+  const { width, height, filepath = null } = attachment as TFile & TAttachmentMetadata;
+  return (
+    imageExtRegex.test(attachment.filename) && width != null && height != null && filepath != null
+  );
+};
+
+const isTextAttachment = (attachment: TAttachment): boolean => {
+  const { text } = attachment as TFile & TAttachmentMetadata;
+  return typeof text === 'string' && text.length > 0;
+};
+
 export default function Attachment({ attachment }: { attachment?: TAttachment }) {
   if (!attachment) {
     return null;
@@ -92,14 +175,13 @@ export default function Attachment({ attachment }: { attachment?: TAttachment })
     return null;
   }
 
-  const { width, height, filepath = null } = attachment as TFile & TAttachmentMetadata;
-  const isImage = attachment.filename
-    ? imageExtRegex.test(attachment.filename) && width != null && height != null && filepath != null
-    : false;
-
-  if (isImage) {
+  if (isImageAttachment(attachment)) {
     return <ImageAttachment attachment={attachment} />;
-  } else if (!attachment.filepath) {
+  }
+  if (isTextAttachment(attachment)) {
+    return <TextAttachment attachment={attachment} />;
+  }
+  if (!attachment.filepath) {
     return null;
   }
   return <FileAttachment attachment={attachment} />;
@@ -112,21 +194,21 @@ export function AttachmentGroup({ attachments }: { attachments?: TAttachment[] }
 
   const fileAttachments: TAttachment[] = [];
   const imageAttachments: TAttachment[] = [];
+  const textAttachments: TAttachment[] = [];
 
   attachments.forEach((attachment) => {
-    const { width, height, filepath = null } = attachment as TFile & TAttachmentMetadata;
-    const isImage = attachment.filename
-      ? imageExtRegex.test(attachment.filename) &&
-        width != null &&
-        height != null &&
-        filepath != null
-      : false;
-
-    if (isImage) {
-      imageAttachments.push(attachment);
-    } else if (attachment.type !== Tools.web_search) {
-      fileAttachments.push(attachment);
+    if (attachment.type === Tools.web_search) {
+      return;
     }
+    if (isImageAttachment(attachment)) {
+      imageAttachments.push(attachment);
+      return;
+    }
+    if (isTextAttachment(attachment)) {
+      textAttachments.push(attachment);
+      return;
+    }
+    fileAttachments.push(attachment);
   });
 
   return (
@@ -138,6 +220,13 @@ export function AttachmentGroup({ attachments }: { attachments?: TAttachment[] }
               <FileAttachment attachment={attachment} key={`file-${index}`} />
             ) : null,
           )}
+        </div>
+      )}
+      {textAttachments.length > 0 && (
+        <div className="my-2 flex flex-col gap-3">
+          {textAttachments.map((attachment, index) => (
+            <TextAttachment attachment={attachment} key={`text-${index}`} />
+          ))}
         </div>
       )}
       {imageAttachments.length > 0 && (

--- a/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
@@ -1,14 +1,14 @@
-import { memo, useId, useState, useEffect } from 'react';
-import { imageExtRegex, Tools } from 'librechat-data-provider';
+import { memo, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
+import { Tools } from 'librechat-data-provider';
 import type { TAttachment, TFile, TAttachmentMetadata } from 'librechat-data-provider';
 import FileContainer from '~/components/Chat/Input/Files/FileContainer';
 import Image from '~/components/Chat/Messages/Content/Image';
-import { useLocalize } from '~/hooks';
+import { isImageAttachment, isTextAttachment } from './attachmentTypes';
 import { useAttachmentLink } from './LogLink';
+import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';
 
 const COLLAPSED_MAX_HEIGHT = 320;
-const COLLAPSE_THRESHOLD = 800;
 
 const FileAttachment = memo(({ attachment }: { attachment: Partial<TAttachment> }) => {
   const [isVisible, setIsVisible] = useState(false);
@@ -57,8 +57,13 @@ const FileAttachment = memo(({ attachment }: { attachment: Partial<TAttachment> 
 const TextAttachment = memo(({ attachment }: { attachment: Partial<TAttachment> }) => {
   const localize = useLocalize();
   const preId = useId();
+  const preRef = useRef<HTMLPreElement>(null);
   const [isVisible, setIsVisible] = useState(false);
   const [expanded, setExpanded] = useState(false);
+  // Decided once after layout: does the text actually overflow the collapsed
+  // height? Char count is a poor proxy (a 100-char file with many newlines can
+  // overflow; 800 chars of dense single-line text may not), so we measure.
+  const [overflowed, setOverflowed] = useState(false);
   const file = attachment as TFile & TAttachmentMetadata;
   const { handleDownload } = useAttachmentLink({
     href: attachment.filepath ?? '',
@@ -69,12 +74,21 @@ const TextAttachment = memo(({ attachment }: { attachment: Partial<TAttachment> 
   });
   const extension = attachment.filename?.split('.').pop();
   const text = file.text ?? '';
-  const canCollapse = text.length > COLLAPSE_THRESHOLD;
 
   useEffect(() => {
     const timer = setTimeout(() => setIsVisible(true), 50);
     return () => clearTimeout(timer);
   }, []);
+
+  useLayoutEffect(() => {
+    const el = preRef.current;
+    if (!el) {
+      return;
+    }
+    setOverflowed(el.scrollHeight > COLLAPSED_MAX_HEIGHT + 1);
+  }, [text]);
+
+  const isClamped = overflowed && !expanded;
 
   return (
     <div
@@ -101,12 +115,16 @@ const TextAttachment = memo(({ attachment }: { attachment: Partial<TAttachment> 
       <div className="rounded-lg bg-surface-secondary p-4">
         <pre
           id={preId}
-          className="overflow-auto whitespace-pre-wrap break-words font-mono text-sm leading-6 text-text-primary"
-          style={canCollapse && !expanded ? { maxHeight: COLLAPSED_MAX_HEIGHT } : undefined}
+          ref={preRef}
+          className={cn(
+            'whitespace-pre-wrap break-words font-mono text-sm leading-6 text-text-primary',
+            isClamped ? 'overflow-hidden' : 'overflow-auto',
+          )}
+          style={isClamped ? { maxHeight: COLLAPSED_MAX_HEIGHT } : undefined}
         >
           {text}
         </pre>
-        {canCollapse && (
+        {overflowed && (
           <button
             type="button"
             onClick={() => setExpanded((prev) => !prev)}
@@ -155,21 +173,6 @@ const ImageAttachment = memo(({ attachment }: { attachment: TAttachment }) => {
     </div>
   );
 });
-
-const isImageAttachment = (attachment: TAttachment): boolean => {
-  if (!attachment.filename) {
-    return false;
-  }
-  const { width, height, filepath = null } = attachment as TFile & TAttachmentMetadata;
-  return (
-    imageExtRegex.test(attachment.filename) && width != null && height != null && filepath != null
-  );
-};
-
-const isTextAttachment = (attachment: TAttachment): boolean => {
-  const { text } = attachment as TFile & TAttachmentMetadata;
-  return typeof text === 'string' && text.length > 0;
-};
 
 export default function Attachment({ attachment }: { attachment?: TAttachment }) {
   if (!attachment) {

--- a/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useEffect } from 'react';
+import { memo, useId, useState, useEffect } from 'react';
 import { imageExtRegex, Tools } from 'librechat-data-provider';
 import type { TAttachment, TFile, TAttachmentMetadata } from 'librechat-data-provider';
 import FileContainer from '~/components/Chat/Input/Files/FileContainer';
@@ -56,6 +56,7 @@ const FileAttachment = memo(({ attachment }: { attachment: Partial<TAttachment> 
 
 const TextAttachment = memo(({ attachment }: { attachment: Partial<TAttachment> }) => {
   const localize = useLocalize();
+  const preId = useId();
   const [isVisible, setIsVisible] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const file = attachment as TFile & TAttachmentMetadata;
@@ -99,6 +100,7 @@ const TextAttachment = memo(({ attachment }: { attachment: Partial<TAttachment> 
       )}
       <div className="rounded-lg bg-surface-secondary p-4">
         <pre
+          id={preId}
           className="overflow-auto whitespace-pre-wrap break-words font-mono text-sm leading-6 text-text-primary"
           style={canCollapse && !expanded ? { maxHeight: COLLAPSED_MAX_HEIGHT } : undefined}
         >
@@ -108,6 +110,8 @@ const TextAttachment = memo(({ attachment }: { attachment: Partial<TAttachment> 
           <button
             type="button"
             onClick={() => setExpanded((prev) => !prev)}
+            aria-expanded={expanded}
+            aria-controls={preId}
             className="mt-2 text-xs text-text-secondary transition-colors hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-heavy"
           >
             {expanded ? localize('com_ui_collapse') : localize('com_ui_show_all')}

--- a/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
@@ -1,9 +1,9 @@
 import { memo, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { Tools } from 'librechat-data-provider';
 import type { TAttachment, TFile, TAttachmentMetadata } from 'librechat-data-provider';
+import { isImageAttachment, isTextAttachment } from './attachmentTypes';
 import FileContainer from '~/components/Chat/Input/Files/FileContainer';
 import Image from '~/components/Chat/Messages/Content/Image';
-import { isImageAttachment, isTextAttachment } from './attachmentTypes';
 import { useAttachmentLink } from './LogLink';
 import { useLocalize } from '~/hooks';
 import { cn } from '~/utils';

--- a/client/src/components/Chat/Messages/Content/Parts/LogContent.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/LogContent.tsx
@@ -26,23 +26,30 @@ const LogContent: React.FC<LogContentProps> = ({ output = '', renderImages, atta
     return parts[0].trim();
   }, [output]);
 
-  const { imageAttachments, nonImageAttachments } = useMemo(() => {
+  const { imageAttachments, textAttachments, nonInlineAttachments } = useMemo(() => {
     const imageAtts: ImageAttachment[] = [];
-    const nonImageAtts: TAttachment[] = [];
+    const textAtts: Array<TFile & TAttachmentMetadata> = [];
+    const otherAtts: TAttachment[] = [];
 
     attachments?.forEach((attachment) => {
-      const { filepath = null } = attachment as TFile & TAttachmentMetadata;
+      const fileData = attachment as TFile & TAttachmentMetadata;
+      const { filepath = null, text } = fileData;
       const isImage = imageExtRegex.test(attachment.filename ?? '') && filepath != null;
       if (isImage) {
         imageAtts.push(attachment as ImageAttachment);
-      } else {
-        nonImageAtts.push(attachment);
+        return;
       }
+      if (typeof text === 'string' && text.length > 0) {
+        textAtts.push(fileData);
+        return;
+      }
+      otherAtts.push(attachment);
     });
 
     return {
       imageAttachments: renderImages === true ? imageAtts : null,
-      nonImageAttachments: nonImageAtts,
+      textAttachments: textAtts,
+      nonInlineAttachments: otherAtts,
     };
   }, [attachments, renderImages]);
 
@@ -59,10 +66,6 @@ const LogContent: React.FC<LogContentProps> = ({ output = '', renderImages, atta
 
     const fileData = file as TFile & TAttachmentMetadata;
     const filepath = file.filepath || '';
-
-    // const expirationText = expiresAt
-    //   ? ` ${localize('com_download_expires', { 0: format(expiresAt, 'MM/dd/yy HH:mm') })}`
-    //   : ` ${localize('com_click_to_download')}`;
 
     return (
       <LogLink
@@ -81,14 +84,33 @@ const LogContent: React.FC<LogContentProps> = ({ output = '', renderImages, atta
   return (
     <>
       {processedContent && <div>{processedContent}</div>}
-      {nonImageAttachments.length > 0 && (
+      {nonInlineAttachments.length > 0 && (
         <div>
           <p>{localize('com_generated_files')}</p>
-          {nonImageAttachments.map((file, index) => (
+          {nonInlineAttachments.map((file, index) => (
             <React.Fragment key={file.filepath}>
               {renderAttachment(file)}
-              {index < nonImageAttachments.length - 1 && ', '}
+              {index < nonInlineAttachments.length - 1 && ', '}
             </React.Fragment>
+          ))}
+        </div>
+      )}
+      {textAttachments.length > 0 && (
+        <div className="mt-2 flex flex-col gap-3">
+          {textAttachments.map((file) => (
+            <div
+              key={file.filepath ?? file.file_id ?? file.filename}
+              className="rounded-lg bg-surface-secondary p-3"
+            >
+              {file.filename && (
+                <div className="mb-1 truncate text-[10px] font-medium uppercase tracking-wide text-text-secondary">
+                  {file.filename}
+                </div>
+              )}
+              <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-5 text-text-primary">
+                {file.text}
+              </pre>
+            </div>
           ))}
         </div>
       )}

--- a/client/src/components/Chat/Messages/Content/Parts/LogContent.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/LogContent.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react';
 import { imageExtRegex } from 'librechat-data-provider';
 import type { TFile, TAttachment, TAttachmentMetadata } from 'librechat-data-provider';
 import Image from '~/components/Chat/Messages/Content/Image';
+import { isTextAttachment } from './attachmentTypes';
 import { useLocalize } from '~/hooks';
 import LogLink from './LogLink';
 
@@ -33,13 +34,15 @@ const LogContent: React.FC<LogContentProps> = ({ output = '', renderImages, atta
 
     attachments?.forEach((attachment) => {
       const fileData = attachment as TFile & TAttachmentMetadata;
-      const { filepath = null, text } = fileData;
+      const { filepath = null } = fileData;
+      // LogContent uses a looser image check than Attachment.tsx (no
+      // width/height requirement) to keep parity with the legacy log surface.
       const isImage = imageExtRegex.test(attachment.filename ?? '') && filepath != null;
       if (isImage) {
         imageAtts.push(attachment as ImageAttachment);
         return;
       }
-      if (typeof text === 'string' && text.length > 0) {
+      if (isTextAttachment(attachment)) {
         textAtts.push(fileData);
         return;
       }

--- a/client/src/components/Chat/Messages/Content/Parts/LogContent.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/LogContent.tsx
@@ -104,7 +104,19 @@ const LogContent: React.FC<LogContentProps> = ({ output = '', renderImages, atta
             >
               {file.filename && (
                 <div className="mb-1 truncate text-[10px] font-medium uppercase tracking-wide text-text-secondary">
-                  {file.filename}
+                  {file.filepath ? (
+                    <LogLink
+                      href={file.filepath}
+                      filename={file.filename}
+                      file_id={file.file_id}
+                      user={file.user}
+                      source={file.source}
+                    >
+                      {file.filename}
+                    </LogLink>
+                  ) : (
+                    file.filename
+                  )}
                 </div>
               )}
               <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-5 text-text-primary">

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/TextAttachment.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/TextAttachment.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
-import { AttachmentGroup, default as Attachment } from '../Attachment';
 import type { TAttachment } from 'librechat-data-provider';
+import Attachment, { AttachmentGroup } from '../Attachment';
 
 jest.mock('~/hooks', () => ({
   useLocalize:
@@ -48,6 +48,11 @@ const textAttachment = (overrides: Partial<TAttachment> = {}): TAttachment =>
     ...overrides,
   }) as TAttachment;
 
+const originalScrollHeightDescriptor = Object.getOwnPropertyDescriptor(
+  HTMLPreElement.prototype,
+  'scrollHeight',
+);
+
 const setScrollHeight = (value: number) => {
   Object.defineProperty(HTMLPreElement.prototype, 'scrollHeight', {
     configurable: true,
@@ -56,6 +61,21 @@ const setScrollHeight = (value: number) => {
     },
   });
 };
+
+const restoreScrollHeight = () => {
+  if (originalScrollHeightDescriptor) {
+    Object.defineProperty(HTMLPreElement.prototype, 'scrollHeight', originalScrollHeightDescriptor);
+  } else {
+    // No own descriptor existed before — delete the override so the prototype
+    // chain falls back to the inherited HTMLElement implementation.
+
+    delete (HTMLPreElement.prototype as any).scrollHeight;
+  }
+};
+
+afterAll(() => {
+  restoreScrollHeight();
+});
 
 describe('TextAttachment (via Attachment default export)', () => {
   beforeEach(() => {

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/TextAttachment.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/TextAttachment.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { AttachmentGroup, default as Attachment } from '../Attachment';
+import type { TAttachment } from 'librechat-data-provider';
+
+jest.mock('~/hooks', () => ({
+  useLocalize:
+    () =>
+    (key: string): string => {
+      const translations: Record<string, string> = {
+        com_ui_show_all: 'Show all',
+        com_ui_collapse: 'Collapse',
+      };
+      return translations[key] ?? key;
+    },
+}));
+
+const mockHandleDownload = jest.fn();
+jest.mock('../LogLink', () => ({
+  useAttachmentLink: () => ({ handleDownload: mockHandleDownload }),
+}));
+
+jest.mock('~/components/Chat/Input/Files/FileContainer', () => ({
+  __esModule: true,
+  default: ({ file, onClick }: { file: { filename?: string }; onClick?: () => void }) => (
+    <button type="button" data-testid="file-container" onClick={onClick}>
+      {file.filename ?? ''}
+    </button>
+  ),
+}));
+
+jest.mock('~/components/Chat/Messages/Content/Image', () => ({
+  __esModule: true,
+  default: ({ altText }: { altText?: string }) => <img alt={altText ?? ''} data-testid="image" />,
+}));
+
+jest.mock('~/utils', () => ({
+  cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
+}));
+
+const textAttachment = (overrides: Partial<TAttachment> = {}): TAttachment =>
+  ({
+    file_id: 'file-1',
+    filename: 'output.csv',
+    filepath: '/files/output.csv',
+    type: 'text/csv',
+    text: 'a,b,c\n1,2,3',
+    ...overrides,
+  }) as TAttachment;
+
+const setScrollHeight = (value: number) => {
+  Object.defineProperty(HTMLPreElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get() {
+      return value;
+    },
+  });
+};
+
+describe('TextAttachment (via Attachment default export)', () => {
+  beforeEach(() => {
+    mockHandleDownload.mockReset();
+    setScrollHeight(0);
+  });
+
+  it('renders the text content inside a <pre>', () => {
+    const { container } = render(<Attachment attachment={textAttachment()} />);
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre!.textContent).toBe('a,b,c\n1,2,3');
+  });
+
+  it('renders a download chip when filepath is present', () => {
+    render(<Attachment attachment={textAttachment()} />);
+    expect(screen.getByTestId('file-container')).toBeInTheDocument();
+  });
+
+  it('hides the download chip when filepath is absent', () => {
+    render(<Attachment attachment={textAttachment({ filepath: '' })} />);
+    expect(screen.queryByTestId('file-container')).not.toBeInTheDocument();
+  });
+
+  it('does not render a show/collapse button when content fits', () => {
+    setScrollHeight(100); // < COLLAPSED_MAX_HEIGHT (320)
+    render(<Attachment attachment={textAttachment()} />);
+    expect(screen.queryByRole('button', { name: /show all|collapse/i })).not.toBeInTheDocument();
+  });
+
+  it('renders an expand button with aria-expanded=false when content overflows', () => {
+    setScrollHeight(800); // > COLLAPSED_MAX_HEIGHT (320)
+    render(<Attachment attachment={textAttachment()} />);
+    const button = screen.getByRole('button', { name: 'Show all' });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(button).toHaveAttribute('aria-controls');
+  });
+
+  it('toggles aria-expanded and label when the button is clicked', () => {
+    setScrollHeight(800);
+    render(<Attachment attachment={textAttachment()} />);
+    const button = screen.getByRole('button', { name: 'Show all' });
+    act(() => {
+      fireEvent.click(button);
+    });
+    const expanded = screen.getByRole('button', { name: 'Collapse' });
+    expect(expanded).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('falls through to FileAttachment when text is missing', () => {
+    const noText = textAttachment({ text: undefined as unknown as string });
+    render(<Attachment attachment={noText} />);
+    // FileAttachment also renders the FileContainer mock — we assert the
+    // <pre> is absent to confirm the text branch was not taken.
+    expect(screen.queryByText('a,b,c\n1,2,3')).not.toBeInTheDocument();
+    expect(screen.getByTestId('file-container')).toBeInTheDocument();
+  });
+
+  it('falls through to FileAttachment when text is the empty string', () => {
+    const empty = textAttachment({ text: '' });
+    const { container } = render(<Attachment attachment={empty} />);
+    expect(container.querySelector('pre')).toBeNull();
+    expect(screen.getByTestId('file-container')).toBeInTheDocument();
+  });
+});
+
+describe('AttachmentGroup', () => {
+  beforeEach(() => {
+    setScrollHeight(0);
+  });
+
+  it('routes text-bearing attachments through the text rendering path', () => {
+    const attachments = [textAttachment({ file_id: 'a', filename: 'a.txt' })] as TAttachment[];
+    const { container } = render(<AttachmentGroup attachments={attachments} />);
+    expect(container.querySelector('pre')).not.toBeNull();
+  });
+
+  it('routes plain-file attachments to the FileAttachment branch', () => {
+    const attachments = [
+      textAttachment({
+        file_id: 'b',
+        filename: 'archive.zip',
+        type: 'application/zip',
+        text: undefined as unknown as string,
+      }),
+    ] as TAttachment[];
+    const { container } = render(<AttachmentGroup attachments={attachments} />);
+    expect(container.querySelector('pre')).toBeNull();
+    expect(screen.getAllByTestId('file-container').length).toBeGreaterThan(0);
+  });
+});

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/attachmentTypes.test.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/attachmentTypes.test.ts
@@ -1,0 +1,93 @@
+import type { TAttachment } from 'librechat-data-provider';
+import { isImageAttachment, isTextAttachment } from '../attachmentTypes';
+
+const baseAttachment = (overrides: Partial<TAttachment> = {}): TAttachment =>
+  ({
+    file_id: 'file-1',
+    filename: 'unset',
+    filepath: '/files/file-1',
+    type: 'application/octet-stream',
+    ...overrides,
+  }) as TAttachment;
+
+describe('isImageAttachment', () => {
+  it('returns true for image filenames with width, height, and filepath', () => {
+    const attachment = baseAttachment({
+      filename: 'chart.png',
+      width: 800,
+      height: 600,
+      filepath: '/files/chart.png',
+    } as Partial<TAttachment>);
+    expect(isImageAttachment(attachment)).toBe(true);
+  });
+
+  it('returns false when filename is missing', () => {
+    const attachment = baseAttachment({ filename: undefined as unknown as string });
+    expect(isImageAttachment(attachment)).toBe(false);
+  });
+
+  it('returns false for non-image extensions', () => {
+    const attachment = baseAttachment({
+      filename: 'notes.txt',
+      width: 800,
+      height: 600,
+    } as Partial<TAttachment>);
+    expect(isImageAttachment(attachment)).toBe(false);
+  });
+
+  it('returns false when width is missing', () => {
+    const attachment = baseAttachment({
+      filename: 'chart.png',
+      height: 600,
+    } as Partial<TAttachment>);
+    expect(isImageAttachment(attachment)).toBe(false);
+  });
+
+  it('returns false when height is missing', () => {
+    const attachment = baseAttachment({
+      filename: 'chart.png',
+      width: 800,
+    } as Partial<TAttachment>);
+    expect(isImageAttachment(attachment)).toBe(false);
+  });
+
+  it('returns false when filepath is null', () => {
+    const attachment = baseAttachment({
+      filename: 'chart.png',
+      width: 800,
+      height: 600,
+      filepath: null as unknown as string,
+    } as Partial<TAttachment>);
+    expect(isImageAttachment(attachment)).toBe(false);
+  });
+});
+
+describe('isTextAttachment', () => {
+  it('returns true when text is a non-empty string', () => {
+    const attachment = baseAttachment({
+      filename: 'output.csv',
+      text: 'a,b,c\n1,2,3',
+    } as Partial<TAttachment>);
+    expect(isTextAttachment(attachment)).toBe(true);
+  });
+
+  it('returns false when text is missing', () => {
+    expect(isTextAttachment(baseAttachment({ filename: 'output.csv' }))).toBe(false);
+  });
+
+  it('returns false when text is an empty string', () => {
+    const attachment = baseAttachment({
+      filename: 'empty.txt',
+      text: '',
+    } as Partial<TAttachment>);
+    expect(isTextAttachment(attachment)).toBe(false);
+  });
+
+  it('returns false when text is non-string (e.g. null)', () => {
+    const attachment = baseAttachment({
+      filename: 'broken.txt',
+      text: null as unknown as string,
+    } as Partial<TAttachment>);
+    expect(isTextAttachment(attachment)).toBe(false);
+  });
+});

--- a/client/src/components/Chat/Messages/Content/Parts/attachmentTypes.ts
+++ b/client/src/components/Chat/Messages/Content/Parts/attachmentTypes.ts
@@ -1,0 +1,27 @@
+import { imageExtRegex } from 'librechat-data-provider';
+import type { TAttachment, TAttachmentMetadata, TFile } from 'librechat-data-provider';
+
+/**
+ * An attachment is treated as an image only when it has the dimensions and
+ * filepath needed to render via `<Image>`. Without width/height the image
+ * cannot reserve layout space, so we fall back to the file card.
+ */
+export const isImageAttachment = (attachment: TAttachment): boolean => {
+  if (!attachment.filename) {
+    return false;
+  }
+  const { width, height, filepath = null } = attachment as TFile & TAttachmentMetadata;
+  return (
+    imageExtRegex.test(attachment.filename) && width != null && height != null && filepath != null
+  );
+};
+
+/**
+ * An attachment renders inline as text when the backend has populated a
+ * non-empty `text` field on the underlying file record. Empty strings are
+ * treated as "no inline text available" and fall through to the download UI.
+ */
+export const isTextAttachment = (attachment: TAttachment): boolean => {
+  const { text } = attachment as TFile & TAttachmentMetadata;
+  return typeof text === 'string' && text.length > 0;
+};

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -220,7 +220,6 @@
   "com_citation_source": "Source",
   "com_click_to_download": "(click here to download)",
   "com_download_expired": "(download expired)",
-  "com_download_expires": "(click here to download - expires {{0}})",
   "com_endpoint": "Endpoint",
   "com_endpoint_agent": "Agent",
   "com_endpoint_agent_placeholder": "Please select an Agent",

--- a/packages/api/src/files/code/classify.spec.ts
+++ b/packages/api/src/files/code/classify.spec.ts
@@ -1,0 +1,125 @@
+import { classifyCodeArtifact } from './classify';
+
+describe('classifyCodeArtifact', () => {
+  describe('utf8-text by extension', () => {
+    it.each([
+      ['report.txt', 'application/octet-stream'],
+      ['notes.md', 'application/octet-stream'],
+      ['data.csv', 'application/octet-stream'],
+      ['rows.tsv', 'application/octet-stream'],
+      ['payload.json', 'application/octet-stream'],
+      ['stream.jsonl', 'application/octet-stream'],
+      ['config.yaml', 'application/octet-stream'],
+      ['feed.xml', 'application/octet-stream'],
+      ['index.html', 'application/octet-stream'],
+      ['icon.svg', 'application/octet-stream'],
+      ['build.log', 'application/octet-stream'],
+      ['server.py', 'application/octet-stream'],
+      ['handler.ts', 'application/octet-stream'],
+      ['app.tsx', 'application/octet-stream'],
+      ['main.go', 'application/octet-stream'],
+      ['lib.rs', 'application/octet-stream'],
+      ['Service.java', 'application/octet-stream'],
+      ['query.sql', 'application/octet-stream'],
+      ['schema.graphql', 'application/octet-stream'],
+      ['Makefile.txt', 'application/octet-stream'],
+    ])('classifies %s as utf8-text', (name, mime) => {
+      expect(classifyCodeArtifact(name, mime)).toBe('utf8-text');
+    });
+  });
+
+  describe('utf8-text by MIME', () => {
+    it.each([
+      ['unknown', 'text/plain'],
+      ['unknown', 'text/csv'],
+      ['unknown', 'application/json'],
+      ['unknown', 'application/xml'],
+      ['unknown', 'application/javascript'],
+      ['unknown', 'image/svg+xml'],
+    ])('classifies %s with mime %s as utf8-text', (name, mime) => {
+      expect(classifyCodeArtifact(name, mime)).toBe('utf8-text');
+    });
+  });
+
+  describe('document by extension', () => {
+    it.each([
+      ['report.docx', 'application/octet-stream'],
+      ['data.xlsx', 'application/octet-stream'],
+      ['legacy.xls', 'application/octet-stream'],
+      ['sheet.ods', 'application/octet-stream'],
+      ['notes.odt', 'application/octet-stream'],
+    ])('classifies %s as document', (name, mime) => {
+      expect(classifyCodeArtifact(name, mime)).toBe('document');
+    });
+  });
+
+  describe('document by MIME', () => {
+    it('classifies docx mime', () => {
+      expect(
+        classifyCodeArtifact(
+          'unknown',
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        ),
+      ).toBe('document');
+    });
+
+    it('classifies xlsx mime', () => {
+      expect(
+        classifyCodeArtifact(
+          'unknown',
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        ),
+      ).toBe('document');
+    });
+
+    it('classifies ods mime', () => {
+      expect(
+        classifyCodeArtifact('unknown', 'application/vnd.oasis.opendocument.spreadsheet'),
+      ).toBe('document');
+    });
+  });
+
+  describe('pptx', () => {
+    it('classifies .pptx by extension', () => {
+      expect(classifyCodeArtifact('slides.pptx', 'application/octet-stream')).toBe('pptx');
+    });
+
+    it('classifies pptx by mime', () => {
+      expect(
+        classifyCodeArtifact(
+          'unknown',
+          'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        ),
+      ).toBe('pptx');
+    });
+  });
+
+  describe('other', () => {
+    it.each([
+      ['photo.png', 'image/png'],
+      ['archive.zip', 'application/zip'],
+      ['binary.exe', 'application/octet-stream'],
+      ['noext', 'application/octet-stream'],
+      ['', ''],
+      ['trailing.dot.', 'application/octet-stream'],
+    ])('classifies %s as other', (name, mime) => {
+      expect(classifyCodeArtifact(name, mime)).toBe('other');
+    });
+  });
+
+  describe('extension wins over MIME', () => {
+    it('treats .py as utf8-text even when MIME is octet-stream', () => {
+      expect(classifyCodeArtifact('script.py', 'application/octet-stream')).toBe('utf8-text');
+    });
+
+    it('treats .docx as document even when MIME is octet-stream', () => {
+      expect(classifyCodeArtifact('letter.docx', 'application/octet-stream')).toBe('document');
+    });
+  });
+
+  it('is case-insensitive on extensions', () => {
+    expect(classifyCodeArtifact('PHOTO.PNG', 'application/octet-stream')).toBe('other');
+    expect(classifyCodeArtifact('REPORT.DOCX', 'application/octet-stream')).toBe('document');
+    expect(classifyCodeArtifact('SCRIPT.PY', 'application/octet-stream')).toBe('utf8-text');
+  });
+});

--- a/packages/api/src/files/code/classify.spec.ts
+++ b/packages/api/src/files/code/classify.spec.ts
@@ -122,4 +122,21 @@ describe('classifyCodeArtifact', () => {
     expect(classifyCodeArtifact('REPORT.DOCX', 'application/octet-stream')).toBe('document');
     expect(classifyCodeArtifact('SCRIPT.PY', 'application/octet-stream')).toBe('utf8-text');
   });
+
+  describe('extensionless filenames', () => {
+    it.each([
+      ['Makefile', 'application/octet-stream'],
+      ['makefile', 'application/octet-stream'],
+      ['MAKEFILE', 'application/octet-stream'],
+      ['Dockerfile', 'application/octet-stream'],
+      ['dockerfile', 'application/octet-stream'],
+      ['/tmp/Dockerfile', 'application/octet-stream'],
+    ])('matches %s as utf8-text', (name, mime) => {
+      expect(classifyCodeArtifact(name, mime)).toBe('utf8-text');
+    });
+
+    it('falls through to other for unknown bare names', () => {
+      expect(classifyCodeArtifact('mystery', 'application/octet-stream')).toBe('other');
+    });
+  });
 });

--- a/packages/api/src/files/code/classify.ts
+++ b/packages/api/src/files/code/classify.ts
@@ -1,0 +1,176 @@
+import { excelMimeTypes } from 'librechat-data-provider';
+
+export type CodeArtifactCategory = 'utf8-text' | 'document' | 'pptx' | 'other';
+
+const UTF8_TEXT_EXTENSIONS = new Set<string>([
+  // plaintext / data
+  'txt',
+  'md',
+  'markdown',
+  'rst',
+  'csv',
+  'tsv',
+  'json',
+  'jsonl',
+  'ndjson',
+  'xml',
+  'yaml',
+  'yml',
+  'toml',
+  'ini',
+  'cfg',
+  'conf',
+  'log',
+  'html',
+  'htm',
+  'svg',
+  'env',
+  // shell / scripts
+  'sh',
+  'bash',
+  'zsh',
+  'fish',
+  'ps1',
+  'bat',
+  'cmd',
+  // web
+  'js',
+  'mjs',
+  'cjs',
+  'jsx',
+  'ts',
+  'tsx',
+  'css',
+  'scss',
+  'sass',
+  'less',
+  'vue',
+  'svelte',
+  // popular languages
+  'py',
+  'pyi',
+  'ipynb',
+  'rb',
+  'go',
+  'rs',
+  'java',
+  'kt',
+  'kts',
+  'scala',
+  'c',
+  'h',
+  'cc',
+  'cpp',
+  'hpp',
+  'cs',
+  'm',
+  'mm',
+  'swift',
+  'php',
+  'pl',
+  'pm',
+  'r',
+  'jl',
+  'lua',
+  'dart',
+  'ex',
+  'exs',
+  'erl',
+  'hs',
+  'clj',
+  'cljs',
+  'fs',
+  'fsx',
+  // data / build / config
+  'sql',
+  'graphql',
+  'gql',
+  'proto',
+  'dockerfile',
+  'makefile',
+  'gradle',
+  'tf',
+  'hcl',
+  'patch',
+  'diff',
+]);
+
+const UTF8_TEXT_MIME_PREFIXES = ['text/'] as const;
+const UTF8_TEXT_MIME_EXACT = new Set<string>([
+  'application/json',
+  'application/ld+json',
+  'application/xml',
+  'application/x-yaml',
+  'application/yaml',
+  'application/x-sh',
+  'application/javascript',
+  'application/x-javascript',
+  'application/typescript',
+  'application/x-typescript',
+  'application/x-httpd-php',
+  'application/sql',
+  'application/graphql',
+  'image/svg+xml',
+]);
+
+const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+const ODT_MIME = 'application/vnd.oasis.opendocument.text';
+const PPTX_MIME = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+
+const DOCUMENT_EXTENSIONS = new Set<string>(['docx', 'odt', 'xlsx', 'xls', 'ods']);
+const PPTX_EXTENSIONS = new Set<string>(['pptx']);
+
+const extensionOf = (name: string): string => {
+  const dot = name.lastIndexOf('.');
+  if (dot < 0 || dot === name.length - 1) {
+    return '';
+  }
+  return name.slice(dot + 1).toLowerCase();
+};
+
+const isUtf8TextMime = (mime: string): boolean => {
+  if (UTF8_TEXT_MIME_EXACT.has(mime)) {
+    return true;
+  }
+  for (const prefix of UTF8_TEXT_MIME_PREFIXES) {
+    if (mime.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const isDocumentMime = (mime: string): boolean => {
+  if (mime === DOCX_MIME || mime === ODT_MIME) {
+    return true;
+  }
+  return excelMimeTypes.test(mime) || mime === 'application/vnd.oasis.opendocument.spreadsheet';
+};
+
+/**
+ * Decide how to render a file produced by the code-execution sandbox.
+ * Extension wins over MIME for code/text files because content sniffing tends
+ * to label `.py`/`.json`/`.csv` as `application/octet-stream`.
+ */
+export function classifyCodeArtifact(name: string, mimeType: string): CodeArtifactCategory {
+  const ext = extensionOf(name);
+  if (ext && UTF8_TEXT_EXTENSIONS.has(ext)) {
+    return 'utf8-text';
+  }
+  if (ext && DOCUMENT_EXTENSIONS.has(ext)) {
+    return 'document';
+  }
+  if (ext && PPTX_EXTENSIONS.has(ext)) {
+    return 'pptx';
+  }
+  if (isUtf8TextMime(mimeType)) {
+    return 'utf8-text';
+  }
+  if (isDocumentMime(mimeType)) {
+    return 'document';
+  }
+  if (mimeType === PPTX_MIME) {
+    return 'pptx';
+  }
+  return 'other';
+}

--- a/packages/api/src/files/code/classify.ts
+++ b/packages/api/src/files/code/classify.ts
@@ -128,6 +128,19 @@ const extensionOf = (name: string): string => {
   return name.slice(dot + 1).toLowerCase();
 };
 
+/**
+ * Lookup key for extensionless filenames (Makefile, Dockerfile, etc.).
+ * Matches against the same UTF8_TEXT_EXTENSIONS set so familiar bare names
+ * still get inline text rendering.
+ */
+const bareNameOf = (name: string): string => {
+  if (name.includes('.')) {
+    return '';
+  }
+  const slash = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));
+  return name.slice(slash + 1).toLowerCase();
+};
+
 const isUtf8TextMime = (mime: string): boolean => {
   if (UTF8_TEXT_MIME_EXACT.has(mime)) {
     return true;
@@ -162,6 +175,10 @@ export function classifyCodeArtifact(name: string, mimeType: string): CodeArtifa
   }
   if (ext && PPTX_EXTENSIONS.has(ext)) {
     return 'pptx';
+  }
+  const bare = bareNameOf(name);
+  if (bare && UTF8_TEXT_EXTENSIONS.has(bare)) {
+    return 'utf8-text';
   }
   if (isUtf8TextMime(mimeType)) {
     return 'utf8-text';

--- a/packages/api/src/files/code/extract.spec.ts
+++ b/packages/api/src/files/code/extract.spec.ts
@@ -1,0 +1,100 @@
+import { extractCodeArtifactText, MAX_TEXT_CACHE_BYTES, MAX_TEXT_EXTRACT_BYTES } from './extract';
+
+const docxText = '__DOCX_PARSED__';
+const docxFailureName = 'force-docx-failure.docx';
+
+jest.mock('~/files/documents/crud', () => ({
+  parseDocument: jest.fn(async ({ file }: { file: { originalname: string } }) => {
+    if (file.originalname === docxFailureName) {
+      throw new Error('parse failed');
+    }
+    return { text: docxText, filename: file.originalname, bytes: docxText.length };
+  }),
+}));
+
+describe('extractCodeArtifactText', () => {
+  describe('utf8-text', () => {
+    it('decodes a UTF-8 buffer', async () => {
+      const buffer = Buffer.from('hello world\n', 'utf-8');
+      const text = await extractCodeArtifactText(buffer, 'note.txt', 'text/plain', 'utf8-text');
+      expect(text).toBe('hello world\n');
+    });
+
+    it('returns null for binary content (null byte)', async () => {
+      const buffer = Buffer.from([0x68, 0x69, 0x00, 0x6f]);
+      const text = await extractCodeArtifactText(buffer, 'fake.txt', 'text/plain', 'utf8-text');
+      expect(text).toBeNull();
+    });
+
+    it('returns null for buffers larger than the extract cap', async () => {
+      const buffer = Buffer.alloc(MAX_TEXT_EXTRACT_BYTES + 1, 'a');
+      const text = await extractCodeArtifactText(buffer, 'big.txt', 'text/plain', 'utf8-text');
+      expect(text).toBeNull();
+    });
+
+    it('truncates content larger than the cache cap with a marker', async () => {
+      const cacheCapPlus = MAX_TEXT_CACHE_BYTES + 1024;
+      const buffer = Buffer.alloc(cacheCapPlus, 'a');
+      const text = await extractCodeArtifactText(buffer, 'big.txt', 'text/plain', 'utf8-text');
+      expect(text).not.toBeNull();
+      expect(text!.endsWith('…[truncated]')).toBe(true);
+      expect(Buffer.byteLength(text!, 'utf-8')).toBeLessThanOrEqual(MAX_TEXT_CACHE_BYTES);
+    });
+
+    it('returns the empty string for an empty buffer', async () => {
+      const text = await extractCodeArtifactText(
+        Buffer.alloc(0),
+        'empty.txt',
+        'text/plain',
+        'utf8-text',
+      );
+      expect(text).toBe('');
+    });
+  });
+
+  describe('document', () => {
+    it('routes through parseDocument and returns its text', async () => {
+      const buffer = Buffer.from('PKfake-docx');
+      const text = await extractCodeArtifactText(
+        buffer,
+        'report.docx',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'document',
+      );
+      expect(text).toBe(docxText);
+    });
+
+    it('returns null when parseDocument throws', async () => {
+      const buffer = Buffer.from('PKfake-docx');
+      const text = await extractCodeArtifactText(
+        buffer,
+        docxFailureName,
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'document',
+      );
+      expect(text).toBeNull();
+    });
+  });
+
+  describe('skipped categories', () => {
+    it('returns null for pptx', async () => {
+      const text = await extractCodeArtifactText(
+        Buffer.from('PK'),
+        'slides.pptx',
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'pptx',
+      );
+      expect(text).toBeNull();
+    });
+
+    it('returns null for other (binary)', async () => {
+      const text = await extractCodeArtifactText(
+        Buffer.from([0xff, 0xd8, 0xff]),
+        'photo.jpg',
+        'image/jpeg',
+        'other',
+      );
+      expect(text).toBeNull();
+    });
+  });
+});

--- a/packages/api/src/files/code/extract.spec.ts
+++ b/packages/api/src/files/code/extract.spec.ts
@@ -101,6 +101,41 @@ describe('extractCodeArtifactText', () => {
       expect(text).toBeNull();
     });
 
+    it('rewrites a generic sniffed MIME to the canonical document MIME by extension', async () => {
+      // Code-output buffers for office docs are commonly sniffed as
+      // application/zip — without canonicalization, parseDocument would
+      // reject these and inline previews would silently disappear.
+      const buffer = Buffer.from('PKfake-docx');
+      await extractCodeArtifactText(buffer, 'report.docx', 'application/zip', 'document');
+      expect(parseDocumentCalls[0]?.originalname).toBe('report.docx');
+    });
+
+    it.each([
+      [
+        'report.docx',
+        'application/zip',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      ],
+      [
+        'data.xlsx',
+        'application/octet-stream',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      ],
+      ['legacy.xls', 'application/octet-stream', 'application/vnd.ms-excel'],
+      ['sheet.ods', 'application/zip', 'application/vnd.oasis.opendocument.spreadsheet'],
+      ['notes.odt', 'application/zip', 'application/vnd.oasis.opendocument.text'],
+    ])('passes canonical mimetype for %s when sniff returns %s', async (name, sniffed, _canon) => {
+      const parseDocumentMock = (
+        jest.requireMock('~/files/documents/crud') as {
+          parseDocument: jest.Mock;
+        }
+      ).parseDocument;
+      parseDocumentMock.mockClear();
+      await extractCodeArtifactText(Buffer.from('PK'), name, sniffed, 'document');
+      const call = parseDocumentMock.mock.calls[0]?.[0];
+      expect(call?.file?.mimetype).toBe(_canon);
+    });
+
     it('writes the temp file inside os.tmpdir() regardless of artifact name', async () => {
       const buffer = Buffer.from('PKfake-docx');
       await extractCodeArtifactText(

--- a/packages/api/src/files/code/extract.spec.ts
+++ b/packages/api/src/files/code/extract.spec.ts
@@ -1,11 +1,6 @@
 import * as os from 'os';
 import * as path from 'path';
-import {
-  extractCodeArtifactText,
-  MAX_TEXT_CACHE_BYTES,
-  MAX_TEXT_EXTRACT_BYTES,
-  withTimeout,
-} from './extract';
+import { extractCodeArtifactText, MAX_TEXT_CACHE_BYTES, MAX_TEXT_EXTRACT_BYTES } from './extract';
 
 const docxText = '__DOCX_PARSED__';
 const docxFailureName = 'force-docx-failure.docx';
@@ -173,21 +168,5 @@ describe('extractCodeArtifactText', () => {
       );
       expect(text).toBeNull();
     });
-  });
-});
-
-describe('withTimeout', () => {
-  it('resolves with the underlying value when the work finishes in time', async () => {
-    await expect(withTimeout(Promise.resolve(42), 100, 'fast')).resolves.toBe(42);
-  });
-
-  it('propagates rejections from the underlying promise', async () => {
-    const failing = Promise.reject(new Error('boom'));
-    await expect(withTimeout(failing, 100, 'rejects')).rejects.toThrow('boom');
-  });
-
-  it('rejects with a timeout error when the promise stalls past the deadline', async () => {
-    const stalled = new Promise(() => {});
-    await expect(withTimeout(stalled, 25, 'stall')).rejects.toThrow('stall timed out after 25ms');
   });
 });

--- a/packages/api/src/files/code/extract.spec.ts
+++ b/packages/api/src/files/code/extract.spec.ts
@@ -45,6 +45,19 @@ describe('extractCodeArtifactText', () => {
       expect(Buffer.byteLength(text!, 'utf-8')).toBeLessThanOrEqual(MAX_TEXT_CACHE_BYTES);
     });
 
+    it('does not split a multi-byte UTF-8 character at the truncation boundary', async () => {
+      // 你 is U+4F60, which encodes as 3 bytes in UTF-8 (E4 BD A0).
+      // Build a buffer where the cut would otherwise land mid-character.
+      const filler = 'a'.repeat(MAX_TEXT_CACHE_BYTES - 30);
+      const tail = '你'.repeat(50);
+      const buffer = Buffer.from(filler + tail, 'utf-8');
+      const text = await extractCodeArtifactText(buffer, 'cjk.txt', 'text/plain', 'utf8-text');
+      expect(text).not.toBeNull();
+      expect(text!.endsWith('…[truncated]')).toBe(true);
+      // U+FFFD (replacement) signals a corrupted boundary — must not appear.
+      expect(text).not.toContain('�');
+    });
+
     it('returns the empty string for an empty buffer', async () => {
       const text = await extractCodeArtifactText(
         Buffer.alloc(0),

--- a/packages/api/src/files/code/extract.spec.ts
+++ b/packages/api/src/files/code/extract.spec.ts
@@ -1,10 +1,14 @@
+import * as os from 'os';
+import * as path from 'path';
 import { extractCodeArtifactText, MAX_TEXT_CACHE_BYTES, MAX_TEXT_EXTRACT_BYTES } from './extract';
 
 const docxText = '__DOCX_PARSED__';
 const docxFailureName = 'force-docx-failure.docx';
+const parseDocumentCalls: Array<{ path: string; originalname: string }> = [];
 
 jest.mock('~/files/documents/crud', () => ({
-  parseDocument: jest.fn(async ({ file }: { file: { originalname: string } }) => {
+  parseDocument: jest.fn(async ({ file }: { file: { path: string; originalname: string } }) => {
+    parseDocumentCalls.push({ path: file.path, originalname: file.originalname });
     if (file.originalname === docxFailureName) {
       throw new Error('parse failed');
     }
@@ -53,6 +57,10 @@ describe('extractCodeArtifactText', () => {
   });
 
   describe('document', () => {
+    beforeEach(() => {
+      parseDocumentCalls.length = 0;
+    });
+
     it('routes through parseDocument and returns its text', async () => {
       const buffer = Buffer.from('PKfake-docx');
       const text = await extractCodeArtifactText(
@@ -73,6 +81,22 @@ describe('extractCodeArtifactText', () => {
         'document',
       );
       expect(text).toBeNull();
+    });
+
+    it('writes the temp file inside os.tmpdir() regardless of artifact name', async () => {
+      const buffer = Buffer.from('PKfake-docx');
+      await extractCodeArtifactText(
+        buffer,
+        '../../../etc/passwd.docx',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'document',
+      );
+      const call = parseDocumentCalls[0];
+      expect(call).toBeDefined();
+      const tmpRoot = path.resolve(os.tmpdir());
+      expect(path.resolve(call.path).startsWith(tmpRoot)).toBe(true);
+      expect(call.path).not.toContain('..');
+      expect(call.originalname).toBe('passwd.docx');
     });
   });
 

--- a/packages/api/src/files/code/extract.spec.ts
+++ b/packages/api/src/files/code/extract.spec.ts
@@ -1,6 +1,11 @@
 import * as os from 'os';
 import * as path from 'path';
-import { extractCodeArtifactText, MAX_TEXT_CACHE_BYTES, MAX_TEXT_EXTRACT_BYTES } from './extract';
+import {
+  extractCodeArtifactText,
+  MAX_TEXT_CACHE_BYTES,
+  MAX_TEXT_EXTRACT_BYTES,
+  withTimeout,
+} from './extract';
 
 const docxText = '__DOCX_PARSED__';
 const docxFailureName = 'force-docx-failure.docx';
@@ -133,5 +138,21 @@ describe('extractCodeArtifactText', () => {
       );
       expect(text).toBeNull();
     });
+  });
+});
+
+describe('withTimeout', () => {
+  it('resolves with the underlying value when the work finishes in time', async () => {
+    await expect(withTimeout(Promise.resolve(42), 100, 'fast')).resolves.toBe(42);
+  });
+
+  it('propagates rejections from the underlying promise', async () => {
+    const failing = Promise.reject(new Error('boom'));
+    await expect(withTimeout(failing, 100, 'rejects')).rejects.toThrow('boom');
+  });
+
+  it('rejects with a timeout error when the promise stalls past the deadline', async () => {
+    const stalled = new Promise(() => {});
+    await expect(withTimeout(stalled, 25, 'stall')).rejects.toThrow('stall timed out after 25ms');
   });
 });

--- a/packages/api/src/files/code/extract.ts
+++ b/packages/api/src/files/code/extract.ts
@@ -47,9 +47,9 @@ const extractUtf8 = (buffer: Buffer): string | null => {
 /**
  * Race a promise against a timeout, rejecting if the work doesn't complete
  * in time. Used to keep document parsing from blocking the response path on
- * pathological inputs.
+ * pathological inputs. Exported for direct unit testing.
  */
-const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T> => {
+export const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T> => {
   let timer: NodeJS.Timeout | undefined;
   const timeout = new Promise<T>((_, reject) => {
     timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);

--- a/packages/api/src/files/code/extract.ts
+++ b/packages/api/src/files/code/extract.ts
@@ -1,6 +1,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import { randomUUID } from 'crypto';
 import { logger } from '@librechat/data-schemas';
 import type { CodeArtifactCategory } from './classify';
 import { parseDocument } from '~/files/documents/crud';
@@ -34,7 +35,7 @@ const extractDocument = async (
   name: string,
   mimeType: string,
 ): Promise<string | null> => {
-  const tempPath = path.join(os.tmpdir(), `code-artifact-${process.pid}-${Date.now()}-${name}`);
+  const tempPath = path.join(os.tmpdir(), `code-artifact-${randomUUID()}`);
   await fs.writeFile(tempPath, buffer);
   try {
     const result = await parseDocument({
@@ -42,7 +43,7 @@ const extractDocument = async (
         path: tempPath,
         size: buffer.length,
         mimetype: mimeType,
-        originalname: name,
+        originalname: path.basename(name),
       } as Express.Multer.File,
     });
     if (!result?.text) {

--- a/packages/api/src/files/code/extract.ts
+++ b/packages/api/src/files/code/extract.ts
@@ -9,17 +9,28 @@ import { isBinaryBuffer } from '~/skills/binary';
 
 export const MAX_TEXT_CACHE_BYTES = 512 * 1024;
 export const MAX_TEXT_EXTRACT_BYTES = 1024 * 1024;
+const DOCUMENT_PARSE_TIMEOUT_MS = 8_000;
 const TRUNCATION_MARKER = '\n\n…[truncated]';
+const TRUNCATION_MARKER_BYTES = Buffer.byteLength(TRUNCATION_MARKER, 'utf-8');
 
-const truncate = (text: string): string => {
-  if (Buffer.byteLength(text, 'utf-8') <= MAX_TEXT_CACHE_BYTES) {
+/**
+ * Truncate UTF-8 content to fit within MAX_TEXT_CACHE_BYTES. Walks back to a
+ * code-point boundary so the cut never lands inside a multi-byte sequence
+ * (which would emit a U+FFFD replacement character — a real concern for CJK
+ * and emoji-heavy content). Accepts an optional pre-built buffer to avoid
+ * re-encoding when the caller already has one.
+ */
+const truncate = (text: string, originalBuffer?: Buffer): string => {
+  const buffer = originalBuffer ?? Buffer.from(text, 'utf-8');
+  if (buffer.length <= MAX_TEXT_CACHE_BYTES) {
     return text;
   }
-  const sliceLen = Math.max(
-    0,
-    MAX_TEXT_CACHE_BYTES - Buffer.byteLength(TRUNCATION_MARKER, 'utf-8'),
-  );
-  const buffer = Buffer.from(text, 'utf-8');
+  let sliceLen = Math.max(0, MAX_TEXT_CACHE_BYTES - TRUNCATION_MARKER_BYTES);
+  // UTF-8 continuation bytes match 0b10xxxxxx; keep walking back while the
+  // proposed cut would split a sequence.
+  while (sliceLen > 0 && (buffer[sliceLen] & 0xc0) === 0x80) {
+    sliceLen--;
+  }
   return buffer.subarray(0, sliceLen).toString('utf-8') + TRUNCATION_MARKER;
 };
 
@@ -27,7 +38,27 @@ const extractUtf8 = (buffer: Buffer): string | null => {
   if (isBinaryBuffer(buffer)) {
     return null;
   }
-  return truncate(buffer.toString('utf-8'));
+  if (buffer.length <= MAX_TEXT_CACHE_BYTES) {
+    return buffer.toString('utf-8');
+  }
+  return truncate(buffer.toString('utf-8'), buffer);
+};
+
+/**
+ * Race a promise against a timeout, rejecting if the work doesn't complete
+ * in time. Used to keep document parsing from blocking the response path on
+ * pathological inputs.
+ */
+const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T> => {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  });
 };
 
 const extractDocument = async (
@@ -38,14 +69,18 @@ const extractDocument = async (
   const tempPath = path.join(os.tmpdir(), `code-artifact-${randomUUID()}`);
   await fs.writeFile(tempPath, buffer);
   try {
-    const result = await parseDocument({
-      file: {
-        path: tempPath,
-        size: buffer.length,
-        mimetype: mimeType,
-        originalname: path.basename(name),
-      } as Express.Multer.File,
-    });
+    const result = await withTimeout(
+      parseDocument({
+        file: {
+          path: tempPath,
+          size: buffer.length,
+          mimetype: mimeType,
+          originalname: path.basename(name),
+        } as Express.Multer.File,
+      }),
+      DOCUMENT_PARSE_TIMEOUT_MS,
+      'parseDocument',
+    );
     if (!result?.text) {
       return null;
     }

--- a/packages/api/src/files/code/extract.ts
+++ b/packages/api/src/files/code/extract.ts
@@ -1,0 +1,90 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { logger } from '@librechat/data-schemas';
+import type { CodeArtifactCategory } from './classify';
+import { parseDocument } from '~/files/documents/crud';
+import { isBinaryBuffer } from '~/skills/binary';
+
+export const MAX_TEXT_CACHE_BYTES = 512 * 1024;
+export const MAX_TEXT_EXTRACT_BYTES = 1024 * 1024;
+const TRUNCATION_MARKER = '\n\n…[truncated]';
+
+const truncate = (text: string): string => {
+  if (Buffer.byteLength(text, 'utf-8') <= MAX_TEXT_CACHE_BYTES) {
+    return text;
+  }
+  const sliceLen = Math.max(
+    0,
+    MAX_TEXT_CACHE_BYTES - Buffer.byteLength(TRUNCATION_MARKER, 'utf-8'),
+  );
+  const buffer = Buffer.from(text, 'utf-8');
+  return buffer.subarray(0, sliceLen).toString('utf-8') + TRUNCATION_MARKER;
+};
+
+const extractUtf8 = (buffer: Buffer): string | null => {
+  if (isBinaryBuffer(buffer)) {
+    return null;
+  }
+  return truncate(buffer.toString('utf-8'));
+};
+
+const extractDocument = async (
+  buffer: Buffer,
+  name: string,
+  mimeType: string,
+): Promise<string | null> => {
+  const tempPath = path.join(os.tmpdir(), `code-artifact-${process.pid}-${Date.now()}-${name}`);
+  await fs.writeFile(tempPath, buffer);
+  try {
+    const result = await parseDocument({
+      file: {
+        path: tempPath,
+        size: buffer.length,
+        mimetype: mimeType,
+        originalname: name,
+      } as Express.Multer.File,
+    });
+    if (!result?.text) {
+      return null;
+    }
+    return truncate(result.text);
+  } finally {
+    fs.unlink(tempPath).catch(() => {});
+  }
+};
+
+/**
+ * Extract a UTF-8 text representation of a code-execution artifact for inline
+ * rendering. Returns `null` for binary, oversized, or unsupported files; the
+ * caller should fall back to the standard download UI in that case.
+ *
+ * - utf8-text: decodes the buffer (with a binary safety net)
+ * - document: dispatches to the existing PDF/DOCX/XLSX/ODT parser
+ * - pptx: not yet supported in this PR — returns null (follow-up work)
+ * - other: returns null (binary file, no inline preview)
+ */
+export async function extractCodeArtifactText(
+  buffer: Buffer,
+  name: string,
+  mimeType: string,
+  category: CodeArtifactCategory,
+): Promise<string | null> {
+  if (category === 'other' || category === 'pptx') {
+    return null;
+  }
+  if (buffer.length > MAX_TEXT_EXTRACT_BYTES) {
+    return null;
+  }
+  try {
+    if (category === 'utf8-text') {
+      return extractUtf8(buffer);
+    }
+    return await extractDocument(buffer, name, mimeType);
+  } catch (error) {
+    logger.debug(
+      `[extractCodeArtifactText] Failed to extract "${name}" (${mimeType}): ${(error as Error).message}`,
+    );
+    return null;
+  }
+}

--- a/packages/api/src/files/code/extract.ts
+++ b/packages/api/src/files/code/extract.ts
@@ -61,11 +61,37 @@ export const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): 
   });
 };
 
+/**
+ * Map a known office-document extension back to its canonical MIME so we can
+ * route through `parseDocument` even when buffer-sniffing yielded a generic
+ * value like `application/zip` or `application/octet-stream`. `parseDocument`
+ * dispatches strictly by MIME, so without this remap a `.docx` with a sniffed
+ * `application/zip` would silently fall back to `null`.
+ */
+const documentMimeFromExtension = (name: string): string | null => {
+  const ext = path.extname(name).toLowerCase();
+  switch (ext) {
+    case '.docx':
+      return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    case '.xlsx':
+      return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    case '.xls':
+      return 'application/vnd.ms-excel';
+    case '.ods':
+      return 'application/vnd.oasis.opendocument.spreadsheet';
+    case '.odt':
+      return 'application/vnd.oasis.opendocument.text';
+    default:
+      return null;
+  }
+};
+
 const extractDocument = async (
   buffer: Buffer,
   name: string,
   mimeType: string,
 ): Promise<string | null> => {
+  const canonicalMime = documentMimeFromExtension(name) ?? mimeType;
   const tempPath = path.join(os.tmpdir(), `code-artifact-${randomUUID()}`);
   await fs.writeFile(tempPath, buffer);
   try {
@@ -74,7 +100,7 @@ const extractDocument = async (
         file: {
           path: tempPath,
           size: buffer.length,
-          mimetype: mimeType,
+          mimetype: canonicalMime,
           originalname: path.basename(name),
         } as Express.Multer.File,
       }),

--- a/packages/api/src/files/code/extract.ts
+++ b/packages/api/src/files/code/extract.ts
@@ -6,6 +6,7 @@ import { logger } from '@librechat/data-schemas';
 import type { CodeArtifactCategory } from './classify';
 import { parseDocument } from '~/files/documents/crud';
 import { isBinaryBuffer } from '~/skills/binary';
+import { withTimeout } from '~/utils/promise';
 
 export const MAX_TEXT_CACHE_BYTES = 512 * 1024;
 export const MAX_TEXT_EXTRACT_BYTES = 1024 * 1024;
@@ -42,23 +43,6 @@ const extractUtf8 = (buffer: Buffer): string | null => {
     return buffer.toString('utf-8');
   }
   return truncate(buffer.toString('utf-8'), buffer);
-};
-
-/**
- * Race a promise against a timeout, rejecting if the work doesn't complete
- * in time. Used to keep document parsing from blocking the response path on
- * pathological inputs. Exported for direct unit testing.
- */
-export const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T> => {
-  let timer: NodeJS.Timeout | undefined;
-  const timeout = new Promise<T>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
-  });
-  return Promise.race([promise, timeout]).finally(() => {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  });
 };
 
 /**
@@ -105,7 +89,7 @@ const extractDocument = async (
         } as Express.Multer.File,
       }),
       DOCUMENT_PARSE_TIMEOUT_MS,
-      'parseDocument',
+      `parseDocument exceeded ${DOCUMENT_PARSE_TIMEOUT_MS}ms`,
     );
     if (!result?.text) {
       return null;

--- a/packages/api/src/files/code/index.ts
+++ b/packages/api/src/files/code/index.ts
@@ -1,0 +1,2 @@
+export * from './classify';
+export * from './extract';

--- a/packages/api/src/files/index.ts
+++ b/packages/api/src/files/index.ts
@@ -1,5 +1,6 @@
 export * from './agents';
 export * from './audio';
+export * from './code';
 export * from './context';
 export * from './documents/crud';
 export * from './encode';

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -116,6 +116,7 @@ export type TFile = {
   height?: number;
   expiresAt?: string | Date;
   preview?: string;
+  text?: string;
   metadata?: { fileIdentifier?: string };
   createdAt?: string | Date;
   updatedAt?: string | Date;


### PR DESCRIPTION
## Summary

When code-execution tools (`bash_tool`, PTC, etc.) emit non-image artifacts, we currently render a click-to-download file card. This PR eagerly extracts text content for text-renderable formats and shows it inline under the tool call, the same way images already render inline.

- **Backend** — new `packages/api/src/files/code/{classify,extract}.ts`. `classifyCodeArtifact()` buckets each artifact into `utf8-text` (txt, md, csv, json, html, code files, etc.), `document` (docx, xlsx, ods, odt — via the existing `parseDocument` dispatcher and `mammoth`/`xlsx` deps already in the tree), `pptx` (stubbed for a follow-up PR), or `other`. `extractCodeArtifactText()` decodes UTF-8 with a `isBinaryBuffer()` safety net (lifted from SkillFiles), routes documents through `parseDocument`, and stores at most 512 KB in `file.text` (mirrors the SkillFiles convention) with a `…[truncated]` marker. `processCodeOutput`'s non-image branch calls these and writes `text` onto the file record. Image path untouched.
- **Frontend** — `Attachment.tsx` gains a `TextAttachment` sibling to `FileAttachment`/`ImageAttachment`. `Attachment` and `AttachmentGroup` now route attachments three ways (image / inline-text / file). `LogContent.tsx` gets the same three-way split for the legacy log surface. `FileContainer` is reused untouched for the file chip and remains the path for non-text-eligible files.
- **Data-provider** — adds `text?: string` to `TFile`.
- PPTX is intentionally classified but not yet extracted — needs a parser dep, scoped to a follow-up PR.

## Test plan

- [x] `packages/api/src/files/code/{classify,extract}.spec.ts` — 54 unit tests cover the extension/MIME matrix, the binary safety net, the 1 MB extract cap, the 512 KB cache cap with truncation marker, and the document/pptx/other branches
- [x] `api/server/services/Files/Code/process.spec.js` — three new cases: `text` populated for utf8-text, `text` omitted when extractor returns null, extraction not invoked for image files
- [x] `api/server/services/Files/Code/__tests__/process-traversal.spec.js` mock updated for the new `@librechat/api` exports
- [x] Full sweep `api server/services/Files server/controllers/agents server/controllers/__tests__/tools.verifyToolAuth.spec.js` — 173 tests across 17 suites pass
- [x] Full `packages/api src/files` — 300 tests across 10 suites pass
- [x] Lint clean on all touched files
- [x] TypeScript clean on all touched files
- [ ] Manual UI verification across docx / xlsx / csv / py / json / large file truncation / binary file fallback