### PR TITLE
🧯 fix: Bound Permission Superset Cache Inputs

### DIFF
--- a/packages/data-schemas/src/methods/aclEntry.spec.ts
+++ b/packages/data-schemas/src/methods/aclEntry.spec.ts
@@ -1626,6 +1626,7 @@ describe('AclEntry Model Tests', () => {
     describe('rejection of out-of-range inputs (cache-growth safety)', () => {
       const MAX =
         PermissionBits.VIEW | PermissionBits.EDIT | PermissionBits.DELETE | PermissionBits.SHARE;
+      const FIRST_TRUNCATED_32_BIT_VALUE = 2 ** 32;
       const SHARED_EMPTY = permissionBitSupersets(MAX + 1);
 
       test('returns a frozen empty array for requiredBits above MAX_PERM_BITS', () => {
@@ -1641,9 +1642,19 @@ describe('AclEntry Model Tests', () => {
         expect(permissionBitSupersets(MAX + 1)).toBe(SHARED_EMPTY);
         expect(permissionBitSupersets(MAX + 100)).toBe(SHARED_EMPTY);
         expect(permissionBitSupersets(-1)).toBe(SHARED_EMPTY);
+        expect(permissionBitSupersets(FIRST_TRUNCATED_32_BIT_VALUE)).toBe(SHARED_EMPTY);
+        expect(permissionBitSupersets(FIRST_TRUNCATED_32_BIT_VALUE * 2)).toBe(SHARED_EMPTY);
         expect(permissionBitSupersets(Number.MAX_SAFE_INTEGER)).toBe(SHARED_EMPTY);
         expect(permissionBitSupersets(NaN)).toBe(SHARED_EMPTY);
         expect(permissionBitSupersets(1.5)).toBe(SHARED_EMPTY);
+      });
+
+      test('rejects large integers that truncate to in-range 32-bit values', () => {
+        expect(FIRST_TRUNCATED_32_BIT_VALUE & ~MAX).toBe(0);
+        expect(permissionBitSupersets(FIRST_TRUNCATED_32_BIT_VALUE)).toBe(SHARED_EMPTY);
+        expect(permissionBitSupersets(FIRST_TRUNCATED_32_BIT_VALUE + PermissionBits.VIEW)).toBe(
+          SHARED_EMPTY,
+        );
       });
 
       test('rejects inputs with bits above MAX_PERM_BITS even if some in-range bits are set', () => {
@@ -1692,6 +1703,7 @@ describe('AclEntry Model Tests', () => {
           const before = setSpy.mock.calls.length;
           for (let i = 0; i < 500; i++) {
             permissionBitSupersets(MAX + 1 + i);
+            permissionBitSupersets(FIRST_TRUNCATED_32_BIT_VALUE + i);
             permissionBitSupersets(-(i + 1));
             permissionBitSupersets(i + 0.5);
           }

--- a/packages/data-schemas/src/methods/aclEntry.ts
+++ b/packages/data-schemas/src/methods/aclEntry.ts
@@ -51,6 +51,7 @@ export function permissionBitSupersets(requiredBits: number): readonly number[] 
   if (
     !Number.isInteger(requiredBits) ||
     requiredBits < 0 ||
+    requiredBits > MAX_PERM_BITS ||
     (requiredBits & ~MAX_PERM_BITS) !== 0
   ) {
     return EMPTY_SUPERSETS;


### PR DESCRIPTION
## Summary

I fixed the permission superset cache guard so out-of-range permission masks cannot bypass validation through JavaScript's 32-bit bitwise coercion.

- Added a numeric upper-bound check before the bitwise mask check in `permissionBitSupersets`.
- Preserved the existing shared empty-array rejection path so invalid attacker-controlled values do not populate the process-global cache.
- Added regression coverage for `2 ** 32`-scaled inputs that previously truncated to in-range 32-bit values.
- Expanded the Map-write probe to include large truncated integers and verify rejected values do not write to the cache.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `NODE_PATH=/Users/danny/Projects/LibreChat/packages/data-schemas/node_modules:/Users/danny/Projects/LibreChat/node_modules /Users/danny/Projects/LibreChat/node_modules/.bin/jest src/methods/aclEntry.spec.ts --runInBand` from `packages/data-schemas`.
- Ran `PATH=/Users/danny/Projects/LibreChat/node_modules/.bin:/Users/danny/Projects/LibreChat/packages/data-schemas/node_modules/.bin:$PATH NODE_PATH=/Users/danny/Projects/LibreChat/packages/data-schemas/node_modules:/Users/danny/Projects/LibreChat/node_modules npm run build` from `packages/data-schemas`.
- Ran `git diff --check`.

### **Test Configuration**:

- Node.js local workspace dependencies from `/Users/danny/Projects/LibreChat`.
- Focused package: `@librechat/data-schemas`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
