### PR TITLE
🛡️ chore: Harden Docker Dev Image Builds

### DIFF
--- a/.github/workflows/dev-branch-images.yml
+++ b/.github/workflows/dev-branch-images.yml
@@ -10,9 +10,14 @@ on:
       - 'client/**'
       - 'packages/**'
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 80
     strategy:
       matrix:
         include:
@@ -69,4 +74,4 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image_name }}:${{ github.sha }}
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image_name }}:latest
           platforms: linux/amd64,linux/arm64
-          target: ${{ matrix.target }} 
+          target: ${{ matrix.target }}

--- a/.github/workflows/dev-branch-images.yml
+++ b/.github/workflows/dev-branch-images.yml
@@ -11,13 +11,13 @@ on:
       - 'packages/**'
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 80
+    timeout-minutes: 130
     strategy:
       matrix:
         include:

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 80
+    timeout-minutes: 130
     strategy:
       matrix:
         include:

--- a/.github/workflows/dev-images.yml
+++ b/.github/workflows/dev-images.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 80
     strategy:
       matrix:
         include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN uv --version
 
 # Set configurable max-old-space-size with default
 ARG NODE_MAX_OLD_SPACE_SIZE=6144
+ARG NPM_CI_TIMEOUT_SECONDS=1500
+ARG NPM_CI_ATTEMPTS=2
 
 RUN mkdir -p /app && chown node:node /app
 WORKDIR /app
@@ -37,7 +39,17 @@ RUN \
     npm config set fetch-retry-maxtimeout 600000 ; \
     npm config set fetch-retries 5 ; \
     npm config set fetch-retry-mintimeout 15000 ; \
-    npm ci --no-audit
+    attempt=1 ; \
+    until timeout "$NPM_CI_TIMEOUT_SECONDS" npm ci --no-audit ; do \
+        status=$? ; \
+        if [ "$attempt" -ge "$NPM_CI_ATTEMPTS" ]; then \
+            exit "$status" ; \
+        fi ; \
+        echo "npm ci --no-audit failed with exit code $status; retrying attempt $((attempt + 1))/$NPM_CI_ATTEMPTS" ; \
+        attempt=$((attempt + 1)) ; \
+        npm cache clean --force || true ; \
+        sleep 10 ; \
+    done
 
 COPY --chown=node:node . .
 

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -6,6 +6,8 @@ ARG NODE_MAX_OLD_SPACE_SIZE=6144
 
 # Base for all builds
 FROM node:20-alpine AS base-min
+ARG NPM_CI_TIMEOUT_SECONDS=1500
+ARG NPM_CI_ATTEMPTS=2
 RUN apk upgrade --no-cache
 RUN apk add --no-cache jemalloc
 # Set environment variable to use jemalloc
@@ -26,8 +28,20 @@ COPY api/package*.json ./api/
 
 # Install all dependencies for every build
 FROM base-min AS base
+ARG NPM_CI_TIMEOUT_SECONDS=1500
+ARG NPM_CI_ATTEMPTS=2
 WORKDIR /app
-RUN npm ci
+RUN attempt=1; \
+    until timeout "$NPM_CI_TIMEOUT_SECONDS" npm ci; do \
+      status=$?; \
+      if [ "$attempt" -ge "$NPM_CI_ATTEMPTS" ]; then \
+        exit "$status"; \
+      fi; \
+      echo "npm ci failed with exit code $status; retrying attempt $((attempt + 1))/$NPM_CI_ATTEMPTS"; \
+      attempt=$((attempt + 1)); \
+      npm cache clean --force || true; \
+      sleep 10; \
+    done
 
 # Build `data-provider` package
 FROM base AS data-provider-build
@@ -69,12 +83,24 @@ RUN npm run build
 
 # API setup (including client dist)
 FROM base-min AS api-build
+ARG NPM_CI_TIMEOUT_SECONDS=1500
+ARG NPM_CI_ATTEMPTS=2
 # Add `uv` for extended MCP support
 COPY --from=ghcr.io/astral-sh/uv:0.6.13 /uv /uvx /bin/
 RUN uv --version
 WORKDIR /app
 # Install only production deps
-RUN npm ci --omit=dev
+RUN attempt=1; \
+    until timeout "$NPM_CI_TIMEOUT_SECONDS" npm ci --omit=dev; do \
+      status=$?; \
+      if [ "$attempt" -ge "$NPM_CI_ATTEMPTS" ]; then \
+        exit "$status"; \
+      fi; \
+      echo "npm ci --omit=dev failed with exit code $status; retrying attempt $((attempt + 1))/$NPM_CI_ATTEMPTS"; \
+      attempt=$((attempt + 1)); \
+      npm cache clean --force || true; \
+      sleep 10; \
+    done
 COPY api ./api
 COPY config ./config
 COPY --from=data-provider-build /app/packages/data-provider/dist ./packages/data-provider/dist


### PR DESCRIPTION
## Summary

I hardened the Docker dev image builds so transient or stuck `npm ci` installs do not burn CI time indefinitely.

- Added configurable `npm ci` timeout and retry controls to `Dockerfile` and `Dockerfile.multi` with defaults of 25 minutes and 2 attempts.
- Wrapped each Docker `npm ci` install with an in-layer retry that cleans the npm cache before retrying.
- Added 130-minute caps to the Docker dev image workflows so the workflow can accommodate the full retry budget across guarded install layers plus remaining build work.
- Scoped dev-branch workflow concurrency by ref so newer runs cancel older runs for the same branch/ref without cross-canceling unrelated manual runs.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check -- Dockerfile Dockerfile.multi .github/workflows/dev-images.yml .github/workflows/dev-branch-images.yml`.
- Parsed the edited workflow YAML files with Ruby's YAML parser.
- Ran shell syntax checks for the Docker retry loop bodies with `/bin/sh -n`.
- I could not run a Docker build smoke test locally because the Docker daemon socket was unavailable in the workspace.

### **Test Configuration**:

- macOS workspace
- GitHub CLI 2.83.0
- Docker CLI present, daemon unavailable

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
