### PR TITLE
🔌 fix: Prevent Repeated Idle Check Triggers for Users With Failed MCP Connections

### DIFF
--- a/packages/api/src/mcp/UserConnectionManager.ts
+++ b/packages/api/src/mcp/UserConnectionManager.ts
@@ -268,10 +268,16 @@ export abstract class UserConnectionManager {
           this.pendingConnections.delete(key);
         }
       }
-      // Ensure user activity timestamp is removed
-      this.userLastActivity.delete(userId);
       logger.info(`[MCP][User: ${userId}] All connections processed for disconnection.`);
     }
+    /**
+     * Always clear the activity timestamp, even when userMap was missing.
+     * `updateUserLastActivity` can be called before a connection is established
+     * (e.g. in MCPManager.callTool prior to getConnection); if that connection
+     * attempt fails, the activity entry would otherwise leak and trigger the
+     * idle check repeatedly for the same userId.
+     */
+    this.userLastActivity.delete(userId);
   }
 
   /** Check for and disconnect idle connections */


### PR DESCRIPTION
## Summary

We’re seeing a group of users’ MCP connections being continuously disconnected because user activity is being recorded before a connection is successfully established. If the connection never succeeds, the activity timestamp is never removed.

This PR changes the cleanup to always clear the activity timestamp, even when userMap was missing, because `updateUserLastActivity` is [called before a connection is established in MCPManager.callTool](https://github.com/danny-avila/LibreChat/blob/738003b220a91ec724286dab0354080e22f8aac9/packages/api/src/mcp/MCPManager.ts#L298-L311) and when that connection attempt fails, the activity entry would be present and trigger the idle check, but fail to get a userMap of connections, so it would fire repeatedly for the same userId.

Another fix would be to only set the activity after the connection succeeds, but I assume that goes against the way activity is intended to be recorded.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

Please describe your test process and include instructions so that we can reproduce your test. If there are any important variables for your testing configuration, list them here.

### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [ ] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.
