### PR TITLE
feat: Add OIDC group sync for Keycloak and generic OpenID providers 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -616,8 +616,9 @@ OPENID_SYNC_GROUPS_FROM_TOKEN=false
 # Examples:
 #   - Keycloak realm roles: realm_access.roles
 #   - Keycloak client roles: resource_access.librechat.roles
-#   - Auth0 groups: https://your-domain.auth0.com/groups
 #   - Generic groups: groups
+# Note: Only dot-notation paths are supported (e.g., 'path.to.claim')
+# URL-based claim paths (Auth0 custom namespaces) are not currently supported
 # Default: realm_access.roles
 OPENID_GROUPS_CLAIM_PATH=realm_access.roles
 
@@ -640,8 +641,17 @@ OPENID_GROUP_SOURCE=oidc
 #   - Exact matches: default-roles-mediawan,manage-account,view-profile,offline_access
 #   - Regex pattern: regex:^default-.*,regex:.*-account$
 #   - Mixed: default-roles-mediawan,regex:^uma_.*,offline_access
+# Security: Regex patterns are limited to 200 characters and checked for ReDoS patterns
 # Leave empty or commented to sync all groups
 # OPENID_GROUPS_EXCLUDE_PATTERN=default-roles-mediawan,manage-account,view-profile,offline_access
+
+# Maximum number of groups to sync per user (security limit to prevent DoS)
+# If a user has more groups than this limit, only the first N groups will be synced
+# Default: 100
+# OPENID_MAX_GROUPS_PER_USER=100
+
+# IMPORTANT: Do not change OPENID_GROUP_SOURCE after initial deployment
+# Changing this value will orphan existing groups and create duplicates
 
 # LDAP
 LDAP_URL=

--- a/.env.example
+++ b/.env.example
@@ -607,48 +607,28 @@ OPENID_GRAPH_SCOPES=User.Read,People.Read,GroupMember.Read.All
 # OIDC Group Synchronization (Keycloak, etc.)  #
 #===============================================#
 
-# Enable automatic group synchronization from JWT token claims
-# Works with any OIDC provider (Keycloak, Auth0, Okta, etc.)
-# Requires OPENID_REUSE_TOKENS=true to be enabled
+# Enable group sync from JWT tokens (requires OPENID_REUSE_TOKENS=true)
 OPENID_SYNC_GROUPS_FROM_TOKEN=false
 
-# Path to groups/roles claim in JWT token using dot notation
-# Examples:
-#   - Keycloak realm roles: realm_access.roles
-#   - Keycloak client roles: resource_access.librechat.roles
-#   - Generic groups: groups
-# Note: Only dot-notation paths are supported (e.g., 'path.to.claim')
-# URL-based claim paths (Auth0 custom namespaces) are not currently supported
+# Path to groups/roles claim in JWT token (dot notation only)
+# Examples: realm_access.roles (Keycloak), resource_access.librechat.roles, groups
 # Default: realm_access.roles
 OPENID_GROUPS_CLAIM_PATH=realm_access.roles
 
-# Which token to extract groups from: 'access' or 'id'
-# access = access_token (recommended for most providers)
-# id = id_token (use if groups are only in ID token)
+# Token to extract groups from: 'access' (recommended) or 'id'
 # Default: access
 OPENID_GROUPS_TOKEN_KIND=access
 
-# Source identifier for synced groups in database
-# Only 'local', 'entra', or 'oidc' are valid values due to schema constraints
-# Use 'oidc' for all OpenID Connect providers (Keycloak, Auth0, Okta, Google, etc.)
+# Source identifier: 'local', 'entra', or 'oidc'
+# Use 'oidc' for all OIDC providers (Keycloak, Auth0, Okta, etc.)
 # Default: oidc
-# IMPORTANT: Do not use provider-specific names like 'keycloak' or 'auth0' - they will cause validation errors
 OPENID_GROUP_SOURCE=oidc
 
-# Exclude specific groups/roles from being synced
-# Comma-separated list of exact role names (case-insensitive) or regex patterns (prefix with 'regex:')
-# Use this to filter out system roles, default roles, or authentication roles
-# Examples:
-#   - Exact matches: default-roles-mediawan,manage-account,view-profile,offline_access
-#   - Regex pattern: regex:^default-.*,regex:.*-account$
-#   - Mixed: default-roles-mediawan,regex:^uma_.*,offline_access
-# Security: Regex patterns are limited to 200 characters and checked for ReDoS patterns
-# Leave empty or commented to sync all groups
-# OPENID_GROUPS_EXCLUDE_PATTERN=default-roles-mediawan,manage-account,view-profile,offline_access
+# Exclude groups from sync (comma-separated exact names or 'regex:' patterns)
+# Example: default-roles-myrealm,regex:^uma_.*,offline_access
+# OPENID_GROUPS_EXCLUDE_PATTERN=default-roles-myrealm,manage-account,view-profile,offline_access
 
-# Maximum number of groups to sync per user (security limit to prevent DoS)
-# If a user has more groups than this limit, only the first N groups will be synced
-# Default: 100
+# Max groups per user (prevents DoS). Default: 100
 # OPENID_MAX_GROUPS_PER_USER=100
 
 # LDAP

--- a/.env.example
+++ b/.env.example
@@ -633,6 +633,16 @@ OPENID_GROUPS_TOKEN_KIND=access
 # Examples: keycloak, auth0, okta, google
 OPENID_GROUP_SOURCE=oidc
 
+# Exclude specific groups/roles from being synced
+# Comma-separated list of exact role names (case-insensitive) or regex patterns (prefix with 'regex:')
+# Use this to filter out system roles, default roles, or authentication roles
+# Examples:
+#   - Exact matches: default-roles-mediawan,manage-account,view-profile,offline_access
+#   - Regex pattern: regex:^default-.*,regex:.*-account$
+#   - Mixed: default-roles-mediawan,regex:^uma_.*,offline_access
+# Leave empty or commented to sync all groups
+# OPENID_GROUPS_EXCLUDE_PATTERN=default-roles-mediawan,manage-account,view-profile,offline_access
+
 # LDAP
 LDAP_URL=
 LDAP_BIND_DN=

--- a/.env.example
+++ b/.env.example
@@ -629,9 +629,10 @@ OPENID_GROUPS_CLAIM_PATH=realm_access.roles
 OPENID_GROUPS_TOKEN_KIND=access
 
 # Source identifier for synced groups in database
-# This allows distinguishing between different OIDC providers
+# Only 'local', 'entra', or 'oidc' are valid values due to schema constraints
+# Use 'oidc' for all OpenID Connect providers (Keycloak, Auth0, Okta, Google, etc.)
 # Default: oidc
-# Examples: keycloak, auth0, okta, google
+# IMPORTANT: Do not use provider-specific names like 'keycloak' or 'auth0' - they will cause validation errors
 OPENID_GROUP_SOURCE=oidc
 
 # Exclude specific groups/roles from being synced
@@ -649,9 +650,6 @@ OPENID_GROUP_SOURCE=oidc
 # If a user has more groups than this limit, only the first N groups will be synced
 # Default: 100
 # OPENID_MAX_GROUPS_PER_USER=100
-
-# IMPORTANT: Do not change OPENID_GROUP_SOURCE after initial deployment
-# Changing this value will orphan existing groups and create duplicates
 
 # LDAP
 LDAP_URL=

--- a/.env.example
+++ b/.env.example
@@ -607,7 +607,7 @@ OPENID_GRAPH_SCOPES=User.Read,People.Read,GroupMember.Read.All
 # OIDC Group Synchronization (Keycloak, etc.)  #
 #===============================================#
 
-# Enable group sync from JWT tokens (requires OPENID_REUSE_TOKENS=true)
+# Enable group sync from JWT token claims (Keycloak, Auth0, Okta, etc.)
 OPENID_SYNC_GROUPS_FROM_TOKEN=false
 
 # Path to groups/roles claim in JWT token (dot notation only)

--- a/.env.example
+++ b/.env.example
@@ -603,6 +603,36 @@ ENTRA_ID_INCLUDE_OWNERS_AS_MEMBERS=false
 # Default scopes provide access to user profiles and group memberships
 OPENID_GRAPH_SCOPES=User.Read,People.Read,GroupMember.Read.All
 
+#===============================================#
+# OIDC Group Synchronization (Keycloak, etc.)  #
+#===============================================#
+
+# Enable automatic group synchronization from JWT token claims
+# Works with any OIDC provider (Keycloak, Auth0, Okta, etc.)
+# Requires OPENID_REUSE_TOKENS=true to be enabled
+OPENID_SYNC_GROUPS_FROM_TOKEN=false
+
+# Path to groups/roles claim in JWT token using dot notation
+# Examples:
+#   - Keycloak realm roles: realm_access.roles
+#   - Keycloak client roles: resource_access.librechat.roles
+#   - Auth0 groups: https://your-domain.auth0.com/groups
+#   - Generic groups: groups
+# Default: realm_access.roles
+OPENID_GROUPS_CLAIM_PATH=realm_access.roles
+
+# Which token to extract groups from: 'access' or 'id'
+# access = access_token (recommended for most providers)
+# id = id_token (use if groups are only in ID token)
+# Default: access
+OPENID_GROUPS_TOKEN_KIND=access
+
+# Source identifier for synced groups in database
+# This allows distinguishing between different OIDC providers
+# Default: oidc
+# Examples: keycloak, auth0, okta, google
+OPENID_GROUP_SOURCE=oidc
+
 # LDAP
 LDAP_URL=
 LDAP_BIND_DN=

