### PR TITLE
🛟 fix: Summarization Provider misses `vertexai` + case-mismatched custom endpoints

### DIFF
--- a/packages/api/src/endpoints/config/providers.spec.ts
+++ b/packages/api/src/endpoints/config/providers.spec.ts
@@ -1,0 +1,99 @@
+import { Providers } from '@librechat/agents';
+import { EModelEndpoint } from 'librechat-data-provider';
+import type { AppConfig } from '@librechat/data-schemas';
+import { getProviderConfig, providerConfigMap } from './providers';
+
+const buildAppConfig = (
+  customEndpoints: Array<{ name: string; baseURL?: string; apiKey?: string }>,
+): AppConfig =>
+  ({
+    endpoints: {
+      [EModelEndpoint.custom]: customEndpoints,
+    },
+  }) as unknown as AppConfig;
+
+describe('getProviderConfig', () => {
+  it('resolves the existing google (API key) path to initializeGoogle', () => {
+    // Regression guard: the API-key path uses `Providers.GOOGLE === 'google'`,
+    // which has always mapped via `EModelEndpoint.google`. Adding the
+    // `Providers.VERTEXAI` entry must not perturb this.
+    const result = getProviderConfig({
+      provider: Providers.GOOGLE,
+      appConfig: buildAppConfig([]),
+    });
+
+    expect(result.overrideProvider).toBe(Providers.GOOGLE);
+    expect(result.getOptions).toBe(providerConfigMap[EModelEndpoint.google]);
+    expect(result.customEndpointConfig).toBeUndefined();
+  });
+
+  it('vertexai resolves to the same initializer as google (issue #13006 follow-up)', () => {
+    const result = getProviderConfig({
+      provider: Providers.VERTEXAI,
+      appConfig: buildAppConfig([]),
+    });
+
+    expect(result.overrideProvider).toBe(Providers.VERTEXAI);
+    expect(result.getOptions).toBe(providerConfigMap[EModelEndpoint.google]);
+    expect(result.customEndpointConfig).toBeUndefined();
+  });
+
+  it('falls back case-insensitively when only a CamelCase match exists', () => {
+    // Agent runtime resolved provider to lowercase `"openrouter"`, but the
+    // user's `librechat.yaml` declared `name: "OpenRouter"`.
+    const appConfig = buildAppConfig([
+      { name: 'OpenRouter', baseURL: 'https://openrouter.ai/api/v1', apiKey: 'sk-test' },
+    ]);
+
+    const result = getProviderConfig({ provider: 'openrouter', appConfig });
+
+    expect(result.overrideProvider).toBe(Providers.OPENROUTER);
+    expect(result.customEndpointConfig?.name).toBe('OpenRouter');
+  });
+
+  it('prefers the exact-case match when both casings exist (preserves case-sensitive identity)', () => {
+    // Two distinct custom endpoints differing only in case is supported by
+    // `loadCustomEndpointsConfig` (the keys are case-preserving). Direct
+    // exact-case lookup should win — case-insensitive fallback must not
+    // shadow the user's intent.
+    const appConfig = buildAppConfig([
+      { name: 'OpenRouter', baseURL: 'https://prod.example/v1', apiKey: 'prod' },
+      { name: 'openrouter', baseURL: 'https://staging.example/v1', apiKey: 'staging' },
+    ]);
+
+    const result = getProviderConfig({ provider: 'openrouter', appConfig });
+
+    expect(result.customEndpointConfig?.baseURL).toBe('https://staging.example/v1');
+  });
+
+  it('resolves an exact-case lowercase entry', () => {
+    const appConfig = buildAppConfig([
+      { name: 'openrouter', baseURL: 'https://openrouter.ai/api/v1', apiKey: 'sk-test' },
+    ]);
+
+    const result = getProviderConfig({ provider: 'openrouter', appConfig });
+
+    expect(result.customEndpointConfig?.name).toBe('openrouter');
+  });
+
+  it('throws on ambiguous case-insensitive matches when no exact-case entry exists (codex review)', () => {
+    // User has two distinct entries differing only in case, both
+    // non-lowercase. The agent runtime resolves provider to lowercase
+    // "openrouter" — neither matches case-sensitively, and silently
+    // picking array-first could route requests to the wrong baseURL/apiKey.
+    const appConfig = buildAppConfig([
+      { name: 'OpenRouter', baseURL: 'https://prod.example/v1', apiKey: 'prod' },
+      { name: 'OPENROUTER', baseURL: 'https://canary.example/v1', apiKey: 'canary' },
+    ]);
+
+    expect(() => getProviderConfig({ provider: 'openrouter', appConfig })).toThrow(
+      /ambiguous.*OpenRouter.*OPENROUTER/i,
+    );
+  });
+
+  it('throws when openrouter has no matching custom endpoint at all', () => {
+    expect(() =>
+      getProviderConfig({ provider: 'openrouter', appConfig: buildAppConfig([]) }),
+    ).toThrow('Provider openrouter not supported');
+  });
+});

--- a/packages/api/src/endpoints/config/providers.ts
+++ b/packages/api/src/endpoints/config/providers.ts
@@ -27,13 +27,21 @@ export function isKnownCustomProvider(provider?: string): boolean {
 }
 
 /**
- * Provider configuration map mapping providers to their initialization functions
+ * Provider configuration map mapping providers to their initialization functions.
+ *
+ * `Providers.VERTEXAI` shares `initializeGoogle` because the runtime distinction
+ * is auth-only — the agent flow may resolve `agent.provider` to `vertexai` when
+ * a service account is configured, but summarization (and other downstream
+ * resolvers) get the same lowercase enum value passed back. Without this
+ * mapping `getProviderConfig` throws "Provider vertexai not supported" and
+ * summarization falls back to the raw provider, dropping client overrides.
  */
 export const providerConfigMap: Record<string, InitializeFn> = {
   [Providers.XAI]: initializeCustom,
   [Providers.DEEPSEEK]: initializeCustom,
   [Providers.MOONSHOT]: initializeCustom,
   [Providers.OPENROUTER]: initializeCustom,
+  [Providers.VERTEXAI]: initializeGoogle,
   [EModelEndpoint.openAI]: initializeOpenAI,
   [EModelEndpoint.google]: initializeGoogle,
   [EModelEndpoint.bedrock]: initializeBedrock,
@@ -87,6 +95,41 @@ export function getProviderConfig({
 
   if (isKnownCustomProvider(overrideProvider) && !customEndpointConfig) {
     customEndpointConfig = getCustomEndpointConfig({ endpoint: provider, appConfig });
+    if (!customEndpointConfig && appConfig) {
+      /**
+       * Case-insensitive fallback for known custom providers only.
+       *
+       * The agent main flow looks up custom endpoints case-sensitively
+       * (case-preserving keys are how `loadCustomEndpointsConfig` lets
+       * users have e.g. `"OpenRouter"` and `"openrouter-staging"` as
+       * distinct entries). After it succeeds, `agent.provider` is
+       * normalized to the lowercase `Providers` enum value
+       * (e.g. `"openrouter"`). Downstream resolvers (summarization,
+       * title) re-enter `getProviderConfig` with that lowercase value,
+       * and the case-sensitive direct lookup misses configs whose
+       * `name` is camel-cased — the most common shape.
+       *
+       * Only fall back when the direct lookup already failed, so users
+       * with case-sensitive endpoint identity are unaffected — their
+       * exact-case match wins first. When multiple case-insensitive
+       * matches exist (e.g. both `OpenRouter` and `OPENROUTER`, neither
+       * lowercase), refuse to silently pick array-first; the caller's
+       * intent is ambiguous and either entry could route requests with
+       * different baseURL/apiKey.
+       */
+      const customEndpoints = appConfig.endpoints?.[EModelEndpoint.custom] ?? [];
+      const target = provider.toLowerCase();
+      const matches = customEndpoints.filter(
+        (endpointConfig) => (endpointConfig.name ?? '').toLowerCase() === target,
+      );
+      if (matches.length > 1) {
+        const names = matches.map((m) => m.name ?? '').join(', ');
+        throw new Error(
+          `Provider ${provider} is ambiguous: multiple custom endpoints match case-insensitively (${names}). Rename one or use the exact-case provider value.`,
+        );
+      }
+      customEndpointConfig = matches[0];
+    }
     if (!customEndpointConfig) {
       throw new Error(`Provider ${provider} not supported`);
     }


### PR DESCRIPTION
## Summary

Two real-world inputs caused `resolveSummarizationProvider` to throw and fall back silently to "raw provider" (dropping client overrides), surfacing as the warning seen in production logs:

```
[resolveSummarizationProvider] failed to resolve "vertexai"; falling back to raw provider
[resolveSummarizationProvider] failed to resolve "openrouter"; falling back to raw provider
```

Companion to the agents-side fix [danny-avila/agents#159](https://github.com/danny-avila/agents/pull/159).

## Root cause

### 1. `vertexai` was missing from `providerConfigMap`

The agent flow may set `agent.provider = Providers.VERTEXAI` when a Google service-account is configured ([packages/api/src/agents/initialize.ts:830](packages/api/src/agents/initialize.ts:830)). When summarization later resolves the provider, `getProviderConfig({ provider: 'vertexai' })` finds nothing in the map and falls through to a custom-endpoint lookup (also empty) → throws `Provider vertexai not supported`.

### 2. Known custom providers + CamelCase `librechat.yaml` entries

The agent main flow looks up custom endpoints case-sensitively. That's intentional: `loadCustomEndpointsConfig` keys `customEndpointsConfig[name] = ...` by the case-preserving name, so users *can* have two distinct custom endpoints differing only in case (e.g. `"OpenRouter"` for prod and `"openrouter-staging"` for staging — case-sensitive identity is part of the contract).

But once the agent main flow succeeds, `agent.provider` is normalized to the lowercase `Providers` enum value (e.g. `"openrouter"`). Downstream resolvers (summarization, title) re-enter `getProviderConfig` with that lowercased value, and the case-sensitive direct lookup misses configs whose `name` is camel-cased — the most common shape.

## Fix (narrow)

- **`providers.ts`** — add `[Providers.VERTEXAI]: initializeGoogle` to `providerConfigMap`. Vertex shares Google initialization (the difference is auth, not init logic).
- **`providers.ts`** — add a case-insensitive fallback to `getProviderConfig`, **narrowly** scoped:
  1. Only fires for known custom providers (`Providers.XAI`, `Providers.DEEPSEEK`, `Providers.OPENROUTER`, `Providers.MOONSHOT`).
  2. Only after the case-sensitive direct lookup already failed.
  3. Doesn't shadow exact-case matches — users with `"OpenRouter"` *and* `"openrouter"` configured as distinct entries still get the exact-case match first.
- **`getCustomEndpointConfig` left untouched** — case-sensitive lookup at that layer remains the contract.

## Tests

`packages/api/src/endpoints/config/providers.spec.ts` — new file, 5 tests:
- vertexai resolves to the Google initializer
- case-insensitive fallback fires when only a CamelCase entry exists
- **exact-case match wins when both casings exist** — explicitly preserves case-sensitive identity
- exact-case lowercase entry still resolves
- still throws when no custom endpoint exists at all

Existing `app/config.test.ts` "should handle mixed case endpoint names" assertion left as-is — `getCustomEndpointConfig` continues to be case-sensitive at the lookup layer.

## Test plan

- [x] vertexai unit test passes
- [x] CamelCase fallback unit test passes
- [x] Exact-case identity preservation unit test passes
- [x] No regression on `app/config` tests (case-sensitive lookup intact)
- [ ] Live verification by user: warnings should disappear from logs after deploy