### PR TITLE
🦘 fix: Skip OpenAI Model Fetch For User-Provided Keys

### DIFF
--- a/packages/api/src/endpoints/models.spec.ts
+++ b/packages/api/src/endpoints/models.spec.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { Time, EModelEndpoint, defaultModels } from 'librechat-data-provider';
+import { Time, EModelEndpoint, defaultModels, AuthType } from 'librechat-data-provider';
 import {
   fetchModels,
   splitAndTrim,
@@ -209,6 +209,17 @@ describe('getOpenAIModels', () => {
 
   it('returns default models when no environment configurations are provided (and fetch fails)', async () => {
     const models = await getOpenAIModels({ user: 'user456' });
+    expect(models).toContain('gpt-4');
+  });
+
+  it('returns default models when OpenAI API key is user provided', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { data: [{ id: 'should-not-appear' }] } });
+    process.env.OPENAI_API_KEY = AuthType.USER_PROVIDED;
+
+    const models = await getOpenAIModels({ user: 'user456' });
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(models).not.toContain('should-not-appear');
     expect(models).toContain('gpt-4');
   });
 

--- a/packages/api/src/endpoints/models.spec.ts
+++ b/packages/api/src/endpoints/models.spec.ts
@@ -240,6 +240,23 @@ describe('getOpenAIModels', () => {
     expect(models).toEqual(['gpt-runtime-key']);
   });
 
+  it('falls back to environment OpenAI API key when options key is empty', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { data: [{ id: 'gpt-env-key' }] } });
+    process.env.OPENAI_API_KEY = 'sk-env';
+
+    const models = await getOpenAIModels({ user: 'user456', openAIApiKey: '' });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining('https://api.openai.com/v1/models'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer sk-env',
+        }),
+      }),
+    );
+    expect(models).toEqual(['gpt-env-key']);
+  });
+
   it('returns `AZURE_OPENAI_MODELS` with `azure` flag (and fetch fails)', async () => {
     process.env.AZURE_OPENAI_MODELS = 'azure-model,azure-model-2';
     const models = await getOpenAIModels({ azure: true });

--- a/packages/api/src/endpoints/models.spec.ts
+++ b/packages/api/src/endpoints/models.spec.ts
@@ -223,6 +223,23 @@ describe('getOpenAIModels', () => {
     expect(models).toContain('gpt-4');
   });
 
+  it('fetches models when OpenAI API key is provided through options', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { data: [{ id: 'gpt-runtime-key' }] } });
+    process.env.OPENAI_API_KEY = AuthType.USER_PROVIDED;
+
+    const models = await getOpenAIModels({ user: 'user456', openAIApiKey: 'sk-runtime' });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining('https://api.openai.com/v1/models'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer sk-runtime',
+        }),
+      }),
+    );
+    expect(models).toEqual(['gpt-runtime-key']);
+  });
+
   it('returns `AZURE_OPENAI_MODELS` with `azure` flag (and fetch fails)', async () => {
     process.env.AZURE_OPENAI_MODELS = 'azure-model,azure-model-2';
     const models = await getOpenAIModels({ azure: true });

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -310,7 +310,7 @@ export async function getOpenAIModels(opts: GetOpenAIModelsOptions = {}): Promis
     return splitAndTrim(process.env[key]);
   }
 
-  if (opts.userProvidedOpenAI) {
+  if (isUserProvided(process.env.OPENAI_API_KEY)) {
     return models;
   }
 

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -228,6 +228,10 @@ export interface GetOpenAIModelsOptions {
   skipCache?: boolean;
 }
 
+function resolveOpenAIApiKey(opts: GetOpenAIModelsOptions): string | undefined {
+  return opts.openAIApiKey || process.env.OPENAI_API_KEY;
+}
+
 /**
  * Fetches models from OpenAI or Azure based on the provided options.
  * @param opts - Options for fetching models
@@ -239,7 +243,7 @@ export async function fetchOpenAIModels(
   _models: string[] = [],
 ): Promise<string[]> {
   let models = _models.slice() ?? [];
-  const apiKey = opts.openAIApiKey ?? process.env.OPENAI_API_KEY;
+  const apiKey = resolveOpenAIApiKey(opts);
   const openaiBaseURL = 'https://api.openai.com/v1';
   let baseURL = openaiBaseURL;
   let reverseProxyUrl = process.env.OPENAI_REVERSE_PROXY;
@@ -308,7 +312,7 @@ export async function getOpenAIModels(opts: GetOpenAIModelsOptions = {}): Promis
     return splitAndTrim(process.env[key]);
   }
 
-  if (isUserProvided(opts.openAIApiKey ?? process.env.OPENAI_API_KEY)) {
+  if (isUserProvided(resolveOpenAIApiKey(opts))) {
     return models;
   }
 

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -308,7 +308,7 @@ export async function getOpenAIModels(opts: GetOpenAIModelsOptions = {}): Promis
     return splitAndTrim(process.env[key]);
   }
 
-  if (isUserProvided(process.env.OPENAI_API_KEY)) {
+  if (isUserProvided(opts.openAIApiKey ?? process.env.OPENAI_API_KEY)) {
     return models;
   }
 

--- a/packages/api/src/endpoints/models.ts
+++ b/packages/api/src/endpoints/models.ts
@@ -224,8 +224,6 @@ export interface GetOpenAIModelsOptions {
   assistants?: boolean;
   /** OpenAI API key (if not using environment variable) */
   openAIApiKey?: string;
-  /** Whether user provides their own API key */
-  userProvidedOpenAI?: boolean;
   /** Skip MODEL_QUERIES cache (e.g., for user-provided keys) */
   skipCache?: boolean;
 }


### PR DESCRIPTION
## Summary

I carried forward the OpenAI model-loading fix from #12797 and removed the unused caller-provided flag from the internal model-loading options.

- Preserve the `OPENAI_API_KEY=user_provided` guard inside `getOpenAIModels` so default model loading does not fetch OpenAI models with a placeholder key.
- Add the regression test from #12797 to assert no OpenAI model request is made when the key is user-provided.
- Remove the unused `userProvidedOpenAI` option from `GetOpenAIModelsOptions` so callers rely on the centralized env check.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm ci`
- `npm run build:data-provider`
- `npm run build:data-schemas`
- `cd packages/api && npx jest src/endpoints/models.spec.ts --runInBand --coverage=false`
- `npm run build:api`

### **Test Configuration**:

- Node.js: `v20.19.5`
- npm: `10.8.2`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
