### PR TITLE
🛰️ fix: Honor Anthropic Vertex Configuration

### DIFF
--- a/api/server/services/Config/EndpointService.js
+++ b/api/server/services/Config/EndpointService.js
@@ -24,9 +24,7 @@ module.exports = {
     openAIApiKey,
     azureOpenAIApiKey,
     userProvidedOpenAI,
-    [EModelEndpoint.anthropic]: generateConfig(
-      anthropicUsesVertex ? 'true' : anthropicApiKey,
-    ),
+    [EModelEndpoint.anthropic]: generateConfig(anthropicUsesVertex ? 'true' : anthropicApiKey),
     [EModelEndpoint.openAI]: generateConfig(openAIApiKey, OPENAI_REVERSE_PROXY),
     [EModelEndpoint.azureOpenAI]: generateConfig(azureOpenAIApiKey, AZURE_OPENAI_BASEURL),
     [EModelEndpoint.assistants]: generateConfig(

--- a/api/server/services/Config/EndpointService.js
+++ b/api/server/services/Config/EndpointService.js
@@ -16,6 +16,7 @@ const {
 } = process.env ?? {};
 
 const userProvidedOpenAI = isUserProvided(openAIApiKey);
+const anthropicUsesVertex = isEnabled(process.env.ANTHROPIC_USE_VERTEX);
 
 module.exports = {
   config: {
@@ -24,7 +25,7 @@ module.exports = {
     azureOpenAIApiKey,
     userProvidedOpenAI,
     [EModelEndpoint.anthropic]: generateConfig(
-      anthropicApiKey || isEnabled(process.env.ANTHROPIC_USE_VERTEX),
+      anthropicUsesVertex ? 'true' : anthropicApiKey,
     ),
     [EModelEndpoint.openAI]: generateConfig(openAIApiKey, OPENAI_REVERSE_PROXY),
     [EModelEndpoint.azureOpenAI]: generateConfig(azureOpenAIApiKey, AZURE_OPENAI_BASEURL),

--- a/api/server/services/Config/__tests__/EndpointService.spec.js
+++ b/api/server/services/Config/__tests__/EndpointService.spec.js
@@ -1,0 +1,84 @@
+const mockDataProvider = {
+  Capabilities: {
+    actions: 'actions',
+    code_interpreter: 'code_interpreter',
+    image_vision: 'image_vision',
+    retrieval: 'retrieval',
+    tools: 'tools',
+  },
+  EModelEndpoint: {
+    agents: 'agents',
+    anthropic: 'anthropic',
+    assistants: 'assistants',
+    azureAssistants: 'azureAssistants',
+    azureOpenAI: 'azureOpenAI',
+    bedrock: 'bedrock',
+    google: 'google',
+    openAI: 'openAI',
+  },
+  defaultAgentCapabilities: [],
+  defaultRetrievalModels: [],
+  defaultAssistantsVersion: {
+    assistants: 1,
+    azureAssistants: 2,
+  },
+  isAgentsEndpoint: (endpoint) => endpoint === 'agents',
+  isAssistantsEndpoint: (endpoint) =>
+    endpoint === 'assistants' || endpoint === 'azureAssistants',
+};
+
+jest.mock(
+  '@librechat/api',
+  () => ({
+    sendEvent: jest.fn(),
+    isEnabled: (value) => value === true || value === 'true' || value === '1',
+    isUserProvided: (value) => value === 'user_provided',
+  }),
+  { virtual: true },
+);
+
+jest.mock('librechat-data-provider', () => mockDataProvider, { virtual: true });
+
+jest.mock('~/server/utils/handleText', () => ({
+  generateConfig: (key) => (key ? { userProvide: key === 'user_provided' } : false),
+}));
+
+describe('EndpointService', () => {
+  let originalEnv;
+  const { EModelEndpoint } = mockDataProvider;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.resetModules();
+  });
+
+  function loadConfig(env) {
+    process.env = { ...originalEnv };
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_USE_VERTEX;
+    Object.assign(process.env, env);
+    return require('../EndpointService').config;
+  }
+
+  it('does not require a user Anthropic API key when Vertex AI is enabled by env', () => {
+    const config = loadConfig({
+      ANTHROPIC_API_KEY: 'user_provided',
+      ANTHROPIC_USE_VERTEX: 'true',
+    });
+
+    expect(config[EModelEndpoint.anthropic]).toEqual({ userProvide: false });
+  });
+
+  it('requires a user Anthropic API key when user_provided is set without Vertex AI', () => {
+    const config = loadConfig({
+      ANTHROPIC_API_KEY: 'user_provided',
+    });
+
+    expect(config[EModelEndpoint.anthropic]).toEqual({ userProvide: true });
+  });
+});

--- a/api/server/services/Config/__tests__/EndpointService.spec.js
+++ b/api/server/services/Config/__tests__/EndpointService.spec.js
@@ -23,8 +23,7 @@ const mockDataProvider = {
     azureAssistants: 2,
   },
   isAgentsEndpoint: (endpoint) => endpoint === 'agents',
-  isAssistantsEndpoint: (endpoint) =>
-    endpoint === 'assistants' || endpoint === 'azureAssistants',
+  isAssistantsEndpoint: (endpoint) => endpoint === 'assistants' || endpoint === 'azureAssistants',
 };
 
 jest.mock(


### PR DESCRIPTION
## Summary

I fixed Anthropic endpoint configuration so Vertex AI mode is treated as system-provided authentication even when `ANTHROPIC_API_KEY=user_provided` is present. Fixes #12966.

- Changed the Anthropic default endpoint config to give `ANTHROPIC_USE_VERTEX=true` precedence over the user-provided API key sentinel.
- Added a focused regression test covering env-based Vertex AI mode with `ANTHROPIC_API_KEY=user_provided`.
- Preserved the existing user-provided API key behavior when Vertex AI is not enabled.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx jest server/services/Config/__tests__/EndpointService.spec.js --runInBand --config '{"testEnvironment":"node","rootDir":".","moduleNameMapper":{"^~/(.*)$":"<rootDir>/$1"}}'` from `api`
- Ran `git diff --check`
- Attempted default workspace checks, but this worktree has no installed dependencies, so the standard commands could not resolve packages such as `dotenv`, `jest`, and `prettier-plugin-tailwindcss`

### **Test Configuration**:

- macOS local Codex worktree
- Node/Jest invoked through `npx` with a minimal Jest config for the focused backend service test

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
