### PR TITLE
fix: resume interrupted generation streams

### DIFF
--- a/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumableSSE.spec.ts
@@ -1,5 +1,5 @@
-import { renderHook, act } from '@testing-library/react';
-import { Constants, LocalStorageKeys } from 'librechat-data-provider';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { Constants, LocalStorageKeys, request } from 'librechat-data-provider';
 import type { TSubmission } from 'librechat-data-provider';
 
 type SSEEventListener = (e: Partial<MessageEvent> & { responseCode?: number }) => void;
@@ -105,6 +105,7 @@ jest.mock('librechat-data-provider', () => {
     apiBaseUrl: jest.fn(() => ''),
     request: {
       post: jest.fn().mockResolvedValue({ streamId: 'stream-123' }),
+      get: jest.fn().mockResolvedValue({ active: false }),
       refreshToken: jest.fn(),
       dispatchTokenUpdatedEvent: jest.fn(),
     },
@@ -174,6 +175,10 @@ describe('useResumableSSE - 404 error path', () => {
     mockSetIsSubmitting.mockClear();
     mockInvalidateQueries.mockClear();
     mockRemoveQueries.mockClear();
+    (request.post as jest.Mock).mockClear();
+    (request.post as jest.Mock).mockResolvedValue({ streamId: 'stream-123' });
+    (request.get as jest.Mock).mockClear();
+    (request.get as jest.Mock).mockResolvedValue({ active: false });
   });
 
   const seedDraft = (conversationId: string) => {
@@ -281,4 +286,126 @@ describe('useResumableSSE - 404 error path', () => {
       unmount();
     },
   );
+
+  it('aborts an active same-conversation job before starting a replacement generation', async () => {
+    const requestPost = request.post as jest.Mock;
+    const requestGet = request.get as jest.Mock;
+    requestPost.mockResolvedValue({ streamId: CONV_ID });
+    requestGet.mockResolvedValue({ active: true, streamId: CONV_ID });
+    const chatHelpers = buildChatHelpers();
+    const firstSubmission = buildSubmission({
+      userMessage: { messageId: 'msg-1' },
+    } as Partial<PartialSubmission>);
+    const secondSubmission = buildSubmission({
+      userMessage: { messageId: 'msg-2' },
+    } as Partial<PartialSubmission>);
+
+    const { rerender, unmount } = renderHook(
+      ({ submission }) => useResumableSSE(submission, chatHelpers),
+      { initialProps: { submission: firstSubmission } },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(requestPost).toHaveBeenCalledWith('/api/agents/chat', { model: 'gpt-4o' });
+
+    rerender({ submission: secondSubmission });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(requestGet).toHaveBeenCalledWith(`/api/agents/chat/status/${CONV_ID}`);
+      expect(requestPost).toHaveBeenNthCalledWith(2, '/api/agents/chat/abort', {
+        streamId: CONV_ID,
+        conversationId: CONV_ID,
+      });
+      expect(requestPost).toHaveBeenNthCalledWith(3, '/api/agents/chat', { model: 'gpt-4o' });
+    });
+    unmount();
+  });
+
+  it('uses the active stream ID to verify replacement jobs for new conversations', async () => {
+    const requestPost = request.post as jest.Mock;
+    const requestGet = request.get as jest.Mock;
+    const generatedConversationId = 'generated-conv-123';
+    requestPost
+      .mockResolvedValueOnce({ streamId: generatedConversationId })
+      .mockResolvedValueOnce({ streamId: 'replacement-stream' });
+    requestGet.mockResolvedValue({ active: true, streamId: generatedConversationId });
+    const chatHelpers = buildChatHelpers();
+    const firstSubmission = buildSubmission({
+      conversation: { conversationId: 'new' },
+      userMessage: { messageId: 'msg-1' },
+    } as Partial<PartialSubmission>);
+    const secondSubmission = buildSubmission({
+      conversation: { conversationId: 'new' },
+      userMessage: { messageId: 'msg-2' },
+    } as Partial<PartialSubmission>);
+
+    const { rerender, unmount } = renderHook(
+      ({ submission }) => useResumableSSE(submission, chatHelpers),
+      { initialProps: { submission: firstSubmission } },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    rerender({ submission: secondSubmission });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(requestGet).toHaveBeenCalledWith(`/api/agents/chat/status/${generatedConversationId}`);
+      expect(requestPost).toHaveBeenNthCalledWith(2, '/api/agents/chat/abort', {
+        streamId: generatedConversationId,
+        conversationId: 'new',
+      });
+      expect(requestPost).toHaveBeenNthCalledWith(3, '/api/agents/chat', { model: 'gpt-4o' });
+    });
+    unmount();
+  });
+
+  it('does not abort a stale same-conversation ref when stream status is no longer active', async () => {
+    const requestPost = request.post as jest.Mock;
+    const requestGet = request.get as jest.Mock;
+    requestPost.mockResolvedValue({ streamId: CONV_ID });
+    requestGet.mockResolvedValue({ active: false, streamId: CONV_ID });
+    const chatHelpers = buildChatHelpers();
+    const firstSubmission = buildSubmission({
+      userMessage: { messageId: 'msg-1' },
+    } as Partial<PartialSubmission>);
+    const secondSubmission = buildSubmission({
+      userMessage: { messageId: 'msg-2' },
+    } as Partial<PartialSubmission>);
+
+    const { rerender, unmount } = renderHook(
+      ({ submission }) => useResumableSSE(submission, chatHelpers),
+      { initialProps: { submission: firstSubmission } },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    rerender({ submission: secondSubmission });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(requestGet).toHaveBeenCalledWith(`/api/agents/chat/status/${CONV_ID}`);
+      expect(requestPost).toHaveBeenCalledTimes(2);
+      expect(requestPost).not.toHaveBeenCalledWith('/api/agents/chat/abort', expect.anything());
+      expect(requestPost).toHaveBeenNthCalledWith(2, '/api/agents/chat', { model: 'gpt-4o' });
+    });
+    unmount();
+  });
 });

--- a/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.ts
+++ b/client/src/hooks/SSE/__tests__/useResumeOnLoad.spec.ts
@@ -1,0 +1,124 @@
+import { renderHook } from '@testing-library/react';
+import { Constants } from 'librechat-data-provider';
+import type { TConversation, TMessage, TSubmission } from 'librechat-data-provider';
+
+const mockSetSubmission = jest.fn();
+const mockUseStreamStatus = jest.fn();
+let mockUseRecoilValueCallIndex = 0;
+
+let mockCurrentSubmission: TSubmission | null = null;
+let mockCurrentConversation: TConversation | null = {
+  conversationId: 'conv-123',
+  endpoint: 'openAI',
+} as TConversation;
+
+jest.mock('recoil', () => ({
+  ...jest.requireActual('recoil'),
+  useSetRecoilState: () => mockSetSubmission,
+  useRecoilValue: jest.fn(() => {
+    const callIndex = mockUseRecoilValueCallIndex++;
+    return callIndex % 2 === 0 ? mockCurrentSubmission : mockCurrentConversation;
+  }),
+}));
+
+jest.mock('~/store', () => ({
+  __esModule: true,
+  default: {
+    submissionByIndex: jest.fn(),
+    conversationByIndex: jest.fn(),
+  },
+}));
+
+jest.mock('~/data-provider', () => ({
+  useStreamStatus: (...args: unknown[]) => mockUseStreamStatus(...args),
+}));
+
+import useResumeOnLoad from '~/hooks/SSE/useResumeOnLoad';
+
+const buildSubmission = (conversationId = 'conv-123'): TSubmission =>
+  ({
+    conversation: { conversationId, endpoint: 'openAI' },
+    userMessage: {
+      messageId: 'user-1',
+      conversationId,
+      text: 'hello',
+      isCreatedByUser: true,
+    },
+    messages: [],
+    initialResponse: {
+      messageId: 'response-1',
+      conversationId,
+      text: '',
+      isCreatedByUser: false,
+    },
+    endpointOption: {},
+  }) as TSubmission;
+
+describe('useResumeOnLoad', () => {
+  beforeEach(() => {
+    mockSetSubmission.mockClear();
+    mockUseStreamStatus.mockClear();
+    mockUseRecoilValueCallIndex = 0;
+    mockCurrentSubmission = null;
+    mockCurrentConversation = {
+      conversationId: 'conv-123',
+      endpoint: 'openAI',
+    } as TConversation;
+    mockUseStreamStatus.mockReturnValue({
+      data: { active: false },
+      isSuccess: true,
+      isFetching: false,
+    });
+  });
+
+  it('rechecks stream status in the same conversation after the active submission clears', () => {
+    mockCurrentSubmission = buildSubmission();
+
+    const { rerender } = renderHook(() =>
+      useResumeOnLoad('conv-123', () => [] as TMessage[], 0, true),
+    );
+
+    expect(mockUseStreamStatus).toHaveBeenLastCalledWith('conv-123', false);
+
+    mockUseRecoilValueCallIndex = 0;
+    mockCurrentSubmission = null;
+    rerender();
+
+    expect(mockUseStreamStatus).toHaveBeenLastCalledWith('conv-123', true);
+  });
+
+  it('creates a resume submission when stream status reports an active job', () => {
+    mockUseStreamStatus.mockReturnValue({
+      data: {
+        active: true,
+        streamId: 'conv-123',
+        status: 'running',
+        resumeState: {
+          userMessage: {
+            messageId: 'user-1',
+            conversationId: 'conv-123',
+            text: 'hello',
+            parentMessageId: Constants.NO_PARENT,
+          },
+          responseMessageId: 'response-1',
+          aggregatedContent: [{ type: 'text', text: 'partial answer' }],
+          runSteps: [],
+        },
+      },
+      isSuccess: true,
+      isFetching: false,
+    });
+
+    renderHook(() => useResumeOnLoad('conv-123', () => [] as TMessage[], 0, true));
+
+    expect(mockSetSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resumeStreamId: 'conv-123',
+        initialResponse: expect.objectContaining({
+          messageId: 'response-1',
+          content: [{ type: 'text', text: 'partial answer' }],
+        }),
+      }),
+    );
+  });
+});

