### PR TITLE
🛡️ fix: Filter `user_provided` Sentinel in Tool Credential Loading

### DIFF
--- a/api/server/services/Tools/credentials.js
+++ b/api/server/services/Tools/credentials.js
@@ -1,3 +1,4 @@
+const { AuthType } = require('librechat-data-provider');
 const { getUserPluginAuthValue } = require('~/server/services/PluginService');
 
 /**
@@ -19,17 +20,18 @@ const loadAuthValues = async ({ userId, authFields, optional, throwError = true 
    */
   const findAuthValue = async (fields) => {
     for (const field of fields) {
-      let value = process.env[field];
-      if (value) {
-        return { authField: field, authValue: value };
+      const envValue = process.env[field];
+      if (envValue && envValue.trim() !== '' && envValue !== AuthType.USER_PROVIDED) {
+        return { authField: field, authValue: envValue };
       }
+      let value;
       try {
         value = await getUserPluginAuthValue(userId, field, throwError);
       } catch (err) {
         if (optional && optional.has(field)) {
           return { authField: field, authValue: undefined };
         }
-        if (field === fields[fields.length - 1] && !value) {
+        if (field === fields[fields.length - 1]) {
           throw err;
         }
       }

--- a/api/server/services/Tools/credentials.spec.js
+++ b/api/server/services/Tools/credentials.spec.js
@@ -1,0 +1,134 @@
+const { AuthType } = require('librechat-data-provider');
+
+jest.mock('~/server/services/PluginService', () => ({
+  getUserPluginAuthValue: jest.fn(),
+}));
+
+const { getUserPluginAuthValue } = require('~/server/services/PluginService');
+const { loadAuthValues } = require('./credentials');
+
+describe('loadAuthValues', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should return env value when set to a real key', async () => {
+    process.env.MY_API_KEY = 'real-key-123';
+
+    const result = await loadAuthValues({
+      userId: 'user1',
+      authFields: ['MY_API_KEY'],
+    });
+
+    expect(result).toEqual({ MY_API_KEY: 'real-key-123' });
+  });
+
+  it('should skip user_provided sentinel and try user DB value', async () => {
+    process.env.GOOGLE_KEY = AuthType.USER_PROVIDED;
+    getUserPluginAuthValue.mockResolvedValue('user-stored-key');
+
+    const result = await loadAuthValues({
+      userId: 'user1',
+      authFields: ['GOOGLE_KEY'],
+    });
+
+    expect(getUserPluginAuthValue).toHaveBeenCalledWith('user1', 'GOOGLE_KEY', true);
+    expect(result).toEqual({ GOOGLE_KEY: 'user-stored-key' });
+  });
+
+  it('should skip user_provided and continue to next field in fallback chain', async () => {
+    process.env.GOOGLE_KEY = AuthType.USER_PROVIDED;
+    process.env.GOOGLE_SERVICE_KEY_FILE = '/path/to/service-account.json';
+    getUserPluginAuthValue.mockRejectedValue(new Error('No auth found'));
+
+    const result = await loadAuthValues({
+      userId: 'user1',
+      authFields: ['GEMINI_API_KEY||GOOGLE_KEY||GOOGLE_SERVICE_KEY_FILE'],
+    });
+
+    expect(result).toEqual({ GOOGLE_SERVICE_KEY_FILE: '/path/to/service-account.json' });
+  });
+
+  it('should skip empty and whitespace-only env values', async () => {
+    process.env.EMPTY_KEY = '';
+    process.env.WHITESPACE_KEY = '   ';
+    process.env.REAL_KEY = 'valid';
+
+    const result = await loadAuthValues({
+      userId: 'user1',
+      authFields: ['EMPTY_KEY||WHITESPACE_KEY||REAL_KEY'],
+    });
+
+    expect(result).toEqual({ REAL_KEY: 'valid' });
+  });
+
+  it('should not return user_provided as an auth value', async () => {
+    process.env.GOOGLE_KEY = AuthType.USER_PROVIDED;
+    getUserPluginAuthValue.mockResolvedValue(null);
+
+    const result = await loadAuthValues({
+      userId: 'user1',
+      authFields: ['GOOGLE_KEY'],
+      throwError: false,
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it('should return env value without calling DB when env is valid', async () => {
+    process.env.MY_KEY = 'valid-key';
+
+    const result = await loadAuthValues({
+      userId: 'user1',
+      authFields: ['MY_KEY'],
+    });
+
+    expect(result).toEqual({ MY_KEY: 'valid-key' });
+    expect(getUserPluginAuthValue).not.toHaveBeenCalled();
+  });
+
+  it('should return real env value from first matching field in fallback chain', async () => {
+    process.env.GEMINI_API_KEY = 'gemini-key';
+    process.env.GOOGLE_KEY = 'google-key';
+
+    const result = await loadAuthValues({
+      userId: 'user1',
+      authFields: ['GEMINI_API_KEY||GOOGLE_KEY'],
+    });
+
+    expect(result).toEqual({ GEMINI_API_KEY: 'gemini-key' });
+  });
+
+  it('should return undefined for optional field when sentinel is filtered and DB throws', async () => {
+    process.env.GOOGLE_KEY = AuthType.USER_PROVIDED;
+    getUserPluginAuthValue.mockRejectedValue(new Error('No auth found'));
+
+    const optional = new Set(['GOOGLE_KEY']);
+    const result = await loadAuthValues({
+      userId: 'user1',
+      authFields: ['GOOGLE_KEY'],
+      optional,
+    });
+
+    expect(result).toEqual({ GOOGLE_KEY: undefined });
+  });
+
+  it('should not leak sentinel through catch path when DB lookup throws', async () => {
+    process.env.GOOGLE_KEY = AuthType.USER_PROVIDED;
+    getUserPluginAuthValue.mockRejectedValue(new Error('No auth found'));
+
+    await expect(
+      loadAuthValues({
+        userId: 'user1',
+        authFields: ['GOOGLE_KEY'],
+      }),
+    ).rejects.toThrow('No auth found');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #12839

When `GOOGLE_KEY=user_provided` is set as an endpoint configuration (a documented sentinel value meaning "let users provide their own key via UI"), `loadAuthValues()` in `credentials.js` passes the literal string `"user_provided"` to tools through the `||` fallback chain.

This causes **Gemini Image Tools** to fail at runtime with an invalid API key error, because `initializeGeminiClient()` receives the sentinel value instead of a real key and attempts `new GoogleGenAI({ apiKey: 'user_provided' })`.

The root cause is an inconsistency: `checkPluginAuth()` in `format.ts` already correctly excludes `user_provided` and empty/whitespace values, but `loadAuthValues()` does not apply the same filtering. This fix aligns the two functions.

### What changed

**`api/server/services/Tools/credentials.js`** — The `findAuthValue()` function now:
- Separates env lookup (`const envValue`) from DB lookup (`let value`) to prevent the sentinel from leaking through the catch path when `getUserPluginAuthValue` throws
- Skips env values that are empty, whitespace-only, or equal to the `user_provided` sentinel, consistent with `checkPluginAuth()` in `format.ts`
- When a sentinel is encountered, continues to try user DB values or the next field in the `||` chain

**`api/server/services/Tools/credentials.spec.js`** — New test file with 9 regression tests covering: real env values, sentinel skipping, fallback chains, empty/whitespace filtering, optional fields, env short-circuit (no DB call), and the catch-path sentinel leak.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

**Steps to reproduce the bug:**
1. Set `GOOGLE_KEY=user_provided` in `.env`
2. Create an agent with the Gemini Image Tools tool
3. Ask the agent to generate an image
4. Observe: runtime error — `"user_provided"` passed as literal API key

**Steps to verify the fix:**
1. Apply the fix
2. Same setup as above
3. `loadAuthValues()` now skips the sentinel, falls through to user DB value or next field in chain
4. If no valid key exists, the tool correctly reports missing auth instead of crashing with an opaque error

**Unit tests:**
```
PASS  server/services/Tools/credentials.spec.js
  loadAuthValues
    ✓ should return env value when set to a real key
    ✓ should skip user_provided sentinel and try user DB value
    ✓ should skip user_provided and continue to next field in fallback chain
    ✓ should skip empty and whitespace-only env values
    ✓ should not return user_provided as an auth value
    ✓ should return env value without calling DB when env is valid
    ✓ should return real env value from first matching field in fallback chain
    ✓ should return undefined for optional field when sentinel is filtered and DB throws
    ✓ should not leak sentinel through catch path when DB lookup throws
```

Existing test suites (148 suites, 3852 tests) continue to pass.

### Test Configuration

- Node.js v24
- npm 11.10.0
- Jest 30
- Commit: 738003b (main at time of fix)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