--- a/api/server/controllers/PermissionsController.js
+++ b/api/server/controllers/PermissionsController.js
@@ -486,6 +486,7 @@ const searchPrincipals = async (req, res) => {
       sources: {
         local: finalResults.filter((r) => r.source === 'local').length,
         entra: finalResults.filter((r) => r.source === 'entra').length,
+        oidc: finalResults.filter((r) => r.source === 'oidc').length,
       },
     });
   } catch (error) {

--- a/api/server/controllers/auth/oauth.js
+++ b/api/server/controllers/auth/oauth.js
@@ -6,7 +6,10 @@ const {
   isAdminPanelRedirect,
   generateAdminExchangeCode,
 } = require('@librechat/api');
-const { syncUserEntraGroupMemberships } = require('~/server/services/PermissionService');
+const {
+  syncUserEntraGroupMemberships,
+  syncUserOidcGroupsFromToken,
+} = require('~/server/services/PermissionService');
 const { setAuthTokens, setOpenIDAuthTokens } = require('~/server/services/AuthService');
 const getLogStores = require('~/cache/getLogStores');
 const { checkBan } = require('~/server/middleware');
@@ -61,13 +64,23 @@ function createOAuthHandler(redirectUri = domains.client) {
         return res.redirect(callbackUrl.toString());
       }
 
+      /** Sync groups from OpenID provider (independent of token reuse setting) */
+      /** Both sync functions have their own feature flag checks internally */
+      if (req.user && req.user.provider === 'openid' && req.user.tokenset) {
+        /** Sync Entra ID groups from Microsoft Graph API (if enabled via USE_ENTRA_ID_FOR_PEOPLE_SEARCH) */
+        await syncUserEntraGroupMemberships(req.user, req.user.tokenset.access_token);
+
+        /** Sync OIDC groups from JWT token claims (if enabled via OPENID_SYNC_GROUPS_FROM_TOKEN) */
+        await syncUserOidcGroupsFromToken(req.user, req.user.tokenset);
+      }
+
       /** Standard OAuth flow - set cookies and redirect */
+      /** Handle session token management (based on token reuse setting) */
       if (
         req.user &&
-        req.user.provider == 'openid' &&
+        req.user.provider === 'openid' &&
         isEnabled(process.env.OPENID_REUSE_TOKENS) === true
       ) {
-        await syncUserEntraGroupMemberships(req.user, req.user.tokenset.access_token);
         setOpenIDAuthTokens(req.user.tokenset, req, res, {
           userId: req.user._id.toString(),
           tenantId: req.user.tenantId,

--- a/api/server/controllers/auth/oauth.js
+++ b/api/server/controllers/auth/oauth.js
@@ -64,23 +64,17 @@ function createOAuthHandler(redirectUri = domains.client) {
         return res.redirect(callbackUrl.toString());
       }
 
-      /** Sync groups from OpenID provider (independent of token reuse setting) */
-      /** Both sync functions have their own feature flag checks internally */
       if (req.user && req.user.provider === 'openid' && req.user.tokenset) {
-        /** Sync Entra ID groups from Microsoft Graph API (if enabled via USE_ENTRA_ID_FOR_PEOPLE_SEARCH) */
-        await syncUserEntraGroupMemberships(req.user, req.user.tokenset.access_token);
-
-        /** Sync OIDC groups from JWT token claims (if enabled via OPENID_SYNC_GROUPS_FROM_TOKEN) */
         await syncUserOidcGroupsFromToken(req.user, req.user.tokenset);
       }
 
-      /** Standard OAuth flow - set cookies and redirect */
-      /** Handle session token management (based on token reuse setting) */
+      // Entra Graph-API sync stays coupled to OPENID_REUSE_TOKENS to preserve pre-existing behavior
       if (
         req.user &&
         req.user.provider === 'openid' &&
         isEnabled(process.env.OPENID_REUSE_TOKENS) === true
       ) {
+        await syncUserEntraGroupMemberships(req.user, req.user.tokenset.access_token);
         setOpenIDAuthTokens(req.user.tokenset, req, res, {
           userId: req.user._id.toString(),
           tenantId: req.user.tenantId,

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -682,6 +682,9 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     const groupSource = process.env.OPENID_GROUP_SOURCE || 'oidc';
     const exclusionPattern = process.env.OPENID_GROUPS_EXCLUDE_PATTERN || null;
 
+    // Tenant-scope queries when user.tenantId is set; no-op for single-tenant deployments
+    const tenantFilter = user.tenantId ? { tenantId: user.tenantId } : {};
+
     // Extract groups from token
     let groupNames = extractGroupsFromToken(tokenset, claimPath, tokenKind, exclusionPattern);
 
@@ -712,6 +715,7 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
       const sessionOptions = session ? { session } : {};
       await Group.updateMany(
         {
+          ...tenantFilter,
           source: groupSource,
           memberIds: user.idOnTheSource,
         },
@@ -737,6 +741,7 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     // Bulk optimization: Fetch all existing groups in one query
     const existingGroups = await Group.find(
       {
+        ...tenantFilter,
         idOnTheSource: { $in: groupNames },
         source: groupSource,
       },
@@ -756,6 +761,7 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
           idOnTheSource: groupName,
           source: groupSource,
           memberIds: [user.idOnTheSource],
+          ...tenantFilter,
         });
       } else if (
         !existing.memberIds.some((memberId) => String(memberId) === String(user.idOnTheSource))
@@ -785,6 +791,7 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
           try {
             await Group.updateMany(
               {
+                ...tenantFilter,
                 idOnTheSource: { $in: createdNames },
                 source: groupSource,
               },
@@ -814,7 +821,7 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     if (groupsToUpdate.length > 0) {
       try {
         await Group.updateMany(
-          { _id: { $in: groupsToUpdate } },
+          { ...tenantFilter, _id: { $in: groupsToUpdate } },
           { $addToSet: { memberIds: user.idOnTheSource } },
           sessionOptions,
         );
@@ -836,6 +843,7 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     try {
       await Group.updateMany(
         {
+          ...tenantFilter,
           source: groupSource,
           memberIds: user.idOnTheSource,
           idOnTheSource: { $nin: groupNames },

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -731,10 +731,14 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     const sessionOptions = session ? { session } : {};
 
     // Bulk optimization: Fetch all existing groups in one query
-    const existingGroups = await Group.find({
-      idOnTheSource: { $in: groupNames },
-      source: groupSource,
-    });
+    const existingGroups = await Group.find(
+      {
+        idOnTheSource: { $in: groupNames },
+        source: groupSource,
+      },
+      null,
+      sessionOptions,
+    );
 
     const existingMap = new Map(existingGroups.map(g => [g.idOnTheSource, g]));
     const groupsToCreate = [];
@@ -749,7 +753,11 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
           source: groupSource,
           memberIds: [user.idOnTheSource],
         });
-      } else if (!existing.memberIds.includes(user.idOnTheSource)) {
+      } else if (
+        !existing.memberIds.some(
+          (memberId) => String(memberId) === String(user.idOnTheSource),
+        )
+      ) {
         groupsToUpdate.push(existing._id);
       }
     }
@@ -794,15 +802,22 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     }
 
     // Remove user from groups they are no longer part of
-    await Group.updateMany(
-      {
-        source: groupSource,
-        memberIds: user.idOnTheSource,
-        idOnTheSource: { $nin: groupNames },
-      },
-      { $pull: { memberIds: user.idOnTheSource } },
-      sessionOptions,
-    );
+    try {
+      await Group.updateMany(
+        {
+          source: groupSource,
+          memberIds: user.idOnTheSource,
+          idOnTheSource: { $nin: groupNames },
+        },
+        { $pull: { memberIds: user.idOnTheSource } },
+        sessionOptions,
+      );
+    } catch (error) {
+      logger.error(
+        `[PermissionService.syncUserOidcGroupsFromToken] Error removing user from old groups:`,
+        error,
+      );
+    }
 
     logger.info(
       `[PermissionService.syncUserOidcGroupsFromToken] Successfully synced groups for user ${user.email}`,

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -666,9 +666,10 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     const claimPath = process.env.OPENID_GROUPS_CLAIM_PATH || 'realm_access.roles';
     const tokenKind = process.env.OPENID_GROUPS_TOKEN_KIND || 'access';
     const groupSource = process.env.OPENID_GROUP_SOURCE || 'oidc';
+    const exclusionPattern = process.env.OPENID_GROUPS_EXCLUDE_PATTERN || null;
 
     // Extract groups from token
-    const groupNames = extractGroupsFromToken(tokenset, claimPath, tokenKind);
+    const groupNames = extractGroupsFromToken(tokenset, claimPath, tokenKind, exclusionPattern);
 
     if (!groupNames || groupNames.length === 0) {
       logger.info(

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -679,18 +679,12 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     // Get configuration
     const claimPath = process.env.OPENID_GROUPS_CLAIM_PATH || 'realm_access.roles';
     const tokenKind = process.env.OPENID_GROUPS_TOKEN_KIND || 'access';
-    // Reject reserved sources owned by other sync paths (would corrupt their groups)
-    const RESERVED_GROUP_SOURCES = ['entra', 'local'];
-    const configuredSource = process.env.OPENID_GROUP_SOURCE;
-    let groupSource = 'oidc';
-    if (configuredSource) {
-      if (RESERVED_GROUP_SOURCES.includes(configuredSource)) {
-        logger.warn(
-          `[PermissionService.syncUserOidcGroupsFromToken] OPENID_GROUP_SOURCE='${configuredSource}' is reserved; falling back to 'oidc'`,
-        );
-      } else {
-        groupSource = configuredSource;
-      }
+    // Group.source schema enum is 'local' | 'entra' | 'oidc'; only 'oidc' is valid here
+    const groupSource = 'oidc';
+    if (process.env.OPENID_GROUP_SOURCE && process.env.OPENID_GROUP_SOURCE !== 'oidc') {
+      logger.warn(
+        `[PermissionService.syncUserOidcGroupsFromToken] OPENID_GROUP_SOURCE='${process.env.OPENID_GROUP_SOURCE}' is not allowed; falling back to 'oidc'`,
+      );
     }
     const exclusionPattern = process.env.OPENID_GROUPS_EXCLUDE_PATTERN || null;
 
@@ -786,7 +780,9 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
           ...tenantFilter,
         });
       } else if (
-        !existing.memberIds.some((memberId) => String(memberId) === String(user.idOnTheSource))
+        !(existing.memberIds || []).some(
+          (memberId) => String(memberId) === String(user.idOnTheSource),
+        )
       ) {
         groupsToUpdate.push(existing._id);
       }

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -632,9 +632,9 @@ const syncUserEntraGroupMemberships = async (user, accessToken, session = null) 
  * - Add transaction wrapping for full atomicity (currently relies on passed session)
  * - Implement bulk query optimization for large group counts (>20 groups)
  * - Add configurable group name transformation/mapping
- * - Add role filtering to exclude system/default roles
  * - Add orphaned group cleanup (groups with no members)
  * - Add manual sync trigger via admin API
+ * - Add support for URL-based claim paths (e.g., Auth0 custom namespaces)
  * 
  * @param {Object} user - User object from authentication
  * @param {string} user.idOnTheSource - User's external ID (oid or sub from token claims)
@@ -656,6 +656,12 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
       return;
     }
 
+    // Security: Validate idOnTheSource type to prevent MongoDB injection
+    if (typeof user.idOnTheSource !== 'string' || user.idOnTheSource.trim().length === 0) {
+      logger.warn('[PermissionService.syncUserOidcGroupsFromToken] Invalid idOnTheSource type or empty value');
+      return;
+    }
+
     // Validate tokenset
     if (!tokenset || typeof tokenset !== 'object') {
       logger.warn('[PermissionService.syncUserOidcGroupsFromToken] Invalid tokenset provided');
@@ -669,7 +675,21 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     const exclusionPattern = process.env.OPENID_GROUPS_EXCLUDE_PATTERN || null;
 
     // Extract groups from token
-    const groupNames = extractGroupsFromToken(tokenset, claimPath, tokenKind, exclusionPattern);
+    let groupNames = extractGroupsFromToken(tokenset, claimPath, tokenKind, exclusionPattern);
+
+    // Security: Limit maximum number of groups to prevent DoS attacks
+    const MAX_GROUPS_PER_USER = parseInt(process.env.OPENID_MAX_GROUPS_PER_USER) || 100;
+    if (groupNames.length > MAX_GROUPS_PER_USER) {
+      logger.warn(
+        `[PermissionService.syncUserOidcGroupsFromToken] User ${user.email} has ${groupNames.length} groups, limiting to ${MAX_GROUPS_PER_USER}`,
+        {
+          userId: user._id,
+          originalCount: groupNames.length,
+          limitedCount: MAX_GROUPS_PER_USER,
+        },
+      );
+      groupNames = groupNames.slice(0, MAX_GROUPS_PER_USER);
+    }
 
     if (!groupNames || groupNames.length === 0) {
       logger.info(

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -624,10 +624,10 @@ const syncUserEntraGroupMemberships = async (user, accessToken, session = null) 
 /**
  * Sync user's OIDC groups from JWT token claims to LibreChat's Group database
  * Extracts groups/roles from JWT token and syncs group memberships automatically on login
- * 
+ *
  * Supports any OpenID Connect provider (Keycloak, Auth0, Okta, etc.) by reading groups/roles
  * from configurable JWT claim paths.
- * 
+ *
  * TODO: Future improvements:
  * - Add transaction wrapping for full atomicity (currently relies on passed session)
  * - Implement bulk query optimization for large group counts (>20 groups)
@@ -635,7 +635,7 @@ const syncUserEntraGroupMemberships = async (user, accessToken, session = null) 
  * - Add orphaned group cleanup (groups with no members)
  * - Add manual sync trigger via admin API
  * - Add support for URL-based claim paths (e.g., Auth0 custom namespaces)
- * 
+ *
  * @param {Object} user - User object from authentication
  * @param {string} user.idOnTheSource - User's external ID (oid or sub from token claims)
  * @param {string} user.provider - Authentication provider ('openid')
@@ -652,7 +652,9 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
 
     // Validate user authentication
     if (!user || user.provider !== 'openid' || !user.idOnTheSource) {
-      logger.debug('[PermissionService.syncUserOidcGroupsFromToken] User not eligible for OIDC group sync');
+      logger.debug(
+        '[PermissionService.syncUserOidcGroupsFromToken] User not eligible for OIDC group sync',
+      );
       return;
     }
 
@@ -662,7 +664,9 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
       user.idOnTheSource.trim().length === 0 ||
       /[${}.]/.test(user.idOnTheSource)
     ) {
-      logger.warn('[PermissionService.syncUserOidcGroupsFromToken] Invalid idOnTheSource: contains special characters or is empty');
+      logger.warn(
+        '[PermissionService.syncUserOidcGroupsFromToken] Invalid idOnTheSource: contains special characters or is empty',
+      );
       return;
     }
 
@@ -740,7 +744,7 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
       sessionOptions,
     );
 
-    const existingMap = new Map(existingGroups.map(g => [g.idOnTheSource, g]));
+    const existingMap = new Map(existingGroups.map((g) => [g.idOnTheSource, g]));
     const groupsToCreate = [];
     const groupsToUpdate = [];
 
@@ -754,9 +758,7 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
           memberIds: [user.idOnTheSource],
         });
       } else if (
-        !existing.memberIds.some(
-          (memberId) => String(memberId) === String(user.idOnTheSource),
-        )
+        !existing.memberIds.some((memberId) => String(memberId) === String(user.idOnTheSource))
       ) {
         groupsToUpdate.push(existing._id);
       }
@@ -785,10 +787,10 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
         await Group.updateMany(
           { _id: { $in: groupsToUpdate } },
           { $addToSet: { memberIds: user.idOnTheSource } },
-          sessionOptions
+          sessionOptions,
         );
         for (const groupId of groupsToUpdate) {
-          const group = existingGroups.find(g => g._id.equals(groupId));
+          const group = existingGroups.find((g) => g._id.equals(groupId));
           logger.debug(
             `[PermissionService.syncUserOidcGroupsFromToken] Added user to group: ${group ? group.idOnTheSource : groupId}`,
           );
@@ -823,10 +825,7 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
       `[PermissionService.syncUserOidcGroupsFromToken] Successfully synced groups for user ${user.email}`,
     );
   } catch (error) {
-    logger.error(
-      `[PermissionService.syncUserOidcGroupsFromToken] Error syncing groups:`,
-      error,
-    );
+    logger.error(`[PermissionService.syncUserOidcGroupsFromToken] Error syncing groups:`, error);
   }
 };
 

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -657,8 +657,12 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     }
 
     // Security: Validate idOnTheSource type to prevent MongoDB injection
-    if (typeof user.idOnTheSource !== 'string' || user.idOnTheSource.trim().length === 0) {
-      logger.warn('[PermissionService.syncUserOidcGroupsFromToken] Invalid idOnTheSource type or empty value');
+    if (
+      typeof user.idOnTheSource !== 'string' ||
+      user.idOnTheSource.trim().length === 0 ||
+      /[${}.]/.test(user.idOnTheSource)
+    ) {
+      logger.warn('[PermissionService.syncUserOidcGroupsFromToken] Invalid idOnTheSource: contains special characters or is empty');
       return;
     }
 
@@ -678,7 +682,7 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     let groupNames = extractGroupsFromToken(tokenset, claimPath, tokenKind, exclusionPattern);
 
     // Security: Limit maximum number of groups to prevent DoS attacks
-    const MAX_GROUPS_PER_USER = parseInt(process.env.OPENID_MAX_GROUPS_PER_USER) || 100;
+    const MAX_GROUPS_PER_USER = parseInt(process.env.OPENID_MAX_GROUPS_PER_USER, 10) || 100;
     if (groupNames.length > MAX_GROUPS_PER_USER) {
       logger.warn(
         `[PermissionService.syncUserOidcGroupsFromToken] User ${user.email} has ${groupNames.length} groups, limiting to ${MAX_GROUPS_PER_USER}`,
@@ -726,56 +730,64 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
 
     const sessionOptions = session ? { session } : {};
 
-    // TODO: Performance optimization - Replace N+1 queries with bulk operations
-    // Current implementation queries each group individually (acceptable for <20 groups)
-    // Future improvement: Fetch all existing groups in single query, then bulk create/update
-    // Example:
-    //   const existingGroups = await Group.find({ idOnTheSource: { $in: groupNames }, source: groupSource });
-    //   const existingIds = new Set(existingGroups.map(g => g.idOnTheSource));
-    //   const newGroups = groupNames.filter(name => !existingIds.has(name)).map(name => ({ ... }));
-    //   await Group.insertMany(newGroups, sessionOptions);
+    // Bulk optimization: Fetch all existing groups in one query
+    const existingGroups = await Group.find({
+      idOnTheSource: { $in: groupNames },
+      source: groupSource,
+    });
 
-    // Create or update groups and add user to them
+    const existingMap = new Map(existingGroups.map(g => [g.idOnTheSource, g]));
+    const groupsToCreate = [];
+    const groupsToUpdate = [];
+
     for (const groupName of groupNames) {
-      try {
-        // Check if group exists
-        let group = await Group.findOne({
+      const existing = existingMap.get(groupName);
+      if (!existing) {
+        groupsToCreate.push({
+          name: groupName,
           idOnTheSource: groupName,
           source: groupSource,
+          memberIds: [user.idOnTheSource],
         });
+      } else if (!existing.memberIds.includes(user.idOnTheSource)) {
+        groupsToUpdate.push(existing._id);
+      }
+    }
 
-        if (!group) {
-          // Create new group
-          group = await Group.create(
-            [
-              {
-                name: groupName,
-                idOnTheSource: groupName,
-                source: groupSource,
-                memberIds: [user.idOnTheSource],
-              },
-            ],
-            sessionOptions,
-          );
+    // Bulk create new groups
+    if (groupsToCreate.length > 0) {
+      try {
+        await Group.insertMany(groupsToCreate, sessionOptions);
+        for (const group of groupsToCreate) {
           logger.info(
-            `[PermissionService.syncUserOidcGroupsFromToken] Created new group: ${groupName}`,
+            `[PermissionService.syncUserOidcGroupsFromToken] Created new group: ${group.idOnTheSource}`,
           );
-        } else {
-          // Add user to existing group if not already a member
-          if (!group.memberIds.includes(user.idOnTheSource)) {
-            await Group.updateOne(
-              { _id: group._id },
-              { $addToSet: { memberIds: user.idOnTheSource } },
-              sessionOptions,
-            );
-            logger.debug(
-              `[PermissionService.syncUserOidcGroupsFromToken] Added user to group: ${groupName}`,
-            );
-          }
         }
       } catch (error) {
         logger.error(
-          `[PermissionService.syncUserOidcGroupsFromToken] Error processing group ${groupName}:`,
+          `[PermissionService.syncUserOidcGroupsFromToken] Error creating groups:`,
+          error,
+        );
+      }
+    }
+
+    // Bulk update existing groups to add user
+    if (groupsToUpdate.length > 0) {
+      try {
+        await Group.updateMany(
+          { _id: { $in: groupsToUpdate } },
+          { $addToSet: { memberIds: user.idOnTheSource } },
+          sessionOptions
+        );
+        for (const groupId of groupsToUpdate) {
+          const group = existingGroups.find(g => g._id.equals(groupId));
+          logger.debug(
+            `[PermissionService.syncUserOidcGroupsFromToken] Added user to group: ${group ? group.idOnTheSource : groupId}`,
+          );
+        }
+      } catch (error) {
+        logger.error(
+          `[PermissionService.syncUserOidcGroupsFromToken] Error updating groups:`,
           error,
         );
       }

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -679,7 +679,19 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     // Get configuration
     const claimPath = process.env.OPENID_GROUPS_CLAIM_PATH || 'realm_access.roles';
     const tokenKind = process.env.OPENID_GROUPS_TOKEN_KIND || 'access';
-    const groupSource = process.env.OPENID_GROUP_SOURCE || 'oidc';
+    // Reject reserved sources owned by other sync paths (would corrupt their groups)
+    const RESERVED_GROUP_SOURCES = ['entra', 'local'];
+    const configuredSource = process.env.OPENID_GROUP_SOURCE;
+    let groupSource = 'oidc';
+    if (configuredSource) {
+      if (RESERVED_GROUP_SOURCES.includes(configuredSource)) {
+        logger.warn(
+          `[PermissionService.syncUserOidcGroupsFromToken] OPENID_GROUP_SOURCE='${configuredSource}' is reserved; falling back to 'oidc'`,
+        );
+      } else {
+        groupSource = configuredSource;
+      }
+    }
     const exclusionPattern = process.env.OPENID_GROUPS_EXCLUDE_PATTERN || null;
 
     // Tenant-scope queries when user.tenantId is set; no-op for single-tenant deployments
@@ -696,8 +708,10 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
       return;
     }
 
-    // Security: Limit maximum number of groups to prevent DoS attacks
-    const MAX_GROUPS_PER_USER = parseInt(process.env.OPENID_MAX_GROUPS_PER_USER, 10) || 100;
+    // Cap groups; reject non-positive values so slice(0, N) can't chop from the end
+    const parsedMaxGroups = parseInt(process.env.OPENID_MAX_GROUPS_PER_USER, 10);
+    const MAX_GROUPS_PER_USER =
+      Number.isFinite(parsedMaxGroups) && parsedMaxGroups > 0 ? parsedMaxGroups : 100;
     if (groupNames.length > MAX_GROUPS_PER_USER) {
       logger.warn(
         `[PermissionService.syncUserOidcGroupsFromToken] User ${user.email} has ${groupNames.length} groups, limiting to ${MAX_GROUPS_PER_USER}`,

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -662,7 +662,7 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     if (
       typeof user.idOnTheSource !== 'string' ||
       user.idOnTheSource.trim().length === 0 ||
-      /[${}.]/.test(user.idOnTheSource)
+      /[${}]/.test(user.idOnTheSource)
     ) {
       logger.warn(
         '[PermissionService.syncUserOidcGroupsFromToken] Invalid idOnTheSource: contains special characters or is empty',
@@ -764,20 +764,49 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
       }
     }
 
-    // Bulk create new groups
+    // ordered: false so a duplicate on one group doesn't abort the rest
     if (groupsToCreate.length > 0) {
       try {
-        await Group.insertMany(groupsToCreate, sessionOptions);
+        await Group.insertMany(groupsToCreate, { ...sessionOptions, ordered: false });
         for (const group of groupsToCreate) {
           logger.info(
             `[PermissionService.syncUserOidcGroupsFromToken] Created new group: ${group.idOnTheSource}`,
           );
         }
       } catch (error) {
-        logger.error(
-          `[PermissionService.syncUserOidcGroupsFromToken] Error creating groups:`,
-          error,
-        );
+        // Recover from concurrent-login races where another request created the group(s) first
+        const isDuplicateKey =
+          error?.code === 11000 ||
+          (Array.isArray(error?.writeErrors) &&
+            error.writeErrors.some((e) => e?.code === 11000 || e?.err?.code === 11000));
+
+        if (isDuplicateKey) {
+          const createdNames = groupsToCreate.map((g) => g.idOnTheSource);
+          try {
+            await Group.updateMany(
+              {
+                idOnTheSource: { $in: createdNames },
+                source: groupSource,
+              },
+              { $addToSet: { memberIds: user.idOnTheSource } },
+              sessionOptions,
+            );
+            logger.info(
+              `[PermissionService.syncUserOidcGroupsFromToken] Resolved duplicate-key race for user ${user.email}; ensured membership on existing groups`,
+              { groups: createdNames },
+            );
+          } catch (recoveryError) {
+            logger.error(
+              `[PermissionService.syncUserOidcGroupsFromToken] Failed to recover from duplicate-key race:`,
+              recoveryError,
+            );
+          }
+        } else {
+          logger.error(
+            `[PermissionService.syncUserOidcGroupsFromToken] Error creating groups:`,
+            error,
+          );
+        }
       }
     }
 

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -10,7 +10,9 @@ const {
   getGroupMembers,
   getGroupOwners,
 } = require('~/server/services/GraphApiService');
+const { extractGroupsFromToken } = require('~/utils/extractJwtClaims');
 const db = require('~/models');
+const { AclEntry, AccessRole, Group } = require('~/db/models');
 
 /** @type {boolean|null} */
 let transactionSupportCache = null;
@@ -620,6 +622,167 @@ const syncUserEntraGroupMemberships = async (user, accessToken, session = null) 
 };
 
 /**
+ * Sync user's OIDC groups from JWT token claims to LibreChat's Group database
+ * Extracts groups/roles from JWT token and syncs group memberships automatically on login
+ * 
+ * Supports any OpenID Connect provider (Keycloak, Auth0, Okta, etc.) by reading groups/roles
+ * from configurable JWT claim paths.
+ * 
+ * TODO: Future improvements:
+ * - Add transaction wrapping for full atomicity (currently relies on passed session)
+ * - Implement bulk query optimization for large group counts (>20 groups)
+ * - Add configurable group name transformation/mapping
+ * - Add role filtering to exclude system/default roles
+ * - Add orphaned group cleanup (groups with no members)
+ * - Add manual sync trigger via admin API
+ * 
+ * @param {Object} user - User object from authentication
+ * @param {string} user.idOnTheSource - User's external ID (oid or sub from token claims)
+ * @param {string} user.provider - Authentication provider ('openid')
+ * @param {Object} tokenset - OpenID Connect tokenset containing access_token and id_token
+ * @param {mongoose.ClientSession} [session] - Optional MongoDB session for transactions
+ * @returns {Promise<void>}
+ */
+const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
+  try {
+    // Check if feature is enabled
+    if (!isEnabled(process.env.OPENID_SYNC_GROUPS_FROM_TOKEN)) {
+      return;
+    }
+
+    // Validate user authentication
+    if (!user || user.provider !== 'openid' || !user.idOnTheSource) {
+      logger.debug('[PermissionService.syncUserOidcGroupsFromToken] User not eligible for OIDC group sync');
+      return;
+    }
+
+    // Validate tokenset
+    if (!tokenset || typeof tokenset !== 'object') {
+      logger.warn('[PermissionService.syncUserOidcGroupsFromToken] Invalid tokenset provided');
+      return;
+    }
+
+    // Get configuration
+    const claimPath = process.env.OPENID_GROUPS_CLAIM_PATH || 'realm_access.roles';
+    const tokenKind = process.env.OPENID_GROUPS_TOKEN_KIND || 'access';
+    const groupSource = process.env.OPENID_GROUP_SOURCE || 'oidc';
+
+    // Extract groups from token
+    const groupNames = extractGroupsFromToken(tokenset, claimPath, tokenKind);
+
+    if (!groupNames || groupNames.length === 0) {
+      logger.info(
+        `[PermissionService.syncUserOidcGroupsFromToken] No groups found for user ${user.email}`,
+        {
+          claimPath,
+          tokenKind,
+        },
+      );
+
+      // Remove user from all OIDC groups if they no longer have any groups
+      const sessionOptions = session ? { session } : {};
+      await Group.updateMany(
+        {
+          source: groupSource,
+          memberIds: user.idOnTheSource,
+        },
+        { $pull: { memberIds: user.idOnTheSource } },
+        sessionOptions,
+      );
+
+      return;
+    }
+
+    logger.info(
+      `[PermissionService.syncUserOidcGroupsFromToken] Syncing ${groupNames.length} groups for user ${user.email}`,
+      {
+        groups: groupNames,
+        claimPath,
+        tokenKind,
+        source: groupSource,
+      },
+    );
+
+    const sessionOptions = session ? { session } : {};
+
+    // TODO: Performance optimization - Replace N+1 queries with bulk operations
+    // Current implementation queries each group individually (acceptable for <20 groups)
+    // Future improvement: Fetch all existing groups in single query, then bulk create/update
+    // Example:
+    //   const existingGroups = await Group.find({ idOnTheSource: { $in: groupNames }, source: groupSource });
+    //   const existingIds = new Set(existingGroups.map(g => g.idOnTheSource));
+    //   const newGroups = groupNames.filter(name => !existingIds.has(name)).map(name => ({ ... }));
+    //   await Group.insertMany(newGroups, sessionOptions);
+
+    // Create or update groups and add user to them
+    for (const groupName of groupNames) {
+      try {
+        // Check if group exists
+        let group = await Group.findOne({
+          idOnTheSource: groupName,
+          source: groupSource,
+        });
+
+        if (!group) {
+          // Create new group
+          group = await Group.create(
+            [
+              {
+                name: groupName,
+                idOnTheSource: groupName,
+                source: groupSource,
+                memberIds: [user.idOnTheSource],
+              },
+            ],
+            sessionOptions,
+          );
+          logger.info(
+            `[PermissionService.syncUserOidcGroupsFromToken] Created new group: ${groupName}`,
+          );
+        } else {
+          // Add user to existing group if not already a member
+          if (!group.memberIds.includes(user.idOnTheSource)) {
+            await Group.updateOne(
+              { _id: group._id },
+              { $addToSet: { memberIds: user.idOnTheSource } },
+              sessionOptions,
+            );
+            logger.debug(
+              `[PermissionService.syncUserOidcGroupsFromToken] Added user to group: ${groupName}`,
+            );
+          }
+        }
+      } catch (error) {
+        logger.error(
+          `[PermissionService.syncUserOidcGroupsFromToken] Error processing group ${groupName}:`,
+          error,
+        );
+      }
+    }
+
+    // Remove user from groups they are no longer part of
+    await Group.updateMany(
+      {
+        source: groupSource,
+        memberIds: user.idOnTheSource,
+        idOnTheSource: { $nin: groupNames },
+      },
+      { $pull: { memberIds: user.idOnTheSource } },
+      sessionOptions,
+    );
+
+    logger.info(
+      `[PermissionService.syncUserOidcGroupsFromToken] Successfully synced groups for user ${user.email}`,
+    );
+  } catch (error) {
+    logger.error(
+      `[PermissionService.syncUserOidcGroupsFromToken] Error syncing groups:`,
+      error,
+    );
+  }
+};
+
+/**
  * Check if public has a specific permission on a resource
  * @param {Object} params - Parameters for checking public permission
  * @param {string} params.resourceType - Type of resource (e.g., 'agent')
@@ -917,5 +1080,6 @@ module.exports = {
   ensurePrincipalExists,
   ensureGroupPrincipalExists,
   syncUserEntraGroupMemberships,
+  syncUserOidcGroupsFromToken,
   removeAllPermissions,
 };

--- a/api/server/services/PermissionService.js
+++ b/api/server/services/PermissionService.js
@@ -688,6 +688,14 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
     // Extract groups from token
     let groupNames = extractGroupsFromToken(tokenset, claimPath, tokenKind, exclusionPattern);
 
+    // null = extraction failed; preserve memberships (mirrors syncUserEntraGroupMemberships)
+    if (groupNames === null) {
+      logger.warn(
+        `[PermissionService.syncUserOidcGroupsFromToken] Group extraction failed for user ${user.email}; preserving existing memberships`,
+      );
+      return;
+    }
+
     // Security: Limit maximum number of groups to prevent DoS attacks
     const MAX_GROUPS_PER_USER = parseInt(process.env.OPENID_MAX_GROUPS_PER_USER, 10) || 100;
     if (groupNames.length > MAX_GROUPS_PER_USER) {
@@ -702,9 +710,9 @@ const syncUserOidcGroupsFromToken = async (user, tokenset, session = null) => {
       groupNames = groupNames.slice(0, MAX_GROUPS_PER_USER);
     }
 
-    if (!groupNames || groupNames.length === 0) {
+    if (groupNames.length === 0) {
       logger.info(
-        `[PermissionService.syncUserOidcGroupsFromToken] No groups found for user ${user.email}`,
+        `[PermissionService.syncUserOidcGroupsFromToken] No groups in token for user ${user.email}; removing from all OIDC groups`,
         {
           claimPath,
           tokenKind,

--- a/api/server/services/PermissionService.oidc.spec.js
+++ b/api/server/services/PermissionService.oidc.spec.js
@@ -241,14 +241,14 @@ describe('syncUserOidcGroupsFromToken', () => {
       const tokenset = { access_token: 'token' };
 
       extractGroupsFromToken.mockReturnValue(['admin']);
-      
+
       const existingGroup = {
         _id: 'group-id',
         idOnTheSource: 'admin',
         name: 'admin',
         memberIds: ['other-user'],
       };
-      
+
       Group.find = jest.fn().mockResolvedValue([existingGroup]);
       Group.insertMany = jest.fn().mockResolvedValue([]);
       Group.updateMany = jest.fn().mockResolvedValue({});
@@ -273,14 +273,14 @@ describe('syncUserOidcGroupsFromToken', () => {
       const tokenset = { access_token: 'token' };
 
       extractGroupsFromToken.mockReturnValue(['admin']);
-      
+
       const existingGroup = {
         _id: 'group-id',
         idOnTheSource: 'admin',
         name: 'admin',
         memberIds: ['user-123', 'other-user'],
       };
-      
+
       Group.find = jest.fn().mockResolvedValue([existingGroup]);
       Group.insertMany = jest.fn().mockResolvedValue([]);
       Group.updateMany = jest.fn().mockResolvedValue({});
@@ -415,7 +415,7 @@ describe('syncUserOidcGroupsFromToken', () => {
       const tokenset = { access_token: 'token' };
 
       extractGroupsFromToken.mockReturnValue(['admin', 'developer', 'user']);
-      
+
       Group.find = jest.fn().mockResolvedValue([]);
       Group.insertMany = jest.fn().mockRejectedValue(new Error('Database error'));
       Group.updateMany = jest.fn().mockResolvedValue({});
@@ -450,15 +450,10 @@ describe('syncUserOidcGroupsFromToken', () => {
 
       await syncUserOidcGroupsFromToken(user, tokenset, session);
 
-      expect(Group.insertMany).toHaveBeenCalledWith(
-        expect.any(Array),
-        { session },
-      );
-      expect(Group.updateMany).toHaveBeenCalledWith(
-        expect.any(Object),
-        expect.any(Object),
-        { session },
-      );
+      expect(Group.insertMany).toHaveBeenCalledWith(expect.any(Array), { session });
+      expect(Group.updateMany).toHaveBeenCalledWith(expect.any(Object), expect.any(Object), {
+        session,
+      });
     });
   });
 
@@ -497,9 +492,7 @@ describe('syncUserOidcGroupsFromToken', () => {
         expect.any(Object),
       );
       expect(Group.insertMany).toHaveBeenCalledWith(
-        expect.not.arrayContaining([
-          expect.objectContaining({ name: 'group5' }),
-        ]),
+        expect.not.arrayContaining([expect.objectContaining({ name: 'group5' })]),
         expect.any(Object),
       );
     });
@@ -602,4 +595,3 @@ describe('syncUserOidcGroupsFromToken', () => {
     });
   });
 });
-

--- a/api/server/services/PermissionService.oidc.spec.js
+++ b/api/server/services/PermissionService.oidc.spec.js
@@ -1,0 +1,401 @@
+const { syncUserOidcGroupsFromToken } = require('./PermissionService');
+const { extractGroupsFromToken } = require('~/utils/extractJwtClaims');
+const { Group } = require('~/db/models');
+
+// Mock dependencies
+jest.mock('~/utils/extractJwtClaims');
+jest.mock('~/db/models');
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe('syncUserOidcGroupsFromToken', () => {
+  let originalEnv;
+
+  beforeAll(() => {
+    originalEnv = { ...process.env };
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset environment variables
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('Feature Flag and Validation', () => {
+    it('should return early if feature is not enabled', async () => {
+      process.env.OPENID_SYNC_GROUPS_FROM_TOKEN = 'false';
+
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(extractGroupsFromToken).not.toHaveBeenCalled();
+    });
+
+    it('should return early if user provider is not openid', async () => {
+      process.env.OPENID_SYNC_GROUPS_FROM_TOKEN = 'true';
+
+      const user = {
+        email: 'test@example.com',
+        provider: 'google',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(extractGroupsFromToken).not.toHaveBeenCalled();
+    });
+
+    it('should return early if user does not have idOnTheSource', async () => {
+      process.env.OPENID_SYNC_GROUPS_FROM_TOKEN = 'true';
+
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+      };
+      const tokenset = { access_token: 'token' };
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(extractGroupsFromToken).not.toHaveBeenCalled();
+    });
+
+    it('should return early if tokenset is invalid', async () => {
+      process.env.OPENID_SYNC_GROUPS_FROM_TOKEN = 'true';
+
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+
+      await syncUserOidcGroupsFromToken(user, null);
+
+      expect(extractGroupsFromToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Group Extraction and Sync', () => {
+    beforeEach(() => {
+      process.env.OPENID_SYNC_GROUPS_FROM_TOKEN = 'true';
+    });
+
+    it('should use default configuration values', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin', 'user']);
+      Group.findOne = jest.fn().mockResolvedValue(null);
+      Group.create = jest.fn().mockResolvedValue({});
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(extractGroupsFromToken).toHaveBeenCalledWith(
+        tokenset,
+        'realm_access.roles', // default claim path
+        'access', // default token kind
+      );
+    });
+
+    it('should use configured environment variables', async () => {
+      process.env.OPENID_GROUPS_CLAIM_PATH = 'custom.path.groups';
+      process.env.OPENID_GROUPS_TOKEN_KIND = 'id';
+      process.env.OPENID_GROUP_SOURCE = 'keycloak';
+
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { id_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['group1']);
+      Group.findOne = jest.fn().mockResolvedValue(null);
+      Group.create = jest.fn().mockResolvedValue({});
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(extractGroupsFromToken).toHaveBeenCalledWith(
+        tokenset,
+        'custom.path.groups',
+        'id',
+      );
+    });
+
+    it('should create new groups that do not exist', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin', 'developer']);
+      Group.findOne = jest.fn().mockResolvedValue(null);
+      Group.create = jest.fn().mockResolvedValue({});
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.create).toHaveBeenCalledTimes(2);
+      expect(Group.create).toHaveBeenCalledWith(
+        [
+          {
+            name: 'admin',
+            idOnTheSource: 'admin',
+            source: 'oidc',
+            memberIds: ['user-123'],
+          },
+        ],
+        {},
+      );
+      expect(Group.create).toHaveBeenCalledWith(
+        [
+          {
+            name: 'developer',
+            idOnTheSource: 'developer',
+            source: 'oidc',
+            memberIds: ['user-123'],
+          },
+        ],
+        {},
+      );
+    });
+
+    it('should add user to existing group if not already a member', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+      
+      const existingGroup = {
+        _id: 'group-id',
+        name: 'admin',
+        memberIds: ['other-user'],
+      };
+      
+      Group.findOne = jest.fn().mockResolvedValue(existingGroup);
+      Group.updateOne = jest.fn().mockResolvedValue({});
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.updateOne).toHaveBeenCalledWith(
+        { _id: 'group-id' },
+        { $addToSet: { memberIds: 'user-123' } },
+        {},
+      );
+    });
+
+    it('should not add user if already a member', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+      
+      const existingGroup = {
+        _id: 'group-id',
+        name: 'admin',
+        memberIds: ['user-123', 'other-user'],
+      };
+      
+      Group.findOne = jest.fn().mockResolvedValue(existingGroup);
+      Group.updateOne = jest.fn().mockResolvedValue({});
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.updateOne).not.toHaveBeenCalled();
+    });
+
+    it('should remove user from groups they no longer belong to', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin', 'developer']);
+      Group.findOne = jest.fn().mockResolvedValue(null);
+      Group.create = jest.fn().mockResolvedValue({});
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.updateMany).toHaveBeenCalledWith(
+        {
+          source: 'oidc',
+          memberIds: 'user-123',
+          idOnTheSource: { $nin: ['admin', 'developer'] },
+        },
+        { $pull: { memberIds: 'user-123' } },
+        {},
+      );
+    });
+
+    it('should handle empty groups list by removing user from all groups', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.updateMany).toHaveBeenCalledWith(
+        {
+          source: 'oidc',
+          memberIds: 'user-123',
+        },
+        { $pull: { memberIds: 'user-123' } },
+        {},
+      );
+      expect(Group.findOne).not.toHaveBeenCalled();
+      expect(Group.create).not.toHaveBeenCalled();
+    });
+
+    it('should use custom group source', async () => {
+      process.env.OPENID_GROUP_SOURCE = 'keycloak';
+
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+      Group.findOne = jest.fn().mockResolvedValue(null);
+      Group.create = jest.fn().mockResolvedValue({});
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.create).toHaveBeenCalledWith(
+        [
+          {
+            name: 'admin',
+            idOnTheSource: 'admin',
+            source: 'keycloak',
+            memberIds: ['user-123'],
+          },
+        ],
+        {},
+      );
+    });
+  });
+
+  describe('Error Handling', () => {
+    beforeEach(() => {
+      process.env.OPENID_SYNC_GROUPS_FROM_TOKEN = 'true';
+    });
+
+    it('should handle errors gracefully and not throw', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockImplementation(() => {
+        throw new Error('Extraction failed');
+      });
+
+      await expect(syncUserOidcGroupsFromToken(user, tokenset)).resolves.not.toThrow();
+    });
+
+    it('should continue processing other groups if one fails', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin', 'developer', 'user']);
+      
+      Group.findOne = jest.fn()
+        .mockResolvedValueOnce(null) // admin - will create
+        .mockRejectedValueOnce(new Error('Database error')) // developer - will fail
+        .mockResolvedValueOnce(null); // user - will create
+      
+      Group.create = jest.fn().mockResolvedValue({});
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      // Should have attempted to create admin and user, but not developer
+      expect(Group.create).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Session Support', () => {
+    beforeEach(() => {
+      process.env.OPENID_SYNC_GROUPS_FROM_TOKEN = 'true';
+    });
+
+    it('should pass session to database operations when provided', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+      const session = { id: 'session-123' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+      Group.findOne = jest.fn().mockResolvedValue(null);
+      Group.create = jest.fn().mockResolvedValue({});
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset, session);
+
+      expect(Group.create).toHaveBeenCalledWith(
+        expect.any(Array),
+        { session },
+      );
+      expect(Group.updateMany).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        { session },
+      );
+    });
+  });
+});
+

--- a/api/server/services/PermissionService.oidc.spec.js
+++ b/api/server/services/PermissionService.oidc.spec.js
@@ -685,4 +685,108 @@ describe('syncUserOidcGroupsFromToken', () => {
       expect(Group.insertMany).toHaveBeenCalled();
     });
   });
+
+  describe('Multi-tenant scoping', () => {
+    beforeEach(() => {
+      process.env.OPENID_SYNC_GROUPS_FROM_TOKEN = 'true';
+    });
+
+    it('should scope find/update/insert to user.tenantId when present', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+        tenantId: 'tenant-a',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.find).toHaveBeenCalledWith(
+        {
+          tenantId: 'tenant-a',
+          idOnTheSource: { $in: ['admin'] },
+          source: 'oidc',
+        },
+        null,
+        {},
+      );
+      expect(Group.insertMany).toHaveBeenCalledWith(
+        [
+          {
+            name: 'admin',
+            idOnTheSource: 'admin',
+            source: 'oidc',
+            memberIds: ['user-123'],
+            tenantId: 'tenant-a',
+          },
+        ],
+        { ordered: false },
+      );
+      // Cleanup updateMany also tenant-scoped
+      expect(Group.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'tenant-a' }),
+        { $pull: { memberIds: 'user-123' } },
+        {},
+      );
+    });
+
+    it('should omit tenantId entirely when user has none (single-tenant deployments)', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      const findFilter = Group.find.mock.calls[0][0];
+      expect(findFilter).not.toHaveProperty('tenantId');
+
+      const insertedDoc = Group.insertMany.mock.calls[0][0][0];
+      expect(insertedDoc).not.toHaveProperty('tenantId');
+    });
+
+    it('should scope duplicate-key recovery query to tenantId', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+        tenantId: 'tenant-b',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+      Group.find = jest.fn().mockResolvedValue([]);
+
+      const dupErr = new Error('E11000 duplicate key error');
+      dupErr.code = 11000;
+      Group.insertMany = jest.fn().mockRejectedValue(dupErr);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.updateMany).toHaveBeenNthCalledWith(
+        1,
+        {
+          tenantId: 'tenant-b',
+          idOnTheSource: { $in: ['admin'] },
+          source: 'oidc',
+        },
+        { $addToSet: { memberIds: 'user-123' } },
+        {},
+      );
+    });
+  });
 });

--- a/api/server/services/PermissionService.oidc.spec.js
+++ b/api/server/services/PermissionService.oidc.spec.js
@@ -228,7 +228,7 @@ describe('syncUserOidcGroupsFromToken', () => {
             memberIds: ['user-123'],
           },
         ],
-        {},
+        { ordered: false },
       );
     });
 
@@ -381,7 +381,7 @@ describe('syncUserOidcGroupsFromToken', () => {
             memberIds: ['user-123'],
           },
         ],
-        {},
+        { ordered: false },
       );
     });
   });
@@ -427,6 +427,61 @@ describe('syncUserOidcGroupsFromToken', () => {
       // Should still call cleanup updateMany despite insertMany error
       expect(Group.updateMany).toHaveBeenCalledTimes(1);
     });
+
+    it('should recover from duplicate-key race by adding membership to existing groups', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin', 'developer']);
+      Group.find = jest.fn().mockResolvedValue([]); // appeared empty at read time
+
+      const dupErr = new Error('E11000 duplicate key error');
+      dupErr.code = 11000;
+      Group.insertMany = jest.fn().mockRejectedValue(dupErr);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      // First updateMany call: recovery $addToSet on the racing groups
+      expect(Group.updateMany).toHaveBeenNthCalledWith(
+        1,
+        { idOnTheSource: { $in: ['admin', 'developer'] }, source: 'oidc' },
+        { $addToSet: { memberIds: 'user-123' } },
+        {},
+      );
+      // Second updateMany call: regular cleanup (remove from old groups) still runs
+      expect(Group.updateMany).toHaveBeenCalledTimes(2);
+    });
+
+    it('should detect duplicate-key inside writeErrors (BulkWriteError shape)', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+      Group.find = jest.fn().mockResolvedValue([]);
+
+      const bulkErr = new Error('BulkWriteError');
+      bulkErr.writeErrors = [{ code: 11000, err: { code: 11000 } }];
+      Group.insertMany = jest.fn().mockRejectedValue(bulkErr);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.updateMany).toHaveBeenNthCalledWith(
+        1,
+        { idOnTheSource: { $in: ['admin'] }, source: 'oidc' },
+        { $addToSet: { memberIds: 'user-123' } },
+        {},
+      );
+    });
   });
 
   describe('Session Support', () => {
@@ -450,7 +505,10 @@ describe('syncUserOidcGroupsFromToken', () => {
 
       await syncUserOidcGroupsFromToken(user, tokenset, session);
 
-      expect(Group.insertMany).toHaveBeenCalledWith(expect.any(Array), { session });
+      expect(Group.insertMany).toHaveBeenCalledWith(expect.any(Array), {
+        session,
+        ordered: false,
+      });
       expect(Group.updateMany).toHaveBeenCalledWith(expect.any(Object), expect.any(Object), {
         session,
       });
@@ -578,20 +636,53 @@ describe('syncUserOidcGroupsFromToken', () => {
       expect(Group.find).not.toHaveBeenCalled();
     });
 
-    it('should reject idOnTheSource with dots', async () => {
+    it('should accept idOnTheSource containing dots (e.g. email-like sub)', async () => {
       const user = {
         email: 'test@example.com',
         provider: 'openid',
-        idOnTheSource: 'user.admin',
+        idOnTheSource: 'alice.smith@example.com',
       };
       const tokenset = { access_token: 'token' };
 
       extractGroupsFromToken.mockReturnValue(['admin']);
-      Group.find = jest.fn();
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
 
       await syncUserOidcGroupsFromToken(user, tokenset);
 
-      expect(Group.find).not.toHaveBeenCalled();
+      // Validation should pass and sync should proceed
+      expect(Group.find).toHaveBeenCalled();
+      expect(Group.insertMany).toHaveBeenCalledWith(
+        [
+          {
+            name: 'admin',
+            idOnTheSource: 'admin',
+            source: 'oidc',
+            memberIds: ['alice.smith@example.com'],
+          },
+        ],
+        { ordered: false },
+      );
+    });
+
+    it('should accept idOnTheSource containing dots (e.g. URI-style sub)', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'https://login.example.com/users/123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.find).toHaveBeenCalled();
+      expect(Group.insertMany).toHaveBeenCalled();
     });
   });
 });

--- a/api/server/services/PermissionService.oidc.spec.js
+++ b/api/server/services/PermissionService.oidc.spec.js
@@ -264,6 +264,37 @@ describe('syncUserOidcGroupsFromToken', () => {
       expect(Group.insertMany).not.toHaveBeenCalled();
     });
 
+    it('should add user to existing group whose memberIds field is undefined', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+
+      // memberIds is optional in the schema; absent field must not throw
+      const existingGroup = {
+        _id: 'group-id',
+        idOnTheSource: 'admin',
+        name: 'admin',
+      };
+
+      Group.find = jest.fn().mockResolvedValue([existingGroup]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await expect(syncUserOidcGroupsFromToken(user, tokenset)).resolves.not.toThrow();
+
+      expect(Group.updateMany).toHaveBeenCalledWith(
+        { _id: { $in: ['group-id'] } },
+        { $addToSet: { memberIds: 'user-123' } },
+        {},
+      );
+      expect(Group.insertMany).not.toHaveBeenCalled();
+    });
+
     it('should not add user if already a member', async () => {
       const user = {
         email: 'test@example.com',
@@ -749,7 +780,9 @@ describe('syncUserOidcGroupsFromToken', () => {
       );
     });
 
-    it('should accept non-reserved custom values for OPENID_GROUP_SOURCE', async () => {
+    it("should fall back to 'oidc' for non-enum OPENID_GROUP_SOURCE values (e.g. 'keycloak')", async () => {
+      // Group.source schema enum is local|entra|oidc; non-enum values would
+      // pass our guard and then fail Mongoose validation, silently skipping sync.
       process.env.OPENID_GROUP_SOURCE = 'keycloak';
 
       const user = {
@@ -767,7 +800,7 @@ describe('syncUserOidcGroupsFromToken', () => {
       await syncUserOidcGroupsFromToken(user, tokenset);
 
       expect(Group.insertMany).toHaveBeenCalledWith(
-        expect.arrayContaining([expect.objectContaining({ source: 'keycloak' })]),
+        expect.arrayContaining([expect.objectContaining({ source: 'oidc' })]),
         { ordered: false },
       );
     });

--- a/api/server/services/PermissionService.oidc.spec.js
+++ b/api/server/services/PermissionService.oidc.spec.js
@@ -355,6 +355,58 @@ describe('syncUserOidcGroupsFromToken', () => {
       expect(Group.insertMany).not.toHaveBeenCalled();
     });
 
+    it('should preserve existing memberships when extractGroupsFromToken returns null (extraction failure)', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(null);
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.find).not.toHaveBeenCalled();
+      expect(Group.insertMany).not.toHaveBeenCalled();
+      expect(Group.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('should distinguish null (failure) from [] (legitimate empty)', async () => {
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      // null = extraction failure -> no destructive ops
+      extractGroupsFromToken.mockReturnValue(null);
+      await syncUserOidcGroupsFromToken(user, tokenset);
+      expect(Group.updateMany).not.toHaveBeenCalled();
+
+      jest.clearAllMocks();
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      // [] = legitimately empty -> purge memberships
+      extractGroupsFromToken.mockReturnValue([]);
+      await syncUserOidcGroupsFromToken(user, tokenset);
+      expect(Group.updateMany).toHaveBeenCalledWith(
+        { source: 'oidc', memberIds: 'user-123' },
+        { $pull: { memberIds: 'user-123' } },
+        {},
+      );
+    });
+
     it('should use custom group source', async () => {
       process.env.OPENID_GROUP_SOURCE = 'oidc';
 

--- a/api/server/services/PermissionService.oidc.spec.js
+++ b/api/server/services/PermissionService.oidc.spec.js
@@ -630,6 +630,148 @@ describe('syncUserOidcGroupsFromToken', () => {
       expect(insertCall.length).toBe(100);
     });
 
+    it('should fall back to default limit when OPENID_MAX_GROUPS_PER_USER is negative', async () => {
+      process.env.OPENID_MAX_GROUPS_PER_USER = '-5';
+
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      const manyGroups = Array.from({ length: 150 }, (_, i) => `group${i}`);
+      extractGroupsFromToken.mockReturnValue(manyGroups);
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      const insertCall = Group.insertMany.mock.calls[0][0];
+      expect(insertCall.length).toBe(100);
+    });
+
+    it('should fall back to default limit when OPENID_MAX_GROUPS_PER_USER is zero', async () => {
+      process.env.OPENID_MAX_GROUPS_PER_USER = '0';
+
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      const manyGroups = Array.from({ length: 150 }, (_, i) => `group${i}`);
+      extractGroupsFromToken.mockReturnValue(manyGroups);
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      const insertCall = Group.insertMany.mock.calls[0][0];
+      expect(insertCall.length).toBe(100);
+    });
+
+    it('should fall back to default limit when OPENID_MAX_GROUPS_PER_USER is non-numeric', async () => {
+      process.env.OPENID_MAX_GROUPS_PER_USER = 'abc';
+
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      const manyGroups = Array.from({ length: 150 }, (_, i) => `group${i}`);
+      extractGroupsFromToken.mockReturnValue(manyGroups);
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      const insertCall = Group.insertMany.mock.calls[0][0];
+      expect(insertCall.length).toBe(100);
+    });
+
+    it("should reject reserved 'entra' value for OPENID_GROUP_SOURCE and fall back to 'oidc'", async () => {
+      process.env.OPENID_GROUP_SOURCE = 'entra';
+
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.insertMany).toHaveBeenCalledWith(
+        [
+          {
+            name: 'admin',
+            idOnTheSource: 'admin',
+            source: 'oidc',
+            memberIds: ['user-123'],
+          },
+        ],
+        { ordered: false },
+      );
+    });
+
+    it("should reject reserved 'local' value for OPENID_GROUP_SOURCE and fall back to 'oidc'", async () => {
+      process.env.OPENID_GROUP_SOURCE = 'local';
+
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.insertMany).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ source: 'oidc' })]),
+        { ordered: false },
+      );
+    });
+
+    it('should accept non-reserved custom values for OPENID_GROUP_SOURCE', async () => {
+      process.env.OPENID_GROUP_SOURCE = 'keycloak';
+
+      const user = {
+        email: 'test@example.com',
+        provider: 'openid',
+        idOnTheSource: 'user-123',
+      };
+      const tokenset = { access_token: 'token' };
+
+      extractGroupsFromToken.mockReturnValue(['admin']);
+      Group.find = jest.fn().mockResolvedValue([]);
+      Group.insertMany = jest.fn().mockResolvedValue([]);
+      Group.updateMany = jest.fn().mockResolvedValue({});
+
+      await syncUserOidcGroupsFromToken(user, tokenset);
+
+      expect(Group.insertMany).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ source: 'keycloak' })]),
+        { ordered: false },
+      );
+    });
+
     it('should pass exclusion pattern to extractGroupsFromToken', async () => {
       process.env.OPENID_GROUPS_EXCLUDE_PATTERN = 'system-role,regex:^test-.*';
 

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -461,7 +461,7 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
     email: email,
     openidId: claims.sub || userinfo.sub,
     openidIssuer,
-    idOnTheSource: claims.oid || userinfo.oid,
+    idOnTheSource: claims.oid || claims.sub, // Use sub as fallback for non-Microsoft OIDC providers
     strategyName: 'openidStrategy',
   });
   let user = result.user;
@@ -565,8 +565,12 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
       email: email || '',
       emailVerified: userinfo.email_verified || false,
       name: fullName,
+<<<<<<< HEAD
       idOnTheSource: userinfo.oid,
       openidIssuer,
+=======
+      idOnTheSource: userinfo.oid || userinfo.sub, // Use sub as fallback for non-Microsoft OIDC providers
+>>>>>>> b91703fe7 (feat: Add OIDC group sync for Keycloak and generic OpenID providers)
     };
 
     const balanceConfig = getBalanceConfig(appConfig);
@@ -579,7 +583,7 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
     }
     user.username = username;
     user.name = fullName;
-    user.idOnTheSource = userinfo.oid;
+    user.idOnTheSource = userinfo.oid || userinfo.sub; // Use sub as fallback for non-Microsoft OIDC providers
     if (email && email !== user.email) {
       user.email = email;
       user.emailVerified = userinfo.email_verified || false;

--- a/api/strategies/openidStrategy.js
+++ b/api/strategies/openidStrategy.js
@@ -565,12 +565,8 @@ async function processOpenIDAuth(tokenset, existingUsersOnly = false) {
       email: email || '',
       emailVerified: userinfo.email_verified || false,
       name: fullName,
-<<<<<<< HEAD
-      idOnTheSource: userinfo.oid,
-      openidIssuer,
-=======
       idOnTheSource: userinfo.oid || userinfo.sub, // Use sub as fallback for non-Microsoft OIDC providers
->>>>>>> b91703fe7 (feat: Add OIDC group sync for Keycloak and generic OpenID providers)
+      openidIssuer,
     };
 
     const balanceConfig = getBalanceConfig(appConfig);

--- a/api/strategies/openidStrategy.spec.js
+++ b/api/strategies/openidStrategy.spec.js
@@ -1915,4 +1915,69 @@ describe('setupOpenId', () => {
       expect(details).toEqual({ message: 'Email domain not allowed' });
     });
   });
+
+  describe('idOnTheSource fallback for non-Microsoft OIDC providers', () => {
+    it('should use oid claim for idOnTheSource when available (Microsoft)', async () => {
+      const userinfoWithOid = {
+        ...tokenset.claims(),
+        oid: 'microsoft-object-id-12345',
+      };
+
+      const { user } = await validate({ ...tokenset, claims: () => userinfoWithOid });
+
+      expect(createUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idOnTheSource: 'microsoft-object-id-12345',
+        }),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('should fallback to sub claim for idOnTheSource when oid is missing (non-Microsoft)', async () => {
+      const userinfoWithoutOid = { ...tokenset.claims() };
+      delete userinfoWithoutOid.oid;
+
+      const { user } = await validate({ ...tokenset, claims: () => userinfoWithoutOid });
+
+      expect(createUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idOnTheSource: userinfoWithoutOid.sub,
+        }),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('should update existing user with idOnTheSource using oid || sub fallback', async () => {
+      const existingUser = {
+        _id: 'existingUserId',
+        provider: 'openid',
+        email: tokenset.claims().email,
+        openidId: tokenset.claims().sub,
+        username: 'existinguser',
+        name: 'Existing User',
+      };
+      findUser.mockImplementation(async (query) => {
+        if (query.openidId === tokenset.claims().sub || query.email === tokenset.claims().email) {
+          return existingUser;
+        }
+        return null;
+      });
+
+      const userinfoWithoutOid = { ...tokenset.claims() };
+      delete userinfoWithoutOid.oid;
+
+      await validate({ ...tokenset, claims: () => userinfoWithoutOid });
+
+      expect(updateUser).toHaveBeenCalledWith(
+        existingUser._id,
+        expect.objectContaining({
+          idOnTheSource: userinfoWithoutOid.sub,
+        }),
+      );
+    });
+  });
 });

--- a/api/utils/extractJwtClaims.js
+++ b/api/utils/extractJwtClaims.js
@@ -130,8 +130,8 @@ function shouldExcludeGroup(groupName, exclusionPattern) {
           continue;
         }
         
-        // Security: Detect potentially dangerous regex patterns
-        const dangerousPatterns = /(\+\*|\*\+|\{\d+,\}|\(\?[^:)])/;
+        // Security: Detect potentially dangerous regex patterns (nested quantifiers, catastrophic backtracking)
+        const dangerousPatterns = /(\*\*|\+\+|\*\+|\+\*)|((\(.*\)){2,}[\*\+])|(\[[^\]]{100,}\])/;
         if (dangerousPatterns.test(regexStr)) {
           logger.warn(`[shouldExcludeGroup] Potentially dangerous regex pattern detected, skipping: ${pattern}`);
           continue;
@@ -199,7 +199,7 @@ function extractGroupsFromToken(tokenset, claimPath, tokenKind = 'access', exclu
     // Remove duplicates
     const uniqueGroups = [...new Set(filteredGroups)];
 
-    const excludedCount = sanitizedGroups.length - uniqueGroups.length;
+    const excludedCount = sanitizedGroups.length - filteredGroups.length;
     if (excludedCount > 0) {
       logger.info(
         `[extractGroupsFromToken] Excluded ${excludedCount} groups based on exclusion pattern`,

--- a/api/utils/extractJwtClaims.js
+++ b/api/utils/extractJwtClaims.js
@@ -1,0 +1,160 @@
+const jwtDecode = require('jsonwebtoken/decode');
+const { logger } = require('@librechat/data-schemas');
+
+/**
+ * JWT Claim Extraction Utilities for OIDC Group Synchronization
+ * 
+ * Provides safe extraction and sanitization of groups/roles from JWT tokens
+ * for various OpenID Connect providers (Keycloak, Auth0, Okta, etc.)
+ * 
+ * TODO: Future enhancements:
+ * - Add claim path validation against OIDC provider metadata
+ * - Add caching for frequently accessed claims
+ * - Add support for nested array claims (e.g., groups[*].name)
+ * - Add claim transformation functions (e.g., uppercase, prefix removal)
+ */
+
+/**
+ * Extracts a claim value from a JWT token using dot-notation path
+ * @param {string} token - The JWT token to decode
+ * @param {string} claimPath - Dot-notation path to the claim (e.g., 'realm_access.roles')
+ * @returns {Array<string>|null} Array of claim values, or null if not found
+ */
+function extractClaimFromToken(token, claimPath) {
+  try {
+    if (!token || typeof token !== 'string') {
+      logger.warn('[extractClaimFromToken] Invalid token provided');
+      return null;
+    }
+
+    if (!claimPath || typeof claimPath !== 'string') {
+      logger.warn('[extractClaimFromToken] Invalid claim path provided');
+      return null;
+    }
+
+    const decoded = jwtDecode(token);
+    
+    if (!decoded || typeof decoded !== 'object') {
+      logger.warn('[extractClaimFromToken] Failed to decode token');
+      return null;
+    }
+
+    // Navigate the claim path
+    const pathParts = claimPath.split('.');
+    let value = decoded;
+    
+    for (const part of pathParts) {
+      if (value === null || value === undefined || typeof value !== 'object') {
+        logger.debug(`[extractClaimFromToken] Claim path '${claimPath}' not found in token`);
+        return null;
+      }
+      value = value[part];
+    }
+
+    // Ensure we return an array
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (Array.isArray(value)) {
+      return value.filter(item => typeof item === 'string' && item.trim().length > 0);
+    }
+
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return [value];
+    }
+
+    logger.warn(`[extractClaimFromToken] Claim at path '${claimPath}' is not a string or array: ${typeof value}`);
+    return null;
+  } catch (error) {
+    logger.error('[extractClaimFromToken] Error extracting claim from token:', error);
+    return null;
+  }
+}
+
+/**
+ * Sanitizes a group name to ensure it's safe for database storage
+ * Removes or replaces characters that could cause issues in MongoDB
+ * @param {string} groupName - The raw group name from JWT
+ * @returns {string} Sanitized group name
+ */
+function sanitizeGroupName(groupName) {
+  if (!groupName || typeof groupName !== 'string') {
+    return '';
+  }
+
+  // Remove leading/trailing whitespace
+  let sanitized = groupName.trim();
+
+  // Remove leading slashes from hierarchical group names (e.g., /admin/users -> admin/users)
+  sanitized = sanitized.replace(/^\/+/, '');
+
+  // Replace remaining slashes with hyphens for flat structure
+  sanitized = sanitized.replace(/\//g, '-');
+
+  // Remove MongoDB operators and special characters
+  sanitized = sanitized.replace(/[${}]/g, '');
+
+  // Limit length (MongoDB field size limits)
+  if (sanitized.length > 100) {
+    sanitized = sanitized.substring(0, 100);
+    logger.warn(`[sanitizeGroupName] Group name truncated to 100 characters: ${groupName}`);
+  }
+
+  return sanitized;
+}
+
+/**
+ * Extracts groups from JWT token for OIDC group synchronization
+ * @param {Object} tokenset - OpenID token set containing access_token and id_token
+ * @param {string} claimPath - Dot-notation path to groups/roles claim
+ * @param {string} tokenKind - Which token to extract from ('access' or 'id')
+ * @returns {Array<string>} Array of sanitized group names
+ */
+function extractGroupsFromToken(tokenset, claimPath, tokenKind = 'access') {
+  try {
+    if (!tokenset || typeof tokenset !== 'object') {
+      logger.warn('[extractGroupsFromToken] Invalid tokenset provided');
+      return [];
+    }
+
+    const token = tokenKind === 'id' ? tokenset.id_token : tokenset.access_token;
+
+    if (!token) {
+      logger.warn(`[extractGroupsFromToken] ${tokenKind} token not found in tokenset`);
+      return [];
+    }
+
+    const claimValues = extractClaimFromToken(token, claimPath);
+
+    if (!claimValues || claimValues.length === 0) {
+      logger.debug(`[extractGroupsFromToken] No groups found in ${tokenKind} token at path: ${claimPath}`);
+      return [];
+    }
+
+    // Sanitize all group names
+    const sanitizedGroups = claimValues
+      .map(sanitizeGroupName)
+      .filter(name => name.length > 0);
+
+    // Remove duplicates
+    const uniqueGroups = [...new Set(sanitizedGroups)];
+
+    logger.info(
+      `[extractGroupsFromToken] Extracted ${uniqueGroups.length} unique groups from ${tokenKind} token`,
+      { groups: uniqueGroups },
+    );
+
+    return uniqueGroups;
+  } catch (error) {
+    logger.error('[extractGroupsFromToken] Error extracting groups from token:', error);
+    return [];
+  }
+}
+
+module.exports = {
+  extractClaimFromToken,
+  sanitizeGroupName,
+  extractGroupsFromToken,
+};
+

--- a/api/utils/extractJwtClaims.js
+++ b/api/utils/extractJwtClaims.js
@@ -15,7 +15,32 @@ const { logger } = require('@librechat/data-schemas');
  */
 
 /**
- * Extracts a claim value from a JWT token using dot-notation path
+ * Splits a claim path on unescaped '.'; '\.' is treated as a literal dot so
+ * namespaced OIDC claim keys (e.g. Auth0 'https://app\.example\.com/roles') resolve.
+ * @param {string} claimPath
+ * @returns {string[]}
+ */
+function splitClaimPath(claimPath) {
+  const parts = [];
+  let current = '';
+  for (let i = 0; i < claimPath.length; i++) {
+    if (claimPath[i] === '\\' && claimPath[i + 1] === '.') {
+      current += '.';
+      i += 1;
+    } else if (claimPath[i] === '.') {
+      parts.push(current);
+      current = '';
+    } else {
+      current += claimPath[i];
+    }
+  }
+  parts.push(current);
+  return parts;
+}
+
+/**
+ * Extracts a claim value from a JWT token using dot-notation path.
+ * Use '\.' to embed a literal dot in a single segment (e.g. namespaced claims).
  * @param {string} token - The JWT token to decode
  * @param {string} claimPath - Dot-notation path to the claim (e.g., 'realm_access.roles')
  * @returns {Array<string>|null} Array of claim values, or null if not found
@@ -39,8 +64,7 @@ function extractClaimFromToken(token, claimPath) {
       return null;
     }
 
-    // Navigate the claim path
-    const pathParts = claimPath.split('.');
+    const pathParts = splitClaimPath(claimPath);
     let value = decoded;
 
     for (const part of pathParts) {
@@ -75,29 +99,19 @@ function extractClaimFromToken(token, claimPath) {
 }
 
 /**
- * Sanitizes a group name to ensure it's safe for database storage
- * Removes or replaces characters that could cause issues in MongoDB
+ * Strips MongoDB operator characters and length-limits a group identifier.
+ * Slashes/dots are preserved so distinct upstream groups (e.g. '/team-a' vs
+ * 'team-a') don't collapse to the same idOnTheSource.
  * @param {string} groupName - The raw group name from JWT
- * @returns {string} Sanitized group name
+ * @returns {string}
  */
 function sanitizeGroupName(groupName) {
   if (!groupName || typeof groupName !== 'string') {
     return '';
   }
 
-  // Remove leading/trailing whitespace
-  let sanitized = groupName.trim();
+  let sanitized = groupName.trim().replace(/[${}]/g, '');
 
-  // Remove leading slashes from hierarchical group names (e.g., /admin/users -> admin/users)
-  sanitized = sanitized.replace(/^\/+/, '');
-
-  // Replace remaining slashes with hyphens for flat structure
-  sanitized = sanitized.replace(/\//g, '-');
-
-  // Remove MongoDB operators and special characters
-  sanitized = sanitized.replace(/[${}]/g, '');
-
-  // Limit length (MongoDB field size limits)
   if (sanitized.length > 100) {
     sanitized = sanitized.substring(0, 100);
     logger.warn(`[sanitizeGroupName] Group name truncated to 100 characters: ${groupName}`);

--- a/api/utils/extractJwtClaims.js
+++ b/api/utils/extractJwtClaims.js
@@ -169,12 +169,22 @@ function shouldExcludeGroup(groupName, exclusionPattern) {
 }
 
 /**
- * Extracts groups from JWT token for OIDC group synchronization
+ * Extracts groups from JWT token for OIDC group synchronization.
+ *
+ * Return values:
+ *   null      - extraction failed (invalid tokenset, missing/undecodable token,
+ *               wrong claim path, unexpected exception). Callers should treat
+ *               this as "cannot determine memberships" and avoid destructive
+ *               operations like purging existing memberships.
+ *   []        - extraction succeeded but the token contains no groups (user
+ *               legitimately has no roles assigned). Callers may purge.
+ *   string[]  - groups successfully extracted.
+ *
  * @param {Object} tokenset - OpenID token set containing access_token and id_token
  * @param {string} claimPath - Dot-notation path to groups/roles claim
  * @param {string} tokenKind - Which token to extract from ('access' or 'id')
  * @param {string|null} exclusionPattern - Optional exclusion pattern for filtering groups
- * @returns {Array<string>} Array of sanitized group names
+ * @returns {Array<string>|null} Sanitized group names, or null on extraction failure
  */
 function extractGroupsFromToken(
   tokenset,
@@ -185,34 +195,40 @@ function extractGroupsFromToken(
   try {
     if (!tokenset || typeof tokenset !== 'object') {
       logger.warn('[extractGroupsFromToken] Invalid tokenset provided');
-      return [];
+      return null;
     }
 
     const token = tokenKind === 'id' ? tokenset.id_token : tokenset.access_token;
 
     if (!token) {
       logger.warn(`[extractGroupsFromToken] ${tokenKind} token not found in tokenset`);
-      return [];
+      return null;
     }
 
     const claimValues = extractClaimFromToken(token, claimPath);
 
-    if (!claimValues || claimValues.length === 0) {
+    // null -> token couldn't be decoded or claim path didn't resolve -> failure
+    if (claimValues === null) {
+      logger.warn(
+        `[extractGroupsFromToken] Could not resolve claim '${claimPath}' in ${tokenKind} token`,
+      );
+      return null;
+    }
+
+    // [] -> claim resolved but no values -> user legitimately has no groups
+    if (claimValues.length === 0) {
       logger.debug(
         `[extractGroupsFromToken] No groups found in ${tokenKind} token at path: ${claimPath}`,
       );
       return [];
     }
 
-    // Sanitize all group names
     const sanitizedGroups = claimValues.map(sanitizeGroupName).filter((name) => name.length > 0);
 
-    // Apply exclusion filter
     const filteredGroups = exclusionPattern
       ? sanitizedGroups.filter((g) => !shouldExcludeGroup(g, exclusionPattern))
       : sanitizedGroups;
 
-    // Remove duplicates
     const uniqueGroups = [...new Set(filteredGroups)];
 
     const excludedCount = sanitizedGroups.length - filteredGroups.length;
@@ -231,7 +247,7 @@ function extractGroupsFromToken(
     return uniqueGroups;
   } catch (error) {
     logger.error('[extractGroupsFromToken] Error extracting groups from token:', error);
-    return [];
+    return null;
   }
 }
 

--- a/api/utils/extractJwtClaims.spec.js
+++ b/api/utils/extractJwtClaims.spec.js
@@ -1,0 +1,338 @@
+const jwtDecode = require('jsonwebtoken/decode');
+const {
+  extractClaimFromToken,
+  sanitizeGroupName,
+  extractGroupsFromToken,
+} = require('./extractJwtClaims');
+
+// Mock jsonwebtoken/decode
+jest.mock('jsonwebtoken/decode');
+
+describe('extractClaimFromToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should extract a simple claim from token', () => {
+    const token = 'dummy.jwt.token';
+    jwtDecode.mockReturnValue({
+      sub: 'user-123',
+      email: 'user@example.com',
+    });
+
+    const result = extractClaimFromToken(token, 'email');
+    expect(result).toEqual(['user@example.com']);
+  });
+
+  it('should extract nested claim using dot notation', () => {
+    const token = 'dummy.jwt.token';
+    jwtDecode.mockReturnValue({
+      realm_access: {
+        roles: ['admin', 'user', 'developer'],
+      },
+    });
+
+    const result = extractClaimFromToken(token, 'realm_access.roles');
+    expect(result).toEqual(['admin', 'user', 'developer']);
+  });
+
+  it('should extract deeply nested claim', () => {
+    const token = 'dummy.jwt.token';
+    jwtDecode.mockReturnValue({
+      resource_access: {
+        librechat: {
+          roles: ['admin', 'moderator'],
+        },
+      },
+    });
+
+    const result = extractClaimFromToken(token, 'resource_access.librechat.roles');
+    expect(result).toEqual(['admin', 'moderator']);
+  });
+
+  it('should return null for non-existent claim', () => {
+    const token = 'dummy.jwt.token';
+    jwtDecode.mockReturnValue({
+      sub: 'user-123',
+    });
+
+    const result = extractClaimFromToken(token, 'nonexistent.path');
+    expect(result).toBeNull();
+  });
+
+  it('should return null for invalid token', () => {
+    jwtDecode.mockImplementation(() => {
+      throw new Error('Invalid token');
+    });
+
+    const result = extractClaimFromToken('invalid.token', 'email');
+    expect(result).toBeNull();
+  });
+
+  it('should handle empty token', () => {
+    const result = extractClaimFromToken('', 'email');
+    expect(result).toBeNull();
+  });
+
+  it('should handle null token', () => {
+    const result = extractClaimFromToken(null, 'email');
+    expect(result).toBeNull();
+  });
+
+  it('should handle empty claim path', () => {
+    const token = 'dummy.jwt.token';
+    jwtDecode.mockReturnValue({ email: 'test@example.com' });
+
+    const result = extractClaimFromToken(token, '');
+    expect(result).toBeNull();
+  });
+
+  it('should convert string value to array', () => {
+    const token = 'dummy.jwt.token';
+    jwtDecode.mockReturnValue({
+      role: 'admin',
+    });
+
+    const result = extractClaimFromToken(token, 'role');
+    expect(result).toEqual(['admin']);
+  });
+
+  it('should filter out empty strings from array', () => {
+    const token = 'dummy.jwt.token';
+    jwtDecode.mockReturnValue({
+      groups: ['admin', '', 'user', '  ', 'moderator'],
+    });
+
+    const result = extractClaimFromToken(token, 'groups');
+    expect(result).toEqual(['admin', 'user', 'moderator']);
+  });
+
+  it('should return null if claim is not string or array', () => {
+    const token = 'dummy.jwt.token';
+    jwtDecode.mockReturnValue({
+      data: { nested: 'object' },
+    });
+
+    const result = extractClaimFromToken(token, 'data');
+    expect(result).toBeNull();
+  });
+});
+
+describe('sanitizeGroupName', () => {
+  it('should trim whitespace', () => {
+    expect(sanitizeGroupName('  admin  ')).toBe('admin');
+  });
+
+  it('should remove leading slashes', () => {
+    expect(sanitizeGroupName('/admin')).toBe('admin');
+    expect(sanitizeGroupName('///admin')).toBe('admin');
+  });
+
+  it('should replace remaining slashes with hyphens', () => {
+    expect(sanitizeGroupName('admin/users')).toBe('admin-users');
+    expect(sanitizeGroupName('org/dept/team')).toBe('org-dept-team');
+  });
+
+  it('should remove MongoDB special characters', () => {
+    expect(sanitizeGroupName('admin$user')).toBe('adminuser');
+    expect(sanitizeGroupName('admin{role}')).toBe('adminrole');
+    expect(sanitizeGroupName('admin}test')).toBe('admintest');
+  });
+
+  it('should handle hierarchical paths', () => {
+    expect(sanitizeGroupName('/engineering/backend/team')).toBe('engineering-backend-team');
+  });
+
+  it('should truncate long group names', () => {
+    const longName = 'a'.repeat(150);
+    const result = sanitizeGroupName(longName);
+    expect(result.length).toBe(100);
+  });
+
+  it('should handle empty string', () => {
+    expect(sanitizeGroupName('')).toBe('');
+  });
+
+  it('should handle null', () => {
+    expect(sanitizeGroupName(null)).toBe('');
+  });
+
+  it('should handle undefined', () => {
+    expect(sanitizeGroupName(undefined)).toBe('');
+  });
+
+  it('should preserve hyphens', () => {
+    expect(sanitizeGroupName('admin-user')).toBe('admin-user');
+  });
+
+  it('should preserve underscores', () => {
+    expect(sanitizeGroupName('admin_user')).toBe('admin_user');
+  });
+});
+
+describe('extractGroupsFromToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should extract groups from access token by default', () => {
+    const tokenset = {
+      access_token: 'access.jwt.token',
+      id_token: 'id.jwt.token',
+    };
+
+    jwtDecode.mockReturnValue({
+      realm_access: {
+        roles: ['admin', 'user'],
+      },
+    });
+
+    const result = extractGroupsFromToken(tokenset, 'realm_access.roles');
+    expect(jwtDecode).toHaveBeenCalledWith('access.jwt.token');
+    expect(result).toEqual(['admin', 'user']);
+  });
+
+  it('should extract groups from id token when specified', () => {
+    const tokenset = {
+      access_token: 'access.jwt.token',
+      id_token: 'id.jwt.token',
+    };
+
+    jwtDecode.mockReturnValue({
+      groups: ['admin', 'user'],
+    });
+
+    const result = extractGroupsFromToken(tokenset, 'groups', 'id');
+    expect(jwtDecode).toHaveBeenCalledWith('id.jwt.token');
+    expect(result).toEqual(['admin', 'user']);
+  });
+
+  it('should sanitize all group names', () => {
+    const tokenset = {
+      access_token: 'access.jwt.token',
+    };
+
+    jwtDecode.mockReturnValue({
+      groups: ['/admin', '/engineering/backend', 'user$role'],
+    });
+
+    const result = extractGroupsFromToken(tokenset, 'groups');
+    expect(result).toEqual(['admin', 'engineering-backend', 'userrole']);
+  });
+
+  it('should remove duplicate groups', () => {
+    const tokenset = {
+      access_token: 'access.jwt.token',
+    };
+
+    jwtDecode.mockReturnValue({
+      groups: ['admin', 'admin', 'user', 'admin'],
+    });
+
+    const result = extractGroupsFromToken(tokenset, 'groups');
+    expect(result).toEqual(['admin', 'user']);
+  });
+
+  it('should return empty array for invalid tokenset', () => {
+    const result = extractGroupsFromToken(null, 'groups');
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when token is missing', () => {
+    const tokenset = {
+      id_token: 'id.jwt.token',
+    };
+
+    const result = extractGroupsFromToken(tokenset, 'groups', 'access');
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty array when claim is not found', () => {
+    const tokenset = {
+      access_token: 'access.jwt.token',
+    };
+
+    jwtDecode.mockReturnValue({
+      sub: 'user-123',
+    });
+
+    const result = extractGroupsFromToken(tokenset, 'nonexistent.claim');
+    expect(result).toEqual([]);
+  });
+
+  it('should filter out empty group names after sanitization', () => {
+    const tokenset = {
+      access_token: 'access.jwt.token',
+    };
+
+    jwtDecode.mockReturnValue({
+      groups: ['admin', '  ', '//', '', 'user'],
+    });
+
+    const result = extractGroupsFromToken(tokenset, 'groups');
+    expect(result).toEqual(['admin', 'user']);
+  });
+
+  it('should handle extraction errors gracefully', () => {
+    const tokenset = {
+      access_token: 'invalid.token',
+    };
+
+    jwtDecode.mockImplementation(() => {
+      throw new Error('Decode error');
+    });
+
+    const result = extractGroupsFromToken(tokenset, 'groups');
+    expect(result).toEqual([]);
+  });
+
+  it('should handle Keycloak realm roles', () => {
+    const tokenset = {
+      access_token: 'access.jwt.token',
+    };
+
+    jwtDecode.mockReturnValue({
+      realm_access: {
+        roles: ['admin', 'developer', 'user'],
+      },
+    });
+
+    const result = extractGroupsFromToken(tokenset, 'realm_access.roles', 'access');
+    expect(result).toEqual(['admin', 'developer', 'user']);
+  });
+
+  it('should handle Keycloak client roles', () => {
+    const tokenset = {
+      access_token: 'access.jwt.token',
+    };
+
+    jwtDecode.mockReturnValue({
+      resource_access: {
+        librechat: {
+          roles: ['chat-admin', 'prompt-creator'],
+        },
+      },
+    });
+
+    const result = extractGroupsFromToken(tokenset, 'resource_access.librechat.roles', 'access');
+    expect(result).toEqual(['chat-admin', 'prompt-creator']);
+  });
+
+  it('should handle Auth0 groups', () => {
+    const tokenset = {
+      id_token: 'id.jwt.token',
+    };
+
+    jwtDecode.mockReturnValue({
+      'https://example.auth0.com/groups': ['engineering', 'product'],
+    });
+
+    const result = extractGroupsFromToken(
+      tokenset,
+      'https://example.auth0.com/groups',
+      'id',
+    );
+    expect(result).toEqual(['engineering', 'product']);
+  });
+});
+

--- a/api/utils/extractJwtClaims.spec.js
+++ b/api/utils/extractJwtClaims.spec.js
@@ -438,4 +438,3 @@ describe('shouldExcludeGroup', () => {
     });
   });
 });
-

--- a/api/utils/extractJwtClaims.spec.js
+++ b/api/utils/extractJwtClaims.spec.js
@@ -317,22 +317,5 @@ describe('extractGroupsFromToken', () => {
     const result = extractGroupsFromToken(tokenset, 'resource_access.librechat.roles', 'access');
     expect(result).toEqual(['chat-admin', 'prompt-creator']);
   });
-
-  it('should handle Auth0 groups', () => {
-    const tokenset = {
-      id_token: 'id.jwt.token',
-    };
-
-    jwtDecode.mockReturnValue({
-      'https://example.auth0.com/groups': ['engineering', 'product'],
-    });
-
-    const result = extractGroupsFromToken(
-      tokenset,
-      'https://example.auth0.com/groups',
-      'id',
-    );
-    expect(result).toEqual(['engineering', 'product']);
-  });
 });
 

--- a/api/utils/extractJwtClaims.spec.js
+++ b/api/utils/extractJwtClaims.spec.js
@@ -116,6 +116,44 @@ describe('extractClaimFromToken', () => {
     const result = extractClaimFromToken(token, 'data');
     expect(result).toBeNull();
   });
+
+  it('should resolve namespaced claim keys with escaped dots', () => {
+    const token = 'dummy.jwt.token';
+    jwtDecode.mockReturnValue({
+      'https://myapp.example.com/roles': ['admin', 'user'],
+    });
+
+    const result = extractClaimFromToken(
+      token,
+      'https://myapp\\.example\\.com/roles',
+    );
+    expect(result).toEqual(['admin', 'user']);
+  });
+
+  it('should still split unescaped dots normally', () => {
+    const token = 'dummy.jwt.token';
+    jwtDecode.mockReturnValue({
+      realm_access: { roles: ['admin'] },
+    });
+
+    const result = extractClaimFromToken(token, 'realm_access.roles');
+    expect(result).toEqual(['admin']);
+  });
+
+  it('should support a mix of escaped and unescaped dots', () => {
+    const token = 'dummy.jwt.token';
+    jwtDecode.mockReturnValue({
+      'https://app.example.com': {
+        roles: ['admin'],
+      },
+    });
+
+    const result = extractClaimFromToken(
+      token,
+      'https://app\\.example\\.com.roles',
+    );
+    expect(result).toEqual(['admin']);
+  });
 });
 
 describe('sanitizeGroupName', () => {
@@ -123,14 +161,19 @@ describe('sanitizeGroupName', () => {
     expect(sanitizeGroupName('  admin  ')).toBe('admin');
   });
 
-  it('should remove leading slashes', () => {
-    expect(sanitizeGroupName('/admin')).toBe('admin');
-    expect(sanitizeGroupName('///admin')).toBe('admin');
+  it('should preserve leading slashes (distinct upstream identity)', () => {
+    expect(sanitizeGroupName('/admin')).toBe('/admin');
+    expect(sanitizeGroupName('///admin')).toBe('///admin');
   });
 
-  it('should replace remaining slashes with hyphens', () => {
-    expect(sanitizeGroupName('admin/users')).toBe('admin-users');
-    expect(sanitizeGroupName('org/dept/team')).toBe('org-dept-team');
+  it('should preserve internal slashes (distinct upstream identity)', () => {
+    expect(sanitizeGroupName('admin/users')).toBe('admin/users');
+    expect(sanitizeGroupName('org/dept/team')).toBe('org/dept/team');
+  });
+
+  it('should keep path-style and flat-style names distinct', () => {
+    expect(sanitizeGroupName('/team-a')).not.toBe(sanitizeGroupName('team-a'));
+    expect(sanitizeGroupName('finance/admin')).not.toBe(sanitizeGroupName('finance-admin'));
   });
 
   it('should remove MongoDB special characters', () => {
@@ -139,8 +182,8 @@ describe('sanitizeGroupName', () => {
     expect(sanitizeGroupName('admin}test')).toBe('admintest');
   });
 
-  it('should handle hierarchical paths', () => {
-    expect(sanitizeGroupName('/engineering/backend/team')).toBe('engineering-backend-team');
+  it('should preserve hierarchical paths verbatim', () => {
+    expect(sanitizeGroupName('/engineering/backend/team')).toBe('/engineering/backend/team');
   });
 
   it('should truncate long group names', () => {
@@ -207,7 +250,7 @@ describe('extractGroupsFromToken', () => {
     expect(result).toEqual(['admin', 'user']);
   });
 
-  it('should sanitize all group names', () => {
+  it('should preserve slashes and only strip MongoDB operators', () => {
     const tokenset = {
       access_token: 'access.jwt.token',
     };
@@ -217,7 +260,7 @@ describe('extractGroupsFromToken', () => {
     });
 
     const result = extractGroupsFromToken(tokenset, 'groups');
-    expect(result).toEqual(['admin', 'engineering-backend', 'userrole']);
+    expect(result).toEqual(['/admin', '/engineering/backend', 'userrole']);
   });
 
   it('should remove duplicate groups', () => {
@@ -273,13 +316,13 @@ describe('extractGroupsFromToken', () => {
     expect(result).toEqual([]);
   });
 
-  it('should filter out empty group names after sanitization', () => {
+  it('should filter out group names that become empty after sanitization', () => {
     const tokenset = {
       access_token: 'access.jwt.token',
     };
 
     jwtDecode.mockReturnValue({
-      groups: ['admin', '  ', '//', '', 'user'],
+      groups: ['admin', '   ', '${}', '', 'user'],
     });
 
     const result = extractGroupsFromToken(tokenset, 'groups');

--- a/api/utils/extractJwtClaims.spec.js
+++ b/api/utils/extractJwtClaims.spec.js
@@ -233,21 +233,21 @@ describe('extractGroupsFromToken', () => {
     expect(result).toEqual(['admin', 'user']);
   });
 
-  it('should return empty array for invalid tokenset', () => {
+  it('should return null for invalid tokenset (extraction failure)', () => {
     const result = extractGroupsFromToken(null, 'groups');
-    expect(result).toEqual([]);
+    expect(result).toBeNull();
   });
 
-  it('should return empty array when token is missing', () => {
+  it('should return null when token is missing (extraction failure)', () => {
     const tokenset = {
       id_token: 'id.jwt.token',
     };
 
     const result = extractGroupsFromToken(tokenset, 'groups', 'access');
-    expect(result).toEqual([]);
+    expect(result).toBeNull();
   });
 
-  it('should return empty array when claim is not found', () => {
+  it('should return null when claim is not found (extraction failure)', () => {
     const tokenset = {
       access_token: 'access.jwt.token',
     };
@@ -257,6 +257,19 @@ describe('extractGroupsFromToken', () => {
     });
 
     const result = extractGroupsFromToken(tokenset, 'nonexistent.claim');
+    expect(result).toBeNull();
+  });
+
+  it('should return empty array when claim resolves to empty array (legitimate empty)', () => {
+    const tokenset = {
+      access_token: 'access.jwt.token',
+    };
+
+    jwtDecode.mockReturnValue({
+      groups: [],
+    });
+
+    const result = extractGroupsFromToken(tokenset, 'groups');
     expect(result).toEqual([]);
   });
 
@@ -273,7 +286,7 @@ describe('extractGroupsFromToken', () => {
     expect(result).toEqual(['admin', 'user']);
   });
 
-  it('should handle extraction errors gracefully', () => {
+  it('should return null when decode throws (extraction failure)', () => {
     const tokenset = {
       access_token: 'invalid.token',
     };
@@ -283,7 +296,7 @@ describe('extractGroupsFromToken', () => {
     });
 
     const result = extractGroupsFromToken(tokenset, 'groups');
-    expect(result).toEqual([]);
+    expect(result).toBeNull();
   });
 
   it('should handle Keycloak realm roles', () => {

--- a/packages/api/src/admin/groups.ts
+++ b/packages/api/src/admin/groups.ts
@@ -17,7 +17,7 @@ import { parsePagination } from './pagination';
 
 type GroupListFilter = Pick<GroupFilterOptions, 'source' | 'search'>;
 
-const VALID_GROUP_SOURCES: ReadonlySet<string> = new Set(['local', 'entra']);
+const VALID_GROUP_SOURCES: ReadonlySet<string> = new Set(['local', 'entra', 'oidc']);
 const MAX_CREATE_MEMBER_IDS = 500;
 const MAX_SEARCH_LENGTH = 200;
 const MAX_NAME_LENGTH = 500;

--- a/packages/data-provider/src/accessPermissions.ts
+++ b/packages/data-provider/src/accessPermissions.ts
@@ -238,6 +238,7 @@ export type TPrincipalSearchResponse = {
   sources: {
     local: number;
     entra: number;
+    oidc: number;
   };
 };
 

--- a/packages/data-provider/src/accessPermissions.ts
+++ b/packages/data-provider/src/accessPermissions.ts
@@ -32,7 +32,7 @@ export enum PrincipalModel {
 /**
  * Source of the principal (local LibreChat or external Entra ID)
  */
-export type TPrincipalSource = 'local' | 'entra';
+export type TPrincipalSource = 'local' | 'entra' | 'oidc';
 
 /**
  * Access levels for agents
@@ -95,10 +95,10 @@ export const principalSchema = z.object({
   id: z.string().optional(), // undefined for 'public' type, role name for 'role' type
   name: z.string().optional(),
   email: z.string().optional(), // for user and group types
-  source: z.enum(['local', 'entra']).optional(),
+  source: z.enum(['local', 'entra', 'oidc']).optional(),
   avatar: z.string().optional(), // for user and group types
   description: z.string().optional(), // for group and role types
-  idOnTheSource: z.string().optional(), // Entra ID for users/groups
+  idOnTheSource: z.string().optional(), // External ID for users/groups (Entra, OIDC, etc.)
   accessRoleId: z.nativeEnum(AccessRoleIds).optional(), // Access role ID for permissions
   memberCount: z.number().optional(), // for group type
 });
@@ -126,7 +126,7 @@ export const permissionEntrySchema = z.object({
   grantedBy: z.string(),
   grantedAt: z.string(), // ISO date string
   inheritedFrom: z.string().optional(), // for project-level inheritance
-  source: z.enum(['local', 'entra']).optional(),
+  source: z.enum(['local', 'entra', 'oidc']).optional(),
 });
 
 /**
@@ -220,10 +220,10 @@ export type TPrincipalSearchResult = {
   username?: string; // for users
   avatar?: string; // for users and groups
   provider?: string; // for users
-  source: 'local' | 'entra';
+  source: 'local' | 'entra' | 'oidc';
   memberCount?: number; // for groups
   description?: string; // for groups
-  idOnTheSource?: string; // Entra ID for users (maps to openidId) and groups (maps to idOnTheSource)
+  idOnTheSource?: string; // External ID for users (maps to openidId) and groups (maps to idOnTheSource)
 };
 
 /**

--- a/packages/data-provider/src/types/queries.ts
+++ b/packages/data-provider/src/types/queries.ts
@@ -160,6 +160,7 @@ export type PrincipalSearchResponse = {
   sources: {
     local: number;
     entra: number;
+    oidc: number;
   };
 };
 

--- a/packages/data-schemas/src/methods/userGroup.ts
+++ b/packages/data-schemas/src/methods/userGroup.ts
@@ -36,7 +36,7 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')) {
    */
   async function findGroupByExternalId(
     idOnTheSource: string,
-    source: 'entra' | 'local' = 'entra',
+    source: 'entra' | 'local' | 'oidc' = 'entra',
     projection: Record<string, 0 | 1> = {},
     session?: ClientSession,
   ): Promise<IGroup | null> {
@@ -57,7 +57,7 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')) {
    */
   async function findGroupsByExternalIds(
     idsOnTheSource: string[],
-    source: 'entra' | 'local' = 'entra',
+    source: 'entra' | 'local' | 'oidc' = 'entra',
     session?: ClientSession,
   ): Promise<IGroup[]> {
     const Group = mongoose.models.Group as Model<IGroup>;
@@ -81,7 +81,7 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')) {
    */
   async function findGroupsByNamePattern(
     namePattern: string,
-    source: 'entra' | 'local' | null = null,
+    source: 'entra' | 'local' | 'oidc' | null = null,
     limit: number = 20,
     session?: ClientSession,
   ): Promise<IGroup[]> {
@@ -156,7 +156,7 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')) {
    */
   async function upsertGroupByExternalId(
     idOnTheSource: string,
-    source: 'entra' | 'local',
+    source: 'entra' | 'local' | 'oidc',
     updateData: Partial<IGroup>,
     session?: ClientSession,
   ): Promise<IGroup | null> {
@@ -684,7 +684,7 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')) {
   }
 
   function buildGroupQuery(filter: {
-    source?: 'local' | 'entra';
+    source?: 'local' | 'entra' | 'oidc';
     search?: string;
   }): FilterQuery<IGroup> {
     const query: FilterQuery<IGroup> = {};
@@ -706,7 +706,7 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')) {
    */
   async function listGroups(
     filter: {
-      source?: 'local' | 'entra';
+      source?: 'local' | 'entra' | 'oidc';
       search?: string;
       limit?: number;
       offset?: number;
@@ -731,7 +731,7 @@ export function createUserGroupMethods(mongoose: typeof import('mongoose')) {
    * @param session - Optional MongoDB session for transactions
    */
   async function countGroups(
-    filter: { source?: 'local' | 'entra'; search?: string } = {},
+    filter: { source?: 'local' | 'entra' | 'oidc'; search?: string } = {},
     session?: ClientSession,
   ): Promise<number> {
     const Group = mongoose.models.Group as Model<IGroup>;

--- a/packages/data-schemas/src/schema/group.ts
+++ b/packages/data-schemas/src/schema/group.ts
@@ -29,10 +29,10 @@ const groupSchema = new Schema<IGroup>(
     ],
     source: {
       type: String,
-      enum: ['local', 'entra'],
+      enum: ['local', 'entra', 'oidc'],
       default: 'local',
     },
-    /** External ID (e.g., Entra ID) */
+    /** External ID (e.g., Entra ID, OIDC provider) */
     idOnTheSource: {
       type: String,
       sparse: true,

--- a/packages/data-schemas/src/types/group.ts
+++ b/packages/data-schemas/src/types/group.ts
@@ -9,8 +9,8 @@ export interface IGroup extends Document {
   avatar?: string;
   /** Array of member IDs (stores idOnTheSource values, not ObjectIds) */
   memberIds?: string[];
-  source: 'local' | 'entra';
-  /** External ID (e.g., Entra ID) - required for non-local sources */
+  source: 'local' | 'entra' | 'oidc';
+  /** External ID (e.g., Entra ID, OIDC provider) - required for non-local sources */
   idOnTheSource?: string;
   createdAt?: Date;
   updatedAt?: Date;
@@ -23,7 +23,7 @@ export interface CreateGroupRequest {
   email?: string;
   avatar?: string;
   memberIds?: string[];
-  source: 'local' | 'entra';
+  source: 'local' | 'entra' | 'oidc';
   idOnTheSource?: string;
 }
 
@@ -33,13 +33,13 @@ export interface UpdateGroupRequest {
   email?: string;
   avatar?: string;
   memberIds?: string[];
-  source?: 'local' | 'entra' | 'ldap';
+  source?: 'local' | 'entra' | 'oidc' | 'ldap';
   idOnTheSource?: string;
 }
 
 export interface GroupFilterOptions extends CursorPaginationParams {
   // Includes email, name and description
   search?: string;
-  source?: 'local' | 'entra' | 'ldap';
+  source?: 'local' | 'entra' | 'oidc' | 'ldap';
   hasMember?: string;
 }


### PR DESCRIPTION
**Continuation of #10015 — clean rebase onto `dev` as requested**

Implements JWT token-based group synchronization to enable LibreChat's granular permissions system with any OIDC provider (Keycloak, Auth0, Okta, etc.). Currently, group discovery only works with Microsoft Entra ID via Graph API. This implementation allows any OIDC provider to sync groups/roles from JWT tokens.

**Related to:** #10006  
**Original PR:** #10015 (left open for reference)

### Changes

- Add JWT claim extraction utilities with sanitization (`api/utils/extractJwtClaims.js`)
- Implement `syncUserOidcGroupsFromToken` in `PermissionService`
- Fix `idOnTheSource` to use `sub` as fallback for non-Microsoft providers (Keycloak compatibility)
- Integrate OIDC group sync into the OAuth controller — decoupled from `OPENID_REUSE_TOKENS`
- Add `'oidc'` as valid group source in schema
- Comprehensive unit tests (166 test cases)
- Documentation in `.env.example`

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Unit tests:

```bash
cd api && npx jest --testPathPatterns="extractJwtClaims|PermissionService.oidc|openidStrategy.spec"
```

✅ 3 test suites, 166 tests passing.

Manual end-to-end testing with Keycloak 26.x confirmed:
- Groups extracted from JWT and created in MongoDB with `source: 'oidc'`
- User automatically added to groups on login
- User removed from groups when roles revoked in Keycloak (on next login)
- Groups available in LibreChat sharing UI
- `sub` claim fallback working for non-Microsoft providers

### Test Configuration

```bash
OPENID_REUSE_TOKENS=true
OPENID_SYNC_GROUPS_FROM_TOKEN=true
OPENID_GROUPS_CLAIM_PATH=realm_access.roles
OPENID_GROUPS_TOKEN_KIND=access
OPENID_GROUP_SOURCE=oidc
```

<details>
<summary>Keycloak Setup Guide for first-time testing</summary>

#### 1. Start Keycloak

```bash
docker run -p 8080:8080 \
  -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
  -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
  quay.io/keycloak/keycloak:26.0 start-dev
```

Open `http://localhost:8080` and log in with `admin/admin`.

#### 2. Create a Realm

1. Click **Create realm**
2. Name it e.g. `librechat-test`
3. Click **Create**

#### 3. Create a Client

1. Go to **Clients** → **Create client**
2. Set **Client ID:** `librechat`, **Client type:** OpenID Connect
3. Click **Next** → enable **Client authentication** → **Save**
4. **Credentials** tab → copy the **Client secret**
5. **Settings** tab → set:
   - **Valid redirect URIs:** `http://localhost:3080/oauth/openid/callback`
   - **Web origins:** `http://localhost:3080`
6. **Save**

#### 4. Create Realm Roles

Go to **Realm roles** → **Create role** and create a few (e.g. `engineers`, `admins`).

#### 5. Create a Test User

1. **Users** → **Create new user** → fill in username/email → **Create**
2. **Credentials** tab → set a password (disable "Temporary")
3. **Role mappings** tab → assign the roles you created

#### 6. Configure LibreChat `.env`

```bash
OPENID_ISSUER=http://localhost:8080/realms/librechat-test
OPENID_CLIENT_ID=librechat
OPENID_CLIENT_SECRET=<your-client-secret>
OPENID_CALLBACK_URL=/oauth/openid/callback
OPENID_SCOPE=openid profile email
OPENID_BUTTON_LABEL=Login with Keycloak
OPENID_SESSION_SECRET=any-random-string
OPENID_REUSE_TOKENS=true
OPENID_SYNC_GROUPS_FROM_TOKEN=true
OPENID_GROUPS_CLAIM_PATH=realm_access.roles
OPENID_GROUPS_TOKEN_KIND=access
OPENID_GROUP_SOURCE=oidc
```

#### 7. Start LibreChat and Test

1. `npm run backend:dev`
2. Open `http://localhost:3080`, click **Login with Keycloak**
3. Verify groups in MongoDB:

```bash
docker exec mongodb mongosh LibreChat --eval "db.groups.find({ source: 'oidc' }).pretty()"
```

**Expected:** One group per realm role, each with `source: "oidc"` and the user's Keycloak `sub` in `memberIds`.

#### 8. Test Role Removal

1. Remove a role from the test user in Keycloak admin
2. Log out and log back in
3. Re-run the MongoDB query — user should be removed from the corresponding group

</details>

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules
- [x] A pull request for updating the documentation has been submitted (merged: LibreChat-AI/librechat.ai#426)
