### PR TITLE
🧯 fix: Harden Code Env Filepath Uploads

### DIFF
--- a/packages/api/src/files/code/form.spec.ts
+++ b/packages/api/src/files/code/form.spec.ts
@@ -92,4 +92,11 @@ describe('code env FormData filenames', () => {
       filename: 'my notes @ draft.py',
     });
   });
+
+  it('scrubs control characters from fallback filenames', () => {
+    expect(getCodeEnvFileOptions('report\nContent-Disposition.py')).toEqual({
+      filename: 'report_Content-Disposition.py',
+    });
+    expect(getCodeEnvFileOptions('../evil\r.py')).toEqual({ filename: 'evil_.py' });
+  });
 });

--- a/packages/api/src/files/code/form.spec.ts
+++ b/packages/api/src/files/code/form.spec.ts
@@ -49,4 +49,33 @@ describe('code env FormData filenames', () => {
       filepath: 'pptx/pptx.py',
     });
   });
+
+  it('does not preserve traversal paths as filepath options', async () => {
+    expect(getCodeEnvFileOptions('../../evil.py')).toEqual({ filename: 'evil.py' });
+
+    const disposition = await renderMultipartDisposition((form) => {
+      appendCodeEnvFile(form, Readable.from(['x']), '../../evil.py');
+    });
+
+    expect(disposition).toContain('filename="evil.py"');
+    expect(disposition).not.toContain('../');
+  });
+
+  it('does not preserve absolute paths as filepath options', () => {
+    expect(getCodeEnvFileOptions('/tmp/evil.py')).toEqual({ filename: 'evil.py' });
+    expect(getCodeEnvFileOptions('C:\\tmp\\evil.py')).toEqual({ filename: 'evil.py' });
+  });
+
+  it('does not preserve empty or dot path segments as filepath options', () => {
+    expect(getCodeEnvFileOptions('pptx//pptx.py')).toEqual({ filename: 'pptx.py' });
+    expect(getCodeEnvFileOptions('pptx/./pptx.py')).toEqual({ filename: 'pptx.py' });
+    expect(getCodeEnvFileOptions('pptx/..')).toEqual({ filename: 'file' });
+    expect(getCodeEnvFileOptions('pptx/')).toEqual({ filename: 'pptx' });
+  });
+
+  it('keeps unsafe flat filenames flat instead of rewriting user-visible names', () => {
+    expect(getCodeEnvFileOptions('my notes @ draft.py')).toEqual({
+      filename: 'my notes @ draft.py',
+    });
+  });
 });

--- a/packages/api/src/files/code/form.spec.ts
+++ b/packages/api/src/files/code/form.spec.ts
@@ -31,6 +31,13 @@ describe('code env FormData filenames', () => {
     expect(disposition).toContain('filename="pptx/pptx.py"');
   });
 
+  it('uses filepath for deeply nested safe filenames', () => {
+    expect(getCodeEnvFileOptions('a/b/c/d.py')).toEqual({
+      filename: 'd.py',
+      filepath: 'a/b/c/d.py',
+    });
+  });
+
   it('documents the form-data string overload regression', async () => {
     const disposition = await renderMultipartDisposition((form) => {
       form.append('file', Readable.from(['x']), 'pptx/pptx.py');
@@ -52,6 +59,7 @@ describe('code env FormData filenames', () => {
 
   it('does not preserve traversal paths as filepath options', async () => {
     expect(getCodeEnvFileOptions('../../evil.py')).toEqual({ filename: 'evil.py' });
+    expect(getCodeEnvFileOptions('..\\..\\evil.py')).toEqual({ filename: 'evil.py' });
 
     const disposition = await renderMultipartDisposition((form) => {
       appendCodeEnvFile(form, Readable.from(['x']), '../../evil.py');
@@ -71,6 +79,12 @@ describe('code env FormData filenames', () => {
     expect(getCodeEnvFileOptions('pptx/./pptx.py')).toEqual({ filename: 'pptx.py' });
     expect(getCodeEnvFileOptions('pptx/..')).toEqual({ filename: 'file' });
     expect(getCodeEnvFileOptions('pptx/')).toEqual({ filename: 'pptx' });
+  });
+
+  it('uses safe fallback names for empty or degenerate filenames', () => {
+    expect(getCodeEnvFileOptions('')).toEqual({ filename: 'file' });
+    expect(getCodeEnvFileOptions('.')).toEqual({ filename: 'file' });
+    expect(getCodeEnvFileOptions('..')).toEqual({ filename: 'file' });
   });
 
   it('keeps unsafe flat filenames flat instead of rewriting user-visible names', () => {

--- a/packages/api/src/files/code/form.ts
+++ b/packages/api/src/files/code/form.ts
@@ -7,10 +7,10 @@ export interface CodeEnvFileOptions {
   filepath?: string;
 }
 
-const CODE_ENV_FILEPATH_CHARS = /^[a-zA-Z0-9._\-/]+$/;
+const CODE_ENV_SAFE_FILEPATH_PATTERN = /^[a-zA-Z0-9._\-/]+$/;
 
 function isSafeCodeEnvFilepath(filepath: string): boolean {
-  if (!filepath || filepath.startsWith('/') || !CODE_ENV_FILEPATH_CHARS.test(filepath)) {
+  if (!filepath || filepath.startsWith('/') || !CODE_ENV_SAFE_FILEPATH_PATTERN.test(filepath)) {
     return false;
   }
 

--- a/packages/api/src/files/code/form.ts
+++ b/packages/api/src/files/code/form.ts
@@ -8,6 +8,7 @@ export interface CodeEnvFileOptions {
 }
 
 const CODE_ENV_SAFE_FILEPATH_PATTERN = /^[a-zA-Z0-9._\-/]+$/;
+const CODE_ENV_FILENAME_CONTROL_CHARS_PATTERN = /[\x00-\x1f\x7f]/g;
 
 function isSafeCodeEnvFilepath(filepath: string): boolean {
   if (!filepath || filepath.startsWith('/') || !CODE_ENV_SAFE_FILEPATH_PATTERN.test(filepath)) {
@@ -19,13 +20,17 @@ function isSafeCodeEnvFilepath(filepath: string): boolean {
 }
 
 function getCodeEnvBasename(filepath: string): string {
-  const basename = path.posix.basename(filepath);
+  const basename = getSafeCodeEnvFilename(path.posix.basename(filepath));
 
   if (!basename || basename === '.' || basename === '..') {
     return 'file';
   }
 
   return basename;
+}
+
+function getSafeCodeEnvFilename(filename: string): string {
+  return filename.replace(CODE_ENV_FILENAME_CONTROL_CHARS_PATTERN, '_');
 }
 
 /**
@@ -37,7 +42,7 @@ export function getCodeEnvFileOptions(filename: string): CodeEnvFileOptions {
   const basename = getCodeEnvBasename(normalized);
 
   if (normalized === filename && filename === basename) {
-    return { filename };
+    return { filename: getSafeCodeEnvFilename(filename) };
   }
 
   if (!isSafeCodeEnvFilepath(normalized)) {

--- a/packages/api/src/files/code/form.ts
+++ b/packages/api/src/files/code/form.ts
@@ -7,16 +7,41 @@ export interface CodeEnvFileOptions {
   filepath?: string;
 }
 
+const CODE_ENV_FILEPATH_CHARS = /^[a-zA-Z0-9._\-/]+$/;
+
+function isSafeCodeEnvFilepath(filepath: string): boolean {
+  if (!filepath || filepath.startsWith('/') || !CODE_ENV_FILEPATH_CHARS.test(filepath)) {
+    return false;
+  }
+
+  const segments = filepath.split('/');
+  return segments.every((segment) => segment !== '' && segment !== '.' && segment !== '..');
+}
+
+function getCodeEnvBasename(filepath: string): string {
+  const basename = path.posix.basename(filepath);
+
+  if (!basename || basename === '.' || basename === '..') {
+    return 'file';
+  }
+
+  return basename;
+}
+
 /**
  * Uses `filepath` for nested names because `form-data` strips directories from
- * the bare string filename overload before codeapi can preserve them.
+ * the bare string filename overload before codeapi can preserve safe paths.
  */
 export function getCodeEnvFileOptions(filename: string): CodeEnvFileOptions {
   const normalized = filename.replace(/\\/g, '/');
-  const basename = path.posix.basename(normalized);
+  const basename = getCodeEnvBasename(normalized);
 
-  if (normalized === basename) {
+  if (normalized === filename && filename === basename) {
     return { filename };
+  }
+
+  if (!isSafeCodeEnvFilepath(normalized)) {
+    return { filename: basename };
   }
 
   return { filename: basename, filepath: normalized };


### PR DESCRIPTION
## Summary

I hardened code-environment multipart file option generation so nested paths are preserved only after safe relative-path validation, closing the traversal path from decoded upload filenames.

- Validate path-bearing code-env filenames before emitting `form-data` `filepath` options.
- Fall back to basename-only multipart filenames for traversal paths, absolute paths, Windows-drive paths, empty segments, and dot segments.
- Preserve existing safe nested skill-file behavior such as `skill-name/references/file.md`.
- Added focused tests covering safe nested paths and unsafe path fallback behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/files/code/form.spec.ts --coverage=false`
- `npm run build:data-provider`
- `npm run build:data-schemas`
- `npm run build` from `packages/api`

### **Test Configuration**:

- Node.js: `v20.19.5`
- npm: `10.8.2`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes