### PR TITLE
🌩️ feat: Strict CloudFront signed cookie enforcement via `requireSignedAccess`

### DIFF
--- a/packages/api/src/app/__tests__/cdn.test.ts
+++ b/packages/api/src/app/__tests__/cdn.test.ts
@@ -122,6 +122,34 @@ describe('initializeFileStorage', () => {
     expect(initializeS3).not.toHaveBeenCalled();
   });
 
+  it('throws when CloudFront init fails and requireSignedAccess is true', () => {
+    (initializeCloudFront as jest.Mock).mockReturnValue(false);
+    const cloudfrontConfig = {
+      domain: 'https://d123.cloudfront.net',
+      requireSignedAccess: true,
+    };
+    const appConfig = {
+      ...baseAppConfig,
+      fileStrategy: FileSources.cloudfront,
+      cloudfront: cloudfrontConfig,
+    } as AppConfig;
+    expect(() => initializeFileStorage(appConfig)).toThrow(/requireSignedAccess=true/);
+  });
+
+  it('does not throw when CloudFront init fails and requireSignedAccess is false', () => {
+    (initializeCloudFront as jest.Mock).mockReturnValue(false);
+    const cloudfrontConfig = {
+      domain: 'https://d123.cloudfront.net',
+      requireSignedAccess: false,
+    };
+    const appConfig = {
+      ...baseAppConfig,
+      fileStrategy: FileSources.cloudfront,
+      cloudfront: cloudfrontConfig,
+    } as AppConfig;
+    expect(() => initializeFileStorage(appConfig)).not.toThrow();
+  });
+
   it('does not call any initializer when fileStrategy is local with no fileStrategies', () => {
     const appConfig = { ...baseAppConfig, fileStrategy: FileSources.local } as AppConfig;
     initializeFileStorage(appConfig);

--- a/packages/api/src/app/__tests__/cdn.test.ts
+++ b/packages/api/src/app/__tests__/cdn.test.ts
@@ -21,6 +21,7 @@ jest.mock('~/cdn/cloudfront', () => ({
 }));
 
 import type { AppConfig } from '@librechat/data-schemas';
+import type { CloudFrontConfig } from 'librechat-data-provider';
 import { initializeFileStorage } from '../cdn';
 import { initializeFirebase } from '~/cdn/firebase';
 import { initializeAzureBlobService } from '~/cdn/azure';
@@ -32,6 +33,23 @@ const baseAppConfig: AppConfig = {
   fileStrategy: FileSources.local,
   imageOutputType: 'png',
 };
+
+type RequiredCloudFrontConfig = NonNullable<CloudFrontConfig>;
+
+function makeCloudFrontConfig(
+  overrides: Partial<RequiredCloudFrontConfig> = {},
+): RequiredCloudFrontConfig {
+  return {
+    domain: 'https://d123.cloudfront.net',
+    invalidateOnDelete: false,
+    imageSigning: 'none',
+    urlExpiry: 3600,
+    cookieExpiry: 1800,
+    includeRegionInPath: false,
+    requireSignedAccess: false,
+    ...overrides,
+  };
+}
 
 describe('initializeFileStorage', () => {
   beforeEach(() => {
@@ -88,7 +106,7 @@ describe('initializeFileStorage', () => {
   });
 
   it('initializes CloudFront with config when fileStrategy is cloudfront', () => {
-    const cloudfrontConfig = { domain: 'https://d123.cloudfront.net' };
+    const cloudfrontConfig = makeCloudFrontConfig();
     const appConfig = {
       ...baseAppConfig,
       fileStrategy: FileSources.cloudfront,
@@ -109,7 +127,7 @@ describe('initializeFileStorage', () => {
   });
 
   it('initializes CloudFront from fileStrategies when fileStrategy is local, but avatar is configured for CloudFront', () => {
-    const cloudfrontConfig = { domain: 'https://d123.cloudfront.net' };
+    const cloudfrontConfig = makeCloudFrontConfig();
     const appConfig = {
       ...baseAppConfig,
       fileStrategy: FileSources.local,
@@ -124,10 +142,11 @@ describe('initializeFileStorage', () => {
 
   it('throws when CloudFront init fails and requireSignedAccess is true', () => {
     (initializeCloudFront as jest.Mock).mockReturnValue(false);
-    const cloudfrontConfig = {
-      domain: 'https://d123.cloudfront.net',
+    const cloudfrontConfig = makeCloudFrontConfig({
+      imageSigning: 'cookies',
+      cookieDomain: '.example.com',
       requireSignedAccess: true,
-    };
+    });
     const appConfig = {
       ...baseAppConfig,
       fileStrategy: FileSources.cloudfront,
@@ -138,10 +157,7 @@ describe('initializeFileStorage', () => {
 
   it('does not throw when CloudFront init fails and requireSignedAccess is false', () => {
     (initializeCloudFront as jest.Mock).mockReturnValue(false);
-    const cloudfrontConfig = {
-      domain: 'https://d123.cloudfront.net',
-      requireSignedAccess: false,
-    };
+    const cloudfrontConfig = makeCloudFrontConfig();
     const appConfig = {
       ...baseAppConfig,
       fileStrategy: FileSources.cloudfront,

--- a/packages/api/src/app/cdn.ts
+++ b/packages/api/src/app/cdn.ts
@@ -18,16 +18,21 @@ function initializeStrategy(strategy: FileSources, appConfig: AppConfig): void {
   } else if (strategy === FileSources.cloudfront) {
     const cloudfrontConfig = appConfig.cloudfront;
     if (!cloudfrontConfig) {
-      logger.error(
-        '[initializeFileStorage] CloudFront strategy requires cloudfront config in librechat.yaml',
-      );
+      const message =
+        '[initializeFileStorage] CloudFront strategy requires cloudfront config in librechat.yaml';
+      logger.error(message);
       return;
     }
     const initialized = initializeCloudFront(cloudfrontConfig);
     if (!initialized) {
-      logger.error(
-        '[initializeFileStorage] CloudFront initialization failed. CloudFront operations will not work.',
-      );
+      const message =
+        '[initializeFileStorage] CloudFront initialization failed. CloudFront operations will not work.';
+      if (cloudfrontConfig.requireSignedAccess === true) {
+        throw new Error(
+          '[initializeFileStorage] CloudFront initialization failed and cloudfront.requireSignedAccess=true; refusing to start.',
+        );
+      }
+      logger.error(message);
     }
   }
 }

--- a/packages/api/src/app/cdn.ts
+++ b/packages/api/src/app/cdn.ts
@@ -18,21 +18,21 @@ function initializeStrategy(strategy: FileSources, appConfig: AppConfig): void {
   } else if (strategy === FileSources.cloudfront) {
     const cloudfrontConfig = appConfig.cloudfront;
     if (!cloudfrontConfig) {
-      const message =
-        '[initializeFileStorage] CloudFront strategy requires cloudfront config in librechat.yaml';
-      logger.error(message);
+      logger.error(
+        '[initializeFileStorage] CloudFront strategy requires cloudfront config in librechat.yaml',
+      );
       return;
     }
     const initialized = initializeCloudFront(cloudfrontConfig);
     if (!initialized) {
-      const message =
-        '[initializeFileStorage] CloudFront initialization failed. CloudFront operations will not work.';
       if (cloudfrontConfig.requireSignedAccess === true) {
         throw new Error(
           '[initializeFileStorage] CloudFront initialization failed and cloudfront.requireSignedAccess=true; refusing to start.',
         );
       }
-      logger.error(message);
+      logger.error(
+        '[initializeFileStorage] CloudFront initialization failed. CloudFront operations will not work.',
+      );
     }
   }
 }

--- a/packages/api/src/cdn/__tests__/cloudfront.test.ts
+++ b/packages/api/src/cdn/__tests__/cloudfront.test.ts
@@ -153,12 +153,28 @@ describe('CloudFront CDN module', () => {
 
       it('returns false and logs strict failure when keys are missing', async () => {
         const { initializeCloudFront } = await load();
-        expect(initializeCloudFront(makeConfig({ requireSignedAccess: true }))).toBe(false);
+        expect(
+          initializeCloudFront(
+            makeConfig({ imageSigning: 'cookies', requireSignedAccess: true }),
+          ),
+        ).toBe(false);
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Strict startup failure'),
         );
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('CLOUDFRONT_KEY_PAIR_ID'),
+        );
+      });
+
+      it('returns false when imageSigning is "none" even if keys are present', async () => {
+        process.env.CLOUDFRONT_KEY_PAIR_ID = 'K123';
+        process.env.CLOUDFRONT_PRIVATE_KEY = 'my-private-key';
+        const { initializeCloudFront } = await load();
+        expect(
+          initializeCloudFront(makeConfig({ imageSigning: 'none', requireSignedAccess: true })),
+        ).toBe(false);
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          expect.stringContaining('requireSignedAccess=true requires imageSigning="cookies"'),
         );
       });
 
@@ -170,7 +186,7 @@ describe('CloudFront CDN module', () => {
           initializeCloudFront(makeConfig({ imageSigning: 'url', requireSignedAccess: true })),
         ).toBe(false);
         expect(mockLogger.error).toHaveBeenCalledWith(
-          expect.stringContaining('imageSigning="url" is not yet implemented'),
+          expect.stringContaining('requireSignedAccess=true requires imageSigning="cookies"'),
         );
       });
     });

--- a/packages/api/src/cdn/__tests__/cloudfront.test.ts
+++ b/packages/api/src/cdn/__tests__/cloudfront.test.ts
@@ -149,6 +149,9 @@ describe('CloudFront CDN module', () => {
         expect(mockLogger.info).toHaveBeenCalledWith(
           expect.stringContaining('Strict signed CloudFront access enabled at startup'),
         );
+        expect(mockLogger.info).not.toHaveBeenCalledWith(
+          expect.stringContaining('CloudFront cookie signing enabled'),
+        );
       });
 
       it('returns false and logs strict failure when keys are missing', async () => {

--- a/packages/api/src/cdn/__tests__/cloudfront.test.ts
+++ b/packages/api/src/cdn/__tests__/cloudfront.test.ts
@@ -22,6 +22,7 @@ function makeConfig(overrides: Partial<RequiredCloudFrontConfig> = {}): Required
     urlExpiry: 3600,
     cookieExpiry: 1800,
     includeRegionInPath: false,
+    requireSignedAccess: false,
     ...overrides,
   };
 }
@@ -135,6 +136,43 @@ describe('CloudFront CDN module', () => {
           '[initializeCloudFront] imageSigning="url" is configured but not yet implemented',
         ),
       );
+    });
+
+    describe('requireSignedAccess (strict mode)', () => {
+      it('logs strict-mode startup info when enabled and keys are present', async () => {
+        process.env.CLOUDFRONT_KEY_PAIR_ID = 'K123';
+        process.env.CLOUDFRONT_PRIVATE_KEY = 'my-private-key';
+        const { initializeCloudFront } = await load();
+        expect(
+          initializeCloudFront(makeConfig({ imageSigning: 'cookies', requireSignedAccess: true })),
+        ).toBe(true);
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          expect.stringContaining('Strict signed CloudFront access enabled at startup'),
+        );
+      });
+
+      it('returns false and logs strict failure when keys are missing', async () => {
+        const { initializeCloudFront } = await load();
+        expect(initializeCloudFront(makeConfig({ requireSignedAccess: true }))).toBe(false);
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          expect.stringContaining('Strict startup failure'),
+        );
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          expect.stringContaining('CLOUDFRONT_KEY_PAIR_ID'),
+        );
+      });
+
+      it('returns false when imageSigning is "url" even if keys are present', async () => {
+        process.env.CLOUDFRONT_KEY_PAIR_ID = 'K123';
+        process.env.CLOUDFRONT_PRIVATE_KEY = 'my-private-key';
+        const { initializeCloudFront } = await load();
+        expect(
+          initializeCloudFront(makeConfig({ imageSigning: 'url', requireSignedAccess: true })),
+        ).toBe(false);
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          expect.stringContaining('imageSigning="url" is not yet implemented'),
+        );
+      });
     });
   });
 

--- a/packages/api/src/cdn/__tests__/cloudfront.test.ts
+++ b/packages/api/src/cdn/__tests__/cloudfront.test.ts
@@ -154,9 +154,7 @@ describe('CloudFront CDN module', () => {
       it('returns false and logs strict failure when keys are missing', async () => {
         const { initializeCloudFront } = await load();
         expect(
-          initializeCloudFront(
-            makeConfig({ imageSigning: 'cookies', requireSignedAccess: true }),
-          ),
+          initializeCloudFront(makeConfig({ imageSigning: 'cookies', requireSignedAccess: true })),
         ).toBe(false);
         expect(mockLogger.error).toHaveBeenCalledWith(
           expect.stringContaining('Strict startup failure'),
@@ -174,7 +172,9 @@ describe('CloudFront CDN module', () => {
           initializeCloudFront(makeConfig({ imageSigning: 'none', requireSignedAccess: true })),
         ).toBe(false);
         expect(mockLogger.error).toHaveBeenCalledWith(
-          expect.stringContaining('requireSignedAccess=true requires imageSigning="cookies"'),
+          expect.stringContaining(
+            'cloudfront.requireSignedAccess=true requires cloudfront.imageSigning="cookies"',
+          ),
         );
       });
 
@@ -186,7 +186,9 @@ describe('CloudFront CDN module', () => {
           initializeCloudFront(makeConfig({ imageSigning: 'url', requireSignedAccess: true })),
         ).toBe(false);
         expect(mockLogger.error).toHaveBeenCalledWith(
-          expect.stringContaining('requireSignedAccess=true requires imageSigning="cookies"'),
+          expect.stringContaining(
+            'cloudfront.requireSignedAccess=true requires cloudfront.imageSigning="cookies"',
+          ),
         );
       });
     });

--- a/packages/api/src/cdn/cloudfront-cookies.ts
+++ b/packages/api/src/cdn/cloudfront-cookies.ts
@@ -341,6 +341,10 @@ export function setCloudFrontCookies(
       path: '/',
     });
 
+    logger.info(
+      `[setCloudFrontCookies] Issued signed CloudFront cookies (paths=${signedCookieSets.length}, expiresInSec=${cookieExpiry}).`,
+    );
+
     return true;
   } catch (error) {
     logger.error('[setCloudFrontCookies] Failed to generate signed cookies:', error);

--- a/packages/api/src/cdn/cloudfront-cookies.ts
+++ b/packages/api/src/cdn/cloudfront-cookies.ts
@@ -341,7 +341,7 @@ export function setCloudFrontCookies(
       path: '/',
     });
 
-    logger.info(
+    logger.debug(
       `[setCloudFrontCookies] Issued signed CloudFront cookies (paths=${signedCookieSets.length}, expiresInSec=${cookieExpiry}).`,
     );
 

--- a/packages/api/src/cdn/cloudfront.ts
+++ b/packages/api/src/cdn/cloudfront.ts
@@ -29,6 +29,26 @@ export function initializeCloudFront(config: CloudFrontConfig): boolean {
   const keyPairId = process.env.CLOUDFRONT_KEY_PAIR_ID ?? null;
   const privateKey = process.env.CLOUDFRONT_PRIVATE_KEY ?? null;
 
+  const requireSignedAccess = config.requireSignedAccess === true;
+
+  if (requireSignedAccess) {
+    logger.info('[initializeCloudFront] Strict signed CloudFront access enabled at startup.');
+
+    if (!keyPairId || !privateKey) {
+      logger.error(
+        '[initializeCloudFront] Strict startup failure: requireSignedAccess=true but CLOUDFRONT_KEY_PAIR_ID and/or CLOUDFRONT_PRIVATE_KEY are missing.',
+      );
+      return false;
+    }
+
+    if (config.imageSigning === 'url') {
+      logger.error(
+        '[initializeCloudFront] Strict startup failure: imageSigning="url" is not yet implemented; cannot enforce requireSignedAccess.',
+      );
+      return false;
+    }
+  }
+
   if (config.imageSigning === 'cookies' && (!keyPairId || !privateKey)) {
     logger.error(
       '[initializeCloudFront] imageSigning="cookies" requires CLOUDFRONT_KEY_PAIR_ID and CLOUDFRONT_PRIVATE_KEY env vars.',

--- a/packages/api/src/cdn/cloudfront.ts
+++ b/packages/api/src/cdn/cloudfront.ts
@@ -58,7 +58,7 @@ export function initializeCloudFront(config: CloudFrontConfig): boolean {
 
   cloudFrontConfig = { ...config, privateKey, keyPairId };
 
-  if (config.imageSigning === 'cookies') {
+  if (config.imageSigning === 'cookies' && !requireSignedAccess) {
     logger.info(
       '[initializeCloudFront] CloudFront cookie signing enabled. Cookies will be set during auth.',
     );

--- a/packages/api/src/cdn/cloudfront.ts
+++ b/packages/api/src/cdn/cloudfront.ts
@@ -36,14 +36,14 @@ export function initializeCloudFront(config: CloudFrontConfig): boolean {
 
     if (config.imageSigning !== 'cookies') {
       logger.error(
-        `[initializeCloudFront] Strict startup failure: requireSignedAccess=true requires imageSigning="cookies" (got "${config.imageSigning ?? 'none'}"); signed URL mode is not yet implemented.`,
+        `[initializeCloudFront] Strict startup failure: cloudfront.requireSignedAccess=true requires cloudfront.imageSigning="cookies" (got "${config.imageSigning ?? 'none'}"); signed URL mode is not yet implemented.`,
       );
       return false;
     }
 
     if (!keyPairId || !privateKey) {
       logger.error(
-        '[initializeCloudFront] Strict startup failure: requireSignedAccess=true but CLOUDFRONT_KEY_PAIR_ID and/or CLOUDFRONT_PRIVATE_KEY are missing.',
+        '[initializeCloudFront] Strict startup failure: cloudfront.requireSignedAccess=true but CLOUDFRONT_KEY_PAIR_ID and/or CLOUDFRONT_PRIVATE_KEY are missing.',
       );
       return false;
     }

--- a/packages/api/src/cdn/cloudfront.ts
+++ b/packages/api/src/cdn/cloudfront.ts
@@ -34,16 +34,16 @@ export function initializeCloudFront(config: CloudFrontConfig): boolean {
   if (requireSignedAccess) {
     logger.info('[initializeCloudFront] Strict signed CloudFront access enabled at startup.');
 
-    if (!keyPairId || !privateKey) {
+    if (config.imageSigning !== 'cookies') {
       logger.error(
-        '[initializeCloudFront] Strict startup failure: requireSignedAccess=true but CLOUDFRONT_KEY_PAIR_ID and/or CLOUDFRONT_PRIVATE_KEY are missing.',
+        `[initializeCloudFront] Strict startup failure: requireSignedAccess=true requires imageSigning="cookies" (got "${config.imageSigning ?? 'none'}"); signed URL mode is not yet implemented.`,
       );
       return false;
     }
 
-    if (config.imageSigning === 'url') {
+    if (!keyPairId || !privateKey) {
       logger.error(
-        '[initializeCloudFront] Strict startup failure: imageSigning="url" is not yet implemented; cannot enforce requireSignedAccess.',
+        '[initializeCloudFront] Strict startup failure: requireSignedAccess=true but CLOUDFRONT_KEY_PAIR_ID and/or CLOUDFRONT_PRIVATE_KEY are missing.',
       );
       return false;
     }

--- a/packages/api/src/storage/cloudfront/__tests__/crud.test.ts
+++ b/packages/api/src/storage/cloudfront/__tests__/crud.test.ts
@@ -54,6 +54,7 @@ function makeConfig(overrides: Partial<CloudFrontFullConfig> = {}): CloudFrontFu
     urlExpiry: 3600,
     cookieExpiry: 1800,
     includeRegionInPath: false,
+    requireSignedAccess: false,
     privateKey: null,
     keyPairId: null,
     ...overrides,

--- a/packages/data-provider/src/cloudfront-config.spec.ts
+++ b/packages/data-provider/src/cloudfront-config.spec.ts
@@ -95,4 +95,37 @@ describe('cloudfrontConfigSchema cross-field refinements', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('rejects requireSignedAccess=true when imageSigning is "none"', () => {
+    const result = cloudfrontConfigSchema.safeParse({
+      domain: 'https://cdn.example.com',
+      requireSignedAccess: true,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(['requireSignedAccess']);
+    }
+  });
+
+  it('rejects requireSignedAccess=true when imageSigning is "url"', () => {
+    const result = cloudfrontConfigSchema.safeParse({
+      domain: 'https://cdn.example.com',
+      imageSigning: 'url',
+      requireSignedAccess: true,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toEqual(['requireSignedAccess']);
+    }
+  });
+
+  it('accepts requireSignedAccess=true with imageSigning="cookies" and cookieDomain', () => {
+    const result = cloudfrontConfigSchema.safeParse({
+      domain: 'https://cdn.example.com',
+      imageSigning: 'cookies',
+      cookieDomain: '.example.com',
+      requireSignedAccess: true,
+    });
+    expect(result.success).toBe(true);
+  });
 });

--- a/packages/data-provider/src/cloudfront-config.spec.ts
+++ b/packages/data-provider/src/cloudfront-config.spec.ts
@@ -103,6 +103,9 @@ describe('cloudfrontConfigSchema cross-field refinements', () => {
     });
     expect(result.success).toBe(false);
     if (!result.success) {
+      expect(result.error.issues[0].message).toContain(
+        'cloudfront.requireSignedAccess=true requires cloudfront.imageSigning="cookies"',
+      );
       expect(result.error.issues[0].path).toEqual(['requireSignedAccess']);
     }
   });
@@ -115,6 +118,9 @@ describe('cloudfrontConfigSchema cross-field refinements', () => {
     });
     expect(result.success).toBe(false);
     if (!result.success) {
+      expect(result.error.issues[0].message).toContain(
+        'cloudfront.requireSignedAccess=true requires cloudfront.imageSigning="cookies"',
+      );
       expect(result.error.issues[0].path).toEqual(['requireSignedAccess']);
     }
   });

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -215,6 +215,7 @@ export const cloudfrontConfigSchema = z
       .optional(),
     storageRegion: z.string().min(1).optional(),
     includeRegionInPath: z.boolean().default(false),
+    requireSignedAccess: z.boolean().default(false),
   })
   .refine((data) => !data.invalidateOnDelete || !!data.distributionId, {
     message: 'distributionId is required when invalidateOnDelete is true',

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -228,7 +228,7 @@ export const cloudfrontConfigSchema = z
   })
   .refine((data) => !data.requireSignedAccess || data.imageSigning === 'cookies', {
     message:
-      'requireSignedAccess=true requires imageSigning="cookies" (signed URL mode is not yet implemented)',
+      'cloudfront.requireSignedAccess=true requires cloudfront.imageSigning="cookies" (signed URL mode is not yet implemented)',
     path: ['requireSignedAccess'],
   })
   .optional();

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -226,6 +226,11 @@ export const cloudfrontConfigSchema = z
       'cookieDomain is required when imageSigning is "cookies" (e.g., ".example.com" for API at api.example.com and CDN at cdn.example.com)',
     path: ['cookieDomain'],
   })
+  .refine((data) => !data.requireSignedAccess || data.imageSigning === 'cookies', {
+    message:
+      'requireSignedAccess=true requires imageSigning="cookies" (signed URL mode is not yet implemented)',
+    path: ['requireSignedAccess'],
+  })
   .optional();
 
 export type CloudFrontConfig = z.infer<typeof cloudfrontConfigSchema>;


### PR DESCRIPTION
## Summary

Adds an opt-in `cloudfront.requireSignedAccess` config flag that turns the existing CloudFront signed-cookie support into a hard startup contract. Today the cookie strategy is best-effort: misconfigured deployments silently fall back to public OAC or to broken image delivery. Operators who put CloudFront in front of LibreChat specifically to keep private images private have no way to assert that signing is actually wired up — strict mode closes that gap.

When `requireSignedAccess: true`:

- `imageSigning` **must** equal `"cookies"` (signed URL mode is not implemented yet). Enforced both by a Zod refinement on `cloudfrontConfigSchema` and by a runtime guard in `initializeCloudFront`, so misconfiguration fails fast with a clear message.
- Both `CLOUDFRONT_KEY_PAIR_ID` and `CLOUDFRONT_PRIVATE_KEY` must be set. Missing either one fails initialization.
- `initializeFileStorage` throws on CloudFront init failure to block startup rather than logging and continuing.

When the flag is unset / `false`, existing OSS behavior is unchanged: missing keys still log-and-continue, and the cookie strategy stays best-effort.

Also adds low-noise logs at startup (strict mode enabled, strict failure reasons) and a single success log on cookie issuance with only path count + expiry seconds — no signed URLs, policies, signatures, private keys, or cookie values are ever logged.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

Unit-tested via Jest in the affected workspaces. From the repo root:

```bash
npm run build:data-provider
(cd packages/data-provider && npx jest src/cloudfront-config.spec.ts)
(cd packages/api && npx jest src/cdn/__tests__/cloudfront.test.ts src/app/__tests__/cdn.test.ts)
```

New coverage:

- `cloudfront-config.spec.ts`: schema rejects `requireSignedAccess=true` when `imageSigning` is `"none"` or `"url"`, accepts it with `"cookies"` + `cookieDomain`.
- `cloudfront.test.ts`: runtime guard returns false (and logs the strict-failure reason) for missing keys, `imageSigning="none"`, and `imageSigning="url"`; logs strict-mode-enabled info when configured correctly.
- `cdn.test.ts`: `initializeFileStorage` throws when CloudFront init fails and `requireSignedAccess=true`; does not throw when `false`.

### **Test Configuration**:

No special configuration. Tests use `jest.mock` for the AWS SDK and logger — no live CloudFront, no real keys.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes