### PR TITLE
🧰 fix: Scope MCP Registry Initialization To Config Fingerprints

### DIFF
--- a/packages/api/src/mcp/registry/MCPServersInitializer.ts
+++ b/packages/api/src/mcp/registry/MCPServersInitializer.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { logger } from '@librechat/data-schemas';
 import type * as t from '~/mcp/types';
 import { registryStatusCache as statusCache } from './cache/RegistryStatusCache';
@@ -6,8 +7,30 @@ import { sanitizeUrlForLogging } from '~/mcp/utils';
 import { withTimeout } from '~/utils';
 import { isLeader } from '~/cluster';
 
-const MCP_INIT_TIMEOUT_MS =
-  process.env.MCP_INIT_TIMEOUT_MS != null ? parseInt(process.env.MCP_INIT_TIMEOUT_MS) : 30_000;
+const DEFAULT_MCP_INIT_TIMEOUT_MS = 30_000;
+const DEFAULT_FOLLOWER_RETRY_MS = 3000;
+
+const parseDurationMs = (
+  value: string | undefined,
+  fallback: number,
+  allowZero = false,
+): number => {
+  if (value == null) {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  if (allowZero) {
+    return parsed >= 0 ? parsed : fallback;
+  }
+  return parsed > 0 ? parsed : fallback;
+};
+
+type InitializeRegistryOptions = {
+  skipStatusLeaderCheck?: boolean;
+};
 
 /**
  * Handles initialization of MCP servers at application startup with distributed coordination.
@@ -37,35 +60,70 @@ export class MCPServersInitializer {
   }
 
   public static async initialize(rawConfigs: t.MCPServers): Promise<void> {
+    const configHash = MCPServersInitializer.configHash(rawConfigs);
     // On first call in this process, always reset and re-initialize
     // This ensures we don't use stale Redis data from previous runs
-    const isFirstCallThisProcess = !MCPServersInitializer.hasInitializedThisProcess;
-    // Set flag immediately so recursive calls (from followers) use Redis cache for coordination
+    let isFirstAttemptThisProcess = !MCPServersInitializer.hasInitializedThisProcess;
+    // Set flag immediately so follower retries use Redis cache for coordination
     MCPServersInitializer.hasInitializedThisProcess = true;
+    const followerWaitStartedAt = performance.now();
 
-    if (!isFirstCallThisProcess && (await statusCache.isInitialized())) return;
+    while (true) {
+      if (!isFirstAttemptThisProcess && (await statusCache.isInitializedFor(configHash))) {
+        return;
+      }
 
-    if (await isLeader()) {
-      // Leader performs initialization - always reset on first call
-      await statusCache.reset();
-      await MCPServersRegistry.getInstance().reset();
-      const serverNames = Object.keys(rawConfigs);
-      await Promise.allSettled(
-        serverNames.map((serverName) =>
-          withTimeout(
-            MCPServersInitializer.initializeServer(serverName, rawConfigs[serverName]),
-            MCP_INIT_TIMEOUT_MS,
-            `${MCPServersInitializer.prefix(serverName)} Server initialization timed out`,
-            logger.error,
-          ),
+      if (await isLeader()) {
+        await MCPServersInitializer.initializeRegistry(rawConfigs, configHash);
+        return;
+      }
+
+      const followerWaitMs = performance.now() - followerWaitStartedAt;
+      const followerMaxWaitMs = MCPServersInitializer.followerMaxWaitMs();
+      if (followerWaitMs >= followerMaxWaitMs) {
+        logger.warn(
+          '[MCP] Timed out waiting for leader to initialize registry for current config fingerprint; initializing on this instance',
+        );
+        await MCPServersInitializer.initializeRegistry(rawConfigs, configHash, {
+          skipStatusLeaderCheck: true,
+        });
+        return;
+      }
+
+      logger.debug(
+        '[MCP] Waiting for leader to initialize registry for current config fingerprint',
+      );
+      isFirstAttemptThisProcess = false;
+      await new Promise((resolve) =>
+        setTimeout(
+          resolve,
+          Math.min(MCPServersInitializer.followerRetryMs(), followerMaxWaitMs - followerWaitMs),
         ),
       );
-      await statusCache.setInitialized(true);
-    } else {
-      // Followers try again after a delay if not initialized
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-      await this.initialize(rawConfigs);
     }
+  }
+
+  private static async initializeRegistry(
+    rawConfigs: t.MCPServers,
+    configHash: string,
+    options?: InitializeRegistryOptions,
+  ): Promise<void> {
+    await statusCache.reset();
+    await MCPServersRegistry.getInstance().reset();
+    const serverNames = Object.keys(rawConfigs);
+    await Promise.allSettled(
+      serverNames.map((serverName) =>
+        withTimeout(
+          MCPServersInitializer.initializeServer(serverName, rawConfigs[serverName]),
+          MCPServersInitializer.initTimeoutMs(),
+          `${MCPServersInitializer.prefix(serverName)} Server initialization timed out`,
+          logger.error,
+        ),
+      ),
+    );
+    await statusCache.setInitialized(true, configHash, {
+      skipLeaderCheck: options?.skipStatusLeaderCheck,
+    });
   }
 
   /** Initializes a single server with all its metadata and adds it to appropriate collections */
@@ -109,5 +167,47 @@ export class MCPServersInitializer {
   // Returns formatted log prefix for server messages
   private static prefix(serverName: string): string {
     return `[MCP][${serverName}]`;
+  }
+
+  private static configHash(rawConfigs: t.MCPServers): string {
+    const registry = MCPServersRegistry.getInstance();
+    const fingerprint = {
+      rawConfigs,
+      allowedDomains: registry.getAllowedDomains() ?? null,
+      allowedAddresses: registry.getAllowedAddresses() ?? null,
+    };
+    return createHash('sha256')
+      .update(JSON.stringify(MCPServersInitializer.sortForHash(fingerprint)))
+      .digest('hex');
+  }
+
+  private static followerRetryMs(): number {
+    return parseDurationMs(process.env.MCP_INIT_FOLLOWER_RETRY_MS, DEFAULT_FOLLOWER_RETRY_MS);
+  }
+
+  private static followerMaxWaitMs(): number {
+    return parseDurationMs(
+      process.env.MCP_INIT_FOLLOWER_MAX_WAIT_MS,
+      MCPServersInitializer.initTimeoutMs() + MCPServersInitializer.followerRetryMs(),
+      true,
+    );
+  }
+
+  private static initTimeoutMs(): number {
+    return parseDurationMs(process.env.MCP_INIT_TIMEOUT_MS, DEFAULT_MCP_INIT_TIMEOUT_MS);
+  }
+
+  private static sortForHash(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item) => MCPServersInitializer.sortForHash(item));
+    }
+    if (value !== null && typeof value === 'object') {
+      return Object.fromEntries(
+        Object.entries(value as Record<string, unknown>)
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([key, item]) => [key, MCPServersInitializer.sortForHash(item)]),
+      );
+    }
+    return value;
   }
 }

--- a/packages/api/src/mcp/registry/__tests__/MCPServersInitializer.test.ts
+++ b/packages/api/src/mcp/registry/__tests__/MCPServersInitializer.test.ts
@@ -1,5 +1,6 @@
 import { logger } from '@librechat/data-schemas';
 import * as t from '~/mcp/types';
+import { isLeader } from '~/cluster';
 import { registryStatusCache } from '~/mcp/registry/cache/RegistryStatusCache';
 import { MCPServersInitializer } from '~/mcp/registry/MCPServersInitializer';
 import { MCPServerInspector } from '~/mcp/registry/MCPServerInspector';
@@ -46,6 +47,33 @@ const mockLogger = logger as jest.Mocked<typeof logger>;
 const mockInspect = MCPServerInspector.inspect as jest.MockedFunction<
   typeof MCPServerInspector.inspect
 >;
+
+const withFollowerWaitEnv = async (
+  retryMs: string,
+  maxWaitMs: string,
+  callback: () => Promise<void>,
+): Promise<void> => {
+  const originalRetryMs = process.env.MCP_INIT_FOLLOWER_RETRY_MS;
+  const originalMaxWaitMs = process.env.MCP_INIT_FOLLOWER_MAX_WAIT_MS;
+  process.env.MCP_INIT_FOLLOWER_RETRY_MS = retryMs;
+  process.env.MCP_INIT_FOLLOWER_MAX_WAIT_MS = maxWaitMs;
+
+  try {
+    await callback();
+  } finally {
+    if (originalRetryMs == null) {
+      delete process.env.MCP_INIT_FOLLOWER_RETRY_MS;
+    } else {
+      process.env.MCP_INIT_FOLLOWER_RETRY_MS = originalRetryMs;
+    }
+
+    if (originalMaxWaitMs == null) {
+      delete process.env.MCP_INIT_FOLLOWER_MAX_WAIT_MS;
+    } else {
+      process.env.MCP_INIT_FOLLOWER_MAX_WAIT_MS = originalMaxWaitMs;
+    }
+  }
+};
 
 describe('MCPServersInitializer', () => {
   let mockConnection: jest.Mocked<MCPConnection>;
@@ -184,6 +212,7 @@ describe('MCPServersInitializer', () => {
     await registry.reset();
     MCPServersInitializer.resetProcessFlag();
     jest.clearAllMocks();
+    (isLeader as jest.MockedFunction<typeof isLeader>).mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -219,6 +248,115 @@ describe('MCPServersInitializer', () => {
       await MCPServersInitializer.initialize(testConfigs);
 
       expect(mockInspect).not.toHaveBeenCalled();
+    });
+
+    it('should re-initialize when the shared initialized status belongs to a different config', async () => {
+      await MCPServersInitializer.initialize(testConfigs);
+      expect(await registryStatusCache.isInitialized()).toBe(true);
+      const firstConfigHash = await registryStatusCache.getInitializedConfigHash();
+
+      const updatedConfigs: t.MCPServers = {
+        ...testConfigs,
+        new_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['new-server.js'],
+        },
+      };
+
+      jest.clearAllMocks();
+
+      await MCPServersInitializer.initialize(updatedConfigs);
+
+      expect(mockInspect).toHaveBeenCalledTimes(6);
+      expect(await registry.getServerConfig('new_server')).toBeDefined();
+      expect(await registryStatusCache.getInitializedConfigHash()).not.toBe(firstConfigHash);
+    });
+
+    it('should not let a follower accept stale initialized status from another config', async () => {
+      await MCPServersInitializer.initialize(testConfigs);
+
+      const updatedConfigs: t.MCPServers = {
+        ...testConfigs,
+        new_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['new-server.js'],
+        },
+      };
+      const mockIsLeader = isLeader as jest.MockedFunction<typeof isLeader>;
+      mockIsLeader.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+      jest.clearAllMocks();
+
+      await withFollowerWaitEnv('1', '50', async () => {
+        await MCPServersInitializer.initialize(updatedConfigs);
+      });
+
+      expect(mockInspect).toHaveBeenCalledTimes(6);
+      expect(mockIsLeader.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(await registry.getServerConfig('new_server')).toBeDefined();
+    });
+
+    it('should initialize locally when a stale follower wait is exhausted', async () => {
+      await MCPServersInitializer.initialize(testConfigs);
+
+      const updatedConfigs: t.MCPServers = {
+        ...testConfigs,
+        new_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['new-server.js'],
+        },
+      };
+      const mockIsLeader = isLeader as jest.MockedFunction<typeof isLeader>;
+      mockIsLeader.mockResolvedValue(false);
+
+      jest.clearAllMocks();
+
+      await withFollowerWaitEnv('1', '1', async () => {
+        await MCPServersInitializer.initialize(updatedConfigs);
+      });
+
+      expect(mockInspect).toHaveBeenCalledTimes(6);
+      expect(mockIsLeader).toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Timed out waiting'));
+      expect(await registry.getServerConfig('new_server')).toBeDefined();
+    });
+
+    it('should ignore invalid follower max wait env values', async () => {
+      await MCPServersInitializer.initialize(testConfigs);
+
+      const updatedConfigs: t.MCPServers = {
+        ...testConfigs,
+        new_server: {
+          type: 'stdio',
+          command: 'node',
+          args: ['new-server.js'],
+        },
+      };
+      const mockIsLeader = isLeader as jest.MockedFunction<typeof isLeader>;
+      mockIsLeader.mockResolvedValue(false);
+      const originalInitTimeoutMs = process.env.MCP_INIT_TIMEOUT_MS;
+      process.env.MCP_INIT_TIMEOUT_MS = '1';
+
+      jest.clearAllMocks();
+
+      try {
+        await withFollowerWaitEnv('1', 'not-a-number', async () => {
+          await MCPServersInitializer.initialize(updatedConfigs);
+        });
+      } finally {
+        if (originalInitTimeoutMs == null) {
+          delete process.env.MCP_INIT_TIMEOUT_MS;
+        } else {
+          process.env.MCP_INIT_TIMEOUT_MS = originalInitTimeoutMs;
+        }
+      }
+
+      expect(mockInspect).toHaveBeenCalledTimes(6);
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Timed out waiting'));
+      expect(await registry.getServerConfig('new_server')).toBeDefined();
     });
 
     it('should process all server configs through inspector', async () => {

--- a/packages/api/src/mcp/registry/cache/RegistryStatusCache.ts
+++ b/packages/api/src/mcp/registry/cache/RegistryStatusCache.ts
@@ -3,6 +3,11 @@ import { BaseRegistryCache } from './BaseRegistryCache';
 
 // Status keys
 const INITIALIZED = 'INITIALIZED';
+const INITIALIZED_CONFIG_HASH = 'INITIALIZED_CONFIG_HASH';
+
+type StatusSetOptions = {
+  skipLeaderCheck?: boolean;
+};
 
 /**
  * Cache for tracking MCP Servers Registry global metadata and status across distributed instances.
@@ -20,16 +25,41 @@ class RegistryStatusCache extends BaseRegistryCache {
     return (await this.get(INITIALIZED)) === true;
   }
 
-  public async setInitialized(value: boolean): Promise<void> {
-    await this.set(INITIALIZED, value);
+  public async isInitializedFor(configHash: string): Promise<boolean> {
+    if (!(await this.isInitialized())) {
+      return false;
+    }
+    return (await this.getInitializedConfigHash()) === configHash;
+  }
+
+  public async getInitializedConfigHash(): Promise<string | undefined> {
+    return this.get<string>(INITIALIZED_CONFIG_HASH);
+  }
+
+  public async setInitialized(
+    value: boolean,
+    configHash?: string,
+    options?: StatusSetOptions,
+  ): Promise<void> {
+    if (configHash != null) {
+      await this.set(INITIALIZED_CONFIG_HASH, configHash, undefined, options);
+    }
+    await this.set(INITIALIZED, value, undefined, options);
   }
 
   private async get<T = unknown>(key: string): Promise<T | undefined> {
     return this.cache.get(key);
   }
 
-  private async set(key: string, value: string | number | boolean, ttl?: number): Promise<void> {
-    await this.leaderCheck('set MCP Servers Registry status');
+  private async set(
+    key: string,
+    value: string | number | boolean,
+    ttl?: number,
+    options?: StatusSetOptions,
+  ): Promise<void> {
+    if (!options?.skipLeaderCheck) {
+      await this.leaderCheck('set MCP Servers Registry status');
+    }
     const success = await this.cache.set(key, value, ttl);
     this.successCheck(`set status key "${key}"`, success);
   }


### PR DESCRIPTION
## Summary

I fixed MCP registry initialization so rolling deployments with shared Redis do not reuse stale startup state from a different LibreChat config or hang behind an older leader pod.

- Scope the shared MCP registry initialized marker to a stable fingerprint of configured MCP servers and MCP allowlists.
- Reinitialize the registry when a pod sees an initialized marker for a different config, including follower-to-leader retry paths.
- Bound follower waits for stale config fingerprints and allow the current instance to initialize after the leader wait is exhausted.
- Preserve the existing skip path for repeated initialization with the same config in a single process.
- Add regression coverage for stale config fingerprints, follower behavior during rolling deployment, and stale follower timeout fallback.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `npm run reinstall`
- [x] `npx jest src/mcp/registry/__tests__/MCPServersInitializer.test.ts --runInBand`
- [x] `USE_REDIS=true REDIS_URI=redis://127.0.0.1:6387 REDIS_KEY_PREFIX=MCPRollingLocalTest4 REDIS_RETRY_MAX_ATTEMPTS=2 npx jest src/mcp/registry/__tests__/MCPServersInitializer.cache_integration.spec.ts --runInBand --coverage=false --forceExit --silent`
- [x] `USE_REDIS=true REDIS_URI=redis://127.0.0.1:6387 REDIS_KEY_PREFIX=MCPStatusLocalTest4 REDIS_RETRY_MAX_ATTEMPTS=2 npx jest src/mcp/registry/cache/__tests__/RegistryStatusCache.cache_integration.spec.ts --runInBand --coverage=false --forceExit --silent`
- [x] `npx eslint packages/api/src/mcp/registry/MCPServersInitializer.ts packages/api/src/mcp/registry/cache/RegistryStatusCache.ts packages/api/src/mcp/registry/__tests__/MCPServersInitializer.test.ts`
- [x] `npm run build:api`
- [x] `git diff --check`

### **Test Configuration**:

- Node.js v20.19.5
- npm 10.8.2
- Redis 8.4.0
- Local Redis: `redis://127.0.0.1:6387`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
