### PR TITLE
🪵 fix: Restore Winston Format Factory Shape In Test Mocks

### DIFF
--- a/api/test/__mocks__/logger.js
+++ b/api/test/__mocks__/logger.js
@@ -1,5 +1,13 @@
 jest.mock('winston', () => {
-  const mockFormatFunction = jest.fn((fn) => fn);
+  // Real `winston.format(fn)` returns a Format constructor whose instances
+  // expose a `.transform(info, opts)` method that winston's pipeline calls.
+  // The previous mock `(fn) => fn` collapsed this — `parsers.redactFormat()`
+  // (called at @librechat/data-schemas dist module-load) ended up invoking
+  // the inner transform fn with no `info` argument, throwing on `info.level`.
+  // Returning a thunk that yields `{ transform: fn }` matches real winston's
+  // shape just enough that module-load completes cleanly; the inner fn is
+  // only ever invoked by winston's pipeline (never at load time).
+  const mockFormatFunction = jest.fn((fn) => () => ({ transform: fn }));
 
   mockFormatFunction.colorize = jest.fn();
   mockFormatFunction.combine = jest.fn();

--- a/packages/api/src/agents/__tests__/initialize.test.ts
+++ b/packages/api/src/agents/__tests__/initialize.test.ts
@@ -39,20 +39,34 @@ import type { ServerRequest, InitializeResultBase, EndpointTokenConfig } from '~
 import type { InitializeAgentDbMethods } from '../initialize';
 import { DEFAULT_MAX_CONTEXT_TOKENS } from '../initialize';
 
-// Mock logger
+// Mock logger — `format` must be a callable factory so @librechat/data-schemas
+// dist module-load completes cleanly; see api/test/__mocks__/logger.js.
 jest.mock('winston', () => ({
   createLogger: jest.fn(() => ({
     debug: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
+    info: jest.fn(),
   })),
-  format: {
-    combine: jest.fn(),
-    colorize: jest.fn(),
-    simple: jest.fn(),
-  },
+  format: Object.assign(
+    jest.fn((fn) => () => ({ transform: fn })),
+    {
+      combine: jest.fn(),
+      colorize: jest.fn(),
+      simple: jest.fn(),
+      label: jest.fn(),
+      timestamp: jest.fn(),
+      printf: jest.fn(),
+      errors: jest.fn(),
+      splat: jest.fn(),
+      json: jest.fn(),
+    },
+  ),
+  addColors: jest.fn(),
   transports: {
     Console: jest.fn(),
+    DailyRotateFile: jest.fn(),
+    File: jest.fn(),
   },
 }));
 

--- a/packages/api/src/agents/__tests__/memory.test.ts
+++ b/packages/api/src/agents/__tests__/memory.test.ts
@@ -5,19 +5,35 @@ import type { MemoryArtifact } from 'librechat-data-provider';
 import { createMemoryTool, processMemory } from '../memory';
 
 // Mock the logger
+// `winston.format` must be a callable factory (real winston returns a Format
+// constructor) so that `@librechat/data-schemas` dist code can complete its
+// module-load — see api/test/__mocks__/logger.js for the canonical shape.
 jest.mock('winston', () => ({
   createLogger: jest.fn(() => ({
     debug: jest.fn(),
     warn: jest.fn(),
     error: jest.fn(),
+    info: jest.fn(),
   })),
-  format: {
-    combine: jest.fn(),
-    colorize: jest.fn(),
-    simple: jest.fn(),
-  },
+  format: Object.assign(
+    jest.fn((fn) => () => ({ transform: fn })),
+    {
+      combine: jest.fn(),
+      colorize: jest.fn(),
+      simple: jest.fn(),
+      label: jest.fn(),
+      timestamp: jest.fn(),
+      printf: jest.fn(),
+      errors: jest.fn(),
+      splat: jest.fn(),
+      json: jest.fn(),
+    },
+  ),
+  addColors: jest.fn(),
   transports: {
     Console: jest.fn(),
+    DailyRotateFile: jest.fn(),
+    File: jest.fn(),
   },
 }));
 

--- a/packages/api/src/agents/__tests__/run-summarization.test.ts
+++ b/packages/api/src/agents/__tests__/run-summarization.test.ts
@@ -9,7 +9,8 @@ import {
 } from 'librechat-data-provider';
 import { createRun } from '~/agents/run';
 
-// Mock winston logger
+// Mock winston logger — `format` must be callable so @librechat/data-schemas
+// dist module-load completes cleanly; see api/test/__mocks__/logger.js.
 jest.mock('winston', () => ({
   createLogger: jest.fn(() => ({
     debug: jest.fn(),
@@ -17,8 +18,26 @@ jest.mock('winston', () => ({
     error: jest.fn(),
     info: jest.fn(),
   })),
-  format: { combine: jest.fn(), colorize: jest.fn(), simple: jest.fn() },
-  transports: { Console: jest.fn() },
+  format: Object.assign(
+    jest.fn((fn) => () => ({ transform: fn })),
+    {
+      combine: jest.fn(),
+      colorize: jest.fn(),
+      simple: jest.fn(),
+      label: jest.fn(),
+      timestamp: jest.fn(),
+      printf: jest.fn(),
+      errors: jest.fn(),
+      splat: jest.fn(),
+      json: jest.fn(),
+    },
+  ),
+  addColors: jest.fn(),
+  transports: {
+    Console: jest.fn(),
+    DailyRotateFile: jest.fn(),
+    File: jest.fn(),
+  },
 }));
 
 // Mock env utilities so header resolution doesn't fail


### PR DESCRIPTION
## Summary

The four `jest.mock('winston', …)` setups in the test suite return a shape that doesn't satisfy real winston's Format-factory contract. As long as nothing forces `winston.format()` to be evaluated at module-load time, the tests pass — but `@librechat/data-schemas/dist/config/parsers.cjs:52` does exactly that, so any test file whose import graph reaches `@librechat/data-schemas` (directly or transitively) can fail to load on environments where Jest's mock-hoisting actually hits this path.

Affected files:
- [`api/test/__mocks__/logger.js`](https://github.com/danny-avila/LibreChat/blob/main/api/test/__mocks__/logger.js) — `(fn) => fn` returns the inner transform fn directly. When `parsers.cjs` does `const redactFormat = winston.format(fn)` and then `parsers.redactFormat()`, the inner fn is invoked with no `info` argument → `TypeError: Cannot read properties of undefined (reading 'level')` at `parsers.ts:63`.
- [`packages/api/src/agents/__tests__/memory.test.ts`](https://github.com/danny-avila/LibreChat/blob/main/packages/api/src/agents/__tests__/memory.test.ts)
- [`packages/api/src/agents/__tests__/run-summarization.test.ts`](https://github.com/danny-avila/LibreChat/blob/main/packages/api/src/agents/__tests__/run-summarization.test.ts)
- [`packages/api/src/agents/__tests__/initialize.test.ts`](https://github.com/danny-avila/LibreChat/blob/main/packages/api/src/agents/__tests__/initialize.test.ts) — `format` is a plain object with `combine`/`colorize`/`simple` only, so `winston.format(fn)` throws `TypeError: winston.format is not a function`. Once that's patched, the dist code then trips over missing `winston.format.printf`, `winston.addColors`, `new winston.transports.DailyRotateFile(...)`.

The bug was introduced when DB layers were extracted into `@librechat/data-schemas` (#7650, May 2025) and the side-effecting `winston.format()` call moved with them. The test mocks were never updated to follow.

Why it doesn't fail in current CI on `main`: the failure depends on subtleties of Jest's `jest.mock` hoisting interaction with the workspace symlink chain — happens reproducibly on Node 24.x and on some Linux runner configurations, doesn't trigger on the GitHub Actions Ubuntu / Node 20.19 combination that current CI uses. The mock is wrong against the API contract regardless; this fix removes the latent failure across all supported environments.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

**Repro on `main` (Node 24.9.0, Linux):**

```bash
git checkout main
npm ci
npm run build:data-provider && npm run build:data-schemas && npm run build:api
cd packages/api && npx jest src/agents/__tests__/memory.test.ts
# → TypeError: winston.format is not a function
#   at ../data-schemas/src/config/parsers.ts:62
```

**With this PR applied:**

```bash
cd packages/api && npx jest src/agents/__tests__/memory.test.ts src/agents/__tests__/run-summarization.test.ts src/agents/__tests__/initialize.test.ts
# → 3 suites, 106 tests, all pass
```

### Test Configuration

- Node 24.9.0 (also verified the fix works on Node 20.19.6)
- Ubuntu / WSL2
- Jest 30.2.0
- Fresh build of `packages/{data-provider,data-schemas,api}` per the contributor guide

## What the fix does

For all four mocks, `winston.format` becomes a callable factory that mirrors real winston's shape:

```js
format: Object.assign(jest.fn((fn) => () => ({ transform: fn })), {
  combine: jest.fn(),
  colorize: jest.fn(),
  simple: jest.fn(),
  label: jest.fn(),
  timestamp: jest.fn(),
  printf: jest.fn(),
  errors: jest.fn(),
  splat: jest.fn(),
  json: jest.fn(),
}),
addColors: jest.fn(),
transports: {
  Console: jest.fn(),
  DailyRotateFile: jest.fn(),
  File: jest.fn(),
},
```

`winston.format(fn)` now returns a thunk that yields `{ transform: fn }`. Module-load completes cleanly because nothing invokes the inner transform at import time; winston's pipeline (not exercised under mocks) is the only thing that would ever call `.transform(info)`.

`api/test/__mocks__/logger.js` keeps its property-on-function style — the only change there is the closure body returns `() => ({ transform: fn })` instead of `fn`.

## Checklist

- [x] My code adheres to this project's style guidelines (ran `prettier --write` + `eslint`)
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code (each mock now explains why `format` needs to be callable)
- [ ] I have made pertinent documentation changes (no docs affected — test-only patch)
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective (the existing tests now pass on previously-failing environments)
- [x] Local unit tests pass with my changes (`cd packages/api && npx jest src/agents/__tests__/` → green)
- [x] Any changes dependent on mine have been merged and published in downstream modules. (n/a — test-only)
- [ ] A pull request for updating the documentation has been submitted. (n/a — test-only)
