### PR TITLE
🚫 fix: Reject Binary Files in read_file Sandbox Fallback (No More Mojibake)

### DIFF
--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -1213,6 +1213,36 @@ describe('createToolExecuteHandler', () => {
         expect(readSandboxFile).toHaveBeenCalled();
         expect(result.status).toBe('success');
       });
+
+      it('reads SVG files as text (not blocked by the binary denylist)', async () => {
+        /* SVG is XML text — the model has legitimate reasons to inspect
+         * or edit generated SVG output (tweaking colors, paths, viewBox).
+         * The post-fetch NUL-byte sniff still rejects anything that
+         * turns out to be binary despite a `.svg` extension. */
+        const svgContent =
+          '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">\n' +
+          '  <circle cx="5" cy="5" r="4" />\n' +
+          '</svg>';
+        const readSandboxFile = jest.fn(async () => ({ content: svgContent }));
+        const handler = makeReadFileHandler({
+          codeEnvAvailable: true,
+          accessibleSkillIds: skillsInScope(),
+          readSandboxFile,
+        });
+
+        const [result] = await invokeHandler(handler, [
+          {
+            id: 'call_svg',
+            name: Constants.READ_FILE,
+            args: { file_path: '/mnt/data/icon.svg' },
+          },
+        ]);
+
+        expect(readSandboxFile).toHaveBeenCalled();
+        expect(result.status).toBe('success');
+        expect(result.content).toContain('<svg');
+        expect(result.content).toContain('viewBox');
+      });
     });
   });
 });

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -1059,5 +1059,160 @@ describe('createToolExecuteHandler', () => {
       expect(result.errorMessage).toContain('Failed to read');
       expect(result.errorMessage).toContain('bash_tool');
     });
