### PR TITLE
🌐 feat: Anthropic Vertex gateway mode (skip local Google auth)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -152,6 +152,16 @@ ANTHROPIC_API_KEY=user_provided
 # Supports regional locations like us-east5 and multi-region locations: us, eu, global
 # ANTHROPIC_VERTEX_REGION=us-east5
 
+# Gateway mode: route Anthropic Vertex traffic through an upstream AI gateway that
+# owns provider authentication. When ANTHROPIC_VERTEX_SKIP_AUTH=true, LibreChat
+# does not load a Google service account or attach a Google auth header, but
+# still uses native Anthropic Vertex request formatting (rawPredict /
+# streamRawPredict, top-level `system`, `anthropic_version`).
+# ANTHROPIC_VERTEX_SKIP_AUTH=
+# Override the Vertex API base URL with the gateway URL. The SDK still appends
+# /projects/<id>/locations/<region>/publishers/anthropic/models/<deployment>:rawPredict.
+# ANTHROPIC_VERTEX_BASE_URL=
+
 #============#
 # Azure      #
 #============#

--- a/packages/api/src/endpoints/anthropic/initialize.ts
+++ b/packages/api/src/endpoints/anthropic/initialize.ts
@@ -24,7 +24,9 @@ export async function initializeAnthropic({
   const { key: expiresAt } = req.body;
 
   let credentials: Record<string, unknown> = {};
-  let vertexOptions: { region?: string; projectId?: string } | undefined;
+  let vertexOptions:
+    | { region?: string; projectId?: string; skipAuth?: boolean; baseURL?: string }
+    | undefined;
 
   /** @type {undefined | import('librechat-data-provider').TVertexAIConfig} */
   const vertexConfig = appConfig?.endpoints?.[EModelEndpoint.anthropic]?.vertexConfig;
@@ -35,15 +37,33 @@ export async function initializeAnthropic({
     (vertexConfig && vertexConfig.enabled !== false) || isEnabled(process.env.ANTHROPIC_USE_VERTEX);
 
   if (useVertexAI) {
-    // Load credentials with optional YAML config overrides
-    const credentialOptions = vertexConfig ? getVertexCredentialOptions(vertexConfig) : undefined;
+    // Gateway mode: when ANTHROPIC_VERTEX_SKIP_AUTH is set (or skipAuth in YAML),
+    // route Anthropic Vertex requests through an upstream proxy that owns auth.
+    // YAML config takes priority over the env var.
+    const skipAuth =
+      vertexConfig?.skipAuth === true ||
+      (vertexConfig?.skipAuth === undefined && isEnabled(process.env.ANTHROPIC_VERTEX_SKIP_AUTH));
+    const baseURL = vertexConfig?.baseURL || process.env.ANTHROPIC_VERTEX_BASE_URL || undefined;
+
+    // Load credentials with optional YAML config overrides. In skipAuth mode this
+    // returns a placeholder credential without touching any service-account file.
+    // The resolved `skipAuth` already takes the env var into account; merge it
+    // back so env-only gateway mode (no YAML config) and YAML-only both work.
+    let credentialOptions: ReturnType<typeof getVertexCredentialOptions> | undefined;
+    if (vertexConfig) {
+      credentialOptions = { ...getVertexCredentialOptions(vertexConfig), skipAuth };
+    } else if (skipAuth) {
+      credentialOptions = { skipAuth: true };
+    }
     credentials = await loadAnthropicVertexCredentials(credentialOptions);
 
     // Store vertex options for client creation
-    if (vertexConfig) {
+    if (vertexConfig || skipAuth || baseURL) {
       vertexOptions = {
-        region: vertexConfig.region,
-        projectId: vertexConfig.projectId,
+        region: vertexConfig?.region,
+        projectId: vertexConfig?.projectId,
+        skipAuth,
+        baseURL,
       };
     }
   } else {

--- a/packages/api/src/endpoints/anthropic/vertex.spec.ts
+++ b/packages/api/src/endpoints/anthropic/vertex.spec.ts
@@ -1,5 +1,10 @@
 import { AuthKeys } from 'librechat-data-provider';
-import { createAnthropicVertexClient } from './vertex';
+import {
+  createAnthropicVertexClient,
+  loadAnthropicVertexCredentials,
+  getVertexCredentialOptions,
+  VERTEX_GATEWAY_PLACEHOLDER_PROJECT,
+} from './vertex';
 
 describe('createAnthropicVertexClient', () => {
   const credentials = {
@@ -25,6 +30,147 @@ describe('createAnthropicVertexClient', () => {
 
       expect(client.region).toBe(region);
       expect(client.baseURL).toBe(baseURL);
+    });
+  });
+});
+
+describe('Anthropic Vertex gateway mode', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.ANTHROPIC_VERTEX_BASE_URL;
+    delete process.env.ANTHROPIC_VERTEX_REGION;
+    delete process.env.VERTEX_PROJECT_ID;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('loadAnthropicVertexCredentials with skipAuth', () => {
+    it('returns a placeholder credential without touching the filesystem', async () => {
+      const creds = await loadAnthropicVertexCredentials({
+        skipAuth: true,
+        projectId: 'my-project',
+      });
+
+      const serviceKey = creds[AuthKeys.GOOGLE_SERVICE_KEY];
+      expect(serviceKey).toBeDefined();
+      expect(serviceKey?.project_id).toBe('my-project');
+      expect(serviceKey?.private_key).toBeUndefined();
+      expect(serviceKey?.client_email).toBeUndefined();
+    });
+
+    it('falls back to a sentinel project_id when none provided', async () => {
+      const creds = await loadAnthropicVertexCredentials({ skipAuth: true });
+      const serviceKey = creds[AuthKeys.GOOGLE_SERVICE_KEY];
+      expect(serviceKey?.project_id).toBe(VERTEX_GATEWAY_PLACEHOLDER_PROJECT);
+    });
+  });
+
+  describe('getVertexCredentialOptions', () => {
+    it('propagates skipAuth from YAML config', () => {
+      const opts = getVertexCredentialOptions({
+        projectId: 'my-project',
+        region: 'us-east5',
+        skipAuth: true,
+        baseURL: 'https://gateway.example.com/google-vertex-ai/v1',
+      });
+
+      expect(opts.skipAuth).toBe(true);
+      expect(opts.projectId).toBe('my-project');
+      expect(opts.region).toBe('us-east5');
+    });
+  });
+
+  describe('createAnthropicVertexClient with skipAuth', () => {
+    it('overrides the base URL with the gateway URL', () => {
+      const client = createAnthropicVertexClient(
+        { [AuthKeys.GOOGLE_SERVICE_KEY]: { project_id: 'my-project' } },
+        undefined,
+        {
+          region: 'us-east5',
+          projectId: 'my-project',
+          skipAuth: true,
+          baseURL: 'https://gateway.example.com/google-vertex-ai/v1',
+        },
+      );
+
+      expect(client.baseURL).toBe('https://gateway.example.com/google-vertex-ai/v1');
+      expect(client.region).toBe('us-east5');
+      expect(client.projectId).toBe('my-project');
+    });
+
+    it('reads ANTHROPIC_VERTEX_BASE_URL from env when not provided in options', () => {
+      process.env.ANTHROPIC_VERTEX_BASE_URL = 'https://env-gateway.example.com/vertex/v1';
+
+      const client = createAnthropicVertexClient(
+        { [AuthKeys.GOOGLE_SERVICE_KEY]: { project_id: 'my-project' } },
+        undefined,
+        { region: 'us-east5', projectId: 'my-project', skipAuth: true },
+      );
+
+      expect(client.baseURL).toBe('https://env-gateway.example.com/vertex/v1');
+    });
+
+    it('does not attach a Google auth header when skipAuth is set', async () => {
+      const client = createAnthropicVertexClient(
+        { [AuthKeys.GOOGLE_SERVICE_KEY]: { project_id: 'my-project' } },
+        undefined,
+        {
+          region: 'us-east5',
+          projectId: 'my-project',
+          skipAuth: true,
+          baseURL: 'https://gateway.example.com/v1',
+        },
+      );
+
+      // The SDK calls prepareOptions before each request, which awaits the
+      // internal auth client's getRequestHeaders(). In gateway mode this must
+      // return an empty header map so the gateway is the sole source of auth.
+      const opts = { headers: undefined as unknown };
+      // @ts-expect-error - prepareOptions is protected but reachable for testing
+      await client.prepareOptions(opts);
+
+      // The SDK stores headers in a tagged object: { values: Headers, nulls: Set }.
+      // We verify no Google auth headers landed in `values`.
+      const headerCarrier = opts.headers as { values?: Headers } | undefined;
+      expect(headerCarrier).toBeDefined();
+      const collected = headerCarrier?.values;
+      expect(collected).toBeInstanceOf(Headers);
+      expect(collected?.get('authorization')).toBeNull();
+      expect(collected?.get('x-goog-user-project')).toBeNull();
+    });
+
+    it('still falls back to default Vertex base URL when only skipAuth is set', () => {
+      // skipAuth alone (no baseURL) is still valid — e.g., for testing or a gateway
+      // that mirrors the real Vertex hostname. The SDK should produce the standard URL.
+      const client = createAnthropicVertexClient(
+        { [AuthKeys.GOOGLE_SERVICE_KEY]: { project_id: 'my-project' } },
+        undefined,
+        { region: 'us-east5', projectId: 'my-project', skipAuth: true },
+      );
+
+      expect(client.baseURL).toBe('https://us-east5-aiplatform.googleapis.com/v1');
+    });
+
+    it('still uses Google auth when skipAuth is false', () => {
+      // Sanity: the existing non-gateway path remains unchanged.
+      const client = createAnthropicVertexClient(
+        {
+          [AuthKeys.GOOGLE_SERVICE_KEY]: {
+            project_id: 'real-project',
+            client_email: 'sa@real-project.iam.gserviceaccount.com',
+            private_key: 'k',
+          },
+        },
+        undefined,
+        { region: 'us-east5', projectId: 'real-project' },
+      );
+
+      expect(client.baseURL).toBe('https://us-east5-aiplatform.googleapis.com/v1');
+      expect(client.projectId).toBe('real-project');
     });
   });
 });

--- a/packages/api/src/endpoints/anthropic/vertex.ts
+++ b/packages/api/src/endpoints/anthropic/vertex.ts
@@ -1,10 +1,19 @@
 import path from 'path';
 import { GoogleAuth } from 'google-auth-library';
+import type { AuthClient } from 'google-auth-library';
 import { AuthKeys } from 'librechat-data-provider';
 import { AnthropicVertex } from '@anthropic-ai/vertex-sdk';
 import type { ClientOptions } from '@anthropic-ai/sdk';
 import type { AnthropicCredentials, VertexAIClientOptions } from '~/types/anthropic';
 import { loadServiceKey } from '~/utils/key';
+
+/**
+ * Sentinel project_id used when Vertex traffic is routed through an AI gateway
+ * that handles provider authentication. The gateway is responsible for the
+ * Authorization header, but the SDK still needs a non-empty projectId to build
+ * the `/projects/<id>/locations/<region>/.../rawPredict` request path.
+ */
+export const VERTEX_GATEWAY_PLACEHOLDER_PROJECT = 'librechat-vertex-gateway';
 
 /**
  * Options for loading Vertex AI credentials
@@ -16,6 +25,15 @@ export interface VertexCredentialOptions {
   projectId?: string;
   /** Region for Vertex AI */
   region?: string;
+  /**
+   * Skip local Google service account auth entirely. Use when an AI gateway
+   * upstream (e.g., LiteLLM, Helicone, a corporate proxy) owns Vertex
+   * authentication and LibreChat just needs to format Anthropic Vertex requests
+   * (`rawPredict` / `streamRawPredict`, top-level `system`, `anthropic_version`).
+   * When set, `loadAnthropicVertexCredentials` will not require a service key
+   * file and will not call `GoogleAuth`.
+   */
+  skipAuth?: boolean;
 }
 
 /**
@@ -29,16 +47,32 @@ export interface VertexAIConfigInput {
   serviceKeyFile?: string;
   deploymentName?: string;
   models?: string[] | Record<string, boolean | { deploymentName?: string }>;
+  /** Skip local Google service-account auth when an upstream gateway handles it */
+  skipAuth?: boolean;
+  /** Override the Vertex API base URL (typically the gateway URL) */
+  baseURL?: string;
 }
 
 /**
  * Loads Google service account configuration for Vertex AI.
  * Supports both YAML configuration and environment variables.
+ *
+ * When `skipAuth` is true (gateway mode), returns a placeholder credential
+ * marker without loading any service key. The gateway upstream owns auth.
+ *
  * @param options - Optional configuration from YAML or other sources
  */
 export async function loadAnthropicVertexCredentials(
   options?: VertexCredentialOptions,
 ): Promise<AnthropicCredentials> {
+  if (options?.skipAuth) {
+    return {
+      [AuthKeys.GOOGLE_SERVICE_KEY]: {
+        project_id: options.projectId || VERTEX_GATEWAY_PLACEHOLDER_PROJECT,
+      },
+    };
+  }
+
   /** Path priority: options > env var > default location */
   const serviceKeyPath =
     options?.serviceKeyFile ||
@@ -67,6 +101,7 @@ export function getVertexCredentialOptions(config?: VertexAIConfigInput): Vertex
     serviceKeyFile: config?.serviceKeyFile,
     projectId: config?.projectId,
     region: config?.region,
+    skipAuth: config?.skipAuth,
   };
 }
 
@@ -75,6 +110,21 @@ export function getVertexCredentialOptions(config?: VertexAIConfigInput): Vertex
  */
 export function isAnthropicVertexCredentials(credentials: AnthropicCredentials): boolean {
   return !!credentials[AuthKeys.GOOGLE_SERVICE_KEY] && !credentials[AuthKeys.ANTHROPIC_API_KEY];
+}
+
+/**
+ * Builds an `AuthClient`-shaped object that satisfies the AnthropicVertex SDK
+ * without contacting Google's metadata server. Used in gateway mode where
+ * the upstream proxy handles Vertex authentication.
+ *
+ * The SDK only calls `.getRequestHeaders()` and reads `.projectId`. Returning
+ * an empty header map means no `Authorization` header is attached client-side.
+ */
+function createGatewayAuthClient(projectId: string): AuthClient {
+  return {
+    projectId,
+    getRequestHeaders: async () => ({}),
+  } as unknown as AuthClient;
 }
 
 /**
@@ -168,9 +218,17 @@ export function getVertexDeploymentName(
  * Creates and configures a Vertex AI client for Anthropic.
  * Supports both YAML configuration and environment variables for region/projectId.
  * The projectId is automatically extracted from the service key if not explicitly provided.
+ *
+ * When `vertexOptions.skipAuth` is true (gateway mode), the client uses a no-op
+ * auth client so no `Authorization` header is set locally; the upstream gateway
+ * specified by `vertexOptions.baseURL` is expected to inject provider auth.
+ * Request path construction (`rawPredict` / `streamRawPredict`, projectId,
+ * region) and body shape (top-level `system`, `anthropic_version`) are
+ * preserved so the gateway sees a native Anthropic Vertex request.
+ *
  * @param credentials - The Google service account credentials
  * @param options - SDK client options
- * @param vertexOptions - Vertex AI specific options (region, projectId) from YAML config
+ * @param vertexOptions - Vertex AI specific options (region, projectId, skipAuth, baseURL)
  */
 export function createAnthropicVertexClient(
   credentials: AnthropicCredentials,
@@ -187,14 +245,10 @@ export function createAnthropicVertexClient(
   const region = vertexOptions?.region || process.env.ANTHROPIC_VERTEX_REGION || 'us-east5';
   const projectId =
     vertexOptions?.projectId || process.env.VERTEX_PROJECT_ID || serviceKey.project_id;
+  const skipAuth = vertexOptions?.skipAuth === true;
+  const baseURL = vertexOptions?.baseURL || process.env.ANTHROPIC_VERTEX_BASE_URL || undefined;
 
   try {
-    const googleAuth = new GoogleAuth({
-      credentials: serviceKey,
-      scopes: 'https://www.googleapis.com/auth/cloud-platform',
-      ...(projectId && { projectId }),
-    });
-
     // Filter out unsupported anthropic-beta header values for Vertex AI
     const filteredOptions = options
       ? {
@@ -205,10 +259,28 @@ export function createAnthropicVertexClient(
         }
       : undefined;
 
-    return new AnthropicVertex({
-      region: region,
-      googleAuth: googleAuth,
+    if (skipAuth) {
+      const gatewayProjectId = projectId || VERTEX_GATEWAY_PLACEHOLDER_PROJECT;
+      return new AnthropicVertex({
+        region,
+        projectId: gatewayProjectId,
+        authClient: createGatewayAuthClient(gatewayProjectId),
+        ...(baseURL && { baseURL }),
+        ...filteredOptions,
+      });
+    }
+
+    const googleAuth = new GoogleAuth({
+      credentials: serviceKey,
+      scopes: 'https://www.googleapis.com/auth/cloud-platform',
       ...(projectId && { projectId }),
+    });
+
+    return new AnthropicVertex({
+      region,
+      googleAuth,
+      ...(projectId && { projectId }),
+      ...(baseURL && { baseURL }),
       ...filteredOptions,
     });
   } catch (error) {

--- a/packages/api/src/types/anthropic.ts
+++ b/packages/api/src/types/anthropic.ts
@@ -22,6 +22,17 @@ export interface VertexAIClientOptions {
   region?: string;
   /** Google Cloud Project ID */
   projectId?: string;
+  /**
+   * Skip local Google service-account auth when an AI gateway upstream owns
+   * Vertex authentication. No `Authorization` header is attached client-side.
+   */
+  skipAuth?: boolean;
+  /**
+   * Override the Vertex API base URL. Typically the gateway URL, e.g.
+   * `https://gateway.example.com/google-vertex-ai/v1`. The SDK still constructs
+   * the `/projects/<id>/locations/<region>/.../rawPredict` path on top of this.
+   */
+  baseURL?: string;
 }
 
 export interface ThinkingConfigDisabled {

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -683,6 +683,23 @@ export const vertexAISchema = z.object({
   deploymentName: z.string().optional(),
   /** Optional: Available models - can be string array or object with deploymentName mapping */
   models: z.union([z.array(z.string()), z.record(z.string(), vertexModelConfigSchema)]).optional(),
+  /**
+   * Gateway mode: skip local Google service-account auth when an upstream AI
+   * gateway (e.g., LiteLLM, Helicone, a corporate proxy) owns Vertex
+   * authentication. No `Authorization` header is attached client-side; the
+   * gateway is expected to inject it. Native Anthropic Vertex request
+   * formatting (`rawPredict` / `streamRawPredict`, top-level `system`,
+   * `anthropic_version`) is preserved.
+   */
+  skipAuth: z.boolean().optional(),
+  /**
+   * Gateway mode: override the Vertex API base URL with the gateway URL, e.g.
+   * `https://gateway.example.com/google-vertex-ai/v1`. The Anthropic Vertex
+   * SDK still constructs the
+   * `/projects/<id>/locations/<region>/publishers/anthropic/models/<deployment>:rawPredict`
+   * path on top of this base.
+   */
+  baseURL: z.string().optional(),
 });
 
 export type TVertexAISchema = z.infer<typeof vertexAISchema>;


### PR DESCRIPTION
Closes #13085.

## What

Adds gateway-mode support to the Anthropic Vertex code path so deployments can route Vertex Claude traffic through an upstream AI gateway / proxy that owns provider authentication, without requiring a local Google service account key.

Two new toggles, mirroring [Claude Code's prior art](https://docs.anthropic.com/en/docs/claude-code/third-party-integrations#connect-through-a-gateway) (`CLAUDE_CODE_USE_VERTEX` + `CLAUDE_CODE_SKIP_VERTEX_AUTH` + `ANTHROPIC_VERTEX_BASE_URL`):

| Env var | YAML key | Effect |
| --- | --- | --- |
| `ANTHROPIC_VERTEX_SKIP_AUTH=true` | `endpoints.anthropic.vertex.skipAuth: true` | Skip `loadServiceKey` + `GoogleAuth`. No `Authorization` / `x-goog-user-project` header attached client-side. |
| `ANTHROPIC_VERTEX_BASE_URL=https://gateway.example.com/google-vertex-ai/v1` | `endpoints.anthropic.vertex.baseURL: ...` | Override the default `aiplatform.googleapis.com` host with the gateway URL. |

Both can be combined or used independently. YAML config takes priority over env vars, matching the existing pattern.

## Why

Per #13085, some deployments route Anthropic Vertex through a corporate AI gateway:

```
LibreChat → AI Gateway / proxy → Vertex Claude
```

The gateway already holds Google credentials and signs requests. LibreChat shouldn't need a redundant local service account just to format the request.

Custom Endpoints aren't a clean substitute because they don't reproduce Vertex semantics:

- `rawPredict` / `streamRawPredict` URL construction
- top-level Anthropic `system` formatting
- `anthropic_version`
- streaming behaviour
- model-to-deployment mapping

This PR keeps all of that intact and makes only the auth and host layers pluggable. The Anthropic Vertex SDK already accepts a pre-built `authClient` and a `baseURL`, so the change is small and surgical — no fork of the SDK, no upstream changes required.

## Example YAML

```yaml
endpoints:
  anthropic:
    vertex:
      region: us-east5
      projectId: my-project
      skipAuth: true
      baseURL: https://gateway.example.com/google-vertex-ai/v1
      models:
        claude-sonnet:
          deploymentName: claude-sonnet-4-5
```

## Example env

```bash
ANTHROPIC_USE_VERTEX=true
ANTHROPIC_VERTEX_REGION=us-east5
ANTHROPIC_VERTEX_SKIP_AUTH=true
ANTHROPIC_VERTEX_BASE_URL=https://gateway.example.com/google-vertex-ai/v1
VERTEX_PROJECT_ID=my-project
```

## Files touched

- `packages/api/src/endpoints/anthropic/vertex.ts` — gateway-mode credential loader and a no-op `AuthClient` for the SDK
- `packages/api/src/endpoints/anthropic/initialize.ts` — wire env + YAML toggles through to `vertexOptions`
- `packages/api/src/types/anthropic.ts` — `skipAuth` + `baseURL` on `VertexAIClientOptions`
- `packages/data-provider/src/config.ts` — `skipAuth` + `baseURL` on `vertexAISchema`
- `packages/api/src/endpoints/anthropic/vertex.spec.ts` — 8 new tests covering gateway mode
- `.env.example` — document the two new env vars next to `ANTHROPIC_USE_VERTEX`

## Test plan

- [x] `cd packages/api && npx jest --testPathPatterns=\"endpoints/anthropic\"` — 99 / 99 passing (existing 91 + 8 new)
- [x] `npx eslint` clean on changed files
- [x] `packages/data-provider` and `packages/api` build green
- [x] Gateway-mode unit tests verify:
  - placeholder credential returned in `skipAuth` mode (no filesystem access)
  - `baseURL` override applied via options
  - `ANTHROPIC_VERTEX_BASE_URL` env var honored when YAML / option not set
  - no `Authorization` / `x-goog-user-project` header attached when `skipAuth` is set
  - default Vertex base URL still produced when only `skipAuth` is set (no baseURL)
  - legacy `GoogleAuth` path unchanged when `skipAuth` is false

Backward compatible: every existing config keeps working unchanged. The new behaviour only activates when the operator opts in.