### PR TITLE
🛡️ fix: Pass interface.autoSubmitFromUrl through to startup config

### DIFF
--- a/packages/data-schemas/src/app/interface.spec.ts
+++ b/packages/data-schemas/src/app/interface.spec.ts
@@ -26,4 +26,43 @@ describe('loadDefaultInterface', () => {
 
     expect(interfaceConfig).not.toHaveProperty('temporaryChatRetention');
   });
+
+  it('falls back to the schema default for autoSubmitFromUrl when unset', async () => {
+    const interfaceConfig = await loadDefaultInterface({
+      config: {},
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.autoSubmitFromUrl).toBe(true);
+  });
+
+  it('propagates an explicit autoSubmitFromUrl: false to the loaded interface', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {
+        autoSubmitFromUrl: false,
+      },
+    };
+
+    const interfaceConfig = await loadDefaultInterface({
+      config,
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.autoSubmitFromUrl).toBe(false);
+  });
+
+  it('propagates an explicit autoSubmitFromUrl: true to the loaded interface', async () => {
+    const config: Partial<TCustomConfig> = {
+      interface: {
+        autoSubmitFromUrl: true,
+      },
+    };
+
+    const interfaceConfig = await loadDefaultInterface({
+      config,
+      configDefaults: getConfigDefaults(),
+    });
+
+    expect(interfaceConfig?.autoSubmitFromUrl).toBe(true);
+  });
 });

--- a/packages/data-schemas/src/app/interface.ts
+++ b/packages/data-schemas/src/app/interface.ts
@@ -38,6 +38,7 @@ export async function loadDefaultInterface({
     termsOfService: interfaceConfig?.termsOfService ?? defaults.termsOfService,
     mcpServers: interfaceConfig?.mcpServers ?? defaults.mcpServers,
     customWelcome: interfaceConfig?.customWelcome ?? defaults.customWelcome,
+    autoSubmitFromUrl: interfaceConfig?.autoSubmitFromUrl ?? defaults.autoSubmitFromUrl,
 
     // Permissions and related settings - only include if explicitly configured
     bookmarks: interfaceConfig?.bookmarks,


### PR DESCRIPTION
## What

Surface the `interface.autoSubmitFromUrl` flag introduced in #12929 in the server's response to `GET /api/config` so the client-side gate added in the same PR can actually take effect.

## Why

PR #12929 added `interface.autoSubmitFromUrl` to `interfaceSchema` (default `true` to preserve existing behavior) and gated the auto-submit branch in `client/src/hooks/Input/useQueryParams.ts` on the value reaching the SPA via the startup config payload.

`loadDefaultInterface()` in `packages/data-schemas/src/app/interface.ts` whitelists which interface fields are returned to the client. The new field was not added to that whitelist, so `appConfig.interfaceConfig.autoSubmitFromUrl` is always `undefined`, the runtime payload at `/api/config` does not contain the key, and the client's check

```ts
const autoSubmitEnabled = startupConfig?.interface?.autoSubmitFromUrl !== false;
```

evaluates to `true` regardless of what the operator wrote in `librechat.yaml`.

This was [flagged in review](https://github.com/danny-avila/LibreChat/pull/12929#discussion_r3178534115) on the original PR but was not addressed before merge. It is the root cause reported in #13016 and reproducible against any deployment of v0.8.5-rc1+ that sets `interface.autoSubmitFromUrl: false` and observes that `/c/new?prompt=…&submit=true` still auto-submits.

## What changed

- `packages/data-schemas/src/app/interface.ts`: add `autoSubmitFromUrl: interfaceConfig?.autoSubmitFromUrl ?? defaults.autoSubmitFromUrl` to the loaded interface object, mirroring the existing pattern used for other UI-element fields (`mcpServers`, `customWelcome`, etc.).
- `packages/data-schemas/src/app/interface.spec.ts`: add three test cases — schema default when unset, explicit `false` propagation (the bug fix), explicit `true` propagation.

## Verification

```
$ cd packages/data-schemas
$ npx jest src/app/interface.spec.ts
PASS src/app/interface.spec.ts
  loadDefaultInterface
    ✓ preserves the configured temporary chat retention period
    ✓ omits temporary chat retention when it is not explicitly configured
    ✓ falls back to the schema default for autoSubmitFromUrl when unset
    ✓ propagates an explicit autoSubmitFromUrl: false to the loaded interface
    ✓ propagates an explicit autoSubmitFromUrl: true to the loaded interface

Tests: 5 passed, 5 total
```

End-to-end: with this change deployed, an operator setting

```yaml
interface:
  autoSubmitFromUrl: false
```

in `librechat.yaml` and restarting the API will see `/api/config` return `interface.autoSubmitFromUrl: false`, and `https://<host>/c/new?prompt=…&submit=true` will pre-fill the composer without submitting until the user explicitly presses Send.

## References

- Fixes #13016
- Refs #12929 — addresses the unresolved Copilot review comment at https://github.com/danny-avila/LibreChat/pull/12929#discussion_r3178534115