### PR TITLE
fix: preserve text for resumable content responses

### DIFF
--- a/api/app/clients/BaseClient.js
+++ b/api/app/clients/BaseClient.js
@@ -18,6 +18,7 @@ const {
   excludedKeys,
   EModelEndpoint,
   mergeFileConfig,
+  parseTextParts,
   isParamEndpoint,
   isAgentsEndpoint,
   isEphemeralAgentId,
@@ -29,6 +30,23 @@ const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { logViolation } = require('~/cache');
 const TextStream = require('./TextStream');
 const db = require('~/models');
+
+function withTopLevelTextFromContent(message) {
+  if (typeof message.text === 'string' && message.text.length > 0) {
+    return message;
+  }
+
+  if (!Array.isArray(message.content) || message.content.length === 0) {
+    return message;
+  }
+
+  const text = parseTextParts(message.content, true);
+  if (!text) {
+    return message;
+  }
+
+  return { ...message, text };
+}
 
 class BaseClient {
   constructor(apiKey, options = {}) {
@@ -661,14 +679,16 @@ class BaseClient {
       responseMessage.contextMeta = this.contextMeta;
     }
 
-    responseMessage.databasePromise = this.saveMessageToDatabase(
-      responseMessage,
+    const responseMessageWithText = withTopLevelTextFromContent(responseMessage);
+
+    responseMessageWithText.databasePromise = this.saveMessageToDatabase(
+      responseMessageWithText,
       saveOptions,
       user,
     );
-    this.savedMessageIds.add(responseMessage.messageId);
-    delete responseMessage.tokenCount;
-    return responseMessage;
+    this.savedMessageIds.add(responseMessageWithText.messageId);
+    delete responseMessageWithText.tokenCount;
+    return responseMessageWithText;
   }
 
   async loadHistory(conversationId, parentMessageId = null) {

--- a/api/app/clients/specs/BaseClient.test.js
+++ b/api/app/clients/specs/BaseClient.test.js
@@ -1,4 +1,4 @@
-const { Constants } = require('librechat-data-provider');
+const { Constants, ContentTypes, EModelEndpoint } = require('librechat-data-provider');
 const { initializeFakeClient } = require('./FakeClient');
 
 jest.mock('~/db/connect');
@@ -1254,6 +1254,49 @@ describe('BaseClient', () => {
       );
       expect(userSave[0].files).toHaveLength(1);
       expect(userSave[0].files[0].file_id).toBe('file-abc');
+    });
+  });
+
+  describe('sendMessage structured content text', () => {
+    beforeEach(() => {
+      TestClient.clientName = EModelEndpoint.agents;
+      TestClient.saveMessageToDatabase = jest.fn().mockImplementation((msg) => {
+        return Promise.resolve({ message: msg });
+      });
+    });
+
+    test('populates top-level text before saving agent text content parts', async () => {
+      TestClient.sendCompletion = jest.fn(async () => ({
+        completion: [{ type: ContentTypes.TEXT, text: 'generated text' }],
+        metadata: undefined,
+      }));
+
+      const response = await TestClient.sendMessage('Hello');
+
+      const responseSave = TestClient.saveMessageToDatabase.mock.calls.find(
+        ([msg]) => !msg.isCreatedByUser,
+      );
+      expect(responseSave).toBeDefined();
+      expect(responseSave[0].text).toBe('generated text');
+      expect(response.text).toBe('generated text');
+    });
+
+    test('does not include think content in populated top-level text', async () => {
+      TestClient.sendCompletion = jest.fn(async () => ({
+        completion: [
+          { type: ContentTypes.THINK, think: 'internal reasoning' },
+          { type: ContentTypes.TEXT, text: 'visible answer' },
+        ],
+        metadata: undefined,
+      }));
+
+      await TestClient.sendMessage('Hello');
+
+      const responseSave = TestClient.saveMessageToDatabase.mock.calls.find(
+        ([msg]) => !msg.isCreatedByUser,
+      );
+      expect(responseSave).toBeDefined();
+      expect(responseSave[0].text).toBe('visible answer');
     });
   });
 });

