### PR TITLE
🧷 fix: Disable Text Upload Attachment Previews

### DIFF
--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -480,6 +480,14 @@ const getDownloadFileMetadata = (file) => {
   }, {});
 };
 
+const getTextFileDownloadStream = async (file_id) => {
+  const file = await db.findFileById(file_id);
+  if (file?.text == null) {
+    return null;
+  }
+  return Readable.from([Buffer.from(file.text, 'utf8')]);
+};
+
 router.get('/download-url/:userId/:file_id', fileAccess, async (req, res) => {
   try {
     const { userId, file_id } = req.params;
@@ -531,14 +539,6 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
       return res.status(400).send('The model used when creating this file is not available');
     }
 
-    const { getDownloadStream, getDownloadURL } = getStrategyFunctions(file.source);
-    if (!getDownloadStream && !getDownloadURL) {
-      logger.warn(
-        `File download requested by user ${userId} has no download method implemented: ${file.source}`,
-      );
-      return res.status(501).send('Not Implemented');
-    }
-
     const setHeaders = () => {
       res.setHeader('Content-Disposition', getContentDisposition(file.filename));
       res.setHeader('Content-Type', 'application/octet-stream');
@@ -547,6 +547,25 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
         encodeURIComponent(JSON.stringify(getDownloadFileMetadata(file))),
       );
     };
+
+    if (file.source === FileSources.text) {
+      const fileStream = await getTextFileDownloadStream(file_id);
+      if (!fileStream) {
+        logger.warn(`Text file download requested by user ${userId} has no text: ${file_id}`);
+        return res.status(404).send('File content not found');
+      }
+
+      setHeaders();
+      return fileStream.pipe(res);
+    }
+
+    const { getDownloadStream, getDownloadURL } = getStrategyFunctions(file.source);
+    if (!getDownloadStream && !getDownloadURL) {
+      logger.warn(
+        `File download requested by user ${userId} has no download method implemented: ${file.source}`,
+      );
+      return res.status(501).send('Not Implemented');
+    }
 
     if (checkOpenAIStorage(file.source)) {
       req.body = { model: file.model };

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -480,12 +480,12 @@ const getDownloadFileMetadata = (file) => {
   }, {});
 };
 
