### PR TITLE
⛴️ fix: Stop Double-Wrapping configYamlContent in Helm ConfigMap

### DIFF
--- a/helm/librechat/templates/configmap.yaml
+++ b/helm/librechat/templates/configmap.yaml
@@ -5,6 +5,6 @@ metadata:
   name: {{ include "librechat.fullname" $ }}-config
 data:
   librechat.yaml: |
-{{ .Values.librechat.configYamlContent | toYaml | indent 4 }}
+{{ .Values.librechat.configYamlContent | indent 4 }}
 
 {{- end }}

--- a/helm/librechat/tests/configmap_render_test.sh
+++ b/helm/librechat/tests/configmap_render_test.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Regression test for the librechat ConfigMap template.
+#
+# Background: at one point templates/configmap.yaml ran
+# `.Values.librechat.configYamlContent | toYaml | indent 4`. Because the
+# value is already a YAML literal string, toYaml re-wrapped it in another `|`
+# block scalar, producing a mounted /app/librechat.yaml whose first line was
+# a bare `|`. js-yaml "recovered" by returning the body as a string, so
+# LibreChat silently fell back to internal defaults for every config block
+# (endpoints, interface, modelSpecs, ...).
+#
+# This test renders the ConfigMap with a sample configYamlContent and asserts
+# that the rendered librechat.yaml is a proper YAML object preserving nested
+# keys.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VALUES_FILE="$(mktemp -t librechat-configmap-values.XXXXXX)"
+RENDERED_FILE="$(mktemp -t librechat-configmap-render.XXXXXX)"
+trap 'rm -f "${VALUES_FILE}" "${RENDERED_FILE}"' EXIT
+
+cat > "${VALUES_FILE}" <<'YAML'
+librechat:
+  configYamlContent: |
+    version: 1.3.11
+    endpoints:
+      agents:
+        disableBuilder: false
+YAML
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "FAIL: helm not on PATH" >&2
+  exit 1
+fi
+
+# Render only the chart's templates so dependent sub-charts don't need network access.
+helm template librechat "${CHART_DIR}" \
+  --show-only templates/configmap.yaml \
+  -f "${VALUES_FILE}" > "${RENDERED_FILE}"
+
+# Pull the block scalar body that lives under `librechat.yaml: |`.
+# awk: enter the block on the header line, then emit subsequent lines while
+# they are indented (the body) and stop at the next unindented line.
+BODY="$(awk '
+  /^  librechat\.yaml: \|/ { in_block = 1; next }
+  in_block {
+    if ($0 ~ /^    /) { sub(/^    /, ""); print; next }
+    if ($0 ~ /^$/)    { print; next }
+    exit
+  }
+' "${RENDERED_FILE}")"
+
+if [[ -z "${BODY}" ]]; then
+  echo "FAIL: could not extract librechat.yaml body from rendered ConfigMap" >&2
+  cat "${RENDERED_FILE}" >&2
+  exit 1
+fi
+
+FIRST_LINE="$(printf '%s\n' "${BODY}" | awk 'NF { print; exit }')"
+if [[ "${FIRST_LINE}" == "|" ]]; then
+  echo "FAIL: rendered librechat.yaml starts with a bare '|' — configYamlContent is double-wrapped" >&2
+  echo "----- rendered body -----" >&2
+  printf '%s\n' "${BODY}" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "${BODY}" | grep -qE '^version: 1\.3\.11$'; then
+  echo "FAIL: expected top-level 'version: 1.3.11' in rendered librechat.yaml" >&2
+  printf '%s\n' "${BODY}" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "${BODY}" | grep -qE '^endpoints:$'; then
+  echo "FAIL: expected top-level 'endpoints:' key in rendered librechat.yaml" >&2
+  printf '%s\n' "${BODY}" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "${BODY}" | grep -qE '^  agents:$'; then
+  echo "FAIL: expected nested 'endpoints.agents' key in rendered librechat.yaml" >&2
+  printf '%s\n' "${BODY}" >&2
+  exit 1
+fi
+
+# If a YAML parser is available, do a real parse to confirm the body loads as
+# an object (not a string) and that endpoints.agents survives the round trip.
+PARSER=""
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+  PARSER="python3"
+elif command -v node >/dev/null 2>&1 && node -e 'require("js-yaml")' >/dev/null 2>&1; then
+  PARSER="node"
+fi
+
+case "${PARSER}" in
+  python3)
+    BODY="${BODY}" python3 - <<'PY'
+import os, sys, yaml
+body = os.environ["BODY"]
+doc = yaml.safe_load(body)
+if not isinstance(doc, dict):
+    sys.stderr.write(f"FAIL: parsed librechat.yaml is {type(doc).__name__}, expected dict\n")
+    sys.exit(1)
+agents = (doc.get("endpoints") or {}).get("agents")
+if not isinstance(agents, dict) or "disableBuilder" not in agents:
+    sys.stderr.write(f"FAIL: endpoints.agents missing or malformed after parse: {agents!r}\n")
+    sys.exit(1)
+PY
+    ;;
+  node)
+    BODY="${BODY}" node -e '
+      const yaml = require("js-yaml");
+      const doc = yaml.load(process.env.BODY);
+      if (doc === null || typeof doc !== "object" || Array.isArray(doc)) {
+        console.error("FAIL: parsed librechat.yaml is " + typeof doc + ", expected object");
+        process.exit(1);
+      }
+      const agents = doc.endpoints && doc.endpoints.agents;
+      if (!agents || typeof agents.disableBuilder === "undefined") {
+        console.error("FAIL: endpoints.agents missing after parse: " + JSON.stringify(agents));
+        process.exit(1);
+      }
+    '
+    ;;
+  *)
+    echo "NOTE: skipping YAML-parser assertion (install python3+pyyaml or node+js-yaml to enable)"
+    ;;
+esac
+
+echo "PASS: rendered librechat.yaml is a proper YAML document with nested keys preserved"


### PR DESCRIPTION
Fixes #13197.

## Summary
Fix double-wrapped YAML in the `configYamlContent` ConfigMap so LibreChat actually reads the user's `librechat.yaml` instead of silently falling back to internal defaults.

## The bug
`templates/configmap.yaml` piped `.Values.librechat.configYamlContent` through `toYaml` before indenting. Because the value is documented as — and used as — a YAML literal string, `toYaml` re-wrapped it in another `|` block scalar. The mounted `/app/librechat.yaml` ended up like this:

**Before (broken):**
```yaml
data:
  librechat.yaml: |
    |
      version: 1.3.11
      endpoints:
        agents:
          disableBuilder: false
```

The first character of the file is a literal `|`, which is not a valid top-level YAML document. `js-yaml` (LibreChat's parser) "recovers" by returning the body as a **string** rather than throwing — so every `config.<block>` lookup downstream returns `undefined`.

**After (fixed):**
```yaml
data:
  librechat.yaml: |
    version: 1.3.11
    endpoints:
      agents:
        disableBuilder: false
```

The fix is one line — `| toYaml` was redundant and harmful. `| indent 4` is correct and stays.

## User-visible impact
Anywhere `configYamlContent` is set via Helm values, the file was being parsed to a `string`, so the application fell back to compiled-in defaults for every config-driven feature, with no error logged. Things that silently broke:

- `endpoints.agents` — Agents endpoint not registered.
- `interface.*` — interface customizations ignored (privacyPolicy, termsOfService, modelSelect toggles, etc.).
- `modelSpecs` — custom model specs not surfaced.
- `registration` / `OPENID_ADMIN_ROLE_*` role mapping — skipped.
- `mcpServers`, `webSearch`, `memory`, `balance`, `fileConfig`, `rateLimits`, …

Users who set `configYamlContent` got a working pod that quietly behaved as if the config was empty.

## Repro
```bash
git clone https://github.com/danny-avila/LibreChat
cd LibreChat
helm dependency build helm/librechat

cat > /tmp/test-values.yaml <<'EOF'
librechat:
  configYamlContent: |
    version: 1.3.11
    endpoints:
      agents:
        disableBuilder: false
EOF

helm template librechat helm/librechat -f /tmp/test-values.yaml \
  --show-only templates/configmap.yaml
```

Before this PR the rendered `librechat.yaml` starts with `    |` on the line after `librechat.yaml: |`. After this PR it starts with `    version: 1.3.11`.

Confirm the broken vs. fixed YAML parses differently with `js-yaml`:

```bash
mkdir -p /tmp/js-yaml-test && cd /tmp/js-yaml-test
npm init -y >/dev/null && npm install js-yaml >/dev/null
node -e '
const yaml = require("js-yaml");
const broken = `|
  version: 1.3.11
  endpoints:
    agents:
      disableBuilder: false`;
const fixed = `version: 1.3.11
endpoints:
  agents:
    disableBuilder: false`;
console.log("broken parse:", typeof yaml.load(broken));   // string  — BUG
console.log("fixed  parse:", typeof yaml.load(fixed));    // object  — OK
console.log("broken endpoints.agents:", yaml.load(broken)?.endpoints?.agents); // undefined
console.log("fixed  endpoints.agents:", yaml.load(fixed)?.endpoints?.agents);  // { disableBuilder: false }
'
```

## Regression test
Added `helm/librechat/tests/configmap_render_test.sh`. It renders the ConfigMap with a sample `configYamlContent`, asserts the rendered `librechat.yaml` body does not start with `|`, and (when a YAML parser is available locally) confirms it parses to an object with `endpoints.agents` preserved. The chart has no existing unit-test framework (only the in-cluster `helm test` Pod hook), so this is a portable bash + optional `python3`/`node` script with zero new runtime dependencies. Run it directly:

```bash
./helm/librechat/tests/configmap_render_test.sh
```

I verified the test fails against the pre-fix template and passes against the post-fix template.

## Risk / migration
None. The `configYamlContent` values-schema is unchanged. Users who already had a working `configYamlContent` continue to work — they'll just *start* getting the actual configuration they wrote, instead of internal defaults. There is no downgrade path concern because the broken behavior was always a silent no-op.

## Chart version
I left `Chart.yaml` at `2.0.3`. Happy to bump to `2.0.4` if the maintainers prefer per-PR patch bumps for bugfixes — recent history is mixed.

## Test plan
- [x] `helm lint helm/librechat` — clean.
- [x] `helm template … --show-only templates/configmap.yaml` shows a single `|` (the `data:` key's block scalar header) and no inner `|`.
- [x] `helm/librechat/tests/configmap_render_test.sh` — PASS on this branch.
- [x] Same test FAILS when the `| toYaml` is reintroduced (confirms it actually catches the regression).
- [x] `node` + `js-yaml` parse of the rendered body yields an object with `endpoints.agents.disableBuilder = false`.
