### PR TITLE
🧭 fix: Preserve File Search Upload Target

### DIFF
--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -81,7 +81,7 @@ const AttachFileMenu = ({
   const [ephemeralAgent, setEphemeralAgent] = useRecoilState(
     ephemeralAgentByConvoId(conversationId),
   );
-  const [toolResource, setToolResource] = useState<EToolResources | undefined>();
+  const toolResourceRef = useRef<EToolResources | undefined>();
   const { handleFileChange } = useFileHandlingNoChatContext(undefined, {
     files,
     setFiles,
@@ -90,7 +90,7 @@ const AttachFileMenu = ({
   });
   const { handleSharePointFiles, isProcessing, downloadProgress } =
     useSharePointFileHandlingNoChatContext(
-      { toolResource },
+      { toolResource: toolResourceRef.current },
       { files, setFiles, setFilesLoading, conversation },
     );
 
@@ -142,6 +142,10 @@ const AttachFileMenu = ({
   );
 
   const dropdownItems = useMemo(() => {
+    const setToolResource = (value: EToolResources | undefined) => {
+      toolResourceRef.current = value;
+    };
+
     const createMenuItems = (onAction: (fileType?: FileUploadType) => void) => {
       const items: MenuItemProps[] = [];
 
@@ -257,7 +261,6 @@ const AttachFileMenu = ({
     capabilities,
     useResponsesApi,
     handleUploadClick,
-    setToolResource,
     setEphemeralAgent,
     sharePointEnabled,
     codeAllowedByAgent,
@@ -301,7 +304,8 @@ const AttachFileMenu = ({
       <FileUpload
         ref={inputRef}
         handleFileChange={(e) => {
-          handleFileChange(e, toolResource);
+          handleFileChange(e, toolResourceRef.current);
+          toolResourceRef.current = undefined;
         }}
       >
         <DropdownPopup

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { RecoilRoot } from 'recoil';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { EModelEndpoint, Providers } from 'librechat-data-provider';
+import { EModelEndpoint, EToolResources, Providers } from 'librechat-data-provider';
 import AttachFileMenu from '../AttachFileMenu';
 
 jest.mock('~/hooks', () => ({
@@ -31,7 +31,20 @@ jest.mock('@librechat/client', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const R = require('react');
   return {
-    FileUpload: (props) => R.createElement('div', { 'data-testid': 'file-upload' }, props.children),
+    FileUpload: R.forwardRef((props, ref) =>
+      R.createElement(
+        'div',
+        { 'data-testid': 'file-upload' },
+        props.children,
+        R.createElement('input', {
+          ref,
+          multiple: true,
+          type: 'file',
+          'data-testid': 'file-input',
+          onChange: props.handleFileChange,
+        }),
+      ),
+    ),
     TooltipAnchor: (props) => props.render,
     DropdownPopup: (props) =>
       R.createElement(
@@ -317,6 +330,50 @@ describe('AttachFileMenu', () => {
       expect(screen.getByText('Upload as Text')).toBeInTheDocument();
       expect(screen.getByText('Upload for File Search')).toBeInTheDocument();
       expect(screen.getByText('Upload Code Files')).toBeInTheDocument();
+    });
+
+    it('passes File Search resource when the file input changes before React state commits', () => {
+      setupMocks();
+      const handleFileChange = jest.fn();
+      mockUseFileHandlingNoChatContext.mockReturnValue({ handleFileChange });
+      mockUseAgentCapabilities.mockReturnValue({
+        contextEnabled: false,
+        fileSearchEnabled: true,
+        codeEnabled: false,
+      });
+      mockUseAgentToolPermissions.mockReturnValue({
+        fileSearchAllowedByAgent: true,
+        codeAllowedByAgent: false,
+        provider: undefined,
+      });
+      const originalClick = HTMLInputElement.prototype.click;
+      const file = new File(['data'], 'sheet.xlsx', {
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      });
+
+      HTMLInputElement.prototype.click = function click() {
+        Object.defineProperty(this, 'files', {
+          configurable: true,
+          value: [file],
+        });
+        fireEvent.change(this);
+      };
+
+      try {
+        renderMenu({ endpointType: EModelEndpoint.openAI });
+        openMenu();
+        fireEvent.click(screen.getByText('Upload to Provider'));
+        fireEvent.click(screen.getByText('Upload for File Search'));
+      } finally {
+        HTMLInputElement.prototype.click = originalClick;
+      }
+
+      expect(handleFileChange).toHaveBeenNthCalledWith(1, expect.any(Object), undefined);
+      expect(handleFileChange).toHaveBeenNthCalledWith(
+        2,
+        expect.any(Object),
+        EToolResources.file_search,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

I fixed #13011 by preserving the selected upload target before the native file picker can fire its change event.

- Added ref-backed tracking for the attachment menu upload target so File Search uploads pass `EToolResources.file_search` even if React state has not committed yet.
- Reset the upload target after each file input change so provider uploads do not inherit a stale tool resource.
- Added a focused regression test that simulates the stale state timing path for File Search uploads.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm exec --workspace=client -- jest src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx --runInBand --coverage=false`
- `npm exec -- eslint client/src/components/Chat/Input/Files/AttachFileMenu.tsx client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx`

### **Test Configuration**:

- Node.js v20.19.5
- npm v10.8.2
- Playwright/browser verification was not used for this PR; this PR covers the frontend state timing path with a unit regression test.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes