### PR TITLE
📝 refactor: Preserve Agent Builder Drafts

### DIFF
--- a/client/src/components/SidePanel/Agents/AgentFooter.tsx
+++ b/client/src/components/SidePanel/Agents/AgentFooter.tsx
@@ -25,12 +25,14 @@ export default function AgentFooter({
   updateMutation,
   setActivePanel,
   setCurrentAgentId,
+  onDraftClear,
   isAvatarUploading = false,
 }: Pick<
   AgentPanelProps,
   'setCurrentAgentId' | 'createMutation' | 'activePanel' | 'setActivePanel'
 > & {
   updateMutation: ReturnType<typeof useUpdateAgentMutation>;
+  onDraftClear?: (agentId: string) => void;
   isAvatarUploading?: boolean;
 }) {
   const localize = useLocalize();
@@ -88,6 +90,7 @@ export default function AgentFooter({
               agent_id={agent_id}
               setCurrentAgentId={setCurrentAgentId}
               createMutation={createMutation}
+              onDraftClear={onDraftClear}
             />
           )}
         {(agent?.author === user?.id || user?.role === SystemRoles.ADMIN || canShareThisAgent) &&

--- a/client/src/components/SidePanel/Agents/AgentPanel.test.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.test.tsx
@@ -10,6 +10,7 @@ import type { AgentForm } from '~/common';
 
 // Mock toast context - define this after all mocks
 let mockShowToast: jest.Mock;
+const MOCK_USER_ID = 'user-123';
 
 // Mock notification severity enum before other imports
 jest.mock('~/common/types', () => ({
@@ -99,7 +100,7 @@ jest.mock('~/utils', () => ({
 jest.mock('~/hooks', () => ({
   useSelectAgent: () => ({ onSelect: jest.fn() }),
   useLocalize: () => (key: string) => key,
-  useAuthContext: () => ({ user: { id: 'user-123', role: 'USER' } }),
+  useAuthContext: () => ({ user: { id: MOCK_USER_ID, role: 'USER' } }),
 }));
 
 jest.mock('~/hooks/useResourcePermissions', () => ({
@@ -414,26 +415,30 @@ describe('AgentPanel - Update Agent Toast Messages', () => {
       });
       mockUpdateAgent.mockResolvedValue(createMockAgent({ name: 'Test Agent', version: 2 }));
 
-      saveAgentDraft('agent-123', {
-        id: 'agent-123',
-        name: 'Unsaved Agent',
-        description: '',
-        instructions: 'Unsaved instructions',
-        model: 'gpt-4',
-        model_parameters: {},
-        provider: 'openai',
-        category: 'general',
-        execute_code: false,
-        file_search: false,
-        web_search: false,
-      } as AgentForm);
+      saveAgentDraft(
+        'agent-123',
+        {
+          id: 'agent-123',
+          name: 'Unsaved Agent',
+          description: '',
+          instructions: 'Unsaved instructions',
+          model: 'gpt-4',
+          model_parameters: {},
+          provider: 'openai',
+          category: 'general',
+          execute_code: false,
+          file_search: false,
+          web_search: false,
+        } as AgentForm,
+        MOCK_USER_ID,
+      );
 
-      expect(getAgentDraft('agent-123')).toBeDefined();
+      expect(getAgentDraft('agent-123', MOCK_USER_ID)).toBeDefined();
 
       await renderAndSubmitForm();
 
       await waitFor(() => {
-        expect(getAgentDraft('agent-123')).toBeUndefined();
+        expect(getAgentDraft('agent-123', MOCK_USER_ID)).toBeUndefined();
       });
     });
   });

--- a/client/src/components/SidePanel/Agents/AgentPanel.test.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.test.tsx
@@ -6,6 +6,7 @@ import { render, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Agent } from 'librechat-data-provider';
+import type { AgentForm } from '~/common';
 
 // Mock toast context - define this after all mocks
 let mockShowToast: jest.Mock;
@@ -206,6 +207,7 @@ jest.mock('react-hook-form', () => {
 import { dataService } from 'librechat-data-provider';
 import { useGetAgentByIdQuery } from '~/data-provider';
 import AgentPanel from './AgentPanel';
+import { clearAllAgentDrafts, getAgentDraft, saveAgentDraft } from './drafts';
 
 // Mock useGetAgentByIdQuery
 jest.mock('~/data-provider', () => {
@@ -288,6 +290,7 @@ const renderAndSubmitForm = async () => {
 describe('AgentPanel - Update Agent Toast Messages', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    clearAllAgentDrafts();
     mockShowToast = jest.fn();
     mockFormSubmitHandler = null;
   });
@@ -399,6 +402,38 @@ describe('AgentPanel - Update Agent Toast Messages', () => {
           message: 'com_agents_update_error com_ui_error: Update failed',
           status: 'error',
         });
+      });
+    });
+
+    it('should clear the draft after a successful update', async () => {
+      const { mockUseGetAgentByIdQuery, mockUpdateAgent } = setupMocks();
+
+      mockAgentQuery(mockUseGetAgentByIdQuery, {
+        name: 'Test Agent',
+        version: 1,
+      });
+      mockUpdateAgent.mockResolvedValue(createMockAgent({ name: 'Test Agent', version: 2 }));
+
+      saveAgentDraft('agent-123', {
+        id: 'agent-123',
+        name: 'Unsaved Agent',
+        description: '',
+        instructions: 'Unsaved instructions',
+        model: 'gpt-4',
+        model_parameters: {},
+        provider: 'openai',
+        category: 'general',
+        execute_code: false,
+        file_search: false,
+        web_search: false,
+      } as AgentForm);
+
+      expect(getAgentDraft('agent-123')).toBeDefined();
+
+      await renderAndSubmitForm();
+
+      await waitFor(() => {
+        expect(getAgentDraft('agent-123')).toBeUndefined();
       });
     });
   });

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useEffect, useCallback, useRef, useState } from 'react';
 import { Plus } from 'lucide-react';
+import debounce from 'lodash/debounce';
 import { Button, useToastContext } from '@librechat/client';
 import { useWatch, useForm, FormProvider } from 'react-hook-form';
 import { useGetModelsQuery } from 'librechat-data-provider/react-query';
@@ -26,6 +27,7 @@ import { createProviderOption, getDefaultAgentFormValues } from '~/utils';
 import { useResourcePermissions } from '~/hooks/useResourcePermissions';
 import { useSelectAgent, useLocalize, useAuthContext } from '~/hooks';
 import { useAgentPanelContext } from '~/Providers/AgentPanelContext';
+import { clearAgentDrafts, getAgentDraft, saveAgentDraft } from './drafts';
 import AgentPanelSkeleton from './AgentPanelSkeleton';
 import AdvancedPanel from './Advanced/AdvancedPanel';
 import { Panel, isEphemeralAgent } from '~/common';
@@ -33,7 +35,6 @@ import AgentConfig from './AgentConfig';
 import AgentSelect from './AgentSelect';
 import AgentFooter from './AgentFooter';
 import ModelPanel from './ModelPanel';
-import { clearAgentDrafts, getAgentDraft, saveAgentDraft } from './drafts';
 
 /* Helpers */
 function getUpdateToastMessage(
@@ -229,10 +230,11 @@ const isPersistableDraftField = (name?: string): boolean => {
   );
 };
 
-const getDraftFormValues = (draftValues?: Partial<AgentForm>): AgentForm => ({
-  ...getDefaultAgentFormValues(),
-  ...draftValues,
-});
+const getDraftFormValues = (draftValues?: Partial<AgentForm>): AgentForm =>
+  ({
+    ...getDefaultAgentFormValues(),
+    ...draftValues,
+  }) as AgentForm;
 
 export default function AgentPanel() {
   const localize = useLocalize();
@@ -291,7 +293,9 @@ export default function AgentPanel() {
   const draftUserIdRef = useRef<string | undefined>(draftUserId);
   const [hasDraft, setHasDraft] = useState(draftValues != null);
   const shouldPersistDraftRef = useRef(hasDraft);
+  const dirtyFieldsRef = useRef(dirtyFields);
   const [isAvatarUploadInFlight, setIsAvatarUploadInFlight] = useState(false);
+  dirtyFieldsRef.current = dirtyFields;
 
   const persistAgentDraft = useCallback((agentId: string | undefined, values: AgentForm) => {
     saveAgentDraft(agentId, values, draftUserIdRef.current);
@@ -300,11 +304,20 @@ export default function AgentPanel() {
     }
   }, []);
 
-  const clearDraftsForAgentIds = useCallback((agentIds: Array<string | null | undefined>) => {
-    shouldPersistDraftRef.current = false;
-    clearAgentDrafts(agentIds, draftUserIdRef.current);
-    setHasDraft(getAgentDraft(currentAgentIdRef.current, draftUserIdRef.current) != null);
-  }, []);
+  const debouncedPersistAgentDraft = useMemo(
+    () => debounce(persistAgentDraft, 250),
+    [persistAgentDraft],
+  );
+
+  const clearDraftsForAgentIds = useCallback(
+    (agentIds: Array<string | null | undefined>) => {
+      shouldPersistDraftRef.current = false;
+      debouncedPersistAgentDraft.cancel();
+      clearAgentDrafts(agentIds, draftUserIdRef.current);
+      setHasDraft(getAgentDraft(currentAgentIdRef.current, draftUserIdRef.current) != null);
+    },
+    [debouncedPersistAgentDraft],
+  );
 
   const handleAgentChange = useCallback(
     (selectedAgentId?: string | null) => {
@@ -319,9 +332,18 @@ export default function AgentPanel() {
     setCurrentAgentId(undefined);
   }, [clearDraftsForAgentIds, reset, setCurrentAgentId]);
 
-  const shouldPersistDraft = hasPersistableDirtyFields(dirtyFields);
-  const shouldPersistAvatarResetDraft =
-    dirtyFields?.avatar_action === true && getValues('avatar_action') === 'reset';
+  const handleDeleteDraftClear = useCallback(
+    (agentId: string) => {
+      clearDraftsForAgentIds([agentId]);
+    },
+    [clearDraftsForAgentIds],
+  );
+
+  const shouldPersistDraft = useMemo(() => hasPersistableDirtyFields(dirtyFields), [dirtyFields]);
+  const shouldPersistAvatarResetDraft = useMemo(
+    () => dirtyFields?.avatar_action === true && getValues('avatar_action') === 'reset',
+    [dirtyFields?.avatar_action, getValues],
+  );
 
   const isDirtyPersistableDraftField = useCallback(
     (name?: string): boolean => {
@@ -350,7 +372,11 @@ export default function AgentPanel() {
       return;
     }
 
-    if (agentChanged && shouldPersistDraftRef.current) {
+    if ((agentChanged || userChanged) && shouldPersistDraftRef.current) {
+      debouncedPersistAgentDraft.cancel();
+    }
+
+    if (agentChanged && !userChanged && shouldPersistDraftRef.current) {
       saveAgentDraft(currentAgentIdRef.current, getValues(), draftUserIdRef.current);
     }
 
@@ -368,7 +394,7 @@ export default function AgentPanel() {
     if (userChanged) {
       reset(getDefaultAgentFormValues());
     }
-  }, [current_agent_id, draftUserId, getValues, reset]);
+  }, [current_agent_id, debouncedPersistAgentDraft, draftUserId, getValues, reset]);
 
   useEffect(() => {
     if (hasDraft) {
@@ -382,8 +408,8 @@ export default function AgentPanel() {
     }
 
     shouldPersistDraftRef.current = true;
-    persistAgentDraft(currentAgentIdRef.current, getValues());
-  }, [getValues, persistAgentDraft, shouldPersistAvatarResetDraft, shouldPersistDraft]);
+    setHasDraft(true);
+  }, [shouldPersistAvatarResetDraft, shouldPersistDraft]);
 
   useEffect(() => {
     const subscription = watch((_, { name }) => {
@@ -392,16 +418,18 @@ export default function AgentPanel() {
       }
 
       shouldPersistDraftRef.current = true;
-      persistAgentDraft(currentAgentIdRef.current, getValues());
+      setHasDraft(true);
+      debouncedPersistAgentDraft(currentAgentIdRef.current, getValues());
     });
 
     return () => {
+      debouncedPersistAgentDraft.cancel();
       if (shouldPersistDraftRef.current) {
         saveAgentDraft(currentAgentIdRef.current, getValues(), draftUserIdRef.current);
       }
       subscription.unsubscribe();
     };
-  }, [getValues, isDirtyPersistableDraftField, persistAgentDraft, watch]);
+  }, [debouncedPersistAgentDraft, getValues, isDirtyPersistableDraftField, watch]);
 
   const uploadAvatarMutation = useUploadAgentAvatarMutation({
     onSuccess: (updatedAgent) => {
@@ -527,7 +555,6 @@ export default function AgentPanel() {
 
   const create = useCreateAgentMutation({
     onSuccess: async (data) => {
-      setCurrentAgentId(data.id);
       showToast({
         message: `${localize('com_assistants_create_success')} ${
           data.name ?? localize('com_ui_agent')
@@ -549,6 +576,7 @@ export default function AgentPanel() {
         ...getValues(),
         id: data.id ?? getValues('id'),
       });
+      setCurrentAgentId(data.id);
     },
     onError: (err) => {
       const error = err as Error;
@@ -578,7 +606,7 @@ export default function AgentPanel() {
       const { payload: basePayload, provider, model } = composeAgentUpdatePayload(data, agent_id);
 
       if (agent_id) {
-        if (data.avatar_action === 'upload' && isAvatarUploadOnlyDirty(dirtyFields)) {
+        if (data.avatar_action === 'upload' && isAvatarUploadOnlyDirty(dirtyFieldsRef.current)) {
           try {
             const uploaded = await handleAvatarUpload(agent_id);
             if (!uploaded) {
@@ -622,7 +650,6 @@ export default function AgentPanel() {
     [
       agent_id,
       create,
-      dirtyFields,
       reset,
       getValues,
       current_agent_id,
@@ -727,6 +754,7 @@ export default function AgentPanel() {
             activePanel={activePanel}
             setActivePanel={setActivePanel}
             setCurrentAgentId={setCurrentAgentId}
+            onDraftClear={handleDeleteDraftClear}
           />
         )}
       </form>

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -262,7 +262,6 @@ export default function AgentPanel() {
 
   const models = useMemo(() => modelsQuery.data ?? {}, [modelsQuery.data]);
   const draftValues = useMemo(() => getAgentDraft(current_agent_id), [current_agent_id]);
-  const hasDraft = draftValues != null;
   const defaultValues = useMemo(
     () => ({
       ...getDefaultAgentFormValues(),
@@ -285,12 +284,21 @@ export default function AgentPanel() {
     formState: { dirtyFields },
   } = methods;
   const currentAgentIdRef = useRef<string | undefined>(current_agent_id);
+  const [hasDraft, setHasDraft] = useState(draftValues != null);
   const shouldPersistDraftRef = useRef(hasDraft);
   const [isAvatarUploadInFlight, setIsAvatarUploadInFlight] = useState(false);
+
+  const persistAgentDraft = useCallback((agentId: string | undefined, values: AgentForm) => {
+    saveAgentDraft(agentId, values);
+    if (agentId === currentAgentIdRef.current) {
+      setHasDraft(true);
+    }
+  }, []);
 
   const clearDraftsForAgentIds = useCallback((agentIds: Array<string | null | undefined>) => {
     shouldPersistDraftRef.current = false;
     clearAgentDrafts(agentIds);
+    setHasDraft(getAgentDraft(currentAgentIdRef.current) != null);
   }, []);
 
   const handleAgentChange = useCallback(
@@ -318,6 +326,9 @@ export default function AgentPanel() {
     }
 
     currentAgentIdRef.current = current_agent_id;
+    const nextHasDraft = getAgentDraft(current_agent_id) != null;
+    shouldPersistDraftRef.current = nextHasDraft;
+    setHasDraft(nextHasDraft);
   }, [current_agent_id, getValues]);
 
   useEffect(() => {
@@ -332,8 +343,8 @@ export default function AgentPanel() {
     }
 
     shouldPersistDraftRef.current = true;
-    saveAgentDraft(currentAgentIdRef.current, getValues());
-  }, [getValues, shouldPersistDraft]);
+    persistAgentDraft(currentAgentIdRef.current, getValues());
+  }, [getValues, persistAgentDraft, shouldPersistDraft]);
 
   useEffect(() => {
     const subscription = watch((_, { name }) => {
@@ -342,7 +353,7 @@ export default function AgentPanel() {
       }
 
       shouldPersistDraftRef.current = true;
-      saveAgentDraft(currentAgentIdRef.current, getValues());
+      persistAgentDraft(currentAgentIdRef.current, getValues());
     });
 
     return () => {
@@ -351,7 +362,7 @@ export default function AgentPanel() {
       }
       subscription.unsubscribe();
     };
-  }, [getValues, watch]);
+  }, [getValues, persistAgentDraft, watch]);
 
   const uploadAvatarMutation = useUploadAgentAvatarMutation({
     onSuccess: (updatedAgent) => {

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useRef, useState } from 'react';
+import React, { useMemo, useEffect, useCallback, useRef, useState } from 'react';
 import { Plus } from 'lucide-react';
 import { Button, useToastContext } from '@librechat/client';
 import { useWatch, useForm, FormProvider } from 'react-hook-form';
@@ -33,6 +33,7 @@ import AgentConfig from './AgentConfig';
 import AgentSelect from './AgentSelect';
 import AgentFooter from './AgentFooter';
 import ModelPanel from './ModelPanel';
+import { clearAgentDrafts, getAgentDraft, saveAgentDraft } from './drafts';
 
 /* Helpers */
 function getUpdateToastMessage(
@@ -212,6 +213,22 @@ export const isAvatarUploadOnlyDirty = (
   return result.sawDirty && result.onlyAvatarDirty;
 };
 
+const hasPersistableDirtyFields = (dirtyFields?: FieldNamesMarkedBoolean<AgentForm>): boolean => {
+  if (!dirtyFields) {
+    return false;
+  }
+
+  const result = evaluateDirtyFields(dirtyFields);
+  return result.sawDirty && !result.onlyAvatarDirty;
+};
+
+const isPersistableDraftField = (name?: string): boolean => {
+  const [fieldName] = name?.split('.') ?? [];
+  return Boolean(
+    fieldName && !AVATAR_ONLY_DIRTY_FIELDS.has(fieldName) && !IGNORED_DIRTY_FIELDS.has(fieldName),
+  );
+};
+
 export default function AgentPanel() {
   const localize = useLocalize();
   const { user } = useAuthContext();
@@ -244,8 +261,17 @@ export default function AgentPanel() {
   const agentQuery = canEdit && expandedAgentQuery.data ? expandedAgentQuery : basicAgentQuery;
 
   const models = useMemo(() => modelsQuery.data ?? {}, [modelsQuery.data]);
+  const draftValues = useMemo(() => getAgentDraft(current_agent_id), [current_agent_id]);
+  const hasDraft = draftValues != null;
+  const defaultValues = useMemo(
+    () => ({
+      ...getDefaultAgentFormValues(),
+      ...draftValues,
+    }),
+    [draftValues],
+  );
   const methods = useForm<AgentForm>({
-    defaultValues: getDefaultAgentFormValues(),
+    defaultValues,
     mode: 'onChange',
   });
 
@@ -253,11 +279,80 @@ export default function AgentPanel() {
     control,
     handleSubmit,
     reset,
+    watch,
     getValues,
     setValue,
     formState: { dirtyFields },
   } = methods;
+  const currentAgentIdRef = useRef<string | undefined>(current_agent_id);
+  const shouldPersistDraftRef = useRef(hasDraft);
   const [isAvatarUploadInFlight, setIsAvatarUploadInFlight] = useState(false);
+
+  const clearDraftsForAgentIds = useCallback((agentIds: Array<string | null | undefined>) => {
+    shouldPersistDraftRef.current = false;
+    clearAgentDrafts(agentIds);
+  }, []);
+
+  const handleAgentChange = useCallback(
+    (selectedAgentId?: string | null) => {
+      clearDraftsForAgentIds([currentAgentIdRef.current, selectedAgentId]);
+    },
+    [clearDraftsForAgentIds],
+  );
+
+  const handleCreateNewAgent = useCallback(() => {
+    clearDraftsForAgentIds([currentAgentIdRef.current, undefined]);
+    reset(getDefaultAgentFormValues());
+    setCurrentAgentId(undefined);
+  }, [clearDraftsForAgentIds, reset, setCurrentAgentId]);
+
+  const shouldPersistDraft = hasPersistableDirtyFields(dirtyFields);
+
+  useEffect(() => {
+    if (currentAgentIdRef.current === current_agent_id) {
+      return;
+    }
+
+    if (shouldPersistDraftRef.current) {
+      saveAgentDraft(currentAgentIdRef.current, getValues());
+    }
+
+    currentAgentIdRef.current = current_agent_id;
+  }, [current_agent_id, getValues]);
+
+  useEffect(() => {
+    if (hasDraft) {
+      shouldPersistDraftRef.current = true;
+    }
+  }, [hasDraft]);
+
+  useEffect(() => {
+    if (!shouldPersistDraft) {
+      return;
+    }
+
+    shouldPersistDraftRef.current = true;
+    saveAgentDraft(currentAgentIdRef.current, getValues());
+  }, [getValues, shouldPersistDraft]);
+
+  useEffect(() => {
+    const subscription = watch((_, { name }) => {
+      if (!shouldPersistDraftRef.current && !isPersistableDraftField(name)) {
+        return;
+      }
+
+      shouldPersistDraftRef.current = true;
+      saveAgentDraft(currentAgentIdRef.current, getValues());
+    });
+
+    return () => {
+      if (shouldPersistDraftRef.current) {
+        saveAgentDraft(currentAgentIdRef.current, getValues());
+      }
+      subscription.unsubscribe();
+    };
+  }, [getValues, watch]);
+
   const uploadAvatarMutation = useUploadAgentAvatarMutation({
     onSuccess: (updatedAgent) => {
       showToast({ message: localize('com_ui_upload_agent_avatar') });
@@ -363,6 +458,9 @@ export default function AgentPanel() {
         setValue('avatar_preview', '', { shouldDirty: false });
       }
 
+      clearDraftsForAgentIds([current_agent_id, data.id ?? agent_id]);
+      reset(getValues());
+
       // Clear the ref after use
       previousVersionRef.current = undefined;
     },
@@ -395,6 +493,12 @@ export default function AgentPanel() {
           status: 'error',
         });
       }
+
+      clearDraftsForAgentIds([undefined, current_agent_id, data.id]);
+      reset({
+        ...getValues(),
+        id: data.id ?? getValues('id'),
+      });
     },
     onError: (err) => {
       const error = err as Error;
@@ -432,6 +536,7 @@ export default function AgentPanel() {
                 message: localize('com_agents_avatar_upload_error'),
                 status: 'error',
               });
+              return;
             }
           } catch (error) {
             console.error('[AgentPanel] Avatar upload failed for avatar-only submission', error);
@@ -439,7 +544,10 @@ export default function AgentPanel() {
               message: localize('com_agents_avatar_upload_error'),
               status: 'error',
             });
+            return;
           }
+          clearDraftsForAgentIds([current_agent_id, agent_id]);
+          reset(getValues());
           return;
         }
         update.mutate({ agent_id, data: { ...basePayload, tools } });
@@ -461,7 +569,19 @@ export default function AgentPanel() {
 
       create.mutate({ ...basePayload, model, tools, provider });
     },
-    [agent_id, create, dirtyFields, handleAvatarUpload, update, showToast, localize],
+    [
+      agent_id,
+      create,
+      dirtyFields,
+      reset,
+      getValues,
+      current_agent_id,
+      handleAvatarUpload,
+      update,
+      showToast,
+      localize,
+      clearDraftsForAgentIds,
+    ],
   );
 
   const handleSelectAgent = useCallback(() => {
@@ -495,6 +615,8 @@ export default function AgentPanel() {
               <AgentSelect
                 createMutation={create}
                 agentQuery={agentQuery}
+                hasDraft={hasDraft}
+                onAgentChange={handleAgentChange}
                 setCurrentAgentId={setCurrentAgentId}
                 selectedAgentId={agentQuery.isInitialLoading ? null : (current_agent_id ?? null)}
               />
@@ -505,10 +627,7 @@ export default function AgentPanel() {
                   type="button"
                   variant="outline"
                   className="w-full justify-center"
-                  onClick={() => {
-                    reset(getDefaultAgentFormValues());
-                    setCurrentAgentId(undefined);
-                  }}
+                  onClick={handleCreateNewAgent}
                   disabled={agentQuery.isInitialLoading}
                   aria-label={localize('com_ui_create_new_agent')}
                 >

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -266,7 +266,11 @@ export default function AgentPanel() {
   const agentQuery = canEdit && expandedAgentQuery.data ? expandedAgentQuery : basicAgentQuery;
 
   const models = useMemo(() => modelsQuery.data ?? {}, [modelsQuery.data]);
-  const draftValues = useMemo(() => getAgentDraft(current_agent_id), [current_agent_id]);
+  const draftUserId = user?.id;
+  const draftValues = useMemo(
+    () => getAgentDraft(current_agent_id, draftUserId),
+    [current_agent_id, draftUserId],
+  );
   const defaultValues = useMemo(() => getDraftFormValues(draftValues), [draftValues]);
   const methods = useForm<AgentForm>({
     defaultValues,
@@ -284,12 +288,13 @@ export default function AgentPanel() {
     formState: { dirtyFields },
   } = methods;
   const currentAgentIdRef = useRef<string | undefined>(current_agent_id);
+  const draftUserIdRef = useRef<string | undefined>(draftUserId);
   const [hasDraft, setHasDraft] = useState(draftValues != null);
   const shouldPersistDraftRef = useRef(hasDraft);
   const [isAvatarUploadInFlight, setIsAvatarUploadInFlight] = useState(false);
 
   const persistAgentDraft = useCallback((agentId: string | undefined, values: AgentForm) => {
-    saveAgentDraft(agentId, values);
+    saveAgentDraft(agentId, values, draftUserIdRef.current);
     if (agentId === currentAgentIdRef.current) {
       setHasDraft(true);
     }
@@ -297,8 +302,8 @@ export default function AgentPanel() {
 
   const clearDraftsForAgentIds = useCallback((agentIds: Array<string | null | undefined>) => {
     shouldPersistDraftRef.current = false;
-    clearAgentDrafts(agentIds);
-    setHasDraft(getAgentDraft(currentAgentIdRef.current) != null);
+    clearAgentDrafts(agentIds, draftUserIdRef.current);
+    setHasDraft(getAgentDraft(currentAgentIdRef.current, draftUserIdRef.current) != null);
   }, []);
 
   const handleAgentChange = useCallback(
@@ -328,23 +333,32 @@ export default function AgentPanel() {
   );
 
   useEffect(() => {
-    if (currentAgentIdRef.current === current_agent_id) {
+    const agentChanged = currentAgentIdRef.current !== current_agent_id;
+    const userChanged = draftUserIdRef.current !== draftUserId;
+
+    if (!agentChanged && !userChanged) {
       return;
     }
 
-    if (shouldPersistDraftRef.current) {
-      saveAgentDraft(currentAgentIdRef.current, getValues());
+    if (agentChanged && shouldPersistDraftRef.current) {
+      saveAgentDraft(currentAgentIdRef.current, getValues(), draftUserIdRef.current);
     }
 
     currentAgentIdRef.current = current_agent_id;
-    const nextDraft = getAgentDraft(current_agent_id);
+    draftUserIdRef.current = draftUserId;
+    const nextDraft = getAgentDraft(current_agent_id, draftUserId);
     const nextHasDraft = nextDraft != null;
     shouldPersistDraftRef.current = nextHasDraft;
     setHasDraft(nextHasDraft);
     if (nextDraft) {
       reset(getDraftFormValues(nextDraft));
+      return;
     }
-  }, [current_agent_id, getValues, reset]);
+
+    if (userChanged) {
+      reset(getDefaultAgentFormValues());
+    }
+  }, [current_agent_id, draftUserId, getValues, reset]);
 
   useEffect(() => {
     if (hasDraft) {
@@ -373,7 +387,7 @@ export default function AgentPanel() {
 
     return () => {
       if (shouldPersistDraftRef.current) {
-        saveAgentDraft(currentAgentIdRef.current, getValues());
+        saveAgentDraft(currentAgentIdRef.current, getValues(), draftUserIdRef.current);
       }
       subscription.unsubscribe();
     };

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -229,6 +229,11 @@ const isPersistableDraftField = (name?: string): boolean => {
   );
 };
 
+const getDraftFormValues = (draftValues?: Partial<AgentForm>): AgentForm => ({
+  ...getDefaultAgentFormValues(),
+  ...draftValues,
+});
+
 export default function AgentPanel() {
   const localize = useLocalize();
   const { user } = useAuthContext();
@@ -262,13 +267,7 @@ export default function AgentPanel() {
 
   const models = useMemo(() => modelsQuery.data ?? {}, [modelsQuery.data]);
   const draftValues = useMemo(() => getAgentDraft(current_agent_id), [current_agent_id]);
-  const defaultValues = useMemo(
-    () => ({
-      ...getDefaultAgentFormValues(),
-      ...draftValues,
-    }),
-    [draftValues],
-  );
+  const defaultValues = useMemo(() => getDraftFormValues(draftValues), [draftValues]);
   const methods = useForm<AgentForm>({
     defaultValues,
     mode: 'onChange',
@@ -338,10 +337,14 @@ export default function AgentPanel() {
     }
 
     currentAgentIdRef.current = current_agent_id;
-    const nextHasDraft = getAgentDraft(current_agent_id) != null;
+    const nextDraft = getAgentDraft(current_agent_id);
+    const nextHasDraft = nextDraft != null;
     shouldPersistDraftRef.current = nextHasDraft;
     setHasDraft(nextHasDraft);
-  }, [current_agent_id, getValues]);
+    if (nextDraft) {
+      reset(getDraftFormValues(nextDraft));
+    }
+  }, [current_agent_id, getValues, reset]);
 
   useEffect(() => {
     if (hasDraft) {

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -320,16 +320,26 @@ export default function AgentPanel() {
   }, [clearDraftsForAgentIds, reset, setCurrentAgentId]);
 
   const shouldPersistDraft = hasPersistableDirtyFields(dirtyFields);
+  const shouldPersistAvatarResetDraft =
+    dirtyFields?.avatar_action === true && getValues('avatar_action') === 'reset';
 
   const isDirtyPersistableDraftField = useCallback(
     (name?: string): boolean => {
+      const [fieldName] = name?.split('.') ?? [];
+      if (fieldName === 'avatar_action') {
+        return (
+          getFieldState(name as FieldPath<AgentForm>).isDirty &&
+          getValues('avatar_action') === 'reset'
+        );
+      }
+
       if (!isPersistableDraftField(name)) {
         return false;
       }
 
       return getFieldState(name as FieldPath<AgentForm>).isDirty;
     },
-    [getFieldState],
+    [getFieldState, getValues],
   );
 
   useEffect(() => {
@@ -367,13 +377,13 @@ export default function AgentPanel() {
   }, [hasDraft]);
 
   useEffect(() => {
-    if (!shouldPersistDraft) {
+    if (!shouldPersistDraft && !shouldPersistAvatarResetDraft) {
       return;
     }
 
     shouldPersistDraftRef.current = true;
     persistAgentDraft(currentAgentIdRef.current, getValues());
-  }, [getValues, persistAgentDraft, shouldPersistDraft]);
+  }, [getValues, persistAgentDraft, shouldPersistAvatarResetDraft, shouldPersistDraft]);
 
   useEffect(() => {
     const subscription = watch((_, { name }) => {

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -11,7 +11,7 @@ import {
   PermissionBits,
   isAssistantsEndpoint,
 } from 'librechat-data-provider';
-import type { FieldNamesMarkedBoolean } from 'react-hook-form';
+import type { FieldNamesMarkedBoolean, FieldPath } from 'react-hook-form';
 import type { Agent } from 'librechat-data-provider';
 import type { TranslationKeys } from '~/hooks/useLocalize';
 import type { AgentForm, StringOption } from '~/common';
@@ -280,6 +280,7 @@ export default function AgentPanel() {
     reset,
     watch,
     getValues,
+    getFieldState,
     setValue,
     formState: { dirtyFields },
   } = methods;
@@ -316,6 +317,17 @@ export default function AgentPanel() {
 
   const shouldPersistDraft = hasPersistableDirtyFields(dirtyFields);
 
+  const isDirtyPersistableDraftField = useCallback(
+    (name?: string): boolean => {
+      if (!isPersistableDraftField(name)) {
+        return false;
+      }
+
+      return getFieldState(name as FieldPath<AgentForm>).isDirty;
+    },
+    [getFieldState],
+  );
+
   useEffect(() => {
     if (currentAgentIdRef.current === current_agent_id) {
       return;
@@ -348,7 +360,7 @@ export default function AgentPanel() {
 
   useEffect(() => {
     const subscription = watch((_, { name }) => {
-      if (!shouldPersistDraftRef.current && !isPersistableDraftField(name)) {
+      if (!shouldPersistDraftRef.current && !isDirtyPersistableDraftField(name)) {
         return;
       }
 
@@ -362,7 +374,7 @@ export default function AgentPanel() {
       }
       subscription.unsubscribe();
     };
-  }, [getValues, persistAgentDraft, watch]);
+  }, [getValues, isDirtyPersistableDraftField, persistAgentDraft, watch]);
 
   const uploadAvatarMutation = useUploadAgentAvatarMutation({
     onSuccess: (updatedAgent) => {

--- a/client/src/components/SidePanel/Agents/AgentPanel.tsx
+++ b/client/src/components/SidePanel/Agents/AgentPanel.tsx
@@ -319,12 +319,9 @@ export default function AgentPanel() {
     [debouncedPersistAgentDraft],
   );
 
-  const handleAgentChange = useCallback(
-    (selectedAgentId?: string | null) => {
-      clearDraftsForAgentIds([currentAgentIdRef.current, selectedAgentId]);
-    },
-    [clearDraftsForAgentIds],
-  );
+  const handleAgentChange = useCallback(() => {
+    clearDraftsForAgentIds([currentAgentIdRef.current]);
+  }, [clearDraftsForAgentIds]);
 
   const handleCreateNewAgent = useCallback(() => {
     clearDraftsForAgentIds([currentAgentIdRef.current, undefined]);
@@ -365,8 +362,10 @@ export default function AgentPanel() {
   );
 
   useEffect(() => {
-    const agentChanged = currentAgentIdRef.current !== current_agent_id;
-    const userChanged = draftUserIdRef.current !== draftUserId;
+    const previousAgentId = currentAgentIdRef.current;
+    const previousUserId = draftUserIdRef.current;
+    const agentChanged = previousAgentId !== current_agent_id;
+    const userChanged = previousUserId !== draftUserId;
 
     if (!agentChanged && !userChanged) {
       return;
@@ -377,12 +376,25 @@ export default function AgentPanel() {
     }
 
     if (agentChanged && !userChanged && shouldPersistDraftRef.current) {
-      saveAgentDraft(currentAgentIdRef.current, getValues(), draftUserIdRef.current);
+      saveAgentDraft(previousAgentId, getValues(), previousUserId);
+    }
+
+    const nextDraft = getAgentDraft(current_agent_id, draftUserId);
+    if (
+      agentChanged &&
+      !userChanged &&
+      previousAgentId == null &&
+      shouldPersistDraftRef.current &&
+      !nextDraft
+    ) {
+      // AgentPanelSwitch can restore the chat agent id after a remount while a new-agent draft is visible.
+      setCurrentAgentId(undefined);
+      setHasDraft(shouldPersistDraftRef.current);
+      return;
     }
 
     currentAgentIdRef.current = current_agent_id;
     draftUserIdRef.current = draftUserId;
-    const nextDraft = getAgentDraft(current_agent_id, draftUserId);
     const nextHasDraft = nextDraft != null;
     shouldPersistDraftRef.current = nextHasDraft;
     setHasDraft(nextHasDraft);
@@ -394,7 +406,14 @@ export default function AgentPanel() {
     if (userChanged) {
       reset(getDefaultAgentFormValues());
     }
-  }, [current_agent_id, debouncedPersistAgentDraft, draftUserId, getValues, reset]);
+  }, [
+    current_agent_id,
+    debouncedPersistAgentDraft,
+    draftUserId,
+    getValues,
+    reset,
+    setCurrentAgentId,
+  ]);
 
   useEffect(() => {
     if (hasDraft) {

--- a/client/src/components/SidePanel/Agents/AgentSelect.tsx
+++ b/client/src/components/SidePanel/Agents/AgentSelect.tsx
@@ -14,11 +14,15 @@ const keys = new Set(Object.keys(defaultAgentFormValues));
 
 function AgentSelect({
   agentQuery,
+  hasDraft = false,
   selectedAgentId = null,
+  onAgentChange,
   setCurrentAgentId,
   createMutation,
 }: {
+  hasDraft?: boolean;
   selectedAgentId: string | null;
+  onAgentChange?: (selectedAgentId?: string | null) => void;
   agentQuery: QueryObserverResult<Agent>;
   setCurrentAgentId: React.Dispatch<React.SetStateAction<string | undefined>>;
   createMutation: UseMutationResult<Agent, Error, AgentCreateParams>;
@@ -156,6 +160,10 @@ function AgentSelect({
 
   const onSelect = useCallback(
     (selectedId: string) => {
+      if (selectedId !== selectedAgentId) {
+        onAgentChange?.(selectedId || null);
+      }
+
       const agentExists = !!(selectedId
         ? (agents ?? []).find((agent) => agent.id === selectedId)
         : undefined);
@@ -175,17 +183,35 @@ function AgentSelect({
 
       resetAgentForm(agent);
     },
-    [agents, createMutation, setCurrentAgentId, agentQuery.data, resetAgentForm, reset],
+    [
+      agents,
+      selectedAgentId,
+      onAgentChange,
+      createMutation,
+      setCurrentAgentId,
+      agentQuery.data,
+      resetAgentForm,
+      reset,
+    ],
   );
 
   useEffect(() => {
+    if (hasDraft) {
+      return;
+    }
+
     if (agentQuery.data && agentQuery.isSuccess) {
       resetAgentForm(agentQuery.data);
     }
-  }, [agentQuery.data, agentQuery.isSuccess, resetAgentForm]);
+  }, [agentQuery.data, agentQuery.isSuccess, hasDraft, resetAgentForm]);
 
   useEffect(() => {
     let timerId: NodeJS.Timeout | null = null;
+
+    if (hasDraft) {
+      lastSelectedAgent.current = selectedAgentId;
+      return;
+    }
 
     if (selectedAgentId === lastSelectedAgent.current) {
       return;
@@ -203,7 +229,7 @@ function AgentSelect({
         clearTimeout(timerId);
       }
     };
-  }, [selectedAgentId, agents, onSelect]);
+  }, [selectedAgentId, agents, hasDraft, onSelect]);
 
   const createAgent = localize('com_ui_create_new_agent');
 
@@ -249,6 +275,8 @@ const MemoizedAgentSelect = memo(
   AgentSelect,
   (prevProps, nextProps) =>
     prevProps.selectedAgentId === nextProps.selectedAgentId &&
+    prevProps.hasDraft === nextProps.hasDraft &&
+    prevProps.onAgentChange === nextProps.onAgentChange &&
     prevProps.agentQuery.data === nextProps.agentQuery.data &&
     prevProps.agentQuery.isSuccess === nextProps.agentQuery.isSuccess &&
     prevProps.createMutation.data?.id === nextProps.createMutation.data?.id &&

--- a/client/src/components/SidePanel/Agents/DeleteButton.tsx
+++ b/client/src/components/SidePanel/Agents/DeleteButton.tsx
@@ -17,6 +17,7 @@ import { useDeleteAgentMutation } from '~/data-provider';
 import { isEphemeralAgent } from '~/common';
 import { useLocalize } from '~/hooks';
 import store from '~/store';
+import { clearAgentDraft } from './drafts';
 
 function DeleteButton({
   agent_id,
@@ -44,6 +45,7 @@ function DeleteButton({
         message: localize('com_ui_agent_deleted'),
         status: 'success',
       });
+      clearAgentDraft(vars.agent_id);
 
       if (createMutation.data?.id ?? '') {
         logger.log('agents', 'resetting createMutation');

--- a/client/src/components/SidePanel/Agents/DeleteButton.tsx
+++ b/client/src/components/SidePanel/Agents/DeleteButton.tsx
@@ -14,22 +14,22 @@ import type { Agent, AgentCreateParams } from 'librechat-data-provider';
 import type { UseMutationResult } from '@tanstack/react-query';
 import { logger, getDefaultAgentFormValues } from '~/utils';
 import { useDeleteAgentMutation } from '~/data-provider';
+import { useLocalize } from '~/hooks';
 import { isEphemeralAgent } from '~/common';
-import { useAuthContext, useLocalize } from '~/hooks';
 import store from '~/store';
-import { clearAgentDraft } from './drafts';
 
 function DeleteButton({
   agent_id,
   setCurrentAgentId,
   createMutation,
+  onDraftClear,
 }: {
   agent_id: string;
   setCurrentAgentId: React.Dispatch<React.SetStateAction<string | undefined>>;
   createMutation: UseMutationResult<Agent, Error, AgentCreateParams>;
+  onDraftClear?: (agentId: string) => void;
 }) {
   const localize = useLocalize();
-  const { user } = useAuthContext();
   const { reset } = useFormContext();
   const { showToast } = useToastContext();
   const setConversation = useSetRecoilState(store.conversationByIndex(0));
@@ -46,7 +46,7 @@ function DeleteButton({
         message: localize('com_ui_agent_deleted'),
         status: 'success',
       });
-      clearAgentDraft(vars.agent_id, user?.id);
+      onDraftClear?.(vars.agent_id);
 
       if (createMutation.data?.id ?? '') {
         logger.log('agents', 'resetting createMutation');
@@ -131,6 +131,7 @@ const MemoizedDeleteButton = memo(
   (prevProps, nextProps) =>
     prevProps.agent_id === nextProps.agent_id &&
     prevProps.setCurrentAgentId === nextProps.setCurrentAgentId &&
+    prevProps.onDraftClear === nextProps.onDraftClear &&
     prevProps.createMutation.data?.id === nextProps.createMutation.data?.id &&
     prevProps.createMutation.isLoading === nextProps.createMutation.isLoading,
 );

--- a/client/src/components/SidePanel/Agents/DeleteButton.tsx
+++ b/client/src/components/SidePanel/Agents/DeleteButton.tsx
@@ -15,7 +15,7 @@ import type { UseMutationResult } from '@tanstack/react-query';
 import { logger, getDefaultAgentFormValues } from '~/utils';
 import { useDeleteAgentMutation } from '~/data-provider';
 import { isEphemeralAgent } from '~/common';
-import { useLocalize } from '~/hooks';
+import { useAuthContext, useLocalize } from '~/hooks';
 import store from '~/store';
 import { clearAgentDraft } from './drafts';
 
@@ -29,6 +29,7 @@ function DeleteButton({
   createMutation: UseMutationResult<Agent, Error, AgentCreateParams>;
 }) {
   const localize = useLocalize();
+  const { user } = useAuthContext();
   const { reset } = useFormContext();
   const { showToast } = useToastContext();
   const setConversation = useSetRecoilState(store.conversationByIndex(0));
@@ -45,7 +46,7 @@ function DeleteButton({
         message: localize('com_ui_agent_deleted'),
         status: 'success',
       });
-      clearAgentDraft(vars.agent_id);
+      clearAgentDraft(vars.agent_id, user?.id);
 
       if (createMutation.data?.id ?? '') {
         logger.log('agents', 'resetting createMutation');

--- a/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
@@ -26,6 +26,7 @@ const PROGRAMMATIC_UPDATE_LABEL = 'Programmatic agent update';
 const AVATAR_ACTION_LABEL = 'Avatar action';
 const RESET_AVATAR_LABEL = 'Reset avatar';
 const DELETE_AGENT_LABEL = 'Delete Agent';
+const SELECT_AGENT_WITH_DRAFT_LABEL = 'Select agent with draft';
 const MOCK_USER_ID = 'user-123';
 
 type MockButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -35,6 +36,7 @@ type MockButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 
 type MockAgentSelectProps = {
   hasDraft?: boolean;
+  onAgentChange?: (selectedAgentId?: string | null) => void;
 };
 
 type MockAgentFooterProps = {
@@ -146,7 +148,7 @@ jest.mock('~/common', () => {
 
 jest.mock('../AgentSelect', () => ({
   __esModule: true,
-  default: function MockAgentSelect({ hasDraft }: MockAgentSelectProps) {
+  default: function MockAgentSelect({ hasDraft, onAgentChange }: MockAgentSelectProps) {
     const { useFormContext } = jest.requireActual(
       'react-hook-form',
     ) as typeof import('react-hook-form');
@@ -161,6 +163,9 @@ jest.mock('../AgentSelect', () => ({
           onClick={() => setValue('name', 'Saved from API', { shouldDirty: false })}
         >
           {PROGRAMMATIC_UPDATE_LABEL}
+        </button>
+        <button type="button" onClick={() => onAgentChange?.('agent-456')}>
+          {SELECT_AGENT_WITH_DRAFT_LABEL}
         </button>
       </>
     );
@@ -382,6 +387,77 @@ describe('AgentPanel draft preservation', () => {
     expect(screen.getByLabelText('Draft instructions')).toHaveValue('Draft for the switched agent');
     expect(getAgentDraft('agent-123', MOCK_USER_ID)?.name).toBe('Previous agent draft');
     expect(mockLastAgentSelectHasDraft).toBe(true);
+  });
+
+  it('preserves a selected agent draft when leaving another agent', async () => {
+    mockCurrentAgentId = 'agent-123';
+    const { rerender } = render(<Harness />);
+
+    fireEvent.change(screen.getByLabelText('Draft name'), {
+      target: { value: 'Draft for current agent' },
+    });
+    await waitFor(() => {
+      expect(getAgentDraft('agent-123', MOCK_USER_ID)?.name).toBe('Draft for current agent');
+    });
+
+    saveAgentDraft(
+      'agent-456',
+      {
+        id: 'agent-456',
+        name: 'Destination agent draft',
+        description: '',
+        instructions: 'Keep the destination draft',
+        model: 'gpt-4o',
+        model_parameters: {} as AgentForm['model_parameters'],
+        provider: { label: 'OpenAI', value: 'openAI' },
+        tools: [],
+        tool_options: {},
+        category: 'general',
+        execute_code: false,
+        file_search: false,
+        web_search: false,
+      } as AgentForm,
+      MOCK_USER_ID,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: SELECT_AGENT_WITH_DRAFT_LABEL }));
+
+    expect(getAgentDraft('agent-123', MOCK_USER_ID)).toBeUndefined();
+    expect(getAgentDraft('agent-456', MOCK_USER_ID)?.name).toBe('Destination agent draft');
+
+    mockCurrentAgentId = 'agent-456';
+    rerender(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Draft name')).toHaveValue('Destination agent draft');
+    });
+  });
+
+  it('keeps remounted new-agent drafts keyed as new when a chat agent id is restored', async () => {
+    const { rerender } = render(<Harness />);
+
+    fireEvent.change(screen.getByLabelText('Draft name'), {
+      target: { value: 'New agent draft' },
+    });
+    await waitFor(() => {
+      expect(getAgentDraft(undefined, MOCK_USER_ID)?.name).toBe('New agent draft');
+    });
+
+    mockCurrentAgentId = 'agent-123';
+    rerender(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Draft name')).toHaveValue('New agent draft');
+    });
+
+    fireEvent.change(screen.getByLabelText('Draft name'), {
+      target: { value: 'New agent draft continued' },
+    });
+
+    await waitFor(() => {
+      expect(getAgentDraft(undefined, MOCK_USER_ID)?.name).toBe('New agent draft continued');
+    });
+    expect(getAgentDraft('agent-123', MOCK_USER_ID)).toBeUndefined();
   });
 
   it('does not carry drafts across user changes while mounted', async () => {

--- a/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
@@ -313,4 +313,38 @@ describe('AgentPanel draft preservation', () => {
     expect(getAgentDraft('agent-123')).toBeUndefined();
     expect(mockLastAgentSelectHasDraft).toBe(false);
   });
+
+  it('restores a draft when the current agent changes while mounted', async () => {
+    mockCurrentAgentId = 'agent-123';
+    const { rerender } = render(<Harness />);
+
+    fireEvent.change(screen.getByLabelText('Draft name'), {
+      target: { value: 'Previous agent draft' },
+    });
+    saveAgentDraft('agent-456', {
+      id: 'agent-456',
+      name: 'Mounted switch draft',
+      description: '',
+      instructions: 'Draft for the switched agent',
+      model: 'gpt-4o',
+      model_parameters: {},
+      provider: { label: 'OpenAI', value: 'openAI' },
+      tools: [],
+      tool_options: {},
+      category: 'general',
+      execute_code: false,
+      file_search: false,
+      web_search: false,
+    } as AgentForm);
+
+    mockCurrentAgentId = 'agent-456';
+    rerender(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Draft name')).toHaveValue('Mounted switch draft');
+    });
+    expect(screen.getByLabelText('Draft instructions')).toHaveValue('Draft for the switched agent');
+    expect(getAgentDraft('agent-123')?.name).toBe('Previous agent draft');
+    expect(mockLastAgentSelectHasDraft).toBe(true);
+  });
 });

--- a/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
@@ -12,6 +12,15 @@ import { getAgentDraft, saveAgentDraft, clearAllAgentDrafts } from '../drafts';
 
 let mockCurrentAgentId: string | undefined;
 
+const AGENT_SELECT_LABEL = 'Agent Select';
+const ADVANCED_PANEL_LABEL = 'Advanced Panel';
+const LOADING_LABEL = 'Loading';
+const MODEL_PANEL_LABEL = 'Model Panel';
+const SAVE_AGENT_LABEL = 'Save Agent';
+const AGENTS_BUTTON_LABEL = 'Agents';
+const FILES_BUTTON_LABEL = 'Files';
+const FILES_PANEL_LABEL = 'Files panel';
+
 type MockButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: string;
   variant?: string;
@@ -122,12 +131,12 @@ jest.mock('~/common', () => {
 
 jest.mock('../AgentSelect', () => ({
   __esModule: true,
-  default: () => <div>Agent Select</div>,
+  default: () => <div>{AGENT_SELECT_LABEL}</div>,
 }));
 
 jest.mock('../AgentConfig', () => ({
   __esModule: true,
-  default: () => {
+  default: function MockAgentConfig() {
     const { useFormContext } = jest.requireActual(
       'react-hook-form',
     ) as typeof import('react-hook-form');
@@ -145,22 +154,22 @@ jest.mock('../AgentConfig', () => ({
 
 jest.mock('../AgentFooter', () => ({
   __esModule: true,
-  default: () => <button type="submit">Save Agent</button>,
+  default: () => <button type="submit">{SAVE_AGENT_LABEL}</button>,
 }));
 
 jest.mock('../Advanced/AdvancedPanel', () => ({
   __esModule: true,
-  default: () => <div>Advanced Panel</div>,
+  default: () => <div>{ADVANCED_PANEL_LABEL}</div>,
 }));
 
 jest.mock('../AgentPanelSkeleton', () => ({
   __esModule: true,
-  default: () => <div>Loading</div>,
+  default: () => <div>{LOADING_LABEL}</div>,
 }));
 
 jest.mock('../ModelPanel', () => ({
   __esModule: true,
-  default: () => <div>Model Panel</div>,
+  default: () => <div>{MODEL_PANEL_LABEL}</div>,
 }));
 
 function PanelControls() {
@@ -169,10 +178,10 @@ function PanelControls() {
   return (
     <>
       <button type="button" onClick={() => setActive('agents')}>
-        Agents
+        {AGENTS_BUTTON_LABEL}
       </button>
       <button type="button" onClick={() => setActive('files')}>
-        Files
+        {FILES_BUTTON_LABEL}
       </button>
     </>
   );
@@ -191,7 +200,7 @@ function Harness() {
       title: 'com_sidepanel_attach_files',
       icon: Icon,
       id: 'files',
-      Component: () => <div>Files panel</div>,
+      Component: () => <div>{FILES_PANEL_LABEL}</div>,
     },
   ] as NavLink[];
 
@@ -223,10 +232,10 @@ describe('AgentPanel draft preservation', () => {
       target: { value: 'gpt-4o-mini' },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Files' }));
-    expect(screen.getByText('Files panel')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: FILES_BUTTON_LABEL }));
+    expect(screen.getByText(FILES_PANEL_LABEL)).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Agents' }));
+    fireEvent.click(screen.getByRole('button', { name: AGENTS_BUTTON_LABEL }));
 
     expect(screen.getByLabelText('Draft name')).toHaveValue('Navigation survivor');
     expect(screen.getByLabelText('Draft instructions')).toHaveValue('Keep these instructions.');

--- a/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
@@ -11,6 +11,7 @@ import AgentPanel from '../AgentPanel';
 import { getAgentDraft, saveAgentDraft, clearAllAgentDrafts } from '../drafts';
 
 let mockCurrentAgentId: string | undefined;
+let mockLastAgentSelectHasDraft: boolean | undefined;
 
 const AGENT_SELECT_LABEL = 'Agent Select';
 const ADVANCED_PANEL_LABEL = 'Advanced Panel';
@@ -24,6 +25,10 @@ const FILES_PANEL_LABEL = 'Files panel';
 type MockButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: string;
   variant?: string;
+};
+
+type MockAgentSelectProps = {
+  hasDraft?: boolean;
 };
 
 jest.mock('@librechat/client', () => ({
@@ -131,7 +136,10 @@ jest.mock('~/common', () => {
 
 jest.mock('../AgentSelect', () => ({
   __esModule: true,
-  default: () => <div>{AGENT_SELECT_LABEL}</div>,
+  default: ({ hasDraft }: MockAgentSelectProps) => {
+    mockLastAgentSelectHasDraft = hasDraft;
+    return <div>{AGENT_SELECT_LABEL}</div>;
+  },
 }));
 
 jest.mock('../AgentConfig', () => ({
@@ -216,6 +224,7 @@ describe('AgentPanel draft preservation', () => {
   beforeEach(() => {
     localStorage.setItem('side:active-panel', 'agents');
     mockCurrentAgentId = undefined;
+    mockLastAgentSelectHasDraft = undefined;
     clearAllAgentDrafts();
   });
 
@@ -263,6 +272,7 @@ describe('AgentPanel draft preservation', () => {
     render(<Harness />);
 
     expect(screen.getByLabelText('Draft name')).toHaveValue('Unsaved saved-agent name');
+    expect(mockLastAgentSelectHasDraft).toBe(true);
 
     fireEvent.click(screen.getByRole('button', { name: 'com_ui_create_new_agent' }));
 
@@ -271,5 +281,6 @@ describe('AgentPanel draft preservation', () => {
     expect(screen.getByLabelText('Draft model')).toHaveValue('');
     expect(getAgentDraft('agent-123')).toBeUndefined();
     expect(getAgentDraft(undefined)).toBeUndefined();
+    expect(mockLastAgentSelectHasDraft).toBe(false);
   });
 });

--- a/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
@@ -12,6 +12,7 @@ import { getAgentDraft, saveAgentDraft, clearAllAgentDrafts } from '../drafts';
 
 let mockCurrentAgentId: string | undefined;
 let mockLastAgentSelectHasDraft: boolean | undefined;
+let mockUserId: string | undefined;
 
 const AGENT_SELECT_LABEL = 'Agent Select';
 const ADVANCED_PANEL_LABEL = 'Advanced Panel';
@@ -22,6 +23,7 @@ const AGENTS_BUTTON_LABEL = 'Agents';
 const FILES_BUTTON_LABEL = 'Files';
 const FILES_PANEL_LABEL = 'Files panel';
 const PROGRAMMATIC_UPDATE_LABEL = 'Programmatic agent update';
+const MOCK_USER_ID = 'user-123';
 
 type MockButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: string;
@@ -78,7 +80,7 @@ jest.mock('~/data-provider', () => ({
 jest.mock('~/hooks', () => ({
   useSelectAgent: () => ({ onSelect: jest.fn() }),
   useLocalize: () => (key: string) => key,
-  useAuthContext: () => ({ user: { id: 'user-123', role: 'USER' } }),
+  useAuthContext: () => ({ user: { id: mockUserId, role: 'USER' } }),
 }));
 
 jest.mock('~/hooks/useResourcePermissions', () => ({
@@ -241,6 +243,7 @@ describe('AgentPanel draft preservation', () => {
     localStorage.setItem('side:active-panel', 'agents');
     mockCurrentAgentId = undefined;
     mockLastAgentSelectHasDraft = undefined;
+    mockUserId = MOCK_USER_ID;
     clearAllAgentDrafts();
   });
 
@@ -269,21 +272,25 @@ describe('AgentPanel draft preservation', () => {
 
   it('clears an existing draft when Create new agent is clicked', () => {
     mockCurrentAgentId = 'agent-123';
-    saveAgentDraft('agent-123', {
-      id: 'agent-123',
-      name: 'Unsaved saved-agent name',
-      description: '',
-      instructions: 'Unsaved saved-agent instructions',
-      model: 'gpt-4o',
-      model_parameters: {},
-      provider: { label: 'OpenAI', value: 'openAI' },
-      tools: [],
-      tool_options: {},
-      category: 'general',
-      execute_code: false,
-      file_search: false,
-      web_search: false,
-    } as AgentForm);
+    saveAgentDraft(
+      'agent-123',
+      {
+        id: 'agent-123',
+        name: 'Unsaved saved-agent name',
+        description: '',
+        instructions: 'Unsaved saved-agent instructions',
+        model: 'gpt-4o',
+        model_parameters: {},
+        provider: { label: 'OpenAI', value: 'openAI' },
+        tools: [],
+        tool_options: {},
+        category: 'general',
+        execute_code: false,
+        file_search: false,
+        web_search: false,
+      } as AgentForm,
+      MOCK_USER_ID,
+    );
 
     render(<Harness />);
 
@@ -295,8 +302,8 @@ describe('AgentPanel draft preservation', () => {
     expect(screen.getByLabelText('Draft name')).toHaveValue('');
     expect(screen.getByLabelText('Draft instructions')).toHaveValue('');
     expect(screen.getByLabelText('Draft model')).toHaveValue('');
-    expect(getAgentDraft('agent-123')).toBeUndefined();
-    expect(getAgentDraft(undefined)).toBeUndefined();
+    expect(getAgentDraft('agent-123', MOCK_USER_ID)).toBeUndefined();
+    expect(getAgentDraft(undefined, MOCK_USER_ID)).toBeUndefined();
     expect(mockLastAgentSelectHasDraft).toBe(false);
   });
 
@@ -310,7 +317,7 @@ describe('AgentPanel draft preservation', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Draft name')).toHaveValue('Saved from API');
     });
-    expect(getAgentDraft('agent-123')).toBeUndefined();
+    expect(getAgentDraft('agent-123', MOCK_USER_ID)).toBeUndefined();
     expect(mockLastAgentSelectHasDraft).toBe(false);
   });
 
@@ -321,21 +328,25 @@ describe('AgentPanel draft preservation', () => {
     fireEvent.change(screen.getByLabelText('Draft name'), {
       target: { value: 'Previous agent draft' },
     });
-    saveAgentDraft('agent-456', {
-      id: 'agent-456',
-      name: 'Mounted switch draft',
-      description: '',
-      instructions: 'Draft for the switched agent',
-      model: 'gpt-4o',
-      model_parameters: {},
-      provider: { label: 'OpenAI', value: 'openAI' },
-      tools: [],
-      tool_options: {},
-      category: 'general',
-      execute_code: false,
-      file_search: false,
-      web_search: false,
-    } as AgentForm);
+    saveAgentDraft(
+      'agent-456',
+      {
+        id: 'agent-456',
+        name: 'Mounted switch draft',
+        description: '',
+        instructions: 'Draft for the switched agent',
+        model: 'gpt-4o',
+        model_parameters: {},
+        provider: { label: 'OpenAI', value: 'openAI' },
+        tools: [],
+        tool_options: {},
+        category: 'general',
+        execute_code: false,
+        file_search: false,
+        web_search: false,
+      } as AgentForm,
+      MOCK_USER_ID,
+    );
 
     mockCurrentAgentId = 'agent-456';
     rerender(<Harness />);
@@ -344,7 +355,25 @@ describe('AgentPanel draft preservation', () => {
       expect(screen.getByLabelText('Draft name')).toHaveValue('Mounted switch draft');
     });
     expect(screen.getByLabelText('Draft instructions')).toHaveValue('Draft for the switched agent');
-    expect(getAgentDraft('agent-123')?.name).toBe('Previous agent draft');
+    expect(getAgentDraft('agent-123', MOCK_USER_ID)?.name).toBe('Previous agent draft');
     expect(mockLastAgentSelectHasDraft).toBe(true);
+  });
+
+  it('does not carry drafts across user changes while mounted', async () => {
+    const { rerender } = render(<Harness />);
+
+    fireEvent.change(screen.getByLabelText('Draft name'), {
+      target: { value: 'First user draft' },
+    });
+    expect(getAgentDraft(undefined, MOCK_USER_ID)?.name).toBe('First user draft');
+
+    mockUserId = 'user-456';
+    rerender(<Harness />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Draft name')).toHaveValue('');
+    });
+    expect(getAgentDraft(undefined, 'user-456')).toBeUndefined();
+    expect(getAgentDraft(undefined, MOCK_USER_ID)?.name).toBe('First user draft');
   });
 });

--- a/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
@@ -1,0 +1,266 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import type { AgentForm, NavLink } from '~/common';
+import { ActivePanelProvider, useActivePanel } from '~/Providers/ActivePanelContext';
+import Nav from '~/components/SidePanel/Nav';
+import AgentPanel from '../AgentPanel';
+import { getAgentDraft, saveAgentDraft, clearAllAgentDrafts } from '../drafts';
+
+let mockCurrentAgentId: string | undefined;
+
+type MockButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  size?: string;
+  variant?: string;
+};
+
+jest.mock('@librechat/client', () => ({
+  Button: ({ children, onClick, size: _size, variant: _variant, ...props }: MockButtonProps) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+  useToastContext: () => ({
+    showToast: jest.fn(),
+  }),
+}));
+
+jest.mock('librechat-data-provider/react-query', () => ({
+  useGetModelsQuery: () => ({ data: {} }),
+}));
+
+jest.mock('~/Providers', () => jest.requireActual('~/Providers/ActivePanelContext'));
+
+jest.mock('~/data-provider', () => ({
+  useGetAgentByIdQuery: () => ({
+    data: null,
+    isInitialLoading: false,
+    isSuccess: false,
+  }),
+  useGetExpandedAgentByIdQuery: () => ({
+    data: null,
+    isInitialLoading: false,
+    isSuccess: false,
+  }),
+  useCreateAgentMutation: () => ({
+    mutate: jest.fn(),
+    reset: jest.fn(),
+    isLoading: false,
+  }),
+  useUpdateAgentMutation: () => ({
+    mutate: jest.fn(),
+    isLoading: false,
+  }),
+  useUploadAgentAvatarMutation: () => ({
+    mutateAsync: jest.fn(),
+    isLoading: false,
+  }),
+}));
+
+jest.mock('~/hooks', () => ({
+  useSelectAgent: () => ({ onSelect: jest.fn() }),
+  useLocalize: () => (key: string) => key,
+  useAuthContext: () => ({ user: { id: 'user-123', role: 'USER' } }),
+}));
+
+jest.mock('~/hooks/useResourcePermissions', () => ({
+  useResourcePermissions: () => ({
+    hasPermission: jest.fn(() => true),
+    isLoading: false,
+  }),
+}));
+
+jest.mock('~/Providers/AgentPanelContext', () => ({
+  useAgentPanelContext: () => ({
+    activePanel: 'builder',
+    agentsConfig: { allowedProviders: [] },
+    setActivePanel: jest.fn(),
+    endpointsConfig: {},
+    setCurrentAgentId: jest.fn(),
+    agent_id: mockCurrentAgentId,
+  }),
+}));
+
+jest.mock('~/utils', () => ({
+  createProviderOption: jest.fn((provider: string) => ({ value: provider, label: provider })),
+  getDefaultAgentFormValues: jest.fn(() => ({
+    id: '',
+    name: '',
+    description: '',
+    instructions: '',
+    model: '',
+    model_parameters: {},
+    provider: { value: '', label: '' },
+    tools: [],
+    tool_options: {},
+    category: 'general',
+    execute_code: false,
+    file_search: false,
+    web_search: false,
+    avatar_file: null,
+    avatar_preview: '',
+    avatar_action: null,
+  })),
+}));
+
+jest.mock('~/common', () => {
+  const actual = jest.requireActual('~/common') as typeof import('~/common');
+
+  return {
+    ...actual,
+    Panel: {
+      model: 'model',
+      builder: 'builder',
+      advanced: 'advanced',
+    },
+    isEphemeralAgent: (agentId: string | null | undefined): boolean => !agentId,
+  };
+});
+
+jest.mock('../AgentSelect', () => ({
+  __esModule: true,
+  default: () => <div>Agent Select</div>,
+}));
+
+jest.mock('../AgentConfig', () => ({
+  __esModule: true,
+  default: () => {
+    const { useFormContext } = jest.requireActual(
+      'react-hook-form',
+    ) as typeof import('react-hook-form');
+    const { register } = useFormContext();
+
+    return (
+      <div>
+        <input aria-label="Draft name" {...register('name')} />
+        <textarea aria-label="Draft instructions" {...register('instructions')} />
+        <input aria-label="Draft model" {...register('model')} />
+      </div>
+    );
+  },
+}));
+
+jest.mock('../AgentFooter', () => ({
+  __esModule: true,
+  default: () => <button type="submit">Save Agent</button>,
+}));
+
+jest.mock('../Advanced/AdvancedPanel', () => ({
+  __esModule: true,
+  default: () => <div>Advanced Panel</div>,
+}));
+
+jest.mock('../AgentPanelSkeleton', () => ({
+  __esModule: true,
+  default: () => <div>Loading</div>,
+}));
+
+jest.mock('../ModelPanel', () => ({
+  __esModule: true,
+  default: () => <div>Model Panel</div>,
+}));
+
+function PanelControls() {
+  const { setActive } = useActivePanel();
+
+  return (
+    <>
+      <button type="button" onClick={() => setActive('agents')}>
+        Agents
+      </button>
+      <button type="button" onClick={() => setActive('files')}>
+        Files
+      </button>
+    </>
+  );
+}
+
+function Harness() {
+  const Icon = () => null;
+  const links = [
+    {
+      title: 'com_sidepanel_agent_builder',
+      icon: Icon,
+      id: 'agents',
+      Component: AgentPanel,
+    },
+    {
+      title: 'com_sidepanel_attach_files',
+      icon: Icon,
+      id: 'files',
+      Component: () => <div>Files panel</div>,
+    },
+  ] as NavLink[];
+
+  return (
+    <ActivePanelProvider>
+      <PanelControls />
+      <Nav links={links} />
+    </ActivePanelProvider>
+  );
+}
+
+describe('AgentPanel draft preservation', () => {
+  beforeEach(() => {
+    localStorage.setItem('side:active-panel', 'agents');
+    mockCurrentAgentId = undefined;
+    clearAllAgentDrafts();
+  });
+
+  it('restores unsaved new-agent values after switching to Files and back', () => {
+    render(<Harness />);
+
+    fireEvent.change(screen.getByLabelText('Draft name'), {
+      target: { value: 'Navigation survivor' },
+    });
+    fireEvent.change(screen.getByLabelText('Draft instructions'), {
+      target: { value: 'Keep these instructions.' },
+    });
+    fireEvent.change(screen.getByLabelText('Draft model'), {
+      target: { value: 'gpt-4o-mini' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Files' }));
+    expect(screen.getByText('Files panel')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Agents' }));
+
+    expect(screen.getByLabelText('Draft name')).toHaveValue('Navigation survivor');
+    expect(screen.getByLabelText('Draft instructions')).toHaveValue('Keep these instructions.');
+    expect(screen.getByLabelText('Draft model')).toHaveValue('gpt-4o-mini');
+  });
+
+  it('clears an existing draft when Create new agent is clicked', () => {
+    mockCurrentAgentId = 'agent-123';
+    saveAgentDraft('agent-123', {
+      id: 'agent-123',
+      name: 'Unsaved saved-agent name',
+      description: '',
+      instructions: 'Unsaved saved-agent instructions',
+      model: 'gpt-4o',
+      model_parameters: {},
+      provider: { label: 'OpenAI', value: 'openAI' },
+      tools: [],
+      tool_options: {},
+      category: 'general',
+      execute_code: false,
+      file_search: false,
+      web_search: false,
+    } as AgentForm);
+
+    render(<Harness />);
+
+    expect(screen.getByLabelText('Draft name')).toHaveValue('Unsaved saved-agent name');
+
+    fireEvent.click(screen.getByRole('button', { name: 'com_ui_create_new_agent' }));
+
+    expect(screen.getByLabelText('Draft name')).toHaveValue('');
+    expect(screen.getByLabelText('Draft instructions')).toHaveValue('');
+    expect(screen.getByLabelText('Draft model')).toHaveValue('');
+    expect(getAgentDraft('agent-123')).toBeUndefined();
+    expect(getAgentDraft(undefined)).toBeUndefined();
+  });
+});

--- a/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
@@ -23,6 +23,8 @@ const AGENTS_BUTTON_LABEL = 'Agents';
 const FILES_BUTTON_LABEL = 'Files';
 const FILES_PANEL_LABEL = 'Files panel';
 const PROGRAMMATIC_UPDATE_LABEL = 'Programmatic agent update';
+const AVATAR_ACTION_LABEL = 'Avatar action';
+const RESET_AVATAR_LABEL = 'Reset avatar';
 const MOCK_USER_ID = 'user-123';
 
 type MockButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -166,13 +168,20 @@ jest.mock('../AgentConfig', () => ({
     const { useFormContext } = jest.requireActual(
       'react-hook-form',
     ) as typeof import('react-hook-form');
-    const { register } = useFormContext();
+    const { register, setValue } = useFormContext<AgentForm>();
 
     return (
       <div>
         <input aria-label="Draft name" {...register('name')} />
         <textarea aria-label="Draft instructions" {...register('instructions')} />
         <input aria-label="Draft model" {...register('model')} />
+        <input aria-label={AVATAR_ACTION_LABEL} {...register('avatar_action')} />
+        <button
+          type="button"
+          onClick={() => setValue('avatar_action', 'reset', { shouldDirty: true })}
+        >
+          {RESET_AVATAR_LABEL}
+        </button>
       </div>
     );
   },
@@ -375,5 +384,23 @@ describe('AgentPanel draft preservation', () => {
     });
     expect(getAgentDraft(undefined, 'user-456')).toBeUndefined();
     expect(getAgentDraft(undefined, MOCK_USER_ID)?.name).toBe('First user draft');
+  });
+
+  it('restores avatar reset-only drafts after switching to Files and back', async () => {
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole('button', { name: RESET_AVATAR_LABEL }));
+    await waitFor(() => {
+      expect(getAgentDraft(undefined, MOCK_USER_ID)?.avatar_action).toBe('reset');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: FILES_BUTTON_LABEL }));
+    expect(screen.getByText(FILES_PANEL_LABEL)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: AGENTS_BUTTON_LABEL }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(AVATAR_ACTION_LABEL)).toHaveValue('reset');
+    });
   });
 });

--- a/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import * as React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import type { AgentForm, NavLink } from '~/common';
 import { ActivePanelProvider, useActivePanel } from '~/Providers/ActivePanelContext';
@@ -21,6 +21,7 @@ const SAVE_AGENT_LABEL = 'Save Agent';
 const AGENTS_BUTTON_LABEL = 'Agents';
 const FILES_BUTTON_LABEL = 'Files';
 const FILES_PANEL_LABEL = 'Files panel';
+const PROGRAMMATIC_UPDATE_LABEL = 'Programmatic agent update';
 
 type MockButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: string;
@@ -136,9 +137,24 @@ jest.mock('~/common', () => {
 
 jest.mock('../AgentSelect', () => ({
   __esModule: true,
-  default: ({ hasDraft }: MockAgentSelectProps) => {
+  default: function MockAgentSelect({ hasDraft }: MockAgentSelectProps) {
+    const { useFormContext } = jest.requireActual(
+      'react-hook-form',
+    ) as typeof import('react-hook-form');
+    const { setValue } = useFormContext<AgentForm>();
+
     mockLastAgentSelectHasDraft = hasDraft;
-    return <div>{AGENT_SELECT_LABEL}</div>;
+    return (
+      <>
+        <div>{AGENT_SELECT_LABEL}</div>
+        <button
+          type="button"
+          onClick={() => setValue('name', 'Saved from API', { shouldDirty: false })}
+        >
+          {PROGRAMMATIC_UPDATE_LABEL}
+        </button>
+      </>
+    );
   },
 }));
 
@@ -281,6 +297,20 @@ describe('AgentPanel draft preservation', () => {
     expect(screen.getByLabelText('Draft model')).toHaveValue('');
     expect(getAgentDraft('agent-123')).toBeUndefined();
     expect(getAgentDraft(undefined)).toBeUndefined();
+    expect(mockLastAgentSelectHasDraft).toBe(false);
+  });
+
+  it('does not save a draft for programmatic form updates', async () => {
+    mockCurrentAgentId = 'agent-123';
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole('button', { name: PROGRAMMATIC_UPDATE_LABEL }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Draft name')).toHaveValue('Saved from API');
+    });
+    expect(getAgentDraft('agent-123')).toBeUndefined();
     expect(mockLastAgentSelectHasDraft).toBe(false);
   });
 });

--- a/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
+++ b/client/src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx
@@ -3,7 +3,7 @@
  */
 import * as React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import type { AgentForm, NavLink } from '~/common';
 import { ActivePanelProvider, useActivePanel } from '~/Providers/ActivePanelContext';
 import Nav from '~/components/SidePanel/Nav';
@@ -25,6 +25,7 @@ const FILES_PANEL_LABEL = 'Files panel';
 const PROGRAMMATIC_UPDATE_LABEL = 'Programmatic agent update';
 const AVATAR_ACTION_LABEL = 'Avatar action';
 const RESET_AVATAR_LABEL = 'Reset avatar';
+const DELETE_AGENT_LABEL = 'Delete Agent';
 const MOCK_USER_ID = 'user-123';
 
 type MockButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -34,6 +35,10 @@ type MockButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 
 type MockAgentSelectProps = {
   hasDraft?: boolean;
+};
+
+type MockAgentFooterProps = {
+  onDraftClear?: (agentId: string) => void;
 };
 
 jest.mock('@librechat/client', () => ({
@@ -189,7 +194,14 @@ jest.mock('../AgentConfig', () => ({
 
 jest.mock('../AgentFooter', () => ({
   __esModule: true,
-  default: () => <button type="submit">{SAVE_AGENT_LABEL}</button>,
+  default: ({ onDraftClear }: MockAgentFooterProps) => (
+    <>
+      <button type="button" onClick={() => onDraftClear?.('agent-123')}>
+        {DELETE_AGENT_LABEL}
+      </button>
+      <button type="submit">{SAVE_AGENT_LABEL}</button>
+    </>
+  ),
 }));
 
 jest.mock('../Advanced/AdvancedPanel', () => ({
@@ -256,6 +268,10 @@ describe('AgentPanel draft preservation', () => {
     clearAllAgentDrafts();
   });
 
+  afterEach(() => {
+    localStorage.removeItem('side:active-panel');
+  });
+
   it('restores unsaved new-agent values after switching to Files and back', () => {
     render(<Harness />);
 
@@ -289,7 +305,7 @@ describe('AgentPanel draft preservation', () => {
         description: '',
         instructions: 'Unsaved saved-agent instructions',
         model: 'gpt-4o',
-        model_parameters: {},
+        model_parameters: {} as AgentForm['model_parameters'],
         provider: { label: 'OpenAI', value: 'openAI' },
         tools: [],
         tool_options: {},
@@ -345,7 +361,7 @@ describe('AgentPanel draft preservation', () => {
         description: '',
         instructions: 'Draft for the switched agent',
         model: 'gpt-4o',
-        model_parameters: {},
+        model_parameters: {} as AgentForm['model_parameters'],
         provider: { label: 'OpenAI', value: 'openAI' },
         tools: [],
         tool_options: {},
@@ -374,7 +390,9 @@ describe('AgentPanel draft preservation', () => {
     fireEvent.change(screen.getByLabelText('Draft name'), {
       target: { value: 'First user draft' },
     });
-    expect(getAgentDraft(undefined, MOCK_USER_ID)?.name).toBe('First user draft');
+    await waitFor(() => {
+      expect(getAgentDraft(undefined, MOCK_USER_ID)?.name).toBe('First user draft');
+    });
 
     mockUserId = 'user-456';
     rerender(<Harness />);
@@ -401,6 +419,29 @@ describe('AgentPanel draft preservation', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText(AVATAR_ACTION_LABEL)).toHaveValue('reset');
+    });
+  });
+
+  it('does not recreate a deleted agent draft when the active agent changes', async () => {
+    mockCurrentAgentId = 'agent-123';
+    const { rerender } = render(<Harness />);
+
+    fireEvent.change(screen.getByLabelText('Draft name'), {
+      target: { value: 'Edited before delete' },
+    });
+
+    await waitFor(() => {
+      expect(getAgentDraft('agent-123', MOCK_USER_ID)?.name).toBe('Edited before delete');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: DELETE_AGENT_LABEL }));
+    expect(getAgentDraft('agent-123', MOCK_USER_ID)).toBeUndefined();
+
+    mockCurrentAgentId = 'agent-456';
+    rerender(<Harness />);
+
+    await waitFor(() => {
+      expect(getAgentDraft('agent-123', MOCK_USER_ID)).toBeUndefined();
     });
   });
 });

--- a/client/src/components/SidePanel/Agents/__tests__/drafts.spec.ts
+++ b/client/src/components/SidePanel/Agents/__tests__/drafts.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+import { AgentCapabilities } from 'librechat-data-provider';
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import type { AgentForm, ExtendedFile } from '~/common';
+import { getAgentDraft, saveAgentDraft, clearAgentDraft, clearAllAgentDrafts } from '../drafts';
+
+const createForm = (overrides: Partial<AgentForm> = {}): AgentForm => {
+  const file = new File(['avatar'], 'avatar.png', { type: 'image/png' });
+  const contextFile: ExtendedFile = {
+    file,
+    file_id: 'file-1',
+    size: 12,
+    progress: 1,
+  };
+
+  return {
+    id: 'agent-1',
+    name: 'Draft agent',
+    description: 'Draft description',
+    instructions: 'Draft instructions',
+    model: 'gpt-4o',
+    model_parameters: {},
+    tools: ['mcp__server__tool'],
+    tool_options: {},
+    provider: { label: 'OpenAI', value: 'openAI' },
+    category: 'general',
+    support_contact: {
+      name: '',
+      email: '',
+    },
+    skills: ['skill-1'],
+    skills_enabled: true,
+    [AgentCapabilities.execute_code]: false,
+    [AgentCapabilities.file_search]: true,
+    [AgentCapabilities.web_search]: false,
+    avatar_file: file,
+    avatar_preview: 'data:image/png;base64,abc',
+    avatar_action: 'upload',
+    agent: {
+      id: 'agent-1',
+      label: 'Draft agent',
+      value: 'agent-1',
+      context_files: [['file-1', contextFile]],
+    } as AgentForm['agent'],
+    ...overrides,
+  };
+};
+
+describe('agent drafts', () => {
+  beforeEach(() => {
+    clearAllAgentDrafts();
+  });
+
+  it('stores new-agent drafts in memory without avatar uploads or File objects', () => {
+    saveAgentDraft(undefined, createForm());
+
+    const draft = getAgentDraft(undefined);
+    const agent = draft?.agent;
+
+    expect(draft?.name).toBe('Draft agent');
+    expect(draft?.instructions).toBe('Draft instructions');
+    expect(draft?.model).toBe('gpt-4o');
+    expect(draft?.avatar_file).toBeUndefined();
+    expect(draft?.avatar_preview).toBeUndefined();
+    expect(draft?.avatar_action).toBeUndefined();
+    expect(typeof agent).toBe('object');
+    expect(
+      typeof agent === 'object' ? agent?.context_files?.[0]?.[1].file : undefined,
+    ).toBeUndefined();
+  });
+
+  it('keeps drafts isolated by agent id and clears only the requested id', () => {
+    saveAgentDraft('agent-a', createForm({ id: 'agent-a', name: 'Agent A' }));
+    saveAgentDraft('agent-b', createForm({ id: 'agent-b', name: 'Agent B' }));
+
+    clearAgentDraft('agent-a');
+
+    expect(getAgentDraft('agent-a')).toBeUndefined();
+    expect(getAgentDraft('agent-b')?.name).toBe('Agent B');
+  });
+});

--- a/client/src/components/SidePanel/Agents/__tests__/drafts.spec.ts
+++ b/client/src/components/SidePanel/Agents/__tests__/drafts.spec.ts
@@ -80,4 +80,17 @@ describe('agent drafts', () => {
     expect(getAgentDraft('agent-a')).toBeUndefined();
     expect(getAgentDraft('agent-b')?.name).toBe('Agent B');
   });
+
+  it('keeps drafts isolated by user id', () => {
+    saveAgentDraft(undefined, createForm({ name: 'User A new draft' }), 'user-a');
+    saveAgentDraft(undefined, createForm({ name: 'User B new draft' }), 'user-b');
+    saveAgentDraft('agent-1', createForm({ name: 'User A saved-agent draft' }), 'user-a');
+
+    clearAgentDraft(undefined, 'user-a');
+
+    expect(getAgentDraft(undefined, 'user-a')).toBeUndefined();
+    expect(getAgentDraft(undefined, 'user-b')?.name).toBe('User B new draft');
+    expect(getAgentDraft('agent-1', 'user-a')?.name).toBe('User A saved-agent draft');
+    expect(getAgentDraft('agent-1', 'user-b')).toBeUndefined();
+  });
 });

--- a/client/src/components/SidePanel/Agents/__tests__/drafts.spec.ts
+++ b/client/src/components/SidePanel/Agents/__tests__/drafts.spec.ts
@@ -93,4 +93,21 @@ describe('agent drafts', () => {
     expect(getAgentDraft('agent-1', 'user-a')?.name).toBe('User A saved-agent draft');
     expect(getAgentDraft('agent-1', 'user-b')).toBeUndefined();
   });
+
+  it('preserves avatar reset intent without upload files', () => {
+    saveAgentDraft(
+      undefined,
+      createForm({
+        avatar_action: 'reset',
+        avatar_file: null,
+        avatar_preview: '/images/avatar.png',
+      }),
+    );
+
+    const draft = getAgentDraft(undefined);
+
+    expect(draft?.avatar_action).toBe('reset');
+    expect(draft?.avatar_preview).toBe('');
+    expect(draft?.avatar_file).toBeUndefined();
+  });
 });

--- a/client/src/components/SidePanel/Agents/__tests__/drafts.spec.ts
+++ b/client/src/components/SidePanel/Agents/__tests__/drafts.spec.ts
@@ -4,7 +4,13 @@
 import { AgentCapabilities } from 'librechat-data-provider';
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import type { AgentForm, ExtendedFile } from '~/common';
-import { getAgentDraft, saveAgentDraft, clearAgentDraft, clearAllAgentDrafts } from '../drafts';
+import {
+  getAgentDraft,
+  saveAgentDraft,
+  clearAgentDraft,
+  getAgentDraftKey,
+  clearAllAgentDrafts,
+} from '../drafts';
 
 const createForm = (overrides: Partial<AgentForm> = {}): AgentForm => {
   const file = new File(['avatar'], 'avatar.png', { type: 'image/png' });
@@ -21,7 +27,7 @@ const createForm = (overrides: Partial<AgentForm> = {}): AgentForm => {
     description: 'Draft description',
     instructions: 'Draft instructions',
     model: 'gpt-4o',
-    model_parameters: {},
+    model_parameters: {} as AgentForm['model_parameters'],
     tools: ['mcp__server__tool'],
     tool_options: {},
     provider: { label: 'OpenAI', value: 'openAI' },
@@ -109,5 +115,10 @@ describe('agent drafts', () => {
     expect(draft?.avatar_action).toBe('reset');
     expect(draft?.avatar_preview).toBe('');
     expect(draft?.avatar_file).toBeUndefined();
+  });
+
+  it('uses nullish draft key fallbacks without rewriting empty strings', () => {
+    expect(getAgentDraftKey(undefined, undefined)).toBe('anonymous:new');
+    expect(getAgentDraftKey('', '')).toBe(':');
   });
 });

--- a/client/src/components/SidePanel/Agents/drafts.ts
+++ b/client/src/components/SidePanel/Agents/drafts.ts
@@ -1,0 +1,58 @@
+import type { AgentForm, ExtendedFile } from '~/common';
+
+export const NEW_AGENT_DRAFT_KEY = 'new';
+
+export type AgentDraftValues = Partial<AgentForm>;
+
+const drafts = new Map<string, AgentDraftValues>();
+
+export function getAgentDraftKey(agentId?: string | null): string {
+  return agentId || NEW_AGENT_DRAFT_KEY;
+}
+
+const sanitizeFile = ({ file: _file, ...value }: ExtendedFile): ExtendedFile => value;
+
+const sanitizeFileEntries = (
+  entries?: Array<[string, ExtendedFile]>,
+): Array<[string, ExtendedFile]> | undefined =>
+  entries?.map(([id, file]): [string, ExtendedFile] => [id, sanitizeFile(file)]);
+
+export function sanitizeAgentDraft(values: AgentForm): AgentDraftValues {
+  const {
+    avatar_file: _avatarFile,
+    avatar_preview: _avatarPreview,
+    avatar_action: _avatarAction,
+    ...draft
+  } = values;
+
+  if (typeof draft.agent === 'object' && draft.agent != null) {
+    draft.agent = {
+      ...draft.agent,
+      context_files: sanitizeFileEntries(draft.agent.context_files),
+      knowledge_files: sanitizeFileEntries(draft.agent.knowledge_files),
+      code_files: sanitizeFileEntries(draft.agent.code_files),
+    };
+  }
+
+  return draft;
+}
+
+export function getAgentDraft(agentId?: string | null): AgentDraftValues | undefined {
+  return drafts.get(getAgentDraftKey(agentId));
+}
+
+export function saveAgentDraft(agentId: string | null | undefined, values: AgentForm): void {
+  drafts.set(getAgentDraftKey(agentId), sanitizeAgentDraft(values));
+}
+
+export function clearAgentDraft(agentId?: string | null): void {
+  drafts.delete(getAgentDraftKey(agentId));
+}
+
+export function clearAgentDrafts(agentIds: Array<string | null | undefined>): void {
+  agentIds.forEach(clearAgentDraft);
+}
+
+export function clearAllAgentDrafts(): void {
+  drafts.clear();
+}

--- a/client/src/components/SidePanel/Agents/drafts.ts
+++ b/client/src/components/SidePanel/Agents/drafts.ts
@@ -6,8 +6,8 @@ export type AgentDraftValues = Partial<AgentForm>;
 
 const drafts = new Map<string, AgentDraftValues>();
 
-export function getAgentDraftKey(agentId?: string | null): string {
-  return agentId || NEW_AGENT_DRAFT_KEY;
+export function getAgentDraftKey(agentId?: string | null, userId?: string | null): string {
+  return `${userId || 'anonymous'}:${agentId || NEW_AGENT_DRAFT_KEY}`;
 }
 
 const sanitizeFile = ({ file: _file, ...value }: ExtendedFile): ExtendedFile => value;
@@ -37,20 +37,30 @@ export function sanitizeAgentDraft(values: AgentForm): AgentDraftValues {
   return draft;
 }
 
-export function getAgentDraft(agentId?: string | null): AgentDraftValues | undefined {
-  return drafts.get(getAgentDraftKey(agentId));
+export function getAgentDraft(
+  agentId?: string | null,
+  userId?: string | null,
+): AgentDraftValues | undefined {
+  return drafts.get(getAgentDraftKey(agentId, userId));
 }
 
-export function saveAgentDraft(agentId: string | null | undefined, values: AgentForm): void {
-  drafts.set(getAgentDraftKey(agentId), sanitizeAgentDraft(values));
+export function saveAgentDraft(
+  agentId: string | null | undefined,
+  values: AgentForm,
+  userId?: string | null,
+): void {
+  drafts.set(getAgentDraftKey(agentId, userId), sanitizeAgentDraft(values));
 }
 
-export function clearAgentDraft(agentId?: string | null): void {
-  drafts.delete(getAgentDraftKey(agentId));
+export function clearAgentDraft(agentId?: string | null, userId?: string | null): void {
+  drafts.delete(getAgentDraftKey(agentId, userId));
 }
 
-export function clearAgentDrafts(agentIds: Array<string | null | undefined>): void {
-  agentIds.forEach(clearAgentDraft);
+export function clearAgentDrafts(
+  agentIds: Array<string | null | undefined>,
+  userId?: string | null,
+): void {
+  agentIds.forEach((agentId) => clearAgentDraft(agentId, userId));
 }
 
 export function clearAllAgentDrafts(): void {

--- a/client/src/components/SidePanel/Agents/drafts.ts
+++ b/client/src/components/SidePanel/Agents/drafts.ts
@@ -1,29 +1,38 @@
 import type { AgentForm, ExtendedFile } from '~/common';
 
-export const NEW_AGENT_DRAFT_KEY = 'new';
+const NEW_AGENT_DRAFT_KEY = 'new';
 
 export type AgentDraftValues = Partial<AgentForm>;
 
 const drafts = new Map<string, AgentDraftValues>();
 
 export function getAgentDraftKey(agentId?: string | null, userId?: string | null): string {
-  return `${userId || 'anonymous'}:${agentId || NEW_AGENT_DRAFT_KEY}`;
+  return `${userId ?? 'anonymous'}:${agentId ?? NEW_AGENT_DRAFT_KEY}`;
 }
 
-const sanitizeFile = ({ file: _file, ...value }: ExtendedFile): ExtendedFile => value;
+const sanitizeFile = (value: ExtendedFile): ExtendedFile => {
+  if (!value.file) {
+    return value;
+  }
+
+  const { file: _file, ...sanitized } = value;
+  return sanitized;
+};
 
 const sanitizeFileEntries = (
   entries?: Array<[string, ExtendedFile]>,
 ): Array<[string, ExtendedFile]> | undefined =>
   entries?.map(([id, file]): [string, ExtendedFile] => [id, sanitizeFile(file)]);
 
+/** Strips non-serializable File objects and avatar upload state; preserves avatar reset intent. */
 export function sanitizeAgentDraft(values: AgentForm): AgentDraftValues {
   const {
     avatar_file: _avatarFile,
     avatar_preview: _avatarPreview,
     avatar_action: avatarAction,
-    ...draft
+    ...baseDraft
   } = values;
+  const draft: AgentDraftValues = { ...baseDraft };
 
   if (avatarAction === 'reset') {
     draft.avatar_action = avatarAction;

--- a/client/src/components/SidePanel/Agents/drafts.ts
+++ b/client/src/components/SidePanel/Agents/drafts.ts
@@ -21,9 +21,14 @@ export function sanitizeAgentDraft(values: AgentForm): AgentDraftValues {
   const {
     avatar_file: _avatarFile,
     avatar_preview: _avatarPreview,
-    avatar_action: _avatarAction,
+    avatar_action: avatarAction,
     ...draft
   } = values;
+
+  if (avatarAction === 'reset') {
+    draft.avatar_action = avatarAction;
+    draft.avatar_preview = '';
+  }
 
   if (typeof draft.agent === 'object' && draft.agent != null) {
     draft.agent = {

--- a/client/src/hooks/Config/useClearStates.ts
+++ b/client/src/hooks/Config/useClearStates.ts
@@ -1,4 +1,5 @@
 import { useRecoilCallback } from 'recoil';
+import { clearAllAgentDrafts } from '~/components/SidePanel/Agents/drafts';
 import { clearLocalStorage } from '~/utils/localStorage';
 import store from '~/store';
 
@@ -44,6 +45,7 @@ export default function useClearStates() {
         }
 
         clearLocalStorage(skipFirst);
+        clearAllAgentDrafts();
       },
     [],
   );


### PR DESCRIPTION
## Summary

I fixed the agent builder form reset by preserving unsaved agent drafts in memory while the side panel switches between Agents and Files.

- Added an in-memory draft store keyed by agent id or `new`, with avatar uploads and nested `File` objects sanitized out of saved draft values.
- Initialized the agent builder form from an existing draft before falling back to the normal default form values.
- Persisted draftable form values while the form changes and when the Agents panel unmounts during side-panel navigation.
- Prevented agent query hydration from overwriting a known unsaved draft after remount.
- Cleared drafts on successful create/update, avatar-only save, explicit Create new agent, delete, and selecting a different agent.
- Added regression coverage for Agents → Files → Agents restoration, intentional reset, draft isolation, draft sanitization, and update-success clearing.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm ci --ignore-scripts --no-audit --no-fund` to install the missing workspace dependencies.
- Ran `npm run build:data-provider`.
- Ran `npm run build:client-package`.
- Ran `cd client && npx jest src/components/SidePanel/Agents/__tests__/drafts.spec.ts src/components/SidePanel/Agents/__tests__/AgentPanel.drafts.spec.tsx src/components/SidePanel/Agents/AgentPanel.test.tsx --runInBand`.

### **Test Configuration**:

- macOS local Codex worktree
- Jest focused frontend suites
- Built `packages/data-provider` and `packages/client` before running frontend tests

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes