### PR TITLE
🔄 feat: Cross-Origin Admin OAuth Refresh

### DIFF
--- a/api/server/controllers/auth/oauth.js
+++ b/api/server/controllers/auth/oauth.js
@@ -46,6 +46,7 @@ function createOAuthHandler(redirectUri = domains.client) {
         /** Get refresh token from tokenset for OpenID users */
         const refreshToken =
           req.user.tokenset?.refresh_token || req.user.federatedTokens?.refresh_token;
+        const expiresAt = Date.now() + sessionExpiry;
 
         const callbackUrl = new URL(redirectUri);
         const exchangeCode = await generateAdminExchangeCode(
@@ -55,6 +56,7 @@ function createOAuthHandler(redirectUri = domains.client) {
           refreshToken,
           callbackUrl.origin,
           req.pkceChallenge,
+          expiresAt,
         );
         callbackUrl.searchParams.set('code', exchangeCode);
         logger.info(`[OAuth] Admin panel redirect with exchange code for user: ${req.user.email}`);

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -485,6 +485,16 @@ router.post('/oauth/exchange', middleware.loginLimiter, async (req, res) => {
  * POST /api/admin/oauth/refresh
  * Body:     { refresh_token: string, user_id?: string }
  * Response: { token: string, refreshToken?: string, user: object, expiresAt: number }
+ *
+ * Errors (all responses are `{ error: string, error_code: string }`):
+ *   400 MISSING_REFRESH_TOKEN  — refresh_token absent or empty
+ *   401 REFRESH_FAILED         — IdP rejected the refresh grant
+ *   401 USER_NOT_FOUND         — no LibreChat user matches the refreshed sub
+ *   401 USER_ID_MISMATCH       — supplied user_id resolves to a user with a different openidId
+ *   502 IDP_INCOMPLETE         — IdP returned a tokenset missing access_token
+ *   502 CLAIMS_INCOMPLETE      — IdP tokenset has no readable claims or no sub
+ *   503 OPENID_NOT_CONFIGURED  — OpenID is not configured on this server
+ *   500 INTERNAL_ERROR         — anything else (logged server-side)
  */
 router.post('/oauth/refresh', middleware.loginLimiter, async (req, res) => {
   try {

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -3,13 +3,19 @@ const passport = require('passport');
 const crypto = require('node:crypto');
 const openIdClient = require('openid-client');
 const { CacheKeys } = require('librechat-data-provider');
-const { logger, DEFAULT_SESSION_EXPIRY, SystemCapabilities } = require('@librechat/data-schemas');
+const {
+  logger,
+  DEFAULT_SESSION_EXPIRY,
+  SystemCapabilities,
+  getTenantId,
+} = require('@librechat/data-schemas');
 const {
   getAdminPanelUrl,
   exchangeAdminCode,
   createSetBalanceConfig,
   storeAndStripChallenge,
   tenantContextMiddleware,
+  preAuthTenantMiddleware,
   applyAdminRefresh,
   AdminRefreshError,
 } = require('@librechat/api');
@@ -492,98 +498,105 @@ router.post('/oauth/exchange', middleware.loginLimiter, async (req, res) => {
  *   401 USER_NOT_FOUND         — no LibreChat user matches the refreshed sub
  *   401 USER_ID_MISMATCH       — supplied user_id resolves to a user with a different openidId
  *   401 ISSUER_MISMATCH        — refreshed tokenset was issued by an unexpected issuer
+ *   401 TENANT_MISMATCH        — resolved user belongs to a different tenant than the request
  *   403 FORBIDDEN              — resolved user no longer holds ACCESS_ADMIN
  *   502 IDP_INCOMPLETE         — IdP returned a tokenset missing access_token
  *   502 CLAIMS_INCOMPLETE      — IdP tokenset has no readable claims or no sub
  *   503 OPENID_NOT_CONFIGURED  — OpenID is not configured on this server
  *   500 INTERNAL_ERROR         — anything else (logged server-side)
  */
-router.post('/oauth/refresh', middleware.loginLimiter, async (req, res) => {
-  try {
-    const { refresh_token: refreshToken, user_id: userId } = req.body ?? {};
-    if (typeof refreshToken !== 'string' || refreshToken.length === 0) {
-      return res.status(400).json({
-        error: 'Missing refresh_token',
-        error_code: 'MISSING_REFRESH_TOKEN',
-      });
-    }
-
-    let openIdConfig;
+router.post(
+  '/oauth/refresh',
+  middleware.loginLimiter,
+  preAuthTenantMiddleware,
+  async (req, res) => {
     try {
-      openIdConfig = getOpenIdConfig();
-    } catch {
-      return res.status(503).json({
-        error: 'OpenID is not configured',
-        error_code: 'OPENID_NOT_CONFIGURED',
-      });
-    }
-
-    const refreshParams = process.env.OPENID_SCOPE ? { scope: process.env.OPENID_SCOPE } : {};
-    let tokenset;
-    try {
-      tokenset = await openIdClient.refreshTokenGrant(openIdConfig, refreshToken, refreshParams);
-    } catch (err) {
-      logger.warn('[admin/oauth/refresh] IdP refresh grant failed', {
-        code: err?.code,
-        name: err?.name,
-      });
-      return res.status(401).json({
-        error: 'Refresh failed',
-        error_code: 'REFRESH_FAILED',
-      });
-    }
-
-    const sessionExpiry = Number(process.env.SESSION_EXPIRY) || DEFAULT_SESSION_EXPIRY;
-    const expectedIssuer = openIdConfig.serverMetadata?.()?.issuer;
-
-    try {
-      const result = await applyAdminRefresh(
-        tokenset,
-        {
-          findUsers,
-          getUserById,
-          canAccessAdmin: async (user) => {
-            try {
-              return await hasCapability(
-                {
-                  id: user.id ?? user._id?.toString(),
-                  role: user.role ?? '',
-                  tenantId: user.tenantId,
-                },
-                SystemCapabilities.ACCESS_ADMIN,
-              );
-            } catch (err) {
-              logger.warn(
-                `[admin/oauth/refresh] capability check failed, denying: ${err?.message}`,
-              );
-              return false;
-            }
-          },
-          mintToken: async (user) => ({
-            token: await generateToken(user, sessionExpiry),
-            expiresAt: Date.now() + sessionExpiry,
-          }),
-        },
-        {
-          userId: typeof userId === 'string' && userId.length > 0 ? userId : undefined,
-          previousRefreshToken: refreshToken,
-          expectedIssuer,
-        },
-      );
-      return res.json(result);
-    } catch (err) {
-      if (err instanceof AdminRefreshError) {
-        return res.status(err.status).json({ error: err.message, error_code: err.code });
+      const { refresh_token: refreshToken, user_id: userId } = req.body ?? {};
+      if (typeof refreshToken !== 'string' || refreshToken.length === 0) {
+        return res.status(400).json({
+          error: 'Missing refresh_token',
+          error_code: 'MISSING_REFRESH_TOKEN',
+        });
       }
-      throw err;
+
+      let openIdConfig;
+      try {
+        openIdConfig = getOpenIdConfig();
+      } catch {
+        return res.status(503).json({
+          error: 'OpenID is not configured',
+          error_code: 'OPENID_NOT_CONFIGURED',
+        });
+      }
+
+      const refreshParams = process.env.OPENID_SCOPE ? { scope: process.env.OPENID_SCOPE } : {};
+      let tokenset;
+      try {
+        tokenset = await openIdClient.refreshTokenGrant(openIdConfig, refreshToken, refreshParams);
+      } catch (err) {
+        logger.warn('[admin/oauth/refresh] IdP refresh grant failed', {
+          code: err?.code,
+          name: err?.name,
+        });
+        return res.status(401).json({
+          error: 'Refresh failed',
+          error_code: 'REFRESH_FAILED',
+        });
+      }
+
+      const sessionExpiry = Number(process.env.SESSION_EXPIRY) || DEFAULT_SESSION_EXPIRY;
+      const expectedIssuer = openIdConfig.serverMetadata?.()?.issuer;
+
+      try {
+        const result = await applyAdminRefresh(
+          tokenset,
+          {
+            findUsers,
+            getUserById,
+            canAccessAdmin: async (user) => {
+              try {
+                return await hasCapability(
+                  {
+                    id: user.id ?? user._id?.toString(),
+                    role: user.role ?? '',
+                    tenantId: user.tenantId,
+                  },
+                  SystemCapabilities.ACCESS_ADMIN,
+                );
+              } catch (err) {
+                logger.warn(
+                  `[admin/oauth/refresh] capability check failed, denying: ${err?.message}`,
+                );
+                return false;
+              }
+            },
+            mintToken: async (user) => ({
+              token: await generateToken(user, sessionExpiry),
+              expiresAt: Date.now() + sessionExpiry,
+            }),
+          },
+          {
+            userId: typeof userId === 'string' && userId.length > 0 ? userId : undefined,
+            previousRefreshToken: refreshToken,
+            expectedIssuer,
+            tenantId: getTenantId(),
+          },
+        );
+        return res.json(result);
+      } catch (err) {
+        if (err instanceof AdminRefreshError) {
+          return res.status(err.status).json({ error: err.message, error_code: err.code });
+        }
+        throw err;
+      }
+    } catch (error) {
+      logger.error('[admin/oauth/refresh] Error:', error);
+      res.status(500).json({
+        error: 'Internal server error',
+        error_code: 'INTERNAL_ERROR',
+      });
     }
-  } catch (error) {
-    logger.error('[admin/oauth/refresh] Error:', error);
-    res.status(500).json({
-      error: 'Internal server error',
-      error_code: 'INTERNAL_ERROR',
-    });
-  }
-});
+  },
+);
 
 module.exports = router;

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -507,8 +507,10 @@ router.post('/oauth/refresh', middleware.loginLimiter, async (req, res) => {
       });
     }
 
-    const openIdConfig = getOpenIdConfig();
-    if (!openIdConfig) {
+    let openIdConfig;
+    try {
+      openIdConfig = getOpenIdConfig();
+    } catch {
       return res.status(503).json({
         error: 'OpenID is not configured',
         error_code: 'OPENID_NOT_CONFIGURED',

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -491,6 +491,7 @@ router.post('/oauth/exchange', middleware.loginLimiter, async (req, res) => {
  *   401 REFRESH_FAILED         — IdP rejected the refresh grant
  *   401 USER_NOT_FOUND         — no LibreChat user matches the refreshed sub
  *   401 USER_ID_MISMATCH       — supplied user_id resolves to a user with a different openidId
+ *   401 ISSUER_MISMATCH        — refreshed tokenset was issued by an unexpected issuer
  *   502 IDP_INCOMPLETE         — IdP returned a tokenset missing access_token
  *   502 CLAIMS_INCOMPLETE      — IdP tokenset has no readable claims or no sub
  *   503 OPENID_NOT_CONFIGURED  — OpenID is not configured on this server
@@ -530,6 +531,7 @@ router.post('/oauth/refresh', middleware.loginLimiter, async (req, res) => {
     }
 
     const sessionExpiry = Number(process.env.SESSION_EXPIRY) || DEFAULT_SESSION_EXPIRY;
+    const expectedIssuer = openIdConfig.serverMetadata?.()?.issuer;
 
     try {
       const result = await applyAdminRefresh(
@@ -545,6 +547,7 @@ router.post('/oauth/refresh', middleware.loginLimiter, async (req, res) => {
         {
           userId: typeof userId === 'string' && userId.length > 0 ? userId : undefined,
           previousRefreshToken: refreshToken,
+          expectedIssuer,
         },
       );
       return res.json(result);

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -1,19 +1,28 @@
 const express = require('express');
 const passport = require('passport');
 const crypto = require('node:crypto');
+const openIdClient = require('openid-client');
 const { CacheKeys } = require('librechat-data-provider');
-const { logger, SystemCapabilities } = require('@librechat/data-schemas');
+const { logger, DEFAULT_SESSION_EXPIRY, SystemCapabilities } = require('@librechat/data-schemas');
 const {
   getAdminPanelUrl,
   exchangeAdminCode,
   createSetBalanceConfig,
   storeAndStripChallenge,
   tenantContextMiddleware,
+  applyAdminRefresh,
+  AdminRefreshError,
 } = require('@librechat/api');
 const { loginController } = require('~/server/controllers/auth/LoginController');
 const { requireCapability } = require('~/server/middleware/roles/capabilities');
 const { createOAuthHandler } = require('~/server/controllers/auth/oauth');
-const { findBalanceByUser, upsertBalanceFields } = require('~/models');
+const {
+  findBalanceByUser,
+  findUsers,
+  generateToken,
+  getUserById,
+  upsertBalanceFields,
+} = require('~/models');
 const { getAppConfig } = require('~/server/services/Config');
 const getLogStores = require('~/cache/getLogStores');
 const { getOpenIdConfig } = require('~/strategies');
@@ -457,6 +466,80 @@ router.post('/oauth/exchange', middleware.loginLimiter, async (req, res) => {
     res.json(result);
   } catch (error) {
     logger.error('[admin/oauth/exchange] Error:', error);
+    res.status(500).json({
+      error: 'Internal server error',
+      error_code: 'INTERNAL_ERROR',
+    });
+  }
+});
+
+/**
+ * Admin-panel-shaped token refresh.
+ *
+ * The standard `/api/auth/refresh` controller reads the refresh token from
+ * cookies, which a cross-origin admin panel can't set. This endpoint accepts
+ * the refresh token in the request body, exchanges it at the IdP, mints a
+ * fresh LibreChat JWT, and returns the same response shape as
+ * `/api/admin/oauth/exchange`.
+ *
+ * POST /api/admin/oauth/refresh
+ * Body:     { refresh_token: string, user_id?: string }
+ * Response: { token: string, refreshToken?: string, user: object, expiresAt: number }
+ */
+router.post('/oauth/refresh', middleware.loginLimiter, async (req, res) => {
+  try {
+    const { refresh_token: refreshToken, user_id: userId } = req.body ?? {};
+    if (typeof refreshToken !== 'string' || refreshToken.length === 0) {
+      return res.status(400).json({
+        error: 'Missing refresh_token',
+        error_code: 'MISSING_REFRESH_TOKEN',
+      });
+    }
+
+    const openIdConfig = getOpenIdConfig();
+    if (!openIdConfig) {
+      return res.status(503).json({
+        error: 'OpenID is not configured',
+        error_code: 'OPENID_NOT_CONFIGURED',
+      });
+    }
+
+    const refreshParams = process.env.OPENID_SCOPE ? { scope: process.env.OPENID_SCOPE } : {};
+    let tokenset;
+    try {
+      tokenset = await openIdClient.refreshTokenGrant(openIdConfig, refreshToken, refreshParams);
+    } catch (err) {
+      logger.warn('[admin/oauth/refresh] IdP refresh grant failed', {
+        code: err?.code,
+        name: err?.name,
+      });
+      return res.status(401).json({
+        error: 'Refresh failed',
+        error_code: 'REFRESH_FAILED',
+      });
+    }
+
+    const sessionExpiry = Number(process.env.SESSION_EXPIRY) || DEFAULT_SESSION_EXPIRY;
+
+    try {
+      const result = await applyAdminRefresh(
+        tokenset,
+        {
+          findUsers,
+          getUserById,
+          mintToken: (user) => generateToken(user, sessionExpiry),
+        },
+        { userId: typeof userId === 'string' && userId.length > 0 ? userId : undefined },
+      );
+      return res.json(result);
+    } catch (err) {
+      if (err instanceof AdminRefreshError) {
+        return res.status(err.status).json({ error: err.message, error_code: err.code });
+      }
+      throw err;
+    }
+  } catch (error) {
+    logger.error('[admin/oauth/refresh] Error:', error);
     res.status(500).json({
       error: 'Internal server error',
       error_code: 'INTERNAL_ERROR',

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -14,7 +14,7 @@ const {
   AdminRefreshError,
 } = require('@librechat/api');
 const { loginController } = require('~/server/controllers/auth/LoginController');
-const { requireCapability } = require('~/server/middleware/roles/capabilities');
+const { hasCapability, requireCapability } = require('~/server/middleware/roles/capabilities');
 const { createOAuthHandler } = require('~/server/controllers/auth/oauth');
 const {
   findBalanceByUser,
@@ -492,6 +492,7 @@ router.post('/oauth/exchange', middleware.loginLimiter, async (req, res) => {
  *   401 USER_NOT_FOUND         — no LibreChat user matches the refreshed sub
  *   401 USER_ID_MISMATCH       — supplied user_id resolves to a user with a different openidId
  *   401 ISSUER_MISMATCH        — refreshed tokenset was issued by an unexpected issuer
+ *   403 FORBIDDEN              — resolved user no longer holds ACCESS_ADMIN
  *   502 IDP_INCOMPLETE         — IdP returned a tokenset missing access_token
  *   502 CLAIMS_INCOMPLETE      — IdP tokenset has no readable claims or no sub
  *   503 OPENID_NOT_CONFIGURED  — OpenID is not configured on this server
@@ -541,6 +542,23 @@ router.post('/oauth/refresh', middleware.loginLimiter, async (req, res) => {
         {
           findUsers,
           getUserById,
+          canAccessAdmin: async (user) => {
+            try {
+              return await hasCapability(
+                {
+                  id: user.id ?? user._id?.toString(),
+                  role: user.role ?? '',
+                  tenantId: user.tenantId,
+                },
+                SystemCapabilities.ACCESS_ADMIN,
+              );
+            } catch (err) {
+              logger.warn(
+                `[admin/oauth/refresh] capability check failed, denying: ${err?.message}`,
+              );
+              return false;
+            }
+          },
           mintToken: async (user) => ({
             token: await generateToken(user, sessionExpiry),
             expiresAt: Date.now() + sessionExpiry,

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -527,9 +527,15 @@ router.post('/oauth/refresh', middleware.loginLimiter, async (req, res) => {
         {
           findUsers,
           getUserById,
-          mintToken: (user) => generateToken(user, sessionExpiry),
+          mintToken: async (user) => ({
+            token: await generateToken(user, sessionExpiry),
+            expiresAt: Date.now() + sessionExpiry,
+          }),
         },
-        { userId: typeof userId === 'string' && userId.length > 0 ? userId : undefined },
+        {
+          userId: typeof userId === 'string' && userId.length > 0 ? userId : undefined,
+          previousRefreshToken: refreshToken,
+        },
       );
       return res.json(result);
     } catch (err) {

--- a/api/server/routes/admin/auth.js
+++ b/api/server/routes/admin/auth.js
@@ -10,6 +10,7 @@ const {
   getTenantId,
 } = require('@librechat/data-schemas');
 const {
+  isEnabled,
   getAdminPanelUrl,
   exchangeAdminCode,
   createSetBalanceConfig,
@@ -500,6 +501,7 @@ router.post('/oauth/exchange', middleware.loginLimiter, async (req, res) => {
  *   401 ISSUER_MISMATCH        — refreshed tokenset was issued by an unexpected issuer
  *   401 TENANT_MISMATCH        — resolved user belongs to a different tenant than the request
  *   403 FORBIDDEN              — resolved user no longer holds ACCESS_ADMIN
+ *   403 TOKEN_REUSE_DISABLED   — OPENID_REUSE_TOKENS is not enabled on the server
  *   502 IDP_INCOMPLETE         — IdP returned a tokenset missing access_token
  *   502 CLAIMS_INCOMPLETE      — IdP tokenset has no readable claims or no sub
  *   503 OPENID_NOT_CONFIGURED  — OpenID is not configured on this server
@@ -516,6 +518,13 @@ router.post(
         return res.status(400).json({
           error: 'Missing refresh_token',
           error_code: 'MISSING_REFRESH_TOKEN',
+        });
+      }
+
+      if (!isEnabled(process.env.OPENID_REUSE_TOKENS)) {
+        return res.status(403).json({
+          error: 'OpenID token reuse is not enabled',
+          error_code: 'TOKEN_REUSE_DISABLED',
         });
       }
 

--- a/packages/api/src/auth/exchange.ts
+++ b/packages/api/src/auth/exchange.ts
@@ -30,7 +30,10 @@ export interface AdminExchangeUser {
 }
 
 /**
- * Data stored in cache for admin OAuth exchange
+ * Data stored in cache for admin OAuth exchange.
+ *
+ * `expiresAt` is the absolute expiry of `token` (ms epoch). Used by admin
+ * panel clients to drive proactive refresh before the bearer expires.
  */
 export interface AdminExchangeData {
   userId: string;
@@ -39,6 +42,7 @@ export interface AdminExchangeData {
   refreshToken?: string;
   origin?: string;
   codeChallenge?: string;
+  expiresAt?: number;
 }
 
 /**
@@ -48,6 +52,7 @@ export interface AdminExchangeResponse {
   token: string;
   refreshToken?: string;
   user: AdminExchangeUser;
+  expiresAt?: number;
 }
 
 /**
@@ -94,6 +99,7 @@ export function verifyCodeChallenge(verifier: string, challenge: string): boolea
  * @param refreshToken - Optional refresh token for OpenID users
  * @param origin - The admin panel origin (scheme://host:port) for origin binding
  * @param codeChallenge - PKCE code_challenge (hex-encoded SHA-256 of code_verifier)
+ * @param expiresAt - Optional absolute expiry of `token` (ms epoch); admin panel uses for proactive refresh
  * @returns The generated exchange code
  */
 export async function generateAdminExchangeCode(
@@ -103,6 +109,7 @@ export async function generateAdminExchangeCode(
   refreshToken?: string,
   origin?: string,
   codeChallenge?: string,
+  expiresAt?: number,
 ): Promise<string> {
   const exchangeCode = crypto.randomBytes(32).toString('hex');
 
@@ -113,6 +120,7 @@ export async function generateAdminExchangeCode(
     refreshToken,
     origin,
     codeChallenge,
+    expiresAt,
   };
 
   await cache.set(exchangeCode, data);
@@ -165,6 +173,7 @@ export async function exchangeAdminCode(
     token: data.token,
     refreshToken: data.refreshToken,
     user: data.user,
+    expiresAt: data.expiresAt,
   };
 }
 

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -1,6 +1,7 @@
 export * from './domain';
 export * from './openid';
 export * from './exchange';
+export * from './refresh';
 export * from './agent';
 export * from './password';
 export * from './invite';

--- a/packages/api/src/auth/openid.ts
+++ b/packages/api/src/auth/openid.ts
@@ -56,7 +56,7 @@ function isLegacyOpenIdIssuer(openidIssuer: string | undefined): boolean {
   return openidIssuer != null && loginIssuer != null && openidIssuer === loginIssuer;
 }
 
-function getIssuerBoundConditions(
+export function getIssuerBoundConditions(
   field: OpenIdLookupField,
   value: string | undefined,
   openidIssuer: string | undefined,
@@ -76,7 +76,7 @@ function getIssuerBoundConditions(
   return conditions;
 }
 
-function isUserIssuerAllowed(user: IUser, openidIssuer: string | undefined): boolean {
+export function isUserIssuerAllowed(user: IUser, openidIssuer: string | undefined): boolean {
   if (!openidIssuer) return true;
 
   const userIssuer = normalizeOpenIdIssuer(user.openidIssuer);

--- a/packages/api/src/auth/refresh.spec.ts
+++ b/packages/api/src/auth/refresh.spec.ts
@@ -386,6 +386,56 @@ describe('applyAdminRefresh', () => {
     });
   });
 
+  describe('admin-access guard', () => {
+    it('throws FORBIDDEN and does not mint when canAccessAdmin returns false', async () => {
+      const user = makeUser();
+      const canAccessAdmin = jest.fn().mockResolvedValue(false);
+      const deps = makeDeps(user, { canAccessAdmin });
+
+      await expect(applyAdminRefresh(makeTokenset(), deps)).rejects.toMatchObject({
+        name: 'AdminRefreshError',
+        code: 'FORBIDDEN',
+        status: 403,
+      });
+
+      expect(canAccessAdmin).toHaveBeenCalledWith(user);
+      expect(deps.mintToken).not.toHaveBeenCalled();
+      expect(deps.onRefreshSuccess).not.toHaveBeenCalled();
+    });
+
+    it('mints when canAccessAdmin returns true', async () => {
+      const user = makeUser();
+      const canAccessAdmin = jest.fn().mockResolvedValue(true);
+      const deps = makeDeps(user, { canAccessAdmin });
+
+      const result = await applyAdminRefresh(makeTokenset(), deps);
+
+      expect(canAccessAdmin).toHaveBeenCalledWith(user);
+      expect(deps.mintToken).toHaveBeenCalledWith(user, expect.any(Object));
+      expect(result.token).toBe('minted-jwt');
+    });
+
+    it('skips the check when canAccessAdmin is not provided', async () => {
+      const user = makeUser();
+      const { canAccessAdmin: _omit, ...rest } = makeDeps(user);
+      const deps: AdminRefreshDeps = rest;
+
+      const result = await applyAdminRefresh(makeTokenset(), deps);
+      expect(result.token).toBe('minted-jwt');
+    });
+
+    it('propagates errors thrown by canAccessAdmin without minting', async () => {
+      const user = makeUser();
+      const boom = new Error('capability backend exploded');
+      const canAccessAdmin = jest.fn().mockRejectedValue(boom);
+      const deps = makeDeps(user, { canAccessAdmin });
+
+      await expect(applyAdminRefresh(makeTokenset(), deps)).rejects.toBe(boom);
+      expect(deps.mintToken).not.toHaveBeenCalled();
+      expect(deps.onRefreshSuccess).not.toHaveBeenCalled();
+    });
+  });
+
   describe('logging', () => {
     it('logs the refreshed user email at debug', async () => {
       const deps = makeDeps(makeUser());

--- a/packages/api/src/auth/refresh.spec.ts
+++ b/packages/api/src/auth/refresh.spec.ts
@@ -227,6 +227,62 @@ describe('applyAdminRefresh', () => {
     });
   });
 
+  describe('issuer guard', () => {
+    it('passes when expected and actual issuers match', async () => {
+      const deps = makeDeps(makeUser());
+      const tokenset = makeTokenset({
+        claims: () => ({ sub: SUB, iss: 'https://issuer.example.com' }),
+      });
+
+      await expect(
+        applyAdminRefresh(tokenset, deps, { expectedIssuer: 'https://issuer.example.com' }),
+      ).resolves.toBeDefined();
+    });
+
+    it('passes when expected and actual issuers match modulo trailing slash', async () => {
+      const deps = makeDeps(makeUser());
+      const tokenset = makeTokenset({
+        claims: () => ({ sub: SUB, iss: 'https://issuer.example.com/' }),
+      });
+
+      await expect(
+        applyAdminRefresh(tokenset, deps, { expectedIssuer: 'https://issuer.example.com' }),
+      ).resolves.toBeDefined();
+    });
+
+    it('throws ISSUER_MISMATCH when issuers differ', async () => {
+      const deps = makeDeps(makeUser());
+      const tokenset = makeTokenset({
+        claims: () => ({ sub: SUB, iss: 'https://attacker.example.com' }),
+      });
+
+      await expect(
+        applyAdminRefresh(tokenset, deps, { expectedIssuer: 'https://issuer.example.com' }),
+      ).rejects.toMatchObject({ code: 'ISSUER_MISMATCH', status: 401 });
+      expect(deps.findUsers).not.toHaveBeenCalled();
+      expect(deps.mintToken).not.toHaveBeenCalled();
+    });
+
+    it('skips the check when expectedIssuer is not provided', async () => {
+      const deps = makeDeps(makeUser());
+      const tokenset = makeTokenset({
+        claims: () => ({ sub: SUB, iss: 'https://attacker.example.com' }),
+      });
+
+      await expect(applyAdminRefresh(tokenset, deps)).resolves.toBeDefined();
+    });
+
+    it('skips the check when the tokenset has no iss claim', async () => {
+      const deps = makeDeps(makeUser());
+
+      await expect(
+        applyAdminRefresh(makeTokenset(), deps, {
+          expectedIssuer: 'https://issuer.example.com',
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+
   describe('refresh-token preservation', () => {
     it('preserves the inbound refresh token when the IdP does not rotate', async () => {
       const deps = makeDeps(makeUser());

--- a/packages/api/src/auth/refresh.spec.ts
+++ b/packages/api/src/auth/refresh.spec.ts
@@ -1,0 +1,277 @@
+import { Types } from 'mongoose';
+import { logger } from '@librechat/data-schemas';
+import type { IUser } from '@librechat/data-schemas';
+
+import type { AdminRefreshDeps, RefreshTokenset } from './refresh';
+
+import { applyAdminRefresh, AdminRefreshError } from './refresh';
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+const SUB = 'idp-sub-12345';
+
+function makeUser(overrides: Partial<IUser> = {}): IUser {
+  const _id = overrides._id ?? new Types.ObjectId();
+  return {
+    _id,
+    email: 'admin@example.com',
+    name: 'Admin User',
+    username: 'admin',
+    role: 'ADMIN',
+    provider: 'openid',
+    openidId: SUB,
+    ...overrides,
+  } as unknown as IUser;
+}
+
+function makeTokenset(overrides: Partial<RefreshTokenset> = {}): RefreshTokenset {
+  return {
+    access_token: 'new-access',
+    refresh_token: 'new-refresh',
+    claims: () => ({ sub: SUB }),
+    ...overrides,
+  };
+}
+
+function makeDeps(user: IUser | undefined, overrides: Partial<AdminRefreshDeps> = {}) {
+  const findUsers = jest.fn().mockResolvedValue(user ? [user] : []);
+  const getUserById = jest.fn().mockResolvedValue(user ?? null);
+  const mintToken = jest.fn().mockResolvedValue({ token: 'minted-jwt', expiresAt: 1234567890 });
+  const onRefreshSuccess = jest.fn().mockResolvedValue(undefined);
+  return {
+    findUsers,
+    getUserById,
+    mintToken,
+    onRefreshSuccess,
+    ...overrides,
+  };
+}
+
+describe('applyAdminRefresh', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('happy path', () => {
+    it('returns a fully-populated AdminExchangeResponse', async () => {
+      const user = makeUser();
+      const deps = makeDeps(user);
+      const tokenset = makeTokenset();
+
+      const result = await applyAdminRefresh(tokenset, deps);
+
+      expect(result).toEqual({
+        token: 'minted-jwt',
+        refreshToken: 'new-refresh',
+        user: expect.objectContaining({
+          email: 'admin@example.com',
+          openidId: SUB,
+        }),
+        expiresAt: 1234567890,
+      });
+      expect(deps.mintToken).toHaveBeenCalledWith(user, tokenset);
+      expect(deps.onRefreshSuccess).toHaveBeenCalledWith(user, tokenset);
+    });
+
+    it('uses findUsers when no userId is supplied', async () => {
+      const user = makeUser();
+      const deps = makeDeps(user);
+
+      await applyAdminRefresh(makeTokenset(), deps);
+
+      expect(deps.findUsers).toHaveBeenCalledWith(
+        { openidId: SUB },
+        '-password -__v -totpSecret -backupCodes',
+        { sort: { updatedAt: -1 }, limit: 1 },
+      );
+      expect(deps.getUserById).not.toHaveBeenCalled();
+    });
+
+    it('skips onRefreshSuccess when not provided', async () => {
+      const user = makeUser();
+      const { onRefreshSuccess: _omit, ...rest } = makeDeps(user);
+      const deps: AdminRefreshDeps = rest;
+
+      await expect(applyAdminRefresh(makeTokenset(), deps)).resolves.toBeDefined();
+    });
+  });
+
+  describe('userId disambiguation', () => {
+    it('returns the direct user when userId resolves and openidId matches', async () => {
+      const id = new Types.ObjectId();
+      const user = makeUser({ _id: id });
+      const deps = makeDeps(user);
+
+      await applyAdminRefresh(makeTokenset(), deps, { userId: id.toString() });
+
+      expect(deps.getUserById).toHaveBeenCalledWith(
+        id.toString(),
+        '-password -__v -totpSecret -backupCodes',
+      );
+      expect(deps.findUsers).not.toHaveBeenCalled();
+    });
+
+    it('falls through to findUsers when userId is not a valid ObjectId', async () => {
+      const user = makeUser();
+      const deps = makeDeps(user);
+
+      await applyAdminRefresh(makeTokenset(), deps, { userId: 'not-a-valid-id' });
+
+      expect(deps.getUserById).not.toHaveBeenCalled();
+      expect(deps.findUsers).toHaveBeenCalled();
+    });
+
+    it('falls through to findUsers when userId resolves to null', async () => {
+      const user = makeUser();
+      const id = new Types.ObjectId().toString();
+      const deps = makeDeps(user, { getUserById: jest.fn().mockResolvedValue(null) });
+
+      await applyAdminRefresh(makeTokenset(), deps, { userId: id });
+
+      expect(deps.getUserById).toHaveBeenCalled();
+      expect(deps.findUsers).toHaveBeenCalled();
+    });
+
+    it('throws USER_ID_MISMATCH when the resolved user has a different openidId', async () => {
+      const id = new Types.ObjectId();
+      const user = makeUser({ _id: id, openidId: 'different-sub' });
+      const deps = makeDeps(user, {
+        getUserById: jest.fn().mockResolvedValue(user),
+        findUsers: jest.fn(),
+      });
+
+      await expect(
+        applyAdminRefresh(makeTokenset(), deps, { userId: id.toString() }),
+      ).rejects.toMatchObject({
+        name: 'AdminRefreshError',
+        code: 'USER_ID_MISMATCH',
+        status: 401,
+      });
+      expect(deps.findUsers).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error branches', () => {
+    it('throws IDP_INCOMPLETE when access_token is missing', async () => {
+      const deps = makeDeps(makeUser());
+      const tokenset = makeTokenset({ access_token: undefined });
+
+      await expect(applyAdminRefresh(tokenset, deps)).rejects.toMatchObject({
+        code: 'IDP_INCOMPLETE',
+        status: 502,
+      });
+      expect(deps.mintToken).not.toHaveBeenCalled();
+    });
+
+    it('throws CLAIMS_INCOMPLETE when claims() throws', async () => {
+      const deps = makeDeps(makeUser());
+      const tokenset = makeTokenset({
+        claims: () => {
+          throw new Error('id_token missing');
+        },
+      });
+
+      await expect(applyAdminRefresh(tokenset, deps)).rejects.toMatchObject({
+        code: 'CLAIMS_INCOMPLETE',
+        status: 502,
+      });
+    });
+
+    it('throws CLAIMS_INCOMPLETE when sub is missing', async () => {
+      const deps = makeDeps(makeUser());
+      const tokenset = makeTokenset({ claims: () => ({}) });
+
+      await expect(applyAdminRefresh(tokenset, deps)).rejects.toMatchObject({
+        code: 'CLAIMS_INCOMPLETE',
+        status: 502,
+      });
+    });
+
+    it('throws USER_NOT_FOUND when no user matches the refreshed identity', async () => {
+      const deps = makeDeps(undefined);
+
+      await expect(applyAdminRefresh(makeTokenset(), deps)).rejects.toMatchObject({
+        code: 'USER_NOT_FOUND',
+        status: 401,
+      });
+      expect(deps.mintToken).not.toHaveBeenCalled();
+    });
+
+    it('propagates errors thrown from mintToken', async () => {
+      const deps = makeDeps(makeUser(), {
+        mintToken: jest.fn().mockRejectedValue(new Error('signing failure')),
+      });
+
+      await expect(applyAdminRefresh(makeTokenset(), deps)).rejects.toThrow('signing failure');
+    });
+
+    it('propagates errors thrown from onRefreshSuccess', async () => {
+      const deps = makeDeps(makeUser(), {
+        onRefreshSuccess: jest.fn().mockRejectedValue(new Error('cache write failed')),
+      });
+
+      await expect(applyAdminRefresh(makeTokenset(), deps)).rejects.toThrow('cache write failed');
+    });
+  });
+
+  describe('refresh-token preservation', () => {
+    it('preserves the inbound refresh token when the IdP does not rotate', async () => {
+      const deps = makeDeps(makeUser());
+      const tokenset = makeTokenset({ refresh_token: undefined });
+
+      const result = await applyAdminRefresh(tokenset, deps, {
+        previousRefreshToken: 'inbound-refresh',
+      });
+
+      expect(result.refreshToken).toBe('inbound-refresh');
+    });
+
+    it('prefers the rotated refresh token over the previousRefreshToken fallback', async () => {
+      const deps = makeDeps(makeUser());
+      const tokenset = makeTokenset({ refresh_token: 'rotated-refresh' });
+
+      const result = await applyAdminRefresh(tokenset, deps, {
+        previousRefreshToken: 'inbound-refresh',
+      });
+
+      expect(result.refreshToken).toBe('rotated-refresh');
+    });
+
+    it('returns undefined refreshToken when neither rotation nor fallback is available', async () => {
+      const deps = makeDeps(makeUser());
+      const tokenset = makeTokenset({ refresh_token: undefined });
+
+      const result = await applyAdminRefresh(tokenset, deps);
+
+      expect(result.refreshToken).toBeUndefined();
+    });
+  });
+
+  describe('logging', () => {
+    it('logs the refreshed user email at debug', async () => {
+      const deps = makeDeps(makeUser());
+
+      await applyAdminRefresh(makeTokenset(), deps);
+
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('admin@example.com'));
+    });
+  });
+});
+
+describe('AdminRefreshError', () => {
+  it('captures code, status, and message', () => {
+    const err = new AdminRefreshError('SOME_CODE', 418, 'teapot');
+    expect(err.name).toBe('AdminRefreshError');
+    expect(err.code).toBe('SOME_CODE');
+    expect(err.status).toBe(418);
+    expect(err.message).toBe('teapot');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/packages/api/src/auth/refresh.spec.ts
+++ b/packages/api/src/auth/refresh.spec.ts
@@ -386,6 +386,89 @@ describe('applyAdminRefresh', () => {
     });
   });
 
+  describe('tenant scoping', () => {
+    it('constrains the fallback findUsers filter to options.tenantId', async () => {
+      const user = makeUser({ tenantId: 'tenant-a' } as Partial<IUser>);
+      const deps = makeDeps(user);
+
+      await applyAdminRefresh(makeTokenset(), deps, { tenantId: 'tenant-a' });
+
+      const [filter] = (deps.findUsers as jest.Mock).mock.calls[0];
+      expect(filter).toMatchObject({ openidId: SUB, tenantId: 'tenant-a' });
+    });
+
+    it('returns the tenant-A user when two users share (sub, iss) across tenants', async () => {
+      const userA = makeUser({ tenantId: 'tenant-a', email: 'a@example.com' } as Partial<IUser>);
+      const userB = makeUser({ tenantId: 'tenant-b', email: 'b@example.com' } as Partial<IUser>);
+
+      const findUsers = jest.fn().mockImplementation(async (filter: { tenantId?: string }) => {
+        if (filter.tenantId === 'tenant-a') return [userA];
+        if (filter.tenantId === 'tenant-b') return [userB];
+        return [userA, userB];
+      });
+      const deps = makeDeps(userA, { findUsers });
+
+      const result = await applyAdminRefresh(makeTokenset(), deps, { tenantId: 'tenant-a' });
+
+      expect(result.user.email).toBe('a@example.com');
+      expect(findUsers).toHaveBeenCalledWith(
+        { openidId: SUB, tenantId: 'tenant-a' },
+        '-password -__v -totpSecret -backupCodes',
+        { sort: { updatedAt: -1 }, limit: 1 },
+      );
+    });
+
+    it('throws TENANT_MISMATCH when direct user_id resolves to a different tenant', async () => {
+      const id = new Types.ObjectId();
+      const user = makeUser({ _id: id, tenantId: 'tenant-b' } as Partial<IUser>);
+      const deps = makeDeps(user, {
+        getUserById: jest.fn().mockResolvedValue(user),
+        findUsers: jest.fn(),
+      });
+
+      await expect(
+        applyAdminRefresh(makeTokenset(), deps, {
+          userId: id.toString(),
+          tenantId: 'tenant-a',
+        }),
+      ).rejects.toMatchObject({
+        name: 'AdminRefreshError',
+        code: 'TENANT_MISMATCH',
+        status: 401,
+      });
+      expect(deps.findUsers).not.toHaveBeenCalled();
+      expect(deps.mintToken).not.toHaveBeenCalled();
+    });
+
+    it('accepts direct user_id when stored tenantId matches options.tenantId', async () => {
+      const id = new Types.ObjectId();
+      const user = makeUser({ _id: id, tenantId: 'tenant-a' } as Partial<IUser>);
+      const deps = makeDeps(user, {
+        getUserById: jest.fn().mockResolvedValue(user),
+        findUsers: jest.fn(),
+      });
+
+      const result = await applyAdminRefresh(makeTokenset(), deps, {
+        userId: id.toString(),
+        tenantId: 'tenant-a',
+      });
+
+      expect(result.token).toBe('minted-jwt');
+      expect(deps.findUsers).not.toHaveBeenCalled();
+    });
+
+    it('falls back to openidId-only filter when options.tenantId is omitted', async () => {
+      const user = makeUser();
+      const deps = makeDeps(user);
+
+      await applyAdminRefresh(makeTokenset(), deps);
+
+      const [filter] = (deps.findUsers as jest.Mock).mock.calls[0];
+      expect(filter).toEqual({ openidId: SUB });
+      expect(filter).not.toHaveProperty('tenantId');
+    });
+  });
+
   describe('admin-access guard', () => {
     it('throws FORBIDDEN and does not mint when canAccessAdmin returns false', async () => {
       const user = makeUser();

--- a/packages/api/src/auth/refresh.spec.ts
+++ b/packages/api/src/auth/refresh.spec.ts
@@ -227,6 +227,76 @@ describe('applyAdminRefresh', () => {
     });
   });
 
+  describe('issuer-bound user lookup', () => {
+    it('binds findUsers to (openidId, openidIssuer) when expectedIssuer is provided', async () => {
+      const user = makeUser();
+      const deps = makeDeps(user);
+      const tokenset = makeTokenset({
+        claims: () => ({ sub: SUB, iss: 'https://issuer.example.com' }),
+      });
+
+      await applyAdminRefresh(tokenset, deps, {
+        expectedIssuer: 'https://issuer.example.com',
+      });
+
+      const [filter] = (deps.findUsers as jest.Mock).mock.calls[0];
+      expect(filter).toMatchObject({
+        $or: expect.arrayContaining([
+          { openidId: SUB, openidIssuer: 'https://issuer.example.com' },
+        ]),
+      });
+    });
+
+    it('falls back to openidId-only lookup when expectedIssuer is not provided', async () => {
+      const user = makeUser();
+      const deps = makeDeps(user);
+
+      await applyAdminRefresh(makeTokenset(), deps);
+
+      expect(deps.findUsers).toHaveBeenCalledWith(
+        { openidId: SUB },
+        '-password -__v -totpSecret -backupCodes',
+        { sort: { updatedAt: -1 }, limit: 1 },
+      );
+    });
+
+    it('throws USER_ID_MISMATCH when direct user_id resolves but issuer differs', async () => {
+      const id = new Types.ObjectId();
+      const user = makeUser({ _id: id, openidIssuer: 'https://other-issuer.example.com' });
+      const deps = makeDeps(user, {
+        getUserById: jest.fn().mockResolvedValue(user),
+        findUsers: jest.fn(),
+      });
+      const tokenset = makeTokenset({
+        claims: () => ({ sub: SUB, iss: 'https://issuer.example.com' }),
+      });
+
+      await expect(
+        applyAdminRefresh(tokenset, deps, {
+          userId: id.toString(),
+          expectedIssuer: 'https://issuer.example.com',
+        }),
+      ).rejects.toMatchObject({ code: 'USER_ID_MISMATCH', status: 401 });
+      expect(deps.findUsers).not.toHaveBeenCalled();
+    });
+
+    it('accepts direct user_id when stored openidIssuer matches the expected issuer', async () => {
+      const id = new Types.ObjectId();
+      const user = makeUser({ _id: id, openidIssuer: 'https://issuer.example.com' });
+      const deps = makeDeps(user, { getUserById: jest.fn().mockResolvedValue(user) });
+      const tokenset = makeTokenset({
+        claims: () => ({ sub: SUB, iss: 'https://issuer.example.com' }),
+      });
+
+      await expect(
+        applyAdminRefresh(tokenset, deps, {
+          userId: id.toString(),
+          expectedIssuer: 'https://issuer.example.com',
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+
   describe('issuer guard', () => {
     it('passes when expected and actual issuers match', async () => {
       const deps = makeDeps(makeUser());

--- a/packages/api/src/auth/refresh.spec.ts
+++ b/packages/api/src/auth/refresh.spec.ts
@@ -1,7 +1,7 @@
 import { Types } from 'mongoose';
 import { logger } from '@librechat/data-schemas';
-import type { IUser } from '@librechat/data-schemas';
 
+import type { IUser } from '@librechat/data-schemas';
 import type { AdminRefreshDeps, RefreshTokenset } from './refresh';
 
 import { applyAdminRefresh, AdminRefreshError } from './refresh';
@@ -99,7 +99,9 @@ describe('applyAdminRefresh', () => {
       const { onRefreshSuccess: _omit, ...rest } = makeDeps(user);
       const deps: AdminRefreshDeps = rest;
 
-      await expect(applyAdminRefresh(makeTokenset(), deps)).resolves.toBeDefined();
+      const result = await applyAdminRefresh(makeTokenset(), deps);
+      expect(result.token).toBe('minted-jwt');
+      expect(result.user.email).toBe('admin@example.com');
     });
   });
 
@@ -135,8 +137,12 @@ describe('applyAdminRefresh', () => {
 
       await applyAdminRefresh(makeTokenset(), deps, { userId: id });
 
-      expect(deps.getUserById).toHaveBeenCalled();
-      expect(deps.findUsers).toHaveBeenCalled();
+      expect(deps.getUserById).toHaveBeenCalledWith(id, '-password -__v -totpSecret -backupCodes');
+      expect(deps.findUsers).toHaveBeenCalledWith(
+        { openidId: SUB },
+        '-password -__v -totpSecret -backupCodes',
+        { sort: { updatedAt: -1 }, limit: 1 },
+      );
     });
 
     it('throws USER_ID_MISMATCH when the resolved user has a different openidId', async () => {

--- a/packages/api/src/auth/refresh.ts
+++ b/packages/api/src/auth/refresh.ts
@@ -52,6 +52,15 @@ export interface AdminRefreshDeps {
    */
   mintToken: (user: IUser, tokenset: RefreshTokenset) => Promise<MintedToken>;
   /**
+   * Authorizes the resolved user against the same admin-access invariant
+   * the initial OAuth callback enforces. The IdP refresh token can outlive
+   * a capability/role change, so the bearer must not be reissued for a
+   * user who no longer holds `ACCESS_ADMIN`. Optional only for backward
+   * compatibility with existing callers; route handlers that mint admin
+   * bearers should always inject this.
+   */
+  canAccessAdmin?: (user: IUser) => Promise<boolean>;
+  /**
    * Optional post-success hook for forks that need to do additional work
    * with the refreshed tokenset and resolved user (e.g. update a server-side
    * token cache or reconcile downstream session state). Errors thrown here
@@ -202,6 +211,10 @@ export async function applyAdminRefresh(
   const user = await resolveAdminUser(deps, openidId, expected, options);
   if (!user) {
     throw new AdminRefreshError('USER_NOT_FOUND', 401, 'No user found for the refreshed identity');
+  }
+
+  if (deps.canAccessAdmin && !(await deps.canAccessAdmin(user))) {
+    throw new AdminRefreshError('FORBIDDEN', 403, 'User does not have admin access');
   }
 
   const minted = await deps.mintToken(user, tokenset);

--- a/packages/api/src/auth/refresh.ts
+++ b/packages/api/src/auth/refresh.ts
@@ -5,12 +5,14 @@ import type { IUser } from '@librechat/data-schemas';
 import type { FilterQuery } from 'mongoose';
 import type { AdminExchangeResponse } from '~/auth/exchange';
 
+import { normalizeOpenIdIssuer } from '~/auth/openid';
 import { serializeUserForExchange } from '~/auth/exchange';
 
 const SAFE_USER_PROJECTION = '-password -__v -totpSecret -backupCodes';
 
 interface AdminRefreshClaims {
   sub?: string;
+  iss?: string;
 }
 
 /**
@@ -68,6 +70,14 @@ export interface AdminRefreshOptions {
    * admin panel would receive `undefined` and lose its refresh capability.
    */
   previousRefreshToken?: string;
+  /**
+   * Issuer URL of the OpenID provider this server trusts. When provided
+   * alongside an `iss` claim on the refreshed tokenset, the helper rejects
+   * the refresh if the two don't match. Defends against tokensets emitted
+   * by an unexpected issuer, even though `IUser` lookup is still keyed by
+   * `openidId` alone.
+   */
+  expectedIssuer?: string;
 }
 
 export class AdminRefreshError extends Error {
@@ -160,6 +170,16 @@ export async function applyAdminRefresh(
       'CLAIMS_INCOMPLETE',
       502,
       'IdP returned a tokenset missing the required `sub` claim',
+    );
+  }
+
+  const expected = normalizeOpenIdIssuer(options.expectedIssuer);
+  const actual = normalizeOpenIdIssuer(claims.iss);
+  if (expected && actual && expected !== actual) {
+    throw new AdminRefreshError(
+      'ISSUER_MISMATCH',
+      401,
+      'Refreshed tokenset was issued by an unexpected issuer',
     );
   }
 

--- a/packages/api/src/auth/refresh.ts
+++ b/packages/api/src/auth/refresh.ts
@@ -1,0 +1,155 @@
+import { runAsSystem, logger } from '@librechat/data-schemas';
+import type { FilterQuery } from 'mongoose';
+import type { IUser } from '@librechat/data-schemas';
+import type { AdminExchangeResponse } from '~/auth/exchange';
+import { serializeUserForExchange } from '~/auth/exchange';
+
+interface AdminRefreshClaims {
+  sub?: string;
+  email?: string;
+  exp?: number;
+}
+
+/**
+ * The minimal shape this module needs from an `openid-client` tokenset.
+ * Avoids a hard import dependency on `openid-client` types in this package.
+ */
+export interface RefreshTokenset {
+  access_token?: string;
+  id_token?: string;
+  refresh_token?: string;
+  claims: () => AdminRefreshClaims;
+}
+
+export interface AdminRefreshDeps {
+  findUsers: (
+    filter: FilterQuery<IUser>,
+    projection: string | null,
+    options: { sort: Record<string, 1 | -1>; limit: number },
+  ) => Promise<IUser[]>;
+  getUserById: (id: string, projection: string) => Promise<IUser | null>;
+  /**
+   * Mints the bearer token returned to the admin panel. The default OSS path
+   * is to call `generateToken(user, expiresInMs)` which signs an HS256
+   * LibreChat JWT — pass that here. Forks that prefer to hand back a
+   * different bearer (e.g. an IdP-signed id_token) override this hook.
+   */
+  mintToken: (user: IUser, tokenset: RefreshTokenset) => Promise<string>;
+  /**
+   * Optional post-success hook for forks that need to do additional work
+   * with the refreshed tokenset and resolved user (e.g. update a server-side
+   * token cache or reconcile downstream session state). Errors thrown here
+   * propagate to the route handler.
+   */
+  onRefreshSuccess?: (user: IUser, tokenset: RefreshTokenset) => Promise<void>;
+}
+
+export interface AdminRefreshOptions {
+  /**
+   * Optional user `_id` from the previous admin-panel session. When provided,
+   * disambiguates the lookup if multiple user docs share `openidId` (e.g.
+   * multi-tenant deployments). Falls back to the most-recently-updated doc
+   * if absent.
+   */
+  userId?: string;
+}
+
+export class AdminRefreshError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AdminRefreshError';
+  }
+}
+
+const DEFAULT_TOKEN_LIFETIME_MS = 15 * 60 * 1000;
+
+function resolveExpiresAt(claimExp: number | undefined): number {
+  if (typeof claimExp === 'number') {
+    return claimExp * 1000;
+  }
+  return Date.now() + DEFAULT_TOKEN_LIFETIME_MS;
+}
+
+async function resolveAdminUser(
+  deps: AdminRefreshDeps,
+  openidId: string,
+  options: AdminRefreshOptions,
+): Promise<IUser | undefined> {
+  if (options.userId) {
+    const direct = await runAsSystem(() =>
+      deps.getUserById(options.userId as string, '-password -__v -totpSecret -backupCodes'),
+    );
+    if (direct && direct.openidId === openidId) {
+      return direct;
+    }
+  }
+
+  const [user] = await runAsSystem(() =>
+    deps.findUsers({ openidId } as FilterQuery<IUser>, null, {
+      sort: { updatedAt: -1 },
+      limit: 1,
+    }),
+  );
+  return user;
+}
+
+/**
+ * Looks up the active admin user for a freshly-refreshed OpenID tokenset,
+ * mints the bearer the admin panel should send on subsequent requests, and
+ * returns the response shape used by `/api/admin/oauth/exchange`.
+ *
+ * The route handler is responsible for the IdP `refreshTokenGrant` call;
+ * this helper takes the resulting tokenset and turns it into an admin-panel
+ * exchange response.
+ */
+export async function applyAdminRefresh(
+  tokenset: RefreshTokenset,
+  deps: AdminRefreshDeps,
+  options: AdminRefreshOptions = {},
+): Promise<AdminExchangeResponse> {
+  if (!tokenset.access_token) {
+    throw new AdminRefreshError(
+      'IDP_INCOMPLETE',
+      502,
+      'IdP returned an incomplete tokenset (missing access_token)',
+    );
+  }
+
+  const claims = tokenset.claims();
+  const openidId = claims.sub;
+  if (!openidId) {
+    throw new AdminRefreshError(
+      'CLAIMS_INCOMPLETE',
+      502,
+      'IdP returned a tokenset missing the required `sub` claim',
+    );
+  }
+
+  const expiresAt = resolveExpiresAt(claims.exp);
+
+  const user = await resolveAdminUser(deps, openidId, options);
+  if (!user) {
+    throw new AdminRefreshError('USER_NOT_FOUND', 401, 'No user found for the refreshed identity');
+  }
+
+  const token = await deps.mintToken(user, tokenset);
+
+  if (deps.onRefreshSuccess) {
+    await deps.onRefreshSuccess(user, tokenset);
+  }
+
+  const responseUser = serializeUserForExchange(user);
+
+  logger.debug(`[adminRefresh] Refreshed tokens for user: ${responseUser.email}`);
+
+  return {
+    token,
+    refreshToken: tokenset.refresh_token,
+    user: responseUser,
+    expiresAt,
+  };
+}

--- a/packages/api/src/auth/refresh.ts
+++ b/packages/api/src/auth/refresh.ts
@@ -1,5 +1,5 @@
 import { Types } from 'mongoose';
-import { runAsSystem, logger } from '@librechat/data-schemas';
+import { logger } from '@librechat/data-schemas';
 
 import type { IUser } from '@librechat/data-schemas';
 import type { FilterQuery } from 'mongoose';
@@ -91,6 +91,16 @@ export interface AdminRefreshOptions {
    * `openidId` alone.
    */
   expectedIssuer?: string;
+  /**
+   * Trusted tenant id resolved by the route layer (e.g. `getTenantId()` from
+   * the pre-auth tenant ALS scope). When provided, the helper:
+   *   - constrains the fallback `findUsers` lookup with `tenantId`, and
+   *   - asserts a direct `getUserById` result has a matching `tenantId`,
+   * so the same `(sub, iss)` existing in another tenant can never resolve
+   * here. Multi-tenant deployments MUST pass this. Single-tenant deployments
+   * may omit it.
+   */
+  tenantId?: string;
 }
 
 export class AdminRefreshError extends Error {
@@ -110,10 +120,10 @@ async function resolveAdminUser(
   normalizedIssuer: string | undefined,
   options: AdminRefreshOptions,
 ): Promise<IUser | undefined> {
+  const expectedTenantId = options.tenantId;
+
   if (options.userId && Types.ObjectId.isValid(options.userId)) {
-    const direct = await runAsSystem(() =>
-      deps.getUserById(options.userId as string, SAFE_USER_PROJECTION),
-    );
+    const direct = await deps.getUserById(options.userId as string, SAFE_USER_PROJECTION);
     if (direct) {
       if (direct.openidId !== openidId) {
         throw new AdminRefreshError(
@@ -129,6 +139,13 @@ async function resolveAdminUser(
           'Provided user_id matches sub but issuer differs from the refreshed identity',
         );
       }
+      if (expectedTenantId && direct.tenantId !== expectedTenantId) {
+        throw new AdminRefreshError(
+          'TENANT_MISMATCH',
+          401,
+          'Provided user_id resolves outside the request tenant',
+        );
+      }
       return direct;
     }
     logger.debug(
@@ -137,15 +154,16 @@ async function resolveAdminUser(
   }
 
   const issuerBound = getIssuerBoundConditions('openidId', openidId, normalizedIssuer);
-  const filter: FilterQuery<IUser> =
+  const baseFilter: FilterQuery<IUser> =
     issuerBound.length > 0 ? { $or: issuerBound } : ({ openidId } as FilterQuery<IUser>);
+  const filter: FilterQuery<IUser> = expectedTenantId
+    ? ({ ...baseFilter, tenantId: expectedTenantId } as FilterQuery<IUser>)
+    : baseFilter;
 
-  const [user] = await runAsSystem(() =>
-    deps.findUsers(filter, SAFE_USER_PROJECTION, {
-      sort: { updatedAt: -1 },
-      limit: 1,
-    }),
-  );
+  const [user] = await deps.findUsers(filter, SAFE_USER_PROJECTION, {
+    sort: { updatedAt: -1 },
+    limit: 1,
+  });
   return user;
 }
 

--- a/packages/api/src/auth/refresh.ts
+++ b/packages/api/src/auth/refresh.ts
@@ -11,7 +11,6 @@ const SAFE_USER_PROJECTION = '-password -__v -totpSecret -backupCodes';
 
 interface AdminRefreshClaims {
   sub?: string;
-  exp?: number;
 }
 
 /**
@@ -34,7 +33,7 @@ export interface MintedToken {
 export interface AdminRefreshDeps {
   findUsers: (
     filter: FilterQuery<IUser>,
-    projection: string | null,
+    projection: string,
     options: { sort: Record<string, 1 | -1>; limit: number },
   ) => Promise<IUser[]>;
   getUserById: (id: string, projection: string) => Promise<IUser | null>;
@@ -118,7 +117,12 @@ async function resolveAdminUser(
 function readClaims(tokenset: RefreshTokenset): AdminRefreshClaims {
   try {
     return tokenset.claims();
-  } catch (_err) {
+  } catch (err) {
+    const error = err as { name?: string; message?: string };
+    logger.warn('[adminRefresh] tokenset.claims() threw', {
+      name: error?.name,
+      message: error?.message,
+    });
     throw new AdminRefreshError(
       'CLAIMS_INCOMPLETE',
       502,

--- a/packages/api/src/auth/refresh.ts
+++ b/packages/api/src/auth/refresh.ts
@@ -5,7 +5,11 @@ import type { IUser } from '@librechat/data-schemas';
 import type { FilterQuery } from 'mongoose';
 import type { AdminExchangeResponse } from '~/auth/exchange';
 
-import { normalizeOpenIdIssuer } from '~/auth/openid';
+import {
+  isUserIssuerAllowed,
+  normalizeOpenIdIssuer,
+  getIssuerBoundConditions,
+} from '~/auth/openid';
 import { serializeUserForExchange } from '~/auth/exchange';
 
 const SAFE_USER_PROJECTION = '-password -__v -totpSecret -backupCodes';
@@ -94,6 +98,7 @@ export class AdminRefreshError extends Error {
 async function resolveAdminUser(
   deps: AdminRefreshDeps,
   openidId: string,
+  normalizedIssuer: string | undefined,
   options: AdminRefreshOptions,
 ): Promise<IUser | undefined> {
   if (options.userId && Types.ObjectId.isValid(options.userId)) {
@@ -108,6 +113,13 @@ async function resolveAdminUser(
           'Provided user_id does not match the refreshed identity',
         );
       }
+      if (!isUserIssuerAllowed(direct, normalizedIssuer)) {
+        throw new AdminRefreshError(
+          'USER_ID_MISMATCH',
+          401,
+          'Provided user_id matches sub but issuer differs from the refreshed identity',
+        );
+      }
       return direct;
     }
     logger.debug(
@@ -115,8 +127,12 @@ async function resolveAdminUser(
     );
   }
 
+  const issuerBound = getIssuerBoundConditions('openidId', openidId, normalizedIssuer);
+  const filter: FilterQuery<IUser> =
+    issuerBound.length > 0 ? { $or: issuerBound } : ({ openidId } as FilterQuery<IUser>);
+
   const [user] = await runAsSystem(() =>
-    deps.findUsers({ openidId } as FilterQuery<IUser>, SAFE_USER_PROJECTION, {
+    deps.findUsers(filter, SAFE_USER_PROJECTION, {
       sort: { updatedAt: -1 },
       limit: 1,
     }),
@@ -183,7 +199,7 @@ export async function applyAdminRefresh(
     );
   }
 
-  const user = await resolveAdminUser(deps, openidId, options);
+  const user = await resolveAdminUser(deps, openidId, expected, options);
   if (!user) {
     throw new AdminRefreshError('USER_NOT_FOUND', 401, 'No user found for the refreshed identity');
   }

--- a/packages/api/src/auth/refresh.ts
+++ b/packages/api/src/auth/refresh.ts
@@ -1,12 +1,16 @@
+import { Types } from 'mongoose';
 import { runAsSystem, logger } from '@librechat/data-schemas';
-import type { FilterQuery } from 'mongoose';
+
 import type { IUser } from '@librechat/data-schemas';
+import type { FilterQuery } from 'mongoose';
 import type { AdminExchangeResponse } from '~/auth/exchange';
+
 import { serializeUserForExchange } from '~/auth/exchange';
+
+const SAFE_USER_PROJECTION = '-password -__v -totpSecret -backupCodes';
 
 interface AdminRefreshClaims {
   sub?: string;
-  email?: string;
   exp?: number;
 }
 
@@ -16,9 +20,15 @@ interface AdminRefreshClaims {
  */
 export interface RefreshTokenset {
   access_token?: string;
-  id_token?: string;
   refresh_token?: string;
   claims: () => AdminRefreshClaims;
+}
+
+export interface MintedToken {
+  /** Bearer the admin panel will send on subsequent requests. */
+  token: string;
+  /** Absolute expiry of `token` (ms epoch). Drives the admin panel's proactive refresh. */
+  expiresAt: number;
 }
 
 export interface AdminRefreshDeps {
@@ -29,12 +39,13 @@ export interface AdminRefreshDeps {
   ) => Promise<IUser[]>;
   getUserById: (id: string, projection: string) => Promise<IUser | null>;
   /**
-   * Mints the bearer token returned to the admin panel. The default OSS path
-   * is to call `generateToken(user, expiresInMs)` which signs an HS256
-   * LibreChat JWT — pass that here. Forks that prefer to hand back a
-   * different bearer (e.g. an IdP-signed id_token) override this hook.
+   * Mints the bearer the admin panel will send on subsequent requests, and
+   * reports its absolute expiry. The minter is authoritative for the bearer's
+   * lifetime — the helper does not attempt to derive expiry from the IdP's
+   * `exp` claim. Default OSS callers pass `generateToken(user, sessionExpiry)`
+   * and `Date.now() + sessionExpiry`.
    */
-  mintToken: (user: IUser, tokenset: RefreshTokenset) => Promise<string>;
+  mintToken: (user: IUser, tokenset: RefreshTokenset) => Promise<MintedToken>;
   /**
    * Optional post-success hook for forks that need to do additional work
    * with the refreshed tokenset and resolved user (e.g. update a server-side
@@ -47,11 +58,17 @@ export interface AdminRefreshDeps {
 export interface AdminRefreshOptions {
   /**
    * Optional user `_id` from the previous admin-panel session. When provided,
-   * disambiguates the lookup if multiple user docs share `openidId` (e.g.
-   * multi-tenant deployments). Falls back to the most-recently-updated doc
-   * if absent.
+   * the resolved user must have a matching `openidId` — otherwise the refresh
+   * is rejected as a possible identity-swap attempt.
    */
   userId?: string;
+  /**
+   * The refresh token the admin panel sent in. Preserved as the response
+   * `refreshToken` when the IdP doesn't rotate (Auth0 with rotation off,
+   * Microsoft personal accounts in some flows). Without this fallback, the
+   * admin panel would receive `undefined` and lose its refresh capability.
+   */
+  previousRefreshToken?: string;
 }
 
 export class AdminRefreshError extends Error {
@@ -65,36 +82,49 @@ export class AdminRefreshError extends Error {
   }
 }
 
-const DEFAULT_TOKEN_LIFETIME_MS = 15 * 60 * 1000;
-
-function resolveExpiresAt(claimExp: number | undefined): number {
-  if (typeof claimExp === 'number') {
-    return claimExp * 1000;
-  }
-  return Date.now() + DEFAULT_TOKEN_LIFETIME_MS;
-}
-
 async function resolveAdminUser(
   deps: AdminRefreshDeps,
   openidId: string,
   options: AdminRefreshOptions,
 ): Promise<IUser | undefined> {
-  if (options.userId) {
+  if (options.userId && Types.ObjectId.isValid(options.userId)) {
     const direct = await runAsSystem(() =>
-      deps.getUserById(options.userId as string, '-password -__v -totpSecret -backupCodes'),
+      deps.getUserById(options.userId as string, SAFE_USER_PROJECTION),
     );
-    if (direct && direct.openidId === openidId) {
+    if (direct) {
+      if (direct.openidId !== openidId) {
+        throw new AdminRefreshError(
+          'USER_ID_MISMATCH',
+          401,
+          'Provided user_id does not match the refreshed identity',
+        );
+      }
       return direct;
     }
+    logger.debug(
+      `[adminRefresh] user_id ${options.userId} not found; falling through to openidId lookup`,
+    );
   }
 
   const [user] = await runAsSystem(() =>
-    deps.findUsers({ openidId } as FilterQuery<IUser>, null, {
+    deps.findUsers({ openidId } as FilterQuery<IUser>, SAFE_USER_PROJECTION, {
       sort: { updatedAt: -1 },
       limit: 1,
     }),
   );
   return user;
+}
+
+function readClaims(tokenset: RefreshTokenset): AdminRefreshClaims {
+  try {
+    return tokenset.claims();
+  } catch (_err) {
+    throw new AdminRefreshError(
+      'CLAIMS_INCOMPLETE',
+      502,
+      'IdP returned a tokenset whose claims could not be read (no id_token?)',
+    );
+  }
 }
 
 /**
@@ -119,7 +149,7 @@ export async function applyAdminRefresh(
     );
   }
 
-  const claims = tokenset.claims();
+  const claims = readClaims(tokenset);
   const openidId = claims.sub;
   if (!openidId) {
     throw new AdminRefreshError(
@@ -129,14 +159,12 @@ export async function applyAdminRefresh(
     );
   }
 
-  const expiresAt = resolveExpiresAt(claims.exp);
-
   const user = await resolveAdminUser(deps, openidId, options);
   if (!user) {
     throw new AdminRefreshError('USER_NOT_FOUND', 401, 'No user found for the refreshed identity');
   }
 
-  const token = await deps.mintToken(user, tokenset);
+  const minted = await deps.mintToken(user, tokenset);
 
   if (deps.onRefreshSuccess) {
     await deps.onRefreshSuccess(user, tokenset);
@@ -147,9 +175,9 @@ export async function applyAdminRefresh(
   logger.debug(`[adminRefresh] Refreshed tokens for user: ${responseUser.email}`);
 
   return {
-    token,
-    refreshToken: tokenset.refresh_token,
+    token: minted.token,
+    refreshToken: tokenset.refresh_token ?? options.previousRefreshToken,
     user: responseUser,
-    expiresAt,
+    expiresAt: minted.expiresAt,
   };
 }


### PR DESCRIPTION
## Summary

The existing `/api/auth/refresh` controller reads the refresh token from cookies. That works for same-origin callers, but a cross-origin admin panel (one served from a different host than the LibreChat backend) doesn't ship cookies on its fetches and can't refresh, so its session dies at the JWT lifetime with no recovery.

This adds `POST /api/admin/oauth/refresh`, a body-based refresh endpoint for the cross-origin BFF case. It accepts the refresh token in the JSON body, exchanges it via `openid-client.refreshTokenGrant`, and returns the same response shape as `/api/admin/oauth/exchange`: `{ token, refreshToken, user, expiresAt }`.

The route is a thin wrapper around `applyAdminRefresh` in `packages/api/src/auth/refresh.ts`. The helper validates the refreshed tokenset, looks up the admin user by `openidId` (with optional `user_id` disambiguation when multiple user docs share the same sub), mints the bearer the admin panel will send on subsequent requests via an injected `mintToken` hook, and runs an optional `onRefreshSuccess` hook for forks that need to update server-side session state.

The default `mintToken` (passed by the route) signs an HS256 LibreChat JWT via `generateToken`, matching the legacy admin-exchange behavior so existing admin-panel callers continue using the local `jwt` strategy. Forks that hand back a different bearer (e.g. an IdP id_token) override `mintToken` without changing the helper or route.

Also threads an optional `expiresAt` (ms epoch) through `AdminExchangeData` and `AdminExchangeResponse` so admin-panel clients can drive proactive refresh before the bearer expires.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Changes

- `packages/api/src/auth/refresh.ts` — new `applyAdminRefresh` helper plus `AdminRefreshError`, `AdminRefreshDeps`, `AdminRefreshOptions`, `MintedToken`, and `RefreshTokenset` types
- `packages/api/src/auth/refresh.spec.ts` — 18 unit tests covering happy path, all error branches, `userId` disambiguation, and refresh-token preservation
- `packages/api/src/auth/exchange.ts` — add optional `expiresAt` to `AdminExchangeData` and `AdminExchangeResponse`, and as a parameter to `generateAdminExchangeCode`
- `packages/api/src/auth/index.ts` — re-export the new helper
- `api/server/routes/admin/auth.js` — new `POST /oauth/refresh` route handler
- `api/server/controllers/auth/oauth.js` — populate `expiresAt = Date.now() + sessionExpiry` on the existing admin-redirect path

## Helper API notes (forks)

`AdminRefreshDeps.mintToken` returns `{ token, expiresAt }` rather than a bare bearer string. The minter is authoritative for the bearer's lifetime — the helper does not derive `expiresAt` from the IdP's `exp` claim, since for the default OSS path the bearer is the LibreChat JWT (lifetime = `SESSION_EXPIRY`), not the IdP token.

`AdminRefreshOptions.previousRefreshToken` lets the caller hand the inbound refresh token to the helper. When the IdP returns a tokenset without a `refresh_token` (Auth0 with rotation off, Microsoft personal accounts, etc.), the helper falls back to this value so the admin panel keeps its refresh capability.

## Hardening (review feedback)

- `Types.ObjectId.isValid` guards `getUserById` so a malformed `user_id` no longer surfaces as a Mongoose `CastError` / 500.
- When `user_id` resolves to a user whose `openidId` differs from the refreshed `sub`, the helper throws `USER_ID_MISMATCH` (401) rather than silently swapping in another user matching the `sub`.
- `tokenset.claims()` is wrapped in a `readClaims` helper that maps thrown errors to `CLAIMS_INCOMPLETE` (502) instead of bubbling raw.
- `findUsers` now uses the same `'-password -__v -totpSecret -backupCodes'` projection as `getUserById`, so the fallback path no longer pulls sensitive fields into memory.

## Testing

- Tested locally against Microsoft Entra (Azure AD) personal-account tenant (`https://login.microsoftonline.com/consumers/v2.0`) with `OPENID_REUSE_TOKENS=true` and `OPENID_SCOPE="openid profile email offline_access"`.
- Logged into the LC client to JIT-create a user with `provider: openid` and a stored Entra refresh token, then POSTed it to `/api/admin/oauth/refresh`. Got `200 OK` with a valid `AdminExchangeResponse` payload: a fresh HS256 LibreChat JWT, an Entra-rotated refresh token, the user object, and `expiresAt` set to ~24h from now.
- All 328 tests in `packages/api/src/auth/` pass (310 prior + 18 new for `refresh.ts`).
- `npm run build` clean, ESLint clean.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes