### PR TITLE
🛡️ fix: Harden MCP Redirect SSRF Checks

### DIFF
--- a/packages/api/src/mcp/__tests__/MCPConnectionSSRF.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionSSRF.test.ts
@@ -39,7 +39,15 @@ jest.mock('@librechat/data-schemas', () => ({
 }));
 
 jest.mock('~/auth', () => ({
-  createSSRFSafeUndiciConnect: jest.fn(() => undefined),
+  createSSRFSafeUndiciConnect: jest.fn(() => ({
+    lookup: (_hostname: string, optionsOrCallback: unknown, maybeCallback?: LookupCallback) => {
+      const callback =
+        typeof optionsOrCallback === 'function'
+          ? (optionsOrCallback as LookupCallback)
+          : maybeCallback;
+      callback?.(null, '127.0.0.1', 4);
+    },
+  })),
   resolveHostnameSSRF: jest.fn(async () => false),
 }));
 
@@ -53,6 +61,57 @@ const mockedResolveHostnameSSRF = resolveHostnameSSRF as jest.MockedFunction<
 const mockedCreateSSRFSafeUndiciConnect = createSSRFSafeUndiciConnect as jest.MockedFunction<
   typeof createSSRFSafeUndiciConnect
 >;
+
+function getLookupCallback(
+  optionsOrCallback: unknown,
+  maybeCallback?: LookupCallback,
+): LookupCallback {
+  if (typeof optionsOrCallback === 'function') {
+    return optionsOrCallback as LookupCallback;
+  }
+  if (maybeCallback) {
+    return maybeCallback;
+  }
+  throw new Error('lookup callback missing');
+}
+
+function createRebindBlockingLookup(): jest.Mock {
+  return jest.fn((hostname: string, optionsOrCallback: unknown, maybeCallback?: LookupCallback) => {
+    const callback = getLookupCallback(optionsOrCallback, maybeCallback);
+    if (hostname !== 'rebind.test') {
+      callback(null, '127.0.0.1', 4);
+      return;
+    }
+    const err = Object.assign(
+      new Error('SSRF protection: rebind.test resolved to blocked address 127.0.0.1'),
+      { code: 'ESSRF' },
+    ) as NodeJS.ErrnoException;
+    callback(err, '127.0.0.1', 4);
+  });
+}
+
+function collectErrorMessages(error: unknown): string[] {
+  const messages: string[] = [];
+  let current: unknown = error;
+  while (current instanceof Error) {
+    messages.push(current.message);
+    current = (current as { cause?: unknown }).cause;
+  }
+  return messages;
+}
+
+async function expectRebindSSRFRejection(promise: Promise<unknown>): Promise<void> {
+  let caught: unknown;
+  try {
+    await promise;
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeDefined();
+  expect(
+    collectErrorMessages(caught).some((message) => /SSRF protection: rebind\.test/.test(message)),
+  ).toBe(true);
+}
 
 async function safeDisconnect(conn: MCPConnection | null): Promise<void> {
   if (!conn) {
@@ -598,20 +657,8 @@ describe('MCP SSRF protection – 307/308 redirect to private IP', () => {
       rebindUrl.hostname = 'rebind.test';
       server = await createCrossOriginRedirectingServer(rebindUrl.href, 308);
       mockedResolveHostnameSSRF.mockResolvedValueOnce(false);
-
-      const lookup = jest.fn(
-        (_hostname: string, optionsOrCallback: unknown, maybeCallback?: LookupCallback) => {
-          const callback =
-            typeof optionsOrCallback === 'function'
-              ? (optionsOrCallback as LookupCallback)
-              : maybeCallback!;
-          const err = Object.assign(
-            new Error('SSRF protection: rebind.test resolved to blocked address 127.0.0.1'),
-            { code: 'ESSRF' },
-          ) as NodeJS.ErrnoException;
-          callback(err, '127.0.0.1', 4);
-        },
-      );
+      mockedCreateSSRFSafeUndiciConnect.mockClear();
+      const lookup = createRebindBlockingLookup();
       mockedCreateSSRFSafeUndiciConnect.mockReturnValueOnce({
         lookup,
       } as ReturnType<typeof createSSRFSafeUndiciConnect>);
@@ -622,10 +669,41 @@ describe('MCP SSRF protection – 307/308 redirect to private IP', () => {
         useSSRFProtection: false,
       });
 
-      await expect(conn.connect()).rejects.toThrow();
+      await expectRebindSSRFRejection(conn.connect());
       expect(server.redirectHit).toBe(true);
+      expect(mockedCreateSSRFSafeUndiciConnect).toHaveBeenCalledTimes(1);
       expect(lookup).toHaveBeenCalled();
       expect(lookup.mock.calls[0]?.[0]).toBe('rebind.test');
+      expect(capture.receivedHeaders).toHaveLength(0);
+    } finally {
+      await capture.close();
+    }
+  });
+
+  it('should keep using the original SSRF-safe dispatcher when protection is already on', async () => {
+    const capture = await createHeaderCaptureServer();
+    try {
+      const rebindUrl = new URL(capture.url);
+      rebindUrl.hostname = 'rebind.test';
+      server = await createCrossOriginRedirectingServer(rebindUrl.href, 308);
+      mockedResolveHostnameSSRF.mockResolvedValueOnce(false);
+      mockedCreateSSRFSafeUndiciConnect.mockClear();
+      const lookup = createRebindBlockingLookup();
+      mockedCreateSSRFSafeUndiciConnect.mockReturnValueOnce({
+        lookup,
+      } as ReturnType<typeof createSSRFSafeUndiciConnect>);
+
+      conn = new MCPConnection({
+        serverName: 'redirect-rebinding-block-protection-on',
+        serverConfig: { type: 'streamable-http', url: server.url },
+        useSSRFProtection: true,
+      });
+
+      await expectRebindSSRFRejection(conn.connect());
+      expect(server.redirectHit).toBe(true);
+      expect(mockedCreateSSRFSafeUndiciConnect).toHaveBeenCalledTimes(1);
+      expect(lookup).toHaveBeenCalled();
+      expect(lookup.mock.calls.some(([hostname]) => hostname === 'rebind.test')).toBe(true);
       expect(capture.receivedHeaders).toHaveLength(0);
     } finally {
       await capture.close();

--- a/packages/api/src/mcp/__tests__/MCPConnectionSSRF.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionSSRF.test.ts
@@ -45,7 +45,10 @@ jest.mock('~/auth', () => ({
         typeof optionsOrCallback === 'function'
           ? (optionsOrCallback as LookupCallback)
           : maybeCallback;
-      callback?.(null, '127.0.0.1', 4);
+      if (!callback) {
+        throw new Error('lookup callback missing');
+      }
+      callback(null, '127.0.0.1', 4);
     },
   })),
   resolveHostnameSSRF: jest.fn(async () => false),
@@ -102,12 +105,16 @@ function collectErrorMessages(error: unknown): string[] {
 
 async function expectRebindSSRFRejection(promise: Promise<unknown>): Promise<void> {
   let caught: unknown;
+  let didReject = false;
   try {
     await promise;
   } catch (error) {
+    didReject = true;
     caught = error;
   }
-  expect(caught).toBeDefined();
+  if (!didReject) {
+    throw new Error('Expected promise to reject with SSRF error, but it resolved');
+  }
   expect(
     collectErrorMessages(caught).some((message) => /SSRF protection: rebind\.test/.test(message)),
   ).toBe(true);

--- a/packages/api/src/mcp/__tests__/MCPConnectionSSRF.test.ts
+++ b/packages/api/src/mcp/__tests__/MCPConnectionSSRF.test.ts
@@ -24,9 +24,10 @@ import type {
 } from 'undici';
 import type { Socket } from 'net';
 import { MCPConnection } from '~/mcp/connection';
-import { resolveHostnameSSRF } from '~/auth';
+import { createSSRFSafeUndiciConnect, resolveHostnameSSRF } from '~/auth';
 
 type CustomFetch = (input: UndiciRequestInfo, init?: UndiciRequestInit) => Promise<UndiciResponse>;
+type LookupCallback = (err: NodeJS.ErrnoException | null, address: string, family: number) => void;
 
 jest.mock('@librechat/data-schemas', () => ({
   logger: {
@@ -48,6 +49,9 @@ jest.mock('~/mcp/mcpConfig', () => ({
 
 const mockedResolveHostnameSSRF = resolveHostnameSSRF as jest.MockedFunction<
   typeof resolveHostnameSSRF
+>;
+const mockedCreateSSRFSafeUndiciConnect = createSSRFSafeUndiciConnect as jest.MockedFunction<
+  typeof createSSRFSafeUndiciConnect
 >;
 
 async function safeDisconnect(conn: MCPConnection | null): Promise<void> {
@@ -581,6 +585,47 @@ describe('MCP SSRF protection – 307/308 redirect to private IP', () => {
 
       await expect(conn.connect()).rejects.toThrow();
       expect(server.redirectHit).toBe(true);
+      expect(capture.receivedHeaders).toHaveLength(0);
+    } finally {
+      await capture.close();
+    }
+  });
+
+  it('should block DNS rebinding between redirect pre-check and connect-time lookup', async () => {
+    const capture = await createHeaderCaptureServer();
+    try {
+      const rebindUrl = new URL(capture.url);
+      rebindUrl.hostname = 'rebind.test';
+      server = await createCrossOriginRedirectingServer(rebindUrl.href, 308);
+      mockedResolveHostnameSSRF.mockResolvedValueOnce(false);
+
+      const lookup = jest.fn(
+        (_hostname: string, optionsOrCallback: unknown, maybeCallback?: LookupCallback) => {
+          const callback =
+            typeof optionsOrCallback === 'function'
+              ? (optionsOrCallback as LookupCallback)
+              : maybeCallback!;
+          const err = Object.assign(
+            new Error('SSRF protection: rebind.test resolved to blocked address 127.0.0.1'),
+            { code: 'ESSRF' },
+          ) as NodeJS.ErrnoException;
+          callback(err, '127.0.0.1', 4);
+        },
+      );
+      mockedCreateSSRFSafeUndiciConnect.mockReturnValueOnce({
+        lookup,
+      } as ReturnType<typeof createSSRFSafeUndiciConnect>);
+
+      conn = new MCPConnection({
+        serverName: 'redirect-rebinding-block',
+        serverConfig: { type: 'streamable-http', url: server.url },
+        useSSRFProtection: false,
+      });
+
+      await expect(conn.connect()).rejects.toThrow();
+      expect(server.redirectHit).toBe(true);
+      expect(lookup).toHaveBeenCalled();
+      expect(lookup.mock.calls[0]?.[0]).toBe('rebind.test');
       expect(capture.receivedHeaders).toHaveLength(0);
     } finally {
       await capture.close();

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -570,6 +570,7 @@ export class MCPConnection extends EventEmitter {
   ): (input: UndiciRequestInfo, init?: UndiciRequestInit) => Promise<UndiciResponse> {
     const ssrfConnect = this.useSSRFProtection ? createSSRFSafeUndiciConnect() : undefined;
     const connectOpts = ssrfConnect != null ? { connect: ssrfConnect } : {};
+    /** Capture only the fields needed by the fetch closure; see factory note above. */
     const useSSRFProtection = this.useSSRFProtection;
     const agents = this.agents;
     const effectiveTimeout = timeout || DEFAULT_TIMEOUT;
@@ -592,16 +593,18 @@ export class MCPConnection extends EventEmitter {
 
     let safeRedirectPostAgent: Agent | undefined;
     let safeRedirectGetAgent: Agent | undefined;
+    /**
+     * Allowlist mode keeps the original MCP URL admin-approved, but redirect
+     * targets are server-controlled. These agents add connect-time DNS checks
+     * for those cross-origin hops so DNS rebinding cannot beat the standalone
+     * resolveHostnameSSRF pre-check.
+     */
     const createSafeRedirectAgent = (bodyTimeout: number): Agent => {
-      const redirectSSRFConnect = createSSRFSafeUndiciConnect() as
-        | ReturnType<typeof createSSRFSafeUndiciConnect>
-        | undefined;
-      const redirectConnectOpts =
-        redirectSSRFConnect != null ? { connect: redirectSSRFConnect } : {};
+      const redirectSSRFConnect = createSSRFSafeUndiciConnect();
       const agent = new Agent({
         bodyTimeout,
         headersTimeout: effectiveTimeout,
-        ...redirectConnectOpts,
+        connect: redirectSSRFConnect,
       });
       agents.push(agent);
       return agent;
@@ -690,6 +693,12 @@ export class MCPConnection extends EventEmitter {
         }
 
         if (!useSSRFProtection && isCrossOriginRedirect) {
+          /**
+           * Once a server-controlled cross-origin hop is seen, keep the safe
+           * dispatcher for the rest of this redirect chain. Restoring the
+           * original dispatcher on a later hop back to the original origin
+           * would re-open the allowlist-mode rebinding gap.
+           */
           currentInit = {
             ...currentInit,
             dispatcher: getSafeRedirectDispatcher(isGet),

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -570,6 +570,8 @@ export class MCPConnection extends EventEmitter {
   ): (input: UndiciRequestInfo, init?: UndiciRequestInit) => Promise<UndiciResponse> {
     const ssrfConnect = this.useSSRFProtection ? createSSRFSafeUndiciConnect() : undefined;
     const connectOpts = ssrfConnect != null ? { connect: ssrfConnect } : {};
+    const useSSRFProtection = this.useSSRFProtection;
+    const agents = this.agents;
     const effectiveTimeout = timeout || DEFAULT_TIMEOUT;
     const postAgent = new Agent({
       bodyTimeout: effectiveTimeout,
@@ -587,6 +589,31 @@ export class MCPConnection extends EventEmitter {
       });
       this.agents.push(getAgent);
     }
+
+    let safeRedirectPostAgent: Agent | undefined;
+    let safeRedirectGetAgent: Agent | undefined;
+    const createSafeRedirectAgent = (bodyTimeout: number): Agent => {
+      const redirectSSRFConnect = createSSRFSafeUndiciConnect() as
+        | ReturnType<typeof createSSRFSafeUndiciConnect>
+        | undefined;
+      const redirectConnectOpts =
+        redirectSSRFConnect != null ? { connect: redirectSSRFConnect } : {};
+      const agent = new Agent({
+        bodyTimeout,
+        headersTimeout: effectiveTimeout,
+        ...redirectConnectOpts,
+      });
+      agents.push(agent);
+      return agent;
+    };
+    const getSafeRedirectDispatcher = (isGetRequest: boolean): Agent => {
+      if (!isGetRequest || sseBodyTimeout == null) {
+        safeRedirectPostAgent ??= createSafeRedirectAgent(effectiveTimeout);
+        return safeRedirectPostAgent;
+      }
+      safeRedirectGetAgent ??= createSafeRedirectAgent(sseBodyTimeout);
+      return safeRedirectGetAgent;
+    };
 
     return async function customFetch(
       input: UndiciRequestInfo,
@@ -635,12 +662,13 @@ export class MCPConnection extends EventEmitter {
         }
 
         const targetUrl = new URL(location, currentUrlString);
+        const isCrossOriginRedirect = targetUrl.origin !== originalOrigin;
 
         /**
-         * Defense-in-depth SSRF check on every redirect hop. The dispatcher's
-         * connect-time `lookup` only fires when `useSSRFProtection` is true;
-         * allowlist deployments disable it, and the allowlist only covers the
-         * originally-configured URL — not server-controlled redirect targets.
+         * Keep the standalone check for immediate literal/current-DNS blocks.
+         * Cross-origin allowlist redirects also switch to a connect-time
+         * SSRF-safe dispatcher below so DNS rebinding cannot change the
+         * address between this check and the socket connection.
          */
         if (await resolveHostnameSSRF(targetUrl.hostname)) {
           logger.warn(
@@ -651,13 +679,20 @@ export class MCPConnection extends EventEmitter {
 
         await response.body?.cancel().catch(() => undefined);
 
-        if (targetUrl.origin !== originalOrigin && currentInit.headers != null) {
+        if (isCrossOriginRedirect && currentInit.headers != null) {
           currentInit = {
             ...currentInit,
             headers: stripCrossOriginHeaders(
               currentInit.headers as Record<string, string>,
               secretHeaderKeys,
             ),
+          };
+        }
+
+        if (!useSSRFProtection && isCrossOriginRedirect) {
+          currentInit = {
+            ...currentInit,
+            dispatcher: getSafeRedirectDispatcher(isGet),
           };
         }
 


### PR DESCRIPTION
## Summary

I hardened MCP 307/308 redirect handling so allowlist-mode cross-origin redirect hops cannot bypass connect-time SSRF enforcement through DNS rebinding.

- Added lazy SSRF-safe redirect dispatchers for cross-origin MCP redirects when the original MCP connection runs without global SSRF protection because `allowedDomains` is configured.
- Preserved same-origin redirect behavior so trusted MCP servers can continue path-level 307/308 flows without breaking session continuity.
- Kept the existing redirect hostname pre-check for immediate private/reserved target blocking while adding connect-time enforcement for redirected next-hop connections.
- Added a regression test that simulates a redirect pre-check allowing `rebind.test`, followed by a connect-time lookup resolving to loopback and blocking the request before the internal target is reached.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran the focused MCP SSRF, SSRF agent, MCP agent lifecycle, formatting, and API package build checks.

### **Test Configuration**:

- Node.js: `v20.19.5`
- npm: `10.8.2`
- Branch base: `origin/dev` at `1b79e0b78`

Commands:

```sh
npx jest src/mcp/__tests__/MCPConnectionSSRF.test.ts --runInBand --coverage=false
npx jest src/auth/agent.spec.ts --runInBand --coverage=false
npx jest src/mcp/__tests__/MCPConnectionAgentLifecycle.test.ts --runInBand --coverage=false
npx prettier --check packages/api/src/mcp/connection.ts packages/api/src/mcp/__tests__/MCPConnectionSSRF.test.ts
npm run build
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes