### PR TITLE
🔑 feat: Per-User Google SA For Claude On Vertex

### DIFF
--- a/packages/api/src/endpoints/anthropic/initialize.customHeaders.spec.ts
+++ b/packages/api/src/endpoints/anthropic/initialize.customHeaders.spec.ts
@@ -1,0 +1,109 @@
+import { EModelEndpoint } from 'librechat-data-provider';
+import type { AnthropicClientOptions } from '@librechat/agents';
+import type { BaseInitializeParams, ServerRequest } from '~/types';
+import { FINE_GRAINED_TOOL_STREAMING_BETA } from './helpers';
+import { initializeAnthropic } from './initialize';
+
+const getDefaultHeaders = (llmConfig: unknown): Record<string, string> =>
+  ((llmConfig as AnthropicClientOptions).clientOptions?.defaultHeaders ?? {}) as Record<
+    string,
+    string
+  >;
+
+function createParams(
+  endpointsConfig: Record<string, unknown>,
+  env: Record<string, string | undefined> = {},
+): { params: BaseInitializeParams; restore: () => void } {
+  const savedEnv: Record<string, string | undefined> = {};
+  for (const key of Object.keys(env)) {
+    savedEnv[key] = process.env[key];
+  }
+  Object.assign(process.env, env);
+
+  const params: BaseInitializeParams = {
+    req: {
+      user: { id: 'user-42' },
+      body: { conversationId: 'convo-xyz' },
+      config: { endpoints: endpointsConfig },
+    } as unknown as ServerRequest,
+    endpoint: EModelEndpoint.anthropic,
+    model_parameters: { model: 'claude-sonnet-4-5' },
+    db: {
+      getUserKey: jest.fn(),
+      getUserKeyValues: jest.fn(),
+    },
+  };
+
+  const restore = () => {
+    for (const key of Object.keys(env)) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  };
+
+  return { params, restore };
+}
+
+describe('initializeAnthropic – custom headers', () => {
+  it('threads configured headers into clientOptions.defaultHeaders without resolving placeholders', async () => {
+    const { params, restore } = createParams(
+      {
+        [EModelEndpoint.anthropic]: {
+          headers: { 'X-Conversation-Id': '{{LIBRECHAT_BODY_CONVERSATIONID}}' },
+        },
+      },
+      { ANTHROPIC_API_KEY: 'sk-ant-test', ANTHROPIC_REVERSE_PROXY: 'https://gateway.example.com' },
+    );
+
+    try {
+      const result = await initializeAnthropic(params);
+      const defaultHeaders = getDefaultHeaders(result.llmConfig);
+      /** Placeholder kept intact — resolved at request time, not init time */
+      expect(defaultHeaders['X-Conversation-Id']).toBe('{{LIBRECHAT_BODY_CONVERSATIONID}}');
+      /** Provider-managed beta header preserved alongside the custom header */
+      expect(defaultHeaders['anthropic-beta']).toBe(FINE_GRAINED_TOOL_STREAMING_BETA);
+      /** Reverse proxy still wired through native Anthropic config */
+      expect(result.llmConfig).toHaveProperty('anthropicApiUrl', 'https://gateway.example.com');
+    } finally {
+      restore();
+    }
+  });
+
+  it('merges endpoints.all headers beneath endpoint-specific headers', async () => {
+    const { params, restore } = createParams(
+      {
+        all: { headers: { 'X-Common': 'all', 'X-Override': 'all' } },
+        [EModelEndpoint.anthropic]: { headers: { 'X-Override': 'anthropic' } },
+      },
+      { ANTHROPIC_API_KEY: 'sk-ant-test' },
+    );
+
+    try {
+      const result = await initializeAnthropic(params);
+      const defaultHeaders = getDefaultHeaders(result.llmConfig);
+      expect(defaultHeaders['X-Common']).toBe('all');
+      expect(defaultHeaders['X-Override']).toBe('anthropic');
+    } finally {
+      restore();
+    }
+  });
+
+  it('leaves defaultHeaders provider-managed when no custom headers are configured', async () => {
+    const { params, restore } = createParams(
+      { [EModelEndpoint.anthropic]: {} },
+      { ANTHROPIC_API_KEY: 'sk-ant-test' },
+    );
+
+    try {
+      const result = await initializeAnthropic(params);
+      expect(getDefaultHeaders(result.llmConfig)).toEqual({
+        'anthropic-beta': FINE_GRAINED_TOOL_STREAMING_BETA,
+      });
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/api/src/endpoints/anthropic/initialize.spec.ts
+++ b/packages/api/src/endpoints/anthropic/initialize.spec.ts
@@ -1,37 +1,81 @@
-import { EModelEndpoint } from 'librechat-data-provider';
-import type { AnthropicClientOptions } from '@librechat/agents';
-import type { BaseInitializeParams, ServerRequest } from '~/types';
-import { FINE_GRAINED_TOOL_STREAMING_BETA } from './helpers';
+import { AuthKeys, EModelEndpoint, ErrorTypes } from 'librechat-data-provider';
+import type { BaseInitializeParams } from '~/types';
+
+const mockLoadAnthropicVertexCredentials = jest.fn();
+const mockGetVertexCredentialOptions = jest.fn();
+jest.mock('./vertex', () => ({
+  loadAnthropicVertexCredentials: (...args: unknown[]) =>
+    mockLoadAnthropicVertexCredentials(...args),
+  getVertexCredentialOptions: (...args: unknown[]) => mockGetVertexCredentialOptions(...args),
+}));
+
+const mockGetLLMConfig = jest
+  .fn()
+  .mockReturnValue({ llmConfig: { model: 'claude-3-7-sonnet-20250219' } });
+jest.mock('./llm', () => ({
+  getLLMConfig: (...args: unknown[]) => mockGetLLMConfig(...args),
+}));
+
+const mockLoadServiceKey = jest.fn();
+jest.mock('~/utils', () => ({
+  isEnabled: (val?: unknown) => val === 'true' || val === true,
+  loadServiceKey: (...args: unknown[]) => mockLoadServiceKey(...args),
+  checkUserKeyExpiry: jest.fn(),
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
 import { initializeAnthropic } from './initialize';
 
-const getDefaultHeaders = (llmConfig: unknown): Record<string, string> =>
-  ((llmConfig as AnthropicClientOptions).clientOptions?.defaultHeaders ?? {}) as Record<
-    string,
-    string
-  >;
+const GLOBAL_SERVICE_KEY = {
+  project_id: 'global-project',
+  client_email: 'global@global-project.iam.gserviceaccount.com',
+  private_key: 'global-private-key',
+};
+
+const USER_SERVICE_KEY = {
+  project_id: 'user-project',
+  client_email: 'user@user-project.iam.gserviceaccount.com',
+  private_key: 'user-private-key',
+};
 
 function createParams(
-  endpointsConfig: Record<string, unknown>,
-  env: Record<string, string | undefined> = {},
-): { params: BaseInitializeParams; restore: () => void } {
+  env: Record<string, string | undefined>,
+  dbOverrides: Partial<BaseInitializeParams['db']> = {},
+  userId: string | null = 'user-1',
+): BaseInitializeParams & { _restore: () => void } {
   const savedEnv: Record<string, string | undefined> = {};
   for (const key of Object.keys(env)) {
     savedEnv[key] = process.env[key];
+    if (env[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = env[key];
+    }
   }
-  Object.assign(process.env, env);
+
+  const db = {
+    getUserKey: jest.fn(),
+    getUserKeyValues: jest.fn(),
+    ...dbOverrides,
+  } as unknown as BaseInitializeParams['db'];
 
   const params: BaseInitializeParams = {
     req: {
-      user: { id: 'user-42' },
-      body: { conversationId: 'convo-xyz' },
-      config: { endpoints: endpointsConfig },
-    } as unknown as ServerRequest,
+      user: userId ? { id: userId } : undefined,
+      body: {},
+      config: { endpoints: {} },
+    } as unknown as BaseInitializeParams['req'],
     endpoint: EModelEndpoint.anthropic,
-    model_parameters: { model: 'claude-sonnet-4-5' },
-    db: {
-      getUserKey: jest.fn(),
-      getUserKeyValues: jest.fn(),
-    },
+    model_parameters: { model: 'claude-3-7-sonnet-20250219' },
+    db,
   };
 
   const restore = () => {
@@ -44,66 +88,187 @@ function createParams(
     }
   };
 
-  return { params, restore };
+  return Object.assign(params, { _restore: restore });
 }
 
-describe('initializeAnthropic – custom headers', () => {
-  it('threads configured headers into clientOptions.defaultHeaders without resolving placeholders', async () => {
-    const { params, restore } = createParams(
-      {
-        [EModelEndpoint.anthropic]: {
-          headers: { 'X-Conversation-Id': '{{LIBRECHAT_BODY_CONVERSATIONID}}' },
-        },
-      },
-      { ANTHROPIC_API_KEY: 'sk-ant-test', ANTHROPIC_REVERSE_PROXY: 'https://gateway.example.com' },
-    );
-
-    try {
-      const result = await initializeAnthropic(params);
-      const defaultHeaders = getDefaultHeaders(result.llmConfig);
-      /** Placeholder kept intact — resolved at request time, not init time */
-      expect(defaultHeaders['X-Conversation-Id']).toBe('{{LIBRECHAT_BODY_CONVERSATIONID}}');
-      /** Provider-managed beta header preserved alongside the custom header */
-      expect(defaultHeaders['anthropic-beta']).toBe(FINE_GRAINED_TOOL_STREAMING_BETA);
-      /** Reverse proxy still wired through native Anthropic config */
-      expect(result.llmConfig).toHaveProperty('anthropicApiUrl', 'https://gateway.example.com');
-    } finally {
-      restore();
-    }
+describe('initializeAnthropic – per-user Vertex service-account credentials', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoadAnthropicVertexCredentials.mockResolvedValue({
+      [AuthKeys.GOOGLE_SERVICE_KEY]: GLOBAL_SERVICE_KEY,
+    });
+    mockGetVertexCredentialOptions.mockReturnValue({});
   });
 
-  it('merges endpoints.all headers beneath endpoint-specific headers', async () => {
-    const { params, restore } = createParams(
+  it('uses the user-stored Google SA when GOOGLE_KEY=user_provided and a valid key is registered', async () => {
+    const storedUserKey = JSON.stringify({
+      [AuthKeys.GOOGLE_SERVICE_KEY]: 'stringified-sa-json-from-storage',
+    });
+    mockLoadServiceKey.mockResolvedValueOnce(USER_SERVICE_KEY);
+
+    const params = createParams(
       {
-        all: { headers: { 'X-Common': 'all', 'X-Override': 'all' } },
-        [EModelEndpoint.anthropic]: { headers: { 'X-Override': 'anthropic' } },
+        ANTHROPIC_USE_VERTEX: 'true',
+        GOOGLE_KEY: 'user_provided',
       },
-      { ANTHROPIC_API_KEY: 'sk-ant-test' },
+      {
+        getUserKey: jest.fn().mockResolvedValue(storedUserKey),
+      },
     );
 
     try {
-      const result = await initializeAnthropic(params);
-      const defaultHeaders = getDefaultHeaders(result.llmConfig);
-      expect(defaultHeaders['X-Common']).toBe('all');
-      expect(defaultHeaders['X-Override']).toBe('anthropic');
+      await initializeAnthropic(params);
     } finally {
-      restore();
+      params._restore();
     }
+
+    expect(params.db.getUserKey).toHaveBeenCalledWith({
+      userId: 'user-1',
+      name: EModelEndpoint.google,
+    });
+    expect(mockLoadServiceKey).toHaveBeenCalledWith('stringified-sa-json-from-storage');
+    expect(mockLoadAnthropicVertexCredentials).not.toHaveBeenCalled();
+
+    const [credentials] = mockGetLLMConfig.mock.calls[0] as [Record<string, unknown>];
+    expect(credentials[AuthKeys.GOOGLE_SERVICE_KEY]).toEqual(USER_SERVICE_KEY);
   });
 
-  it('leaves defaultHeaders provider-managed when no custom headers are configured', async () => {
-    const { params, restore } = createParams(
-      { [EModelEndpoint.anthropic]: {} },
-      { ANTHROPIC_API_KEY: 'sk-ant-test' },
+  it('falls back to global file-based service key when the user has no stored Google key', async () => {
+    const noUserKeyErr = new Error(JSON.stringify({ type: ErrorTypes.NO_USER_KEY }));
+    const params = createParams(
+      {
+        ANTHROPIC_USE_VERTEX: 'true',
+        GOOGLE_KEY: 'user_provided',
+      },
+      {
+        getUserKey: jest.fn().mockRejectedValue(noUserKeyErr),
+      },
     );
 
     try {
-      const result = await initializeAnthropic(params);
-      expect(getDefaultHeaders(result.llmConfig)).toEqual({
-        'anthropic-beta': FINE_GRAINED_TOOL_STREAMING_BETA,
-      });
+      await initializeAnthropic(params);
     } finally {
-      restore();
+      params._restore();
     }
+
+    expect(params.db.getUserKey).toHaveBeenCalled();
+    expect(mockLoadAnthropicVertexCredentials).toHaveBeenCalledTimes(1);
+    const [credentials] = mockGetLLMConfig.mock.calls[0] as [Record<string, unknown>];
+    expect(credentials[AuthKeys.GOOGLE_SERVICE_KEY]).toEqual(GLOBAL_SERVICE_KEY);
+  });
+
+  it('falls back to global service key when the stored Google entry is not valid JSON', async () => {
+    const params = createParams(
+      {
+        ANTHROPIC_USE_VERTEX: 'true',
+        GOOGLE_KEY: 'user_provided',
+      },
+      {
+        getUserKey: jest.fn().mockResolvedValue('not-json'),
+      },
+    );
+
+    try {
+      await initializeAnthropic(params);
+    } finally {
+      params._restore();
+    }
+
+    expect(mockLoadServiceKey).not.toHaveBeenCalled();
+    expect(mockLoadAnthropicVertexCredentials).toHaveBeenCalledTimes(1);
+    const [credentials] = mockGetLLMConfig.mock.calls[0] as [Record<string, unknown>];
+    expect(credentials[AuthKeys.GOOGLE_SERVICE_KEY]).toEqual(GLOBAL_SERVICE_KEY);
+  });
+
+  it('falls back to global service key when loadServiceKey returns a malformed result', async () => {
+    const storedUserKey = JSON.stringify({
+      [AuthKeys.GOOGLE_SERVICE_KEY]: 'stringified-sa-json',
+    });
+    mockLoadServiceKey.mockResolvedValueOnce({ project_id: 'only-project-no-private-key' });
+
+    const params = createParams(
+      {
+        ANTHROPIC_USE_VERTEX: 'true',
+        GOOGLE_KEY: 'user_provided',
+      },
+      {
+        getUserKey: jest.fn().mockResolvedValue(storedUserKey),
+      },
+    );
+
+    try {
+      await initializeAnthropic(params);
+    } finally {
+      params._restore();
+    }
+
+    expect(mockLoadAnthropicVertexCredentials).toHaveBeenCalledTimes(1);
+    const [credentials] = mockGetLLMConfig.mock.calls[0] as [Record<string, unknown>];
+    expect(credentials[AuthKeys.GOOGLE_SERVICE_KEY]).toEqual(GLOBAL_SERVICE_KEY);
+  });
+
+  it('does not attempt per-user lookup when GOOGLE_KEY is not set to user_provided', async () => {
+    const params = createParams(
+      {
+        ANTHROPIC_USE_VERTEX: 'true',
+        GOOGLE_KEY: 'AIza-some-static-google-api-key',
+      },
+      {
+        getUserKey: jest.fn(),
+      },
+    );
+
+    try {
+      await initializeAnthropic(params);
+    } finally {
+      params._restore();
+    }
+
+    expect(params.db.getUserKey).not.toHaveBeenCalled();
+    expect(mockLoadAnthropicVertexCredentials).toHaveBeenCalledTimes(1);
+    const [credentials] = mockGetLLMConfig.mock.calls[0] as [Record<string, unknown>];
+    expect(credentials[AuthKeys.GOOGLE_SERVICE_KEY]).toEqual(GLOBAL_SERVICE_KEY);
+  });
+
+  it('does not attempt per-user lookup when there is no authenticated user', async () => {
+    const params = createParams(
+      {
+        ANTHROPIC_USE_VERTEX: 'true',
+        GOOGLE_KEY: 'user_provided',
+      },
+      { getUserKey: jest.fn() },
+      null,
+    );
+
+    try {
+      await initializeAnthropic(params);
+    } finally {
+      params._restore();
+    }
+
+    expect(params.db.getUserKey).not.toHaveBeenCalled();
+    expect(mockLoadAnthropicVertexCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles non-NO_USER_KEY db errors by falling back gracefully', async () => {
+    const params = createParams(
+      {
+        ANTHROPIC_USE_VERTEX: 'true',
+        GOOGLE_KEY: 'user_provided',
+      },
+      {
+        getUserKey: jest.fn().mockRejectedValue(new Error('mongo down')),
+      },
+    );
+
+    try {
+      await initializeAnthropic(params);
+    } finally {
+      params._restore();
+    }
+
+    expect(mockLoadAnthropicVertexCredentials).toHaveBeenCalledTimes(1);
+    const [credentials] = mockGetLLMConfig.mock.calls[0] as [Record<string, unknown>];
+    expect(credentials[AuthKeys.GOOGLE_SERVICE_KEY]).toEqual(GLOBAL_SERVICE_KEY);
   });
 });

--- a/packages/api/src/endpoints/anthropic/initialize.ts
+++ b/packages/api/src/endpoints/anthropic/initialize.ts
@@ -1,7 +1,8 @@
-import { EModelEndpoint, AuthKeys } from 'librechat-data-provider';
+import { EModelEndpoint, AuthKeys, ErrorTypes } from 'librechat-data-provider';
+import { logger } from '@librechat/data-schemas';
 import type { BaseInitializeParams, InitializeResultBase, AnthropicConfigOptions } from '~/types';
 import { loadAnthropicVertexCredentials, getVertexCredentialOptions } from './vertex';
-import { checkUserKeyExpiry, isEnabled, mergeHeaders } from '~/utils';
+import { checkUserKeyExpiry, isEnabled, loadServiceKey, mergeHeaders } from '~/utils';
 import { getLLMConfig } from './llm';
 
 /**
@@ -20,7 +21,7 @@ export async function initializeAnthropic({
 }: BaseInitializeParams): Promise<InitializeResultBase> {
   void endpoint;
   const appConfig = req.config;
-  const { ANTHROPIC_API_KEY, ANTHROPIC_REVERSE_PROXY, PROXY } = process.env;
+  const { ANTHROPIC_API_KEY, ANTHROPIC_REVERSE_PROXY, PROXY, GOOGLE_KEY } = process.env;
   const { key: expiresAt } = req.body;
 
   let credentials: Record<string, unknown> = {};
@@ -35,9 +36,73 @@ export async function initializeAnthropic({
     (vertexConfig && vertexConfig.enabled !== false) || isEnabled(process.env.ANTHROPIC_USE_VERTEX);
 
   if (useVertexAI) {
-    // Load credentials with optional YAML config overrides
-    const credentialOptions = vertexConfig ? getVertexCredentialOptions(vertexConfig) : undefined;
-    credentials = await loadAnthropicVertexCredentials(credentialOptions);
+    /**
+     * When Gemini is configured for per-user service-account keys (GOOGLE_KEY=user_provided),
+     * reuse the user's stored Google SA JSON for Claude-via-Vertex too. This matches the
+     * pattern Gemini already follows in `initializeGoogle` and lets a single per-user SA
+     * back both Gemini and Claude on Vertex.
+     *
+     * Falls back to the file/env-based loader on miss, parse error, or any other failure
+     * so the global config path keeps working when a user has not registered a key.
+     */
+    const userId = req.user?.id;
+    const allowPerUserVertex = GOOGLE_KEY === 'user_provided' && !!userId;
+    let userServiceKeyLoaded = false;
+
+    if (allowPerUserVertex) {
+      try {
+        const stored = await db.getUserKey({
+          userId: userId as string,
+          name: EModelEndpoint.google,
+        });
+
+        let parsed: Record<string, unknown> | null = null;
+        try {
+          parsed = JSON.parse(stored) as Record<string, unknown>;
+        } catch (parseErr) {
+          logger.warn(
+            '[initializeAnthropic] Failed to parse stored Google key for per-user Vertex; falling back to global service key',
+            parseErr,
+          );
+        }
+
+        const sa = parsed?.[AuthKeys.GOOGLE_SERVICE_KEY];
+        if (typeof sa === 'string' && sa.trim() !== '') {
+          const loaded = await loadServiceKey(sa);
+          if (loaded?.private_key && loaded?.project_id) {
+            credentials[AuthKeys.GOOGLE_SERVICE_KEY] = loaded;
+            userServiceKeyLoaded = true;
+          } else {
+            logger.warn(
+              '[initializeAnthropic] Stored Google SA key for user missing private_key or project_id; falling back to global service key',
+            );
+          }
+        }
+      } catch (err) {
+        // NO_USER_KEY: user has not registered a per-user SA; fall back silently.
+        // Other errors: log but continue with the global service key so we degrade gracefully.
+        const message = err instanceof Error ? err.message : String(err);
+        let isNoUserKey = false;
+        try {
+          const parsed = JSON.parse(message) as { type?: string };
+          isNoUserKey = parsed?.type === ErrorTypes.NO_USER_KEY;
+        } catch {
+          // not a structured error, ignore
+        }
+        if (!isNoUserKey) {
+          logger.warn(
+            '[initializeAnthropic] Per-user Vertex SA lookup failed; falling back to global service key',
+            err,
+          );
+        }
+      }
+    }
+
+    if (!userServiceKeyLoaded) {
+      // Load credentials with optional YAML config overrides
+      const credentialOptions = vertexConfig ? getVertexCredentialOptions(vertexConfig) : undefined;
+      credentials = await loadAnthropicVertexCredentials(credentialOptions);
+    }
 
     // Store vertex options for client creation
     if (vertexConfig) {


### PR DESCRIPTION
Closes #12979.

Gemini in LibreChat already supports per-user Google service-account JSON via the `GOOGLE_KEY=user_provided` path. Claude-via-Vertex (`ANTHROPIC_USE_VERTEX=true`) currently forces every user onto the same global `GOOGLE_SERVICE_KEY_FILE`, which makes it impossible to back Claude with a personal or institutional SA the way Gemini already allows.

## Change

In `packages/api/src/endpoints/anthropic/initialize.ts`, when:

- `useVertexAI` is true, and
- `GOOGLE_KEY === 'user_provided'`, and
- the request has an authenticated `req.user.id`,

we read the user's stored Google key via `db.getUserKey({ userId, name: EModelEndpoint.google })`, pull `AuthKeys.GOOGLE_SERVICE_KEY` out of the parsed payload, run it through the existing `loadServiceKey` helper (which already handles file-paths, URLs, raw JSON, and base64), and use the result as the per-call Vertex credential. This is the same per-user-keys path Gemini uses in `initializeGoogle`.

If anything goes wrong (`NO_USER_KEY`, malformed JSON, missing `private_key`/`project_id`, or any other DB error), we fall back to the existing file/env-based loader so the global-config path keeps working for users who have not registered a key. `NO_USER_KEY` is treated as the expected silent fallback; other failures are logged at `warn` level so admins can see them.

## Why this shape

The issue author included a working monkey-patch that does exactly this. I kept the same shape because it is the minimal-surface change that fits the existing per-user-keys model, and productionized it with:

- explicit handling of `ErrorTypes.NO_USER_KEY` vs other DB errors
- warn-level logging instead of a silent `catch {}`
- a guard that the loaded SA actually has `private_key` and `project_id` before we use it
- no change to the non-Vertex Anthropic path

## Tests

Added `packages/api/src/endpoints/anthropic/initialize.spec.ts` covering:

- happy path: user has a valid SA, it gets used and `loadAnthropicVertexCredentials` is not called
- `NO_USER_KEY`: falls back to global file-based loader
- stored value is not JSON: falls back to global
- `loadServiceKey` returns a result missing `private_key`/`project_id`: falls back to global
- `GOOGLE_KEY` is not `user_provided`: per-user lookup is skipped entirely
- unauthenticated request: per-user lookup is skipped entirely
- other DB error (e.g. mongo down): falls back to global

```
PASS src/endpoints/anthropic/initialize.spec.ts
  initializeAnthropic – per-user Vertex service-account credentials
    ✓ uses the user-stored Google SA when GOOGLE_KEY=user_provided and a valid key is registered
    ✓ falls back to global file-based service key when the user has no stored Google key
    ✓ falls back to global service key when the stored Google entry is not valid JSON
    ✓ falls back to global service key when loadServiceKey returns a malformed result
    ✓ does not attempt per-user lookup when GOOGLE_KEY is not set to user_provided
    ✓ does not attempt per-user lookup when there is no authenticated user
    ✓ handles non-NO_USER_KEY db errors by falling back gracefully

Tests:       7 passed, 7 total
```

The full anthropic suite (98 tests) and the full endpoints suite (489 tests) still pass.

## Compatibility

- No new env vars, no schema change, no UI change.
- Existing global-`GOOGLE_SERVICE_KEY_FILE` deployments are unaffected because we only attempt the per-user lookup when `GOOGLE_KEY=user_provided`.
- Reuses the existing Gemini per-user-keys storage, so users who already registered an SA for Gemini get Claude-via-Vertex with the same credential automatically.