### PR TITLE
📚 docs: Add Skills, Subagents, and CloudFront References

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -679,6 +679,9 @@ AWS_BUCKET_NAME=
 # Required for path-style S3-compatible providers (MinIO, Hetzner, Backblaze B2, etc.)
 # that don't support virtual-hosted-style URLs (bucket.endpoint). Not needed for AWS S3.
 # AWS_FORCE_PATH_STYLE=false
+# Required for CloudFront signed cookies and signed download URLs
+# CLOUDFRONT_KEY_PAIR_ID=
+# CLOUDFRONT_PRIVATE_KEY=
 
 #========================#
 # Azure Blob Storage     #

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@
     - Agent Marketplace: Discover and deploy community-built agents
     - Collaborative Sharing: Share agents with specific users and groups
     - Flexible & Extensible: Use MCP Servers, tools, file search, code execution, and more
+    - [Skills](https://www.librechat.ai/docs/features/skills): Create reusable `SKILL.md` instruction bundles for manual, automatic, or always-on agent workflows
+    - [Subagents](https://www.librechat.ai/docs/features/subagents): Delegate focused work to isolated child agent runs with their own context windows
     - Compatible with Custom Endpoints, OpenAI, Azure, Anthropic, AWS Bedrock, Google, Vertex AI, Responses API, and more
     - [Model Context Protocol (MCP) Support](https://modelcontextprotocol.io/clients#librechat) for Tools
 
@@ -137,6 +139,7 @@
 
 - ⚙️ **Configuration & Deployment**:  
   - Configure Proxy, Reverse Proxy, Docker, & many Deployment options  
+  - Use [S3 with CloudFront](https://www.librechat.ai/docs/configuration/cdn/cloudfront) for stable media links, edge delivery, signed cookies, and secured downloads
   - Use completely local or deploy on the cloud
 
 - 📖 **Open-Source & Community**:  


### PR DESCRIPTION
## Summary

I added in-repo references for the new Skills, Subagents, and CloudFront documentation work.

- Added Skills and Subagents links to the README agent feature list.
- Added a CloudFront with S3 link to the README deployment section.
- Added commented CloudFront signing env vars to `.env.example` for signed cookies and signed download URLs.

## Change Type

- [x] Documentation update

## Testing

- Ran `git diff --check`.
- Attempted `npx --no-install prettier --check README.md`; this worktree is missing `prettier-plugin-tailwindcss`, so the formatter could not start.

### **Test Configuration**:

- Base branch: `origin/dev`
- Branch: `danny-avila/docs-v0.8.6-features`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
