### PR TITLE
🤝 fix: Honor OPENID_REUSE_TOKENS in Admin OAuth Exchange

### DIFF
--- a/api/server/controllers/auth/oauth.js
+++ b/api/server/controllers/auth/oauth.js
@@ -45,7 +45,9 @@ function createOAuthHandler(redirectUri = domains.client) {
 
         /** Get refresh token from tokenset for OpenID users */
         const refreshToken =
-          req.user.tokenset?.refresh_token || req.user.federatedTokens?.refresh_token;
+          req.user.provider === 'openid' && isEnabled(process.env.OPENID_REUSE_TOKENS) === true
+            ? req.user.tokenset?.refresh_token || req.user.federatedTokens?.refresh_token
+            : undefined;
         const expiresAt = Date.now() + sessionExpiry;
 
         const callbackUrl = new URL(redirectUri);

--- a/api/server/controllers/auth/oauth.spec.js
+++ b/api/server/controllers/auth/oauth.spec.js
@@ -1,0 +1,151 @@
+const mockIsEnabled = jest.fn();
+const mockGetAdminPanelUrl = jest.fn();
+const mockIsAdminPanelRedirect = jest.fn();
+const mockGenerateAdminExchangeCode = jest.fn();
+const mockSyncUserEntraGroupMemberships = jest.fn();
+const mockSetAuthTokens = jest.fn();
+const mockSetOpenIDAuthTokens = jest.fn();
+const mockGetLogStores = jest.fn();
+const mockCheckBan = jest.fn();
+const mockGenerateToken = jest.fn();
+const mockLogger = { info: jest.fn(), error: jest.fn() };
+
+jest.mock('librechat-data-provider', () => ({
+  CacheKeys: { ADMIN_OAUTH_EXCHANGE: 'admin-oauth-exchange' },
+}));
+
+jest.mock('@librechat/data-schemas', () => ({
+  logger: mockLogger,
+  DEFAULT_SESSION_EXPIRY: 60000,
+}));
+
+jest.mock('@librechat/api', () => ({
+  isEnabled: (...args) => mockIsEnabled(...args),
+  getAdminPanelUrl: (...args) => mockGetAdminPanelUrl(...args),
+  isAdminPanelRedirect: (...args) => mockIsAdminPanelRedirect(...args),
+  generateAdminExchangeCode: (...args) => mockGenerateAdminExchangeCode(...args),
+}));
+
+jest.mock('~/server/services/PermissionService', () => ({
+  syncUserEntraGroupMemberships: (...args) => mockSyncUserEntraGroupMemberships(...args),
+}));
+
+jest.mock('~/server/services/AuthService', () => ({
+  setAuthTokens: (...args) => mockSetAuthTokens(...args),
+  setOpenIDAuthTokens: (...args) => mockSetOpenIDAuthTokens(...args),
+}));
+
+jest.mock(
+  '~/cache/getLogStores',
+  () =>
+    (...args) =>
+      mockGetLogStores(...args),
+);
+
+jest.mock('~/server/middleware', () => ({
+  checkBan: (...args) => mockCheckBan(...args),
+}));
+
+jest.mock('~/models', () => ({
+  generateToken: (...args) => mockGenerateToken(...args),
+}));
+
+const { createOAuthHandler } = require('./oauth');
+
+const ORIGINAL_ENV = process.env;
+
+function buildReq(overrides = {}) {
+  return {
+    user: {
+      _id: 'user-123',
+      email: 'admin@example.com',
+      provider: 'openid',
+      tokenset: { refresh_token: 'openid-refresh-token', access_token: 'openid-access-token' },
+      federatedTokens: { refresh_token: 'federated-refresh-token' },
+    },
+    pkceChallenge: 'pkce-challenge',
+    banned: false,
+    ...overrides,
+  };
+}
+
+function buildRes() {
+  return {
+    headersSent: false,
+    redirect: jest.fn(),
+  };
+}
+
+describe('createOAuthHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...ORIGINAL_ENV,
+      DOMAIN_CLIENT: 'http://localhost:3080',
+      DOMAIN_SERVER: 'http://localhost:3080',
+      OPENID_REUSE_TOKENS: 'false',
+    };
+    mockIsEnabled.mockImplementation((value) => value === 'true' || value === true);
+    mockGetAdminPanelUrl.mockReturnValue('http://admin.example.com');
+    mockIsAdminPanelRedirect.mockReturnValue(true);
+    mockGetLogStores.mockReturnValue({});
+    mockCheckBan.mockResolvedValue(undefined);
+    mockGenerateToken.mockResolvedValue('jwt-token');
+    mockGenerateAdminExchangeCode.mockResolvedValue('exchange-code');
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('omits refresh token from admin exchange when OPENID_REUSE_TOKENS is disabled', async () => {
+    const handler = createOAuthHandler('http://admin.example.com/auth/openid/callback');
+    const req = buildReq();
+    const res = buildRes();
+    const next = jest.fn();
+
+    await handler(req, res, next);
+
+    expect(mockGenerateAdminExchangeCode).toHaveBeenCalledWith(
+      {},
+      req.user,
+      'jwt-token',
+      undefined,
+      'http://admin.example.com',
+      'pkce-challenge',
+      expect.any(Number),
+    );
+    expect(res.redirect).toHaveBeenCalledWith(
+      'http://admin.example.com/auth/openid/callback?code=exchange-code',
+    );
+    expect(mockSetOpenIDAuthTokens).not.toHaveBeenCalled();
+    expect(mockSetAuthTokens).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('includes refresh token in admin exchange when OPENID_REUSE_TOKENS is enabled', async () => {
+    process.env.OPENID_REUSE_TOKENS = 'true';
+    const handler = createOAuthHandler('http://admin.example.com/auth/openid/callback');
+    const req = buildReq();
+    const res = buildRes();
+    const next = jest.fn();
+
+    await handler(req, res, next);
+
+    expect(mockGenerateAdminExchangeCode).toHaveBeenCalledWith(
+      {},
+      req.user,
+      'jwt-token',
+      'openid-refresh-token',
+      'http://admin.example.com',
+      'pkce-challenge',
+      expect.any(Number),
+    );
+    expect(res.redirect).toHaveBeenCalledWith(
+      'http://admin.example.com/auth/openid/callback?code=exchange-code',
+    );
+    expect(mockSetOpenIDAuthTokens).not.toHaveBeenCalled();
+    expect(mockSetAuthTokens).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #13033  — honor `OPENID_REUSE_TOKENS` in the **admin OAuth exchange** path.

The `/api/admin/oauth/refresh` endpoint already enforces this flag (returns `403 TOKEN_REUSE_DISABLED` when disabled, added in #13007). However, the upstream `/api/admin/oauth/exchange` path in `api/server/controllers/auth/oauth.js` unconditionally extracted and forwarded the IdP `refreshToken` into the exchange payload, regardless of the `OPENID_REUSE_TOKENS` setting. This left a sensitive IdP refresh token stored in the admin-panel BFF session even when the operator had explicitly disabled token reuse — a policy inconsistency and unnecessary token exposure.

**Fix:** gate the `refreshToken` extraction in the admin-panel redirect branch on `req.user.provider === 'openid' && isEnabled(process.env.OPENID_REUSE_TOKENS) === true`, mirroring the logic already applied in the standard (non-admin) OAuth path and the refresh endpoint.

```diff
- const refreshToken =
-   req.user.tokenset?.refresh_token || req.user.federatedTokens?.refresh_token;
+ const refreshToken =
+   req.user.provider === 'openid' && isEnabled(process.env.OPENID_REUSE_TOKENS) === true
+     ? req.user.tokenset?.refresh_token || req.user.federatedTokens?.refresh_token
+     : undefined;
```

**Changed files:**

| File | Change |
|------|--------|
| `api/server/controllers/auth/oauth.js` | Gate refresh-token extraction on `OPENID_REUSE_TOKENS` flag |
| `api/server/controllers/auth/oauth.spec.js` | New — unit tests for both enabled/disabled branches |

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Test Configuration

| Variable | Value |
|----------|-------|
| `OPENID_REUSE_TOKENS` | `false` (disabled branch), `true` (enabled branch) |
| Node.js | v20.20.2 |

### New Unit Tests

`api/server/controllers/auth/oauth.spec.js` — added two focused unit tests for the admin-panel redirect path:

1. **`OPENID_REUSE_TOKENS` disabled** — asserts that `generateAdminExchangeCode` receives `undefined` as the refresh-token argument, so the exchange payload never contains an IdP token.
2. **`OPENID_REUSE_TOKENS` enabled** — asserts that `generateAdminExchangeCode` receives the OpenID `refresh_token`, preserving the existing enabled-path behavior.

Run the new controller tests:

```bash
npm --prefix api run test:ci -- \
  --runTestsByPath api/server/controllers/auth/oauth.spec.js
```

Result:

```
PASS server/controllers/auth/oauth.spec.js
  createOAuthHandler
    ✓ omits refresh token from admin exchange when OPENID_REUSE_TOKENS is disabled (3 ms)
    ✓ includes refresh token in admin exchange when OPENID_REUSE_TOKENS is enabled (1 ms)

Tests: 2 passed, 2 total
```

Run together with the related admin refresh regression suite:

```bash
npm --prefix api run test:ci -- \
  --runTestsByPath api/server/controllers/auth/oauth.spec.js \
                  api/server/routes/admin/auth.refresh.test.js
```


Result:

```
PASS server/controllers/auth/oauth.spec.js
PASS server/routes/admin/auth.refresh.test.js

Test Suites: 2 passed, 2 total
Tests:       8 passed, 8 total
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