--- a/client/src/hooks/SSE/useResumableSSE.ts
+++ b/client/src/hooks/SSE/useResumableSSE.ts
@@ -22,7 +22,7 @@ import {
   queueTitleGeneration,
   streamStatusQueryKey,
 } from '~/data-provider';
-import type { ActiveJobsResponse } from '~/data-provider';
+import type { ActiveJobsResponse, StreamStatusResponse } from '~/data-provider';
 import { useAuthContext } from '~/hooks/AuthContext';
 import useEventHandlers from './useEventHandlers';
 import { clearAllDrafts } from '~/utils';
@@ -39,6 +39,11 @@ type ChatHelpers = Pick<
 >;
 
 const MAX_RETRIES = 5;
+
+type ActiveGeneration = {
+  streamId: string;
+  conversationId?: string;
+};
 
 /**
  * Hook for resumable SSE streams.
@@ -95,6 +100,7 @@ export default function useResumableSSE(
   const reconnectAttemptRef = useRef(0);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const submissionRef = useRef<TSubmission | null>(null);
+  const activeGenerationRef = useRef<ActiveGeneration | null>(null);
 
   const {
     setMessages,
@@ -184,6 +190,7 @@ export default function useResumableSSE(
             clearStepMaps();
             // Optimistically remove from active jobs
             removeActiveJob(currentStreamId);
+            activeGenerationRef.current = null;
             (startupConfig?.balance?.enabled ?? false) && balanceQuery.refetch();
             sse.close();
             setStreamId(null);
@@ -361,6 +368,7 @@ export default function useResumableSSE(
             queryClient.invalidateQueries({ queryKey: [QueryKeys.messages, convoId] });
             queryClient.removeQueries({ queryKey: streamStatusQueryKey(convoId) });
           }
+          activeGenerationRef.current = null;
           setIsSubmitting(false);
           setShowStopButton(false);
           setStreamId(null);
@@ -435,6 +443,7 @@ export default function useResumableSSE(
           setIsSubmitting(false);
           setShowStopButton(false);
           setStreamId(null);
+          activeGenerationRef.current = null;
           reconnectAttemptRef.current = 0;
           return;
         }
@@ -476,6 +485,7 @@ export default function useResumableSSE(
           setIsSubmitting(false);
           setShowStopButton(false);
           setStreamId(null);
+          activeGenerationRef.current = null;
         }
       });
 
@@ -553,6 +563,52 @@ export default function useResumableSSE(
       removeActiveJob,
       queryClient,
     ],
+  );
+
+  const abortActiveGenerationForConversation = useCallback(
+    async (conversationId?: string) => {
+      const activeGeneration = activeGenerationRef.current;
+      if (!activeGeneration || !conversationId) {
+        return;
+      }
+      if (activeGeneration.conversationId !== conversationId) {
+        return;
+      }
+
+      console.log('[ResumableSSE] Aborting active generation before replacement:', {
+        streamId: activeGeneration.streamId,
+        conversationId,
+      });
+
+      try {
+        const status = await request.get<StreamStatusResponse>(
+          `${apiBaseUrl()}/api/agents/chat/status/${activeGeneration.streamId}`,
+        );
+        if (!status.active || status.streamId !== activeGeneration.streamId) {
+          console.log('[ResumableSSE] Skipping replacement abort; active generation is stale:', {
+            streamId: activeGeneration.streamId,
+            conversationId,
+            statusStreamId: status.streamId,
+            statusActive: status.active,
+          });
+          return;
+        }
+
+        await request.post(`${apiBaseUrl()}/api/agents/chat/abort`, {
+          streamId: activeGeneration.streamId,
+          conversationId,
+        });
+        removeActiveJob(activeGeneration.streamId);
+      } catch (error) {
+        console.error(
+          '[ResumableSSE] Failed to abort active generation before replacement:',
+          error,
+        );
+      } finally {
+        activeGenerationRef.current = null;
+      }
+    },
+    [removeActiveJob],
   );
 
   /**
@@ -658,15 +714,24 @@ export default function useResumableSSE(
         // Resume: just subscribe to existing stream, don't start new generation
         console.log('[ResumableSSE] Resuming existing stream:', resumeStreamId);
         setStreamId(resumeStreamId);
+        activeGenerationRef.current = {
+          streamId: resumeStreamId,
+          conversationId: submission.conversation?.conversationId,
+        };
         // Optimistically add to active jobs (in case it's not already there)
         addActiveJob(resumeStreamId);
         subscribeToStream(resumeStreamId, submission, true); // isResume=true
       } else {
         // New generation: start and then subscribe
         console.log('[ResumableSSE] Starting NEW generation');
+        await abortActiveGenerationForConversation(submission.conversation?.conversationId);
         const newStreamId = await startGeneration(submission);
         if (newStreamId) {
           setStreamId(newStreamId);
+          activeGenerationRef.current = {
+            streamId: newStreamId,
+            conversationId: submission.conversation?.conversationId,
+          };
           // Optimistically add to active jobs
           addActiveJob(newStreamId);
           // Queue title generation if this is a new conversation (first message)

--- a/client/src/hooks/SSE/useResumeOnLoad.ts
+++ b/client/src/hooks/SSE/useResumeOnLoad.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { Constants, tMessageSchema, isAssistantsEndpoint } from 'librechat-data-provider';
 import type { TMessage, TConversation, TSubmission, Agents } from 'librechat-data-provider';
@@ -109,9 +109,6 @@ export default function useResumeOnLoad(
   const endpointType = currentConversation?.endpointType;
   const actualEndpoint = endpointType ?? endpoint;
   const resumableEnabled = !isAssistantsEndpoint(actualEndpoint);
-  // Track conversations we've already processed (either resumed or skipped)
-  const processedConvoRef = useRef<string | null>(null);
-
   // Check for active stream when conversation changes
   // Allow check if no submission OR submission is for a different conversation (stale)
   const submissionConvoId = currentSubmission?.conversation?.conversationId;
@@ -122,8 +119,7 @@ export default function useResumeOnLoad(
     messagesLoaded && // Wait for messages to load before checking
     !hasActiveSubmissionForThisConvo && // Allow if no submission or stale submission
     !!conversationId &&
-    conversationId !== Constants.NEW_CONVO &&
-    processedConvoRef.current !== conversationId; // Don't re-check processed convos
+    conversationId !== Constants.NEW_CONVO;
 
   const {
     data: streamStatus,
@@ -142,7 +138,6 @@ export default function useResumeOnLoad(
       isFetching,
       streamStatusActive: streamStatus?.active,
       streamStatusStreamId: streamStatus?.streamId,
-      processedConvoRef: processedConvoRef.current,
     });
 
     if (!resumableEnabled || !conversationId || conversationId === Constants.NEW_CONVO) {
@@ -160,8 +155,6 @@ export default function useResumeOnLoad(
     // A stale submission with undefined/different conversationId should not block us
     if (hasActiveSubmissionForThisConvo) {
       console.log('[ResumeOnLoad] Skipping - already have active submission for this conversation');
-      // Mark as processed so we don't try again
-      processedConvoRef.current = conversationId;
       return;
     }
 
@@ -183,19 +176,10 @@ export default function useResumeOnLoad(
       return;
     }
 
-    // Don't process the same conversation twice
-    if (processedConvoRef.current === conversationId) {
-      console.log('[ResumeOnLoad] Skipping - already processed this conversation');
-      return;
-    }
-
     if (!streamStatus.active || !streamStatus.streamId) {
       console.log('[ResumeOnLoad] No active job to resume for:', conversationId);
-      processedConvoRef.current = conversationId;
       return;
     }
-
-    processedConvoRef.current = conversationId;
 
     console.log('[ResumeOnLoad] Found active job, creating submission...', {
       streamId: streamStatus.streamId,
@@ -249,16 +233,4 @@ export default function useResumeOnLoad(
     getMessages,
     setSubmission,
   ]);
-
-  // Reset processedConvoRef when conversation changes to allow re-checking
-  useEffect(() => {
-    // Always reset when conversation changes - this allows resuming when navigating back
-    if (conversationId !== processedConvoRef.current) {
-      console.log('[ResumeOnLoad] Resetting processedConvoRef for new conversation:', {
-        old: processedConvoRef.current,
-        new: conversationId,
-      });
-      processedConvoRef.current = null;
-    }
-  }, [conversationId]);
 }


### PR DESCRIPTION
## Summary

This fixes an edge case in resumable agent SSE streams where the UI can leave a generated response partial after the frontend stream disconnects.

Two frontend behaviors were involved:

- `useResumeOnLoad` remembered a conversation as already processed, so after the current submission cleared it would not re-check the same conversation for an active resumable job.
- `useResumableSSE` always aborted the previous stream when a new same-conversation submission replaced it, even when the backend status already showed that stream was no longer active. That can convert an interrupted/stale stream into an unnecessary abort instead of allowing the UI to resume or refresh the completed result.

## Changes

- Re-check the same conversation in `useResumeOnLoad` once there is no active submission.
- Track the active frontend generation in `useResumableSSE` and confirm backend stream status before aborting it during same-conversation replacement.
- Add regression coverage for:
  - rechecking the same conversation after submission clears
  - resuming active jobs on the same conversation
  - aborting only truly active replaced streams
  - skipping abort for stale/inactive replaced streams

## Testing

Ran on a clean branch based on `upstream/main` (`738003b22`):

```bash
npm ci
npm run build:data-provider
cd packages/client && npm run build
cd ../../client && npx jest src/hooks/SSE/__tests__/useResumeOnLoad.spec.ts src/hooks/SSE/__tests__/useResumableSSE.spec.ts --runInBand
```

Result: 2 test suites passed, 11 tests passed.
