### PR TITLE
🪙 fix: Pass appConfig to getBalanceConfig in set-balance script

### DIFF
--- a/config/set-balance.js
+++ b/config/set-balance.js
@@ -5,6 +5,7 @@ const { User, Balance } = require('@librechat/data-schemas').createModels(mongoo
 require('module-alias')({ base: path.resolve(__dirname, '..', 'api') });
 const { askQuestion, silentExit } = require('./helpers');
 const connect = require('./connect');
+const { getAppConfig } = require('~/server/services/Config');
 
 (async () => {
   await connect();
@@ -31,7 +32,8 @@ const connect = require('./connect');
     // console.purple(`[DEBUG] Args Length: ${process.argv.length}`);
   }
 
-  const balanceConfig = getBalanceConfig();
+  const appConfig = await getAppConfig();
+  const balanceConfig = getBalanceConfig(appConfig);
   if (!balanceConfig?.enabled) {
     console.red('Error: Balance is not enabled. Use librechat.yaml to enable it');
     silentExit(1);


### PR DESCRIPTION
## Summary

`config/set-balance.js` always fails with:

```
Error: Balance is not enabled. Use librechat.yaml to enable it
```

even when balance **is** enabled in `librechat.yaml`.

## Root cause

The script calls `getBalanceConfig()` with no argument:

https://github.com/danny-avila/LibreChat/blob/main/config/set-balance.js#L34

After the App Config refactor in #9234, `getBalanceConfig` expects the parsed `appConfig` as its argument and reads `balance.enabled` from it. Without that argument it returns nothing useful, so the `!balanceConfig?.enabled` guard fails and the script exits early — regardless of what the config actually says.

The sibling script `config/add-balance.js` was updated to the new pattern but `set-balance.js` was missed.

## Fix

Mirror the pattern already in `add-balance.js`:

```js
const { getAppConfig } = require('~/server/services/Config');
// ...
const appConfig = await getAppConfig();
const balanceConfig = getBalanceConfig(appConfig);
```

## Reproduction

With `balance.enabled: true` in `librechat.yaml`:

```
$ npm run set-balance user@example.com 1000000
...
Error: Balance is not enabled. Use librechat.yaml to enable it

$ npm run add-balance user@example.com 1000000   # works
Transaction created successfully!
```

After the patch, `set-balance` succeeds and updates the user's `tokenCredits` as expected.