### PR TITLE
🧰 refactor: Use Bash PTC for Agent Tools

### DIFF
--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -1262,7 +1262,11 @@ async function loadToolsForExecution({
   }
 
   const isToolSearch = toolNames.includes(AgentConstants.TOOL_SEARCH);
-  const isPTC = toolNames.includes(AgentConstants.BASH_PROGRAMMATIC_TOOL_CALLING);
+  const ptcToolNames = [
+    AgentConstants.BASH_PROGRAMMATIC_TOOL_CALLING,
+    AgentConstants.PROGRAMMATIC_TOOL_CALLING,
+  ].filter((name) => toolNames.includes(name));
+  const isPTC = ptcToolNames.length > 0;
 
   logger.debug(
     `[loadToolsForExecution] isToolSearch: ${isToolSearch}, toolRegistry: ${toolRegistry?.size ?? 'undefined'}`,
@@ -1284,10 +1288,13 @@ async function loadToolsForExecution({
        * LibreChat threads per-request Code API auth through the agents
        * library so PTC calls share the same managed auth context.
        */
-      const ptcTool = createBashProgrammaticToolCallingTool({
-        authHeaders: () => getCodeApiAuthHeaders(req),
-      });
-      allLoadedTools.push(ptcTool);
+      for (const name of ptcToolNames) {
+        const ptcTool = createBashProgrammaticToolCallingTool({
+          authHeaders: () => getCodeApiAuthHeaders(req),
+        });
+        ptcTool.name = name;
+        allLoadedTools.push(ptcTool);
+      }
     } catch (error) {
       logger.error('[loadToolsForExecution] Error creating PTC tool:', error);
     }

--- a/api/server/services/ToolService.js
+++ b/api/server/services/ToolService.js
@@ -7,7 +7,7 @@ const {
   createToolSearch,
   createBashExecutionTool,
   Constants: AgentConstants,
-  createProgrammaticToolCallingTool,
+  createBashProgrammaticToolCallingTool,
 } = require('@librechat/agents');
 const {
   sendEvent,
@@ -1262,7 +1262,7 @@ async function loadToolsForExecution({
   }
 
   const isToolSearch = toolNames.includes(AgentConstants.TOOL_SEARCH);
-  const isPTC = toolNames.includes(AgentConstants.PROGRAMMATIC_TOOL_CALLING);
+  const isPTC = toolNames.includes(AgentConstants.BASH_PROGRAMMATIC_TOOL_CALLING);
 
   logger.debug(
     `[loadToolsForExecution] isToolSearch: ${isToolSearch}, toolRegistry: ${toolRegistry?.size ?? 'undefined'}`,
@@ -1284,7 +1284,7 @@ async function loadToolsForExecution({
        * LibreChat threads per-request Code API auth through the agents
        * library so PTC calls share the same managed auth context.
        */
-      const ptcTool = createProgrammaticToolCallingTool({
+      const ptcTool = createBashProgrammaticToolCallingTool({
         authHeaders: () => getCodeApiAuthHeaders(req),
       });
       allLoadedTools.push(ptcTool);
@@ -1308,6 +1308,7 @@ async function loadToolsForExecution({
   const specialToolNames = new Set([
     AgentConstants.TOOL_SEARCH,
     AgentConstants.PROGRAMMATIC_TOOL_CALLING,
+    AgentConstants.BASH_PROGRAMMATIC_TOOL_CALLING,
     AgentConstants.BASH_TOOL,
     AgentConstants.SKILL_TOOL,
     AgentConstants.READ_FILE,
@@ -1381,7 +1382,11 @@ async function loadToolsForExecution({
   if (isPTC && allLoadedTools.length > 0) {
     const ptcToolMap = new Map();
     for (const tool of allLoadedTools) {
-      if (tool.name && tool.name !== AgentConstants.PROGRAMMATIC_TOOL_CALLING) {
+      if (
+        tool.name &&
+        tool.name !== AgentConstants.PROGRAMMATIC_TOOL_CALLING &&
+        tool.name !== AgentConstants.BASH_PROGRAMMATIC_TOOL_CALLING
+      ) {
         ptcToolMap.set(tool.name, tool);
       }
     }

--- a/api/server/services/__tests__/ToolService.spec.js
+++ b/api/server/services/__tests__/ToolService.spec.js
@@ -300,6 +300,26 @@ describe('ToolService - Action Capability Gating', () => {
     const actionToolName = `get_weather${actionDelimiter}api_example_com`;
     const regularTool = Tools.web_search;
 
+    it('loads bash PTC under the legacy programmatic tool name for event-driven compatibility', async () => {
+      const req = createMockReq([]);
+      const toolRegistry = new Map([['custom_tool', { name: 'custom_tool' }]]);
+
+      const result = await loadToolsForExecution({
+        req,
+        res: {},
+        agent: { id: 'agent_ptc' },
+        toolNames: [Constants.PROGRAMMATIC_TOOL_CALLING],
+        toolRegistry,
+        actionsEnabled: false,
+      });
+
+      expect(result.loadedTools.map((tool) => tool.name)).toEqual([
+        Constants.PROGRAMMATIC_TOOL_CALLING,
+      ]);
+      expect(result.configurable.toolRegistry).toBe(toolRegistry);
+      expect(result.configurable.ptcToolMap.size).toBe(0);
+    });
+
     it('should skip action tool loading when actionsEnabled=false', async () => {
       const req = createMockReq([]);
       req.config = {};

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -135,7 +135,8 @@ const Part = memo(function Part({
     if (
       isToolCall &&
       (toolCall.name === Tools.execute_code ||
-        toolCall.name === Constants.PROGRAMMATIC_TOOL_CALLING)
+        toolCall.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
+        toolCall.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING)
     ) {
       return (
         <ExecuteCode

--- a/client/src/components/Chat/Messages/Content/ToolOutput/ToolIcon.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolOutput/ToolIcon.tsx
@@ -51,7 +51,11 @@ export function getToolIconType(name: string): ToolIconType {
   if (name.includes(Constants.mcp_delimiter)) {
     return 'mcp';
   }
-  if (name === 'execute_code' || name === Constants.PROGRAMMATIC_TOOL_CALLING) {
+  if (
+    name === 'execute_code' ||
+    name === Constants.PROGRAMMATIC_TOOL_CALLING ||
+    name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+  ) {
     return 'execute_code';
   }
   if (name === 'web_search') {

--- a/client/src/components/Chat/Messages/Content/__tests__/ToolIcon.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/ToolIcon.test.tsx
@@ -25,6 +25,7 @@ describe('getToolIconType - ACTN-01: Action delimiter detection', () => {
   it('returns correct types for existing tool names', () => {
     expect(getToolIconType('execute_code')).toBe('execute_code');
     expect(getToolIconType(Constants.PROGRAMMATIC_TOOL_CALLING)).toBe('execute_code');
+    expect(getToolIconType(Constants.BASH_PROGRAMMATIC_TOOL_CALLING)).toBe('execute_code');
     expect(getToolIconType('web_search')).toBe('web_search');
     expect(getToolIconType('image_gen_oai')).toBe('image_gen');
     expect(getToolIconType('image_edit_oai')).toBe('image_gen');

--- a/client/src/utils/toolLabels.ts
+++ b/client/src/utils/toolLabels.ts
@@ -12,6 +12,7 @@ import type { TranslationKeys } from '~/hooks';
 export const TOOL_FRIENDLY_NAME_KEYS: Record<string, TranslationKeys> = {
   execute_code: 'com_ui_tool_name_code',
   run_tools_with_code: 'com_ui_tool_name_code',
+  run_tools_with_bash: 'com_ui_tool_name_code',
   web_search: 'com_ui_tool_name_web_search',
   image_gen_oai: 'com_ui_tool_name_image_gen',
   image_edit_oai: 'com_ui_tool_name_image_edit',

--- a/packages/api/src/agents/handlers.spec.ts
+++ b/packages/api/src/agents/handlers.spec.ts
@@ -244,6 +244,40 @@ describe('createToolExecuteHandler', () => {
     });
   });
 
+  describe('programmatic tool config', () => {
+    it('injects tool definitions for the legacy PTC tool name', async () => {
+      const capturedConfigs: Record<string, unknown>[] = [];
+      const legacyPtcTool = createMockTool(Constants.PROGRAMMATIC_TOOL_CALLING, capturedConfigs);
+      const toolRegistry = new Map([
+        ['custom_tool', { name: 'custom_tool' }],
+        [Constants.PROGRAMMATIC_TOOL_CALLING, { name: Constants.PROGRAMMATIC_TOOL_CALLING }],
+        [
+          Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+          { name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING },
+        ],
+        [Constants.TOOL_SEARCH, { name: Constants.TOOL_SEARCH }],
+      ]);
+      const ptcToolMap = new Map([['custom_tool', createMockTool('custom_tool', [])]]);
+      const loadTools: ToolExecuteOptions['loadTools'] = jest.fn(async () => ({
+        loadedTools: [legacyPtcTool] as never[],
+        configurable: { toolRegistry, ptcToolMap },
+      }));
+      const handler = createToolExecuteHandler({ loadTools });
+
+      await invokeHandler(handler, [
+        {
+          id: 'call_1',
+          name: Constants.PROGRAMMATIC_TOOL_CALLING,
+          args: { code: 'custom_tool "{}"' },
+        },
+      ]);
+
+      expect(capturedConfigs).toHaveLength(1);
+      expect(capturedConfigs[0].toolDefs).toEqual([{ name: 'custom_tool' }]);
+      expect(capturedConfigs[0].toolMap).toBe(ptcToolMap);
+    });
+  });
+
   describe('skill tool model-invocation gate', () => {
     function createSkillHandler(getSkillByName: ToolExecuteOptions['getSkillByName']) {
       const loadTools: ToolExecuteOptions['loadTools'] = jest.fn(async () => ({

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -1116,7 +1116,10 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
                     }
                   }
 
-                  if (tc.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING) {
+                  if (
+                    tc.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING ||
+                    tc.name === Constants.PROGRAMMATIC_TOOL_CALLING
+                  ) {
                     const toolRegistry = mergedConfigurable?.toolRegistry as
                       | LCToolRegistry
                       | undefined;

--- a/packages/api/src/agents/handlers.ts
+++ b/packages/api/src/agents/handlers.ts
@@ -1116,7 +1116,7 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
                     }
                   }
 
-                  if (tc.name === Constants.PROGRAMMATIC_TOOL_CALLING) {
+                  if (tc.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING) {
                     const toolRegistry = mergedConfigurable?.toolRegistry as
                       | LCToolRegistry
                       | undefined;
@@ -1127,6 +1127,7 @@ export function createToolExecuteHandler(options: ToolExecuteOptions): EventHand
                       const toolDefs: LCTool[] = Array.from(toolRegistry.values()).filter(
                         (t) =>
                           t.name !== Constants.PROGRAMMATIC_TOOL_CALLING &&
+                          t.name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING &&
                           t.name !== Constants.TOOL_SEARCH,
                       );
                       toolCallConfig.toolDefs = toolDefs;

--- a/packages/api/src/tools/classification.spec.ts
+++ b/packages/api/src/tools/classification.spec.ts
@@ -350,9 +350,28 @@ describe('classification.ts', () => {
         definitionsOnly: true,
       });
 
-      expect(result.toolDefinitions.some((d) => d.name === 'run_tools_with_code')).toBe(true);
-      expect(result.toolRegistry?.has('run_tools_with_code')).toBe(true);
+      expect(result.toolDefinitions.some((d) => d.name === 'run_tools_with_bash')).toBe(true);
+      expect(result.toolRegistry?.has('run_tools_with_bash')).toBe(true);
       expect(result.additionalTools.length).toBe(0);
+    });
+
+    it('should create bash PTC tool when agent has programmatic tools', async () => {
+      const loadedTools: GenericTool[] = [createMCPTool('tool1')];
+
+      const agentToolOptions: AgentToolOptions = {
+        tool1: { allowed_callers: ['code_execution'] },
+      };
+
+      const result = await buildToolClassification({
+        loadedTools,
+        userId: 'user1',
+        agentId: 'agent1',
+        agentToolOptions,
+      });
+
+      expect(result.additionalTools.some((t) => t.name === 'run_tools_with_bash')).toBe(true);
+      expect(result.additionalTools.some((t) => t.name === 'run_tools_with_code')).toBe(false);
+      expect(result.toolDefinitions.some((d) => d.name === 'run_tools_with_bash')).toBe(true);
     });
 
     it('should create tool instances when definitionsOnly=false (default)', async () => {

--- a/packages/api/src/tools/classification.ts
+++ b/packages/api/src/tools/classification.ts
@@ -10,8 +10,8 @@ import { Constants } from 'librechat-data-provider';
 import {
   createToolSearch,
   ToolSearchToolDefinition,
-  createProgrammaticToolCallingTool,
-  ProgrammaticToolCallingDefinition,
+  BashProgrammaticToolCallingDefinition,
+  createBashProgrammaticToolCallingTool,
 } from '@librechat/agents';
 import type { AgentToolOptions } from 'librechat-data-provider';
 import type {
@@ -333,12 +333,12 @@ export async function buildToolClassification(
   /** In definitions-only mode, add PTC definition without creating the tool instance */
   if (definitionsOnly) {
     toolDefinitions.push({
-      name: ProgrammaticToolCallingDefinition.name,
-      description: ProgrammaticToolCallingDefinition.description,
-      parameters: ProgrammaticToolCallingDefinition.schema as unknown as LCTool['parameters'],
+      name: BashProgrammaticToolCallingDefinition.name,
+      description: BashProgrammaticToolCallingDefinition.description,
+      parameters: BashProgrammaticToolCallingDefinition.schema as unknown as LCTool['parameters'],
     });
-    toolRegistry.set(ProgrammaticToolCallingDefinition.name, {
-      name: ProgrammaticToolCallingDefinition.name,
+    toolRegistry.set(BashProgrammaticToolCallingDefinition.name, {
+      name: BashProgrammaticToolCallingDefinition.name,
       allowed_callers: ['direct'],
     });
     logger.debug(
@@ -348,19 +348,19 @@ export async function buildToolClassification(
   }
 
   try {
-    const ptcTool = createProgrammaticToolCallingTool({ authHeaders } as Parameters<
-      typeof createProgrammaticToolCallingTool
+    const ptcTool = createBashProgrammaticToolCallingTool({ authHeaders } as Parameters<
+      typeof createBashProgrammaticToolCallingTool
     >[0] & { authHeaders?: BuildToolClassificationParams['authHeaders'] });
     additionalTools.push(ptcTool);
 
     /** Add PTC definition for event-driven mode */
     toolDefinitions.push({
-      name: ProgrammaticToolCallingDefinition.name,
-      description: ProgrammaticToolCallingDefinition.description,
-      parameters: ProgrammaticToolCallingDefinition.schema as unknown as LCTool['parameters'],
+      name: BashProgrammaticToolCallingDefinition.name,
+      description: BashProgrammaticToolCallingDefinition.description,
+      parameters: BashProgrammaticToolCallingDefinition.schema as unknown as LCTool['parameters'],
     });
-    toolRegistry.set(ProgrammaticToolCallingDefinition.name, {
-      name: ProgrammaticToolCallingDefinition.name,
+    toolRegistry.set(BashProgrammaticToolCallingDefinition.name, {
+      name: BashProgrammaticToolCallingDefinition.name,
       allowed_callers: ['direct'],
     });
 

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2163,6 +2163,8 @@ export enum Constants {
   EPHEMERAL_AGENT_ID = 'ephemeral',
   /** Programmatic Tool Calling tool name */
   PROGRAMMATIC_TOOL_CALLING = 'run_tools_with_code',
+  /** Bash Programmatic Tool Calling tool name */
+  BASH_PROGRAMMATIC_TOOL_CALLING = 'run_tools_with_bash',
   /** Subagent spawn tool name (must match `@librechat/agents` `Constants.SUBAGENT`). */
   SUBAGENT = 'subagent',
 }


### PR DESCRIPTION
## Summary

I split the programmatic tool-calling migration into its own stacked PR on top of #13028. This keeps the Code API auth PR focused while preserving the bash-first PTC behavior.

- Switch agent programmatic tool registration from `run_tools_with_code` to `run_tools_with_bash`.
- Add UI/tool-label handling for the bash PTC tool name.
- Preserve recognition of legacy `run_tools_with_code` event payloads as a compatibility alias, while still routing them through the bash PTC implementation.
- Add coverage for classification, event-handler injection, ToolService loading, and the tool icon mapping.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

- `cd api && npx jest server/services/__tests__/ToolService.spec.js --runInBand`
- `cd packages/api && npx jest src/agents/handlers.spec.ts src/tools/classification.spec.ts --runInBand`
- `npm run build:client-package`
- `cd client && npx jest src/components/Chat/Messages/Content/__tests__/ToolIcon.test.tsx --runInBand`

### **Test Configuration**:

- Local LibreChat worktree on Node/Jest workspace dependencies.
- The first direct client Jest run failed until `@librechat/client` was built; after `npm run build:client-package`, the targeted client test passed.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.