### PR TITLE
🏷️ fix: Harden Helm Chart Tag Parsing

### DIFF
--- a/.github/workflows/helmcharts.yml
+++ b/.github/workflows/helmcharts.yml
@@ -37,8 +37,15 @@ jobs:
 
       - name: Get Chart Version
         id: chart-version
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          CHART_VERSION=$(echo "${{ github.ref_name }}" | cut -d'-' -f2)
+          CHART_VERSION="${REF_NAME#chart-}"
+          SEMVER_REGEX='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+          if [[ ! "$CHART_VERSION" =~ $SEMVER_REGEX ]]; then
+            echo "Invalid chart version: $CHART_VERSION" >&2
+            exit 1
+          fi
           echo "CHART_VERSION=${CHART_VERSION}" >> "$GITHUB_OUTPUT"
 
       # Log in to GitHub Container Registry


### PR DESCRIPTION
## Summary

I hardened the Helm chart release workflow so chart tag names are handled as data instead of being interpolated directly into the runner shell.

- Moved `github.ref_name` into a step environment variable before reading it from Bash.
- Replaced the `echo ... | cut` parsing with shell parameter expansion to strip the `chart-` prefix without reinterpreting tag contents.
- Added SemVer-style validation so malformed or payload-shaped chart tags fail before publishing Helm charts.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `git diff --check`.
- Simulated valid chart tags and confirmed `chart-1.2.3`, `chart-1.2.3-rc.1`, `chart-1.2.3+build.4`, and `chart-1.2.3-rc.1+build.4` parse successfully.
- Simulated a payload-shaped tag, `chart-$(touch${IFS}/tmp/ci-pwned;echo${IFS}1.2.3)`, and confirmed it is rejected without executing the payload.
- Attempted `actionlint .github/workflows/helmcharts.yml`, but `actionlint` is not installed in this environment.

### **Test Configuration**:

- macOS local worktree
- Bash shell simulation for the GitHub Actions `run` block

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings