### PR TITLE
🚦 fix: Preserve URL Auto-Submit Startup Config

### DIFF
--- a/packages/data-schemas/src/app/interface.spec.ts
+++ b/packages/data-schemas/src/app/interface.spec.ts
@@ -3,6 +3,21 @@ import type { TCustomConfig } from 'librechat-data-provider';
 import { loadDefaultInterface } from './interface';
 
 describe('loadDefaultInterface', () => {
+  it('preserves disabled URL auto-submit config', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {
+        autoSubmitFromUrl: false,
+      },
+    };
+
+    const interfaceConfig = await loadDefaultInterface({
+      config,
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.autoSubmitFromUrl).toBe(false);
+  });
+
   it('preserves the configured temporary chat retention period', async () => {
     const config: Partial<TCustomConfig> = {
       interface: {

--- a/packages/data-schemas/src/app/interface.spec.ts
+++ b/packages/data-schemas/src/app/interface.spec.ts
@@ -3,6 +3,15 @@ import type { TCustomConfig } from 'librechat-data-provider';
 import { loadDefaultInterface } from './interface';
 
 describe('loadDefaultInterface', () => {
+  it('uses the schema default for URL auto-submit when not configured', async () => {
+    const interfaceConfig = await loadDefaultInterface({
+      config: {},
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.autoSubmitFromUrl).toBe(true);
+  });
+
   it('preserves disabled URL auto-submit config', async () => {
     const config: Partial<TCustomConfig> = {
       interface: {
@@ -16,6 +25,21 @@ describe('loadDefaultInterface', () => {
     });
 
     expect(interfaceConfig?.autoSubmitFromUrl).toBe(false);
+  });
+
+  it('preserves enabled URL auto-submit config', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {
+        autoSubmitFromUrl: true,
+      },
+    };
+
+    const interfaceConfig = await loadDefaultInterface({
+      config,
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.autoSubmitFromUrl).toBe(true);
   });
 
   it('preserves the configured temporary chat retention period', async () => {

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -38,6 +38,7 @@ export async function loadDefaultInterface({
     termsOfService: interfaceConfig?.termsOfService ?? defaults.termsOfService,
     mcpServers: interfaceConfig?.mcpServers ?? defaults.mcpServers,
     customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,
+    autoSubmitFromUrl: interfaceConfig?.autoSubmitFromUrl ?? defaults.autoSubmitFromUrl,
 
     // Permissions and related settings - only include if explicitly configured
     bookmarks: interfaceConfig?.bookmarks,


### PR DESCRIPTION
## Summary

I preserved the URL auto-submit interface setting through startup config loading, fixing #13016 and the issue reported in [PR #12929 discussion](https://github.com/danny-avila/LibreChat/pull/12929#discussion_r3209051954) where `interface.autoSubmitFromUrl: false` still allowed URL-driven auto-submit.

- Carry `autoSubmitFromUrl` through `loadDefaultInterface` so `/api/config/startup` includes the configured value.
- Preserve the existing default behavior by falling back to the schema default when the setting is omitted.
- Add regression coverage for default, disabled, and explicitly enabled URL auto-submit config.

Fixes #13016.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm run build:data-provider`.
- Ran `npx jest src/app/interface.spec.ts --runInBand` from `packages/data-schemas`.
- Ran `npm run build:data-schemas`.
- Ran `git diff --check`.

### **Test Configuration**:

- Node.js: v20.19.5
- npm: 10.8.2

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes