### PR TITLE
🛂 refactor: Avoid Default Tavily Safe Search

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -651,7 +651,7 @@ endpoints:
 #     # includeImages: true     # Include images in results
 #     # includeFavicon: true    # Include favicon URL for each result
 #     # chunksPerSource: 3      # Chunks per source, only with 'advanced' depth (1-3)
-#     # safeSearch: false       # Override Tavily safe search filtering
+#     # safeSearch: false       # Override Tavily safe_search filtering (true is enterprise-only)
 #     # includeDomains:         # Restrict search to specific domains (max 300)
 #     #   - 'example.com'
 #     #   - 'docs.example.com'

--- a/packages/api/src/web/web.spec.ts
+++ b/packages/api/src/web/web.spec.ts
@@ -129,6 +129,7 @@ describe('web.ts', () => {
       expect(result.authResult).toHaveProperty('searchProvider', 'serper');
       expect(result.authResult).toHaveProperty('scraperProvider', 'firecrawl');
       expect(['jina', 'cohere']).toContain(result.authResult.rerankerType as string);
+      expect(result.authResult.safeSearch).toBe(SafeSearchTypes.MODERATE);
     });
 
     it('should return authenticated=false when a required category is not authenticated', async () => {
@@ -774,6 +775,7 @@ describe('web.ts', () => {
       expect(result.authResult.tavilyApiKey).toBe('tavily-api-key');
       expect(result.authResult.tavilySearchUrl).toBe('https://api.tavily.com/search');
       expect(result.authResult.tavilySearchOptions).toEqual(webSearchConfig.tavilySearchOptions);
+      expect(result.authResult.safeSearch).toBeUndefined();
     });
 
     it('should fail authentication when Tavily search API key is missing', async () => {

--- a/packages/api/src/web/web.ts
+++ b/packages/api/src/web/web.ts
@@ -2,14 +2,14 @@ import {
   AuthType,
   SafeSearchTypes,
   SearchCategories,
+  SearchProviders,
+  ScraperProviders,
   extractVariableName,
 } from 'librechat-data-provider';
 import { webSearchAuth } from '@librechat/data-schemas';
 import type {
   RerankerTypes,
   TCustomConfig,
-  SearchProviders,
-  ScraperProviders,
   TWebSearchConfig,
 } from 'librechat-data-provider';
 import type { TWebSearchKeys, TWebSearchCategories } from '@librechat/data-schemas';
@@ -248,15 +248,18 @@ export async function loadWebSearchAuth({
   }
 
   const scraperProvider =
-    authResult.scraperProvider ?? webSearchConfig?.scraperProvider ?? 'firecrawl';
+    authResult.scraperProvider ?? webSearchConfig?.scraperProvider ?? ScraperProviders.FIRECRAWL;
   let scraperOptionsTimeout: number | undefined;
-  if (scraperProvider === 'tavily') {
+  if (scraperProvider === ScraperProviders.TAVILY) {
     scraperOptionsTimeout = webSearchConfig?.tavilyScraperOptions?.timeout;
-  } else if (scraperProvider === 'firecrawl') {
+  } else if (scraperProvider === ScraperProviders.FIRECRAWL) {
     scraperOptionsTimeout = webSearchConfig?.firecrawlOptions?.timeout;
   }
 
-  authResult.safeSearch = webSearchConfig?.safeSearch ?? SafeSearchTypes.MODERATE;
+  const searchProvider = authResult.searchProvider ?? webSearchConfig?.searchProvider;
+  if (searchProvider !== SearchProviders.TAVILY) {
+    authResult.safeSearch = webSearchConfig?.safeSearch ?? SafeSearchTypes.MODERATE;
+  }
   authResult.scraperTimeout = webSearchConfig?.scraperTimeout ?? scraperOptionsTimeout ?? 7500;
   authResult.firecrawlOptions = webSearchConfig?.firecrawlOptions;
   authResult.tavilySearchOptions = webSearchConfig?.tavilySearchOptions;


### PR DESCRIPTION
## Summary

I fixed Tavily web search auth so LibreChat no longer forwards the default global safe search setting into Tavily's enterprise-only `safe_search` parameter.

- Omitted `authResult.safeSearch` when Tavily is the resolved search provider, preventing the default `SafeSearchTypes.MODERATE` value from becoming `safe_search: true` in the agents package.
- Preserved the existing global safe search default for non-Tavily search providers.
- Added test assertions covering both behaviors: Serper keeps the default, Tavily omits the global value.
- Updated the Tavily YAML example to note that `safe_search: true` is enterprise-only.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- [x] Ran `NODE_PATH=/Users/danny/Projects/LibreChat/node_modules /Users/danny/Projects/LibreChat/node_modules/.bin/jest src/web/web.spec.ts --coverage=false --runInBand` from `packages/api` — 48 tests passed.
- [x] Ran `npm run build:api` — build completed successfully. It still emits the existing Redis type warning at `packages/api/src/cache/cacheFactory.ts:47`.

### **Test Configuration**:

- Node/dependencies from the local LibreChat development checkout dependency cache.
- Branch based on latest `origin/dev`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
