### PR TITLE
📂 fix: Preserve Nested Skill Paths in Code-Env Uploads

### DIFF
--- a/api/server/services/Files/Code/crud.js
+++ b/api/server/services/Files/Code/crud.js
@@ -2,6 +2,7 @@ const FormData = require('form-data');
 const { logger } = require('@librechat/data-schemas');
 const { getCodeBaseURL } = require('@librechat/agents');
 const {
+  appendCodeEnvFile,
   logAxiosError,
   createAxiosInstance,
   codeServerHttpAgent,
@@ -62,7 +63,7 @@ async function uploadCodeEnvFile({ req, stream, filename, entity_id = '' }) {
     if (entity_id.length > 0) {
       form.append('entity_id', entity_id);
     }
-    form.append('file', stream, filename);
+    appendCodeEnvFile(form, stream, filename);
 
     const baseURL = getCodeBaseURL();
     /** @type {import('axios').AxiosRequestConfig} */
@@ -131,7 +132,7 @@ async function batchUploadCodeEnvFiles({ req, files, entity_id = '', read_only =
       form.append('read_only', 'true');
     }
     for (const file of files) {
-      form.append('file', file.stream, file.filename);
+      appendCodeEnvFile(form, file.stream, file.filename);
     }
 
     const baseURL = getCodeBaseURL();

--- a/api/server/services/Files/Code/crud.js
+++ b/api/server/services/Files/Code/crud.js
@@ -2,8 +2,8 @@ const FormData = require('form-data');
 const { logger } = require('@librechat/data-schemas');
 const { getCodeBaseURL } = require('@librechat/agents');
 const {
-  appendCodeEnvFile,
   logAxiosError,
+  appendCodeEnvFile,
   createAxiosInstance,
   codeServerHttpAgent,
   codeServerHttpsAgent,

--- a/api/server/services/Files/Code/crud.spec.js
+++ b/api/server/services/Files/Code/crud.spec.js
@@ -13,6 +13,9 @@ jest.mock('@librechat/api', () => {
   const http = require('http');
   const https = require('https');
   return {
+    appendCodeEnvFile: jest.fn((form, stream, filename) => {
+      form.append('file', stream, { filename });
+    }),
     logAxiosError: jest.fn(({ message }) => message),
     createAxiosInstance: jest.fn(() => mockAxios),
     codeServerHttpAgent: new http.Agent({ keepAlive: false }),

--- a/packages/api/src/files/code/form.spec.ts
+++ b/packages/api/src/files/code/form.spec.ts
@@ -1,0 +1,52 @@
+import { Readable } from 'stream';
+import FormData from 'form-data';
+
+import { appendCodeEnvFile, getCodeEnvFileOptions } from './form';
+
+function renderMultipartDisposition(append: (form: FormData) => void): Promise<string> {
+  const form = new FormData();
+  append(form);
+
+  const chunks: Buffer[] = [];
+  form.on('data', (chunk: Buffer | string) => {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  });
+
+  return new Promise<string>((resolve, reject) => {
+    form.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf8');
+      resolve(body.match(/Content-Disposition:.*/)?.[0] ?? '');
+    });
+    form.on('error', reject);
+    form.resume();
+  });
+}
+
+describe('code env FormData filenames', () => {
+  it('uses filepath for nested filenames so form-data preserves directories', async () => {
+    const disposition = await renderMultipartDisposition((form) => {
+      appendCodeEnvFile(form, Readable.from(['x']), 'pptx/pptx.py');
+    });
+
+    expect(disposition).toContain('filename="pptx/pptx.py"');
+  });
+
+  it('documents the form-data string overload regression', async () => {
+    const disposition = await renderMultipartDisposition((form) => {
+      form.append('file', Readable.from(['x']), 'pptx/pptx.py');
+    });
+
+    expect(disposition).toContain('filename="pptx.py"');
+  });
+
+  it('keeps flat filenames as filename-only options', () => {
+    expect(getCodeEnvFileOptions('script.py')).toEqual({ filename: 'script.py' });
+  });
+
+  it('normalizes Windows separators before sending path-bearing filenames', () => {
+    expect(getCodeEnvFileOptions('pptx\\pptx.py')).toEqual({
+      filename: 'pptx.py',
+      filepath: 'pptx/pptx.py',
+    });
+  });
+});

--- a/packages/api/src/files/code/form.ts
+++ b/packages/api/src/files/code/form.ts
@@ -1,0 +1,31 @@
+import * as path from 'path';
+
+import type FormData from 'form-data';
+
+export interface CodeEnvFileOptions {
+  filename: string;
+  filepath?: string;
+}
+
+/**
+ * Uses `filepath` for nested names because `form-data` strips directories from
+ * the bare string filename overload before codeapi can preserve them.
+ */
+export function getCodeEnvFileOptions(filename: string): CodeEnvFileOptions {
+  const normalized = filename.replace(/\\/g, '/');
+  const basename = path.posix.basename(normalized);
+
+  if (normalized === basename) {
+    return { filename };
+  }
+
+  return { filename: basename, filepath: normalized };
+}
+
+export function appendCodeEnvFile(
+  form: FormData,
+  stream: NodeJS.ReadableStream,
+  filename: string,
+): void {
+  form.append('file', stream, getCodeEnvFileOptions(filename));
+}

--- a/packages/api/src/files/code/index.ts
+++ b/packages/api/src/files/code/index.ts
@@ -1,2 +1,3 @@
 export * from './classify';
 export * from './extract';
+export * from './form';


### PR DESCRIPTION
## Summary

Fixes the LibreChat half of nested code-environment file uploads. Skill priming builds filenames like `pptx/pptx.py`, but the Node `form-data` string overload silently converts that to `filename="pptx.py"` before CodeAPI receives the multipart request.

The new backend logic lives in `packages/api`: `appendCodeEnvFile` uses the `form-data` `filepath` option for path-bearing names so the multipart filename remains `pptx/pptx.py`. The legacy `/api` upload service only imports that package helper and applies it to single-file and batch CodeEnv uploads.

CodeAPI already has `busboy({ preservePath: true })`, header encoding, RFC 5987 download parsing, and recursive sandbox placement, so this lets the existing server-side path preservation finally see the path LibreChat intended to send.

## Root Cause

`form.append("file", stream, "pptx/pptx.py")` does not send that string verbatim. In `form-data`, the bare string overload is treated as `options.filename` and passed through `path.basename`, producing:

```http
Content-Disposition: form-data; name="file"; filename="pptx.py"
```

Using `filepath` produces the path-bearing multipart header CodeAPI expects:

```http
Content-Disposition: form-data; name="file"; filename="pptx/pptx.py"
```

Without this, skill helper modules still land flat at `/mnt/data/pptx.py` and can shadow installed packages like `python-pptx`.

## Changes

- Add a TypeScript CodeEnv FormData helper in `packages/api/src/files/code/form.ts` that uses `{ filename, filepath }` for nested filenames and normalizes Windows separators.
- Export the helper from `@librechat/api` and keep `/api/server/services/Files/Code/crud.js` as the thin legacy caller.
- Add regression coverage showing the bare string overload strips paths and the package helper preserves them.

## Test Plan

- [x] `cd packages/api && npx jest src/files/code/form.spec.ts --runInBand`
- [x] `cd api && npx jest server/services/Files/Code/crud.spec.js --runInBand`
- [x] `cd packages/api && npm run build`
- [x] `npx eslint packages/api/src/files/code/form.ts packages/api/src/files/code/form.spec.ts api/server/services/Files/Code/crud.js api/server/services/Files/Code/crud.spec.js`
- [ ] Local integration: prime the pptx skill and confirm `/mnt/data/pptx/pptx.py` exists while `/mnt/data/pptx.py` does not.

## Related

Pairs with ClickHouse/ai#1358 for CodeAPI-side internal header hardening.
