### PR TITLE
☁️ fix: Enable Azure Agent Provider Uploads

### DIFF
--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -55,6 +55,10 @@ const systemTools = {
 
 const MAX_SEARCH_LEN = 100;
 const escapeRegex = (str = '') => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const getSafeModelParameters = (modelParameters) => {
+  const { useResponsesApi } = modelParameters ?? {};
+  return typeof useResponsesApi === 'boolean' ? { useResponsesApi } : {};
+};
 
 /**
  * Looks up each referenced agent id in Mongo, splits them into three
@@ -458,6 +462,7 @@ const getAgentHandler = async (req, res, expandProperties = false) => {
         author: agent.author,
         provider: agent.provider,
         model: agent.model,
+        model_parameters: getSafeModelParameters(agent.model_parameters),
         isPublic: agent.isPublic,
         version: agent.version,
         // Safe metadata

--- a/api/server/controllers/agents/v1.spec.js
+++ b/api/server/controllers/agents/v1.spec.js
@@ -72,6 +72,7 @@ jest.mock('~/cache', () => ({
 
 const {
   createAgent: createAgentHandler,
+  getAgent: getAgentHandler,
   duplicateAgent: duplicateAgentHandler,
   revertAgentVersion: revertAgentVersionHandler,
   updateAgent: updateAgentHandler,
@@ -480,6 +481,34 @@ describe('Agent Controllers - Mass Assignment Protection', () => {
           error: 'Invalid request data',
         }),
       );
+    });
+  });
+
+  describe('getAgentHandler', () => {
+    test('should return the safe Responses API flag in the basic VIEW response', async () => {
+      const agent = await Agent.create({
+        id: `agent_${uuidv4()}`,
+        name: 'Azure Agent',
+        description: 'Uses Responses API',
+        provider: 'azureOpenAI',
+        model: 'gpt-5.5',
+        author: mockReq.user.id,
+        model_parameters: {
+          useResponsesApi: true,
+          temperature: 0.7,
+          apiKey: 'secret-value',
+        },
+      });
+
+      mockReq.params = { id: agent.id };
+
+      await getAgentHandler(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      const response = mockRes.json.mock.calls[0][0];
+      expect(response.model_parameters).toEqual({ useResponsesApi: true });
+      expect(response.model_parameters.temperature).toBeUndefined();
+      expect(response.model_parameters.apiKey).toBeUndefined();
     });
   });
 

--- a/client/src/Providers/DragDropContext.tsx
+++ b/client/src/Providers/DragDropContext.tsx
@@ -38,8 +38,7 @@ export function DragDropProvider({ children }: { children: React.ReactNode }) {
     if (!isAgents || !conversation?.agent_id) {
       return undefined;
     }
-    const agent = agentData || agentsMap?.[conversation.agent_id];
-    return agent?.provider;
+    return agentData?.provider ?? agentsMap?.[conversation.agent_id]?.provider;
   }, [conversation?.endpoint, conversation?.agent_id, agentData, agentsMap]);
 
   const endpointType = useMemo(
@@ -49,11 +48,13 @@ export function DragDropProvider({ children }: { children: React.ReactNode }) {
 
   const useResponsesApi = useMemo(() => {
     const isAgents = isAgentsEndpoint(conversation?.endpoint);
-    if (!isAgents || !conversation?.agent_id || conversation?.useResponsesApi) {
+    if (!isAgents || !conversation?.agent_id || conversation?.useResponsesApi !== undefined) {
       return conversation?.useResponsesApi;
     }
-    const agent = agentData || agentsMap?.[conversation.agent_id];
-    return agent?.model_parameters?.useResponsesApi;
+    return (
+      agentData?.model_parameters?.useResponsesApi ??
+      agentsMap?.[conversation.agent_id]?.model_parameters?.useResponsesApi
+    );
   }, [
     conversation?.endpoint,
     conversation?.agent_id,

--- a/client/src/Providers/__tests__/DragDropContext.spec.tsx
+++ b/client/src/Providers/__tests__/DragDropContext.spec.tsx
@@ -100,6 +100,55 @@ describe('DragDropContext endpointType resolution', () => {
       const { result } = renderHook(() => useDragDropContext(), { wrapper });
       expect(result.current.endpointType).toBe(EModelEndpoint.custom);
     });
+
+    it('falls back to agentsMap provider when agentData omits provider', () => {
+      mockConversation = { endpoint: EModelEndpoint.agents, agent_id: 'agent-1' };
+      mockAgentsMap = {
+        'agent-1': { provider: EModelEndpoint.openAI, model_parameters: {} } as Partial<Agent>,
+      };
+      mockAgentQueryData = {} as Partial<Agent>;
+      const { result } = renderHook(() => useDragDropContext(), { wrapper });
+      expect(result.current.endpointType).toBe(EModelEndpoint.openAI);
+    });
+  });
+
+  describe('useResponsesApi resolution for agents', () => {
+    it('uses fetched agent model parameters when conversation does not override them', () => {
+      mockConversation = { endpoint: EModelEndpoint.agents, agent_id: 'agent-1' };
+      mockAgentQueryData = {
+        provider: EModelEndpoint.azureOpenAI,
+        model_parameters: { useResponsesApi: true },
+      } as Partial<Agent>;
+      const { result } = renderHook(() => useDragDropContext(), { wrapper });
+      expect(result.current.useResponsesApi).toBe(true);
+    });
+
+    it('falls back to agentsMap model parameters when fetched agent omits them', () => {
+      mockConversation = { endpoint: EModelEndpoint.agents, agent_id: 'agent-1' };
+      mockAgentsMap = {
+        'agent-1': {
+          provider: EModelEndpoint.azureOpenAI,
+          model_parameters: { useResponsesApi: true },
+        } as Partial<Agent>,
+      };
+      mockAgentQueryData = { provider: EModelEndpoint.azureOpenAI } as Partial<Agent>;
+      const { result } = renderHook(() => useDragDropContext(), { wrapper });
+      expect(result.current.useResponsesApi).toBe(true);
+    });
+
+    it('preserves an explicit conversation useResponsesApi false override', () => {
+      mockConversation = {
+        endpoint: EModelEndpoint.agents,
+        agent_id: 'agent-1',
+        useResponsesApi: false,
+      };
+      mockAgentQueryData = {
+        provider: EModelEndpoint.azureOpenAI,
+        model_parameters: { useResponsesApi: true },
+      } as Partial<Agent>;
+      const { result } = renderHook(() => useDragDropContext(), { wrapper });
+      expect(result.current.useResponsesApi).toBe(false);
+    });
   });
 
   describe('agents endpoint without provider', () => {

--- a/client/src/components/Chat/Input/Files/AttachFileChat.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileChat.tsx
@@ -48,11 +48,13 @@ function AttachFileChat({
   });
 
   const useResponsesApi = useMemo(() => {
-    if (!isAgents || !conversation?.agent_id || conversation?.useResponsesApi) {
+    if (!isAgents || !conversation?.agent_id || conversation?.useResponsesApi !== undefined) {
       return conversation?.useResponsesApi;
     }
-    const agent = agentData || agentsMap?.[conversation.agent_id];
-    return agent?.model_parameters?.useResponsesApi;
+    return (
+      agentData?.model_parameters?.useResponsesApi ??
+      agentsMap?.[conversation.agent_id]?.model_parameters?.useResponsesApi
+    );
   }, [isAgents, conversation?.agent_id, conversation?.useResponsesApi, agentData, agentsMap]);
 
   const { data: fileConfig = null } = useGetFileConfig({
@@ -65,8 +67,7 @@ function AttachFileChat({
     if (!isAgents || !conversation?.agent_id) {
       return undefined;
     }
-    const agent = agentData || agentsMap?.[conversation.agent_id];
-    return agent?.provider;
+    return agentData?.provider ?? agentsMap?.[conversation.agent_id]?.provider;
   }, [isAgents, conversation?.agent_id, agentData, agentsMap]);
 
   const endpointType = useMemo(

--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -157,7 +157,9 @@ const AttachFileMenu = ({
       }
 
       const isAzureWithResponsesApi =
-        currentProvider === EModelEndpoint.azureOpenAI && useResponsesApi;
+        (currentProvider === EModelEndpoint.azureOpenAI ||
+          endpointType === EModelEndpoint.azureOpenAI) &&
+        useResponsesApi === true;
 
       if (
         isDocumentSupportedProvider(endpointType) ||

--- a/client/src/components/Chat/Input/Files/DragDropModal.tsx
+++ b/client/src/components/Chat/Input/Files/DragDropModal.tsx
@@ -68,7 +68,9 @@ const DragDropModal = ({ onOptionSelect, setShowModal, files, isVisible }: DragD
     const getFileType = (file: File) => inferMimeType(file.name, file.type);
 
     const isAzureWithResponsesApi =
-      currentProvider === EModelEndpoint.azureOpenAI && useResponsesApi;
+      (currentProvider === EModelEndpoint.azureOpenAI ||
+        endpointType === EModelEndpoint.azureOpenAI) &&
+      useResponsesApi === true;
 
     // Check if provider supports document upload
     if (

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileChat.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileChat.spec.tsx
@@ -128,6 +128,51 @@ describe('AttachFileChat', () => {
       renderComponent({ endpoint: EModelEndpoint.agents, agent_id: 'agent-2' });
       expect(mockAttachFileMenuProps.endpointType).toBe(EModelEndpoint.custom);
     });
+
+    it('falls back to agentsMap provider when fetched agent omits provider', () => {
+      mockAgentsMap = {
+        'agent-1': { provider: EModelEndpoint.openAI, model_parameters: {} } as Partial<Agent>,
+      };
+      mockAgentQueryData = {} as Partial<Agent>;
+      renderComponent({ endpoint: EModelEndpoint.agents, agent_id: 'agent-1' });
+      expect(mockAttachFileMenuProps.endpointType).toBe(EModelEndpoint.openAI);
+    });
+  });
+
+  describe('useResponsesApi resolution for agents', () => {
+    it('passes useResponsesApi from fetched agent model parameters', () => {
+      mockAgentQueryData = {
+        provider: EModelEndpoint.azureOpenAI,
+        model_parameters: { useResponsesApi: true },
+      } as Partial<Agent>;
+      renderComponent({ endpoint: EModelEndpoint.agents, agent_id: 'agent-1' });
+      expect(mockAttachFileMenuProps.useResponsesApi).toBe(true);
+    });
+
+    it('falls back to agentsMap model parameters when fetched agent omits them', () => {
+      mockAgentsMap = {
+        'agent-1': {
+          provider: EModelEndpoint.azureOpenAI,
+          model_parameters: { useResponsesApi: true },
+        } as Partial<Agent>,
+      };
+      mockAgentQueryData = { provider: EModelEndpoint.azureOpenAI } as Partial<Agent>;
+      renderComponent({ endpoint: EModelEndpoint.agents, agent_id: 'agent-1' });
+      expect(mockAttachFileMenuProps.useResponsesApi).toBe(true);
+    });
+
+    it('preserves an explicit conversation useResponsesApi false override', () => {
+      mockAgentQueryData = {
+        provider: EModelEndpoint.azureOpenAI,
+        model_parameters: { useResponsesApi: true },
+      } as Partial<Agent>;
+      renderComponent({
+        endpoint: EModelEndpoint.agents,
+        agent_id: 'agent-1',
+        useResponsesApi: false,
+      });
+      expect(mockAttachFileMenuProps.useResponsesApi).toBe(false);
+    });
   });
 
   describe('endpointType resolution for non-agents', () => {

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
@@ -203,6 +203,17 @@ describe('AttachFileMenu', () => {
       expect(screen.getByText('Upload to Provider')).toBeInTheDocument();
     });
 
+    it('shows "Upload to Provider" for azureOpenAI endpointType with useResponsesApi', () => {
+      setupMocks();
+      renderMenu({
+        endpoint: EModelEndpoint.agents,
+        endpointType: EModelEndpoint.azureOpenAI,
+        useResponsesApi: true,
+      });
+      openMenu();
+      expect(screen.getByText('Upload to Provider')).toBeInTheDocument();
+    });
+
     it('shows "Upload Image" for azureOpenAI without useResponsesApi', () => {
       setupMocks({ provider: EModelEndpoint.azureOpenAI });
       renderMenu({ endpointType: EModelEndpoint.azureOpenAI, useResponsesApi: false });

--- a/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx
@@ -124,6 +124,25 @@ describe('DragDropModal - Provider Detection', () => {
           isDocumentSupportedProvider(scenario.currentProvider),
       ).toBe(true);
     });
+
+    it('should handle Azure OpenAI endpointType when Responses API is enabled', () => {
+      const scenario = {
+        currentProvider: EModelEndpoint.agents,
+        endpointType: EModelEndpoint.azureOpenAI,
+        useResponsesApi: true,
+      };
+
+      const isAzureWithResponsesApi =
+        (scenario.currentProvider === EModelEndpoint.azureOpenAI ||
+          scenario.endpointType === EModelEndpoint.azureOpenAI) &&
+        scenario.useResponsesApi === true;
+
+      expect(
+        isDocumentSupportedProvider(scenario.endpointType) ||
+          isDocumentSupportedProvider(scenario.currentProvider) ||
+          isAzureWithResponsesApi,
+      ).toBe(true);
+    });
   });
 
   describe('HEIC/HEIF file type inference', () => {


### PR DESCRIPTION
I fixed the Azure OpenAI Agents attachment menu so `Upload to Provider` appears when the agent uses the Responses API, and covered the chat and drag/drop paths with regressions for issue #13043.

- Preserved explicit conversation-level `useResponsesApi: false` overrides instead of falling back to the agent default.
- Read `useResponsesApi` from fetched agent data first, with an `agentsMap` fallback, so Azure agents can hydrate the upload capability reliably.
- Checked Azure support against both the resolved endpoint type and current provider in the attach menu and drag/drop modal.
- Returned only the safe `model_parameters.useResponsesApi` boolean from the basic agent VIEW response so the client can detect Responses API without exposing sensitive model settings.
- Added focused regressions for AttachFileChat, AttachFileMenu, DragDropContext, DragDropModal, and the basic agent response.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Ran `npm ci`
- [x] Ran `npm run build:data-provider`
- [x] Ran `npm run build:client-package`
- [x] Ran `npm run build:data-schemas && npm run build:api`
- [x] Ran `cd client && npx jest src/components/Chat/Input/Files/__tests__/AttachFileChat.spec.tsx src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx src/components/Chat/Input/Files/__tests__/DragDropModal.spec.tsx src/Providers/__tests__/DragDropContext.spec.tsx --runInBand --ci`
- [x] Ran `cd api && npx jest server/controllers/agents/v1.spec.js --runInBand --ci`

### **Test Configuration**:

- Node.js v20.19.5
- npm 10.8.2

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes