### PR TITLE
🪵 chore: Log Subagent Limit Hits

### DIFF
--- a/api/server/services/Endpoints/agents/initialize.js
+++ b/api/server/services/Endpoints/agents/initialize.js
@@ -647,6 +647,12 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
       return;
     }
     if (subagentGraphIds.size >= MAX_SUBAGENT_GRAPH_NODES) {
+      logger.warn('[initializeClient] Subagent graph node limit exceeded', {
+        agentId,
+        primaryAgentId: primaryConfig.id,
+        loadedSubagentCount: subagentGraphIds.size,
+        maxSubagentGraphNodes: MAX_SUBAGENT_GRAPH_NODES,
+      });
       throw new Error(
         `Subagent graph exceeds the maximum of ${MAX_SUBAGENT_GRAPH_NODES} unique agents.`,
       );
@@ -670,6 +676,13 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
 
     if (loadedSubagentConfigIds.has(config.id)) {
       if ((config.subagentAgentConfigs?.length ?? 0) > 0 && depth >= MAX_SUBAGENT_DEPTH) {
+        logger.warn('[initializeClient] Subagent graph depth limit exceeded', {
+          agentId: config.id,
+          primaryAgentId: primaryConfig.id,
+          depth,
+          maxSubagentDepth: MAX_SUBAGENT_DEPTH,
+          childCount: config.subagentAgentConfigs.length,
+        });
         throw new Error(
           `Subagent graph exceeds the maximum depth of ${MAX_SUBAGENT_DEPTH} at agent ${config.id}.`,
         );
@@ -690,6 +703,13 @@ const initializeClient = async ({ req, res, signal, endpointOption }) => {
     );
 
     if (explicitSubagentIds.length > 0 && depth >= MAX_SUBAGENT_DEPTH) {
+      logger.warn('[initializeClient] Subagent graph depth limit exceeded', {
+        agentId: config.id,
+        primaryAgentId: primaryConfig.id,
+        depth,
+        maxSubagentDepth: MAX_SUBAGENT_DEPTH,
+        childCount: explicitSubagentIds.length,
+      });
       throw new Error(
         `Subagent graph exceeds the maximum depth of ${MAX_SUBAGENT_DEPTH} at agent ${config.id}.`,
       );

--- a/api/server/services/Endpoints/agents/initialize.spec.js
+++ b/api/server/services/Endpoints/agents/initialize.spec.js
@@ -68,8 +68,11 @@ jest.mock('~/cache', () => ({
 }));
 
 const { initializeClient } = require('./initialize');
+const { logger } = require('@librechat/data-schemas');
 const { User, AclEntry } = require('~/db/models');
 const { createAgent } = require('~/models');
+
+jest.spyOn(logger, 'warn').mockImplementation(() => {});
 
 const PRIMARY_ID = 'agent_primary';
 const TARGET_ID = 'agent_target';
@@ -504,6 +507,16 @@ describe('initializeClient — subagent loading', () => {
         endpointOption: makeEndpointOption(),
       }),
     ).rejects.toThrow(`maximum depth of ${MAX_SUBAGENT_DEPTH}`);
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[initializeClient] Subagent graph depth limit exceeded',
+      expect.objectContaining({
+        agentId: `agent_depth_${MAX_SUBAGENT_DEPTH - 1}`,
+        primaryAgentId: PRIMARY_ID,
+        depth: MAX_SUBAGENT_DEPTH,
+        maxSubagentDepth: MAX_SUBAGENT_DEPTH,
+        childCount: 1,
+      }),
+    );
     expect(agentClientArgs).toBeUndefined();
   });
 
@@ -542,6 +555,15 @@ describe('initializeClient — subagent loading', () => {
         endpointOption: makeEndpointOption(),
       }),
     ).rejects.toThrow(`maximum depth of ${MAX_SUBAGENT_DEPTH}`);
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[initializeClient] Subagent graph depth limit exceeded',
+      expect.objectContaining({
+        primaryAgentId: PRIMARY_ID,
+        depth: MAX_SUBAGENT_DEPTH,
+        maxSubagentDepth: MAX_SUBAGENT_DEPTH,
+        childCount: 1,
+      }),
+    );
     expect(agentClientArgs).toBeUndefined();
   });
 
