### PR TITLE
🛟 fix: Allow Empty `modelSpecs.list` to Unstick Admin-Panel Saves

### DIFF
--- a/api/server/middleware/buildEndpointOption.js
+++ b/api/server/middleware/buildEndpointOption.js
@@ -48,7 +48,7 @@ async function buildEndpointOption(req, res, next) {
   }
 
   const appConfig = req.config;
-  if (appConfig.modelSpecs?.list && appConfig.modelSpecs?.enforce) {
+  if (appConfig.modelSpecs?.list?.length && appConfig.modelSpecs?.enforce) {
     /** @type {{ list: TModelSpec[] }}*/
     const { list } = appConfig.modelSpecs;
     const { spec } = parsedBody;

--- a/api/server/middleware/buildEndpointOption.spec.js
+++ b/api/server/middleware/buildEndpointOption.spec.js
@@ -234,4 +234,34 @@ describe('buildEndpointOption - defaultParamsEndpoint parsing', () => {
     expect(parsedResult.maxOutputTokens).toBeUndefined();
     expect(parsedResult.max_tokens).toBe(4096);
   });
+
+  it('should not enter the enforce branch when modelSpecs.list is empty', async () => {
+    mockGetEndpointsConfig.mockResolvedValue({});
+
+    const req = createReq(
+      {
+        endpoint: EModelEndpoint.openAI,
+        model: 'gpt-4',
+      },
+      {
+        modelSpecs: {
+          enforce: true,
+          list: [],
+        },
+      },
+    );
+    const res = createRes();
+    const { handleError } = require('@librechat/api');
+
+    await buildEndpointOption(req, res, jest.fn());
+
+    expect(handleError).not.toHaveBeenCalledWith(
+      res,
+      expect.objectContaining({ text: 'No model spec selected' }),
+    );
+    expect(handleError).not.toHaveBeenCalledWith(
+      res,
+      expect.objectContaining({ text: 'Invalid model spec' }),
+    );
+  });
 });

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -10,6 +10,7 @@ import {
   summarizationTriggerSchema,
   summarizationConfigSchema,
 } from '../src/config';
+import { specsConfigSchema } from '../src/models';
 import { tModelSpecPresetSchema, EModelEndpoint } from '../src/schemas';
 import { FileSources } from '../src/types/files';
 