+
+    describe('binary file guard', () => {
+      /**
+       * Regression for the matplotlib-shape bug where `read_file` on
+       * `/mnt/data/simple_graph.png` shelled `cat` through codeapi and
+       * line-numbered the lossy-string-decoded PNG bytes back to the
+       * model. The guard short-circuits BEFORE the network call for any
+       * extension that can never round-trip through codeapi's JSON
+       * `/exec` transport, and falls back to a NUL-byte sniff after the
+       * read for unknown extensions.
+       */
+      it('rejects images by extension without ever calling readSandboxFile', async () => {
+        const readSandboxFile = jest.fn();
+        const handler = makeReadFileHandler({
+          codeEnvAvailable: true,
+          accessibleSkillIds: skillsInScope(),
+          readSandboxFile,
+        });
+
+        const [result] = await invokeHandler(handler, [
+          {
+            id: 'call_png',
+            name: Constants.READ_FILE,
+            args: { file_path: '/mnt/data/simple_graph.png' },
+            codeSessionContext: { session_id: 'sess-Z' },
+          } as unknown as ToolCallRequest,
+        ]);
+
+        expect(readSandboxFile).not.toHaveBeenCalled();
+        expect(result.status).toBe('error');
+        expect(result.errorMessage).toContain('image file');
+        expect(result.errorMessage).toContain('.png');
+        expect(result.errorMessage).toContain('already attached');
+        expect(result.errorMessage).toContain('bash_tool');
+      });
+
+      it('rejects non-image binary types with a bash-pointing message (not the image-attachment hint)', async () => {
+        const readSandboxFile = jest.fn();
+        const handler = makeReadFileHandler({
+          codeEnvAvailable: true,
+          accessibleSkillIds: skillsInScope(),
+          readSandboxFile,
+        });
+
+        const [result] = await invokeHandler(handler, [
+          {
+            id: 'call_zip',
+            name: Constants.READ_FILE,
+            args: { file_path: '/mnt/data/archive.zip' },
+          },
+        ]);
+
+        expect(readSandboxFile).not.toHaveBeenCalled();
+        expect(result.status).toBe('error');
+        expect(result.errorMessage).toContain('binary file');
+        expect(result.errorMessage).toContain('.zip');
+        expect(result.errorMessage).not.toContain('already attached');
+        expect(result.errorMessage).toContain('bash_tool');
+      });
+
+      it('is case-insensitive on the extension match (PNG vs .png)', async () => {
+        const readSandboxFile = jest.fn();
+        const handler = makeReadFileHandler({
+          codeEnvAvailable: true,
+          accessibleSkillIds: skillsInScope(),
+          readSandboxFile,
+        });
+
+        const [result] = await invokeHandler(handler, [
+          {
+            id: 'call_uppercase',
+            name: Constants.READ_FILE,
+            args: { file_path: '/mnt/data/CHART.PNG' },
+          },
+        ]);
+
+        expect(readSandboxFile).not.toHaveBeenCalled();
+        expect(result.status).toBe('error');
+        expect(result.errorMessage).toContain('image file');
+      });
+
+      it('rejects binary content (NUL bytes) post-fetch when the extension was unknown', async () => {
+        /* No extension → no precheck shortcut → read goes through, but the
+         * NUL-byte sniff catches it before line-numbering. Mojibake from
+         * codeapi's lossy JSON-encoding still round-trips through whatever
+         * string LibreChat builds, and the NUL terminator from the binary
+         * header survives that. */
+        const binaryWithNul = '   \rIHDR  ';
+        const readSandboxFile = jest.fn(async () => ({ content: binaryWithNul }));
+        const handler = makeReadFileHandler({
+          codeEnvAvailable: true,
+          accessibleSkillIds: skillsInScope(),
+          readSandboxFile,
+        });
+
+        const [result] = await invokeHandler(handler, [
+          {
+            id: 'call_nul_sniff',
+            name: Constants.READ_FILE,
+            args: { file_path: '/mnt/data/mystery_file' },
+          },
+        ]);
+
+        expect(readSandboxFile).toHaveBeenCalled();
+        expect(result.status).toBe('error');
+        expect(result.errorMessage).toContain('binary');
+        expect(result.errorMessage).toContain('bash_tool');
+        // The bytes themselves never reach the model.
+        expect(result.content).toBe('');
+      });
+
+      it('still allows text files with binary-adjacent extensions (e.g. log.txt → readable)', async () => {
+        const readSandboxFile = jest.fn(async () => ({ content: 'plain text\nline 2' }));
+        const handler = makeReadFileHandler({
+          codeEnvAvailable: true,
+          accessibleSkillIds: skillsInScope(),
+          readSandboxFile,
+        });
+
+        const [result] = await invokeHandler(handler, [
+          {
+            id: 'call_text',
+            name: Constants.READ_FILE,
+            args: { file_path: '/mnt/data/notes.txt' },
+          },
+        ]);
+
+        expect(readSandboxFile).toHaveBeenCalled();
+        expect(result.status).toBe('success');
+        expect(result.content).toContain('plain text');
+      });
+
+      it('does not false-trigger on filenames containing `.` in directory names', async () => {
+        /* `lowercaseExtension` must use the basename, not the path —
+         * `proj.v1/notes` should yield `''` (no extension), not `.v1/notes`,
+         * so the file goes through the normal read path. */
+        const readSandboxFile = jest.fn(async () => ({ content: 'text from a dotted-dir path' }));
+        const handler = makeReadFileHandler({
+          codeEnvAvailable: true,
+          accessibleSkillIds: skillsInScope(),
+          readSandboxFile,
+        });
+
+        const [result] = await invokeHandler(handler, [
+          {
+            id: 'call_dotted_dir',
+            name: Constants.READ_FILE,
+            args: { file_path: '/mnt/data/proj.v1/notes' },
+          },
+        ]);
+
+        expect(readSandboxFile).toHaveBeenCalled();
+        expect(result.status).toBe('success');
+      });
+    });
   });
 });

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -159,7 +159,12 @@ function addLineNumbers(content: string): string {
  * code-execution artifact pipeline — re-attaching here would dup it.
  */
 const BINARY_EXTENSIONS_NEVER_READABLE = new Set([
-  // Images (already attached as artifacts by the code-execution pipeline)
+  // Raster images (already attached as artifacts by the code-execution
+  // pipeline). `.svg` is intentionally NOT in this list — it's an XML
+  // text format with no mojibake risk, and there are legitimate reasons
+  // for the model to inspect or edit a generated SVG. The post-fetch
+  // NUL-byte sniff still catches anything that turns out to be binary
+  // despite a `.svg` extension.
   '.png',
   '.jpg',
   '.jpeg',
@@ -172,7 +177,6 @@ const BINARY_EXTENSIONS_NEVER_READABLE = new Set([
   '.heic',
   '.heif',
   '.avif',
-  '.svg',
   // Documents (binary container formats)
   '.pdf',
   '.doc',
@@ -251,7 +255,6 @@ const IMAGE_EXTENSIONS_FOR_HINT = new Set([
   '.heic',
   '.heif',
   '.avif',
-  '.svg',
 ]);
 
 function lowercaseExtension(filePath: string): string {

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -148,6 +148,151 @@ function addLineNumbers(content: string): string {
 }
 
 /**
+ * Extensions whose contents `read_file` must never serialize as text. `cat`
+ * on a PNG inside the sandbox returns the raw bytes as stdout, JSON-encoded
+ * by codeapi with lossy UTF-8 replacement and then line-numbered by us —
+ * the result is a multi-KB blob of mojibake that pollutes the LLM context
+ * and exposes the raw bytes anyway. Short-circuit before the network call.
+ *
+ * Image categories surface a "use the existing attachment" message because
+ * the file was already attached to the conversation as part of the
+ * code-execution artifact pipeline — re-attaching here would dup it.
+ */
+const BINARY_EXTENSIONS_NEVER_READABLE = new Set([
+  // Images (already attached as artifacts by the code-execution pipeline)
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.tiff',
+  '.tif',
+  '.ico',
+  '.heic',
+  '.heif',
+  '.avif',
+  '.svg',
+  // Documents (binary container formats)
+  '.pdf',
+  '.doc',
+  '.docx',
+  '.xls',
+  '.xlsx',
+  '.ppt',
+  '.pptx',
+  '.odt',
+  '.ods',
+  '.odp',
+  // Archives
+  '.zip',
+  '.tar',
+  '.gz',
+  '.tgz',
+  '.bz2',
+  '.xz',
+  '.7z',
+  '.rar',
+  '.lz4',
+  '.zst',
+  // Audio / video
+  '.mp3',
+  '.wav',
+  '.flac',
+  '.ogg',
+  '.m4a',
+  '.aac',
+  '.wma',
+  '.mp4',
+  '.mkv',
+  '.mov',
+  '.avi',
+  '.webm',
+  '.flv',
+  '.m4v',
+  // Executables / object files / native libs
+  '.exe',
+  '.dll',
+  '.so',
+  '.dylib',
+  '.o',
+  '.obj',
+  '.a',
+  '.lib',
+  '.bin',
+  '.class',
+  '.jar',
+  // Other byte-soup formats
+  '.parquet',
+  '.bson',
+  '.db',
+  '.sqlite',
+  '.sqlite3',
+  '.pyc',
+  '.pyo',
+  '.wasm',
+  '.ttf',
+  '.otf',
+  '.woff',
+  '.woff2',
+  '.eot',
+]);
+
+const IMAGE_EXTENSIONS_FOR_HINT = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.tiff',
+  '.tif',
+  '.ico',
+  '.heic',
+  '.heif',
+  '.avif',
+  '.svg',
+]);
+
+function lowercaseExtension(filePath: string): string {
+  const dot = filePath.lastIndexOf('.');
+  const slash = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+  if (dot < 0 || dot < slash) return '';
+  return filePath.slice(dot).toLowerCase();
+}
+
+/**
+ * Builds the model-visible error returned when `read_file` is invoked on
+ * a binary path. Phrasing is tuned for the LLM: states the fact (file is
+ * binary, can't be read as text), points at the correct affordance for
+ * each common case (image already in the chat; bash for everything else),
+ * and includes the path verbatim so the model can copy-paste into its
+ * next call.
+ */
+function buildBinaryFileError(filePath: string, ext: string): string {
+  if (IMAGE_EXTENSIONS_FOR_HINT.has(ext)) {
+    return `"${filePath}" is an image file (${ext}) and cannot be read as text. The image is already attached to the conversation and visible to the user. To process it programmatically, use \`bash_tool\` (e.g. \`file ${filePath}\` for metadata, or \`python3 -c '...'\` to operate on the bytes).`;
+  }
+  return `"${filePath}" is a binary file (${ext}) and cannot be read as text by \`read_file\`. Use \`bash_tool\` to process it (e.g. \`file ${filePath}\` for metadata, or a runtime-appropriate command for the format).`;
+}
+
+/**
+ * True when the first chunk of a string contains a NUL byte. Used as a
+ * post-fetch safety net for files whose extension didn't match the
+ * blocklist (no extension, novel format, etc.) — sniffs `cat` stdout to
+ * avoid ever forwarding mangled bytes to the LLM. 8KB is the same
+ * window the skill-file path uses; enough for any reasonable magic
+ * number while bounded enough to stay cheap.
+ */
+function looksBinary(content: string): boolean {
+  const limit = Math.min(content.length, 8192);
+  for (let i = 0; i < limit; i++) {
+    if (content.charCodeAt(i) === 0) return true;
+  }
+  return false;
+}
+
+/**
  * Routes a `read_file` call to the code-execution sandbox via the
  * host-provided `readSandboxFile` callback. The sandbox session id and
  * primed file refs come from `tc.codeSessionContext` (emitted by ToolNode
@@ -156,12 +301,30 @@ function addLineNumbers(content: string): string {
  * `ToolExecuteResult` with the file content (line-numbered) on success,
  * or an instructive error pointing the model at `bash_tool` when the
  * sandbox isn't reachable from this configuration.
+ *
+ * Two binary guards keep `cat`-on-a-PNG-style mojibake out of the LLM
+ * context: (1) an extension precheck that short-circuits known binary
+ * types BEFORE any network call, and (2) a NUL-byte content sniff after
+ * the read for unknown extensions. The codeapi `/exec` transport is JSON,
+ * which already lossily down-converts non-UTF-8 stdout to replacement
+ * characters — the bytes are unrecoverable here, so the goal is to fail
+ * fast with an instructive message rather than ship garbage.
  */
 async function handleSandboxFileFallback(
   tc: ToolCallRequest,
   filePath: string,
   options: ToolExecuteOptions,
 ): Promise<ToolExecuteResult> {
+  const ext = lowercaseExtension(filePath);
+  if (BINARY_EXTENSIONS_NEVER_READABLE.has(ext)) {
+    return {
+      toolCallId: tc.id,
+      status: 'error',
+      content: '',
+      errorMessage: buildBinaryFileError(filePath, ext),
+    };
+  }
+
   const { readSandboxFile } = options;
   if (!readSandboxFile) {
     return {
@@ -187,6 +350,14 @@ async function handleSandboxFileFallback(
         status: 'error',
         content: '',
         errorMessage: `Failed to read "${filePath}" from the code-execution sandbox. Try \`bash_tool\` (e.g. \`cat ${filePath}\`).`,
+      };
+    }
+    if (looksBinary(result.content)) {
+      return {
+        toolCallId: tc.id,
+        status: 'error',
+        content: '',
+        errorMessage: `"${filePath}" appears to be a binary file and cannot be read as text. Use \`bash_tool\` to process it (e.g. \`file ${filePath}\` for metadata).`,
       };
     }
     /**


### PR DESCRIPTION
## Summary

`read_file("/mnt/data/simple_graph.png")` was shelling `cat` through codeapi `/exec` and shipping the result back to the model. codeapi's transport is JSON, so `stdout` containing PNG bytes round-tripped through lossy UTF-8 replacement (every non-ASCII byte became `U+FFFD`), got line-numbered by `addLineNumbers`, and arrived in the model's context as a multi-KB blob of `\`�PNG\r\n  2 | …\``. The bytes were unrecoverable through this transport — and the same codeapi sandbox logged the same mojibake — so the goal is fail-fast, not retrieval.

Two guards added to `handleSandboxFileFallback` in [packages/api/src/agents/handlers.ts](packages/api/src/agents/handlers.ts):

1. **Extension precheck** (BEFORE any network call) for known-binary types — images, documents, archives, audio, video, native libs, fonts, and other byte-soup formats. Image extensions get a message that points at the existing chat attachment (\"the image is already shown to the user, use \`bash_tool\` for programmatic processing\"); other binaries get the generic \"use bash\" hint.
2. **NUL-byte sniff** (AFTER the read) on the first 8KB for unknown extensions or no-extension paths. The codeapi `/exec` JSON encoding mangles most non-UTF-8 bytes but a NUL terminator from a magic header survives the round-trip — catches novel binary formats without an extension precheck.

`lowercaseExtension` uses the basename to avoid false-triggering on directory-name dots (e.g. `proj.v1/notes` has no extension, not `.v1/notes`).

## Test plan

- [x] +6 cases in [packages/api/src/agents/handlers.spec.ts](packages/api/src/agents/handlers.spec.ts):
  - Image rejected by extension, never calls `readSandboxFile`, message points at the existing attachment.
  - Non-image binary (`.zip`) rejected with a different (bash-only) message.
  - Case-insensitive extension match (`.PNG` vs `.png`).
  - NUL-byte sniff catches unknown-extension binary post-fetch.
  - Text files with binary-adjacent extensions (`.txt`) still readable.
  - Dotted directory names don't false-trigger the extension match.
- [x] 38/38 `handlers.spec.ts` pass.
- [ ] Live verification: confirm `read_file("/mnt/data/simple_graph.png")` no longer returns line-numbered byte mojibake; the model receives the new error message instead.

## Out of scope

The companion bash \"command not found\" issue from the same conversation is a separate LLM mistake (writing raw Python as the bash command without `python3 -c` / heredoc wrapper). Could be addressed in a follow-up by either (a) tightening the bash_tool description or (b) detecting Python-style content in the args and returning a hinting error. Flagged for the user but not coded here.