### PR TITLE
🩹 fix: Sync ControlCombobox popover width with trigger after layout changes

### DIFF
--- a/packages/client/src/components/ControlCombobox.spec.tsx
+++ b/packages/client/src/components/ControlCombobox.spec.tsx
@@ -44,7 +44,7 @@ const items = [
   { label: 'Option B', value: 'b' },
 ];
 
-const renderCombobox = (initialButtonWidth: number) => {
+const renderCombobox = (initialButtonWidth: number, isCollapsed = false) => {
   const offsetWidthSpy = jest
     .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
     .mockReturnValue(initialButtonWidth);
@@ -56,7 +56,7 @@ const renderCombobox = (initialButtonWidth: number) => {
       items={items}
       setValue={() => undefined}
       ariaLabel="Test combobox"
-      isCollapsed={false}
+      isCollapsed={isCollapsed}
       showCarat
     />,
   );
@@ -119,5 +119,53 @@ describe('ControlCombobox popover sizing', () => {
     expect(observer).toBeDefined();
     unmount();
     expect(observer.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not observe the trigger button when isCollapsed is true', () => {
+    renderCombobox(275, true);
+    const triggerObservers = observers.filter(
+      (o) => (o.target as HTMLElement | null)?.tagName === 'BUTTON',
+    );
+    expect(triggerObservers).toHaveLength(0);
+  });
+
+  it('falls back to synchronous offsetWidth when ResizeObserver is unavailable', () => {
+    (window as unknown as { ResizeObserver: typeof ResizeObserver | undefined }).ResizeObserver =
+      undefined;
+
+    renderCombobox(275);
+    openPopover();
+
+    expect(getPopoverWidth()).toBe('275px');
+    const triggerObservers = observers.filter(
+      (o) => (o.target as HTMLElement | null)?.tagName === 'BUTTON',
+    );
+    expect(triggerObservers).toHaveLength(0);
+  });
+
+  it('ignores zero-width resize entries', () => {
+    renderCombobox(275);
+    openPopover();
+    expect(getPopoverWidth()).toBe('275px');
+
+    const observer = observers[0];
+    expect(observer).toBeDefined();
+
+    act(() => {
+      observer.callback(
+        [
+          {
+            target: observer.target as Element,
+            contentRect: { width: 0 } as DOMRectReadOnly,
+            borderBoxSize: [{ inlineSize: 0, blockSize: 0 }],
+            contentBoxSize: [{ inlineSize: 0, blockSize: 0 }],
+            devicePixelContentBoxSize: [{ inlineSize: 0, blockSize: 0 }],
+          } as unknown as ResizeObserverEntry,
+        ],
+        observer as unknown as ResizeObserver,
+      );
+    });
+
+    expect(getPopoverWidth()).toBe('275px');
   });
 });

--- a/packages/client/src/components/ControlCombobox.spec.tsx
+++ b/packages/client/src/components/ControlCombobox.spec.tsx
@@ -143,6 +143,34 @@ describe('ControlCombobox popover sizing', () => {
     expect(triggerObservers).toHaveLength(0);
   });
 
+  it('uses button.offsetWidth when borderBoxSize is unavailable', () => {
+    const { offsetWidthSpy } = renderCombobox(26);
+    openPopover();
+    expect(getPopoverWidth()).toBe('26px');
+
+    const observer = observers[0];
+    expect(observer).toBeDefined();
+
+    offsetWidthSpy.mockReturnValue(275);
+
+    act(() => {
+      observer.callback(
+        [
+          {
+            target: observer.target as Element,
+            contentRect: { width: 251 } as DOMRectReadOnly,
+            borderBoxSize: undefined,
+            contentBoxSize: undefined,
+            devicePixelContentBoxSize: undefined,
+          } as unknown as ResizeObserverEntry,
+        ],
+        observer as unknown as ResizeObserver,
+      );
+    });
+
+    expect(getPopoverWidth()).toBe('275px');
+  });
+
   it('ignores zero-width resize entries', () => {
     renderCombobox(275);
     openPopover();

--- a/packages/client/src/components/ControlCombobox.spec.tsx
+++ b/packages/client/src/components/ControlCombobox.spec.tsx
@@ -1,0 +1,123 @@
+import { act, render, screen } from '@testing-library/react';
+import ControlCombobox from './ControlCombobox';
+
+type CapturedObserver = {
+  callback: ResizeObserverCallback;
+  target: Element | null;
+  disconnect: jest.Mock;
+};
+
+const observers: CapturedObserver[] = [];
+
+class CapturingResizeObserver {
+  callback: ResizeObserverCallback;
+  target: Element | null = null;
+  disconnect = jest.fn();
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    observers.push(this);
+  }
+
+  observe(target: Element) {
+    this.target = target;
+  }
+
+  unobserve = jest.fn();
+}
+
+const originalResizeObserver = window.ResizeObserver;
+
+beforeEach(() => {
+  observers.length = 0;
+  (window as unknown as { ResizeObserver: typeof CapturingResizeObserver }).ResizeObserver =
+    CapturingResizeObserver;
+});
+
+afterEach(() => {
+  (window as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+    originalResizeObserver;
+});
+
+const items = [
+  { label: 'Option A', value: 'a' },
+  { label: 'Option B', value: 'b' },
+];
+
+const renderCombobox = (initialButtonWidth: number) => {
+  const offsetWidthSpy = jest
+    .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+    .mockReturnValue(initialButtonWidth);
+
+  const utils = render(
+    <ControlCombobox
+      selectedValue="a"
+      displayValue="Option A"
+      items={items}
+      setValue={() => undefined}
+      ariaLabel="Test combobox"
+      isCollapsed={false}
+      showCarat
+    />,
+  );
+
+  return { ...utils, offsetWidthSpy };
+};
+
+const getPopoverWidth = () => {
+  const popover = document.querySelector('.animate-popover') as HTMLElement | null;
+  return popover?.style.width ?? null;
+};
+
+const openPopover = () => {
+  const trigger = screen.getByRole('combobox');
+  act(() => {
+    trigger.click();
+  });
+};
+
+describe('ControlCombobox popover sizing', () => {
+  it('uses the button width measured on mount when layout is stable', () => {
+    renderCombobox(275);
+    openPopover();
+    expect(getPopoverWidth()).toBe('275px');
+  });
+
+  it('updates the popover width when the trigger resizes after mount (regression: agent select dropdown rendering at narrow width)', () => {
+    const { offsetWidthSpy } = renderCombobox(26);
+    openPopover();
+    expect(getPopoverWidth()).toBe('26px');
+
+    const observer = observers[0];
+    expect(observer).toBeDefined();
+    expect(observer.target).not.toBeNull();
+
+    offsetWidthSpy.mockReturnValue(275);
+
+    act(() => {
+      observer.callback(
+        [
+          {
+            target: observer.target as Element,
+            contentRect: { width: 275 } as DOMRectReadOnly,
+            borderBoxSize: [{ inlineSize: 275, blockSize: 36 }],
+            contentBoxSize: [{ inlineSize: 275, blockSize: 36 }],
+            devicePixelContentBoxSize: [{ inlineSize: 275, blockSize: 36 }],
+          } as unknown as ResizeObserverEntry,
+        ],
+        observer as unknown as ResizeObserver,
+      );
+    });
+
+    expect(getPopoverWidth()).toBe('275px');
+  });
+
+  it('disconnects the ResizeObserver on unmount', () => {
+    const { unmount } = renderCombobox(275);
+    openPopover();
+    const observer = observers[0];
+    expect(observer).toBeDefined();
+    unmount();
+    expect(observer.disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/client/src/components/ControlCombobox.tsx
+++ b/packages/client/src/components/ControlCombobox.tsx
@@ -96,7 +96,7 @@ function ControlCombobox({
       if (!entry) {
         return;
       }
-      const width = entry.borderBoxSize?.[0]?.inlineSize ?? entry.contentRect.width;
+      const width = entry.borderBoxSize?.[0]?.inlineSize ?? button.offsetWidth;
       if (width > 0) {
         setButtonWidth(width);
       }

--- a/packages/client/src/components/ControlCombobox.tsx
+++ b/packages/client/src/components/ControlCombobox.tsx
@@ -80,9 +80,30 @@ function ControlCombobox({
   }, [searchValue, items]);
 
   useEffect(() => {
-    if (buttonRef.current && !isCollapsed) {
-      setButtonWidth(buttonRef.current.offsetWidth);
+    const button = buttonRef.current;
+    if (!button || isCollapsed) {
+      return;
     }
+
+    setButtonWidth(button.offsetWidth);
+
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) {
+        return;
+      }
+      const width = entry.borderBoxSize?.[0]?.inlineSize ?? entry.contentRect.width;
+      if (width > 0) {
+        setButtonWidth(width);
+      }
+    });
+
+    observer.observe(button);
+    return () => observer.disconnect();
   }, [isCollapsed]);
 
   const selectIconClassName = cn(


### PR DESCRIPTION
## Summary

Fixes a UI bug where the **Agent Builder's agent selector dropdown** renders in the wrong place (anchored to the very far left of the viewport, only ~26px wide, with no options fully visible) under the following scenario:

1. Close the sidebar.
2. Reload the page (sidebar correctly remains closed).
3. Click the **Agent Builder** icon to open the agent builder panel.
4. Click the agent selector / dropdown.

### Root cause

`packages/client/src/components/ControlCombobox.tsx` measures the trigger's `offsetWidth` once on mount via `useEffect`, and applies that as the inline `width` of the Ariakit `SelectPopover`. When the Agent Builder side panel mounts after a page reload with the sidebar collapsed, the trigger button is measured during the side panel's expansion transition (~26px) and is never re-measured. The popover is then rendered against that stale width, causing the misplacement.

### Fix

Use a `ResizeObserver` on the trigger button to keep `buttonWidth` in sync with the trigger's actual rendered width. The observer is disconnected on unmount, and the implementation gracefully no-ops in environments without `ResizeObserver`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Manual reproduction (before the fix)

1. Close the sidebar in LibreChat.
2. Reload the page — sidebar stays closed.
3. Click the **Agent Builder** icon.
4. Click the **Agent** dropdown — observe that the popover renders at the far left of the viewport, ~26px wide, options not visible.

### Manual verification (after the fix)

Repeated the exact same steps:
- Popover renders directly under the trigger button.
- Popover width matches the trigger width (275px) and shows all agents and the search input correctly.
- Verified via `document.querySelector('.animate-popover')` that `style.width === '275px'` and `getBoundingClientRect().left === trigger.left`.

### Automated regression tests

Added `packages/client/src/components/ControlCombobox.spec.tsx`:

- `uses the button width measured on mount when layout is stable` — sanity check that the existing on-mount measurement still works.
- `updates the popover width when the trigger resizes after mount (regression: agent select dropdown rendering at narrow width)` — directly reproduces the bug: simulates the trigger being measured at 26px on mount, asserts the popover starts at 26px, then fires a `ResizeObserver` callback at 275px and asserts the popover updates to 275px.
- `disconnects the ResizeObserver on unmount` — ensures no observer leak.

Run with:

```bash
cd packages/client && npx jest ControlCombobox.spec
```

All 3 tests pass.

### **Test Configuration**:

- Node.js: v20+
- LibreChat docker stack: `docker compose up -d --build`
- Browser verification via Playwright at `http://localhost:3080`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
