### PR TITLE
feat: align File Search upload menu with RBAC permissions

### DIFF
--- a/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
+++ b/client/src/components/Chat/Input/Files/AttachFileMenu.tsx
@@ -23,15 +23,19 @@ import {
   defaultAgentCapabilities,
   bedrockDocumentExtensions,
   isDocumentSupportedProvider,
+  PermissionTypes,
+  Permissions,
 } from 'librechat-data-provider';
 import type { EndpointFileConfig, TConversation } from 'librechat-data-provider';
 import type { ExtendedFile, FileSetter } from '~/common';
+import { isEphemeralAgent } from '~/common';
 import {
   useAgentToolPermissions,
   useAgentCapabilities,
   useGetAgentsConfig,
   useFileHandlingNoChatContext,
   useLocalize,
+  useHasAccess,
 } from '~/hooks';
 import { useSharePointFileHandlingNoChatContext } from '~/hooks/Files/useSharePointFileHandling';
 import { SharePointPickerDialog } from '~/components/SharePoint';
@@ -110,6 +114,10 @@ const AttachFileMenu = ({
     agentId,
     ephemeralAgent,
   );
+  const canUseFileSearch = useHasAccess({
+    permissionType: PermissionTypes.FILE_SEARCH,
+    permission: Permissions.USE,
+  });
 
   const handleUploadClick = useCallback(
     (fileType?: FileUploadType) => {
@@ -205,7 +213,7 @@ const AttachFileMenu = ({
         });
       }
 
-      if (capabilities.fileSearchEnabled && fileSearchAllowedByAgent) {
+      if (capabilities.fileSearchEnabled && canUseFileSearch && (isEphemeralAgent(agentId) || fileSearchAllowedByAgent)) {
         items.push({
           label: localize('com_ui_upload_file_search'),
           onClick: () => {
@@ -266,7 +274,7 @@ const AttachFileMenu = ({
     setEphemeralAgent,
     sharePointEnabled,
     codeAllowedByAgent,
-    fileSearchAllowedByAgent,
+    canUseFileSearch,
     setIsSharePointDialogOpen,
   ]);
 

--- a/client/src/components/Chat/Input/Files/DragDropModal.tsx
+++ b/client/src/components/Chat/Input/Files/DragDropModal.tsx
@@ -16,13 +16,17 @@ import {
   isBedrockDocumentType,
   defaultAgentCapabilities,
   isDocumentSupportedProvider,
+  PermissionTypes,
+  Permissions,
 } from 'librechat-data-provider';
 import {
   useAgentToolPermissions,
   useAgentCapabilities,
   useGetAgentsConfig,
   useLocalize,
+  useHasAccess,
 } from '~/hooks';
+import { isEphemeralAgent } from '~/common';
 import { ephemeralAgentByConvoId } from '~/store';
 import { useDragDropContext } from '~/Providers';
 
@@ -54,6 +58,10 @@ const DragDropModal = ({ onOptionSelect, setShowModal, files, isVisible }: DragD
     agentId,
     ephemeralAgent,
   );
+  const canUseFileSearch = useHasAccess({
+    permissionType: PermissionTypes.FILE_SEARCH,
+    permission: Permissions.USE,
+  });
 
   const options = useMemo(() => {
     const _options: FileOption[] = [];
@@ -116,7 +124,7 @@ const DragDropModal = ({ onOptionSelect, setShowModal, files, isVisible }: DragD
         condition: files.every((file) => getFileType(file)?.startsWith('image/')),
       });
     }
-    if (capabilities.fileSearchEnabled && fileSearchAllowedByAgent) {
+    if (capabilities.fileSearchEnabled && canUseFileSearch && (isEphemeralAgent(agentId) || fileSearchAllowedByAgent)) {
       _options.push({
         label: localize('com_ui_upload_file_search'),
         value: EToolResources.file_search,
@@ -148,7 +156,7 @@ const DragDropModal = ({ onOptionSelect, setShowModal, files, isVisible }: DragD
     capabilities,
     useResponsesApi,
     codeAllowedByAgent,
-    fileSearchAllowedByAgent,
+    canUseFileSearch,
   ]);
 
   if (!isVisible) {

--- a/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
+++ b/client/src/components/Chat/Input/Files/__tests__/AttachFileMenu.spec.tsx
@@ -11,6 +11,7 @@ jest.mock('~/hooks', () => ({
   useGetAgentsConfig: jest.fn(),
   useFileHandlingNoChatContext: jest.fn(),
   useLocalize: jest.fn(),
+  useHasAccess: jest.fn(),
 }));
 
 jest.mock('~/hooks/Files/useSharePointFileHandling', () => ({
@@ -82,6 +83,7 @@ const mockUseAgentToolPermissions = jest.requireMock('~/hooks').useAgentToolPerm
 const mockUseAgentCapabilities = jest.requireMock('~/hooks').useAgentCapabilities;
 const mockUseGetAgentsConfig = jest.requireMock('~/hooks').useGetAgentsConfig;
 const mockUseFileHandlingNoChatContext = jest.requireMock('~/hooks').useFileHandlingNoChatContext;
+const mockUseHasAccess = jest.requireMock('~/hooks').useHasAccess;
 const mockUseLocalize = jest.requireMock('~/hooks').useLocalize;
 const mockUseSharePointFileHandling = jest.requireMock(
   '~/hooks/Files/useSharePointFileHandling',
@@ -111,6 +113,7 @@ function setupMocks(overrides: { provider?: string } = {}) {
   });
   mockUseGetAgentsConfig.mockReturnValue({ agentsConfig: {} });
   mockUseFileHandlingNoChatContext.mockReturnValue({ handleFileChange: jest.fn() });
+  mockUseHasAccess.mockReturnValue(true);
   const sharePointReturnValue = {
     handleSharePointFiles: jest.fn(),
     isProcessing: false,
@@ -296,6 +299,31 @@ describe('AttachFileMenu', () => {
 
     it('does NOT show File Search when enabled but not allowed by agent', () => {
       setupMocks();
+      mockUseAgentCapabilities.mockReturnValue({
+        contextEnabled: false,
+        fileSearchEnabled: true,
+        codeEnabled: false,
+      });
+      renderMenu({ endpointType: EModelEndpoint.openAI, agentId: 'agent_without_fs' });
+      openMenu();
+      expect(screen.queryByText('Upload for File Search')).not.toBeInTheDocument();
+    });
+
+    it('shows File Search for non-agent conversations with RBAC allowed', () => {
+      setupMocks();
+      mockUseAgentCapabilities.mockReturnValue({
+        contextEnabled: false,
+        fileSearchEnabled: true,
+        codeEnabled: false,
+      });
+      renderMenu({ endpointType: EModelEndpoint.openAI });
+      openMenu();
+      expect(screen.getByText('Upload for File Search')).toBeInTheDocument();
+    });
+
+    it('does NOT show File Search for non-agent conversations when RBAC denied', () => {
+      setupMocks();
+      mockUseHasAccess.mockReturnValue(false);
       mockUseAgentCapabilities.mockReturnValue({
         contextEnabled: false,
         fileSearchEnabled: true,


### PR DESCRIPTION
## Summary
The File Search upload menu (paperclip icon) uses `fileSearchAllowedByAgent` to show "Upload for File Search", while the File Search toolbar toggle uses `useHasAccess` (RBAC permission check). This creates an inconsistency: the toggle is visible for non-agent conversations (e.g., OpenRouter direct chat) but the upload option remains hidden.
This PR aligns the upload menu with the toolbar toggle by replacing `fileSearchAllowedByAgent` with `canUseFileSearch` (RBAC) as the primary gate. For agent conversations, the agent-specific permission (`fileSearchAllowedByAgent`) is preserved as an additional check.

## Change Type
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Translation update

## Testing
```bash
npm run test:client -- --testPathPattern="AttachFileMenu"
npm run test:client -- --testPathPattern="DragDropModal"
npm run test:api

## Test Configuration
No specific configuration required.

## Checklist
- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes