### PR TITLE
fix: allow hyphens for MCP server titles

### DIFF
--- a/packages/data-provider/specs/mcp.spec.ts
+++ b/packages/data-provider/specs/mcp.spec.ts
@@ -1,6 +1,38 @@
-import { SSEOptionsSchema, MCPServerUserInputSchema } from '../src/mcp';
+import { MCPOptionsSchema, SSEOptionsSchema, MCPServerUserInputSchema } from '../src/mcp';
 
 describe('MCPServerUserInputSchema', () => {
+  describe('title validation', () => {
+    it('should accept hyphenated MCP server titles in config', () => {
+      const result = MCPOptionsSchema.safeParse({
+        type: 'sse',
+        url: 'https://example.com/mcp',
+        title: 'My-Test Server',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept hyphenated MCP server titles in user input', () => {
+      const result = MCPServerUserInputSchema.safeParse({
+        type: 'sse',
+        url: 'https://example.com/mcp',
+        title: 'My-Test Server',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should still reject unsupported title characters', () => {
+      const result = MCPOptionsSchema.safeParse({
+        type: 'sse',
+        url: 'https://example.com/mcp',
+        title: 'My_Test Server',
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe('env variable exfiltration prevention', () => {
     it('should confirm admin schema resolves env vars (attack vector baseline)', () => {
       process.env.FAKE_SECRET = 'leaked-secret-value';

--- a/packages/data-provider/specs/mcp.spec.ts
+++ b/packages/data-provider/specs/mcp.spec.ts
@@ -1,19 +1,9 @@
 import { MCPOptionsSchema, SSEOptionsSchema, MCPServerUserInputSchema } from '../src/mcp';
 
-describe('MCPServerUserInputSchema', () => {
+describe('MCPOptionsSchema', () => {
   describe('title validation', () => {
     it('should accept hyphenated MCP server titles in config', () => {
       const result = MCPOptionsSchema.safeParse({
-        type: 'sse',
-        url: 'https://example.com/mcp',
-        title: 'My-Test Server',
-      });
-
-      expect(result.success).toBe(true);
-    });
-
-    it('should accept hyphenated MCP server titles in user input', () => {
-      const result = MCPServerUserInputSchema.safeParse({
         type: 'sse',
         url: 'https://example.com/mcp',
         title: 'My-Test Server',
@@ -30,6 +20,20 @@ describe('MCPServerUserInputSchema', () => {
       });
 
       expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe('MCPServerUserInputSchema', () => {
+  describe('title validation', () => {
+    it('should accept hyphenated MCP server titles in user input', () => {
+      const result = MCPServerUserInputSchema.safeParse({
+        type: 'sse',
+        url: 'https://example.com/mcp',
+        title: 'My-Test Server',
+      });
+
+      expect(result.success).toBe(true);
     });
   });
 

--- a/packages/data-provider/src/mcp.ts
+++ b/packages/data-provider/src/mcp.ts
@@ -3,10 +3,10 @@ import { TokenExchangeMethodEnum } from './types/agents';
 import { extractEnvVariable } from './utils';
 
 const BaseOptionsSchema = z.object({
-  /** Display name for the MCP server - only letters, numbers, and spaces allowed */
+  /** Display name for the MCP server - only letters, numbers, spaces, and hyphens allowed */
   title: z
     .string()
-    .regex(/^[a-zA-Z0-9 ]+$/, 'Title can only contain letters, numbers, and spaces')
+    .regex(/^[a-zA-Z0-9 -]+$/, 'Title can only contain letters, numbers, spaces, and hyphens')
     .optional(),
   /** Description of the MCP server */
   description: z.string().optional(),


### PR DESCRIPTION
# Pull Request Template

## Summary

This PR updates the validation regex for the `mcpServers.<server>.title` field to allow hyphens (`-`). Hyphens are already displayed in scenarios where the explicit title is missing on a given server and the MCP server key contains a hyphen. This does not break any existing behavior but allows for more flexible naming by using words like "read-only" correctly.

## Change Type

Please delete any irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

I added some tests to validate the regex correctly allows hyphens in the MCP server's title configuration.
### **Test Configuration**:

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [x] A pull request for updating the documentation has been submitted.
