### PR TITLE
fix: sanitize MCP tool inputSchema top-level combinators for LLM API compatibility

### DIFF
--- a/packages/api/src/mcp/registry/MCPServerInspector.ts
+++ b/packages/api/src/mcp/registry/MCPServerInspector.ts
@@ -1,6 +1,7 @@
 import { Constants } from 'librechat-data-provider';
 import type { JsonSchemaType } from '@librechat/data-schemas';
 import type { MCPConnection } from '~/mcp/connection';
+import { sanitizeToolSchema } from '~/mcp/zod';
 import type * as t from '~/mcp/types';
 import { isMCPDomainAllowed, extractMCPServerDomain } from '~/auth/domain';
 import { MCPConnectionFactory } from '~/mcp/MCPConnectionFactory';
@@ -151,7 +152,7 @@ export class MCPServerInspector {
         ['function']: {
           name,
           description: tool.description,
-          parameters: tool.inputSchema as JsonSchemaType,
+          parameters: sanitizeToolSchema(tool.inputSchema as JsonSchemaType),
         },
       };
     });

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -1,6 +1,7 @@
 import { logger } from '@librechat/data-schemas';
 import { Constants } from 'librechat-data-provider';
 import type { JsonSchemaType } from '@librechat/agents';
+import { sanitizeToolSchema } from './zod';
 import type { LCAvailableTools, LCFunctionTool } from './types';
 
 export interface MCPToolInput {
@@ -45,7 +46,7 @@ export function createMCPToolCacheService(deps: MCPToolCacheDeps) {
           ['function']: {
             name,
             description: tool.description ?? '',
-            parameters: tool.inputSchema ?? ({ type: 'object', properties: {} } as JsonSchemaType),
+            parameters: sanitizeToolSchema(tool.inputSchema),
           },
         };
         serverTools[name] = entry;

--- a/packages/api/src/mcp/zod.ts
+++ b/packages/api/src/mcp/zod.ts
@@ -327,11 +327,14 @@ const COMBINATOR_KEYS = ['oneOf', 'anyOf', 'allOf'] as const;
 /**
  * Sanitizes an MCP tool inputSchema for strict LLM API compatibility.
  *
- * Anthropic and OpenAI reject schemas with `oneOf`/`anyOf`/`allOf`/`not`/`enum` at the
- * top level. When any of these combinators are present at the root, this function merges
- * all sub-schema properties into a single `type: "object"` schema, dropping constraints
- * that cannot be expressed without combinators. Top-level `description` and `required`
- * are preserved. The result is then passed through `normalizeJsonSchema` for full cleanup.
+ * Anthropic and OpenAI reject schemas with `oneOf`/`anyOf`/`allOf`/`not` at the
+ * top level. When any of these combinators are present at the root, this function:
+ *   1. Resolves all `$ref` references so combinator branches are fully expanded
+ *   2. Merges `properties` and `required` from all sub-schemas into a single
+ *      `type: "object"` schema
+ *
+ * Top-level `description` is preserved. The result passes through `normalizeJsonSchema`
+ * for full cleanup. Schemas without top-level combinators pass through unchanged.
  *
  * Google Gemini is more permissive and does not require this transformation.
  */
@@ -341,22 +344,32 @@ export function sanitizeToolSchema(schema: JsonSchemaType | undefined): JsonSche
     return fallback;
   }
 
-  const s = schema as Record<string, unknown>;
-  const hasCombinator = COMBINATOR_KEYS.some((k) => Array.isArray(s[k]));
-  const hasTopLevelNot = s['not'] != null;
+  const resolved = resolveJsonSchemaRefs(schema as Record<string, unknown>) as Record<
+    string,
+    unknown
+  >;
+  const hasCombinator = COMBINATOR_KEYS.some((k) => Array.isArray(resolved[k]));
+  const hasTopLevelNot = resolved['not'] != null;
 
   if (!hasCombinator && !hasTopLevelNot) {
-    return normalizeJsonSchema(s) as JsonSchemaType;
+    return normalizeJsonSchema(resolved) as JsonSchemaType;
   }
 
   const mergedProperties: Record<string, unknown> = {};
+  const mergedRequired = new Set<string>(
+    Array.isArray(resolved.required) ? (resolved.required as string[]) : [],
+  );
 
-  if (s.properties && typeof s.properties === 'object' && !Array.isArray(s.properties)) {
-    Object.assign(mergedProperties, s.properties);
+  if (
+    resolved.properties &&
+    typeof resolved.properties === 'object' &&
+    !Array.isArray(resolved.properties)
+  ) {
+    Object.assign(mergedProperties, resolved.properties);
   }
 
   for (const key of COMBINATOR_KEYS) {
-    const subSchemas = s[key];
+    const subSchemas = resolved[key];
     if (!Array.isArray(subSchemas)) {
       continue;
     }
@@ -368,6 +381,11 @@ export function sanitizeToolSchema(schema: JsonSchemaType | undefined): JsonSche
       if (subRecord.properties && typeof subRecord.properties === 'object') {
         Object.assign(mergedProperties, subRecord.properties);
       }
+      if (Array.isArray(subRecord.required)) {
+        for (const field of subRecord.required as string[]) {
+          mergedRequired.add(field);
+        }
+      }
     }
   }
 