@@ -716,5 +717,44 @@ describe('summarizationTriggerSchema', () => {
       trigger: { type: 'token_ratio', value: 0.8 },
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe('specsConfigSchema', () => {
+  it('accepts an empty list (defaults applied)', () => {
+    const result = specsConfigSchema.safeParse({ list: [] });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.list).toEqual([]);
+      expect(result.data.enforce).toBe(false);
+      expect(result.data.prioritize).toBe(true);
+    }
+  });
+
+  it('defaults list to [] when omitted', () => {
+    const result = specsConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.list).toEqual([]);
+    }
+  });
+
+  it('accepts a populated list', () => {
+    const result = specsConfigSchema.safeParse({
+      enforce: true,
+      list: [
+        {
+          name: 'spec-1',
+          label: 'Spec 1',
+          preset: { endpoint: EModelEndpoint.openAI },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('still rejects null list', () => {
+    const result = specsConfigSchema.safeParse({ list: null });
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -10,8 +10,8 @@ import {
   summarizationTriggerSchema,
   summarizationConfigSchema,
 } from '../src/config';
-import { specsConfigSchema } from '../src/models';
 import { tModelSpecPresetSchema, EModelEndpoint } from '../src/schemas';
+import { specsConfigSchema } from '../src/models';
 import { FileSources } from '../src/types/files';
 
 describe('paramDefinitionSchema', () => {

--- a/packages/data-provider/src/models.ts
+++ b/packages/data-provider/src/models.ts
@@ -62,7 +62,7 @@ export const tModelSpecSchema = z.object({
 export const specsConfigSchema = z.object({
   enforce: z.boolean().default(false),
   prioritize: z.boolean().default(true),
-  list: z.array(tModelSpecSchema).min(1),
+  list: z.array(tModelSpecSchema).default([]),
   addedEndpoints: z.array(z.union([z.string(), eModelEndpointSchema])).optional(),
 });
 

--- a/packages/data-schemas/src/app/specs.ts
+++ b/packages/data-schemas/src/app/specs.ts
@@ -37,6 +37,11 @@ export function processModelSpecs(
   }
 
   if (!list || list.length === 0) {
+    if (_modelSpecs.enforce) {
+      logger.warn(
+        'modelSpecs.enforce is true but list is empty — enforcement disabled at runtime.',
+      );
+    }
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

The unconditional `.min(1)` on `specsConfigSchema.list` rejects an empty list even when `enforce: false`. Admin panels (and any tool that issues path-granular saves) have no atomic way to clear the list once it's been populated, so once an admin reaches `list: [entry]` and deletes the only entry, every subsequent save fails schema validation and the section becomes stuck. The user has no per-field reset that escapes the state.

`.min(1)` was added in #5218 as part of bundled cleanup, not as a deliberate rule, and no consumer is load-bearing on `length >= 1`. Every reader of `modelSpecs.list` (`buildEndpointOption`, `agents/load`, `agents/added`, `BadgeRowContext`, `useAppStartup`, `useMentions`, `useQueryParams`, `getModelSpec`, `getDefaultModelSpec`, `ModelSelector`, `FavoritesList`, `interface.ts`, `checks.ts`) already handles empty/undefined defensively, and `processModelSpecs` short-circuits to `undefined` on empty list so the runtime treats the empty case as "no specs configured."

This relaxes the schema to `.default([])`, tightens the `buildEndpointOption.js` enforce guard to use `?.list?.length` instead of just `?.list` (empty arrays are truthy in JS, so the original guard could enter the enforce branch on `[]` had `processModelSpecs` ever been bypassed), and adds a runtime warn when `enforce: true` is configured alongside an empty list so operators see the resulting "enforcement disabled" state in logs rather than silently getting a permissive runtime.

### Changes

- `packages/data-provider/src/models.ts` -- `specsConfigSchema.list` from `.min(1)` to `.default([])`
- `packages/data-schemas/src/app/specs.ts` -- log a warning in `processModelSpecs` when `enforce: true` collapses to "no specs" because the list is empty
- `api/server/middleware/buildEndpointOption.js` -- defensive guard `?.list?.length && ?.enforce` instead of `?.list && ?.enforce`
- `packages/data-provider/specs/config-schemas.spec.ts` -- coverage for the empty-list parse path and `.default([])` defaulting
- `api/server/middleware/buildEndpointOption.spec.js` -- coverage for empty-list-with-enforce no longer entering the spec-rejection branch

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

1. Reproduce on `dev`: run a backend with `librechat.yaml` containing `modelSpecs: { enforce: true, list: [{ name: "x", preset: { endpoint: "openAI" } }] }`. Use an admin tool to remove the entry from the list while leaving `enforce: true`. The save fails repeatedly against `.min(1)` and the section becomes unrecoverable.
2. With this branch checked out: run the same flow. The save succeeds. The runtime collapses `list: []` to no-specs and logs `"modelSpecs.enforce is true but list is empty -- enforcement disabled at runtime"`. Chat continues to work without spec enforcement.
3. Boot the server with `librechat.yaml` containing `modelSpecs: { enforce: true }` (no list). Before: server crashes at boot with a Zod error. After: server boots, warn appears in logs, chat works.
4. `cd packages/data-provider && npx jest specs/config-schemas.spec.ts` -- 70 passing including 4 new.
5. `cd api && npx jest middleware/buildEndpointOption.spec.js` -- 6 passing including 1 new.
6. `cd packages/data-schemas && npx jest src/app` -- 50 passing.
7. `npm run build:data-provider` -- clean.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes