### PR TITLE
feat: add Cmd/Ctrl+Shift+O keyboard shortcut for new chat

### DIFF
--- a/client/src/components/Nav/NewChat.tsx
+++ b/client/src/components/Nav/NewChat.tsx
@@ -1,8 +1,9 @@
+import { useCallback } from 'react';
 import { useRecoilValue } from 'recoil';
 import { QueryKeys } from 'librechat-data-provider';
 import { useQueryClient } from '@tanstack/react-query';
 import { TooltipAnchor, Button, NewChatIcon } from '@librechat/client';
-import { useLocalize, useNewConvo } from '~/hooks';
+import { useLocalize, useNewConvo, useKeyboardShortcut } from '~/hooks';
 import { clearMessagesCache, cn } from '~/utils';
 import store from '~/store';
 
@@ -12,15 +13,22 @@ export default function NewChat({ className }: { className?: string }) {
   const { newConversation } = useNewConvo();
   const conversation = useRecoilValue(store.conversationByIndex(0));
 
+  const startNewChat = useCallback(() => {
+    clearMessagesCache(queryClient, conversation?.conversationId);
+    queryClient.invalidateQueries([QueryKeys.messages]);
+    newConversation();
+  }, [queryClient, conversation?.conversationId, newConversation]);
+
   const clickHandler: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     if (e.button === 0 && (e.ctrlKey || e.metaKey)) {
       window.open('/c/new', '_blank');
       return;
     }
-    clearMessagesCache(queryClient, conversation?.conversationId);
-    queryClient.invalidateQueries([QueryKeys.messages]);
-    newConversation();
+    startNewChat();
   };
+
+  // Cmd/Ctrl+Shift+O — start a new chat (matches ChatGPT, Claude, and Gemini)
+  useKeyboardShortcut({ key: 'o', modifiers: ['mod', 'shift'] }, startNewChat, [startNewChat]);
 
   return (
     <TooltipAnchor

--- a/client/src/hooks/Generic/index.ts
+++ b/client/src/hooks/Generic/index.ts
@@ -1,2 +1,3 @@
 export * from './useLazyEffect';
 export { default as useShiftKey } from './useShiftKey';
+export { default as useKeyboardShortcut } from './useKeyboardShortcut';

--- a/client/src/hooks/Generic/useKeyboardShortcut.ts
+++ b/client/src/hooks/Generic/useKeyboardShortcut.ts
@@ -1,0 +1,83 @@
+import { useEffect } from 'react';
+
+type Modifier = 'mod' | 'shift' | 'alt';
+
+interface ShortcutOptions {
+  /** Key to match (case-insensitive). E.g. 'o', 's', 'Escape'. */
+  key: string;
+  /**
+   * Modifiers required for the shortcut to fire.
+   * - 'mod': Cmd on macOS, Ctrl elsewhere (matches `metaKey || ctrlKey`).
+   * - 'shift' / 'alt': literal modifiers.
+   */
+  modifiers?: Modifier[];
+  /** Disable the shortcut without unmounting the component. */
+  disabled?: boolean;
+  /** Prevent the browser default when the shortcut fires (default true). */
+  preventDefault?: boolean;
+  /** Skip when focus is in an input/textarea/contenteditable element (default false). */
+  ignoreInInput?: boolean;
+}
+
+const isEditableTarget = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    target.isContentEditable
+  );
+};
+
+/**
+ * Register a global keyboard shortcut. Uses the `'mod'` modifier to mean
+ * Cmd on macOS / Ctrl elsewhere, matching common conventions.
+ *
+ * @example
+ *   useKeyboardShortcut(
+ *     { key: 'o', modifiers: ['mod', 'shift'] },
+ *     () => startNewChat(),
+ *     [startNewChat],
+ *   );
+ */
+export default function useKeyboardShortcut(
+  options: ShortcutOptions,
+  handler: (e: KeyboardEvent) => void,
+  deps: React.DependencyList = [],
+): void {
+  const {
+    key,
+    modifiers = [],
+    disabled = false,
+    preventDefault = true,
+    ignoreInInput = false,
+  } = options;
+
+  useEffect(() => {
+    if (disabled) {
+      return;
+    }
+
+    const needsMod = modifiers.includes('mod');
+    const needsShift = modifiers.includes('shift');
+    const needsAlt = modifiers.includes('alt');
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() !== key.toLowerCase()) return;
+      if (needsShift !== e.shiftKey) return;
+      if (needsAlt !== e.altKey) return;
+      if (needsMod !== (e.metaKey || e.ctrlKey)) return;
+      if (ignoreInInput && isEditableTarget(e.target)) return;
+
+      if (preventDefault) {
+        e.preventDefault();
+      }
+      handler(e);
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, disabled, preventDefault, ignoreInInput, ...deps]);
+}


### PR DESCRIPTION
# feat: add `Cmd/Ctrl+Shift+O` keyboard shortcut for new chat

## Summary

Adds a global keyboard shortcut to start a new chat — **`⌘+Shift+O` on macOS, `Ctrl+Shift+O` on Windows/Linux** — matching the convention used by ChatGPT, Claude, and Gemini. This is the only "new chat" shortcut all three products implement identically, so it's the most familiar binding for users coming from any of them.

## Changes

- **New hook** `client/src/hooks/Generic/useKeyboardShortcut.ts` — small reusable wrapper around `window.addEventListener('keydown', …)` with a `'mod'` modifier that resolves to Cmd on macOS / Ctrl elsewhere. Same idiom already used elsewhere in the codebase (e.g. `useShiftKey`, the speech-to-text hooks); just deduplicated into one place.
- **`client/src/components/Nav/NewChat.tsx`** — extracted the new-chat side-effects into a `startNewChat` callback so it can be triggered by both the click handler and the new shortcut.

## Why a new generic hook?

LibreChat doesn't currently use a hotkey library (no `react-hotkeys-hook`, no shortcut registry). Existing keyboard handling is spread across components/hooks as ad-hoc `useEffect + addEventListener('keydown', …)` blocks. A 70-line typed hook keeps the new feature consistent with that pattern while making it easy to add more shortcuts later (e.g. `Cmd+/` for a help dialog) without growing the boilerplate.

## Behavior

- Fires on `keydown`, anywhere on the page (no input focus required).
- Calls `e.preventDefault()` before invoking the handler.
- Cleans up on unmount.
- Mac/Win/Linux are handled via `metaKey || ctrlKey` so a single shortcut works everywhere.

## Testing

- Manually verified on macOS Chrome and Firefox: `⌘+Shift+O` creates a new chat from any route.
- Verified click behavior is unchanged (regular click + `Ctrl/Cmd+click` still works).
- Verified the listener is removed on unmount via React DevTools.

## Screenshots / Demo

Triggerd new chat by `⌘+Shift+O`  on Macos

<img width="1914" height="897" alt="Screenshot 2026-05-08 at 3 16 14 PM" src="https://github.com/user-attachments/assets/42977c88-6152-41cd-8c2f-29fcc76f06c9" />

