### PR TITLE
🌐 feat: Support custom headers on the built-in OpenAI endpoint

### DIFF
--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -646,6 +646,21 @@ endpoints:
   #     #   claude-3.5-haiku:
   #     #     deploymentName: claude-3-5-haiku@20241022  # Override for this model
 
+  # OpenAI built-in endpoint configuration
+  # openAI:
+  #   # (optional) Stream rate limiting in milliseconds
+  #   streamRate: 20
+  #   # (optional) Title model for conversation titles
+  #   titleModel: gpt-4o-mini
+  #   # (optional) Static headers merged into every OpenAI request.
+  #   # Values support env-var (`${VAR}`), user (`{{user_email}}`, `{{user_id}}`),
+  #   # and request-body (`{{LIBRECHAT_BODY_*}}`) placeholders, matching the
+  #   # behavior on Custom Endpoints. Useful for routing OpenAI traffic through
+  #   # an AI Gateway that consumes metadata headers per request.
+  #   headers:
+  #     cf-aig-metadata: '{"user_email":"{{user_email}}","app":"librechat"}'
+  #     x-portkey-metadata: '{"user":"{{user_id}}"}'
+
   custom:
     # Anthropic-compatible Example (native `/v1/messages` API)
     # Set `provider: anthropic` to use the native Anthropic client instead of the

--- a/packages/api/src/endpoints/openai/initialize.spec.ts
+++ b/packages/api/src/endpoints/openai/initialize.spec.ts
@@ -267,3 +267,77 @@ describe('initializeOpenAI – custom headers', () => {
     expect(options.headers).toEqual({ 'X-Global': '{{LIBRECHAT_USER_ID}}' });
   });
 });
+
+describe('initializeOpenAI – endpoint headers (built-in)', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards endpoint.headers from YAML config into clientOptions.headers', async () => {
+    const params = createParams({ OPENAI_API_KEY: 'sk-test' });
+    (params.req as unknown as { config: unknown }).config = {
+      endpoints: {
+        [EModelEndpoint.openAI]: {
+          headers: {
+            'cf-aig-metadata': '{"app":"librechat"}',
+            'x-trace-id': '{{LIBRECHAT_BODY_PARENTMESSAGEID}}',
+          },
+        },
+      },
+    };
+
+    try {
+      await initializeOpenAI(params);
+    } finally {
+      (params as unknown as { _restore: () => void })._restore();
+    }
+
+    expect(mockGetOpenAIConfig).toHaveBeenCalledTimes(1);
+    const [, clientOptions] = mockGetOpenAIConfig.mock.calls[0];
+    const headers = (clientOptions as { headers?: Record<string, string> }).headers;
+    expect(headers).toEqual({
+      'cf-aig-metadata': '{"app":"librechat"}',
+      'x-trace-id': '{{LIBRECHAT_BODY_PARENTMESSAGEID}}',
+    });
+  });
+
+  it('omits headers when none are configured on the OpenAI endpoint', async () => {
+    const params = createParams({ OPENAI_API_KEY: 'sk-test' });
+
+    try {
+      await initializeOpenAI(params);
+    } finally {
+      (params as unknown as { _restore: () => void })._restore();
+    }
+
+    const [, clientOptions] = mockGetOpenAIConfig.mock.calls[0];
+    expect((clientOptions as { headers?: unknown }).headers).toBeUndefined();
+  });
+
+  it('skips forwarding endpoint.headers for the azureOpenAI endpoint (Azure path already manages headers)', async () => {
+    const params = createParams({ OPENAI_API_KEY: 'sk-test', AZURE_API_KEY: 'sk-azure' });
+    params.endpoint = EModelEndpoint.azureOpenAI;
+    (params.req as unknown as { config: unknown }).config = {
+      endpoints: {
+        [EModelEndpoint.openAI]: {
+          headers: { 'should-not-leak': '1' },
+        },
+        [EModelEndpoint.azureOpenAI]: undefined,
+      },
+    };
+
+    try {
+      // Azure flow without azureConfig throws on missing groups; just verify the openAI branch
+      // doesn't pollute clientOptions.headers on a non-OpenAI path before any throw.
+      await initializeOpenAI(params).catch(() => undefined);
+    } finally {
+      (params as unknown as { _restore: () => void })._restore();
+    }
+
+    if (mockGetOpenAIConfig.mock.calls.length > 0) {
+      const [, clientOptions] = mockGetOpenAIConfig.mock.calls[0];
+      const headers = (clientOptions as { headers?: Record<string, string> }).headers;
+      expect(headers?.['should-not-leak']).toBeUndefined();
+    }
+  });
+});

--- a/packages/api/src/endpoints/openai/initialize.ts
+++ b/packages/api/src/endpoints/openai/initialize.ts
@@ -182,6 +182,22 @@ export async function initializeOpenAI({
     user: req.user?.id,
   };
 
+  /**
+   * Forward any static headers declared on the built-in OpenAI endpoint
+   * (e.g. AI Gateway routing/metadata headers). Placeholder resolution
+   * (`{{user_email}}`, `{{LIBRECHAT_BODY_*}}`, env vars) happens at
+   * request time in `agents/run.ts` via `resolveHeaders` on
+   * `llmConfig.configuration.defaultHeaders`, matching the Custom
+   * Endpoint flow. Skipped for Azure, which already populates
+   * `clientOptions.headers` from `mapModelToAzureConfig` above.
+   */
+  if (!isAzureOpenAI) {
+    const endpointHeaders = appConfig?.endpoints?.[EModelEndpoint.openAI]?.headers;
+    if (endpointHeaders && Object.keys(endpointHeaders).length > 0) {
+      clientOptions.headers = { ...endpointHeaders, ...(clientOptions.headers ?? {}) };
+    }
+  }
+
   const finalClientOptions: OpenAIConfigOptions = {
     ...clientOptions,
     modelOptions,

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -1376,3 +1376,54 @@ describe('configSchema langfuse', () => {
     expect(result.success).toBe(false);
   });
 });
