### PR TITLE
feat: add Bedrock prompt cache TTL config

### DIFF
--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -75,6 +75,12 @@ librechat:
   #   registration:
   #     socialLogins: ["discord", "facebook", "github", "google", "openid"] 
   #   endpoints:
+  #     bedrock:
+  #       models:
+  #         - "anthropic.claude-sonnet-4-5-20250929-v1:0"
+  #       # Optional. Use "1h" only with Bedrock models that support 1-hour prompt cache TTL.
+  #       # Omit this field to keep Bedrock's default 5-minute prompt cache TTL.
+  #       promptCacheTtl: "1h"
   #     azureOpenAI:
   #      # Endpoint-level configuration
   #      titleModel: "gpt-4o"

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -552,6 +552,12 @@ endpoints:
   #     - "anthropic.claude-3-7-sonnet-20250219-v1:0"
   #     - "anthropic.claude-3-5-sonnet-20241022-v2:0"
   #
+  #   # Prompt Cache TTL
+  #   # Optional. Bedrock supports 5-minute cache checkpoints, and 1-hour checkpoints
+  #   # for Claude 4.5 models. When omitted, Bedrock uses its default 5-minute TTL.
+  #   # Reference: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CachePointBlock.html
+  #   promptCacheTtl: "1h"
+  #
   #   # Inference Profiles Configuration
   #   # Maps model IDs to their inference profile ARNs
   #   # IMPORTANT: The model ID (key) MUST be a valid AWS Bedrock model ID that you've added to the models list above

--- a/packages/api/src/endpoints/bedrock/initialize.spec.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.spec.ts
@@ -109,6 +109,81 @@ describe('initializeBedrock', () => {
       expect(result.llmConfig).toHaveProperty('region', 'us-east-1');
     });
 
