### PR TITLE
fix: Preserve Unicode characters in uploaded filenames

### DIFF
--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -3,6 +3,7 @@ const express = require('express');
 const { logger, SystemCapabilities } = require('@librechat/data-schemas');
 const {
   refreshS3FileUrls,
+  buildContentDisposition,
   resolveUploadErrorMessage,
   verifyAgentUploadPermission,
 } = require('@librechat/api');
@@ -398,7 +399,7 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
 
     const setHeaders = () => {
       const cleanedFilename = cleanFileName(file.filename);
-      res.setHeader('Content-Disposition', `attachment; filename="${cleanedFilename}"`);
+      res.setHeader('Content-Disposition', buildContentDisposition(cleanedFilename));
       res.setHeader('Content-Type', 'application/octet-stream');
       res.setHeader('X-File-Metadata', JSON.stringify(file));
     };

--- a/api/server/routes/files/multer.spec.js
+++ b/api/server/routes/files/multer.spec.js
@@ -127,6 +127,22 @@ describe('Multer Configuration', () => {
         storage.getFilename(mockReq, unsafeFile, cb);
       });
 
+      it('should preserve Unicode characters in filenames', (done) => {
+        const unicodeFile = {
+          ...mockFile,
+          originalname: encodeURIComponent('日本語レポート.jpg'),
+        };
+
+        const cb = jest.fn((err, filename) => {
+          expect(err).toBeNull();
+          expect(filename).toContain('日本語レポート');
+          expect(filename).toContain('.jpg');
+          done();
+        });
+
+        storage.getFilename(mockReq, unicodeFile, cb);
+      });
+
       it('should handle very long filenames with actual crypto', (done) => {
         const longFile = {
           ...mockFile,

--- a/packages/api/src/skills/handlers.ts
+++ b/packages/api/src/skills/handlers.ts
@@ -32,6 +32,7 @@ import type {
   TSkillFileContentResponse,
 } from 'librechat-data-provider';
 import type { ServerRequest } from '~/types/http';
+import { buildContentDisposition } from '~/utils/files';
 import { isBinaryBuffer } from './binary';
 
 /** Thin error shape the skill methods throw on validation failure. */
@@ -645,7 +646,7 @@ export function createSkillsHandlers(deps: SkillsHandlersDeps) {
         res.setHeader('X-Content-Type-Options', 'nosniff');
         res.setHeader(
           'Content-Disposition',
-          `${isImageMime ? 'inline' : 'attachment'}; filename="${safeName}"`,
+          buildContentDisposition(safeName, isImageMime ? 'inline' : 'attachment'),
         );
         const stream = await strategy.getDownloadStream(req, file.filepath);
         stream.on('error', (err: Error) => {

--- a/packages/api/src/storage/s3/crud.ts
+++ b/packages/api/src/storage/s3/crud.ts
@@ -22,6 +22,7 @@ import type {
   UrlBuilder,
   S3FileRef,
 } from '~/storage/types';
+import { buildContentDisposition } from '~/utils/files';
 import { initializeS3 } from '~/cdn/s3';
 import { deleteRagFile } from '~/files';
 import { s3Config } from './s3Config';
@@ -54,7 +55,7 @@ export async function getS3URL({
 
   if (customFilename) {
     const safeFilename = customFilename.replace(/["\r\n]/g, '');
-    params.ResponseContentDisposition = `attachment; filename="${safeFilename}"`;
+    params.ResponseContentDisposition = buildContentDisposition(safeFilename);
   }
   if (contentType) {
     params.ResponseContentType = contentType;

--- a/packages/api/src/utils/files.spec.ts
+++ b/packages/api/src/utils/files.spec.ts
@@ -2,6 +2,7 @@ import {
   sanitizeFilename,
   sanitizeArtifactPath,
   flattenArtifactPath,
+  buildContentDisposition,
   resolveUploadErrorMessage,
 } from './files';
 
@@ -63,6 +64,42 @@ describe('sanitizeFilename', () => {
 
   test('handles input with only special characters', () => {
     expect(sanitizeFilename('@#$%^&*')).toBe('_______');
+  });
+
+  test('preserves CJK characters', () => {
+    expect(sanitizeFilename('测试文件.pdf')).toBe('测试文件.pdf');
+  });
+
+  test('preserves Cyrillic characters', () => {
+    expect(sanitizeFilename('файл.txt')).toBe('файл.txt');
+  });
+
+  test('preserves accented Latin characters', () => {
+    expect(sanitizeFilename('résumé.pdf')).toBe('résumé.pdf');
+  });
+
+  test('preserves Arabic characters', () => {
+    expect(sanitizeFilename('ملف.txt')).toBe('ملف.txt');
+  });
+
+  test('preserves Japanese characters', () => {
+    expect(sanitizeFilename('テスト.txt')).toBe('テスト.txt');
+  });
+
+  test('preserves Korean characters', () => {
+    expect(sanitizeFilename('테스트.txt')).toBe('테스트.txt');
+  });
+
+  test('preserves underscores', () => {
+    expect(sanitizeFilename('my_file_name.txt')).toBe('my_file_name.txt');
+  });
+
+  test('NFC-normalizes decomposed characters', () => {
+    expect(sanitizeFilename('résumé.pdf')).toBe('résumé.pdf');
+  });
+
+  test('strips shell-dangerous characters from Unicode filenames', () => {
+    expect(sanitizeFilename('测试;rm -rf.txt')).toBe('测试_rm_-rf.txt');
   });
 });
 
@@ -320,6 +357,16 @@ describe('sanitizeArtifactPath', () => {
     });
   });
 
+  test('preserves Unicode characters in nested path segments', () => {
+    expect(sanitizeArtifactPath('测试/文件.txt')).toBe('测试/文件.txt');
+  });
+
+  test('NFC-normalizes Unicode path input', () => {
+    const raw = 'données/résultat.csv';
+    const result = sanitizeArtifactPath(raw);
+    expect(result).toContain('é');
+  });
+
   test('preserves the dotfile underscore prefix when the leaf also needs truncation', () => {
     /* A long hidden-file leaf (`._very_long_name`) goes through the
      * underscore-prefix branch first; truncation must run AFTER that
@@ -484,6 +531,49 @@ describe('resolveUploadErrorMessage', () => {
     expect(resolveUploadErrorMessage({ message: 'file_ids limit' }, 'Upload failed')).toBe(
       'Upload failed: file_ids limit',
     );
+  });
+});
+
+describe('buildContentDisposition', () => {
+  test('returns simple header for ASCII-only names', () => {
+    expect(buildContentDisposition('report.pdf')).toBe('attachment; filename="report.pdf"');
+  });
+
+  test('defaults to attachment disposition', () => {
+    expect(buildContentDisposition('file.txt')).toContain('attachment;');
+  });
+
+  test('supports inline disposition', () => {
+    expect(buildContentDisposition('image.png', 'inline')).toContain('inline;');
+  });
+
+  test('adds filename* parameter for non-ASCII names', () => {
+    const result = buildContentDisposition('测试.pdf');
+    expect(result).toContain('filename="');
+    expect(result).toContain("filename*=UTF-8''");
+    expect(result).toContain(encodeURIComponent('测试'));
+  });
+
+  test('ASCII fallback replaces non-ASCII characters', () => {
+    const result = buildContentDisposition('测试.pdf');
+    const asciiMatch = result.match(/filename="([^"]*)"/);
+    expect(asciiMatch).toBeTruthy();
+    expect(/^[\x20-\x7E]+$/.test(asciiMatch![1])).toBe(true);
+  });
+
+  test('skips filename* for pure ASCII names', () => {
+    expect(buildContentDisposition('simple.txt')).not.toContain('filename*=');
+  });
+
+  test('handles Cyrillic filenames', () => {
+    const result = buildContentDisposition('файл.txt');
+    expect(result).toContain("filename*=UTF-8''");
+  });
+
+  test('handles mixed ASCII and Unicode', () => {
+    const result = buildContentDisposition('report_2024_测试.pdf');
+    expect(result).toContain("filename*=UTF-8''");
+    expect(result).toContain('filename="report_2024___.pdf"');
   });
 });
 

--- a/packages/api/src/utils/files.ts
+++ b/packages/api/src/utils/files.ts
@@ -3,6 +3,8 @@ import crypto from 'node:crypto';
 import { createReadStream } from 'fs';
 import { readFile, stat } from 'fs/promises';
 
+const UNSAFE_FILENAME_CHARS = /[^\p{L}\p{N}.\-_]/gu;
+
 const USER_FACING_UPLOAD_ERRORS = [
   'Invalid file format',
   'exceeds token limit',
@@ -36,23 +38,14 @@ export function resolveUploadErrorMessage(
   return defaultMessage;
 }
 
-/**
- * Sanitize a filename by removing any directory components, replacing non-alphanumeric characters
- * @param inputName
- */
 export function sanitizeFilename(inputName: string): string {
-  // Remove any directory components
-  let name = path.basename(inputName);
+  let name = path.basename(inputName).normalize('NFC');
+  name = name.replace(UNSAFE_FILENAME_CHARS, '_');
 
-  // Replace any non-alphanumeric characters except for '.' and '-'
-  name = name.replace(/[^a-zA-Z0-9.-]/g, '_');
-
-  // Ensure the name doesn't start with a dot (hidden file in Unix-like systems)
   if (name.startsWith('.') || name === '') {
     name = '_' + name;
   }
 
-  // Limit the length of the filename
   const MAX_LENGTH = 255;
   if (name.length > MAX_LENGTH) {
     const ext = path.extname(name);
@@ -213,6 +206,7 @@ function embedDisambiguatorInLeaf(segment: string, hashSource: string): string {
  */
 export function sanitizeArtifactPath(inputName: string): string {
   if (!inputName) return '_';
+  inputName = inputName.normalize('NFC');
   if (path.isAbsolute(inputName)) return sanitizeFilename(inputName);
   const normalized = path.posix.normalize(inputName);
   if (
@@ -226,7 +220,7 @@ export function sanitizeArtifactPath(inputName: string): string {
   }
   const segments = normalized
     .split('/')
-    .map((seg) => seg.replace(/[^a-zA-Z0-9.-]/g, '_'))
+    .map((seg) => seg.replace(UNSAFE_FILENAME_CHARS, '_'))
     .filter((seg) => seg.length > 0 && seg !== '.');
   if (segments.length === 0) return '_';
   const leafIdx = segments.length - 1;
@@ -339,6 +333,20 @@ export function flattenArtifactPath(safePath: string, maxLength?: number): strin
 /**
  * Options for reading files
  */
+export function buildContentDisposition(
+  filename: string,
+  disposition: 'attachment' | 'inline' = 'attachment',
+): string {
+  const asciiName = filename.replace(/[^\x20-\x7E]/g, '_').replace(/["\\]/g, '_');
+  const needsUtf8 = asciiName !== filename;
+  const base = `${disposition}; filename="${asciiName}"`;
+  if (!needsUtf8) {
+    return base;
+  }
+  const encoded = encodeURIComponent(filename).replace(/'/g, '%27');
+  return `${base}; filename*=UTF-8''${encoded}`;
+}
+
 export interface ReadFileOptions {
   encoding?: BufferEncoding;
   /** Size threshold in bytes. Files larger than this will be streamed. Default: 10MB */


### PR DESCRIPTION
## Summary
- Replace ASCII-only sanitization regex (`/[^a-zA-Z0-9.-]/g`) with Unicode-aware `/[^\p{L}\p{N}.\-_]/gu` in `sanitizeFilename()` and `sanitizeArtifactPath()`, preserving CJK, Cyrillic, Arabic, accented Latin, and other non-ASCII scripts instead of replacing them with underscores
- Add NFC normalization to prevent homograph issues and ensure consistent storage
- Add `buildContentDisposition()` helper producing RFC 8187 `filename*=UTF-8''...` headers for proper Unicode filename delivery to browsers
- Use the new helper in the download route, skills handler, and S3 presigned URLs

Fixes #12975

## Test plan
- [x] All existing `sanitizeFilename` and `sanitizeArtifactPath` tests pass (strict superset behavior)
- [x] New unit tests for CJK, Cyrillic, Arabic, Japanese, Korean, accented Latin filename preservation
- [x] New unit tests for NFC normalization of decomposed characters
- [x] New unit tests for `buildContentDisposition` (ASCII-only, Unicode with `filename*`, inline disposition, mixed content)
- [x] New multer integration test for Unicode filename round-trip
- [x] Shell-dangerous characters still stripped from Unicode filenames
- [x] Zero TypeScript diagnostics on all changed files
- [ ] Manual: upload file with Unicode name, verify correct storage and download filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)