--- a/api/server/controllers/agents/__tests__/jobReplacement.spec.js
+++ b/api/server/controllers/agents/__tests__/jobReplacement.spec.js
@@ -280,7 +280,10 @@ describe('Job Replacement Detection', () => {
         parentMessageId: userMessage.messageId,
         sender: 'Agent',
         text: '',
-        content: [{ type: 'text', text: 'generated text' }],
+        content: [
+          { type: 'think', think: 'internal reasoning' },
+          { type: 'text', text: 'generated text' },
+        ],
         databasePromise: Promise.resolve({
           conversation: { conversationId: streamId, title: 'New Chat' },
         }),

--- a/api/server/controllers/agents/__tests__/jobReplacement.spec.js
+++ b/api/server/controllers/agents/__tests__/jobReplacement.spec.js
@@ -27,6 +27,9 @@ const mockGenerationJobManager = {
 
 const mockSaveMessage = jest.fn();
 const mockDecrementPendingRequest = jest.fn();
+const mockDisposeClient = jest.fn();
+const mockHandleAbortError = jest.fn();
+const mockLogViolation = jest.fn();
 
 jest.mock('@librechat/data-schemas', () => ({
   logger: mockLogger,
@@ -47,9 +50,24 @@ jest.mock('~/models', () => ({
   saveMessage: (...args) => mockSaveMessage(...args),
 }));
 
+jest.mock('~/server/cleanup', () => ({
+  disposeClient: (...args) => mockDisposeClient(...args),
+  clientRegistry: null,
+  requestDataMap: new WeakMap(),
+}));
+
+jest.mock('~/server/middleware', () => ({
+  handleAbortError: (...args) => mockHandleAbortError(...args),
+}));
+
+jest.mock('~/cache', () => ({
+  logViolation: (...args) => mockLogViolation(...args),
+}));
+
 describe('Job Replacement Detection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockHandleAbortError.mockResolvedValue();
   });
 
   describe('Job Creation Timestamp Tracking', () => {
@@ -243,6 +261,84 @@ describe('Job Replacement Detection', () => {
       }
 
       expect(callOrder).toEqual(['saveMessage', 'emitDone']);
+    });
+
+    it('should populate top-level text from content parts before saving and emitting final response', async () => {
+      const AgentController = require('../request');
+      const streamId = 'test-stream-123';
+      const userMessage = {
+        messageId: 'user-message-123',
+        conversationId: streamId,
+        parentMessageId: '00000000-0000-0000-0000-000000000000',
+        text: 'hello',
+        sender: 'User',
+        isCreatedByUser: true,
+      };
+      const responseMessage = {
+        messageId: 'response-message-123',
+        conversationId: streamId,
+        parentMessageId: userMessage.messageId,
+        sender: 'Agent',
+        text: '',
+        content: [{ type: 'text', text: 'generated text' }],
+        databasePromise: Promise.resolve({
+          conversation: { conversationId: streamId, title: 'New Chat' },
+        }),
+      };
+      const client = {
+        sender: 'Agent',
+        options: {},
+        savedMessageIds: new Set(),
+        sendMessage: jest.fn(async (_text, options) => {
+          options.onStart(userMessage, responseMessage.messageId, false);
+          return { ...responseMessage };
+        }),
+      };
+      const req = {
+        user: { id: 'user-123' },
+        body: {
+          text: 'hello',
+          endpointOption: {
+            endpoint: 'agents',
+            modelOptions: { model: 'agent-model' },
+          },
+          conversationId: streamId,
+          parentMessageId: '00000000-0000-0000-0000-000000000000',
+        },
+      };
+      const res = { json: jest.fn() };
+
+      mockGenerationJobManager.createJob.mockResolvedValue({
+        createdAt: 1000,
+        readyPromise: Promise.resolve(),
+        abortController: new AbortController(),
+        emitter: { on: jest.fn() },
+      });
+      mockGenerationJobManager.getJob.mockResolvedValue({ createdAt: 1000 });
+      mockSaveMessage.mockResolvedValue();
+
+      await AgentController(req, res, jest.fn(), async () => ({ client }), undefined);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(mockSaveMessage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          messageId: responseMessage.messageId,
+          text: 'generated text',
+        }),
+        expect.objectContaining({
+          context: 'api/server/controllers/agents/request.js - resumable response end',
+        }),
+      );
+      expect(mockGenerationJobManager.emitDone).toHaveBeenCalledWith(
+        streamId,
+        expect.objectContaining({
+          responseMessage: expect.objectContaining({
+            messageId: responseMessage.messageId,
+            text: 'generated text',
+          }),
+        }),
+      );
     });
   });
 

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -41,7 +41,7 @@ function withTopLevelTextFromContent(message) {
     return message;
   }
 
-  const text = parseTextParts(message.content);
+  const text = parseTextParts(message.content, true);
   if (!text) {
     return message;
   }

--- a/api/server/controllers/agents/request.js
+++ b/api/server/controllers/agents/request.js
@@ -1,5 +1,5 @@
 const { logger } = require('@librechat/data-schemas');
-const { Constants, ViolationTypes } = require('librechat-data-provider');
+const { Constants, ViolationTypes, parseTextParts } = require('librechat-data-provider');
 const {
   sendEvent,
   getViolationInfo,
@@ -30,6 +30,23 @@ function createCloseHandler(abortController) {
     abortController.abort();
     logger.debug('[AgentController] Request aborted on close');
   };
+}
+
+function withTopLevelTextFromContent(message) {
+  if (typeof message.text === 'string' && message.text.length > 0) {
+    return message;
+  }
+
+  if (!Array.isArray(message.content) || message.content.length === 0) {
+    return message;
+  }
+
+  const text = parseTextParts(message.content);
+  if (!text) {
+    return message;
+  }
+
+  return { ...message, text };
 }
 
 /**
@@ -137,7 +154,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
             isTemporary: req?.body?.isTemporary,
             interfaceConfig: req?.config?.interfaceConfig,
           },
-          partialMessage,
+          withTopLevelTextFromContent(partialMessage),
           { context: 'api/server/controllers/agents/request.js - partial response on disconnect' },
         );
 
@@ -248,10 +265,13 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
 
         const messageId = response.messageId;
         const endpoint = endpointOption.endpoint;
-        response.endpoint = endpoint;
+        const responseWithText = withTopLevelTextFromContent({
+          ...response,
+          endpoint,
+        });
 
-        const databasePromise = response.databasePromise;
-        delete response.databasePromise;
+        const databasePromise = responseWithText.databasePromise;
+        delete responseWithText.databasePromise;
 
         const { conversation: convoData = {} } = await databasePromise;
         const conversation = { ...convoData };
@@ -295,7 +315,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         if (client.savedMessageIds && !client.savedMessageIds.has(messageId)) {
           await saveMessage(
             reqCtx,
-            { ...response, user: userId, unfinished: wasAbortedBeforeComplete },
+            { ...responseWithText, user: userId, unfinished: wasAbortedBeforeComplete },
             { context: 'api/server/controllers/agents/request.js - resumable response end' },
           );
         }
@@ -322,14 +342,14 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
             conversation,
             title: conversation.title,
             requestMessage: sanitizeMessageForTransmit(userMessage),
-            responseMessage: { ...response },
+            responseMessage: { ...responseWithText },
           };
 
           logger.debug(`[ResumableAgentController] Emitting FINAL event`, {
             streamId,
             wasAbortedBeforeComplete,
             userMessageId: userMessage?.messageId,
-            responseMessageId: response?.messageId,
+            responseMessageId: responseWithText?.messageId,
             conversationId: conversation?.conversationId,
           });
 
@@ -342,14 +362,14 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
             conversation,
             title: conversation.title,
             requestMessage: sanitizeMessageForTransmit(userMessage),
-            responseMessage: { ...response, unfinished: true },
+            responseMessage: { ...responseWithText, unfinished: true },
           };
 
           logger.debug(`[ResumableAgentController] Emitting ABORTED FINAL event`, {
             streamId,
             wasAbortedBeforeComplete,
             userMessageId: userMessage?.messageId,
-            responseMessageId: response?.messageId,
+            responseMessageId: responseWithText?.messageId,
             conversationId: conversation?.conversationId,
           });
 
@@ -361,7 +381,7 @@ const ResumableAgentController = async (req, res, next, initializeClient, addTit
         if (shouldGenerateTitle) {
           addTitle(req, {
             text,
-            response: { ...response },
+            response: { ...responseWithText },
             client,
           })
             .catch((err) => {


### PR DESCRIPTION
## Summary
- Populate top-level `text` from text content parts for resumable agent responses before saving or emitting final events.
- Apply the same normalization to partial responses saved after subscriber disconnects.
- Add a regression test covering content-only responses with empty `text`.

## Test Plan
- [x] `NODE_PATH=/data/projects/LibreChat/node_modules:/data/projects/LibreChat/api/node_modules /data/projects/LibreChat/node_modules/.bin/jest server/controllers/agents/__tests__/jobReplacement.spec.js --runInBand --coverage=false`