+    it('should include promptCacheTtl from Bedrock endpoint config', async () => {
+      const params = createMockParams({
+        model_parameters: {
+          model: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+        },
+        config: {
+          endpoints: {
+            [EModelEndpoint.bedrock]: {
+              promptCacheTtl: '1h',
+            },
+          },
+        },
+      });
+      const result = await initializeBedrock(params);
+
+      expect(result.llmConfig).toHaveProperty('promptCacheTtl', '1h');
+      expect(result.llmConfig).toHaveProperty('promptCache', true);
+    });
+
+    it('should omit one-hour promptCacheTtl for models that only support 5 minutes', async () => {
+      const params = createMockParams({
+        config: {
+          endpoints: {
+            [EModelEndpoint.bedrock]: {
+              promptCacheTtl: '1h',
+            },
+          },
+        },
+      });
+      const result = await initializeBedrock(params);
+
+      expect(result.llmConfig).not.toHaveProperty('promptCacheTtl');
+      expect(result.llmConfig).toHaveProperty('promptCache', true);
+    });
+
+    it('should not include promptCacheTtl when not configured', async () => {
+      const params = createMockParams();
+      const result = await initializeBedrock(params);
+
+      expect(result.llmConfig).not.toHaveProperty('promptCacheTtl');
+    });
+
+    it('should not allow model parameters to enable promptCacheTtl without endpoint config', async () => {
+      const params = createMockParams({
+        model_parameters: {
+          model: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+          promptCacheTtl: '1h',
+        },
+      });
+      const result = await initializeBedrock(params);
+
+      expect(result.llmConfig).not.toHaveProperty('promptCacheTtl');
+      expect(result.llmConfig).toHaveProperty('promptCache', true);
+    });
+
+    it('should prefer Bedrock endpoint promptCacheTtl over model parameters', async () => {
+      const params = createMockParams({
+        model_parameters: {
+          model: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+          promptCacheTtl: '5m',
+        },
+        config: {
+          endpoints: {
+            [EModelEndpoint.bedrock]: {
+              promptCacheTtl: '1h',
+            },
+          },
+        },
+      });
+      const result = await initializeBedrock(params);
+
+      expect(result.llmConfig).toHaveProperty('promptCacheTtl', '1h');
+      expect(result.llmConfig).toHaveProperty('promptCache', true);
+    });
+
     it('should handle model_parameters', async () => {
       const params = createMockParams({
         model_parameters: {

--- a/packages/api/src/endpoints/bedrock/initialize.ts
+++ b/packages/api/src/endpoints/bedrock/initialize.ts
@@ -15,6 +15,7 @@ import type {
   BaseInitializeParams,
   InitializeResultBase,
   BedrockCredentials,
+  BedrockPromptCacheTtl,
   GuardrailConfiguration,
   InferenceProfileConfig,
 } from '~/types';
@@ -106,6 +107,7 @@ export async function initializeBedrock({
     | ({
         guardrailConfig?: GuardrailConfiguration;
         inferenceProfiles?: InferenceProfileConfig;
+        promptCacheTtl?: BedrockPromptCacheTtl;
       } & Record<string, unknown>)
     | undefined;
 
@@ -210,6 +212,7 @@ export async function initializeBedrock({
   const requestOptions: Record<string, unknown> = {
     model: model_parameters?.model as string | undefined,
     region: BEDROCK_AWS_DEFAULT_REGION,
+    promptCacheTtl: bedrockConfig?.promptCacheTtl,
   };
 
   const configOptions: Record<string, unknown> = {};
@@ -217,8 +220,8 @@ export async function initializeBedrock({
   const llmConfig = bedrockOutputParser(
     bedrockInputParser.parse(
       removeNullishValues({
-        ...requestOptions,
         ...(model_parameters ?? {}),
+        ...requestOptions,
       }),
     ),
   ) as InitializeResultBase['llmConfig'] & {
@@ -230,6 +233,7 @@ export async function initializeBedrock({
     profile?: string;
     guardrailConfig?: GuardrailConfiguration;
     applicationInferenceProfile?: string;
+    promptCacheTtl?: BedrockPromptCacheTtl;
   };
 
   if (bedrockConfig?.guardrailConfig) {

--- a/packages/api/src/types/bedrock.ts
+++ b/packages/api/src/types/bedrock.ts
@@ -36,6 +36,7 @@ export interface GuardrailConfiguration {
  * @see https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles.html
  */
 export type InferenceProfileConfig = Record<string, string>;
+export type BedrockPromptCacheTtl = '5m' | '1h';
 
 /**
  * Configuration options for Bedrock LLM
@@ -56,6 +57,8 @@ export interface BedrockConfigOptions {
   guardrailConfig?: GuardrailConfiguration;
   /** Inference profile ARNs keyed by model ID / friendly name */
   inferenceProfiles?: InferenceProfileConfig;
+  /** Bedrock prompt cache checkpoint TTL. Defaults to Bedrock's 5-minute TTL when unset. */
+  promptCacheTtl?: BedrockPromptCacheTtl;
 }
 
 /**
@@ -70,6 +73,7 @@ export interface BedrockLLMConfigResult {
     endpointHost?: string;
     guardrailConfig?: GuardrailConfiguration;
     applicationInferenceProfile?: string;
+    promptCacheTtl?: BedrockPromptCacheTtl;
   };
   configOptions: Record<string, unknown>;
 }

--- a/packages/data-provider/specs/bedrock.spec.ts
+++ b/packages/data-provider/specs/bedrock.spec.ts
@@ -998,6 +998,68 @@ describe('bedrockInputParser', () => {
       expect(result.promptCache).toBe(true);
     });
 
+    test('should preserve one-hour promptCacheTtl for Claude 4.5 models', () => {
+      const input = {
+        model: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+        promptCache: true,
+        promptCacheTtl: '1h',
+      };
+      const result = bedrockInputParser.parse(input) as Record<string, unknown>;
+      expect(result.promptCache).toBe(true);
+      expect(result.promptCacheTtl).toBe('1h');
+    });
+
+    test('should strip one-hour promptCacheTtl for models that only support 5 minutes', () => {
+      const result = bedrockInputParser.parse({
+        model: 'amazon.nova-pro-v1:0',
+        promptCache: true,
+        promptCacheTtl: '1h',
+      }) as Record<string, unknown>;
+      expect(result.promptCache).toBe(true);
+      expect(result.promptCacheTtl).toBeUndefined();
+    });
+
+    test('should preserve explicit 5-minute promptCacheTtl for Nova models', () => {
+      const input = {
+        model: 'amazon.nova-pro-v1:0',
+        promptCache: true,
+        promptCacheTtl: '5m',
+      };
+      const result = bedrockInputParser.parse(input) as Record<string, unknown>;
+      expect(result.promptCache).toBe(true);
+      expect(result.promptCacheTtl).toBe('5m');
+    });
+
+    test('should strip promptCacheTtl when promptCache is disabled', () => {
+      const input = {
+        model: 'anthropic.claude-sonnet-4-20250514-v1:0',
+        promptCache: false,
+        promptCacheTtl: '1h',
+      };
+      const result = bedrockInputParser.parse(input) as Record<string, unknown>;
+      expect(result.promptCache).toBe(false);
+      expect(result.promptCacheTtl).toBeUndefined();
+    });
+
+    test('should strip stale promptCacheTtl when switching to non-Claude/Nova model', () => {
+      const staleConversationData = {
+        model: 'deepseek.deepseek-r1',
+        promptCacheTtl: '1h',
+      };
+      const result = bedrockInputParser.parse(staleConversationData) as Record<string, unknown>;
+      expect(result.promptCacheTtl).toBeUndefined();
+    });
+
+    test('bedrockInputSchema should strip stale promptCacheTtl when promptCache is disabled', () => {
+      const result = bedrockInputSchema.parse({
+        model: 'anthropic.claude-sonnet-4-20250514-v1:0',
+        promptCache: false,
+        promptCacheTtl: '1h',
+      }) as Record<string, unknown>;
+      expect(result.promptCache).toBe(false);
+      expect(result.promptCacheTtl).toBeUndefined();
+    });
+
     test('should strip stale thinking config from additionalModelRequestFields for non-Anthropic models', () => {
       const staleConversationData = {
         model: 'moonshot.kimi-k2-0711-thinking',

--- a/packages/data-provider/src/bedrock.ts
+++ b/packages/data-provider/src/bedrock.ts
@@ -40,6 +40,42 @@ function extractPersistedDisplay(amrf: unknown): string | undefined {
   return typeof display === 'string' ? display : undefined;
 }
 
+function supportsBedrockPromptCache(model: unknown): boolean {
+  return typeof model === 'string' && (model.includes('claude') || model.includes('nova'));
+}
+
+function supportsOneHourBedrockPromptCache(model: unknown): boolean {
+  if (typeof model !== 'string') {
+    return false;
+  }
+
+  return (
+    model.includes('anthropic.claude-opus-4-5') ||
+    model.includes('anthropic.claude-sonnet-4-5') ||
+    model.includes('anthropic.claude-haiku-4-5')
+  );
+}
+
+function normalizeBedrockPromptCache(data: Record<string, unknown>) {
+  if (supportsBedrockPromptCache(data.model)) {
+    if (data.promptCache === undefined) {
+      data.promptCache = true;
+    }
+    if (data.promptCacheTtl === '1h' && !supportsOneHourBedrockPromptCache(data.model)) {
+      data.promptCacheTtl = undefined;
+    }
+  } else {
+    if (data.promptCache === true) {
+      data.promptCache = undefined;
+    }
+    data.promptCacheTtl = undefined;
+  }
+
+  if (data.promptCache === false) {
+    data.promptCacheTtl = undefined;
+  }
+}
+
 export function resolveThinkingDisplay(
   model: string,
   explicit?: s.ThinkingDisplay | string | null,
@@ -235,6 +271,7 @@ export const bedrockInputSchema = s.tConversationSchema
     thinkingDisplay: true,
     reasoning_effort: true,
     promptCache: true,
+    promptCacheTtl: true,
     /* Catch-all fields */
     topK: true,
     additionalModelRequestFields: true,
@@ -259,6 +296,7 @@ export const bedrockInputSchema = s.tConversationSchema
       }
       delete obj.additionalModelRequestFields;
     }
+    normalizeBedrockPromptCache(obj as Record<string, unknown>);
     return s.removeNullishValues(obj);
   })
   .catch(() => ({}));
@@ -290,6 +328,7 @@ export const bedrockInputParser = s.tConversationSchema
     thinkingDisplay: true,
     reasoning_effort: true,
     promptCache: true,
+    promptCacheTtl: true,
     /* Catch-all fields */
     topK: true,
     additionalModelRequestFields: true,
@@ -313,6 +352,7 @@ export const bedrockInputParser = s.tConversationSchema
       'topP',
       'stop',
       'promptCache',
+      'promptCacheTtl',
     ];
 
     const additionalFields: Record<string, unknown> = {};
@@ -468,16 +508,7 @@ export const bedrockInputParser = s.tConversationSchema
     }
 
     /** Default promptCache for claude and nova models, if not defined */
-    if (
-      typeof typedData.model === 'string' &&
-      (typedData.model.includes('claude') || typedData.model.includes('nova'))
-    ) {
-      if (typedData.promptCache === undefined) {
-        typedData.promptCache = true;
-      }
-    } else if (typedData.promptCache === true) {
-      typedData.promptCache = undefined;
-    }
+    normalizeBedrockPromptCache(typedData);
 
     if (Object.keys(additionalFields).length > 0) {
       typedData.additionalModelRequestFields = {

--- a/packages/data-provider/src/config.spec.ts
+++ b/packages/data-provider/src/config.spec.ts
@@ -3,6 +3,7 @@ import { EModelEndpoint, isDocumentSupportedProvider } from './schemas';
 import { getEndpointFileConfig, mergeFileConfig } from './file-config';
 import {
   allowedAddressesSchema,
+  bedrockEndpointSchema,
   configSchema,
   excludedKeys,
   resolveEndpointType,
@@ -54,6 +55,15 @@ describe('bedrockEndpointSchema', () => {
       return;
     }
     expect(result.data.endpoints?.bedrock?.guardrailConfig).toEqual(guardrailConfig);
+  });
+
+  it('accepts supported Bedrock prompt cache TTL values', () => {
+    expect(bedrockEndpointSchema.parse({ promptCacheTtl: '5m' }).promptCacheTtl).toBe('5m');
+    expect(bedrockEndpointSchema.parse({ promptCacheTtl: '1h' }).promptCacheTtl).toBe('1h');
+  });
+
+  it('rejects unsupported Bedrock prompt cache TTL values', () => {
+    expect(() => bedrockEndpointSchema.parse({ promptCacheTtl: '30m' })).toThrow();
   });
 });
 

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -416,6 +416,7 @@ export const bedrockEndpointSchema = baseEndpointSchema.merge(
     models: z.array(z.string()).optional(),
     guardrailConfig: bedrockGuardrailConfigSchema.optional(),
     inferenceProfiles: z.record(z.string(), z.string()).optional(),
+    promptCacheTtl: z.enum(['5m', '1h']).optional(),
   }),
 );
 

--- a/packages/data-provider/src/schemas.ts
+++ b/packages/data-provider/src/schemas.ts
@@ -800,8 +800,11 @@ export const tConversationSchema = z.object({
   maxOutputTokens: coerceNumber.nullable().optional(),
   maxContextTokens: coerceNumber.optional(),
   max_tokens: coerceNumber.optional(),
-  /* Anthropic */
+  /* Anthropic/Bedrock */
   promptCache: z.boolean().optional(),
+  /* Bedrock */
+  promptCacheTtl: z.enum(['5m', '1h']).optional(),
+  /* Anthropic */
   system: z.string().optional(),
   thinking: z.boolean().optional(),
   thinkingBudget: coerceNumber.optional(),
@@ -953,6 +956,8 @@ export const tQueryParamsSchema = tConversationSchema
     maxOutputTokens: true,
     /** @endpoints anthropic */
     promptCache: true,
+    /** @endpoints bedrock */
+    promptCacheTtl: true,
     thinking: true,
     thinkingBudget: true,
     thinkingLevel: true,

--- a/packages/data-provider/src/types.ts
+++ b/packages/data-provider/src/types.ts
@@ -49,8 +49,11 @@ export type TEndpointOption = Pick<
   | 'stop'
   | 'region'
   | 'additionalModelRequestFields'
-  // Anthropic-specific
+  // Anthropic/Bedrock
   | 'promptCache'
+  // Bedrock-specific
+  | 'promptCacheTtl'
+  // Anthropic-specific
   | 'thinking'
   | 'thinkingBudget'
   | 'thinkingLevel'

--- a/packages/data-schemas/src/schema/defaults.ts
+++ b/packages/data-schemas/src/schema/defaults.ts
@@ -73,10 +73,16 @@ export const conversationPreset = {
   resendImages: {
     type: Boolean,
   },
-  /* Anthropic only */
+  /* Anthropic/Bedrock */
   promptCache: {
     type: Boolean,
   },
+  /* Bedrock */
+  promptCacheTtl: {
+    type: String,
+    enum: ['5m', '1h'],
+  },
+  /* Anthropic */
   thinking: {
     type: Boolean,
   },

--- a/packages/data-schemas/src/schema/preset.ts
+++ b/packages/data-schemas/src/schema/preset.ts
@@ -28,6 +28,7 @@ export interface IPreset extends Document {
   file_ids?: string[];
   resendImages?: boolean;
   promptCache?: boolean;
+  promptCacheTtl?: '5m' | '1h';
   thinking?: boolean;
   thinkingBudget?: number;
   effort?: string;

--- a/packages/data-schemas/src/types/convo.ts
+++ b/packages/data-schemas/src/types/convo.ts
@@ -27,6 +27,7 @@ export interface IConversation extends Document {
   file_ids?: string[];
   resendImages?: boolean;
   promptCache?: boolean;
+  promptCacheTtl?: '5m' | '1h';
   thinking?: boolean;
   thinkingBudget?: number;
   effort?: string;


### PR DESCRIPTION
## Summary

Bedrock prompt caching now supports both 5-minute and 1-hour cache checkpoint TTLs. This PR adds an optional `endpoints.bedrock.promptCacheTtl` YAML config so LibreChat admins can choose `5m` or `1h`; when the setting is omitted, LibreChat does not send a TTL and Bedrock keeps the existing 5-minute default behavior.

This is useful for longer Bedrock/Claude sessions where users reuse large system prompts, tools, or reference context across turns that may be more than five minutes apart. The 1-hour TTL lets supported Bedrock Claude 4.5 models retain those cache checkpoints longer when the admin explicitly opts in.

## Changes

- Add Bedrock endpoint config validation for `promptCacheTtl: "5m" | "1h"`
- Pass `promptCacheTtl` from `librechat.yaml` into Bedrock `llmConfig`
- Preserve `1h` only for Claude 4.5 Bedrock model IDs, and strip stale/unsupported TTL values so unsupported models fall back to Bedrock default 5-minute behavior
- Preserve explicit `5m` for prompt-cache-supported Claude/Nova models
- Strip TTL when prompt caching is disabled or when the selected model does not support Bedrock prompt caching
- Add conversation/preset schema support for the new value
- Document the YAML option in `librechat.example.yaml` and the Helm `configYamlContent` example

## Deployment configuration

Docker/Compose users can set this in the mounted `librechat.yaml` file. Helm users can set the same YAML under `librechat.configYamlContent`, or provide an existing ConfigMap through `librechat.existingConfigYaml` with a `librechat.yaml` key.

```yaml
endpoints:
  bedrock:
    models:
      - "anthropic.claude-sonnet-4-5-20250929-v1:0"
    promptCacheTtl: "1h"
```

## References

- AWS CachePointBlock API reference: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CachePointBlock.html
- AWS Bedrock prompt caching guide: https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html
- AWS announcement for 1-hour prompt caching: https://aws.amazon.com/about-aws/whats-new/2026/01/amazon-bedrock-one-hour-duration-prompt-caching/
- Depends on agents runtime support for emitting `cachePoint.ttl`: https://github.com/danny-avila/agents/pull/123

## Testing

- `cd packages/data-provider && npx jest specs/bedrock.spec.ts src/config.spec.ts --runInBand --coverage=false`
- `npm run build:data-provider`
- `cd packages/api && npx jest src/endpoints/bedrock/initialize.spec.ts --runInBand --coverage=false`
- `npm run build:data-schemas`
- `helm lint helm/librechat`
- `helm template bedrock-test helm/librechat -f <values-with-bedrock-promptCacheTtl.yaml>`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml config`
- `docker compose -f deploy-compose.yml config`
- `git diff --check`