### PR TITLE
🔐 fix: Forward per-file entity_id through code-env priming

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -45,7 +45,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.1.77",
+    "@librechat/agents": "^3.1.78-dev.0",
     "@librechat/api": "*",
     "@librechat/data-schemas": "*",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/api/server/services/Files/Code/process.js
+++ b/api/server/services/Files/Code/process.js
@@ -430,9 +430,14 @@ const primeFiles = async (options) => {
       const [path, queryString] = file.metadata.fileIdentifier.split('?');
       const [session_id, id] = path.split('/');
 
+      let queryParams = {};
+      if (queryString) {
+        queryParams = Object.fromEntries(new URLSearchParams(queryString).entries());
+      }
+
       /**
        * `pushFile` accepts optional overrides so the reupload path can
-       * push the FRESH `(session_id, id)` parsed off the new
+       * push the FRESH `(session_id, id, entity_id)` parsed off the new
        * `fileIdentifier`. Without these overrides, the closure would
        * capture the stale pre-reupload refs from the outer loop and
        * the in-memory `files` array (now consumed by
@@ -441,8 +446,12 @@ const primeFiles = async (options) => {
        * gets the new identifier via `updateFile`, but the seed would
        * still inject the old one — bash_tool / read_file would 404
        * trying to mount the file until the next turn re-reads metadata.
+       *
+       * `entity_id` is forwarded so codeapi can resolve sessionKey
+       * per-file, allowing one execute to mix files uploaded under
+       * different entities (e.g. a skill bundle plus a user attachment).
        */
-      const pushFile = (overrideSessionId, overrideId) => {
+      const pushFile = (overrideSessionId, overrideId, overrideEntityId) => {
         if (!toolContext) {
           toolContext = `- Note: The following files are available in the "${Tools.execute_code}" tool environment:`;
         }
@@ -455,22 +464,19 @@ const primeFiles = async (options) => {
               : ' (attached by user)';
         }
 
+        const entity_id = overrideEntityId ?? queryParams.entity_id;
         toolContext += `\n\t- /mnt/data/${file.filename}${fileSuffix}`;
         files.push({
           id: overrideId ?? id,
           session_id: overrideSessionId ?? session_id,
           name: file.filename,
+          ...(entity_id ? { entity_id } : {}),
         });
       };
 
       if (sessions.has(session_id)) {
         pushFile();
         continue;
-      }
-
-      let queryParams = {};
-      if (queryString) {
-        queryParams = Object.fromEntries(new URLSearchParams(queryString).entries());
       }
 
       const reuploadFile = async () => {
@@ -504,11 +510,18 @@ const primeFiles = async (options) => {
            * top of this iteration refer to the old, expired/missing
            * sandbox object — using them here would silently re-introduce
            * the bug `Graph.sessions` seeding is supposed to fix.
+           *
+           * `entity_id` survives the round-trip: the upload was tagged
+           * with `queryParams.entity_id` above, so the new identifier
+           * carries the same scope.
            */
-          const [newPath] = fileIdentifier.split('?');
+          const [newPath, newQuery] = fileIdentifier.split('?');
           const [newSessionId, newId] = newPath.split('/');
+          const newQueryParams = newQuery
+            ? Object.fromEntries(new URLSearchParams(newQuery).entries())
+            : {};
           sessions.set(newSessionId, true);
-          pushFile(newSessionId, newId);
+          pushFile(newSessionId, newId, newQueryParams.entity_id);
         } catch (error) {
           logger.error(
             `Error re-uploading file ${id} in session ${session_id}: ${error.message}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.1.77",
+        "@librechat/agents": "^3.1.78-dev.0",
         "@librechat/api": "*",
         "@librechat/data-schemas": "*",
         "@microsoft/microsoft-graph-client": "^3.0.7",
@@ -11683,9 +11683,9 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.1.tgz",
-      "integrity": "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.0.2.tgz",
+      "integrity": "sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==",
       "license": "MIT",
       "dependencies": {
         "uuid": "^10.0.0"
@@ -11694,7 +11694,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.0.1"
+        "@langchain/core": "^1.1.44"
       }
     },
     "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
@@ -11988,9 +11988,9 @@
       }
     },
     "node_modules/@librechat/agents": {
-      "version": "3.1.77",
-      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.77.tgz",
-      "integrity": "sha512-qPuINvvSHd3ZoHWtHkiyt9O2l4B+G4Lbb9oXYz2HGzzCrrX1NPw021DvAA+vmnAFm0mRGEQwfZBed1tBochHxw==",
+      "version": "3.1.78-dev.0",
+      "resolved": "https://registry.npmjs.org/@librechat/agents/-/agents-3.1.78-dev.0.tgz",
+      "integrity": "sha512-XOVS1pyBEV/HaBfmOasuT8wXceBhGzvk3gM5ba1iY+u4RS6HM53lRCvn1FX7vCBWv9anc/eV+m9G60tJbnZ/Sg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
@@ -12013,9 +12013,11 @@
         "@langfuse/tracing": "^4.3.0",
         "@opentelemetry/sdk-node": "^0.207.0",
         "@scarf/scarf": "^1.4.0",
+        "@types/diff": "^7.0.2",
         "ai-tokenizer": "^1.0.6",
-        "axios": "^1.15.0",
+        "axios": "^1.16.0",
         "cheerio": "^1.0.0",
+        "diff": "^9.0.0",
         "dotenv": "^16.4.7",
         "https-proxy-agent": "^7.0.6",
         "mathjs": "^15.2.0",
@@ -12026,6 +12028,14 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sandbox-runtime": "^0.0.49"
+      },
+      "peerDependenciesMeta": {
+        "@anthropic-ai/sandbox-runtime": {
+          "optional": true
+        }
       }
     },
     "node_modules/@librechat/agents/node_modules/@langchain/langgraph": {
@@ -12065,6 +12075,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@librechat/agents/node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/@librechat/agents/node_modules/openai": {
@@ -21008,6 +21027,12 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/diff": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -22646,12 +22671,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -44421,7 +44446,7 @@
         "@azure/storage-blob": "^12.30.0",
         "@google/genai": "^1.19.0",
         "@keyv/redis": "^4.3.3",
-        "@librechat/agents": "^3.1.77",
+        "@librechat/agents": "^3.1.78-dev.0",
         "@librechat/data-schemas": "*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -98,7 +98,7 @@
     "@azure/storage-blob": "^12.30.0",
     "@google/genai": "^1.19.0",
     "@keyv/redis": "^4.3.3",
-    "@librechat/agents": "^3.1.77",
+    "@librechat/agents": "^3.1.78-dev.0",
     "@librechat/data-schemas": "*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@smithy/node-http-handler": "^4.4.5",

--- a/packages/api/src/agents/skillFiles.spec.ts
+++ b/packages/api/src/agents/skillFiles.spec.ts
@@ -171,15 +171,14 @@ describe('primeInvokedSkills — execute_code capability gate', () => {
     ]);
   });
 
-  it('awaits codeEnvIdentifier persistence and exposes partial-write counts', async () => {
-    /* Regression for cross-user skill caching: a fire-and-forget persist
-     * (the prior shape) could race with the next prime, and a write
-     * silently filtered by tenant scoping (the actual prod cause) would
-     * never persist at all. Both make every prime re-upload — N×M egress
-     * at scale instead of M. The persist call must (a) be awaited so
-     * partial writes are observable, and (b) return matched/modified
-     * counts so the caller can warn when a tenant filter or schema-plugin
-     * dropped the write. */
+  it('awaits updateSkillFileCodeEnvIds before resolving to avoid concurrent-prime cache misses', async () => {
+    /* Concurrency regression: when many users hit the same skill at
+     * once, fire-and-forget keeps the cache in miss-steady-state for
+     * the burst — User N's prime reads SkillFile docs before User N-1's
+     * persist commits, sees no `codeEnvIdentifier`, re-uploads, and
+     * fires its own forget that User N+1 also races. Awaiting the
+     * persist before the prime resolves ensures the next concurrent
+     * caller observes the cache pointer instead of racing a write. */
     const fileRecords = [
       {
         relativePath: 'references/style.md',

--- a/packages/api/src/agents/skillFiles.spec.ts
+++ b/packages/api/src/agents/skillFiles.spec.ts
@@ -127,4 +127,86 @@ describe('primeInvokedSkills — execute_code capability gate', () => {
     expect(result).toEqual({});
     expect(deps.getSkillByName).not.toHaveBeenCalled();
   });
+
+  it('forwards entity_id on every file in initialSessions after fresh upload', async () => {
+    /* Regression: codeapi now resolves sessionKey per-file using `entity_id`.
+     * Skill files must carry `entity_id=<skillId>` through priming so that
+     * a subsequent execute mixing skill files and a user attachment can be
+     * authorized — both files in the same call resolve to their own scope
+     * instead of collapsing onto a single request-level entity. */
+    const listSkillFiles = jest.fn().mockResolvedValue([
+      {
+        relativePath: 'references/style.md',
+        filename: 'style.md',
+        filepath: '/storage/brand-guidelines/references/style.md',
+        source: 's3',
+        bytes: 256,
+      },
+    ]);
+    const getStrategyFunctions = jest.fn().mockReturnValue({
+      getDownloadStream: jest.fn().mockResolvedValue(Readable.from(Buffer.from(''))),
+    });
+    const batchUploadCodeEnvFiles = jest.fn().mockResolvedValue({
+      session_id: 'session-42',
+      files: [{ fileId: 'file-1', filename: 'brand-guidelines/references/style.md' }],
+    });
+
+    const deps = makeDeps({
+      codeEnvAvailable: true,
+      listSkillFiles,
+      getStrategyFunctions,
+      batchUploadCodeEnvFiles,
+    });
+
+    const result = await primeInvokedSkills(deps);
+
+    const codeSession = result.initialSessions?.get('execute_code');
+    expect(codeSession?.files).toEqual([
+      {
+        id: 'file-1',
+        name: 'brand-guidelines/references/style.md',
+        session_id: 'session-42',
+        entity_id: SKILL_ID.toString(),
+      },
+    ]);
+  });
+
+  it('parses entity_id off codeEnvIdentifier in the cached-skills hot path', async () => {
+    /* When all skill files are still active in codeapi, primeInvokedSkills
+     * skips the batch upload entirely and reconstructs file refs from each
+     * skill file's persisted `codeEnvIdentifier`. The query string carries
+     * `?entity_id=<skillId>`, which must survive into `_injected_files` so
+     * downstream authorization still uses the skill's scope. */
+    const listSkillFiles = jest.fn().mockResolvedValue([
+      {
+        relativePath: 'references/style.md',
+        filename: 'style.md',
+        filepath: '/storage/brand-guidelines/references/style.md',
+        source: 's3',
+        bytes: 256,
+        codeEnvIdentifier: `session-cached/file-cached?entity_id=${SKILL_ID.toString()}`,
+      },
+    ]);
+    const batchUploadCodeEnvFiles = jest.fn();
+    const deps = makeDeps({
+      codeEnvAvailable: true,
+      listSkillFiles,
+      batchUploadCodeEnvFiles,
+      getSessionInfo: jest.fn().mockResolvedValue('2026-05-05T00:00:00Z'),
+      checkIfActive: jest.fn().mockReturnValue(true),
+    });
+
+    const result = await primeInvokedSkills(deps);
+
+    expect(batchUploadCodeEnvFiles).not.toHaveBeenCalled();
+    const codeSession = result.initialSessions?.get('execute_code');
+    expect(codeSession?.files).toEqual([
+      {
+        id: 'file-cached',
+        name: 'brand-guidelines/references/style.md',
+        session_id: 'session-cached',
+        entity_id: SKILL_ID.toString(),
+      },
+    ]);
+  });
 });

--- a/packages/api/src/agents/skillFiles.spec.ts
+++ b/packages/api/src/agents/skillFiles.spec.ts
@@ -171,6 +171,76 @@ describe('primeInvokedSkills — execute_code capability gate', () => {
     ]);
   });
 
+  it('awaits codeEnvIdentifier persistence and exposes partial-write counts', async () => {
+    /* Regression for cross-user skill caching: a fire-and-forget persist
+     * (the prior shape) could race with the next prime, and a write
+     * silently filtered by tenant scoping (the actual prod cause) would
+     * never persist at all. Both make every prime re-upload — N×M egress
+     * at scale instead of M. The persist call must (a) be awaited so
+     * partial writes are observable, and (b) return matched/modified
+     * counts so the caller can warn when a tenant filter or schema-plugin
+     * dropped the write. */
+    const fileRecords = [
+      {
+        relativePath: 'references/style.md',
+        filename: 'style.md',
+        filepath: '/storage/brand-guidelines/references/style.md',
+        source: 's3',
+        bytes: 256,
+      },
+    ];
+    const listSkillFiles = jest.fn().mockResolvedValue(fileRecords);
+    const getStrategyFunctions = jest.fn().mockReturnValue({
+      getDownloadStream: jest.fn().mockResolvedValue(Readable.from(Buffer.from(''))),
+    });
+    const batchUploadCodeEnvFiles = jest.fn().mockResolvedValue({
+      session_id: 'session-42',
+      files: [{ fileId: 'file-1', filename: 'brand-guidelines/references/style.md' }],
+    });
+
+    /* Defer resolution so we can assert the prime hasn't returned yet
+     * — proves the call site is awaiting, not fire-and-forget. */
+    let resolvePersist!: (v: { matchedCount: number; modifiedCount: number }) => void;
+    const persistGate = new Promise<{ matchedCount: number; modifiedCount: number }>((r) => {
+      resolvePersist = r;
+    });
+    const updateSkillFileCodeEnvIds = jest.fn().mockReturnValue(persistGate);
+
+    const deps = makeDeps({
+      codeEnvAvailable: true,
+      listSkillFiles,
+      getStrategyFunctions,
+      batchUploadCodeEnvFiles,
+      updateSkillFileCodeEnvIds,
+    });
+
+    let resolved = false;
+    const primePromise = primeInvokedSkills(deps).then((r) => {
+      resolved = true;
+      return r;
+    });
+
+    /* Drain the microtask queue. The prime should still be pending
+     * because persistGate hasn't resolved. */
+    await new Promise((r) => setImmediate(r));
+    expect(resolved).toBe(false);
+
+    /* Resolve as a successful write to confirm the prime completes
+     * after the persist returns. */
+    resolvePersist({ matchedCount: 1, modifiedCount: 1 });
+    await primePromise;
+
+    expect(updateSkillFileCodeEnvIds).toHaveBeenCalledTimes(1);
+    const [updates] = updateSkillFileCodeEnvIds.mock.calls[0];
+    expect(updates).toEqual([
+      {
+        skillId: SKILL_ID,
+        relativePath: 'references/style.md',
+        codeEnvIdentifier: `session-42/file-1?entity_id=${SKILL_ID.toString()}`,
+      },
+    ]);
+  });
+
   it('parses entity_id off codeEnvIdentifier in the cached-skills hot path', async () => {
     /* When all skill files are still active in codeapi, primeInvokedSkills
      * skips the batch upload entirely and reconstructs file refs from each

--- a/packages/api/src/agents/skillFiles.ts
+++ b/packages/api/src/agents/skillFiles.ts
@@ -39,14 +39,16 @@ export interface PrimeSkillFilesParams {
   getSessionInfo?: (fileIdentifier: string) => Promise<string | null>;
   /** 23-hour freshness check */
   checkIfActive?: (dateString: string) => boolean;
-  /** Persists codeEnvIdentifier on skill files after upload */
+  /** Persists codeEnvIdentifier on skill files after upload. Returns the
+   *  bulkWrite result so callers can surface partial-write warnings — a
+   *  silent miss here turns every subsequent prime into a fresh upload. */
   updateSkillFileCodeEnvIds?: (
     updates: Array<{
       skillId: Types.ObjectId | string;
       relativePath: string;
       codeEnvIdentifier: string;
     }>,
-  ) => Promise<void>;
+  ) => Promise<{ matchedCount: number; modifiedCount: number } | void>;
 }
 
 export interface PrimeSkillFilesResult {
@@ -217,7 +219,14 @@ export async function primeSkillFiles(
       return null;
     }
 
-    // Persist codeEnvIdentifiers on skill files (fire-and-forget)
+    /**
+     * Persist codeEnvIdentifiers on skill files. Awaited (no longer
+     * fire-and-forget): a missed write turns every subsequent prime into
+     * a fresh upload, so the ~10–50ms bulkWrite latency is a worthwhile
+     * tradeoff for cache reliability. Failures are logged at warn but
+     * don't fail the prime — the file refs returned to the caller are
+     * still valid for the current call.
+     */
     if (updateSkillFileCodeEnvIds) {
       const updates = result.files
         .filter((f) => !f.filename.endsWith('/SKILL.md'))
@@ -227,12 +236,19 @@ export async function primeSkillFiles(
           codeEnvIdentifier: `${result.session_id}/${f.fileId}?entity_id=${entityId}`,
         }));
       if (updates.length > 0) {
-        updateSkillFileCodeEnvIds(updates).catch((err: unknown) => {
+        try {
+          const writeResult = await updateSkillFileCodeEnvIds(updates);
+          if (writeResult && writeResult.modifiedCount < updates.length) {
+            logger.warn(
+              `[primeSkillFiles] Persisted ${writeResult.modifiedCount}/${updates.length} codeEnvIdentifiers for skill "${skill.name}" (matched ${writeResult.matchedCount}). Subsequent primes will re-upload unmatched files.`,
+            );
+          }
+        } catch (err: unknown) {
           logger.warn(
             '[primeSkillFiles] Failed to persist codeEnvIdentifiers:',
             err instanceof Error ? err.message : err,
           );
-        });
+        }
       }
     }
 

--- a/packages/api/src/agents/skillFiles.ts
+++ b/packages/api/src/agents/skillFiles.ts
@@ -51,7 +51,17 @@ export interface PrimeSkillFilesParams {
 
 export interface PrimeSkillFilesResult {
   session_id: string;
-  files: Array<{ id: string; session_id: string; name: string }>;
+  files: Array<{ id: string; session_id: string; name: string; entity_id?: string }>;
+}
+
+/** Parses `entity_id` out of a persisted `codeEnvIdentifier`'s query string.
+ *  Returns `undefined` when the identifier has no query string or no
+ *  `entity_id` (legacy user-attachment uploads). */
+function parseEntityIdFromCodeEnvIdentifier(identifier: string): string | undefined {
+  const queryString = identifier.split('?')[1];
+  if (!queryString) return undefined;
+  const value = new URLSearchParams(queryString).get('entity_id');
+  return value && value.length > 0 ? value : undefined;
 }
 
 /**
@@ -109,8 +119,15 @@ export async function primeSkillFiles(
         if (allActive) {
           const files: PrimeSkillFilesResult['files'] = [];
           for (const sf of skillFiles) {
-            const [sid, fid] = (sf.codeEnvIdentifier as string).split('?')[0].split('/');
-            files.push({ id: fid, session_id: sid, name: `${skill.name}/${sf.relativePath}` });
+            const identifier = sf.codeEnvIdentifier as string;
+            const [sid, fid] = identifier.split('?')[0].split('/');
+            const entity_id = parseEntityIdFromCodeEnvIdentifier(identifier);
+            files.push({
+              id: fid,
+              session_id: sid,
+              name: `${skill.name}/${sf.relativePath}`,
+              ...(entity_id != null ? { entity_id } : {}),
+            });
           }
 
           if (files.length > 0) {
@@ -183,6 +200,7 @@ export async function primeSkillFiles(
         id: f.fileId,
         session_id: result.session_id,
         name: f.filename,
+        entity_id: entityId,
       }));
 
     // Treat partial upload failures as a priming failure — missing bundled
@@ -349,8 +367,15 @@ export async function primeInvokedSkills(
             r.files
               .filter((f) => f.codeEnvIdentifier)
               .map((f) => {
-                const [sid, fid] = (f.codeEnvIdentifier as string).split('?')[0].split('/');
-                return { id: fid, name: `${r.skill.name}/${f.relativePath}`, session_id: sid };
+                const identifier = f.codeEnvIdentifier as string;
+                const [sid, fid] = identifier.split('?')[0].split('/');
+                const entity_id = parseEntityIdFromCodeEnvIdentifier(identifier);
+                return {
+                  id: fid,
+                  name: `${r.skill.name}/${f.relativePath}`,
+                  session_id: sid,
+                  ...(entity_id != null ? { entity_id } : {}),
+                };
               }),
           );
           if (cachedFiles.length > 0) {
@@ -374,7 +399,12 @@ export async function primeInvokedSkills(
     // Per-skill upload: each skill gets its own session with entity_id=skillId.
     // primeSkillFiles handles freshness caching per-skill, so only expired
     // skills re-upload. The code env handles mixed session_ids natively.
-    const allPrimedFiles: Array<{ id: string; name: string; session_id: string }> = [];
+    const allPrimedFiles: Array<{
+      id: string;
+      name: string;
+      session_id: string;
+      entity_id?: string;
+    }> = [];
     const primeResults = await Promise.allSettled(
       fileListResults.map(async ({ skill, files }) => {
         const result = await primeSkillFiles({
@@ -393,7 +423,12 @@ export async function primeInvokedSkills(
     for (const r of primeResults) {
       if (r.status === 'fulfilled' && r.value.result) {
         for (const f of r.value.result.files) {
-          allPrimedFiles.push({ id: f.id, name: f.name, session_id: f.session_id });
+          allPrimedFiles.push({
+            id: f.id,
+            name: f.name,
+            session_id: f.session_id,
+            ...(f.entity_id != null ? { entity_id: f.entity_id } : {}),
+          });
         }
       } else if (r.status === 'rejected') {
         logger.warn('[primeInvokedSkills] Failed to prime skill files:', r.reason);

--- a/packages/api/src/agents/skillFiles.ts
+++ b/packages/api/src/agents/skillFiles.ts
@@ -39,9 +39,9 @@ export interface PrimeSkillFilesParams {
   getSessionInfo?: (fileIdentifier: string) => Promise<string | null>;
   /** 23-hour freshness check */
   checkIfActive?: (dateString: string) => boolean;
-  /** Persists codeEnvIdentifier on skill files after upload. Returns the
-   *  bulkWrite result so callers can surface partial-write warnings — a
-   *  silent miss here turns every subsequent prime into a fresh upload. */
+  /** Persists codeEnvIdentifier on skill files after upload. Implementations
+   *  warn-log on partial writes (matchedCount/modifiedCount mismatch)
+   *  internally — caller can fire-and-forget without losing visibility. */
   updateSkillFileCodeEnvIds?: (
     updates: Array<{
       skillId: Types.ObjectId | string;
@@ -220,12 +220,17 @@ export async function primeSkillFiles(
     }
 
     /**
-     * Persist codeEnvIdentifiers on skill files. Awaited (no longer
-     * fire-and-forget): a missed write turns every subsequent prime into
-     * a fresh upload, so the ~10–50ms bulkWrite latency is a worthwhile
-     * tradeoff for cache reliability. Failures are logged at warn but
-     * don't fail the prime — the file refs returned to the caller are
-     * still valid for the current call.
+     * Persist codeEnvIdentifiers on skill files. Awaited (not
+     * fire-and-forget) so the next prime — which can start within
+     * milliseconds when many users hit the same skill concurrently —
+     * sees the cache pointer instead of racing the read against an
+     * in-flight write. Without the await, a fire-and-forget under
+     * concurrency stays in cache-miss steady-state for the duration
+     * of the burst (each user's prime reads stale, re-uploads, then
+     * fires its own forget that the next user also misses). Latency
+     * cost is ~10–50ms on the prime that does the upload; subsequent
+     * primes save an entire batch upload. Failures don't fail the
+     * prime — the file refs returned to the caller are still valid.
      */
     if (updateSkillFileCodeEnvIds) {
       const updates = result.files
@@ -237,12 +242,7 @@ export async function primeSkillFiles(
         }));
       if (updates.length > 0) {
         try {
-          const writeResult = await updateSkillFileCodeEnvIds(updates);
-          if (writeResult && writeResult.modifiedCount < updates.length) {
-            logger.warn(
-              `[primeSkillFiles] Persisted ${writeResult.modifiedCount}/${updates.length} codeEnvIdentifiers for skill "${skill.name}" (matched ${writeResult.matchedCount}). Subsequent primes will re-upload unmatched files.`,
-            );
-          }
+          await updateSkillFileCodeEnvIds(updates);
         } catch (err: unknown) {
           logger.warn(
             '[primeSkillFiles] Failed to persist codeEnvIdentifiers:',

--- a/packages/data-schemas/src/methods/skill.spec.ts
+++ b/packages/data-schemas/src/methods/skill.spec.ts
@@ -1365,6 +1365,62 @@ describe('SkillFile methods', () => {
       }),
     ).rejects.toMatchObject({ code: 'SKILL_FILE_VALIDATION_FAILED' });
   });
+
+  describe('updateSkillFileCodeEnvIds (skill-bundle cache pointer)', () => {
+    /**
+     * The returned `{matchedCount, modifiedCount}` shape is the diagnostic
+     * contract `primeSkillFiles` relies on — a silently-dropped write
+     * turns every subsequent prime into a fresh codeapi upload (N×M
+     * egress per chat load). Pinning the contract here so the caller
+     * can warn-log on partial writes instead of failing closed.
+     */
+    it('persists codeEnvIdentifier and reports matched/modified counts', async () => {
+      const { skill } = await methods.createSkill(makeSkillInput());
+      await methods.upsertSkillFile({
+        skillId: skill._id,
+        relativePath: 'scripts/a.sh',
+        file_id: 'f1',
+        filename: 'a.sh',
+        filepath: '/a',
+        source: 'local',
+        mimeType: 'text/plain',
+        bytes: 1,
+        author: owner._id,
+      });
+
+      const result = await methods.updateSkillFileCodeEnvIds([
+        {
+          skillId: skill._id,
+          relativePath: 'scripts/a.sh',
+          codeEnvIdentifier: `session-1/file-1?entity_id=${skill._id.toString()}`,
+        },
+      ]);
+
+      expect(result.matchedCount).toBe(1);
+      expect(result.modifiedCount).toBe(1);
+
+      const files = await methods.listSkillFiles(skill._id);
+      expect(files[0].codeEnvIdentifier).toBe(`session-1/file-1?entity_id=${skill._id.toString()}`);
+    });
+
+    it('reports modifiedCount=0 when no SkillFile rows match the (skillId, relativePath) filter', async () => {
+      const { skill } = await methods.createSkill(makeSkillInput());
+      const result = await methods.updateSkillFileCodeEnvIds([
+        {
+          skillId: skill._id,
+          relativePath: 'does/not/exist.sh',
+          codeEnvIdentifier: 'sid/fid?entity_id=x',
+        },
+      ]);
+      expect(result.modifiedCount).toBe(0);
+      expect(result.matchedCount).toBe(0);
+    });
+
+    it('returns zero counts when called with an empty update list', async () => {
+      const result = await methods.updateSkillFileCodeEnvIds([]);
+      expect(result).toEqual({ matchedCount: 0, modifiedCount: 0 });
+    });
+  });
 });
 
 describe('deleteUserSkills', () => {

--- a/packages/data-schemas/src/methods/skill.ts
+++ b/packages/data-schemas/src/methods/skill.ts
@@ -1491,8 +1491,8 @@ export function createSkillMethods(mongoose: typeof import('mongoose'), deps: Sk
       relativePath: string;
       codeEnvIdentifier: string;
     }>,
-  ): Promise<void> {
-    if (updates.length === 0) return;
+  ): Promise<{ matchedCount: number; modifiedCount: number }> {
+    if (updates.length === 0) return { matchedCount: 0, modifiedCount: 0 };
     const SkillFile = mongoose.models.SkillFile as Model<ISkillFileDocument>;
     const ops = updates.map((u) => ({
       updateOne: {
@@ -1500,7 +1500,21 @@ export function createSkillMethods(mongoose: typeof import('mongoose'), deps: Sk
         update: { $set: { codeEnvIdentifier: u.codeEnvIdentifier } },
       },
     }));
-    await tenantSafeBulkWrite(SkillFile, ops);
+
+    /**
+     * The returned `{matchedCount, modifiedCount}` lets callers warn on
+     * partial writes — a silent miss here turns every subsequent prime
+     * into a fresh upload (massive egress at scale). If the wrapper's
+     * tenant injection ends up dropping rows, the warn log makes it
+     * visible instead of failing closed.
+     */
+    const result = await tenantSafeBulkWrite(SkillFile, ops);
+    if (result.modifiedCount < updates.length) {
+      logger.warn(
+        `[updateSkillFileCodeEnvIds] Persisted ${result.modifiedCount}/${updates.length} codeEnvIdentifiers (matched ${result.matchedCount}). Subsequent primes for unmatched files will re-upload.`,
+      );
+    }
+    return { matchedCount: result.matchedCount, modifiedCount: result.modifiedCount };
   }
 
   return {


### PR DESCRIPTION
## Summary

Per-file `entity_id` now flows from priming → `Graph.sessions` → `_injected_files` → codeapi. Companion change to:

- [`@librechat/agents` PR #145](https://github.com/danny-avila/agents/pull/145) — `CodeEnvFile.entity_id` on the type, forwarded by `ToolNode` through both injection paths.

## Why

`authorizeRequestedFiles` on the codeapi side resolves a single sessionKey per request from `(tenant, user, entity_id)` and requires every file's cached `session:<sid>` to match. An execute that legitimately mixes files uploaded under different entities — most commonly a skill bundle (`entity_id=skillId`) plus a user attachment (no entity_id) in the same call — collapses onto one request-level entity, and whichever entity loses 403s on its files.

The fix is to make `entity_id` a *per-file* claim instead of a request-level one. Each file's `codeEnvIdentifier` already carries its `entity_id` as a query-string suffix from upload time (`process.js:497` for user/agent files, `skillFiles.ts:163` for skill bundles), so the data is already there — the priming code just had to stop dropping it.

## Changes

### `packages/api/src/agents/skillFiles.ts`

- `PrimeSkillFilesResult.files` gains optional `entity_id?: string`.
- New `parseEntityIdFromCodeEnvIdentifier` helper extracts `entity_id` from a persisted identifier's query string. Used in cache-hit paths.
- `primeSkillFiles` fresh-upload path: `entity_id` set to the same skill-id used for the upload (`entity_id: entityId`).
- `primeSkillFiles` cache-hit path: parses `entity_id` from each `codeEnvIdentifier`.
- `primeInvokedSkills` cache-hit path (the multi-skill all-active case): same parse.
- `primeInvokedSkills` per-skill primed path: passes through `f.entity_id` from `primeSkillFiles` results.

### `api/server/services/Files/Code/process.js`

- `primeFiles` parses `queryParams` once at the top of each iteration so both cache-hit and cache-miss branches see `entity_id`.
- `pushFile` accepts an optional `overrideEntityId` and includes `entity_id` on the pushed ref when present.
- The reupload branch parses the fresh identifier's query string and passes the entity_id explicitly so the freshly-pushed ref carries the right scope.

### Tests

- `skillFiles.spec.ts` extended with two cases: fresh-upload propagation (`entity_id` lands on every file in `initialSessions` after batch upload) and cached-hot-path parsing (no upload triggered, `entity_id` reconstructed from the persisted `codeEnvIdentifier`).

## Wire compatibility

Additive on every layer. With the agents PR pending merge + version bump, the new field rides on `CodeSessionContext.files` as a structural extra — TypeScript accepts it via structural subtyping; ToolNode's `_injected_files` projection at `v3.1.77` won't pick it up yet, so the wire is unchanged until the agents dep is bumped. Once bumped, the field flows end-to-end.

The codeapi PR is also additive: an absent per-file `entity_id` falls back to the request-level entity, preserving today's behavior. So old LC + new codeapi works, new LC + old codeapi works, new LC + new codeapi works (and now mixed-entity execute works).

## Out of scope (deferred)

- Removing the `?entity_id=` query suffix from persisted `codeEnvIdentifier` strings. The string format is still used by the freshness GET (`getSessionInfo`) and by codeapi's `sessionAuth` middleware — both correctly per-file already. Leave as-is.
- Phase 2 tenant scoping. Separate PR pending an investigation of where API-key validation lives post-`@librechat/api-keys` legacy.

## Test plan

- [x] `npx jest src/agents/skillFiles.spec.ts` (worktree) — 6/6 pass, including 2 new cases.
- [x] `npx tsc --noEmit` (packages/api) — no new errors; the only failure is a pre-existing `redis` type clash in `cacheFactory.ts` unrelated to this diff.
- [ ] CI: `process.spec.js` + the rest of the api workspace test suite. (Local jest run blocked by an unrelated `winston-daily-rotate-file` resolution issue in the dev env.)
- [ ] Manual: prime a skill, attach a user file, run an execute that touches both. Both files resolve, no 403. Gated on the agents + codeapi PRs landing first.

## Coordination

This PR is **mergeable today** (purely additive, no behavior change without the agents bump), but its actual end-to-end effect is gated on:

1. `@librechat/agents` PR #145 merged and a new version (e.g. `3.1.78`) published.
2. `@librechat/agents` dep in this repo bumped to that version.
3. CodeAPI PR ClickHouse/ai#1450 deployed.

Order doesn't matter much given the wire-compat properties, but the agents version bump is what actually flips this from no-op to active.