### PR TITLE
🐳 ci: Build Docker Client Package With Data Provider Dist

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,0 +1,36 @@
+name: Docker Build Smoke Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/docker-smoke.yml'
+      - '.dockerignore'
+      - 'Dockerfile.multi'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'packages/client/**'
+      - 'packages/data-provider/**'
+
+permissions:
+  contents: read
+
+jobs:
+  client-package-target:
+    name: Build Docker client package target
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build client package target
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.multi
+          platforms: linux/amd64
+          push: false
+          target: client-package-build

--- a/Dockerfile.multi
+++ b/Dockerfile.multi
@@ -68,6 +68,7 @@ RUN npm run build
 FROM base AS client-package-build
 WORKDIR /app/packages/client
 COPY packages/client ./
+COPY --from=data-provider-build /app/packages/data-provider/dist /app/packages/data-provider/dist
 RUN npm run build
 
 # Client build


### PR DESCRIPTION
## Summary

I fixed the Docker multi-stage build for `@librechat/client` after the client package started importing runtime code from `librechat-data-provider`.

- Added the built `packages/data-provider/dist` output to the `client-package-build` Docker stage before Rollup builds `packages/client`.
- Added a focused Docker smoke workflow that builds the `client-package-build` target on PRs touching the Dockerfile, install metadata, `packages/client`, or `packages/data-provider`.
- Kept the smoke check single-platform and non-pushing so it catches missing Docker stage artifacts before the slower image publish workflow runs.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `docker buildx build --progress=plain --platform linux/amd64 --target client-package-build -f Dockerfile.multi .`
- Ran `git diff --cached --check`
- Parsed `.github/workflows/docker-smoke.yml` with Ruby YAML loading

### **Test Configuration**:

- Docker 29.4.2
- Buildx v0.33.0-desktop.1
- Node image: `node:20-alpine`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
