### PR TITLE
✨ v0.8.6-rc1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# v0.8.5
+# v0.8.6-rc1
 
 # Base node image
 FROM node:20-alpine AS node

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -1,5 +1,5 @@
 # Dockerfile.multi
-# v0.8.5
+# v0.8.6-rc1
 
 # Set configurable max-old-space-size with default
 ARG NODE_MAX_OLD_SPACE_SIZE=6144

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/backend",
-  "version": "v0.8.5",
+  "version": "v0.8.6-rc1",
   "description": "",
   "scripts": {
     "start": "echo 'please run this from the root directory'",

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "0.8.5",
+      "version": "0.8.6-rc1",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.14.3",
         "@aws-sdk/client-bedrock-runtime": "^3.980.0",
@@ -130,7 +130,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "0.8.5",
+      "version": "0.8.6-rc1",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
         "@ariakit/react-core": "^0.4.17",
@@ -264,7 +264,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.29",
+      "version": "1.7.30",
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
         "@babel/preset-react": "^7.18.6",
@@ -345,7 +345,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.58",
+      "version": "0.4.59",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.28.5",
@@ -433,7 +433,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.501",
+      "version": "0.8.502",
       "dependencies": {
         "axios": "^1.13.5",
         "dayjs": "^1.11.13",
@@ -470,7 +470,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.50",
+      "version": "0.0.51",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^29.0.0",

--- a/client/jest.config.cjs
+++ b/client/jest.config.cjs
@@ -1,4 +1,4 @@
-/** v0.8.5 */
+/** v0.8.6-rc1 */
 module.exports = {
   roots: ['<rootDir>/src'],
   testEnvironment: 'jsdom',

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/frontend",
-  "version": "v0.8.5",
+  "version": "v0.8.6-rc1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/e2e/jestSetup.js
+++ b/e2e/jestSetup.js
@@ -1,3 +1,3 @@
-// v0.8.5
+// v0.8.6-rc1
 // See .env.test.example for an example of the '.env.test' file.
 require('dotenv').config({ path: './e2e/.env.test' });

--- a/helm/librechat/Chart.yaml
+++ b/helm/librechat/Chart.yaml
@@ -23,7 +23,7 @@ version: 2.0.3
 # It is recommended to use it with quotes.
 
 # renovate: image=registry.librechat.ai/danny-avila/librechat
-appVersion: "v0.8.5"
+appVersion: "v0.8.6-rc1"
 
 home: https://www.librechat.ai
 

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -2,7 +2,7 @@
 # https://www.librechat.ai/docs/configuration/librechat_yaml
 
 # Configuration version (required)
-version: 1.3.10
+version: 1.3.11
 
 # Cache settings: Set to true to enable caching
 cache: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.5",
+  "version": "v0.8.6-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "LibreChat",
-      "version": "v0.8.5",
+      "version": "v0.8.6-rc1",
       "license": "ISC",
       "workspaces": [
         "api",
@@ -46,7 +46,7 @@
     },
     "api": {
       "name": "@librechat/backend",
-      "version": "v0.8.5",
+      "version": "v0.8.6-rc1",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.16.0",
@@ -395,7 +395,7 @@
     },
     "client": {
       "name": "@librechat/frontend",
-      "version": "v0.8.5",
+      "version": "v0.8.6-rc1",
       "license": "ISC",
       "dependencies": {
         "@ariakit/react": "^0.4.15",
@@ -44521,7 +44521,7 @@
     },
     "packages/api": {
       "name": "@librechat/api",
-      "version": "1.7.29",
+      "version": "1.7.30",
       "license": "ISC",
       "devDependencies": {
         "@babel/preset-env": "^7.29.5",
@@ -44648,7 +44648,7 @@
     },
     "packages/client": {
       "name": "@librechat/client",
-      "version": "0.4.58",
+      "version": "0.4.59",
       "devDependencies": {
         "@babel/core": "^7.28.5",
         "@babel/preset-env": "^7.29.5",
@@ -45122,7 +45122,7 @@
     },
     "packages/data-provider": {
       "name": "librechat-data-provider",
-      "version": "0.8.501",
+      "version": "0.8.502",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.16.0",
@@ -45203,7 +45203,7 @@
     },
     "packages/data-schemas": {
       "name": "@librechat/data-schemas",
-      "version": "0.0.50",
+      "version": "0.0.51",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "LibreChat",
-  "version": "v0.8.5",
+  "version": "v0.8.6-rc1",
   "description": "",
   "packageManager": "npm@11.10.0",
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/api",
-  "version": "1.7.29",
+  "version": "1.7.30",
   "type": "commonjs",
   "description": "MCP services for LibreChat",
   "main": "dist/index.js",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/client",
-  "version": "0.4.58",
+  "version": "0.4.59",
   "description": "React components for LibreChat",
   "repository": {
     "type": "git",

--- a/packages/data-provider/package.json
+++ b/packages/data-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-data-provider",
-  "version": "0.8.501",
+  "version": "0.8.502",
   "description": "data services for librechat apps",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2132,9 +2132,9 @@ export enum TTSProviders {
 /** Enum for app-wide constants */
 export enum Constants {
   /** Key for the app's version. */
-  VERSION = 'v0.8.5',
+  VERSION = 'v0.8.6-rc1',
   /** Key for the Custom Config's version (librechat.yaml). */
-  CONFIG_VERSION = '1.3.10',
+  CONFIG_VERSION = '1.3.11',
   /** Standard value for the first message's `parentMessageId` value, to indicate no parent exists. */
   NO_PARENT = '00000000-0000-0000-0000-000000000000',
   /** Standard value to use whatever the submission prelim. `responseMessageId` is */

--- a/packages/data-schemas/package.json
+++ b/packages/data-schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/data-schemas",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "Mongoose schemas and models for LibreChat",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

I bumped release metadata to v0.8.6-rc1 and incremented the related config and internal workspace package versions.

- Updated the main app version markers in Dockerfiles, package manifests, Jest setup comments, Helm `appVersion`, and `Constants.VERSION`.
- Incremented the LibreChat config schema version to `1.3.11` in `librechat.example.yaml` and `Constants.CONFIG_VERSION`.
- Incremented internal package versions: `@librechat/api` to `1.7.30`, `@librechat/client` to `0.4.59`, `librechat-data-provider` to `0.8.502`, and `@librechat/data-schemas` to `0.0.51`.
- Mirrored all workspace/package version updates in `package-lock.json` and `bun.lock`.

## Change Type

- [x] Version bump / release maintenance

## Testing

- Ran `git diff --check`.
- Ran a targeted Node verification script against all package manifests and `package-lock.json` workspace entries.
- Checked the final diff to confirm only version strings changed in the requested files.

### **Test Configuration**:

- Branch base: `origin/dev` at `6b5596ec3`
- Node: local workspace Node runtime

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