+
+describe('built-in openAI endpoint headers', () => {
+  it('accepts a static headers map on the built-in openAI endpoint', () => {
+    const result = configSchema.safeParse({
+      version: '1.0.0',
+      endpoints: {
+        [EModelEndpoint.openAI]: {
+          headers: {
+            'cf-aig-metadata': '{"app":"librechat"}',
+            'x-portkey-metadata': '{"user":"{{user_id}}"}',
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const openAIBlock = result.data.endpoints?.[EModelEndpoint.openAI];
+      expect(openAIBlock?.headers).toEqual({
+        'cf-aig-metadata': '{"app":"librechat"}',
+        'x-portkey-metadata': '{"user":"{{user_id}}"}',
+      });
+    }
+  });
+
+  it('keeps the openAI endpoint optional and omits headers when not provided', () => {
+    const result = configSchema.safeParse({
+      version: '1.0.0',
+      endpoints: {
+        [EModelEndpoint.openAI]: { streamRate: 25 },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const openAIBlock = result.data.endpoints?.[EModelEndpoint.openAI];
+      expect(openAIBlock?.streamRate).toBe(25);
+      expect(openAIBlock?.headers).toBeUndefined();
+    }
+  });
+
+  it('rejects non-string header values', () => {
+    const result = configSchema.safeParse({
+      version: '1.0.0',
+      endpoints: {
+        [EModelEndpoint.openAI]: {
+          headers: { 'x-bad': 123 as unknown as string },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -2126,7 +2126,18 @@ export const configSchema = z.object({
        * endpoint > a custom endpoint's own config.
        */
       all: baseEndpointSchema.omit({ baseURL: true }).optional(),
-      [EModelEndpoint.openAI]: baseEndpointSchema.optional(),
+      [EModelEndpoint.openAI]: baseEndpointSchema
+        .merge(
+          z.object({
+            /**
+             * Optional static headers merged into every request to this built-in endpoint.
+             * Values support placeholder resolution (env vars, `{{user_*}}`, `{{LIBRECHAT_BODY_*}}`,
+             * custom user variables), matching the behavior on Custom Endpoints.
+             */
+            headers: z.record(z.string()).optional(),
+          }),
+        )
+        .optional(),
       [EModelEndpoint.google]: baseEndpointSchema.optional(),
       [EModelEndpoint.anthropic]: anthropicEndpointSchema.optional(),
       [EModelEndpoint.azureOpenAI]: azureEndpointSchema.optional(),


### PR DESCRIPTION
## Summary

Closes #13082. Adds an optional `headers` map to the built-in `openAI` endpoint block in `librechat.yaml`, mirroring the existing Custom Endpoints behavior. Header values support the same placeholder resolution that custom endpoints already get (env vars like `${VAR}`, user fields like `{{user_email}}` / `{{user_id}}`, request-body fields like `{{LIBRECHAT_BODY_PARENTMESSAGEID}}`, and custom user variables). The original use case in the issue is routing OpenAI traffic through an AI Gateway (Cloudflare AI Gateway / Portkey / Helicone) that consumes per-request metadata headers, for example:

```yaml
endpoints:
  openAI:
    headers:
      cf-aig-metadata: '{"user_email":"{{user_email}}","app":"librechat"}'
      x-portkey-metadata: '{"user":"{{user_id}}"}'
```

Today the only way to get that behavior is to clone the OpenAI block under `custom:`, which duplicates auth and model config.

## Scope

This PR is intentionally scoped to the built-in `openAI` endpoint (the most common AI Gateway target) so it stays reviewable. The same author also filed #13085 for the Vertex-backed Anthropic/Google gateway case; that one needs a different header pipeline because Anthropic threads headers through `requestOptions.clientOptions.defaultHeaders` and Google uses `customHeaders` on the LLM config, neither of which is touched by the existing `resolveHeaders` call on `llmConfig.configuration.defaultHeaders`. I'd be happy to follow up with those once this lands and the maintainers agree on the shape.

## Wiring

- `packages/data-provider/src/config.ts` — merges `headers: z.record(z.string()).optional()` onto the built-in `openAI` endpoint schema. Other built-in schemas (`google`, `anthropic`, `azureOpenAI`, etc.) are unchanged.
- `packages/api/src/endpoints/openai/initialize.ts` — reads `appConfig.endpoints.openAI.headers` and forwards it into `clientOptions.headers`. Skipped on the Azure path, which already builds headers from `mapModelToAzureConfig`. `getOpenAIConfig` already maps `clientOptions.headers` to `configOptions.defaultHeaders`, so no changes are needed there.
- `packages/api/src/agents/run.ts` and `api/server/controllers/agents/client.js` — the existing `resolveHeaders` call on `llmConfig.configuration.defaultHeaders` / `clientOptions.configuration.defaultHeaders` already runs the same placeholder substitution as the Custom Endpoint flow. The pre-existing comments noted "if this is added to non-custom endpoints, needs consideration of varying provider header configs" — updated to reflect that built-in OpenAI now participates and to call out that Anthropic/Google still need their own pipelines wired up.
- `librechat.example.yaml` — documents the new option with a Cloudflare AI Gateway / Portkey example.

## Tests

New cases, all passing:

- `packages/data-provider/specs/config-schemas.spec.ts`
  - accepts a static headers map on the built-in `openAI` endpoint
  - keeps the `openAI` endpoint optional and omits headers when not provided
  - rejects non-string header values
- `packages/api/src/endpoints/openai/initialize.spec.ts`
  - forwards `endpoint.headers` from YAML config into `clientOptions.headers`
  - omits headers when none are configured on the OpenAI endpoint
  - does not leak `openAI.headers` onto the `azureOpenAI` path

Local run results:

- `packages/data-provider`: 20 test suites, 1092 passing (1 pre-existing skipped)
- `packages/api` (OpenAI / custom / agents): 36 test suites, 970 passing (4 pre-existing skipped)
- `packages/api` `tsc --noEmit`: clean

## Test plan

- [x] Schema accepts `headers` on built-in `openAI`, rejects non-string values
- [x] `initializeOpenAI` threads YAML `headers` into `clientOptions.headers`
- [x] Azure path is not affected by `openAI.headers`
- [x] `getOpenAIConfig` -> `configOptions.defaultHeaders` -> `resolveHeaders` chain unchanged, so per-request `{{user_email}}` / `{{LIBRECHAT_BODY_*}}` substitution applies automatically
- [x] `librechat.example.yaml` documents the new field
- [x] `tsc --noEmit` and the touched jest suites are green

Happy to split this further (e.g. move docs into a separate commit) or expand to Anthropic/Google in this PR if that's preferable; I left it focused per the contributor guide's preference for small, reviewable changes.