### PR TITLE
🍪 feat(auth): make cookie SameSite configurable via COOKIE_SAMESITE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -750,6 +750,14 @@ REFRESH_TOKEN_EXPIRY=(1000 * 60 * 60 * 24) * 7
 # Set to false only for HTTP-only deployments where browsers drop Secure cookies.
 # SESSION_COOKIE_SECURE=false
 
+# Controls the SameSite attribute for authentication cookies (refreshToken,
+# token_provider, openid_*). Accepts: strict | lax | none. Defaults to strict
+# when unset or set to an unrecognized value. Use "none" only when the API is
+# embedded cross-origin (e.g. an iframe on another domain or a separate SPA
+# origin); the browser requires Secure for SameSite=None, so the API will
+# force Secure=true in that case regardless of NODE_ENV/DOMAIN_SERVER.
+# COOKIE_SAMESITE=strict
+
 # Leave these blank to use generated temporary secrets from .env.temp.
 # Configure unique, persistent values before using a production instance.
 JWT_SECRET=

--- a/api/server/services/AuthService.js
+++ b/api/server/services/AuthService.js
@@ -17,7 +17,7 @@ const {
   parseCloudFrontCookieScope,
   CLOUDFRONT_SCOPE_COOKIE,
   isEmailDomainAllowed,
-  shouldUseSecureCookie,
+  getAuthCookieOptions,
   resolveAppConfigForUser,
 } = require('@librechat/api');
 const {
@@ -672,17 +672,16 @@ const setAuthTokens = async (userId, res, _session = null, req = null) => {
     const sessionExpiry = math(process.env.SESSION_EXPIRY, DEFAULT_SESSION_EXPIRY);
     const token = await generateToken(user, sessionExpiry);
 
+    const cookieOptions = getAuthCookieOptions();
     res.cookie('refreshToken', refreshToken, {
       expires: new Date(refreshTokenExpires),
       httpOnly: true,
-      secure: shouldUseSecureCookie(),
-      sameSite: 'strict',
+      ...cookieOptions,
     });
     res.cookie('token_provider', 'librechat', {
       expires: new Date(refreshTokenExpires),
       httpOnly: true,
-      secure: shouldUseSecureCookie(),
-      sameSite: 'strict',
+      ...cookieOptions,
     });
 
     setCloudFrontAuthCookies(req, res, user, { userId: user?._id ?? userId });
@@ -784,11 +783,11 @@ const setOpenIDAuthTokens = (
      * The refresh token is small (opaque string) so it doesn't hit the HTTP/2 header
      * size limits that motivated session storage for the larger access_token/id_token.
      */
+    const cookieOptions = getAuthCookieOptions();
     res.cookie('refreshToken', refreshToken, {
       expires: expirationDate,
       httpOnly: true,
-      secure: shouldUseSecureCookie(),
-      sameSite: 'strict',
+      ...cookieOptions,
     });
 
     /** Store tokens server-side in session to avoid large cookies */
@@ -805,15 +804,13 @@ const setOpenIDAuthTokens = (
       res.cookie('openid_access_token', tokenset.access_token, {
         expires: expirationDate,
         httpOnly: true,
-        secure: shouldUseSecureCookie(),
-        sameSite: 'strict',
+        ...cookieOptions,
       });
       if (tokenset.id_token) {
         res.cookie('openid_id_token', tokenset.id_token, {
           expires: expirationDate,
           httpOnly: true,
-          secure: shouldUseSecureCookie(),
-          sameSite: 'strict',
+          ...cookieOptions,
         });
       }
     }
@@ -822,8 +819,7 @@ const setOpenIDAuthTokens = (
     res.cookie('token_provider', 'openid', {
       expires: expirationDate,
       httpOnly: true,
-      secure: shouldUseSecureCookie(),
-      sameSite: 'strict',
+      ...cookieOptions,
     });
     if (userId && isEnabled(process.env.OPENID_REUSE_TOKENS)) {
       /** JWT-signed user ID cookie for image path validation when OPENID_REUSE_TOKENS is enabled */
@@ -833,8 +829,7 @@ const setOpenIDAuthTokens = (
       res.cookie('openid_user_id', signedUserId, {
         expires: expirationDate,
         httpOnly: true,
-        secure: shouldUseSecureCookie(),
-        sameSite: 'strict',
+        ...cookieOptions,
       });
     }
 

--- a/api/server/services/AuthService.spec.js
+++ b/api/server/services/AuthService.spec.js
@@ -24,7 +24,7 @@ jest.mock(
     checkEmailConfig: jest.fn(),
     isEmailDomainAllowed: jest.fn(),
     math: jest.fn((val, fallback) => (val ? Number(val) : fallback)),
-    shouldUseSecureCookie: jest.fn(() => false),
+    getAuthCookieOptions: jest.fn(() => ({ secure: false, sameSite: 'strict' })),
     resolveAppConfigForUser: jest.fn(async (_getAppConfig, _user) => ({})),
     setCloudFrontCookies: jest.fn(() => true),
     getCloudFrontConfig: jest.fn(() => ({
@@ -74,7 +74,7 @@ jest.mock('~/server/utils', () => ({ sendEmail: jest.fn() }));
 
 const {
   checkEmailConfig,
-  shouldUseSecureCookie,
+  getAuthCookieOptions,
   isEmailDomainAllowed,
   resolveAppConfigForUser,
   setCloudFrontCookies,
@@ -310,7 +310,7 @@ describe('setOpenIDAuthTokens', () => {
   });
 
   describe('cookie secure flag', () => {
-    it('should call shouldUseSecureCookie for every cookie set', () => {
+    it('should apply getAuthCookieOptions to every cookie set', () => {
       const tokenset = {
         id_token: 'the-id-token',
         access_token: 'the-access-token',
@@ -322,17 +322,17 @@ describe('setOpenIDAuthTokens', () => {
       setOpenIDAuthTokens(tokenset, req, res, 'user-123');
 
       // token_provider + openid_user_id (session path, so no refreshToken/openid_access_token cookies)
-      const secureCalls = shouldUseSecureCookie.mock.calls.length;
-      expect(secureCalls).toBeGreaterThanOrEqual(2);
+      expect(getAuthCookieOptions.mock.calls.length).toBeGreaterThanOrEqual(1);
 
-      // Verify all cookies use the result of shouldUseSecureCookie
+      // Default mock returns { secure: false, sameSite: 'strict' }; every cookie should carry it.
       for (const [, cookie] of Object.entries(res._cookies)) {
         expect(cookie.options.secure).toBe(false);
+        expect(cookie.options.sameSite).toBe('strict');
       }
     });
 
-    it('should set secure: true when shouldUseSecureCookie returns true', () => {
-      shouldUseSecureCookie.mockReturnValue(true);
+    it('should set secure: true when getAuthCookieOptions returns secure=true', () => {
+      getAuthCookieOptions.mockReturnValue({ secure: true, sameSite: 'strict' });
 
       const tokenset = {
         id_token: 'the-id-token',
@@ -346,11 +346,12 @@ describe('setOpenIDAuthTokens', () => {
 
       for (const [, cookie] of Object.entries(res._cookies)) {
         expect(cookie.options.secure).toBe(true);
+        expect(cookie.options.sameSite).toBe('strict');
       }
     });
 
-    it('should use shouldUseSecureCookie for cookie fallback path (no session)', () => {
-      shouldUseSecureCookie.mockReturnValue(false);
+    it('should propagate getAuthCookieOptions to the cookie fallback path (no session)', () => {
+      getAuthCookieOptions.mockReturnValue({ secure: false, sameSite: 'strict' });
 
       const tokenset = {
         id_token: 'the-id-token',
@@ -366,18 +367,43 @@ describe('setOpenIDAuthTokens', () => {
       expect(res.cookie).toHaveBeenCalledWith(
         'refreshToken',
         expect.any(String),
-        expect.objectContaining({ secure: false }),
+        expect.objectContaining({ secure: false, sameSite: 'strict' }),
       );
       expect(res.cookie).toHaveBeenCalledWith(
         'openid_access_token',
         expect.any(String),
-        expect.objectContaining({ secure: false }),
+        expect.objectContaining({ secure: false, sameSite: 'strict' }),
       );
       expect(res.cookie).toHaveBeenCalledWith(
         'token_provider',
         'openid',
-        expect.objectContaining({ secure: false }),
+        expect.objectContaining({ secure: false, sameSite: 'strict' }),
       );
+    });
+
+    it.each([
+      ['strict', false],
+      ['lax', false],
+      ['none', true],
+    ])('should apply sameSite=%s (secure=%s) to every cookie set', (sameSite, secure) => {
+      getAuthCookieOptions.mockReturnValue({ secure, sameSite });
+
+      const tokenset = {
+        id_token: 'the-id-token',
+        access_token: 'the-access-token',
+        refresh_token: 'the-refresh-token',
+      };
+      const req = { session: null };
+      const res = mockResponse();
+
+      setOpenIDAuthTokens(tokenset, req, res, 'user-123');
+
+      // 4 cookies on the fallback path. Each must carry the configured options.
+      expect(Object.keys(res._cookies).length).toBeGreaterThanOrEqual(4);
+      for (const [, cookie] of Object.entries(res._cookies)) {
+        expect(cookie.options.secure).toBe(secure);
+        expect(cookie.options.sameSite).toBe(sameSite);
+      }
     });
   });
 
@@ -1332,6 +1358,31 @@ describe('CloudFront cookie integration', () => {
 
       expect(result).toBe('mock-access-token');
     });
+
+    it.each([
+      ['strict', false],
+      ['lax', false],
+      ['none', true],
+    ])(
+      'applies sameSite=%s (secure=%s) to refreshToken and token_provider',
+      async (sameSite, secure) => {
+        getAuthCookieOptions.mockReturnValue({ secure, sameSite });
+        const res = mockResponse();
+
+        await setAuthTokens('user-123', res);
+
+        expect(res.cookie).toHaveBeenCalledWith(
+          'refreshToken',
+          expect.any(String),
+          expect.objectContaining({ secure, sameSite }),
+        );
+        expect(res.cookie).toHaveBeenCalledWith(
+          'token_provider',
+          'librechat',
+          expect.objectContaining({ secure, sameSite }),
+        );
+      },
+    );
   });
 });
 

--- a/packages/api/src/oauth/csrf.spec.ts
+++ b/packages/api/src/oauth/csrf.spec.ts
@@ -1,4 +1,4 @@
-import { shouldUseSecureCookie } from './csrf';
+import { shouldUseSecureCookie, getAuthCookieSameSite, getAuthCookieOptions } from './csrf';
 
 describe('shouldUseSecureCookie', () => {
   const originalEnv = process.env;
@@ -124,5 +124,114 @@ describe('shouldUseSecureCookie', () => {
       process.env.DOMAIN_SERVER = 'http://LOCALHOST:3080';
       expect(shouldUseSecureCookie()).toBe(false);
     });
+  });
+});
+
+describe('getAuthCookieSameSite', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should default to strict when COOKIE_SAMESITE is unset', () => {
+    delete process.env.COOKIE_SAMESITE;
+    expect(getAuthCookieSameSite()).toBe('strict');
+  });
+
+  it('should default to strict when COOKIE_SAMESITE is empty', () => {
+    process.env.COOKIE_SAMESITE = '';
+    expect(getAuthCookieSameSite()).toBe('strict');
+  });
+
+  it('should return strict when COOKIE_SAMESITE=strict', () => {
+    process.env.COOKIE_SAMESITE = 'strict';
+    expect(getAuthCookieSameSite()).toBe('strict');
+  });
+
+  it('should return lax when COOKIE_SAMESITE=lax', () => {
+    process.env.COOKIE_SAMESITE = 'lax';
+    expect(getAuthCookieSameSite()).toBe('lax');
+  });
+
+  it('should return none when COOKIE_SAMESITE=none', () => {
+    process.env.COOKIE_SAMESITE = 'none';
+    expect(getAuthCookieSameSite()).toBe('none');
+  });
+
+  it('should accept case-insensitive values', () => {
+    process.env.COOKIE_SAMESITE = 'LAX';
+    expect(getAuthCookieSameSite()).toBe('lax');
+    process.env.COOKIE_SAMESITE = 'None';
+    expect(getAuthCookieSameSite()).toBe('none');
+    process.env.COOKIE_SAMESITE = 'Strict';
+    expect(getAuthCookieSameSite()).toBe('strict');
+  });
+
+  it('should trim whitespace before matching', () => {
+    process.env.COOKIE_SAMESITE = '  lax  ';
+    expect(getAuthCookieSameSite()).toBe('lax');
+  });
+
+  it('should fall back to strict on unrecognized values', () => {
+    process.env.COOKIE_SAMESITE = 'nope';
+    expect(getAuthCookieSameSite()).toBe('strict');
+    process.env.COOKIE_SAMESITE = 'true';
+    expect(getAuthCookieSameSite()).toBe('strict');
+    process.env.COOKIE_SAMESITE = 'STRICTLY';
+    expect(getAuthCookieSameSite()).toBe('strict');
+  });
+});
+
+describe('getAuthCookieOptions', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.NODE_ENV = 'development';
+    process.env.DOMAIN_SERVER = 'http://localhost:3080';
+    delete process.env.COOKIE_SAMESITE;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should default to { secure: shouldUseSecureCookie(), sameSite: "strict" }', () => {
+    expect(getAuthCookieOptions()).toEqual({ secure: false, sameSite: 'strict' });
+  });
+
+  it('should pass sameSite=lax through and use the secure heuristic', () => {
+    process.env.COOKIE_SAMESITE = 'lax';
+    expect(getAuthCookieOptions()).toEqual({ secure: false, sameSite: 'lax' });
+  });
+
+  it('should force secure=true when sameSite=none even on localhost', () => {
+    process.env.COOKIE_SAMESITE = 'none';
+    // shouldUseSecureCookie() would return false here, but SameSite=None
+    // requires Secure or browsers will drop the cookie.
+    expect(getAuthCookieOptions()).toEqual({ secure: true, sameSite: 'none' });
+  });
+
+  it('should keep secure=true when sameSite=none in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DOMAIN_SERVER = 'https://chat.example.com';
+    process.env.COOKIE_SAMESITE = 'none';
+    expect(getAuthCookieOptions()).toEqual({ secure: true, sameSite: 'none' });
+  });
+
+  it('should use shouldUseSecureCookie() result when sameSite=strict in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DOMAIN_SERVER = 'https://chat.example.com';
+    expect(getAuthCookieOptions()).toEqual({ secure: true, sameSite: 'strict' });
+  });
+
+  it('should fall back to strict for unrecognized sameSite values', () => {
+    process.env.COOKIE_SAMESITE = 'bogus';
+    expect(getAuthCookieOptions()).toEqual({ secure: false, sameSite: 'strict' });
   });
 });

--- a/packages/api/src/oauth/csrf.ts
+++ b/packages/api/src/oauth/csrf.ts
@@ -47,6 +47,43 @@ export function shouldUseSecureCookie(): boolean {
   return isProduction && !isLocalhost;
 }
 
+export type AuthCookieSameSite = 'strict' | 'lax' | 'none';
+
+/**
+ * Resolves the SameSite attribute for authentication cookies from the
+ * `COOKIE_SAMESITE` environment variable. Accepts `strict`, `lax`, or `none`
+ * (case-insensitive). Anything else (including unset) falls back to `strict`,
+ * which preserves the historical behavior.
+ *
+ * Use `getAuthCookieOptions()` instead of calling this directly when setting
+ * cookies, so the `SameSite=None` requires `Secure` invariant is enforced.
+ */
+export function getAuthCookieSameSite(): AuthCookieSameSite {
+  const raw = (process.env.COOKIE_SAMESITE || '').trim().toLowerCase();
+  if (raw === 'lax' || raw === 'none' || raw === 'strict') {
+    return raw;
+  }
+  return 'strict';
+}
+
+/**
+ * Returns the `{ secure, sameSite }` pair that should be applied to every
+ * authentication cookie set by the API. Centralizing the choice keeps all
+ * cookie-setting sites in sync and enforces the browser rule that
+ * `SameSite=None` cookies must also be `Secure`. When the user opts into
+ * `SameSite=None`, `secure` is forced to `true` regardless of the local
+ * `shouldUseSecureCookie()` heuristic, because non-secure SameSite=None
+ * cookies are silently dropped by modern browsers.
+ */
+export function getAuthCookieOptions(): {
+  secure: boolean;
+  sameSite: AuthCookieSameSite;
+} {
+  const sameSite = getAuthCookieSameSite();
+  const secure = sameSite === 'none' ? true : shouldUseSecureCookie();
+  return { secure, sameSite };
+}
+
 /** Generates an HMAC-based token for OAuth CSRF protection */
 export function generateOAuthCsrfToken(flowId: string, secret?: string): string {
   const key = secret || process.env.JWT_SECRET;


### PR DESCRIPTION
Closes #4610.

## Summary

The auth cookies set by `AuthService` (`refreshToken`, `token_provider`, `openid_access_token`, `openid_id_token`, `openid_user_id`) were hardcoded to `SameSite=Strict`. That works for same-origin deployments, but breaks any setup where the API is loaded cross-origin: an embedded iframe on a different domain, a separate SPA origin, or some OAuth redirect flows where the landing request is not classified as same-site.

This PR adds a single env var, `COOKIE_SAMESITE`, that accepts `strict | lax | none` (case-insensitive). Unset or unrecognized values fall back to `strict`, so the default behavior is unchanged.

## How it works

The choice is centralized in a new `getAuthCookieOptions()` helper in `packages/api/src/oauth/csrf.ts` (next to the existing `shouldUseSecureCookie`). It returns the `{ secure, sameSite }` pair that every auth cookie should use. `AuthService.js` was updated to spread that helper into every `res.cookie(...)` call instead of repeating `secure: shouldUseSecureCookie(), sameSite: 'strict'` seven times.

Centralizing the decision keeps the seven cookie sites in sync and lets the helper enforce the browser invariant that `SameSite=None` requires `Secure`. If a user opts into `COOKIE_SAMESITE=none`, the helper forces `secure: true` regardless of the local `shouldUseSecureCookie()` heuristic, since browsers silently drop non-secure SameSite=None cookies. The docs comment in `.env.example` calls this out so operators don't get surprised.

## Out of scope

Two other cookie families intentionally stay hardcoded:

- `packages/api/src/oauth/csrf.ts` OAuth CSRF and session cookies are explicitly `SameSite=Lax` because they need to survive the cross-site OAuth redirect from the IdP. Making those configurable would let an operator break the OAuth flow.
- `packages/api/src/cdn/cloudfront-cookies.ts` signed CloudFront cookies are explicitly `SameSite=None` because they are designed to be sent on requests to a separate CDN origin. Browser policy requires `None` there.

The express-session `cookie` configs in `socialLogins.js` only set `secure` and inherit the express-session default for `sameSite` (none of these were `strict` before, so they are not part of this issue).

## .env.example

A commented-out entry was added next to the other session config:

```
# Controls the SameSite attribute for authentication cookies (refreshToken,
# token_provider, openid_*). Accepts: strict | lax | none. Defaults to strict
# when unset or set to an unrecognized value. Use "none" only when the API is
# embedded cross-origin (e.g. an iframe on another domain or a separate SPA
# origin); the browser requires Secure for SameSite=None, so the API will
# force Secure=true in that case regardless of NODE_ENV/DOMAIN_SERVER.
# COOKIE_SAMESITE=strict
```

## Tests

All new unit tests added; full suite passes locally.

`packages/api/src/oauth/csrf.spec.ts` (14 new cases on top of the existing 15):
- `getAuthCookieSameSite()` covers default, empty, each accepted value, case-insensitivity, whitespace trim, and unrecognized fallback.
- `getAuthCookieOptions()` covers default behavior, `lax` passthrough, the `none + secure=true` invariant on localhost and in production, the production `strict` path, and unrecognized fallback.

`api/server/services/AuthService.spec.js`:
- Existing `cookie secure flag` block rewritten to assert against `getAuthCookieOptions` and to check both `secure` and `sameSite` are propagated to every cookie set on the session and non-session code paths.
- New parameterized test exercises all three values end-to-end (`strict`, `lax`, `none`) against `setOpenIDAuthTokens` and `setAuthTokens`, asserting every cookie carries the configured `sameSite` and the matching `secure` flag.

```
PASS api/server/services/AuthService.spec.js    (45 tests)
PASS packages/api/src/oauth/csrf.spec.ts        (29 tests)
PASS api/server/routes/auth.cloudfront.test.js  ( 4 tests)
```

## Test plan

- [x] Existing AuthService unit tests still pass.
- [x] New unit tests for `getAuthCookieSameSite` / `getAuthCookieOptions`.
- [x] Parameterized end-to-end tests for all three values through `setAuthTokens` and `setOpenIDAuthTokens`.
- [x] `SameSite=None` forces `Secure=true` even when `shouldUseSecureCookie()` returns false (localhost dev).
- [x] Unrecognized values fall back to `strict` (no surprise downgrade).
- [x] `.env.example` documents the new var and the `Secure` invariant.