### PR TITLE
fix(mcp): warn when composed MCP tool name exceeds OpenAI 64-char limit

### DIFF
--- a/packages/api/src/mcp/registry/MCPServerInspector.ts
+++ b/packages/api/src/mcp/registry/MCPServerInspector.ts
@@ -1,4 +1,3 @@
-import { Constants } from 'librechat-data-provider';
 import type { JsonSchemaType } from '@librechat/data-schemas';
 import type { MCPConnection } from '~/mcp/connection';
 import type * as t from '~/mcp/types';
@@ -7,6 +6,7 @@ import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
 import { hasCustomUserVars, isUserSourced } from '~/mcp/utils';
 import { MCPDomainNotAllowedError } from '~/mcp/errors';
 import { detectOAuthRequirement } from '~/mcp/oauth';
+import { composeMCPToolName } from '~/mcp/tools';
 import { isEnabled } from '~/utils';
 
 /**
@@ -141,7 +141,7 @@ export class MCPServerInspector {
 
     const toolFunctions: t.LCAvailableTools = {};
     tools.forEach((tool) => {
-      const name = `${tool.name}${Constants.mcp_delimiter}${serverName}`;
+      const name = composeMCPToolName(tool.name, serverName, { context: 'MCP Inspector' });
       toolFunctions[name] = {
         type: 'function',
         ['function']: {

--- a/packages/api/src/mcp/registry/__tests__/MCPServerInspector.toolName.spec.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServerInspector.toolName.spec.ts
@@ -1,0 +1,74 @@
+import { MCPServerInspector } from '~/mcp/registry/MCPServerInspector';
+import { createMockConnection } from './mcpConnectionsMock.helper';
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const { logger } = jest.requireMock('@librechat/data-schemas') as {
+  logger: { warn: jest.Mock; debug: jest.Mock; error: jest.Mock; info: jest.Mock };
+};
+
+describe('MCPServerInspector.getToolFunctions tool-name length', () => {
+  beforeEach(() => {
+    logger.warn.mockClear();
+  });
+
+  it('warns once when the composed tool name exceeds the OpenAI 64-char limit', async () => {
+    const mockConnection = createMockConnection('ignored');
+    // 25 server + 5 delimiter ("_mcp_") + 40 tool = 70 chars (> 64)
+    const longServerName = 'my-very-long-mcp-server-1';
+    const longToolName = 'execute_extremely_descriptive_action_name';
+    mockConnection.client.listTools = jest.fn().mockResolvedValue({
+      tools: [{ name: longToolName, description: 'long', inputSchema: { type: 'object' } }],
+    });
+
+    const result = await MCPServerInspector.getToolFunctions(longServerName, mockConnection);
+
+    const expectedKey = `${longToolName}_mcp_${longServerName}`;
+    expect(result[expectedKey]).toBeDefined();
+    expect(result[expectedKey].function.name).toBe(expectedKey);
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const message = logger.warn.mock.calls[0][0] as string;
+    expect(message).toContain('MCP Inspector');
+    expect(message).toContain(longServerName);
+    expect(message).toContain(longToolName);
+    expect(message).toContain('exceeds');
+    expect(message).toContain('64');
+  });
+
+  it('does not warn for tool names within the OpenAI 64-char limit', async () => {
+    const mockConnection = createMockConnection('brave');
+    mockConnection.client.listTools = jest.fn().mockResolvedValue({
+      tools: [{ name: 'search', description: 'ok', inputSchema: { type: 'object' } }],
+    });
+
+    const result = await MCPServerInspector.getToolFunctions('brave', mockConnection);
+
+    expect(result['search_mcp_brave']).toBeDefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns per offending tool when multiple tools exceed the limit', async () => {
+    const mockConnection = createMockConnection('ignored');
+    const longServerName = 'my-very-long-mcp-server-1';
+    mockConnection.client.listTools = jest.fn().mockResolvedValue({
+      tools: [
+        { name: 'execute_extremely_descriptive_action_name', description: 'a' },
+        { name: 'ok', description: 'b' }, // ok_mcp_my-very-long-mcp-server-1 = 32 chars
+        { name: 'another_extremely_descriptive_tool_name_x', description: 'c' },
+      ],
+    });
+
+    await MCPServerInspector.getToolFunctions(longServerName, mockConnection);
+
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/api/src/mcp/tools.spec.ts
+++ b/packages/api/src/mcp/tools.spec.ts
@@ -3,6 +3,16 @@ import { createMCPToolCacheService } from './tools';
 import type { LCAvailableTools } from './types';
 import type { MCPToolInput, MCPToolCacheDeps } from './tools';
 
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
 function createMockDeps(overrides: Partial<MCPToolCacheDeps> = {}): MCPToolCacheDeps {
   return {
     getCachedTools: jest.fn().mockResolvedValue(null),
@@ -67,6 +77,49 @@ describe('createMCPToolCacheService', () => {
       await expect(
         updateMCPServerTools({ userId: 'u1', serverName: 'srv', tools }),
       ).rejects.toThrow('Redis down');
+    });
+
+    it('warns when the composed tool name exceeds the OpenAI 64-char limit', async () => {
+      const { logger } = jest.requireMock('@librechat/data-schemas') as {
+        logger: { warn: jest.Mock; debug: jest.Mock; error: jest.Mock };
+      };
+      logger.warn.mockClear();
+
+      const deps = createMockDeps();
+      const { updateMCPServerTools } = createMCPToolCacheService(deps);
+
+      // 25 + 5 (delimiter "_mcp_") + 40 = 70 > 64
+      const longServerName = 'my-very-long-mcp-server-1';
+      const longToolName = 'execute_extremely_descriptive_action_name';
+      const tools: MCPToolInput[] = [{ name: longToolName }];
+
+      await updateMCPServerTools({
+        userId: 'u1',
+        serverName: longServerName,
+        tools,
+      });
+
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      const message = logger.warn.mock.calls[0][0] as string;
+      expect(message).toContain(longServerName);
+      expect(message).toContain(longToolName);
+      expect(message).toContain('exceeds');
+      expect(message).toContain('64');
+    });
+
+    it('does not warn for tool names within the OpenAI 64-char limit', async () => {
+      const { logger } = jest.requireMock('@librechat/data-schemas') as {
+        logger: { warn: jest.Mock; debug: jest.Mock; error: jest.Mock };
+      };
+      logger.warn.mockClear();
+
+      const deps = createMockDeps();
+      const { updateMCPServerTools } = createMCPToolCacheService(deps);
+
+      const tools: MCPToolInput[] = [{ name: 'search' }];
+      await updateMCPServerTools({ userId: 'u1', serverName: 'brave', tools });
+
+      expect(logger.warn).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -3,6 +3,18 @@ import { Constants } from 'librechat-data-provider';
 import type { JsonSchemaType } from '@librechat/agents';
 import type { LCAvailableTools, LCFunctionTool } from './types';
 
+/**
+ * Maximum allowed length for tool function names accepted by OpenAI-compatible
+ * Chat Completions / Responses APIs. Tool calls whose names exceed this limit
+ * are rejected with HTTP 400 ("string too long. Expected ... maximum length 64").
+ * MCP tool names are constructed as `${toolName}${mcp_delimiter}${serverName}`,
+ * so callers must keep the combined length within this bound.
+ *
+ * Refs: https://platform.openai.com/docs/api-reference/chat/create
+ *       https://github.com/danny-avila/LibreChat/issues/7435
+ */
+const MAX_OPENAI_TOOL_NAME_LENGTH = 64;
+
 export interface MCPToolInput {
   name: string;
   description?: string;
@@ -40,6 +52,16 @@ export function createMCPToolCacheService(deps: MCPToolCacheDeps) {
 
       for (const tool of tools) {
         const name = `${tool.name}${mcpDelimiter}${serverName}`;
+        if (name.length > MAX_OPENAI_TOOL_NAME_LENGTH) {
+          logger.warn(
+            `[MCP Cache] Tool name "${name}" (${name.length} chars) exceeds the ` +
+              `${MAX_OPENAI_TOOL_NAME_LENGTH}-char limit enforced by OpenAI-compatible APIs ` +
+              `(server: "${serverName}", tool: "${tool.name}", delimiter: "${mcpDelimiter}"). ` +
+              `Calls including this tool will be rejected with HTTP 400. ` +
+              `Shorten the MCP server name or the tool name to fit within ` +
+              `${MAX_OPENAI_TOOL_NAME_LENGTH - mcpDelimiter.length} characters combined.`,
+          );
+        }
         const entry: LCFunctionTool = {
           type: 'function',
           ['function']: {

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -13,7 +13,51 @@ import type { LCAvailableTools, LCFunctionTool } from './types';
  * Refs: https://platform.openai.com/docs/api-reference/chat/create
  *       https://github.com/danny-avila/LibreChat/issues/7435
  */
-const MAX_OPENAI_TOOL_NAME_LENGTH = 64;
+export const MAX_OPENAI_TOOL_NAME_LENGTH = 64;
+
+/**
+ * Minimal logger surface used by {@link composeMCPToolName}. Allows callers to
+ * inject the shared `logger` from `@librechat/data-schemas` or any compatible
+ * stub (e.g. in tests) without coupling this helper to a specific instance.
+ */
+export interface MCPToolNameLogger {
+  warn: (message: string) => void;
+}
+
+/**
+ * Composes an MCP tool function name (`${toolName}${mcp_delimiter}${serverName}`)
+ * and emits an actionable warning when the result exceeds the OpenAI-compatible
+ * 64-character limit. The composed name is returned in all cases — the warning
+ * is diagnostic only and does not alter behavior — so existing call sites can
+ * adopt the helper without changing their downstream logic.
+ *
+ * @param toolName - Raw MCP tool name as reported by the server.
+ * @param serverName - LibreChat-side name configured for the MCP server.
+ * @param options.logger - Optional logger; falls back to the shared logger.
+ * @param options.context - Short tag prefixed onto the warning (e.g. "MCP Cache",
+ *   "MCP Inspector") so operators can trace which path materialized the name.
+ */
+export function composeMCPToolName(
+  toolName: string,
+  serverName: string,
+  options: { logger?: MCPToolNameLogger; context?: string } = {},
+): string {
+  const delimiter = Constants.mcp_delimiter;
+  const name = `${toolName}${delimiter}${serverName}`;
+  if (name.length > MAX_OPENAI_TOOL_NAME_LENGTH) {
+    const log = options.logger ?? logger;
+    const tag = options.context ?? 'MCP';
+    log.warn(
+      `[${tag}] Tool name "${name}" (${name.length} chars) exceeds the ` +
+        `${MAX_OPENAI_TOOL_NAME_LENGTH}-char limit enforced by OpenAI-compatible APIs ` +
+        `(server: "${serverName}", tool: "${toolName}", delimiter: "${delimiter}"). ` +
+        `Calls including this tool will be rejected with HTTP 400. ` +
+        `Shorten the MCP server name or the tool name to fit within ` +
+        `${MAX_OPENAI_TOOL_NAME_LENGTH - delimiter.length} characters combined.`,
+    );
+  }
+  return name;
+}
 
 export interface MCPToolInput {
   name: string;
@@ -43,7 +87,6 @@ export function createMCPToolCacheService(deps: MCPToolCacheDeps) {
     const { userId, serverName, tools } = params;
     try {
       const serverTools: LCAvailableTools = {};
-      const mcpDelimiter = Constants.mcp_delimiter;
 
       if (tools == null || tools.length === 0) {
         logger.debug(`[MCP Cache] No tools to update for server ${serverName} (user: ${userId})`);
@@ -51,17 +94,7 @@ export function createMCPToolCacheService(deps: MCPToolCacheDeps) {
       }
 
       for (const tool of tools) {
-        const name = `${tool.name}${mcpDelimiter}${serverName}`;
-        if (name.length > MAX_OPENAI_TOOL_NAME_LENGTH) {
-          logger.warn(
-            `[MCP Cache] Tool name "${name}" (${name.length} chars) exceeds the ` +
-              `${MAX_OPENAI_TOOL_NAME_LENGTH}-char limit enforced by OpenAI-compatible APIs ` +
-              `(server: "${serverName}", tool: "${tool.name}", delimiter: "${mcpDelimiter}"). ` +
-              `Calls including this tool will be rejected with HTTP 400. ` +
-              `Shorten the MCP server name or the tool name to fit within ` +
-              `${MAX_OPENAI_TOOL_NAME_LENGTH - mcpDelimiter.length} characters combined.`,
-          );
-        }
+        const name = composeMCPToolName(tool.name, serverName, { context: 'MCP Cache' });
         const entry: LCFunctionTool = {
           type: 'function',
           ['function']: {


### PR DESCRIPTION
## Bug

When an MCP server name and tool name combine such that
\`\${tool.name}\${mcp_delimiter}\${serverName}\` exceeds 64 characters, the
resulting Chat Completions / Responses request is rejected by
OpenAI-compatible providers with HTTP 400:

\`\`\`
Invalid 'tools[3].function.name': string too long.
Expected a string with maximum length 64, but got a string with length 67 instead.
\`\`\`

This only surfaces at request time inside the agent runtime — the cause is
hard to identify because the end user only sees the provider's truncated
error. The reporter identified the construction site at
\`packages/api/src/mcp/tools.ts\`, where every MCP tool's effective name is
materialised on first cache write.

## Repro

1. Configure an MCP server whose name is ~25 characters long.
2. Expose a tool whose name is ~40 characters long.
3. Send any chat that may invoke this tool.
4. Get \`HTTP 400 string too long\` from the provider — with no breadcrumbs
   pointing at which MCP server / tool produced the over-long name.

## Fix

Emit \`logger.warn\` at tool-cache build time when the composed
\`{toolName}{mcp_delimiter}{serverName}\` exceeds OpenAI's 64-char limit.
The warning identifies:

- the offending composed name and its length
- the MCP server name and tool name separately
- the budget remaining for the operator (64 - delimiter length)

No behavior change for tool names that already fit the limit. The
canonical limit is captured as a documented constant linked to
[OpenAI's API reference](https://platform.openai.com/docs/api-reference/chat/create)
and to issue #7435.

## Test

Two new cases in \`packages/api/src/mcp/tools.spec.ts\`:

1. \`warns when the composed tool name exceeds the OpenAI 64-char limit\` —
   constructs a 70-char composed name and asserts \`logger.warn\` was
   called once with the server name, tool name, "exceeds", and "64" in
   the message.
2. \`does not warn for tool names within the OpenAI 64-char limit\` —
   verifies the existing happy path still does not log a warning.

The spec file is updated to mock \`@librechat/data-schemas\`'s \`logger\`
the same way other spec files in this repo do.

Closes #7435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)