@@ -375,11 +393,11 @@ export function sanitizeToolSchema(schema: JsonSchemaType | undefined): JsonSche
   if (Object.keys(mergedProperties).length > 0) {
     result.properties = mergedProperties;
   }
-  if (s.description != null) {
-    result.description = s.description;
+  if (mergedRequired.size > 0) {
+    result.required = [...mergedRequired];
   }
-  if (Array.isArray(s.required) && s.required.length > 0) {
-    result.required = s.required;
+  if (resolved.description != null) {
+    result.description = resolved.description;
   }
 
   return normalizeJsonSchema(result) as JsonSchemaType;

--- a/packages/api/src/mcp/zod.ts
+++ b/packages/api/src/mcp/zod.ts
@@ -322,6 +322,69 @@ export function normalizeJsonSchema<T extends Record<string, unknown>>(schema: T
   return result as T;
 }
 
+const COMBINATOR_KEYS = ['oneOf', 'anyOf', 'allOf'] as const;
+
+/**
+ * Sanitizes an MCP tool inputSchema for strict LLM API compatibility.
+ *
+ * Anthropic and OpenAI reject schemas with `oneOf`/`anyOf`/`allOf`/`not`/`enum` at the
+ * top level. When any of these combinators are present at the root, this function merges
+ * all sub-schema properties into a single `type: "object"` schema, dropping constraints
+ * that cannot be expressed without combinators. Top-level `description` and `required`
+ * are preserved. The result is then passed through `normalizeJsonSchema` for full cleanup.
+ *
+ * Google Gemini is more permissive and does not require this transformation.
+ */
+export function sanitizeToolSchema(schema: JsonSchemaType | undefined): JsonSchemaType {
+  const fallback: JsonSchemaType = { type: 'object', properties: {} };
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return fallback;
+  }
+
+  const s = schema as Record<string, unknown>;
+  const hasCombinator = COMBINATOR_KEYS.some((k) => Array.isArray(s[k]));
+  const hasTopLevelNot = s['not'] != null;
+
+  if (!hasCombinator && !hasTopLevelNot) {
+    return normalizeJsonSchema(s) as JsonSchemaType;
+  }
+
+  const mergedProperties: Record<string, unknown> = {};
+
+  if (s.properties && typeof s.properties === 'object' && !Array.isArray(s.properties)) {
+    Object.assign(mergedProperties, s.properties);
+  }
+
+  for (const key of COMBINATOR_KEYS) {
+    const subSchemas = s[key];
+    if (!Array.isArray(subSchemas)) {
+      continue;
+    }
+    for (const sub of subSchemas) {
+      if (!sub || typeof sub !== 'object' || Array.isArray(sub)) {
+        continue;
+      }
+      const subRecord = sub as Record<string, unknown>;
+      if (subRecord.properties && typeof subRecord.properties === 'object') {
+        Object.assign(mergedProperties, subRecord.properties);
+      }
+    }
+  }
+
+  const result: Record<string, unknown> = { type: 'object' };
+  if (Object.keys(mergedProperties).length > 0) {
+    result.properties = mergedProperties;
+  }
+  if (s.description != null) {
+    result.description = s.description;
+  }
+  if (Array.isArray(s.required) && s.required.length > 0) {
+    result.required = s.required;
+  }
+
+  return normalizeJsonSchema(result) as JsonSchemaType;
+}
+
 /**
  * Converts a JSON Schema to a Zod schema.
  *


### PR DESCRIPTION
## Problem

MCP servers that auto-generate their tool schemas from OpenAPI specs or TypeScript/Pydantic types often produce `inputSchema` definitions with `oneOf`, `anyOf`, `allOf`, or `not` at the top level. Both **Anthropic** and **OpenAI** reject these with 400 errors:

- **Anthropic:** `input_schema does not support oneOf, allOf, or anyOf at the top level`
- **OpenAI:** `schema must have type 'object' and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'not' at the top level`

Google Gemini is more permissive and works without issue. LibreChat was passing `inputSchema` through as-is, so any MCP server using these patterns would fail silently for Claude and GPT models.

## Solution

Add `sanitizeToolSchema()` in `packages/api/src/mcp/zod.ts` that detects top-level combinators and flattens them into a single `type: "object"` schema by merging `properties` from all sub-schemas. Top-level `description` and `required` are preserved. The result is then passed through the existing `normalizeJsonSchema()` for full cleanup.

Apply it at both tool-ingestion sites:
- `MCPServerInspector.getToolFunctions()` — covers the startup inspection path
- `createMCPToolCacheService.updateMCPServerTools()` — covers the user-scoped tool caching path

## Changes

- `packages/api/src/mcp/zod.ts` — new `sanitizeToolSchema()` export
- `packages/api/src/mcp/registry/MCPServerInspector.ts` — apply sanitization when building tool functions
- `packages/api/src/mcp/tools.ts` — apply sanitization in tool cache service

## Testing

Verified against an MCP server whose `create_transcription` tool exposes a top-level `oneOf` schema. Before this fix: 400 from both Anthropic and OpenAI. After: works correctly with all providers.

Made with [Cursor](https://cursor.com)