### PR TITLE
💠 feat: Extend `thinkingLevel` Support to Gemma 4 Models

### DIFF
--- a/packages/api/src/endpoints/google/llm.spec.ts
+++ b/packages/api/src/endpoints/google/llm.spec.ts
@@ -724,6 +724,43 @@ describe('getGoogleConfig', () => {
       expect(config).toMatchObject({ includeThoughts: true });
     });
 
+    it('should use thinkingLevel for Gemma 4 models', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemma-4-31b-it',
+          thinking: true,
+          thinkingLevel: ThinkingLevel.high,
+        },
+      });
+
+      expect((result.llmConfig as Record<string, unknown>).thinkingConfig).toMatchObject({
+        includeThoughts: true,
+        thinkingLevel: 'HIGH',
+      });
+    });
+
+    it('should ignore thinkingBudget for Gemma 4 models', () => {
+      const credentials = {
+        [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',
+      };
+
+      const result = getGoogleConfig(credentials, {
+        modelOptions: {
+          model: 'gemma-4-31b-it',
+          thinking: true,
+          thinkingBudget: 5000,
+        },
+      });
+
+      const config = (result.llmConfig as Record<string, unknown>).thinkingConfig;
+      expect(config).not.toHaveProperty('thinkingBudget');
+      expect(config).toMatchObject({ includeThoughts: true });
+    });
+
     it('should NOT classify gemini-2.9-flash as Gemini 3+', () => {
       const credentials = {
         [AuthKeys.GOOGLE_API_KEY]: 'test-api-key',

--- a/packages/api/src/endpoints/google/llm.ts
+++ b/packages/api/src/endpoints/google/llm.ts
@@ -318,18 +318,18 @@ export function getGoogleConfig(
   const modelName = (modelOptions?.model ?? '') as string;
 
   /**
-   * Gemini 3+ uses a qualitative `thinkingLevel` ('minimal'|'low'|'medium'|'high')
-   * instead of the numeric `thinkingBudget` used by Gemini 2.5 and earlier.
+   * Gemini 3+ and Gemma 4+ use a qualitative `thinkingLevel` ('minimal'|'low'|'medium'|'high')
+   * instead of the numeric `thinkingBudget` used by earlier models.
    * When `thinking` is enabled (default: true), we always send `thinkingConfig`
-   * with `includeThoughts: true`. The `thinkingBudget` param is ignored for Gemini 3+.
+   * with `includeThoughts: true`. The `thinkingBudget` param is ignored for these models.
    *
    * For Vertex AI, top-level `includeThoughts` is still required because
    * `@librechat/agents/langchain/google-common`'s `formatGenerationConfig` reads it separately
    * from `thinkingConfig` — they serve different purposes in the request pipeline.
    */
-  const isGemini3Plus = /gemini-([3-9]|\d{2,})/i.test(modelName);
+  const supportsThinkingLevel = /gemini-([3-9]|\d{2,})|gemma-([4-9]|\d{2,})/i.test(modelName);
 
-  if (isGemini3Plus && thinking) {
+  if (supportsThinkingLevel && thinking) {
     const thinkingConfig: GoogleThinkingConfig = {
       includeThoughts: true,
     };
@@ -343,7 +343,7 @@ export function getGoogleConfig(
       (llmConfig as { thinkingConfig?: GoogleThinkingConfig }).thinkingConfig = thinkingConfig;
       (llmConfig as VertexAIClientOptions).includeThoughts = true;
     }
-  } else if (!isGemini3Plus) {
+  } else if (!supportsThinkingLevel) {
     const shouldEnableThinking =
       thinking && thinkingBudget != null && (thinkingBudget > 0 || thinkingBudget === -1);
 


### PR DESCRIPTION
# Summary

This PR fixes support for `thinkingLevel` configuration (Minimal, Low, Medium, High) for the newly released **Gemma 4** model family.

## Problem
Previously, the logic for determining whether to use `thinkingLevel` (introduced in Gemini 3+) or the older `thinkingBudget` (Gemini 2.x) was strictly tied to the `gemini-` model prefix. This caused Gemma 4 models to incorrectly fall back to `thinkingBudget`, which is incompatible with the API.

## Solution
- Updated the regex in `packages/api/src/endpoints/google/llm.ts` to include `gemma-` models starting from version 4.
- Renamed `isGemini3Plus` to `supportsThinkingLevel` for better semantic clarity.
- Ensured `thinkingBudget` is ignored for Gemma 4 models, consistent with Gemini 3+ behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Verified the configuration logic using the project's test suite.

### **Test Configuration**:
- **Environment**: Bun v1.3.13 / Node v26.0.0
- **Test File**: `packages/api/src/endpoints/google/llm.spec.ts`

### **Verified Scenarios**:
1. **Gemma 4 Support**: Confirmed `gemma-4-31b-it` correctly maps `thinkingLevel` to the LLM config.
2. **Backward Compatibility**: Confirmed Gemini 2.5 still uses `thinkingBudget`.
3. **Budget Exclusion**: Confirmed `thinkingBudget` is explicitly ignored for Gemma 4 models when `thinkingLevel` is applicable.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes (verified via `bun test`)

## References

https://ai.google.dev/gemma/docs/core/gemma_on_gemini_api#supported_models

>The Gemini API supports the following Gemma 4 models:
>    gemma-4-31b-it
>    gemma-4-26b-a4b-it


```js
import { GoogleGenAI, ThinkingLevel } from "@google/genai";

const ai = new GoogleGenAI();

const response = await ai.models.generateContent({
  model: "gemma-4-26b-a4b-it",
  contents: "What is the water formula?",
  config: {
    thinkingConfig: {
      thinkingLevel: ThinkingLevel.HIGH,
    },
  },
});
console.log(response.text);

```