### PR TITLE
🛡️ fix: Handle MCP Tool Cache Lookup Failures

### DIFF
--- a/api/server/controllers/mcp.js
+++ b/api/server/controllers/mcp.js
@@ -78,12 +78,20 @@ const getMCPTools = async (req, res) => {
     const mcpManager = getMCPManager();
     const mcpServers = {};
 
-    const cachePromises = configuredServers.map((serverName) =>
-      getMCPServerTools(userId, serverName).then((tools) => ({ serverName, tools })),
-    );
-    const cacheResults = await Promise.all(cachePromises);
-
     const serverToolsMap = new Map();
+    const cacheResults = await Promise.all(
+      configuredServers.map(async (serverName) => {
+        try {
+          return {
+            serverName,
+            tools: await getMCPServerTools(userId, serverName),
+          };
+        } catch (error) {
+          logger.error(`[getMCPTools] Error fetching cached tools for ${serverName}:`, error);
+          return { serverName, tools: null };
+        }
+      }),
+    );
     for (const { serverName, tools } of cacheResults) {
       if (tools) {
         serverToolsMap.set(serverName, tools);

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -2008,6 +2008,43 @@ describe('MCP Routes', () => {
         tools: [],
       });
     });
+
+    it('should return configured servers when all cache lookups fail', async () => {
+      const { logger } = require('@librechat/data-schemas');
+      const { getMCPServerTools } = require('~/server/services/Config');
+
+      mockResolveAllMcpConfigs.mockResolvedValueOnce({
+        'first-server': {
+          type: 'sse',
+          url: 'https://first.example.com/sse',
+        },
+        'second-server': {
+          type: 'sse',
+          url: 'https://second.example.com/sse',
+        },
+      });
+
+      getMCPServerTools.mockRejectedValue(new Error('cache unavailable'));
+
+      const mockGetServerToolFunctions = jest.fn().mockResolvedValue(null);
+      require('~/config').getMCPManager.mockReturnValue({
+        getServerToolFunctions: mockGetServerToolFunctions,
+      });
+
+      const response = await request(app).get('/api/mcp/tools');
+
+      expect(response.status).toBe(200);
+      expect(response.body.servers['first-server']).toMatchObject({
+        name: 'first-server',
+        tools: [],
+      });
+      expect(response.body.servers['second-server']).toMatchObject({
+        name: 'second-server',
+        tools: [],
+      });
+      expect(logger.error).toHaveBeenCalledTimes(2);
+      expect(mockGetServerToolFunctions).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('GET /servers', () => {

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -1950,6 +1950,7 @@ describe('MCP Routes', () => {
   describe('GET /tools', () => {
     it('should continue returning MCP tools when one server cache lookup fails', async () => {
       const { Constants } = require('librechat-data-provider');
+      const { logger } = require('@librechat/data-schemas');
       const { getMCPServerTools } = require('~/server/services/Config');
 
       mockResolveAllMcpConfigs.mockResolvedValueOnce({
@@ -1964,6 +1965,7 @@ describe('MCP Routes', () => {
         },
       });
 
+      // Mock order matches Object.keys() order from the config above.
       getMCPServerTools
         .mockRejectedValueOnce(new Error('cache unavailable'))
         .mockResolvedValueOnce({
@@ -1977,13 +1979,19 @@ describe('MCP Routes', () => {
           },
         });
 
+      const mockGetServerToolFunctions = jest.fn().mockResolvedValue(null);
       require('~/config').getMCPManager.mockReturnValue({
-        getServerToolFunctions: jest.fn().mockResolvedValue(null),
+        getServerToolFunctions: mockGetServerToolFunctions,
       });
 
       const response = await request(app).get('/api/mcp/tools');
 
       expect(response.status).toBe(200);
+      expect(logger.error).toHaveBeenCalledWith(
+        '[getMCPTools] Error fetching cached tools for bad-server:',
+        expect.any(Error),
+      );
+      expect(mockGetServerToolFunctions).toHaveBeenCalledWith('test-user-id', 'bad-server');
       expect(response.body.servers['good-server']).toMatchObject({
         name: 'good-server',
         icon: '/icons/good.svg',

--- a/api/server/routes/__tests__/mcp.spec.js
+++ b/api/server/routes/__tests__/mcp.spec.js
@@ -1947,6 +1947,61 @@ describe('MCP Routes', () => {
     });
   });
 
+  describe('GET /tools', () => {
+    it('should continue returning MCP tools when one server cache lookup fails', async () => {
+      const { Constants } = require('librechat-data-provider');
+      const { getMCPServerTools } = require('~/server/services/Config');
+
+      mockResolveAllMcpConfigs.mockResolvedValueOnce({
+        'bad-server': {
+          type: 'sse',
+          url: 'https://bad.example.com/sse',
+        },
+        'good-server': {
+          type: 'sse',
+          url: 'https://good.example.com/sse',
+          iconPath: '/icons/good.svg',
+        },
+      });
+
+      getMCPServerTools
+        .mockRejectedValueOnce(new Error('cache unavailable'))
+        .mockResolvedValueOnce({
+          [`search${Constants.mcp_delimiter}good-server`]: {
+            type: 'function',
+            function: {
+              name: `search${Constants.mcp_delimiter}good-server`,
+              description: 'Search good server',
+              parameters: { type: 'object' },
+            },
+          },
+        });
+
+      require('~/config').getMCPManager.mockReturnValue({
+        getServerToolFunctions: jest.fn().mockResolvedValue(null),
+      });
+
+      const response = await request(app).get('/api/mcp/tools');
+
+      expect(response.status).toBe(200);
+      expect(response.body.servers['good-server']).toMatchObject({
+        name: 'good-server',
+        icon: '/icons/good.svg',
+        tools: [
+          {
+            name: 'search',
+            pluginKey: `search${Constants.mcp_delimiter}good-server`,
+            description: 'Search good server',
+          },
+        ],
+      });
+      expect(response.body.servers['bad-server']).toMatchObject({
+        name: 'bad-server',
+        tools: [],
+      });
+    });
+  });
+
   describe('GET /servers', () => {
     // mockRegistryInstance is defined at the top of the file
 

--- a/api/server/services/Config/__tests__/getCachedTools.spec.js
+++ b/api/server/services/Config/__tests__/getCachedTools.spec.js
@@ -1,6 +1,12 @@
 const { CacheKeys } = require('librechat-data-provider');
 
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
 jest.mock('~/cache/getLogStores');
+const { logger } = require('@librechat/data-schemas');
 const getLogStores = require('~/cache/getLogStores');
 
 const mockCache = { get: jest.fn(), set: jest.fn(), delete: jest.fn() };
@@ -73,6 +79,17 @@ describe('getCachedTools', () => {
       await getMCPServerTools('user1', 'github');
       expect(getLogStores).toHaveBeenCalledWith(CacheKeys.TOOL_CACHE);
       expect(mockCache.get).toHaveBeenCalledWith(ToolCacheKeys.MCP_SERVER('user1', 'github'));
+    });
+
+    it('getMCPServerTools should return null when the cache lookup fails', async () => {
+      const error = new Error('cache unavailable');
+      mockCache.get.mockRejectedValue(error);
+
+      await expect(getMCPServerTools('user1', 'github')).resolves.toBeNull();
+      expect(logger.error).toHaveBeenCalledWith(
+        '[getMCPServerTools] Error fetching cached tools for github:',
+        error,
+      );
     });
 
     it('should NOT use CONFIG_STORE namespace', async () => {

--- a/api/server/services/Config/__tests__/getCachedTools.spec.js
+++ b/api/server/services/Config/__tests__/getCachedTools.spec.js
@@ -92,6 +92,19 @@ describe('getCachedTools', () => {
       );
     });
 
+    it('getMCPServerTools should return null when the cache store is unavailable', async () => {
+      const error = new Error('cache store unavailable');
+      getLogStores.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      await expect(getMCPServerTools('user1', 'github')).resolves.toBeNull();
+      expect(logger.error).toHaveBeenCalledWith(
+        '[getMCPServerTools] Error fetching cached tools for github:',
+        error,
+      );
+    });
+
     it('should NOT use CONFIG_STORE namespace', async () => {
       mockCache.get.mockResolvedValue(null);
       await getCachedTools();

--- a/api/server/services/Config/getCachedTools.js
+++ b/api/server/services/Config/getCachedTools.js
@@ -1,4 +1,5 @@
 const { CacheKeys, Time } = require('librechat-data-provider');
+const { logger } = require('@librechat/data-schemas');
 const getLogStores = require('~/cache/getLogStores');
 
 /**
@@ -90,7 +91,13 @@ async function invalidateCachedTools(options = {}) {
  */
 async function getMCPServerTools(userId, serverName) {
   const cache = getLogStores(CacheKeys.TOOL_CACHE);
-  const serverTools = await cache.get(ToolCacheKeys.MCP_SERVER(userId, serverName));
+  let serverTools;
+  try {
+    serverTools = await cache.get(ToolCacheKeys.MCP_SERVER(userId, serverName));
+  } catch (error) {
+    logger.error(`[getMCPServerTools] Error fetching cached tools for ${serverName}:`, error);
+    return null;
+  }
 
   if (serverTools) {
     return serverTools;

--- a/api/server/services/Config/getCachedTools.js
+++ b/api/server/services/Config/getCachedTools.js
@@ -90,20 +90,13 @@ async function invalidateCachedTools(options = {}) {
  * @returns {Promise<LCAvailableTools|null>} The available tools for the server
  */
 async function getMCPServerTools(userId, serverName) {
-  const cache = getLogStores(CacheKeys.TOOL_CACHE);
-  let serverTools;
   try {
-    serverTools = await cache.get(ToolCacheKeys.MCP_SERVER(userId, serverName));
+    const cache = getLogStores(CacheKeys.TOOL_CACHE);
+    return (await cache.get(ToolCacheKeys.MCP_SERVER(userId, serverName))) || null;
   } catch (error) {
     logger.error(`[getMCPServerTools] Error fetching cached tools for ${serverName}:`, error);
     return null;
   }
-
-  if (serverTools) {
-    return serverTools;
-  }
-
-  return null;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary

- Make `GET /api/mcp/tools` tolerate per-server cache lookup failures.
- Harden `getMCPServerTools` itself so all callers degrade to cache-miss behavior when the tool cache backend is unavailable.
- Guard both cache-store resolution and cache reads in `getMCPServerTools`.
- Preserve the existing live MCP manager fallback for servers whose cached tools cannot be read.
- Add regression coverage for partial route-level cache failure, total route-level cache outage, helper-level cache read failure, and helper-level cache-store failure.

## Root Cause

The MCP tools endpoint gathered cached tools for every configured server with a single aggregate promise. If one server's cache read rejected, the whole endpoint returned a 500 before later per-server error isolation could run. The same helper was also used by agent-loading paths, so centralizing the fallback in `getMCPServerTools` prevents cache read failures from breaking those callers as well.

## Review Resolution

- Addressed the major finding by hardening `getMCPServerTools` centrally.
- Addressed the route-test findings by asserting the live fallback is called, asserting the cache error is logged, and documenting the mock ordering.
- Added helper coverage verifying cache lookup failures return `null` and log the error.
- Added route coverage for the case where every configured server cache lookup fails.
- Addressed the follow-up nit by including `getLogStores` inside the helper guard and adding coverage for cache-store resolution failure.

## Validation

- `node --check api/server/controllers/mcp.js`
- `node --check api/server/routes/__tests__/mcp.spec.js`
- `node --check api/server/services/Config/getCachedTools.js`
- `node --check api/server/services/Config/__tests__/getCachedTools.spec.js`
- `git diff --check -- api/server/controllers/mcp.js api/server/routes/__tests__/mcp.spec.js api/server/services/Config/getCachedTools.js api/server/services/Config/__tests__/getCachedTools.spec.js`

Attempted:

- `cd api && npx jest server/routes/__tests__/mcp.spec.js --runInBand`
- `cd api && npx jest server/services/Config/__tests__/getCachedTools.spec.js --runInBand`

Both Jest runs failed before executing tests because this worktree has no installed dependencies and Jest setup cannot resolve `dotenv` from `api/test/jestSetup.js`.