### PR TITLE
feat: add Sora to Azure OpenAI default models (closes #7702)

### DIFF
--- a/packages/api/src/endpoints/models.spec.ts
+++ b/packages/api/src/endpoints/models.spec.ts
@@ -218,6 +218,11 @@ describe('getOpenAIModels', () => {
     expect(models).toEqual(expect.arrayContaining(['azure-model', 'azure-model-2']));
   });
 
+  it('returns Azure OpenAI defaults with Sora when azure flag is set', async () => {
+    const models = await getOpenAIModels({ azure: true });
+    expect(models).toContain('sora');
+  });
+
   it('returns `OPENAI_MODELS` with no flags (and fetch fails)', async () => {
     process.env.OPENAI_MODELS = 'openai-model,openai-model-2';
     const models = await getOpenAIModels({});

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -294,7 +294,7 @@ export async function getOpenAIModels(opts: GetOpenAIModelsOptions = {}): Promis
   if (opts.assistants) {
     models = defaultModels[EModelEndpoint.assistants];
   } else if (opts.azure) {
-    models = defaultModels[EModelEndpoint.azureAssistants];
+    models = defaultModels[EModelEndpoint.azureOpenAI];
   }
 
   let key: string;

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -4,6 +4,7 @@ import {
   azureEndpointSchema,
   endpointSchema,
   configSchema,
+  initialModelsConfig,
   interfaceSchema,
   fileStorageSchema,
   fileStrategiesSchema,
@@ -203,6 +204,13 @@ describe('tModelSpecPresetSchema', () => {
       expect(result.data.topP).toBe(0.9);
       expect(result.data.maxOutputTokens).toBe(4096);
     }
+  });
+});
+
+describe('initialModelsConfig', () => {
+  it('includes Sora for Azure OpenAI defaults without adding it to OpenAI defaults', () => {
+    expect(initialModelsConfig[EModelEndpoint.azureOpenAI]).toContain('sora');
+    expect(initialModelsConfig[EModelEndpoint.openAI]).not.toContain('sora');
   });
 });
 

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -1308,6 +1308,14 @@ export const defaultModels = {
   [EModelEndpoint.azureAssistants]: sharedOpenAIModels,
   [EModelEndpoint.assistants]: [...sharedOpenAIModels, 'chatgpt-4o-latest'],
   [EModelEndpoint.agents]: sharedOpenAIModels, // TODO: Add agent models (agentsModels)
+  [EModelEndpoint.azureOpenAI]: [
+    ...sharedOpenAIModels,
+    'chatgpt-4o-latest',
+    'gpt-4-vision-preview',
+    'gpt-3.5-turbo-instruct-0914',
+    'gpt-3.5-turbo-instruct',
+    'sora',
+  ],
   [EModelEndpoint.google]: [
     // Gemini 3.1 Models
     'gemini-3.1-pro-preview',
@@ -1337,13 +1345,14 @@ const fitlerAssistantModels = (str: string) => {
 };
 
 const openAIModels = defaultModels[EModelEndpoint.openAI];
+const azureOpenAIModels = defaultModels[EModelEndpoint.azureOpenAI];
 
 export const initialModelsConfig: TModelsConfig = {
   initial: [],
   [EModelEndpoint.openAI]: openAIModels,
   [EModelEndpoint.assistants]: openAIModels.filter(fitlerAssistantModels),
   [EModelEndpoint.agents]: openAIModels, // TODO: Add agent models (agentsModels)
-  [EModelEndpoint.azureOpenAI]: openAIModels,
+  [EModelEndpoint.azureOpenAI]: azureOpenAIModels,
   [EModelEndpoint.google]: defaultModels[EModelEndpoint.google],
   [EModelEndpoint.anthropic]: defaultModels[EModelEndpoint.anthropic],
   [EModelEndpoint.bedrock]: defaultModels[EModelEndpoint.bedrock],


### PR DESCRIPTION
/claim #7702

Closes #7702.

Adds `sora` to the Azure OpenAI default model list so users can select Sora video generation when the Azure provider is configured. Also fixes the Azure fallback in `getOpenAIModels` so the API correctly returns Azure OpenAI defaults rather than Azure Assistants defaults.

### Changes
- `packages/data-provider/src/config.ts` — explicit `azureOpenAI` defaults including `sora`; wire through to `initialModelsConfig`
- `packages/data-provider/specs/config-schemas.spec.ts` — test confirming sora is in Azure OpenAI defaults but not OpenAI defaults
- `packages/api/src/endpoints/models.ts` — return Azure OpenAI defaults (not Azure Assistants defaults) on the azure code path
- `packages/api/src/endpoints/models.spec.ts` — covers new behavior

### Verification
`npm run build:packages` passes locally. PR-time CI will run the full test suite.