@@ -581,6 +603,14 @@ describe('initializeClient — subagent loading', () => {
         endpointOption: makeEndpointOption(),
       }),
     ).rejects.toThrow(`maximum of ${MAX_SUBAGENT_GRAPH_NODES} unique agents`);
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[initializeClient] Subagent graph node limit exceeded',
+      expect.objectContaining({
+        primaryAgentId: PRIMARY_ID,
+        loadedSubagentCount: MAX_SUBAGENT_GRAPH_NODES,
+        maxSubagentGraphNodes: MAX_SUBAGENT_GRAPH_NODES,
+      }),
+    );
     expect(agentClientArgs).toBeUndefined();
   });
 

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -1,3 +1,4 @@
+import { logger } from '@librechat/data-schemas';
 import type { AppConfig } from '@librechat/data-schemas';
 import type { SummarizationConfig, TEndpoint } from 'librechat-data-provider';
 import {
@@ -24,6 +25,16 @@ jest.mock('winston', () => ({
 jest.mock('~/utils/env', () => ({
   resolveHeaders: jest.fn((opts: { headers: unknown }) => opts?.headers ?? {}),
   createSafeUser: jest.fn(() => ({})),
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  ...jest.requireActual('@librechat/data-schemas'),
+  logger: {
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
 }));
 
 // Mock Run.create to capture the graphConfig it receives
@@ -1007,6 +1018,14 @@ describe('subagentConfigs', () => {
       }),
     ).rejects.toThrow(`maximum depth of ${MAX_SUBAGENT_DEPTH}`);
 
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[createRun] Subagent graph depth limit exceeded',
+      expect.objectContaining({
+        agentId: `agent_chain_${MAX_SUBAGENT_DEPTH + 1}`,
+        depth: MAX_SUBAGENT_DEPTH + 1,
+        maxSubagentDepth: MAX_SUBAGENT_DEPTH,
+      }),
+    );
     expect(Run.create).not.toHaveBeenCalled();
   });
 
@@ -1020,6 +1039,14 @@ describe('subagentConfigs', () => {
       }),
     ).rejects.toThrow(`maximum of ${MAX_SUBAGENT_RUN_CONFIGS} expanded entries`);
 
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[createRun] Subagent run configuration limit exceeded',
+      expect.objectContaining({
+        expandedConfigCount: MAX_SUBAGENT_RUN_CONFIGS + 1,
+        maxSubagentRunConfigs: MAX_SUBAGENT_RUN_CONFIGS,
+        rootAgentIds: ['agent_dag_root'],
+      }),
+    );
     expect(Run.create).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/agents/run.ts
+++ b/packages/api/src/agents/run.ts
@@ -551,11 +551,17 @@ const SELF_SUBAGENT_TYPE = 'self';
 
 interface SubagentBuildState {
   configCount: number;
+  rootAgentIds: string[];
 }
 
 function countSubagentConfig(state: SubagentBuildState): void {
   state.configCount += 1;
   if (state.configCount > MAX_SUBAGENT_RUN_CONFIGS) {
+    logger.warn('[createRun] Subagent run configuration limit exceeded', {
+      expandedConfigCount: state.configCount,
+      maxSubagentRunConfigs: MAX_SUBAGENT_RUN_CONFIGS,
+      rootAgentIds: state.rootAgentIds,
+    });
     throw new Error(
       `Subagent run configuration exceeds the maximum of ${MAX_SUBAGENT_RUN_CONFIGS} expanded entries.`,
     );
@@ -564,6 +570,11 @@ function countSubagentConfig(state: SubagentBuildState): void {
 
 function assertSubagentDepth(depth: number, agentId: string): void {
   if (depth > MAX_SUBAGENT_DEPTH) {
+    logger.warn('[createRun] Subagent graph depth limit exceeded', {
+      agentId,
+      depth,
+      maxSubagentDepth: MAX_SUBAGENT_DEPTH,
+    });
     throw new Error(
       `Subagent graph exceeds the maximum depth of ${MAX_SUBAGENT_DEPTH} at agent ${agentId}.`,
     );
@@ -922,7 +933,10 @@ export async function createRun({
   };
 
   const agentInputs: AgentInputs[] = [];
-  const subagentBuildState: SubagentBuildState = { configCount: 0 };
+  const subagentBuildState: SubagentBuildState = {
+    configCount: 0,
+    rootAgentIds: agents.map((agent) => agent.id),
+  };
   for (const agent of agents) {
     const agentInput = buildAgentInput(agent);
     const subagentConfigs = buildSubagentConfigs(


### PR DESCRIPTION
## Summary

I added explicit warning logs for the subagent limit guards added in the prior security fix so operators can see when a request is rejected by depth, graph-size, or run-expansion budgets.

- Logged initialization-time subagent graph depth limit hits with the primary agent id, current agent id, depth, max depth, and child count.
- Logged initialization-time unique subagent target limit hits with the primary agent id, attempted agent id, loaded count, and max graph-node budget.
- Logged run-construction depth and expanded-config limit hits with the offending agent id or root agent ids and the relevant budget values.
- Added regression assertions to ensure each limit path emits the expected structured warning.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran the focused suites covering subagent initialization and run config construction.

### **Test Configuration**:

- Node.js: v20.19.5
- npm: 10.8.2

```sh
cd api && npx jest server/services/Endpoints/agents/initialize.spec.js --runInBand
cd packages/api && npx jest src/agents/__tests__/run-summarization.test.ts --runInBand
git diff --check
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
