### PR TITLE
🧼 fix: Sanitize HTML In Admin Banner And MCP Config Dialog

### DIFF
--- a/client/src/components/Banners/Banner.tsx
+++ b/client/src/components/Banners/Banner.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef } from 'react';
+import DOMPurify from 'dompurify';
 import { XIcon } from 'lucide-react';
 import { useRecoilState } from 'recoil';
 import { Button, cn } from '@librechat/client';
+import { useEffect, useMemo, useRef } from 'react';
 import { useGetBannerQuery } from '~/data-provider';
 import store from '~/store';
 
@@ -9,6 +10,25 @@ export const Banner = ({ onHeightChange }: { onHeightChange?: (height: number) =
   const { data: banner } = useGetBannerQuery();
   const [hideBannerHint, setHideBannerHint] = useRecoilState<string[]>(store.hideBannerHint);
   const bannerRef = useRef<HTMLDivElement>(null);
+
+  const sanitizedMessage = useMemo(() => {
+    if (!banner?.message) {
+      return '';
+    }
+    const sanitizer = DOMPurify();
+    sanitizer.addHook('afterSanitizeAttributes', (node) => {
+      if (node.tagName === 'A') {
+        node.setAttribute('target', '_blank');
+        node.setAttribute('rel', 'noopener noreferrer');
+      }
+    });
+    return sanitizer.sanitize(banner.message, {
+      ALLOWED_TAGS: ['a', 'strong', 'b', 'em', 'i', 'br', 'code', 'span'],
+      ALLOWED_ATTR: ['href', 'class', 'target', 'rel'],
+      ALLOW_DATA_ATTR: false,
+      ALLOW_ARIA_ATTR: false,
+    });
+  }, [banner?.message]);
 
   useEffect(() => {
     if (onHeightChange && bannerRef.current) {
@@ -45,7 +65,7 @@ export const Banner = ({ onHeightChange }: { onHeightChange?: (height: number) =
           'text-md w-full truncate text-center [&_a]:text-blue-700 [&_a]:underline dark:[&_a]:text-blue-400',
           !banner.persistable && 'px-4',
         )}
-        dangerouslySetInnerHTML={{ __html: banner.message }}
+        dangerouslySetInnerHTML={{ __html: sanitizedMessage }}
       ></div>
       {!banner.persistable && (
         <Button

--- a/client/src/components/Chat/Input/MCPConfigDialog.tsx
+++ b/client/src/components/Chat/Input/MCPConfigDialog.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import DOMPurify from 'dompurify';
+import React, { useEffect, useMemo } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { Button, Input, Label, OGDialog, OGDialogTemplate } from '@librechat/client';
 import type { ConfigFieldDetail } from '~/common';
@@ -34,6 +35,25 @@ export default function MCPConfigDialog({
   } = useForm<Record<string, string>>({
     defaultValues: initialValues,
   });
+
+  const sanitizer = useMemo(() => {
+    const instance = DOMPurify();
+    instance.addHook('afterSanitizeAttributes', (node) => {
+      if (node.tagName === 'A') {
+        node.setAttribute('target', '_blank');
+        node.setAttribute('rel', 'noopener noreferrer');
+      }
+    });
+    return instance;
+  }, []);
+
+  const sanitize = (html: string) =>
+    sanitizer.sanitize(html, {
+      ALLOWED_TAGS: ['a', 'strong', 'b', 'em', 'i', 'br', 'code', 'span', 'p'],
+      ALLOWED_ATTR: ['href', 'class', 'target', 'rel'],
+      ALLOW_DATA_ATTR: false,
+      ALLOW_ARIA_ATTR: false,
+    });
 
   useEffect(() => {
     if (isOpen) {
@@ -83,7 +103,7 @@ export default function MCPConfigDialog({
                 {details.description && (
                   <p
                     className="text-xs text-text-secondary [&_a]:text-blue-500 [&_a]:hover:text-blue-600 dark:[&_a]:text-blue-400 dark:[&_a]:hover:text-blue-300"
-                    dangerouslySetInnerHTML={{ __html: details.description }}
+                    dangerouslySetInnerHTML={{ __html: sanitize(details.description) }}
                   />
                 )}
                 {errors[key] && <p className="text-xs text-red-500">{errors[key]?.message}</p>}


### PR DESCRIPTION
## Summary

I wrapped two admin-supplied HTML sinks in DOMPurify so a compromised admin or yaml supply-chain payload cannot execute arbitrary script in users' browsers.

- Sanitized `banner.message` in `client/src/components/Banners/Banner.tsx` before passing to `dangerouslySetInnerHTML`.
- Sanitized each MCP `customUserVars` description in `client/src/components/Chat/Input/MCPConfigDialog.tsx` before rendering inside the configuration dialog.
- Reused the sanitizer pattern from `CustomUserVarsSection.tsx` and `Tooltip.tsx`: instance-scoped `DOMPurify()` with an `afterSanitizeAttributes` hook that injects `target="_blank"` and `rel="noopener noreferrer"` on `<a>` tags.
- Restricted the allowed tag set to `a, strong, b, em, i, br, code, span` (plus `p` in the dialog) and the allowed attribute set to `href, class, target, rel`, preserving the existing link-formatting use case while stripping `<img>`, `<script>`, event handlers, and other vectors.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Set a banner via admin with `<img src=x onerror=alert(1)>` and confirm no alert fires; the `<img>` is removed from the rendered DOM. Repeat with a malicious description in `librechat.yaml` `customUserVars` and open the MCP configuration dialog to confirm the payload is sanitized.

Verify legitimate banner and description content using `<a href>`, `<strong>`, and `<code>` still renders correctly in both surfaces.

### **Test Configuration**:

- Latest `dev`
- A `librechat.yaml` with at least one MCP server defining `customUserVars`
- Admin banner configured via the existing banner mechanism

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes