### PR TITLE
💎 fix: Stop Double-Counting Cache Tokens for Gemini/OpenAI in Usage Spend

### DIFF
--- a/api/server/controllers/agents/callbacks.js
+++ b/api/server/controllers/agents/callbacks.js
@@ -75,6 +75,9 @@ class ModelEndHandler {
       if (modelName) {
         usage.model = modelName;
       }
+      if (agentContext.provider) {
+        usage.provider = agentContext.provider;
+      }
 
       const taggedUsage = markSummarizationUsage(usage, metadata);
 

--- a/packages/api/src/agents/usage.bulk-parity.spec.ts
+++ b/packages/api/src/agents/usage.bulk-parity.spec.ts
@@ -171,8 +171,8 @@ describe('recordCollectedUsage — bulk path parity', () => {
     });
   });
 
-  describe('cache token handling - OpenAI format', () => {
-    it('should route cache entries to structured path — same input_tokens as legacy', async () => {
+  describe('cache token handling - OpenAI format (input_tokens already includes cache)', () => {
+    it('subtracts cache from input portion in bulk docs — same return as legacy', async () => {
       const collectedUsage: UsageMetadata[] = [
         {
           input_tokens: 100,
@@ -184,17 +184,41 @@ describe('recordCollectedUsage — bulk path parity', () => {
 
       const result = await recordCollectedUsage(deps, { ...baseParams, collectedUsage });
 
-      expect(result?.input_tokens).toBe(130); // 100 + 20 + 10
+      expect(result?.input_tokens).toBe(100);
       expect(mockInsertMany).toHaveBeenCalledTimes(1);
       expect(mockSpendStructuredTokens).not.toHaveBeenCalled();
       expect(mockSpendTokens).not.toHaveBeenCalled();
 
       const docs = mockInsertMany.mock.calls[0][0];
       const promptDoc = docs.find((d: { tokenType: string }) => d.tokenType === 'prompt');
-      expect(promptDoc.inputTokens).toBe(-100);
+      expect(promptDoc.inputTokens).toBe(-70);
       expect(promptDoc.writeTokens).toBe(-20);
       expect(promptDoc.readTokens).toBe(-10);
       expect(promptDoc.model).toBe('gpt-4');
+    });
+  });
+
+  describe('cache token handling - Gemini format (input_tokens already includes cache)', () => {
+    it('does not double-count cache_read for Gemini in bulk path — issue #12855', async () => {
+      const collectedUsage: UsageMetadata[] = [
+        {
+          input_tokens: 11125,
+          output_tokens: 20,
+          model: 'gemini-3-flash-preview',
+          input_token_details: { cache_read: 7441 },
+        },
+      ];
+
+      const result = await recordCollectedUsage(deps, { ...baseParams, collectedUsage });
+
+      expect(result?.input_tokens).toBe(11125);
+      expect(mockInsertMany).toHaveBeenCalledTimes(1);
+
+      const docs = mockInsertMany.mock.calls[0][0];
+      const promptDoc = docs.find((d: { tokenType: string }) => d.tokenType === 'prompt');
+      expect(promptDoc.inputTokens).toBe(-3684);
+      expect(promptDoc.readTokens).toBe(-7441);
+      expect(promptDoc.writeTokens || 0).toBe(0);
     });
   });
 

--- a/packages/api/src/agents/usage.bulk-parity.spec.ts
+++ b/packages/api/src/agents/usage.bulk-parity.spec.ts
@@ -171,13 +171,14 @@ describe('recordCollectedUsage — bulk path parity', () => {
     });
   });
 
-  describe('cache token handling - OpenAI format (input_tokens already includes cache)', () => {
-    it('subtracts cache from input portion in bulk docs — same return as legacy', async () => {
+  describe('cache token handling - subset providers (input_tokens already includes cache)', () => {
+    it('subtracts cache from input portion in bulk docs for OpenAI', async () => {
       const collectedUsage: UsageMetadata[] = [
         {
           input_tokens: 100,
           output_tokens: 50,
           model: 'gpt-4',
+          provider: 'openAI',
           input_token_details: { cache_creation: 20, cache_read: 10 },
         },
       ];
@@ -196,15 +197,14 @@ describe('recordCollectedUsage — bulk path parity', () => {
       expect(promptDoc.readTokens).toBe(-10);
       expect(promptDoc.model).toBe('gpt-4');
     });
-  });
 
-  describe('cache token handling - Gemini format (input_tokens already includes cache)', () => {
     it('does not double-count cache_read for Gemini in bulk path — issue #12855', async () => {
       const collectedUsage: UsageMetadata[] = [
         {
           input_tokens: 11125,
           output_tokens: 20,
           model: 'gemini-3-flash-preview',
+          provider: 'google',
           input_token_details: { cache_read: 7441 },
         },
       ];

--- a/packages/api/src/agents/usage.spec.ts
+++ b/packages/api/src/agents/usage.spec.ts
@@ -197,13 +197,14 @@ describe('recordCollectedUsage', () => {
     });
   });
 
-  describe('cache token handling - OpenAI format (input_tokens already includes cache)', () => {
-    it('subtracts cache from input_tokens to avoid double-counting', async () => {
+  describe('cache token handling - subset providers (input_tokens already includes cache)', () => {
+    it('subtracts cache from input_tokens for OpenAI to avoid double-counting', async () => {
       const collectedUsage: UsageMetadata[] = [
         {
           input_tokens: 100,
           output_tokens: 50,
           model: 'gpt-4',
+          provider: 'openAI',
           input_token_details: {
             cache_creation: 20,
             cache_read: 10,
@@ -227,16 +228,15 @@ describe('recordCollectedUsage', () => {
       );
       expect(result?.input_tokens).toBe(100);
     });
-  });
 
-  describe('cache token handling - Gemini format (input_tokens already includes cache)', () => {
-    it('does not double-count cache_read for Gemini models — issue #12855', async () => {
+    it('does not double-count cache_read for Gemini — issue #12855', async () => {
       // Real numbers from the issue report
       const collectedUsage: UsageMetadata[] = [
         {
           input_tokens: 11125,
           output_tokens: 20,
           model: 'gemini-3-flash-preview',
+          provider: 'google',
           input_token_details: { cache_read: 7441 },
         },
       ];
@@ -257,12 +257,38 @@ describe('recordCollectedUsage', () => {
       expect(result?.input_tokens).toBe(11125);
     });
 
+    it('also applies to Vertex AI', async () => {
+      const collectedUsage: UsageMetadata[] = [
+        {
+          input_tokens: 5000,
+          output_tokens: 100,
+          model: 'gemini-2.5-pro',
+          provider: 'vertexai',
+          input_token_details: { cache_read: 4000 },
+        },
+      ];
+
+      await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      expect(mockSpendStructuredTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gemini-2.5-pro' }),
+        {
+          promptTokens: { input: 1000, write: 0, read: 4000 },
+          completionTokens: 100,
+        },
+      );
+    });
+
     it('handles cache_read >= input_tokens defensively (clamps inputOnly to 0)', async () => {
       const collectedUsage: UsageMetadata[] = [
         {
           input_tokens: 1000,
           output_tokens: 30,
           model: 'gemini-2.5-pro',
+          provider: 'google',
           input_token_details: { cache_read: 1000 },
         },
       ];
@@ -279,6 +305,32 @@ describe('recordCollectedUsage', () => {
           completionTokens: 30,
         },
       );
+    });
+
+    it('falls through to additive (historical default) when provider is missing', async () => {
+      // Defensive: an unclassified or pre-this-PR usage entry should keep old behavior
+      const collectedUsage: UsageMetadata[] = [
+        {
+          input_tokens: 100,
+          output_tokens: 50,
+          model: 'gpt-4',
+          input_token_details: { cache_creation: 20, cache_read: 10 },
+        },
+      ];
+
+      const result = await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      expect(mockSpendStructuredTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gpt-4' }),
+        {
+          promptTokens: { input: 100, write: 20, read: 10 },
+          completionTokens: 50,
+        },
+      );
+      expect(result?.input_tokens).toBe(130);
     });
   });
 
@@ -450,6 +502,7 @@ describe('recordCollectedUsage', () => {
           input_tokens: 100,
           output_tokens: 50,
           model: 'gpt-4',
+          provider: 'openAI',
           input_token_details: { cache_creation: 20, cache_read: 10 },
         },
       ];
@@ -459,7 +512,7 @@ describe('recordCollectedUsage', () => {
         collectedUsage,
       });
 
-      // gpt-4 is a subset provider → input_tokens already includes cache
+      // openAI is a subset provider → input_tokens already includes cache
       expect(result).toEqual({ input_tokens: 100, output_tokens: 50 });
     });
   });

--- a/packages/api/src/agents/usage.spec.ts
+++ b/packages/api/src/agents/usage.spec.ts
@@ -197,8 +197,8 @@ describe('recordCollectedUsage', () => {
     });
   });
 
-  describe('cache token handling - OpenAI format', () => {
-    it('should use spendStructuredTokens for cache tokens (input_token_details)', async () => {
+  describe('cache token handling - OpenAI format (input_tokens already includes cache)', () => {
+    it('subtracts cache from input_tokens to avoid double-counting', async () => {
       const collectedUsage: UsageMetadata[] = [
         {
           input_tokens: 100,
@@ -221,11 +221,64 @@ describe('recordCollectedUsage', () => {
       expect(mockSpendStructuredTokens).toHaveBeenCalledWith(
         expect.objectContaining({ model: 'gpt-4' }),
         {
-          promptTokens: { input: 100, write: 20, read: 10 },
+          promptTokens: { input: 70, write: 20, read: 10 },
           completionTokens: 50,
         },
       );
-      expect(result?.input_tokens).toBe(130); // 100 + 20 + 10
+      expect(result?.input_tokens).toBe(100);
+    });
+  });
+
+  describe('cache token handling - Gemini format (input_tokens already includes cache)', () => {
+    it('does not double-count cache_read for Gemini models — issue #12855', async () => {
+      // Real numbers from the issue report
+      const collectedUsage: UsageMetadata[] = [
+        {
+          input_tokens: 11125,
+          output_tokens: 20,
+          model: 'gemini-3-flash-preview',
+          input_token_details: { cache_read: 7441 },
+        },
+      ];
+
+      const result = await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      expect(mockSpendStructuredTokens).toHaveBeenCalledTimes(1);
+      expect(mockSpendStructuredTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gemini-3-flash-preview' }),
+        {
+          promptTokens: { input: 3684, write: 0, read: 7441 },
+          completionTokens: 20,
+        },
+      );
+      expect(result?.input_tokens).toBe(11125);
+    });
+
+    it('handles cache_read >= input_tokens defensively (clamps inputOnly to 0)', async () => {
+      const collectedUsage: UsageMetadata[] = [
+        {
+          input_tokens: 1000,
+          output_tokens: 30,
+          model: 'gemini-2.5-pro',
+          input_token_details: { cache_read: 1000 },
+        },
+      ];
+
+      await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      expect(mockSpendStructuredTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gemini-2.5-pro' }),
+        {
+          promptTokens: { input: 0, write: 0, read: 1000 },
+          completionTokens: 30,
+        },
+      );
     });
   });
 
@@ -406,7 +459,8 @@ describe('recordCollectedUsage', () => {
         collectedUsage,
       });
 
-      expect(result).toEqual({ input_tokens: 130, output_tokens: 50 });
+      // gpt-4 is a subset provider → input_tokens already includes cache
+      expect(result).toEqual({ input_tokens: 100, output_tokens: 50 });
     });
   });
 

--- a/packages/api/src/agents/usage.ts
+++ b/packages/api/src/agents/usage.ts
@@ -22,6 +22,58 @@ type SpendStructuredTokensFn = (
   tokenUsage: StructuredTokenUsage,
 ) => Promise<unknown>;
 
+/**
+ * Provider semantics for `usage_metadata.input_tokens`:
+ *
+ *   - Anthropic / Bedrock: `input_tokens` EXCLUDES cache tokens. Cache reads/writes
+ *     arrive as separate values that must be added on top to get the total prompt size.
+ *   - Gemini / OpenAI: `input_tokens` ALREADY INCLUDES the cached portion
+ *     (Google's `promptTokenCount`, OpenAI's `prompt_tokens`). The cache fields are
+ *     a subset of `input_tokens`, so adding them again double-counts.
+ *
+ * Returning false here means "additive" (the historical default). Add a provider
+ * here only when its `input_tokens` is the all-inclusive total.
+ */
+function inputTokensIncludesCache(model?: string): boolean {
+  if (!model) {
+    return false;
+  }
+  return /^(?:models\/)?(gemini|gpt|o[1-9]|chatgpt)/i.test(model);
+}
+
+interface SplitUsage {
+  /** Non-cached input portion — what gets billed at the standard input rate */
+  inputOnly: number;
+  cacheCreation: number;
+  cacheRead: number;
+  /** Total prompt tokens including cached portion */
+  totalInput: number;
+}
+
+function splitUsage(usage: UsageMetadata, fallbackModel?: string): SplitUsage {
+  const cacheCreation =
+    Number(usage.input_token_details?.cache_creation) ||
+    Number(usage.cache_creation_input_tokens) ||
+    0;
+  const cacheRead =
+    Number(usage.input_token_details?.cache_read) || Number(usage.cache_read_input_tokens) || 0;
+  const rawInput = Number(usage.input_tokens) || 0;
+  if (inputTokensIncludesCache(usage.model ?? fallbackModel)) {
+    return {
+      inputOnly: Math.max(0, rawInput - cacheCreation - cacheRead),
+      cacheCreation,
+      cacheRead,
+      totalInput: rawInput,
+    };
+  }
+  return {
+    inputOnly: rawInput,
+    cacheCreation,
+    cacheRead,
+    totalInput: rawInput + cacheCreation + cacheRead,
+  };
+}
+
 export interface RecordUsageDeps {
   spendTokens: SpendTokensFn;
   spendStructuredTokens: SpendStructuredTokensFn;
@@ -83,16 +135,7 @@ export async function recordCollectedUsage(
   }
 
   const firstUsage = messageUsages[0];
-  const input_tokens =
-    firstUsage == null
-      ? 0
-      : (firstUsage.input_tokens || 0) +
-        (Number(firstUsage.input_token_details?.cache_creation) ||
-          Number(firstUsage.cache_creation_input_tokens) ||
-          0) +
-        (Number(firstUsage.input_token_details?.cache_read) ||
-          Number(firstUsage.cache_read_input_tokens) ||
-          0);
+  const input_tokens = firstUsage == null ? 0 : splitUsage(firstUsage, model).totalInput;
 
   let total_output_tokens = 0;
 
@@ -109,12 +152,7 @@ export async function recordCollectedUsage(
         continue;
       }
 
-      const cache_creation =
-        Number(usage.input_token_details?.cache_creation) ||
-        Number(usage.cache_creation_input_tokens) ||
-        0;
-      const cache_read =
-        Number(usage.input_token_details?.cache_read) || Number(usage.cache_read_input_tokens) || 0;
+      const { inputOnly, cacheCreation, cacheRead } = splitUsage(usage, model);
 
       total_output_tokens += Number(usage.output_tokens) || 0;
 
@@ -131,14 +169,14 @@ export async function recordCollectedUsage(
 
       if (useBulk) {
         const entries =
-          cache_creation > 0 || cache_read > 0
+          cacheCreation > 0 || cacheRead > 0
             ? prepareStructuredTokenSpend(
                 txMetadata,
                 {
                   promptTokens: {
-                    input: usage.input_tokens,
-                    write: cache_creation,
-                    read: cache_read,
+                    input: inputOnly,
+                    write: cacheCreation,
+                    read: cacheRead,
                   },
                   completionTokens: usage.output_tokens,
                 },
@@ -147,7 +185,7 @@ export async function recordCollectedUsage(
             : prepareTokenSpend(
                 txMetadata,
                 {
-                  promptTokens: usage.input_tokens,
+                  promptTokens: inputOnly,
                   completionTokens: usage.output_tokens,
                 },
                 pricing,
@@ -156,13 +194,13 @@ export async function recordCollectedUsage(
         continue;
       }
 
-      if (cache_creation > 0 || cache_read > 0) {
+      if (cacheCreation > 0 || cacheRead > 0) {
         deps
           .spendStructuredTokens(txMetadata, {
             promptTokens: {
-              input: usage.input_tokens,
-              write: cache_creation,
-              read: cache_read,
+              input: inputOnly,
+              write: cacheCreation,
+              read: cacheRead,
             },
             completionTokens: usage.output_tokens,
           })
@@ -177,7 +215,7 @@ export async function recordCollectedUsage(
 
       deps
         .spendTokens(txMetadata, {
-          promptTokens: usage.input_tokens,
+          promptTokens: inputOnly,
           completionTokens: usage.output_tokens,
         })
         .catch((err) => {

--- a/packages/api/src/agents/usage.ts
+++ b/packages/api/src/agents/usage.ts
@@ -1,4 +1,5 @@
 import { logger } from '@librechat/data-schemas';
+import { Providers } from 'librechat-data-provider';
 import type { TCustomConfig, TTransactionsConfig } from 'librechat-data-provider';
 import type {
   StructuredTokenUsage,
@@ -23,22 +24,30 @@ type SpendStructuredTokensFn = (
 ) => Promise<unknown>;
 
 /**
- * Provider semantics for `usage_metadata.input_tokens`:
+ * Providers whose `usage_metadata.input_tokens` ALREADY INCLUDES cached tokens
+ * (i.e. `input_token_details.cache_*` is a subset, not an additional charge):
  *
- *   - Anthropic / Bedrock: `input_tokens` EXCLUDES cache tokens. Cache reads/writes
- *     arrive as separate values that must be added on top to get the total prompt size.
- *   - Gemini / OpenAI: `input_tokens` ALREADY INCLUDES the cached portion
- *     (Google's `promptTokenCount`, OpenAI's `prompt_tokens`). The cache fields are
- *     a subset of `input_tokens`, so adding them again double-counts.
+ *   - Google / Vertex AI: `input_tokens` = `promptTokenCount` (includes `cachedContentTokenCount`)
+ *   - OpenAI / Azure OpenAI: `input_tokens` = `prompt_tokens` (includes `prompt_tokens_details.cached_tokens`)
+ *   - xAI, DeepSeek, OpenRouter, Moonshot: extend `ChatOpenAI`, same semantics
  *
- * Returning false here means "additive" (the historical default). Add a provider
- * here only when its `input_tokens` is the all-inclusive total.
+ * Anthropic and Bedrock keep cache values separate from `input_tokens`, so they
+ * must be added back to compute the total prompt size — that's the historical
+ * additive default. Providers not listed here fall through to additive.
  */
-function inputTokensIncludesCache(model?: string): boolean {
-  if (!model) {
-    return false;
-  }
-  return /^(?:models\/)?(gemini|gpt|o[1-9]|chatgpt)/i.test(model);
+const SUBSET_PROVIDERS: ReadonlySet<string> = new Set([
+  Providers.OPENAI,
+  Providers.AZURE,
+  Providers.GOOGLE,
+  Providers.VERTEXAI,
+  Providers.XAI,
+  Providers.DEEPSEEK,
+  Providers.OPENROUTER,
+  Providers.MOONSHOT,
+]);
+
+function inputTokensIncludesCache(provider?: string): boolean {
+  return provider != null && SUBSET_PROVIDERS.has(provider);
 }
 
 interface SplitUsage {
@@ -50,7 +59,7 @@ interface SplitUsage {
   totalInput: number;
 }
 
-function splitUsage(usage: UsageMetadata, fallbackModel?: string): SplitUsage {
+function splitUsage(usage: UsageMetadata): SplitUsage {
   const cacheCreation =
     Number(usage.input_token_details?.cache_creation) ||
     Number(usage.cache_creation_input_tokens) ||
@@ -58,7 +67,7 @@ function splitUsage(usage: UsageMetadata, fallbackModel?: string): SplitUsage {
   const cacheRead =
     Number(usage.input_token_details?.cache_read) || Number(usage.cache_read_input_tokens) || 0;
   const rawInput = Number(usage.input_tokens) || 0;
-  if (inputTokensIncludesCache(usage.model ?? fallbackModel)) {
+  if (inputTokensIncludesCache(usage.provider)) {
     return {
       inputOnly: Math.max(0, rawInput - cacheCreation - cacheRead),
       cacheCreation,
@@ -135,7 +144,7 @@ export async function recordCollectedUsage(
   }
 
   const firstUsage = messageUsages[0];
-  const input_tokens = firstUsage == null ? 0 : splitUsage(firstUsage, model).totalInput;
+  const input_tokens = firstUsage == null ? 0 : splitUsage(firstUsage).totalInput;
 
   let total_output_tokens = 0;
 
@@ -152,7 +161,7 @@ export async function recordCollectedUsage(
         continue;
       }
 
-      const { inputOnly, cacheCreation, cacheRead } = splitUsage(usage, model);
+      const { inputOnly, cacheCreation, cacheRead } = splitUsage(usage);
 
       total_output_tokens += Number(usage.output_tokens) || 0;
 


### PR DESCRIPTION
## Summary

Closes [#12855](https://github.com/danny-avila/LibreChat/issues/12855).

`recordCollectedUsage` was double-counting cache tokens for Gemini (and OpenAI) because it treated `input_token_details.cache_*` as **additive** for every provider — but Gemini/OpenAI's `input_tokens` already includes the cached portion. Anthropic and Bedrock are unaffected.

### Provider semantics

| Provider | `input_tokens` semantics | `cache_read` |
|---|---|---|
| Anthropic | **Excludes** cache | additive (separate field) |
| Bedrock Converse | **Excludes** cache | additive (separate field) |
| **Google / Vertex AI** | **Includes** cached (`promptTokenCount`) | **subset** of `input_tokens` |
| **OpenAI / Azure OpenAI** | **Includes** cached (`prompt_tokens`) | **subset** of `input_tokens` |
| **xAI / DeepSeek / OpenRouter / Moonshot** | inherits from `ChatOpenAI` | **subset** |

Verified against `@langchain/anthropic`, `@langchain/openai`, `@langchain/xai`, `@langchain/deepseek`, and `@librechat/agents` (`google/`, `bedrock/`, `openrouter/`) usage-metadata mappings.

### What changed

`UsageMetadata.provider` already existed in [IJobStore.ts](packages/api/src/stream/interfaces/IJobStore.ts) but was never being populated. Two-part fix:

1. **[`callbacks.js#ModelEndHandler`](api/server/controllers/agents/callbacks.js)** — attaches `usage.provider = agentContext.provider` alongside `usage.model` when it builds each usage entry.
2. **[`usage.ts`](packages/api/src/agents/usage.ts)** — classifies via `SUBSET_PROVIDERS` (a `Set` of `Providers` enum values from `librechat-data-provider`), not a model-name regex. New helpers:
   - `inputTokensIncludesCache(provider)` — true when `usage_metadata.input_tokens` already contains the cached portion.
   - `splitUsage(usage)` returns `{ inputOnly, cacheCreation, cacheRead, totalInput }` — used by both spend paths and the returned summary.

`inputOnly = input_tokens − cache_read − cache_creation` for subset providers, clamped to zero. Additive providers (the historical default) are bit-identical to before. **Missing-provider entries fall through to additive** so the title-generation flow (which doesn't propagate provider) and any pre-this-PR usage records keep their existing behavior.

### Impact for affected users

From the issue report (a real Gemini cache-hit request):

```
input_tokens = 11125, cache_read = 7441
Before: billed 11125 + 7441 = 18566 prompt tokens (1.67x overcharge)
After:  billed 11125 prompt tokens (3684 input + 7441 cache_read), matching GCP
```

At ~95% cache-hit rate the overcharge approached **2.9x**.

### Tests

- Updated existing OpenAI cache test in `usage.spec.ts` and `usage.bulk-parity.spec.ts` — they previously asserted the buggy additive math.
- Added Gemini regression tests using the exact numbers from the issue (`input=11125, cache_read=7441 → input portion=3684`).
- Added a Vertex AI test (separate provider value, same semantics).
- Added a "missing provider falls through to additive" test to lock in the safe default.
- Added a defensive test for `cache_read >= input_tokens` (clamps to 0 instead of going negative).
- Anthropic/Bedrock test paths are unchanged and pass bit-identically.

```
Test Suites: 2 passed, 2 total
Tests:       68 passed, 68 total
```

(Pre-existing failures in `validation.spec.ts`, `handlers.spec.ts`, `summarization.e2e.test.ts` exist on `origin/dev` without these changes — unrelated.)

## Test plan

- [x] Unit: `usage.spec.ts` + `usage.bulk-parity.spec.ts` — 68 pass
- [x] Unit: transactions tests still pass — 40 pass
- [x] TypeScript: no new errors in touched files
- [ ] Manual smoke: agent conversation with Gemini cache hit, confirm `transactions` collection records the non-doubled value
- [ ] Manual smoke: agent conversation with Claude (cache hit) — confirm bill amount unchanged from before this PR