### PR TITLE
🚦 feat: Make URL Auto-Submit Configurable

### DIFF
--- a/client/src/hooks/Input/useQueryParams.ts
+++ b/client/src/hooks/Input/useQueryParams.ts
@@ -266,7 +266,10 @@ export default function useQueryParams({
       const { decodedPrompt, validSettings, shouldAutoSubmit } = processQueryParams();
       const hasSettings = Object.keys(validSettings).length > 0;
 
-      if (!shouldAutoSubmit) {
+      const autoSubmitAllowed = startupConfig.interface?.autoSubmitFromUrl !== false;
+      const willAutoSubmit = shouldAutoSubmit && autoSubmitAllowed;
+
+      if (!willAutoSubmit) {
         submissionHandledRef.current = true;
       }
 
@@ -291,7 +294,7 @@ export default function useQueryParams({
       }
 
       // Handle auto-submission
-      if (shouldAutoSubmit && decodedPrompt) {
+      if (willAutoSubmit && decodedPrompt) {
         if (hasSettings) {
           // Settings are changing, defer submission
           pendingSubmitRef.current = true;

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -725,6 +725,7 @@ export const interfaceSchema = z
       .optional(),
     temporaryChat: z.boolean().optional(),
     temporaryChatRetention: z.number().min(1).max(8760).optional(),
+    autoSubmitFromUrl: z.boolean().optional(),
     runCode: z.boolean().optional(),
     webSearch: z.boolean().optional(),
     peoplePicker: z
@@ -782,6 +783,7 @@ export const interfaceSchema = z
       public: false,
     },
     temporaryChat: true,
+    autoSubmitFromUrl: true,
     runCode: true,
     webSearch: true,
     peoplePicker: {


### PR DESCRIPTION
## Summary

I added an `interface.autoSubmitFromUrl` flag so operators handling sensitive memory or tool data can disable the `/c/new?prompt=…&submit=true` auto-submit behavior, while preserving current behavior by default for everyone else.

- Added `autoSubmitFromUrl: z.boolean().optional()` to `interfaceSchema` in `packages/data-provider/src/config.ts`.
- Defaulted the flag to `true` inside the schema's `.default()` block so existing deployments continue to auto-submit URL-supplied prompts without configuration changes.
- Gated the auto-submit branch in `client/src/hooks/Input/useQueryParams.ts` on `startupConfig.interface?.autoSubmitFromUrl !== false`.
- Falls back to pre-filling the composer when the flag is disabled, so the URL still seeds the prompt but the user has to press Send explicitly.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Default install (no `librechat.yaml` change): navigate to `/c/new?prompt=hello&submit=true` while authenticated and confirm the prompt auto-submits as before.

Set `interface.autoSubmitFromUrl: false` in `librechat.yaml`, restart the backend, and navigate to the same URL: confirm the prompt is pre-filled in the composer but does not submit until the user clicks Send.

Confirm that manual chat send works in both modes and that other URL-driven behavior (model spec selection, settings application) is unchanged.

### **Test Configuration**:

- Latest `dev`
- A test `librechat.yaml` with the new flag both omitted and explicitly set to `false`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes