### PR TITLE
⏳ fix: Preserve Temporary Chat Retention Config

### DIFF
--- a/packages/data-schemas/src/app/interface.spec.ts
+++ b/packages/data-schemas/src/app/interface.spec.ts
@@ -1,0 +1,29 @@
+import { getConfigDefaults } from 'librechat-data-provider';
+import type { TCustomConfig } from 'librechat-data-provider';
+import { loadDefaultInterface } from './interface';
+
+describe('loadDefaultInterface', () => {
+  it('preserves the configured temporary chat retention period', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {
+        temporaryChatRetention: 24,
+      },
+    };
+
+    const interfaceConfig = await loadDefaultInterface({
+      config,
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.temporaryChatRetention).toBe(24);
+  });
+
+  it('omits temporary chat retention when it is not explicitly configured', async () => {
+    const interfaceConfig = await loadDefaultInterface({
+      config: {},
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig).not.toHaveProperty('temporaryChatRetention');
+  });
+});

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -39,13 +39,14 @@ export async function loadDefaultInterface({
     mcpServers: interfaceConfig?.mcpServers ?? defaults.mcpServers,
     customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,
 
-    // Permissions - only include if explicitly configured
+    // Permissions and related settings - only include if explicitly configured
     bookmarks: interfaceConfig?.bookmarks,
     memories: shouldDisableMemories ? false : interfaceConfig?.memories,
     prompts: interfaceConfig?.prompts,
     multiConvo: interfaceConfig?.multiConvo,
     agents: interfaceConfig?.agents,
     temporaryChat: interfaceConfig?.temporaryChat,
+    temporaryChatRetention: interfaceConfig?.temporaryChatRetention,
     runCode: interfaceConfig?.runCode,
     webSearch: interfaceConfig?.webSearch,
     fileSearch: interfaceConfig?.fileSearch,


### PR DESCRIPTION
## Summary

I fixed the temporary chat retention config path so `interface.temporaryChatRetention` from `librechat.yaml` is preserved in the loaded app interface config and reaches temporary chat expiration logic. Fixes #12984.

- Preserve `temporaryChatRetention` in `loadDefaultInterface` alongside temporary chat settings.
- Add a regression spec proving configured retention values survive default interface loading.
- Keep unset retention omitted so the existing default retention behavior remains unchanged.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx jest src/app/interface.spec.ts --runInBand` from `packages/data-schemas`.
- Ran `npx jest src/utils/tempChatRetention.spec.ts --runInBand` from `packages/data-schemas`.
- Ran `npm run build:data-schemas` from the repo root.

### **Test Configuration**:

- Node.js: v20.19.5
- npm: v10.8.2

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes