### PR TITLE
⛴️ chore: Use Bitnami Legacy MongoDB Image in Helm Chart

### DIFF
--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.2
+version: 2.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/librechat/values.yaml
+++ b/helm/librechat/values.yaml
@@ -291,6 +291,10 @@ additionalConfigMaps: {}
 # MongoDB Parameters
 mongodb:
   enabled: true
+  # Bitnami moved versioned image tags to docker.io/bitnamilegacy on 2025-08-28.
+  # See https://github.com/bitnami/charts/issues/35164
+  image:
+    repository: bitnamilegacy/mongodb
   auth:
     enabled: false
   databases:


### PR DESCRIPTION
## Summary

- Bitnami moved versioned image tags (e.g. `mongodb:8.0.13-debian-12-r0`) from `docker.io/bitnami` to `docker.io/bitnamilegacy` on 2025-08-28 (see [bitnami/charts#35164](https://github.com/bitnami/charts/issues/35164)). The Bitnami MongoDB subchart still references the old path, so a fresh `helm install` of `librechat` fails with `Init:ImagePullBackOff`.
- Override `mongodb.image.repository` to `bitnamilegacy/mongodb` in `values.yaml` so the chart installs out of the box again, and bump chart `version` to `2.0.3`.
- Redis subchart pins `tag: latest`, which Bitnami says still resolves at `docker.io/bitnami`, so no change there.

Closes #11568

## Test plan

- [x] `helm dependency update helm/librechat`
- [x] `helm install librechat ./helm/librechat -n librechat --create-namespace` succeeds with default values
- [x] `kubectl -n librechat get pods` shows the MongoDB pod transitioning to `Running` (no `ImagePullBackOff`)
- [x] LibreChat backend connects to MongoDB and the app reaches a healthy state

