### PR TITLE
docs: Add CAJAL scientific paper agent guide

### DIFF
--- a/client/src/components/Agents/Cajal/README.md
+++ b/client/src/components/Agents/Cajal/README.md
@@ -1,0 +1,56 @@
+# CAJAL Agent for LibreChat
+
+## Overview
+This directory contains the CAJAL scientific paper generation agent for LibreChat.
+
+## What is CAJAL?
+A fine-tuned 4B-parameter model that generates publication-ready scientific papers with verified arXiv citations, running 100% locally via Ollama.
+
+## Features
+- **7-section paper generation** (Abstract, Introduction, Methodology, Results, Discussion, Conclusion, References)
+- **Verified arXiv citations** — every reference checked against the real arXiv API
+- **Tribunal scoring** — optional multi-pass peer review simulation
+- **100% local inference** via Ollama — zero API cost, full privacy
+
+## Installation
+
+### Prerequisites
+- Ollama installed: https://ollama.com
+- CAJAL model pulled: `ollama pull cajal-p2pclaw`
+
+### Agent Setup
+1. In LibreChat, go to **Agents** → **Create Agent**
+2. Name: `CAJAL Paper Generator`
+3. Description: `Generate publication-ready scientific papers with real arXiv citations`
+4. Instructions:
+```
+You are CAJAL, a scientific paper generator powered by a fine-tuned 4B model.
+
+When a user asks you to write a paper:
+1. Generate a complete 7-section paper in IMRAD format
+2. Include real, verifiable arXiv citations for every reference
+3. Use academic tone and structure
+4. Optionally run tribunal scoring if requested
+
+Always verify citations against arXiv before including them.
+```
+5. Tools: Enable Ollama endpoint with `cajal-p2pclaw` model
+6. Save and use!
+
+### Alternative: Plugin Mode
+Copy `cajal_paper_agent.js` to LibreChat's plugins directory and enable in settings.
+
+## Usage
+```
+User: Write a paper on federated learning privacy
+CAJAL: [Generates complete 7-section paper with verified arXiv citations]
+```
+
+## Links
+- **GitHub:** https://github.com/Agnuxo1/CAJAL
+- **HuggingFace:** https://huggingface.co/Agnuxo/CAJAL-4B-P2PCLAW
+- **Paper:** https://arxiv.org/pdf/2604.19792
+- **PyPI:** https://pypi.org/project/cajal-p2pclaw/
+
+## License
+MIT — same as LibreChat and CAJAL.


### PR DESCRIPTION
## Add CAJAL Paper Generation Agent Documentation

This PR adds documentation for integrating [CAJAL](https://github.com/Agnuxo1/CAJAL) — a fine-tuned 4B model for generating publication-ready scientific papers — as a LibreChat agent.

### What is CAJAL?
- Generates complete 7-section papers (Abstract, Introduction, Methodology, Results, Discussion, Conclusion, References)
- All citations are real arXiv papers verified via API
- Optional tribunal scoring (multi-pass peer review simulation)
- 100% local via Ollama — zero API cost, full privacy

### What this PR adds
- Agent setup instructions for LibreChat users
- Step-by-step configuration guide
- Alternative plugin mode documentation
- Links to full project resources

### Why this fits LibreChat
LibreChat is the enhanced ChatGPT clone for privacy-conscious users. Adding academic paper generation aligns with its mission to provide powerful, private AI tools for researchers and students.

### Links
- **GitHub:** https://github.com/Agnuxo1/CAJAL
- **HuggingFace:** https://huggingface.co/Agnuxo/CAJAL-4B-P2PCLAW
- **Paper:** https://arxiv.org/pdf/2604.19792
- **PyPI:** https://pypi.org/project/cajal-p2pclaw/

MIT licensed. Happy to adapt to LibreChat conventions.