-const getTextFileDownloadStream = async (file_id) => {
-  const file = await db.findFileById(file_id);
-  if (file?.text == null) {
+const getTextFileDownloadStream = async (file) => {
+  const withText = await db.findFileById(file.file_id, { _id: file._id });
+  if (withText?.text == null) {
     return null;
   }
-  return Readable.from([Buffer.from(file.text, 'utf8')]);
+  return Readable.from([withText.text]);
 };
 
 router.get('/download-url/:userId/:file_id', fileAccess, async (req, res) => {
@@ -549,7 +549,7 @@ router.get('/download/:userId/:file_id', fileAccess, async (req, res) => {
     };
 
     if (file.source === FileSources.text) {
-      const fileStream = await getTextFileDownloadStream(file_id);
+      const fileStream = await getTextFileDownloadStream(file);
       if (!fileStream) {
         logger.warn(`Text file download requested by user ${userId} has no text: ${file_id}`);
         return res.status(404).send('File content not found');

--- a/api/server/routes/files/files.js
+++ b/api/server/routes/files/files.js
@@ -401,7 +401,7 @@ router.get('/:file_id/preview', fileAccess, async (req, res) => {
     const status = file.status ?? 'ready';
     const payload = { file_id, status };
     if (status === 'ready') {
-      const withText = await db.findFileById(file_id);
+      const withText = await db.findFileById(file_id, { _id: file._id });
       if (withText?.text != null) {
         payload.text = withText.text;
         payload.textFormat = withText.textFormat ?? null;

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -669,6 +669,39 @@ describe('File Routes - Delete with Agent Access', () => {
   });
 
   describe('GET /files/download/:userId/:file_id', () => {
+    it('streams text-source downloads from stored DB text instead of the temp filepath', async () => {
+      const userFileId = uuidv4();
+      const text = 'hello from db text';
+      getStrategyFunctions.mockImplementation(() => {
+        throw new Error('Text downloads should not use file storage strategies');
+      });
+
+      await createFile({
+        user: otherUserId,
+        file_id: userFileId,
+        filename: 'example.txt',
+        filepath: '/app/uploads/temp/69dd0839e87a2378a28225b0/example.txt',
+        bytes: Buffer.byteLength(text, 'utf8'),
+        type: 'text/plain',
+        source: FileSources.text,
+        text,
+      });
+
+      const response = await request(app).get(`/files/download/${otherUserId}/${userFileId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.toString()).toBe(text);
+      const metadata = JSON.parse(decodeURIComponent(response.headers['x-file-metadata']));
+      expect(metadata).toMatchObject({
+        file_id: userFileId,
+        filename: 'example.txt',
+        filepath: '/app/uploads/temp/69dd0839e87a2378a28225b0/example.txt',
+        source: FileSources.text,
+      });
+      expect(metadata).not.toHaveProperty('text');
+      expect(getStrategyFunctions).not.toHaveBeenCalled();
+    });
+
     it('streams proxied downloads by default when a direct URL is available', async () => {
       const userFileId = uuidv4();
       const getDownloadURL = jest.fn().mockResolvedValue('https://cdn.example.com/file.pdf?signed');

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -672,9 +672,6 @@ describe('File Routes - Delete with Agent Access', () => {
     it('streams text-source downloads from stored DB text instead of the temp filepath', async () => {
       const userFileId = uuidv4();
       const text = 'hello from db text';
-      getStrategyFunctions.mockImplementation(() => {
-        throw new Error('Text downloads should not use file storage strategies');
-      });
 
       await createFile({
         user: otherUserId,
@@ -699,6 +696,50 @@ describe('File Routes - Delete with Agent Access', () => {
         source: FileSources.text,
       });
       expect(metadata).not.toHaveProperty('text');
+      expect(getStrategyFunctions).not.toHaveBeenCalled();
+    });
+
+    it('scopes text-source downloads to the authorized file record', async () => {
+      const duplicatedFileId = uuidv4();
+      const authorizedText = 'authorized text';
+
+      await File.create({
+        user: authorId,
+        file_id: duplicatedFileId,
+        filename: 'shadow.txt',
+        filepath: '/app/uploads/temp/shadow/example.txt',
+        bytes: Buffer.byteLength('shadow text', 'utf8'),
+        type: 'text/plain',
+        source: FileSources.text,
+        text: 'shadow text',
+      });
+
+      const authorizedFile = await File.create({
+        user: otherUserId,
+        file_id: duplicatedFileId,
+        filename: 'example.txt',
+        filepath: '/app/uploads/temp/authorized/example.txt',
+        bytes: Buffer.byteLength(authorizedText, 'utf8'),
+        type: 'text/plain',
+        source: FileSources.text,
+        text: authorizedText,
+      });
+      await File.updateOne(
+        { _id: authorizedFile._id },
+        { updatedAt: new Date(Date.now() + 1000) },
+      );
+
+      const response = await request(app).get(`/files/download/${otherUserId}/${duplicatedFileId}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.toString()).toBe(authorizedText);
+      const metadata = JSON.parse(decodeURIComponent(response.headers['x-file-metadata']));
+      expect(metadata).toMatchObject({
+        file_id: duplicatedFileId,
+        filename: 'example.txt',
+        filepath: '/app/uploads/temp/authorized/example.txt',
+        source: FileSources.text,
+      });
       expect(getStrategyFunctions).not.toHaveBeenCalled();
     });
 

--- a/api/server/routes/files/files.test.js
+++ b/api/server/routes/files/files.test.js
@@ -724,10 +724,7 @@ describe('File Routes - Delete with Agent Access', () => {
         source: FileSources.text,
         text: authorizedText,
       });
-      await File.updateOne(
-        { _id: authorizedFile._id },
-        { updatedAt: new Date(Date.now() + 1000) },
-      );
+      await File.updateOne({ _id: authorizedFile._id }, { updatedAt: new Date(Date.now() + 1000) });
 
       const response = await request(app).get(`/files/download/${otherUserId}/${duplicatedFileId}`);
 

--- a/api/server/routes/files/preview.spec.js
+++ b/api/server/routes/files/preview.spec.js
@@ -163,7 +163,13 @@ describe('GET /files/:file_id/preview', () => {
 
   it('returns status:ready with text + textFormat when the deferred render succeeded', async () => {
     mockGetFiles.mockResolvedValueOnce([
-      { file_id: 'fid-ready', user: OWNER_USER_ID, filename: 'data.xlsx', status: 'ready' },
+      {
+        _id: 'mongo-ready',
+        file_id: 'fid-ready',
+        user: OWNER_USER_ID,
+        filename: 'data.xlsx',
+        status: 'ready',
+      },
     ]);
     /* Text is fetched only on the terminal ready response. */
     mockFindFileById.mockResolvedValueOnce({
@@ -172,6 +178,7 @@ describe('GET /files/:file_id/preview', () => {
       textFormat: 'html',
     });
     const res = await request(buildApp()).get('/files/fid-ready/preview');
+    expect(mockFindFileById).toHaveBeenCalledWith('fid-ready', { _id: 'mongo-ready' });
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       file_id: 'fid-ready',

--- a/client/src/components/Chat/Input/Files/FileContainer.tsx
+++ b/client/src/components/Chat/Input/Files/FileContainer.tsx
@@ -14,6 +14,7 @@ const FileContainer = ({
   containerClassName,
   onDelete,
   onClick,
+  disabled,
 }: {
   file: Partial<ExtendedFile | TFile>;
   overrideType?: string;
@@ -36,6 +37,7 @@ const FileContainer = ({
   containerClassName?: string;
   onDelete?: () => void;
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  disabled?: boolean;
 }) => {
   const fileType = getFileType(overrideType ?? file.type);
   const visibleName = displayName ?? file.filename ?? '';
@@ -47,9 +49,11 @@ const FileContainer = ({
       <button
         type="button"
         onClick={onClick}
+        disabled={disabled}
         aria-label={visibleName}
         className={cn(
           'relative overflow-hidden rounded-2xl border border-border-light bg-surface-hover-alt',
+          disabled && 'cursor-default',
           buttonClassName,
         )}
       >

--- a/client/src/components/Chat/Messages/Content/FilePreviewDialog.tsx
+++ b/client/src/components/Chat/Messages/Content/FilePreviewDialog.tsx
@@ -94,35 +94,50 @@ function formatBytes(bytes: number): string {
   return `${bytes} B`;
 }
 
-function getDisplayType(fileType?: string, fileName?: string): string {
-  if (fileType) {
-    if (fileType.includes('pdf')) {
-      return 'PDF';
-    }
-    if (fileType.includes('word') || fileType.includes('document')) {
-      return 'Document';
-    }
-    if (fileType.includes('spreadsheet') || fileType.includes('excel')) {
-      return 'Spreadsheet';
-    }
-    if (fileType.includes('presentation') || fileType.includes('powerpoint')) {
-      return 'Presentation';
-    }
-    if (fileType.includes('image')) {
-      return 'Image';
-    }
-    if (fileType.startsWith('text/')) {
-      return fileType.split('/')[1]?.toUpperCase() || 'Text';
-    }
-    if (fileType.includes('json')) {
-      return 'JSON';
-    }
-    if (fileType.includes('xml')) {
-      return 'XML';
-    }
+function getMimeDisplayType(fileType?: string): string | undefined {
+  if (!fileType) {
+    return undefined;
   }
+  if (fileType.includes('pdf')) {
+    return 'PDF';
+  }
+  if (fileType.includes('word') || fileType.includes('document')) {
+    return 'Document';
+  }
+  if (fileType.includes('spreadsheet') || fileType.includes('excel')) {
+    return 'Spreadsheet';
+  }
+  if (fileType.includes('presentation') || fileType.includes('powerpoint')) {
+    return 'Presentation';
+  }
+  if (fileType.includes('image')) {
+    return 'Image';
+  }
+  if (fileType.startsWith('text/')) {
+    return fileType.split('/')[1]?.toUpperCase() || 'Text';
+  }
+  if (fileType.includes('json')) {
+    return 'JSON';
+  }
+  if (fileType.includes('xml')) {
+    return 'XML';
+  }
+  return undefined;
+}
+
+function getDisplayType(fileType?: string, fileName?: string): string {
+  const mimeDisplayType = getMimeDisplayType(fileType);
+
+  if (mimeDisplayType) {
+    return mimeDisplayType;
+  }
+
   const ext = fileName ? getFileExtension(fileName) : '';
   return ext ? ext.toUpperCase() : 'File';
+}
+
+function createTextDownloadUrl(text: string, fileType?: string): string {
+  return URL.createObjectURL(new Blob([text], { type: fileType || 'text/plain' }));
 }
 
 export default function FilePreviewDialog({
@@ -165,6 +180,69 @@ export default function FilePreviewDialog({
     return result.data?.status === 'ready' ? result.data.text : undefined;
   }, [fetchTextPreview, fileContent]);
 
+  const markPreviewUnavailable = useCallback(() => {
+    if (cancelledRef.current) {
+      return;
+    }
+    setPreviewError(true);
+  }, []);
+
+  const finishLoading = useCallback(() => {
+    loadingRef.current = false;
+
+    if (cancelledRef.current) {
+      return;
+    }
+    setLoading(false);
+  }, []);
+
+  const loadTextSourcePreview = useCallback(async () => {
+    const text = await getTextSourceContent();
+
+    if (cancelledRef.current) {
+      return;
+    }
+    if (text == null) {
+      markPreviewUnavailable();
+      return;
+    }
+    setFileContent(text);
+  }, [getTextSourceContent, markPreviewUnavailable]);
+
+  const loadStoredPreview = useCallback(async () => {
+    const result = await downloadFile();
+
+    if (cancelledRef.current) {
+      return;
+    }
+    if (!result.data) {
+      markPreviewUnavailable();
+      return;
+    }
+
+    const resp = await fetch(result.data);
+    const blob = await resp.blob();
+
+    if (cancelledRef.current) {
+      return;
+    }
+    if (previewKind === 'text') {
+      setFileContent(await blob.text());
+      return;
+    }
+
+    const typed = new Blob([blob], { type: 'application/pdf' });
+    setFileBlobUrl(URL.createObjectURL(typed));
+  }, [downloadFile, markPreviewUnavailable, previewKind]);
+
+  const loadPreviewContent = useCallback(async () => {
+    if (isTextSource) {
+      await loadTextSourcePreview();
+      return;
+    }
+    await loadStoredPreview();
+  }, [isTextSource, loadStoredPreview, loadTextSourcePreview]);
+
   const loadPreview = useCallback(async () => {
     if (!fileId || !previewKind || loadingRef.current) {
       return;
@@ -175,101 +253,74 @@ export default function FilePreviewDialog({
     setPreviewError(false);
 
     try {
-      if (isTextSource) {
-        const text = await getTextSourceContent();
-        if (cancelledRef.current || text == null) {
-          if (!cancelledRef.current) {
-            setPreviewError(true);
-          }
-          return;
-        }
-        setFileContent(text);
-        return;
-      }
-
-      const result = await downloadFile();
-      if (cancelledRef.current || !result.data) {
-        if (!cancelledRef.current) {
-          setPreviewError(true);
-        }
-        return;
-      }
-
-      const resp = await fetch(result.data);
-      const blob = await resp.blob();
-
-      if (cancelledRef.current) {
-        return;
-      }
-
-      if (previewKind === 'text') {
-        setFileContent(await blob.text());
-      } else {
-        const typed = new Blob([blob], { type: 'application/pdf' });
-        setFileBlobUrl(URL.createObjectURL(typed));
-      }
+      await loadPreviewContent();
     } catch {
-      if (!cancelledRef.current) {
-        setPreviewError(true);
-      }
+      markPreviewUnavailable();
     } finally {
-      loadingRef.current = false;
-      if (!cancelledRef.current) {
-        setLoading(false);
-      }
+      finishLoading();
     }
-  }, [fileId, previewKind, isTextSource, getTextSourceContent, downloadFile]);
+  }, [fileId, finishLoading, loadPreviewContent, markPreviewUnavailable, previewKind]);
+
+  const downloadTextSourceFile = useCallback(async () => {
+    const text = await getTextSourceContent();
+
+    if (text == null) {
+      return;
+    }
+    triggerDownload(createTextDownloadUrl(text, fileType), fileName);
+  }, [fileName, fileType, getTextSourceContent]);
+
+  const downloadStoredFile = useCallback(async () => {
+    const result = await downloadFile();
+
+    if (!result.data) {
+      return;
+    }
+    triggerDownload(result.data, fileName);
+  }, [downloadFile, fileName]);
 
   const handleDownload = useCallback(async () => {
     if (!fileId) {
       return;
     }
+
     try {
       if (isTextSource) {
-        const text = await getTextSourceContent();
-        if (text == null) {
-          return;
-        }
-        const downloadURL = URL.createObjectURL(
-          new Blob([text], { type: fileType || 'text/plain' }),
-        );
-        triggerDownload(downloadURL, fileName);
+        await downloadTextSourceFile();
         return;
       }
-
-      const result = await downloadFile();
-      if (!result.data) {
-        return;
-      }
-      triggerDownload(result.data, fileName);
+      await downloadStoredFile();
     } catch (err) {
       logger.error('[FilePreviewDialog] Download failed:', err);
     }
-  }, [downloadFile, fileId, fileName, fileType, isTextSource, getTextSourceContent]);
+  }, [downloadStoredFile, downloadTextSourceFile, fileId, isTextSource]);
 
   useEffect(() => {
-    if (open && previewKind && !fileContent && !fileBlobUrl) {
-      loadPreview();
+    if (!open || !previewKind || fileContent || fileBlobUrl) {
+      return;
     }
+    loadPreview();
   }, [open, previewKind, fileContent, fileBlobUrl, loadPreview]);
 
   useEffect(() => {
     return () => {
-      if (fileBlobUrl) {
-        URL.revokeObjectURL(fileBlobUrl);
+      if (!fileBlobUrl) {
+        return;
       }
+      URL.revokeObjectURL(fileBlobUrl);
     };
   }, [fileBlobUrl]);
 
   useEffect(() => {
-    if (!open) {
-      cancelledRef.current = true;
-      setFileContent(null);
-      setFileBlobUrl(null);
-      setPreviewError(false);
-      setLoading(false);
-      setIsCopied(false);
+    if (open) {
+      return;
     }
+    cancelledRef.current = true;
+    setFileContent(null);
+    setFileBlobUrl(null);
+    setPreviewError(false);
+    setLoading(false);
+    setIsCopied(false);
   }, [open]);
 
   const handleCopy = useCallback(() => {

--- a/client/src/components/Chat/Messages/Content/FilePreviewDialog.tsx
+++ b/client/src/components/Chat/Messages/Content/FilePreviewDialog.tsx
@@ -2,10 +2,11 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import copy from 'copy-to-clipboard';
 import { useRecoilValue } from 'recoil';
 import { Download } from 'lucide-react';
+import { FileSources } from 'librechat-data-provider';
 import { OGDialog, OGDialogContent, OGDialogTitle, OGDialogDescription } from '@librechat/client';
 import CopyButton from '~/components/Messages/Content/CopyButton';
 import { logger, sortPagesByRelevance, triggerDownload } from '~/utils';
-import { useFileDownload } from '~/data-provider';
+import { useFileDownload, useFilePreview } from '~/data-provider';
 import { useLocalize } from '~/hooks';
 import store from '~/store';
 
@@ -19,6 +20,7 @@ interface FilePreviewDialogProps {
   pageRelevance?: Record<number, number>;
   fileType?: string;
   fileSize?: number;
+  source?: string | null;
 }
 
 function getFileExtension(filename: string): string {
@@ -133,10 +135,18 @@ export default function FilePreviewDialog({
   pageRelevance,
   fileType,
   fileSize,
+  source,
 }: FilePreviewDialogProps) {
   const localize = useLocalize();
   const user = useRecoilValue(store.user);
+  const isTextSource = source === FileSources.text;
+  const previewKind = isTextSource
+    ? 'text'
+    : canPreviewByMime(fileType) || canPreviewByExt(fileName);
   const { refetch: downloadFile } = useFileDownload(user?.id ?? '', fileId, { direct: false });
+  const { refetch: fetchTextPreview } = useFilePreview(isTextSource ? fileId : undefined, {
+    enabled: false,
+  });
 
   const [fileContent, setFileContent] = useState<string | null>(null);
   const [fileBlobUrl, setFileBlobUrl] = useState<string | null>(null);
@@ -145,9 +155,15 @@ export default function FilePreviewDialog({
   const [isCopied, setIsCopied] = useState(false);
   const loadingRef = useRef(false);
 
-  const previewKind = canPreviewByMime(fileType) || canPreviewByExt(fileName);
-
   const cancelledRef = useRef(false);
+
+  const getTextSourceContent = useCallback(async () => {
+    if (fileContent != null) {
+      return fileContent;
+    }
+    const result = await fetchTextPreview();
+    return result.data?.status === 'ready' ? result.data.text : undefined;
+  }, [fetchTextPreview, fileContent]);
 
   const loadPreview = useCallback(async () => {
     if (!fileId || !previewKind || loadingRef.current) {
@@ -159,6 +175,18 @@ export default function FilePreviewDialog({
     setPreviewError(false);
 
     try {
+      if (isTextSource) {
+        const text = await getTextSourceContent();
+        if (cancelledRef.current || text == null) {
+          if (!cancelledRef.current) {
+            setPreviewError(true);
+          }
+          return;
+        }
+        setFileContent(text);
+        return;
+      }
+
       const result = await downloadFile();
       if (cancelledRef.current || !result.data) {
         if (!cancelledRef.current) {
@@ -190,13 +218,25 @@ export default function FilePreviewDialog({
         setLoading(false);
       }
     }
-  }, [fileId, previewKind, downloadFile]);
+  }, [fileId, previewKind, isTextSource, getTextSourceContent, downloadFile]);
 
   const handleDownload = useCallback(async () => {
     if (!fileId) {
       return;
     }
     try {
+      if (isTextSource) {
+        const text = await getTextSourceContent();
+        if (text == null) {
+          return;
+        }
+        const downloadURL = URL.createObjectURL(
+          new Blob([text], { type: fileType || 'text/plain' }),
+        );
+        triggerDownload(downloadURL, fileName);
+        return;
+      }
+
       const result = await downloadFile();
       if (!result.data) {
         return;
@@ -205,7 +245,7 @@ export default function FilePreviewDialog({
     } catch (err) {
       logger.error('[FilePreviewDialog] Download failed:', err);
     }
-  }, [downloadFile, fileId, fileName]);
+  }, [downloadFile, fileId, fileName, fileType, isTextSource, getTextSourceContent]);
 
   useEffect(() => {
     if (open && previewKind && !fileContent && !fileBlobUrl) {

--- a/client/src/components/Chat/Messages/Content/Files.tsx
+++ b/client/src/components/Chat/Messages/Content/Files.tsx
@@ -5,50 +5,91 @@ import FileContainer from '~/components/Chat/Input/Files/FileContainer';
 import FilePreviewDialog from './FilePreviewDialog';
 import Image from './Image';
 
+type MessageFile = Partial<TFile>;
+
+type SplitMessageFiles = {
+  imageFiles: MessageFile[];
+  otherFiles: MessageFile[];
+};
+
 const isUploadAsTextAttachment = (file: Partial<TFile>) =>
   file.source === FileSources.text && file.context === FileContext.message_attachment;
 
-const Files = ({ message }: { message?: TMessage }) => {
-  const imageFiles = useMemo(() => {
-    return message?.files?.filter((file) => file.type?.startsWith('image/')) || [];
-  }, [message?.files]);
+const splitMessageFiles = (files?: MessageFile[]): SplitMessageFiles => {
+  if (!files?.length) {
+    return { imageFiles: [], otherFiles: [] };
+  }
 
-  const otherFiles = useMemo(() => {
-    return message?.files?.filter((file) => !file.type?.startsWith('image/')) || [];
-  }, [message?.files]);
+  return files.reduce<SplitMessageFiles>(
+    (acc, file) => {
+      const bucket = file.type?.startsWith('image/') === true ? acc.imageFiles : acc.otherFiles;
+      bucket.push(file);
+      return acc;
+    },
+    { imageFiles: [], otherFiles: [] },
+  );
+};
+
+const getMessageFileKey = (file: MessageFile, index: number) =>
+  file.file_id ?? `${file.filename ?? 'file'}-${index}`;
+
+const MessageFileContainer = ({
+  file,
+  onSelect,
+}: {
+  file: MessageFile;
+  onSelect: (file: MessageFile) => void;
+}) => {
+  const previewDisabled = isUploadAsTextAttachment(file);
+  const handleClick = useCallback(() => onSelect(file), [file, onSelect]);
+
+  return (
+    <FileContainer
+      file={file as TFile}
+      disabled={previewDisabled}
+      onClick={previewDisabled ? undefined : handleClick}
+    />
+  );
+};
+
+const MessageImage = ({ file }: { file: MessageFile }) => (
+  <Image
+    imagePath={file.preview ?? file.filepath ?? ''}
+    height={file.height ?? 1920}
+    width={file.width ?? 1080}
+    altText={file.filename ?? 'Uploaded Image'}
+  />
+);
+
+const Files = ({ message }: { message?: TMessage }) => {
+  const { imageFiles, otherFiles } = useMemo(
+    () => splitMessageFiles(message?.files),
+    [message?.files],
+  );
 
   const [selectedFile, setSelectedFile] = useState<Partial<TFile> | null>(null);
 
   const handleClose = useCallback((open: boolean) => {
-    if (!open) {
-      setSelectedFile(null);
+    if (open) {
+      return;
     }
+    setSelectedFile(null);
   }, []);
+
+  const handleSelect = useCallback((file: MessageFile) => setSelectedFile(file), []);
 
   return (
     <>
-      {otherFiles.length > 0 &&
-        otherFiles.map((file) => {
-          const previewDisabled = isUploadAsTextAttachment(file);
-          return (
-            <FileContainer
-              key={file.file_id}
-              file={file as TFile}
-              disabled={previewDisabled}
-              onClick={previewDisabled ? undefined : () => setSelectedFile(file)}
-            />
-          );
-        })}
-      {imageFiles.length > 0 &&
-        imageFiles.map((file) => (
-          <Image
-            key={file.file_id}
-            imagePath={file.preview ?? file.filepath ?? ''}
-            height={file.height ?? 1920}
-            width={file.width ?? 1080}
-            altText={file.filename ?? 'Uploaded Image'}
-          />
-        ))}
+      {otherFiles.map((file, index) => (
+        <MessageFileContainer
+          key={getMessageFileKey(file, index)}
+          file={file}
+          onSelect={handleSelect}
+        />
+      ))}
+      {imageFiles.map((file, index) => (
+        <MessageImage key={getMessageFileKey(file, index)} file={file} />
+      ))}
       <FilePreviewDialog
         open={selectedFile !== null}
         onOpenChange={handleClose}

--- a/client/src/components/Chat/Messages/Content/Files.tsx
+++ b/client/src/components/Chat/Messages/Content/Files.tsx
@@ -1,8 +1,12 @@
 import { useMemo, useState, useCallback, memo } from 'react';
+import { FileContext, FileSources } from 'librechat-data-provider';
 import type { TFile, TMessage } from 'librechat-data-provider';
 import FileContainer from '~/components/Chat/Input/Files/FileContainer';
 import FilePreviewDialog from './FilePreviewDialog';
 import Image from './Image';
+
+const isUploadAsTextAttachment = (file: Partial<TFile>) =>
+  file.source === FileSources.text && file.context === FileContext.message_attachment;
 
 const Files = ({ message }: { message?: TMessage }) => {
   const imageFiles = useMemo(() => {
@@ -24,13 +28,17 @@ const Files = ({ message }: { message?: TMessage }) => {
   return (
     <>
       {otherFiles.length > 0 &&
-        otherFiles.map((file) => (
-          <FileContainer
-            key={file.file_id}
-            file={file as TFile}
-            onClick={() => setSelectedFile(file)}
-          />
-        ))}
+        otherFiles.map((file) => {
+          const previewDisabled = isUploadAsTextAttachment(file);
+          return (
+            <FileContainer
+              key={file.file_id}
+              file={file as TFile}
+              disabled={previewDisabled}
+              onClick={previewDisabled ? undefined : () => setSelectedFile(file)}
+            />
+          );
+        })}
       {imageFiles.length > 0 &&
         imageFiles.map((file) => (
           <Image

--- a/client/src/components/Chat/Messages/Content/Files.tsx
+++ b/client/src/components/Chat/Messages/Content/Files.tsx
@@ -48,6 +48,7 @@ const Files = ({ message }: { message?: TMessage }) => {
         fileId={selectedFile?.file_id}
         fileType={selectedFile?.type ?? undefined}
         fileSize={(selectedFile as TFile)?.bytes}
+        source={selectedFile?.source}
       />
     </>
   );

--- a/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
+++ b/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
@@ -21,6 +21,7 @@ interface FileSource {
   pageRelevance: Record<number, number>;
   fileType?: string;
   fileBytes?: number;
+  source?: string;
   metadata?: Record<string, unknown>;
 }
 
@@ -66,6 +67,7 @@ function extractFileSources(attachments?: TAttachment[]): FileSource[] {
           pageRelevance: source.pageRelevance || {},
           fileType: (meta?.fileType as string) || undefined,
           fileBytes: (meta?.fileBytes as number) || undefined,
+          source: (meta?.storageType as string) || undefined,
           metadata: meta,
         });
       }
@@ -90,6 +92,7 @@ interface DisplayResult {
   pageRelevance?: Record<number, number>;
   fileType?: string;
   fileBytes?: number;
+  source?: string;
 }
 
 interface FileMatch {
@@ -97,6 +100,7 @@ interface FileMatch {
   fileName: string;
   fileType?: string;
   fileBytes?: number;
+  source?: string;
 }
 
 function normalizeFilename(filename: string): string {
@@ -140,6 +144,7 @@ function buildFileLookup(
       fileName: source.fileName,
       fileType: source.fileType,
       fileBytes: source.fileBytes,
+      source: source.source,
     });
   }
 
@@ -158,6 +163,7 @@ function buildFileLookup(
       fileName: file.filename,
       fileType: file.type ?? undefined,
       fileBytes: file.bytes,
+      source: file.source,
     });
   }
 
@@ -179,6 +185,7 @@ function mergeRetrievalResults(
       pageRelevance: source.pageRelevance,
       fileType: source.fileType,
       fileBytes: source.fileBytes,
+      source: source.source,
     }));
   }
 
@@ -195,6 +202,7 @@ function mergeRetrievalResults(
       content: result.content,
       fileType: match?.fileType,
       fileBytes: match?.fileBytes,
+      source: match?.source,
     };
   });
 }
@@ -470,6 +478,7 @@ export default function RetrievalCall({
         pages={previewData?.pages}
         pageRelevance={previewData?.pageRelevance}
         fileType={previewData?.fileType}
+        source={previewData?.source}
       />
     </div>
   );

--- a/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
+++ b/client/src/components/Chat/Messages/Content/RetrievalCall.tsx
@@ -399,6 +399,7 @@ export default function RetrievalCall({
       pages: result.pages,
       pageRelevance: result.pageRelevance,
       fileType: result.fileType,
+      source: result.source,
     };
   }, [displayResults, previewIndex]);
 

--- a/client/src/components/Chat/Messages/Content/__tests__/FilePreviewDialog.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/FilePreviewDialog.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { FileSources } from 'librechat-data-provider';
+import FilePreviewDialog from '../FilePreviewDialog';
+
+const mockDownloadFile = jest.fn();
+const mockFetchTextPreview = jest.fn();
+const mockTriggerDownload = jest.fn();
+const mockCreateObjectURL = jest.fn();
+
+jest.mock('recoil', () => ({
+  useRecoilValue: () => ({ id: 'user-1' }),
+}));
+
+jest.mock('@librechat/client', () => ({
+  OGDialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  OGDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  OGDialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  OGDialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+}));
+
+jest.mock('~/components/Messages/Content/CopyButton', () => ({
+  __esModule: true,
+  default: ({ label }: { label: string }) => <button type="button">{label}</button>,
+}));
+
+jest.mock('~/data-provider', () => ({
+  useFileDownload: () => ({ refetch: mockDownloadFile }),
+  useFilePreview: () => ({ refetch: mockFetchTextPreview }),
+}));
+
+jest.mock('~/hooks', () => ({
+  useLocalize: () => (key: string) => key,
+}));
+
+jest.mock('~/store', () => ({
+  __esModule: true,
+  default: { user: {} },
+}));
+
+jest.mock('~/utils', () => ({
+  logger: { error: jest.fn() },
+  sortPagesByRelevance: (pages: number[]) => pages,
+  triggerDownload: (...args: Parameters<typeof mockTriggerDownload>) =>
+    mockTriggerDownload(...args),
+}));
+
+describe('FilePreviewDialog text-source previews', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateObjectURL.mockReturnValue('blob:text-source');
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: mockCreateObjectURL,
+    });
+  });
+
+  it('loads text-backed files from the preview endpoint instead of the download route', async () => {
+    mockFetchTextPreview.mockResolvedValueOnce({
+      data: { file_id: 'file-text', status: 'ready', text: 'hello from db' },
+    });
+
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={jest.fn()}
+        fileName="example.txt"
+        fileId="file-text"
+        fileType="text/plain"
+        source={FileSources.text}
+      />,
+    );
+
+    expect(await screen.findByText('hello from db')).toBeInTheDocument();
+    expect(mockFetchTextPreview).toHaveBeenCalledTimes(1);
+    expect(mockDownloadFile).not.toHaveBeenCalled();
+  });
+
+  it('creates a local text blob for text-source downloads', async () => {
+    mockFetchTextPreview.mockResolvedValueOnce({
+      data: { file_id: 'file-text', status: 'ready', text: 'download me' },
+    });
+
+    render(
+      <FilePreviewDialog
+        open
+        onOpenChange={jest.fn()}
+        fileName="example.txt"
+        fileId="file-text"
+        fileType="text/plain"
+        source={FileSources.text}
+      />,
+    );
+
+    await screen.findByText('download me');
+    fireEvent.click(screen.getByRole('button', { name: 'com_ui_download example.txt' }));
+
+    await waitFor(() => {
+      expect(mockTriggerDownload).toHaveBeenCalledWith('blob:text-source', 'example.txt');
+    });
+    expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(mockDownloadFile).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/Chat/Messages/Content/__tests__/Files.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/Files.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FileContext, FileSources } from 'librechat-data-provider';
+import type { TFile, TMessage } from 'librechat-data-provider';
+import Files from '../Files';
+
+jest.mock('~/components/Chat/Input/Files/FileContainer', () => ({
+  __esModule: true,
+  default: ({
+    file,
+    disabled,
+    onClick,
+  }: {
+    file: Partial<TFile>;
+    disabled?: boolean;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  }) => (
+    <button
+      type="button"
+      data-testid={`file-chip-${file.file_id}`}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {file.filename}
+    </button>
+  ),
+}));
+
+jest.mock('../FilePreviewDialog', () => ({
+  __esModule: true,
+  default: ({ open, fileId }: { open: boolean; fileId?: string }) =>
+    open ? <div data-testid="file-preview-dialog" data-file-id={fileId} /> : null,
+}));
+
+jest.mock('../Image', () => ({
+  __esModule: true,
+  default: ({ altText }: { altText: string }) => <img alt={altText} />,
+}));
+
+const messageWithFile = (file: Partial<TFile>): TMessage =>
+  ({
+    messageId: 'message-1',
+    files: [
+      {
+        file_id: 'file-1',
+        filename: 'example.txt',
+        type: 'text/plain',
+        bytes: 12,
+        ...file,
+      },
+    ],
+  }) as TMessage;
+
+describe('message file previews', () => {
+  it('disables previewing upload-as-text message attachments', () => {
+    render(
+      <Files
+        message={messageWithFile({
+          source: FileSources.text,
+          context: FileContext.message_attachment,
+        })}
+      />,
+    );
+
+    const chip = screen.getByTestId('file-chip-file-1');
+    expect(chip).toBeDisabled();
+
+    fireEvent.click(chip);
+
+    expect(screen.queryByTestId('file-preview-dialog')).not.toBeInTheDocument();
+  });
+
+  it('keeps normal message attachments previewable', () => {
+    render(
+      <Files
+        message={messageWithFile({
+          source: FileSources.local,
+          context: FileContext.message_attachment,
+        })}
+      />,
+    );
+
+    const chip = screen.getByTestId('file-chip-file-1');
+    expect(chip).not.toBeDisabled();
+
+    fireEvent.click(chip);
+
+    expect(screen.getByTestId('file-preview-dialog')).toHaveAttribute('data-file-id', 'file-1');
+  });
+});

--- a/client/src/components/Chat/Messages/Content/__tests__/RetrievalCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/__tests__/RetrievalCall.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { RecoilRoot } from 'recoil';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { FileSources } from 'librechat-data-provider';
 import type { TAttachment } from 'librechat-data-provider';
 import RetrievalCall from '../RetrievalCall';
 
@@ -74,6 +75,7 @@ jest.mock('../ToolOutput', () => ({
 jest.mock('~/utils', () => ({
   cn: (...classes: (string | boolean | undefined)[]) => classes.filter(Boolean).join(' '),
   logger: { error: jest.fn(), debug: jest.fn() },
+  sortPagesByRelevance: (pages: number[]) => pages,
 }));
 
 jest.mock('~/data-provider', () => ({
@@ -82,9 +84,19 @@ jest.mock('~/data-provider', () => ({
 
 jest.mock('../FilePreviewDialog', () => ({
   __esModule: true,
-  default: ({ open, fileId, fileName }: { open: boolean; fileId?: string; fileName: string }) =>
+  default: ({
+    open,
+    fileId,
+    fileName,
+    source,
+  }: {
+    open: boolean;
+    fileId?: string;
+    fileName: string;
+    source?: string;
+  }) =>
     open ? (
-      <div data-testid="file-preview-dialog" data-file-id={fileId}>
+      <div data-testid="file-preview-dialog" data-file-id={fileId} data-source={source}>
         {fileName}
       </div>
     ) : null,
@@ -271,6 +283,45 @@ describe('RetrievalCall - file preview resolution', () => {
 
     expect(screen.getAllByRole('button', { name: 'Preview: Tutorial Imazing.pdf' })).toHaveLength(
       2,
+    );
+  });
+
+  it('preserves storage source metadata when opening a retrieval preview', () => {
+    renderRetrievalCall({
+      initialProgress: 1,
+      isSubmitting: false,
+      output: 'Retrieved text-backed source',
+      attachments: [
+        {
+          type: 'file_search',
+          toolCallId: 'call-1',
+          file_search: {
+            sources: [
+              {
+                fileId: 'file-text',
+                fileName: 'notes.txt',
+                relevance: 0.9,
+                content: 'Text-backed result',
+                pages: [1],
+                pageRelevance: { 1: 0.9 },
+                metadata: {
+                  fileType: 'text/plain',
+                  fileBytes: 18,
+                  storageType: FileSources.text,
+                },
+              },
+            ],
+          },
+        },
+      ] as any,
+    });
+
+    fireEvent.click(screen.getByTestId('progress-text'));
+    fireEvent.click(screen.getByRole('button', { name: 'Preview: notes.txt' }));
+
+    expect(screen.getByTestId('file-preview-dialog')).toHaveAttribute(
+      'data-source',
+      FileSources.text,
     );
   });
 });

--- a/client/src/components/Web/Citation.tsx
+++ b/client/src/components/Web/Citation.tsx
@@ -10,6 +10,7 @@ import { useLocalize } from '~/hooks';
 interface FileCitationMetadata {
   fileBytes?: number;
   fileType?: string;
+  storageType?: string;
 }
 
 interface FileCitationSource {
@@ -37,6 +38,7 @@ function getFileCitationData(source?: FileCitationSource) {
     filePages: isFileType ? source.pages : undefined,
     fileRelevance: isFileType ? source.relevance : undefined,
     filePageRelevance: isFileType ? source.pageRelevance : undefined,
+    fileSource: isFileType ? source.metadata?.storageType : undefined,
   };
 }
 
@@ -93,8 +95,16 @@ export function CompositeCitation(props: CompositeCitationProps) {
   };
 
   const currentSource = sources[currentPage] as FileCitationSource;
-  const { isFileType, fileId, fileMeta, fileName, filePages, fileRelevance, filePageRelevance } =
-    getFileCitationData(currentSource);
+  const {
+    isFileType,
+    fileId,
+    fileMeta,
+    fileName,
+    filePages,
+    fileRelevance,
+    filePageRelevance,
+    fileSource,
+  } = getFileCitationData(currentSource);
 
   const handleFileClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -273,6 +283,7 @@ export function CompositeCitation(props: CompositeCitationProps) {
           pageRelevance={filePageRelevance}
           fileType={fileMeta?.fileType}
           fileSize={fileMeta?.fileBytes}
+          source={fileSource}
         />
       )}
     </>
@@ -297,8 +308,16 @@ export function Citation(props: CitationComponentProps) {
     index: citation?.index || 0,
   }) as FileCitationSource | undefined;
 
-  const { isFileType, fileId, fileMeta, fileName, filePages, fileRelevance, filePageRelevance } =
-    getFileCitationData(refData);
+  const {
+    isFileType,
+    fileId,
+    fileMeta,
+    fileName,
+    filePages,
+    fileRelevance,
+    filePageRelevance,
+    fileSource,
+  } = getFileCitationData(refData);
 
   const [showPreview, setShowPreview] = useState(false);
 
@@ -349,6 +368,7 @@ export function Citation(props: CitationComponentProps) {
           pageRelevance={filePageRelevance}
           fileType={fileMeta?.fileType}
           fileSize={fileMeta?.fileBytes}
+          source={fileSource}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

I fixed upload-as-text file behavior so `FileSources.text` message attachments no longer try to preview a temporary local upload path.

- Disabled preview opening for `source: text` + `context: message_attachment` file chips, which is the upload-as-text message attachment path.
- Flattened the message file rendering and preview dialog flow with guard clauses, a one-pass attachment split, and named preview/download helpers.
- Left normal message attachments previewable and added a shared disabled state to `FileContainer` for non-previewable chips.
- Kept text-source preview/download handling for non-message contexts and a backend download-route fallback for older clients or direct calls.
- Scoped full-text re-fetches to the already-authorized DB `_id` for both download and preview routes.
- Added backend and frontend regressions covering text-source download/preview behavior, retrieval preview source propagation, and disabled upload-as-text message previews.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `NODE_PATH=/Users/danny/Projects/ClickHouse-LibreChat/node_modules:/Users/danny/Projects/ClickHouse-LibreChat/api/node_modules /Users/danny/Projects/ClickHouse-LibreChat/node_modules/.bin/jest server/routes/files/files.test.js server/routes/files/preview.spec.js --runInBand` from `api`.
- Ran `node /Users/danny/Projects/ClickHouse-LibreChat/node_modules/jest/bin/jest.js src/components/Chat/Messages/Content/__tests__/Files.test.tsx src/components/Chat/Messages/Content/__tests__/RetrievalCall.test.tsx src/components/Chat/Messages/Content/__tests__/FilePreviewDialog.test.tsx --runInBand --coverage=false` from `client` with root/client dependency symlinks into the worktree.
- Ran `npm run test:ci -- src/components/Chat/Messages/Content/__tests__/Files.test.tsx` from `client` with root/client dependency symlinks into the worktree.
- Ran `npx eslint client/src/components/Chat/Messages/Content/Files.tsx client/src/components/Chat/Messages/Content/FilePreviewDialog.tsx client/src/components/Chat/Messages/Content/__tests__/Files.test.tsx`.
- Ran `node --check api/server/routes/files/files.js` and `node --check api/server/routes/files/preview.spec.js`.
- Ran ESLint on all touched backend/frontend files.
- Ran `git diff --check`.
- Ran `npm run typecheck` from `client`; it currently reports existing repo-wide type errors outside this change set and no errors from the touched files.

### **Test Configuration**:

- Database: `mongodb-memory-server`
- Dependencies: main checkout `node_modules` and `client/node_modules` linked into the worktree for focused test/lint commands

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
