### PR TITLE
🧾 fix: Route Text-Backed File Access Through DB

### DIFF
--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -480,6 +480,14 @@ const getDownloadFileMetadata = (file) => {
   }, {});
 };
 
+const getTextFileDownloadStream = async (file_id) => {
+  const file = await db.findFileById(file_id);
+  if (file?.text == null) {
+    return null;
+  }
+  return Readable.from([Buffer.from(file.text, 'utf8')]);
+};
+
 router.get('/download-url/:userId/:file_id', fileAccess, async (req, res) => {
   try {
     const { userId, file_id } = req.params;
@@ -531,14 +539,6 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
       return res.status(400).send('The model used when creating this file is not available');
     }
 
-    const { getDownloadStream, getDownloadURL } = getStrategyFunctions(file.source);
-    if (!getDownloadStream && !getDownloadURL) {
-      logger.warn(
-        `File download requested by user ${userId} has no download method implemented: ${file.source}`,
-      );
-      return res.status(501).send('Not Implemented');
-    }
-
     const setHeaders = () => {
       res.setHeader('Content-Disposition', getContentDisposition(file.filename));
       res.setHeader('Content-Type', 'application/octet-stream');
@@ -547,6 +547,25 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
         encodeURIComponent(JSON.stringify(getDownloadFileMetadata(file))),
       );
     };
+
+    if (file.source === FileSources.text) {
+      const fileStream = await getTextFileDownloadStream(file_id);
+      if (!fileStream) {
+        logger.warn(`Text file download requested by user ${userId} has no text: ${file_id}`);
+        return res.status(404).send('File content not found');
+      }
+
+      setHeaders();
+      return fileStream.pipe(res);
+    }
+
+    const { getDownloadStream, getDownloadURL } = getStrategyFunctions(file.source);
+    if (!getDownloadStream && !getDownloadURL) {
+      logger.warn(
+        `File download requested by user ${userId} has no download method implemented: ${file.source}`,
+      );
+      return res.status(501).send('Not Implemented');
+    }
 
     if (checkOpenAIStorage(file.source)) {
       req.body = { model: file.model };

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -480,12 +480,12 @@ const getDownloadFileMetadata = (file) => {
   }, {});
 };
 
-const getTextFileDownloadStream = async (file_id) => {
-  const file = await db.findFileById(file_id);
-  if (file?.text == null) {
+const getTextFileDownloadStream = async (file) => {
+  const withText = await db.findFileById(file.file_id, { _id: file._id });
+  if (withText?.text == null) {
     return null;
   }
-  return Readable.from([Buffer.from(file.text, 'utf8')]);
+  return Readable.from([withText.text]);
 };
 
 router.get('/download-url/:userId/:file_id', fileAccess, async (req, res) => {
@@ -549,7 +549,7 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
     };
 
     if (file.source === FileSources.text) {
-      const fileStream = await getTextFileDownloadStream(file_id);
+      const fileStream = await getTextFileDownloadStream(file);
       if (!fileStream) {
         logger.warn(`Text file download requested by user ${userId} has no text: ${file_id}`);
         return res.status(404).send('File content not found');

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -401,7 +401,7 @@ router.get('/:file_id/preview', fileAccess, async (req, res) => {
     const status = file.status ?? 'ready';
     const payload = { file_id, status };
     if (status === 'ready') {
-      const withText = await db.findFileById(file_id);
+      const withText = await db.findFileById(file_id, { _id: file._id });
       if (withText?.text != null) {
         payload.text = withText.text;
         payload.textFormat = withText.textFormat ?? null;

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -669,6 +669,39 @@ describe('File Routes - Delete with Agent Access', () => {
   });
 
   describe('GET /files/download/:userId/:file_id', () => {
+    it('streams text-source downloads from stored DB text instead of the temp filepath', async () => {
+      const userFileId = uuidv4();
+      const text = 'hello from db text';
+      getStrategyFunctions.mockImplementation(() => {
+        throw new Error('Text downloads should not use file storage strategies');
+      });
+
+      await createFile({
+        user: otherUserId,
+        file_id: userFileId,
+        filename: 'example.txt',
+        filepath: '/app/uploads/temp/69dd0839e87a2378a28225b0/example.txt',
+        bytes: Buffer.byteLength(text, 'utf8'),
+        type: 'text/plain',
+        source: FileSources.text,
+        text,
+      });
+
+      const response = await request(app).get(`/files/download/${otherUserId}/${userFileId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.toString()).toBe(text);
+      const metadata = JSON.parse(decodeURIComponent(response.headers['x-file-metadata']));
+      expect(metadata).toMatchObject({
+        file_id: userFileId,
+        filename: 'example.txt',
+        filepath: '/app/uploads/temp/69dd0839e87a2378a28225b0/example.txt',
+        source: FileSources.text,
+      });
+      expect(metadata).not.toHaveProperty('text');
+      expect(getStrategyFunctions).not.toHaveBeenCalled();
+    });
+
     it('streams proxied downloads by default when a direct URL is available', async () => {
       const userFileId = uuidv4();
       const getDownloadURL = jest.fn().mockResolvedValue('https://cdn.example.com/file.pdf?signed');

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -672,9 +672,6 @@ describe('File Routes - Delete with Agent Access', () => {
     it('streams text-source downloads from stored DB text instead of the temp filepath', async () => {
       const userFileId = uuidv4();
       const text = 'hello from db text';
-      getStrategyFunctions.mockImplementation(() => {
-        throw new Error('Text downloads should not use file storage strategies');
-      });
 
       await createFile({
         user: otherUserId,
@@ -699,6 +696,50 @@ describe('File Routes - Delete with Agent Access', () => {
         source: FileSources.text,
       });
       expect(metadata).not.toHaveProperty('text');
+      expect(getStrategyFunctions).not.toHaveBeenCalled();
+    });
+
+    it('scopes text-source downloads to the authorized file record', async () => {
+      const duplicatedFileId = uuidv4();
+      const authorizedText = 'authorized text';
+
+      await File.create({
+        user: authorId,
+        file_id: duplicatedFileId,
+        filename: 'shadow.txt',
+        filepath: '/app/uploads/temp/shadow/example.txt',
+        bytes: Buffer.byteLength('shadow text', 'utf8'),
+        type: 'text/plain',
+        source: FileSources.text,
+        text: 'shadow text',
+      });
+
+      const authorizedFile = await File.create({
+        user: otherUserId,
+        file_id: duplicatedFileId,
+        filename: 'example.txt',
+        filepath: '/app/uploads/temp/authorized/example.txt',
+        bytes: Buffer.byteLength(authorizedText, 'utf8'),
+        type: 'text/plain',
+        source: FileSources.text,
+        text: authorizedText,
+      });
+      await File.updateOne(
+        { _id: authorizedFile._id },
+        { updatedAt: new Date(Date.now() + 1000) },
+      );
+
+      const response = await request(app).get(`/files/download/${otherUserId}/${duplicatedFileId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.toString()).toBe(authorizedText);
+      const metadata = JSON.parse(decodeURIComponent(response.headers['x-file-metadata']));
+      expect(metadata).toMatchObject({
+        file_id: duplicatedFileId,
+        filename: 'example.txt',
+        filepath: '/app/uploads/temp/authorized/example.txt',
+        source: FileSources.text,
+      });
       expect(getStrategyFunctions).not.toHaveBeenCalled();
     });
 

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -724,10 +724,7 @@ describe('File Routes - Delete with Agent Access', () => {
         source: FileSources.text,
         text: authorizedText,
       });
-      await File.updateOne(
-        { _id: authorizedFile._id },
-        { updatedAt: new Date(Date.now() + 1000) },
-      );
+      await File.updateOne({ _id: authorizedFile._id }, { updatedAt: new Date(Date.now() + 1000) });
 
       const response = await request(app).get(`/files/download/${otherUserId}/${duplicatedFileId}`);
 

--- a/api/server/routes/files/preview.spec.js
+++ b/api/server/routes/files/preview.spec.js
@@ -163,7 +163,13 @@ describe('GET /files/:file_id/preview', () => {
 
   it('returns status:ready with text + textFormat when the deferred render succeeded', async () => {
     mockGetFiles.mockResolvedValueOnce([
-      { file_id: 'fid-ready', user: OWNER_USER_ID, filename: 'data.xlsx', status: 'ready' },
+      {
+        _id: 'mongo-ready',
+        file_id: 'fid-ready',
+        user: OWNER_USER_ID,
+        filename: 'data.xlsx',
+        status: 'ready',
+      },
     ]);
     /* Text is fetched only on the terminal ready response. */
     mockFindFileById.mockResolvedValueOnce({
@@ -172,6 +178,7 @@ describe('GET /files/:file_id/preview', () => {
       textFormat: 'html',
     });
     const res = await request(buildApp()).get('/files/fid-ready/preview');
+    expect(mockFindFileById).toHaveBeenCalledWith('fid-ready', { _id: 'mongo-ready' });
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       file_id: 'fid-ready',

--- a/client/src/components/Chat/Messages/Content/FilePreviewDialog.tsx
+++ b/client/src/components/Chat/Messages/Content/FilePreviewDialog.tsx
@@ -2,10 +2,11 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import copy from 'copy-to-clipboard';
 import { useRecoilValue } from 'recoil';
 import { Download } from 'lucide-react';
+import { FileSources } from 'librechat-data-provider';
 import { OGDialog, OGDialogContent, OGDialogTitle, OGDialogDescription } from '@librechat/client';
 import CopyButton from '~/components/Messages/Content/CopyButton';
 import { logger, sortPagesByRelevance, triggerDownload } from '~/utils';
-import { useFileDownload } from '~/data-provider';
+import { useFileDownload, useFilePreview } from '~/data-provider';
 import { useLocalize } from '~/hooks';
 import store from '~/store';
 
@@ -19,6 +20,7 @@ interface FilePreviewDialogProps {
   pageRelevance?: Record<number, number>;
   fileType?: string;
   fileSize?: number;
+  source?: string | null;
 }
 
 function getFileExtension(filename: string): string {
@@ -133,10 +135,18 @@ export default function FilePreviewDialog({
   pageRelevance,
   fileType,
   fileSize,
+  source,
 }: FilePreviewDialogProps) {
   const localize = useLocalize();
   const user = useRecoilValue(store.user);
+  const isTextSource = source === FileSources.text;
+  const previewKind = isTextSource
+    ? 'text'
+    : canPreviewByMime(fileType) || canPreviewByExt(fileName);
   const { refetch: downloadFile } = useFileDownload(user?.id ?? '', fileId, { direct: false });
+  const { refetch: fetchTextPreview } = useFilePreview(isTextSource ? fileId : undefined, {
+    enabled: false,
+  });
 
   const [fileContent, setFileContent] = useState<string | null>(null);
   const [fileBlobUrl, setFileBlobUrl] = useState<string | null>(null);
@@ -145,9 +155,15 @@ export default function FilePreviewDialog({
   const [isCopied, setIsCopied] = useState(false);
   const loadingRef = useRef(false);
 
-  const previewKind = canPreviewByMime(fileType) || canPreviewByExt(fileName);
-
   const cancelledRef = useRef(false);
+
+  const getTextSourceContent = useCallback(async () => {
+    if (fileContent != null) {
+      return fileContent;
+    }
+    const result = await fetchTextPreview();
+    return result.data?.status === 'ready' ? result.data.text : undefined;
+  }, [fetchTextPreview, fileContent]);
 
   const loadPreview = useCallback(async () => {
     if (!fileId || !previewKind || loadingRef.current) {
@@ -159,6 +175,18 @@ export default function FilePreviewDialog({
     setPreviewError(false);
 
     try {
+      if (isTextSource) {
+        const text = await getTextSourceContent();
+        if (cancelledRef.current || text == null) {
+          if (!cancelledRef.current) {
+            setPreviewError(true);
+          }
+          return;
+        }
+        setFileContent(text);
+        return;
+      }
+
       const result = await downloadFile();
       if (cancelledRef.current || !result.data) {
         if (!cancelledRef.current) {
@@ -190,13 +218,25 @@ export default function FilePreviewDialog({
         setLoading(false);
       }
     }
-  }, [fileId, previewKind, downloadFile]);
+  }, [fileId, previewKind, isTextSource, getTextSourceContent, downloadFile]);
 
   const handleDownload = useCallback(async () => {
     if (!fileId) {
       return;
     }
     try {
+      if (isTextSource) {
+        const text = await getTextSourceContent();
+        if (text == null) {
+          return;
+        }
+        const downloadURL = URL.createObjectURL(
+          new Blob([text], { type: fileType || 'text/plain' }),
+        );
+        triggerDownload(downloadURL, fileName);
+        return;
+      }
+
       const result = await downloadFile();
       if (!result.data) {
         return;
@@ -205,7 +245,7 @@ export default function FilePreviewDialog({
     } catch (err) {
       logger.error('[FilePreviewDialog] Download failed:', err);
     }
-  }, [downloadFile, fileId, fileName]);
+  }, [downloadFile, fileId, fileName, fileType, isTextSource, getTextSourceContent]);
 
   useEffect(() => {
     if (open && previewKind && !fileContent && !fileBlobUrl) {

--- a/client/src/components/Chat/Messages/Content/Files.tsx
+++ b/client/src/components/Chat/Messages/Content/Files.tsx
@@ -48,6 +48,7 @@ const Files = ({ message }: { message?: TMessage }) => {
         fileId={selectedFile?.file_id}
         fileType={selectedFile?.type ?? undefined}
         fileSize={(selectedFile as TFile)?.bytes}
+        source={selectedFile?.source}
       />
     </>
   );

--- a/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
+++ b/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
@@ -21,6 +21,7 @@ interface FileSource {
   pageRelevance: Record<number, number>;
   fileType?: string;
   fileBytes?: number;
+  source?: string;
   metadata?: Record<string, unknown>;
 }
 
@@ -66,6 +67,7 @@ function extractFileSources(attachments?: TAttachment[]): FileSource[] {
           pageRelevance: source.pageRelevance || {},
           fileType: (meta?.fileType as string) || undefined,
           fileBytes: (meta?.fileBytes as number) || undefined,
+          source: (meta?.storageType as string) || undefined,
           metadata: meta,
         });
       }
@@ -90,6 +92,7 @@ interface DisplayResult {
   pageRelevance?: Record<number, number>;
   fileType?: string;
   fileBytes?: number;
+  source?: string;
 }
 
 interface FileMatch {
@@ -97,6 +100,7 @@ interface FileMatch {
   fileName: string;
   fileType?: string;
   fileBytes?: number;
+  source?: string;
 }
 
 function normalizeFilename(filename: string): string {
@@ -140,6 +144,7 @@ function buildFileLookup(
       fileName: source.fileName,
       fileType: source.fileType,
       fileBytes: source.fileBytes,
+      source: source.source,
     });
   }
 
@@ -158,6 +163,7 @@ function buildFileLookup(
       fileName: file.filename,
       fileType: file.type ?? undefined,
       fileBytes: file.bytes,
+      source: file.source,
     });
   }
 
@@ -179,6 +185,7 @@ function mergeRetrievalResults(
       pageRelevance: source.pageRelevance,
       fileType: source.fileType,
       fileBytes: source.fileBytes,
+      source: source.source,
     }));
   }
 
@@ -195,6 +202,7 @@ function mergeRetrievalResults(
       content: result.content,
       fileType: match?.fileType,
       fileBytes: match?.fileBytes,
+      source: match?.source,
     };
   });
 }
@@ -470,6 +478,7 @@ export default function RetrievalCall({
         pages={previewData?.pages}
         pageRelevance={previewData?.pageRelevance}
         fileType={previewData?.fileType}
+        source={previewData?.source}
       />
     </div>
   );

--- a/client/src/components/Chat/Messages/Content/__tests__/FilePreviewDialog.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/FilePreviewDialog.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { FileSources } from 'librechat-data-provider';
+import FilePreviewDialog from '../FilePreviewDialog';
+
+const mockDownloadFile = jest.fn();
+const mockFetchTextPreview = jest.fn();
+const mockTriggerDownload = jest.fn();
+const mockCreateObjectURL = jest.fn();
+
+jest.mock('recoil', () => ({
+  useRecoilValue: () => ({ id: 'user-1' }),
+}));
+
+jest.mock('@librechat/client', () => ({
+  OGDialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  OGDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  OGDialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  OGDialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+}));
+
+jest.mock('~/components/Messages/Content/CopyButton', () => ({
+  __esModule: true,
+  default: ({ label }: { label: string }) => <button type="button">{label}</button>,
+}));
+
+jest.mock('~/data-provider', () => ({
+  useFileDownload: () => ({ refetch: mockDownloadFile }),
+  useFilePreview: () => ({ refetch: mockFetchTextPreview }),
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+}));
+
+jest.mock('~/store', () => ({
+  __esModule: true,
+  default: { user: {} },
+}));
+
+jest.mock('~/utils', () => ({
+  logger: { error: jest.fn() },
+  sortPagesByRelevance: (pages: number[]) => pages,
+  triggerDownload: (...args: Parameters<typeof mockTriggerDownload>) =>
+    mockTriggerDownload(...args),
+}));
+
+describe('FilePreviewDialog text-source previews', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateObjectURL.mockReturnValue('blob:text-source');
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: mockCreateObjectURL,
+    });
+  });
+
+  it('loads text-backed files from the preview endpoint instead of the download route', async () => {
+    mockFetchTextPreview.mockResolvedValueOnce({
+      data: { file_id: 'file-text', status: 'ready', text: 'hello from db' },
+    });
+
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={jest.fn()}
+        fileName="example.txt"
+        fileId="file-text"
+        fileType="text/plain"
+        source={FileSources.text}
+      />,
+    );
+
+    expect(await screen.findByText('hello from db')).toBeInTheDocument();
+    expect(mockFetchTextPreview).toHaveBeenCalledTimes(1);
+    expect(mockDownloadFile).not.toHaveBeenCalled();
+  });
+
+  it('creates a local text blob for text-source downloads', async () => {
+    mockFetchTextPreview.mockResolvedValueOnce({
+      data: { file_id: 'file-text', status: 'ready', text: 'download me' },
+    });
+
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={jest.fn()}
+        fileName="example.txt"
+        fileId="file-text"
+        fileType="text/plain"
+        source={FileSources.text}
+      />,
+    );
+
+    await screen.findByText('download me');
+    fireEvent.click(screen.getByRole('button', { name: 'com_ui_download example.txt' }));
+
+    await waitFor(() => {
+      expect(mockTriggerDownload).toHaveBeenCalledWith('blob:text-source', 'example.txt');
+    });
+    expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(mockDownloadFile).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/Web/Citation.tsx
+++ b/client/src/components/Web/Citation.tsx
@@ -10,6 +10,7 @@ import { useLocalize } from '~/hooks';
 interface FileCitationMetadata {
   fileBytes?: number;
   fileType?: string;
+  storageType?: string;
 }
 
 interface FileCitationSource {
@@ -37,6 +38,7 @@ function getFileCitationData(source?: FileCitationSource) {
     filePages: isFileType ? source.pages : undefined,
     fileRelevance: isFileType ? source.relevance : undefined,
     filePageRelevance: isFileType ? source.pageRelevance : undefined,
+    fileSource: isFileType ? source.metadata?.storageType : undefined,
   };
 }
 
@@ -93,8 +95,16 @@ export function CompositeCitation(props: CompositeCitationProps) {
   };
 
   const currentSource = sources[currentPage] as FileCitationSource;
-  const { isFileType, fileId, fileMeta, fileName, filePages, fileRelevance, filePageRelevance } =
-    getFileCitationData(currentSource);
+  const {
+    isFileType,
+    fileId,
+    fileMeta,
+    fileName,
+    filePages,
+    fileRelevance,
+    filePageRelevance,
+    fileSource,
+  } = getFileCitationData(currentSource);
 
   const handleFileClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -273,6 +283,7 @@ export function CompositeCitation(props: CompositeCitationProps) {
           pageRelevance={filePageRelevance}
           fileType={fileMeta?.fileType}
           fileSize={fileMeta?.fileBytes}
+          source={fileSource}
         />
       )}
     </>
@@ -297,8 +308,16 @@ export function Citation(props: CitationComponentProps) {
     index: citation?.index || 0,
   }) as FileCitationSource | undefined;
 
-  const { isFileType, fileId, fileMeta, fileName, filePages, fileRelevance, filePageRelevance } =
-    getFileCitationData(refData);
+  const {
+    isFileType,
+    fileId,
+    fileMeta,
+    fileName,
+    filePages,
+    fileRelevance,
+    filePageRelevance,
+    fileSource,
+  } = getFileCitationData(refData);
 
   const [showPreview, setShowPreview] = useState(false);
 
@@ -349,6 +368,7 @@ export function Citation(props: CitationComponentProps) {
           pageRelevance={filePageRelevance}
           fileType={fileMeta?.fileType}
           fileSize={fileMeta?.fileBytes}
+          source={fileSource}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

I fixed text-backed file preview and download behavior so `FileSources.text` uses persisted Mongo text instead of temporary upload paths.

- Routed text-source previews in `FilePreviewDialog` through the file preview endpoint instead of the proxied download route.
- Generated manual downloads for text-source files from the persisted preview text as a local browser blob, avoiding `/api/files/download` for upload-as-text records.
- Passed file source metadata from message file chips, retrieval results, and file citations into the preview dialog so text-backed callers take the DB-text path.
- Kept the backend download route as a defensive fallback for text-source records and scoped both download and preview full-text re-fetches to the authorized DB `_id`.
- Added backend regressions for text-source download/preview behavior and a frontend regression proving text-source previews do not call the download hook.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `NODE_PATH=/Users/danny/Projects/ClickHouse-LibreChat/node_modules:/Users/danny/Projects/ClickHouse-LibreChat/api/node_modules /Users/danny/Projects/ClickHouse-LibreChat/node_modules/.bin/jest server/routes/files/files.test.js server/routes/files/preview.spec.js --runInBand` from `api`.
- Ran `node /Users/danny/Projects/ClickHouse-LibreChat/node_modules/jest/bin/jest.js src/components/Chat/Messages/Content/__tests__/FilePreviewDialog.test.tsx --runInBand --coverage=false` from `client` with root/client dependency symlinks into the worktree.
- Ran `node --check api/server/routes/files/files.js` and `node --check api/server/routes/files/preview.spec.js`.
- Ran ESLint on all touched backend/frontend files.
- Ran `git diff --check`.

### **Test Configuration**:

- Database: `mongodb-memory-server`
- Dependencies: main checkout `node_modules` and `client/node_modules` linked into the worktree for focused test/lint commands

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes