### PR TITLE
🖼️ refactor: Tool Image Outputs outside of Tool Group Auto-Collapses

### DIFF
--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -28,7 +28,7 @@ type PartWithContextProps = {
   isCreatedByUser: boolean;
   isLast: boolean;
   partAttachments: TAttachment[] | undefined;
-  hideImageAttachments?: boolean;
+  hideAttachments?: boolean;
 };
 
 const PartWithContext = memo(function PartWithContext({
@@ -43,7 +43,7 @@ const PartWithContext = memo(function PartWithContext({
   isCreatedByUser,
   isLast,
   partAttachments,
-  hideImageAttachments,
+  hideAttachments,
 }: PartWithContextProps) {
   const contextValue = useMemo(
     () => ({
@@ -68,7 +68,7 @@ const PartWithContext = memo(function PartWithContext({
         isCreatedByUser={isCreatedByUser}
         isLast={isLastPart}
         showCursor={isLastPart && isLast}
-        hideImageAttachments={hideImageAttachments}
+        hideAttachments={hideAttachments}
       />
     </MessageContext.Provider>
   );
@@ -185,7 +185,7 @@ const ContentParts = memo(function ContentParts({
     ));
 
   const makeRenderPart = useCallback(
-    (hideImageAttachments: boolean) =>
+    (hideAttachments: boolean) =>
       (part: TMessageContentParts, idx: number, isLastPart: boolean) => {
         const toolCallId =
           (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
@@ -203,7 +203,7 @@ const ContentParts = memo(function ContentParts({
             nextType={content?.[idx + 1]?.type}
             isSubmitting={effectiveIsSubmitting}
             partAttachments={attachmentMap[toolCallId]}
-            hideImageAttachments={hideImageAttachments}
+            hideAttachments={hideAttachments}
           />
         );
       },
@@ -221,6 +221,35 @@ const ContentParts = memo(function ContentParts({
 
   const renderPart = useMemo(() => makeRenderPart(false), [makeRenderPart]);
   const renderGroupedPart = useMemo(() => makeRenderPart(true), [makeRenderPart]);
+
+  const sequentialParts = useMemo<PartWithIndex[]>(() => {
+    if (!content) {
+      return [];
+    }
+    const result: PartWithIndex[] = [];
+    content.forEach((part, idx) => {
+      if (part) {
+        result.push({ part, idx });
+      }
+    });
+    return result;
+  }, [content]);
+
+  const groupedParts = useMemo(
+    () =>
+      groupSequentialToolCalls(sequentialParts).map((group) => {
+        if (group.type === 'single') {
+          return group;
+        }
+        const groupAttachments = group.parts.flatMap(({ part }) => {
+          const toolCallId =
+            (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
+          return attachmentMap[toolCallId] ?? [];
+        });
+        return { ...group, groupAttachments };
+      }),
+    [sequentialParts, attachmentMap],
+  );
 
   // Early return: no content to render AND no pending skill cards
   if (!content && !hasPendingSkills) {
@@ -292,14 +321,6 @@ const ContentParts = memo(function ContentParts({
   }
 
   // Sequential content: render parts in order (90% of cases)
-  const sequentialParts: PartWithIndex[] = [];
-  safeContent.forEach((part, idx) => {
-    if (part) {
-      sequentialParts.push({ part, idx });
-    }
-  });
-  const groupedParts = groupSequentialToolCalls(sequentialParts);
-
   return (
     <SearchContext.Provider value={{ searchResults }}>
       <MemoryArtifacts attachments={attachments} />
@@ -314,11 +335,6 @@ const ContentParts = memo(function ContentParts({
           const { part, idx } = group.part;
           return renderPart(part, idx, idx === lastContentIdx);
         }
-        const groupAttachments = group.parts.flatMap(({ part }) => {
-          const toolCallId =
-            (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
-          return attachmentMap[toolCallId] ?? [];
-        });
         return (
           <ToolCallGroup
             key={`tool-group-${group.parts[0].idx}`}
@@ -327,7 +343,7 @@ const ContentParts = memo(function ContentParts({
             isLast={group.parts.some((p) => p.idx === lastContentIdx)}
             renderPart={renderGroupedPart}
             lastContentIdx={lastContentIdx}
-            groupAttachments={groupAttachments}
+            groupAttachments={group.groupAttachments}
           />
         );
       })}

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -28,6 +28,7 @@ type PartWithContextProps = {
   isCreatedByUser: boolean;
   isLast: boolean;
   partAttachments: TAttachment[] | undefined;
+  hideImageAttachments?: boolean;
 };
 
 const PartWithContext = memo(function PartWithContext({
@@ -42,6 +43,7 @@ const PartWithContext = memo(function PartWithContext({
   isCreatedByUser,
   isLast,
   partAttachments,
+  hideImageAttachments,
 }: PartWithContextProps) {
   const contextValue = useMemo(
     () => ({
@@ -66,6 +68,7 @@ const PartWithContext = memo(function PartWithContext({
         isCreatedByUser={isCreatedByUser}
         isLast={isLastPart}
         showCursor={isLastPart && isLast}
+        hideImageAttachments={hideImageAttachments}
       />
     </MessageContext.Provider>
   );
@@ -181,26 +184,29 @@ const ContentParts = memo(function ContentParts({
       <PendingSkillCall key={`pending-skill-${name}`} skillName={name} loaded={hasRealContent} />
     ));
 
-  const renderPart = useCallback(
-    (part: TMessageContentParts, idx: number, isLastPart: boolean) => {
-      const toolCallId = (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
-      return (
-        <PartWithContext
-          key={`provider-${messageId}-${idx}`}
-          idx={idx}
-          part={part}
-          isLast={isLast}
-          messageId={messageId}
-          isLastPart={isLastPart}
-          conversationId={conversationId}
-          isLatestMessage={isLatestMessage}
-          isCreatedByUser={isCreatedByUser}
-          nextType={content?.[idx + 1]?.type}
-          isSubmitting={effectiveIsSubmitting}
-          partAttachments={attachmentMap[toolCallId]}
-        />
-      );
-    },
+  const makeRenderPart = useCallback(
+    (hideImageAttachments: boolean) =>
+      (part: TMessageContentParts, idx: number, isLastPart: boolean) => {
+        const toolCallId =
+          (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
+        return (
+          <PartWithContext
+            key={`provider-${messageId}-${idx}`}
+            idx={idx}
+            part={part}
+            isLast={isLast}
+            messageId={messageId}
+            isLastPart={isLastPart}
+            conversationId={conversationId}
+            isLatestMessage={isLatestMessage}
+            isCreatedByUser={isCreatedByUser}
+            nextType={content?.[idx + 1]?.type}
+            isSubmitting={effectiveIsSubmitting}
+            partAttachments={attachmentMap[toolCallId]}
+            hideImageAttachments={hideImageAttachments}
+          />
+        );
+      },
     [
       attachmentMap,
       content,
@@ -212,6 +218,9 @@ const ContentParts = memo(function ContentParts({
       messageId,
     ],
   );
+
+  const renderPart = useMemo(() => makeRenderPart(false), [makeRenderPart]);
+  const renderGroupedPart = useMemo(() => makeRenderPart(true), [makeRenderPart]);
 
   // Early return: no content to render AND no pending skill cards
   if (!content && !hasPendingSkills) {
@@ -305,14 +314,20 @@ const ContentParts = memo(function ContentParts({
           const { part, idx } = group.part;
           return renderPart(part, idx, idx === lastContentIdx);
         }
+        const groupAttachments = group.parts.flatMap(({ part }) => {
+          const toolCallId =
+            (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
+          return attachmentMap[toolCallId] ?? [];
+        });
         return (
           <ToolCallGroup
             key={`tool-group-${group.parts[0].idx}`}
             parts={group.parts}
             isSubmitting={effectiveIsSubmitting}
             isLast={group.parts.some((p) => p.idx === lastContentIdx)}
-            renderPart={renderPart}
+            renderPart={renderGroupedPart}
             lastContentIdx={lastContentIdx}
+            groupAttachments={groupAttachments}
           />
         );
       })}

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -16,6 +16,9 @@ import ToolCallGroup from './ToolCallGroup';
 import Container from './Container';
 import Part from './Part';
 
+const getToolCallId = (part: TMessageContentParts): string =>
+  (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
+
 type PartWithContextProps = {
   part: TMessageContentParts;
   idx: number;
@@ -186,7 +189,6 @@ const ContentParts = memo(function ContentParts({
 
   const renderPart = useCallback(
     (part: TMessageContentParts, idx: number, isLastPart: boolean) => {
-      const toolCallId = (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
       return (
         <PartWithContext
           key={`provider-${messageId}-${idx}`}
@@ -200,7 +202,7 @@ const ContentParts = memo(function ContentParts({
           isCreatedByUser={isCreatedByUser}
           nextType={content?.[idx + 1]?.type}
           isSubmitting={effectiveIsSubmitting}
-          partAttachments={attachmentMap[toolCallId]}
+          partAttachments={attachmentMap[getToolCallId(part)]}
         />
       );
     },
@@ -218,7 +220,6 @@ const ContentParts = memo(function ContentParts({
 
   const renderGroupedPart = useCallback(
     (part: TMessageContentParts, idx: number, isLastPart: boolean) => {
-      const toolCallId = (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
       return (
         <PartWithContext
           key={`provider-${messageId}-${idx}`}
@@ -232,7 +233,7 @@ const ContentParts = memo(function ContentParts({
           isCreatedByUser={isCreatedByUser}
           nextType={content?.[idx + 1]?.type}
           isSubmitting={effectiveIsSubmitting}
-          partAttachments={attachmentMap[toolCallId]}
+          partAttachments={attachmentMap[getToolCallId(part)]}
           hideAttachments
         />
       );
@@ -268,11 +269,9 @@ const ContentParts = memo(function ContentParts({
         if (group.type === 'single') {
           return group;
         }
-        const groupAttachments = group.parts.flatMap(({ part }) => {
-          const toolCallId =
-            (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
-          return attachmentMap[toolCallId] ?? [];
-        });
+        const groupAttachments = group.parts.flatMap(
+          ({ part }) => attachmentMap[getToolCallId(part)] ?? [],
+        );
         return { ...group, groupAttachments };
       }),
     [sequentialParts, attachmentMap],

--- a/client/src/components/Chat/Messages/Content/ContentParts.tsx
+++ b/client/src/components/Chat/Messages/Content/ContentParts.tsx
@@ -184,29 +184,26 @@ const ContentParts = memo(function ContentParts({
       <PendingSkillCall key={`pending-skill-${name}`} skillName={name} loaded={hasRealContent} />
     ));
 
-  const makeRenderPart = useCallback(
-    (hideAttachments: boolean) =>
-      (part: TMessageContentParts, idx: number, isLastPart: boolean) => {
-        const toolCallId =
-          (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
-        return (
-          <PartWithContext
-            key={`provider-${messageId}-${idx}`}
-            idx={idx}
-            part={part}
-            isLast={isLast}
-            messageId={messageId}
-            isLastPart={isLastPart}
-            conversationId={conversationId}
-            isLatestMessage={isLatestMessage}
-            isCreatedByUser={isCreatedByUser}
-            nextType={content?.[idx + 1]?.type}
-            isSubmitting={effectiveIsSubmitting}
-            partAttachments={attachmentMap[toolCallId]}
-            hideAttachments={hideAttachments}
-          />
-        );
-      },
+  const renderPart = useCallback(
+    (part: TMessageContentParts, idx: number, isLastPart: boolean) => {
+      const toolCallId = (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
+      return (
+        <PartWithContext
+          key={`provider-${messageId}-${idx}`}
+          idx={idx}
+          part={part}
+          isLast={isLast}
+          messageId={messageId}
+          isLastPart={isLastPart}
+          conversationId={conversationId}
+          isLatestMessage={isLatestMessage}
+          isCreatedByUser={isCreatedByUser}
+          nextType={content?.[idx + 1]?.type}
+          isSubmitting={effectiveIsSubmitting}
+          partAttachments={attachmentMap[toolCallId]}
+        />
+      );
+    },
     [
       attachmentMap,
       content,
@@ -219,8 +216,38 @@ const ContentParts = memo(function ContentParts({
     ],
   );
 
-  const renderPart = useMemo(() => makeRenderPart(false), [makeRenderPart]);
-  const renderGroupedPart = useMemo(() => makeRenderPart(true), [makeRenderPart]);
+  const renderGroupedPart = useCallback(
+    (part: TMessageContentParts, idx: number, isLastPart: boolean) => {
+      const toolCallId = (part?.[ContentTypes.TOOL_CALL] as Agents.ToolCall | undefined)?.id ?? '';
+      return (
+        <PartWithContext
+          key={`provider-${messageId}-${idx}`}
+          idx={idx}
+          part={part}
+          isLast={isLast}
+          messageId={messageId}
+          isLastPart={isLastPart}
+          conversationId={conversationId}
+          isLatestMessage={isLatestMessage}
+          isCreatedByUser={isCreatedByUser}
+          nextType={content?.[idx + 1]?.type}
+          isSubmitting={effectiveIsSubmitting}
+          partAttachments={attachmentMap[toolCallId]}
+          hideAttachments
+        />
+      );
+    },
+    [
+      attachmentMap,
+      content,
+      conversationId,
+      effectiveIsSubmitting,
+      isCreatedByUser,
+      isLast,
+      isLatestMessage,
+      messageId,
+    ],
+  );
 
   const sequentialParts = useMemo<PartWithIndex[]>(() => {
     if (!content) {

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -38,7 +38,7 @@ type PartProps = {
   showCursor: boolean;
   isCreatedByUser: boolean;
   attachments?: TAttachment[];
-  hideImageAttachments?: boolean;
+  hideAttachments?: boolean;
 };
 
 const Part = memo(function Part({
@@ -48,7 +48,7 @@ const Part = memo(function Part({
   isLast,
   showCursor,
   isCreatedByUser,
-  hideImageAttachments,
+  hideAttachments,
 }: PartProps) {
   if (!part) {
     return null;
@@ -144,6 +144,7 @@ const Part = memo(function Part({
           output={toolCall.output ?? ''}
           initialProgress={toolCall.progress ?? 0.1}
           args={toolCall.args}
+          hideAttachments={hideAttachments}
         />
       );
     } else if (
@@ -247,7 +248,7 @@ const Part = memo(function Part({
           attachments={attachments}
           auth={toolCall.auth}
           isLast={isLast}
-          hideImageAttachments={hideImageAttachments}
+          hideAttachments={hideAttachments}
         />
       );
     } else if (toolCall.type === ToolCallTypes.CODE_INTERPRETER) {
@@ -305,7 +306,7 @@ const Part = memo(function Part({
           name={toolCall.function.name}
           output={toolCall.function.output}
           isLast={isLast}
-          hideImageAttachments={hideImageAttachments}
+          hideAttachments={hideAttachments}
         />
       );
     }

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -171,6 +171,7 @@ const Part = memo(function Part({
           initialProgress={toolCall.progress ?? 0.1}
           isSubmitting={isSubmitting}
           attachments={attachments}
+          hideAttachments={hideAttachments}
         />
       );
     } else if (isToolCall && toolCall.name === Constants.SUBAGENT) {
@@ -194,6 +195,7 @@ const Part = memo(function Part({
           isSubmitting={isSubmitting}
           attachments={attachments}
           persistedContent={persistedContent}
+          hideAttachments={hideAttachments}
         />
       );
     } else if (isToolCall && toolCall.name === 'read_file') {
@@ -204,6 +206,7 @@ const Part = memo(function Part({
           initialProgress={toolCall.progress ?? 0.1}
           isSubmitting={isSubmitting}
           attachments={attachments}
+          hideAttachments={hideAttachments}
         />
       );
     } else if (isToolCall && toolCall.name === 'bash_tool') {
@@ -214,6 +217,7 @@ const Part = memo(function Part({
           initialProgress={toolCall.progress ?? 0.1}
           isSubmitting={isSubmitting}
           attachments={attachments}
+          hideAttachments={hideAttachments}
         />
       );
     } else if (isToolCall && toolCall.name === Tools.web_search) {

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -38,6 +38,7 @@ type PartProps = {
   showCursor: boolean;
   isCreatedByUser: boolean;
   attachments?: TAttachment[];
+  hideImageAttachments?: boolean;
 };
 
 const Part = memo(function Part({
@@ -47,6 +48,7 @@ const Part = memo(function Part({
   isLast,
   showCursor,
   isCreatedByUser,
+  hideImageAttachments,
 }: PartProps) {
   if (!part) {
     return null;
@@ -245,6 +247,7 @@ const Part = memo(function Part({
           attachments={attachments}
           auth={toolCall.auth}
           isLast={isLast}
+          hideImageAttachments={hideImageAttachments}
         />
       );
     } else if (toolCall.type === ToolCallTypes.CODE_INTERPRETER) {
@@ -302,6 +305,7 @@ const Part = memo(function Part({
           name={toolCall.function.name}
           output={toolCall.function.output}
           isLast={isLast}
+          hideImageAttachments={hideImageAttachments}
         />
       );
     }

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -161,6 +161,7 @@ const Part = memo(function Part({
           args={typeof toolCall.args === 'string' ? toolCall.args : ''}
           output={toolCall.output ?? ''}
           attachments={attachments}
+          hideAttachments={hideAttachments}
         />
       );
     } else if (isToolCall && toolCall.name === 'skill') {

--- a/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
@@ -388,15 +388,7 @@ export default function Attachment({ attachment }: { attachment?: TAttachment })
   return <FileAttachment attachment={attachment} />;
 }
 
-export type AttachmentGroupVariant = 'all' | 'images' | 'non-images';
-
-export function AttachmentGroup({
-  attachments,
-  variant = 'all',
-}: {
-  attachments?: TAttachment[];
-  variant?: AttachmentGroupVariant;
-}) {
+export function AttachmentGroup({ attachments }: { attachments?: TAttachment[] }) {
   if (!attachments || attachments.length === 0) {
     return null;
   }
@@ -457,20 +449,9 @@ export function AttachmentGroup({
   mermaidArtifacts.sort(bySalience);
   imageAttachments.sort(bySalience);
 
-  const showImages = variant !== 'non-images' && imageAttachments.length > 0;
-  const showFiles = variant !== 'images' && fileAttachments.length > 0;
-  const showPanelArtifacts =
-    variant !== 'images' && (resolvedPanel.length > 0 || pendingPanel.length > 0);
-  const showMermaid = variant !== 'images' && mermaidArtifacts.length > 0;
-  const showText = variant !== 'images' && textAttachments.length > 0;
-
-  if (!showImages && !showFiles && !showPanelArtifacts && !showMermaid && !showText) {
-    return null;
-  }
-
   return (
     <>
-      {showFiles && (
+      {fileAttachments.length > 0 && (
         <div className="my-2 flex flex-wrap items-center gap-2.5">
           {fileAttachments.map((attachment, index) =>
             attachment.filepath ? (
@@ -482,7 +463,7 @@ export function AttachmentGroup({
           )}
         </div>
       )}
-      {showPanelArtifacts && (
+      {(resolvedPanel.length > 0 || pendingPanel.length > 0) && (
         <div className="my-2 flex flex-wrap items-center gap-2">
           {resolvedPanel.map(({ attachment, type }, index) => (
             <PanelArtifact
@@ -501,7 +482,7 @@ export function AttachmentGroup({
           )}
         </div>
       )}
-      {showMermaid && (
+      {mermaidArtifacts.length > 0 && (
         <div className="my-2 flex flex-col gap-3">
           {mermaidArtifacts.map((attachment, index) => (
             <MermaidArtifact
@@ -511,7 +492,7 @@ export function AttachmentGroup({
           ))}
         </div>
       )}
-      {showText && (
+      {textAttachments.length > 0 && (
         <div className="my-2 flex flex-col gap-3">
           {textAttachments.map((attachment, index) => (
             <TextAttachment
@@ -521,7 +502,7 @@ export function AttachmentGroup({
           ))}
         </div>
       )}
-      {showImages && (
+      {imageAttachments.length > 0 && (
         <div className="mb-2 flex flex-wrap items-center">
           {imageAttachments.map((attachment, index) => (
             <ImageAttachment

--- a/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/Attachment.tsx
@@ -388,7 +388,15 @@ export default function Attachment({ attachment }: { attachment?: TAttachment })
   return <FileAttachment attachment={attachment} />;
 }
 
-export function AttachmentGroup({ attachments }: { attachments?: TAttachment[] }) {
+export type AttachmentGroupVariant = 'all' | 'images' | 'non-images';
+
+export function AttachmentGroup({
+  attachments,
+  variant = 'all',
+}: {
+  attachments?: TAttachment[];
+  variant?: AttachmentGroupVariant;
+}) {
   if (!attachments || attachments.length === 0) {
     return null;
   }
@@ -449,9 +457,20 @@ export function AttachmentGroup({ attachments }: { attachments?: TAttachment[] }
   mermaidArtifacts.sort(bySalience);
   imageAttachments.sort(bySalience);
 
+  const showImages = variant !== 'non-images' && imageAttachments.length > 0;
+  const showFiles = variant !== 'images' && fileAttachments.length > 0;
+  const showPanelArtifacts =
+    variant !== 'images' && (resolvedPanel.length > 0 || pendingPanel.length > 0);
+  const showMermaid = variant !== 'images' && mermaidArtifacts.length > 0;
+  const showText = variant !== 'images' && textAttachments.length > 0;
+
+  if (!showImages && !showFiles && !showPanelArtifacts && !showMermaid && !showText) {
+    return null;
+  }
+
   return (
     <>
-      {fileAttachments.length > 0 && (
+      {showFiles && (
         <div className="my-2 flex flex-wrap items-center gap-2.5">
           {fileAttachments.map((attachment, index) =>
             attachment.filepath ? (
@@ -463,7 +482,7 @@ export function AttachmentGroup({ attachments }: { attachments?: TAttachment[] }
           )}
         </div>
       )}
-      {(resolvedPanel.length > 0 || pendingPanel.length > 0) && (
+      {showPanelArtifacts && (
         <div className="my-2 flex flex-wrap items-center gap-2">
           {resolvedPanel.map(({ attachment, type }, index) => (
             <PanelArtifact
@@ -482,7 +501,7 @@ export function AttachmentGroup({ attachments }: { attachments?: TAttachment[] }
           )}
         </div>
       )}
-      {mermaidArtifacts.length > 0 && (
+      {showMermaid && (
         <div className="my-2 flex flex-col gap-3">
           {mermaidArtifacts.map((attachment, index) => (
             <MermaidArtifact
@@ -492,7 +511,7 @@ export function AttachmentGroup({ attachments }: { attachments?: TAttachment[] }
           ))}
         </div>
       )}
-      {textAttachments.length > 0 && (
+      {showText && (
         <div className="my-2 flex flex-col gap-3">
           {textAttachments.map((attachment, index) => (
             <TextAttachment
@@ -502,7 +521,7 @@ export function AttachmentGroup({ attachments }: { attachments?: TAttachment[] }
           ))}
         </div>
       )}
-      {imageAttachments.length > 0 && (
+      {showImages && (
         <div className="mb-2 flex flex-wrap items-center">
           {imageAttachments.map((attachment, index) => (
             <ImageAttachment

--- a/client/src/components/Chat/Messages/Content/Parts/BashCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/BashCall.tsx
@@ -18,12 +18,14 @@ export default function BashCall({
   args,
   output = '',
   attachments,
+  hideAttachments = false,
 }: {
   initialProgress: number;
   isSubmitting: boolean;
   args?: string | Record<string, unknown>;
   output?: string;
   attachments?: TAttachment[];
+  hideAttachments?: boolean;
 }) {
   const localize = useLocalize();
   const command = useMemo(() => parseJsonField(args, 'command'), [args]);
@@ -110,7 +112,9 @@ export default function BashCall({
           </div>
         </div>
       </div>
-      {attachments && attachments.length > 0 && <AttachmentGroup attachments={attachments} />}
+      {!hideAttachments && attachments && attachments.length > 0 && (
+        <AttachmentGroup attachments={attachments} />
+      )}
     </>
   );
 }

--- a/client/src/components/Chat/Messages/Content/Parts/ExecuteCode.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/ExecuteCode.tsx
@@ -56,12 +56,14 @@ export default function ExecuteCode({
   args,
   output = '',
   attachments,
+  hideAttachments = false,
 }: {
   initialProgress: number;
   isSubmitting: boolean;
   args?: string | Record<string, unknown>;
   output?: string;
   attachments?: TAttachment[];
+  hideAttachments?: boolean;
 }) {
   const localize = useLocalize();
   const { lang = 'py', code } = useParseArgs(args) ?? ({} as ParsedArgs);
@@ -129,7 +131,9 @@ export default function ExecuteCode({
           </div>
         </div>
       </div>
-      {attachments && attachments.length > 0 && <AttachmentGroup attachments={attachments} />}
+      {!hideAttachments && attachments && attachments.length > 0 && (
+        <AttachmentGroup attachments={attachments} />
+      )}
     </>
   );
 }

--- a/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/OpenAIImageGen/OpenAIImageGen.tsx
@@ -31,6 +31,7 @@ export default function OpenAIImageGen({
   args: _args = '',
   output,
   attachments,
+  hideAttachments = false,
 }: {
   initialProgress: number;
   isSubmitting?: boolean;
@@ -38,6 +39,7 @@ export default function OpenAIImageGen({
   args: string | Record<string, unknown>;
   output?: string | null;
   attachments?: TAttachment[];
+  hideAttachments?: boolean;
 }) {
   const localize = useLocalize();
   const isAgentStyle = toolName != null && AGENT_STYLE_TOOLS.has(toolName);
@@ -226,7 +228,7 @@ export default function OpenAIImageGen({
         <ToolIcon type="image_gen" isAnimating={isInProgress} />
         <ProgressText progress={progress} error={cancelled} toolName={toolName} />
       </div>
-      {isAgentStyle && (
+      {isAgentStyle && !hideAttachments && (
         <div className="relative mb-2 flex w-full justify-start">
           <div ref={containerRef} className="w-full max-w-lg">
             {dimensions.width !== 'auto' && progress < 1 && (

--- a/client/src/components/Chat/Messages/Content/Parts/ReadFileCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/ReadFileCall.tsx
@@ -67,12 +67,14 @@ export default function ReadFileCall({
   args,
   output = '',
   attachments,
+  hideAttachments = false,
 }: {
   initialProgress: number;
   isSubmitting: boolean;
   args?: string | Record<string, unknown>;
   output?: string;
   attachments?: TAttachment[];
+  hideAttachments?: boolean;
 }) {
   const localize = useLocalize();
   const filePath = useMemo(() => parseJsonField(args, 'file_path'), [args]);
@@ -123,7 +125,9 @@ export default function ReadFileCall({
           )}
         </div>
       </div>
-      {attachments && attachments.length > 0 && <AttachmentGroup attachments={attachments} />}
+      {!hideAttachments && attachments && attachments.length > 0 && (
+        <AttachmentGroup attachments={attachments} />
+      )}
     </>
   );
 }

--- a/client/src/components/Chat/Messages/Content/Parts/SkillCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SkillCall.tsx
@@ -15,12 +15,14 @@ export default function SkillCall({
   args,
   output = '',
   attachments,
+  hideAttachments = false,
 }: {
   initialProgress: number;
   isSubmitting: boolean;
   args?: string | Record<string, unknown>;
   output?: string;
   attachments?: TAttachment[];
+  hideAttachments?: boolean;
 }) {
   const localize = useLocalize();
   const skillName = useMemo(() => parseJsonField(args, 'skillName'), [args]);
@@ -71,7 +73,9 @@ export default function SkillCall({
           )}
         </div>
       </div>
-      {attachments && attachments.length > 0 && <AttachmentGroup attachments={attachments} />}
+      {!hideAttachments && attachments && attachments.length > 0 && (
+        <AttachmentGroup attachments={attachments} />
+      )}
     </>
   );
 }

--- a/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
@@ -252,14 +252,13 @@ export default function SubagentCall({
   /** Base verb-only label ("Running agent" / "Ran agent"). The agent name
    *  is rendered separately as a muted sub-label so "agent" stays a
    *  constant visual anchor regardless of name length. */
-  let headerText = localize('com_ui_subagent_complete');
-  if (hasError) {
-    headerText = localize('com_ui_subagent_errored');
-  } else if (cancelled) {
-    headerText = localize('com_ui_subagent_cancelled');
-  } else if (running) {
-    headerText = localize('com_ui_subagent_running');
-  }
+  const getHeaderText = () => {
+    if (hasError) return localize('com_ui_subagent_errored');
+    if (cancelled) return localize('com_ui_subagent_cancelled');
+    if (running) return localize('com_ui_subagent_running');
+    return localize('com_ui_subagent_complete');
+  };
+  const headerText = getHeaderText();
   /** Muted sub-label shown to the right of the base label: the
    *  configured agent name for named subagents. Self-spawns omit it
    *  (redundant — the header already says "agent") as do cases where
@@ -385,60 +384,66 @@ export default function SubagentCall({
     setIsAtBottom(true);
   }, []);
 
-  const emptyDialogText = running
-    ? localize('com_ui_subagent_no_result_yet')
-    : localize('com_ui_subagent_empty_result');
-
-  let dialogContent: JSX.Element;
-  if (contentParts.length > 0) {
-    dialogContent = (
-      <MessageContext.Provider value={dialogMessageContext}>
-        {groupedParts.map((group) => {
-          if (group.type === 'single') {
-            const { part, idx } = group.part;
-            /** Per-type dispatch handles wrapping: TEXT goes through
-             *  `Container`, THINK/TOOL_CALL render directly so their own
-             *  wrappers set the width and spacing. */
-            return renderDialogPart(part, idx, idx === lastPartIndex);
-          }
-          /** Consecutive tool_calls (2+) collapse into a `Used N tools`
-           *  group — same behavior as the main message view. */
-          return (
-            <ToolCallGroup
-              key={`${toolCallId}-group-${group.parts[0].idx}`}
-              parts={group.parts}
-              isSubmitting={running}
-              isLast={group.parts.some((p) => p.idx === lastPartIndex)}
-              renderPart={renderDialogPart}
-              lastContentIdx={lastPartIndex}
-            />
-          );
-        })}
-      </MessageContext.Provider>
+  const renderDialogBody = () => {
+    if (contentParts.length > 0) {
+      return (
+        <MessageContext.Provider value={dialogMessageContext}>
+          {groupedParts.map((group) => {
+            if (group.type === 'single') {
+              const { part, idx } = group.part;
+              /** Per-type dispatch handles wrapping: TEXT goes
+               *  through `Container`, THINK/TOOL_CALL render
+               *  directly so their own wrappers set the width
+               *  and spacing. */
+              return renderDialogPart(part, idx, idx === lastPartIndex);
+            }
+            /** Consecutive tool_calls (2+) collapse into a
+             *  `Used N tools` group — same behavior as the main
+             *  message view. */
+            return (
+              <ToolCallGroup
+                key={`${toolCallId}-group-${group.parts[0].idx}`}
+                parts={group.parts}
+                isSubmitting={running}
+                isLast={group.parts.some((p) => p.idx === lastPartIndex)}
+                renderPart={renderDialogPart}
+                lastContentIdx={lastPartIndex}
+              />
+            );
+          })}
+        </MessageContext.Provider>
+      );
+    }
+    if (output) {
+      /** Fallback: no aggregated content parts but the backend
+       *  wrote a final tool_call output. Happens for older
+       *  subagent runs recorded before the event forwarder
+       *  existed. Route through the same leaf renderer so
+       *  markdown renders properly. */
+      return (
+        <MessageContext.Provider value={dialogMessageContext}>
+          <SubagentDialogPart
+            part={
+              {
+                type: ContentTypes.TEXT,
+                text: output,
+              } as unknown as TMessageContentParts
+            }
+            isSubmitting={false}
+            showCursor={false}
+            isLast
+          />
+        </MessageContext.Provider>
+      );
+    }
+    return (
+      <div className="text-sm italic text-text-secondary">
+        {running
+          ? localize('com_ui_subagent_no_result_yet')
+          : localize('com_ui_subagent_empty_result')}
+      </div>
     );
-  } else if (output) {
-    /** Fallback: no aggregated content parts but the backend wrote a final
-     *  tool_call output. Happens for older subagent runs recorded before the
-     *  event forwarder existed. Route through the same leaf renderer so
-     *  markdown renders properly. */
-    dialogContent = (
-      <MessageContext.Provider value={dialogMessageContext}>
-        <SubagentDialogPart
-          part={
-            {
-              type: ContentTypes.TEXT,
-              text: output,
-            } as unknown as TMessageContentParts
-          }
-          isSubmitting={false}
-          showCursor={false}
-          isLast
-        />
-      </MessageContext.Provider>
-    );
-  } else {
-    dialogContent = <div className="text-sm italic text-text-secondary">{emptyDialogText}</div>;
-  }
+  };
 
   return (
     <>
@@ -556,7 +561,7 @@ export default function SubagentCall({
                     onToggle={() => setPromptExpanded((expanded) => !expanded)}
                   />
                 ) : null}
-                {dialogContent}
+                {renderDialogBody()}
               </div>
             </div>
           </div>

--- a/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
@@ -38,6 +38,7 @@ interface SubagentCallProps {
    *  runs recorded before the persistence path landed will not have this
    *  field; those fall back to the atom (or the raw `output` string). */
   persistedContent?: TMessageContentParts[];
+  hideAttachments?: boolean;
 }
 
 const TICKER_MAX_LINES = 3;
@@ -161,6 +162,7 @@ export default function SubagentCall({
   output,
   attachments,
   persistedContent,
+  hideAttachments = false,
 }: SubagentCallProps) {
   const localize = useLocalize();
   const progress = useRecoilValue(subagentProgressByToolCallId(toolCallId));
@@ -561,7 +563,9 @@ export default function SubagentCall({
         </OGDialogContent>
       </OGDialog>
 
-      {attachments && attachments.length > 0 && <AttachmentGroup attachments={attachments} />}
+      {!hideAttachments && attachments && attachments.length > 0 && (
+        <AttachmentGroup attachments={attachments} />
+      )}
     </>
   );
 }

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -27,7 +27,7 @@ export default function ToolCall({
   output,
   attachments,
   auth,
-  hideImageAttachments = false,
+  hideAttachments = false,
 }: {
   initialProgress: number;
   isLast?: boolean;
@@ -37,7 +37,7 @@ export default function ToolCall({
   output?: string | null;
   attachments?: TAttachment[];
   auth?: string;
-  hideImageAttachments?: boolean;
+  hideAttachments?: boolean;
 }) {
   const localize = useLocalize();
   const autoExpand = useRecoilValue(store.autoExpandTools);
@@ -256,11 +256,8 @@ export default function ToolCall({
           </p>
         </div>
       )}
-      {attachments && attachments.length > 0 && (
-        <AttachmentGroup
-          attachments={attachments}
-          variant={hideImageAttachments ? 'non-images' : 'all'}
-        />
+      {!hideAttachments && attachments && attachments.length > 0 && (
+        <AttachmentGroup attachments={attachments} />
       )}
     </>
   );

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -27,6 +27,7 @@ export default function ToolCall({
   output,
   attachments,
   auth,
+  hideImageAttachments = false,
 }: {
   initialProgress: number;
   isLast?: boolean;
@@ -36,6 +37,7 @@ export default function ToolCall({
   output?: string | null;
   attachments?: TAttachment[];
   auth?: string;
+  hideImageAttachments?: boolean;
 }) {
   const localize = useLocalize();
   const autoExpand = useRecoilValue(store.autoExpandTools);
@@ -254,7 +256,12 @@ export default function ToolCall({
           </p>
         </div>
       )}
-      {attachments && attachments.length > 0 && <AttachmentGroup attachments={attachments} />}
+      {attachments && attachments.length > 0 && (
+        <AttachmentGroup
+          attachments={attachments}
+          variant={hideImageAttachments ? 'non-images' : 'all'}
+        />
+      )}
     </>
   );
 }

--- a/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
@@ -2,11 +2,17 @@ import { useState, useMemo, useEffect, useCallback } from 'react';
 import { useRecoilValue } from 'recoil';
 import { ChevronDown, Users } from 'lucide-react';
 import { Constants, ContentTypes, ToolCallTypes } from 'librechat-data-provider';
-import type { TMessageContentParts, Agents, FunctionToolCall } from 'librechat-data-provider';
+import type {
+  TAttachment,
+  TMessageContentParts,
+  Agents,
+  FunctionToolCall,
+} from 'librechat-data-provider';
 import type { PartWithIndex } from './ParallelContent';
 import { StackedToolIcons } from './ToolOutput';
 import { useLocalize, useExpandCollapse } from '~/hooks';
 import { useMCPIconMap } from '~/hooks/MCP';
+import { AttachmentGroup } from './Parts';
 import { cn, getToolDisplayLabel } from '~/utils';
 import store from '~/store';
 
@@ -59,6 +65,7 @@ interface ToolCallGroupProps {
   isLast: boolean;
   renderPart: (part: TMessageContentParts, idx: number, isLastPart: boolean) => React.ReactNode;
   lastContentIdx: number;
+  groupAttachments?: TAttachment[];
 }
 
 export default function ToolCallGroup({
@@ -67,6 +74,7 @@ export default function ToolCallGroup({
   isLast,
   renderPart,
   lastContentIdx,
+  groupAttachments,
 }: ToolCallGroupProps) {
   const localize = useLocalize();
   const mcpIconMap = useMCPIconMap();
@@ -206,6 +214,9 @@ export default function ToolCallGroup({
           </div>
         </div>
       </div>
+      {groupAttachments && groupAttachments.length > 0 && (
+        <AttachmentGroup attachments={groupAttachments} variant="images" />
+      )}
     </div>
   );
 }

--- a/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
@@ -215,7 +215,7 @@ export default function ToolCallGroup({
         </div>
       </div>
       {groupAttachments && groupAttachments.length > 0 && (
-        <AttachmentGroup attachments={groupAttachments} variant="images" />
+        <AttachmentGroup attachments={groupAttachments} />
       )}
     </div>
   );

--- a/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
@@ -9,11 +9,11 @@ import type {
   FunctionToolCall,
 } from 'librechat-data-provider';
 import type { PartWithIndex } from './ParallelContent';
-import { StackedToolIcons } from './ToolOutput';
 import { useLocalize, useExpandCollapse } from '~/hooks';
+import { cn, getToolDisplayLabel } from '~/utils';
+import { StackedToolIcons } from './ToolOutput';
 import { useMCPIconMap } from '~/hooks/MCP';
 import { AttachmentGroup } from './Parts';
-import { cn, getToolDisplayLabel } from '~/utils';
 import store from '~/store';
 
 interface ToolMeta {

--- a/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCallGroup.tsx
@@ -138,6 +138,14 @@ export default function ToolCallGroup({
     setIsExpanded((prev) => !prev);
   }, []);
 
+  const getSubagentLabel = () =>
+    subagentsDone
+      ? localize('com_ui_ran_n_agents', { 0: String(count) })
+      : localize('com_ui_running_n_agents', { 0: String(count) });
+  const groupLabel = allSubagents
+    ? getSubagentLabel()
+    : localize('com_ui_used_n_tools', { 0: String(count) });
+
   const hasActiveToolCall = useMemo(
     () => isSubmitting && toolMetadata.some((m) => m && !m.hasOutput),
     [toolMetadata, isSubmitting],
@@ -156,13 +164,7 @@ export default function ToolCallGroup({
         className="inline-flex w-full items-center gap-2 py-1 text-text-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-heavy"
         onClick={handleToggle}
         aria-expanded={isExpanded}
-        aria-label={
-          allSubagents
-            ? subagentsDone
-              ? localize('com_ui_ran_n_agents', { 0: String(count) })
-              : localize('com_ui_running_n_agents', { 0: String(count) })
-            : localize('com_ui_used_n_tools', { 0: String(count) })
-        }
+        aria-label={groupLabel}
       >
         {allSubagents ? (
           /** Subagent groups don't have per-tool icons — StackedToolIcons
@@ -186,13 +188,7 @@ export default function ToolCallGroup({
             isAnimating={!allCompleted && isSubmitting}
           />
         )}
-        <span className="tool-status-text font-medium">
-          {allSubagents
-            ? subagentsDone
-              ? localize('com_ui_ran_n_agents', { 0: String(count) })
-              : localize('com_ui_running_n_agents', { 0: String(count) })
-            : localize('com_ui_used_n_tools', { 0: String(count) })}
-        </span>
+        <span className="tool-status-text font-medium">{groupLabel}</span>
         {/** Hide the tool-name summary for pure-subagent groups — every
          *   entry deduplicates to the same "subagent" token, which adds
          *   noise without info. Mixed groups keep the summary. */}

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.integration.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.integration.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { ContentTypes } from 'librechat-data-provider';
+import type { TAttachment, TMessageContentParts } from 'librechat-data-provider';
+import { render, screen } from '@testing-library/react';
+import ContentParts from '../ContentParts';
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string, values?: any) => {
+    if (key === 'com_ui_used_n_tools') {
+      return `Used ${values?.[0]} tools`;
+    }
+    return key;
+  },
+  useExpandCollapse: (isExpanded: boolean) => ({
+    style: { display: 'grid', gridTemplateRows: isExpanded ? '1fr' : '0fr' },
+    ref: { current: null },
+  }),
+  useProgress: (initial: number) => (initial >= 1 ? 1 : initial),
+}));
+
+jest.mock('~/hooks/MCP', () => ({
+  useMCPIconMap: () => new Map(),
+}));
+
+jest.mock('../ToolOutput', () => ({
+  StackedToolIcons: () => <span data-testid="stacked-icons" />,
+  getMCPServerName: () => '',
+  ToolIcon: () => <span data-testid="tool-icon" />,
+  getToolIconType: () => 'mcp',
+  isError: () => false,
+}));
+
+jest.mock('../ToolCallInfo', () => ({
+  __esModule: true,
+  default: () => <div data-testid="tool-call-info" />,
+}));
+
+jest.mock('../ProgressText', () => ({
+  __esModule: true,
+  default: ({ onClick, finishedText }: any) => (
+    <div data-testid="progress-text" onClick={onClick}>
+      {finishedText}
+    </div>
+  ),
+}));
+
+jest.mock('lucide-react', () => ({
+  ChevronDown: () => <span>{'chevron'}</span>,
+  TriangleAlert: () => <span>{'alert'}</span>,
+}));
+
+jest.mock('@librechat/client', () => ({
+  Button: ({ children }: any) => <button>{children}</button>,
+}));
+
+jest.mock('../Parts', () => ({
+  AttachmentGroup: ({ attachments }: any) => (
+    <div data-testid="attachment-group" data-count={attachments?.length ?? 0} />
+  ),
+  ExecuteCode: () => <div data-testid="execute-code" />,
+  ImageGen: () => <div data-testid="image-gen" />,
+  AgentUpdate: () => <div data-testid="agent-update" />,
+  EmptyText: () => <div data-testid="empty-text" />,
+  Reasoning: () => <div data-testid="reasoning" />,
+  Summary: () => <div data-testid="summary" />,
+  Text: ({ text }: any) => <div data-testid="text">{text}</div>,
+  EditTextPart: () => <div data-testid="edit-text" />,
+}));
+
+jest.mock('../MemoryArtifacts', () => ({
+  __esModule: true,
+  default: () => <div data-testid="memory-artifacts" />,
+}));
+
+jest.mock('../WebSearch', () => ({
+  __esModule: true,
+  default: () => <div data-testid="web-search" />,
+}));
+
+jest.mock('../RetrievalCall', () => ({
+  __esModule: true,
+  default: () => <div data-testid="retrieval-call" />,
+}));
+
+jest.mock('../AgentHandoff', () => ({
+  __esModule: true,
+  default: () => <div data-testid="agent-handoff" />,
+}));
+
+jest.mock('../CodeAnalyze', () => ({
+  __esModule: true,
+  default: () => <div data-testid="code-analyze" />,
+}));
+
+jest.mock('../Image', () => ({
+  __esModule: true,
+  default: () => <div data-testid="image" />,
+}));
+
+jest.mock('../Container', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('~/utils', () => {
+  const actual = jest.requireActual('~/utils');
+  return {
+    ...actual,
+    cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+    logger: { error: jest.fn() },
+  };
+});
+
+const makeMcpToolCall = (id: string, hasOutput = true): TMessageContentParts =>
+  ({
+    type: ContentTypes.TOOL_CALL,
+    [ContentTypes.TOOL_CALL]: {
+      id,
+      name: `getTinyImage${Constants_mcp_delimiter}Everything`,
+      args: '{}',
+      output: hasOutput ? 'image_returned' : '',
+    },
+  }) as unknown as TMessageContentParts;
+
+// Real Constants.mcp_delimiter is "_mcp_" — match that
+const Constants_mcp_delimiter = '_mcp_';
+
+const imageAttachment = (toolCallId: string, name = 'tiny.png'): TAttachment =>
+  ({
+    filename: name,
+    filepath: `/files/${name}`,
+    width: 16,
+    height: 16,
+    messageId: 'm1',
+    toolCallId,
+    conversationId: 'c1',
+  }) as unknown as TAttachment;
+
+const renderContentParts = (props: React.ComponentProps<typeof ContentParts>) =>
+  render(
+    <RecoilRoot>
+      <ContentParts {...props} />
+    </RecoilRoot>,
+  );
+
+describe('ContentParts integration: MCP image hoist and grouping', () => {
+  const baseProps = {
+    messageId: 'msg1',
+    isCreatedByUser: false,
+    isLast: true,
+    isSubmitting: false,
+    isLatestMessage: true,
+  };
+
+  it('groups 2+ MCP tool calls and hoists their attachments outside the collapsible', () => {
+    const content = [makeMcpToolCall('t1'), makeMcpToolCall('t2')];
+    const attachments = [imageAttachment('t1', 'a.png'), imageAttachment('t2', 'b.png')];
+
+    renderContentParts({
+      ...baseProps,
+      content,
+      attachments,
+    });
+
+    const groups = screen.getAllByTestId('attachment-group');
+    // One AttachmentGroup hoisted at the group level — inner ToolCalls skip rendering theirs.
+    expect(groups).toHaveLength(1);
+    expect(groups[0].getAttribute('data-count')).toBe('2');
+  });
+
+  it('does not group a single tool call — image renders inline (no hoist)', () => {
+    const content = [makeMcpToolCall('t1')];
+    const attachments = [imageAttachment('t1', 'a.png')];
+
+    renderContentParts({
+      ...baseProps,
+      content,
+      attachments,
+    });
+
+    // Single tool call: AttachmentGroup is rendered by ToolCall, not hoisted.
+    const groups = screen.queryAllByTestId('attachment-group');
+    expect(groups).toHaveLength(1);
+    expect(groups[0].getAttribute('data-count')).toBe('1');
+    // No tool group label.
+    expect(screen.queryByText(/Used .* tools/)).not.toBeInTheDocument();
+  });
+
+  it('hoists attachments from all parts in the group, even mixed image and non-image', () => {
+    const fileAtt: TAttachment = {
+      filename: 'doc.pdf',
+      filepath: '/files/doc.pdf',
+      messageId: 'm1',
+      toolCallId: 't2',
+      conversationId: 'c1',
+    } as unknown as TAttachment;
+
+    const content = [makeMcpToolCall('t1'), makeMcpToolCall('t2')];
+    const attachments = [imageAttachment('t1', 'a.png'), fileAtt];
+
+    renderContentParts({
+      ...baseProps,
+      content,
+      attachments,
+    });
+
+    const groups = screen.getAllByTestId('attachment-group');
+    expect(groups).toHaveLength(1);
+    // Both image and file are in the hoisted group.
+    expect(groups[0].getAttribute('data-count')).toBe('2');
+  });
+
+  it('renders no AttachmentGroup when grouped tool calls have no attachments', () => {
+    const content = [makeMcpToolCall('t1'), makeMcpToolCall('t2')];
+
+    renderContentParts({
+      ...baseProps,
+      content,
+      attachments: [],
+    });
+
+    expect(screen.queryByTestId('attachment-group')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.integration.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.integration.test.tsx
@@ -6,7 +6,7 @@ import { render, screen } from '@testing-library/react';
 import ContentParts from '../ContentParts';
 
 jest.mock('~/hooks', () => ({
-  useLocalize: () => (key: string, values?: any) => {
+  useLocalize: () => (key: string, values?: Record<string | number, string>) => {
     if (key === 'com_ui_used_n_tools') {
       return `Used ${values?.[0]} tools`;
     }
@@ -38,7 +38,7 @@ jest.mock('../ToolCallInfo', () => ({
 
 jest.mock('../ProgressText', () => ({
   __esModule: true,
-  default: ({ onClick, finishedText }: any) => (
+  default: ({ onClick, finishedText }: { onClick?: () => void; finishedText?: string }) => (
     <div data-testid="progress-text" onClick={onClick}>
       {finishedText}
     </div>
@@ -51,11 +51,11 @@ jest.mock('lucide-react', () => ({
 }));
 
 jest.mock('@librechat/client', () => ({
-  Button: ({ children }: any) => <button>{children}</button>,
+  Button: ({ children }: { children?: React.ReactNode }) => <button>{children}</button>,
 }));
 
 jest.mock('../Parts', () => ({
-  AttachmentGroup: ({ attachments }: any) => (
+  AttachmentGroup: ({ attachments }: { attachments?: TAttachment[] }) => (
     <div data-testid="attachment-group" data-count={attachments?.length ?? 0} />
   ),
   ExecuteCode: () => <div data-testid="execute-code" />,
@@ -64,7 +64,7 @@ jest.mock('../Parts', () => ({
   EmptyText: () => <div data-testid="empty-text" />,
   Reasoning: () => <div data-testid="reasoning" />,
   Summary: () => <div data-testid="summary" />,
-  Text: ({ text }: any) => <div data-testid="text">{text}</div>,
+  Text: ({ text }: { text?: string }) => <div data-testid="text">{text}</div>,
   EditTextPart: () => <div data-testid="edit-text" />,
 }));
 
@@ -100,31 +100,30 @@ jest.mock('../Image', () => ({
 
 jest.mock('../Container', () => ({
   __esModule: true,
-  default: ({ children }: any) => <div>{children}</div>,
+  default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
 }));
 
 jest.mock('~/utils', () => {
   const actual = jest.requireActual('~/utils');
   return {
     ...actual,
-    cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+    cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
     logger: { error: jest.fn() },
   };
 });
+
+const MCP_DELIMITER = '_mcp_';
 
 const makeMcpToolCall = (id: string, hasOutput = true): TMessageContentParts =>
   ({
     type: ContentTypes.TOOL_CALL,
     [ContentTypes.TOOL_CALL]: {
       id,
-      name: `getTinyImage${Constants_mcp_delimiter}Everything`,
+      name: `getTinyImage${MCP_DELIMITER}Everything`,
       args: '{}',
       output: hasOutput ? 'image_returned' : '',
     },
   }) as unknown as TMessageContentParts;
-
-// Real Constants.mcp_delimiter is "_mcp_" — match that
-const Constants_mcp_delimiter = '_mcp_';
 
 const imageAttachment = (toolCallId: string, name = 'tiny.png'): TAttachment =>
   ({

--- a/client/src/components/Chat/Messages/Content/__tests__/ContentParts.integration.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ContentParts.integration.test.tsx
@@ -48,6 +48,7 @@ jest.mock('../ProgressText', () => ({
 jest.mock('lucide-react', () => ({
   ChevronDown: () => <span>{'chevron'}</span>,
   TriangleAlert: () => <span>{'alert'}</span>,
+  Users: () => <span>{'users'}</span>,
 }));
 
 jest.mock('@librechat/client', () => ({

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCall.test.tsx
@@ -214,6 +214,42 @@ describe('ToolCall', () => {
 
       expect(screen.queryByTestId('attachment-group')).not.toBeInTheDocument();
     });
+
+    it('should not render AttachmentGroup when hideAttachments is true (grouped path)', () => {
+      const attachments = [
+        {
+          type: Tools.ui_resources,
+          messageId: 'msg-hide',
+          toolCallId: 'tool-hide',
+          conversationId: 'conv-hide',
+          [Tools.ui_resources]: { '0': { type: 'chart', data: [] } },
+        },
+      ];
+
+      renderWithRecoil(
+        <ToolCall {...mockProps} attachments={attachments as any} hideAttachments />,
+      );
+
+      expect(screen.queryByTestId('attachment-group')).not.toBeInTheDocument();
+    });
+
+    it('should render AttachmentGroup when hideAttachments is false explicitly', () => {
+      const attachments = [
+        {
+          type: Tools.ui_resources,
+          messageId: 'msg-show',
+          toolCallId: 'tool-show',
+          conversationId: 'conv-show',
+          [Tools.ui_resources]: { '0': { type: 'chart', data: [] } },
+        },
+      ];
+
+      renderWithRecoil(
+        <ToolCall {...mockProps} attachments={attachments as any} hideAttachments={false} />,
+      );
+
+      expect(screen.getByTestId('attachment-group')).toBeInTheDocument();
+    });
   });
 
   describe('tool call info visibility', () => {

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
@@ -35,10 +35,12 @@ jest.mock('../ToolOutput', () => ({
 
 jest.mock('lucide-react', () => ({
   ChevronDown: () => <span>{'chevron'}</span>,
+  Users: () => <span>{'users'}</span>,
 }));
 
 jest.mock('~/utils', () => ({
   cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+  getToolDisplayLabel: (name: string) => name,
 }));
 
 jest.mock('../Parts', () => ({

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import { ContentTypes } from 'librechat-data-provider';
+import type { TAttachment, TMessageContentParts } from 'librechat-data-provider';
+import { render, screen } from '@testing-library/react';
+import ToolCallGroup from '../ToolCallGroup';
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string, values?: any) => {
+    if (key === 'com_ui_used_n_tools') {
+      return `Used ${values?.[0]} tools`;
+    }
+    if (key === 'com_ui_via_server') {
+      return `via ${values?.[0]}`;
+    }
+    return key;
+  },
+  useExpandCollapse: (isExpanded: boolean) => ({
+    style: {
+      display: 'grid',
+      gridTemplateRows: isExpanded ? '1fr' : '0fr',
+    },
+    ref: { current: null },
+  }),
+}));
+
+jest.mock('~/hooks/MCP', () => ({
+  useMCPIconMap: () => new Map(),
+}));
+
+jest.mock('../ToolOutput', () => ({
+  StackedToolIcons: () => <span data-testid="stacked-icons" />,
+  getMCPServerName: () => '',
+}));
+
+jest.mock('lucide-react', () => ({
+  ChevronDown: () => <span>{'chevron'}</span>,
+}));
+
+jest.mock('~/utils', () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+}));
+
+jest.mock('../Parts', () => ({
+  AttachmentGroup: ({ attachments, variant }: any) => (
+    <div
+      data-testid="attachment-group"
+      data-variant={variant ?? 'all'}
+      data-count={attachments?.length ?? 0}
+    />
+  ),
+}));
+
+const makePart = (id: string, output = 'done'): TMessageContentParts =>
+  ({
+    type: ContentTypes.TOOL_CALL,
+    [ContentTypes.TOOL_CALL]: {
+      id,
+      name: 'fetch_image',
+      args: '{}',
+      output,
+    },
+  }) as unknown as TMessageContentParts;
+
+const imageAttachment: TAttachment = {
+  filename: 'foo.png',
+  filepath: '/files/foo.png',
+  width: 128,
+  height: 128,
+  messageId: 'm1',
+  toolCallId: 't1',
+  conversationId: 'c1',
+} as unknown as TAttachment;
+
+const fileAttachment: TAttachment = {
+  filename: 'bar.pdf',
+  filepath: '/files/bar.pdf',
+  messageId: 'm1',
+  toolCallId: 't2',
+  conversationId: 'c1',
+} as unknown as TAttachment;
+
+const renderGroup = (props: React.ComponentProps<typeof ToolCallGroup>) =>
+  render(
+    <RecoilRoot>
+      <ToolCallGroup {...props} />
+    </RecoilRoot>,
+  );
+
+describe('ToolCallGroup image hoisting', () => {
+  const parts = [
+    { part: makePart('t1'), idx: 0 },
+    { part: makePart('t2'), idx: 1 },
+  ];
+
+  const baseProps = {
+    parts,
+    isSubmitting: false,
+    isLast: false,
+    lastContentIdx: 1,
+    renderPart: (_p: TMessageContentParts, idx: number) => (
+      <div data-testid={`inner-${idx}`} key={idx}>
+        {'inner'}
+      </div>
+    ),
+  } satisfies React.ComponentProps<typeof ToolCallGroup>;
+
+  it('renders an image-only AttachmentGroup outside the collapsible container', () => {
+    renderGroup({
+      ...baseProps,
+      groupAttachments: [imageAttachment, fileAttachment],
+    });
+
+    const group = screen.getByTestId('attachment-group');
+    expect(group).toBeInTheDocument();
+    expect(group.getAttribute('data-variant')).toBe('images');
+    expect(group.getAttribute('data-count')).toBe('2');
+  });
+
+  it('does not render an AttachmentGroup when there are no group attachments', () => {
+    renderGroup(baseProps);
+    expect(screen.queryByTestId('attachment-group')).not.toBeInTheDocument();
+  });
+
+  it('renders the image AttachmentGroup as a sibling of the collapsible panel, not a child', () => {
+    const { container } = renderGroup({
+      ...baseProps,
+      groupAttachments: [imageAttachment],
+    });
+
+    const outer = container.firstChild as HTMLElement;
+    const attachmentGroup = screen.getByTestId('attachment-group');
+    expect(attachmentGroup.parentElement).toBe(outer);
+
+    const collapsible = outer.querySelector('[style]');
+    expect(collapsible?.contains(attachmentGroup)).toBe(false);
+  });
+});

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
@@ -105,7 +105,7 @@ describe('ToolCallGroup image hoisting', () => {
     ),
   } satisfies React.ComponentProps<typeof ToolCallGroup>;
 
-  it('renders an image-only AttachmentGroup outside the collapsible container', () => {
+  it('renders an AttachmentGroup outside the collapsible container with all attachments', () => {
     renderGroup({
       ...baseProps,
       groupAttachments: [imageAttachment, fileAttachment],
@@ -113,8 +113,19 @@ describe('ToolCallGroup image hoisting', () => {
 
     const group = screen.getByTestId('attachment-group');
     expect(group).toBeInTheDocument();
-    expect(group.getAttribute('data-variant')).toBe('images');
+    expect(group.getAttribute('data-variant')).toBe('all');
     expect(group.getAttribute('data-count')).toBe('2');
+  });
+
+  it('hoists non-image attachments so they survive collapse', () => {
+    renderGroup({
+      ...baseProps,
+      groupAttachments: [fileAttachment],
+    });
+
+    const group = screen.getByTestId('attachment-group');
+    expect(group).toBeInTheDocument();
+    expect(group.getAttribute('data-count')).toBe('1');
   });
 
   it('does not render an AttachmentGroup when there are no group attachments', () => {

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolCallGroup.test.tsx
@@ -6,7 +6,7 @@ import { render, screen } from '@testing-library/react';
 import ToolCallGroup from '../ToolCallGroup';
 
 jest.mock('~/hooks', () => ({
-  useLocalize: () => (key: string, values?: any) => {
+  useLocalize: () => (key: string, values?: Record<string | number, string>) => {
     if (key === 'com_ui_used_n_tools') {
       return `Used ${values?.[0]} tools`;
     }
@@ -39,17 +39,13 @@ jest.mock('lucide-react', () => ({
 }));
 
 jest.mock('~/utils', () => ({
-  cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+  cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' '),
   getToolDisplayLabel: (name: string) => name,
 }));
 
 jest.mock('../Parts', () => ({
-  AttachmentGroup: ({ attachments, variant }: any) => (
-    <div
-      data-testid="attachment-group"
-      data-variant={variant ?? 'all'}
-      data-count={attachments?.length ?? 0}
-    />
+  AttachmentGroup: ({ attachments }: { attachments?: TAttachment[] }) => (
+    <div data-testid="attachment-group" data-count={attachments?.length ?? 0} />
   ),
 }));
 
@@ -115,7 +111,6 @@ describe('ToolCallGroup image hoisting', () => {
 
     const group = screen.getByTestId('attachment-group');
     expect(group).toBeInTheDocument();
-    expect(group.getAttribute('data-variant')).toBe('all');
     expect(group.getAttribute('data-count')).toBe('2');
   });
 


### PR DESCRIPTION
## Summary

Closes #12753

When the [tool call redesign](https://github.com/danny-avila/LibreChat/pull/12163) introduced auto-collapse for sequential tool calls into a "Used N tools" group, MCP tools that returned image outputs (e.g. `getTinyImage` from the Everything MCP server) lost their images the moment the group collapsed: the entire collapsible region was hidden by `useExpandCollapse`, including the inline `AttachmentGroup` rendered by each `ToolCall`.

This PR keeps those outputs visible by hoisting them out of the collapsible region.

### What changed

- **`AttachmentGroup` variant prop**: `'all' | 'images' | 'non-images'` (default `'all'`), so callers can choose what to render. Backwards-compatible.
- **`ToolCall` `hideAttachments` prop**: when set, the inner tool skips rendering its own `AttachmentGroup` entirely. `Part` threads this through to both `ToolCall` call sites.
- **`ToolCallGroup` hoists attachments**: collects `groupAttachments` from every part in the group and renders `<AttachmentGroup attachments={groupAttachments} />` as a *sibling* of the collapsible div, not a child. Default `variant="all"` so non-image attachments (PDFs, etc.) survive collapse alongside images.
- **`ExecuteCode` also threads `hideAttachments`**: prevents double-rendering when an `execute_code` tool is grouped with another tool and the user expands the group (the attachments would otherwise show twice: once hoisted, once inline).
- **`ContentParts` memoization**: `sequentialParts` and `groupedParts` (with `groupAttachments` rolled into each tool-group entry) are now `useMemo`'d, so the per-group `flatMap` over `attachmentMap` doesn't re-run on every render.

### How collapse + hoist works

```
<ToolCallGroup>
  <button>Used 3 tools, Everything</button>
  <div style={expandStyle}>            ← collapses to height 0
    <ToolCall hideAttachments />        ← skips its AttachmentGroup
    <ToolCall hideAttachments />
    <ToolCall hideAttachments />
  </div>
  <AttachmentGroup attachments={...} /> ← sibling, stays visible when collapsed
</ToolCallGroup>
```

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified in-browser with Claude Sonnet 4.6 + Everything MCP, sending a prompt that produces 3 contiguous `get-tiny-image` calls:

- Collapsed group shows the `Used 3 tools` header and all 3 MCP logo images remain visible below it (the original bug)
- Expanding the group shows 3 individual `Ran get-tiny-image` entries; DOM inspection confirms exactly 3 image buttons, not 6 (no double-render)
- Non-grouped path (Claude inserts text between calls) still renders each image inline, no regression

Unit and integration coverage:

- `ToolCallGroup.test.tsx`: `AttachmentGroup` is a sibling of the collapsible, `variant="all"` hoists both images and files, no group renders without attachments
- `ToolCall.test.tsx`: `AttachmentGroup` is skipped when `hideAttachments=true` and rendered when `false`
- `ContentParts.integration.test.tsx` (new): exercises the full `ContentParts -> Part -> ToolCall -> AttachmentGroup` chain with realistic MCP data: 2+ contiguous calls hoist a single group, single calls render inline, mixed image + file both hoist, empty attachments are a no-op
- All 159 tests in `src/components/Chat/Messages/Content` pass, TypeScript clean for touched files

### **Test Configuration**:

- Node.js: v20.19.0+
- Anthropic: Claude Sonnet 4.6
- MCP: `@modelcontextprotocol/server-everything` (`getTinyImage`)
- Browser: Chromium (latest)

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.