### PR TITLE
⏩ refactor: Speed Up Subagent Ticker Refresh

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx
@@ -42,10 +42,10 @@ interface SubagentCallProps {
 }
 
 const TICKER_MAX_LINES = 3;
-/** Trailing-edge throttle window for the live preview. Tuned down from
- *  the original 1.2s so the ticker feels snappy when the container is
- *  already full and frames are scrolling. */
-const TICKER_THROTTLE_MS = 800;
+/** Trailing-edge refresh window for the live preview once the ticker has
+ *  enough text to fill the row. Keeps long streaming lines from repainting
+ *  every token while still letting the collapsed subagent UI feel responsive. */
+export const SUBAGENT_TICKER_THROTTLE_MS = 400;
 /** Below this live-buffer length we skip throttling entirely. Without
  *  this the user would see "Reasoning: I" for ~1s while the model
  *  streams the rest of the sentence — the pass-through lets early
@@ -243,7 +243,7 @@ export default function SubagentCall({
 
   const displayedTickerLines = useThrottledValue(
     tickerLines,
-    TICKER_THROTTLE_MS,
+    SUBAGENT_TICKER_THROTTLE_MS,
     shouldThrottleTicker,
   );
 

--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/SubagentCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/SubagentCall.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { RecoilRoot, useRecoilCallback } from 'recoil';
-import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, act, fireEvent, waitFor, within } from '@testing-library/react';
 import type { SubagentUpdateEvent } from 'librechat-data-provider';
 import type {
   SubagentContentPart,
@@ -16,7 +16,7 @@ import {
   initSubagentTickerState,
 } from '~/utils/subagentContent';
 import { subagentProgressByToolCallId } from '~/store/subagents';
-import SubagentCall from '../SubagentCall';
+import SubagentCall, { SUBAGENT_TICKER_THROTTLE_MS } from '../SubagentCall';
 
 jest.mock('~/hooks', () => ({
   useLocalize:
@@ -83,18 +83,22 @@ jest.mock('../Attachment', () => ({
   ),
 }));
 
-jest.mock('@librechat/client', () => ({
-  OGDialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  OGDialogContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="dialog-content">{children}</div>
-  ),
-  OGDialogTitle: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="dialog-title">{children}</div>
-  ),
-  OGDialogDescription: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="dialog-description">{children}</div>
-  ),
-}));
+jest.mock(
+  '@librechat/client',
+  () => ({
+    OGDialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    OGDialogContent: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="dialog-content">{children}</div>
+    ),
+    OGDialogTitle: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="dialog-title">{children}</div>
+    ),
+    OGDialogDescription: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="dialog-description">{children}</div>
+    ),
+  }),
+  { virtual: true },
+);
 
 jest.mock('lucide-react', () => ({
   // eslint-disable-next-line i18next/no-literal-string
@@ -130,6 +134,10 @@ jest.mock('~/utils', () => ({
   ...jest.requireActual('~/utils/toolLabels'),
   cn: (...classes: unknown[]) => classes.filter(Boolean).join(' '),
 }));
+
+afterEach(() => {
+  jest.useRealTimers();
+});
 
 /** The dialog wraps single parts in `Container` and grouped tool_calls in
  *  `ToolCallGroup`. Stub both as transparent wrappers so the tests still
@@ -229,10 +237,13 @@ function renderWithState(args: {
       />
     </RecoilRoot>,
   );
-  act(() => {
-    setter.current?.(args.progress ?? null);
-  });
-  return rendered;
+  const setProgress = (next: SubagentProgress | null) => {
+    act(() => {
+      setter.current?.(next);
+    });
+  };
+  setProgress(args.progress ?? null);
+  return { ...rendered, setProgress };
 }
 
 describe('SubagentCall — status resolution', () => {
@@ -442,6 +453,52 @@ describe('SubagentCall — ticker', () => {
     );
     /** Only one "Writing:" label, not three — deltas collapse into one live line. */
     expect(screen.getAllByText('Writing:')).toHaveLength(1);
+  });
+
+  it('refreshes long live previews after the subagent ticker throttle window', () => {
+    jest.useFakeTimers();
+    const firstPreview = 'First live preview '.repeat(8).trim();
+    const secondPreview = 'Second live preview '.repeat(8).trim();
+    const eventForText = (text: string): SubagentUpdateEvent => ({
+      runId: 'p',
+      subagentRunId: 'run_a',
+      subagentType: 'self',
+      subagentAgentId: 'child',
+      phase: 'message_delta',
+      data: { delta: { content: [{ type: 'text', text }] } },
+      timestamp: '',
+    });
+    const progressForText = (text: string): SubagentProgress =>
+      progressFromEvents({
+        subagentRunId: 'run_a',
+        subagentType: 'self',
+        status: 'message_delta',
+        events: [eventForText(text)],
+      });
+
+    const { setProgress } = renderWithState({
+      toolCallId: 'call_throttled_writing',
+      initialProgress: 0.3,
+      isSubmitting: true,
+      progress: progressForText(firstPreview),
+    });
+    const ticker = within(screen.getByRole('button', { name: 'Running agent' }));
+
+    expect(ticker.getByText(firstPreview)).toBeInTheDocument();
+    setProgress(progressForText(secondPreview));
+    expect(ticker.getByText(firstPreview)).toBeInTheDocument();
+    expect(ticker.queryByText(secondPreview)).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(SUBAGENT_TICKER_THROTTLE_MS - 1);
+    });
+    expect(ticker.getByText(firstPreview)).toBeInTheDocument();
+    expect(ticker.queryByText(secondPreview)).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(ticker.getByText(secondPreview)).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

I sped up the collapsed subagent ticker refresh so long live previews update twice as fast while preserving the intentional throttle that prevents noisy per-token repainting.

- Reduced the subagent ticker trailing refresh window from 800ms to 400ms and exposed it as a named constant.
- Updated the throttle documentation to describe the current behavior without stale historical timing.
- Added fake-timer coverage that verifies long live previews remain throttled until the refresh window elapses.
- Made the component test's `@librechat/client` stub virtual so the test does not depend on a built package artifact when the module is fully mocked.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm ci` to install workspace dependencies in this clean worktree.
- Ran `npm run build:data-provider` so Jest could resolve the local `librechat-data-provider` workspace package.
- Ran `cd client && npx jest src/components/Chat/Messages/Content/Parts/__tests__/SubagentCall.test.tsx --runInBand`.
- Ran `npx eslint client/src/components/Chat/Messages/Content/Parts/SubagentCall.tsx client/src/components/Chat/Messages/Content/Parts/__tests__/SubagentCall.test.tsx`.
- Ran `git diff --check`.

### **Test Configuration**:

- Node.js: v20.19.5
- npm: 10.8.2

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes