### PR TITLE
🏷️ feat: Hide Model Spec Badge Rows

### DIFF
--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -22,9 +22,10 @@ import {
   useFocusChatEffect,
 } from '~/hooks';
 import { mainTextareaId, BadgeItem } from '~/common';
+import { useGetStartupConfig } from '~/data-provider';
 import AttachFileChat from './Files/AttachFileChat';
 import FileFormChat from './Files/FileFormChat';
-import { cn, removeFocusRings } from '~/utils';
+import { cn, getModelSpec, removeFocusRings } from '~/utils';
 import TextareaHeader from './TextareaHeader';
 import PendingManualSkillsChips from './PendingManualSkillsChips';
 import SkillsCommand from './SkillsCommand';
@@ -96,11 +97,17 @@ const ChatForm = memo(function ChatForm({
     setConversation: setAddedConvo,
   } = useAddedChatContext();
   const assistantMap = useAssistantsMapContext();
+  const { data: startupConfig } = useGetStartupConfig();
 
   const endpoint = useMemo(
     () => conversation?.endpointType ?? conversation?.endpoint,
     [conversation?.endpointType, conversation?.endpoint],
   );
+  const modelSpec = useMemo(
+    () => getModelSpec({ specName: conversation?.spec, startupConfig }),
+    [conversation?.spec, startupConfig],
+  );
+  const hideBadgeRow = modelSpec?.hideBadgeRow === true;
   const conversationId = useMemo(
     () => conversation?.conversationId ?? Constants.NEW_CONVO,
     [conversation?.conversationId],
@@ -353,18 +360,20 @@ const ChatForm = memo(function ChatForm({
                   setFilesLoading={setFilesLoading}
                 />
               </div>
-              <BadgeRow
-                showEphemeralBadges={
-                  !!endpoint && !isAgentsEndpoint(endpoint) && !isAssistantsEndpoint(endpoint)
-                }
-                isSubmitting={isSubmitting}
-                conversationId={conversationId}
-                specName={conversation?.spec}
-                onChange={setBadges}
-                isInChat={
-                  Array.isArray(conversation?.messages) && conversation.messages.length >= 1
-                }
-              />
+              {!hideBadgeRow && (
+                <BadgeRow
+                  showEphemeralBadges={
+                    !!endpoint && !isAgentsEndpoint(endpoint) && !isAssistantsEndpoint(endpoint)
+                  }
+                  isSubmitting={isSubmitting}
+                  conversationId={conversationId}
+                  specName={conversation?.spec}
+                  onChange={setBadges}
+                  isInChat={
+                    Array.isArray(conversation?.messages) && conversation.messages.length >= 1
+                  }
+                />
+              )}
               <div className="mx-auto flex" />
               {SpeechToText && (
                 <AudioRecorder

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -360,20 +360,21 @@ const ChatForm = memo(function ChatForm({
                   setFilesLoading={setFilesLoading}
                 />
               </div>
-              {!hideBadgeRow && (
-                <BadgeRow
-                  showEphemeralBadges={
-                    !!endpoint && !isAgentsEndpoint(endpoint) && !isAssistantsEndpoint(endpoint)
-                  }
-                  isSubmitting={isSubmitting}
-                  conversationId={conversationId}
-                  specName={conversation?.spec}
-                  onChange={setBadges}
-                  isInChat={
-                    Array.isArray(conversation?.messages) && conversation.messages.length >= 1
-                  }
-                />
-              )}
+              <BadgeRow
+                showEphemeralBadges={
+                  !!endpoint &&
+                  !hideBadgeRow &&
+                  !isAgentsEndpoint(endpoint) &&
+                  !isAssistantsEndpoint(endpoint)
+                }
+                isSubmitting={isSubmitting}
+                conversationId={conversationId}
+                specName={conversation?.spec}
+                onChange={setBadges}
+                isInChat={
+                  Array.isArray(conversation?.messages) && conversation.messages.length >= 1
+                }
+              />
               <div className="mx-auto flex" />
               {SpeechToText && (
                 <AudioRecorder

--- a/client/src/components/Chat/Input/ChatForm.tsx
+++ b/client/src/components/Chat/Input/ChatForm.tsx
@@ -21,13 +21,13 @@ import {
   useSubmitMessage,
   useFocusChatEffect,
 } from '~/hooks';
-import { mainTextareaId, BadgeItem } from '~/common';
+import PendingManualSkillsChips from './PendingManualSkillsChips';
+import { cn, getModelSpec, removeFocusRings } from '~/utils';
 import { useGetStartupConfig } from '~/data-provider';
+import { mainTextareaId, BadgeItem } from '~/common';
 import AttachFileChat from './Files/AttachFileChat';
 import FileFormChat from './Files/FileFormChat';
-import { cn, getModelSpec, removeFocusRings } from '~/utils';
 import TextareaHeader from './TextareaHeader';
-import PendingManualSkillsChips from './PendingManualSkillsChips';
 import SkillsCommand from './SkillsCommand';
 import PromptsCommand from './PromptsCommand';
 import AudioRecorder from './AudioRecorder';

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -624,6 +624,7 @@ endpoints:
 #       label: "General Assistant"
 #       description: "General purpose assistant"
 #       # No 'group' field - appears as standalone item at top level (not nested)
+#       # hideBadgeRow: true  # Optional: hides the tool badge row for this spec
 #       preset:
 #         endpoint: "openAI"
 #         model: "gpt-4o-mini"

--- a/packages/data-provider/specs/config-schemas.spec.ts
+++ b/packages/data-provider/specs/config-schemas.spec.ts
@@ -767,11 +767,15 @@ describe('specsConfigSchema', () => {
         {
           name: 'spec-1',
           label: 'Spec 1',
+          hideBadgeRow: true,
           preset: { endpoint: EModelEndpoint.openAI },
         },
       ],
     });
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.list[0].hideBadgeRow).toBe(true);
+    }
   });
 
   it('still rejects null list', () => {

--- a/packages/data-provider/src/models.ts
+++ b/packages/data-provider/src/models.ts
@@ -32,6 +32,8 @@ export type TModelSpec = {
   showIconInHeader?: boolean;
   iconURL?: string | EModelEndpoint; // Allow using project-included icons
   authType?: AuthType;
+  /** Hide the chat input tool badge row while this model spec is active. */
+  hideBadgeRow?: boolean;
   webSearch?: boolean;
   fileSearch?: boolean;
   executeCode?: boolean;
@@ -52,6 +54,7 @@ export const tModelSpecSchema = z.object({
   showIconInHeader: z.boolean().optional(),
   iconURL: z.union([z.string(), eModelEndpointSchema]).optional(),
   authType: authTypeSchema.optional(),
+  hideBadgeRow: z.boolean().optional(),
   webSearch: z.boolean().optional(),
   fileSearch: z.boolean().optional(),
   executeCode: z.boolean().optional(),


### PR DESCRIPTION
## Summary

I added an optional model spec setting that hides the chat input badge row when an admin-configured spec should not expose tool toggles.

- Added `hideBadgeRow` to the shared model spec type and Zod schema so `librechat.yaml` preserves the option.
- Looked up the active model spec in `ChatForm` and skipped rendering `BadgeRow` when `hideBadgeRow` is enabled.
- Documented the YAML option in the model specs example.
- Added schema coverage to confirm populated model specs retain `hideBadgeRow`.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- `npx jest specs/config-schemas.spec.ts --runInBand`
- `npm run build:data-provider`
- `npx eslint client/src/components/Chat/Input/ChatForm.tsx packages/data-provider/src/models.ts packages/data-provider/specs/config-schemas.spec.ts`

### **Test Configuration**:

- macOS
- Node dependencies reused from the main local checkout for this worktree

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes