### PR TITLE
🪪 fix: Preserve OIDC Logout ID Token Hint

### DIFF
--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -499,6 +499,8 @@ const setOpenIDAuthTokens = (tokenset, req, res, userId, existingRefreshToken) =
      * Falls back to access_token for providers where id_token is not available.
      */
     const appAuthToken = tokenset.id_token || tokenset.access_token;
+    const sessionIdToken = req.session?.openidTokens?.idToken;
+    const logoutIdToken = tokenset.id_token || sessionIdToken;
 
     /**
      * Always set refresh token cookie so it survives express session expiry.
@@ -520,7 +522,7 @@ const setOpenIDAuthTokens = (tokenset, req, res, userId, existingRefreshToken) =
     if (req.session) {
       req.session.openidTokens = {
         accessToken: tokenset.access_token,
-        idToken: tokenset.id_token,
+        idToken: logoutIdToken,
         refreshToken: refreshToken,
         expiresAt: expirationDate.getTime(),
       };

--- a/api/server/services/AuthService.spec.js
+++ b/api/server/services/AuthService.spec.js
@@ -168,7 +168,30 @@ describe('setOpenIDAuthTokens', () => {
       setOpenIDAuthTokens(tokenset, req, res, 'user-123');
 
       expect(req.session.openidTokens.accessToken).toBe('the-access-token');
+      expect(req.session.openidTokens.idToken).toBe('the-id-token');
       expect(req.session.openidTokens.refreshToken).toBe('the-refresh-token');
+    });
+
+    it('should preserve the existing session id_token when refresh omits one', () => {
+      const tokenset = {
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+      };
+      const req = mockRequest({
+        openidTokens: {
+          accessToken: 'old-access-token',
+          idToken: 'existing-id-token',
+          refreshToken: 'old-refresh-token',
+        },
+      });
+      const res = mockResponse();
+
+      const result = setOpenIDAuthTokens(tokenset, req, res, 'user-123');
+
+      expect(result).toBe('new-access-token');
+      expect(req.session.openidTokens.accessToken).toBe('new-access-token');
+      expect(req.session.openidTokens.idToken).toBe('existing-id-token');
+      expect(req.session.openidTokens.refreshToken).toBe('new-refresh-token');
     });
   });
 


### PR DESCRIPTION
## Summary

I fixed the OIDC logout token preservation path so LibreChat can continue sending `id_token_hint` after an OpenID refresh response omits a replacement ID token.

- Preserved the existing session `idToken` when `setOpenIDAuthTokens` refreshes OpenID tokens without receiving a new `id_token`.
- Kept the fresh access token as the active app authentication fallback so refresh behavior does not reuse an old ID token as the bearer token.
- Added regression coverage for the refresh-then-logout case where the stored logout hint must survive.
- Addressed #12997.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

CI should run the full validation for this branch.

I ran lightweight local checks before publishing:

- `node --check api/server/services/AuthService.js`
- `node --check api/server/services/AuthService.spec.js`
- `git diff --check`

I did not run local Jest tests per request; this PR relies on CI for unit test validation.

### **Test Configuration**:

- Local Node.js: v20.19.5
- Package manager: npm

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works