### PR TITLE
🧬 refactor: Align OpenRouter Reasoning Payloads

### DIFF
--- a/packages/api/src/agents/openai/handlers.spec.ts
+++ b/packages/api/src/agents/openai/handlers.spec.ts
@@ -1,0 +1,65 @@
+import type { Response as ServerResponse } from 'express';
+import type { OpenAIResponseContext } from './types';
+import { sendFinalChunk, OpenAIModelEndHandler, createOpenAIStreamTracker } from './handlers';
+
+describe('OpenAI-compatible agent stream handlers', () => {
+  const context: OpenAIResponseContext = {
+    requestId: 'chatcmpl-test',
+    created: 1778317637,
+    model: 'anthropic/claude-sonnet-4.6',
+  };
+
+  it('preserves reasoning token usage from model end metadata', () => {
+    const tracker = createOpenAIStreamTracker();
+    const write = jest.fn();
+    const handler = new OpenAIModelEndHandler({
+      context,
+      tracker,
+      res: { write } as unknown as ServerResponse,
+    });
+
+    handler.handle('on_chat_model_end', {
+      output: {
+        usage_metadata: {
+          input_tokens: 64,
+          output_tokens: 3315,
+          output_token_details: {
+            reasoning: 641,
+          },
+        },
+      },
+    });
+
+    expect(tracker.usage).toEqual({
+      promptTokens: 64,
+      completionTokens: 3315,
+      reasoningTokens: 641,
+    });
+  });
+
+  it('includes reasoning token details in the final streamed usage chunk', () => {
+    const tracker = createOpenAIStreamTracker();
+    tracker.usage.promptTokens = 64;
+    tracker.usage.completionTokens = 3315;
+    tracker.usage.reasoningTokens = 641;
+
+    const writes: string[] = [];
+    const res = {
+      write: (chunk: string) => {
+        writes.push(chunk);
+      },
+    } as unknown as ServerResponse;
+
+    sendFinalChunk({ context, tracker, res });
+
+    const finalChunk = JSON.parse(writes[0].replace(/^data: /, '').trim());
+    expect(finalChunk.usage).toEqual({
+      prompt_tokens: 64,
+      completion_tokens: 3315,
+      total_tokens: 3379,
+      completion_tokens_details: {
+        reasoning_tokens: 641,
+      },
+    });
+  });
+});

--- a/packages/api/src/agents/openai/handlers.ts
+++ b/packages/api/src/agents/openai/handlers.ts
@@ -218,6 +218,10 @@ export interface ModelEndData {
       input_tokens?: number;
       output_tokens?: number;
       model?: string;
+      output_token_details?: {
+        reasoning?: number;
+        reasoning_tokens?: number;
+      };
     };
   };
 }
@@ -354,6 +358,8 @@ export class OpenAIModelEndHandler implements EventHandler {
 
     this.config.tracker.usage.promptTokens += usage.input_tokens ?? 0;
     this.config.tracker.usage.completionTokens += usage.output_tokens ?? 0;
+    this.config.tracker.usage.reasoningTokens +=
+      usage.output_token_details?.reasoning ?? usage.output_token_details?.reasoning_tokens ?? 0;
   }
 }
 

--- a/packages/api/src/endpoints/openai/config.spec.ts
+++ b/packages/api/src/endpoints/openai/config.spec.ts
@@ -1255,9 +1255,9 @@ describe('getOpenAIConfig', () => {
       // Should NOT have useResponsesApi for OpenRouter
       expect(result.llmConfig.useResponsesApi).toBeUndefined();
       expect(result.llmConfig.maxTokens).toBe(2000);
+      expect(result.llmConfig.verbosity).toBe(Verbosity.medium);
       expect(result.llmConfig.modelKwargs).toEqual({
         reasoning: { effort: ReasoningEffort.high },
-        verbosity: Verbosity.medium,
         customParam: 'custom-value',
         plugins: [{ id: 'web' }], // OpenRouter web search format
       });
@@ -1573,8 +1573,9 @@ describe('getOpenAIConfig', () => {
           promptCache: true,
         });
         expect(result.llmConfig.include_reasoning).toBeUndefined();
+        expect(result.llmConfig.verbosity).toBe(ReasoningEffort.high);
         expect(result.llmConfig.modelKwargs).toMatchObject({
-          reasoning: { effort: ReasoningEffort.high },
+          reasoning: { enabled: true },
         });
         expect(result.configOptions?.baseURL).toBe(baseURL);
         expect(result.configOptions?.defaultHeaders).toMatchObject({

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -762,6 +762,43 @@ describe('getOpenAILLMConfig', () => {
       expect(result.llmConfig.modelKwargs).toBeUndefined();
     });
 
+    it('should pass OpenRouter Responses API verbosity under text', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        modelOptions: {
+          model: 'anthropic/claude-opus-4.7',
+          useResponsesApi: true,
+          verbosity: 'xhigh',
+        },
+      });
+
+      expect(result.llmConfig).not.toHaveProperty('verbosity');
+      expect(result.llmConfig.modelKwargs).toHaveProperty('text', {
+        verbosity: 'xhigh',
+      });
+    });
+
+    it('should pass adaptive OpenRouter Responses API effort verbosity under text', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        modelOptions: {
+          model: '~anthropic/claude-4.7-opus-20260416',
+          useResponsesApi: true,
+          reasoning_effort: ReasoningEffort.xhigh,
+        },
+      });
+
+      expect(result.llmConfig).not.toHaveProperty('verbosity');
+      expect(result.llmConfig.modelKwargs).toMatchObject({
+        reasoning: { enabled: true },
+        text: { verbosity: ReasoningEffort.xhigh },
+      });
+    });
+
     it('should let OpenRouter added verbosity override model verbosity', () => {
       const result = getOpenAILLMConfig({
         apiKey: 'test-api-key',

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -696,6 +696,23 @@ describe('getOpenAILLMConfig', () => {
       expect(result.llmConfig).toHaveProperty('verbosity', 'max');
     });
 
+    it('should preserve extra-high OpenRouter verbosity for future adaptive Claude models', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        modelOptions: {
+          model: 'anthropic/claude-sonnet-5',
+          reasoning_effort: ReasoningEffort.xhigh,
+        },
+      });
+
+      expect(result.llmConfig.modelKwargs).toHaveProperty('reasoning', {
+        enabled: true,
+      });
+      expect(result.llmConfig).toHaveProperty('verbosity', ReasoningEffort.xhigh);
+    });
+
     it('should pass OpenRouter verbosity as a top-level parameter', () => {
       const result = getOpenAILLMConfig({
         apiKey: 'test-api-key',

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -626,6 +626,158 @@ describe('getOpenAILLMConfig', () => {
       expect(result.llmConfig).not.toHaveProperty('reasoning_effort');
     });
 
+    it('should map OpenRouter adaptive Claude reasoning effort to enabled reasoning and verbosity', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        modelOptions: {
+          model: 'anthropic/claude-sonnet-4.6',
+          reasoning_effort: ReasoningEffort.high,
+        },
+      });
+
+      expect(result.llmConfig.modelKwargs).toHaveProperty('reasoning', {
+        enabled: true,
+      });
+      expect(result.llmConfig).toHaveProperty('verbosity', ReasoningEffort.high);
+      expect(result.llmConfig).not.toHaveProperty('include_reasoning');
+    });
+
+    it('should not override explicit OpenRouter verbosity for adaptive Claude models', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        modelOptions: {
+          model: 'anthropic/claude-opus-4.7',
+          verbosity: Verbosity.low,
+          reasoning_effort: ReasoningEffort.xhigh,
+        },
+      });
+
+      expect(result.llmConfig.modelKwargs).toHaveProperty('reasoning', {
+        enabled: true,
+      });
+      expect(result.llmConfig).toHaveProperty('verbosity', Verbosity.low);
+    });
+
+    it('should handle OpenRouter adaptive Claude model ids with latest routing prefix', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        modelOptions: {
+          model: '~anthropic/claude-4.7-opus-20260416',
+          reasoning_effort: ReasoningEffort.xhigh,
+        },
+      });
+
+      expect(result.llmConfig.modelKwargs).toHaveProperty('reasoning', {
+        enabled: true,
+      });
+      expect(result.llmConfig).toHaveProperty('verbosity', ReasoningEffort.xhigh);
+    });
+
+    it('should map extra-high OpenRouter Claude 4.6 effort to max verbosity', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        modelOptions: {
+          model: 'anthropic/claude-sonnet-4.6',
+          reasoning_effort: ReasoningEffort.xhigh,
+        },
+      });
+
+      expect(result.llmConfig.modelKwargs).toHaveProperty('reasoning', {
+        enabled: true,
+      });
+      expect(result.llmConfig).toHaveProperty('verbosity', 'max');
+    });
+
+    it('should pass OpenRouter verbosity as a top-level parameter', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        modelOptions: {
+          model: 'anthropic/claude-sonnet-4.6',
+          verbosity: Verbosity.high,
+        },
+      });
+
+      expect(result.llmConfig).toHaveProperty('verbosity', Verbosity.high);
+      expect(result.llmConfig.modelKwargs).toBeUndefined();
+    });
+
+    it('should pass OpenRouter default verbosity as a top-level parameter', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        defaultParams: {
+          verbosity: Verbosity.high,
+        },
+        modelOptions: {
+          model: 'anthropic/claude-sonnet-4.6',
+        },
+      });
+
+      expect(result.llmConfig).toHaveProperty('verbosity', Verbosity.high);
+      expect(result.llmConfig.modelKwargs).toBeUndefined();
+    });
+
+    it('should pass OpenRouter max verbosity as a top-level parameter', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        addParams: {
+          verbosity: 'max',
+        },
+        modelOptions: {
+          model: 'anthropic/claude-sonnet-4.6',
+        },
+      });
+
+      expect(result.llmConfig).toHaveProperty('verbosity', 'max');
+      expect(result.llmConfig.modelKwargs).toBeUndefined();
+    });
+
+    it('should let OpenRouter added verbosity override model verbosity', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        addParams: {
+          verbosity: Verbosity.high,
+        },
+        modelOptions: {
+          model: 'anthropic/claude-sonnet-4.6',
+          verbosity: Verbosity.low,
+        },
+      });
+
+      expect(result.llmConfig).toHaveProperty('verbosity', Verbosity.high);
+      expect(result.llmConfig.modelKwargs).toBeUndefined();
+    });
+
+    it('should disable adaptive Claude reasoning when OpenRouter reasoning_effort is none', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        modelOptions: {
+          model: 'anthropic/claude-opus-4.7',
+          reasoning_effort: ReasoningEffort.none,
+        },
+      });
+
+      expect(result.llmConfig).toHaveProperty('include_reasoning', false);
+      expect(result.llmConfig).not.toHaveProperty('modelKwargs');
+    });
+
     it('should exclude reasoning_summary from OpenRouter reasoning object', () => {
       const result = getOpenAILLMConfig({
         apiKey: 'test-api-key',

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -762,6 +762,23 @@ describe('getOpenAILLMConfig', () => {
       expect(result.llmConfig.modelKwargs).toBeUndefined();
     });
 
+    it('should preserve provider-specific OpenRouter verbosity values', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        useOpenRouter: true,
+        addParams: {
+          verbosity: 'ultra',
+        },
+        modelOptions: {
+          model: 'custom/openrouter-model',
+        },
+      });
+
+      expect(result.llmConfig).toHaveProperty('verbosity', 'ultra');
+      expect(result.llmConfig.modelKwargs).toBeUndefined();
+    });
+
     it('should pass OpenRouter Responses API verbosity under text', () => {
       const result = getOpenAILLMConfig({
         apiKey: 'test-api-key',
@@ -959,6 +976,21 @@ describe('getOpenAILLMConfig', () => {
       });
 
       expect(result.llmConfig.modelKwargs).toHaveProperty('verbosity', Verbosity.high);
+    });
+
+    it('should preserve provider-specific verbosity values in modelKwargs', () => {
+      const result = getOpenAILLMConfig({
+        apiKey: 'test-api-key',
+        streaming: true,
+        defaultParams: {
+          verbosity: 'detailed',
+        },
+        modelOptions: {
+          model: 'custom-model',
+        },
+      });
+
+      expect(result.llmConfig.modelKwargs).toHaveProperty('verbosity', 'detailed');
     });
 
     it('should convert verbosity to text object with Responses API', () => {

--- a/packages/api/src/endpoints/openai/llm.spec.ts
+++ b/packages/api/src/endpoints/openai/llm.spec.ts
@@ -767,10 +767,12 @@ describe('getOpenAILLMConfig', () => {
         apiKey: 'test-api-key',
         streaming: true,
         useOpenRouter: true,
+        addParams: {
+          verbosity: 'xhigh',
+        },
         modelOptions: {
           model: 'anthropic/claude-opus-4.7',
           useResponsesApi: true,
-          verbosity: 'xhigh',
         },
       });
 

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -11,12 +11,10 @@ import type * as t from '~/types';
 import { sanitizeModelName, constructAzureURL } from '~/utils/azure';
 import { isEnabled } from '~/utils/common';
 
-type OpenRouterVerbosity = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
-
 type OpenAILLMConfig = Omit<Partial<t.OAIClientOptions>, 'verbosity'> &
   Omit<Partial<t.OpenAIParameters>, 'verbosity'> &
   Omit<Partial<AzureOpenAIInput>, 'verbosity'> & {
-    verbosity?: OpenRouterVerbosity | null;
+    verbosity?: string | null;
   };
 
 export const knownOpenAIParams = new Set([
@@ -99,14 +97,8 @@ const openRouterAnthropicVerbosityByEffort: Record<
   xhigh: 'xhigh',
 };
 
-function isOpenRouterVerbosity(value: unknown): value is OpenRouterVerbosity {
-  return (
-    value === 'low' ||
-    value === 'medium' ||
-    value === 'high' ||
-    value === 'xhigh' ||
-    value === 'max'
-  );
+function isStringVerbosity(value: unknown): value is string {
+  return typeof value === 'string' && value !== '';
 }
 
 function applyVerbosityParam({
@@ -122,7 +114,7 @@ function applyVerbosityParam({
   modelKwargs: Record<string, unknown>;
   useOpenRouter?: boolean;
 }): boolean {
-  if (!isOpenRouterVerbosity(value)) {
+  if (!isStringVerbosity(value)) {
     return false;
   }
 

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -212,6 +212,48 @@ function applyOpenRouterReasoningConfig({
   return true;
 }
 
+function getModelKwargsText(modelKwargs: Record<string, unknown>): Record<string, unknown> {
+  const { text } = modelKwargs;
+  if (text == null || typeof text !== 'object' || Array.isArray(text)) {
+    return {};
+  }
+  return text as Record<string, unknown>;
+}
+
+function applyResponsesVerbosity({
+  llmConfig,
+  modelKwargs,
+  useOpenRouter,
+}: {
+  llmConfig: OpenAILLMConfig;
+  modelKwargs: Record<string, unknown>;
+  useOpenRouter?: boolean;
+}): boolean {
+  if (llmConfig.useResponsesApi !== true) {
+    return false;
+  }
+
+  if (useOpenRouter && llmConfig.verbosity) {
+    modelKwargs.text = {
+      ...getModelKwargsText(modelKwargs),
+      verbosity: llmConfig.verbosity,
+    };
+    delete llmConfig.verbosity;
+    return true;
+  }
+
+  if (!useOpenRouter && modelKwargs.verbosity) {
+    modelKwargs.text = {
+      ...getModelKwargsText(modelKwargs),
+      verbosity: modelKwargs.verbosity,
+    };
+    delete modelKwargs.verbosity;
+    return true;
+  }
+
+  return false;
+}
+
 /**
  * Extracts default parameters from customParams.paramDefinitions
  * @param paramDefinitions - Array of parameter definitions with key and default values
@@ -515,10 +557,12 @@ export function getOpenAILLMConfig({
     });
   }
 
-  if (modelKwargs.verbosity && llmConfig.useResponsesApi === true) {
-    modelKwargs.text = { verbosity: modelKwargs.verbosity };
-    delete modelKwargs.verbosity;
-  }
+  hasModelKwargs =
+    applyResponsesVerbosity({
+      llmConfig,
+      modelKwargs,
+      useOpenRouter,
+    }) || hasModelKwargs;
 
   if (
     llmConfig.model &&

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -1,4 +1,8 @@
-import { EModelEndpoint, removeNullishValues } from 'librechat-data-provider';
+import {
+  EModelEndpoint,
+  removeNullishValues,
+  supportsAdaptiveThinking,
+} from 'librechat-data-provider';
 import type { BindToolsInput } from '@librechat/agents/langchain/language_models/chat_models';
 import type { AzureOpenAIInput } from '@librechat/agents/langchain/openai';
 import type { SettingDefinition } from 'librechat-data-provider';
@@ -6,6 +10,14 @@ import type { OpenAI } from 'openai';
 import type * as t from '~/types';
 import { sanitizeModelName, constructAzureURL } from '~/utils/azure';
 import { isEnabled } from '~/utils/common';
+
+type OpenRouterVerbosity = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+type OpenAILLMConfig = Omit<Partial<t.OAIClientOptions>, 'verbosity'> &
+  Omit<Partial<t.OpenAIParameters>, 'verbosity'> &
+  Omit<Partial<AzureOpenAIInput>, 'verbosity'> & {
+    verbosity?: OpenRouterVerbosity | null;
+  };
 
 export const knownOpenAIParams = new Set([
   // Constructor/Instance Parameters
@@ -74,6 +86,130 @@ function hasReasoningParams({
     (reasoning_effort != null && reasoning_effort !== '') ||
     (reasoning_summary != null && reasoning_summary !== '')
   );
+}
+
+const openRouterAnthropicVerbosityByEffort: Record<
+  string,
+  NonNullable<OpenAILLMConfig['verbosity']>
+> = {
+  minimal: 'low',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+};
+
+function isOpenRouterVerbosity(value: unknown): value is OpenRouterVerbosity {
+  return (
+    value === 'low' ||
+    value === 'medium' ||
+    value === 'high' ||
+    value === 'xhigh' ||
+    value === 'max'
+  );
+}
+
+function applyVerbosityParam({
+  value,
+  override,
+  llmConfig,
+  modelKwargs,
+  useOpenRouter,
+}: {
+  value: unknown;
+  override: boolean;
+  llmConfig: OpenAILLMConfig;
+  modelKwargs: Record<string, unknown>;
+  useOpenRouter?: boolean;
+}): boolean {
+  if (!isOpenRouterVerbosity(value)) {
+    return false;
+  }
+
+  if (useOpenRouter && (override || llmConfig.verbosity === undefined)) {
+    llmConfig.verbosity = value;
+    return false;
+  }
+
+  if (useOpenRouter) {
+    return false;
+  }
+
+  if (!override && modelKwargs.verbosity !== undefined) {
+    return true;
+  }
+
+  modelKwargs.verbosity = value;
+  return true;
+}
+
+function isOpenRouterAnthropicAdaptiveModel(model?: string | null): boolean {
+  if (typeof model !== 'string') {
+    return false;
+  }
+  const normalizedModel = normalizeOpenRouterModel(model);
+  return normalizedModel.startsWith('anthropic/') && supportsAdaptiveThinking(model);
+}
+
+function normalizeOpenRouterModel(model: string): string {
+  return model.toLowerCase().replace(/^~/, '');
+}
+
+function isOpenRouterClaude47OpusModel(model: string): boolean {
+  const normalizedModel = normalizeOpenRouterModel(model);
+  return (
+    /claude[-.]opus[-.]4[-.]7/.test(normalizedModel) ||
+    /claude[-.]4[-.]7[-.]opus/.test(normalizedModel)
+  );
+}
+
+function getOpenRouterAnthropicVerbosity(
+  reasoningEffort?: string | null,
+  model?: string | null,
+): OpenAILLMConfig['verbosity'] | undefined {
+  if (!reasoningEffort) {
+    return undefined;
+  }
+  const verbosity = openRouterAnthropicVerbosityByEffort[reasoningEffort];
+  if (verbosity !== 'xhigh' || typeof model !== 'string') {
+    return verbosity;
+  }
+  return isOpenRouterClaude47OpusModel(model) ? 'xhigh' : 'max';
+}
+
+function applyOpenRouterReasoningConfig({
+  model,
+  llmConfig,
+  modelKwargs,
+  reasoningEffort,
+}: {
+  model?: string | null;
+  llmConfig: OpenAILLMConfig;
+  modelKwargs: Record<string, unknown>;
+  reasoningEffort?: string | null;
+}): boolean {
+  if (!hasReasoningParams({ reasoning_effort: reasoningEffort })) {
+    llmConfig.include_reasoning = true;
+    return false;
+  }
+
+  if (!isOpenRouterAnthropicAdaptiveModel(model)) {
+    modelKwargs.reasoning = { effort: reasoningEffort };
+    return true;
+  }
+
+  const adaptiveVerbosity = getOpenRouterAnthropicVerbosity(reasoningEffort, model);
+  if (adaptiveVerbosity != null && llmConfig.verbosity == null) {
+    llmConfig.verbosity = adaptiveVerbosity;
+  }
+
+  if (reasoningEffort === 'none') {
+    llmConfig.include_reasoning = false;
+    return false;
+  }
+
+  modelKwargs.reasoning = { enabled: true };
+  return true;
 }
 
 /**
@@ -162,7 +298,7 @@ export function getOpenAILLMConfig({
       model: modelOptions.model ?? '',
     },
     modelOptions,
-  ) as Partial<t.OAIClientOptions> & Partial<t.OpenAIParameters> & Partial<AzureOpenAIInput>;
+  ) as OpenAILLMConfig;
 
   if (frequency_penalty != null) {
     llmConfig.frequencyPenalty = frequency_penalty;
@@ -174,7 +310,9 @@ export function getOpenAILLMConfig({
   const modelKwargs: Record<string, unknown> = {};
   let hasModelKwargs = false;
 
-  if (verbosity != null && verbosity !== '') {
+  if (verbosity != null && verbosity !== '' && useOpenRouter) {
+    llmConfig.verbosity = verbosity;
+  } else if (verbosity != null && verbosity !== '') {
     modelKwargs.verbosity = verbosity;
     hasModelKwargs = true;
   }
@@ -195,6 +333,17 @@ export function getOpenAILLMConfig({
         if (enablePromptCache === undefined && typeof value === 'boolean') {
           enablePromptCache = value;
         }
+        continue;
+      }
+      if (key === 'verbosity') {
+        hasModelKwargs =
+          applyVerbosityParam({
+            value,
+            override: false,
+            llmConfig,
+            modelKwargs,
+            useOpenRouter,
+          }) || hasModelKwargs;
         continue;
       }
 
@@ -225,6 +374,17 @@ export function getOpenAILLMConfig({
         }
         continue;
       }
+      if (key === 'verbosity') {
+        hasModelKwargs =
+          applyVerbosityParam({
+            value,
+            override: true,
+            llmConfig,
+            modelKwargs,
+            useOpenRouter,
+          }) || hasModelKwargs;
+        continue;
+      }
       if (knownOpenAIParams.has(key)) {
         (llmConfig as Record<string, unknown>)[key] = value;
       } else {
@@ -235,19 +395,19 @@ export function getOpenAILLMConfig({
   }
 
   if (useOpenRouter) {
-    if (hasReasoningParams({ reasoning_effort })) {
-      /**
-       * OpenRouter uses a `reasoning` object — `summary` is not supported.
-       * ChatOpenRouter treats `reasoning` and `include_reasoning` as mutually exclusive:
-       * `include_reasoning` is legacy compat that maps to `{ enabled: true }` only when
-       * no `reasoning` object is present, so we intentionally omit it here.
-       */
-      modelKwargs.reasoning = { effort: reasoning_effort };
-      hasModelKwargs = true;
-    } else {
-      /** No explicit effort; fall back to legacy `include_reasoning` for reasoning token inclusion */
-      llmConfig.include_reasoning = true;
-    }
+    /**
+     * OpenRouter uses a `reasoning` object — `summary` is not supported.
+     * ChatOpenRouter treats `reasoning` and `include_reasoning` as mutually exclusive:
+     * `include_reasoning` is legacy compat that maps to `{ enabled: true }` only when
+     * no `reasoning` object is present, so we intentionally omit it here.
+     */
+    hasModelKwargs =
+      applyOpenRouterReasoningConfig({
+        reasoningEffort: reasoning_effort,
+        model: modelOptions.model,
+        modelKwargs,
+        llmConfig,
+      }) || hasModelKwargs;
   } else if (
     hasReasoningParams({ reasoning_effort, reasoning_summary }) &&
     (llmConfig.useResponsesApi === true ||

--- a/packages/api/src/endpoints/openai/llm.ts
+++ b/packages/api/src/endpoints/openai/llm.ts
@@ -155,11 +155,11 @@ function normalizeOpenRouterModel(model: string): string {
   return model.toLowerCase().replace(/^~/, '');
 }
 
-function isOpenRouterClaude47OpusModel(model: string): boolean {
+function isOpenRouterClaude46Model(model: string): boolean {
   const normalizedModel = normalizeOpenRouterModel(model);
   return (
-    /claude[-.]opus[-.]4[-.]7/.test(normalizedModel) ||
-    /claude[-.]4[-.]7[-.]opus/.test(normalizedModel)
+    /claude[-.](?:opus|sonnet)[-.]4[-.]6/.test(normalizedModel) ||
+    /claude[-.]4[-.]6[-.](?:opus|sonnet)/.test(normalizedModel)
   );
 }
 
@@ -174,7 +174,7 @@ function getOpenRouterAnthropicVerbosity(
   if (verbosity !== 'xhigh' || typeof model !== 'string') {
     return verbosity;
   }
-  return isOpenRouterClaude47OpusModel(model) ? 'xhigh' : 'max';
+  return isOpenRouterClaude46Model(model) ? 'max' : 'xhigh';
 }
 
 function applyOpenRouterReasoningConfig({

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -32,7 +32,7 @@ export type OAIClientOptions = Omit<OpenAIClientOptions, 'verbosity'> & {
   include_reasoning?: boolean;
   promptCache?: boolean;
   _lc_stream_delay?: number;
-  verbosity?: OpenAIClientOptions['verbosity'] | 'xhigh' | 'max';
+  verbosity?: string | null;
 };
 
 /**

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -28,10 +28,11 @@ export interface OpenAIConfigOptions {
 
 export type OpenAIConfiguration = OpenAIClientOptions['configuration'];
 
-export type OAIClientOptions = OpenAIClientOptions & {
+export type OAIClientOptions = Omit<OpenAIClientOptions, 'verbosity'> & {
   include_reasoning?: boolean;
   promptCache?: boolean;
   _lc_stream_delay?: number;
+  verbosity?: OpenAIClientOptions['verbosity'] | 'xhigh' | 'max';
 };
 
 /**


### PR DESCRIPTION
## Summary

I aligned OpenRouter reasoning payload construction with current Claude adaptive-thinking behavior and preserved reasoning token usage reported by OpenRouter streams.

- Map OpenRouter adaptive Claude models to `reasoning: { enabled: true }` plus top-level `verbosity`, including `~anthropic/...` model IDs.
- Map LibreChat's Extra High effort to `verbosity: "max"` for Claude 4.6 adaptive models and `verbosity: "xhigh"` for Claude Opus 4.7, matching OpenRouter's migration guidance.
- Keep non-adaptive OpenRouter models, including Gemini thinking models, on `reasoning.effort` so existing OpenRouter behavior is not conflated with Claude-specific adaptive thinking.
- Forward OpenRouter `verbosity` from model options, defaults, and added params as a top-level payload parameter instead of nesting it under `modelKwargs`.
- Preserve OpenRouter/OpenAI-compatible `output_token_details.reasoning` usage in final streamed agent usage chunks.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx eslint packages/api/src/types/openai.ts packages/api/src/endpoints/openai/llm.ts packages/api/src/endpoints/openai/llm.spec.ts packages/api/src/agents/openai/handlers.ts packages/api/src/agents/openai/handlers.spec.ts`
- `npx jest src/endpoints/openai/llm.spec.ts src/agents/openai/handlers.spec.ts --runInBand --coverage=false`
- `npm run build:api`
- Live OpenRouter smoke test through LibreChat helpers and `@librechat/agents` `ChatOpenRouter`:
  - `anthropic/claude-sonnet-4.6` + `reasoning_effort: "high"` emitted `reasoning: { enabled: true }`, `verbosity: "high"`, streamed reasoning chunks, and returned `output_token_details.reasoning`.
  - `anthropic/claude-sonnet-4.6` + `reasoning_effort: "xhigh"` emitted `reasoning: { enabled: true }`, `verbosity: "max"`, streamed content, and returned reasoning token usage.
  - `anthropic/claude-opus-4.7` + `reasoning_effort: "xhigh"` emitted `reasoning: { enabled: true }`, `verbosity: "xhigh"`, and completed successfully with a capped request.
  - Local helper probe verified `google/gemini-3.1-pro-preview` still emits `reasoning: { effort: "high" }`.

### **Test Configuration**:

- OpenRouter key loaded from `/Users/danny/Projects/LibreChat/.env`
- Live requests capped with `max_tokens` to avoid OpenRouter reserving the full Claude output window

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
