### PR TITLE
🛟 refactor: Gracefully Skip Unavailable Web Search Rerankers

### DIFF
--- a/packages/api/src/web/web.spec.ts
+++ b/packages/api/src/web/web.spec.ts
@@ -689,8 +689,7 @@ describe('web.ts', () => {
       const originalEnv = process.env;
       process.env = {
         ...originalEnv,
-        SERPER_API_KEY: 'test-key',
-        // Missing other keys to force authentication failure
+        JINA_API_KEY: 'test-key',
       };
 
       // Initialize webSearchConfig with environment variable references
@@ -710,10 +709,9 @@ describe('web.ts', () => {
       mockLoadAuthValues.mockImplementation(({ authFields }) => {
         const result: Record<string, string> = {};
         authFields.forEach((field: string) => {
-          if (field === 'SERPER_API_KEY') {
+          if (field === 'JINA_API_KEY') {
             result[field] = 'test-key';
           }
-          // Other fields are intentionally missing
         });
         return Promise.resolve(result);
       });
@@ -1104,6 +1102,47 @@ describe('web.ts', () => {
           call[0].authFields.includes('JINA_API_KEY'),
       );
       expect(cohereCalls.length).toBe(0);
+    });
+
+    it('should fallback to no reranker when rerankerType is omitted and no reranker is authenticated', async () => {
+      const webSearchConfig: TCustomConfig['webSearch'] = {
+        searxngInstanceUrl: '${SEARXNG_INSTANCE_URL}',
+        searxngApiKey: '${SEARXNG_API_KEY}',
+        firecrawlApiKey: '${FIRECRAWL_API_KEY}',
+        firecrawlApiUrl: '${FIRECRAWL_API_URL}',
+        jinaApiKey: '${JINA_API_KEY}',
+        jinaApiUrl: '${JINA_API_URL}',
+        cohereApiKey: '${COHERE_API_KEY}',
+        safeSearch: SafeSearchTypes.MODERATE,
+        searchProvider: 'searxng' as SearchProviders,
+        scraperProvider: 'firecrawl' as ScraperProviders,
+      };
+
+      mockLoadAuthValues.mockImplementation(({ authFields }) => {
+        const result: Record<string, string> = {};
+        authFields.forEach((field: string) => {
+          if (field === 'SEARXNG_INSTANCE_URL') {
+            result[field] = 'https://search.example';
+          } else if (field === 'SEARXNG_API_KEY') {
+            result[field] = 'searxng-api-key';
+          } else if (field === 'FIRECRAWL_API_KEY') {
+            result[field] = 'firecrawl-api-key';
+          } else if (field === 'FIRECRAWL_API_URL') {
+            result[field] = 'https://api.firecrawl.dev';
+          }
+        });
+        return Promise.resolve(result);
+      });
+
+      const result = await loadWebSearchAuth({
+        userId,
+        webSearchConfig,
+        loadAuthValues: mockLoadAuthValues,
+      });
+
+      expect(result.authenticated).toBe(true);
+      expect(result.authResult.rerankerType).toBe('none');
+      expect(result.authTypes).toContainEqual(['rerankers', AuthType.SYSTEM_DEFINED]);
     });
 
     it('should handle invalid specified service gracefully', async () => {

--- a/packages/api/src/web/web.ts
+++ b/packages/api/src/web/web.ts
@@ -7,11 +7,7 @@ import {
   extractVariableName,
 } from 'librechat-data-provider';
 import { webSearchAuth } from '@librechat/data-schemas';
-import type {
-  RerankerTypes,
-  TCustomConfig,
-  TWebSearchConfig,
-} from 'librechat-data-provider';
+import type { RerankerTypes, TCustomConfig, TWebSearchConfig } from 'librechat-data-provider';
 import type { TWebSearchKeys, TWebSearchCategories } from '@librechat/data-schemas';
 import { isSSRFTarget, resolveHostnameSSRF } from '../auth';
 
@@ -209,8 +205,7 @@ export async function loadWebSearchAuth({
           const isUserProvidedOptInUrlKey =
             originalKey != null && USER_PROVIDED_OPT_IN_URL_KEYS.has(originalKey);
           const isUserProvidedUrlEnabled =
-            isUserProvidedUrlKey ||
-            (isUserProvidedOptInUrlKey && isUserProvidedEnabled(field));
+            isUserProvidedUrlKey || (isUserProvidedOptInUrlKey && isUserProvidedEnabled(field));
           let contributed = false;
 
           if (isUserProvidedOptInUrlKey && isFieldUserProvided && !isUserProvidedUrlEnabled) {
@@ -252,6 +247,10 @@ export async function loadWebSearchAuth({
       } catch {
         continue;
       }
+    }
+    if (category === SearchCategories.RERANKERS && !webSearchConfig?.rerankerType) {
+      authResult.rerankerType = 'none' as RerankerTypes;
+      return [true, false];
     }
     return [false, isUserProvided];
   }


### PR DESCRIPTION
## Summary

I updated web search auth so an omitted `rerankerType` no longer blocks setup when no reranker credentials are available, while explicit reranker selections still require authentication.

Related discussion: https://github.com/danny-avila/LibreChat/discussions/13178

- Added a fallback that sets `rerankerType` to `none` after auto-detection cannot authenticate Jina or Cohere and no reranker was explicitly configured.
- Preserved auto-detection for available reranker credentials and strict failure for explicit `jina` or `cohere` selections.
- Added regression coverage for SearXNG + Firecrawl configs without usable reranker credentials.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm ci --ignore-scripts`
- Ran `npm run build:data-provider && npm run build:data-schemas`
- Ran `cd packages/api && npx jest src/web/web.spec.ts --runInBand`
- Ran `npm run build:api`
- Ran `npx eslint packages/api/src/web/web.ts packages/api/src/web/web.spec.ts`

### **Test Configuration**:

- Node.js v20.19.5
- npm 10.8.2

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
