### PR TITLE
🛡️ feat: Optionally Block Private IPs On User-Provided baseURL

### DIFF
--- a/api/server/routes/keys.js
+++ b/api/server/routes/keys.js
@@ -1,17 +1,46 @@
 const express = require('express');
 const { updateUserKey, deleteUserKey, getUserKeyExpiry } = require('~/models');
 const { requireJwtAuth } = require('~/server/middleware');
+const configMiddleware = require('~/server/middleware/config/app');
+const { validateUserBaseURL } = require('~/server/utils/validateBaseURL');
 
 const router = express.Router();
 
-router.put('/', requireJwtAuth, async (req, res) => {
+router.put('/', requireJwtAuth, configMiddleware, async (req, res) => {
   if (req.body == null || typeof req.body !== 'object') {
     return res.status(400).send({ error: 'Invalid request body.' });
   }
   const { name, value, expiresAt } = req.body;
+
+  if (req.config?.interfaceConfig?.blockPrivateUserBaseURL && typeof value === 'string') {
+    const submittedBaseURL = extractBaseURL(value);
+    if (submittedBaseURL) {
+      try {
+        await validateUserBaseURL(submittedBaseURL);
+      } catch (err) {
+        return res.status(400).send({ error: err.message });
+      }
+    }
+  }
+
   await updateUserKey({ userId: req.user.id, name, value, expiresAt });
   res.status(201).send();
 });
+
+function extractBaseURL(value) {
+  if (!value.startsWith('{')) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed && typeof parsed.baseURL === 'string' && parsed.baseURL.length > 0) {
+      return parsed.baseURL;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
 
 router.delete('/:name', requireJwtAuth, async (req, res) => {
   const { name } = req.params;

--- a/api/server/utils/validateBaseURL.js
+++ b/api/server/utils/validateBaseURL.js
@@ -1,0 +1,43 @@
+const dns = require('node:dns').promises;
+const { isPrivateIP } = require('@librechat/api');
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+/**
+ * Validates that a user-supplied baseURL is safe to fetch from.
+ *
+ * Throws when the URL is malformed, uses a non-http(s) protocol, or
+ * resolves (now) to a private/loopback/link-local address. The DNS
+ * check is best-effort and does not protect against rebinding at
+ * fetch time — runtime call sites should still use SSRF-safe agents.
+ *
+ * @param {string} rawBaseURL
+ * @returns {Promise<void>}
+ */
+async function validateUserBaseURL(rawBaseURL) {
+  let parsed;
+  try {
+    parsed = new URL(rawBaseURL);
+  } catch {
+    throw new Error('baseURL is not a valid URL');
+  }
+
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+    throw new Error(`baseURL must use http or https, got "${parsed.protocol}"`);
+  }
+
+  let addresses;
+  try {
+    addresses = await dns.lookup(parsed.hostname, { all: true });
+  } catch {
+    throw new Error('baseURL hostname could not be resolved');
+  }
+
+  for (const { address } of addresses) {
+    if (isPrivateIP(address)) {
+      throw new Error('baseURL resolves to a private or reserved IP address');
+    }
+  }
+}
+
+module.exports = { validateUserBaseURL };

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -725,6 +725,7 @@ export const interfaceSchema = z
       .optional(),
     temporaryChat: z.boolean().optional(),
     temporaryChatRetention: z.number().min(1).max(8760).optional(),
+    blockPrivateUserBaseURL: z.boolean().optional(),
     runCode: z.boolean().optional(),
     webSearch: z.boolean().optional(),
     peoplePicker: z


### PR DESCRIPTION
## Summary

I added an `interface.blockPrivateUserBaseURL` flag plus save-time validation in `/api/keys` so that on instances where an admin opts in, a user cannot point a custom-endpoint baseURL at internal services (cloud metadata endpoints, intranet APIs, etc.) and have the backend issue requests there on every model-listing fetch.

- Added `blockPrivateUserBaseURL: z.boolean().optional()` to `interfaceSchema` in `packages/data-provider/src/config.ts`. Default is `false` so existing deployments — including legitimate self-hosted-LLM use cases on private IPs — continue to work without changes.
- Added `validateUserBaseURL` at `api/server/utils/validateBaseURL.js`. Rejects malformed URLs, non-http(s) protocols, and hostnames that resolve to private/loopback/link-local IPs. Uses `isPrivateIP` from `@librechat/api`.
- Applied `configMiddleware` and the new validator to the PUT handler in `api/server/routes/keys.js`.
- Parsed the JSON-encoded `value` payload sent from `SetKeyDialog` and validated the `baseURL` field when present, rejecting with HTTP 400 + the validator error on failure.

This is save-time validation only. DNS-rebinding bypass remains theoretically possible; runtime call sites should adopt SSRF-safe agents in a follow-up for full defense in depth.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Default install with `endpoints.custom[].baseURL: 'user_provided'`: PUT a user-key payload with `baseURL: http://localhost:11434` and confirm the save succeeds. The flag is off by default so backward-compatible behavior is preserved.

Set `interface.blockPrivateUserBaseURL: true` in `librechat.yaml`, restart the backend, and:

- PUT the same private-IP payload and confirm a 400 response with the resolves-to-private error message.
- PUT a payload with `baseURL: file:///etc/passwd` and confirm a 400 with the protocol-rejection message.
- PUT a payload with `baseURL: https://api.openai.com` and confirm the save succeeds.
- PUT a payload with `baseURL: http://no-such-host.invalid` and confirm a 400 with the resolution-failed message.

Verify that the existing model-listing flow continues to use the saved baseURL once the value is accepted.

### **Test Configuration**:

- Latest `dev`
- A `librechat.yaml` with at least one custom endpoint configured as `baseURL: 'user_provided'`
- The new flag tested both omitted and set to `true`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes