### PR TITLE
🔧 fix: Replace Literal NUL Bytes in handlers.spec Test Fixture + Normalize CRLF

### DIFF
--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -1146,7 +1146,7 @@ describe('createToolExecuteHandler', () => {
          * codeapi's lossy JSON-encoding still round-trips through whatever
          * string LibreChat builds, and the NUL terminator from the binary
          * header survives that. */
-        const binaryWithNul = '   \rIHDR  ';
+        const binaryWithNul = '\x00\x00\x00\rIHDR\x00\x00\x04';
         const readSandboxFile = jest.fn(async () => ({ content: binaryWithNul }));
         const handler = makeReadFileHandler({
           codeEnvAvailable: true,


### PR DESCRIPTION
Follow-up to [#12851](https://github.com/danny-avila/LibreChat/pull/12851) (already merged) — two test-file hygiene fixes Codex (P3) and Copilot flagged but didn't make the merge:

## 1. Literal NUL bytes in test fixture

The `'rejects binary content (NUL bytes) post-fetch'` test embedded raw `\x00` bytes directly in the source string:

```ts
const binaryWithNul = '<3 NULs>\rIHDR<2 NULs>\x04';
```

Embedding NUL bytes in source files breaks editors, linters, ts-loader, and most git tooling — `grep` even classifies the file as binary. Replaced with `\x00` escape sequences in the literal so the source is plain ASCII while the runtime string value is unchanged. Test continues to pass.

## 2. CRLF line endings

Earlier commits to this file picked up Windows-style `\r\n` from git's `core.autocrlf=true` checkout conversion, then committed with CRLF endings. The diff against `dev` showed the entire file as changed even though only a few lines were touched semantically. Normalized the whole file back to LF.

## Diff size

The diff for this PR is large (~1248 lines marked changed) but **every change is one of**:

- CRLF → LF (mechanical, line-ending normalization)
- the single `binaryWithNul` literal → escape-sequence rewrite

No semantic test changes.

## Test plan

- [x] `npx jest src/agents/handlers.spec.ts` — 39/39 pass (unchanged behavior)
- [x] No NUL bytes remain in the file (verified)
- [x] No CRLF line endings remain in the file (verified)