### PR TITLE
🛂 fix: Skip Inherited / Mark Skill Files Read-Only in Code-Env Pipeline

### DIFF
--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -543,6 +543,15 @@ function createToolEndCallback({ req, res, artifactPromises, streamId = null }) 
     }
 
     for (const file of output.artifact.files) {
+      /* `inherited` files are unchanged passthroughs of inputs the caller
+       * already owns (skill files, prior session inputs, inherited
+       * .dirkeep markers). Skip post-processing: re-downloading with the
+       * user's session key 403s when the file is entity-scoped, and the
+       * input is already persisted at its origin. They remain available
+       * to subsequent calls via primeInvokedSkills / session inheritance. */
+      if (file.inherited) {
+        continue;
+      }
       const { id, name } = file;
       artifactPromises.push(
         (async () => {
@@ -760,6 +769,15 @@ function createResponsesToolEndCallback({ req, res, tracker, artifactPromises })
     }
 
     for (const file of output.artifact.files) {
+      /* `inherited` files are unchanged passthroughs of inputs the caller
+       * already owns (skill files, prior session inputs, inherited
+       * .dirkeep markers). Skip post-processing: re-downloading with the
+       * user's session key 403s when the file is entity-scoped, and the
+       * input is already persisted at its origin. They remain available
+       * to subsequent calls via primeInvokedSkills / session inheritance. */
+      if (file.inherited) {
+        continue;
+      }
       const { id, name } = file;
       artifactPromises.push(
         (async () => {

--- a/api/server/controllers/tools.js
+++ b/api/server/controllers/tools.js
@@ -180,6 +180,15 @@ const callTool = async (req, res) => {
 
     const artifactPromises = [];
     for (const file of artifact.files) {
+      /* Files flagged `inherited` by codeapi are unchanged passthroughs of
+       * inputs the caller already owns (skill files, prior downloaded inputs,
+       * inherited .dirkeep markers). Re-downloading them is wasted work and
+       * 403s when the file is scoped to a different entity (e.g. skill
+       * entity_id) than the user's session key. They remain available for
+       * subsequent tool calls via primeInvokedSkills / session inheritance. */
+      if (file.inherited) {
+        continue;
+      }
       const { id, name } = file;
       artifactPromises.push(
         (async () => {

--- a/api/server/services/Files/Code/crud.js
+++ b/api/server/services/Files/Code/crud.js
@@ -112,14 +112,23 @@ async function uploadCodeEnvFile({ req, stream, filename, entity_id = '' }) {
  * @param {import('express').Request & { user: { id: string } }} params.req - The request object.
  * @param {Array<{ stream: NodeJS.ReadableStream; filename: string }>} params.files - Files to upload.
  * @param {string} [params.entity_id] - Optional entity ID.
+ * @param {boolean} [params.read_only] - When true, codeapi tags every file in
+ *   the batch as infrastructure (e.g. skill files). The flag is persisted as
+ *   MinIO object metadata (`X-Amz-Meta-Read-Only`) and travels with the file
+ *   through subsequent download/walk passes — sandboxed-code modifications
+ *   are dropped on the floor and the original ref is echoed back as
+ *   `inherited: true`, never as a generated artifact.
  * @returns {Promise<{ session_id: string; files: Array<{ fileId: string; filename: string }> }>}
  * @throws {Error} If the batch upload fails entirely.
  */
-async function batchUploadCodeEnvFiles({ req, files, entity_id = '' }) {
+async function batchUploadCodeEnvFiles({ req, files, entity_id = '', read_only = false }) {
   try {
     const form = new FormData();
     if (entity_id.length > 0) {
       form.append('entity_id', entity_id);
+    }
+    if (read_only) {
+      form.append('read_only', 'true');
     }
     for (const file of files) {
       form.append('file', file.stream, file.filename);

--- a/packages/api/src/agents/skillFiles.spec.ts
+++ b/packages/api/src/agents/skillFiles.spec.ts
@@ -106,6 +106,10 @@ describe('primeInvokedSkills — execute_code capability gate', () => {
        auth internally. */
     expect(uploadArgs).not.toHaveProperty('apiKey');
     expect(uploadArgs.entity_id).toBe(SKILL_ID.toString());
+    /* Skill files are infrastructure inputs; the read_only flag tells codeapi
+       to seal them so any sandboxed-code modifications are dropped instead
+       of surfaced as ghost generated artifacts. */
+    expect(uploadArgs.read_only).toBe(true);
     /* One uploaded file per `fileRecords` entry plus the synthetic
        SKILL.md that `primeSkillFiles` always prepends. */
     expect(uploadArgs.files).toHaveLength(fileRecords.length + 1);

--- a/packages/api/src/agents/skillFiles.ts
+++ b/packages/api/src/agents/skillFiles.ts
@@ -27,6 +27,10 @@ export interface PrimeSkillFilesParams {
     req: ServerRequest;
     files: Array<{ stream: NodeJS.ReadableStream; filename: string }>;
     entity_id?: string;
+    /** When true, codeapi tags every file in the batch as infrastructure
+     *  (read-only inputs that must never surface as generated artifacts,
+     *  even if sandboxed code mutates the bytes on disk). */
+    read_only?: boolean;
   }) => Promise<{
     session_id: string;
     files: Array<{ fileId: string; filename: string }>;
@@ -161,6 +165,14 @@ export async function primeSkillFiles(
       req,
       files: filesToUpload,
       entity_id: entityId,
+      /* Skill files are infrastructure: SKILL.md + bundled scripts/schemas/
+       * docs that the agent reads but should never edit. Tag the upload as
+       * read-only so codeapi seals the inputs (chmod 444 in-sandbox) and
+       * walker echoes the original refs as `inherited: true` even if some
+       * sandboxed code path mutates bytes on disk. Without this, modified
+       * skill files surface as ghost generated artifacts the user has no
+       * authority to download. */
+      read_only: true,
     });
     // Exclude SKILL.md from the returned files array — it is uploaded to disk
     // for bash access but has no codeEnvIdentifier (cannot be cached). Omitting


### PR DESCRIPTION
## Summary

Two related fixes for how LibreChat handles files echoed back by the codeapi sandbox in `output.artifact.files`.
### Problem

When a bash/code-interpreter call lists or imports inputs the user already owns (skill files primed via `primeInvokedSkills`, files inherited from a prior session), codeapi echoes those files back in the tool result so subsequent calls retain visibility.

We were treating every entry as a generated artifact and calling `processCodeOutput` on each:

1. **403 storms.** Skill files are uploaded under the skill's `entity_id`, but `processCodeOutput` downloads with the user's session key. Every skill file 403'd — a single bash call that lists 30+ files produces 30+ `Unauthorized download` log lines.
2. **Phantom chips in the UI.** Inputs the agent merely *referenced* show up as if they were generated outputs (~18 ghost chips from a single skill-priming run, see linked issue).
3. **Wasted round-trips.** Even when no auth boundary is crossed, the file is already persisted at its origin — re-downloading achieves nothing.
4. **Modifications surface as ghosts.** Even after gating on the runtime `inherited` flag, any sandboxed code path that mutates a skill file (pip writing pyc near a .py, accidental edits) flows through codeapi's modified-input branch, gets a fresh user-owned `file_id`, uploads as a "generated" output, and shows up as a chip.

### Fix

#### 1. Honor codeapi's runtime `inherited` flag (3 loops)

Skips files where `file.inherited === true` in:
- `api/server/controllers/tools.js` (sync tool invocation)
- `api/server/controllers/agents/callbacks.js` — `createToolEndCallback` (streaming)
- `api/server/controllers/agents/callbacks.js` — `createResponsesToolEndCallback` (Responses API)

```js
for (const file of artifact.files) {
  if (file.inherited) {
    continue;
  }
  // ...processCodeOutput
}
```

Inherited files remain available to subsequent calls via `primeInvokedSkills` / session inheritance — they just don't get redundantly downloaded.

#### 2. Mark skill files `read_only` at upload time

The `inherited` skip only handles unchanged inputs. To prevent *modified* skill files from surfacing as ghosts, this PR also wires the upload-time `read_only` contract added in the codeapi PR:

- `api/server/services/Files/Code/crud.js` — `batchUploadCodeEnvFiles({ ..., read_only })` forwards the flag as a multipart form field. Default `false` preserves existing behavior for user-attached files.
- `packages/api/src/agents/skillFiles.ts` — type signature gains `read_only?: boolean`; `primeSkillFiles` passes `true`.
- `packages/api/src/agents/skillFiles.spec.ts` — asserts the upload call carries `read_only: true`.

Codeapi seals these inputs with `chmod 444` in the sandbox and the walker echoes the original refs as `inherited: true` regardless of `wasModified` — modifications are dropped on the floor.

The flag is intentionally not skill-specific. Any future infrastructure-input flow (system fixtures, cached datasets, etc.) can opt in the same way.

## Test plan

- [x] `node --check` syntax pass for both controllers.
- [x] Lint-staged pre-commit hooks pass (eslint clean).
- [x] `npx jest src/agents/skillFiles.spec.ts` — 4/4 pass; new assertion confirms `read_only: true` is forwarded.
- [ ] Local: invoke a skill that uploads files (e.g. pptx). After the agent's first bash call lists the skill files, log file should be free of `Unauthorized download` errors.
- [ ] Local: UI shows no phantom chips for skill files.
- [ ] Local: subsequent bash calls in the same conversation still see all skill files.
- [ ] Local: agent edits a skill file via bash (e.g. `echo modified > /mnt/data/pptx/SKILL.md`) — original ref still echoed, no new chip appears.
- [ ] Local: user-attached input edited by agent — modified output still surfaces correctly (regression guard).