### PR TITLE
🍪 feat: Add Session Cookie Secure Override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -488,6 +488,10 @@ ALLOW_UNVERIFIED_EMAIL_LOGIN=true
 
 SESSION_EXPIRY=1000 * 60 * 15
 REFRESH_TOKEN_EXPIRY=(1000 * 60 * 60 * 24) * 7
+# Overrides the Secure attribute for session/auth cookies when set to true or false;
+# leave unset to use the default NODE_ENV/DOMAIN_SERVER heuristic.
+# Set to false only for HTTP-only deployments where browsers drop Secure cookies.
+# SESSION_COOKIE_SECURE=false
 
 JWT_SECRET=16f8c0ef4a5d391b26034086c628469d3f9f497f08163ab9b40137092f2909ef
 JWT_REFRESH_SECRET=eaa5191f2914e30b9387fd84e254e4ba6fc51b4654968a9b0803b456a54b8418

--- a/packages/api/src/oauth/csrf.spec.ts
+++ b/packages/api/src/oauth/csrf.spec.ts
@@ -5,6 +5,7 @@ describe('shouldUseSecureCookie', () => {
 
   beforeEach(() => {
     process.env = { ...originalEnv };
+    delete process.env.SESSION_COOKIE_SECURE;
   });
 
   afterAll(() => {
@@ -27,6 +28,34 @@ describe('shouldUseSecureCookie', () => {
     delete process.env.NODE_ENV;
     process.env.DOMAIN_SERVER = 'https://myapp.example.com';
     expect(shouldUseSecureCookie()).toBe(false);
+  });
+
+  it('should return true when SESSION_COOKIE_SECURE=true', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.DOMAIN_SERVER = 'http://localhost:3080';
+    process.env.SESSION_COOKIE_SECURE = 'true';
+    expect(shouldUseSecureCookie()).toBe(true);
+  });
+
+  it('should return false when SESSION_COOKIE_SECURE=false', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DOMAIN_SERVER = 'http://10.0.0.5:3080';
+    process.env.SESSION_COOKIE_SECURE = 'false';
+    expect(shouldUseSecureCookie()).toBe(false);
+  });
+
+  it('should trim and normalize SESSION_COOKIE_SECURE values', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.DOMAIN_SERVER = 'http://localhost:3080';
+    process.env.SESSION_COOKIE_SECURE = ' TRUE ';
+    expect(shouldUseSecureCookie()).toBe(true);
+  });
+
+  it('should ignore invalid SESSION_COOKIE_SECURE values', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DOMAIN_SERVER = 'https://myapp.example.com';
+    process.env.SESSION_COOKIE_SECURE = 'yes';
+    expect(shouldUseSecureCookie()).toBe(true);
   });
 
   describe('localhost detection in production', () => {

--- a/packages/api/src/oauth/csrf.ts
+++ b/packages/api/src/oauth/csrf.ts
@@ -1,6 +1,8 @@
 import crypto from 'crypto';
 import type { Request, Response, NextFunction } from 'express';
 
+import { isEnabled } from '~/utils/common';
+
 export const OAUTH_CSRF_COOKIE = 'oauth_csrf';
 export const OAUTH_CSRF_MAX_AGE = 10 * 60 * 1000;
 
@@ -10,11 +12,17 @@ export const OAUTH_SESSION_COOKIE_PATH = '/api';
 
 /**
  * Determines if secure cookies should be used.
- * Returns `true` in production unless the server is running on localhost (HTTP).
- * This allows cookies to work on `http://localhost` during local development
+ * SESSION_COOKIE_SECURE=true/false explicitly overrides the environment heuristic.
+ * Returns `true` in production unless DOMAIN_SERVER uses a localhost-style hostname.
+ * This allows cookies to work on localhost during local development
  * even when `NODE_ENV=production` (common in Docker Compose setups).
  */
 export function shouldUseSecureCookie(): boolean {
+  const secureOverride = process.env.SESSION_COOKIE_SECURE?.trim().toLowerCase();
+  if (secureOverride === 'true' || secureOverride === 'false') {
+    return isEnabled(secureOverride);
+  }
+
   const isProduction = process.env.NODE_ENV === 'production';
   const domainServer = process.env.DOMAIN_SERVER || '';
 

--- a/packages/api/src/oauth/csrf.ts
+++ b/packages/api/src/oauth/csrf.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 import type { Request, Response, NextFunction } from 'express';
-
 import { isEnabled } from '~/utils/common';
 
 export const OAUTH_CSRF_COOKIE = 'oauth_csrf';


### PR DESCRIPTION
Closes #13188.

## Summary

I added an explicit `SESSION_COOKIE_SECURE` override for LibreChat session and auth cookies so HTTP-only deployments can opt out of the `Secure` cookie flag when the production hostname heuristic would otherwise enable it.

- Added `SESSION_COOKIE_SECURE=true|false` handling inside `shouldUseSecureCookie()` before the existing `NODE_ENV` and `DOMAIN_SERVER` heuristic runs.
- Preserved the current default behavior when the override is unset or invalid, so production non-localhost deployments still use secure cookies by default.
- Documented the override in `.env.example`, including guidance to set it to `false` only for HTTP-only deployments where browsers drop `Secure` cookies.
- Added unit tests for explicit `true`, explicit `false`, normalized values, and invalid-value fallback.

The behavior that broke HTTP-only non-localhost OIDC deployments came from secure-cookie hardening in #11407, followed by the localhost-only bypass in #11518. That fixed local Docker over HTTP but still classified non-localhost HTTP endpoints as secure-cookie deployments, so browsers dropped the OIDC `connect.sid` cookie and later auth cookies.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- [x] Ran `npm run smart-reinstall` to install dependencies and build packages.
- [x] Ran `cd packages/api && npx jest src/oauth/csrf.spec.ts --coverage=false --runInBand`.

### **Test Configuration**:

- Node.js v20.19.5
- npm 10.8.2
- Targeted Jest suite: `packages/api/src/oauth/csrf.spec.ts` passes with 19 tests.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes