### PR TITLE
🎯 feat: Expand LIBRECHAT_USER_* placeholders in prompt templates

### DIFF
--- a/packages/data-provider/specs/parsers.spec.ts
+++ b/packages/data-provider/specs/parsers.spec.ts
@@ -167,6 +167,88 @@ describe('replaceSpecialVars', () => {
     expect(result).toContain('2024-04-29T16:34:56.000Z'); // iso_datetime
     expect(result).toContain('Test User'); // current_user
   });
+
+  describe('LIBRECHAT_USER_* placeholders', () => {
+    const fullUser = {
+      id: 'user-abc-123',
+      name: 'Test User',
+      username: 'tuser',
+      email: 'tuser@example.com',
+      role: 'USER',
+      provider: 'ldap',
+    } as TUser;
+
+    test('expands LIBRECHAT_USER_USERNAME and LIBRECHAT_USER_ID', () => {
+      const result = replaceSpecialVars({
+        text: 'USERNAME={{LIBRECHAT_USER_USERNAME}} USER_ID={{LIBRECHAT_USER_ID}}',
+        user: fullUser,
+      });
+      expect(result).toBe('USERNAME=tuser USER_ID=user-abc-123');
+    });
+
+    test('alongside {{current_date}} (modelSpecs.promptPrefix scenario from #12686)', () => {
+      const result = replaceSpecialVars({
+        text: [
+          'DATE={{current_date}}',
+          'USERNAME={{LIBRECHAT_USER_USERNAME}}',
+          'USER_ID={{LIBRECHAT_USER_ID}}',
+        ].join('\n'),
+        user: fullUser,
+      });
+      expect(result).toBe(
+        ['DATE=2024-04-29 (Monday)', 'USERNAME=tuser', 'USER_ID=user-abc-123'].join('\n'),
+      );
+    });
+
+    test('expands email, role, provider, and name fields', () => {
+      const result = replaceSpecialVars({
+        text:
+          'email={{LIBRECHAT_USER_EMAIL}} role={{LIBRECHAT_USER_ROLE}} ' +
+          'provider={{LIBRECHAT_USER_PROVIDER}} name={{LIBRECHAT_USER_NAME}}',
+        user: fullUser,
+      });
+      expect(result).toBe(
+        'email=tuser@example.com role=USER provider=ldap name=Test User',
+      );
+    });
+
+    test('is case-insensitive and tolerates surrounding whitespace', () => {
+      const result = replaceSpecialVars({
+        text: '{{ librechat_user_username }} / {{LIBRECHAT_USER_username}}',
+        user: fullUser,
+      });
+      expect(result).toBe('tuser / tuser');
+    });
+
+    test('leaves placeholder intact when the user field is missing', () => {
+      const partialUser = { id: 'u1', name: 'Only Name' } as TUser;
+      const result = replaceSpecialVars({
+        text: 'u={{LIBRECHAT_USER_USERNAME}} id={{LIBRECHAT_USER_ID}}',
+        user: partialUser,
+      });
+      expect(result).toBe('u={{LIBRECHAT_USER_USERNAME}} id=u1');
+    });
+
+    test('leaves placeholders intact when no user is supplied', () => {
+      const result = replaceSpecialVars({
+        text: '{{LIBRECHAT_USER_USERNAME}} {{LIBRECHAT_USER_ID}}',
+      });
+      expect(result).toBe('{{LIBRECHAT_USER_USERNAME}} {{LIBRECHAT_USER_ID}}');
+    });
+
+    test('does not expand fields outside the allowlist', () => {
+      const userWithExtras = {
+        id: 'u1',
+        name: 'N',
+        avatar: 'https://example.com/a.png',
+      } as TUser;
+      const result = replaceSpecialVars({
+        text: '{{LIBRECHAT_USER_AVATAR}} {{LIBRECHAT_USER_PASSWORD}}',
+        user: userWithExtras,
+      });
+      expect(result).toBe('{{LIBRECHAT_USER_AVATAR}} {{LIBRECHAT_USER_PASSWORD}}');
+    });
+  });
 });
 
 describe('parseCompactConvo', () => {

--- a/packages/data-provider/src/parsers.ts
+++ b/packages/data-provider/src/parsers.ts
@@ -444,6 +444,27 @@ function applyTimezone(value: dayjs.Dayjs, timezone?: string): dayjs.Dayjs {
   }
 }
 
+/**
+ * Fields on the user object that may be expanded via
+ * `{{LIBRECHAT_USER_<FIELD>}}` placeholders inside a prompt template
+ * (e.g. modelSpecs `promptPrefix`, agent instructions, prompts).
+ *
+ * The set is intentionally limited to non-sensitive identity fields and
+ * mirrors the allowlist used by MCP/header placeholder resolution in
+ * `@librechat/api`. Placeholders for fields that are missing on the user
+ * object are left intact (matching the existing `{{current_user}}` contract).
+ */
+export const librechatUserFields = [
+  'id',
+  'name',
+  'username',
+  'email',
+  'provider',
+  'role',
+] as const;
+
+export type LibreChatUserField = (typeof librechatUserFields)[number];
+
 export function replaceSpecialVars({
   text,
   user,
@@ -474,6 +495,20 @@ export function replaceSpecialVars({
 
   if (user && user.name) {
     result = result.replace(/{{\s*current_user\s*}}/gi, user.name);
+  }
+
+  if (user) {
+    for (const field of librechatUserFields) {
+      const fieldValue = (user as Record<string, unknown>)[field];
+      if (fieldValue == null || fieldValue === '') {
+        continue;
+      }
+      const pattern = new RegExp(
+        `{{\\s*LIBRECHAT_USER_${field.toUpperCase()}\\s*}}`,
+        'gi',
+      );
+      result = result.replace(pattern, String(fieldValue));
+    }
   }
 
   return result;


### PR DESCRIPTION
Closes #12686.

### Summary

`replaceSpecialVars` in `packages/data-provider/src/parsers.ts` only knew about the four temporal/identity placeholders (`current_date`, `current_datetime`, `iso_datetime`, `current_user`). The MCP/header pipeline in `packages/api/src/utils/env.ts` separately recognises `{{LIBRECHAT_USER_<FIELD>}}` for env vars, headers, args, and URLs, but the prompt-text path never gained that vocabulary. Result: a `modelSpecs.promptPrefix` like

```yaml
promptPrefix: |
  DATE={{current_date}}
  USERNAME={{LIBRECHAT_USER_USERNAME}}
  USER_ID={{LIBRECHAT_USER_ID}}
```

expands `DATE` but leaves the two identity lines as literal `{{...}}` braces in the system prompt.

### What changed

Extended `replaceSpecialVars` to also resolve `{{LIBRECHAT_USER_<FIELD>}}` placeholders against the supplied `user`.

- Fields are allowlisted to the same non-sensitive identity set used by `processUserPlaceholders` in `@librechat/api`: `id`, `name`, `username`, `email`, `provider`, `role`. Anything outside that list is ignored, so the placeholder remains visible if someone tries `{{LIBRECHAT_USER_PASSWORD}}` etc.
- Missing or empty fields on the user object leave the placeholder intact, matching the existing `{{current_user}}` contract that the prompts UI relies on.
- The pattern is case-insensitive and tolerates whitespace inside the braces, consistent with the other special vars.

Because every call site that already passes `user` to `replaceSpecialVars` benefits automatically, no plumbing changes are needed:
- Client chat submit path: `client/src/hooks/Chat/useChatFunctions.ts` already runs `replaceSpecialVars({ text: conversation.promptPrefix, user })` on the modelSpec-derived prefix before sending.
- Agents endpoint: `packages/api/src/agents/initialize.ts` runs `replaceSpecialVars({ text: agent.instructions, user: req.user, now: req.conversationCreatedAt })`.
- Prompts UI: `VariableForm.tsx`, `PromptDetails.tsx`, `useSubmitMessage.ts` all pass `user` through.

### Tests

Added a new `LIBRECHAT_USER_* placeholders` block in `packages/data-provider/specs/parsers.spec.ts` covering:

- `{{LIBRECHAT_USER_USERNAME}}` and `{{LIBRECHAT_USER_ID}}` expansion
- The exact mixed `{{current_date}}` + `{{LIBRECHAT_USER_USERNAME}}` + `{{LIBRECHAT_USER_ID}}` template from #12686
- The remaining allowlisted fields (`email`, `role`, `provider`, `name`)
- Case-insensitivity and whitespace tolerance: `{{ librechat_user_username }}`
- Missing field on user object leaves placeholder intact
- No user supplied leaves both placeholders intact
- Fields outside the allowlist (`AVATAR`, `PASSWORD`) are not touched

`packages/data-provider` test suite passes locally (51/51).

### Notes

- Sensitive fields like `avatar`, `plugins`, `backupCodes` etc. are intentionally excluded; the allowlist mirrors what `@librechat/api` already considers safe to surface in MCP env/headers.
- The agents path uses `req.user` server-side via `initialize.ts`, so for the agents endpoint these placeholders resolve from the authoritative `IUser` even though only the narrower `TUser` shape is available client-side.