### PR TITLE
🕵🏻 ci: Improve Flaky Subagents Test

### DIFF
--- a/client/src/components/Chat/Messages/Content/Parts/__tests__/SubagentCall.test.tsx
+++ b/client/src/components/Chat/Messages/Content/Parts/__tests__/SubagentCall.test.tsx
@@ -83,22 +83,19 @@ jest.mock('../Attachment', () => ({
   ),
 }));
 
-jest.mock(
-  '@librechat/client',
-  () => ({
-    OGDialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-    OGDialogContent: ({ children }: { children: React.ReactNode }) => (
-      <div data-testid="dialog-content">{children}</div>
-    ),
-    OGDialogTitle: ({ children }: { children: React.ReactNode }) => (
-      <div data-testid="dialog-title">{children}</div>
-    ),
-    OGDialogDescription: ({ children }: { children: React.ReactNode }) => (
-      <div data-testid="dialog-description">{children}</div>
-    ),
-  }),
-  { virtual: true },
-);
+jest.mock('@librechat/client', () => ({
+  __esModule: true,
+  OGDialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  OGDialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dialog-content">{children}</div>
+  ),
+  OGDialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dialog-title">{children}</div>
+  ),
+  OGDialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dialog-description">{children}</div>
+  ),
+}));
 
 jest.mock('lucide-react', () => ({
   // eslint-disable-next-line i18next/no-literal-string
@@ -244,6 +241,13 @@ function renderWithState(args: {
   };
   setProgress(args.progress ?? null);
   return { ...rendered, setProgress };
+}
+
+/** Open the subagent dialog. Required when another test file in the same Jest
+ *  worker has already loaded the real `@librechat/client` module; Radix only
+ *  mounts dialog content while `open` is true. */
+function openSubagentDialog(headerLabel = 'Ran agent') {
+  fireEvent.click(screen.getByRole('button', { name: headerLabel }));
 }
 
 describe('SubagentCall — status resolution', () => {
@@ -519,6 +523,7 @@ describe('SubagentCall — dialog content', () => {
       </RecoilRoot>,
     );
 
+    openSubagentDialog();
     expect(screen.getByTestId('prompt-markdown')).toHaveTextContent('# Review prompt');
     expect(screen.getByText('final answer')).toBeInTheDocument();
 
@@ -594,8 +599,7 @@ describe('SubagentCall — dialog content', () => {
       }),
     });
 
-    /** The mocked `OGDialog` always renders children, so dialog content is
-     *  inspectable without simulating a click. */
+    openSubagentDialog();
     expect(screen.getByTestId('reasoning-part')).toHaveTextContent('Let me compute.');
     expect(screen.getByTestId('tool-call-part')).toHaveAttribute('data-name', 'calculator');
     expect(screen.getByTestId('tool-call-part')).toHaveTextContent('4');
@@ -603,15 +607,9 @@ describe('SubagentCall — dialog content', () => {
   });
 
   it('falls back to the raw tool output when no content parts were recorded', () => {
-    renderWithState({
-      toolCallId: 'call_fallback',
-      initialProgress: 1,
-      isSubmitting: false,
-      progress: null,
-    });
     /** No events → no aggregated parts. The SubagentCall should still
      *  render the raw final `output` that came back in the parent's
-     *  tool_call (we pass it explicitly below). */
+     *  tool_call. */
     const { rerender } = render(
       <RecoilRoot>
         <SubagentCall
@@ -622,6 +620,7 @@ describe('SubagentCall — dialog content', () => {
         />
       </RecoilRoot>,
     );
+    openSubagentDialog();
     expect(screen.getByText('raw final text')).toBeInTheDocument();
     rerender(<RecoilRoot />);
   });
@@ -661,6 +660,7 @@ describe('SubagentCall — dialog content', () => {
       </RecoilRoot>,
     );
 
+    openSubagentDialog();
     expect(screen.getByTestId('reasoning-part')).toHaveTextContent('Prior thinking.');
     expect(screen.getByTestId('tool-call-part')).toHaveAttribute('data-name', 'calculator');
     expect(screen.getByTestId('tool-call-part')).toHaveTextContent('2436');
@@ -694,6 +694,7 @@ describe('SubagentCall — dialog content', () => {
         />
       </RecoilRoot>,
     );
+    openSubagentDialog();
     expect(screen.getByText('Persisted answer.')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

Fixes flaky failures in `SubagentCall.test.tsx` under the full client Jest suite (`--maxWorkers=50%`), which caused **Frontend Unit Tests** to fail in CI with `Unable to find [data-testid="prompt-markdown"]` (and similar dialog assertions).

The dialog-content tests assumed the mocked `OGDialog` always mounts its children. When another spec in the same Jest worker has already loaded the real `@librechat/client` module, `SubagentCall` can render the real Radix dialog with `open={false}`, so dialog content is not in the DOM until the user opens it.

This change opens the subagent dialog via the header button before asserting on dialog content, removes the redundant `renderWithState` setup in the raw-output fallback test, and drops `{ virtual: true }` on the `@librechat/client` mock in favor of a normal `__esModule` mock.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

From `client/`:

```bash
# Reproduces CI failure without fix (parallel full suite, dialog tests)
NODE_ENV=development npx jest --ci --maxWorkers=50% --no-coverage -t "SubagentCall — dialog content"

# Isolated file always passes (with or without fix)
NODE_ENV=development npx jest src/components/Chat/Messages/Content/Parts/__tests__/SubagentCall.test.tsx --no-coverage

# With fix: full client suite should pass
NODE_ENV=development npm run test:ci
```

Before the fix, the full parallel suite intermittently failed 5 tests in `SubagentCall — dialog content`; after the fix, repeated `--maxWorkers=50%` full-suite runs passed locally.

### **Test Configuration**:

- Node 20.x, default `client/jest.config.cjs` (`maxWorkers: '50%'`)
- No extra env vars

## Checklist

Please delete any irrelevant options.

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.
- [ ] A pull request for updating the documentation has been submitted.