### PR TITLE
🔐 fix: Avoid Logging Password On Login Validation Error

### DIFF
--- a/api/strategies/localStrategy.js
+++ b/api/strategies/localStrategy.js
@@ -18,7 +18,7 @@ async function passportLogin(req, email, password, done) {
   try {
     const validationError = await validateLoginRequest(req);
     if (validationError) {
-      logError('Passport Local Strategy - Validation Error', { reqBody: req.body });
+      logError('Passport Local Strategy - Validation Error', { email: req.body?.email });
       logger.error(`[Login] [Login failed] [Username: ${email}] [Request-IP: ${req.ip}]`);
       return done(null, false, { message: validationError });
     }


### PR DESCRIPTION
## Summary

I removed the user's password from a winston error log on the Passport local strategy validation path.

- Replaced `logError('… - Validation Error', { reqBody: req.body })` with `{ email: req.body?.email }` in `api/strategies/localStrategy.js`.
- Matched the metadata shape used by sibling `logError` calls in the same function.
- Stopped the cleartext password from landing in `error-*.log`, stdout, and `journalctl` whenever a login payload fails Zod validation. The existing `redactFormat()` only scrubs `info.message`, not the metadata `parameters` array, so the prior log shape leaked the full body to disk.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manual reproduction:

```
curl -X POST http://localhost:3080/api/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"email":"not-email","password":"CANARY_PWD_42"}'
```

Confirm `error-*.log` records the validation error with the email but no longer includes `CANARY_PWD_42`.

Smoke-test the happy-path login flow to confirm normal authentication is unaffected.

### **Test Configuration**:

- Node 20.x
- Local MongoDB instance

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes