### PR TITLE
🧷 fix: Pin GitNexus Native Dependency

### DIFF
--- a/.github/workflows/gitnexus-index.yml
+++ b/.github/workflows/gitnexus-index.yml
@@ -128,11 +128,13 @@ jobs:
             'audit=false' \
             'fund=false' \
             > "$RUNNER_TEMP/gitnexus-cli/.npmrc"
+          # Keep GitNexus' native DB dependency deterministic in fresh CI installs.
           npm install \
             --prefix "$RUNNER_TEMP/gitnexus-cli" \
             --no-save \
             --no-package-lock \
-            "gitnexus@${{ env.GITNEXUS_VERSION }}"
+            "gitnexus@${{ env.GITNEXUS_VERSION }}" \
+            "@ladybugdb/core@0.15.2"
           test -x "$RUNNER_TEMP/gitnexus-cli/node_modules/.bin/gitnexus"
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary

I pinned GitNexus' native LadybugDB dependency in the hardened index workflow so fresh CI installs stay on the known-good version while preserving the security hardening from PR #12935.

- Pin `@ladybugdb/core@0.15.2` alongside `gitnexus@1.5.3` during the isolated `$RUNNER_TEMP` CLI install.
- Keep the index job's hardened execution model intact, including install-before-checkout, clean npm config, read-only index permissions, and `persist-credentials: false`.
- Document why the transitive native dependency is pinned so the install is not accidentally floated back to the failing version.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran YAML parse validation for `.github/workflows/gitnexus-index.yml`.
- Ran `git diff --check -- .github/workflows/gitnexus-index.yml`.
- Reproduced a hardened-style isolated install with `gitnexus@1.5.3` and `@ladybugdb/core@0.15.2`, then ran graph-only `gitnexus analyze` against a detached temp worktree successfully.

### **Test Configuration**:

- Local macOS worktree
- GitNexus `1.5.3`
- `@ladybugdb/core` pinned to `0.15.2`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
