### PR TITLE
🧹 chore: Type Agent MCP lean projection in ServerConfigsDB

### DIFF
--- a/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
+++ b/packages/api/src/mcp/registry/db/ServerConfigsDB.ts
@@ -6,7 +6,7 @@ import {
   PermissionBits,
 } from 'librechat-data-provider';
 import { logger, encryptV2, decryptV2, createMethods } from '@librechat/data-schemas';
-import type { AllMethods, MCPServerDocument } from '@librechat/data-schemas';
+import type { AllMethods, IAgent, MCPServerDocument } from '@librechat/data-schemas';
 import type { IServerConfigsRepositoryInterface } from '~/mcp/registry/ServerConfigsRepositoryInterface';
 import type { ParsedServerConfig, AddServerResult } from '~/mcp/types';
 import { AccessControlService } from '~/acl/accessControlService';
@@ -370,14 +370,9 @@ export class ServerConfigsDB implements IServerConfigsRepositoryInterface {
           mcpServerNames: { $exists: true, $not: { $size: 0 } },
         },
         { mcpServerNames: 1 },
-      ).lean();
+      ).lean<Pick<IAgent, 'mcpServerNames'>[]>();
 
-      agentMCPServerNames = [
-        ...new Set(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          agentsWithMCP.flatMap((a: any) => a.mcpServerNames || []),
-        ),
-      ];
+      agentMCPServerNames = [...new Set(agentsWithMCP.flatMap((a) => a.mcpServerNames ?? []))];
     }
 
     const directResults = await this._dbMethods.getListMCPServersByIds({


### PR DESCRIPTION
## Summary

Drops the `(a: any)` cast (and its eslint-disable) in `ServerConfigsDB.getAll()`. The Mongoose query only projects `mcpServerNames`, so passing `Pick<IAgent, 'mcpServerNames'>[]` as the `.lean<T[]>()` generic gives us the right shape without `any`.

Also `|| []` → `?? []` while I was in there. No runtime change.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing

`getAll()` is already covered by `ServerConfigsDB.test.ts`. Ran `tsc --noEmit` and `npm run test:ci` in `packages/api` locally — both clean.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [ ] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted
