### PR TITLE
🧮 feat: Add GPT-5.5 Token Definitions

### DIFF
--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -234,6 +234,9 @@ describe('getModelMaxTokens', () => {
   });
 
   test('should return correct tokens for gpt-5.5 matches', () => {
+    expect(maxTokensMap[EModelEndpoint.openAI]['gpt-5.5']).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-5.5-pro'],
+    );
     expect(getModelMaxTokens('gpt-5.5')).toBe(maxTokensMap[EModelEndpoint.openAI]['gpt-5.5']);
     expect(getModelMaxTokens('gpt-5.5-thinking')).toBe(
       maxTokensMap[EModelEndpoint.openAI]['gpt-5.5'],

--- a/api/utils/tokens.spec.js
+++ b/api/utils/tokens.spec.js
@@ -233,6 +233,28 @@ describe('getModelMaxTokens', () => {
     );
   });
 
+  test('should return correct tokens for gpt-5.5 matches', () => {
+    expect(getModelMaxTokens('gpt-5.5')).toBe(maxTokensMap[EModelEndpoint.openAI]['gpt-5.5']);
+    expect(getModelMaxTokens('gpt-5.5-thinking')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-5.5'],
+    );
+    expect(getModelMaxTokens('openai/gpt-5.5')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-5.5'],
+    );
+    expect(getModelMaxTokens('gpt-5.5-2026-04-23')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-5.5'],
+    );
+  });
+
+  test('should return correct tokens for gpt-5.5-pro matches', () => {
+    expect(getModelMaxTokens('gpt-5.5-pro')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-5.5-pro'],
+    );
+    expect(getModelMaxTokens('openai/gpt-5.5-pro')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-5.5-pro'],
+    );
+  });
+
   test('should return correct tokens for Anthropic models', () => {
     const models = [
       'claude-2.1',
@@ -516,6 +538,8 @@ describe('getModelMaxTokens', () => {
       'gpt-5.3',
       'gpt-5.4',
       'gpt-5.4-pro',
+      'gpt-5.5',
+      'gpt-5.5-pro',
       'gpt-5-mini',
       'gpt-5-nano',
       'gpt-5-pro',
@@ -564,6 +588,12 @@ describe('findMatchingPattern - longest match wins', () => {
   test('should match gpt-5.2-pro over shorter patterns', () => {
     expect(getModelMaxTokens('gpt-5.2-pro-chat-2025-12-11')).toBe(
       maxTokensMap[EModelEndpoint.openAI]['gpt-5.2-pro'],
+    );
+  });
+
+  test('should match gpt-5.5-pro over shorter patterns', () => {
+    expect(getModelMaxTokens('gpt-5.5-pro-2026-04-23')).toBe(
+      maxTokensMap[EModelEndpoint.openAI]['gpt-5.5-pro'],
     );
   });
 
@@ -829,6 +859,12 @@ describe('matchModelName', () => {
     expect(matchModelName('openai/gpt-5.4')).toBe('gpt-5.4');
     expect(matchModelName('gpt-5.4-thinking')).toBe('gpt-5.4');
     expect(matchModelName('gpt-5.4-pro')).toBe('gpt-5.4-pro');
+  });
+
+  it('should return the closest matching key for gpt-5.5 matches', () => {
+    expect(matchModelName('openai/gpt-5.5')).toBe('gpt-5.5');
+    expect(matchModelName('gpt-5.5-thinking')).toBe('gpt-5.5');
+    expect(matchModelName('gpt-5.5-pro')).toBe('gpt-5.5-pro');
   });
 
   it('should return the input model name if no match is found - Google models', () => {

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -57,7 +57,7 @@ const openAIModels = {
   'gpt-5.3': 400000,
   'gpt-5.4': 272000, // standard context; 1M experimental available via API opt-in (2x rate)
   'gpt-5.4-pro': 272000, // same window as gpt-5.4
-  'gpt-5.5': 1000000,
+  'gpt-5.5': 1050000,
   'gpt-5.5-pro': 1050000,
   'gpt-5-mini': 400000,
   'gpt-5-nano': 400000,

--- a/packages/api/src/utils/tokens.ts
+++ b/packages/api/src/utils/tokens.ts
@@ -57,6 +57,8 @@ const openAIModels = {
   'gpt-5.3': 400000,
   'gpt-5.4': 272000, // standard context; 1M experimental available via API opt-in (2x rate)
   'gpt-5.4-pro': 272000, // same window as gpt-5.4
+  'gpt-5.5': 1000000,
+  'gpt-5.5-pro': 1050000,
   'gpt-5-mini': 400000,
   'gpt-5-nano': 400000,
   'gpt-5-pro': 400000,
@@ -368,6 +370,8 @@ export const modelMaxOutputs = {
   'gpt-5.3': 128000,
   'gpt-5.4': 128000,
   'gpt-5.4-pro': 128000,
+  'gpt-5.5': 128000,
+  'gpt-5.5-pro': 128000,
   'gpt-5-mini': 128000,
   'gpt-5-nano': 128000,
   'gpt-5-pro': 128000,


### PR DESCRIPTION
## Summary

I added GPT-5.5 token definitions so LibreChat can resolve context and output limits for the latest GPT-5.5 model IDs. Fixes #12971.

- Added explicit max context token entries for `gpt-5.5` and `gpt-5.5-pro`.
- Added matching max output token entries for both GPT-5.5 models.
- Covered provider-prefixed, suffixed, Thinking, Pro, max-output, and longest-match behavior in the token utility tests.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran `npm run smart-reinstall`.
- Ran `npm run build:data-schemas`.
- Ran `npm run build:api`.
- Ran `cd api && npx jest utils/tokens.spec.js --runInBand --coverage=false`.

### **Test Configuration**:

- Node.js: `v20.19.5`
- npm: `10.8.2`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
