### PR TITLE
🧠 fix: charge Gemini reasoning tokens in agent usage accounting

### DIFF
--- a/packages/api/src/agents/usage.spec.ts
+++ b/packages/api/src/agents/usage.spec.ts
@@ -364,6 +364,106 @@ describe('recordCollectedUsage', () => {
     });
   });
 
+  describe('reasoning token handling - issue #13006', () => {
+    it('adds reasoning to completionTokens when Vertex omits it from output_tokens', async () => {
+      const collectedUsage: UsageMetadata[] = [
+        {
+          input_tokens: 80657,
+          output_tokens: 766,
+          total_tokens: 83265,
+          output_token_details: { reasoning: 1842 },
+          model: 'gemini-3-flash-preview',
+          provider: 'vertexai',
+        },
+      ];
+
+      const result = await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      expect(mockSpendTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gemini-3-flash-preview' }),
+        { promptTokens: 80657, completionTokens: 2608 },
+      );
+      expect(result?.output_tokens).toBe(2608);
+    });
+
+    it('does not double-count when reasoning is already a subset of output_tokens (OpenAI o-series)', async () => {
+      const collectedUsage: UsageMetadata[] = [
+        {
+          input_tokens: 100,
+          output_tokens: 500,
+          total_tokens: 600,
+          output_token_details: { reasoning: 200 },
+          model: 'o1-preview',
+          provider: 'openAI',
+        },
+      ];
+
+      const result = await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      expect(mockSpendTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'o1-preview' }),
+        { promptTokens: 100, completionTokens: 500 },
+      );
+      expect(result?.output_tokens).toBe(500);
+    });
+
+    it('routes reasoning correction through structured spend when cache tokens are present', async () => {
+      const collectedUsage: UsageMetadata[] = [
+        {
+          input_tokens: 80657,
+          output_tokens: 766,
+          total_tokens: 83265,
+          output_token_details: { reasoning: 1842 },
+          input_token_details: { cache_read: 30000 },
+          model: 'gemini-3-flash-preview',
+          provider: 'vertexai',
+        },
+      ];
+
+      await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      expect(mockSpendStructuredTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gemini-3-flash-preview' }),
+        {
+          promptTokens: { input: 50657, write: 0, read: 30000 },
+          completionTokens: 2608,
+        },
+      );
+    });
+
+    it('no-op when output_token_details is absent', async () => {
+      const collectedUsage: UsageMetadata[] = [
+        {
+          input_tokens: 100,
+          output_tokens: 50,
+          total_tokens: 150,
+          model: 'gpt-4',
+          provider: 'openAI',
+        },
+      ];
+
+      const result = await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      expect(mockSpendTokens).toHaveBeenCalledWith(
+        expect.anything(),
+        { promptTokens: 100, completionTokens: 50 },
+      );
+      expect(result?.output_tokens).toBe(50);
+    });
+  });
+
   describe('mixed cache and non-cache entries', () => {
     it('should handle mixed entries correctly', async () => {
       const collectedUsage: UsageMetadata[] = [

--- a/packages/api/src/agents/usage.spec.ts
+++ b/packages/api/src/agents/usage.spec.ts
@@ -365,7 +365,7 @@ describe('recordCollectedUsage', () => {
   });
 
   describe('reasoning token handling - issue #13006', () => {
-    it('adds reasoning to completionTokens when Vertex omits it from output_tokens', async () => {
+    it('uses total - input when output_tokens undercounts (Vertex stream undercount with details present)', async () => {
       const collectedUsage: UsageMetadata[] = [
         {
           input_tokens: 80657,
@@ -389,7 +389,30 @@ describe('recordCollectedUsage', () => {
       expect(result?.output_tokens).toBe(2608);
     });
 
-    it('does not double-count when reasoning is already a subset of output_tokens (OpenAI o-series)', async () => {
+    it('uses total - input even when output_token_details is missing (raw langchain google-common path)', async () => {
+      const collectedUsage: UsageMetadata[] = [
+        {
+          input_tokens: 12,
+          output_tokens: 135,
+          total_tokens: 309,
+          model: 'gemini-3-flash-preview',
+          provider: 'vertexai',
+        },
+      ];
+
+      const result = await recordCollectedUsage(deps, {
+        ...baseParams,
+        collectedUsage,
+      });
+
+      expect(mockSpendTokens).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'gemini-3-flash-preview' }),
+        { promptTokens: 12, completionTokens: 297 },
+      );
+      expect(result?.output_tokens).toBe(297);
+    });
+
+    it('does not change output when invariant already holds (OpenAI o-series, reasoning already a subset)', async () => {
       const collectedUsage: UsageMetadata[] = [
         {
           input_tokens: 100,
@@ -413,7 +436,7 @@ describe('recordCollectedUsage', () => {
       expect(result?.output_tokens).toBe(500);
     });
 
-    it('routes reasoning correction through structured spend when cache tokens are present', async () => {
+    it('routes correction through structured spend when cache tokens are present', async () => {
       const collectedUsage: UsageMetadata[] = [
         {
           input_tokens: 80657,
@@ -440,12 +463,11 @@ describe('recordCollectedUsage', () => {
       );
     });
 
-    it('no-op when output_token_details is absent', async () => {
+    it('no-op when total_tokens is absent or zero', async () => {
       const collectedUsage: UsageMetadata[] = [
         {
           input_tokens: 100,
           output_tokens: 50,
-          total_tokens: 150,
           model: 'gpt-4',
           provider: 'openAI',
         },

--- a/packages/api/src/agents/usage.ts
+++ b/packages/api/src/agents/usage.ts
@@ -52,33 +52,28 @@ function inputTokensIncludesCache(provider?: string): boolean {
 
 /**
  * Resolves `completionTokens` for billing, repairing providers whose
- * `usage_metadata.output_tokens` undercounts by omitting reasoning.
+ * `usage_metadata.output_tokens` undercounts.
  *
  * The documented `UsageMetadata` contract (`@langchain/core`) is
- * `total_tokens === input_tokens + output_tokens` and `output_tokens` is
- * "the sum of all output token types". Most providers honor this — their
- * `output_token_details.reasoning` is a *subset* of `output_tokens`, so we
- * must not double-count.
+ * `total_tokens === input_tokens + output_tokens`. Compliant providers
+ * (OpenAI, Anthropic, Google API via agents' `CustomChatGoogleGenerativeAI`)
+ * include any reasoning/thinking tokens inside `output_tokens` already,
+ * so the invariant holds.
  *
  * Vertex AI Gemini through `@langchain/google-common`'s streaming path
- * breaks the contract: `output_tokens = candidatesTokenCount` only,
- * dropping `thoughtsTokenCount`. The gap shows up as
- * `total_tokens - input_tokens > output_tokens`, with the missing amount
- * surfaced in `output_token_details.reasoning`. We fold it back when —
- * and only when — the gap is present, so all other providers are no-ops.
+ * emits `output_tokens = candidatesTokenCount` and drops `thoughtsTokenCount`,
+ * leaving `total - input > output`. When that gap shows up we use the
+ * invariant to recover the correct billable output (`total - input`).
+ * Compliant providers have a zero gap, so this is a no-op for them.
  *
  * Tracked in: https://github.com/danny-avila/LibreChat/issues/13006
  */
 function resolveCompletionTokens(usage: UsageMetadata): number {
   const output = Number(usage.output_tokens) || 0;
-  const reasoning = Number(usage.output_token_details?.reasoning) || 0;
-  if (reasoning <= 0) {
-    return output;
-  }
-  const input = Number(usage.input_tokens) || 0;
   const total = Number(usage.total_tokens) || 0;
-  if (total - input > output) {
-    return output + reasoning;
+  const input = Number(usage.input_tokens) || 0;
+  if (total > input + output) {
+    return total - input;
   }
   return output;
 }

--- a/packages/api/src/agents/usage.ts
+++ b/packages/api/src/agents/usage.ts
@@ -50,6 +50,39 @@ function inputTokensIncludesCache(provider?: string): boolean {
   return provider != null && SUBSET_PROVIDERS.has(provider);
 }
 
+/**
+ * Resolves `completionTokens` for billing, repairing providers whose
+ * `usage_metadata.output_tokens` undercounts by omitting reasoning.
+ *
+ * The documented `UsageMetadata` contract (`@langchain/core`) is
+ * `total_tokens === input_tokens + output_tokens` and `output_tokens` is
+ * "the sum of all output token types". Most providers honor this — their
+ * `output_token_details.reasoning` is a *subset* of `output_tokens`, so we
+ * must not double-count.
+ *
+ * Vertex AI Gemini through `@langchain/google-common`'s streaming path
+ * breaks the contract: `output_tokens = candidatesTokenCount` only,
+ * dropping `thoughtsTokenCount`. The gap shows up as
+ * `total_tokens - input_tokens > output_tokens`, with the missing amount
+ * surfaced in `output_token_details.reasoning`. We fold it back when —
+ * and only when — the gap is present, so all other providers are no-ops.
+ *
+ * Tracked in: https://github.com/danny-avila/LibreChat/issues/13006
+ */
+function resolveCompletionTokens(usage: UsageMetadata): number {
+  const output = Number(usage.output_tokens) || 0;
+  const reasoning = Number(usage.output_token_details?.reasoning) || 0;
+  if (reasoning <= 0) {
+    return output;
+  }
+  const input = Number(usage.input_tokens) || 0;
+  const total = Number(usage.total_tokens) || 0;
+  if (total - input > output) {
+    return output + reasoning;
+  }
+  return output;
+}
+
 interface SplitUsage {
   /** Non-cached input portion — what gets billed at the standard input rate */
   inputOnly: number;
@@ -57,6 +90,8 @@ interface SplitUsage {
   cacheRead: number;
   /** Total prompt tokens including cached portion */
   totalInput: number;
+  /** Output tokens for billing (includes reasoning when omitted from `output_tokens`) */
+  completion: number;
 }
 
 function splitUsage(usage: UsageMetadata): SplitUsage {
@@ -67,12 +102,14 @@ function splitUsage(usage: UsageMetadata): SplitUsage {
   const cacheRead =
     Number(usage.input_token_details?.cache_read) || Number(usage.cache_read_input_tokens) || 0;
   const rawInput = Number(usage.input_tokens) || 0;
+  const completion = resolveCompletionTokens(usage);
   if (inputTokensIncludesCache(usage.provider)) {
     return {
       inputOnly: Math.max(0, rawInput - cacheCreation - cacheRead),
       cacheCreation,
       cacheRead,
       totalInput: rawInput,
+      completion,
     };
   }
   return {
@@ -80,6 +117,7 @@ function splitUsage(usage: UsageMetadata): SplitUsage {
     cacheCreation,
     cacheRead,
     totalInput: rawInput + cacheCreation + cacheRead,
+    completion,
   };
 }
 
@@ -161,9 +199,9 @@ export async function recordCollectedUsage(
         continue;
       }
 
-      const { inputOnly, cacheCreation, cacheRead } = splitUsage(usage);
+      const { inputOnly, cacheCreation, cacheRead, completion } = splitUsage(usage);
 
-      total_output_tokens += Number(usage.output_tokens) || 0;
+      total_output_tokens += completion;
 
       const txMetadata: TxMetadata = {
         user,
@@ -187,7 +225,7 @@ export async function recordCollectedUsage(
                     write: cacheCreation,
                     read: cacheRead,
                   },
-                  completionTokens: usage.output_tokens,
+                  completionTokens: completion,
                 },
                 pricing,
               )
@@ -195,7 +233,7 @@ export async function recordCollectedUsage(
                 txMetadata,
                 {
                   promptTokens: inputOnly,
-                  completionTokens: usage.output_tokens,
+                  completionTokens: completion,
                 },
                 pricing,
               );
@@ -211,7 +249,7 @@ export async function recordCollectedUsage(
               write: cacheCreation,
               read: cacheRead,
             },
-            completionTokens: usage.output_tokens,
+            completionTokens: completion,
           })
           .catch((err) => {
             logger.error(
@@ -225,7 +263,7 @@ export async function recordCollectedUsage(
       deps
         .spendTokens(txMetadata, {
           promptTokens: inputOnly,
-          completionTokens: usage.output_tokens,
+          completionTokens: completion,
         })
         .catch((err) => {
           logger.error(

--- a/packages/api/src/stream/interfaces/IJobStore.ts
+++ b/packages/api/src/stream/interfaces/IJobStore.ts
@@ -98,6 +98,16 @@ export interface UsageMetadata {
    * Present for Claude models. Mutually exclusive with input_token_details.
    */
   cache_read_input_tokens?: number;
+  /**
+   * Breakdown of output token counts. Per the LangChain core contract,
+   * `output_tokens` is the sum of all output token types — these fields
+   * are subsets of `output_tokens`, *not* additional charges.
+   */
+  output_token_details?: {
+    /** Reasoning/thinking tokens generated as chain-of-thought (o1, Gemini thinking, etc.) */
+    reasoning?: number;
+    audio?: number;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Resolves [#13006](https://github.com/danny-avila/LibreChat/issues/13006). Vertex AI Gemini thinking-model usage was undercounted: `output_tokens` (text only) was billed, but `output_token_details.reasoning` (thinking tokens) was silently dropped — invisibly cheaper than the actual API charge.

## Root cause (recap)

\`@langchain/google-common\`'s streaming \`_streamResponseChunks\` builds \`usage_metadata\` inline as \`output_tokens = candidatesTokenCount\` and drops \`thoughtsTokenCount\` ([chat_models.cjs:178-182](https://github.com/langchain-ai/langchainjs/blob/main/libs/providers/langchain-google-common/src/chat_models.ts)). For Vertex this surfaces as the documented \`total_tokens === input_tokens + output_tokens\` invariant being broken:

```
input_tokens:  80657
output_tokens: 766           ← candidatesTokenCount only (under-count)
total_tokens:  83265
output_token_details: { reasoning: 1842 }   ← thoughtsTokenCount
```

\`83265 - 80657 = 2608\` ≠ \`766\`. The gap *is* the unbilled reasoning.

## Fix

Two layers, paired with [danny-avila/agents#157](https://github.com/danny-avila/agents/pull/157):

1. **In agents (PR #157)** — patches the source: \`ChatVertexAI._streamResponseChunks\` now folds reasoning back into \`output_tokens\` so the contract holds before the value reaches LibreChat.
2. **In LibreChat (this PR)** — defense-in-depth at the billing sink: `resolveCompletionTokens(usage)` adds `output_token_details.reasoning` when (and *only* when) \`total - input > output\`, the gap that signals a contract violation. Providers that already include reasoning in \`output_tokens\` (OpenAI o-series, Anthropic, the Google-API path via agents' \`CustomChatGoogleGenerativeAI\`) are no-ops — \`total - input === output\` for them, so the gap check is false and nothing changes. No double-counting risk.

Both layers stack: the agents fix prevents the bug, this PR catches anything that slips through (older agents versions, future providers, bare \`@langchain/google-genai\`).

## Files changed

- [packages/api/src/agents/usage.ts](packages/api/src/agents/usage.ts) — new \`resolveCompletionTokens\` helper; \`SplitUsage\` gains a \`completion\` field; all four billing call sites in \`processUsageGroup\` (bulk + non-bulk × cache + non-cache) use \`completion\` instead of \`usage.output_tokens\`. Result's \`output_tokens\` aggregate also uses it.
- [packages/api/src/stream/interfaces/IJobStore.ts](packages/api/src/stream/interfaces/IJobStore.ts) — adds \`output_token_details?: { reasoning?, audio? }\` to \`UsageMetadata\` for type safety.
- [packages/api/src/agents/usage.spec.ts](packages/api/src/agents/usage.spec.ts) — 4 new tests under \`reasoning token handling - issue #13006\`.

## Test plan

- [x] All 45 existing \`usage.spec.ts\` tests still pass
- [x] All 27 \`usage.bulk-parity.spec.ts\` tests still pass
- [x] New tests cover: Vertex undercount fix, OpenAI no-double-count, structured-spend path with cache + reasoning combined, no-op when \`output_token_details\` absent
- [x] No new TS errors (\`tsc --noEmit\` clean on changed files)