### PR TITLE
feat: route relative markdown links in Skills UI to the skill file viewer

### DIFF
--- a/client/src/components/Skills/display/SkillDetail.tsx
+++ b/client/src/components/Skills/display/SkillDetail.tsx
@@ -180,7 +180,11 @@ export default function SkillDetail({ skill, onEdit, onDelete }: SkillDetailProp
       {/* Content — fills remaining space, no card wrapper */}
       <div className="min-h-0 flex-1 overflow-auto">
         {viewMode === 'rendered' ? (
-          <SkillMarkdownRenderer content={cleanBody} />
+          <SkillMarkdownRenderer
+            content={cleanBody}
+            skillId={skill._id}
+            currentFilePath="SKILL.md"
+          />
         ) : (
           <pre className="whitespace-pre-wrap font-mono text-sm leading-relaxed text-text-primary">
             {skill.body ?? ''}

--- a/client/src/components/Skills/display/SkillFileViewer.tsx
+++ b/client/src/components/Skills/display/SkillFileViewer.tsx
@@ -186,7 +186,11 @@ function SkillFileViewer({ skillId, relativePath }: SkillFileViewerProps) {
                   </div>
                 )}
                 {viewMode === 'rendered' ? (
-                  <SkillMarkdownRenderer content={parsed.body} />
+                  <SkillMarkdownRenderer
+                    content={parsed.body}
+                    skillId={skillId}
+                    currentFilePath={relativePath}
+                  />
                 ) : (
                   <pre className="whitespace-pre-wrap font-mono text-sm leading-relaxed text-text-primary">
                     {data.content}

--- a/client/src/components/Skills/display/SkillMarkdownRenderer.tsx
+++ b/client/src/components/Skills/display/SkillMarkdownRenderer.tsx
@@ -1,12 +1,15 @@
-import { memo } from 'react';
+import { memo, useMemo, useCallback } from 'react';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import supersub from 'remark-supersub';
 import ReactMarkdown from 'react-markdown';
+import { useNavigate } from 'react-router-dom';
 import rehypeHighlight from 'rehype-highlight';
+import type { MouseEvent, AnchorHTMLAttributes } from 'react';
 import type { PluggableList } from 'unified';
 import { codeNoExecution } from '~/components/Chat/Messages/Content/MarkdownComponents';
+import { isExternalSkillLink, splitHrefHash, resolveSkillRelativePath } from '../utils';
 import { langSubset } from '~/utils';
 
 const REMARK_PLUGINS: PluggableList = [
@@ -27,21 +30,75 @@ const REHYPE_PLUGINS: PluggableList = [
   ],
 ];
 
-const MARKDOWN_COMPONENTS = { code: codeNoExecution };
-
 interface SkillMarkdownRendererProps {
   content: string;
   className?: string;
+  skillId?: string;
+  currentFilePath?: string;
 }
 
-function SkillMarkdownRenderer({ content, className }: SkillMarkdownRendererProps) {
+function SkillMarkdownRenderer({
+  content,
+  className,
+  skillId,
+  currentFilePath,
+}: SkillMarkdownRendererProps) {
+  const navigate = useNavigate();
+
+  const handleSkillLinkClick = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>, target: string) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      event.preventDefault();
+      navigate(target);
+    },
+    [navigate],
+  );
+
+  const components = useMemo(() => {
+    const SkillLink = ({ href, children, ...rest }: AnchorHTMLAttributes<HTMLAnchorElement>) => {
+      if (!skillId || !href || isExternalSkillLink(href)) {
+        return (
+          <a href={href} {...rest}>
+            {children}
+          </a>
+        );
+      }
+      const { path, hash } = splitHrefHash(href);
+      const resolved = resolveSkillRelativePath(path, currentFilePath);
+      if (!resolved) {
+        return (
+          <a href={href} {...rest}>
+            {children}
+          </a>
+        );
+      }
+      const target = `/skills/${skillId}?file=${encodeURIComponent(resolved)}${hash}`;
+      return (
+        <a href={target} onClick={(event) => handleSkillLinkClick(event, target)} {...rest}>
+          {children}
+        </a>
+      );
+    };
+
+    return { code: codeNoExecution, a: SkillLink };
+  }, [skillId, currentFilePath, handleSkillLinkClick]);
+
   return (
     <ReactMarkdown
       /** @ts-ignore - PluggableList vs Pluggable[] shape drift */
       remarkPlugins={REMARK_PLUGINS}
       /** @ts-ignore - PluggableList vs Pluggable[] shape drift */
       rehypePlugins={REHYPE_PLUGINS}
-      components={MARKDOWN_COMPONENTS as unknown as Record<string, React.ElementType>}
+      components={components as unknown as Record<string, React.ElementType>}
       className={
         className ??
         'markdown prose dark:prose-invert light w-full break-words leading-[1.65rem] text-text-primary'

--- a/client/src/components/Skills/utils/__tests__/skillLinks.test.ts
+++ b/client/src/components/Skills/utils/__tests__/skillLinks.test.ts
@@ -1,0 +1,86 @@
+import { isExternalSkillLink, splitHrefHash, resolveSkillRelativePath } from '../skillLinks';
+
+describe('isExternalSkillLink', () => {
+  it('treats empty hrefs as external', () => {
+    expect(isExternalSkillLink('')).toBe(true);
+  });
+
+  it.each([
+    ['http://example.com'],
+    ['https://example.com/path'],
+    ['mailto:user@example.com'],
+    ['tel:+12025550100'],
+    ['//cdn.example.com/script.js'],
+    ['/skills/abc'],
+    ['#anchor'],
+  ])('flags %s as external', (href) => {
+    expect(isExternalSkillLink(href)).toBe(true);
+  });
+
+  it.each([
+    ['references/notes.md'],
+    ['./sibling.md'],
+    ['../other/file.md'],
+    ['nested/deep/page.md'],
+  ])('treats %s as internal', (href) => {
+    expect(isExternalSkillLink(href)).toBe(false);
+  });
+});
+
+describe('splitHrefHash', () => {
+  it('returns the full href and empty hash when no fragment is present', () => {
+    expect(splitHrefHash('references/notes.md')).toEqual({
+      path: 'references/notes.md',
+      hash: '',
+    });
+  });
+
+  it('splits a hash fragment from the path', () => {
+    expect(splitHrefHash('references/notes.md#section')).toEqual({
+      path: 'references/notes.md',
+      hash: '#section',
+    });
+  });
+
+  it('handles a hash-only href by leaving the path empty', () => {
+    expect(splitHrefHash('#top')).toEqual({ path: '', hash: '#top' });
+  });
+});
+
+describe('resolveSkillRelativePath', () => {
+  it('resolves from the skill root when no current file is given', () => {
+    expect(resolveSkillRelativePath('references/notes.md')).toBe('references/notes.md');
+  });
+
+  it('resolves a sibling relative to the current file directory', () => {
+    expect(resolveSkillRelativePath('sibling.md', 'references/source-selection.md')).toBe(
+      'references/sibling.md',
+    );
+  });
+
+  it('treats `./foo` the same as `foo`', () => {
+    expect(resolveSkillRelativePath('./sibling.md', 'references/source.md')).toBe(
+      'references/sibling.md',
+    );
+  });
+
+  it('walks up the tree with `..`', () => {
+    expect(resolveSkillRelativePath('../other.md', 'references/source.md')).toBe('other.md');
+  });
+
+  it('cannot escape the skill root with extra `..` segments', () => {
+    expect(resolveSkillRelativePath('../../../escaped.md', 'references/source.md')).toBe(
+      'escaped.md',
+    );
+  });
+
+  it('drops empty segments produced by adjacent separators', () => {
+    expect(resolveSkillRelativePath('references//notes.md')).toBe('references/notes.md');
+  });
+
+  it('resolves relative to SKILL.md at the bundle root', () => {
+    expect(resolveSkillRelativePath('references/source-selection.md', 'SKILL.md')).toBe(
+      'references/source-selection.md',
+    );
+  });
+});

--- a/client/src/components/Skills/utils/index.ts
+++ b/client/src/components/Skills/utils/index.ts
@@ -1,4 +1,5 @@
 export { parseFrontmatter } from './frontmatter';
 export { parseSkillMd } from './parseSkillMd';
+export { isExternalSkillLink, splitHrefHash, resolveSkillRelativePath } from './skillLinks';
 export type { FrontmatterField, ParsedFrontmatter } from './frontmatter';
 export type { ParsedSkillMd } from './parseSkillMd';

--- a/client/src/components/Skills/utils/skillLinks.ts
+++ b/client/src/components/Skills/utils/skillLinks.ts
@@ -1,0 +1,58 @@
+/**
+ * Identify links that should never be rewritten to a skill file route:
+ * external URLs, absolute app paths, in-page anchors, mailto/tel,
+ * and protocol-relative URLs.
+ */
+export function isExternalSkillLink(href: string): boolean {
+  if (!href) {
+    return true;
+  }
+  if (href.startsWith('#') || href.startsWith('/')) {
+    return true;
+  }
+  if (href.startsWith('//')) {
+    return true;
+  }
+  return /^[a-z][a-z0-9+.-]*:/i.test(href);
+}
+
+interface SplitHref {
+  path: string;
+  hash: string;
+}
+
+/**
+ * Split `path#hash` (used to preserve in-file anchors when rewriting the link).
+ */
+export function splitHrefHash(href: string): SplitHref {
+  const hashIdx = href.indexOf('#');
+  if (hashIdx === -1) {
+    return { path: href, hash: '' };
+  }
+  return { path: href.slice(0, hashIdx), hash: href.slice(hashIdx) };
+}
+
+/**
+ * Resolve a relative href from inside a skill markdown file to an absolute
+ * path inside the skill bundle (no leading slash, POSIX separators).
+ *
+ * `currentFilePath` is the skill-relative path of the file containing the
+ * link (e.g. `SKILL.md` or `references/notes.md`). When omitted, the link
+ * is resolved from the skill root.
+ */
+export function resolveSkillRelativePath(href: string, currentFilePath?: string): string {
+  const baseDir = currentFilePath ? currentFilePath.split('/').slice(0, -1) : [];
+  const segments = href.split('/');
+  const resolved: string[] = [...baseDir];
+  for (const segment of segments) {
+    if (segment === '' || segment === '.') {
+      continue;
+    }
+    if (segment === '..') {
+      resolved.pop();
+      continue;
+    }
+    resolved.push(segment);
+  }
+  return resolved.join('/');
+}


### PR DESCRIPTION
## Problem

Closes #13138.

Skill markdown bodies often contain relative links to other files inside the
same skill bundle, for example:

```md
[source selection](references/source-selection.md)
```

When clicked in the Skills UI, the browser navigates to
`/references/source-selection.md`. That route does not exist in the SPA, so
the user lands on the React Router error page:

```
No route matches URL "/references/source-selection.md"
```

The Skills route already supports file viewing via
`/skills/:skillId?file=<relative-path>`, but `SkillMarkdownRenderer` only
registered a custom `code` component, leaving anchor tags to fall through to
default behavior.

## Solution

- Add a small utility module (`skillLinks.ts`) that classifies hrefs
  (external / absolute / hash / relative), splits the trailing hash
  fragment, and resolves a relative href against the current file's
  directory inside the skill bundle. `..` segments are clamped at the skill
  root so a link cannot escape the bundle.
- Teach `SkillMarkdownRenderer` to render an `a` component that intercepts
  same-bundle relative links. The link's `href` is rewritten to
  `/skills/${skillId}?file=${encodeURIComponent(resolved)}${hash}` (so
  middle-click / open-in-new-tab continue to work) and the click handler
  uses `react-router-dom`'s `useNavigate` for plain left-clicks, while
  modifier-click / non-primary buttons keep their browser-native behavior.
- External URLs (`http`, `https`, `mailto:`, `tel:`, protocol-relative
  `//`, absolute paths starting with `/`, and pure `#anchor` links) are
  left untouched.
- Both call sites are updated to pass context: `SkillDetail` passes
  `skillId` with `currentFilePath="SKILL.md"`, and `SkillFileViewer`
  forwards its own `skillId` and `relativePath`. When `skillId` is not
  available the renderer falls back to plain anchors, preserving existing
  behavior.

## Testing

- Added `skillLinks.test.ts` (22 cases) covering external/internal
  classification, hash splitting, and path resolution (siblings, `./`,
  `..`, root clamping, double slashes, `SKILL.md` root).
- `cd client && npx jest src/components/Skills/utils/__tests__/skillLinks.test.ts`
  → 22/22 pass.
- `cd client && npx tsc --noEmit -p tsconfig.json` reports no new errors
  in the Skills `display/` or `utils/` directories.
- `npx eslint` clean on all five touched files.

### Manual reproduction

1. Open a skill whose `SKILL.md` or a reference file contains a relative
   link such as `[source selection](references/source-selection.md)`.
2. Before: clicking the link navigates to `/references/source-selection.md`
   and shows the route error page.
3. After: clicking opens the file in `SkillFileViewer` via
   `/skills/<id>?file=references%2Fsource-selection.md`.